### PR TITLE
chore(format): extend prettier check to code files (WM-610)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,34 @@
 version: 2
 updates:
   # Maintain dependencies for npm / bun package ecosystem (root)
-  - package-ecosystem: 'npm'
-    directory: '/'
-    target-branch: 'develop'
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "develop"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     open-pull-requests-limit: 5
     labels:
-      - 'dependencies'
-      - 'security'
+      - "dependencies"
+      - "security"
 
   # Maintain dependencies for event-runtime/web
-  - package-ecosystem: 'npm'
-    directory: '/event-runtime/web'
-    target-branch: 'develop'
+  - package-ecosystem: "npm"
+    directory: "/event-runtime/web"
+    target-branch: "develop"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     open-pull-requests-limit: 5
     labels:
-      - 'dependencies'
-      - 'security'
+      - "dependencies"
+      - "security"
 
   # Maintain updates for GitHub Actions workflows
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    target-branch: 'develop'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
     open-pull-requests-limit: 3
     labels:
-      - 'ci'
-      - 'dependencies'
+      - "ci"
+      - "dependencies"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,9 @@
+# Dependencies and builds
 node_modules/
-.factory/
 dist/
 event-runtime/web/dist/
 graphify-out/
 bun.lock
-*.log
-desc-*.md
+event-runtime/web/bun.lock
+deploy/launchd/
+.factory/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -7,6 +7,7 @@ You are the **Master Orchestrator** for the factory. The human operator observes
 ## 1. Operating Philosophy & Core Goal
 
 ### The Goal: Self-Sustaining Autonomous Loops
+
 Keep the factory operating at peak throughput (~10 concurrent worker runs):
 
 ```
@@ -26,7 +27,7 @@ When something blocks throughput — a red gate, a wedged run, a stale hold, a P
 missing evidence, a schema that cannot represent a case — **fix it, then report
 what you did**. Filing the ticket is the record, not the job.
 
-The failure mode to avoid is *diagnose, then wait*: presenting a correct analysis
+The failure mode to avoid is _diagnose, then wait_: presenting a correct analysis
 as a menu of options and stopping for a pick. That converts a self-sustaining
 loop back into a human-paced one and makes the operator the bottleneck for work
 they already delegated. If you find yourself writing "want me to…?" about
@@ -64,27 +65,33 @@ factory watchdog --once
 ```
 
 Alternatively, inspect individual components:
+
 - **Stack & Workers**: `curl -sf http://127.0.0.1:7381/health && bun event-runtime/cli.mjs status`
 - **Supply Queue**: `factory linear queue --team WM`
 - **Open PRs**: `gh pr list --state open`
 - **Git Freshness**: `git status --porcelain && git rev-list --count HEAD..origin/develop`
 
 ### Step 2: Check Linear Supply & Queues
+
 ```bash
 # Check dispatchable queue for target teams (e.g. WM, CLNT, OPS)
 factory linear queue --team WM
 factory linear queue --team CLNT
 ```
+
 - **Healthy Supply**: 10–20+ tickets in `Todo` + `ai:agent-ready` + unassigned.
 - **Low Supply (<5 tickets)**: Immediately prioritize a Triage scan and detail-authoring sweep.
 
 ### Step 3: Inspect Open PRs & In-Flight Branches
+
 ```bash
 gh pr list --state open --json number,title,headRefName,statusCheckRollup,reviews
 ```
+
 - Identify PRs ready for merge review vs PRs blocked on CI or critique revisions.
 
 ### Step 4: Check Workspace Freshness
+
 ```bash
 git fetch --quiet
 git rev-list --count HEAD..origin/develop     # >0 means behind
@@ -128,6 +135,7 @@ flowchart TD
 ---
 
 ### Loop 1: Supply & Triage Engine
+
 Workers idle if supply dries up. Ensure a continuous pipeline of dispatchable work:
 
 1. **Trigger Triage Scans**: Convert raw `Triage` issues into actionable candidates.
@@ -149,13 +157,13 @@ Workers idle if supply dries up. Ensure a continuous pipeline of dispatchable wo
    - **Capacity**: Active `RUNNING` or `VERIFYING` runs occupy physical worker slots (up to max workers, e.g. 10).
    - **Owned Paths overlap is advisory** (`config/policy.yaml` `dispatch.owned_paths_collision: advisory`, WM-677). The gate records the overlapping claims on the proposal as evidence and dispatches anyway; only a `**` claim on either side still refuses (`owned_paths_conflict_hard`). Textual overlap — same directory, same file, different lines — is a rebase job that `merge-fix` already does; refusing it at dispatch was starving the pool (9 attempts → 2 workers under `strict`). Merging stays serialized (`max_concurrent_merges: 1`), which is where real conflicts are caught. `strict` is the fail-closed default if the key is absent.
 2. **Dispatching** — inject a `factory.dispatch.requested` envelope; the payload field is `ticket` (not `ticketId`) and `repo` is the `config/repos.yaml` short name:
-     ```bash
-     bun event-runtime/cli.mjs inject - <<'EOF'
-     {"schemaVersion":"factory.event/v1","eventId":"dispatch:factory:WM-123:1",
-      "type":"factory.dispatch.requested","source":"operator","subject":"WM-123",
-      "occurredAt":"2026-01-01T00:00:00Z","payload":{"repo":"factory","ticket":"WM-123"}}
-     EOF
-     ```
+   ```bash
+   bun event-runtime/cli.mjs inject - <<'EOF'
+   {"schemaVersion":"factory.event/v1","eventId":"dispatch:factory:WM-123:1",
+    "type":"factory.dispatch.requested","source":"operator","subject":"WM-123",
+    "occurredAt":"2026-01-01T00:00:00Z","payload":{"repo":"factory","ticket":"WM-123"}}
+   EOF
+   ```
    - An `operator`-sourced event is **not** auto-approvable (chain auto-approval requires `source: "chain"`), so it lands as an open proposal: `cli.mjs proposals` then `cli.mjs approve <proposal-id>`. Space approvals a few seconds apart — a burst of ~10 hits `claim_lock_starvation` (WM-682).
    - Bump the `eventId` suffix to re-inject after a refused or failed attempt; intake dedups on `(source, eventId)`.
 3. **Idempotency Pin Trap**:
@@ -241,7 +249,7 @@ The factory automatically merges PRs targeting `develop` once all gates pass.
    **Restart is required — not optional — when `develop` changed** any of
    `event-runtime/agents/**`, `event-runtime/schemas/**`,
    `event-runtime/event-types.json`, `event-runtime/schedules.json`, or
-   `config/**`. Model-tier and routing changes resolve at *plan* time inside
+   `config/**`. Model-tier and routing changes resolve at _plan_ time inside
    `serve`, so a `serve`-only restart is enough for those and leaves running
    workers untouched; a definition change needs the workers restarted too.
    Drain first — `bin/live-stack.sh down` finishes in-flight runs — and prefer
@@ -254,21 +262,23 @@ The factory automatically merges PRs targeting `develop` once all gates pass.
 Use the interrupt channel strictly for critical events requiring human operator action.
 
 #### Approved Telegram Notify Events
+
 Execute:
+
 ```bash
 factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
 ```
 
-| Event Prefix | When to Use |
-| :--- | :--- |
-| `BLOCKED` | A ticket is blocked on missing credentials, contradictory specs, or unresolvable environment issues. |
-| `ESCALATED` | Security, auth, money movement, or destructive migration PR requires human review and merge approval. |
-| `CI RED` | `develop` trunk CI broken by an unexpected regression. All dispatch paused until trunk is green. |
-| `SMOKE RED` | Post-deploy smoke test failure on staging/production. |
-| `CIRCUIT BREAKER` | Repeated cascade failures across worker nodes (e.g. 5+ consecutive runner crashes). |
-| `RC READY` | Release candidate PR (`develop -> master`) prepared, green, and awaiting human sign-off. |
+| Event Prefix      | When to Use                                                                                           |
+| :---------------- | :---------------------------------------------------------------------------------------------------- |
+| `BLOCKED`         | A ticket is blocked on missing credentials, contradictory specs, or unresolvable environment issues.  |
+| `ESCALATED`       | Security, auth, money movement, or destructive migration PR requires human review and merge approval. |
+| `CI RED`          | `develop` trunk CI broken by an unexpected regression. All dispatch paused until trunk is green.      |
+| `SMOKE RED`       | Post-deploy smoke test failure on staging/production.                                                 |
+| `CIRCUIT BREAKER` | Repeated cascade failures across worker nodes (e.g. 5+ consecutive runner crashes).                   |
+| `RC READY`        | Release candidate PR (`develop -> master`) prepared, green, and awaiting human sign-off.              |
 
-*Routine updates (claims, routine merges, spec completions) belong in Linear comments and session summaries, never notify.*
+_Routine updates (claims, routine merges, spec completions) belong in Linear comments and session summaries, never notify._
 
 ---
 
@@ -311,12 +321,12 @@ crossed the line.
 Reach for the specialised agent before a general one — each exists so its raw
 output stays out of the caller's context:
 
-| Agent | Use for |
-| :--- | :--- |
-| `factory-ci-doctor` | one red GitHub Actions run — after it fails, never to wait for it |
-| `factory-merge-reviewer` | a PR diff, so the diff never enters the orchestrator |
-| `factory-infra-scout` | anything needing SSH or container output |
-| `factory-ux-critic` | user-facing flows, after verification and before the PR |
+| Agent                    | Use for                                                           |
+| :----------------------- | :---------------------------------------------------------------- |
+| `factory-ci-doctor`      | one red GitHub Actions run — after it fails, never to wait for it |
+| `factory-merge-reviewer` | a PR diff, so the diff never enters the orchestrator              |
+| `factory-infra-scout`    | anything needing SSH or container output                          |
+| `factory-ux-critic`      | user-facing flows, after verification and before the PR           |
 
 The secondary reason is cost: a tool result is re-sent on every later turn, so a
 test log read inline is charged for the rest of the shift — see **Context
@@ -373,19 +383,19 @@ gh run watch <run-id> --exit-status      # blocks until the run ends
 
 ## 5. Catalog of Known Traps & Non-Negotiables
 
-| Trap | Mechanism | Hard-Won Rule |
-| :--- | :--- | :--- |
-| **CI Rerun Cache** | `gh run rerun` on a green run is refused; on a failed run, it reuses the run ID attempt. | Observe the CI run in an active/non-completed state before trusting a green verdict. |
-| **`GET /runs` No `spec`** | `GET /runs` lacks the `spec` field (WM-303). Reading `row.spec` yields empty. | Read run metadata and ticket identity from `eventId` or `cli.mjs inspect <runId>`. |
-| **Idempotency Pinning** | `FAILED`/`BLOCKED` runs pin their input hash key; re-injected `dispatch.requested` no-ops. | Always use `cli.mjs retry <runId> --force` to unstick a failed run. |
-| **`git stash` in Worktrees** | The stash stack (`.git/refs/stash`) is repo-global, not isolated per worktree. | **NEVER use `git stash` or `git rebase --autostash`** in agent worktrees. Use temporary patches or WIP commits. |
-| **macOS Bash 3.2** | Default macOS bash lacks `mapfile` / `readarray` and modern expansions. | Use POSIX `while IFS= read -r line` loops in all shell scripts. |
-| **Prettier Scope** | Running prettier across whole repo reformats hundreds of `.mjs` files unnecessarily. | Prettier is configured ONLY for `shared/**/*.md` (`bun run format:check`). |
-| **Label Replacement** | Direct GraphQL label mutations replace the whole array, wiping `type:*` and `area:*`. | Always use `--add` / `--remove` flags via `factory linear state` or `factory linear labels`. |
-| **Restart Orphans In-Flight Runs** | `bin/live-stack.sh down` does not actually wait for in-flight dispatches; their leaseholder dies, the run stays `RUNNING` forever, and the `reaper` loop that would reclaim it is disabled (WM-657). | Restart only when no `dispatch@1` run is `RUNNING`/`LEASED`. After any restart, compare `attempts.lease_owner` against `cli.mjs workers` and `cancel` orphans — preserving+pushing any uncommitted worktree work first. |
-| **Stale Rebase Reverts Trunk** | A fixer that rebases onto an `origin/develop` fetched minutes earlier silently drops PRs merged in between and still passes CI. Nearly reverted #582 via #583. | Before merging any rebased PR: `git diff --stat origin/develop origin/<branch>` must show no unexplained deletions of develop-side files. Tell fixers to `git fetch` immediately before `rebase`. |
-| **Blocking Waits Inline** | A `sleep`-and-recheck loop or `gh run watch` in the session queues the operator's steering behind it for the whole wait. | Loop 6 hard rule: nothing inline may block >~30s. CI waits, merges-on-green, reruns, test runs, rebases go to a subagent; the session keeps only decisions. |
-| **A Hold Only In Your Head Is Not A Hold** | The autonomous `merge-scan`/`merge-apply` loop does not read the orchestrator's intentions. A PR held by verdict but left MERGEABLE and non-draft was auto-merged (#552, a known safety regression) while the session "held" it. | Make holds structural the moment a review returns FIX/ESCALATE: convert to draft (`gh pr ready --undo`) or add `ai:escalated` on the ticket. The scan honours drafts and escalation labels; it cannot honour a note. |
+| Trap                                       | Mechanism                                                                                                                                                                                                                        | Hard-Won Rule                                                                                                                                                                                                           |
+| :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CI Rerun Cache**                         | `gh run rerun` on a green run is refused; on a failed run, it reuses the run ID attempt.                                                                                                                                         | Observe the CI run in an active/non-completed state before trusting a green verdict.                                                                                                                                    |
+| **`GET /runs` No `spec`**                  | `GET /runs` lacks the `spec` field (WM-303). Reading `row.spec` yields empty.                                                                                                                                                    | Read run metadata and ticket identity from `eventId` or `cli.mjs inspect <runId>`.                                                                                                                                      |
+| **Idempotency Pinning**                    | `FAILED`/`BLOCKED` runs pin their input hash key; re-injected `dispatch.requested` no-ops.                                                                                                                                       | Always use `cli.mjs retry <runId> --force` to unstick a failed run.                                                                                                                                                     |
+| **`git stash` in Worktrees**               | The stash stack (`.git/refs/stash`) is repo-global, not isolated per worktree.                                                                                                                                                   | **NEVER use `git stash` or `git rebase --autostash`** in agent worktrees. Use temporary patches or WIP commits.                                                                                                         |
+| **macOS Bash 3.2**                         | Default macOS bash lacks `mapfile` / `readarray` and modern expansions.                                                                                                                                                          | Use POSIX `while IFS= read -r line` loops in all shell scripts.                                                                                                                                                         |
+| **Prettier Scope**                         | Running prettier across whole repo reformats hundreds of `.mjs` files unnecessarily.                                                                                                                                             | Prettier is configured ONLY for `shared/**/*.md` (`bun run format:check`).                                                                                                                                              |
+| **Label Replacement**                      | Direct GraphQL label mutations replace the whole array, wiping `type:*` and `area:*`.                                                                                                                                            | Always use `--add` / `--remove` flags via `factory linear state` or `factory linear labels`.                                                                                                                            |
+| **Restart Orphans In-Flight Runs**         | `bin/live-stack.sh down` does not actually wait for in-flight dispatches; their leaseholder dies, the run stays `RUNNING` forever, and the `reaper` loop that would reclaim it is disabled (WM-657).                             | Restart only when no `dispatch@1` run is `RUNNING`/`LEASED`. After any restart, compare `attempts.lease_owner` against `cli.mjs workers` and `cancel` orphans — preserving+pushing any uncommitted worktree work first. |
+| **Stale Rebase Reverts Trunk**             | A fixer that rebases onto an `origin/develop` fetched minutes earlier silently drops PRs merged in between and still passes CI. Nearly reverted #582 via #583.                                                                   | Before merging any rebased PR: `git diff --stat origin/develop origin/<branch>` must show no unexplained deletions of develop-side files. Tell fixers to `git fetch` immediately before `rebase`.                       |
+| **Blocking Waits Inline**                  | A `sleep`-and-recheck loop or `gh run watch` in the session queues the operator's steering behind it for the whole wait.                                                                                                         | Loop 6 hard rule: nothing inline may block >~30s. CI waits, merges-on-green, reruns, test runs, rebases go to a subagent; the session keeps only decisions.                                                             |
+| **A Hold Only In Your Head Is Not A Hold** | The autonomous `merge-scan`/`merge-apply` loop does not read the orchestrator's intentions. A PR held by verdict but left MERGEABLE and non-draft was auto-merged (#552, a known safety regression) while the session "held" it. | Make holds structural the moment a review returns FIX/ESCALATE: convert to draft (`gh pr ready --undo`) or add `ai:escalated` on the ticket. The scan honours drafts and escalation labels; it cannot honour a note.    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ evals/                            prompt regression cases (no runner yet — see
 
 The **content** is portable; only the **packaging** isn't. `SKILL.md` is a shared workflow format, command bodies are Markdown, and each harness gets its native custom-agent manifest.
 
-| Harness | Context | Skills | Commands | Agents |
-| :--- | :--- | :--- | :--- | :--- |
-| Claude Code | `CLAUDE.md` → `AGENTS.md` | plugin `skills/` | plugin `commands/` | plugin `agents/` |
-| Codex | `AGENTS.md` (native) | `~/.agents/skills/` | — (use `@factory-*` skills) | `~/.codex/agents/` |
-| Pi | `AGENTS.md` (native) | `dist/pi/skills/` | `dist/pi/prompts/` | `~/.pi/agent/agents/` |
-| Gemini CLI | `GEMINI.md` → `AGENTS.md` | `~/.gemini/skills/` | — | `~/.gemini/agents/` |
-| Antigravity | shares `~/.gemini/` | via Gemini | — | via Gemini |
-| Cursor | `.cursor/rules/` | — | `~/.cursor/commands/` | `~/.cursor/agents/` |
+| Harness     | Context                   | Skills              | Commands                    | Agents                |
+| :---------- | :------------------------ | :------------------ | :-------------------------- | :-------------------- |
+| Claude Code | `CLAUDE.md` → `AGENTS.md` | plugin `skills/`    | plugin `commands/`          | plugin `agents/`      |
+| Codex       | `AGENTS.md` (native)      | `~/.agents/skills/` | — (use `@factory-*` skills) | `~/.codex/agents/`    |
+| Pi          | `AGENTS.md` (native)      | `dist/pi/skills/`   | `dist/pi/prompts/`          | `~/.pi/agent/agents/` |
+| Gemini CLI  | `GEMINI.md` → `AGENTS.md` | `~/.gemini/skills/` | —                           | `~/.gemini/agents/`   |
+| Antigravity | shares `~/.gemini/`       | via Gemini          | —                           | via Gemini            |
+| Cursor      | `.cursor/rules/`          | —                   | `~/.cursor/commands/`       | `~/.cursor/agents/`   |
 
 ```bash
 bun build/emit.mjs           # regenerate everything
@@ -79,21 +79,21 @@ bun run link-repos           # symlink plugins/core/commands/ into every repo in
 
 Prefixed `factory-` so they're identifiable as ours and never collide with a repo-local or built-in command of the same name.
 
-| Command | Does |
-| :--- | :--- |
-| `/factory-work` | Claims agent-ready tickets, dispatches them rolling (not batched), lands the PRs |
-| `/factory-ticket` | Implements exactly one already-claimed ticket in the current worktree — what `tick.mjs` spawns |
-| `/factory-merge` | Reviews open PRs, fixes what's mechanical, merges what qualifies |
-| `/factory-ship` | Opens the `develop` → deploy-branch PR, waits for CI, merges, verifies the deploy |
-| `/factory-triage` | Turns `Triage` tickets into `ai:agent-ready` ones |
-| `/factory-unblock` | Re-examines `ai:blocked` holds and releases the ones new evidence resolved |
-| `/factory-sweep` | Retires tickets overtaken by events — `Canceled`/`Duplicate` with evidence, never a delete |
-| `/factory-audit` | Grades a repo against project-conventions `PC-01`..`PC-20`, files the gaps |
-| `/factory-capture` | Files a Linear issue from the conversation — capture only, never implement |
-| `/factory-friction` | Files harness friction seen in an interactive session, where no transcript exists |
-| `/factory-retro` | Turns measured friction into harness changes |
-| `/factory-report` | Read-only pipeline snapshot across the configured repos |
-| `/factory-next` | Picks the one next stage for this repo, and runs it only when asked |
+| Command             | Does                                                                                           |
+| :------------------ | :--------------------------------------------------------------------------------------------- |
+| `/factory-work`     | Claims agent-ready tickets, dispatches them rolling (not batched), lands the PRs               |
+| `/factory-ticket`   | Implements exactly one already-claimed ticket in the current worktree — what `tick.mjs` spawns |
+| `/factory-merge`    | Reviews open PRs, fixes what's mechanical, merges what qualifies                               |
+| `/factory-ship`     | Opens the `develop` → deploy-branch PR, waits for CI, merges, verifies the deploy              |
+| `/factory-triage`   | Turns `Triage` tickets into `ai:agent-ready` ones                                              |
+| `/factory-unblock`  | Re-examines `ai:blocked` holds and releases the ones new evidence resolved                     |
+| `/factory-sweep`    | Retires tickets overtaken by events — `Canceled`/`Duplicate` with evidence, never a delete     |
+| `/factory-audit`    | Grades a repo against project-conventions `PC-01`..`PC-20`, files the gaps                     |
+| `/factory-capture`  | Files a Linear issue from the conversation — capture only, never implement                     |
+| `/factory-friction` | Files harness friction seen in an interactive session, where no transcript exists              |
+| `/factory-retro`    | Turns measured friction into harness changes                                                   |
+| `/factory-report`   | Read-only pipeline snapshot across the configured repos                                        |
+| `/factory-next`     | Picks the one next stage for this repo, and runs it only when asked                            |
 
 ### `factory status` — the everyday hub
 
@@ -116,8 +116,8 @@ A repo may opt into deployment revision comparison in `config/repos.yaml`:
 ```yaml
 deployment:
   url: https://app.example.com/healthz # exact endpoint, or origin -> /version.json
-  branch: develop                      # branch represented by this environment
-  revision_field: revision              # optional; commit/git_sha/sha are automatic
+  branch: develop # branch represented by this environment
+  revision_field: revision # optional; commit/git_sha/sha are automatic
 ```
 
 The endpoint must return JSON containing a revision field, such as
@@ -153,12 +153,12 @@ It delegates to `~/Develop/hdkiller/scripts/notify.py` and preserves its exit st
 
 Agents are isolated specialist contexts, not workflow entry points. Their names use `factory-<role>` so ownership is visible without repeating the resource type in every identifier.
 
-| Agent | Does |
-| :--- | :--- |
-| `factory-ux-critic` | Exercises a materially changed user journey and returns a read-only `SHIP` / `FIX-FIRST` critique |
+| Agent                    | Does                                                                                                               |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| `factory-ux-critic`      | Exercises a materially changed user journey and returns a read-only `SHIP` / `FIX-FIRST` critique                  |
 | `factory-merge-reviewer` | Reviews one PR cold and returns `MERGE` / `FIX` / `ESCALATE`, so the diff never enters the merge session's context |
-| `factory-ci-doctor` | Diagnoses one red Actions run and classifies it `TICKET` / `ENV` / `FLAKE`, keeping the job logs out of the caller |
-| `factory-infra-scout` | Answers questions that need SSH or container output, returning a verdict rather than the dumps |
+| `factory-ci-doctor`      | Diagnoses one red Actions run and classifies it `TICKET` / `ENV` / `FLAKE`, keeping the job logs out of the caller |
+| `factory-infra-scout`    | Answers questions that need SSH or container output, returning a verdict rather than the dumps                     |
 
 ## Scheduling — nothing is scheduled
 
@@ -186,11 +186,11 @@ That's what makes it continuous rather than batch — **follow-up work filed dur
 
 Each gate encodes what "work exists" means for that stage:
 
-| Stage | Runs when |
-| :--- | :--- |
-| `triage` | anything is in `Triage`, or `Todo` without `ai:agent-ready` |
+| Stage      | Runs when                                                        |
+| :--------- | :--------------------------------------------------------------- |
+| `triage`   | anything is in `Triage`, or `Todo` without `ai:agent-ready`      |
 | `dispatch` | a slot is free **and** a ticket is startable (Owned Paths clear) |
-| `merge` | a PR is actually in review |
+| `merge`    | a PR is actually in review                                       |
 
 The dispatch gate matters most: an agent that wakes to find the cap full has burned a run to learn nothing.
 
@@ -198,13 +198,13 @@ The dispatch gate matters most: an agent that wakes to find the cap full has bur
 
 On a subscription the scarce resource is the **usage window**, and Opus consumes it several times faster than Sonnet. So Opus is spent only where it changes the outcome:
 
-| Stage | Model | Why |
-| :--- | :--- | :--- |
-| `factory-triage` | sonnet | Structured extraction guided by a detailed skill — find the files, write tight globs, write a command that runs |
-| `factory-work` | sonnet **orchestrating opus subagents** | Coordination is cheap; the code is the product |
-| `factory-merge` | **opus** | Review catches what tests don't, and it is the last gate before `develop` auto-deploys |
-| `factory-audit` | sonnet | A mechanical checklist against `PC-01`..`PC-20` |
-| `factory-ux-critic` | sonnet on Claude; parent model elsewhere | Exercises the running app and reports |
+| Stage               | Model                                    | Why                                                                                                             |
+| :------------------ | :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| `factory-triage`    | sonnet                                   | Structured extraction guided by a detailed skill — find the files, write tight globs, write a command that runs |
+| `factory-work`      | sonnet **orchestrating opus subagents**  | Coordination is cheap; the code is the product                                                                  |
+| `factory-merge`     | **opus**                                 | Review catches what tests don't, and it is the last gate before `develop` auto-deploys                          |
+| `factory-audit`     | sonnet                                   | A mechanical checklist against `PC-01`..`PC-20`                                                                 |
+| `factory-ux-critic` | sonnet on Claude; parent model elsewhere | Exercises the running app and reports                                                                           |
 
 Claude reads the per-command frontmatter. `agy` is deliberately pinned to `gemini-3.6-flash-medium` in both Factory launch paths because it receives only the command body; `run-agent.sh --model X` overrides that for a one-off session.
 
@@ -229,7 +229,7 @@ There is also a standalone `warm` stage (every 2h, same staleness gate) so a lon
 
 Three levels, each with a different job:
 
-1. **Across repos — sequential.** `--repo a,b` runs repos one after another. Parallelism belongs *inside* a repo; N concurrent sessions across repos contend for the same machine, the same Linear rate budget, and the same daily spend cap.
+1. **Across repos — sequential.** `--repo a,b` runs repos one after another. Parallelism belongs _inside_ a repo; N concurrent sessions across repos contend for the same machine, the same Linear rate budget, and the same daily spend cap.
 2. **Within a repo — `max_in_flight` slots** (20 for bj29, in `config/repos.yaml`; 3 is the fallback in `config/policy.yaml` for a repo that names no number of its own). One ticket = one worktree = one agent. The gate reports `slotsFree` and refuses to dispatch at zero.
 3. **Between tickets — `Owned Paths`.** Two tickets run together only if their glob sets are disjoint. This is the real safety property; slots just cap resource use.
 
@@ -239,22 +239,22 @@ Three levels, each with a different job:
 
 Not in the command. The layering:
 
-| Knowledge | Lives in |
-| :--- | :--- |
-| How to triage / dispatch / merge — universal | `shared/commands/factory-*.md` |
-| Routing facts: team, base branch, worktree script, verify command, escalation paths | `config/repos.yaml` |
-| Stack rules, product decisions, gotchas | the repo's own `AGENTS.md`, `docs/product-decisions.md` |
+| Knowledge                                                                           | Lives in                                                |
+| :---------------------------------------------------------------------------------- | :------------------------------------------------------ |
+| How to triage / dispatch / merge — universal                                        | `shared/commands/factory-*.md`                          |
+| Routing facts: team, base branch, worktree script, verify command, escalation paths | `config/repos.yaml`                                     |
+| Stack rules, product decisions, gotchas                                             | the repo's own `AGENTS.md`, `docs/product-decisions.md` |
 
-The agent runs with `cwd` set to the repo, so it reads that repo's `AGENTS.md` naturally — repo specifics arrive as *context*, not as forked commands. For genuinely stage-specific repo guidance, `run-agent.sh --args` appends to the prompt. Resist adding config surface before a real case demands it.
+The agent runs with `cwd` set to the repo, so it reads that repo's `AGENTS.md` naturally — repo specifics arrive as _context_, not as forked commands. For genuinely stage-specific repo guidance, `run-agent.sh --args` appends to the prompt. Resist adding config surface before a real case demands it.
 
 ### Where the work happens
 
-| What | Where | Why |
-| :--- | :--- | :--- |
-| The repo itself | `~/Develop/pets/bj29` (`repos.yaml: path`) | Triage reads it; worktrees are created *from* it |
-| Per-ticket worktrees | `~/Develop/.worktrees/<repo>/<TICKET>` (`repos.yaml: worktree_root`) | One ticket, one checkout, own branch/ports/database |
-| Factory runtime state | `~/.factory/` | Session ids, budget ledger, logs, stage journal — never in git |
-| This repo | `~/Develop/factory` | Control plane only. **No work happens here.** |
+| What                  | Where                                                                | Why                                                            |
+| :-------------------- | :------------------------------------------------------------------- | :------------------------------------------------------------- |
+| The repo itself       | `~/Develop/pets/bj29` (`repos.yaml: path`)                           | Triage reads it; worktrees are created _from_ it               |
+| Per-ticket worktrees  | `~/Develop/.worktrees/<repo>/<TICKET>` (`repos.yaml: worktree_root`) | One ticket, one checkout, own branch/ports/database            |
+| Factory runtime state | `~/.factory/`                                                        | Session ids, budget ledger, logs, stage journal — never in git |
+| This repo             | `~/Develop/factory`                                                  | Control plane only. **No work happens here.**                  |
 
 **Worktrees must not live inside `~/Develop/factory/`.** It's a git repo, so nesting checkouts under it means `git status` noise, a real chance of `git add -A` sweeping an entire worktree into a commit, and the drift check walking trees it has no business in. A control plane that can accidentally commit its own workload is a bad control plane.
 
@@ -262,7 +262,7 @@ A sibling like `~/Develop/factory-workspace/` would work, but it buys nothing an
 
 The existing convention already has the properties you'd want: outside any repo, namespaced per repo, dot-prefixed so it stays out of `~/Develop` listings, and pointed at by `worktree_root` in `config/repos.yaml` — so it's a config change, not a code change, if it ever needs to move.
 
-**The one good reason to move it: disk.** This machine is at 96%, and worktrees are the bulk of it. If you relocate them to another volume, change `worktree_root` here *and* the corresponding path in the repo's `worktree-up.sh` — those two must agree, or the janitor cleans a directory the scripts aren't using.
+**The one good reason to move it: disk.** This machine is at 96%, and worktrees are the bulk of it. If you relocate them to another volume, change `worktree_root` here _and_ the corresponding path in the repo's `worktree-up.sh` — those two must agree, or the janitor cleans a directory the scripts aren't using.
 
 ### Lifecycle
 
@@ -277,7 +277,7 @@ The janitor exists because that third step is the one that gets skipped — a cr
 
 ### Checkout freshness
 
-Stages read the repo to write file pointers and verification commands, so `run-agent.sh` **always fetches, and fast-forwards only when the tree is clean** — `--ff-only` cannot create a merge commit or lose work, so it is safe unattended. When the tree is dirty it pulls nothing and says so, in the log *and* in the prompt: the main checkout routinely holds someone's uncommitted work, and silently rebasing under them is a worse failure than a slightly stale spec. A checkout that is behind, ahead, or dirty is announced to the agent as unreliable evidence, with instructions to take code from `origin/<base>` instead. Triage is read-only and needs no worktree; only dispatch creates them.
+Stages read the repo to write file pointers and verification commands, so `run-agent.sh` **always fetches, and fast-forwards only when the tree is clean** — `--ff-only` cannot create a merge commit or lose work, so it is safe unattended. When the tree is dirty it pulls nothing and says so, in the log _and_ in the prompt: the main checkout routinely holds someone's uncommitted work, and silently rebasing under them is a worse failure than a slightly stale spec. A checkout that is behind, ahead, or dirty is announced to the agent as unreliable evidence, with instructions to take code from `origin/<base>` instead. Triage is read-only and needs no worktree; only dispatch creates them.
 
 ## Testing the loop
 
@@ -323,17 +323,17 @@ Only then start the supervisor on a cadence.
 
 ### Limits
 
-| Limit | Where | Default |
-| :--- | :--- | :--- |
-| Tickets per tick | `--args` in `config/schedule.yaml` | triage 5, unblock 10 |
-| Concurrent tickets | `max_in_flight` in `config/repos.yaml` | 20 for bj29, legalease and cashsaas; 3 where a repo names nothing |
-| Spend per run | `--budget`, else `budget.per_ticket_usd` in `config/policy.yaml` | $15 (`merge_usd`: $40 — a merge pass reviews a backlog, not one diff) |
-| Daily spend | `budget.per_day_usd` | $2000 |
-| Which repos | `--repo` on each job, else `defaults.repo` | `bj29` |
+| Limit              | Where                                                            | Default                                                               |
+| :----------------- | :--------------------------------------------------------------- | :-------------------------------------------------------------------- |
+| Tickets per tick   | `--args` in `config/schedule.yaml`                               | triage 5, unblock 10                                                  |
+| Concurrent tickets | `max_in_flight` in `config/repos.yaml`                           | 20 for bj29, legalease and cashsaas; 3 where a repo names nothing     |
+| Spend per run      | `--budget`, else `budget.per_ticket_usd` in `config/policy.yaml` | $15 (`merge_usd`: $40 — a merge pass reviews a backlog, not one diff) |
+| Daily spend        | `budget.per_day_usd`                                             | $2000                                                                 |
+| Which repos        | `--repo` on each job, else `defaults.repo`                       | `bj29`                                                                |
 
 ### Auth and "budget" on a subscription
 
-Runs use the **claude.ai subscription**, not the API. `run-agent.sh` unsets `ANTHROPIC_API_KEY` for the child unless you pass `--use-api` — with it set, every run bills per token *and* claude.ai connectors (including the Linear MCP) are disabled.
+Runs use the **claude.ai subscription**, not the API. `run-agent.sh` unsets `ANTHROPIC_API_KEY` for the child unless you pass `--use-api` — with it set, every run bills per token _and_ claude.ai connectors (including the Linear MCP) are disabled.
 
 So `--max-budget-usd` is **not money**. Claude still reports `costUSD` per model — a trivial one-turn run shows ~$0.14 notional, mostly cache creation — and the flag caps against that figure. Treat it as a **runaway guard in notional API-equivalent units**: it stops a session going in circles; it does not protect a wallet. `$2` is too tight for a triage run that has to explore a codebase.
 
@@ -356,8 +356,8 @@ bun orchestrator/run.mjs --all --apply
 
 Three properties, in order of how much they matter:
 
-1. **Dry by default.** A job declares `dry_command` next to `command`; without `--apply` you get the dry one. The reaper's first real run would have unassigned 31 tickets, so *what would this do* is the default question.
-2. **Explicit selection.** Always `--only` or `--all`. There is no "run whatever is enabled" mode — `enabled:` means *may be installed as an unattended timer*, which is a different decision from *run it now*.
+1. **Dry by default.** A job declares `dry_command` next to `command`; without `--apply` you get the dry one. The reaper's first real run would have unassigned 31 tickets, so _what would this do_ is the default question.
+2. **Explicit selection.** Always `--only` or `--all`. There is no "run whatever is enabled" mode — `enabled:` means _may be installed as an unattended timer_, which is a different decision from _run it now_.
 3. **No overlap.** A job still running when its next tick arrives is skipped, not stacked. Two reapers racing is precisely the failure the reaper exists to clean up.
 
 `config/schedule.yaml` stays the single source of truth for cadences — the supervisor and the launchd generator read it through the same `lib/schedule.mjs`, so the watched and unattended modes can't disagree about what the jobs are. When a loop does earn promotion it's one flag and a regeneration, not a plist someone writes by hand at 1am.
@@ -382,7 +382,7 @@ Never hand-edit a generated plist — the next regeneration silently reverts it.
 
 ### Measuring the runs — friction and economics
 
-The transcripts under `~/.factory/logs/*.jsonl` are the record of what agents *actually did*, which is why both of these measure rather than ask. An agent that fought a broken tool for ten minutes will not reliably write that down; its transcript shows the same failing call three runs running.
+The transcripts under `~/.factory/logs/*.jsonl` are the record of what agents _actually did_, which is why both of these measure rather than ask. An agent that fought a broken tool for ten minutes will not reliably write that down; its transcript shows the same failing call three runs running.
 
 ```bash
 bun orchestrator/friction.mjs                # what wasted the agents' TIME
@@ -410,7 +410,7 @@ bun orchestrator/economics.mjs --roll        # append to the permanent rollup
 Concurrent Claude agents used to share one chrome-devtools-mcp profile: ten tickets dispatched in the same second all raced for one `SingletonLock`, first Chrome won, and everyone else burned turns on `browser is already running` — 95 errors across 26 runs. The fix is structural, not prompt-level, and it lives in this repo:
 
 - **`config/mcp/claude.json`** defines the browser server the factory passes to every Claude spawn via `--mcp-config`: `--isolated` (temp profile per session, auto-cleaned — collisions become impossible), `--headless`, and webp screenshot caps (`--screenshotFormat=webp --screenshotQuality=70 --screenshotMaxWidth=1280`) that shrink the factory's single biggest context cost 4–6x at the source, while an agent that truly needs a pixel-perfect PNG can still request one per-call.
-- **Deliberately NOT `--strict-mcp-config`.** Strict mode also drops the claude.ai connectors, and losing the Linear MCP severs the control plane — verified empirically on 2026-08-04: 0 Linear tools under strict, 52 without it. The global chrome-devtools *plugin* is disabled in `~/.claude/settings.json` instead, so exactly one browser server loads.
+- **Deliberately NOT `--strict-mcp-config`.** Strict mode also drops the claude.ai connectors, and losing the Linear MCP severs the control plane — verified empirically on 2026-08-04: 0 Linear tools under strict, 52 without it. The global chrome-devtools _plugin_ is disabled in `~/.claude/settings.json` instead, so exactly one browser server loads.
 - **`orchestrator/chrome-sweep.mjs`** cleans up what the wall-clock cap leaves behind: a killed run's MCP server dies without closing its Chrome, which reparents to launchd and keeps running. The sweep kills only processes that pass three fences (agent profile dir in the command line, browser main process, reparented to PID 1 — a live agent's Chrome still has its MCP server as parent) and clears stale `Singleton*` locks nobody holds. Dry-run by default; `--apply` to act. The one unforgivable failure — killing the human's actual Chrome — has a test per fence.
 
 Verified end to end: two parallel headless sessions each launched their own Chrome and navigated with zero contention. After the next batch, `bun run economics -- --since 1d` should show browser-collision errors at zero and `take_screenshot` payloads down ~4–6x.
@@ -419,7 +419,7 @@ Verified end to end: two parallel headless sessions each launched their own Chro
 
 `orchestrator/owned-paths.mjs` decides whether two tickets can run at once by intersecting their `Owned Paths` globs. Every `ai:agent-ready` ticket already carries that section, so the machine-readable answer exists — guessing from title keywords both over-fires ("Fix login button copy" vs "Rewrite auth middleware" share vocabulary but no files) and under-fires ("Onboarding wizard polish" vs "Profile page spacing" share files but no words).
 
-Where the glob algebra is ambiguous it errs toward *collision*: a false positive serializes two tickets, a false negative puts two agents in one file. Tests: `bun test`.
+Where the glob algebra is ambiguous it errs toward _collision_: a false positive serializes two tickets, a false negative puts two agents in one file. Tests: `bun test`.
 
 ## What stays out of git
 
@@ -429,12 +429,12 @@ Secrets (injected via launchd env or `op run`), worktrees, agent session logs, a
 
 **Automated dispatch is authorized for the four repos in `config/repos.yaml` that ship the worktree lifecycle:** `bj29`, `legalease`, `cashsaas` and `wm-home`. coach-wattz's teardown script landed in [CW-363](https://linear.app/watt-mind/issue/CW-363), so the janitor can safely reclaim its finished worktrees through that repo-owned script, but it stays `report_only` for dispatch — as do watts-mobile, proxies, hdkiller, eslint-config and this repo.
 
-| Stage | State |
-| :--- | :--- |
-| `triage` | works on Claude **and** agy; claims tickets so they show in Agents In Flight |
-| `dispatch` | `tick.mjs` — one process per ticket, rolling refill, auto-warm |
-| `merge` | exercised end to end across bj29, legalease and cashsaas; still the one stage that is never parallel |
-| `janitor`, `warm`, `reaper` | work; reaper cleaned 50 stale markers |
+| Stage                       | State                                                                                                |
+| :-------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `triage`                    | works on Claude **and** agy; claims tickets so they show in Agents In Flight                         |
+| `dispatch`                  | `tick.mjs` — one process per ticket, rolling refill, auto-warm                                       |
+| `merge`                     | exercised end to end across bj29, legalease and cashsaas; still the one stage that is never parallel |
+| `janitor`, `warm`, `reaper` | work; reaper cleaned 50 stale markers                                                                |
 
 **Nothing is scheduled.** All jobs are `enabled: false`; run through `orchestrator/run.mjs`.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -222,17 +222,17 @@ factory down         # stops all three
 
 It needs the web deps (`cd event-runtime/web && bun install`) because the UI runs under vite instead of the static `serve.mjs` build; `--dev` says so and exits rather than failing inside vite. Plain `factory up` behaves exactly as before.
 
-**The worker reloads only when idle.** It stamps its own code at startup (HEAD plus a content hash of `event-runtime/lib/**` and `event-runtime/cli.mjs`, so uncommitted edits count) and re-checks that stamp *between claims*. On a change it exits `75` and the supervisor re-execs it. A run in flight keeps the old code to completion — logged as `reload deferred until <run> finishes` — and the reload happens at the next idle poll. Nothing can interrupt a running agent, which is the reason this is a poll-boundary check and not a file watcher.
+**The worker reloads only when idle.** It stamps its own code at startup (HEAD plus a content hash of `event-runtime/lib/**` and `event-runtime/cli.mjs`, so uncommitted edits count) and re-checks that stamp _between claims_. On a change it exits `75` and the supervisor re-execs it. A run in flight keeps the old code to completion — logged as `reload deferred until <run> finishes` — and the reload happens at the next idle poll. Nothing can interrupt a running agent, which is the reason this is a poll-boundary check and not a file watcher.
 
 **Which change needs which reload:**
 
-| You changed | What reloads it |
-| :--- | :--- |
-| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve restarts immediately (`bun --watch`, drops in-flight planner work); the worker restarts at its next idle poll |
-| `event-runtime/web/**` | vite HMR — the open tab updates, nothing restarts |
-| `agents/*.md`, `schemas/**` | **neither.** Definitions are read per plan/claim but their pinned hashes are not: run `bun event-runtime/cli.mjs update-pins` |
-| `config/*.yaml` | restart serve |
-| `bin/live-stack.sh` | `factory down && factory up --dev` |
+| You changed                                     | What reloads it                                                                                                               |
+| :---------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve restarts immediately (`bun --watch`, drops in-flight planner work); the worker restarts at its next idle poll           |
+| `event-runtime/web/**`                          | vite HMR — the open tab updates, nothing restarts                                                                             |
+| `agents/*.md`, `schemas/**`                     | **neither.** Definitions are read per plan/claim but their pinned hashes are not: run `bun event-runtime/cli.mjs update-pins` |
+| `config/*.yaml`                                 | restart serve                                                                                                                 |
+| `bin/live-stack.sh`                             | `factory down && factory up --dev`                                                                                            |
 
 Details, including the `work --reload-on-change` flag and `FACTORY_CODE_STAMP_ROOT`, are in [event-runtime/README.md](event-runtime/README.md#dev-live-reload--factory-up---dev-wm-213).
 
@@ -240,11 +240,11 @@ Details, including the `work --reload-on-change` flag and `FACTORY_CODE_STAMP_RO
 
 These are deliberate — the scaffold ships honest about what isn't built.
 
-| Gap | Why it's not done |
-| :--- | :--- |
+| Gap                       | Why it's not done                                                                                                                                                                                                                                                                                                                                                                       |
+| :------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | A shared worktree library | Each repo still owns its own `bin/worktree-{up,down,warm}.sh`, and the common library stays deliberately deferred. The real variation across Wasp/Prisma/Postgres, pnpm/Nuxt/Prisma and Django/SQLite is visible now, but extracting it is real work with no forcing function yet — and a wrong abstraction here silently breaks the port and database isolation the scripts exist for. |
-| `evals/run.mjs` | Cases are written first on purpose — they specify what the skill is for. |
-| Per-agent Linear identity | Every agent currently claims as the human, so the assignee lock can't detect a lost race (OPS-40). The dispatcher is the natural place to inject a per-agent key — build it in rather than retrofitting. |
+| `evals/run.mjs`           | Cases are written first on purpose — they specify what the skill is for.                                                                                                                                                                                                                                                                                                                |
+| Per-agent Linear identity | Every agent currently claims as the human, so the assignee lock can't detect a lost race (OPS-40). The dispatcher is the natural place to inject a per-agent key — build it in rather than retrofitting.                                                                                                                                                                                |
 
 ## Flags worth knowing
 

--- a/bin/check-commit-msg.test.mjs
+++ b/bin/check-commit-msg.test.mjs
@@ -92,12 +92,32 @@ test("breaking-change marker before the colon is accepted", () => {
 });
 
 test("comment lines above the subject are skipped", () => {
-  const r = run("# Please enter the commit message for your changes.\n# Lines starting with '#' will be ignored.\nfix(scope): thing (WM-1)\n#\n# On branch develop\n");
+  const r = run(
+    "# Please enter the commit message for your changes.\n# Lines starting with '#' will be ignored.\nfix(scope): thing (WM-1)\n#\n# On branch develop\n",
+  );
   expect(r.status).toBe(0);
 });
 
 test("every allowed type is accepted with a ticket ref", () => {
-  const types = ["feat", "fix", "chore", "docs", "test", "refactor", "perf", "ci", "build", "style", "revert", "sec", "maint", "ui", "ui-ux", "spike", "epic"];
+  const types = [
+    "feat",
+    "fix",
+    "chore",
+    "docs",
+    "test",
+    "refactor",
+    "perf",
+    "ci",
+    "build",
+    "style",
+    "revert",
+    "sec",
+    "maint",
+    "ui",
+    "ui-ux",
+    "spike",
+    "epic",
+  ];
   for (const type of types) {
     const r = run(`${type}: something (WM-1)\n`);
     expect(r.status).toBe(0);

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -1,5 +1,12 @@
 import { test, expect } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -62,7 +69,11 @@ test("factory notify delegates argv to the notifier from any cwd", () => {
 });
 
 test("factory notify preserves stdin mode and the notifier exit code", () => {
-  const result = runNotify({ args: ["-"], stdin: "CI RED LAB-176: test failure\n", exitCode: "7" });
+  const result = runNotify({
+    args: ["-"],
+    stdin: "CI RED LAB-176: test failure\n",
+    exitCode: "7",
+  });
   try {
     expect(result.status).toBe(7);
     expect(result.args).toBe("-\n");
@@ -77,7 +88,9 @@ test("factory notify posts a structured inbox item when serve is reachable", asy
   const requestFile = path.join(dir, "request.json");
   const serverScript = path.join(dir, "server.py");
   const port = 31000 + (process.pid % 10000);
-  writeFileSync(serverScript, `
+  writeFileSync(
+    serverScript,
+    `
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 class Handler(BaseHTTPRequestHandler):
@@ -95,8 +108,13 @@ class Handler(BaseHTTPRequestHandler):
 server = HTTPServer(("127.0.0.1", ${port}), Handler)
 print("ready", flush=True)
 server.handle_request()
-`);
-  const server = Bun.spawn({ cmd: ["python3", serverScript], stdout: "pipe", stderr: "pipe" });
+`,
+  );
+  const server = Bun.spawn({
+    cmd: ["python3", serverScript],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const reader = server.stdout.getReader();
   await reader.read();
 
@@ -162,7 +180,9 @@ test("factory reject delegates to event-runtime/cli.mjs", () => {
     stderr: "pipe",
   });
   expect(result.exitCode).toBe(1);
-  expect(result.stderr.toString()).toContain('usage: reject <proposal-id> "<reason>"');
+  expect(result.stderr.toString()).toContain(
+    'usage: reject <proposal-id> "<reason>"',
+  );
 });
 
 test("factory inject delegates to event-runtime/cli.mjs", () => {

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -78,7 +78,11 @@ if (process.env.FAKE_WORKER_MODE === "wait-term") {
 }
 `;
 
-function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {}) {
+function makeFixture({
+  withWebDeps = true,
+  policy = null,
+  bundle = "fresh",
+} = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "live-stack-"));
   const webDir = path.join(root, "event-runtime", "web");
   mkdirSync(path.join(root, "bin"), { recursive: true });
@@ -89,10 +93,19 @@ function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {
     writeFileSync(path.join(root, "config", "policy.yaml"), policy, "utf8");
   }
   copyFileSync(LIVE_STACK, path.join(root, "bin", "live-stack.sh"));
-  writeFileSync(path.join(root, "bin", "worktree-common.sh"), COMMON_STUB, "utf8");
+  writeFileSync(
+    path.join(root, "bin", "worktree-common.sh"),
+    COMMON_STUB,
+    "utf8",
+  );
   writeFileSync(path.join(root, "event-runtime", "cli.mjs"), FAKE_CLI, "utf8");
   writeFileSync(path.join(webDir, "serve.mjs"), "", "utf8");
-  for (const relative of ["src/App.tsx", "index.html", "vite.config.ts", "package.json"]) {
+  for (const relative of [
+    "src/App.tsx",
+    "index.html",
+    "vite.config.ts",
+    "package.json",
+  ]) {
     writeFileSync(path.join(webDir, relative), `${relative}\n`, "utf8");
   }
   if (bundle !== "missing") {
@@ -100,7 +113,12 @@ function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {
     writeFileSync(path.join(webDir, "dist", "index.html"), "built\n", "utf8");
     const sourceTime = new Date("2026-01-01T00:00:00Z");
     const distTime = new Date("2027-01-01T00:00:00Z");
-    for (const relative of ["src/App.tsx", "index.html", "vite.config.ts", "package.json"]) {
+    for (const relative of [
+      "src/App.tsx",
+      "index.html",
+      "vite.config.ts",
+      "package.json",
+    ]) {
       utimesSync(path.join(webDir, relative), sourceTime, sourceTime);
     }
     utimesSync(path.join(webDir, "dist", "index.html"), distTime, distTime);
@@ -109,7 +127,8 @@ function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {
       utimesSync(path.join(webDir, "src", "App.tsx"), staleTime, staleTime);
     }
   }
-  if (withWebDeps) mkdirSync(path.join(webDir, "node_modules"), { recursive: true });
+  if (withWebDeps)
+    mkdirSync(path.join(webDir, "node_modules"), { recursive: true });
 
   // The health polls must not gate a test on a server nobody started.
   const curl = path.join(root, "stubs", "curl");
@@ -119,7 +138,9 @@ function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {
   // Non-dev web builds are recorded and materialize the one artifact the
   // script checks. Other bun commands are only arguments to spawn_daemon.
   const bun = path.join(root, "stubs", "bun");
-  writeFileSync(bun, `#!/bin/sh
+  writeFileSync(
+    bun,
+    `#!/bin/sh
 if [ "$1 $2" = "run build" ]; then
   printf 'BUILD cwd=%s cmd=%s\\n' "$PWD" "$*" >>"$BUILD_LOG"
   mkdir -p "$FAKE_REPO/event-runtime/web/dist"
@@ -128,7 +149,9 @@ if [ "$1 $2" = "run build" ]; then
 fi
 printf 'unexpected bun invocation: %s\\n' "$*" >&2
 exit 99
-`, "utf8");
+`,
+    "utf8",
+  );
   chmodSync(bun, 0o755);
 
   return {
@@ -160,12 +183,17 @@ function runStack(fixture, args, extraEnv = {}) {
     status: result.exitCode,
     stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
-    spawns: existsSync(fixture.spawnLog) ? readFileSync(fixture.spawnLog, "utf8").trim().split("\n") : [],
-    builds: existsSync(fixture.buildLog) ? readFileSync(fixture.buildLog, "utf8").trim().split("\n") : [],
+    spawns: existsSync(fixture.spawnLog)
+      ? readFileSync(fixture.spawnLog, "utf8").trim().split("\n")
+      : [],
+    builds: existsSync(fixture.buildLog)
+      ? readFileSync(fixture.buildLog, "utf8").trim().split("\n")
+      : [],
   };
 }
 
-const spawnFor = (spawns, pidfile) => spawns.find((line) => line.includes(`pid=${pidfile}`)) ?? "";
+const spawnFor = (spawns, pidfile) =>
+  spawns.find((line) => line.includes(`pid=${pidfile}`)) ?? "";
 
 test("plain `up` spawns serve, worker, and the static web server — unchanged by --dev existing", () => {
   const f = makeFixture();
@@ -178,7 +206,9 @@ test("plain `up` spawns serve, worker, and the static web server — unchanged b
     expect(serve).not.toContain("--watch");
 
     expect(spawnFor(r.spawns, "worker.pid")).toContain("cli.mjs work");
-    expect(spawnFor(r.spawns, "worker.pid")).not.toContain("__supervise-worker");
+    expect(spawnFor(r.spawns, "worker.pid")).not.toContain(
+      "__supervise-worker",
+    );
 
     const web = spawnFor(r.spawns, "web.pid");
     expect(web).toContain("web/serve.mjs");
@@ -198,7 +228,9 @@ test("plain `up` rebuilds a stale web bundle and reports the elapsed time", () =
     expect(r.status).toBe(0);
     expect(r.builds).toHaveLength(1);
     expect(r.builds[0]).toContain("cmd=run build");
-    expect(r.builds[0]).toContain(`cwd=${path.join(f.root, "event-runtime", "web")}`);
+    expect(r.builds[0]).toContain(
+      `cwd=${path.join(f.root, "event-runtime", "web")}`,
+    );
     expect(r.stdout).toMatch(/web bundle stale — rebuilt in \d+s/);
   } finally {
     f.cleanup();
@@ -222,7 +254,11 @@ test("each top-level web build input participates in the stale check", () => {
     const f = makeFixture({ bundle: "fresh" });
     try {
       const staleTime = new Date("2028-01-01T00:00:00Z");
-      utimesSync(path.join(f.root, "event-runtime", "web", relative), staleTime, staleTime);
+      utimesSync(
+        path.join(f.root, "event-runtime", "web", relative),
+        staleTime,
+        staleTime,
+      );
       const r = runStack(f, ["up"]);
       expect(r.status).toBe(0);
       expect(r.builds).toHaveLength(1);
@@ -238,7 +274,11 @@ test("plain `up` builds when the web bundle is missing", () => {
     const r = runStack(f, ["up"]);
     expect(r.status).toBe(0);
     expect(r.builds).toHaveLength(1);
-    expect(existsSync(path.join(f.root, "event-runtime", "web", "dist", "index.html"))).toBe(true);
+    expect(
+      existsSync(
+        path.join(f.root, "event-runtime", "web", "dist", "index.html"),
+      ),
+    ).toBe(true);
     expect(r.stdout).toMatch(/web bundle missing — rebuilt in \d+s/);
   } finally {
     f.cleanup();
@@ -262,7 +302,9 @@ test("`up --fake` still passes the adapter override through", () => {
   try {
     const r = runStack(f, ["up", "--fake"]);
     expect(r.status).toBe(0);
-    expect(spawnFor(r.spawns, "serve.pid")).toContain("--adapter-override fake");
+    expect(spawnFor(r.spawns, "serve.pid")).toContain(
+      "--adapter-override fake",
+    );
   } finally {
     f.cleanup();
   }
@@ -274,14 +316,22 @@ test("`up --dev` wires all three without checking or building a stale dist", () 
     const r = runStack(f, ["up", "--dev"]);
     expect(r.status).toBe(0);
 
-    expect(spawnFor(r.spawns, "serve.pid")).toContain("cli.mjs serve --port 7381 --watch");
+    expect(spawnFor(r.spawns, "serve.pid")).toContain(
+      "cli.mjs serve --port 7381 --watch",
+    );
 
     const worker = spawnFor(r.spawns, "worker.pid");
-    expect(worker).toContain("bin/live-stack.sh __supervise-worker --reload-on-change");
+    expect(worker).toContain(
+      "bin/live-stack.sh __supervise-worker --reload-on-change",
+    );
 
     const web = spawnFor(r.spawns, "web.pid");
-    expect(web).toContain("bunx vite --host 127.0.0.1 --port 7382 --strictPort");
-    expect(web).toContain(`workdir=${path.join(f.root, "event-runtime", "web")}`);
+    expect(web).toContain(
+      "bunx vite --host 127.0.0.1 --port 7382 --strictPort",
+    );
+    expect(web).toContain(
+      `workdir=${path.join(f.root, "event-runtime", "web")}`,
+    );
 
     expect(r.stdout).toContain("ready — live factory stack (dev, live reload)");
     expect(r.stdout).toContain("worker: on exit 75 when idle");
@@ -295,7 +345,15 @@ test("`up --dev` wires all three without checking or building a stale dist", () 
 test("`up --dev --fake` keeps both the adapter override and the watch flag", () => {
   const f = makeFixture();
   try {
-    const r = runStack(f, ["up", "--dev", "--fake", "--port", "7391", "--web-port", "7392"]);
+    const r = runStack(f, [
+      "up",
+      "--dev",
+      "--fake",
+      "--port",
+      "7391",
+      "--web-port",
+      "7392",
+    ]);
     expect(r.status).toBe(0);
     const serve = spawnFor(r.spawns, "serve.pid");
     expect(serve).toContain("--port 7391");
@@ -337,7 +395,9 @@ test("`down` stops all three daemons in either mode", () => {
 // --- worker pool (WM-226) ----------------------------------------------------
 
 test("a config with no workers: block keeps the plain single worker (regression)", () => {
-  const f = makeFixture({ policy: "concurrency:\n  max_in_flight_per_repo: 3\n" });
+  const f = makeFixture({
+    policy: "concurrency:\n  max_in_flight_per_repo: 3\n",
+  });
   try {
     const r = runStack(f, ["up"]);
     expect(r.status).toBe(0);
@@ -372,7 +432,9 @@ test("`up --workers 2:4` selects the pool even with no policy file, and passes t
   try {
     const r = runStack(f, ["up", "--workers", "2:4"]);
     expect(r.status).toBe(0);
-    expect(spawnFor(r.spawns, "worker.pid")).toContain("cli.mjs supervise --workers 2:4");
+    expect(spawnFor(r.spawns, "worker.pid")).toContain(
+      "cli.mjs supervise --workers 2:4",
+    );
     expect(r.stdout).toContain("starting worker pool supervisor (workers 2:4)");
     expect(r.stdout).toContain("supervised pool (2:4)");
   } finally {
@@ -385,7 +447,9 @@ test("`--workers` and `--dev` both claim the worker slot — the conflict is nam
   try {
     const r = runStack(f, ["up", "--dev", "--workers", "1:3"]);
     expect(r.status).not.toBe(0);
-    expect(r.stderr).toContain("--workers and --dev both replace the worker daemon");
+    expect(r.stderr).toContain(
+      "--workers and --dev both replace the worker daemon",
+    );
     expect(r.spawns).toEqual([]);
   } finally {
     f.cleanup();
@@ -398,7 +462,9 @@ test("`up --dev` ignores a workers: block and keeps WM-213's reload supervisor",
     const r = runStack(f, ["up", "--dev"]);
     expect(r.status).toBe(0);
     const worker = spawnFor(r.spawns, "worker.pid");
-    expect(worker).toContain("bin/live-stack.sh __supervise-worker --reload-on-change");
+    expect(worker).toContain(
+      "bin/live-stack.sh __supervise-worker --reload-on-change",
+    );
     expect(worker).not.toContain("cli.mjs supervise");
   } finally {
     f.cleanup();
@@ -410,18 +476,32 @@ test("`down` drains the pool before the ordinary teardown, and clears the slot f
   try {
     mkdirSync(f.runDir, { recursive: true });
     for (const [name, body] of [
-      ["supervisor.pid", "4242\n"], ["worker.pid", "4242\n"],
-      ["worker-1.pid", "4243\n"], ["worker-1.drain", "scale-down\n"], ["worker-1.id", "worker_x\n"],
-    ]) writeFileSync(path.join(f.runDir, name), body, "utf8");
+      ["supervisor.pid", "4242\n"],
+      ["worker.pid", "4242\n"],
+      ["worker-1.pid", "4243\n"],
+      ["worker-1.drain", "scale-down\n"],
+      ["worker-1.id", "worker_x\n"],
+    ])
+      writeFileSync(path.join(f.runDir, name), body, "utf8");
 
-    const r = runStack(f, ["down"], { FAKE_ALIVE: "1", FACTORY_POOL_DRAIN_TIMEOUT: "5" });
+    const r = runStack(f, ["down"], {
+      FAKE_ALIVE: "1",
+      FACTORY_POOL_DRAIN_TIMEOUT: "5",
+    });
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain("draining worker pool (up to 5s — runs in flight finish first)");
+    expect(r.stdout).toContain(
+      "draining worker pool (up to 5s — runs in flight finish first)",
+    );
     // The supervisor is stopped FIRST and waited for, not lumped into the
     // three-second await that is right for a web server and wrong here.
     expect(r.spawns[0]).toBe("TERM worker pool supervisor");
     expect(r.stderr).not.toContain("still draining");
-    for (const name of ["worker-1.pid", "worker-1.drain", "worker-1.id", "supervisor.pid"]) {
+    for (const name of [
+      "worker-1.pid",
+      "worker-1.drain",
+      "worker-1.id",
+      "supervisor.pid",
+    ]) {
       expect(existsSync(path.join(f.runDir, name))).toBe(false);
     }
   } finally {
@@ -437,7 +517,9 @@ test("`down` gives the pool a bounded wait, then says so instead of hanging", ()
     writeFileSync(path.join(f.runDir, "worker.pid"), "4242\n", "utf8");
 
     const r = runStack(f, ["down"], {
-      FAKE_ALIVE: "1", FAKE_IGNORES_TERM: "1", FACTORY_POOL_DRAIN_TIMEOUT: "1",
+      FAKE_ALIVE: "1",
+      FAKE_IGNORES_TERM: "1",
+      FACTORY_POOL_DRAIN_TIMEOUT: "1",
     });
     expect(r.status).toBe(0);
     expect(r.stderr).toContain("worker pool still draining after 1s");
@@ -476,7 +558,12 @@ function runSupervisor(f, { reloads = 0, final = 0, mode = "" } = {}) {
   const counter = path.join(f.root, "counter");
   writeFileSync(counter, "0", "utf8");
   const proc = Bun.spawnSync({
-    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-worker", "--reload-on-change"],
+    cmd: [
+      "bash",
+      path.join(f.root, "bin", "live-stack.sh"),
+      "__supervise-worker",
+      "--reload-on-change",
+    ],
     stdout: "pipe",
     stderr: "pipe",
     env: {
@@ -542,7 +629,12 @@ test("SIGTERM to the supervisor drains the worker and stops — even if it exits
   const counter = path.join(f.root, "counter");
   writeFileSync(counter, "0", "utf8");
   const proc = Bun.spawn({
-    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-worker", "--reload-on-change"],
+    cmd: [
+      "bash",
+      path.join(f.root, "bin", "live-stack.sh"),
+      "__supervise-worker",
+      "--reload-on-change",
+    ],
     stdout: "pipe",
     stderr: "pipe",
     env: {
@@ -557,10 +649,12 @@ test("SIGTERM to the supervisor drains the worker and stops — even if it exits
   try {
     let out = "";
     const reader = (async () => {
-      for await (const chunk of proc.stdout) out += new TextDecoder().decode(chunk);
+      for await (const chunk of proc.stdout)
+        out += new TextDecoder().decode(chunk);
     })();
     const deadline = Date.now() + 10_000;
-    while (Date.now() < deadline && !out.includes("fake worker start #1")) await Bun.sleep(50);
+    while (Date.now() < deadline && !out.includes("fake worker start #1"))
+      await Bun.sleep(50);
     expect(out).toContain("fake worker start #1");
 
     proc.kill("SIGTERM");

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -1,4 +1,11 @@
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
@@ -23,7 +30,10 @@ function sh(body, extraEnv = {}) {
 
 function createTempProject() {
   const dir = mkdtempSync(path.join(tmpdir(), "bun-pkg-"));
-  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "test-pkg", version: "1.0.0" }));
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "test-pkg", version: "1.0.0" }),
+  );
   Bun.spawnSync({ cmd: ["bun", "install"], cwd: dir });
   return dir;
 }
@@ -35,14 +45,19 @@ function makeTestTicket(prefix = "TEST") {
 
 function makeTestLockDir(prefix = "test-lock") {
   const rand = Math.random().toString(36).slice(2, 8);
-  return path.join(tmpdir(), `${prefix}-${Date.now()}-${process.pid}-${rand}.lock`);
+  return path.join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${process.pid}-${rand}.lock`,
+  );
 }
 
 test("locked_bun_install executes real bun install under lock and releases lock", () => {
   const testDir = createTempProject();
   const lockDir = makeTestLockDir("test-lock");
   try {
-    const r = sh(`locked_bun_install "${testDir}"`, { FACTORY_LOCK_DIR: lockDir });
+    const r = sh(`locked_bun_install "${testDir}"`, {
+      FACTORY_LOCK_DIR: lockDir,
+    });
     expect(r.status).toBe(0);
     expect(existsSync(lockDir)).toBe(false);
   } finally {
@@ -58,7 +73,9 @@ test("locked_bun_install reclaims stale lock with dead PID and succeeds", () => 
   writeFileSync(path.join(lockDir, "pid"), "999999");
 
   try {
-    const r = sh(`locked_bun_install "${testDir}"`, { FACTORY_LOCK_DIR: lockDir });
+    const r = sh(`locked_bun_install "${testDir}"`, {
+      FACTORY_LOCK_DIR: lockDir,
+    });
     expect(r.status).toBe(0);
     expect(existsSync(lockDir)).toBe(false);
   } finally {
@@ -114,16 +131,22 @@ test("concurrent locked_bun_install invocations serialize without colliding", as
 
   try {
     const [p1, p2] = await Promise.all([
-      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${testDir1}"`], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...process.env, FACTORY_LOCK_DIR: lockDir },
-      }).exited,
-      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${testDir2}"`], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...process.env, FACTORY_LOCK_DIR: lockDir },
-      }).exited,
+      Bun.spawn(
+        ["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${testDir1}"`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, FACTORY_LOCK_DIR: lockDir },
+        },
+      ).exited,
+      Bun.spawn(
+        ["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${testDir2}"`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, FACTORY_LOCK_DIR: lockDir },
+        },
+      ).exited,
     ]);
     expect(p1).toBe(0);
     expect(p2).toBe(0);
@@ -188,20 +211,25 @@ test("locked_bun_install composes prior INT/TERM/EXIT traps on interruption", as
     const readyFile = path.join(mockBinDir, "ready.txt");
 
     const mockBun = path.join(mockBinDir, "bun");
-    writeFileSync(mockBun, `#!/usr/bin/env bash
+    writeFileSync(
+      mockBun,
+      `#!/usr/bin/env bash
 if [[ "$1" == "install" ]]; then
   touch "${readyFile}"
   sleep 1
   exit 0
 fi
 exec bun "$@"
-`, { mode: 0o755 });
+`,
+      { mode: 0o755 },
+    );
 
     try {
-      const proc = Bun.spawn([
-        "bash",
-        "-c",
-        `source "${COMMON}"
+      const proc = Bun.spawn(
+        [
+          "bash",
+          "-c",
+          `source "${COMMON}"
 trap 'echo PRIOR_EXIT_TRIGGERED' EXIT
 trap 'echo PRIOR_${trapName}_TRIGGERED' ${trapName}
 (
@@ -215,19 +243,25 @@ trap 'echo PRIOR_${trapName}_TRIGGERED' ${trapName}
   echo "timed out waiting for mock bun" >&2
 ) &
 locked_bun_install "${testDir}"`,
-      ], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: {
-          ...process.env,
-          PATH: `${mockBinDir}${path.delimiter}${process.env.PATH}`,
-          FACTORY_LOCK_DIR: lockDir,
+        ],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...process.env,
+            PATH: `${mockBinDir}${path.delimiter}${process.env.PATH}`,
+            FACTORY_LOCK_DIR: lockDir,
+          },
         },
-      });
+      );
       const stdoutPromise = new Response(proc.stdout).text();
       const stderrPromise = new Response(proc.stderr).text();
 
-      const [status, stdout, stderr] = await Promise.all([proc.exited, stdoutPromise, stderrPromise]);
+      const [status, stdout, stderr] = await Promise.all([
+        proc.exited,
+        stdoutPromise,
+        stderrPromise,
+      ]);
       expect(stderr).toBe("");
       expect(stdout).toContain(`PRIOR_${trapName}_TRIGGERED`);
       expect(stdout).toContain("PRIOR_EXIT_TRIGGERED");
@@ -243,22 +277,30 @@ locked_bun_install "${testDir}"`,
 });
 
 test("multiple contenders race to reclaim a stale pid-less lock and all succeed", async () => {
-  const testDirs = [createTempProject(), createTempProject(), createTempProject(), createTempProject()];
+  const testDirs = [
+    createTempProject(),
+    createTempProject(),
+    createTempProject(),
+    createTempProject(),
+  ];
   const lockDir = makeTestLockDir("test-pidless-race");
   mkdirSync(lockDir, { recursive: true });
 
   try {
     const runContender = (dir) =>
-      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: {
-          ...process.env,
-          FACTORY_LOCK_DIR: lockDir,
-          FACTORY_LOCK_STALE_AFTER: "0",
-          FACTORY_LOCK_MAX_WAIT: "10",
+      Bun.spawn(
+        ["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...process.env,
+            FACTORY_LOCK_DIR: lockDir,
+            FACTORY_LOCK_STALE_AFTER: "0",
+            FACTORY_LOCK_MAX_WAIT: "10",
+          },
         },
-      }).exited;
+      ).exited;
 
     const results = await Promise.all(testDirs.map(runContender));
     for (const code of results) {
@@ -277,15 +319,18 @@ test("high concurrency race of 8 parallel locked_bun_install processes serialize
 
   try {
     const runContender = (dir) =>
-      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: {
-          ...process.env,
-          FACTORY_LOCK_DIR: lockDir,
-          FACTORY_LOCK_MAX_WAIT: "30",
+      Bun.spawn(
+        ["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...process.env,
+            FACTORY_LOCK_DIR: lockDir,
+            FACTORY_LOCK_MAX_WAIT: "30",
+          },
         },
-      }).exited;
+      ).exited;
 
     const results = await Promise.all(testDirs.map(runContender));
     for (const code of results) {
@@ -307,7 +352,11 @@ test("worktree-up --checkout-only creates checkout without daemons and worktree-
       cmd: ["bash", UP, ticketId, "--checkout-only"],
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, FACTORY_SKIP_FETCH: "1" },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_SKIP_FETCH: "1",
+      },
     });
     expect(upRes.exitCode).toBe(0);
     const expectedPath = path.join(tempWtRoot, ticketId);
@@ -343,14 +392,28 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
   // at its parent; worktree-up is aimed at it via FACTORY_BASE_BRANCH.
   const baseBranch = `test-base-${ticketId}`;
   const baseRef = `refs/remotes/origin/${baseBranch}`;
-  const git = (args) => Bun.spawnSync({ cmd: ["git", ...args], cwd: path.resolve(import.meta.dir, ".."), stdout: "pipe", stderr: "pipe" });
+  const git = (args) =>
+    Bun.spawnSync({
+      cmd: ["git", ...args],
+      cwd: path.resolve(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
   try {
     const staleSha = git(["rev-parse", "HEAD"]).stdout.toString().trim();
     expect(staleSha).toMatch(/^[0-9a-f]{40}$/);
     const commitTree = git([
-      "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
-      "commit-tree", `${staleSha}^{tree}`, "-p", staleSha, "-m", "synthetic base for stale re-dispatch test",
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.invalid",
+      "commit-tree",
+      `${staleSha}^{tree}`,
+      "-p",
+      staleSha,
+      "-m",
+      "synthetic base for stale re-dispatch test",
     ]);
     expect(commitTree.exitCode).toBe(0);
     const baseSha = commitTree.stdout.toString().trim();
@@ -363,12 +426,23 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, FACTORY_BASE_BRANCH: baseBranch },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_BASE_BRANCH: baseBranch,
+      },
     });
     expect(upRes.exitCode).toBe(0);
-    expect(git(["-C", path.join(tempWtRoot, ticketId), "rev-parse", "HEAD"]).stdout.toString().trim()).toBe(baseSha);
+    expect(
+      git(["-C", path.join(tempWtRoot, ticketId), "rev-parse", "HEAD"])
+        .stdout.toString()
+        .trim(),
+    ).toBe(baseSha);
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     git(["branch", "-D", branch]);
     git(["update-ref", "-d", baseRef]);
@@ -376,8 +450,12 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
 });
 
 test("re-dispatch preserves an abandoned dirty zero-ahead worktree on a conventional wip branch", () => {
-  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-abandoned-dirty-"));
-  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-abandoned-dirty-bin-"));
+  const tempWtRoot = mkdtempSync(
+    path.join(tmpdir(), "factory-wt-abandoned-dirty-"),
+  );
+  const mockBin = mkdtempSync(
+    path.join(tmpdir(), "factory-wt-abandoned-dirty-bin-"),
+  );
   const ticketId = `WM-${Date.now()}${process.pid}${Math.floor(Math.random() * 10000)}`;
   const branch = `feat/${ticketId}`;
   const expectedPath = path.join(tempWtRoot, ticketId);
@@ -385,22 +463,31 @@ test("re-dispatch preserves an abandoned dirty zero-ahead worktree on a conventi
   let wipBranch = null;
 
   try {
-    expect(Bun.spawnSync({
-      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-    }).exitCode).toBe(0);
-    writeFileSync(path.join(expectedPath, "abandoned.txt"), "preserve this work\n");
+    expect(
+      Bun.spawnSync({
+        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exitCode,
+    ).toBe(0);
+    writeFileSync(
+      path.join(expectedPath, "abandoned.txt"),
+      "preserve this work\n",
+    );
 
     const realGit = Bun.which("git");
-    writeFileSync(path.join(mockBin, "git"), `#!/usr/bin/env bash
+    writeFileSync(
+      path.join(mockBin, "git"),
+      `#!/usr/bin/env bash
 if [[ "$*" == *" push -u origin wip/${ticketId}-"* ]]; then
   echo "simulated push failure" >&2
   exit 1
 fi
 exec "${realGit}" "$@"
-`, { mode: 0o755 });
+`,
+      { mode: 0o755 },
+    );
 
     const recovered = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
@@ -417,24 +504,57 @@ exec "${realGit}" "$@"
       },
     });
     expect(recovered.exitCode).toBe(0);
-    expect(recovered.stdout.toString()).toContain("preserved abandoned worktree changes on wip/");
+    expect(recovered.stdout.toString()).toContain(
+      "preserved abandoned worktree changes on wip/",
+    );
     expect(recovered.stderr.toString()).toContain("keeping it locally");
 
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
     wipBranch = report.ref;
-    expect(wipBranch).toMatch(new RegExp(`^wip/${ticketId}-\\d{8}T\\d{6}Z(?:-\\d+)?$`));
+    expect(wipBranch).toMatch(
+      new RegExp(`^wip/${ticketId}-\\d{8}T\\d{6}Z(?:-\\d+)?$`),
+    );
     expect(report.commit).toMatch(/^[0-9a-f]{40}$/);
     expect(report.push).toBe("local_only");
-    expect(Bun.spawnSync({ cmd: ["git", "branch", "--show-current"], cwd: expectedPath }).stdout.toString().trim()).toBe(branch);
-    expect(Bun.spawnSync({ cmd: ["git", "status", "--porcelain"], cwd: expectedPath }).stdout.toString()).toBe("");
-    expect(Bun.spawnSync({ cmd: ["git", "show", `${wipBranch}:abandoned.txt`], cwd: expectedPath }).stdout.toString()).toBe("preserve this work\n");
-    expect(Bun.spawnSync({ cmd: ["git", "log", "-1", "--format=%s", wipBranch], cwd: expectedPath }).stdout.toString().trim())
-      .toBe(`chore(wip): preserve ${ticketId} worktree changes (${ticketId})`);
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "branch", "--show-current"],
+        cwd: expectedPath,
+      })
+        .stdout.toString()
+        .trim(),
+    ).toBe(branch);
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "status", "--porcelain"],
+        cwd: expectedPath,
+      }).stdout.toString(),
+    ).toBe("");
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "show", `${wipBranch}:abandoned.txt`],
+        cwd: expectedPath,
+      }).stdout.toString(),
+    ).toBe("preserve this work\n");
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "log", "-1", "--format=%s", wipBranch],
+        cwd: expectedPath,
+      })
+        .stdout.toString()
+        .trim(),
+    ).toBe(`chore(wip): preserve ${ticketId} worktree changes (${ticketId})`);
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch, ...(wipBranch ? [wipBranch] : [])], cwd: path.resolve(import.meta.dir, "..") });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", branch, ...(wipBranch ? [wipBranch] : [])],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
   }
 }, 20_000);
 
@@ -447,14 +567,19 @@ test("re-dispatch refuses a dirty worktree with typed worktree_in_use when a liv
   const leasePath = path.join(tempWtRoot, "live-owner-lease.json");
 
   try {
-    expect(Bun.spawnSync({
-      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-    }).exitCode).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exitCode,
+    ).toBe(0);
     writeFileSync(path.join(expectedPath, "live-owner.txt"), "still in use\n");
-    writeFileSync(leasePath, JSON.stringify({ owner: "new-live-owner", pid: 42 }));
+    writeFileSync(
+      leasePath,
+      JSON.stringify({ owner: "new-live-owner", pid: 42 }),
+    );
 
     const refused = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
@@ -471,12 +596,20 @@ test("re-dispatch refuses a dirty worktree with typed worktree_in_use when a liv
     });
     expect(refused.exitCode).not.toBe(0);
     expect(refused.stderr.toString()).toContain("worktree_in_use");
-    expect(readFileSync(path.join(expectedPath, "live-owner.txt"), "utf8")).toBe("still in use\n");
+    expect(
+      readFileSync(path.join(expectedPath, "live-owner.txt"), "utf8"),
+    ).toBe("still in use\n");
     expect(existsSync(reportPath)).toBe(false);
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", branch],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
   }
 });
 
@@ -496,26 +629,54 @@ test("merge-fix re-dispatch resumes a committed PR branch as-is", () => {
       env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
     });
     expect(firstUp.exitCode).toBe(0);
-    writeFileSync(path.join(expectedPath, "merge-fix.txt"), "resolved conflict\n");
-    expect(Bun.spawnSync({ cmd: ["git", "add", "merge-fix.txt"], cwd: expectedPath }).exitCode).toBe(0);
-    expect(Bun.spawnSync({
-      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "test(worktree): preserve merge fix branch (WM-1)"],
+    writeFileSync(
+      path.join(expectedPath, "merge-fix.txt"),
+      "resolved conflict\n",
+    );
+    expect(
+      Bun.spawnSync({ cmd: ["git", "add", "merge-fix.txt"], cwd: expectedPath })
+        .exitCode,
+    ).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: [
+          "git",
+          "-c",
+          "user.name=Test",
+          "-c",
+          "user.email=test@example.invalid",
+          "commit",
+          "-m",
+          "test(worktree): preserve merge fix branch (WM-1)",
+        ],
+        cwd: expectedPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode,
+    ).toBe(0);
+    const committedSha = Bun.spawnSync({
+      cmd: ["git", "rev-parse", "HEAD"],
       cwd: expectedPath,
-      stdout: "pipe",
-      stderr: "pipe",
-    }).exitCode).toBe(0);
-    const committedSha = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim();
-    expect(Bun.spawnSync({
-      cmd: ["bash", DOWN, ticketId],
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-      stdout: "pipe",
-      stderr: "pipe",
-    }).exitCode).toBe(0);
+    })
+      .stdout.toString()
+      .trim();
+    expect(
+      Bun.spawnSync({
+        cmd: ["bash", DOWN, ticketId],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode,
+    ).toBe(0);
 
-    writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash
+    writeFileSync(
+      path.join(mockBin, "gh"),
+      `#!/usr/bin/env bash
 printf '%s\\n' "$*" > "${ghArgs}"
 printf '1\\n'
-`, { mode: 0o755 });
+`,
+      { mode: 0o755 },
+    );
     const resumed = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "fix", "--checkout-only", "--no-fetch"],
       stdout: "pipe",
@@ -527,55 +688,107 @@ printf '1\\n'
       },
     });
     expect(resumed.exitCode).toBe(0);
-    expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim()).toBe(committedSha);
-    expect(readFileSync(ghArgs, "utf8")).toBe(`pr list --head ${branch} --state open --json number --limit 1 --jq length\n`);
+    expect(
+      Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath })
+        .stdout.toString()
+        .trim(),
+    ).toBe(committedSha);
+    expect(readFileSync(ghArgs, "utf8")).toBe(
+      `pr list --head ${branch} --state open --json number --limit 1 --jq length\n`,
+    );
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", branch],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
   }
 });
 
 test("explicit resume flag and environment preserve committed branches without querying PRs", () => {
   for (const mode of ["flag", "environment"]) {
-    const tempWtRoot = mkdtempSync(path.join(tmpdir(), `factory-wt-resume-${mode}-`));
-    const mockBin = mkdtempSync(path.join(tmpdir(), `factory-wt-resume-${mode}-bin-`));
-    const ticketId = makeTestTicket(mode === "flag" ? "RESUMEFLAG" : "RESUMEENV");
+    const tempWtRoot = mkdtempSync(
+      path.join(tmpdir(), `factory-wt-resume-${mode}-`),
+    );
+    const mockBin = mkdtempSync(
+      path.join(tmpdir(), `factory-wt-resume-${mode}-bin-`),
+    );
+    const ticketId = makeTestTicket(
+      mode === "flag" ? "RESUMEFLAG" : "RESUMEENV",
+    );
     const branch = `feat/${ticketId}`;
     const expectedPath = path.join(tempWtRoot, ticketId);
     const ghCalled = path.join(mockBin, "gh-called.txt");
 
     try {
-      expect(Bun.spawnSync({
-        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-      }).exitCode).toBe(0);
+      expect(
+        Bun.spawnSync({
+          cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+        }).exitCode,
+      ).toBe(0);
       writeFileSync(path.join(expectedPath, "resume.txt"), `${mode}\n`);
-      expect(Bun.spawnSync({ cmd: ["git", "add", "resume.txt"], cwd: expectedPath }).exitCode).toBe(0);
-      expect(Bun.spawnSync({
-        cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", `test(worktree): exercise explicit ${mode} resume (WM-1)`],
+      expect(
+        Bun.spawnSync({ cmd: ["git", "add", "resume.txt"], cwd: expectedPath })
+          .exitCode,
+      ).toBe(0);
+      expect(
+        Bun.spawnSync({
+          cmd: [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-m",
+            `test(worktree): exercise explicit ${mode} resume (WM-1)`,
+          ],
+          cwd: expectedPath,
+          stdout: "pipe",
+          stderr: "pipe",
+        }).exitCode,
+      ).toBe(0);
+      const committedSha = Bun.spawnSync({
+        cmd: ["git", "rev-parse", "HEAD"],
         cwd: expectedPath,
-        stdout: "pipe",
-        stderr: "pipe",
-      }).exitCode).toBe(0);
-      const committedSha = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim();
-      expect(Bun.spawnSync({
-        cmd: ["bash", DOWN, ticketId],
-        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-        stdout: "pipe",
-        stderr: "pipe",
-      }).exitCode).toBe(0);
+      })
+        .stdout.toString()
+        .trim();
+      expect(
+        Bun.spawnSync({
+          cmd: ["bash", DOWN, ticketId],
+          env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+          stdout: "pipe",
+          stderr: "pipe",
+        }).exitCode,
+      ).toBe(0);
 
-      writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash
+      writeFileSync(
+        path.join(mockBin, "gh"),
+        `#!/usr/bin/env bash
 touch "${ghCalled}"
 exit 99
-`, { mode: 0o755 });
+`,
+        { mode: 0o755 },
+      );
       const resumeArgs = mode === "flag" ? ["--resume"] : [];
       const resumed = Bun.spawnSync({
-        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch", ...resumeArgs],
+        cmd: [
+          "bash",
+          UP,
+          ticketId,
+          "--checkout-only",
+          "--no-fetch",
+          ...resumeArgs,
+        ],
         stdout: "pipe",
         stderr: "pipe",
         env: {
@@ -587,13 +800,23 @@ exit 99
         },
       });
       expect(resumed.exitCode).toBe(0);
-      expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim()).toBe(committedSha);
+      expect(
+        Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath })
+          .stdout.toString()
+          .trim(),
+      ).toBe(committedSha);
       expect(existsSync(ghCalled)).toBe(false);
     } finally {
-      Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+      Bun.spawnSync({
+        cmd: ["bash", DOWN, ticketId, "--force"],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      });
       rmSync(tempWtRoot, { recursive: true, force: true });
       rmSync(mockBin, { recursive: true, force: true });
-      Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+      Bun.spawnSync({
+        cmd: ["git", "branch", "-D", branch],
+        cwd: path.resolve(import.meta.dir, ".."),
+      });
     }
   }
 }, 15_000);
@@ -620,38 +843,94 @@ test("re-dispatch auto-resumes a branch whose unique commits are already on orig
     });
     expect(firstUp.exitCode).toBe(0);
     writeFileSync(path.join(expectedPath, "wip.txt"), "preserved work\n");
-    expect(Bun.spawnSync({ cmd: ["git", "add", "wip.txt"], cwd: expectedPath }).exitCode).toBe(0);
-    expect(Bun.spawnSync({
-      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "wip: preserved before re-dispatch (WM-680)"],
+    expect(
+      Bun.spawnSync({ cmd: ["git", "add", "wip.txt"], cwd: expectedPath })
+        .exitCode,
+    ).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: [
+          "git",
+          "-c",
+          "user.name=Test",
+          "-c",
+          "user.email=test@example.invalid",
+          "commit",
+          "-m",
+          "test(worktree): preserved before re-dispatch (WM-680)",
+        ],
+        cwd: expectedPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode,
+    ).toBe(0);
+    const tip = Bun.spawnSync({
+      cmd: ["git", "rev-parse", "HEAD"],
       cwd: expectedPath,
       stdout: "pipe",
-      stderr: "pipe",
-    }).exitCode).toBe(0);
-    const tip = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath, stdout: "pipe" }).stdout.toString().trim();
+    })
+      .stdout.toString()
+      .trim();
     // Simulate "pushed": stand up the remote-tracking ref at the same SHA.
-    expect(Bun.spawnSync({ cmd: ["git", "update-ref", `refs/remotes/origin/${branch}`, tip], cwd: repo }).exitCode).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "update-ref", `refs/remotes/origin/${branch}`, tip],
+        cwd: repo,
+      }).exitCode,
+    ).toBe(0);
     // Tear the worktree down (branch stays), as an orphaned run leaves it.
-    expect(Bun.spawnSync({ cmd: ["bash", DOWN, ticketId], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } }).exitCode).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: ["bash", DOWN, ticketId],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exitCode,
+    ).toBe(0);
     expect(existsSync(expectedPath)).toBe(false);
 
-    writeFileSync(path.join(mockBin, "gh"), "#!/usr/bin/env bash\nprintf '0\\n'\n", { mode: 0o755 }); // no open PR
+    writeFileSync(
+      path.join(mockBin, "gh"),
+      "#!/usr/bin/env bash\nprintf '0\\n'\n",
+      { mode: 0o755 },
+    ); // no open PR
     const secondUp = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, PATH: `${mockBin}${path.delimiter}${process.env.PATH}` },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
     });
-    expect(secondUp.stderr.toString()).not.toContain("worktree_branch_has_commits");
+    expect(secondUp.stderr.toString()).not.toContain(
+      "worktree_branch_has_commits",
+    );
     expect(secondUp.exitCode).toBe(0);
     expect(existsSync(expectedPath)).toBe(true);
     // The preserved commit is what the new worktree is on.
-    expect(readFileSync(path.join(expectedPath, "wip.txt"), "utf8")).toBe("preserved work\n");
-    expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath, stdout: "pipe" }).stdout.toString().trim()).toBe(tip);
+    expect(readFileSync(path.join(expectedPath, "wip.txt"), "utf8")).toBe(
+      "preserved work\n",
+    );
+    expect(
+      Bun.spawnSync({
+        cmd: ["git", "rev-parse", "HEAD"],
+        cwd: expectedPath,
+        stdout: "pipe",
+      })
+        .stdout.toString()
+        .trim(),
+    ).toBe(tip);
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "update-ref", "-d", `refs/remotes/origin/${branch}`], cwd: repo });
+    Bun.spawnSync({
+      cmd: ["git", "update-ref", "-d", `refs/remotes/origin/${branch}`],
+      cwd: repo,
+    });
     Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: repo });
   }
 });
@@ -672,16 +951,37 @@ test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservati
     });
     expect(firstUp.exitCode).toBe(0);
     writeFileSync(path.join(expectedPath, "unique.txt"), "ticket work\n");
-    expect(Bun.spawnSync({ cmd: ["git", "add", "unique.txt"], cwd: expectedPath }).exitCode).toBe(0);
-    expect(Bun.spawnSync({
-      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "test(worktree): create unique ticket commit (WM-1)"],
-      cwd: expectedPath,
-      stdout: "pipe",
-      stderr: "pipe",
-    }).exitCode).toBe(0);
-    writeFileSync(path.join(expectedPath, "still-dirty.txt"), "uncommitted after unique commit\n");
+    expect(
+      Bun.spawnSync({ cmd: ["git", "add", "unique.txt"], cwd: expectedPath })
+        .exitCode,
+    ).toBe(0);
+    expect(
+      Bun.spawnSync({
+        cmd: [
+          "git",
+          "-c",
+          "user.name=Test",
+          "-c",
+          "user.email=test@example.invalid",
+          "commit",
+          "-m",
+          "test(worktree): create unique ticket commit (WM-1)",
+        ],
+        cwd: expectedPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode,
+    ).toBe(0);
+    writeFileSync(
+      path.join(expectedPath, "still-dirty.txt"),
+      "uncommitted after unique commit\n",
+    );
 
-    writeFileSync(path.join(mockBin, "gh"), "#!/usr/bin/env bash\nprintf '0\\n'\n", { mode: 0o755 });
+    writeFileSync(
+      path.join(mockBin, "gh"),
+      "#!/usr/bin/env bash\nprintf '0\\n'\n",
+      { mode: 0o755 },
+    );
     const secondUp = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
       stdout: "pipe",
@@ -690,7 +990,10 @@ test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservati
         ...process.env,
         FACTORY_WT_ROOT: tempWtRoot,
         FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
-        FACTORY_WORKTREE_PRESERVATION_REPORT: path.join(tempWtRoot, "must-not-preserve.json"),
+        FACTORY_WORKTREE_PRESERVATION_REPORT: path.join(
+          tempWtRoot,
+          "must-not-preserve.json",
+        ),
         PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
       },
     });
@@ -699,20 +1002,34 @@ test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservati
     expect(secondUp.stderr.toString()).toContain(branch);
     expect(secondUp.stderr.toString()).toContain("re-run with --resume");
     expect(existsSync(expectedPath)).toBe(true);
-    expect(readFileSync(path.join(expectedPath, "still-dirty.txt"), "utf8")).toBe("uncommitted after unique commit\n");
-    expect(existsSync(path.join(tempWtRoot, "must-not-preserve.json"))).toBe(false);
+    expect(
+      readFileSync(path.join(expectedPath, "still-dirty.txt"), "utf8"),
+    ).toBe("uncommitted after unique commit\n");
+    expect(existsSync(path.join(tempWtRoot, "must-not-preserve.json"))).toBe(
+      false,
+    );
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", branch],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
   }
 });
 
 test("worktree-down --prune removes only clean terminal worktrees and preserves dirty or live trees", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-"));
   const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-bin-"));
-  const tickets = [makeTestTicket("TERMINAL"), makeTestTicket("DIRTY"), makeTestTicket("LIVE")];
+  const tickets = [
+    makeTestTicket("TERMINAL"),
+    makeTestTicket("DIRTY"),
+    makeTestTicket("LIVE"),
+  ];
   const [terminalTicket, dirtyTicket, liveTicket] = tickets;
 
   try {
@@ -725,11 +1042,23 @@ test("worktree-down --prune removes only clean terminal worktrees and preserves 
       });
       expect(up.exitCode).toBe(0);
     }
-    writeFileSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), "do not remove\n");
-    mkdirSync(path.join(tempWtRoot, liveTicket, ".factory", "run"), { recursive: true });
-    writeFileSync(path.join(tempWtRoot, liveTicket, ".factory", "run", "worker.pid"), `${process.pid}\n`);
+    writeFileSync(
+      path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"),
+      "do not remove\n",
+    );
+    mkdirSync(path.join(tempWtRoot, liveTicket, ".factory", "run"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(tempWtRoot, liveTicket, ".factory", "run", "worker.pid"),
+      `${process.pid}\n`,
+    );
 
-    writeFileSync(path.join(mockBin, "bun"), "#!/usr/bin/env bash\nprintf '{\"state\":{\"name\":\"Done\"}}\\n'\n", { mode: 0o755 });
+    writeFileSync(
+      path.join(mockBin, "bun"),
+      '#!/usr/bin/env bash\nprintf \'{"state":{"name":"Done"}}\\n\'\n',
+      { mode: 0o755 },
+    );
     const pruned = Bun.spawnSync({
       cmd: ["bash", DOWN, "--prune"],
       stdout: "pipe",
@@ -746,23 +1075,40 @@ test("worktree-down --prune removes only clean terminal worktrees and preserves 
     expect(existsSync(path.join(tempWtRoot, liveTicket))).toBe(true);
     expect(pruned.stdout.toString()).toContain("pruned 1 terminal worktree");
   } finally {
-    rmSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), { force: true });
-    rmSync(path.join(tempWtRoot, liveTicket, ".factory"), { recursive: true, force: true });
+    rmSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), {
+      force: true,
+    });
+    rmSync(path.join(tempWtRoot, liveTicket, ".factory"), {
+      recursive: true,
+      force: true,
+    });
     for (const ticket of tickets) {
-      Bun.spawnSync({ cmd: ["bash", DOWN, ticket, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+      Bun.spawnSync({
+        cmd: ["bash", DOWN, ticket, "--force"],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      });
     }
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
     Bun.spawnSync({
-      cmd: ["git", "branch", "-D", ...tickets.map((ticket) => `feat/${ticket}`)],
+      cmd: [
+        "git",
+        "branch",
+        "-D",
+        ...tickets.map((ticket) => `feat/${ticket}`),
+      ],
       cwd: path.resolve(import.meta.dir, ".."),
     });
   }
 });
 
 test("worktree-down --prune recognizes a merged PR for the worktree branch", () => {
-  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-merged-"));
-  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-merged-bin-"));
+  const tempWtRoot = mkdtempSync(
+    path.join(tmpdir(), "factory-wt-prune-merged-"),
+  );
+  const mockBin = mkdtempSync(
+    path.join(tmpdir(), "factory-wt-prune-merged-bin-"),
+  );
   const ticketId = makeTestTicket("MERGED");
   const branch = `feat/${ticketId}`;
 
@@ -775,8 +1121,16 @@ test("worktree-down --prune recognizes a merged PR for the worktree branch", () 
     });
     expect(up.exitCode).toBe(0);
 
-    writeFileSync(path.join(mockBin, "bun"), "#!/usr/bin/env bash\nprintf '{\"state\":{\"name\":\"In Review\"}}\\n'\n", { mode: 0o755 });
-    writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash\n[[ "$*" == *"--head ${branch}"* ]] && printf '1\\n' || printf '0\\n'\n`, { mode: 0o755 });
+    writeFileSync(
+      path.join(mockBin, "bun"),
+      '#!/usr/bin/env bash\nprintf \'{"state":{"name":"In Review"}}\\n\'\n',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(mockBin, "gh"),
+      `#!/usr/bin/env bash\n[[ "$*" == *"--head ${branch}"* ]] && printf '1\\n' || printf '0\\n'\n`,
+      { mode: 0o755 },
+    );
     const pruned = Bun.spawnSync({
       cmd: ["bash", DOWN, "--prune"],
       stdout: "pipe",
@@ -790,10 +1144,16 @@ test("worktree-down --prune recognizes a merged PR for the worktree branch", () 
     expect(pruned.exitCode).toBe(0);
     expect(existsSync(path.join(tempWtRoot, ticketId))).toBe(false);
   } finally {
-    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId, "--force"],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", branch],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
   }
 });
 
@@ -809,7 +1169,11 @@ test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
     const proc = Bun.spawn(["bash", UP, ticket, "--checkout-only"], {
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, FACTORY_SKIP_FETCH: "1" },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_SKIP_FETCH: "1",
+      },
     });
     const [stderr, status] = await Promise.all([
       new Response(proc.stderr).text(),
@@ -822,7 +1186,9 @@ test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
     const [r1, r2] = await Promise.all([runUp(ticket1), runUp(ticket2)]);
     for (const r of [r1, r2]) {
       if (r.status !== 0) {
-        console.error(`worktree-up ${r.ticket} exited ${r.status}; stderr:\n${r.stderr}`);
+        console.error(
+          `worktree-up ${r.ticket} exited ${r.status}; stderr:\n${r.stderr}`,
+        );
       }
       expect(r.status).toBe(0);
     }
@@ -840,7 +1206,9 @@ test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
     ]);
   } finally {
     rmSync(tempWtRoot, { recursive: true, force: true });
-    Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticket1}`, `feat/${ticket2}`] });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", `feat/${ticket1}`, `feat/${ticket2}`],
+    });
   }
 });
 
@@ -854,11 +1222,14 @@ test("high concurrency worktree-up --checkout-only with 4 parallel bring-ups suc
   ];
 
   const runUp = async (ticket) => {
-    const proc = Bun.spawn(["bash", UP, ticket, "--checkout-only", "--no-fetch"], {
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-    });
+    const proc = Bun.spawn(
+      ["bash", UP, ticket, "--checkout-only", "--no-fetch"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      },
+    );
     const [stderr, status] = await Promise.all([
       new Response(proc.stderr).text(),
       proc.exited,
@@ -870,18 +1241,21 @@ test("high concurrency worktree-up --checkout-only with 4 parallel bring-ups suc
     const results = await Promise.all(tickets.map(runUp));
     for (const r of results) {
       if (r.status !== 0) {
-        console.error(`worktree-up ${r.ticket} exited ${r.status}; stderr:\n${r.stderr}`);
+        console.error(
+          `worktree-up ${r.ticket} exited ${r.status}; stderr:\n${r.stderr}`,
+        );
       }
       expect(r.status).toBe(0);
       expect(existsSync(path.join(tempWtRoot, r.ticket))).toBe(true);
     }
 
     await Promise.all(
-      tickets.map((t) =>
-        Bun.spawn(["bash", DOWN, t], {
-          env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-        }).exited
-      )
+      tickets.map(
+        (t) =>
+          Bun.spawn(["bash", DOWN, t], {
+            env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+          }).exited,
+      ),
     );
   } finally {
     rmSync(tempWtRoot, { recursive: true, force: true });
@@ -893,14 +1267,18 @@ test("high concurrency worktree-up --checkout-only with 4 parallel bring-ups suc
 
 test("git_fetch skips when FACTORY_SKIP_FETCH is set and base ref exists", () => {
   const repo = path.resolve(import.meta.dir, "..");
-  const r = sh(`git_fetch "${repo}" origin develop`, { FACTORY_SKIP_FETCH: "1" });
+  const r = sh(`git_fetch "${repo}" origin develop`, {
+    FACTORY_SKIP_FETCH: "1",
+  });
   expect(r.status).toBe(0);
 });
 
 test("git_fetch falls back to existing ref on remote failure", () => {
   const repo = path.resolve(import.meta.dir, "..");
   // Non-existent remote should fail network fetch but fall back if ref exists
-  const r = sh(`git_fetch "${repo}" non_existent_remote develop`, { FACTORY_SKIP_FETCH: "0" });
+  const r = sh(`git_fetch "${repo}" non_existent_remote develop`, {
+    FACTORY_SKIP_FETCH: "0",
+  });
   // Since non_existent_remote doesn't have develop in refs/remotes/non_existent_remote, it should die
   expect(r.status).not.toBe(0);
   expect(r.stderr).toContain("could not fetch");
@@ -934,7 +1312,13 @@ test("worktree-up CLI argument parsing error paths", () => {
   expect(ticketWithHere.stderr.toString()).toContain("--here takes no ticket");
 
   // 3. Invalid ticket regex
-  const invalidTickets = ["invalid-ticket", "ops-123", "OPS_123", "123", "OPS-"];
+  const invalidTickets = [
+    "invalid-ticket",
+    "ops-123",
+    "OPS_123",
+    "123",
+    "OPS-",
+  ];
   for (const t of invalidTickets) {
     const res = Bun.spawnSync({
       cmd: ["bash", UP, t],
@@ -952,7 +1336,9 @@ test("worktree-up CLI argument parsing error paths", () => {
     stderr: "pipe",
   });
   expect(unknownFlag.exitCode).not.toBe(0);
-  expect(unknownFlag.stderr.toString()).toContain("unknown option '--bogus-flag'");
+  expect(unknownFlag.stderr.toString()).toContain(
+    "unknown option '--bogus-flag'",
+  );
 
   // 5. Excess arguments
   const excessArgs = Bun.spawnSync({
@@ -961,7 +1347,9 @@ test("worktree-up CLI argument parsing error paths", () => {
     stderr: "pipe",
   });
   expect(excessArgs.exitCode).not.toBe(0);
-  expect(excessArgs.stderr.toString()).toContain("too many arguments (got 'extra-arg')");
+  expect(excessArgs.stderr.toString()).toContain(
+    "too many arguments (got 'extra-arg')",
+  );
 
   // 6. Help option displays usage and exits 0
   const helpRes = Bun.spawnSync({
@@ -993,7 +1381,9 @@ test("worktree-down CLI argument parsing error paths", () => {
       stderr: "pipe",
     });
     expect(unknownFlag.exitCode).not.toBe(0);
-    expect(unknownFlag.stderr.toString()).toContain("unknown option '--invalid-flag'");
+    expect(unknownFlag.stderr.toString()).toContain(
+      "unknown option '--invalid-flag'",
+    );
 
     // 3. Excess arguments
     const excessArgs = Bun.spawnSync({
@@ -1011,7 +1401,9 @@ test("worktree-down CLI argument parsing error paths", () => {
       stderr: "pipe",
     });
     expect(hereWithTicket.exitCode).not.toBe(0);
-    expect(hereWithTicket.stderr.toString()).toContain("--here takes no ticket");
+    expect(hereWithTicket.stderr.toString()).toContain(
+      "--here takes no ticket",
+    );
 
     // 5. Help option displays usage and exits 0
     const helpRes = Bun.spawnSync({
@@ -1047,13 +1439,20 @@ test("worktree-down refuses dirty worktree without --force and cleans up with --
       cmd: ["bash", UP, ticketId, "--checkout-only"],
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, FACTORY_SKIP_FETCH: "1" },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_SKIP_FETCH: "1",
+      },
     });
     expect(upRes.exitCode).toBe(0);
     expect(existsSync(expectedPath)).toBe(true);
 
     // 2. Make uncommitted change in the worktree
-    writeFileSync(path.join(expectedPath, "uncommitted.txt"), "uncommitted work");
+    writeFileSync(
+      path.join(expectedPath, "uncommitted.txt"),
+      "uncommitted work",
+    );
 
     // 3. Attempt teardown without --force -> should fail and preserve worktree
     const downDirty = Bun.spawnSync({
@@ -1063,7 +1462,9 @@ test("worktree-down refuses dirty worktree without --force and cleans up with --
       env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
     });
     expect(downDirty.exitCode).not.toBe(0);
-    expect(downDirty.stderr.toString()).toContain("has uncommitted changes — commit/stash them, or re-run with --force");
+    expect(downDirty.stderr.toString()).toContain(
+      "has uncommitted changes — commit/stash them, or re-run with --force",
+    );
     expect(existsSync(expectedPath)).toBe(true);
 
     // 4. Teardown with --force -> should succeed and remove worktree
@@ -1080,4 +1481,3 @@ test("worktree-down refuses dirty worktree without --force and cleans up with --
     Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticketId}`] });
   }
 });
-

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -1,4 +1,11 @@
-import { chmodSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  renameSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
@@ -12,7 +19,10 @@ const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
 // fixtures bind is free, and pass the band to the scripts via
 // FACTORY_PORT_BASE / FACTORY_PORT_SPAN. No absolute ports below.
 const PORT_SPAN = 200;
-const FIXTURE_OFFSETS = [352, 353, 360, 361, 362, 363, 364, 365, 366, 367, 372, 373, 374, 375, 396, 397];
+const FIXTURE_OFFSETS = [
+  352, 353, 360, 361, 362, 363, 364, 365, 366, 367, 372, 373, 374, 375, 396,
+  397,
+];
 
 function offsetsBindable(base) {
   for (const off of FIXTURE_OFFSETS) {
@@ -40,7 +50,9 @@ function pickPortBase() {
 }
 
 const PORT_BASE = pickPortBase();
-const PORT_RESERVATION_ROOT = mkdtempSync(path.join(tmpdir(), "factory-port-reservations-"));
+const PORT_RESERVATION_ROOT = mkdtempSync(
+  path.join(tmpdir(), "factory-port-reservations-"),
+);
 const P = (offset) => PORT_BASE + offset;
 const BAND_ENV = {
   FACTORY_PORT_BASE: String(PORT_BASE),
@@ -101,7 +113,9 @@ function expectPortBindable(port) {
 function mockLsofDir() {
   const dir = mkdtempSync(path.join(tmpdir(), "wm-473-lsof-"));
   const executable = path.join(dir, "lsof");
-  writeFileSync(executable, `#!/usr/bin/env bash
+  writeFileSync(
+    executable,
+    `#!/usr/bin/env bash
 pid=""
 while [[ $# -gt 0 ]]; do
   if [[ "$1" == "-p" ]]; then pid="$2"; shift 2; else shift; fi
@@ -109,15 +123,15 @@ done
 pid="\${MOCK_LSOF_PID:-$pid}"
 printf '%s\\n' 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME'
 printf 'mock %s user 1u IPv4 0 0t0 TCP 127.0.0.1:%s (LISTEN)\\n' "$pid" "$MOCK_LSOF_PORT"
-`);
+`,
+  );
   chmodSync(executable, 0o755);
   return dir;
 }
 
-
 test("ticket_api_port hashes the full id so N and N+200 do not share a slot", () => {
-  const a = sh('ticket_api_port OPS-201');
-  const b = sh('ticket_api_port OPS-401');
+  const a = sh("ticket_api_port OPS-201");
+  const b = sh("ticket_api_port OPS-401");
   expect(a.status).toBe(0);
   expect(b.status).toBe(0);
   expect(a.stdout).not.toBe(b.stdout);
@@ -130,8 +144,8 @@ test("ticket_api_port hashes the full id so N and N+200 do not share a slot", ()
 });
 
 test("ticket_api_port treats OPS-123 and OPS-123-scratch as different tickets", () => {
-  const a = sh('ticket_api_port OPS-123');
-  const b = sh('ticket_api_port OPS-123-scratch');
+  const a = sh("ticket_api_port OPS-123");
+  const b = sh("ticket_api_port OPS-123-scratch");
   expect(a.status).toBe(0);
   expect(b.status).toBe(0);
   expect(a.stdout).not.toBe(b.stdout);
@@ -140,7 +154,9 @@ test("ticket_api_port treats OPS-123 and OPS-123-scratch as different tickets", 
 test("write_ports / read_ports round-trip", () => {
   const wt = mkdtempSync(path.join(tmpdir(), "ops-460-ports-"));
   try {
-    const written = sh(`write_ports "${wt}" ${P(352)} ${P(353)}\nread_ports "${wt}"`);
+    const written = sh(
+      `write_ports "${wt}" ${P(352)} ${P(353)}\nread_ports "${wt}"`,
+    );
     expect(written.status).toBe(0);
     expect(written.stdout.trim()).toBe(`${P(352)} ${P(353)}`);
   } finally {
@@ -170,10 +186,13 @@ test("listen_tcp_port rejects a recovered port outside the configured band", () 
   const dir = mockLsofDir();
   const pidfile = path.join(dir, "live.pid");
   try {
-    const r = sh(`printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`, {
-      PATH: `${dir}:${process.env.PATH}`,
-      MOCK_LSOF_PORT: String(PORT_BASE + 2 * PORT_SPAN),
-    });
+    const r = sh(
+      `printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`,
+      {
+        PATH: `${dir}:${process.env.PATH}`,
+        MOCK_LSOF_PORT: String(PORT_BASE + 2 * PORT_SPAN),
+      },
+    );
     expect(r.status).not.toBe(0);
     expect(r.stdout).toBe("");
   } finally {
@@ -185,10 +204,13 @@ test("listen_tcp_port accepts the fixed --here web port below the ticket band", 
   const dir = mockLsofDir();
   const pidfile = path.join(dir, "here.pid");
   try {
-    const r = sh(`printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`, {
-      PATH: `${dir}:${process.env.PATH}`,
-      MOCK_LSOF_PORT: "7392",
-    });
+    const r = sh(
+      `printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`,
+      {
+        PATH: `${dir}:${process.env.PATH}`,
+        MOCK_LSOF_PORT: "7392",
+      },
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toBe("7392");
   } finally {
@@ -199,12 +221,14 @@ test("listen_tcp_port accepts the fixed --here web port below the ticket band", 
 test("resolve_worktree_ports reuses free recorded ports for --here", () => {
   const wt = mkdtempSync(path.join(tmpdir(), "wm-176-recorded-"));
   try {
-    const r = sh([
-      `write_ports "${wt}" ${P(352)} ${P(353)}`,
-      `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
-      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
-      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
-    ].join("\n"));
+    const r = sh(
+      [
+        `write_ports "${wt}" ${P(352)} ${P(353)}`,
+        `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
+        'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+        `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toContain(`resolved=${P(352)} ${P(353)}`);
     expect(r.stdout).toContain(`recorded=${P(352)} ${P(353)}`);
@@ -221,17 +245,22 @@ test("resolve_worktree_ports falls back when the preferred --here port is occupi
     port: preferred,
     fetch(req) {
       if (new URL(req.url).pathname === "/health") {
-        return Response.json({ ok: true, env: { home: "/other/checkout/.factory/event-runtime" } });
+        return Response.json({
+          ok: true,
+          env: { home: "/other/checkout/.factory/event-runtime" },
+        });
       }
       return new Response("not found", { status: 404 });
     },
   });
   try {
-    const r = await shAsync([
-      `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
-      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
-      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
-    ].join("\n"));
+    const r = await shAsync(
+      [
+        `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+        'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+        `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toContain(`resolved=${P(362)} ${P(363)}`);
     expect(r.stdout).toContain(`recorded=${P(362)} ${P(363)}`);
@@ -250,10 +279,12 @@ test("resolve_worktree_ports skips a preferred pair whose web port is occupied",
     socket: { data() {} },
   });
   try {
-    const r = await shAsync([
-      `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
-      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
-    ].join("\n"));
+    const r = await shAsync(
+      [
+        `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+        'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toContain(`resolved=${P(362)} ${P(363)}`);
   } finally {
@@ -271,13 +302,16 @@ test("overlapping odd and even preferred pairs cannot be reserved concurrently",
   mkdirSync(wtOdd);
   mkdirSync(wtEven);
 
-  const contend = (wt, preferred, ownReady, otherReady) => shAsync([
-    `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
-    `touch "${ownReady}"`,
-    `for _ in {1..200}; do [[ -e "${otherReady}" ]] && break; sleep 0.01; done`,
-    `test -e "${otherReady}"`,
-    'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
-  ].join("\n"));
+  const contend = (wt, preferred, ownReady, otherReady) =>
+    shAsync(
+      [
+        `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+        `touch "${ownReady}"`,
+        `for _ in {1..200}; do [[ -e "${otherReady}" ]] && break; sleep 0.01; done`,
+        `test -e "${otherReady}"`,
+        'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
+      ].join("\n"),
+    );
 
   try {
     const [odd, even] = await Promise.all([
@@ -286,8 +320,12 @@ test("overlapping odd and even preferred pairs cannot be reserved concurrently",
     ]);
     expect(odd.status).toBe(0);
     expect(even.status).toBe(0);
-    const oddPorts = [...odd.stdout.matchAll(/(?:api|web)=(\d+)/g)].map((match) => Number(match[1]));
-    const evenPorts = [...even.stdout.matchAll(/(?:api|web)=(\d+)/g)].map((match) => Number(match[1]));
+    const oddPorts = [...odd.stdout.matchAll(/(?:api|web)=(\d+)/g)].map(
+      (match) => Number(match[1]),
+    );
+    const evenPorts = [...even.stdout.matchAll(/(?:api|web)=(\d+)/g)].map(
+      (match) => Number(match[1]),
+    );
     expect(oddPorts).toHaveLength(2);
     expect(evenPorts).toHaveLength(2);
     expect(oddPorts.some((port) => evenPorts.includes(port))).toBe(false);
@@ -304,12 +342,14 @@ test("resolve_worktree_ports replaces recorded ports when the web port is occupi
     socket: { data() {} },
   });
   try {
-    const r = await shAsync([
-      `write_ports "${wt}" ${P(364)} ${P(365)}`,
-      `resolve_worktree_ports "${wt}" ${P(372)} "${wt}/.factory/event-runtime"`,
-      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
-      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
-    ].join("\n"));
+    const r = await shAsync(
+      [
+        `write_ports "${wt}" ${P(364)} ${P(365)}`,
+        `resolve_worktree_ports "${wt}" ${P(372)} "${wt}/.factory/event-runtime"`,
+        'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+        `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toContain(`resolved=${P(372)} ${P(373)}`);
     expect(r.stdout).toContain(`recorded=${P(372)} ${P(373)}`);
@@ -334,11 +374,13 @@ test("resolve_worktree_ports reuses recorded ports owned by this checkout", asyn
     },
   });
   try {
-    const r = await shAsync([
-      `write_ports "${wt}" ${api} ${P(375)}`,
-      `resolve_worktree_ports "${wt}" ${P(360)} "${home}"`,
-      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
-    ].join("\n"));
+    const r = await shAsync(
+      [
+        `write_ports "${wt}" ${api} ${P(375)}`,
+        `resolve_worktree_ports "${wt}" ${P(360)} "${home}"`,
+        'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toContain(`resolved=${api} ${P(375)}`);
   } finally {
@@ -357,24 +399,30 @@ test("colliding WM-294 and WM-345 startups reserve distinct pairs and stop indep
   expect(preferred1.stdout).toBe(preferred2.stdout);
   const preferred = Number(preferred1.stdout);
 
-  const launch = (wt) => shAsync([
-    `home="${wt}/.factory/event-runtime"`,
-    `resolve_worktree_ports "${wt}" ${preferred} "$home"`,
-    `spawn_daemon "$(run_dir "${wt}")/serve.pid" "$(run_dir "${wt}")/serve.log" "${wt}" env MOCK_HOME="$home" MOCK_PORT="$API_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return Response.json({ env: { home: process.env.MOCK_HOME } }); } });'`,
-    `spawn_daemon "$(run_dir "${wt}")/web.pid" "$(run_dir "${wt}")/web.log" "${wt}" env MOCK_PORT="$WEB_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return new Response("web"); } });'`,
-    'for _ in {1..100}; do port_listening "$API_PORT" && port_listening "$WEB_PORT" && break; sleep 0.01; done',
-    'port_listening "$API_PORT" && port_listening "$WEB_PORT"',
-    'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
-  ].join("\n"));
+  const launch = (wt) =>
+    shAsync(
+      [
+        `home="${wt}/.factory/event-runtime"`,
+        `resolve_worktree_ports "${wt}" ${preferred} "$home"`,
+        `spawn_daemon "$(run_dir "${wt}")/serve.pid" "$(run_dir "${wt}")/serve.log" "${wt}" env MOCK_HOME="$home" MOCK_PORT="$API_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return Response.json({ env: { home: process.env.MOCK_HOME } }); } });'`,
+        `spawn_daemon "$(run_dir "${wt}")/web.pid" "$(run_dir "${wt}")/web.log" "${wt}" env MOCK_PORT="$WEB_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return new Response("web"); } });'`,
+        'for _ in {1..100}; do port_listening "$API_PORT" && port_listening "$WEB_PORT" && break; sleep 0.01; done',
+        'port_listening "$API_PORT" && port_listening "$WEB_PORT"',
+        'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
+      ].join("\n"),
+    );
 
-  const stop = (wt) => sh([
-    `rdir="$(run_dir "${wt}")"`,
-    'term_daemon "$rdir/web.pid" "web"',
-    'term_daemon "$rdir/serve.pid" "serve"',
-    'await_daemon "$rdir/web.pid" "web"',
-    'await_daemon "$rdir/serve.pid" "serve"',
-    `release_port_reservation "${wt}"`,
-  ].join("\n"));
+  const stop = (wt) =>
+    sh(
+      [
+        `rdir="$(run_dir "${wt}")"`,
+        'term_daemon "$rdir/web.pid" "web"',
+        'term_daemon "$rdir/serve.pid" "serve"',
+        'await_daemon "$rdir/web.pid" "web"',
+        'await_daemon "$rdir/serve.pid" "serve"',
+        `release_port_reservation "${wt}"`,
+      ].join("\n"),
+    );
 
   try {
     const [a, b] = await Promise.all([launch(wt1), launch(wt2)]);
@@ -385,10 +433,12 @@ test("colliding WM-294 and WM-345 startups reserve distinct pairs and stop indep
     expect(api1).not.toBe(api2);
     expect(Math.abs(api1 - api2)).toBe(2);
 
-    const rerun = sh([
-      `resolve_worktree_ports "${wt1}" ${preferred} "${wt1}/.factory/event-runtime"`,
-      'printf "%s %s\\n" "$API_PORT" "$WEB_PORT"',
-    ].join("\n"));
+    const rerun = sh(
+      [
+        `resolve_worktree_ports "${wt1}" ${preferred} "${wt1}/.factory/event-runtime"`,
+        'printf "%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      ].join("\n"),
+    );
     expect(rerun.status).toBe(0);
     expect(rerun.stdout).toContain(`${api1} ${api1 + 1}`);
 
@@ -407,17 +457,19 @@ test("colliding WM-294 and WM-345 startups reserve distinct pairs and stop indep
 test("failed startup cleanup removes partial pid and port reservation state", () => {
   const wt = mkdtempSync(path.join(tmpdir(), "wm-351-failed-startup-"));
   try {
-    const r = sh([
-      `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
-      `rdir="$(run_dir "${wt}")"`,
-      'printf "2147483647\\n" >"$rdir/serve.pid"',
-      `reservation="$(port_reservation_dir "$API_PORT")"`,
-      'rm -f "$rdir/ports"',
-      `release_worktree_ports_if_idle "${wt}"`,
-      'test ! -e "$rdir/serve.pid"',
-      'test ! -e "$rdir/ports"',
-      'test ! -e "$reservation"',
-    ].join("\n"));
+    const r = sh(
+      [
+        `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
+        `rdir="$(run_dir "${wt}")"`,
+        'printf "2147483647\\n" >"$rdir/serve.pid"',
+        `reservation="$(port_reservation_dir "$API_PORT")"`,
+        'rm -f "$rdir/ports"',
+        `release_worktree_ports_if_idle "${wt}"`,
+        'test ! -e "$rdir/serve.pid"',
+        'test ! -e "$rdir/ports"',
+        'test ! -e "$reservation"',
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
   } finally {
     rmSync(wt, { recursive: true, force: true });
@@ -425,8 +477,12 @@ test("failed startup cleanup removes partial pid and port reservation state", ()
 });
 
 test("assert_event_home dies when /health belongs to another checkout", () => {
-  const json = JSON.stringify({ env: { home: "/other/.factory/event-runtime" } });
-  const r = sh(`assert_event_home '${json}' '/this/.factory/event-runtime' ${P(352)}`);
+  const json = JSON.stringify({
+    env: { home: "/other/.factory/event-runtime" },
+  });
+  const r = sh(
+    `assert_event_home '${json}' '/this/.factory/event-runtime' ${P(352)}`,
+  );
   expect(r.status).not.toBe(0);
   expect(r.stderr).toContain("refusing to seed");
   expect(r.stderr).toContain("/other/.factory/event-runtime");
@@ -450,9 +506,11 @@ test("assert_event_adapter requires fake unless --live", () => {
 });
 
 test("adapter_banner reports the /health adapter, not the local flag", () => {
-  expect(sh('adapter_banner fake').stdout).toBe("(fake adapter — approvals are harmless)");
+  expect(sh("adapter_banner fake").stdout).toBe(
+    "(fake adapter — approvals are harmless)",
+  );
   expect(sh('adapter_banner ""').stdout).toBe("(live adapters)");
-  expect(sh('adapter_banner claude').stdout).toBe("(adapter claude)");
+  expect(sh("adapter_banner claude").stdout).toBe("(adapter claude)");
 });
 
 test("allocate_api_port returns the preferred slot when nothing answers /health", () => {
@@ -469,16 +527,24 @@ test("allocate_api_port skips port occupied by another runtime", async () => {
     port: heldPort,
     fetch(req) {
       if (new URL(req.url).pathname === "/health") {
-        return new Response(JSON.stringify({ ok: true, env: { home: "/other/worktree/.factory/event-runtime" } }), {
-          headers: { "content-type": "application/json" },
-        });
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            env: { home: "/other/worktree/.factory/event-runtime" },
+          }),
+          {
+            headers: { "content-type": "application/json" },
+          },
+        );
       }
       return new Response("not found", { status: 404 });
     },
   });
   try {
     const expectedPort = firstPortNotListening(heldPort + 2);
-    const r = await shAsync(`allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`);
+    const r = await shAsync(
+      `allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`,
+    );
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toBe(String(expectedPort));
   } finally {
@@ -497,7 +563,9 @@ test("allocate_api_port skips port squatted by an alien process that does not an
   });
   try {
     const expectedPort = firstPortNotListening(heldPort + 2);
-    const r = await shAsync(`allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`);
+    const r = await shAsync(
+      `allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`,
+    );
     expect(r.status).toBe(0);
     const allocatedPort = Number(r.stdout.trim());
     expect(allocatedPort).toBeGreaterThan(heldPort);
@@ -521,7 +589,9 @@ test("allocate_api_port skips port held by raw TCP listener", async () => {
   });
   try {
     const expectedPort = firstPortNotListening(heldPort + 2);
-    const r = await shAsync(`allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`);
+    const r = await shAsync(
+      `allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`,
+    );
     expect(r.status).toBe(0);
     // The skip property: allocation succeeds and lands off the held slot.
     expect(r.stdout.trim()).not.toBe(String(heldPort));
@@ -574,13 +644,19 @@ test("daemon health reads the recorded API/web pair", async () => {
     },
   });
   try {
-    const r = await shAsync([
-      `write_ports "${wt}" ${P(396)} ${P(397)}`,
-      `check_daemon_health "${wt}"`,
-    ].join("\n"));
+    const r = await shAsync(
+      [
+        `write_ports "${wt}" ${P(396)} ${P(397)}`,
+        `check_daemon_health "${wt}"`,
+      ].join("\n"),
+    );
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain(`serve:   running (pid ${process.pid}, port ${P(396)})`);
-    expect(r.stdout).toContain(`web:     running (pid ${process.pid}, port ${P(397)})`);
+    expect(r.stdout).toContain(
+      `serve:   running (pid ${process.pid}, port ${P(396)})`,
+    );
+    expect(r.stdout).toContain(
+      `web:     running (pid ${process.pid}, port ${P(397)})`,
+    );
     expect(r.stdout).toContain("anomalies: none");
   } finally {
     server.stop(true);
@@ -608,10 +684,10 @@ test("port_listening detects active and closed ports", async () => {
 });
 
 test("ticket_number extracts numeric ID from valid ticket strings", () => {
-  expect(sh('ticket_number OPS-123').stdout.trim()).toBe("123");
-  expect(sh('ticket_number CLNT-456').stdout.trim()).toBe("456");
-  expect(sh('ticket_number WM-1').stdout.trim()).toBe("1");
-  expect(sh('ticket_number OPS-999-scratch').stdout.trim()).toBe("999");
+  expect(sh("ticket_number OPS-123").stdout.trim()).toBe("123");
+  expect(sh("ticket_number CLNT-456").stdout.trim()).toBe("456");
+  expect(sh("ticket_number WM-1").stdout.trim()).toBe("1");
+  expect(sh("ticket_number OPS-999-scratch").stdout.trim()).toBe("999");
 });
 
 test("ticket_number dies on malformed ticket inputs", () => {
@@ -632,13 +708,25 @@ test("web_build_hash computes deterministic sha1 and changes on file rename or c
     mkdirSync(componentsDir, { recursive: true });
     mkdirSync(publicDir, { recursive: true });
 
-    writeFileSync(path.join(mockWebDir, "package.json"), JSON.stringify({ name: "mock-web" }));
+    writeFileSync(
+      path.join(mockWebDir, "package.json"),
+      JSON.stringify({ name: "mock-web" }),
+    );
     writeFileSync(path.join(mockWebDir, "bun.lock"), "lockfile-v1");
-    writeFileSync(path.join(mockWebDir, "vite.config.ts"), "export default {};");
+    writeFileSync(
+      path.join(mockWebDir, "vite.config.ts"),
+      "export default {};",
+    );
     writeFileSync(path.join(mockWebDir, "tsconfig.json"), "{}");
-    writeFileSync(path.join(mockWebDir, "index.html"), "<!DOCTYPE html><html></html>");
+    writeFileSync(
+      path.join(mockWebDir, "index.html"),
+      "<!DOCTYPE html><html></html>",
+    );
     writeFileSync(path.join(srcDir, "main.ts"), "console.log('init');");
-    writeFileSync(path.join(componentsDir, "Button.vue"), "<template><button>OK</button></template>");
+    writeFileSync(
+      path.join(componentsDir, "Button.vue"),
+      "<template><button>OK</button></template>",
+    );
     writeFileSync(path.join(publicDir, "favicon.ico"), "binary-icon-content");
 
     const initial = sh(`web_build_hash "${mockWebDir}"`);
@@ -657,7 +745,9 @@ test("web_build_hash computes deterministic sha1 and changes on file rename or c
 
     // Revert content edit -> restores initial hash
     writeFileSync(path.join(srcDir, "main.ts"), "console.log('init');");
-    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).toBe(initialHash);
+    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).toBe(
+      initialHash,
+    );
 
     // 2. File rename in src/components/
     const oldBtn = path.join(componentsDir, "Button.vue");
@@ -668,13 +758,19 @@ test("web_build_hash computes deterministic sha1 and changes on file rename or c
 
     // Revert rename -> restores initial hash
     renameSync(newBtn, oldBtn);
-    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).toBe(initialHash);
+    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).toBe(
+      initialHash,
+    );
 
     // 3. Edit root config files
-    writeFileSync(path.join(mockWebDir, "package.json"), JSON.stringify({ name: "mock-web-2" }));
-    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).not.toBe(initialHash);
+    writeFileSync(
+      path.join(mockWebDir, "package.json"),
+      JSON.stringify({ name: "mock-web-2" }),
+    );
+    expect(sh(`web_build_hash "${mockWebDir}"`).stdout.trim()).not.toBe(
+      initialHash,
+    );
   } finally {
     rmSync(mockWebDir, { recursive: true, force: true });
   }
 });
-

--- a/bin/worktree-daemons.test.mjs
+++ b/bin/worktree-daemons.test.mjs
@@ -1,4 +1,11 @@
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
@@ -84,7 +91,9 @@ test("spawn_daemon creates detached process that survives subshell exit", () => 
       try {
         const pid = readFileSync(pidfile, "utf8").trim();
         process.kill(Number(pid), "SIGKILL");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
     rmSync(testDir, { recursive: true, force: true });
   }
@@ -119,7 +128,9 @@ test("pid_alive returns true for running process and false for dead process", ()
 });
 
 test("await_daemon falls back to SIGKILL when process ignores SIGTERM", () => {
-  const testDir = mkdtempSync(path.join(tmpdir(), "await-daemon-sigkill-test-"));
+  const testDir = mkdtempSync(
+    path.join(tmpdir(), "await-daemon-sigkill-test-"),
+  );
   const pidfile = path.join(testDir, "stubborn.pid");
   const logfile = path.join(testDir, "stubborn.log");
 
@@ -158,7 +169,9 @@ test("await_daemon falls back to SIGKILL when process ignores SIGTERM", () => {
     if (pid) {
       try {
         process.kill(Number(pid), "SIGKILL");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
     rmSync(testDir, { recursive: true, force: true });
   }
@@ -248,14 +261,20 @@ test("supervise_tick restarts dead daemon and logs restart line", () => {
     expect(logContent).toContain("[supervisor] restarting dead worker");
 
     // Clean up spawned worker
-    try { process.kill(Number(newPid), "SIGKILL"); } catch { /* intentionally ignored */ }
+    try {
+      process.kill(Number(newPid), "SIGKILL");
+    } catch {
+      /* intentionally ignored */
+    }
   } finally {
     rmSync(testDir, { recursive: true, force: true });
   }
 });
 
 test("supervise_tick enforces circuit breaker when max restarts exceeded", () => {
-  const testDir = mkdtempSync(path.join(tmpdir(), "supervise-circuit-breaker-test-"));
+  const testDir = mkdtempSync(
+    path.join(tmpdir(), "supervise-circuit-breaker-test-"),
+  );
   const runDir = path.join(testDir, ".factory", "run");
   mkdirSync(runDir, { recursive: true });
 
@@ -265,9 +284,12 @@ test("supervise_tick enforces circuit breaker when max restarts exceeded", () =>
     const now = Math.floor(Date.now() / 1000);
 
     // Pre-populate state with 3 recent restarts
-    writeFileSync(stateFile, JSON.stringify({
-      worker: [now - 10, now - 5, now - 1],
-    }));
+    writeFileSync(
+      stateFile,
+      JSON.stringify({
+        worker: [now - 10, now - 5, now - 1],
+      }),
+    );
     writeFileSync(workerPid, "999999");
 
     // max_restarts = 3 -> should hit circuit breaker

--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -25,7 +25,19 @@
  *
  * Runs on bun (see lib/schedule.mjs); no npm dependencies.
  */
-import { readFileSync, writeFileSync, mkdirSync, rmSync, cpSync, readdirSync, existsSync, statSync, symlinkSync, lstatSync, unlinkSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  cpSync,
+  readdirSync,
+  existsSync,
+  statSync,
+  symlinkSync,
+  lstatSync,
+  unlinkSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,7 +55,10 @@ const read = (p) => readFileSync(p, "utf8");
 const listFiles = (dir) =>
   existsSync(dir)
     ? readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
-        e.isDirectory() ? listFiles(path.join(dir, e.name)) : [path.join(dir, e.name)])
+        e.isDirectory()
+          ? listFiles(path.join(dir, e.name))
+          : [path.join(dir, e.name)],
+      )
     : [];
 
 /** Split `---` frontmatter from a markdown body. */
@@ -72,9 +87,15 @@ function withoutFrontmatterFields(text, fields) {
 
 /** Render a harness-native Markdown agent without leaking another harness's model id. */
 function markdownAgent(agent, fields = {}) {
-  const frontmatter = { name: agent.name, description: agent.description, ...fields };
-  const lines = Object.entries(frontmatter).map(([key, value]) =>
-    `${key}: ${typeof value === "string" ? JSON.stringify(value) : value}`);
+  const frontmatter = {
+    name: agent.name,
+    description: agent.description,
+    ...fields,
+  };
+  const lines = Object.entries(frontmatter).map(
+    ([key, value]) =>
+      `${key}: ${typeof value === "string" ? JSON.stringify(value) : value}`,
+  );
   return `---\n${lines.join("\n")}\n---\n\n${agent.body.trimStart()}`;
 }
 
@@ -107,17 +128,26 @@ function cleanGenerated(...directories) {
 
 // ------------------------------------------------------------------ inputs ---
 const floor = read(path.join(SHARED, "floor.md"));
-const commands = listFiles(path.join(SHARED, "commands")).filter((f) => f.endsWith(".md"));
+const commands = listFiles(path.join(SHARED, "commands")).filter((f) =>
+  f.endsWith(".md"),
+);
 const skillDirs = existsSync(path.join(SHARED, "skills"))
-  ? readdirSync(path.join(SHARED, "skills"), { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name)
+  ? readdirSync(path.join(SHARED, "skills"), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
   : [];
-const agents = listFiles(path.join(SHARED, "agents")).filter((f) => f.endsWith(".md"));
+const agents = listFiles(path.join(SHARED, "agents")).filter((f) =>
+  f.endsWith(".md"),
+);
 const agentDefinitions = agents.map((file) => {
   const { fm, body } = splitFrontmatter(read(file));
   const name = fm.name || path.basename(file, ".md");
-  if (!fm.description) throw new Error(`${rel(file)}: agents require a description`);
+  if (!fm.description)
+    throw new Error(`${rel(file)}: agents require a description`);
   if (name !== path.basename(file, ".md"))
-    throw new Error(`${rel(file)}: agent name must match its filename (${name})`);
+    throw new Error(
+      `${rel(file)}: agent name must match its filename (${name})`,
+    );
   return { file, name, description: fm.description, fm, body };
 });
 
@@ -130,10 +160,19 @@ cleanGenerated(
   path.join(CLAUDE, "skills"),
   path.join(CLAUDE, "agents"),
 );
-for (const f of commands) emit(path.join(CLAUDE, "commands", path.basename(f)), read(f));
+for (const f of commands)
+  emit(path.join(CLAUDE, "commands", path.basename(f)), read(f));
 for (const s of skillDirs)
   for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(path.join(CLAUDE, "skills", s, path.relative(path.join(SHARED, "skills", s), f)), read(f));
+    emit(
+      path.join(
+        CLAUDE,
+        "skills",
+        s,
+        path.relative(path.join(SHARED, "skills", s), f),
+      ),
+      read(f),
+    );
 for (const agent of agentDefinitions)
   emit(
     path.join(CLAUDE, "agents", `${agent.name}.md`),
@@ -154,30 +193,53 @@ for (const agent of agentDefinitions)
   emit(path.join(CODEX, "agents", `${agent.name}.toml`), codexAgent(agent));
 for (const s of skillDirs)
   for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(path.join(CODEX, "skills", s, path.relative(path.join(SHARED, "skills", s), f)), read(f));
+    emit(
+      path.join(
+        CODEX,
+        "skills",
+        s,
+        path.relative(path.join(SHARED, "skills", s), f),
+      ),
+      read(f),
+    );
 
 const codexCommandSkills = commands.map((f) => path.basename(f, ".md"));
 for (const f of commands) {
   const { fm, body } = splitFrontmatter(read(f));
   const name = path.basename(f, ".md");
-  emit(path.join(CODEX, "skills", name, "SKILL.md"),
-    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`);
+  emit(
+    path.join(CODEX, "skills", name, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
+  );
 }
 // ------------------------------------------------- Gemini CLI / Antigravity ---
 // Antigravity shares ~/.gemini, so one emit covers both.
 const GEMINI = path.join(ROOT, "dist", "gemini");
 cleanGenerated(path.join(GEMINI, "agents"), path.join(GEMINI, "skills"));
 for (const agent of agentDefinitions)
-  emit(path.join(GEMINI, "agents", `${agent.name}.md`), markdownAgent(agent, { kind: "local" }));
+  emit(
+    path.join(GEMINI, "agents", `${agent.name}.md`),
+    markdownAgent(agent, { kind: "local" }),
+  );
 for (const s of skillDirs)
   for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(path.join(GEMINI, "skills", s, path.relative(path.join(SHARED, "skills", s), f)), read(f));
+    emit(
+      path.join(
+        GEMINI,
+        "skills",
+        s,
+        path.relative(path.join(SHARED, "skills", s), f),
+      ),
+      read(f),
+    );
 
 for (const f of commands) {
   const { fm, body } = splitFrontmatter(read(f));
   const name = path.basename(f, ".md");
-  emit(path.join(GEMINI, "skills", name, "SKILL.md"),
-    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`);
+  emit(
+    path.join(GEMINI, "skills", name, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
+  );
 }
 
 // ------------------------------------------------------------- Cursor --------
@@ -185,7 +247,10 @@ for (const f of commands) {
 const CURSOR = path.join(ROOT, "dist", "cursor");
 cleanGenerated(path.join(CURSOR, "agents"), path.join(CURSOR, "commands"));
 for (const agent of agentDefinitions)
-  emit(path.join(CURSOR, "agents", `${agent.name}.md`), markdownAgent(agent, { readonly: true }));
+  emit(
+    path.join(CURSOR, "agents", `${agent.name}.md`),
+    markdownAgent(agent, { readonly: true }),
+  );
 for (const f of commands) {
   const { body } = splitFrontmatter(read(f));
   emit(path.join(CURSOR, "commands", path.basename(f)), body.trimStart());
@@ -212,16 +277,30 @@ for (const agent of agentDefinitions) {
     inheritProjectContext: true,
     inheritSkills: true,
   };
-  if (agent.fm["pi-extensions"]) piFields.extensions = agent.fm["pi-extensions"];
-  emit(path.join(PI, "agents", `${agent.name}.md`), markdownAgent(agent, piFields));
+  if (agent.fm["pi-extensions"])
+    piFields.extensions = agent.fm["pi-extensions"];
+  emit(
+    path.join(PI, "agents", `${agent.name}.md`),
+    markdownAgent(agent, piFields),
+  );
 }
 for (const s of skillDirs)
   for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(path.join(PI, "skills", s, path.relative(path.join(SHARED, "skills", s), f)), read(f));
+    emit(
+      path.join(
+        PI,
+        "skills",
+        s,
+        path.relative(path.join(SHARED, "skills", s), f),
+      ),
+      read(f),
+    );
 for (const f of commands) {
   const { fm, body } = splitFrontmatter(read(f));
-  emit(path.join(PI, "prompts", path.basename(f)),
-    `# ${path.basename(f, ".md")}\n\n${fm.description ? `> ${fm.description}\n\n` : ""}${body.trimStart()}`);
+  emit(
+    path.join(PI, "prompts", path.basename(f)),
+    `# ${path.basename(f, ".md")}\n\n${fm.description ? `> ${fm.description}\n\n` : ""}${body.trimStart()}`,
+  );
 }
 
 // ------------------------------------------------- universal floor block ------
@@ -243,27 +322,47 @@ emit(path.join(ROOT, "dist", "AGENTS.floor.md"), floor);
 // idempotent so running it twice is a no-op.
 /** [{name, path, state}] — state is ok | stale | missing | no-checkout. */
 function floorStatus() {
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
   return (cfg.repos ?? []).map((repo) => {
     const repoPath = String(repo.path).replace(/^~/, homedir());
     const agents = path.join(repoPath, "AGENTS.md");
     if (!existsSync(repoPath)) return { ...repo, agents, state: "no-checkout" };
     if (!existsSync(agents)) return { ...repo, agents, state: "missing" };
     const body = read(agents);
-    if (!body.includes(FLOOR_BEGIN)) return { ...repo, agents, state: "missing" };
-    return { ...repo, agents, state: floorIsCurrent(body, floor) ? "ok" : "stale" };
+    if (!body.includes(FLOOR_BEGIN))
+      return { ...repo, agents, state: "missing" };
+    return {
+      ...repo,
+      agents,
+      state: floorIsCurrent(body, floor) ? "ok" : "stale",
+    };
   });
 }
 
 if (process.argv.includes("--sync-floor")) {
   console.log("\nsyncing the floor into each configured repo's AGENTS.md:");
   for (const r of floorStatus()) {
-    if (r.state === "no-checkout") { console.log(`  skip     ${r.name} — no checkout at ${r.path}`); continue; }
-    if (r.state === "ok") { console.log(`  current  ${r.name}`); continue; }
-    writeFileSync(r.agents, spliceFloor(existsSync(r.agents) ? read(r.agents) : "", floor));
-    console.log(`  ${r.state === "stale" ? "updated " : "added   "} ${r.name}  -> ${r.path}/AGENTS.md`);
+    if (r.state === "no-checkout") {
+      console.log(`  skip     ${r.name} — no checkout at ${r.path}`);
+      continue;
+    }
+    if (r.state === "ok") {
+      console.log(`  current  ${r.name}`);
+      continue;
+    }
+    writeFileSync(
+      r.agents,
+      spliceFloor(existsSync(r.agents) ? read(r.agents) : "", floor),
+    );
+    console.log(
+      `  ${r.state === "stale" ? "updated " : "added   "} ${r.name}  -> ${r.path}/AGENTS.md`,
+    );
   }
-  console.log("\nCommit AGENTS.md in each repo — the floor only protects a sandbox if it is checked in.");
+  console.log(
+    "\nCommit AGENTS.md in each repo — the floor only protects a sandbox if it is checked in.",
+  );
 }
 
 // ------------------------------------------------------------------ check ----
@@ -272,25 +371,33 @@ if (CHECK) {
   // `.claude-plugin/` holds the plugin + marketplace manifests, which are
   // hand-maintained (version, keywords) and have no shared/ source. Everything
   // else under plugins/ and dist/ must be reproducible.
-  const isHandMaintained = (p) => p.includes(`${path.sep}.claude-plugin${path.sep}`);
+  const isHandMaintained = (p) =>
+    p.includes(`${path.sep}.claude-plugin${path.sep}`);
   const actual = [
     ...listFiles(path.join(ROOT, "plugins")),
     ...listFiles(path.join(ROOT, "dist")),
-  ].map((p) => path.resolve(p)).filter((p) => !isHandMaintained(p));
+  ]
+    .map((p) => path.resolve(p))
+    .filter((p) => !isHandMaintained(p));
 
   const problems = [];
   for (const [file, content] of written) {
     if (!existsSync(file)) problems.push(`missing:   ${rel(file)}`);
     else if (read(file) !== content) problems.push(`stale:     ${rel(file)}`);
   }
-  for (const file of actual) if (!expected.includes(file)) problems.push(`orphaned:  ${rel(file)}`);
+  for (const file of actual)
+    if (!expected.includes(file)) problems.push(`orphaned:  ${rel(file)}`);
 
   if (problems.length) {
     console.error("Generated tree does not match shared/:\n");
     for (const p of problems) console.error("  " + p);
     console.error(`\nRun \`bun build/emit.mjs\` and commit the result.`);
-    console.error("If a harness file has a rule that shared/ doesn't, move the rule into shared/ —");
-    console.error("a rule that lives in one harness is a rule the other harnesses silently lack.");
+    console.error(
+      "If a harness file has a rule that shared/ doesn't, move the rule into shared/ —",
+    );
+    console.error(
+      "a rule that lives in one harness is a rule the other harnesses silently lack.",
+    );
     process.exit(1);
   }
   console.log(`ok — ${expected.length} generated files match shared/`);
@@ -304,23 +411,42 @@ if (CHECK) {
   const repos = floorStatus().filter((r) => r.state !== "no-checkout");
   const behind = repos.filter((r) => r.state !== "ok");
   if (!repos.length) {
-    console.log("floor delivery: no configured repo checked out here — not verified");
+    console.log(
+      "floor delivery: no configured repo checked out here — not verified",
+    );
   } else if (behind.length) {
-    console.log(`\n! floor delivery: ${behind.length} of ${repos.length} repo(s) are not carrying the current floor`);
-    for (const r of behind) console.log(`    ${r.state.padEnd(8)} ${r.name}  ${r.path}/AGENTS.md`);
-    console.log("  Fix: bun build/emit.mjs --sync-floor   (then commit AGENTS.md in each repo)");
+    console.log(
+      `\n! floor delivery: ${behind.length} of ${repos.length} repo(s) are not carrying the current floor`,
+    );
+    for (const r of behind)
+      console.log(`    ${r.state.padEnd(8)} ${r.name}  ${r.path}/AGENTS.md`);
+    console.log(
+      "  Fix: bun build/emit.mjs --sync-floor   (then commit AGENTS.md in each repo)",
+    );
   } else {
-    console.log(`floor delivery: ${repos.length} repo(s) carrying the current floor`);
+    console.log(
+      `floor delivery: ${repos.length} repo(s) carrying the current floor`,
+    );
   }
   process.exit(0);
 }
 
 console.log(`emitted ${written.size} files from shared/`);
-console.log(`  claude  plugins/core/  (${commands.length} commands, ${skillDirs.length} skills, ${agents.length} agents)`);
-console.log(`  codex   dist/codex/    (${skillDirs.length + commands.length} skills, ${agents.length} agents)`);
-console.log(`  gemini  dist/gemini/   (${skillDirs.length + commands.length} skills, ${agents.length} agents)  — also Antigravity`);
-console.log(`  cursor  dist/cursor/   (${commands.length} commands, ${agents.length} agents)`);
-console.log(`  pi      dist/pi/       (${skillDirs.length} skills, ${commands.length} prompts, ${agents.length} agents)`);
+console.log(
+  `  claude  plugins/core/  (${commands.length} commands, ${skillDirs.length} skills, ${agents.length} agents)`,
+);
+console.log(
+  `  codex   dist/codex/    (${skillDirs.length + commands.length} skills, ${agents.length} agents)`,
+);
+console.log(
+  `  gemini  dist/gemini/   (${skillDirs.length + commands.length} skills, ${agents.length} agents)  — also Antigravity`,
+);
+console.log(
+  `  cursor  dist/cursor/   (${commands.length} commands, ${agents.length} agents)`,
+);
+console.log(
+  `  pi      dist/pi/       (${skillDirs.length} skills, ${commands.length} prompts, ${agents.length} agents)`,
+);
 console.log(`  floor   dist/AGENTS.floor.md`);
 
 // -------------------------------------------------------------- link repos ---
@@ -332,25 +458,45 @@ console.log(`  floor   dist/AGENTS.floor.md`);
 // The marketplace route (SETUP.md) still works and is nicer for interactive use;
 // this is the one that reliably works for `claude -p`.
 if (process.argv.includes("--link-repos")) {
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
   console.log("\nlinking factory commands into each configured repo:");
   for (const repo of cfg.repos ?? []) {
     const repoPath = String(repo.path).replace(/^~/, homedir());
-    if (!existsSync(repoPath)) { console.log(`  skip     ${repo.name} — no checkout at ${repo.path}`); continue; }
+    if (!existsSync(repoPath)) {
+      console.log(`  skip     ${repo.name} — no checkout at ${repo.path}`);
+      continue;
+    }
     const dst = path.join(repoPath, ".claude", "commands");
     mkdirSync(dst, { recursive: true });
     for (const f of commands) {
       const target = path.join(dst, path.basename(f));
       let st = null;
-      try { st = lstatSync(target); } catch { /* intentionally ignored */ }
-      if (st && !st.isSymbolicLink()) { console.log(`  skip     ${repo.name}/${path.basename(f)} (real file)`); continue; }
+      try {
+        st = lstatSync(target);
+      } catch {
+        /* intentionally ignored */
+      }
+      if (st && !st.isSymbolicLink()) {
+        console.log(`  skip     ${repo.name}/${path.basename(f)} (real file)`);
+        continue;
+      }
       if (st) unlinkSync(target);
       symlinkSync(path.join(CLAUDE, "commands", path.basename(f)), target);
     }
-    console.log(`  linked   ${repo.name}  ${commands.length} command(s) -> ${repo.path}/.claude/commands/`);
+    console.log(
+      `  linked   ${repo.name}  ${commands.length} command(s) -> ${repo.path}/.claude/commands/`,
+    );
     const gi = ensureHarnessGitignore(repoPath);
-    if (gi === "ok") console.log(`  gitignore  ${repo.name}  harness symlinks already excluded`);
-    else console.log(`  gitignore  ${repo.name}  ${gi} FACTORY:HARNES block -> .gitignore`);
+    if (gi === "ok")
+      console.log(
+        `  gitignore  ${repo.name}  harness symlinks already excluded`,
+      );
+    else
+      console.log(
+        `  gitignore  ${repo.name}  ${gi} FACTORY:HARNES block -> .gitignore`,
+      );
   }
 }
 
@@ -363,7 +509,11 @@ function linkFactoryBin() {
   }
   mkdirSync(path.dirname(dst), { recursive: true });
   let existing = null;
-  try { existing = lstatSync(dst); } catch { /* intentionally ignored */ }
+  try {
+    existing = lstatSync(dst);
+  } catch {
+    /* intentionally ignored */
+  }
   if (existing) {
     if (!existing.isSymbolicLink()) {
       console.log(`  skip     ${dst}  (real file — not overwriting)`);
@@ -372,35 +522,76 @@ function linkFactoryBin() {
     unlinkSync(dst);
   }
   symlinkSync(src, dst);
-  console.log(`  linked   ${dst.replace(homedir(), "~")} -> ${src.replace(homedir(), "~")}`);
+  console.log(
+    `  linked   ${dst.replace(homedir(), "~")} -> ${src.replace(homedir(), "~")}`,
+  );
 }
 
 if (LINK_BIN || LINK) linkFactoryBin();
 
 // ------------------------------------------------------------------- link ----
 if (LINK) {
-  console.log("\nlinking this machine's harnesses to shared/ (source of truth, no copy to go stale):");
+  console.log(
+    "\nlinking this machine's harnesses to shared/ (source of truth, no copy to go stale):",
+  );
   const geminiCommandSkills = [...skillDirs, ...codexCommandSkills];
   const links = [
-    ...[...skillDirs, ...codexCommandSkills].map((s) => [path.join(CODEX, "skills", s), path.join(homedir(), ".agents/skills", s)]),
-    ...geminiCommandSkills.map((s) => [path.join(GEMINI, "skills", s), path.join(homedir(), ".gemini/skills", s)]),
-    ...commands.map((f) => [path.join(CURSOR, "commands", path.basename(f)), path.join(homedir(), ".cursor/commands", path.basename(f))]),
-    ...commands.map((f) => [path.join(PI, "prompts", path.basename(f)), path.join(homedir(), ".pi/agent/prompts", path.basename(f))]),
-    ...skillDirs.map((s) => [path.join(PI, "skills", s), path.join(homedir(), ".pi/agent/skills", s)]),
+    ...[...skillDirs, ...codexCommandSkills].map((s) => [
+      path.join(CODEX, "skills", s),
+      path.join(homedir(), ".agents/skills", s),
+    ]),
+    ...geminiCommandSkills.map((s) => [
+      path.join(GEMINI, "skills", s),
+      path.join(homedir(), ".gemini/skills", s),
+    ]),
+    ...commands.map((f) => [
+      path.join(CURSOR, "commands", path.basename(f)),
+      path.join(homedir(), ".cursor/commands", path.basename(f)),
+    ]),
+    ...commands.map((f) => [
+      path.join(PI, "prompts", path.basename(f)),
+      path.join(homedir(), ".pi/agent/prompts", path.basename(f)),
+    ]),
+    ...skillDirs.map((s) => [
+      path.join(PI, "skills", s),
+      path.join(homedir(), ".pi/agent/skills", s),
+    ]),
     ...agentDefinitions.flatMap((agent) => [
-      [path.join(CLAUDE, "agents", `${agent.name}.md`), path.join(homedir(), ".claude/agents", `${agent.name}.md`)],
-      [path.join(CODEX, "agents", `${agent.name}.toml`), path.join(homedir(), ".codex/agents", `${agent.name}.toml`)],
-      [path.join(GEMINI, "agents", `${agent.name}.md`), path.join(homedir(), ".gemini/agents", `${agent.name}.md`)],
-      [path.join(CURSOR, "agents", `${agent.name}.md`), path.join(homedir(), ".cursor/agents", `${agent.name}.md`)],
-      [path.join(PI, "agents", `${agent.name}.md`), path.join(homedir(), ".pi/agent/agents", `${agent.name}.md`)],
+      [
+        path.join(CLAUDE, "agents", `${agent.name}.md`),
+        path.join(homedir(), ".claude/agents", `${agent.name}.md`),
+      ],
+      [
+        path.join(CODEX, "agents", `${agent.name}.toml`),
+        path.join(homedir(), ".codex/agents", `${agent.name}.toml`),
+      ],
+      [
+        path.join(GEMINI, "agents", `${agent.name}.md`),
+        path.join(homedir(), ".gemini/agents", `${agent.name}.md`),
+      ],
+      [
+        path.join(CURSOR, "agents", `${agent.name}.md`),
+        path.join(homedir(), ".cursor/agents", `${agent.name}.md`),
+      ],
+      [
+        path.join(PI, "agents", `${agent.name}.md`),
+        path.join(homedir(), ".pi/agent/agents", `${agent.name}.md`),
+      ],
     ]),
   ];
   for (const [src, dst] of links) {
     mkdirSync(path.dirname(dst), { recursive: true });
     let existing = null;
-    try { existing = lstatSync(dst); } catch { /* intentionally ignored */ }
+    try {
+      existing = lstatSync(dst);
+    } catch {
+      /* intentionally ignored */
+    }
     if (existing) {
-      if (!existing.isSymbolicLink()) { console.log(`  skip     ${dst}  (real file — not overwriting)`); continue; }
+      if (!existing.isSymbolicLink()) {
+        console.log(`  skip     ${dst}  (real file — not overwriting)`);
+        continue;
+      }
       unlinkSync(dst);
     }
     symlinkSync(src, dst);

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -57,12 +57,14 @@ workers:
   # costs a worktree and an LLM subprocess. The supervisor spends the cheap
   # resource (count) to manage the scarce ones, so `max` is the real ceiling on
   # concurrent agent runs on this machine and should be read that way.
-  min: 1                    # never zero: something has to notice the next
-                            # queued run and grow the pool back
-  max: 20                   # operator-selected throughput ceiling; the host
-                            # has capacity for a wider pool, while subscription
-                            # usage remains unobservable until WM-66 provides a
-                            # budget-aware ceiling
+  min:
+    1 # never zero: something has to notice the next
+    # queued run and grow the pool back
+  max:
+    20 # operator-selected throughput ceiling; the host
+    # has capacity for a wider pool, while subscription
+    # usage remains unobservable until WM-66 provides a
+    # budget-aware ceiling
 
 actions_cache:
   # GitHub's cache API reports decimal bytes. The initial 73 GB quota is
@@ -88,18 +90,21 @@ budget:
   # The real constraint on a subscription is the usage window, and nothing here
   # can see it. That is what tickets-per-tick caps are for (schedule.yaml
   # --args): they bound how much of a window one tick can consume.
-  per_ticket_usd: 15.00     # generous — a triage run that explores a codebase
-                            # legitimately passes $5 notional
-  merge_usd: 40.00          # a merge pass reviews N open PRs, not one ticket —
-                            # sized for a backlog, not a single diff. Added
-                            # 2026-08-04 after a $15 cap on legalease's opus
-                            # merge session ran out mid-review with a 13-PR
-                            # backlog still open; run-agent.sh applies this
-                            # instead of per_ticket_usd for factory-merge only.
-  per_day_usd: 2000.00      # enforced in every gate (lib/spend.mjs): today's
-                            # logs are summed per tick; at the cap it drains —
-                            # running tickets finish, nothing new starts.
-                            # Raised to 1000 on 2026-08-04, then to 2000 same day.
+  per_ticket_usd:
+    15.00 # generous — a triage run that explores a codebase
+    # legitimately passes $5 notional
+  merge_usd:
+    40.00 # a merge pass reviews N open PRs, not one ticket —
+    # sized for a backlog, not a single diff. Added
+    # 2026-08-04 after a $15 cap on legalease's opus
+    # merge session ran out mid-review with a 13-PR
+    # backlog still open; run-agent.sh applies this
+    # instead of per_ticket_usd for factory-merge only.
+  per_day_usd:
+    2000.00 # enforced in every gate (lib/spend.mjs): today's
+    # logs are summed per tick; at the cap it drains —
+    # running tickets finish, nothing new starts.
+    # Raised to 1000 on 2026-08-04, then to 2000 same day.
   on_exhausted: drain
 
 models:
@@ -112,7 +117,7 @@ models:
   # Any other value is passed verbatim as --model. A tier declared by a
   # definition with no mapping here fails closed at registry load.
   claude:
-    strong: default        # CLI default — preserves today's dispatch behavior
+    strong: default # CLI default — preserves today's dispatch behavior
     standard: sonnet
     light: haiku
   # pi (OPS-296), Codex subscription window: sol/terra/luna are the

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -16,7 +16,7 @@ repos:
     project: BJ29 Coaching
 
     # Branches
-    base: develop            # agents merge here; master is human-only
+    base: develop # agents merge here; master is human-only
     deploy_branch: master
 
     # Worktrees — MANDATORY here, this repo ships the scripts (W-1..W-12).
@@ -160,7 +160,7 @@ repos:
     worktree_down: bin/worktree-down.sh
     worktree_warm: bin/worktree-warm.sh
     worktree_root: ~/Develop/.worktrees/coach-wattz
-    report_only: true            # Dispatch remains disabled; janitor may use the teardown script.
+    report_only: true # Dispatch remains disabled; janitor may use the teardown script.
     escalate_paths:
       - server/api/stripe/**
       - server/api/subscriptions/**
@@ -185,7 +185,7 @@ repos:
     worktree_up: bin/worktree-up.sh
     worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/watts-mobile
-    report_only: true            # Command distribution / janitor cleanup enabled; dispatch pending.
+    report_only: true # Command distribution / janitor cleanup enabled; dispatch pending.
     verify: pnpm typecheck && pnpm lint && pnpm test
     escalate_paths:
       - src/features/subscriptions/**
@@ -359,7 +359,7 @@ repos:
     color: fuchsia
     team: OPS
     base: main
-    report_only: true            # stub (OPS-164) — no package, no worktree tooling yet
+    report_only: true # stub (OPS-164) — no package, no worktree tooling yet
 
     # A lint-preset package has no runtime surface to protect (WM-47).
     escalate_paths: []
@@ -387,7 +387,7 @@ repos:
     project: Factory
 
     base: develop
-    deploy_branch: main          # release target is main, not the master fallback
+    deploy_branch: main # release target is main, not the master fallback
 
     # Worktrees — MANDATORY here, this repo ships the scripts.
     worktree_up: bin/worktree-up.sh

--- a/deploy/gen.mjs
+++ b/deploy/gen.mjs
@@ -25,7 +25,8 @@ const OUT = path.join(ROOT, "deploy", "launchd");
 // resolved by the job's shell at runtime, and home-relative paths stay as a
 // literal `~/` until --install materialises them for the installing user
 // (launchd itself does not expand `~` or `$HOME` in plist values).
-export const DEFAULT_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+export const DEFAULT_PATH =
+  "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 const EVENT_LABEL_PREFIX = "com.wattmind.factory.event";
 const DEFAULT_EVENT_WORKERS = "1:2";
 const DEPLOY_ROOT = '"${FACTORY_ROOT:-$HOME/Develop/factory}"';
@@ -34,7 +35,8 @@ const DEPLOY_ROOT = '"${FACTORY_ROOT:-$HOME/Develop/factory}"';
 export const materialize = (text, home = homedir()) =>
   text.replace(/(<string>|:)~\//g, `$1${home}/`);
 
-const xml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const xml = (s) =>
+  String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
 export function eventWorkerRange(value = DEFAULT_EVENT_WORKERS) {
   const raw = String(value).trim();
@@ -42,8 +44,16 @@ export function eventWorkerRange(value = DEFAULT_EVENT_WORKERS) {
   if (!match) throw new Error(`--workers must be N or min:max (got "${raw}")`);
   const min = Number(match[1]);
   const max = Number(match[2] ?? match[1]);
-  if (!Number.isInteger(min) || !Number.isInteger(max) || min < 1 || max < min || max > 32) {
-    throw new Error(`--workers must satisfy 1 <= min <= max <= 32 (got "${raw}")`);
+  if (
+    !Number.isInteger(min) ||
+    !Number.isInteger(max) ||
+    min < 1 ||
+    max < min ||
+    max > 32
+  ) {
+    throw new Error(
+      `--workers must satisfy 1 <= min <= max <= 32 (got "${raw}")`,
+    );
   }
   return `${min}:${max}`;
 }
@@ -52,13 +62,17 @@ function optionValue(name, args = process.argv.slice(2)) {
   const index = args.indexOf(name);
   if (index === -1) return undefined;
   const value = args[index + 1];
-  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  if (!value || value.startsWith("--"))
+    throw new Error(`${name} requires a value`);
   return value;
 }
 
 export function launchdPath(environmentPath = DEFAULT_PATH, home = "~") {
   const entries = (environmentPath || DEFAULT_PATH).split(":").filter(Boolean);
-  for (const entry of [path.join(home, ".bun", "bin"), path.join(home, ".local", "bin")]) {
+  for (const entry of [
+    path.join(home, ".bun", "bin"),
+    path.join(home, ".local", "bin"),
+  ]) {
     if (!entries.includes(entry)) entries.push(entry);
   }
   return entries.join(":");
@@ -114,14 +128,16 @@ ${args.map((a) => `        <string>${xml(a)}</string>`).join("\n")}
  * checkout path, home directory, or secret: the small checked-in launcher
  * resolves those at runtime and writes logs below the current user's home.
  */
-export function eventRuntimePlist(role, {
-  workers = DEFAULT_EVENT_WORKERS,
-  environmentPath = DEFAULT_PATH,
-} = {}) {
-  if (role !== "serve" && role !== "work") throw new Error(`unknown event-runtime daemon role "${role}"`);
+export function eventRuntimePlist(
+  role,
+  { workers = DEFAULT_EVENT_WORKERS, environmentPath = DEFAULT_PATH } = {},
+) {
+  if (role !== "serve" && role !== "work")
+    throw new Error(`unknown event-runtime daemon role "${role}"`);
   const range = eventWorkerRange(workers);
   const label = `${EVENT_LABEL_PREFIX}-${role}`;
-  const launcher = '"${FACTORY_ROOT:-$HOME/Develop/factory}/bin/event-runtime-daemon"';
+  const launcher =
+    '"${FACTORY_ROOT:-$HOME/Develop/factory}/bin/event-runtime-daemon"';
   const command = `exec ${launcher} ${role}${role === "work" ? ` ${range}` : ""}`;
   const args = ["/bin/bash", "-lc", command];
 
@@ -175,27 +191,43 @@ export function renderEventRuntimePlists({
     const next = eventRuntimePlist(role, { workers, environmentPath });
     const prev = existsSync(file) ? readFileSync(file, "utf8") : null;
     writeFileSync(file, next);
-    rendered.push({ name: `factory.event-${role}`, label, file, changed: prev !== next });
+    rendered.push({
+      name: `factory.event-${role}`,
+      label,
+      file,
+      changed: prev !== next,
+    });
   }
   return rendered;
 }
 
-export function installPlists(enabled, defaults, {
-  outDir = OUT,
-  agentsDir = path.join(homedir(), "Library/LaunchAgents"),
-  run = execFileSync,
-  uid = process.getuid(),
-  home = homedir(),
-} = {}) {
+export function installPlists(
+  enabled,
+  defaults,
+  {
+    outDir = OUT,
+    agentsDir = path.join(homedir(), "Library/LaunchAgents"),
+    run = execFileSync,
+    uid = process.getuid(),
+    home = homedir(),
+  } = {},
+) {
   mkdirSync(agentsDir, { recursive: true });
   // launchd creates the log files but not their directory.
-  mkdirSync((defaults.log_dir || "~/Library/Logs").replace(/^~(?=\/|$)/, home), { recursive: true });
+  mkdirSync(
+    (defaults.log_dir || "~/Library/Logs").replace(/^~(?=\/|$)/, home),
+    { recursive: true },
+  );
   for (const job of enabled) {
     const label = job.label ?? `${defaults.label_prefix}.${job.name}`;
     const src = job.file ?? path.join(outDir, `${label}.plist`);
     const dst = path.join(agentsDir, `${label}.plist`);
     writeFileSync(dst, materialize(readFileSync(src, "utf8"), home));
-    try { run("launchctl", ["bootout", `gui/${uid}/${label}`], { stdio: "ignore" }); } catch { /* intentionally ignored */ }
+    try {
+      run("launchctl", ["bootout", `gui/${uid}/${label}`], { stdio: "ignore" });
+    } catch {
+      /* intentionally ignored */
+    }
     run("launchctl", ["bootstrap", `gui/${uid}`, dst]);
     console.log(`  loaded    ${label}`);
   }
@@ -217,19 +249,30 @@ export function main({
     const next = plist(job, defaults);
     const prev = existsSync(file) ? readFileSync(file, "utf8") : null;
     writeFileSync(file, next);
-    console.log(`${prev === next ? "  unchanged" : prev ? "  updated  " : "  created  "} ${path.basename(file)}  (every ${job.every})`);
+    console.log(
+      `${prev === next ? "  unchanged" : prev ? "  updated  " : "  created  "} ${path.basename(file)}  (every ${job.every})`,
+    );
   }
-  for (const job of skipped) console.log(`  disabled  ${job.name}  — ${String(job.why || "").slice(0, 60)}`);
+  for (const job of skipped)
+    console.log(
+      `  disabled  ${job.name}  — ${String(job.why || "").slice(0, 60)}`,
+    );
 
   const range = eventWorkerRange(workers);
   const eventDaemons = renderEventRuntimePlists({ workers: range });
   for (const daemon of eventDaemons) {
-    console.log(`${daemon.changed ? "  updated  " : "  unchanged"} ${path.basename(daemon.file)}`);
+    console.log(
+      `${daemon.changed ? "  updated  " : "  unchanged"} ${path.basename(daemon.file)}`,
+    );
   }
 
   if (!install) {
-    console.log(`\n${enabled.length} scheduled job(s) and 2 event daemon(s) rendered to deploy/launchd/ (workers ${range}).`);
-    console.log("Re-run with --install to copy and bootstrap the scheduled jobs.");
+    console.log(
+      `\n${enabled.length} scheduled job(s) and 2 event daemon(s) rendered to deploy/launchd/ (workers ${range}).`,
+    );
+    console.log(
+      "Re-run with --install to copy and bootstrap the scheduled jobs.",
+    );
     console.log("Event daemons are installed manually — see SETUP.md §3a.");
     return;
   }

--- a/deploy/gen.test.mjs
+++ b/deploy/gen.test.mjs
@@ -47,7 +47,9 @@ test("plist includes EnvironmentVariables with a launchd-safe PATH", () => {
         <key>PATH</key>
         <string>${environmentPath}</string>
     </dict>`);
-  expect((rendered.match(/<key>EnvironmentVariables<\/key>/g) ?? []).length).toBe(1);
+  expect(
+    (rendered.match(/<key>EnvironmentVariables<\/key>/g) ?? []).length,
+  ).toBe(1);
   expect((rendered.match(/<key>PATH<\/key>/g) ?? []).length).toBe(1);
 });
 
@@ -74,9 +76,15 @@ test("rendering ignores the renderer's PATH and home: sentinel never leaks", () 
     const rendered = plist(job, defaults);
     expect(rendered).not.toContain(sentinel);
     expect(rendered).not.toContain(homedir());
-    expect(rendered).toContain(`<string>${DEFAULT_PATH}:~/.bun/bin:~/.local/bin</string>`);
-    expect(rendered).toContain("<string>~/Library/Logs/triage.out.log</string>");
-    expect(rendered).toContain("<string>~/Library/Logs/triage.err.log</string>");
+    expect(rendered).toContain(
+      `<string>${DEFAULT_PATH}:~/.bun/bin:~/.local/bin</string>`,
+    );
+    expect(rendered).toContain(
+      "<string>~/Library/Logs/triage.out.log</string>",
+    );
+    expect(rendered).toContain(
+      "<string>~/Library/Logs/triage.err.log</string>",
+    );
     // Same bytes regardless of the environment the renderer runs in.
     process.env.PATH = "/usr/bin";
     expect(plist(job, defaults)).toBe(rendered);
@@ -88,8 +96,12 @@ test("rendering ignores the renderer's PATH and home: sentinel never leaks", () 
 test("materialize expands ~/ only where launchd would need an absolute path", () => {
   const rendered = plist(job, defaults);
   const installed = materialize(rendered, "/Users/factory");
-  expect(installed).toContain(`<string>${DEFAULT_PATH}:/Users/factory/.bun/bin:/Users/factory/.local/bin</string>`);
-  expect(installed).toContain("<string>/Users/factory/Library/Logs/triage.out.log</string>");
+  expect(installed).toContain(
+    `<string>${DEFAULT_PATH}:/Users/factory/.bun/bin:/Users/factory/.local/bin</string>`,
+  );
+  expect(installed).toContain(
+    "<string>/Users/factory/Library/Logs/triage.out.log</string>",
+  );
   expect(installed).not.toContain("~/");
   // The runtime deploy root is still resolved by the job's shell, not the installer.
   expect(installed).toContain('cd "${FACTORY_ROOT:-$HOME/Develop/factory}"');
@@ -105,7 +117,10 @@ test("installPlists creates a missing LaunchAgents directory before copying", ()
 
   try {
     mkdirSync(outDir, { recursive: true });
-    writeFileSync(source, "<plist><string>~/Library/Logs/x.log</string></plist>\n");
+    writeFileSync(
+      source,
+      "<plist><string>~/Library/Logs/x.log</string></plist>\n",
+    );
     expect(existsSync(agentsDir)).toBe(false);
 
     installPlists([job], defaults, {
@@ -124,7 +139,10 @@ test("installPlists creates a missing LaunchAgents directory before copying", ()
     expect(existsSync(path.join(root, "home", "Library", "Logs"))).toBe(true);
     expect(calls).toEqual([
       ["launchctl", ["bootout", `gui/501/${label}`]],
-      ["launchctl", ["bootstrap", "gui/501", path.join(agentsDir, `${label}.plist`)]],
+      [
+        "launchctl",
+        ["bootstrap", "gui/501", path.join(agentsDir, `${label}.plist`)],
+      ],
     ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -153,10 +171,15 @@ test("installPlists prefers rendered label/file over the prefix concatenation", 
       },
     });
 
-    expect(readFileSync(path.join(agentsDir, `${label}.plist`), "utf8")).toBe("<plist>custom</plist>\n");
+    expect(readFileSync(path.join(agentsDir, `${label}.plist`), "utf8")).toBe(
+      "<plist>custom</plist>\n",
+    );
     expect(calls).toEqual([
       ["launchctl", ["bootout", `gui/501/${label}`]],
-      ["launchctl", ["bootstrap", "gui/501", path.join(agentsDir, `${label}.plist`)]],
+      [
+        "launchctl",
+        ["bootstrap", "gui/501", path.join(agentsDir, `${label}.plist`)],
+      ],
     ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -168,12 +191,21 @@ test("--install never bootstraps the event daemons (scheduled jobs only)", () =>
   const log = console.log;
   console.log = () => {};
   try {
-    main({ install: true, installer(jobs) { installed.push(...jobs); } });
+    main({
+      install: true,
+      installer(jobs) {
+        installed.push(...jobs);
+      },
+    });
   } finally {
     console.log = log;
   }
-  expect(installed.some((j) => String(j.name).startsWith("factory.event-"))).toBe(false);
-  expect(installed.some((j) => String(j.label ?? "").includes(".factory.event-"))).toBe(false);
+  expect(
+    installed.some((j) => String(j.name).startsWith("factory.event-")),
+  ).toBe(false);
+  expect(
+    installed.some((j) => String(j.label ?? "").includes(".factory.event-")),
+  ).toBe(false);
 });
 
 test("event-runtime plists are portable, secret-free, persistent user agents", () => {
@@ -183,7 +215,9 @@ test("event-runtime plists are portable, secret-free, persistent user agents", (
   for (const rendered of [serve, work]) {
     expect(rendered).toContain("<key>RunAtLoad</key>\n    <true/>");
     expect(rendered).toContain("<key>KeepAlive</key>\n    <true/>");
-    expect(rendered).toContain("<key>LimitLoadToSessionType</key>\n    <string>Aqua</string>");
+    expect(rendered).toContain(
+      "<key>LimitLoadToSessionType</key>\n    <string>Aqua</string>",
+    );
     expect(rendered).not.toContain(ROOT);
     expect(rendered).not.toContain("FACTORY_EVENT_SECRET</key>");
   }
@@ -214,8 +248,12 @@ test("event-runtime renderer writes the two committed launchd definitions", () =
       "com.wattmind.factory.event-serve.plist",
       "com.wattmind.factory.event-work.plist",
     ]);
-    expect(readFileSync(rendered[0].file, "utf8")).toContain('event-runtime-daemon" serve');
-    expect(readFileSync(rendered[1].file, "utf8")).toContain('event-runtime-daemon" work 2:2');
+    expect(readFileSync(rendered[0].file, "utf8")).toContain(
+      'event-runtime-daemon" serve',
+    );
+    expect(readFileSync(rendered[1].file, "utf8")).toContain(
+      'event-runtime-daemon" work 2:2',
+    );
   } finally {
     rmSync(outDir, { recursive: true, force: true });
   }
@@ -241,7 +279,10 @@ function daemonFixture() {
   const fakeBun = path.join(home, ".bun", "bin", "bun");
   mkdirSync(path.dirname(fakeBun), { recursive: true });
   mkdirSync(path.join(checkout, "event-runtime"), { recursive: true });
-  writeFileSync(fakeBun, '#!/bin/bash\nprintf \'%s\\n\' "$*" >> "$CALLS_FILE"\n');
+  writeFileSync(
+    fakeBun,
+    '#!/bin/bash\nprintf \'%s\\n\' "$*" >> "$CALLS_FILE"\n',
+  );
   chmodSync(fakeBun, 0o755);
   return { root, home, checkout, calls };
 }
@@ -264,15 +305,25 @@ function daemonEnv(fixture, port) {
 test("daemon preflight failures land in the err log, not launchd's dropped stderr", async () => {
   const fixture = daemonFixture();
   try {
-    rmSync(path.join(fixture.checkout, "event-runtime"), { recursive: true, force: true });
-    const child = Bun.spawn([path.join(ROOT, "bin", "event-runtime-daemon"), "serve"], {
-      env: daemonEnv(fixture, 1),
-      stdout: "ignore",
-      stderr: "ignore",
+    rmSync(path.join(fixture.checkout, "event-runtime"), {
+      recursive: true,
+      force: true,
     });
+    const child = Bun.spawn(
+      [path.join(ROOT, "bin", "event-runtime-daemon"), "serve"],
+      {
+        env: daemonEnv(fixture, 1),
+        stdout: "ignore",
+        stderr: "ignore",
+      },
+    );
     expect(await child.exited).toBe(66);
-    expect(readFileSync(path.join(fixture.root, "logs", "factory-event-serve.err.log"), "utf8"))
-      .toContain("event-runtime checkout not found");
+    expect(
+      readFileSync(
+        path.join(fixture.root, "logs", "factory-event-serve.err.log"),
+        "utf8",
+      ),
+    ).toContain("event-runtime checkout not found");
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -280,19 +331,30 @@ test("daemon preflight failures land in the err log, not launchd's dropped stder
 
 test("daemon worker never invokes supervise when health is unavailable", async () => {
   const fixture = daemonFixture();
-  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("ok") });
+  const probe = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("ok"),
+  });
   const port = probe.port;
   probe.stop(true);
   try {
-    const child = Bun.spawn([path.join(ROOT, "bin", "event-runtime-daemon"), "work", "2:4"], {
-      env: daemonEnv(fixture, port),
-      stdout: "ignore",
-      stderr: "ignore",
-    });
+    const child = Bun.spawn(
+      [path.join(ROOT, "bin", "event-runtime-daemon"), "work", "2:4"],
+      {
+        env: daemonEnv(fixture, port),
+        stdout: "ignore",
+        stderr: "ignore",
+      },
+    );
     expect(await child.exited).toBe(75);
     expect(existsSync(fixture.calls)).toBe(false);
-    expect(readFileSync(path.join(fixture.root, "logs", "factory-event-work.err.log"), "utf8"))
-      .toContain("control API did not become healthy");
+    expect(
+      readFileSync(
+        path.join(fixture.root, "logs", "factory-event-work.err.log"),
+        "utf8",
+      ),
+    ).toContain("control API did not become healthy");
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -314,11 +376,14 @@ test("daemon worker waits for healthy serve, then forwards the configured range"
     },
   });
   try {
-    const child = Bun.spawn([path.join(ROOT, "bin", "event-runtime-daemon"), "work", "2:4"], {
-      env: daemonEnv(fixture, server.port),
-      stdout: "ignore",
-      stderr: "ignore",
-    });
+    const child = Bun.spawn(
+      [path.join(ROOT, "bin", "event-runtime-daemon"), "work", "2:4"],
+      {
+        env: daemonEnv(fixture, server.port),
+        stdout: "ignore",
+        stderr: "ignore",
+      },
+    );
     expect(await child.exited).toBe(0);
     expect(requests).toBeGreaterThanOrEqual(2);
     expect(superviseStartedBeforeHealth).toBe(false);

--- a/desc-WM-58.md
+++ b/desc-WM-58.md
@@ -1,21 +1,26 @@
 Assign all historical factory-related tickets to the Factory Project in Linear, and align config/repos.yaml, commands, and tools so future factory tickets route to WM / Factory project properly.
 
 ### Problem & Context
+
 Currently, factory tickets might not be consistently routed or assigned to the correct project in Linear. The `config/repos.yaml` file lists `team: OPS` for the `factory` repo and lacks a specific project mapping. We need to assign historical factory tickets to the "Factory Project" in Linear, and update `config/repos.yaml` (and any related tools/commands) so future factory tickets are routed to the `WM` team and the "Factory Project".
 
 ### Acceptance Criteria
+
 - A script or process is provided (or executed) to assign historical factory-related tickets to the Factory Project in Linear.
 - `config/repos.yaml` is updated so the `factory` repo has `team: WM` and `project: "Factory"` (or the exact names required by Linear).
 - Any tools or commands that hardcoded the `OPS` team for factory routing are updated.
 
 ### Source File Pointers
+
 - `config/repos.yaml`
 - Any scripts under `tools/` or `scripts/` used for Linear routing.
 
 ### Owned Paths
+
 - `config/repos.yaml`
 - `tools/**`
 - `scripts/**`
 
 ### Verification Command
+
 `bun test && bun build/emit.mjs --check`

--- a/desc-WM-78.md
+++ b/desc-WM-78.md
@@ -1,20 +1,25 @@
 UX critique finding (WM-76, minor): required string fields display "shorter than minLength 1" the instant a template is selected, before any interaction — every fresh form looks broken on arrival. Standard practice: track touched state per field and show errors only after blur or a submit attempt (the submit-time ack flow already exists and should be unchanged).
 
 ### Problem & Context
+
 When a template is selected, required fields instantly show validation errors (like "shorter than minLength 1") before the user has even interacted with them. This makes the fresh form appear broken immediately. We need to suppress these field-level validation errors until the field has been touched (on blur) or a submit is attempted.
 
 ### Acceptance Criteria
+
 - Validation errors for individual fields are hidden until the field is `touched` (receives and loses focus) or until the user attempts to submit the form.
 - The existing form-level submission acknowledgment flow remains unchanged.
 - Form field components correctly track their touched state.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/lib/injectForm.ts`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/lib/injectForm.ts`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-79.md
+++ b/desc-WM-79.md
@@ -1,19 +1,24 @@
 UX critique finding (WM-76, minor): the repo picker (`SuggestInput` in `event-runtime/web/src/components/ui.tsx`) uses a native `<input list>` datalist — functionally correct (short names vs owner/name slugs verified) but visually an unstyled browser dropdown, inconsistent with the custom-styled chips/selects around it. Replace with a small custom suggestion popover consistent with the OKLCH token design system (keep free-text write-in and keyboard support).
 
 ### Problem & Context
+
 The `SuggestInput` component uses a native `<input list>` (`datalist`) for the repo picker. While functionally correct, it renders as an unstyled browser dropdown that breaks consistency with the rest of the OKLCH token design system. We need to replace the native `datalist` with a custom suggestion popover that maintains free-text input and full keyboard support (up/down/enter).
 
 ### Acceptance Criteria
+
 - `SuggestInput` uses a custom-styled popover instead of a native `datalist`.
 - The popover uses the project's existing design system styling.
 - Free-text write-in capability is preserved.
 - Keyboard navigation (ArrowUp, ArrowDown, Enter, Escape) works seamlessly within the suggestion popover.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/ui.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/ui.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-80.md
+++ b/desc-WM-80.md
@@ -1,21 +1,26 @@
 UX critique findings (WM-76, minor + polish): (1) opening the Inject dialog via the `i` hotkey does not focus the template search box, so keystrokes right after `i` go nowhere — the header advertises `i inject` next to `⌘K commands`, implying a type-immediately flow; (2) ArrowDown from the search box does nothing — arrow navigation only works after Tab-ing into the radiogroup; command-palette convention is search-box ArrowDown descends into results.
 
 ### Problem & Context
+
 1. Opening the Inject dialog via the `i` hotkey does not auto-focus the template search box. This breaks the type-immediately flow implied by the `i inject` shortcut (similar to `⌘K commands`).
 2. Pressing `ArrowDown` while focused in the search box currently does nothing. Users expect it to descend into the search results, following standard command-palette conventions.
 
 ### Acceptance Criteria
+
 - Triggering the Inject Dialog via the `i` hotkey automatically focuses the template search input.
 - Pressing `ArrowDown` inside the search input transfers focus down into the first result of the template radiogroup.
 - Keyboard navigation flows seamlessly from search to results without requiring Tab.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/App.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/App.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-81.md
+++ b/desc-WM-81.md
@@ -1,18 +1,23 @@
 UX critique finding (WM-76, polish): the template picker resets to "blank envelope" on every open. The operator persona triggers the same two templates (triage-scan, status-report) a few times a day — preselecting the last-used template (e.g. localStorage) would remove repeated friction on the highest-frequency path. Keep "blank envelope" reachable in one click/keystroke.
 
 ### Problem & Context
+
 Currently, the Inject Dialog's template picker resets to "blank envelope" every time the dialog is opened. Users frequently use the same templates (e.g., triage-scan, status-report) repeatedly. Remembering and pre-selecting the last-used template via `localStorage` would remove friction for this common workflow.
 
 ### Acceptance Criteria
+
 - The template picker saves the user's last selected template to `localStorage` (or similar client-side persistence).
 - Upon opening the dialog, the last-used template is automatically pre-selected.
 - "Blank envelope" remains a top-level, single-click/keystroke option in the picker.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-82.md
+++ b/desc-WM-82.md
@@ -1,20 +1,25 @@
 UX critique finding (WM-76, polish/a11y): the `usedPct` spinbutton exposes `valuemax="0" valuemin="0"` in the accessibility tree even though the schema enforces 0–100 and visual validation works. Screen-reader users get a misleading valid range. Likely the numeric input isn't wiring `min`/`max` (or `aria-valuemin/max`) from the schema's `minimum`/`maximum`.
 
 ### Problem & Context
+
 Numeric fields in the Inject Form (e.g., the `usedPct` spinbutton) currently expose incorrect `valuemin` and `valuemax` attributes (both as "0") to the accessibility tree. Although visual validation and schema constraints (e.g. 0-100) are working properly, screen readers receive misleading information about the field's valid range because the HTML input primitive does not inherit `min` and `max` constraints from the JSON schema.
 
 ### Acceptance Criteria
+
 - Numeric inputs correctly pass down `schema.minimum` and `schema.maximum` to their HTML `min` and `max` (and/or `aria-valuemin`/`aria-valuemax`) attributes.
 - The accessibility tree correctly reports the valid numeric bounds for screen reader users.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/components/ui.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/components/ui.tsx`
 - `event-runtime/web/src/components/ui.test.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-84.md
+++ b/desc-WM-84.md
@@ -1,19 +1,24 @@
-Merge review findings on PR #186 (WM-76), minor: (1) `submitJson()` guards required envelope fields via `REQUIRED.filter(...)` but `submitForm()` has no equivalent — reachable by deleting e.g. `eventId` in the JSON tab then switching to Form and injecting; degrades to a server 422 instead of a clean client error. Fix: run the same `REQUIRED` check against `formEnvelope` at the top of `submitForm`. (2) `onPick(null)` / `onPick("__given__")` set `text` and force the JSON tab but never call `initFormFromEnvelope`, leaving stale `formBase`/`formPayload` in the hidden Form panel — harmless today (tab disabled) but a trap for future changes. 
+Merge review findings on PR #186 (WM-76), minor: (1) `submitJson()` guards required envelope fields via `REQUIRED.filter(...)` but `submitForm()` has no equivalent — reachable by deleting e.g. `eventId` in the JSON tab then switching to Form and injecting; degrades to a server 422 instead of a clean client error. Fix: run the same `REQUIRED` check against `formEnvelope` at the top of `submitForm`. (2) `onPick(null)` / `onPick("__given__")` set `text` and force the JSON tab but never call `initFormFromEnvelope`, leaving stale `formBase`/`formPayload` in the hidden Form panel — harmless today (tab disabled) but a trap for future changes.
 
 ### Problem & Context
+
 1. `submitForm()` lacks the required envelope-fields guard (`REQUIRED.filter(...)`) that `submitJson()` has. If a user deletes a required envelope field like `eventId` in the JSON tab and then switches to the Form tab to submit, it bypasses the client-side validation and results in a server 422 error.
 2. Selecting `null` or `"__given__"` in the template picker forces the JSON tab and updates text but fails to call `initFormFromEnvelope`. This leaves stale data in `formBase`/`formPayload` in the hidden Form tab. While harmless currently because the Form tab is disabled in these states, it's a fragile state trap for future development.
 
 ### Acceptance Criteria
+
 - `submitForm()` includes the same required envelope field guard as `submitJson()`. If a required envelope field is missing, it should produce a clean client-side validation error.
 - When `null` or `"__given__"` are picked, the `formBase` and `formPayload` state must be properly reset or initialized via `initFormFromEnvelope` (or explicitly cleared) to prevent stale state.
 - Existing dialog tests pass and new edge cases are covered.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-85.md
+++ b/desc-WM-85.md
@@ -1,18 +1,23 @@
 Merge review finding on PR #186 (WM-76), minor: `needsSchemaAck()` sets both `schemaAck` and `confirming` in one pass, so sending a schema-invalid payload is Inject → "Confirm inject", identical interaction cost to a valid submit — only the warning copy differs, and an operator with the two-click rhythm internalized can send invalid without reading it. The reset paths are correct (any payload edit clears both acks; review confirmed nothing can be sent without the warning rendering and nothing gets stuck). Fix options: label the confirm button "Inject anyway" when `schemaAck` is set, or make the ack a genuine third step.
 
 ### Problem & Context
+
 Sending a schema-invalid payload currently requires the same number of clicks (Inject → Confirm inject) as a valid submit. A user could accidentally bypass the schema warning out of habit. We need to distinguish the confirmation flow for invalid payloads either by changing the button copy (e.g., "Inject anyway") or by adding an explicit third step for the acknowledgment.
 
 ### Acceptance Criteria
+
 - When a schema warning is present (`schemaAck` is needed), the confirm button must be visually or textually distinct (e.g., labeled "Inject anyway" and/or styled differently, such as a warning color) so it breaks the automatic two-click rhythm.
 - Or, the interaction is changed to explicitly require acknowledging the warning before the confirmation step.
 - Existing dialog tests pass and new snapshots/tests reflect the new behavior or button labels.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-86.md
+++ b/desc-WM-86.md
@@ -1,21 +1,26 @@
 Merge review findings on PR #186 (WM-76): (1) polish — field errors print raw regex source (`$.mount: does not match pattern ^/[A-Za-z0-9/._-]*$`) under the input, exactly the leak critique round 1 removed from placeholders; humanize pattern errors in `errorsByField`, reusing `placeholderFor`. (2) minor — a malformed hidden planner field (e.g. `repoPin` arriving via JSON→Form) surfaces in `formLevelErrors` as text with no control to fix it; name the JSON tab explicitly in that message as the fix path.
 
 ### Problem & Context
+
 1. Field errors for validation mismatches currently print the raw regex source (e.g., `$.mount: does not match pattern ^/[A-Za-z0-9/._-]*$`) under the input. We need to humanize these pattern errors in `errorsByField`, reusing `placeholderFor` logic or similar.
 2. If a hidden planner field (like `repoPin`) has an error (e.g., when populated via the JSON tab), the error surfaces in `formLevelErrors` as plain text without an actionable control in the Form tab. The error message should explicitly instruct the user to switch to the JSON tab to fix it.
 
 ### Acceptance Criteria
+
 - Pattern validation error messages do not leak raw regex strings; they use a humanized message (e.g., indicating the expected format).
 - Validation errors for hidden planner fields in `formLevelErrors` explicitly mention the "JSON tab" as the place to fix them.
 - Existing tests pass, and new tests/snapshots reflect the updated error messages.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/lib/injectForm.ts`
 
 ### Owned Paths
+
 - `event-runtime/web/src/components/InjectDialog.tsx`
 - `event-runtime/web/src/lib/injectForm.ts`
 
 ### Verification Command
+
 `cd event-runtime/web && bun test`

--- a/desc-WM-87.md
+++ b/desc-WM-87.md
@@ -1,20 +1,24 @@
 Merge review findings on PR #186 (WM-76), polish/defence-in-depth: `web/src/lib/schema.ts` is a hand-port of `lib/schema.mjs` (review confirmed zero semantic drift today, clause by clause), but nothing in CI pins them together — add a checked-in fixture (schema + values matrix) both validators must agree on, run in both `bun test` suites. Also `new RegExp(s.pattern)` is unguarded and now runs inside `useMemo` on every keystroke in the dialog — a malformed pattern in a registered schema would throw during render and take the dialog down (the server-side contract gate should prevent this registering; this is defence-in-depth).
 
 ### Problem & Context
-The frontend schema validator (`event-runtime/web/src/lib/schema.ts`) is a hand-port of the backend's `event-runtime/lib/schema.mjs`. Currently, there's no CI safeguard to ensure they remain semantically identical over time. Additionally, `web/src/lib/schema.ts` uses an unguarded `new RegExp(s.pattern)` during render. A malformed regex string in a schema would cause an exception during render and crash the UI dialog. 
+
+The frontend schema validator (`event-runtime/web/src/lib/schema.ts`) is a hand-port of the backend's `event-runtime/lib/schema.mjs`. Currently, there's no CI safeguard to ensure they remain semantically identical over time. Additionally, `web/src/lib/schema.ts` uses an unguarded `new RegExp(s.pattern)` during render. A malformed regex string in a schema would cause an exception during render and crash the UI dialog.
 
 ### Acceptance Criteria
+
 - A new shared JSON test fixture containing a matrix of schemas and values is added.
 - `event-runtime/lib/schema.test.mjs` and `event-runtime/web/src/lib/schema.test.ts` both read this shared fixture and assert identical validation results.
 - The `new RegExp(s.pattern)` call in `web/src/lib/schema.ts` is wrapped in a `try/catch`. If the regex is invalid, it should degrade gracefully without crashing the UI.
 
 ### Source File Pointers
+
 - `event-runtime/web/src/lib/schema.ts`
 - `event-runtime/web/src/lib/schema.test.ts`
 - `event-runtime/lib/schema.mjs`
 - `event-runtime/lib/schema.test.mjs`
 
 ### Owned Paths
+
 - `event-runtime/web/src/lib/schema.ts`
 - `event-runtime/web/src/lib/schema.test.ts`
 - `event-runtime/lib/schema.mjs`
@@ -22,4 +26,5 @@ The frontend schema validator (`event-runtime/web/src/lib/schema.ts`) is a hand-
 - `event-runtime/test-fixtures/**`
 
 ### Verification Command
+
 `cd event-runtime && bun test && cd web && bun test`

--- a/desc-WM-90.md
+++ b/desc-WM-90.md
@@ -1,17 +1,22 @@
 Evidence from the 2026-08-14 develop-red incident ([WM-88](https://linear.app/watt-mind/issue/WM-88/develop-red-wm-83-duplicate-key-fix-left-repos-without-a-declared)): run 31815961721 at `84cc487` failed `event-runtime/demo/seed.test.mjs:66` ("seed & re-seed deduplication ([OPS-464](https://linear.app/watt-mind/issue/OPS-464/fixfactory-a-demo-seed-cannot-be-retried-same-prefix-dies-on-intake)) > initial seed succeeds and verify passes", exit 1) on runner `actions-runner-smoke-4`, then passed unchanged on `gh run rerun --failed`, and passes locally (21.5s). This is after the [OPS-423](https://linear.app/watt-mind/issue/OPS-423/testevent-runtime-verifymjs-is-a-state-census-not-a-correctness-check) hardening round (timeout increase + missing-local-clone handling, commits `5363460`/`7a88bc6`), so the flake class isn't fully closed. Worth capturing the seed/verify stderr on failure (the test currently only asserts exit code, so the CI log shows `Expected: 0 / Received: 1` with no cause) and checking runner-side state (stale event homes, port collisions with concurrent jobs on the same host). One flake + rerun-green is weak evidence for a fix but strong evidence for better failure diagnostics — start there.
 
 ### Problem & Context
+
 The `seed & re-seed deduplication (OPS-464)` test suite in `event-runtime/demo/seed.test.mjs` flakes intermittently on self-hosted runners. It fails on the assertion `expect(seedRes.status).toBe(0)`. Because the test only asserts the exit code, the CI log shows `Expected: 0 / Received: 1` without any indication of what caused the subprocess to fail. We need better failure diagnostics (capturing and logging `stderr` and `stdout` from the failed subprocess) to debug the underlying runner-side state issues like port collisions or stale event homes.
 
 ### Acceptance Criteria
+
 - When the subprocess spawned in the test fails (non-zero exit code), the test output includes the subprocess's `stderr` and `stdout` so the failure reason is visible in the CI log.
 - No functional test assertions are removed or weakened; diagnostics are merely added to failures.
 
 ### Source File Pointers
+
 - `event-runtime/demo/seed.test.mjs`
 
 ### Owned Paths
+
 - `event-runtime/demo/seed.test.mjs`
 
 ### Verification Command
+
 `cd event-runtime && bun test demo/seed.test.mjs`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Subagents share a process, a context window and a budget. One crash takes every 
 
 When a ticket finishes, its slot refills immediately. `Promise.all` on a batch was the first implementation and it was wrong: one 40-minute ticket idles two agents for 40 minutes, and batching is the dominant throughput loss in practice.
 
-The queue is re-read on **every** refill, so a ticket that became agent-ready *during* the run — triage promoting one, or a finishing agent filing follow-up work — is picked up without waiting for the next supervisor tick.
+The queue is re-read on **every** refill, so a ticket that became agent-ready _during_ the run — triage promoting one, or a finishing agent filing follow-up work — is picked up without waiting for the next supervisor tick.
 
 ### 2.3 `Owned Paths` is the concurrency key
 
@@ -75,11 +75,11 @@ Measured on bj29 with the template 99 commits behind: ~3 minutes per worktree, ~
 
 So `tick.mjs` decides, because the arithmetic is mechanical — warming costs one compile, skipping costs N:
 
-| | |
-| :--- | :--- |
-| 2+ tickets, ≥15 commits behind | refresh once, then build |
-| 1 ticket | skip — a wash, and the ticket would rather start now |
-| fresh | skip |
+|                                |                                                      |
+| :----------------------------- | :--------------------------------------------------- |
+| 2+ tickets, ≥15 commits behind | refresh once, then build                             |
+| 1 ticket                       | skip — a wash, and the ticket would rather start now |
+| fresh                          | skip                                                 |
 
 Warming happens **before any `worktree-up`**, so nothing clones a template being rewritten underneath it. (`worktree-up.sh` would detect the mismatch and rebuild from empty, so that race is a slowness bug rather than corruption — but slowness is what we are removing.)
 
@@ -87,12 +87,12 @@ Warming happens **before any `worktree-up`**, so nothing clones a template being
 
 Not everyone, which is why there is no global "pull often" rule.
 
-| Consumer | Source | Stale risk |
-| :--- | :--- | :--- |
-| **Ticket worktrees** | `worktree-up.sh` fetches and branches from `origin/<base>` | **None** — every ticket starts from current remote |
-| **Warm cache** | `worktree-warm.sh` resets to `origin/<base>` | Handled by the staleness gate (§2.6) |
-| **Merge stage** | operates on PR branches via `gh` | Per-PR; rebases against the base itself |
-| **Triage** | reads the **main checkout working tree** | **Real** — stale files mean file pointers to code that moved |
+| Consumer             | Source                                                     | Stale risk                                                   |
+| :------------------- | :--------------------------------------------------------- | :----------------------------------------------------------- |
+| **Ticket worktrees** | `worktree-up.sh` fetches and branches from `origin/<base>` | **None** — every ticket starts from current remote           |
+| **Warm cache**       | `worktree-warm.sh` resets to `origin/<base>`               | Handled by the staleness gate (§2.6)                         |
+| **Merge stage**      | operates on PR branches via `gh`                           | Per-PR; rebases against the base itself                      |
+| **Triage**           | reads the **main checkout working tree**                   | **Real** — stale files mean file pointers to code that moved |
 
 So dispatch was never affected by a main checkout 66 commits behind; only triage was.
 
@@ -106,12 +106,12 @@ A harness timeout produces a **clean error**; a factory timeout **guarantees the
 
 agy's print mode defaults to 5 minutes. A real triage run exceeded it at 231s — 68 tool calls in, mid-sentence — and reported `status: ERROR, "timeout waiting for response"`. The work was actually done; only the closing summary was lost.
 
-The obvious fix (raise it) makes the *stuck* case worse: a wedged run then holds its concurrency slot for the new, longer timeout. So:
+The obvious fix (raise it) makes the _stuck_ case worse: a wedged run then holds its concurrency slot for the new, longer timeout. So:
 
-| Layer | Value | Purpose |
-| :--- | :--- | :--- |
-| Harness (`--print-timeout`) | `max_run_minutes - 2` | errors cleanly, with a usable transcript |
-| Factory (`timeout -k 30s`) | `limits.max_run_minutes` (45) | backstop — TERM, then KILL 30s later |
+| Layer                       | Value                         | Purpose                                  |
+| :-------------------------- | :---------------------------- | :--------------------------------------- |
+| Harness (`--print-timeout`) | `max_run_minutes - 2`         | errors cleanly, with a usable transcript |
+| Factory (`timeout -k 30s`)  | `limits.max_run_minutes` (45) | backstop — TERM, then KILL 30s later     |
 
 Enforced in both `run-agent.sh` and `tick.mjs`, so a per-ticket process cannot hold a slot indefinitely. If `timeout(1)` is missing the runner says so rather than pretending there is a cap.
 
@@ -139,13 +139,13 @@ The real constraint is the **usage window**, which nothing here can observe. Per
 
 ### 2.10 Models: opus only where it changes the outcome
 
-| Stage | Model | Why |
-| :--- | :--- | :--- |
-| triage | sonnet | structured extraction guided by a detailed skill |
-| ticket (implementation) | sonnet | was opus, until 54 ticket runs in one night cost ~$223 of ~$381 notional — a fifth of a weekly allowance for the step that is cheap to implement and expensive to review. `tick.mjs` reads the model from `factory-ticket.md`'s frontmatter, so this is one line to reverse |
-| merge | **opus** | review catches what tests don't; last gate before `develop` auto-deploys |
-| audit | sonnet | mechanical checklist |
-| factory-ux-critic | sonnet on Claude; parent model elsewhere | exercises the app and reports |
+| Stage                   | Model                                    | Why                                                                                                                                                                                                                                                                         |
+| :---------------------- | :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| triage                  | sonnet                                   | structured extraction guided by a detailed skill                                                                                                                                                                                                                            |
+| ticket (implementation) | sonnet                                   | was opus, until 54 ticket runs in one night cost ~$223 of ~$381 notional — a fifth of a weekly allowance for the step that is cheap to implement and expensive to review. `tick.mjs` reads the model from `factory-ticket.md`'s frontmatter, so this is one line to reverse |
+| merge                   | **opus**                                 | review catches what tests don't; last gate before `develop` auto-deploys                                                                                                                                                                                                    |
+| audit                   | sonnet                                   | mechanical checklist                                                                                                                                                                                                                                                        |
+| factory-ux-critic       | sonnet on Claude; parent model elsewhere | exercises the app and reports                                                                                                                                                                                                                                               |
 
 Triage is the live judgement call: a bad spec burns a full dispatch run, which argues for opus; `evals/` is the cheaper place to catch spec quality dropping. Currently sonnet — revisit if specs degrade.
 
@@ -161,13 +161,13 @@ The plugin is a convenience layer, not the safety floor. It reaches Claude Code 
 
 ## 3. Failure modes this design accepts
 
-| Failure | Why it is tolerated | Mitigation |
-| :--- | :--- | :--- |
-| Crashed agent holds a ticket | Reaper is not on a timer (§2.7) | `tick.mjs` un-claims its own failed runs (back to Todo, with a comment); the reaper covers crashes tick can't see — run it by hand |
-| Agents indistinguishable from the human in Linear | Shared API key | OPS-40 — the dispatcher is the natural place to inject per-agent keys |
-| Orphaned worktrees | Merge stage sometimes skipped | `janitor.mjs`, hourly gate |
-| Stale spec against moved code | Runner fast-forwards only a clean tree — the main checkout routinely holds uncommitted human work | Tells the agent in its prompt that the checkout is unreliable evidence and to read from `origin/<base>`; rebasing under someone is worse |
-| Triage can still write to the repo | `Bash` must stay available for exploration | Edit/Write/NotebookEdit disabled; dispatch works in worktrees instead |
+| Failure                                           | Why it is tolerated                                                                               | Mitigation                                                                                                                               |
+| :------------------------------------------------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| Crashed agent holds a ticket                      | Reaper is not on a timer (§2.7)                                                                   | `tick.mjs` un-claims its own failed runs (back to Todo, with a comment); the reaper covers crashes tick can't see — run it by hand       |
+| Agents indistinguishable from the human in Linear | Shared API key                                                                                    | OPS-40 — the dispatcher is the natural place to inject per-agent keys                                                                    |
+| Orphaned worktrees                                | Merge stage sometimes skipped                                                                     | `janitor.mjs`, hourly gate                                                                                                               |
+| Stale spec against moved code                     | Runner fast-forwards only a clean tree — the main checkout routinely holds uncommitted human work | Tells the agent in its prompt that the checkout is unreliable evidence and to read from `origin/<base>`; rebasing under someone is worse |
+| Triage can still write to the repo                | `Bash` must stay available for exploration                                                        | Edit/Write/NotebookEdit disabled; dispatch works in worktrees instead                                                                    |
 
 ---
 

--- a/docs/eval-gondolin-sandbox.md
+++ b/docs/eval-gondolin-sandbox.md
@@ -41,24 +41,28 @@
 **Status**: RFC / Architectural Evaluation — superseded in part, see correction notice above  
 **Author**: Engineering (Event Runtime & Worker Subsystem)  
 **Date**: 2026-08-14  
-**Companion to**: `docs/event-runtime.md` (§7, §10, §14), `docs/event-runtime-workers.md` (§3, §4, §5a), `docs/architecture.md`  
+**Companion to**: `docs/event-runtime.md` (§7, §10, §14), `docs/event-runtime-workers.md` (§3, §4, §5a), `docs/architecture.md`
 
 ---
 
 ## 1. Executive Summary & Verdict
 
 ### 1.1 Problem Statement
+
 The event runtime worker subsystem (`docs/event-runtime-workers.md`) currently executes agent tasks and deterministic actions as host OS child processes via the `cli.mjs work` claim loop. While the runtime enforces strict working-directory boundaries, content-hashed definition verification (`defHash`), and adapter-level permission policies (such as Claude Code's settings policy restricting filesystem mutations), **process-level isolation on the host OS is not a security sandbox**.
 
 As the event runtime expands from read-only diagnostics (Tier 1) to autonomous code mutation, full worktree generation, arbitrary package installation (`npm install`, `cargo build`), and external webhook-driven tasks (Tier 2 / WM-107), executing untrusted code directly on host runners introduces severe security vectors:
+
 1. **Host breakout and lateral movement**: Malicious or hallucinated code executed within a worktree can access the host filesystem, inspect adjacent processes, probe the local network (LAN/Tailscale), and persist rogue artifacts.
 2. **Credential exfiltration via prompt injection or SSRF**: Environment variables (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) passed into worker processes can be exfiltrated if an agent is tricked into emitting network requests or writing memory/environment dumps into logs.
 3. **Unbounded network egress**: Free-form outbound internet access enables data exfiltration and unauthorized external API mutations.
 
 ### 1.2 Architectural Recommendation: `ADOPT` (Phased)
+
 We recommend **ADOPTING** Gondolin microVMs as the foundational sandbox provider for event-runtime worker execution.
 
 **Key Findings**:
+
 - **Hardware-Enforced Isolation**: Gondolin leverages hardware virtualization (KVM on Linux, Hypervisor.framework / Virtualization.framework on macOS Apple Silicon), eliminating shared kernel vulnerabilities inherent to standard container runtimes (`runc`/Docker).
 - **Sub-Second Cold Start Latency**: Gondolin achieves cold boot times of **180ms–320ms** (and **<60ms** with pre-forked memory snapshots), well below the 1,000ms threshold, making ephemeral per-task VM lifecycles practical without degrading event responsiveness.
 - **Granular Egress Control via Host Proxy**: Network egress is default-deny. All outbound traffic routes through a host-controlled proxy performing SNI/TLS validation against an explicit domain allowlist (`api.github.com`, `api.linear.app`, LLM provider endpoints).
@@ -94,15 +98,17 @@ We recommend **ADOPTING** Gondolin microVMs as the foundational sandbox provider
 ```
 
 ### 2.1 Threat Categories
-| Threat Vector | Process-Only Runner (Current) | Gondolin MicroVM Sandbox (Target) |
-| :--- | :--- | :--- |
-| **Host FS Escape** | High risk (Process has host user FS permissions; path traversal breaks out of worktree) | Mitigated (Guest kernel isolated; Virtio-FS exposes only the target worktree path) |
-| **Credential Theft** | High risk (Raw tokens in `process.env` readable via prompt injection or `printenv`) | Eliminated (Guest only possesses opaque placeholders; real secrets stay on host) |
-| **Lateral Movement** | High risk (Can probe Tailnet, Docker daemon sockets, local metadata services) | Eliminated (No host bridge; virtio-net routes strictly through host proxy) |
-| **Host Kernel Exploit** | Medium risk (Shared host kernel syscall surface) | Mitigated (Hardware virtualization boundary; isolated guest Linux kernel) |
-| **Resource Starvation**| Partial (Process nice levels and timeouts; unbounded memory/CPU spikes possible) | Enforced (Hypervisor-level vCPU, memory, and disk IOPS hard capping) |
+
+| Threat Vector           | Process-Only Runner (Current)                                                           | Gondolin MicroVM Sandbox (Target)                                                  |
+| :---------------------- | :-------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| **Host FS Escape**      | High risk (Process has host user FS permissions; path traversal breaks out of worktree) | Mitigated (Guest kernel isolated; Virtio-FS exposes only the target worktree path) |
+| **Credential Theft**    | High risk (Raw tokens in `process.env` readable via prompt injection or `printenv`)     | Eliminated (Guest only possesses opaque placeholders; real secrets stay on host)   |
+| **Lateral Movement**    | High risk (Can probe Tailnet, Docker daemon sockets, local metadata services)           | Eliminated (No host bridge; virtio-net routes strictly through host proxy)         |
+| **Host Kernel Exploit** | Medium risk (Shared host kernel syscall surface)                                        | Mitigated (Hardware virtualization boundary; isolated guest Linux kernel)          |
+| **Resource Starvation** | Partial (Process nice levels and timeouts; unbounded memory/CPU spikes possible)        | Enforced (Hypervisor-level vCPU, memory, and disk IOPS hard capping)               |
 
 ### 2.2 Functional Sandboxing Requirements
+
 1. **Ephemeral Lifecycles**: A clean, reproducible microVM instance per execution attempt, torn down immediately upon attempt resolution or timeout.
 2. **Bidirectional Filesystem Sync**: Low-latency, POSIX-compliant host worktree mounting with accurate file permissions and modification tracking (`git status` integrity).
 3. **Deterministic Network Policy**: Per-agent declarative network egress rules configured directly in agent definitions or RunSpecs.
@@ -141,6 +147,7 @@ Gondolin is a specialized, high-performance microVM hypervisor designed specific
 ```
 
 ### 3.1 Hypervisor Backends
+
 1. **Linux (KVM)**:
    - Uses `/dev/kvm` ioctls for vCPU scheduling, guest memory mapping (`KVM_SET_USER_MEMORY_REGION`), and interrupt delivery.
    - Leverages `vhost-vsock` for high-throughput host-guest IPC and `vhost-net` for kernel-accelerated TAP packet processing.
@@ -150,6 +157,7 @@ Gondolin is a specialized, high-performance microVM hypervisor designed specific
    - Built-in support for directory sharing via `VZVirtioFileSystemDeviceConfiguration` (VirtioFS).
 
 ### 3.2 Guest OS Environment
+
 - **Micro-Kernel**: Minimalist customized Linux 6.x kernel stripped of unnecessary device drivers, ACPI tables, and legacy hardware buses.
 - **Root Filesystem**: Read-only, content-addressed initramfs (~25MB uncompressed) containing:
   - Static `musl`-based coreutils (`busybox` / `toybox`).
@@ -157,7 +165,9 @@ Gondolin is a specialized, high-performance microVM hypervisor designed specific
   - Gondolin Guest Agent: Lightweight daemon listening on `vsock:52000` to receive execution commands, pipe streams, and report lifecycle state.
 
 ### 3.3 Host-Guest VFS Bridge (Virtio-FS)
+
 To allow the agent to execute inside a repository worktree while preserving host-side receipt verification and `git status` checks:
+
 - **Virtio-FS with DAX (Direct Access)**: Guest memory maps file pages directly from the host page cache, avoiding double-caching and reducing memory overhead.
 - **Path Confinement**: Only the specific worktree directory allocated for the run (e.g. `/home/user/.factory/worktrees/WM-130`) is shared into the guest at `/workspace`. Host root and metadata paths (`~/.factory/db`, `~/.config`) are completely invisible.
 - **UID/GID Mapping**: Host user IDs are dynamically mapped to guest `root` or `agent` user (UID 1000) ensuring that files created inside the microVM retain correct ownership on the host.
@@ -169,14 +179,15 @@ To allow the agent to execute inside a repository worktree while preserving host
 To evaluate whether microVM sandboxes meet the responsiveness demands of event-driven automation, we evaluated Gondolin against process spawn and Docker container runtimes on Apple Silicon (M3 Max, 64GB) and Linux (AMD EPYC 7763, 32 vCPU).
 
 ### 4.1 Cold-Start & Teardown Latency
+
 All benchmarks represent mean wall-clock times across 1,000 warm-up runs:
 
-| Sandbox Technology | Cold Start Latency | Snapshot Resume | Clean Teardown | Base RSS Overhead |
-| :--- | :--- | :--- | :--- | :--- |
-| **Host Process Spawn** (`child_process.spawn`) | 12 ms | N/A | 4 ms | ~15 MB |
-| **Docker Container** (`runc` / bridge network) | 680 ms | N/A | 140 ms | ~120 MB |
-| **Gondolin MicroVM** (Direct kernel boot) | **240 ms** | N/A | **18 ms** | **38 MB** |
-| **Gondolin MicroVM** (Snapshot Resume via `madvise`) | **42 ms** | **38 ms** | **18 ms** | **45 MB** |
+| Sandbox Technology                                   | Cold Start Latency | Snapshot Resume | Clean Teardown | Base RSS Overhead |
+| :--------------------------------------------------- | :----------------- | :-------------- | :------------- | :---------------- |
+| **Host Process Spawn** (`child_process.spawn`)       | 12 ms              | N/A             | 4 ms           | ~15 MB            |
+| **Docker Container** (`runc` / bridge network)       | 680 ms             | N/A             | 140 ms         | ~120 MB           |
+| **Gondolin MicroVM** (Direct kernel boot)            | **240 ms**         | N/A             | **18 ms**      | **38 MB**         |
+| **Gondolin MicroVM** (Snapshot Resume via `madvise`) | **42 ms**          | **38 ms**       | **18 ms**      | **45 MB**         |
 
 ```
 Startup Latency Comparison (Lower is Better)
@@ -188,7 +199,9 @@ Docker (runc)      [==================================================] 680ms
 ```
 
 ### 4.2 I/O Throughput (Virtio-FS vs Native Host)
+
 Evaluating build and Git operations inside the `/workspace` mount:
+
 - `git status` on 50,000-file repository:
   - Native Host SSD: **48 ms**
   - Gondolin Virtio-FS (DAX enabled): **56 ms** (~86% native speed)
@@ -199,6 +212,7 @@ Evaluating build and Git operations inside the `/workspace` mount:
   - Standard Network NFS/9P: **28.4 s**
 
 ### 4.3 Conclusion on Performance
+
 Gondolin cold boot overhead (~240ms) represents less than 2.5% of an average 10-second agent run and less than 0.1% of a multi-minute Tier 2 build/verify cycle. With memory snapshot resuming, latency drops to ~42ms, rivaling native process execution while providing true hardware-level isolation.
 
 ---
@@ -206,6 +220,7 @@ Gondolin cold boot overhead (~240ms) represents less than 2.5% of an average 10-
 ## 5. Network Egress Filtering & DNS/TLS Interception
 
 ### 5.1 Architecture: Default-Deny Isolated Network
+
 1. **Network Interface**: Guest microVM is attached to a virtual point-to-point TAP device (`vm-tap0`) on the host.
 2. **Routing Isolation**: No default NAT or routing to host public interfaces is configured in host `iptables`/`pf`. All guest TCP/UDP traffic is forwarded to a local host-side proxy port (`127.0.0.1:8443`).
 3. **DNS Enforcement**: Guest `/etc/resolv.conf` points strictly to the host proxy DNS resolver.
@@ -240,6 +255,7 @@ Gondolin cold boot overhead (~240ms) represents less than 2.5% of an average 10-
 ```
 
 ### 5.2 Declarative Egress Policy Specification
+
 Every agent RunSpec can declare an egress profile:
 
 ```json
@@ -273,15 +289,17 @@ A primary vulnerability in traditional agent worker architectures is injecting r
 Gondolin implements a **Zero-Knowledge Secret Placeholder Architecture**.
 
 ### 6.1 Synthetic Secret Placeholders
+
 When preparing the execution environment for a microVM run, the worker assigns high-entropy, opaque synthetic placeholder tokens instead of real secrets:
 
-| Secret Name | Real Host Value (Host Vault Only) | Guest Environment Variable Value |
-| :--- | :--- | :--- |
-| `LINEAR_API_KEY` | `lin_api_a87f0b2c149d...` | `ph_secret_linear_run_01j5m_9fa810e2` |
-| `GITHUB_TOKEN` | `ghp_Z8b0K2x91aQw...` | `ph_secret_github_run_01j5m_3b71c409` |
-| `ANTHROPIC_API_KEY`| `sk-ant-api03-d92A...` | `ph_secret_anthropic_run_01j5m_e5d16a80` |
+| Secret Name         | Real Host Value (Host Vault Only) | Guest Environment Variable Value         |
+| :------------------ | :-------------------------------- | :--------------------------------------- |
+| `LINEAR_API_KEY`    | `lin_api_a87f0b2c149d...`         | `ph_secret_linear_run_01j5m_9fa810e2`    |
+| `GITHUB_TOKEN`      | `ghp_Z8b0K2x91aQw...`             | `ph_secret_github_run_01j5m_3b71c409`    |
+| `ANTHROPIC_API_KEY` | `sk-ant-api03-d92A...`            | `ph_secret_anthropic_run_01j5m_e5d16a80` |
 
 ### 6.2 Host Proxy Interception Workflow
+
 1. **Binding Context**: The host worker registers the run's placeholder-to-secret mapping in the local memory-locked table of the Host Egress Proxy, bound specifically to the guest's TAP IP and authorized hostnames:
    ```json
    {
@@ -318,20 +336,24 @@ When preparing the execution environment for a microVM run, the worker assigns h
 
 The factory event runtime operates across multiple runner architectures. Below is the compatibility matrix for Gondolin:
 
-| Platform / Environment | Virtualization Technology | Status | Implementation Details & Constraints |
-| :--- | :--- | :--- | :--- |
-| **macOS Apple Silicon** (M1/M2/M3/M4) | `Virtualization.framework` / HVF | **Fully Supported** | Native ARM64 Linux VM execution. Fast boot (<200ms). Requires `com.apple.security.hypervisor` entitlement for development binaries. |
-| **macOS Intel (x86_64)** | `Hypervisor.framework` (HVF) | **Supported** | Functional, but not primary target due to Apple Silicon fleet transition. |
-| **Linux Bare Metal** (x86_64 / arm64) | Linux KVM (`/dev/kvm`) | **Tier-1 Native** | Peak performance. Direct `vhost-vsock` and `virtio-fs` kernel drivers. Fully supported in Hetzner/custom lab nodes. |
-| **Linux Cloud VM** (AWS / GCP / Azure) | Nested KVM (`/dev/kvm`) | **Supported** | Requires instance types with nested virtualization enabled (e.g. AWS `c6i.metal`, GCP `n2-standard` with nested virt). |
-| **GitHub Actions Linux Runners** | Standard KVM | **Restricted / Fallback** | GitHub-hosted standard runners lack `/dev/kvm` access. Must fall back to process-level isolation or self-hosted lab runners. |
+| Platform / Environment                 | Virtualization Technology        | Status                    | Implementation Details & Constraints                                                                                                |
+| :------------------------------------- | :------------------------------- | :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------- |
+| **macOS Apple Silicon** (M1/M2/M3/M4)  | `Virtualization.framework` / HVF | **Fully Supported**       | Native ARM64 Linux VM execution. Fast boot (<200ms). Requires `com.apple.security.hypervisor` entitlement for development binaries. |
+| **macOS Intel (x86_64)**               | `Hypervisor.framework` (HVF)     | **Supported**             | Functional, but not primary target due to Apple Silicon fleet transition.                                                           |
+| **Linux Bare Metal** (x86_64 / arm64)  | Linux KVM (`/dev/kvm`)           | **Tier-1 Native**         | Peak performance. Direct `vhost-vsock` and `virtio-fs` kernel drivers. Fully supported in Hetzner/custom lab nodes.                 |
+| **Linux Cloud VM** (AWS / GCP / Azure) | Nested KVM (`/dev/kvm`)          | **Supported**             | Requires instance types with nested virtualization enabled (e.g. AWS `c6i.metal`, GCP `n2-standard` with nested virt).              |
+| **GitHub Actions Linux Runners**       | Standard KVM                     | **Restricted / Fallback** | GitHub-hosted standard runners lack `/dev/kvm` access. Must fall back to process-level isolation or self-hosted lab runners.        |
 
 ### 7.1 Integration with Worker Placement
+
 Using the existing worker label placement model (`docs/event-runtime-workers.md` §4), workers declare their virtualization capabilities upon startup:
+
 ```bash
 factory work --label node=lab-01 --label arch=arm64 --label sandbox=gondolin --label hypervisor=kvm
 ```
+
 Runs requiring strong isolation specify placement requirements in their agent definition:
+
 ```yaml
 placement:
   sandbox: gondolin
@@ -341,13 +363,13 @@ placement:
 
 ## 8. Architectural Trade-offs & Operational Considerations
 
-| Dimension | Process Runner (Current) | Gondolin MicroVM (Target) | Trade-off Mitigation |
-| :--- | :--- | :--- | :--- |
-| **Startup Overhead** | ~12ms | ~240ms cold / ~42ms warm | Negligible in context of agent LLM inference time; use warm snapshot pool for high-frequency tasks. |
-| **Host Resource Usage** | Base Node RSS (~30MB) | VM Memory Overhead (~40MB RSS) | MicroVM memory is ballooned and released immediately on teardown. |
-| **Tooling & Dependency Distribution** | Inherits host tools (`git`, `node`, `bun`, `gh`) | Must be baked into guest rootfs or mounted via Virtio-FS | Standardize minimal guest image; mount large toolchains (`node_modules`) via Virtio-FS. |
-| **Debugging / Inspectability** | Direct `ps`, `lsof`, `gdb` on host | MicroVM console logs, vsock stream, guest crash dumps | Worker captures vsock console buffer directly into attempt log artifacts (`<home>/artifacts/<sha256>/console.log`). |
-| **Development Ergonomics** | Run immediately on any dev laptop | Requires hypervisor permissions on host OS | Provide automatic fallback to process runner on unprivileged dev environments (`--sandbox=auto`). |
+| Dimension                             | Process Runner (Current)                         | Gondolin MicroVM (Target)                                | Trade-off Mitigation                                                                                                |
+| :------------------------------------ | :----------------------------------------------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| **Startup Overhead**                  | ~12ms                                            | ~240ms cold / ~42ms warm                                 | Negligible in context of agent LLM inference time; use warm snapshot pool for high-frequency tasks.                 |
+| **Host Resource Usage**               | Base Node RSS (~30MB)                            | VM Memory Overhead (~40MB RSS)                           | MicroVM memory is ballooned and released immediately on teardown.                                                   |
+| **Tooling & Dependency Distribution** | Inherits host tools (`git`, `node`, `bun`, `gh`) | Must be baked into guest rootfs or mounted via Virtio-FS | Standardize minimal guest image; mount large toolchains (`node_modules`) via Virtio-FS.                             |
+| **Debugging / Inspectability**        | Direct `ps`, `lsof`, `gdb` on host               | MicroVM console logs, vsock stream, guest crash dumps    | Worker captures vsock console buffer directly into attempt log artifacts (`<home>/artifacts/<sha256>/console.log`). |
+| **Development Ergonomics**            | Run immediately on any dev laptop                | Requires hypervisor permissions on host OS               | Provide automatic fallback to process runner on unprivileged dev environments (`--sandbox=auto`).                   |
 
 ---
 
@@ -393,6 +415,7 @@ We propose a four-phase rollout strategy that delivers immediate security enhanc
 ### Detailed Milestone Breakdown
 
 #### Milestone 1: Host Egress Interceptor & Secret Proxy (WM-131)
+
 - **Goal**: Implement the host-side proxy independent of the hypervisor.
 - **Deliverables**:
   - `lib/sandbox/proxy.mjs`: Lightweight HTTP/CONNECT proxy with SNI inspection.
@@ -400,6 +423,7 @@ We propose a four-phase rollout strategy that delivers immediate security enhanc
   - Unit tests verifying allowlist enforcement and response secret redaction.
 
 #### Milestone 2: Linux KVM Gondolin Worker Runtime (WM-132)
+
 - **Goal**: Functional microVM execution on Linux lab runners.
 - **Deliverables**:
   - `lib/sandbox/gondolin-kvm.mjs`: Process manager launching Gondolin microVMs with KVM flags.
@@ -407,12 +431,14 @@ We propose a four-phase rollout strategy that delivers immediate security enhanc
   - Virtio-FS mount integration linking host worktrees to guest `/workspace`.
 
 #### Milestone 3: Apple Silicon macOS Virtualization Driver (WM-133)
+
 - **Goal**: Native microVM sandboxing on macOS development machines.
 - **Deliverables**:
   - `lib/sandbox/gondolin-vz.mjs`: macOS `Virtualization.framework` wrapper via native helper binary.
   - Local setup documentation and entitlement provisioning.
 
 #### Milestone 4: Placement, Hardening & Production Rollout (WM-134)
+
 - **Goal**: End-to-end integration with the factory worker subsystem.
 - **Deliverables**:
   - `placement` schema updates in `lib/planner.mjs` and worker registration in `lib/workers.mjs`.
@@ -424,6 +450,7 @@ We propose a four-phase rollout strategy that delivers immediate security enhanc
 ## 10. Verification & Quality Gates
 
 The architectural adoption of Gondolin sandboxing will be governed by the following strict quality gates:
+
 1. **Security Invariant**: Zero raw secret strings may appear in guest memory dumps or process tables.
 2. **Latency Invariant**: MicroVM launch to guest command execution start must remain strictly `<500ms` for cold starts and `<100ms` for snapshot restores.
 3. **Filing & Integrity Invariant**: All filesystem mutations produced within guest `/workspace` must be 100% bit-for-bit identical on the host upon attempt completion, passing `git status --porcelain` validation.

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -59,7 +59,7 @@ disagree.
 
 **The claim protocol is the dispatcher's, verbatim.** `tick.mjs` claims by
 writing the assignee and reading it back — Linear has no compare-and-swap, so
-the read-back *is* the concurrency control — and serializes the
+the read-back _is_ the concurrency control — and serializes the
 read-decide-claim window through a machine-local lock file
 (`~/.factory/locks/<repo>.dispatch.lock`), because every local supervisor
 authenticates as the same Linear user (OPS-40) and the read-back cannot tell
@@ -79,7 +79,7 @@ only when the ticket still looks like our claim (In Progress, assigned to us,
 Blocked or In Review keeps that state.
 
 **A recorded asymmetry, not a contradiction.** `tick.mjs` deliberately does
-*not* treat an assignee on a Todo ticket as a gate — with one shared Linear
+_not_ treat an assignee on a Todo ticket as a gate — with one shared Linear
 identity, "has an assignee" is indistinguishable from "was claimed and never
 cleared", and skipping such tickets forever is the reaper's failure to fix,
 not dispatch's to avoid. The event run's rule is stricter: assigned →
@@ -150,12 +150,12 @@ ambiguous glob overlap errs toward collision — a false positive serializes
 two tickets, a false negative puts two agents in one file.
 
 **Collision mode (WM-677).** `config/policy.yaml` `dispatch.owned_paths_collision`
-selects what a collision *does*:
+selects what a collision _does_:
 
-| mode | on overlap | still refuses |
-| --- | --- | --- |
-| `strict` (default when absent) | refuse, `owned_paths_overlap` | — |
-| `advisory` | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | `**` on either side → `owned_paths_conflict_hard` |
+| mode                           | on overlap                                                                                                    | still refuses                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `strict` (default when absent) | refuse, `owned_paths_overlap`                                                                                 | —                                                 |
+| `advisory`                     | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | `**` on either side → `owned_paths_conflict_hard` |
 
 Advisory exists because the strict oracle refuses far more than it protects:
 tickets scope themselves with qualified claims (`views/*.tsx (formatter
@@ -165,7 +165,7 @@ became two running workers under strict, while six textually-overlapping PRs
 rebased onto develop clean the same day. Textual overlap is a rebase job and
 `merge-fix` already does it; the pool should not idle waiting for it. What
 advisory keeps hard is only the `**` sentinel, whose whole meaning is
-"alone". Two tickets naming the *same file* is not hard: same file is not
+"alone". Two tickets naming the _same file_ is not hard: same file is not
 same lines — tickets qualify claims (`App.tsx (interval constants only)`) for
 exactly this — and an identical-file rule tried first refused four tickets in
 one batch on `App.tsx`/`hooks.ts`/`api.mjs`. Merging remains serialized (`concurrency.max_concurrent_merges`),
@@ -237,7 +237,7 @@ and it is the wrong shape three ways:
   `factory.trace/v1` events (assistant text, tool use, usage) and captures
   the transcript as a run artifact; a shelled runner collapses all of that
   into an opaque exit code. No trace, no usage, no transcript artifact, no
-  verified result contract — the run would be *less* observable than a
+  verified result contract — the run would be _less_ observable than a
   read-only status report, on the one run class that mutates code.
 - **Duplicated machinery.** The adapter already owns the timeout discipline
   (TERM, then KILL), subscription auth (strips `ANTHROPIC_API_KEY`,
@@ -291,7 +291,7 @@ event-runtime-workers.md §5), with one permanent exception:
 - **The ship chain's deploy-branch merge is PERMANENTLY `watched`.** That
   watched approval **is** the human master-merge decision — policy.yaml:
   master/main always goes through a human, on every repo. It is not an
-  approval *about* the decision; it is the decision, relocated into the
+  approval _about_ the decision; it is the decision, relocated into the
   runtime's inbox. Because §2's earned-automation ratchet only ever loosens,
   this one must be enforced **structurally (WM-111), not by convention**:
   registry validation fails closed on `approval: auto` for any agent whose

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -52,11 +52,11 @@ Cloning after a run is claimed is the wrong fallback:
 
 The control plane therefore separates three states:
 
-| State | Meaning | Tier-2 claim eligible? |
-| :--- | :--- | :--- |
-| absent | no checkout at the node-resolved path | no |
-| present | a full checkout exists, but readiness is unknown or stale | no |
-| ready | path, identity, auth, lifecycle scripts, toolchain, and repo check have a current attestation | yes |
+| State   | Meaning                                                                                       | Tier-2 claim eligible? |
+| :------ | :-------------------------------------------------------------------------------------------- | :--------------------- |
+| absent  | no checkout at the node-resolved path                                                         | no                     |
+| present | a full checkout exists, but readiness is unknown or stale                                     | no                     |
+| ready   | path, identity, auth, lifecycle scripts, toolchain, and repo check have a current attestation | yes                    |
 
 A node can move from absent to ready without any event run or Linear ticket.
 
@@ -73,7 +73,7 @@ single-node commands and interactive operator checkout:
 ```yaml
 repos:
   - name: factory
-    path: ~/Develop/factory       # local default, not a fleet-wide path
+    path: ~/Develop/factory # local default, not a fleet-wide path
     github: watt-mind/factory
     base: develop
     # worktree_up/down/root, verify, toolchain, etc.
@@ -98,7 +98,7 @@ nodes:
     repos_root: ~/.factory/repos
     repos:
       factory:
-        path: ~/Develop/factory   # use the operator-owned checkout here
+        path: ~/Develop/factory # use the operator-owned checkout here
         managed: false
 ```
 
@@ -483,7 +483,7 @@ Devcontainers were considered and rejected for this design:
 
 - The security boundary is already the Gondolin microVM (WM-185), with
   default-deny egress and secret placeholder substitution. A devcontainer is
-a weaker boundary. Putting both on the hot path creates two isolation models,
+  a weaker boundary. Putting both on the hot path creates two isolation models,
   with the weaker one handling execution.
 - The extra isolation a container offers here is filesystem/branch separation.
   Repo-owned worktree scripts already provide that **plus** the parts Git and

--- a/docs/event-runtime-schedules.md
+++ b/docs/event-runtime-schedules.md
@@ -16,8 +16,8 @@ and audit trail as a webhook.
 
 §3's MVP rules currently forbid the runtime to "enable launchd, cron, or
 another unattended timer", and architecture.md §2.7 keeps every job in
-`config/schedule.yaml` disabled on purpose: *the factory runs in the
-foreground, watched, and when it is not running nothing is running.* That
+`config/schedule.yaml` disabled on purpose: _the factory runs in the
+foreground, watched, and when it is not running nothing is running._ That
 policy exists because the reaper has already demonstrated it can act on 31
 tickets from one bad predicate.
 
@@ -53,7 +53,7 @@ primary runtime scheduler:
 - **A separate scheduler process** — more moving parts for something that is
   one timer and one `admitEvent` call, and a third process to supervise.
 
-The worker is *not* involved: it claims runs, and a scheduled run is an
+The worker is _not_ involved: it claims runs, and a scheduled run is an
 ordinary run. `serve` restarting mid-interval must not lose or duplicate a
 tick, which §3 makes cheap — see slots.
 
@@ -84,11 +84,11 @@ approved tick and a replayed one converge on the same run.
 A laptop asleep from 22:00 to 04:00 misses six hourly slots. There is no
 universally right answer, so each loop declares one:
 
-| `catchUp` | Behaviour | Use for |
-| :--- | :--- | :--- |
+| `catchUp`        | Behaviour                                                       | Use for                                                                                    |
+| :--------------- | :-------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
 | `none` (default) | Fire only the current slot; missed ones are recorded as skipped | Idempotent maintenance — running the reaper once now is equivalent to running it six times |
-| `last` | Fire the most recent missed slot, then resume | Loops where one late run still has value |
-| `all` | Fire every missed slot in order | Anything that accumulates per-interval work; rare, and expensive by construction |
+| `last`           | Fire the most recent missed slot, then resume                   | Loops where one late run still has value                                                   |
+| `all`            | Fire every missed slot in order                                 | Anything that accumulates per-interval work; rare, and expensive by construction           |
 
 The count of skipped slots travels on the tick that did fire
 (`payload.skippedSlots`), and `serve` logs it — so a six-hour gap reads as one
@@ -113,8 +113,8 @@ learns to click approve without reading.
 So each loop declares its policy, and it is **earned**:
 
 ```yaml
-approval: watched        # every tick proposes; the operator approves  (default)
-approval: auto           # the scheduler approves; recorded as such
+approval: watched # every tick proposes; the operator approves  (default)
+approval: auto # the scheduler approves; recorded as such
 ```
 
 Two rules make `auto` safe to have at all:
@@ -149,7 +149,7 @@ adapter, OPS-223), not LLM agents:
 
 This matters for §3's capacity rule: every claude-adapter run draws on the
 same unobservable subscription usage window as interactive sessions, so a
-scheduled *LLM* loop can starve the operator's own work on a timer. A
+scheduled _LLM_ loop can starve the operator's own work on a timer. A
 deterministic loop cannot. **Deterministic-command loops ship first**;
 scheduling an LLM agent is a separate decision with the usage-window question
 answered, not a config edit.
@@ -244,11 +244,11 @@ that is **not** `report_only` (today: `bj29`, `wm-home`, `legalease`,
 `cashsaas` — the dispatch doc's §5 rule keeps report-only repos out), three
 per-repo entries in `schedules.json`:
 
-| Loop | Cadence | Fires | Chain it heads |
-| :--- | :--- | :--- | :--- |
-| `work-<repo>` | `30m` | `factory.work.requested {repo}` | work-scan → dispatch (WM-110/108) |
+| Loop           | Cadence                                 | Fires                            | Chain it heads                                                       |
+| :------------- | :-------------------------------------- | :------------------------------- | :------------------------------------------------------------------- |
+| `work-<repo>`  | `30m`                                   | `factory.work.requested {repo}`  | work-scan → dispatch (WM-110/108)                                    |
 | `merge-<repo>` | `30m` fallback (`merge-factory`: `15m`) | `factory.merge.requested {repo}` | full-set sweep → merge-scan → merge-apply / escalate (WM-109/WM-576) |
-| `ship-<repo>` | `7d` | `factory.ship.requested {repo}` | ship-scan → human-only ship-apply (WM-111) |
+| `ship-<repo>`  | `7d`                                    | `factory.ship.requested {repo}`  | ship-scan → human-only ship-apply (WM-111)                           |
 
 Every entry ships `enabled: false`, `approval: "watched"`, `singleton: true`,
 `catchUp: "none"`. Switching a loop on is a deliberate, per-loop operator act
@@ -291,7 +291,7 @@ Notes, stated rather than absorbed:
 The other half of closing the loop: GitHub deliveries, translated at the
 intake boundary into ordinary `factory.event/v1` envelopes. The design
 decision, made against the code: intake's structure allowed a clean seam
-(option *a* of WM-112), so verification and translation live in
+(option _a_ of WM-112), so verification and translation live in
 `lib/intake.mjs` (`verifyGitHubWebhook`, `translateGitHubEvent`) and only the
 route — `POST /github` — sits in `lib/api.mjs`, because intake has no HTTP
 layer. The factory-envelope path on `POST /events` is byte-for-byte
@@ -316,11 +316,11 @@ unchanged.
 
 **Translations** — minimal and typed; anything else refuses:
 
-| Delivery | Condition | Envelope |
-| :--- | :--- | :--- |
-| `pull_request` | action `opened`/`synchronize`/`ready_for_review`, base ref = the configured repo's `base`, repo not `report_only` | `factory.merge.requested`, subject + payload `{repo}` (short name) |
-| `workflow_run` | action `completed`, conclusion `success`, event `pull_request`, exactly one PR targeting the configured base, repo not `report_only` | `factory.merge.requested`, payload `{repo, prNumbers: [N]}`, idempotent as `merge-pr:<repo>:<pr>:<headSha>` |
-| `workflow_run` | action `completed`, conclusion `failure`, repo configured (`report_only` included) | `github.workflow-run.failed`, subject `ci`, payload `{repo: owner/name slug, runId}` — the existing shape ci-log-capture consumes |
+| Delivery       | Condition                                                                                                                            | Envelope                                                                                                                          |
+| :------------- | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `pull_request` | action `opened`/`synchronize`/`ready_for_review`, base ref = the configured repo's `base`, repo not `report_only`                    | `factory.merge.requested`, subject + payload `{repo}` (short name)                                                                |
+| `workflow_run` | action `completed`, conclusion `success`, event `pull_request`, exactly one PR targeting the configured base, repo not `report_only` | `factory.merge.requested`, payload `{repo, prNumbers: [N]}`, idempotent as `merge-pr:<repo>:<pr>:<headSha>`                       |
+| `workflow_run` | action `completed`, conclusion `failure`, repo configured (`report_only` included)                                                   | `github.workflow-run.failed`, subject `ci`, payload `{repo: owner/name slug, runId}` — the existing shape ci-log-capture consumes |
 
 **Refusal cases**, following intake's typed-refusal conventions:
 
@@ -374,11 +374,11 @@ port 7522 — a demo, never a test dependency), or any watched environment:
    a scan, while the 15-minute full-set sweep catches missed events.
 5. **merge proposal**: merge-scan reviews only the selected PR cold and its MERGE
    verdict chains a head-SHA-pinned `merge-apply` plan into a watched
-   proposal. Approving *that* is the merge.
+   proposal. Approving _that_ is the merge.
 
 Ship is the same shape on a weekly clock, with one permanent difference: the
 `ship-apply` approval is structurally human-only (WM-111) — that watched
-approval *is* the master-merge decision, and no schedule, chain, or earned
+approval _is_ the master-merge decision, and no schedule, chain, or earned
 policy can ever make it `auto`.
 
 ## Merge-loop exception (WM-398)
@@ -397,14 +397,14 @@ remain disabled/watched, and deploy/main/master decisions remain human-only.
 mutating orchestrator script. Each command admits the corresponding typed
 event through `lib/emit-event.mjs`:
 
-| Scheduled stage | Admitted event |
-| :--- | :--- |
-| triage | `factory.triage.requested {repo}` |
-| dispatch | `factory.work.requested {repo}` |
-| merge | `factory.merge.requested {repo}` |
-| unblock | `factory.unblock.requested {repo}` |
+| Scheduled stage           | Admitted event                                                                                     |
+| :------------------------ | :------------------------------------------------------------------------------------------------- |
+| triage                    | `factory.triage.requested {repo}`                                                                  |
+| dispatch                  | `factory.work.requested {repo}`                                                                    |
+| merge                     | `factory.merge.requested {repo}`                                                                   |
+| unblock                   | `factory.unblock.requested {repo}`                                                                 |
 | deterministic maintenance | its registered request type (`label-guard`, `warm`, `reconcile`, `unblock-digest`, `janitor-scan`) |
-| reaper | `clock.tick.reaper` with an explicit loop/slot payload |
+| reaper                    | `clock.tick.reaper` with an explicit loop/slot payload                                             |
 
 The command fails non-zero if the runtime is unreachable or refuses the event.
 Once admitted, planning, approval, adapter execution, output verification, and
@@ -419,12 +419,12 @@ has no equivalent typed event and is tracked separately by WM-684.
 The Factory control repo now has the same explicit four-stage floor as client
 repos. Cadences start conservative, and only the lowest-risk stage is on:
 
-| Loop | Cadence | Enabled | Gate | Runtime effect |
-| :--- | :--- | :--- | :--- | :--- |
-| `factory-triage` | `24h` | **yes** | `queue.mjs --repo factory --gate triage` | watched `factory.triage.requested` proposal when supply is low and Triage can help |
-| `factory-dispatch` | `5m` | no | `queue.mjs --repo factory --gate dispatch` | `factory.work.requested`; work-scan chooses bounded candidates |
-| `factory-merge` | `10m` | no | `queue.mjs --repo factory --gate merge` | `factory.merge.requested`; mutating follow-ups retain their own gates |
-| `factory-reaper` | `60m` | no | none; strict stale-claim predicate inside reaper | watched `clock.tick.reaper` proposal |
+| Loop               | Cadence | Enabled | Gate                                             | Runtime effect                                                                     |
+| :----------------- | :------ | :------ | :----------------------------------------------- | :--------------------------------------------------------------------------------- |
+| `factory-triage`   | `24h`   | **yes** | `queue.mjs --repo factory --gate triage`         | watched `factory.triage.requested` proposal when supply is low and Triage can help |
+| `factory-dispatch` | `5m`    | no      | `queue.mjs --repo factory --gate dispatch`       | `factory.work.requested`; work-scan chooses bounded candidates                     |
+| `factory-merge`    | `10m`   | no      | `queue.mjs --repo factory --gate merge`          | `factory.merge.requested`; mutating follow-ups retain their own gates              |
+| `factory-reaper`   | `60m`   | no      | none; strict stale-claim predicate inside reaper | watched `clock.tick.reaper` proposal                                               |
 
 This is **chain-first, not cron-first**. `work-scan@1` emits
 `factory.triage.requested` on `LOW_SUPPLY`, and promoted triage work returns to

--- a/docs/event-runtime-webui-roadmap.md
+++ b/docs/event-runtime-webui-roadmap.md
@@ -9,82 +9,96 @@ This document specifies the UX/UI product feature roadmap, Linear-inspired desig
 ## 1. Core UI/UX Primitives (Linear-Grade Paradigm)
 
 ### 1.1 View Display Primitives
-* **High-Density List View**: Primary view for high-volume inspection. Sticky headers (`sticky top-0 z-10 bg-(--surface-0)`), tabular monospaced metrics, and single-key keyboard selection (`j`/`k`).
-* **Kanban Board View**: Column-based layout for `Runs` and `Proposals` grouped into state columns (`PROPOSED` → `APPROVED` → `QUEUED` → `RUNNING` → `VERIFYING` → `COMPLETED`/`FAILED`).
-* **Timeline / Gantt View**: Chronological Gantt breakdown showing queue wait times, worker lease durations, and parallel attempt execution.
-* **Detail Inspection Modes**: Master-detail side-by-side split, slide-over sheet drawer, and full-screen focus inspector.
+
+- **High-Density List View**: Primary view for high-volume inspection. Sticky headers (`sticky top-0 z-10 bg-(--surface-0)`), tabular monospaced metrics, and single-key keyboard selection (`j`/`k`).
+- **Kanban Board View**: Column-based layout for `Runs` and `Proposals` grouped into state columns (`PROPOSED` → `APPROVED` → `QUEUED` → `RUNNING` → `VERIFYING` → `COMPLETED`/`FAILED`).
+- **Timeline / Gantt View**: Chronological Gantt breakdown showing queue wait times, worker lease durations, and parallel attempt execution.
+- **Detail Inspection Modes**: Master-detail side-by-side split, slide-over sheet drawer, and full-screen focus inspector.
 
 ### 1.2 Grouping & Aggregation Primitives
+
 Operators can dynamically group any view by:
-* **Group by Status**: Group runs into state buckets (Running, Failed, Completed).
-* **Group by Agent**: Cluster proposals and runs by target agent (`factory-status-report`, `factory-triage`).
-* **Group by Intake Source**: Group by origin (`replay-cli`, `webhook:linear`, `webhook:github`).
-* **Group by Adapter**: Separate rows/columns by `claude` (real) vs `fake` (test/demo).
-* **Group by Date/Time**: Bucket into `Today`, `Yesterday`, `This Week`.
+
+- **Group by Status**: Group runs into state buckets (Running, Failed, Completed).
+- **Group by Agent**: Cluster proposals and runs by target agent (`factory-status-report`, `factory-triage`).
+- **Group by Intake Source**: Group by origin (`replay-cli`, `webhook:linear`, `webhook:github`).
+- **Group by Adapter**: Separate rows/columns by `claude` (real) vs `fake` (test/demo).
+- **Group by Date/Time**: Bucket into `Today`, `Yesterday`, `This Week`.
 
 ### 1.3 Filter Engine & Saved Views
-* **Structured Query Bar**: Dropdown chips for multi-attribute queries (e.g. `status:failed agent:factory-status-report adapter:claude created:>1h`).
-* **Context tabs (OPS-356)**: All / In flight / a factory-repo *filter* above the inverted-L. Not a container for agents; unscoped work stays in All. Pin-a-run document tabs are OPS-357.
-* **Saved Views (Bookmarks)**: Custom view tabs saved in top bar or sidebar bookmarks:
-  * *"Failed Runs Today"* (`status:failed created:>24h`)
-  * *"Pending Approvals"* (`status:open decision:run`)
-  * *"Dead-Lettered Webhooks"* (`status:dead_lettered`)
+
+- **Structured Query Bar**: Dropdown chips for multi-attribute queries (e.g. `status:failed agent:factory-status-report adapter:claude created:>1h`).
+- **Context tabs (OPS-356)**: All / In flight / a factory-repo _filter_ above the inverted-L. Not a container for agents; unscoped work stays in All. Pin-a-run document tabs are OPS-357.
+- **Saved Views (Bookmarks)**: Custom view tabs saved in top bar or sidebar bookmarks:
+  - _"Failed Runs Today"_ (`status:failed created:>24h`)
+  - _"Pending Approvals"_ (`status:open decision:run`)
+  - _"Dead-Lettered Webhooks"_ (`status:dead_lettered`)
 
 ### 1.4 Multi-Select & Bulk Action Primitives
-* **Selection Controls**: Table checkboxes, `Shift + Click` range selection, and `⌘A` select all visible rows.
-* **Floating Bulk Action Bar**: Bottom action bar appearing when items are selected (`[ Approve Selected (3) ]`, `[ Reject Selected (3) ]`, `[ Bulk Requeue ]`, `[ Bulk Cancel ]`).
+
+- **Selection Controls**: Table checkboxes, `Shift + Click` range selection, and `⌘A` select all visible rows.
+- **Floating Bulk Action Bar**: Bottom action bar appearing when items are selected (`[ Approve Selected (3) ]`, `[ Reject Selected (3) ]`, `[ Bulk Requeue ]`, `[ Bulk Cancel ]`).
 
 ### 1.5 Display Preferences Popover ("Display" Menu)
-* **Density Controls**: `Compact` (28px row height) vs `Comfortable` (36px row height).
-* **Column Visibility Toggles**: Custom show/hide toggles for optional metadata (Workspace Path, Spec Hash, Idempotency Key, Durations).
-* **Order & Sorting**: Ascending/descending sorting by `Created At`, `Updated At`, `Duration`, `Attempts`, `TTL`.
+
+- **Density Controls**: `Compact` (28px row height) vs `Comfortable` (36px row height).
+- **Column Visibility Toggles**: Custom show/hide toggles for optional metadata (Workspace Path, Spec Hash, Idempotency Key, Durations).
+- **Order & Sorting**: Ascending/descending sorting by `Created At`, `Updated At`, `Duration`, `Attempts`, `TTL`.
 
 ### 1.6 Micro-Interaction Primitives
-* **Contextual Right-Click Menus**: Custom right-click menu on table rows (`Approve`, `Reject`, `Requeue`, `Copy ID`, `Copy Spec Hash`).
-* **Breadcrumb Navigation**: Path breadcrumbs in top header (`Factory / Runs / run_48acf867 / Attempt #1`).
-* **Copy-to-Clipboard & Toasts**: Top-right copy buttons on all code/JSON blocks with non-intrusive bottom-right toast feedback.
+
+- **Contextual Right-Click Menus**: Custom right-click menu on table rows (`Approve`, `Reject`, `Requeue`, `Copy ID`, `Copy Spec Hash`).
+- **Breadcrumb Navigation**: Path breadcrumbs in top header (`Factory / Runs / run_48acf867 / Attempt #1`).
+- **Copy-to-Clipboard & Toasts**: Top-right copy buttons on all code/JSON blocks with non-intrusive bottom-right toast feedback.
 
 ---
 
 ## 2. Module Feature Roadmap
 
 ### 2.1 Executive Dashboard & Operations Center (`/overview`)
-* Real-time stat grid (events, proposals, runs, and `workers.{live,busy,stale}` from `GET /status` — shipped OPS-267, each tile a jump to `/workers` (§2.7)).
-* Doctor anomaly resolution panel (dead letters, stale leases, prompt hash drift, stalled workers still holding a run, no live worker for queued runs).
-* Append-only live activity journal (`GET /journal?since=<seq>`).
-* Published outbox result stream (`factory.agent-result/v1`).
+
+- Real-time stat grid (events, proposals, runs, and `workers.{live,busy,stale}` from `GET /status` — shipped OPS-267, each tile a jump to `/workers` (§2.7)).
+- Doctor anomaly resolution panel (dead letters, stale leases, prompt hash drift, stalled workers still holding a run, no live worker for queued runs).
+- Append-only live activity journal (`GET /journal?since=<seq>`).
+- Published outbox result stream (`factory.agent-result/v1`).
 
 ### 2.2 Watched Approval Engine (`/proposals`)
-* Live TTL countdown timers (`m:ss`).
-* Immutable `RunSpec` JSON inspector & capability risk badges (`filesystem:write`, `network:egress`).
-* Line-by-line red/green spec diff (`SpecDiff.tsx`) when approving expired re-planned proposals.
-* Decision audit history (`/proposals?status=all`).
+
+- Live TTL countdown timers (`m:ss`).
+- Immutable `RunSpec` JSON inspector & capability risk badges (`filesystem:write`, `network:egress`).
+- Line-by-line red/green spec diff (`SpecDiff.tsx`) when approving expired re-planned proposals.
+- Decision audit history (`/proposals?status=all`).
 
 ### 2.3 Run Diagnostics & Execution Timeline (`/runs`)
-* Lifecycle FSM state filtering tabs.
-* Timestamped vertical lifecycle timeline (`seq`, `from` → `to`, `actor`, `reason_code`).
-* Attempt metrics & workspace path inspector.
-* Cryptographic receipts and declared evidence retention (`evidence` payload).
-* Guarded operator verbs (Cancel run with reason, Retry / Force-Retry past attempt budgets).
+
+- Lifecycle FSM state filtering tabs.
+- Timestamped vertical lifecycle timeline (`seq`, `from` → `to`, `actor`, `reason_code`).
+- Attempt metrics & workspace path inspector.
+- Cryptographic receipts and declared evidence retention (`evidence` payload).
+- Guarded operator verbs (Cancel run with reason, Retry / Force-Retry past attempt budgets).
 
 ### 2.4 Event Intake & Replay Engine (`/events`)
-* Status-filtered event inbox (`admitted`, `planned`, `noop`, `human_needed`, `dead_lettered`).
-* Envelope raw JSON inspector.
-* Planning failure error formatting (`planFailures` counter + `lastPlanError`).
-* Requeue (`q`) and Replay verbs (HMAC deduplication testing).
+
+- Status-filtered event inbox (`admitted`, `planned`, `noop`, `human_needed`, `dead_lettered`).
+- Envelope raw JSON inspector.
+- Planning failure error formatting (`planFailures` counter + `lastPlanError`).
+- Requeue (`q`) and Replay verbs (HMAC deduplication testing).
 
 ### 2.5 Agent Registry & Sandbox (`/agents`)
-* Definition cards & output contract types.
-* Monospace prompt viewer & content-hash pin audit table (`promptFile` → `sha256`).
-* JSON schema visualizers (input/output).
-* Event routing matrix.
+
+- Definition cards & output contract types.
+- Monospace prompt viewer & content-hash pin audit table (`promptFile` → `sha256`).
+- JSON schema visualizers (input/output).
+- Event routing matrix.
 
 ### 2.6 Artifact & Transcript Viewer (`/artifacts`)
-* Content-addressed file browser (`/api/artifacts/:sha256`).
-* In-browser transcript viewer (`transcript.jsonl`).
+
+- Content-addressed file browser (`/api/artifacts/:sha256`).
+- In-browser transcript viewer (`transcript.jsonl`).
 
 ### 2.7 Worker Fleet & Placement (`/workers`) — shipped
-* Registry list from `GET /workers`: host, pid, health, placement labels, adapters, current run, heartbeat age.
-* Heartbeat as the lie detector: `stale` outranks the worker's own `busy`/`idle` report (90 s window), and the nav badge flips from the busy count to the stale count.
-* Detail inspector: process identity, declared adapters, placement labels; jump to the held run (`#/runs/:id`).
-* Shipped since: Overview worker tiles and doctor stalled/no-worker anomalies (OPS-267), and `lease_owner` → worker jumps from a run's attempts and lifecycle actors (OPS-268).
+
+- Registry list from `GET /workers`: host, pid, health, placement labels, adapters, current run, heartbeat age.
+- Heartbeat as the lie detector: `stale` outranks the worker's own `busy`/`idle` report (90 s window), and the nav badge flips from the busy count to the stale count.
+- Detail inspector: process identity, declared adapters, placement labels; jump to the held run (`#/runs/:id`).
+- Shipped since: Overview worker tiles and doctor stalled/no-worker anomalies (OPS-267), and `lease_owner` → worker jumps from a run's attempts and lifecycle actors (OPS-268).

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -319,15 +319,15 @@ no shared set. Every rule below is checkable in review.
    icons. If a word fits in the space, no glyph and no icon.
 2. **Approved unicode glyphs.** A _closed_ set, each with exactly one meaning:
 
-   | Glyph     | Meaning                     | Where                                            |
-   | --------- | --------------------------- | ------------------------------------------------ |
-   | `▶`       | collapse/expand chevron     | `GroupHeaderRow` only — 9px, `rotate-90` on open |
+   | Glyph     | Meaning                     | Where                                                               |
+   | --------- | --------------------------- | ------------------------------------------------------------------- |
+   | `▶`       | collapse/expand chevron     | `GroupHeaderRow` only — 9px, `rotate-90` on open                    |
    | `→`       | transition / direction      | lifecycle spans (`QUEUED → RUNNING`), feed transitions, sort orders |
-   | `×`       | dismiss/remove this item    | chips and tokens only — never "failed"           |
-   | `↑` / `↓` | sort direction              | `Th` header cells only                           |
-   | `·`       | inline metadata separator   | footer/status lines                              |
-   | `…`       | truncation / "more follows" | labels, placeholders (`add…`), loading copy      |
-   | `⌘` etc.  | keyboard hints              | inside `<kbd>` or `.mono` spans only             |
+   | `×`       | dismiss/remove this item    | chips and tokens only — never "failed"                              |
+   | `↑` / `↓` | sort direction              | `Th` header cells only                                              |
+   | `·`       | inline metadata separator   | footer/status lines                                                 |
+   | `…`       | truncation / "more follows" | labels, placeholders (`add…`), loading copy                         |
+   | `⌘` etc.  | keyboard hints              | inside `<kbd>` or `.mono` spans only                                |
 
    Rules: always `aria-hidden` (the control carries the accessible name);
    never a glyph as the _only_ content of an interactive element without
@@ -349,7 +349,7 @@ no shared set. Every rule below is checkable in review.
    timeout, adapter, capabilities of a definition. Radix Icons is the one
    sanctioned package — 15×15 viewBox, ~1px optical weight, `currentColor`,
    tree-shaken per-icon imports (`import { TimerIcon } from
-   "@radix-ui/react-icons"`). Rendered at **14px** (`size-3.5`) next to
+"@radix-ui/react-icons"`). Rendered at **14px** (`size-3.5`) next to
    12–13px body text — the 15-grid glyph at 14px sits at the label's own
    optical weight, which is the point: it must not out-shout the word. Rules:
 
@@ -366,39 +366,40 @@ no shared set. Every rule below is checkable in review.
      by construction (WM-483). Views do not pass `icon=` themselves except to
      override deliberately. Current map:
 
-     | Glyph              | Attribute(s)                                                        |
-     | ------------------ | ------------------------------------------------------------------- |
-     | `PersonIcon`       | agent, decided by                                                   |
-     | `Component1Icon`   | adapter                                                             |
-     | `Pencil1Icon`      | mutating                                                            |
-     | `CubeIcon`         | workspace                                                           |
-     | `LockClosedIcon`   | capabilities                                                        |
-     | `DesktopIcon`      | host, hosts                                                         |
-     | `CodeIcon`         | command                                                             |
-     | `ListBulletIcon`   | actionRegistry                                                      |
-     | `PlayIcon`         | execution, execution mode                                           |
-     | `SewingPinIcon`    | placement                                                           |
-     | `GearIcon`         | worker (the entity; `workerId` is an id and stays unmapped)          |
-     | `TargetIcon`       | target                                                              |
-     | `LightningBoltIcon`| model tier                                                          |
-     | `Crosshair2Icon`   | model, model override, model (pinned) — an exact model id           |
-     | `EyeOpenIcon`      | model (observed)                                                    |
-     | `TimerIcon`        | timeout                                                             |
-     | `ReloadIcon`       | attempts                                                            |
-     | `LapTimerIcon`     | ttl, proposal ttl, cadence — an interval, not a moment              |
-     | `FileTextIcon`     | input, input.*                                                      |
-     | `PaperPlaneIcon`   | origin event, event type, type, planned/admitted events             |
-     | `EnterIcon`        | source — where an event came in from; distinct from its type        |
-     | `ChatBubbleIcon`   | reason, proposal reason, planner reason                             |
-     | `CheckCircledIcon` | approval                                                            |
-     | `ClockIcon`        | created, updated, occurredAt, receivedAt, admittedAt, startedAt, stoppedAt, decided at, last fire, last completed, next due — a moment |
-     | `LoopIcon`         | loop, loop name                                                     |
-     | `UpdateIcon`       | catch-up                                                            |
-     | `ArchiveIcon`      | repository                                                          |
-     | `GitHubLogoIcon`   | GitHub                                                              |
-     | `CommitIcon`       | base branch, deploy branch                                          |
+     | Glyph               | Attribute(s)                                                                                                                           |
+     | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+     | `PersonIcon`        | agent, decided by                                                                                                                      |
+     | `Component1Icon`    | adapter                                                                                                                                |
+     | `Pencil1Icon`       | mutating                                                                                                                               |
+     | `CubeIcon`          | workspace                                                                                                                              |
+     | `LockClosedIcon`    | capabilities                                                                                                                           |
+     | `DesktopIcon`       | host, hosts                                                                                                                            |
+     | `CodeIcon`          | command                                                                                                                                |
+     | `ListBulletIcon`    | actionRegistry                                                                                                                         |
+     | `PlayIcon`          | execution, execution mode                                                                                                              |
+     | `SewingPinIcon`     | placement                                                                                                                              |
+     | `GearIcon`          | worker (the entity; `workerId` is an id and stays unmapped)                                                                            |
+     | `TargetIcon`        | target                                                                                                                                 |
+     | `LightningBoltIcon` | model tier                                                                                                                             |
+     | `Crosshair2Icon`    | model, model override, model (pinned) — an exact model id                                                                              |
+     | `EyeOpenIcon`       | model (observed)                                                                                                                       |
+     | `TimerIcon`         | timeout                                                                                                                                |
+     | `ReloadIcon`        | attempts                                                                                                                               |
+     | `LapTimerIcon`      | ttl, proposal ttl, cadence — an interval, not a moment                                                                                 |
+     | `FileTextIcon`      | input, input.*                                                                                                                         |
+     | `PaperPlaneIcon`    | origin event, event type, type, planned/admitted events                                                                                |
+     | `EnterIcon`         | source — where an event came in from; distinct from its type                                                                           |
+     | `ChatBubbleIcon`    | reason, proposal reason, planner reason                                                                                                |
+     | `CheckCircledIcon`  | approval                                                                                                                               |
+     | `ClockIcon`         | created, updated, occurredAt, receivedAt, admittedAt, startedAt, stoppedAt, decided at, last fire, last completed, next due — a moment |
+     | `LoopIcon`          | loop, loop name                                                                                                                        |
+     | `UpdateIcon`        | catch-up                                                                                                                               |
+     | `ArchiveIcon`       | repository                                                                                                                             |
+     | `GitHubLogoIcon`    | GitHub                                                                                                                                 |
+     | `CommitIcon`        | base branch, deploy branch                                                                                                             |
 
      Add to this table in the same PR that adds the registry row.
+
    - Identity rows (`id`, `run`, `version`, hashes, keys, contract) and
      state rows (`state`, `status`, `decision` — those carry a `StateBadge`)
      are **not** in the registry. Inside an iconed section they get an empty
@@ -457,15 +458,15 @@ no shared set. Every rule below is checkable in review.
 Where an icon or glyph may sit, relative to the text it belongs to. Anything
 not in this table is not a placement.
 
-| Context                    | Position                  | Rule                                                                                                           |
-| -------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| State badge / status label | leading, `gap-1.5`        | Icon then word. Never trailing, never alone.                                                                   |
-| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. `<Section icons>` opts a section in; every row then resolves from `attrIcons.tsx` by label and unmapped rows keep an empty slot. |
-| Button                     | leading only              | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                     |
-| Table cell                 | leading, baseline-aligned | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it. |
-| Section / group header     | between chevron and label | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                          |
-| Nav rail                   | none                      | Text-only until the rail outgrows its labels; a leading icon column is the _only_ shape it may take then.      |
-| Keyboard hint              | trailing                  | Style depends on container — see "Keyboard hints" under §5.3. Never inline in prose.                           |
+| Context                     | Position                  | Rule                                                                                                                                                                                |
+| --------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| State badge / status label  | leading, `gap-1.5`        | Icon then word. Never trailing, never alone.                                                                                                                                        |
+| `KV` label (attribute icon) | leading, `gap-1.5`        | Icon then label, in the label column, label color. `<Section icons>` opts a section in; every row then resolves from `attrIcons.tsx` by label and unmapped rows keep an empty slot. |
+| Button                      | leading only              | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                                                                                          |
+| Table cell                  | leading, baseline-aligned | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it.                                                                      |
+| Section / group header      | between chevron and label | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                                                                                               |
+| Nav rail                    | none                      | Text-only until the rail outgrows its labels; a leading icon column is the _only_ shape it may take then.                                                                           |
+| Keyboard hint               | trailing                  | Style depends on container — see "Keyboard hints" under §5.3. Never inline in prose.                                                                                                |
 
 Icons and glyphs sit **on the text baseline** and take the text color of
 their label (`currentColor`); an icon lighter or brighter than its own label
@@ -475,11 +476,11 @@ is a bug.
 
 Icon size follows the type size next to it — it is never set independently:
 
-| Text size        | Icon | Where                                            |
-| ---------------- | ---- | ------------------------------------------------ |
-| 11px (badges)    | 12px | `StateBadge`, table cells, chips                 |
+| Text size        | Icon | Where                                                                                        |
+| ---------------- | ---- | -------------------------------------------------------------------------------------------- |
+| 11px (badges)    | 12px | `StateBadge`, table cells, chips                                                             |
 | 12–13px (body)   | 14px | Default. Buttons, list rows, KV labels and values (Radix attribute icons render at 14px too) |
-| 14–15px (titles) | 16px | `DetailPane` title, `Dialog` title, empty states |
+| 14–15px (titles) | 16px | `DetailPane` title, `Dialog` title, empty states                                             |
 
 Chevrons and sort arrows are the exception: 9px, because they are affordance
 punctuation, not content.
@@ -648,13 +649,13 @@ under the buttons (404/409 are normal, §6), never as a toast alone.
 Visible shortcuts use two idioms; compact utility and standard dismiss
 controls deliberately avoid another piece of visible text:
 
-| Control or surface                                                                                         | Shortcut treatment                                                     | Why                                                                                             |
-| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Bordered, text-labeled control — especially an action `Button`, nav item, tab, or chip                    | trailing faint mono text: `mono ml-1 text-(--text-faint)`              | a box inside a box is noise; the control's border is already the container                      |
-| Standalone or unbordered surface — input placeholder, ⌘K row, `?` dialog, footer legend                   | visible `<kbd>` box, 10px, `border-(--border)`                         | there is no container, so the box supplies one                                                  |
-| Compact icon-only utility control — specifically `CopyActions` (WM-302)                                   | no visible text hint; put the chord in both `title` and `aria-label`   | labels or badges would turn a compact utility row back into a competing action toolbar          |
-| Standard dismiss / close control                                                                          | no `Esc` badge                                                         | `Esc` is the global, standard dismissal path; the text label and accessible name remain `Close` |
-| Prose or body copy                                                                                         | never                                                                  | a shortcut is surfaced by its control or callout, not described in surrounding prose            |
+| Control or surface                                                                      | Shortcut treatment                                                   | Why                                                                                             |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Bordered, text-labeled control — especially an action `Button`, nav item, tab, or chip  | trailing faint mono text: `mono ml-1 text-(--text-faint)`            | a box inside a box is noise; the control's border is already the container                      |
+| Standalone or unbordered surface — input placeholder, ⌘K row, `?` dialog, footer legend | visible `<kbd>` box, 10px, `border-(--border)`                       | there is no container, so the box supplies one                                                  |
+| Compact icon-only utility control — specifically `CopyActions` (WM-302)                 | no visible text hint; put the chord in both `title` and `aria-label` | labels or badges would turn a compact utility row back into a competing action toolbar          |
+| Standard dismiss / close control                                                        | no `Esc` badge                                                       | `Esc` is the global, standard dismissal path; the text label and accessible name remain `Close` |
+| Prose or body copy                                                                      | never                                                                | a shortcut is surfaced by its control or callout, not described in surrounding prose            |
 
 For a bordered text control, the visible hint is `aria-hidden` (the accessible
 name is "Cancel", not "Cancel x"). For an icon-only `CopyActions` control,
@@ -1335,7 +1336,7 @@ and read by the UI, exactly as the agent registry is in §10.6.
 ### 10.15 Chain trace (`#/chain/:correlationId`) — WM-527
 
 The Graph (§10.13) answers "what can happen"; the chain trace answers "what
-happened to *this* one, and where did it start". A chain instance is stitched
+happened to _this_ one, and where did it start". A chain instance is stitched
 by two ids the emitter writes on every hop (`lib/chain.mjs`): `correlationId`,
 inherited unchanged from the origin event (falling back to the origin's own
 `eventId` when it carried none), and `causationId`, the run id that produced
@@ -1358,7 +1359,7 @@ layer spacing because chains are long and thin.
 - **Same chrome as the map.** `j`/`k` (and arrows) walk nodes in reading
   order, `z` / **Show on canvas** pans the selection into view, `Esc` closes,
   **Reset layout** re-runs elk. The panel links out to Events, Runs, the run
-  page, Proposals and Agents, and to the parent run / origin event *inside*
+  page, Proposals and Agents, and to the parent run / origin event _inside_
   the chain. Positions are reused across the 3 s poll while node/edge
   identity is unchanged (§10.13's identity rule).
 

--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -41,7 +41,7 @@ The smallest real step, and a prerequisite for everything after:
   already supports multiple processes on one machine — what it needed was
   `BEGIN IMMEDIATE` on the claim (the default deferred transaction lets two
   workers read the same QUEUED row before either writes) and `busy_timeout`
-  set *before* `journal_mode`, or a second process opening the database
+  set _before_ `journal_mode`, or a second process opening the database
   fails with `SQLITE_BUSY_RECOVERY`. The old plan made Postgres with
   `FOR UPDATE SKIP LOCKED` the remote-node requirement. WM-308 supersedes it:
   SQLite remains private to the control plane, and remote claims cross the
@@ -50,7 +50,7 @@ The smallest real step, and a prerequisite for everything after:
   already contains: claim → workspace → adapter → verify → fenced publish.
   `serve` keeps API, planner, approval, outbox, and the reaper, and no longer
   executes (`--with-worker` restores the all-in-one for a quick demo).
-- **Worker registry and heartbeats.** Leases prove an *attempt* is held; the
+- **Worker registry and heartbeats.** Leases prove an _attempt_ is held; the
   registry answers which processes are alive, where, and with what labels —
   the difference between "busy on a long run" and "died holding a lease".
   The heartbeat runs on its own timer, never inside the claim loop, because
@@ -76,7 +76,7 @@ processes and remembered to stop them. `cli.mjs supervise` makes it a
 deterministic function of observed queue depth.
 
 The insight that shapes the whole design: **idle workers are nearly free.**
-An idle worker costs a poll every 500ms and a heartbeat every 15s. A *busy*
+An idle worker costs a poll every 500ms and a heartbeat every 15s. A _busy_
 one costs a worktree and an LLM subprocess, and draws on a shared
 subscription usage window nothing here can observe (§3, and event-runtime.md
 §3's open problem). So the supervisor spends the cheap resource — process
@@ -86,7 +86,7 @@ real ceiling on concurrent agent runs on that machine.
 - **Its own process, not part of `serve`.** Decisions and execution stay
   separated; restarting the control plane must not kill capacity. Because
   workers are spawned detached with their own pidfiles, a supervisor that
-  restarts *adopts* the running pool rather than replacing it. launchd
+  restarts _adopts_ the running pool rather than replacing it. launchd
   (WM-139) supervises `serve` and the supervisor; the supervisor supervises
   workers.
 - **Deterministic, from config, never model-driven.** The rule is a pure
@@ -101,7 +101,7 @@ real ceiling on concurrent agent runs on that machine.
 - **Scale-down is a request, never a signal.** The supervisor writes
   `worker-N.drain` in the run dir; `work --drain-file` reads it at its **idle
   poll boundary only** — the same place WM-213's code-stamp check lives, and
-  for the same reason. A worker holding a lease finishes its run and *then*
+  for the same reason. A worker holding a lease finishes its run and _then_
   exits 0. The supervisor never sends a signal to a worker it is merely
   shrinking, so "no leased worker is ever killed" is a structural property,
   not a race it usually wins.
@@ -118,7 +118,7 @@ real ceiling on concurrent agent runs on that machine.
   Holds are logged only when the reason changes.
 - **Visible in status/doctor.** `status` grows a `pool` line (supervisor
   liveness, pool size, how many are draining), and a queue with waiting runs
-  behind a *dead* supervisor is an anomaly — nothing is left that can grow
+  behind a _dead_ supervisor is an anomaly — nothing is left that can grow
   the pool. Read from the run dir rather than the control API, because
   pidfile liveness is node-local state the API cannot see.
 
@@ -263,7 +263,7 @@ the whole mechanism:
   process, bin-packing layer, or second coordinator.
 
 Slice 2 is the motivating case: `keephq.disk-alert.raised` remediation must
-execute *on the affected host*. Labels also encode the quota split cleanly:
+execute _on the affected host_. Labels also encode the quota split cleanly:
 `adapter=claude` workers are capped hard; `can=infra-exec` deterministic
 executors (closed action registry, no model) can scale per node with zero
 usage-window risk.
@@ -287,7 +287,7 @@ that answer "can agent A trigger agent B":
   upstream unlocks downstreams. Slice 2's diagnose → remediate pair is the
   first two-node chain.
 - **"Agent A identifies that agent B should work"** — the discovered chain —
-  is a *typed recommendation in A's output contract*, not an action A takes:
+  is a _typed recommendation in A's output contract_, not an action A takes:
   A's artifact carries e.g. `recommendedFollowUp: { type: "...", input: … }`
   drawn from a closed set its schema allows. The result event re-enters the
   planner; the planner (registered mapping, never the model) turns it into a
@@ -312,7 +312,7 @@ First use case: **shipped (OPS-223)** — the CI failure doctor: `github.workflo
 
 ## 5a. Repository access: tier 1 shipped, tier 2 held (OPS-228/OPS-229)
 
-Agents that need a repo split cleanly by whether they *read* code or *build*
+Agents that need a repo split cleanly by whether they _read_ code or _build_
 it, and only the second half is expensive.
 
 **Tier 1 — read-only pinned checkout (shipped).** A bare mirror per repo under
@@ -389,7 +389,7 @@ stand as the rules that design satisfies:
    (`config/policy.yaml`) on observed queue depth; `poolDecision` /
    `poolCounts` / `loadWorkerPolicy` in `lib/workers.mjs`, drain-file
    scale-down honoured at the worker's idle poll boundary (`work
-   --drain-file`), `factory up --workers min:max`, pool liveness in
+--drain-file`), `factory up --workers min:max`, pool liveness in
    status/doctor. Weight-class caps (`heavy`/`light`, item 4's machinery) and
    the budget-aware ceiling (blocked on WM-66) are the explicit follow-ups.
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -961,8 +961,8 @@ lifecycle transitions with the operator as actor:
   for a fixed _event body_; requeue is for a fixed _world_ — after a registry
   or planner fix, the stored event is fine and only the decision was wrong.
 - **decide** — answer an inbox item's hash-bound request through `POST
-  /inbox/:id/decide`; retry a stored response's failed effect through `POST
-  /inbox/:id/decide/retry` without asking for the fields again.
+/inbox/:id/decide`; retry a stored response's failed effect through `POST
+/inbox/:id/decide/retry` without asking for the fields again.
 
 **Dead-lettering.** An event that fails planning repeatedly (default: 3
 attempts) parks as dead-lettered with its last error, visible in status and

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -28,7 +28,7 @@ A fixed sleep is a guess: too long wastes wall clock in a process holding a conc
 
 **Fix:** rule added to `shared/floor.md` (§Waiting). Verified `--watch`, `--fail-fast` and `-i` exist in gh 2.97. factory-ticket.md documents that sleep-polling is blocked by the harness (a blocked tool call kills the run).
 
-**Status:** fixed in the floor + harness block — if sleeps persist in *new* transcripts after Aug 2026, the next step is a `scripts/wait-for-ci.sh` wrapper agents must call.
+**Status:** fixed in the floor + harness block — if sleeps persist in _new_ transcripts after Aug 2026, the next step is a `scripts/wait-for-ci.sh` wrapper agents must call.
 
 ### F-9 · Fixed sleeps waiting for dev servers to boot
 
@@ -44,7 +44,7 @@ Same shape as F-8 but for local processes, and the guess is worse: boot time var
 
 **Seen:** agy triage, `status: ERROR / "timeout waiting for response"` at 231s — its 5-minute print default, 68 tool calls in, cut off mid-summary. Work completed; report lost.
 
-Raising `--print-timeout` alone would trade a short hang for a long one: a wedged run holds its slot for whatever the new timeout is. Two different jobs — the harness timeout should error *cleanly*, the factory timeout should *guarantee the slot frees*.
+Raising `--print-timeout` alone would trade a short hang for a long one: a wedged run holds its slot for whatever the new timeout is. Two different jobs — the harness timeout should error _cleanly_, the factory timeout should _guarantee the slot frees_.
 
 **Fix:** `limits.max_run_minutes` (45) in `policy.yaml`, enforced with `timeout -k 30s` in both `run-agent.sh` and `tick.mjs`; the harness timeout is set two minutes below it so it reports first. **Status: fixed.**
 
@@ -110,7 +110,7 @@ Runs were billed per token instead of drawing on the subscription, and claude.ai
 
 ### F-7 · `Owned Paths` in fenced code blocks parsed as empty — `fixed`
 
-A correctly specced ticket was undispatchable because the parser only read bullet lists. It now accepts bullets, fenced blocks and indented code. This one is worth remembering as a *shape*: a strict parser silently turning good input into no input looks like an upstream failure, not a parser bug.
+A correctly specced ticket was undispatchable because the parser only read bullet lists. It now accepts bullets, fenced blocks and indented code. This one is worth remembering as a _shape_: a strict parser silently turning good input into no input looks like an upstream failure, not a parser bug.
 
 ---
 

--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -13,7 +13,7 @@ container every agent must live in, and not a replacement for the nav rail.
   It is the home for anything that is not a `repos.yaml` project: unscoped
   runs, registry agents, workers, the graph, inject.
 - **A factory repo tab** filters Events / Proposals / Runs (and Overview
-  lists that can be filtered honestly) to rows whose spec or envelope *names*
+  lists that can be filtered honestly) to rows whose spec or envelope _names_
   that repo. It does not remount a different app. A run's repo is optional
   input (`repoPin.repo` / `input.repo` / `input.repos[]`), not a foreign key.
 - **In flight** is a query tab, not a fake repo: Runs in `LEASED` or
@@ -31,8 +31,8 @@ container every agent must live in, and not a replacement for the nav rail.
 - `g e` / `g r` / `j`/`k` / Esc stay inside the current context. Do not steal
   `[` / `]` (status tabs). One poller; background tabs restore a filter on
   focus, they are not keep-alive iframes.
-- The Projects *view* (OPS-300) is a list of the registry, including janitor
-  later. Context tabs *use* `GET /repos`; they do not replace that view.
+- The Projects _view_ (OPS-300) is a list of the registry, including janitor
+  later. Context tabs _use_ `GET /repos`; they do not replace that view.
 - Pinning a specific run as a document tab on the same strip is OPS-357
   (v2) — not this decision.
 

--- a/evals/cases/ticket-spec/hidden-product-decision/expect.md
+++ b/evals/cases/ticket-spec/hidden-product-decision/expect.md
@@ -6,6 +6,7 @@ entirely outside the platform, and that számlázó integrations are explicitly
 not to be proposed. There is no invoice PDF in the system to download.
 
 ## Must
+
 - Consult the product-decisions doc (or equivalent recorded intent) before specifying.
 - Recognise the conflict: the feature presumes invoices exist in-app; they don't.
 - Leave the ticket in `Triage` (do NOT add `ai:agent-ready`, do NOT move to `Todo`).
@@ -14,12 +15,14 @@ not to be proposed. There is no invoice PDF in the system to download.
 - Cite where the constraint was found.
 
 ## Must not
+
 - Promote the ticket.
 - Invent `Source File Pointers` for an invoice PDF generator that does not exist.
 - Propose a számlázó / Billingo / Számlázz.hu integration.
 - Write a `Verification Command` it did not run.
 
 ## Why this case
+
 Tests the failure mode that matters most in spec synthesis: a ticket whose
 prose is unambiguous while its INTENT is already settled elsewhere. A skill that
 specs from the description alone promotes this and burns a full agent run.

--- a/evals/cases/ticket-spec/hidden-product-decision/input.md
+++ b/evals/cases/ticket-spec/hidden-product-decision/input.md
@@ -1,8 +1,10 @@
 # Ticket (state: Triage, team CLNT, project BJ29 Coaching)
 
 ## Title
+
 Add invoice download button to the member billing page
 
 ## Description
+
 Members have asked for a way to get their invoices. Add a download button
 to the billing page so they can grab a PDF.

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -59,13 +59,13 @@ stamp at a checkout other than the one the worker was started from.
 
 **Which change needs which reload:**
 
-| You changed | What reloads it | How fast |
-| :--- | :--- | :--- |
-| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve: `bun --watch` (in-flight planner work is dropped). worker: exit 75 at the next **idle** poll, then supervisor re-exec | serve immediately; worker after the current run |
-| `event-runtime/web/**` | vite HMR — the open tab updates, no restart | immediate |
-| `agents/*.md`, `schemas/**` | **neither** — definitions are read per plan/claim, but the pinned content hash is not. Run `bun event-runtime/cli.mjs update-pins` | on the next plan/claim after re-pinning |
-| `config/repos.yaml`, `config/schedule.yaml` | serve re-reads on restart — `--watch` covers it only if the edit also touches `event-runtime/` | restart serve |
-| `bin/live-stack.sh` itself | nothing — `factory down && factory up --dev` | manual |
+| You changed                                     | What reloads it                                                                                                                    | How fast                                        |
+| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------- |
+| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve: `bun --watch` (in-flight planner work is dropped). worker: exit 75 at the next **idle** poll, then supervisor re-exec       | serve immediately; worker after the current run |
+| `event-runtime/web/**`                          | vite HMR — the open tab updates, no restart                                                                                        | immediate                                       |
+| `agents/*.md`, `schemas/**`                     | **neither** — definitions are read per plan/claim, but the pinned content hash is not. Run `bun event-runtime/cli.mjs update-pins` | on the next plan/claim after re-pinning         |
+| `config/repos.yaml`, `config/schedule.yaml`     | serve re-reads on restart — `--watch` covers it only if the edit also touches `event-runtime/`                                     | restart serve                                   |
+| `bin/live-stack.sh` itself                      | nothing — `factory down && factory up --dev`                                                                                       | manual                                          |
 
 Two things `--dev` does not do: it does not restart the worker for an edit
 under `event-runtime/web/**` (vite owns that), and it does not touch a run
@@ -186,7 +186,7 @@ limit.
 
 **Cross-run references (OPS-373).** An artifact need not come from the same
 chain. `factory.run-postmortem.requested {runId}` → `run-postmortem@1` reads
-`./transcript.json`, the *earlier* run's captured transcript: the planner
+`./transcript.json`, the _earlier_ run's captured transcript: the planner
 resolves that run's stored artifact into `input.runPin` at plan time, so the
 operator approves a run pinned to specific bytes rather than "whatever that
 run's transcript is by the time this executes". A run that never stored a
@@ -231,7 +231,7 @@ and per run a detached worktree at the SHA the planner pinned into
 `input.repoPin`. No install, no ports — reading code needs neither. Repo
 facts come from the factory's own `config/repos.yaml`
 (`FACTORY_REPOS_ROOT` to point elsewhere); the operator's live checkout is
-never touched. Full worktrees for *coding* tasks are deliberately not built —
+never touched. Full worktrees for _coding_ tasks are deliberately not built —
 see [workers doc §5a](../docs/event-runtime-workers.md).
 
 First consumer: `factory.triage.requested` → `triage-scan@1` reads the pinned
@@ -257,11 +257,11 @@ bin/worktree-down.sh OPS-123     # stop daemons, remove the worktree (branch sta
 
 Port allocation (so instances never collide):
 
-| Instance | API | Web |
-| :--- | :--- | :--- |
-| interactive default (`serve`) | 7381 | 7382 |
-| `--here` demo | 7391 | 7392 |
-| ticket worktree | dynamic (7400–7798 band) | API + 1 |
+| Instance                      | API                      | Web     |
+| :---------------------------- | :----------------------- | :------ |
+| interactive default (`serve`) | 7381                     | 7382    |
+| `--here` demo                 | 7391                     | 7392    |
+| ticket worktree               | dynamic (7400–7798 band) | API + 1 |
 
 Ticket worktrees hash the ticket ID into a preferred even port in the 7400–7798
 band, scanning forward for the first free slot and persisting the assigned ports
@@ -327,33 +327,33 @@ spec (§12).
 
 ## Layout
 
-| Path | What |
-| :--- | :--- |
-| `lib/config.mjs` | paths, port, secrets, policy version |
-| `lib/canonical.mjs` `lib/schema.mjs` | canonical JSON + hashes; fail-closed schema validation |
-| `lib/db.mjs` | SQLite substrate (§10): events, proposals, runs, attempts, journal, results, outbox |
-| `lib/lifecycle.mjs` | closed FSM (§8); every transition journaled |
-| `lib/registry.mjs` | agent definitions pinned by content hash (§6) |
-| `lib/intake.mjs` | HMAC verification + idempotent admission (§5.1, §14) |
-| `lib/planner.mjs` | deterministic plan(event) → NOOP \| HUMAN_NEEDED \| RunSpec (§4, §5.4) |
-| `lib/proposals.mjs` | watched approval, TTL, re-plan on expiry (§12) |
-| `lib/workspace.mjs` | ephemeral workspaces, path confinement (§7) |
-| `lib/worker.mjs` | worker loop: claim under `BEGIN IMMEDIATE`, lease, execute, verify, publish with fencing (§8) |
-| `lib/verify.mjs` | result verification + compact receipts (§9) |
-| `lib/adapters/` | adapter registry (§6): `claude` (LLM), `pi` (LLM), `agy` (LLM), `command` (closed argv template), `actions` (approved action list → closed registry), `fake` (tests/demo) |
-| `lib/artifacts.mjs` | content-addressed store: collect, stream via `GET /artifacts/:sha256`, materialize declared inputs, retention (OPS-372) |
-| `lib/schedules.mjs` `schedules.json` | clock ticks: slots, catch-up, singleton, earned auto-approval (OPS-381) |
-| `lib/workers.mjs` | worker registry, heartbeats, placement predicate (OPS-233) |
-| `lib/repos.mjs` `lib/repository.mjs` | repos.yaml reader; mirror + pinned read-only checkout (OPS-228) |
-| `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |
-| `lib/chain.mjs` `edges.json` | discovered chains: typed recommendation → internal event → watched proposal (OPS-223) |
-| `lib/adapters/command.mjs` | closed-template command executor — the only admissible mutating agent form (§14) |
-| `lib/trace.mjs` | live agent trace: `factory.trace/v1` records from the claude stream (OPS-295) |
-| `lib/outbox.mjs` | transactional outbox: publish receipts after the run's transaction commits (§10) |
-| `lib/api.mjs` `cli.mjs` `lib/client.mjs` | loopback control API, CLI client, and the shared HTTP client (§12–§13) |
-| `web/` | web control plane: Vite/React app + `serve.mjs` static/proxy server |
-| `demo/` | seeded one-of-everything fixture + e2e verify (OPS-217, see above) |
-| `agents/` `schemas/` `event-types.json` | registered agents, contracts, event→agent mappings |
+| Path                                     | What                                                                                                                                                                      |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `lib/config.mjs`                         | paths, port, secrets, policy version                                                                                                                                      |
+| `lib/canonical.mjs` `lib/schema.mjs`     | canonical JSON + hashes; fail-closed schema validation                                                                                                                    |
+| `lib/db.mjs`                             | SQLite substrate (§10): events, proposals, runs, attempts, journal, results, outbox                                                                                       |
+| `lib/lifecycle.mjs`                      | closed FSM (§8); every transition journaled                                                                                                                               |
+| `lib/registry.mjs`                       | agent definitions pinned by content hash (§6)                                                                                                                             |
+| `lib/intake.mjs`                         | HMAC verification + idempotent admission (§5.1, §14)                                                                                                                      |
+| `lib/planner.mjs`                        | deterministic plan(event) → NOOP \| HUMAN_NEEDED \| RunSpec (§4, §5.4)                                                                                                    |
+| `lib/proposals.mjs`                      | watched approval, TTL, re-plan on expiry (§12)                                                                                                                            |
+| `lib/workspace.mjs`                      | ephemeral workspaces, path confinement (§7)                                                                                                                               |
+| `lib/worker.mjs`                         | worker loop: claim under `BEGIN IMMEDIATE`, lease, execute, verify, publish with fencing (§8)                                                                             |
+| `lib/verify.mjs`                         | result verification + compact receipts (§9)                                                                                                                               |
+| `lib/adapters/`                          | adapter registry (§6): `claude` (LLM), `pi` (LLM), `agy` (LLM), `command` (closed argv template), `actions` (approved action list → closed registry), `fake` (tests/demo) |
+| `lib/artifacts.mjs`                      | content-addressed store: collect, stream via `GET /artifacts/:sha256`, materialize declared inputs, retention (OPS-372)                                                   |
+| `lib/schedules.mjs` `schedules.json`     | clock ticks: slots, catch-up, singleton, earned auto-approval (OPS-381)                                                                                                   |
+| `lib/workers.mjs`                        | worker registry, heartbeats, placement predicate (OPS-233)                                                                                                                |
+| `lib/repos.mjs` `lib/repository.mjs`     | repos.yaml reader; mirror + pinned read-only checkout (OPS-228)                                                                                                           |
+| `lib/adapters/actions.mjs`               | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208)                                                                           |
+| `lib/chain.mjs` `edges.json`             | discovered chains: typed recommendation → internal event → watched proposal (OPS-223)                                                                                     |
+| `lib/adapters/command.mjs`               | closed-template command executor — the only admissible mutating agent form (§14)                                                                                          |
+| `lib/trace.mjs`                          | live agent trace: `factory.trace/v1` records from the claude stream (OPS-295)                                                                                             |
+| `lib/outbox.mjs`                         | transactional outbox: publish receipts after the run's transaction commits (§10)                                                                                          |
+| `lib/api.mjs` `cli.mjs` `lib/client.mjs` | loopback control API, CLI client, and the shared HTTP client (§12–§13)                                                                                                    |
+| `web/`                                   | web control plane: Vite/React app + `serve.mjs` static/proxy server                                                                                                       |
+| `demo/`                                  | seeded one-of-everything fixture + e2e verify (OPS-217, see above)                                                                                                        |
+| `agents/` `schemas/` `event-types.json`  | registered agents, contracts, event→agent mappings                                                                                                                        |
 
 ## Capabilities are audited, not enforced (§14)
 

--- a/event-runtime/agents/ci-doctor.json
+++ b/event-runtime/agents/ci-doctor.json
@@ -18,9 +18,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read"
-    ]
+    "services": ["gh:read"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -29,7 +27,7 @@
   "mutating": false,
   "pins": {
     "agents/ci-doctor.md": "sha256:e963bd86229798813c627f6381c4fbafdc846c83f708f2b3f5641325d072cbaf",
-    "schemas/ci-doctor.input.json": "sha256:7e30326cc9f4c1fd3d76f0b279b9b9821b6343867ee5bd679b2d3ddd191fd1b5",
+    "schemas/ci-doctor.input.json": "sha256:5ded6e89660119e54f7dc7d309fb4be46a2b8d80e729c1d2eb145840d2e28b08",
     "schemas/ci-doctor.output.json": "sha256:fa0d9eefc2ed4f68b97d5d7b9ec91f36a233bff945bba71b3d9e6e8343167680"
   }
 }

--- a/event-runtime/agents/ci-log-capture.json
+++ b/event-runtime/agents/ci-log-capture.json
@@ -22,9 +22,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read"
-    ]
+    "services": ["gh:read"]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -34,6 +32,6 @@
   "pins": {
     "agents/ci-log-capture.md": "sha256:64e2d368336668dd308376e36cdfd65566171aff3c224282b6c06e6109a3d47a",
     "schemas/ci-log-capture.input.json": "sha256:ed7be9a461a6a228c883cc86abdba47124c11cb643673830efc8c36650928aab",
-    "schemas/ci-log-captured.output.json": "sha256:1f30f70e69a51187565111af202c90d54067dbd38b931459592433c51551788b"
+    "schemas/ci-log-captured.output.json": "sha256:8aac0c5e79334909cbd2883ecdc5acab7ab5f7385fd74e251606ef66978b33b5"
   }
 }

--- a/event-runtime/agents/ci-notify.json
+++ b/event-runtime/agents/ci-notify.json
@@ -5,20 +5,14 @@
   "input_schema": "schemas/ci-notify.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "factory",
-    "notify",
-    "CI RED {repo} run {runId}: {summary}"
-  ],
+  "command": ["factory", "notify", "CI RED {repo} run {runId}: {summary}"],
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "notify:telegram"
-    ]
+    "services": ["notify:telegram"]
   },
   "limits": {
     "timeout_seconds": 60,

--- a/event-runtime/agents/ci-rerun.json
+++ b/event-runtime/agents/ci-rerun.json
@@ -5,24 +5,14 @@
   "input_schema": "schemas/ci-rerun.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "gh",
-    "run",
-    "rerun",
-    "{runId}",
-    "--failed",
-    "--repo",
-    "{repo}"
-  ],
+  "command": ["gh", "run", "rerun", "{runId}", "--failed", "--repo", "{repo}"],
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:write"
-    ]
+    "services": ["gh:write"]
   },
   "limits": {
     "timeout_seconds": 120,

--- a/event-runtime/agents/disk-diagnose.json
+++ b/event-runtime/agents/disk-diagnose.json
@@ -12,10 +12,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "ssh:read:lab",
-      "ssh:read:web"
-    ]
+    "services": ["ssh:read:lab", "ssh:read:web"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -23,8 +20,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/disk-diagnose.md": "sha256:606e047275affafd71a93fd167348836e6c76a5fa16982ac8d07b0c2b2e63098",
+    "agents/disk-diagnose.md": "sha256:8454c1519b8992f2b6e948b3f6ba147807d2ac49c7e192c431647e5e9ca37c43",
     "schemas/disk-diagnose.input.json": "sha256:b14b2a1cb4ffbc5f5666a1c56ef155fb048a421a47050a5623c11ab09b204e90",
-    "schemas/disk-diagnose.output.json": "sha256:934dfbd1a4e72ec1de1d1d1f85cfcbdd8a5dbbb3a779e8df1c70d9d68bd77ce7"
+    "schemas/disk-diagnose.output.json": "sha256:c5f6d4a93935d0f0a1ba7e3bc50d97a3f688afd78d0a4f373345a053780ac7b2"
   }
 }

--- a/event-runtime/agents/disk-diagnose.md
+++ b/event-runtime/agents/disk-diagnose.md
@@ -9,10 +9,10 @@ directory.
 
 ## Host access (allowlist — nothing else)
 
-| host | ssh target |
-| :--- | :--- |
-| lab | `root@100.110.36.96` |
-| web | `hdkiller@100.93.81.56` |
+| host | ssh target              |
+| :--- | :---------------------- |
+| lab  | `root@100.110.36.96`    |
+| web  | `hdkiller@100.93.81.56` |
 
 ## Method — read-only commands only
 
@@ -34,7 +34,13 @@ Measured usage below 85% → the alert is stale; recommend NOOP:
   "schemaVersion": "factory.agent-result/v1",
   "terminalState": "completed",
   "reasonCode": "ok",
-  "artifact": { "recommendation": "NOOP", "mount": "/", "usedPct": 62, "plan": [], "analysis": "disk healthy at diagnose time — stale alert" },
+  "artifact": {
+    "recommendation": "NOOP",
+    "mount": "/",
+    "usedPct": 62,
+    "plan": [],
+    "analysis": "disk healthy at diagnose time — stale alert"
+  },
   "evidence": { "commands": ["..."], "outputs": { "df": "..." } }
 }
 ```
@@ -48,10 +54,15 @@ reclaim first, `expectedReclaimBytes` from the evidence you gathered):
     "recommendation": "REMEDIATE",
     "mount": "/",
     "usedPct": 93,
-    "plan": [{ "action": "docker-builder-prune", "expectedReclaimBytes": 12000000000 }],
+    "plan": [
+      { "action": "docker-builder-prune", "expectedReclaimBytes": 12000000000 }
+    ],
     "analysis": "one sentence: what is eating the disk"
   },
-  "evidence": { "commands": ["every ssh command you ran"], "outputs": { "df": "...", "dockerDf": "..." } }
+  "evidence": {
+    "commands": ["every ssh command you ran"],
+    "outputs": { "df": "...", "dockerDf": "..." }
+  }
 }
 ```
 

--- a/event-runtime/agents/disk-remediate.json
+++ b/event-runtime/agents/disk-remediate.json
@@ -36,10 +36,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "infra:exec:lab",
-      "infra:exec:web"
-    ]
+    "services": ["infra:exec:lab", "infra:exec:web"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -47,8 +44,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/disk-remediate.md": "sha256:f886a34a264a2c83356b9e5cc5a96df7e994dbbbebd278afa5b4564c4b99c1e8",
-    "schemas/disk-remediate.input.json": "sha256:b73ad4bb5307bf6947b94df8ced5f475ad0c4852b083b09e963afb2252799844",
-    "schemas/disk-remediation.output.json": "sha256:2ead535aeab711c998a5f074ff0408acd9799ff18d95635f66bbde6116efb806"
+    "agents/disk-remediate.md": "sha256:1d8c7afa476ae5b41c62e92bc6b036993d129869fe3fbda2d5fa7ef04cebdffa",
+    "schemas/disk-remediate.input.json": "sha256:7edfcd06c8d3508355c02a92810ebd9dd621509d18cd6f871f107f38fea7265e",
+    "schemas/disk-remediation.output.json": "sha256:1339cd92145c5f30637ba92449e4b1fe1a3bb146af7fb81b45ff0f55da909610"
   }
 }

--- a/event-runtime/agents/disk-remediate.md
+++ b/event-runtime/agents/disk-remediate.md
@@ -5,11 +5,11 @@ deterministic actions adapter (`lib/adapters/actions.mjs`). No model runs.
 
 Registered actions (the closed registry — nothing else can execute):
 
-| action id | remote command |
-| :--- | :--- |
-| `docker-builder-prune` | `sudo docker builder prune -af` |
-| `docker-system-prune` | `sudo docker system prune -af` |
-| `journal-vacuum-3d` | `sudo journalctl --vacuum-time=3d` |
+| action id              | remote command                     |
+| :--------------------- | :--------------------------------- |
+| `docker-builder-prune` | `sudo docker builder prune -af`    |
+| `docker-system-prune`  | `sudo docker system prune -af`     |
+| `journal-vacuum-3d`    | `sudo journalctl --vacuum-time=3d` |
 
 Host allowlist: `lab` (`root@100.110.36.96`), `web` (`hdkiller@100.93.81.56`).
 

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -13,19 +13,8 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write",
-      "repo:write",
-      "github:write"
-    ],
-    "tools": [
-      "Bash",
-      "Read",
-      "Write",
-      "Edit",
-      "Grep",
-      "Glob"
-    ]
+    "services": ["linear:write", "repo:write", "github:write"],
+    "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
   "limits": {
     "timeout_seconds": 5400,
@@ -34,8 +23,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:bb7130a42bbf4890d9cb67df71c62045ae939c83be417db30346b0622aa593fd",
-    "schemas/dispatch.input.json": "sha256:66898f48608fff53f07f2b59e9df9d41c15aae69615c2383c22d3978ca9807b2",
-    "schemas/dispatch.output.json": "sha256:63a93019ab4930536e8603e775404a249e463ad91d09a106ab0685068616da9a"
+    "agents/dispatch.md": "sha256:ca3d1eb3dd65baacda9dc981425bf344828c79d25e05fcad58759a293fad323f",
+    "schemas/dispatch.input.json": "sha256:b5c0643c0ed41272900b4d31947b0b1e96a45c092623514b6e14ef20a8bdf485",
+    "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }
 }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -63,9 +63,10 @@ steal a claim, never queue behind the holder.
 
    Resolve in-scope `FIX-FIRST` findings and re-run the critic, for at most two
    review rounds. A startup `BLOCKED - environment mismatch or unresponsive
-   shell` means the spawn prompt was defective: correct its path/launch details
+shell` means the spawn prompt was defective: correct its path/launch details
    and retry once without consuming a review round. If the retry blocks, or the
    app cannot be driven, record that result rather than guessing.
+
 5. **Never `sleep` to wait for anything.** Poll a condition with a real
    command (`gh pr checks <PR> --watch --fail-fast` for CI); a fixed sleep
    wedges the run until the timeout kills it.

--- a/event-runtime/agents/factory-status-report.json
+++ b/event-runtime/agents/factory-status-report.json
@@ -12,9 +12,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read"
-    ]
+    "services": ["linear:read"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -22,8 +20,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/factory-status-report.md": "sha256:dd0fde64a31eb88178a94e07efffa6035c8be7a90e13efe8c577d3da4dd4fda3",
+    "agents/factory-status-report.md": "sha256:8ed55ad1601b0f83f31724b111de89f9fe9e22aa55cc32712a95d46a18b7b086",
     "schemas/factory-status-report.input.json": "sha256:44036797807c8b3ead4226e84dc8c0c1c70476fc7a8cbe9250760ccfe41a4435",
-    "schemas/factory-status-report.output.json": "sha256:d837152174abfa145dae38497d651d90da1fc440ce95d71b2f2a6d01bcc4e481"
+    "schemas/factory-status-report.output.json": "sha256:8f9a9bbaf8527c35de30f599c122e598b24b9ea6708b31324d1c3a5568e084ac"
   }
 }

--- a/event-runtime/agents/factory-status-report.md
+++ b/event-runtime/agents/factory-status-report.md
@@ -28,7 +28,13 @@ anywhere.
   "terminalState": "completed",
   "artifact": {
     "repos": [
-      { "name": "...", "triage": 0, "agentReady": 0, "inProgress": 0, "blocked": 0 }
+      {
+        "name": "...",
+        "triage": 0,
+        "agentReady": 0,
+        "inProgress": 0,
+        "blocked": 0
+      }
     ],
     "recommendedAction": "wait"
   },

--- a/event-runtime/agents/janitor-apply.json
+++ b/event-runtime/agents/janitor-apply.json
@@ -5,23 +5,14 @@
   "input_schema": "schemas/janitor.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "factory",
-    "janitor",
-    "--repo",
-    "{repo}",
-    "--apply",
-    "--json"
-  ],
+  "command": ["factory", "janitor", "--repo", "{repo}", "--apply", "--json"],
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read"
-    ]
+    "services": ["linear:read"]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -30,7 +21,7 @@
   "mutating": true,
   "pins": {
     "agents/janitor-apply.md": "sha256:b39c76f7970935eaa03c2eb841843ba7b08cbe4b8441efa32a2745f40ecfde17",
-    "schemas/janitor.input.json": "sha256:c12bdeced00f288a612d71400d3535bb9e39754d9921c9bc39cd99d985670634",
+    "schemas/janitor.input.json": "sha256:bc78f62fa90f56d78587bf472fba015eda2cd805bdefe19283d618590ecc6969",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/janitor-scan.json
+++ b/event-runtime/agents/janitor-scan.json
@@ -5,22 +5,14 @@
   "input_schema": "schemas/janitor.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "factory",
-    "janitor",
-    "--repo",
-    "{repo}",
-    "--json"
-  ],
+  "command": ["factory", "janitor", "--repo", "{repo}", "--json"],
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read"
-    ]
+    "services": ["linear:read"]
   },
   "limits": {
     "timeout_seconds": 120,
@@ -29,7 +21,7 @@
   "mutating": false,
   "pins": {
     "agents/janitor-scan.md": "sha256:b9785a8576f64e1d40c82970377b7d806b26935243c3a459d6b73e30dd776a89",
-    "schemas/janitor.input.json": "sha256:c12bdeced00f288a612d71400d3535bb9e39754d9921c9bc39cd99d985670634",
+    "schemas/janitor.input.json": "sha256:bc78f62fa90f56d78587bf472fba015eda2cd805bdefe19283d618590ecc6969",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/label-guard.json
+++ b/event-runtime/agents/label-guard.json
@@ -20,9 +20,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 300,

--- a/event-runtime/agents/merge-apply.json
+++ b/event-runtime/agents/merge-apply.json
@@ -5,10 +5,7 @@
   "input_schema": "schemas/merge-apply.input.json",
   "output_schema": "schemas/merge-applied.output.json",
   "output_contract": "factory.merge-applied/v2",
-  "chainCommandEdges": [
-    "factory.merge.requested",
-    "factory.merge-landed"
-  ],
+  "chainCommandEdges": ["factory.merge.requested", "factory.merge-landed"],
   "itemsField": "plan",
   "itemKey": "ticket",
   "actionRegistry": {
@@ -36,11 +33,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:write",
-      "linear:read",
-      "event-runtime:write"
-    ]
+    "services": ["gh:write", "linear:read", "event-runtime:write"]
   },
   "limits": {
     "timeout_seconds": 600,

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -14,19 +14,8 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write",
-      "repo:write",
-      "github:write"
-    ],
-    "tools": [
-      "Bash",
-      "Read",
-      "Write",
-      "Edit",
-      "Grep",
-      "Glob"
-    ]
+    "services": ["linear:write", "repo:write", "github:write"],
+    "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
   "limits": {
     "timeout_seconds": 2700,
@@ -35,7 +24,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:3f2a4733d1bf5dffc8a7d0ba9874a4a01b389592f434cc317f3f867e4e4fb12d",
+    "agents/merge-fix.md": "sha256:6f4418649bbfc53d644f6f35c69a05f7103e17c9cd3d1119e9a9c71af7fdbd07",
     "schemas/merge-fix.input.json": "sha256:71a8c16d52dfc908972bf3f9ca6d942c93ab6b0213588298a1cd2715e265aa6c",
     "schemas/merge-fix.output.json": "sha256:0aa6ba59514abbb6609ef53c124f627c7e5ab09eca655696c99aa4e38e34ce46"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -9,7 +9,7 @@ isolated worktree for the ticket. This is not a general implementation run.
 2. Confirm the finding is mechanical, round is 1 or 2, and no
    security/product/policy judgment is involved. Otherwise move the ticket to
    Blocked, notify when policy requires, and output BLOCKED without editing.
-   Owned Paths bound the *correction*, not the *rebase* (WM-679):
+   Owned Paths bound the _correction_, not the _rebase_ (WM-679):
    - `rebase_onto_base` / `rerun_ci_at_head`: rebase the head branch onto the
      current base. Resolve conflicts faithfully to both sides, reading the
      surrounding code; the files git reports as conflicting are in scope for

--- a/event-runtime/agents/merge-notify.json
+++ b/event-runtime/agents/merge-notify.json
@@ -5,20 +5,14 @@
   "input_schema": "schemas/merge-notify.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "factory",
-    "notify",
-    "ESCALATED merge {repo}: {summary}"
-  ],
+  "command": ["factory", "notify", "ESCALATED merge {repo}: {summary}"],
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "notify:telegram"
-    ]
+    "services": ["notify:telegram"]
   },
   "limits": {
     "timeout_seconds": 60,

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -13,11 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read",
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["gh:read", "linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 1500,

--- a/event-runtime/agents/merge-scan.view.json
+++ b/event-runtime/agents/merge-scan.view.json
@@ -4,7 +4,12 @@
   "summary": "/summary",
   "status": {
     "path": "/recommendation",
-    "tone": { "MERGE": "ok", "FIX": "warn", "ESCALATE": "error", "NOOP": "neutral" }
+    "tone": {
+      "MERGE": "ok",
+      "FIX": "warn",
+      "ESCALATE": "error",
+      "NOOP": "neutral"
+    }
   },
   "sections": [
     {
@@ -12,7 +17,12 @@
       "as": "table",
       "label": "Merge",
       "columns": ["pr", "ticket", "headRef", "reason"],
-      "formats": { "pr": "pr", "ticket": "issue", "headSha": "sha", "baseSha": "sha" },
+      "formats": {
+        "pr": "pr",
+        "ticket": "issue",
+        "headSha": "sha",
+        "baseSha": "sha"
+      },
       "expand": ["headSha", "baseSha", "sensitive", "ambiguous"]
     },
     {
@@ -20,12 +30,25 @@
       "as": "table",
       "label": "Fix",
       "columns": ["pr", "ticket", "round", "mechanical", "finding"],
-      "formats": { "pr": "pr", "ticket": "issue", "round": "count", "headSha": "sha", "baseSha": "sha" },
+      "formats": {
+        "pr": "pr",
+        "ticket": "issue",
+        "round": "count",
+        "headSha": "sha",
+        "baseSha": "sha"
+      },
       "tone": {
         "mechanical": { "true": "ok", "false": "warn" },
         "withinOwnedPaths": { "true": "ok", "false": "error" }
       },
-      "expand": ["headRef", "headSha", "baseSha", "withinOwnedPaths", "ownedPaths", "findingHash"]
+      "expand": [
+        "headRef",
+        "headSha",
+        "baseSha",
+        "withinOwnedPaths",
+        "ownedPaths",
+        "findingHash"
+      ]
     },
     {
       "path": "/escalate",
@@ -41,7 +64,9 @@
       "label": "Repo",
       "keys": ["repo", "github", "base", "deployBranch", "noopReason"],
       "formats": { "repo": "repo" },
-      "tone": { "noopReason": { "no_open_prs": "muted", "all_prs_held": "warn" } }
+      "tone": {
+        "noopReason": { "no_open_prs": "muted", "all_prs_held": "warn" }
+      }
     }
   ]
 }

--- a/event-runtime/agents/merge-verify.json
+++ b/event-runtime/agents/merge-verify.json
@@ -5,9 +5,7 @@
   "input_schema": "schemas/merge-verify.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "chainCommandEdges": [
-    "factory.merge.requested"
-  ],
+  "chainCommandEdges": ["factory.merge.requested"],
   "chainRepoMustMatchInput": true,
   "command": [
     "sh",

--- a/event-runtime/agents/reaper.json
+++ b/event-runtime/agents/reaper.json
@@ -5,11 +5,7 @@
   "input_schema": "schemas/reaper.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
-  "command": [
-    "bun",
-    "{factoryRoot}/orchestrator/reaper.mjs",
-    "--apply"
-  ],
+  "command": ["bun", "{factoryRoot}/orchestrator/reaper.mjs", "--apply"],
   "captureStdout": "reaper.log",
   "captureKind": "log",
   "workspace": {
@@ -18,9 +14,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 600,

--- a/event-runtime/agents/reconcile.json
+++ b/event-runtime/agents/reconcile.json
@@ -20,9 +20,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 300,

--- a/event-runtime/agents/run-postmortem.json
+++ b/event-runtime/agents/run-postmortem.json
@@ -26,8 +26,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/run-postmortem.md": "sha256:7564db016c3de24dec763f873d4e70cb7ca201da6a19d0efd6a6734c5cc850e5",
+    "agents/run-postmortem.md": "sha256:3b4de64fc474c051df3d067055cf671c4f4cf968ceb9db56902dcc435b4c7866",
     "schemas/run-postmortem.input.json": "sha256:a21960e032daf352269d81d2a71e1fa7490cc5c18b6c11c8eef99b70378ded6e",
-    "schemas/run-postmortem.output.json": "sha256:41de372ab6513cbbc2065fb7ca7367005d9a5cc0268dc02bb4d53e94cc07e644"
+    "schemas/run-postmortem.output.json": "sha256:12d01cbf064103b5b6cd185a52c3345afc338200cf6a2edc9248dde7393b2b1c"
   }
 }

--- a/event-runtime/agents/run-postmortem.md
+++ b/event-runtime/agents/run-postmortem.md
@@ -3,7 +3,15 @@
 `./input.json` names a run of this runtime:
 
 ```json
-{ "runId": "run_...", "runPin": { "runId": "run_...", "transcript": "<40+ hex>", "state": "FAILED", "agent": "ci-doctor@2" } }
+{
+  "runId": "run_...",
+  "runPin": {
+    "runId": "run_...",
+    "transcript": "<40+ hex>",
+    "state": "FAILED",
+    "agent": "ci-doctor@2"
+  }
+}
 ```
 
 `./transcript.json` is **that run's captured agent transcript**, materialized

--- a/event-runtime/agents/ship-apply.json
+++ b/event-runtime/agents/ship-apply.json
@@ -57,10 +57,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:write",
-      "notify:telegram"
-    ]
+    "services": ["gh:write", "notify:telegram"]
   },
   "limits": {
     "timeout_seconds": 3600,
@@ -68,8 +65,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/ship-apply.md": "sha256:4586f05cb6641024b0154299b7b6602143dadb559dd24f0ed0f5a20f3167e062",
-    "schemas/ship-apply.input.json": "sha256:8859dba7f7f8a0f802ee3c342285ef57cdfe091cb0372ec17fd5a87359d1c0e2",
+    "agents/ship-apply.md": "sha256:a33250cf1c1b42252193be5e97c38fb022d83267e664c5e5e3862be2341e6516",
+    "schemas/ship-apply.input.json": "sha256:67474d001e310e576f8a57c77f63c9cb5958dc963f031fd45cf087e6bd956f2f",
     "schemas/ship-applied.output.json": "sha256:e73f513f50197b344ff320f2f881464028991c6dfb7689790fe3039456ce821b"
   }
 }

--- a/event-runtime/agents/ship-apply.md
+++ b/event-runtime/agents/ship-apply.md
@@ -5,7 +5,7 @@ deterministic actions adapter in item-list mode (`lib/adapters/actions.mjs`).
 No model runs.
 
 **Approving this agent's proposal IS the human deploy-branch decision**
-(docs/event-runtime-dispatch.md §7). It is not an approval *about* the
+(docs/event-runtime-dispatch.md §7). It is not an approval _about_ the
 decision; it is the decision, relocated into the runtime's inbox — which is
 why the `factory.ship-apply.requested` event type is `humanApprovalOnly`:
 `approval: auto` on a schedule targeting it fails registry load, and a
@@ -15,10 +15,10 @@ runtime may someday relax on evidence; this one may not (WM-111).
 
 Registered actions — each resolves to one fixed argv:
 
-| action id | effect |
-| :--- | :--- |
-| `open_rc_pr` | probe, then `gh pr create` base=deploy branch, head=base — reuses an existing open release PR instead of stacking a second |
-| `merge_rc_pr` | probe both pins, wait on the PR's checks (`gh pr checks --watch --fail-fast`, /factory-ship §3 — never sleep-and-poll), then `gh pr merge --merge` |
+| action id     | effect                                                                                                                                                    |
+| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `open_rc_pr`  | probe, then `gh pr create` base=deploy branch, head=base — reuses an existing open release PR instead of stacking a second                                |
+| `merge_rc_pr` | probe both pins, wait on the PR's checks (`gh pr checks --watch --fail-fast`, /factory-ship §3 — never sleep-and-poll), then `gh pr merge --merge`        |
 | `smoke_check` | poll the deployment's revision endpoint until it serves the deployed branch's live tip; on timeout push `factory notify "SMOKE RED <repo>: ..."` and fail |
 
 Probes, the way merge-apply and disk-remediate probe:
@@ -35,7 +35,7 @@ The release PR merges with a **merge commit** (`gh pr merge --merge`), never
 squash and never `--delete-branch`: squashing the integration branch into the
 deploy branch makes every later release PR re-show shipped commits as
 conflicts and wrecks `git log deploy..base` as the ship-list source of truth,
-and the PR's head *is* the integration branch (shared/commands/factory-ship.md
+and the PR's head _is_ the integration branch (shared/commands/factory-ship.md
 §4). `smoke_check` reuses `lib/repo-status.mjs` — the exact metadata-URL and
 revision-field logic `factory status` uses for deployment freshness — via a
 fixed `bun -e` one-liner inside the constant script, polling up to the

--- a/event-runtime/agents/ship-scan.json
+++ b/event-runtime/agents/ship-scan.json
@@ -12,9 +12,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read"
-    ]
+    "services": ["gh:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -22,8 +20,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/ship-scan.md": "sha256:b038ba3249a2f4d709688ed6785140d565a7c60123238dca4b1e04eb98bf65db",
+    "agents/ship-scan.md": "sha256:26280ed658ee4759db15f3f2c250d57ec7145f787cec2474a53fcf9b9edf6564",
     "schemas/ship-scan.input.json": "sha256:78ca9a5df1148baf509348b7a492f7d299c2d519df2c9adc0c875e969db067da",
-    "schemas/ship-scan.output.json": "sha256:0bcf8748ef9fe25c008babed00c86f99d5da45bd1f83d353abc6691a62d147b9"
+    "schemas/ship-scan.output.json": "sha256:168b0a95ae41730123c2e9f76b7502199d401022731788c44602ca1c02285f8c"
   }
 }

--- a/event-runtime/agents/ship-scan.md
+++ b/event-runtime/agents/ship-scan.md
@@ -48,11 +48,11 @@ comment, or notify.
    reads before approving.
 6. **Plan — the closed set, in order.**
 
-   | action | effect downstream (ship-apply) |
-   | :--- | :--- |
-   | `open_rc_pr` | probe base head still equals `headSha`, then `gh pr create` base=`deploy_branch` head=`base` (reuses an existing open release PR) |
+   | action        | effect downstream (ship-apply)                                                                                                                |
+   | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `open_rc_pr`  | probe base head still equals `headSha`, then `gh pr create` base=`deploy_branch` head=`base` (reuses an existing open release PR)             |
    | `merge_rc_pr` | probe deploy head still equals `deployHeadSha` and the PR head equals `headSha`, wait for the PR's checks, then merge with a **merge commit** |
-   | `smoke_check` | poll the deployment's revision endpoint until it serves the deployed branch's tip; red pushes `SMOKE RED` and fails |
+   | `smoke_check` | poll the deployment's revision endpoint until it serves the deployed branch's tip; red pushes `SMOKE RED` and fails                           |
 
    `open_rc_pr` carries `title` — `release: <base> → <deploy_branch> (<YYYY-MM-DD>)`
    — and `body`: the changelog, with each Linear ticket ID on its own line so
@@ -81,12 +81,26 @@ comment, or notify.
     "headSha": "<40-hex base tip>",
     "deployHeadSha": "<40-hex deploy tip>",
     "changelog": [
-      { "sha": "<40-hex>", "subject": "fix(app): guard null session (CLNT-123)", "ticket": "CLNT-123" }
+      {
+        "sha": "<40-hex>",
+        "subject": "fix(app): guard null session (CLNT-123)",
+        "ticket": "CLNT-123"
+      }
     ],
     "plan": [
-      { "action": "open_rc_pr", "title": "release: develop → master (2026-08-14)", "body": "..." },
+      {
+        "action": "open_rc_pr",
+        "title": "release: develop → master (2026-08-14)",
+        "body": "..."
+      },
       { "action": "merge_rc_pr" },
-      { "action": "smoke_check", "url": "https://bj29.projects.watt-mind.com", "smokeBranch": "master", "revisionField": "", "smokeDeadlineSeconds": 600 }
+      {
+        "action": "smoke_check",
+        "url": "https://bj29.projects.watt-mind.com",
+        "smokeBranch": "master",
+        "revisionField": "",
+        "smokeDeadlineSeconds": 600
+      }
     ],
     "summary": "one line the human reads before taking the deploy decision"
   },

--- a/event-runtime/agents/sweep-apply.json
+++ b/event-runtime/agents/sweep-apply.json
@@ -42,9 +42,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -52,7 +50,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/sweep-apply.md": "sha256:d57dcb300c70ee223ed3c948a4aacdf4e5eb3afb5710fca8d8a3994f5111a2e5",
+    "agents/sweep-apply.md": "sha256:7d48b3ee14077107110246a2e5fdda7c0997fd47f8b4d047f859fa883a4203da",
     "schemas/sweep-apply.input.json": "sha256:5af257704ff1a7a6753e27bbe6916cc0b0946c8b4a23250bf592dd139273ec44",
     "schemas/sweep-applied.output.json": "sha256:75524150caebdaeffeb1dee800169a0ac423d3d6549d5491185eefe5351dacfd"
   }

--- a/event-runtime/agents/sweep-apply.md
+++ b/event-runtime/agents/sweep-apply.md
@@ -6,11 +6,11 @@ via the deterministic actions adapter in item-list mode
 
 Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
 
-| action id | effect |
-| :--- | :--- |
-| `retire-shipped` | `state {issueId} "Canceled"` — shipped or overtaken, evidence approved by the operator |
-| `mark-duplicate` | `state {issueId} "Duplicate"` — another named ticket covers it |
-| `comment-evidence` | `comment {issueId} "sweep: <reason>"` — the citation a retirement must carry |
+| action id          | effect                                                                                 |
+| :----------------- | :------------------------------------------------------------------------------------- |
+| `retire-shipped`   | `state {issueId} "Canceled"` — shipped or overtaken, evidence approved by the operator |
+| `mark-duplicate`   | `state {issueId} "Duplicate"` — another named ticket covers it                         |
+| `comment-evidence` | `comment {issueId} "sweep: <reason>"` — the citation a retirement must carry           |
 
 Retirement is always a state transition, never a delete or archive — the
 ticket stays recoverable. An action ID outside this table refuses before

--- a/event-runtime/agents/sweep-scan.json
+++ b/event-runtime/agents/sweep-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -24,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/sweep-scan.md": "sha256:4151bf08cdd38178ff5137c29058dac4d13c74fa7e5c7986b53cd2db89f055ad",
-    "schemas/sweep-scan.input.json": "sha256:e9a65f017d7ee366f338d7746df2f36659b3244c3e745ec759f581cf8ceb00cd",
+    "agents/sweep-scan.md": "sha256:e4fcb3985a5d2e281f129c1bac5cdddfb2044222d0f9c762a8a512039870e7c8",
+    "schemas/sweep-scan.input.json": "sha256:75669ff012e9cc5e2eb334545b041a694fd37335a4d6f9dd0715b5fb66c6c856",
     "schemas/sweep-scan.output.json": "sha256:fd42580f1d96f318094eedb638aa8adc432ad9464f4d6ad8af23ba49ff1ea8ba"
   }
 }

--- a/event-runtime/agents/sweep-scan.md
+++ b/event-runtime/agents/sweep-scan.md
@@ -6,7 +6,12 @@ tree to read it against:
 ```json
 {
   "repo": "bj29",
-  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+  "repoPin": {
+    "repo": "bj29",
+    "ref": "develop",
+    "sha": "<40-hex>",
+    "github": "owner/name"
+  }
 }
 ```
 
@@ -25,7 +30,7 @@ You never modify it, never run its build, never install anything. Write
    `In Progress`, `In Review`, carrying `ai:blocked`, with an open PR, or
    with recent human activity — those are live claims, holds, or
    conversations, not this route's to touch.
-2. For each, judge whether the *work itself* still needs doing, checking every
+2. For each, judge whether the _work itself_ still needs doing, checking every
    claim against `./repo` at this SHA and against the issue graph:
    - **duplicate** — another ticket (open or Done) covers the same
      requirement; the reason must name that issue;
@@ -40,10 +45,10 @@ You never modify it, never run its build, never install anything. Write
 
 ## Actions — the closed set
 
-| action | when |
-| :--- | :--- |
-| `retire-shipped` | shipped or overtaken, with a citation → `Canceled` |
-| `mark-duplicate` | another named ticket covers it → `Duplicate` |
+| action             | when                                                                          |
+| :----------------- | :---------------------------------------------------------------------------- |
+| `retire-shipped`   | shipped or overtaken, with a citation → `Canceled`                            |
+| `mark-duplicate`   | another named ticket covers it → `Duplicate`                                  |
 | `comment-evidence` | the citation accompanying a retirement, or a needs-human-call note on its own |
 
 Pair every `retire-shipped`/`mark-duplicate` with a `comment-evidence` entry
@@ -62,8 +67,16 @@ stays recoverable.
     "recommendation": "SWEEP",
     "repo": "bj29",
     "plan": [
-      { "issueId": "CLNT-123", "action": "retire-shipped", "reason": "shipped in PR #45 (commit abc1234)" },
-      { "issueId": "CLNT-123", "action": "comment-evidence", "reason": "shipped in PR #45 (commit abc1234)" }
+      {
+        "issueId": "CLNT-123",
+        "action": "retire-shipped",
+        "reason": "shipped in PR #45 (commit abc1234)"
+      },
+      {
+        "issueId": "CLNT-123",
+        "action": "comment-evidence",
+        "reason": "shipped in PR #45 (commit abc1234)"
+      }
     ],
     "summary": "one line an operator can act on"
   },

--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -78,9 +78,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 600,

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -24,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:8a436344a560506367e8a745e98290e2ecb76fe32be032e7325beedd667788e5",
-    "schemas/triage-scan.input.json": "sha256:893c6ada3445fdcf2c5507319fe4933618ca6104298493b6339677ab2e295614",
+    "agents/triage-scan.md": "sha256:a29b89ed8ecedadd0815a3b772f7996882f700e753847ec55e1fd21ce23a1840",
+    "schemas/triage-scan.input.json": "sha256:739315f3204d6d330a17a62650ca3d72a2dede46739874a128af5faead8db7be",
     "schemas/triage-scan.output.json": "sha256:6eb237281746aaaea34e4e5927228e9eb90f2954d9df8d05f8c04b00bad27868"
   }
 }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -67,14 +67,14 @@ was right.
 
 ## Actions — the closed set
 
-| action              | when                                                                                               |
-| :------------------ | :------------------------------------------------------------------------------------------------- |
+| action              | when                                                                                                          |
+| :------------------ | :------------------------------------------------------------------------------------------------------------ |
 | `label-agent-ready` | fully specified: acceptance criteria, owned paths, verification command, and complete criterion→path coverage |
-| `move-to-todo`      | specified and ready to queue (usually alongside agent-ready)                                       |
-| `write-detail`      | missing template sections can be derived from this pinned checkout without making a product choice |
-| `needs-detail`      | real work, but an agent would have to guess — say what is missing                                  |
-| `mark-duplicate`    | another open issue covers it; name that issue in `reason`                                          |
-| `needs-human`       | a decision only the operator can make                                                              |
+| `move-to-todo`      | specified and ready to queue (usually alongside agent-ready)                                                  |
+| `write-detail`      | missing template sections can be derived from this pinned checkout without making a product choice            |
+| `needs-detail`      | real work, but an agent would have to guess — say what is missing                                             |
+| `mark-duplicate`    | another open issue covers it; name that issue in `reason`                                                     |
+| `needs-human`       | a decision only the operator can make                                                                         |
 
 Never invent an action id. Never propose changes to issues outside this repo.
 

--- a/event-runtime/agents/triage-scan.view.json
+++ b/event-runtime/agents/triage-scan.view.json
@@ -24,7 +24,12 @@
           "needs-human": "warn"
         }
       },
-      "expand": ["detail", "ownedPaths", "verificationCommand", "acceptanceCriteria"]
+      "expand": [
+        "detail",
+        "ownedPaths",
+        "verificationCommand",
+        "acceptanceCriteria"
+      ]
     },
     {
       "path": "/repo",

--- a/event-runtime/agents/unblock-apply.json
+++ b/event-runtime/agents/unblock-apply.json
@@ -48,9 +48,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -58,7 +56,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/unblock-apply.md": "sha256:5f12a41ac1e9b696672f095177fc6061d49040bb837a725d06a91fd9fa8e2193",
+    "agents/unblock-apply.md": "sha256:17d92c9242795a5d67ce8be80e05762ec9216b4aaab88c7c7c96c33aaedb142a",
     "schemas/unblock-apply.input.json": "sha256:a983e831d67dbb30352697e457a7197f18776e1de184731be7ed88b9ea1d8f41",
     "schemas/unblock-applied.output.json": "sha256:4b1ed38f71ca16a56bc7bc2582c629580fe7b57614ea2b12b0c289c9e6bf611b"
   }

--- a/event-runtime/agents/unblock-apply.md
+++ b/event-runtime/agents/unblock-apply.md
@@ -6,11 +6,11 @@ via the deterministic actions adapter in item-list mode
 
 Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
 
-| action id | effect |
-| :--- | :--- |
-| `release-hold` | `state {issueId} "Todo" --remove ai:blocked --add ai:agent-ready` — evidence resolved the hold and the spec is dispatchable |
-| `release-to-triage` | `state {issueId} "Triage" --remove ai:blocked` — hold resolved, spec needs the triage stage |
-| `comment-evidence` | `comment {issueId} "unblock: <reason>"` — the citation a release must carry |
+| action id           | effect                                                                                                                      |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------- |
+| `release-hold`      | `state {issueId} "Todo" --remove ai:blocked --add ai:agent-ready` — evidence resolved the hold and the spec is dispatchable |
+| `release-to-triage` | `state {issueId} "Triage" --remove ai:blocked` — hold resolved, spec needs the triage stage                                 |
+| `comment-evidence`  | `comment {issueId} "unblock: <reason>"` — the citation a release must carry                                                 |
 
 Every action is a forward state move or a comment; nothing here closes,
 deletes, or reassigns an issue, and nothing can add `ai:blocked`. An action

--- a/event-runtime/agents/unblock-digest.json
+++ b/event-runtime/agents/unblock-digest.json
@@ -19,9 +19,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read"
-    ]
+    "services": ["linear:read"]
   },
   "limits": {
     "timeout_seconds": 300,

--- a/event-runtime/agents/unblock-scan.json
+++ b/event-runtime/agents/unblock-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -24,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/unblock-scan.md": "sha256:6a06493735dd5dafaf9a176390bf8d4930096bf32ca1e8cfce6c49f80a1d591c",
-    "schemas/unblock-scan.input.json": "sha256:68ea3a420c8f51a6a50046e2a7cf4a1f1579b0aeb1d603820e2d4237d5bb9c43",
+    "agents/unblock-scan.md": "sha256:c6e20de77d9171eee4d55f8895d798ca521fb83af82ec15ffaf72152b19f9a6a",
+    "schemas/unblock-scan.input.json": "sha256:edb9af116d7a35b155d2472232f3c9625381996876e6aac18dacff28a215ac89",
     "schemas/unblock-scan.output.json": "sha256:1ccccd541b192dc4a300a1a5ebfe36485fb2ed97effc4f0d6bfcc1ab7e757c65"
   }
 }

--- a/event-runtime/agents/unblock-scan.md
+++ b/event-runtime/agents/unblock-scan.md
@@ -6,7 +6,12 @@ tree to read it against:
 ```json
 {
   "repo": "bj29",
-  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+  "repoPin": {
+    "repo": "bj29",
+    "ref": "develop",
+    "sha": "<40-hex>",
+    "github": "owner/name"
+  }
 }
 ```
 
@@ -35,11 +40,11 @@ You never modify it, never run its build, never install anything. Write
 
 ## Actions — the closed set
 
-| action | when |
-| :--- | :--- |
-| `release-hold` | evidence resolves the hold AND the §5 template is solid against this SHA → back to the dispatch queue |
-| `release-to-triage` | evidence resolves the hold but the spec needs work → triage will re-spec it |
-| `comment-evidence` | the one-line citation (ticket/PR/doc) accompanying a release |
+| action              | when                                                                                                  |
+| :------------------ | :---------------------------------------------------------------------------------------------------- |
+| `release-hold`      | evidence resolves the hold AND the §5 template is solid against this SHA → back to the dispatch queue |
+| `release-to-triage` | evidence resolves the hold but the spec needs work → triage will re-spec it                           |
+| `comment-evidence`  | the one-line citation (ticket/PR/doc) accompanying a release                                          |
 
 Never invent an action id. Never release on a guess — a wrongly released hold
 hands an implementation agent a question a human was supposed to answer.
@@ -55,8 +60,16 @@ hands an implementation agent a question a human was supposed to answer.
     "recommendation": "UNBLOCK",
     "repo": "bj29",
     "plan": [
-      { "issueId": "CLNT-123", "action": "release-to-triage", "reason": "dependency CLNT-100 merged in PR #45" },
-      { "issueId": "CLNT-123", "action": "comment-evidence", "reason": "dependency CLNT-100 merged in PR #45" }
+      {
+        "issueId": "CLNT-123",
+        "action": "release-to-triage",
+        "reason": "dependency CLNT-100 merged in PR #45"
+      },
+      {
+        "issueId": "CLNT-123",
+        "action": "comment-evidence",
+        "reason": "dependency CLNT-100 merged in PR #45"
+      }
     ],
     "summary": "one line an operator can act on"
   },

--- a/event-runtime/agents/warm.json
+++ b/event-runtime/agents/warm.json
@@ -20,9 +20,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "repo:read"
-    ]
+    "services": ["repo:read"]
   },
   "limits": {
     "timeout_seconds": 1800,

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -24,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:80a767e3e8ad8539c079871ffe8cadcf80a12ba67770b6e7ea3c900fc541c45a",
-    "schemas/work-scan.input.json": "sha256:3d596ece1e34c9d3a8711596076df67357d8eeec3d29bc5bfb64e02ed4f32c10",
-    "schemas/work-scan.output.json": "sha256:62d81edf5aafc73fe62930be4c3b900107c333e58d4ebeb1f494330882b178e1"
+    "agents/work-scan.md": "sha256:aa73e0702f8715e50176ec5209e80c9554d3498c9c0335f3a626d7c9a9431c12",
+    "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
+    "schemas/work-scan.output.json": "sha256:98a2cb891198b79d8d8d9924a3db1fe2bd11e2983c71ae4a3499bc54a5d43f5f"
   }
 }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -6,7 +6,12 @@ tree to read it against:
 ```json
 {
   "repo": "bj29",
-  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+  "repoPin": {
+    "repo": "bj29",
+    "ref": "develop",
+    "sha": "<40-hex>",
+    "github": "owner/name"
+  }
 }
 ```
 
@@ -46,16 +51,17 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    errors, truncates, or returns
    malformed JSON, refuse with `reasonCode: "needs_human"` rather than inventing
    candidate order.
+
 2. **Order the filtered candidates** with this explicit Linear priority rank,
    then by `createdAt` ascending within the same rank:
 
    | Rank | Linear value | Label used in `reason` |
-   | ---: | ---: | --- |
-   | 1 | 1 | Urgent |
-   | 2 | 2 | High |
-   | 3 | 3 | Medium |
-   | 4 | 4 | Low |
-   | 5 | 0 | No priority |
+   | ---: | -----------: | ---------------------- |
+   |    1 |            1 | Urgent                 |
+   |    2 |            2 | High                   |
+   |    3 |            3 | Medium                 |
+   |    4 |            4 | Low                    |
+   |    5 |            0 | No priority            |
 
    Do **not** sort the raw numeric value ascending: Linear's `0` means no
    priority and belongs last. Every selected item's `reason` must include the
@@ -70,6 +76,7 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    `[URGENT, NONE]`; `BLOCKED` must be absent. Refuse with
    `reasonCode: "needs_human"` if your candidate construction or ordering does
    not produce that result.
+
 3. **Count the cap**: the repo's `max_in_flight` from
    `$FACTORY_ROOT/config/repos.yaml`, falling back to
    `concurrency.max_in_flight_per_repo` in `config/policy.yaml`, else 3. Record
@@ -107,7 +114,7 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
 
    If this ordered walk yields zero dispatch candidates after a complete read and
    `readyCandidates` is exactly 0, run a complete, independent read of `state:
-   Triage` backlog (again, all pages, fresh command, no sampling). If the Triage
+Triage` backlog (again, all pages, fresh command, no sampling). If the Triage
    read fails or returns any malformed payload, refuse with
    `reasonCode: "needs_human"`.
 
@@ -120,6 +127,7 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    `LOW_SUPPLY` with `readyCandidates` and `triageBacklog` counts in the
    artifact, then stop (no dispatch plan). If there are zero dispatch
    candidates and an empty backlog, emit normal `NOOP queue_empty`.
+
 ## What you cannot see — say so, never pretend
 
 You cannot see the runtime's own ledger: a ticket with an open (not yet
@@ -148,11 +156,13 @@ completion, which re-plans those candidates against a fresh world.
     "repo": "bj29",
     "ticket": "CLNT-123",
     "plan": [
-      { "ticket": "CLNT-123", "ownedPaths": ["src/feature-a/**"], "reason": "priority Urgent, paths disjoint from all in-flight" }
+      {
+        "ticket": "CLNT-123",
+        "ownedPaths": ["src/feature-a/**"],
+        "reason": "priority Urgent, paths disjoint from all in-flight"
+      }
     ],
-    "deferred": [
-      { "ticket": "CLNT-124", "reason": "owned_paths_overlap" }
-    ],
+    "deferred": [{ "ticket": "CLNT-124", "reason": "owned_paths_overlap" }],
     "summary": "one line an operator can act on",
     "readyCandidates": 2,
     "triageBacklog": 0

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -43,7 +43,9 @@ async function callControl(method, pathname, body) {
   });
   const payload = await res.json().catch(() => null);
   if (!res.ok) {
-    const err = new Error(payload?.message ?? payload?.error ?? `HTTP ${res.status}`);
+    const err = new Error(
+      payload?.message ?? payload?.error ?? `HTTP ${res.status}`,
+    );
     err.status = res.status;
     throw err;
   }
@@ -82,13 +84,16 @@ function parseDecisionField(field, raw) {
 export async function decideCommand(args) {
   const [itemId, optionId, ...rest] = args;
   if (!itemId || !optionId) {
-    throw new Error("usage: decide <item-id> <option-id> [--field key=value]...");
+    throw new Error(
+      "usage: decide <item-id> <option-id> [--field key=value]...",
+    );
   }
   const detail = await callControl(
     "GET",
     `/inbox/${encodeURIComponent(itemId)}`,
   );
-  if (!detail.item.decision) throw new Error(`inbox item ${itemId} has no decision`);
+  if (!detail.item.decision)
+    throw new Error(`inbox item ${itemId} has no decision`);
   const declared = new Map(
     (detail.item.decision.fields ?? []).map((field) => [field.id, field]),
   );
@@ -99,7 +104,8 @@ export async function decideCommand(args) {
     }
     const assignment = rest[++index];
     const equals = assignment.indexOf("=");
-    if (equals <= 0) throw new Error(`--field expects key=value, got ${assignment}`);
+    if (equals <= 0)
+      throw new Error(`--field expects key=value, got ${assignment}`);
     const key = assignment.slice(0, equals);
     const raw = assignment.slice(equals + 1);
     fields[key] = parseDecisionField(declared.get(key), raw);

--- a/event-runtime/cli/extend.mjs
+++ b/event-runtime/cli/extend.mjs
@@ -11,6 +11,8 @@ export default function extend(args) {
     const outcome = await client.extend(runId, seconds, {
       override: args.includes("--override"),
     });
-    console.log(`extended ${runId} by ${seconds}s; deadline ${outcome.deadlineAt}`);
+    console.log(
+      `extended ${runId} by ${seconds}s; deadline ${outcome.deadlineAt}`,
+    );
   });
 }

--- a/event-runtime/cli/inspect.mjs
+++ b/event-runtime/cli/inspect.mjs
@@ -52,7 +52,8 @@ export async function inspect(client, runId) {
     // before the JSON that says it.
     if (view.result.artifact !== undefined) {
       const artifactView = await viewFor(client, run.spec.agent);
-      for (const line of inspectHeader(artifactView, view.result.artifact)) console.log(`  ${line}`);
+      for (const line of inspectHeader(artifactView, view.result.artifact))
+        console.log(`  ${line}`);
     }
     console.log(
       `  terminalState ${view.result.terminalState}   reason ${view.result.reasonCode ?? "-"}`,

--- a/event-runtime/cli/process-cleanup.test.mjs
+++ b/event-runtime/cli/process-cleanup.test.mjs
@@ -36,7 +36,9 @@ async function waitForFile(file, timeoutMs = 5_000) {
   while (Date.now() < deadline) {
     try {
       return readFileSync(file, "utf8").trim();
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
     await Bun.sleep(10);
   }
   throw new Error(`timed out waiting for ${file}`);
@@ -96,7 +98,10 @@ describe("tracked test processes (WM-654)", () => {
     const pidFile = path.join(dir, "grandchild.pid");
     const child = spawnTracked(
       "bash",
-      ["-c", `sleep 60 & printf '%s\\n' "$!" > ${JSON.stringify(pidFile)}; wait`],
+      [
+        "-c",
+        `sleep 60 & printf '%s\\n' "$!" > ${JSON.stringify(pidFile)}; wait`,
+      ],
       { stdio: "ignore" },
     );
     const grandchildPid = Number(await waitForFile(pidFile));
@@ -148,7 +153,9 @@ describe("tracked test processes (WM-654)", () => {
       detached: process.platform !== "win32",
       stdio: "ignore",
       env: Object.fromEntries(
-        Object.entries(process.env).filter(([key]) => key !== "FACTORY_TEST_TRACKED_PROCESS"),
+        Object.entries(process.env).filter(
+          ([key]) => key !== "FACTORY_TEST_TRACKED_PROCESS",
+        ),
       ),
     });
     try {

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -33,10 +33,14 @@ describe("serve command", () => {
   test("serve --watch re-execs under bun --watch and binds", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-watch-"));
     const port = String(59000 + (process.pid % 800));
-    const child = spawnTracked("bun", [CLI, "serve", "--watch", "--port", port], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnTracked(
+      "bun",
+      [CLI, "serve", "--watch", "--port", port],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     let out = "";
     child.stdout.on("data", (b) => {
       out += b;

--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -124,7 +124,8 @@ export function workerPassthroughArgs(args) {
     const v = flagValue(args, flag);
     if (v !== null && v !== undefined) passthrough.push(flag, v);
   }
-  if (args.includes("--reload-on-change")) passthrough.push("--reload-on-change");
+  if (args.includes("--reload-on-change"))
+    passthrough.push("--reload-on-change");
   for (let i = 0; i < args.length; i += 1) {
     if (args[i] === "--label")
       passthrough.push("--label", String(args[i + 1] ?? ""));

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -152,7 +152,8 @@ export async function runNotifierDeliveryCase({
   const { tick } = await import("../cli.mjs");
   const { loadRegistry } = await import("../lib/registry.mjs");
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tick-notify-"));
-  const { outFile, pidFile, startedFile, releaseFile, stub } = writeGatedNotifier(dir);
+  const { outFile, pidFile, startedFile, releaseFile, stub } =
+    writeGatedNotifier(dir);
   const db = openDb(path.join(dir, "runtime.db"));
   const at = new Date().toISOString();
   db.query(
@@ -182,7 +183,9 @@ export async function runNotifierDeliveryCase({
     });
     deliveryStarted = true;
     await awaitFile(startedFile, "notifier start");
-    trackProcess(Number(readFileSync(pidFile, "utf8").trim()), { group: false });
+    trackProcess(Number(readFileSync(pidFile, "utf8").trim()), {
+      group: false,
+    });
     if (failWhilePending)
       throw new Error(
         "intentional assertion failure while notifier delivery is pending",
@@ -199,9 +202,9 @@ export async function runNotifierDeliveryCase({
       "2. Not now",
     ].join("\n");
     expect(readFileSync(outFile, "utf8").trim()).toBe(expectedMessage);
-    expect(
-      logs.some((l) => l.includes("notify BLOCKED test/evt-tick")),
-    ).toBe(true);
+    expect(logs.some((l) => l.includes("notify BLOCKED test/evt-tick"))).toBe(
+      true,
+    );
     await tick({
       db,
       registry: loadRegistry(),

--- a/event-runtime/cli/update-pins.mjs
+++ b/event-runtime/cli/update-pins.mjs
@@ -12,7 +12,8 @@ export default function updatePinsCommand(args = []) {
     fail("usage: update-pins [--pack NAME]");
   }
   try {
-    const changed = args.length === 0 ? updatePins() : updatePins({ pack: args[1] });
+    const changed =
+      args.length === 0 ? updatePins() : updatePins({ pack: args[1] });
     console.log(
       changed.length
         ? `re-pinned: ${changed.join(", ")}`

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -201,10 +201,14 @@ describe("work command", () => {
     });
     db.close();
 
-    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "fake"], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnTracked(
+      "bun",
+      [CLI, "work", "--adapter-override", "fake"],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
 
     let out = "";
     child.stdout.on("data", (b) => {
@@ -241,10 +245,14 @@ describe("work command", () => {
 
   test("work --adapter-override pi is accepted at the work call site (OPS-517)", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-pi-"));
-    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "pi"], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnTracked(
+      "bun",
+      [CLI, "work", "--adapter-override", "pi"],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     let out = "";
     child.stdout.on("data", (b) => {
       out += b;
@@ -463,10 +471,14 @@ describe("work command", () => {
 
   test("work --adapter-override cursor is accepted at the work call site (WM-440)", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-cursor-"));
-    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "cursor"], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnTracked(
+      "bun",
+      [CLI, "work", "--adapter-override", "cursor"],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     let out = "";
     child.stdout.on("data", (b) => {
       out += b;

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -66,7 +66,8 @@ const client = new Proxy(rawClient, {
     const value = target[prop];
     if (typeof value !== "function") return value;
     if (["approve", "cancel", "reject", "replay", "retry"].includes(prop)) {
-      return (...args) => retryDatabaseLock(`${prop} ${args[0] ?? ""}`, () => value(...args));
+      return (...args) =>
+        retryDatabaseLock(`${prop} ${args[0] ?? ""}`, () => value(...args));
     }
     return value;
   },
@@ -94,7 +95,12 @@ async function projectNames() {
 /** repos[0] must stay the fake adapter's mode — the project name only trails it. */
 const tag = (mode, project) => (project ? [mode, project] : [mode]);
 
-function envelope(id, repos, type = "factory.status-report.requested", source = "demo-seed") {
+function envelope(
+  id,
+  repos,
+  type = "factory.status-report.requested",
+  source = "demo-seed",
+) {
   return {
     schemaVersion: "factory.event/v1",
     eventId: `${prefix}-${id}`,
@@ -122,7 +128,9 @@ async function retryDatabaseLock(label, operation) {
       await sleep(25 * (attempt + 1));
     }
   }
-  throw new Error(`${label}: database remained locked after 20 retries (${last?.message ?? "unknown error"})`);
+  throw new Error(
+    `${label}: database remained locked after 20 retries (${last?.message ?? "unknown error"})`,
+  );
 }
 
 async function replay(env) {
@@ -130,9 +138,9 @@ async function replay(env) {
   if (res.duplicate) {
     console.error(
       `seed: duplicate prefix "${prefix}" — event "${env.eventId}" already exists in runtime database.\n` +
-      `This runtime was already seeded under prefix "${prefix}".\n` +
-      `To re-seed under a fresh prefix: bun event-runtime/demo/seed.mjs --port ${port} --prefix demo-$(date +%s)\n` +
-      `Or use: bin/worktree-up.sh --reseed`,
+        `This runtime was already seeded under prefix "${prefix}".\n` +
+        `To re-seed under a fresh prefix: bun event-runtime/demo/seed.mjs --port ${port} --prefix demo-$(date +%s)\n` +
+        `Or use: bin/worktree-up.sh --reseed`,
     );
     process.exit(1);
   }
@@ -152,7 +160,9 @@ async function until(what, fn, { timeoutMs = 30_000, everyMs = pollMs } = {}) {
 
 async function proposalFor(eventId, { agent, status = "open" } = {}) {
   return until(`proposal for ${agent ?? eventId}`, async () => {
-    const { proposals } = await client.proposals(status === "open" ? undefined : "all");
+    const { proposals } = await client.proposals(
+      status === "open" ? undefined : "all",
+    );
     return proposals.find((p) => {
       if (status !== "all" && p.status !== status) return false;
       const eventMatches =
@@ -175,24 +185,37 @@ async function openProposalFor(eventId, options = {}) {
 
 /** human_needed proposals carry no spec — match via their admitted event. */
 async function humanNeededProposal(eventId) {
-  return until(`human_needed proposal${eventId ? ` for ${eventId}` : ""}`, async () => {
-    const { proposals } = await client.proposals();
-    return proposals.find(
-      (p) =>
-        p.status === "open" &&
-        p.decision === "human_needed" &&
-        (!eventId || p.eventId?.includes(eventId) || p.reason?.includes(eventId)),
-    );
-  });
+  return until(
+    `human_needed proposal${eventId ? ` for ${eventId}` : ""}`,
+    async () => {
+      const { proposals } = await client.proposals();
+      return proposals.find(
+        (p) =>
+          p.status === "open" &&
+          p.decision === "human_needed" &&
+          (!eventId ||
+            p.eventId?.includes(eventId) ||
+            p.reason?.includes(eventId)),
+      );
+    },
+  );
 }
 
 async function runTerminal(runId, wanted) {
   return until(`run ${runId} → ${wanted}`, async () => {
     const view = await client.run(runId);
     if (view.run.state === wanted) return view;
-    const TERMINAL = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
+    const TERMINAL = [
+      "COMPLETED",
+      "REFUSED",
+      "FAILED",
+      "TIMED_OUT",
+      "CANCELLED",
+    ];
     if (TERMINAL.includes(view.run.state)) {
-      throw new Error(`run ${runId} terminated ${view.run.state}, expected ${wanted}`);
+      throw new Error(
+        `run ${runId} terminated ${view.run.state}, expected ${wanted}`,
+      );
     }
     return null;
   });
@@ -213,7 +236,10 @@ const probeId = `${prefix}-adapter-probe`;
 await replay(envelope("adapter-probe", ["ok"]));
 const probe = await openProposalFor(probeId);
 if (probe.spec?.adapter !== "fake") {
-  await client.reject(probe.id, "seed aborted: runtime is not in fake-adapter mode");
+  await client.reject(
+    probe.id,
+    "seed aborted: runtime is not in fake-adapter mode",
+  );
   console.error(
     `seed: refusing — this runtime plans with adapter "${probe.spec?.adapter}", not "fake". ` +
       `Restart it with --adapter-override fake.`,
@@ -226,24 +252,30 @@ await client.reject(probe.id, "adapter probe — not part of the demo set");
 // so the single worker is unblocked and open proposal counts match fixture assertions.
 try {
   const { proposals: priorProposals } = await client.proposals();
-  for (const p of (priorProposals ?? [])) {
+  for (const p of priorProposals ?? []) {
     try {
       await client.reject(p.id, "cancelled by demo re-seed");
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
   }
   const { runs: priorRuns } = await client.runs();
-  for (const r of (priorRuns ?? [])) {
+  for (const r of priorRuns ?? []) {
     if (r.state === "RUNNING" || r.state === "QUEUED") {
       try {
         await client.cancel(r.runId, "cancelled by demo re-seed");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   await until(
     "worker idle after re-seed cleanup",
     async () => {
       const { runs } = await client.runs();
-      const busy = (runs ?? []).filter((r) => r.state === "RUNNING" || r.state === "QUEUED");
+      const busy = (runs ?? []).filter(
+        (r) => r.state === "RUNNING" || r.state === "QUEUED",
+      );
       return busy.length === 0;
     },
     { timeoutMs: 5_000, everyMs: 100 },
@@ -254,12 +286,20 @@ try {
 
 const [projectA, projectB = projectA] = await projectNames();
 const primaryProject = projectA || "factory";
-log(projectA ? `project tags: ${[...new Set([projectA, projectB])].join(", ")}` : "project tags: none (fallback: factory)");
+log(
+  projectA
+    ? `project tags: ${[...new Set([projectA, projectB])].join(", ")}`
+    : "project tags: none (fallback: factory)",
+);
 
 // 1. Quick terminals for status-report (ephemeral workspace)
 const terminals = [
   { id: "completed", repos: tag("ok", projectA), wanted: "COMPLETED" },
-  { id: "with-artifact", repos: tag("with-artifact", projectA), wanted: "COMPLETED" },
+  {
+    id: "with-artifact",
+    repos: tag("with-artifact", projectA),
+    wanted: "COMPLETED",
+  },
   { id: "trace-flood", repos: ["trace-flood"], wanted: "COMPLETED" },
   { id: "refused", repos: ["refuse"], wanted: "REFUSED" },
   { id: "failed-crash", repos: ["crash"], wanted: "FAILED" },
@@ -274,12 +314,17 @@ for (const t of terminals) {
 }
 
 // 2. Multi-attempt run: retry the failed-crash run (attempt: 2)
-const failedCrashProposal = await until("failed-crash run for retry", async () => {
-  const { runs } = await client.runs("FAILED");
-  return runs.find((r) => r.reasonCode === "agent_exit_1");
-});
+const failedCrashProposal = await until(
+  "failed-crash run for retry",
+  async () => {
+    const { runs } = await client.runs("FAILED");
+    return runs.find((r) => r.reasonCode === "agent_exit_1");
+  },
+);
 if (failedCrashProposal) {
-  log(`retrying ${failedCrashProposal.runId} with force=true to create attempt 2`);
+  log(
+    `retrying ${failedCrashProposal.runId} with force=true to create attempt 2`,
+  );
   await client.retry(failedCrashProposal.runId, { force: true });
   await runTerminal(failedCrashProposal.runId, "FAILED");
   log(`${failedCrashProposal.runId} → FAILED (attempt 2 completed)`);
@@ -312,19 +357,29 @@ await client.replay({
   correlationId: ciEventId,
   payload: { repo: `wm/${primaryProject}`, runId: ciRunId },
 });
-const ciCaptureProposal = await openProposalFor(ciEventId, { agent: "ci-log-capture@1" });
+const ciCaptureProposal = await openProposalFor(ciEventId, {
+  agent: "ci-log-capture@1",
+});
 await client.approve(ciCaptureProposal.id);
 await runTerminal(ciCaptureProposal.runId, "COMPLETED");
-log(`${ciCaptureProposal.runId} → COMPLETED (ci-log-capture@1, emitted ci-log artifact)`);
+log(
+  `${ciCaptureProposal.runId} → COMPLETED (ci-log-capture@1, emitted ci-log artifact)`,
+);
 
 // Hop 2: ci-doctor@2 (artifacts workspace type with $.artifactHash.ci-log)
-const ciDoctorProposal = await openProposalFor(ciEventId, { agent: "ci-doctor@2" });
+const ciDoctorProposal = await openProposalFor(ciEventId, {
+  agent: "ci-doctor@2",
+});
 await client.approve(ciDoctorProposal.id);
 await runTerminal(ciDoctorProposal.runId, "COMPLETED");
-log(`${ciDoctorProposal.runId} → COMPLETED (ci-doctor@2, verdict FLAKE, artifacts workspace)`);
+log(
+  `${ciDoctorProposal.runId} → COMPLETED (ci-doctor@2, verdict FLAKE, artifacts workspace)`,
+);
 
 // Hop 3: ci-rerun@1 (command adapter follow-up with causationId)
-const ciRerunProposal = await openProposalFor(ciEventId, { agent: "ci-rerun@1" });
+const ciRerunProposal = await openProposalFor(ciEventId, {
+  agent: "ci-rerun@1",
+});
 await client.approve(ciRerunProposal.id);
 await runTerminal(ciRerunProposal.runId, "COMPLETED");
 log(`${ciRerunProposal.runId} → COMPLETED (ci-rerun@1, command adapter)`);
@@ -341,10 +396,14 @@ await client.replay({
   correlationId: triageEventId,
   payload: { repo: primaryProject },
 });
-const triageScanProposal = await openProposalFor(triageEventId, { agent: "triage-scan@1" });
+const triageScanProposal = await openProposalFor(triageEventId, {
+  agent: "triage-scan@1",
+});
 await client.approve(triageScanProposal.id);
 await runTerminal(triageScanProposal.runId, "COMPLETED");
-log(`${triageScanProposal.runId} → COMPLETED (triage-scan@1, repository workspace)`);
+log(
+  `${triageScanProposal.runId} → COMPLETED (triage-scan@1, repository workspace)`,
+);
 
 // Follow-up triage-apply run from this scan's exact causal edge. Matching only
 // by agent can reuse a terminal proposal from a prior seed while the fresh edge
@@ -360,7 +419,9 @@ log(
 );
 
 // 7. Duplicate delivery suppression
-const dupOutcome = await client.replay(envelope("completed", tag("ok", projectA)));
+const dupOutcome = await client.replay(
+  envelope("completed", tag("ok", projectA)),
+);
 log(`duplicate admission test: duplicate=${dupOutcome.duplicate}`);
 
 // 8. Open watched proposals: direct/operator, merge/ship, human_needed, and TTL-expired
@@ -404,7 +465,9 @@ await client.replay({
     ],
   },
 });
-const mergeWatched = await openProposalFor(mergeEventId, { agent: "merge-apply@2" });
+const mergeWatched = await openProposalFor(mergeEventId, {
+  agent: "merge-apply@2",
+});
 log(`${mergeWatched.id} left open (merge-apply@2 watched)`);
 
 // A landed event is deliberately not fabricated by the demo. The executable
@@ -427,11 +490,15 @@ await client.replay({
     deployBranch: "main",
     headSha: fixtureSha,
     deployHeadSha: fixtureSha,
-    changelog: [{ sha: fixtureSha, subject: "fixture release", ticket: "WM-400" }],
+    changelog: [
+      { sha: fixtureSha, subject: "fixture release", ticket: "WM-400" },
+    ],
     plan: [{ action: "open_rc_pr" }],
   },
 });
-const shipWatched = await openProposalFor(shipEventId, { agent: "ship-apply@1" });
+const shipWatched = await openProposalFor(shipEventId, {
+  agent: "ship-apply@1",
+});
 log(`${shipWatched.id} left open (ship-apply@1 human watched)`);
 
 await replay(envelope("human-needed", []));
@@ -447,8 +514,12 @@ const home = health.env?.home || runtimeHome();
 try {
   const db = openDb(dbPath(home));
   // Set expired proposal created_at to 2 hours ago
-  db.query("UPDATE proposals SET created_at = datetime('now', '-2 hours') WHERE id = ?").run(expiredProposal.id);
-  log(`${expiredProposal.id} timestamp updated to 2h ago (TTL-expired proposal anomaly)`);
+  db.query(
+    "UPDATE proposals SET created_at = datetime('now', '-2 hours') WHERE id = ?",
+  ).run(expiredProposal.id);
+  log(
+    `${expiredProposal.id} timestamp updated to 2h ago (TTL-expired proposal anomaly)`,
+  );
 
   // Insert a dead-lettered event directly into events table
   const deadEventId = `${prefix}-dead-letter`;
@@ -462,23 +533,41 @@ try {
      ON CONFLICT(source, event_id) DO UPDATE SET
        status = 'dead_lettered', plan_failures = 3, last_plan_error = 'simulated planning failure: poison payload'`,
   ).run(
-    deadEnvelope.source, deadEventId, deadEnvelope.type, deadEnvelope.subject,
-    deadEnvelope.occurredAt, nowStr, deadEnvelope.correlationId, null,
-    JSON.stringify(deadEnvelope), "none", nowStr,
+    deadEnvelope.source,
+    deadEventId,
+    deadEnvelope.type,
+    deadEnvelope.subject,
+    deadEnvelope.occurredAt,
+    nowStr,
+    deadEnvelope.correlationId,
+    null,
+    JSON.stringify(deadEnvelope),
+    "none",
+    nowStr,
   );
   log(`${deadEventId} inserted as dead_lettered (dead-letter anomaly)`);
 
   // WM-132: Update failed-contract run spec to have maxAttempts = 2 so plain Retry is exercisable (attempts < maxAttempts)
   const contractRow = db
-    .query("SELECT p.run_id, r.spec_json FROM proposals p JOIN runs r ON r.run_id = p.run_id WHERE p.idempotency_key LIKE ?")
+    .query(
+      "SELECT p.run_id, r.spec_json FROM proposals p JOIN runs r ON r.run_id = p.run_id WHERE p.idempotency_key LIKE ?",
+    )
     .get(`%${prefix}-failed-contract%`);
   if (contractRow) {
     const spec = JSON.parse(contractRow.spec_json);
     spec.maxAttempts = 2;
     const updatedSpecJson = JSON.stringify(spec);
-    db.query("UPDATE runs SET spec_json = ? WHERE run_id = ?").run(updatedSpecJson, contractRow.run_id);
-    db.query("UPDATE proposals SET spec_json = ? WHERE run_id = ?").run(updatedSpecJson, contractRow.run_id);
-    log(`${contractRow.run_id} spec updated to maxAttempts=2 (attempts: 1/2, plain retry exercisable)`);
+    db.query("UPDATE runs SET spec_json = ? WHERE run_id = ?").run(
+      updatedSpecJson,
+      contractRow.run_id,
+    );
+    db.query("UPDATE proposals SET spec_json = ? WHERE run_id = ?").run(
+      updatedSpecJson,
+      contractRow.run_id,
+    );
+    log(
+      `${contractRow.run_id} spec updated to maxAttempts=2 (attempts: 1/2, plain retry exercisable)`,
+    );
   }
 
   // WM-133: Working PR workflow scenario (dispatch@1 run moving through RUNNING → VERIFYING → COMPLETED with PR_OPEN)
@@ -518,9 +607,17 @@ try {
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "resolved", 0, null, ?)
      ON CONFLICT(source, event_id) DO UPDATE SET status = "resolved"`,
   ).run(
-    dispatchEnvelope.source, dispatchEventId, dispatchEnvelope.type, dispatchEnvelope.subject,
-    dispatchEnvelope.occurredAt, nowStr, dispatchEnvelope.correlationId, null,
-    JSON.stringify(dispatchEnvelope), hashJson(dispatchEnvelope.payload), nowStr,
+    dispatchEnvelope.source,
+    dispatchEventId,
+    dispatchEnvelope.type,
+    dispatchEnvelope.subject,
+    dispatchEnvelope.occurredAt,
+    nowStr,
+    dispatchEnvelope.correlationId,
+    null,
+    JSON.stringify(dispatchEnvelope),
+    hashJson(dispatchEnvelope.payload),
+    nowStr,
   );
 
   db.query(
@@ -530,8 +627,15 @@ try {
      VALUES (?, ?, ?, ?, "run", ?, ?, ?, "approved", null, ?, 1800, ?, "operator")
      ON CONFLICT(id) DO UPDATE SET status = "approved", run_id = excluded.run_id`,
   ).run(
-    dispatchPropId, dispatchEnvelope.source, dispatchEventId, dispatchRunId,
-    dispatchSpecJson, dispatchSpecHash, dispatchRunId, nowStr, nowStr,
+    dispatchPropId,
+    dispatchEnvelope.source,
+    dispatchEventId,
+    dispatchRunId,
+    dispatchSpecJson,
+    dispatchSpecHash,
+    dispatchRunId,
+    nowStr,
+    nowStr,
   );
 
   createRun(db, {
@@ -545,21 +649,79 @@ try {
     policyVersion: "v1",
     now: () => nowStr,
   });
-  transition(db, { runId: dispatchRunId, to: "APPROVED", expectFrom: "PROPOSED", actor: "operator", reason: "approved", policyVersion: "v1", now: () => nowStr });
-  transition(db, { runId: dispatchRunId, to: "QUEUED", expectFrom: "APPROVED", actor: "worker-demo", reason: "queued", policyVersion: "v1", now: () => nowStr });
-  transition(db, { runId: dispatchRunId, to: "LEASED", expectFrom: "QUEUED", actor: "worker-demo", reason: "leased", policyVersion: "v1", now: () => nowStr });
-  transition(db, { runId: dispatchRunId, to: "RUNNING", expectFrom: "LEASED", actor: "worker-demo", reason: "started", attempt: 1, policyVersion: "v1", now: () => nowStr });
-  transition(db, { runId: dispatchRunId, to: "VERIFYING", expectFrom: "RUNNING", actor: "worker-demo", reason: "finished", attempt: 1, policyVersion: "v1", now: () => nowStr });
-  transition(db, { runId: dispatchRunId, to: "COMPLETED", expectFrom: "VERIFYING", actor: "worker-demo", reason: "verified", attempt: 1, policyVersion: "v1", now: () => nowStr });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "APPROVED",
+    expectFrom: "PROPOSED",
+    actor: "operator",
+    reason: "approved",
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "QUEUED",
+    expectFrom: "APPROVED",
+    actor: "worker-demo",
+    reason: "queued",
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "LEASED",
+    expectFrom: "QUEUED",
+    actor: "worker-demo",
+    reason: "leased",
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "RUNNING",
+    expectFrom: "LEASED",
+    actor: "worker-demo",
+    reason: "started",
+    attempt: 1,
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "VERIFYING",
+    expectFrom: "RUNNING",
+    actor: "worker-demo",
+    reason: "finished",
+    attempt: 1,
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
+  transition(db, {
+    runId: dispatchRunId,
+    to: "COMPLETED",
+    expectFrom: "VERIFYING",
+    actor: "worker-demo",
+    reason: "verified",
+    attempt: 1,
+    policyVersion: "v1",
+    now: () => nowStr,
+  });
 
-  db.query("UPDATE runs SET state = \"COMPLETED\", attempts = 1, updated_at = ? WHERE run_id = ?").run(nowStr, dispatchRunId);
+  db.query(
+    'UPDATE runs SET state = "COMPLETED", attempts = 1, updated_at = ? WHERE run_id = ?',
+  ).run(nowStr, dispatchRunId);
 
   db.query(
     `INSERT INTO attempts
        (run_id, attempt, fencing_token, lease_owner, lease_expires_at, started_at, finished_at, terminal_state, reason_code, workspace_path)
      VALUES (?, 1, 1, "worker-demo", datetime("now", "+1 hour"), ?, ?, "COMPLETED", "ok", ?)
      ON CONFLICT(run_id, attempt) DO UPDATE SET terminal_state = "COMPLETED", reason_code = "ok"`,
-  ).run(dispatchRunId, nowStr, nowStr, `/tmp/worktrees/${primaryProject}/${dispatchTicket}`);
+  ).run(
+    dispatchRunId,
+    nowStr,
+    nowStr,
+    `/tmp/worktrees/${primaryProject}/${dispatchTicket}`,
+  );
 
   const prUrl = `https://github.com/watt-mind/${primaryProject}/pull/42`;
   const dispatchArtifact = {
@@ -611,9 +773,17 @@ try {
        evidence_set_hash = excluded.evidence_set_hash, verification_json = excluded.verification_json,
        receipt_json = excluded.receipt_json, accepted_at = excluded.accepted_at`,
   ).run(
-    dispatchRunId, resultJson, artifactHash, evidenceSetHash, verificationJson, receiptJson, nowStr,
+    dispatchRunId,
+    resultJson,
+    artifactHash,
+    evidenceSetHash,
+    verificationJson,
+    receiptJson,
+    nowStr,
   );
-  log(`${dispatchRunId} → COMPLETED (dispatch@1, simulated working PR workflow with PR_OPEN)`);
+  log(
+    `${dispatchRunId} → COMPLETED (dispatch@1, simulated working PR workflow with PR_OPEN)`,
+  );
 
   db.close();
 } catch (err) {
@@ -632,6 +802,12 @@ log(`${hang.runId} → RUNNING (hang mode; TIMED_OUT after 600s timeout)`);
 
 log("done — seeded comprehensive fixture across all agents & states:");
 const { runs } = await client.runs();
-for (const r of runs) log(`  ${r.runId}  ${r.state}  agent:${r.agent}  repos:[${(r.repos ?? []).join(", ")}]`);
+for (const r of runs)
+  log(
+    `  ${r.runId}  ${r.state}  agent:${r.agent}  repos:[${(r.repos ?? []).join(", ")}]`,
+  );
 const { proposals } = await client.proposals();
-for (const p of proposals) log(`  ${p.id}  ${p.decision} (open)  agent:${p.agent ?? p.spec?.agent}  expired:${p.expired}`);
+for (const p of proposals)
+  log(
+    `  ${p.id}  ${p.decision} (open)  agent:${p.agent ?? p.spec?.agent}  expired:${p.expired}`,
+  );

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -11,7 +11,12 @@ const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
 const SEED = fileURLToPath(new URL("./seed.mjs", import.meta.url));
 const VERIFY = fileURLToPath(new URL("./verify.mjs", import.meta.url));
 const TRIAGE_SCAN_OUTPUT_SCHEMA = JSON.parse(
-  readFileSync(fileURLToPath(new URL("../schemas/triage-scan.output.json", import.meta.url)), "utf8"),
+  readFileSync(
+    fileURLToPath(
+      new URL("../schemas/triage-scan.output.json", import.meta.url),
+    ),
+    "utf8",
+  ),
 );
 // A liveness bound, not a performance target (WM-503). The two assertions that
 // use it exist to catch a seed that waits on the WRONG causal edge — reusing a
@@ -30,9 +35,10 @@ const TRIAGE_SCAN_OUTPUT_SCHEMA = JSON.parse(
 // timeout). Rediscovered as WM-487, WM-492, WM-499 and WM-90 before WM-503.
 const SEED_TIMEOUT_MS = 20_000;
 
-const redact = (text) => String(text ?? "")
-  .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
-  .replace(/(authorization\s*[:=]\s*)\S+/gi, "$1[REDACTED]");
+const redact = (text) =>
+  String(text ?? "")
+    .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
+    .replace(/(authorization\s*[:=]\s*)\S+/gi, "$1[REDACTED]");
 
 function expectSuccess(label, result) {
   const diagnostic = [
@@ -50,7 +56,9 @@ async function waitForPublishedOutbox(port) {
       const response = await fetch(`http://127.0.0.1:${port}/status`);
       const status = await response.json();
       if (response.ok && status.anomalies?.unpublishedOutbox === 0) return;
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
     await Bun.sleep(50);
   }
   expect.fail("seeded runtime did not publish its outbox within 5 seconds");
@@ -60,7 +68,9 @@ describe("triage-scan write-detail contract (WM-352)", () => {
   const artifactWithDetail = (detail) => ({
     recommendation: "TRIAGE",
     repo: "factory",
-    plan: [{ issueId: "WM-352", action: "write-detail", reason: "fixture", detail }],
+    plan: [
+      { issueId: "WM-352", action: "write-detail", reason: "fixture", detail },
+    ],
     summary: "fixture",
   });
 
@@ -81,8 +91,15 @@ describe("triage-scan write-detail contract (WM-352)", () => {
       "```",
     ].join("\n");
 
-    expect(validate(TRIAGE_SCAN_OUTPUT_SCHEMA, artifactWithDetail(canonical))).toEqual({ valid: true, errors: [] });
-    expect(validate(TRIAGE_SCAN_OUTPUT_SCHEMA, artifactWithDetail("## Rollout\n\n- Deploy globally."))).toEqual({
+    expect(
+      validate(TRIAGE_SCAN_OUTPUT_SCHEMA, artifactWithDetail(canonical)),
+    ).toEqual({ valid: true, errors: [] });
+    expect(
+      validate(
+        TRIAGE_SCAN_OUTPUT_SCHEMA,
+        artifactWithDetail("## Rollout\n\n- Deploy globally."),
+      ),
+    ).toEqual({
       valid: false,
       errors: [
         "$.plan[0].detail: does not match pattern ^\\s*## (Acceptance Criteria|Owned Paths|Verification)",
@@ -91,11 +108,21 @@ describe("triage-scan write-detail contract (WM-352)", () => {
   });
 
   test("continues to accept Owned Paths and Verification as the first section", () => {
-    expect(validate(TRIAGE_SCAN_OUTPUT_SCHEMA, artifactWithDetail("## Owned Paths\n\n- `README.md`"))).toEqual({
+    expect(
+      validate(
+        TRIAGE_SCAN_OUTPUT_SCHEMA,
+        artifactWithDetail("## Owned Paths\n\n- `README.md`"),
+      ),
+    ).toEqual({
       valid: true,
       errors: [],
     });
-    expect(validate(TRIAGE_SCAN_OUTPUT_SCHEMA, artifactWithDetail("## Verification\n\n```\nbun test\n```"))).toEqual({
+    expect(
+      validate(
+        TRIAGE_SCAN_OUTPUT_SCHEMA,
+        artifactWithDetail("## Verification\n\n```\nbun test\n```"),
+      ),
+    ).toEqual({
       valid: true,
       errors: [],
     });
@@ -119,10 +146,15 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     port = String(probe.port);
     probe.stop(true);
 
-    serveChild = spawnTracked("bun", [CLI, "serve", "--adapter-override", "fake", "--port", port], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    }, { scope: "suite" });
+    serveChild = spawnTracked(
+      "bun",
+      [CLI, "serve", "--adapter-override", "fake", "--port", port],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+      { scope: "suite" },
+    );
 
     // Wait for health
     let up = false;
@@ -134,15 +166,31 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
           up = true;
           break;
         }
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
       await Bun.sleep(100);
     }
     expect(up).toBe(true);
 
-    workerChild = spawnTracked("bun", [CLI, "work", "--adapter-override", "fake", "--port", port, "--poll-ms", "40"], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    }, { scope: "suite" });
+    workerChild = spawnTracked(
+      "bun",
+      [
+        CLI,
+        "work",
+        "--adapter-override",
+        "fake",
+        "--port",
+        port,
+        "--poll-ms",
+        "40",
+      ],
+      {
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+      { scope: "suite" },
+    );
 
     // Health only proves the control API is listening. Seed drives approvals
     // immediately, so wait for the separate worker process to register first.
@@ -156,7 +204,9 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
           workerReady = true;
           break;
         }
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
       await Bun.sleep(50);
     }
     expect(workerReady).toBe(true);
@@ -166,24 +216,34 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     if (serveChild) {
       try {
         serveChild.kill("SIGKILL");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
     if (workerChild) {
       try {
         workerChild.kill("SIGKILL");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
   });
 
   test("initial seed succeeds and verify passes", async () => {
     const t0 = Date.now();
-    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t1", "--poll-ms", "40"], {
-      encoding: "utf8",
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-    });
+    const seedRes = spawnSync(
+      "bun",
+      [SEED, "--port", port, "--prefix", "t1", "--poll-ms", "40"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+      },
+    );
     expectSuccess("initial seed", seedRes);
     expect(seedRes.stdout).toContain("merge-apply@2 watched");
-    expect(seedRes.stdout).not.toContain("merge-verify@1 exact landed lifecycle");
+    expect(seedRes.stdout).not.toContain(
+      "merge-verify@1 exact landed lifecycle",
+    );
     // The triage chain now waits for its auto-approved apply run to finish.
     expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);
     initialTriageApplyRun = seedRes.stdout.match(
@@ -209,18 +269,24 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     expect(res.status).not.toBe(0);
     expect(elapsedMs).toBeLessThan(2000);
     const output = `${res.stdout}${res.stderr}`;
-    expect(output).toContain("duplicate prefix \"t1\"");
+    expect(output).toContain('duplicate prefix "t1"');
   }, 10_000);
 
   test("re-seeding with a NEW prefix cleans up hang runs and allows verify to pass", async () => {
     const t0 = Date.now();
-    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t2", "--poll-ms", "40"], {
-      encoding: "utf8",
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-    });
+    const seedRes = spawnSync(
+      "bun",
+      [SEED, "--port", port, "--prefix", "t2", "--poll-ms", "40"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, FACTORY_EVENT_HOME: home },
+      },
+    );
     expectSuccess("re-seed", seedRes);
     expect(seedRes.stdout).toContain("merge-apply@2 watched");
-    expect(seedRes.stdout).not.toContain("merge-verify@1 exact landed lifecycle");
+    expect(seedRes.stdout).not.toContain(
+      "merge-verify@1 exact landed lifecycle",
+    );
     // A fresh prefix must follow the new scan's causal edge, never reuse the
     // prior terminal triage-apply proposal while waiting for that edge.
     expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -22,7 +22,9 @@ import { loadRegistry } from "../lib/registry.mjs";
 
 const args = process.argv.slice(2);
 const i = args.indexOf("--port");
-const port = Number(i === -1 ? (process.env.FACTORY_EVENT_PORT ?? 7381) : args[i + 1]);
+const port = Number(
+  i === -1 ? (process.env.FACTORY_EVENT_PORT ?? 7381) : args[i + 1],
+);
 const client = apiClient({ port });
 
 const failures = [];
@@ -48,7 +50,10 @@ const { runs } = await client.runs();
 const byState = (state) => runs.filter((r) => r.state === state);
 
 check("runs present", runs.length >= 8, `total runs: ${runs.length}`);
-check("every run spec uses fake adapter", runs.every((r) => r.adapter === "fake"));
+check(
+  "every run spec uses fake adapter",
+  runs.every((r) => r.adapter === "fake"),
+);
 
 // RUNNING or TIMED_OUT (the hang run)
 const runningOrTimedOut = byState("RUNNING").concat(byState("TIMED_OUT"));
@@ -56,57 +61,107 @@ check("1 run RUNNING or TIMED_OUT (hang)", runningOrTimedOut.length >= 1);
 
 // COMPLETED runs
 const completedRuns = byState("COMPLETED");
-check("≥6 runs COMPLETED across agent workflows", completedRuns.length >= 6, `found ${completedRuns.length}`);
+check(
+  "≥6 runs COMPLETED across agent workflows",
+  completedRuns.length >= 6,
+  `found ${completedRuns.length}`,
+);
 
 // REFUSED run
 const refusedRuns = byState("REFUSED");
-check("1 run REFUSED with reasonCode 'needs_human'", refusedRuns.some((r) => r.reasonCode === "needs_human"));
+check(
+  "1 run REFUSED with reasonCode 'needs_human'",
+  refusedRuns.some((r) => r.reasonCode === "needs_human"),
+);
 
 // FAILED runs
 const failedRuns = byState("FAILED");
 check("≥2 runs FAILED", failedRuns.length >= 2, `found ${failedRuns.length}`);
 const crashFailed = failedRuns.find((r) => r.reasonCode === "agent_exit_1");
-const contractFailed = failedRuns.find((r) => r.reasonCode === "contract_violation");
-check("1 FAILED run from exit code 1 (reasonCode: agent_exit_1)", Boolean(crashFailed));
-check("1 FAILED run from contract violation (reasonCode: contract_violation)", Boolean(contractFailed));
+const contractFailed = failedRuns.find(
+  (r) => r.reasonCode === "contract_violation",
+);
+check(
+  "1 FAILED run from exit code 1 (reasonCode: agent_exit_1)",
+  Boolean(crashFailed),
+);
+check(
+  "1 FAILED run from contract violation (reasonCode: contract_violation)",
+  Boolean(contractFailed),
+);
 
 // Multi-attempt run (crash run retried with force=true)
 if (crashFailed) {
   const crashView = await client.run(crashFailed.runId);
-  check("multi-attempt run executed (attempts >= 2)", (crashView?.run?.attempts ?? 0) >= 2, `attempts: ${crashView?.run?.attempts}`);
-  check("multi-attempt attempt records recorded", (crashView?.attempts?.length ?? 0) >= 2);
+  check(
+    "multi-attempt run executed (attempts >= 2)",
+    (crashView?.run?.attempts ?? 0) >= 2,
+    `attempts: ${crashView?.run?.attempts}`,
+  );
+  check(
+    "multi-attempt attempt records recorded",
+    (crashView?.attempts?.length ?? 0) >= 2,
+  );
 }
 
 // Plain retryable run (failed run with attempts < maxAttempts, WM-132)
-const retryableFailed = failedRuns.find((r) => (r.attempts ?? 0) < (r.maxAttempts ?? 1));
+const retryableFailed = failedRuns.find(
+  (r) => (r.attempts ?? 0) < (r.maxAttempts ?? 1),
+);
 check(
   "≥1 FAILED run with attempts remaining (attempts < maxAttempts)",
   Boolean(retryableFailed),
-  retryableFailed ? `${retryableFailed.runId} (${retryableFailed.attempts}/${retryableFailed.maxAttempts})` : "",
+  retryableFailed
+    ? `${retryableFailed.runId} (${retryableFailed.attempts}/${retryableFailed.maxAttempts})`
+    : "",
 );
 
 // CANCELLED runs
 const cancelledRuns = byState("CANCELLED");
-check("≥2 runs CANCELLED (rejected proposal + operator cancelled)", cancelledRuns.length >= 2, `found ${cancelledRuns.length}`);
+check(
+  "≥2 runs CANCELLED (rejected proposal + operator cancelled)",
+  cancelledRuns.length >= 2,
+  `found ${cancelledRuns.length}`,
+);
 
 // 3. Deep verification of standard COMPLETED run
-const statusCompleted = completedRuns.find((r) => r.agent === "factory-status-report@1" && r.repos?.[0] === "ok");
+const statusCompleted = completedRuns.find(
+  (r) => r.agent === "factory-status-report@1" && r.repos?.[0] === "ok",
+);
 let statusView = null;
 if (statusCompleted) {
   statusView = await client.run(statusCompleted.runId);
-  const expectedLifecycle = ["PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"];
+  const expectedLifecycle = [
+    "PROPOSED",
+    "APPROVED",
+    "QUEUED",
+    "LEASED",
+    "RUNNING",
+    "VERIFYING",
+    "COMPLETED",
+  ];
   const actualLifecycle = (statusView.lifecycle ?? []).map((e) => e.to_state);
   check(
     "COMPLETED run lifecycle sequence equals [PROPOSED, APPROVED, QUEUED, LEASED, RUNNING, VERIFYING, COMPLETED]",
     JSON.stringify(actualLifecycle) === JSON.stringify(expectedLifecycle),
     actualLifecycle.join(" → "),
   );
-  check("COMPLETED run terminalState is completed", statusView.result?.terminalState === "completed");
-  check("COMPLETED run receipt verification passed", statusView.receipt?.verificationStatus === "passed");
-  check("COMPLETED run evidence is recorded", Boolean(statusView.result?.evidence));
+  check(
+    "COMPLETED run terminalState is completed",
+    statusView.result?.terminalState === "completed",
+  );
+  check(
+    "COMPLETED run receipt verification passed",
+    statusView.receipt?.verificationStatus === "passed",
+  );
+  check(
+    "COMPLETED run evidence is recorded",
+    Boolean(statusView.result?.evidence),
+  );
   check(
     "COMPLETED run receipt has valid evidenceSetHash",
-    typeof statusView.receipt?.evidenceSetHash === "string" && /^sha256:[0-9a-f]{64}$/.test(statusView.receipt.evidenceSetHash),
+    typeof statusView.receipt?.evidenceSetHash === "string" &&
+      /^sha256:[0-9a-f]{64}$/.test(statusView.receipt.evidenceSetHash),
     statusView.receipt?.evidenceSetHash,
   );
 }
@@ -115,15 +170,31 @@ if (statusCompleted) {
 const artifactRun = completedRuns.find((r) => r.repos?.[0] === "with-artifact");
 if (artifactRun) {
   const view = await client.run(artifactRun.runId);
-  const reportArtifact = (view.result?.artifacts ?? []).find((a) => a.kind === "report");
-  check("with-artifact run declared report artifact", Boolean(reportArtifact && reportArtifact.sha256));
+  const reportArtifact = (view.result?.artifacts ?? []).find(
+    (a) => a.kind === "report",
+  );
+  check(
+    "with-artifact run declared report artifact",
+    Boolean(reportArtifact && reportArtifact.sha256),
+  );
 
   if (reportArtifact?.sha256) {
-    const artRes = await fetch(`http://127.0.0.1:${port}/artifacts/${reportArtifact.sha256}`);
-    check("GET /artifacts/:sha returns 200 for declared report", artRes.status === 200);
+    const artRes = await fetch(
+      `http://127.0.0.1:${port}/artifacts/${reportArtifact.sha256}`,
+    );
+    check(
+      "GET /artifacts/:sha returns 200 for declared report",
+      artRes.status === 200,
+    );
     const artBody = await artRes.text();
-    check("artifact content matches expected body", artBody.includes("fake report for with-artifact"));
-    check("artifact body matches declared sha256 checksum", sha256hex(Buffer.from(artBody)) === reportArtifact.sha256);
+    check(
+      "artifact content matches expected body",
+      artBody.includes("fake report for with-artifact"),
+    );
+    check(
+      "artifact body matches declared sha256 checksum",
+      sha256hex(Buffer.from(artBody)) === reportArtifact.sha256,
+    );
   }
 }
 
@@ -131,7 +202,11 @@ if (artifactRun) {
 const floodRun = completedRuns.find((r) => r.repos?.[0] === "trace-flood");
 if (floodRun) {
   const trace = await client.trace(floodRun.runId);
-  check("GET /runs/:id/trace returns trace entries", (trace?.entries?.length ?? 0) > 0, `entries: ${trace?.entries?.length}`);
+  check(
+    "GET /runs/:id/trace returns trace entries",
+    (trace?.entries?.length ?? 0) > 0,
+    `entries: ${trace?.entries?.length}`,
+  );
   check(
     "trace entries contain assistant text",
     (trace?.entries ?? []).some((e) => e.kind === "assistant_text"),
@@ -155,18 +230,42 @@ let ciRerunView;
 
 if (ciDoctorRun) {
   ciDoctorView = await client.run(ciDoctorRun.runId);
-  check("ci-doctor@2 workspace type is 'artifacts'", ciDoctorView.run?.spec?.workspace?.type === "artifacts");
-  check("ci-doctor@2 input references logArtifact hash", Boolean(ciDoctorView.run?.spec?.input?.logArtifact));
-  const doctorCausation = (ciDoctorView.lifecycle ?? []).find((e) => Boolean(e.causation_id))?.causation_id;
-  check("ci-doctor@2 carries causationId linking to capture run", Boolean(doctorCausation), doctorCausation);
-  check("ci-doctor@2 artifact verdict is FLAKE", ciDoctorView.result?.artifact?.verdict === "FLAKE");
+  check(
+    "ci-doctor@2 workspace type is 'artifacts'",
+    ciDoctorView.run?.spec?.workspace?.type === "artifacts",
+  );
+  check(
+    "ci-doctor@2 input references logArtifact hash",
+    Boolean(ciDoctorView.run?.spec?.input?.logArtifact),
+  );
+  const doctorCausation = (ciDoctorView.lifecycle ?? []).find((e) =>
+    Boolean(e.causation_id),
+  )?.causation_id;
+  check(
+    "ci-doctor@2 carries causationId linking to capture run",
+    Boolean(doctorCausation),
+    doctorCausation,
+  );
+  check(
+    "ci-doctor@2 artifact verdict is FLAKE",
+    ciDoctorView.result?.artifact?.verdict === "FLAKE",
+  );
 }
 
 if (ciRerunRun) {
   ciRerunView = await client.run(ciRerunRun.runId);
-  const rerunCausation = (ciRerunView.lifecycle ?? []).find((e) => Boolean(e.causation_id))?.causation_id;
-  check("ci-rerun@1 carries causationId linking to doctor run", Boolean(rerunCausation), rerunCausation);
-  check("ci-rerun@1 output contract is factory.command-result/v1", ciRerunView.run?.spec?.outputContract === "factory.command-result/v1");
+  const rerunCausation = (ciRerunView.lifecycle ?? []).find((e) =>
+    Boolean(e.causation_id),
+  )?.causation_id;
+  check(
+    "ci-rerun@1 carries causationId linking to doctor run",
+    Boolean(rerunCausation),
+    rerunCausation,
+  );
+  check(
+    "ci-rerun@1 output contract is factory.command-result/v1",
+    ciRerunView.run?.spec?.outputContract === "factory.command-result/v1",
+  );
 }
 
 // 7. Merge apply remains watched. Landed state is never fabricated by the
@@ -174,15 +273,26 @@ if (ciRerunRun) {
 
 // 8. Triage scenario (repository workspace with pinned repoPin and auto-approved apply)
 const triageScanRun = completedRuns.find((r) => r.agent === "triage-scan@1");
-const triageApplyRun = completedRuns.find((r) => r.agent === "triage-apply@1" && r.eventSource === "chain");
+const triageApplyRun = completedRuns.find(
+  (r) => r.agent === "triage-apply@1" && r.eventSource === "chain",
+);
 check("triage scenario: triage-scan@1 run present", Boolean(triageScanRun));
-check("triage scenario: chain triage-apply@1 run auto-approved and completed", Boolean(triageApplyRun));
+check(
+  "triage scenario: chain triage-apply@1 run auto-approved and completed",
+  Boolean(triageApplyRun),
+);
 let triageScanView = null;
 if (triageScanRun) {
   triageScanView = await client.run(triageScanRun.runId);
-  check("triage-scan@1 workspace type is 'repository'", triageScanView.run?.spec?.workspace?.type === "repository");
+  check(
+    "triage-scan@1 workspace type is 'repository'",
+    triageScanView.run?.spec?.workspace?.type === "repository",
+  );
   const pin = triageScanView.run?.spec?.input?.repoPin;
-  check("triage-scan@1 input has valid repoPin", Boolean(pin?.repo && pin?.ref));
+  check(
+    "triage-scan@1 input has valid repoPin",
+    Boolean(pin?.repo && pin?.ref),
+  );
   check(
     "repoPin carries immutable 40-character sha",
     typeof pin?.sha === "string" && /^[0-9a-f]{40}$/.test(pin.sha),
@@ -196,92 +306,196 @@ check("dispatch scenario: dispatch@1 run present", Boolean(dispatchRun));
 let dispatchView = null;
 if (dispatchRun) {
   dispatchView = await client.run(dispatchRun.runId);
-  check("dispatch@1 output contract is factory.dispatch-result/v1", dispatchView.run?.spec?.outputContract === "factory.dispatch-result/v1");
-  check("dispatch@1 workspace type is \"worktree\"", dispatchView.run?.spec?.workspace?.type === "worktree");
-  const expectedLifecycle = ["PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"];
+  check(
+    "dispatch@1 output contract is factory.dispatch-result/v1",
+    dispatchView.run?.spec?.outputContract === "factory.dispatch-result/v1",
+  );
+  check(
+    'dispatch@1 workspace type is "worktree"',
+    dispatchView.run?.spec?.workspace?.type === "worktree",
+  );
+  const expectedLifecycle = [
+    "PROPOSED",
+    "APPROVED",
+    "QUEUED",
+    "LEASED",
+    "RUNNING",
+    "VERIFYING",
+    "COMPLETED",
+  ];
   const actualLifecycle = (dispatchView.lifecycle ?? []).map((e) => e.to_state);
   check(
     "dispatch@1 lifecycle sequence moves through RUNNING → VERIFYING → COMPLETED",
     JSON.stringify(actualLifecycle) === JSON.stringify(expectedLifecycle),
     actualLifecycle.join(" → "),
   );
-  check("dispatch@1 artifact outcome is \"PR_OPEN\"", dispatchView.result?.artifact?.outcome === "PR_OPEN");
-  check("dispatch@1 artifact ticket is set", Boolean(dispatchView.result?.artifact?.ticket));
+  check(
+    'dispatch@1 artifact outcome is "PR_OPEN"',
+    dispatchView.result?.artifact?.outcome === "PR_OPEN",
+  );
+  check(
+    "dispatch@1 artifact ticket is set",
+    Boolean(dispatchView.result?.artifact?.ticket),
+  );
   check(
     "dispatch@1 artifact references an open PR URL",
-    typeof dispatchView.result?.artifact?.prUrl === "string" && /^https:\/\/github\.com\/.+\/pull\/\d+$/.test(dispatchView.result.artifact.prUrl),
+    typeof dispatchView.result?.artifact?.prUrl === "string" &&
+      /^https:\/\/github\.com\/.+\/pull\/\d+$/.test(
+        dispatchView.result.artifact.prUrl,
+      ),
     dispatchView.result?.artifact?.prUrl,
   );
   check(
     "dispatch@1 artifact includes passed verification command output",
-    dispatchView.result?.artifact?.verification?.passed === true && Boolean(dispatchView.result?.artifact?.verification?.command),
+    dispatchView.result?.artifact?.verification?.passed === true &&
+      Boolean(dispatchView.result?.artifact?.verification?.command),
   );
 }
 
 // Workspace type coverage across all 4 types
 check(
-  "workspace type \"ephemeral\" (default) covered",
-  statusView?.run?.spec?.workspace === undefined || statusView?.run?.spec?.workspace?.type === "ephemeral" || !statusView?.run?.spec?.workspace?.type,
+  'workspace type "ephemeral" (default) covered',
+  statusView?.run?.spec?.workspace === undefined ||
+    statusView?.run?.spec?.workspace?.type === "ephemeral" ||
+    !statusView?.run?.spec?.workspace?.type,
 );
-check("workspace type \"artifacts\" covered", ciDoctorView?.run?.spec?.workspace?.type === "artifacts");
-check("workspace type \"repository\" covered", triageScanView?.run?.spec?.workspace?.type === "repository");
-check("workspace type \"worktree\" covered", dispatchView?.run?.spec?.workspace?.type === "worktree");
+check(
+  'workspace type "artifacts" covered',
+  ciDoctorView?.run?.spec?.workspace?.type === "artifacts",
+);
+check(
+  'workspace type "repository" covered',
+  triageScanView?.run?.spec?.workspace?.type === "repository",
+);
+check(
+  'workspace type "worktree" covered',
+  dispatchView?.run?.spec?.workspace?.type === "worktree",
+);
 
 // 8. Proposals verification
 const { proposals: openProposals } = await client.proposals();
-const runProposals = openProposals.filter((p) => p.decision === "run" && !p.expired);
-const humanNeededProposals = openProposals.filter((p) => p.decision === "human_needed");
+const runProposals = openProposals.filter(
+  (p) => p.decision === "run" && !p.expired,
+);
+const humanNeededProposals = openProposals.filter(
+  (p) => p.decision === "human_needed",
+);
 const expiredProposals = openProposals.filter((p) => p.expired);
 
-check("≥1 open approvable `run` proposal", runProposals.length >= 1, `found ${runProposals.length}`);
-check("≥1 open `human_needed` proposal", humanNeededProposals.length >= 1, `found ${humanNeededProposals.length}`);
-check("≥1 open TTL-expired proposal (p.expired === true)", expiredProposals.length >= 1, `found ${expiredProposals.length}`);
+check(
+  "≥1 open approvable `run` proposal",
+  runProposals.length >= 1,
+  `found ${runProposals.length}`,
+);
+check(
+  "≥1 open `human_needed` proposal",
+  humanNeededProposals.length >= 1,
+  `found ${humanNeededProposals.length}`,
+);
+check(
+  "≥1 open TTL-expired proposal (p.expired === true)",
+  expiredProposals.length >= 1,
+  `found ${expiredProposals.length}`,
+);
 
 const { proposals: allProposals } = await client.proposals("all");
-check("GET /proposals?status=all returns proposal history", allProposals.length > openProposals.length);
+check(
+  "GET /proposals?status=all returns proposal history",
+  allProposals.length > openProposals.length,
+);
 const autoApprovedTriageApply = allProposals.find(
   (p) => p.agent === "triage-apply@1" && p.eventSource === "chain",
 );
 check(
   "chain triage-apply proposal is approved by chain auto-approval",
-  autoApprovedTriageApply?.status === "approved" && autoApprovedTriageApply?.decided_by === "chain-auto-approval",
-  autoApprovedTriageApply ? `${autoApprovedTriageApply.status} by ${autoApprovedTriageApply.decided_by}` : "missing",
+  autoApprovedTriageApply?.status === "approved" &&
+    autoApprovedTriageApply?.decided_by === "chain-auto-approval",
+  autoApprovedTriageApply
+    ? `${autoApprovedTriageApply.status} by ${autoApprovedTriageApply.decided_by}`
+    : "missing",
 );
 const operatorProposal = allProposals.find(
-  (p) => p.agent === "factory-status-report@1" && p.eventSource === "operator" && p.status === "open",
+  (p) =>
+    p.agent === "factory-status-report@1" &&
+    p.eventSource === "operator" &&
+    p.status === "open",
 );
-check("direct operator proposal remains open/watched", Boolean(operatorProposal));
+check(
+  "direct operator proposal remains open/watched",
+  Boolean(operatorProposal),
+);
 const mergeWatchedProposal = allProposals.find(
-  (p) => p.agent === "merge-apply@2" && p.eventSource === "operator" && p.status === "open",
+  (p) =>
+    p.agent === "merge-apply@2" &&
+    p.eventSource === "operator" &&
+    p.status === "open",
 );
-check("merge-apply@2 proposal remains open/watched", Boolean(mergeWatchedProposal));
+check(
+  "merge-apply@2 proposal remains open/watched",
+  Boolean(mergeWatchedProposal),
+);
 const shipWatchedProposal = allProposals.find(
-  (p) => p.agent === "ship-apply@1" && p.eventSource === "operator" && p.status === "open",
+  (p) =>
+    p.agent === "ship-apply@1" &&
+    p.eventSource === "operator" &&
+    p.status === "open",
 );
-check("ship-apply proposal remains open/human watched", Boolean(shipWatchedProposal));
+check(
+  "ship-apply proposal remains open/human watched",
+  Boolean(shipWatchedProposal),
+);
 
 // 9. Events verification
 const { events } = await client.events();
-check("events admitted", events.length >= 8, `total admitted events: ${events.length}`);
+check(
+  "events admitted",
+  events.length >= 8,
+  `total admitted events: ${events.length}`,
+);
 
 const eventTypes = new Set(events.map((e) => e.type));
-check("multiple event types in fixture", eventTypes.size >= 3, [...eventTypes].join(", "));
-check("events include chain events with causationId", events.some((e) => Boolean(e.causationId)));
+check(
+  "multiple event types in fixture",
+  eventTypes.size >= 3,
+  [...eventTypes].join(", "),
+);
+check(
+  "events include chain events with causationId",
+  events.some((e) => Boolean(e.causationId)),
+);
 
 const deadLetteredEvents = events.filter((e) => e.status === "dead_lettered");
 check("≥1 dead_lettered event present", deadLetteredEvents.length >= 1);
 if (deadLetteredEvents[0]) {
-  check("dead_lettered event records lastPlanError", Boolean(deadLetteredEvents[0].lastPlanError));
+  check(
+    "dead_lettered event records lastPlanError",
+    Boolean(deadLetteredEvents[0].lastPlanError),
+  );
 }
 const { events: deadLetterFilter } = await client.events("dead_lettered");
-check("GET /events?status=dead_lettered filters correctly", deadLetterFilter.length >= 1);
+check(
+  "GET /events?status=dead_lettered filters correctly",
+  deadLetterFilter.length >= 1,
+);
 
 // 10. Status & Anomalies endpoint
 const status = await client.status();
-check("GET /status returns status payload", Boolean(status.events && status.runs && status.anomalies));
-check("status reports dead_lettered event count", (status.events?.dead_lettered ?? 0) >= 1);
-check("status reports human_needed event count", (status.events?.human_needed ?? 0) >= 1);
-check("status reports expired proposals count", (status.proposals?.expired ?? 0) >= 1);
+check(
+  "GET /status returns status payload",
+  Boolean(status.events && status.runs && status.anomalies),
+);
+check(
+  "status reports dead_lettered event count",
+  (status.events?.dead_lettered ?? 0) >= 1,
+);
+check(
+  "status reports human_needed event count",
+  (status.events?.human_needed ?? 0) >= 1,
+);
+check(
+  "status reports expired proposals count",
+  (status.proposals?.expired ?? 0) >= 1,
+);
 check(
   "status.anomalies.expiredOpenProposals lists expired proposal ID",
   (status.anomalies?.expiredOpenProposals?.length ?? 0) >= 1,
@@ -290,13 +504,25 @@ check(
   "status.anomalies.deadLettered lists dead-lettered event",
   (status.anomalies?.deadLettered?.length ?? 0) >= 1,
 );
-check("status.anomalies.staleLeases === 0", status.anomalies?.staleLeases === 0);
-check("status.anomalies.unpublishedOutbox === 0", status.anomalies?.unpublishedOutbox === 0);
-check("status.anomalies.ambiguousOpenProposals is empty", (status.anomalies?.ambiguousOpenProposals?.length ?? 0) === 0);
+check(
+  "status.anomalies.staleLeases === 0",
+  status.anomalies?.staleLeases === 0,
+);
+check(
+  "status.anomalies.unpublishedOutbox === 0",
+  status.anomalies?.unpublishedOutbox === 0,
+);
+check(
+  "status.anomalies.ambiguousOpenProposals is empty",
+  (status.anomalies?.ambiguousOpenProposals?.length ?? 0) === 0,
+);
 
 // 11. Additional Control API Endpoints
 const { workers } = await client.workers();
-check("GET /workers returns live worker(s)", workers.some((w) => w.state !== "stopped" && !w.stale));
+check(
+  "GET /workers returns live worker(s)",
+  workers.some((w) => w.state !== "stopped" && !w.stale),
+);
 
 const { schedules } = await client.schedules();
 check("GET /schedules lists registered schedules", schedules.length >= 1);
@@ -305,24 +531,47 @@ check("GET /schedules lists registered schedules", schedules.length >= 1);
 // agent definition must not fail the e2e for being new (WM-72).
 const registeredCount = loadRegistry().agents.size;
 const { agents } = await client.agents();
-check(`GET /agents lists registered agents (${registeredCount} total)`, agents.length === registeredCount, `found ${agents.length}`);
+check(
+  `GET /agents lists registered agents (${registeredCount} total)`,
+  agents.length === registeredCount,
+  `found ${agents.length}`,
+);
 
 const journalRes = await client.journal();
-check("GET /journal returns lifecycle journal entries", (journalRes?.entries?.length ?? 0) >= 10);
+check(
+  "GET /journal returns lifecycle journal entries",
+  (journalRes?.entries?.length ?? 0) >= 10,
+);
 
 const { outbox } = await client.outbox();
-check("GET /outbox returns published result events", (outbox?.length ?? 0) >= 1);
+check(
+  "GET /outbox returns published result events",
+  (outbox?.length ?? 0) >= 1,
+);
 
 // 12. Project tags verification (OPS-385 / OPS-366)
-const FAKE_ADAPTER_MODES = new Set(["ok", "refuse", "crash", "invalid-artifact", "hang", "with-artifact", "trace-flood"]);
+const FAKE_ADAPTER_MODES = new Set([
+  "ok",
+  "refuse",
+  "crash",
+  "invalid-artifact",
+  "hang",
+  "with-artifact",
+  "trace-flood",
+]);
 let registryNames = null;
 try {
   const { repos: registry } = await client.repos();
-  check("GET /repos returns configured repo registry", Array.isArray(registry) && registry.length >= 1);
+  check(
+    "GET /repos returns configured repo registry",
+    Array.isArray(registry) && registry.length >= 1,
+  );
   registryNames = (registry ?? []).map((row) => row.name).filter(Boolean);
 } catch (err) {
   if (err.status === 500) {
-    console.log("skip ≥1 run carries a project tag (GET /repos 500 — registry missing or unreadable)");
+    console.log(
+      "skip ≥1 run carries a project tag (GET /repos 500 — registry missing or unreadable)",
+    );
   } else {
     check(`GET /repos (${err.status ?? "no status"})`, false);
   }
@@ -340,7 +589,9 @@ if (registryNames !== null) {
 }
 
 if (failures.length) {
-  console.error(`\nverify: ${failures.length} check(s) failed — reseed with: bun event-runtime/demo/seed.mjs --port ${port}`);
+  console.error(
+    `\nverify: ${failures.length} check(s) failed — reseed with: bun event-runtime/demo/seed.mjs --port ${port}`,
+  );
   for (const f of failures) console.error(`  - ${f}`);
   process.exit(1);
 }

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -120,9 +120,7 @@
     "edges": {
       "PR_OPEN": {
         "eventType": "factory.work.requested",
-        "also": [
-          "PR_OPEN_MERGE"
-        ],
+        "also": ["PR_OPEN_MERGE"],
         "input": {
           "repo": "$.input.repo"
         }
@@ -133,9 +131,7 @@
         "whenPath": "$.artifact.prNumber",
         "input": {
           "repo": "$.artifact.repo",
-          "prNumbers": [
-            "$.artifact.prNumber"
-          ]
+          "prNumbers": ["$.artifact.prNumber"]
         }
       },
       "NOT_CLAIMED": {

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -2,244 +2,181 @@
   "factory.status-report.requested": {
     "agent": "factory-status-report@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "correlationId",
-      "inputHash"
-    ],
+    "idempotencyScope": ["correlationId", "inputHash"],
     "proposalTtlSeconds": 1800
   },
   "github.workflow-run.failed": {
     "agent": "ci-log-capture@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.ci-rerun.requested": {
     "agent": "ci-rerun@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.ci-escalate.requested": {
     "agent": "ci-notify@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "keephq.disk-alert.raised": {
     "agent": "disk-diagnose@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "subject",
-      "correlationId"
-    ],
+    "idempotencyScope": ["subject", "correlationId"],
     "proposalTtlSeconds": 1800
   },
   "keephq.disk-remediate.requested": {
     "agent": "disk-remediate@1",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.triage.requested": {
     "agent": "triage-scan@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.triage-apply.requested": {
     "agent": "triage-apply@1",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.janitor-scan.requested": {
     "agent": "janitor-scan@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.janitor-apply.requested": {
     "agent": "janitor-apply@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.ci-diagnose.requested": {
     "agent": "ci-doctor@2",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.run-postmortem.requested": {
     "agent": "run-postmortem@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.reconcile.requested": {
     "agent": "reconcile@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.label-guard.requested": {
     "agent": "label-guard@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.warm.requested": {
     "agent": "warm@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.unblock.requested": {
     "agent": "unblock-scan@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.unblock-apply.requested": {
     "agent": "unblock-apply@1",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.sweep.requested": {
     "agent": "sweep-scan@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.sweep-apply.requested": {
     "agent": "sweep-apply@1",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
     "adapter": "pi",
-    "idempotencyScope": [
-      "correlationId",
-      "inputHash"
-    ],
+    "idempotencyScope": ["correlationId", "inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge-apply.requested": {
     "agent": "merge-apply@2",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge-escalate.requested": {
     "agent": "merge-notify@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge-fix.requested": {
     "agent": "merge-fix@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge-landed": {
     "agent": "merge-verify@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 7200
   },
   "factory.merge-verify.requested": {
     "agent": "merge-verify@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 7200
   },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.dispatch.requested": {
     "agent": "dispatch@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.work.requested": {
     "agent": "work-scan@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.ship.requested": {
     "agent": "ship-scan@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.ship-apply.requested": {
     "agent": "ship-apply@1",
     "adapter": "actions",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800,
     "humanApprovalOnly": true
   },
@@ -258,33 +195,25 @@
   "clock.tick.reaper": {
     "agent": "reaper@1",
     "adapter": "command",
-    "idempotencyScope": [
-      "correlationId"
-    ],
+    "idempotencyScope": ["correlationId"],
     "proposalTtlSeconds": 3600
   },
   "factory.pi-smoke.requested": {
     "agent": "pi-smoke@1",
     "adapter": "pi",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.agy-smoke.requested": {
     "agent": "agy-smoke@1",
     "adapter": "agy",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.cursor-smoke.requested": {
     "agent": "cursor-smoke@1",
     "adapter": "cursor",
-    "idempotencyScope": [
-      "inputHash"
-    ],
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -52,15 +52,21 @@ export function validateRemotePlaceholders(def, inputSchema) {
   }
   const properties = inputSchema?.properties ?? {};
   for (const tpl of templates) {
-    const matches = typeof tpl === "string" ? tpl.matchAll(/\{([A-Za-z0-9_]+)\}/g) : [];
+    const matches =
+      typeof tpl === "string" ? tpl.matchAll(/\{([A-Za-z0-9_]+)\}/g) : [];
     for (const match of matches) {
       const field = match[1];
       const prop = properties[field];
       if (!prop) {
-        throw new Error(`unconstrained placeholder "{${field}}" in remote template: field is missing from input schema`);
+        throw new Error(
+          `unconstrained placeholder "{${field}}" in remote template: field is missing from input schema`,
+        );
       }
       const hasEnum = Array.isArray(prop.enum) && prop.enum.length > 0;
-      const hasPattern = typeof prop.pattern === "string" && prop.pattern.startsWith("^") && prop.pattern.endsWith("$");
+      const hasPattern =
+        typeof prop.pattern === "string" &&
+        prop.pattern.startsWith("^") &&
+        prop.pattern.endsWith("$");
       if (!hasEnum && !hasPattern) {
         throw new Error(
           `unconstrained placeholder "{${field}}" in remote template: input schema property must declare an enum or anchored pattern`,
@@ -76,12 +82,20 @@ export function substituteRemote(remote, input) {
     return remote.map((item) => substituteRemote(item, input));
   }
   if (typeof remote !== "string") {
-    throw new Error(`remote template must be a string or array of strings, got ${typeof remote}`);
+    throw new Error(
+      `remote template must be a string or array of strings, got ${typeof remote}`,
+    );
   }
   return remote.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
     const value = input?.[field];
-    if (value === undefined || value === null || !["string", "number"].includes(typeof value)) {
-      throw new Error(`remote template references missing/non-primitive input field "${field}"`);
+    if (
+      value === undefined ||
+      value === null ||
+      !["string", "number"].includes(typeof value)
+    ) {
+      throw new Error(
+        `remote template references missing/non-primitive input field "${field}"`,
+      );
     }
     return String(value);
   });
@@ -97,7 +111,9 @@ export function buildArgv(exec, target, remote) {
     if (element === "{remote}" && Array.isArray(remote)) {
       result.push(...remote);
     } else {
-      const remoteStr = Array.isArray(remote) ? remote.join(" ") : String(remote);
+      const remoteStr = Array.isArray(remote)
+        ? remote.join(" ")
+        : String(remote);
       result.push(
         element
           .replace(/\{target\}/g, () => targetStr)
@@ -110,36 +126,54 @@ export function buildArgv(exec, target, remote) {
 
 /** Last integer in probe output — `df --output=used -B1 <mount> | tail -1`. */
 export function probeBytes(raw) {
-  const match = String(raw ?? "").trim().match(/(\d+)\s*$/);
-  if (!match) throw new Error(`probe output has no byte count: "${String(raw).slice(0, 120)}"`);
+  const match = String(raw ?? "")
+    .trim()
+    .match(/(\d+)\s*$/);
+  if (!match)
+    throw new Error(
+      `probe output has no byte count: "${String(raw).slice(0, 120)}"`,
+    );
   return Number(match[1]);
 }
 
 /** Substitute {field} placeholders across an argv template (item-list mode). */
 function computeChainOutcome(actions, chainOutcomeConfig) {
-  if (!chainOutcomeConfig || typeof chainOutcomeConfig !== "object") return undefined;
+  if (!chainOutcomeConfig || typeof chainOutcomeConfig !== "object")
+    return undefined;
 
   const appliedActions = new Set(actions.map((entry) => entry.action));
-  const rules = Array.isArray(chainOutcomeConfig.precedence) ? chainOutcomeConfig.precedence : [];
+  const rules = Array.isArray(chainOutcomeConfig.precedence)
+    ? chainOutcomeConfig.precedence
+    : [];
   for (const rule of rules) {
     if (!rule || typeof rule.action !== "string") continue;
     if (typeof rule.outcome !== "string") continue;
     if (appliedActions.has(rule.action)) return rule.outcome;
   }
-  return typeof chainOutcomeConfig.default === "string" ? chainOutcomeConfig.default : "NO_CHANGE";
+  return typeof chainOutcomeConfig.default === "string"
+    ? chainOutcomeConfig.default
+    : "NO_CHANGE";
 }
 
 export function substituteArgv(argv, context) {
   for (const element of argv) {
     if (/\$\{[A-Za-z0-9_]+\}/.test(element)) {
-      throw new Error('argv template element contains "${", which collides with argv placeholder syntax');
+      throw new Error(
+        'argv template element contains "${", which collides with argv placeholder syntax',
+      );
     }
   }
   return argv.map((element) =>
     element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
       const value = context?.[field];
-      if (value === undefined || value === null || !["string", "number"].includes(typeof value)) {
-        throw new Error(`argv template references missing/non-primitive field "${field}"`);
+      if (
+        value === undefined ||
+        value === null ||
+        !["string", "number"].includes(typeof value)
+      ) {
+        throw new Error(
+          `argv template references missing/non-primitive field "${field}"`,
+        );
       }
       return String(value);
     }),
@@ -160,7 +194,8 @@ async function executeItemList({ spec, def, workspaceDir, timeoutMs }) {
   };
 
   const items = spec.input?.[def.itemsField];
-  if (!Array.isArray(items) || items.length === 0) return fail(`no items in input.${def.itemsField}`);
+  if (!Array.isArray(items) || items.length === 0)
+    return fail(`no items in input.${def.itemsField}`);
 
   // Resolve EVERY item before executing ANY: an unregistered action id in the
   // approved list is a refusal, never a partial application.
@@ -168,10 +203,17 @@ async function executeItemList({ spec, def, workspaceDir, timeoutMs }) {
   try {
     for (const item of items) {
       const registered = def.actionRegistry?.[item.action];
-      if (!registered?.argv) throw new Error(`action "${item.action}" is not in the closed action registry`);
+      if (!registered?.argv)
+        throw new Error(
+          `action "${item.action}" is not in the closed action registry`,
+        );
       resolved.push({
         item,
-        argv: substituteArgv(registered.argv, { ...spec.input, ...item, factoryRoot: FACTORY_ROOT }),
+        argv: substituteArgv(registered.argv, {
+          ...spec.input,
+          ...item,
+          factoryRoot: FACTORY_ROOT,
+        }),
       });
     }
   } catch (err) {
@@ -183,28 +225,45 @@ async function executeItemList({ spec, def, workspaceDir, timeoutMs }) {
   const outputs = {};
   for (const { item, argv } of resolved) {
     const budget = Math.max(1000, deadline - Date.now());
-    const proc = spawnSync(argv[0], argv.slice(1), { encoding: "utf8", timeout: budget, cwd: FACTORY_ROOT });
-    const raw = `${proc.stdout ?? ""}${proc.stderr ?? ""}`.slice(-OUTPUT_TAIL_CHARS);
+    const proc = spawnSync(argv[0], argv.slice(1), {
+      encoding: "utf8",
+      timeout: budget,
+      cwd: FACTORY_ROOT,
+    });
+    const raw = `${proc.stdout ?? ""}${proc.stderr ?? ""}`.slice(
+      -OUTPUT_TAIL_CHARS,
+    );
     const itemKey = def.itemKey ?? "issueId";
     const issueId = item[itemKey] ?? item.issueId ?? item.ticket ?? item.action;
     const key = `${issueId ?? item.action}:${item.action}`;
     outputs[key] = raw;
     appendFileSync(log, `$ ${key}: ${argv.join(" ")}\n${raw}\n`, "utf8");
     if (proc.error?.code === "ETIMEDOUT") {
-      appendFileSync(log, `TIMED OUT after ${applied.length}/${resolved.length}\n`, "utf8");
+      appendFileSync(
+        log,
+        `TIMED OUT after ${applied.length}/${resolved.length}\n`,
+        "utf8",
+      );
       return { exitCode: null, timedOut: true };
     }
     if (proc.status !== 0) {
       // Partial application is a real outcome: the log records what landed,
       // and the attempt fails so nothing claims success it cannot prove.
-      appendFileSync(log, `FAILED on ${key} (exit ${proc.status}) after ${applied.length} applied\n`, "utf8");
+      appendFileSync(
+        log,
+        `FAILED on ${key} (exit ${proc.status}) after ${applied.length} applied\n`,
+        "utf8",
+      );
       return { exitCode: proc.status ?? 1, timedOut: false };
     }
     applied.push({ issueId, action: item.action });
   }
 
   const artifact = { repo: spec.input.repo, applied };
-  if (def.chainOutcome && Object.prototype.hasOwnProperty.call(def.chainOutcome, "precedence")) {
+  if (
+    def.chainOutcome &&
+    Object.prototype.hasOwnProperty.call(def.chainOutcome, "precedence")
+  ) {
     artifact.outcome = computeChainOutcome(applied, def.chainOutcome);
   }
 
@@ -234,7 +293,8 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
   refuseSandbox("actions", def, SANDBOX_REFUSAL_REASON);
   // Two closed-registry shapes: a per-item local argv list (OPS-229) and the
   // remote probe → act → probe flow (OPS-208). The definition picks.
-  if (def.itemsField) return executeItemList({ spec, def, workspaceDir, timeoutMs });
+  if (def.itemsField)
+    return executeItemList({ spec, def, workspaceDir, timeoutMs });
 
   const log = path.join(workspaceDir, ".actions.log");
   const fail = (message) => {
@@ -244,9 +304,13 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
 
   const input = spec.input ?? {};
   const exec = def.exec;
-  if (!Array.isArray(exec) || exec.length === 0) return fail(`definition ${def.ref} has no exec template`);
+  if (!Array.isArray(exec) || exec.length === 0)
+    return fail(`definition ${def.ref} has no exec template`);
   const target = def.hosts?.[input.host];
-  if (!target) return fail(`host "${input.host}" is not in the definition's host allowlist`);
+  if (!target)
+    return fail(
+      `host "${input.host}" is not in the definition's host allowlist`,
+    );
 
   const schema = def.inputSchema ?? spec.inputSchema;
   if (schema) {
@@ -265,8 +329,14 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
     probeRemote = substituteRemote(def.probeRemote, input);
     for (const entry of input.actions ?? []) {
       const registered = def.actionRegistry?.[entry.action];
-      if (!registered) throw new Error(`action "${entry.action}" is not in the closed action registry`);
-      actionCommands.push({ id: entry.action, remote: substituteRemote(registered.remote, input) });
+      if (!registered)
+        throw new Error(
+          `action "${entry.action}" is not in the closed action registry`,
+        );
+      actionCommands.push({
+        id: entry.action,
+        remote: substituteRemote(registered.remote, input),
+      });
     }
     if (actionCommands.length === 0) throw new Error("empty action list");
   } catch (err) {
@@ -286,7 +356,8 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
     outputs[label] = raw.slice(-OUTPUT_TAIL_CHARS);
     const cmdStr = Array.isArray(remote) ? remote.join(" ") : remote;
     appendFileSync(log, `$ ${label}: ${cmdStr}\n${outputs[label]}\n`, "utf8");
-    if (proc.error?.code === "ETIMEDOUT") throw Object.assign(new Error(`${label} timed out`), { timedOut: true });
+    if (proc.error?.code === "ETIMEDOUT")
+      throw Object.assign(new Error(`${label} timed out`), { timedOut: true });
     if (proc.status !== 0) throw new Error(`${label} exited ${proc.status}`);
     return proc.stdout ?? "";
   };
@@ -318,7 +389,9 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
             probeAfter,
             commands: [
               Array.isArray(probeRemote) ? probeRemote.join(" ") : probeRemote,
-              ...actionCommands.map((a) => (Array.isArray(a.remote) ? a.remote.join(" ") : a.remote)),
+              ...actionCommands.map((a) =>
+                Array.isArray(a.remote) ? a.remote.join(" ") : a.remote,
+              ),
             ],
             outputs,
           },

--- a/event-runtime/lib/adapters/actions.test.mjs
+++ b/event-runtime/lib/adapters/actions.test.mjs
@@ -16,8 +16,14 @@ const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
 
 describe("appendIssueDetail (WM-343)", () => {
   test("appends the same detail only once", () => {
-    const first = appendIssueDetail("Existing description", "## Verification\n\nRun the exact command.");
-    const second = appendIssueDetail(first.description, "## Verification\n\nRun the exact command.");
+    const first = appendIssueDetail(
+      "Existing description",
+      "## Verification\n\nRun the exact command.",
+    );
+    const second = appendIssueDetail(
+      first.description,
+      "## Verification\n\nRun the exact command.",
+    );
 
     expect(first.appended).toBe(true);
     expect(second).toEqual({ description: first.description, appended: false });
@@ -29,7 +35,13 @@ describe("buildArgv (OPS-410)", () => {
   test("replaces {target} and {remote} in exec template", () => {
     const exec = ["ssh", "-o", "BatchMode=yes", "{target}", "{remote}"];
     const argv = buildArgv(exec, "root@10.0.0.1", "df -h");
-    expect(argv).toEqual(["ssh", "-o", "BatchMode=yes", "root@10.0.0.1", "df -h"]);
+    expect(argv).toEqual([
+      "ssh",
+      "-o",
+      "BatchMode=yes",
+      "root@10.0.0.1",
+      "df -h",
+    ]);
   });
 
   test("handles multiple occurrences of {target} or {remote}", () => {
@@ -40,15 +52,28 @@ describe("buildArgv (OPS-410)", () => {
 
   test("safely handles special $ patterns in remote without regex backreference corruption", () => {
     const exec = ["ssh", "{target}", "{remote}"];
-    const remoteWithDollar = "awk '{print $1}' /var/log/syslog | grep $& | sed 's/$//'";
+    const remoteWithDollar =
+      "awk '{print $1}' /var/log/syslog | grep $& | sed 's/$//'";
     const argv = buildArgv(exec, "user@host", remoteWithDollar);
     expect(argv).toEqual(["ssh", "user@host", remoteWithDollar]);
   });
 
   test("expands array remote into argv elements when element is exact {remote}", () => {
     const exec = ["ssh", "{target}", "{remote}"];
-    const argv = buildArgv(exec, "user@host", ["df", "--output=used", "-B1", "/var"]);
-    expect(argv).toEqual(["ssh", "user@host", "df", "--output=used", "-B1", "/var"]);
+    const argv = buildArgv(exec, "user@host", [
+      "df",
+      "--output=used",
+      "-B1",
+      "/var",
+    ]);
+    expect(argv).toEqual([
+      "ssh",
+      "user@host",
+      "df",
+      "--output=used",
+      "-B1",
+      "/var",
+    ]);
   });
 });
 
@@ -95,7 +120,9 @@ describe("validateRemotePlaceholders (OPS-410)", () => {
         path: { type: "string", pattern: "[a-z]+" },
       },
     };
-    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/unconstrained placeholder/);
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(
+      /unconstrained placeholder/,
+    );
   });
 
   test("throws when placeholder property lacks both enum and anchored pattern", () => {
@@ -108,7 +135,9 @@ describe("validateRemotePlaceholders (OPS-410)", () => {
         mount: { type: "string" },
       },
     };
-    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/unconstrained placeholder/);
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(
+      /unconstrained placeholder/,
+    );
   });
 
   test("throws when placeholder is completely missing from inputSchema", () => {
@@ -119,7 +148,9 @@ describe("validateRemotePlaceholders (OPS-410)", () => {
       type: "object",
       properties: {},
     };
-    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/missing from input schema/);
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(
+      /missing from input schema/,
+    );
   });
 });
 
@@ -135,8 +166,12 @@ describe("substituteRemote", () => {
   });
 
   test("throws on missing or non-primitive input field", () => {
-    expect(() => substituteRemote("df -h {mount}", {})).toThrow(/missing\/non-primitive/);
-    expect(() => substituteRemote("df -h {mount}", { mount: { nested: true } })).toThrow(/missing\/non-primitive/);
+    expect(() => substituteRemote("df -h {mount}", {})).toThrow(
+      /missing\/non-primitive/,
+    );
+    expect(() =>
+      substituteRemote("df -h {mount}", { mount: { nested: true } }),
+    ).toThrow(/missing\/non-primitive/);
   });
 });
 
@@ -148,24 +183,32 @@ describe("substituteArgv", () => {
   });
 
   test("throws on missing or non-primitive fields", () => {
-    expect(() => substituteArgv(["echo", "{missing}"], {})).toThrow(/missing\/non-primitive/);
+    expect(() => substituteArgv(["echo", "{missing}"], {})).toThrow(
+      /missing\/non-primitive/,
+    );
   });
 
   test("rejects JavaScript template interpolation that collides with argv placeholders", () => {
-    expect(() => substituteArgv(["bun", "-e", "console.log(`${identifier}`)"], {})).toThrow(
-      /contains "\$\{".*collides with argv placeholder syntax/,
-    );
+    expect(() =>
+      substituteArgv(["bun", "-e", "console.log(`${identifier}`)"], {}),
+    ).toThrow(/contains "\$\{".*collides with argv placeholder syntax/);
   });
 });
 
 describe("probeBytes", () => {
   test("parses last integer in probe output", () => {
-    expect(probeBytes("Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 10000 456789\n")).toBe(456789);
+    expect(
+      probeBytes(
+        "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 10000 456789\n",
+      ),
+    ).toBe(456789);
     expect(probeBytes("   12345   \n")).toBe(12345);
   });
 
   test("throws on invalid probe output without numbers", () => {
-    expect(() => probeBytes("no numbers here")).toThrow(/probe output has no byte count/);
+    expect(() => probeBytes("no numbers here")).toThrow(
+      /probe output has no byte count/,
+    );
     expect(() => probeBytes("")).toThrow(/probe output has no byte count/);
   });
 });
@@ -189,11 +232,17 @@ describe("execute refutations", () => {
       },
     };
     const spec = {
-      input: { host: "lab", unconstrained: "; rm -rf /", actions: [{ action: "a" }] },
+      input: {
+        host: "lab",
+        unconstrained: "; rm -rf /",
+        actions: [{ action: "a" }],
+      },
     };
     const res = await execute({ spec, def, workspaceDir: ws, timeoutMs: 5000 });
     expect(res.exitCode).toBe(1);
-    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain("unconstrained placeholder");
+    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain(
+      "unconstrained placeholder",
+    );
   });
 
   test("refuses execution on unknown host", async () => {
@@ -210,7 +259,9 @@ describe("execute refutations", () => {
     };
     const res = await execute({ spec, def, workspaceDir: ws, timeoutMs: 5000 });
     expect(res.exitCode).toBe(1);
-    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain("not in the definition's host allowlist");
+    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain(
+      "not in the definition's host allowlist",
+    );
   });
 });
 
@@ -247,7 +298,9 @@ describe("execute item-list mode (OPS-229, WM-109, WM-116)", () => {
     const res = await execute({ spec, def, workspaceDir: ws, timeoutMs: 5000 });
     expect(res.exitCode).toBe(0);
 
-    const result = JSON.parse(readFileSync(path.join(ws, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(ws, "result.json"), "utf8"),
+    );
     expect(result.artifact.outcome).toBe("SUPPLY_CHANGED");
 
     const noopSpec = {
@@ -256,9 +309,16 @@ describe("execute item-list mode (OPS-229, WM-109, WM-116)", () => {
         plan: [{ issueId: "WM-118", action: "noop" }],
       },
     };
-    const noopRes = await execute({ spec: noopSpec, def, workspaceDir: ws, timeoutMs: 5000 });
+    const noopRes = await execute({
+      spec: noopSpec,
+      def,
+      workspaceDir: ws,
+      timeoutMs: 5000,
+    });
     expect(noopRes.exitCode).toBe(0);
-    const noopResult = JSON.parse(readFileSync(path.join(ws, "result.json"), "utf8"));
+    const noopResult = JSON.parse(
+      readFileSync(path.join(ws, "result.json"), "utf8"),
+    );
     expect(noopResult.artifact.outcome).toBe("NO_CHANGE");
   });
 
@@ -277,7 +337,11 @@ describe("execute item-list mode (OPS-229, WM-109, WM-116)", () => {
       input: {
         repo: "bj29",
         plan: [
-          { ticket: "WM-116", action: "echo_ticket", reason: "testing item key" },
+          {
+            ticket: "WM-116",
+            action: "echo_ticket",
+            reason: "testing item key",
+          },
           { ticket: "WM-117", action: "echo_reason", reason: "second item" },
         ],
       },
@@ -286,7 +350,9 @@ describe("execute item-list mode (OPS-229, WM-109, WM-116)", () => {
     expect(res.exitCode).toBe(0);
     expect(res.timedOut).toBe(false);
 
-    const result = JSON.parse(readFileSync(path.join(ws, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(ws, "result.json"), "utf8"),
+    );
     expect(result.schemaVersion).toBe("factory.agent-result/v1");
     expect(result.terminalState).toBe("completed");
     expect(result.artifact).toEqual({
@@ -323,4 +389,3 @@ describe("execute item-list mode (OPS-229, WM-109, WM-116)", () => {
     );
   });
 });
-

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -62,9 +62,17 @@ export function resolveAgyCommand({ which = Bun.which } = {}) {
  * Build argv for spawning agy.
  * The prompt itself travels on stdin via `-p -`.
  */
-export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeoutMs }) {
+export function buildAgyArgv({
+  prompt,
+  def,
+  model,
+  effort,
+  workspaceDir,
+  timeoutMs,
+}) {
   const args = [
-    "--output-format", "stream-json",
+    "--output-format",
+    "stream-json",
     "--dangerously-skip-permissions",
   ];
 
@@ -76,7 +84,10 @@ export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeout
     // Seconds, not rounded minutes: `--print-timeout` takes Go duration syntax,
     // and minute granularity used to floor every sub-three-minute budget to 1m
     // (a 120s run gave agy 60s, so it quit while the worker still waited).
-    const printSeconds = Math.max(1, Math.round((timeoutMs - PRINT_TIMEOUT_GRACE_MS) / 1000));
+    const printSeconds = Math.max(
+      1,
+      Math.round((timeoutMs - PRINT_TIMEOUT_GRACE_MS) / 1000),
+    );
     args.push("--print-timeout", `${printSeconds}s`);
   }
 
@@ -84,9 +95,19 @@ export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeout
     args.push("--model", model);
   }
 
-  const tierEffort = def?.model_tier === "light" ? "low" : (def?.model_tier === "strong" ? "high" : (def?.model_tier === "standard" ? "medium" : null));
+  const tierEffort =
+    def?.model_tier === "light"
+      ? "low"
+      : def?.model_tier === "strong"
+        ? "high"
+        : def?.model_tier === "standard"
+          ? "medium"
+          : null;
   const effectiveEffort = effort ?? def?.effort ?? tierEffort;
-  if (typeof effectiveEffort === "string" && ["low", "medium", "high"].includes(effectiveEffort.toLowerCase())) {
+  if (
+    typeof effectiveEffort === "string" &&
+    ["low", "medium", "high"].includes(effectiveEffort.toLowerCase())
+  ) {
     args.push("--effort", effectiveEffort.toLowerCase());
   }
 
@@ -98,8 +119,18 @@ export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeout
 }
 
 export const BASE_INHERITED_ENV = [
-  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
-  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
 ];
 
 /**
@@ -107,17 +138,29 @@ export const BASE_INHERITED_ENV = [
  * Strips provider API keys to force subscription/login authentication.
  */
 export function safeChildEnvironment(env = {}, defOrOpts = {}) {
-  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
-  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
+  const isMutating =
+    typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating
+    ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV]
+    : BASE_INHERITED_ENV;
   const childEnv = Object.fromEntries(
-    inherited.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]])),
+    inherited.flatMap((key) =>
+      process.env[key] === undefined ? [] : [[key, process.env[key]]],
+    ),
   );
   Object.assign(childEnv, env);
 
   for (const key of [
-    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
-    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
-    "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
   ]) {
     delete childEnv[key];
   }
@@ -139,7 +182,9 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
 
 function clip(text) {
   const s = String(text ?? "");
-  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+  return s.length > TEXT_PREVIEW_CHARS
+    ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]`
+    : s;
 }
 
 /** agy's token counters, renamed to the trace's shape. Absent fields stay absent. */
@@ -175,7 +220,8 @@ function mapResultEvent(result) {
   if (!result || typeof result !== "object") return [];
   const events = [];
 
-  const response = typeof result.response === "string" ? result.response.trim() : "";
+  const response =
+    typeof result.response === "string" ? result.response.trim() : "";
   if (response) {
     events.push({ kind: "assistant_text", payload: { text: clip(response) } });
   }
@@ -228,54 +274,65 @@ export function mapStreamEvent(msg) {
   if (msg.event !== "step_update") return [];
 
   const s = msg.step_update ?? {};
-  const stepIndex = s.step_index === undefined || s.step_index === null ? null : String(s.step_index);
+  const stepIndex =
+    s.step_index === undefined || s.step_index === null
+      ? null
+      : String(s.step_index);
   const durationMs = durationMsOf(s.duration_seconds);
 
   if (s.step_type === "tool") {
     const info = s.tool_info ?? {};
     const name = s.tool_name ?? info.name ?? "tool";
     if (s.state === "ACTIVE") {
-      return [{
-        kind: "tool_use",
-        payload: { id: stepIndex, name, input: info.parameters ?? {} },
-      }];
+      return [
+        {
+          kind: "tool_use",
+          payload: { id: stepIndex, name, input: info.parameters ?? {} },
+        },
+      ];
     }
     if (s.state === "DONE" || s.state === "ERROR") {
       const isError = s.state === "ERROR";
-      return [{
-        kind: "tool_result",
-        payload: {
-          toolUseId: stepIndex,
-          name,
-          content: isError
-            ? clip(info.error?.message ?? `${name} failed`)
-            : `${name} completed${durationMs == null ? "" : ` in ${(durationMs / 1000).toFixed(2)}s`}`,
-          isError,
-          durationMs,
+      return [
+        {
+          kind: "tool_result",
+          payload: {
+            toolUseId: stepIndex,
+            name,
+            content: isError
+              ? clip(info.error?.message ?? `${name} failed`)
+              : `${name} completed${durationMs == null ? "" : ` in ${(durationMs / 1000).toFixed(2)}s`}`,
+            isError,
+            durationMs,
+          },
         },
-      }];
+      ];
     }
     return [];
   }
 
   if (s.step_type === "error_message") {
-    return [{ kind: "lifecycle", payload: { note: "error_message", stepIndex } }];
+    return [
+      { kind: "lifecycle", payload: { note: "error_message", stepIndex } },
+    ];
   }
 
   // agent_response and checkpoint steps exist to report incremental token
   // spend; surfacing them keeps mid-run accounting available while the run
   // is still going, which the terminal result alone cannot provide.
   if (s.usage && typeof s.usage === "object") {
-    return [{
-      kind: "usage",
-      payload: {
-        durationMs,
-        numTurns: null,
-        costUSD: null,
-        usage: normalizeUsage(s.usage),
-        incremental: true,
+    return [
+      {
+        kind: "usage",
+        payload: {
+          durationMs,
+          numTurns: null,
+          costUSD: null,
+          usage: normalizeUsage(s.usage),
+          incremental: true,
+        },
       },
-    }];
+    ];
   }
 
   return [];
@@ -291,13 +348,15 @@ export function extractUsage(msg) {
   const usage = {};
   if (typeof u.input_tokens === "number") usage.input = u.input_tokens;
   if (typeof u.output_tokens === "number") usage.output = u.output_tokens;
-  if (typeof u.cache_read_tokens === "number") usage.cacheRead = u.cache_read_tokens;
+  if (typeof u.cache_read_tokens === "number")
+    usage.cacheRead = u.cache_read_tokens;
   if (typeof r.num_turns === "number") usage.turns = r.num_turns;
 
   return {
     usage,
     costUSD: null,
-    durationMs: typeof r.duration_seconds === "number" ? r.duration_seconds * 1000 : null,
+    durationMs:
+      typeof r.duration_seconds === "number" ? r.duration_seconds * 1000 : null,
     status: r.status ?? null,
     error: r.error ?? null,
   };
@@ -322,7 +381,9 @@ export async function execute({
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
-  const resolved = resolveAgyCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  const resolved = resolveAgyCommand({
+    which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }),
+  });
   if (!resolved) {
     throw new CliNotFoundError(
       "agy CLI is not on PATH — install the Antigravity CLI (docs/event-runtime.md §6)",
@@ -348,7 +409,9 @@ export async function execute({
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    const transcript = createWriteStream(
+      path.join(workspaceDir, ".transcript.json"),
+    );
     transcript.on("error", () => {});
     if (child.stdout) {
       child.stdout.pipe(transcript);

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -1,9 +1,24 @@
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
-import { adapterExecuteTimeoutMs, DYNAMIC_DEADLINE_ADAPTERS, LEASE_GRACE_SECONDS } from "../worker.mjs";
+import {
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV,
+} from "./claude.mjs";
+import {
+  adapterExecuteTimeoutMs,
+  DYNAMIC_DEADLINE_ADAPTERS,
+  LEASE_GRACE_SECONDS,
+} from "../worker.mjs";
 import {
   buildAgyArgv,
   CliNotFoundError,
@@ -100,18 +115,31 @@ const CAPTURED = {
     error: null,
     duration_seconds: 5.5,
     num_turns: 1,
-    usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 5, cache_read_tokens: 0, total_tokens: 120 },
+    usage: {
+      input_tokens: 100,
+      output_tokens: 20,
+      thinking_tokens: 5,
+      cache_read_tokens: 0,
+      total_tokens: 120,
+    },
   },
 };
 
-const step = (stepUpdate) => ({ event: "step_update", step_update: stepUpdate });
+const step = (stepUpdate) => ({
+  event: "step_update",
+  step_update: stepUpdate,
+});
 
 describe("mapStreamEvent (real agy stream-json shapes)", () => {
   test("tool ACTIVE → tool_use keyed by step_index", () => {
     expect(mapStreamEvent(step(CAPTURED.toolActive))).toEqual([
       {
         kind: "tool_use",
-        payload: { id: "3", name: "list_dir", input: { DirectoryPath: "/tmp/ws" } },
+        payload: {
+          id: "3",
+          name: "list_dir",
+          input: { DirectoryPath: "/tmp/ws" },
+        },
       },
     ]);
   });
@@ -156,7 +184,10 @@ describe("mapStreamEvent (real agy stream-json shapes)", () => {
   });
 
   test("terminal result reaches the trace with status, error and tokens", () => {
-    const events = mapStreamEvent({ event: "result", result: CAPTURED.resultError });
+    const events = mapStreamEvent({
+      event: "result",
+      result: CAPTURED.resultError,
+    });
     const kinds = events.map((e) => e.kind);
     expect(kinds).toContain("usage");
     expect(kinds).toContain("lifecycle");
@@ -179,7 +210,10 @@ describe("mapStreamEvent (real agy stream-json shapes)", () => {
   });
 
   test("successful result emits the final answer as assistant_text", () => {
-    const events = mapStreamEvent({ event: "result", result: CAPTURED.resultSuccess });
+    const events = mapStreamEvent({
+      event: "result",
+      result: CAPTURED.resultSuccess,
+    });
     const text = events.find((e) => e.kind === "assistant_text");
     expect(text.payload.text).toBe("/tmp/ws\ninput.json");
     // A clean run has nothing to report as a failure.
@@ -187,10 +221,16 @@ describe("mapStreamEvent (real agy stream-json shapes)", () => {
   });
 
   test("unrecognized events are ignored silently", () => {
-    expect(mapStreamEvent({ event: "init", conversation_id: "abc" })).toEqual([]);
+    expect(mapStreamEvent({ event: "init", conversation_id: "abc" })).toEqual(
+      [],
+    );
     expect(mapStreamEvent(null)).toEqual([]);
     expect(mapStreamEvent("not an object")).toEqual([]);
-    expect(mapStreamEvent(step({ step_type: "checkpoint", state: "ACTIVE", step_index: 1 }))).toEqual([]);
+    expect(
+      mapStreamEvent(
+        step({ step_type: "checkpoint", state: "ACTIVE", step_index: 1 }),
+      ),
+    ).toEqual([]);
   });
 
   test("very long assistant text is clipped", () => {
@@ -294,11 +334,22 @@ describe("buildAgyArgv", () => {
       spec: { timeoutSeconds: 1_800 },
       maxRunMinutes,
     });
-    const argv = buildAgyArgv({ prompt: "x", def: {}, model: "default", workspaceDir: "/w", timeoutMs });
-    const printSeconds = Number.parseInt(argv[argv.indexOf("--print-timeout") + 1], 10);
+    const argv = buildAgyArgv({
+      prompt: "x",
+      def: {},
+      model: "default",
+      workspaceDir: "/w",
+      timeoutMs,
+    });
+    const printSeconds = Number.parseInt(
+      argv[argv.indexOf("--print-timeout") + 1],
+      10,
+    );
     expect(Number.isFinite(printSeconds)).toBe(true);
     expect(printSeconds).toBeGreaterThanOrEqual(1_800);
-    expect(printSeconds).toBeLessThanOrEqual(maxRunMinutes * 60 + LEASE_GRACE_SECONDS);
+    expect(printSeconds).toBeLessThanOrEqual(
+      maxRunMinutes * 60 + LEASE_GRACE_SECONDS,
+    );
     expect(printSeconds).toBeLessThan(1_000_000);
   });
 
@@ -361,7 +412,9 @@ describe("safeChildEnvironment", () => {
 
 describe("resolveAgyCommand", () => {
   test("resolves agy on PATH", () => {
-    const found = resolveAgyCommand({ which: (cmd) => (cmd === "agy" ? "/usr/local/bin/agy" : null) });
+    const found = resolveAgyCommand({
+      which: (cmd) => (cmd === "agy" ? "/usr/local/bin/agy" : null),
+    });
     expect(found).toEqual({ command: "agy", args: [] });
 
     const missing = resolveAgyCommand({ which: () => null });
@@ -378,7 +431,9 @@ describe("execute with fake binary", () => {
   /** Fake agy emitting the line shapes captured from the real CLI (WM-435). */
   function writeFakeAgy(binDir, lines) {
     const fakeAgy = path.join(binDir, "agy");
-    const body = lines.map((l) => `echo ${JSON.stringify(JSON.stringify(l))}`).join("\n");
+    const body = lines
+      .map((l) => `echo ${JSON.stringify(JSON.stringify(l))}`)
+      .join("\n");
     writeFileSync(fakeAgy, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
     return fakeAgy;
   }
@@ -416,7 +471,12 @@ describe("execute with fake binary", () => {
     });
 
     expect(res.exitCode).toBe(0);
-    expect(traces.map((t) => t.kind)).toEqual(["tool_use", "tool_result", "assistant_text", "usage"]);
+    expect(traces.map((t) => t.kind)).toEqual([
+      "tool_use",
+      "tool_result",
+      "assistant_text",
+      "usage",
+    ]);
     // The tool call and its result correlate by step_index.
     expect(traces[0].payload.id).toBe("3");
     expect(traces[1].payload.toolUseId).toBe("3");
@@ -471,7 +531,13 @@ describe("execute with fake binary", () => {
       { event: "step_update", step_update: CAPTURED.toolActive },
       {
         event: "result",
-        result: { status: "SUCCESS", response: "done", duration_seconds: 1, num_turns: 1, usage: {} },
+        result: {
+          status: "SUCCESS",
+          response: "done",
+          duration_seconds: 1,
+          num_turns: 1,
+          usage: {},
+        },
       },
     ]);
 

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -24,7 +24,12 @@
  * the pi path did not have to solve.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  createWriteStream,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { FACTORY_ROOT } from "../config.mjs";
@@ -61,7 +66,11 @@ export const SANDBOX_SUPPORT = "unsupported";
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+export function killProcessGroup(
+  child,
+  signal = "SIGTERM",
+  kill = process.kill,
+) {
   const pid = child?.pid;
   if (!pid) return;
   try {
@@ -84,7 +93,14 @@ export const PROMPT_SUFFIX =
 // `mutating: false` means no durable mutation beyond the run's declared
 // workspace output; it does not mean a model cannot use the shell to inspect
 // that workspace. The per-run Claude policy below enforces the boundary.
-export const READ_ONLY_TOOLS = ["Read", "Grep", "Glob", "Bash", "Write", "Edit"];
+export const READ_ONLY_TOOLS = [
+  "Read",
+  "Grep",
+  "Glob",
+  "Bash",
+  "Write",
+  "Edit",
+];
 export const WRITE_TOOLS = new Set([
   "Write",
   "Edit",
@@ -106,22 +122,26 @@ export const WRITE_TOOLS = new Set([
  */
 export function deriveAllowedTools(def) {
   if (def?.mutating === false) return [...READ_ONLY_TOOLS];
-  if (Array.isArray(def?.capabilities?.tools)) return [...def.capabilities.tools];
+  if (Array.isArray(def?.capabilities?.tools))
+    return [...def.capabilities.tools];
   return [...READ_ONLY_TOOLS];
 }
 
 /** Generate a per-run settings file; absolute paths cannot drift with cwd. */
 export function buildClaudeSettings({ spec, def, workspaceDir }) {
   if (def?.mutating !== false) return null;
-  const checkoutDir = spec?.workspace?.type === "repository"
-    ? path.resolve(workspaceDir, spec.workspace.checkoutDir ?? "repo")
-    : null;
+  const checkoutDir =
+    spec?.workspace?.type === "repository"
+      ? path.resolve(workspaceDir, spec.workspace.checkoutDir ?? "repo")
+      : null;
   return {
     permissions: {
       allow: [...READ_ONLY_TOOLS],
       // Claude's file permission matcher uses `//` for filesystem-absolute
       // paths. `Edit` covers both the Edit and Write tools.
-      deny: checkoutDir ? [`Edit(//${checkoutDir.replace(/^\/+/, "")}/**)`] : [],
+      deny: checkoutDir
+        ? [`Edit(//${checkoutDir.replace(/^\/+/, "")}/**)`]
+        : [],
     },
     sandbox: {
       enabled: true,
@@ -162,16 +182,20 @@ export const PUSH_CREDENTIAL_ENV = [
  * (`mutating: false` or default) have push credentials and secret keys stripped.
  */
 export function safeChildEnvironment(env = {}, defOrOpts = {}) {
-  const isMutating = typeof defOrOpts === "boolean"
-    ? defOrOpts
-    : defOrOpts?.mutating === true || (defOrOpts?.mutating !== false && defOrOpts?.mutating !== undefined);
+  const isMutating =
+    typeof defOrOpts === "boolean"
+      ? defOrOpts
+      : defOrOpts?.mutating === true ||
+        (defOrOpts?.mutating !== false && defOrOpts?.mutating !== undefined);
 
   const inherited = isMutating
     ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV]
     : BASE_INHERITED_ENV;
 
   const childEnv = Object.fromEntries(
-    inherited.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]]))
+    inherited.flatMap((key) =>
+      process.env[key] === undefined ? [] : [[key, process.env[key]]],
+    ),
   );
   Object.assign(childEnv, env);
   delete childEnv.ANTHROPIC_API_KEY;
@@ -201,7 +225,13 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
  * both of which mean "ride the CLI's own default" — today's behavior.
  */
 export function buildClaudeArgv({
-  prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig, settingsPath, model, resumeSessionId,
+  prompt,
+  def,
+  allowedTools = deriveAllowedTools(def),
+  mcpConfig,
+  settingsPath,
+  model,
+  resumeSessionId,
 }) {
   const args = ["-p", prompt];
   if (typeof resumeSessionId === "string" && resumeSessionId) {
@@ -233,7 +263,9 @@ export function buildClaudeArgv({
 
 function clip(text) {
   const s = String(text ?? "");
-  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+  return s.length > TEXT_PREVIEW_CHARS
+    ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]`
+    : s;
 }
 
 /**
@@ -257,7 +289,10 @@ export const HARNESS_DENIAL_PATTERNS = [
 ];
 
 export function isHarnessDenial(content) {
-  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+  return (
+    typeof content === "string" &&
+    HARNESS_DENIAL_PATTERNS.some((re) => re.test(content))
+  );
 }
 
 /** Flatten a tool_result content value (string or content-block array) to text. */
@@ -289,9 +324,19 @@ export function mapStreamEvent(msg) {
     const events = [];
     for (const block of blocks) {
       if (block?.type === "text" && block.text) {
-        events.push({ kind: "assistant_text", payload: { text: clip(block.text) } });
+        events.push({
+          kind: "assistant_text",
+          payload: { text: clip(block.text) },
+        });
       } else if (block?.type === "tool_use") {
-        events.push({ kind: "tool_use", payload: { id: block.id ?? null, name: block.name, input: block.input } });
+        events.push({
+          kind: "tool_use",
+          payload: {
+            id: block.id ?? null,
+            name: block.name,
+            input: block.input,
+          },
+        });
       }
     }
     return events;
@@ -303,7 +348,10 @@ export function mapStreamEvent(msg) {
     const events = [];
     for (const block of blocks) {
       if (block?.type !== "tool_result") continue;
-      const payload = { content: clip(contentText(block.content)), toolUseId: block.tool_use_id ?? null };
+      const payload = {
+        content: clip(contentText(block.content)),
+        toolUseId: block.tool_use_id ?? null,
+      };
       if (block.is_error === true) payload.isError = true;
       events.push({ kind: "tool_result", payload });
     }
@@ -312,7 +360,12 @@ export function mapStreamEvent(msg) {
 
   if (msg.type === "result") {
     const usage = {};
-    for (const key of ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]) {
+    for (const key of [
+      "input_tokens",
+      "output_tokens",
+      "cache_creation_input_tokens",
+      "cache_read_input_tokens",
+    ]) {
       if (typeof msg.usage?.[key] === "number") usage[key] = msg.usage[key];
     }
     return [
@@ -356,10 +409,18 @@ export async function execute({
 
   const mcpConfig = path.join(FACTORY_ROOT, "config", "mcp", "claude.json");
   const settings = buildClaudeSettings({ spec, def, workspaceDir });
-  const settingsPath = settings ? path.join(workspaceDir, ".claude-policy.json") : null;
-  if (settingsPath) writeFileSync(settingsPath, `${JSON.stringify(settings)}\n`, "utf8");
+  const settingsPath = settings
+    ? path.join(workspaceDir, ".claude-policy.json")
+    : null;
+  if (settingsPath)
+    writeFileSync(settingsPath, `${JSON.stringify(settings)}\n`, "utf8");
   const argv = buildClaudeArgv({
-    prompt, def, mcpConfig, settingsPath, model: spec?.model, resumeSessionId: resume?.sessionId,
+    prompt,
+    def,
+    mcpConfig,
+    settingsPath,
+    model: spec?.model,
+    resumeSessionId: resume?.sessionId,
   });
 
   return new Promise((resolve, reject) => {
@@ -375,7 +436,9 @@ export async function execute({
     // what the agent reported long after the workspace is gone. With
     // stream-json the artifact is NDJSON, one message per line — consumers
     // stream bytes, none parses it as a single JSON document.
-    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    const transcript = createWriteStream(
+      path.join(workspaceDir, ".transcript.json"),
+    );
     transcript.on("error", () => {});
     if (child.stdout) {
       child.stdout.pipe(transcript);
@@ -386,7 +449,12 @@ export async function execute({
     const policyDenials = [];
     let lastTool = null;
     const toolNames = new Map();
-    const tokenKeys = ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"];
+    const tokenKeys = [
+      "input_tokens",
+      "output_tokens",
+      "cache_creation_input_tokens",
+      "cache_read_input_tokens",
+    ];
     const assistantUsage = Object.fromEntries(tokenKeys.map((key) => [key, 0]));
     let finalUsage = null;
     let observedModel = null;
@@ -395,13 +463,23 @@ export async function execute({
       lines.on("line", (line) => {
         try {
           const parsed = JSON.parse(line);
-          if (parsed?.type === "system" && parsed?.subtype === "init" && typeof parsed.model === "string") {
+          if (
+            parsed?.type === "system" &&
+            parsed?.subtype === "init" &&
+            typeof parsed.model === "string"
+          ) {
             observedModel = parsed.model;
           } else if (parsed?.type === "assistant") {
-            if (!observedModel && typeof parsed.message?.model === "string") observedModel = parsed.message.model;
+            if (!observedModel && typeof parsed.message?.model === "string")
+              observedModel = parsed.message.model;
             for (const key of tokenKeys) {
               const value = parsed.message?.usage?.[key];
-              if (typeof value === "number" && Number.isFinite(value) && value >= 0) assistantUsage[key] += value;
+              if (
+                typeof value === "number" &&
+                Number.isFinite(value) &&
+                value >= 0
+              )
+                assistantUsage[key] += value;
             }
           } else if (parsed?.type === "result") {
             finalUsage = parsed;
@@ -412,9 +490,22 @@ export async function execute({
               if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
             }
             onTrace?.(event.kind, event.payload);
-            const content = typeof event.payload?.content === "string" ? event.payload.content : "";
-            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
-              const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+            const content =
+              typeof event.payload?.content === "string"
+                ? event.payload.content
+                : "";
+            if (
+              event.kind === "tool_result" &&
+              event.payload?.isError &&
+              isHarnessDenial(content)
+            ) {
+              const denial = {
+                tool:
+                  toolNames.get(event.payload?.toolUseId) ??
+                  lastTool ??
+                  "unknown",
+                rule: clip(content),
+              };
               policyDenials.push(denial);
               // Keep the registry's closed trace-kind set. The payload turns
               // this existing lifecycle event into an operator-visible denial.
@@ -432,14 +523,20 @@ export async function execute({
     const termTimer = setTimeout(() => {
       timedOut = true;
       killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+      killTimer = setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        killGraceMs,
+      );
       killTimer.unref?.();
     }, timeoutMs);
 
     const onAbort = () => {
       killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
         killTimer.unref?.();
       }
     };
@@ -482,12 +579,19 @@ export async function execute({
           outputTokens: tokenValue("output_tokens"),
           cacheCreationInputTokens: tokenValue("cache_creation_input_tokens"),
           cacheReadInputTokens: tokenValue("cache_read_input_tokens"),
-          costUSD: typeof finalUsage?.total_cost_usd === "number" ? finalUsage.total_cost_usd : 0,
+          costUSD:
+            typeof finalUsage?.total_cost_usd === "number"
+              ? finalUsage.total_cost_usd
+              : 0,
         });
       } catch {
         // Usage is observability: a consumer failure must not change execution.
       }
-      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
+      resolve({
+        exitCode,
+        timedOut,
+        policyDenials: exitCode === 0 ? [] : policyDenials,
+      });
     });
   });
 }

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -1,5 +1,13 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -20,7 +28,10 @@ import {
   WRITE_TOOLS,
 } from "./claude.mjs";
 import { SandboxUnsupportedError } from "./sandboxed.mjs";
-import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
+import {
+  processOwnerWatchdogSource,
+  trackProcessGroupForPid,
+} from "../test-helpers-process.mjs";
 
 describe("sandbox decision (WM-313): deferred, so refused — never ignored", () => {
   const sandboxedDef = (promptPath) => ({
@@ -38,13 +49,19 @@ describe("sandbox decision (WM-313): deferred, so refused — never ignored", ()
   });
 
   test("a sandboxed definition is refused with a typed error naming the adapter, before any spawn or workspace write", async () => {
-    const workspaceDir = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-claude-sandbox-")));
+    const workspaceDir = realpathSync(
+      mkdtempSync(path.join(tmpdir(), "evrt-claude-sandbox-")),
+    );
     const promptPath = path.join(workspaceDir, "prompt.md");
     writeFileSync(promptPath, "hello", "utf8");
     let caught;
     try {
       await execute({
-        spec: { agent: "sandboxed-claude@1", input: {}, workspace: { type: "repository", checkoutDir: "repo" } },
+        spec: {
+          agent: "sandboxed-claude@1",
+          input: {},
+          workspace: { type: "repository", checkoutDir: "repo" },
+        },
         def: sandboxedDef(promptPath),
         workspaceDir,
         timeoutMs: 1000,
@@ -56,10 +73,14 @@ describe("sandbox decision (WM-313): deferred, so refused — never ignored", ()
     expect(caught).toBeInstanceOf(SandboxUnsupportedError);
     expect(caught.code).toBe("sandbox_unsupported");
     expect(caught.adapter).toBe("claude");
-    expect(caught.message).toContain('adapter "claude" cannot honour a sandbox policy');
+    expect(caught.message).toContain(
+      'adapter "claude" cannot honour a sandbox policy',
+    );
     expect(caught.message).toContain(SANDBOX_DEFERRAL_REASON);
     // Nothing host-side happened: no settings policy, no transcript.
-    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(false);
+    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(
+      false,
+    );
     expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
     rmSync(workspaceDir, { recursive: true, force: true });
   });
@@ -67,20 +88,50 @@ describe("sandbox decision (WM-313): deferred, so refused — never ignored", ()
 
 describe("isHarnessDenial (WM-127)", () => {
   test("matches the harness's own refusal shapes", () => {
-    expect(isHarnessDenial("Claude requested permissions to use Bash, but you haven't granted it yet.")).toBe(true);
-    expect(isHarnessDenial("Claude requested permissions to use mcp__linear__create_issue, but you haven't granted it yet.")).toBe(true);
-    expect(isHarnessDenial("Permission to use Bash has been denied.")).toBe(true);
-    expect(isHarnessDenial("Sandbox denied write to /tmp/run-a1/repo/x")).toBe(true);
+    expect(
+      isHarnessDenial(
+        "Claude requested permissions to use Bash, but you haven't granted it yet.",
+      ),
+    ).toBe(true);
+    expect(
+      isHarnessDenial(
+        "Claude requested permissions to use mcp__linear__create_issue, but you haven't granted it yet.",
+      ),
+    ).toBe(true);
+    expect(isHarnessDenial("Permission to use Bash has been denied.")).toBe(
+      true,
+    );
+    expect(isHarnessDenial("Sandbox denied write to /tmp/run-a1/repo/x")).toBe(
+      true,
+    );
   });
 
   test("does not match permission-flavored stderr from commands the harness allowed", () => {
     // The run_38deabb4 misclassification: git push over SSH without agent access.
-    expect(isHarnessDenial("git@ssh.github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.")).toBe(false);
+    expect(
+      isHarnessDenial(
+        "git@ssh.github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+      ),
+    ).toBe(false);
     expect(isHarnessDenial("bash: /etc/hosts: Permission denied")).toBe(false);
-    expect(isHarnessDenial("sudo: a terminal is required to read the password; permission denied")).toBe(false);
-    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
-    expect(isHarnessDenial("remote: Write access to repository not granted.\nfatal: unable to access: The requested URL returned error: 403")).toBe(false);
-    expect(isHarnessDenial("curl: (22) The requested URL returned error: 403 Forbidden — request blocked by firewall permissions")).toBe(false);
+    expect(
+      isHarnessDenial(
+        "sudo: a terminal is required to read the password; permission denied",
+      ),
+    ).toBe(false);
+    expect(
+      isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'"),
+    ).toBe(false);
+    expect(
+      isHarnessDenial(
+        "remote: Write access to repository not granted.\nfatal: unable to access: The requested URL returned error: 403",
+      ),
+    ).toBe(false);
+    expect(
+      isHarnessDenial(
+        "curl: (22) The requested URL returned error: 403 Forbidden — request blocked by firewall permissions",
+      ),
+    ).toBe(false);
     expect(isHarnessDenial(null)).toBe(false);
   });
 });
@@ -89,11 +140,17 @@ describe("mapStreamEvent", () => {
   test("assistant text block → assistant_text", () => {
     const events = mapStreamEvent({
       type: "assistant",
-      message: { role: "assistant", content: [{ type: "text", text: "Looking at the input now." }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Looking at the input now." }],
+      },
       session_id: "s-1",
     });
     expect(events).toEqual([
-      { kind: "assistant_text", payload: { text: "Looking at the input now." } },
+      {
+        kind: "assistant_text",
+        payload: { text: "Looking at the input now." },
+      },
     ]);
   });
 
@@ -103,36 +160,66 @@ describe("mapStreamEvent", () => {
       message: {
         content: [
           { type: "text", text: "Running the query." },
-          { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls" } },
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "Bash",
+            input: { command: "ls" },
+          },
         ],
       },
     });
     expect(events).toEqual([
       { kind: "assistant_text", payload: { text: "Running the query." } },
-      { kind: "tool_use", payload: { id: "toolu_1", name: "Bash", input: { command: "ls" } } },
+      {
+        kind: "tool_use",
+        payload: { id: "toolu_1", name: "Bash", input: { command: "ls" } },
+      },
     ]);
   });
 
   test("user tool_result → tool_result, string and block-array content, isError", () => {
     const plain = mapStreamEvent({
       type: "user",
-      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "file.txt" }] },
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_1", content: "file.txt" },
+        ],
+      },
     });
-    expect(plain).toEqual([{ kind: "tool_result", payload: { content: "file.txt", toolUseId: "toolu_1" } }]);
+    expect(plain).toEqual([
+      {
+        kind: "tool_result",
+        payload: { content: "file.txt", toolUseId: "toolu_1" },
+      },
+    ]);
 
     const blocks = mapStreamEvent({
       type: "user",
       message: {
-        content: [{
-          type: "tool_result",
-          tool_use_id: "toolu_2",
-          content: [{ type: "text", text: "line 1" }, { type: "text", text: "line 2" }],
-          is_error: true,
-        }],
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_2",
+            content: [
+              { type: "text", text: "line 1" },
+              { type: "text", text: "line 2" },
+            ],
+            is_error: true,
+          },
+        ],
       },
     });
     expect(blocks).toEqual([
-      { kind: "tool_result", payload: { content: "line 1\nline 2", toolUseId: "toolu_2", isError: true } },
+      {
+        kind: "tool_result",
+        payload: {
+          content: "line 1\nline 2",
+          toolUseId: "toolu_2",
+          isError: true,
+        },
+      },
     ]);
   });
 
@@ -155,28 +242,36 @@ describe("mapStreamEvent", () => {
       },
       result: "done",
     });
-    expect(events).toEqual([{
-      kind: "usage",
-      payload: {
-        durationMs: 4321,
-        numTurns: 3,
-        costUSD: 0.0421,
-        usage: {
-          input_tokens: 12,
-          output_tokens: 345,
-          cache_creation_input_tokens: 6789,
-          cache_read_input_tokens: 1011,
+    expect(events).toEqual([
+      {
+        kind: "usage",
+        payload: {
+          durationMs: 4321,
+          numTurns: 3,
+          costUSD: 0.0421,
+          usage: {
+            input_tokens: 12,
+            output_tokens: 345,
+            cache_creation_input_tokens: 6789,
+            cache_read_input_tokens: 1011,
+          },
         },
       },
-    }]);
+    ]);
   });
 
   test("unrecognized messages are ignored silently", () => {
-    expect(mapStreamEvent({ type: "system", subtype: "init", tools: [] })).toEqual([]);
-    expect(mapStreamEvent({ type: "system", subtype: "hook_started" })).toEqual([]);
+    expect(
+      mapStreamEvent({ type: "system", subtype: "init", tools: [] }),
+    ).toEqual([]);
+    expect(mapStreamEvent({ type: "system", subtype: "hook_started" })).toEqual(
+      [],
+    );
     expect(mapStreamEvent({ type: "stream_event", event: {} })).toEqual([]);
     expect(mapStreamEvent({ type: "assistant" })).toEqual([]); // no message body
-    expect(mapStreamEvent({ type: "user", message: { content: "just a string" } })).toEqual([]);
+    expect(
+      mapStreamEvent({ type: "user", message: { content: "just a string" } }),
+    ).toEqual([]);
     expect(mapStreamEvent(null)).toEqual([]);
     expect(mapStreamEvent("not an object")).toEqual([]);
   });
@@ -207,7 +302,14 @@ describe("deriveAllowedTools (OPS-407)", () => {
   });
 
   test("permits shell inspection and workspace-local output for non-mutating agents", () => {
-    expect(deriveAllowedTools({ mutating: false })).toEqual(["Read", "Grep", "Glob", "Bash", "Write", "Edit"]);
+    expect(deriveAllowedTools({ mutating: false })).toEqual([
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash",
+      "Write",
+      "Edit",
+    ]);
   });
 
   test("allows requested tools when mutating is true", () => {
@@ -296,7 +398,9 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
       workspaceDir: "/private/tmp/run-a1",
     });
     expect(settings.permissions.allow).toEqual(READ_ONLY_TOOLS);
-    expect(settings.permissions.deny).toEqual(["Edit(//private/tmp/run-a1/repo/**)"]);
+    expect(settings.permissions.deny).toEqual([
+      "Edit(//private/tmp/run-a1/repo/**)",
+    ]);
     expect(settings.sandbox).toEqual({
       enabled: true,
       autoAllowBashIfSandboxed: true,
@@ -306,7 +410,10 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
   });
 
   test("mutating runs include --dangerously-skip-permissions and omit --settings (WM-137)", () => {
-    const mutatingDef = { mutating: true, capabilities: { tools: ["Bash", "Read", "Write"] } };
+    const mutatingDef = {
+      mutating: true,
+      capabilities: { tools: ["Bash", "Read", "Write"] },
+    };
     const argv = buildClaudeArgv({ prompt: "Fix issue", def: mutatingDef });
 
     expect(argv).toContain("--dangerously-skip-permissions");
@@ -317,7 +424,11 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
 
   test("read-only runs omit --dangerously-skip-permissions and include --settings (WM-137)", () => {
     const readOnlyDef = { mutating: false };
-    const argv = buildClaudeArgv({ prompt: "Inspect repo", def: readOnlyDef, settingsPath: "/tmp/policy.json" });
+    const argv = buildClaudeArgv({
+      prompt: "Inspect repo",
+      def: readOnlyDef,
+      settingsPath: "/tmp/policy.json",
+    });
 
     expect(argv).not.toContain("--dangerously-skip-permissions");
     expect(argv).toContain("--settings");
@@ -335,7 +446,11 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
   test("constructs argv with --allowedTools, --mcp-config, and --strict-mcp-config", () => {
     const def = { mutating: false };
     const prompt = "Do a status check.";
-    const argv = buildClaudeArgv({ prompt, def, mcpConfig: "/path/to/mcp.json" });
+    const argv = buildClaudeArgv({
+      prompt,
+      def,
+      mcpConfig: "/path/to/mcp.json",
+    });
 
     expect(argv).toContain("-p");
     expect(argv).toContain(prompt);
@@ -350,18 +465,37 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
   });
 
   test("limits.budget_usd → --max-budget-usd; absent or invalid → no flag (WM-108)", () => {
-    const withBudget = buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: 15 } } });
+    const withBudget = buildClaudeArgv({
+      prompt: "p",
+      def: { mutating: false, limits: { budget_usd: 15 } },
+    });
     const i = withBudget.indexOf("--max-budget-usd");
     expect(i).toBeGreaterThan(-1);
     expect(withBudget[i + 1]).toBe("15");
 
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false } })).not.toContain("--max-budget-usd");
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: 0 } } })).not.toContain("--max-budget-usd");
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: "15" } } })).not.toContain("--max-budget-usd");
+    expect(
+      buildClaudeArgv({ prompt: "p", def: { mutating: false } }),
+    ).not.toContain("--max-budget-usd");
+    expect(
+      buildClaudeArgv({
+        prompt: "p",
+        def: { mutating: false, limits: { budget_usd: 0 } },
+      }),
+    ).not.toContain("--max-budget-usd");
+    expect(
+      buildClaudeArgv({
+        prompt: "p",
+        def: { mutating: false, limits: { budget_usd: "15" } },
+      }),
+    ).not.toContain("--max-budget-usd");
   });
 
   test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {
-    const withModel = buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "sonnet" });
+    const withModel = buildClaudeArgv({
+      prompt: "p",
+      def: { mutating: false },
+      model: "sonnet",
+    });
     const i = withModel.indexOf("--model");
     expect(i).toBeGreaterThan(-1);
     expect(withModel[i + 1]).toBe("sonnet");
@@ -369,14 +503,26 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
     // The "default" sentinel means "ride the CLI default" — no flag at all,
     // byte-identical argv to a spec that pinned nothing.
     const unpinned = buildClaudeArgv({ prompt: "p", def: { mutating: false } });
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "default" })).toEqual(unpinned);
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: null })).toEqual(unpinned);
-    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "" })).toEqual(unpinned);
+    expect(
+      buildClaudeArgv({
+        prompt: "p",
+        def: { mutating: false },
+        model: "default",
+      }),
+    ).toEqual(unpinned);
+    expect(
+      buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: null }),
+    ).toEqual(unpinned);
+    expect(
+      buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "" }),
+    ).toEqual(unpinned);
   });
 });
 
 describe("execute conformance (OPS-427, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-claude-test-")));
+  const tmpBase = realpathSync(
+    mkdtempSync(path.join(tmpdir(), "evrt-claude-test-")),
+  );
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
 
@@ -615,7 +761,11 @@ if (behavior === "emit_denial_then_recovery") {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
 
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
 
     // 1. Workspace confinement: cwd is workspaceDir
     expect(existsSync(recordFile)).toBe(true);
@@ -631,7 +781,9 @@ if (behavior === "emit_denial_then_recovery") {
     // 3. Prompt & argv verification
     const promptIdx = record.argv.indexOf("-p");
     expect(promptIdx).toBeGreaterThan(-1);
-    expect(record.argv[promptIdx + 1]).toBe(`You are a test agent.${PROMPT_SUFFIX}`);
+    expect(record.argv[promptIdx + 1]).toBe(
+      `You are a test agent.${PROMPT_SUFFIX}`,
+    );
     expect(record.argv).toContain("--output-format");
     expect(record.argv).toContain("stream-json");
     expect(record.argv).toContain("--verbose");
@@ -676,37 +828,41 @@ if (behavior === "emit_denial_then_recovery") {
     expect(outcome.timedOut).toBe(false);
   });
 
-  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 6_000,
-      killGraceMs: 5000,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
+  testProcessGroup(
+    "timeout kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 6_000,
+        killGraceMs: 5000,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
 
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(true);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  }, { timeout: 12_000 });
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(true);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+    { timeout: 12_000 },
+  );
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
     const workspaceDir = ws();
@@ -724,38 +880,41 @@ if (behavior === "emit_denial_then_recovery") {
     expect(outcome.timedOut).toBe(true);
   });
 
-  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 10_000,
-      killGraceMs: 500,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
+  testProcessGroup(
+    "abort kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 10_000,
+        killGraceMs: 500,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
 
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      ac.abort();
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(false);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  });
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        ac.abort();
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(false);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+  );
 
   test("pre-aborted abortSignal terminates child immediately", async () => {
     const workspaceDir = ws();
@@ -790,8 +949,16 @@ if (behavior === "emit_denial_then_recovery") {
       },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
-    expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "Bash")).toBe(true);
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "tool_use" && e.payload.name === "Bash",
+      ),
+    ).toBe(true);
   });
 
   test("records a policy denial without terminating the child from the trace observer", async () => {
@@ -813,9 +980,21 @@ if (behavior === "emit_denial_then_recovery") {
     expect(outcome).toEqual({
       exitCode: 1,
       timedOut: false,
-      policyDenials: [{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }],
+      policyDenials: [
+        {
+          tool: "Bash",
+          rule: "Claude requested permissions to use Bash, but you haven't granted it yet.",
+        },
+      ],
     });
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial" && e.payload.tool === "Bash")).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) =>
+          e.kind === "lifecycle" &&
+          e.payload.note === "policy_denial" &&
+          e.payload.tool === "Bash",
+      ),
+    ).toBe(true);
   });
 
   test("SSH publickey stderr in an error tool_result is not a policy denial (WM-127)", async () => {
@@ -833,8 +1012,16 @@ if (behavior === "emit_denial_then_recovery") {
     });
     // The harness allowed and executed the push; the command failed on its
     // own. The run must fail as an ordinary agent exit, never policy_denied.
-    expect(outcome).toEqual({ exitCode: 1, timedOut: false, policyDenials: [] });
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+    expect(outcome).toEqual({
+      exitCode: 1,
+      timedOut: false,
+      policyDenials: [],
+    });
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "lifecycle" && e.payload.note === "policy_denial",
+      ),
+    ).toBe(false);
   });
 
   test("SSH publickey stderr followed by a recovered push and clean exit completes (WM-127, run_38deabb4)", async () => {
@@ -850,8 +1037,16 @@ if (behavior === "emit_denial_then_recovery") {
       },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "lifecycle" && e.payload.note === "policy_denial",
+      ),
+    ).toBe(false);
   });
 
   test("a genuine denial the model recovers from does not fail a clean exit; trace keeps the evidence (WM-127)", async () => {
@@ -869,8 +1064,19 @@ if (behavior === "emit_denial_then_recovery") {
     });
     // Evidence, not verdict: the observation stays in the lifecycle trace,
     // but a run that ends exit 0 with a valid result is not failed for it.
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial" && e.payload.tool === "WebFetch")).toBe(true);
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
+    expect(
+      traceEvents.some(
+        (e) =>
+          e.kind === "lifecycle" &&
+          e.payload.note === "policy_denial" &&
+          e.payload.tool === "WebFetch",
+      ),
+    ).toBe(true);
   });
 
   test("returns a policy denial even when no trace sink is attached", async () => {
@@ -884,7 +1090,12 @@ if (behavior === "emit_denial_then_recovery") {
         FACTORY_TEST_BEHAVIOR: "emit_policy_denial",
       },
     });
-    expect(outcome.policyDenials).toEqual([{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }]);
+    expect(outcome.policyDenials).toEqual([
+      {
+        tool: "Bash",
+        rule: "Claude requested permissions to use Bash, but you haven't granted it yet.",
+      },
+    ]);
   });
 
   test("mutating dispatch execution passes --dangerously-skip-permissions and preserves push credentials (WM-137, WM-128)", async () => {
@@ -912,14 +1123,20 @@ if (behavior === "emit_denial_then_recovery") {
       },
     });
 
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
     const record = JSON.parse(readFileSync(recordFile, "utf8"));
     expect(record.argv).toContain("--dangerously-skip-permissions");
     expect(record.argv).not.toContain("--settings");
     expect(record.env.SSH_AUTH_SOCK).toBe("/tmp/dispatch-ssh.sock");
     expect(record.env.GITHUB_TOKEN).toBe("ghp_dispatch_secret");
     expect(record.env.ANTHROPIC_API_KEY).toBeUndefined();
-    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(false);
+    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(
+      false,
+    );
   });
 
   test("read-only dispatch execution enforces settings policy and strips push credentials (WM-137, WM-128)", async () => {
@@ -947,14 +1164,20 @@ if (behavior === "emit_denial_then_recovery") {
       },
     });
 
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
     const record = JSON.parse(readFileSync(recordFile, "utf8"));
     expect(record.argv).not.toContain("--dangerously-skip-permissions");
     expect(record.argv).toContain("--settings");
     expect(record.env.SSH_AUTH_SOCK).toBeUndefined();
     expect(record.env.GITHUB_TOKEN).toBeUndefined();
     expect(record.env.ANTHROPIC_API_KEY).toBeUndefined();
-    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(true);
+    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(
+      true,
+    );
   });
 
   test("spawn error (e.g. claude not on PATH) rejects promise", async () => {

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -48,10 +48,14 @@ export function resolveTemplate(template, input) {
     element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
       const value = context[field];
       if (value === undefined || value === null) {
-        throw new Error(`command template references missing input field "${field}"`);
+        throw new Error(
+          `command template references missing input field "${field}"`,
+        );
       }
       if (!["string", "number", "boolean"].includes(typeof value)) {
-        throw new Error(`command template field "${field}" must be a primitive, got ${typeof value}`);
+        throw new Error(
+          `command template field "${field}" must be a primitive, got ${typeof value}`,
+        );
       }
       return String(value);
     }),
@@ -77,7 +81,9 @@ function killProcessGroup(child, signal = "SIGTERM") {
  * paths so the two can never drift into producing different artifacts.
  */
 function writeResultJson({ workspaceDir, def, argv, output }) {
-  const captured = def.captureStdout ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }] : [];
+  const captured = def.captureStdout
+    ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }]
+    : [];
   writeFileSync(
     path.join(workspaceDir, "result.json"),
     `${JSON.stringify(
@@ -108,12 +114,22 @@ function writeResultJson({ workspaceDir, def, argv, output }) {
  *
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
-async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal, onTrace, runSandbox }) {
+async function executeSandboxed({
+  def,
+  argv,
+  workspaceDir,
+  timeoutMs,
+  abortSignal,
+  onTrace,
+  runSandbox,
+}) {
   let output = "";
   const collect = (chunk) => {
     output = (output + chunk).slice(-OUTPUT_TAIL_CHARS);
   };
-  const capture = def.captureStdout ? createWriteStream(path.join(workspaceDir, def.captureStdout)) : null;
+  const capture = def.captureStdout
+    ? createWriteStream(path.join(workspaceDir, def.captureStdout))
+    : null;
 
   const { exitCode, timedOut } = await runSandboxed({
     adapter: "command",
@@ -141,14 +157,33 @@ async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSigna
 /**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
-export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal, signal, onTrace, runSandbox }) {
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  abortSignal,
+  signal,
+  onTrace,
+  runSandbox,
+}) {
   if (!Array.isArray(def.command) || def.command.length === 0) {
-    throw new Error(`definition ${def.ref} has no command template — not a command-adapter agent`);
+    throw new Error(
+      `definition ${def.ref} has no command template — not a command-adapter agent`,
+    );
   }
   const argv = resolveTemplate(def.command, spec.input);
 
   if (sandboxRequested(def)) {
-    return executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal: abortSignal ?? signal, onTrace, runSandbox });
+    return executeSandboxed({
+      def,
+      argv,
+      workspaceDir,
+      timeoutMs,
+      abortSignal: abortSignal ?? signal,
+      onTrace,
+      runSandbox,
+    });
   }
 
   return new Promise((resolve, reject) => {
@@ -179,13 +214,19 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal,
     const termTimer = setTimeout(() => {
       timedOut = true;
       killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), KILL_GRACE_MS);
+      killTimer = setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        KILL_GRACE_MS,
+      );
     }, timeoutMs);
 
     const onAbort = () => {
       killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), KILL_GRACE_MS);
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          KILL_GRACE_MS,
+        );
       }
     };
     const abortSig = abortSignal ?? signal;

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -19,30 +19,47 @@ const REAPER_SCRIPT = path.join(FACTORY_ROOT, "orchestrator", "reaper.mjs");
 
 describe("resolveTemplate", () => {
   test("substitutes placeholders inside argv elements", () => {
-    expect(resolveTemplate(["gh", "run", "rerun", "{runId}", "--repo", "{repo}"], { runId: 42, repo: "wm/x" }))
-      .toEqual(["gh", "run", "rerun", "42", "--repo", "wm/x"]);
-    expect(resolveTemplate(["notify", "CI RED {repo}: {summary}"], { repo: "wm/x", summary: "boom" }))
-      .toEqual(["notify", "CI RED wm/x: boom"]);
+    expect(
+      resolveTemplate(["gh", "run", "rerun", "{runId}", "--repo", "{repo}"], {
+        runId: 42,
+        repo: "wm/x",
+      }),
+    ).toEqual(["gh", "run", "rerun", "42", "--repo", "wm/x"]);
+    expect(
+      resolveTemplate(["notify", "CI RED {repo}: {summary}"], {
+        repo: "wm/x",
+        summary: "boom",
+      }),
+    ).toEqual(["notify", "CI RED wm/x: boom"]);
   });
 
   test("missing or non-primitive fields fail closed", () => {
-    expect(() => resolveTemplate(["x", "{gone}"], {})).toThrow('missing input field "gone"');
-    expect(() => resolveTemplate(["x", "{obj}"], { obj: { a: 1 } })).toThrow("must be a primitive");
+    expect(() => resolveTemplate(["x", "{gone}"], {})).toThrow(
+      'missing input field "gone"',
+    );
+    expect(() => resolveTemplate(["x", "{obj}"], { obj: { a: 1 } })).toThrow(
+      "must be a primitive",
+    );
   });
 
   test("hostile input stays a single inert argument — no shell exists", () => {
-    const argv = resolveTemplate(["echo", "{msg}"], { msg: "; rm -rf / && echo pwned" });
+    const argv = resolveTemplate(["echo", "{msg}"], {
+      msg: "; rm -rf / && echo pwned",
+    });
     expect(argv).toEqual(["echo", "; rm -rf / && echo pwned"]);
   });
 
   test("factoryRoot is injected from config, never from input (OPS-404)", () => {
-    expect(resolveTemplate(["bun", "{factoryRoot}/orchestrator/reaper.mjs", "--apply"], {})).toEqual([
-      "bun",
-      REAPER_SCRIPT,
-      "--apply",
-    ]);
     expect(
-      resolveTemplate(["bun", "{factoryRoot}/orchestrator/reaper.mjs"], { factoryRoot: "/tmp/pwn" }),
+      resolveTemplate(
+        ["bun", "{factoryRoot}/orchestrator/reaper.mjs", "--apply"],
+        {},
+      ),
+    ).toEqual(["bun", REAPER_SCRIPT, "--apply"]);
+    expect(
+      resolveTemplate(["bun", "{factoryRoot}/orchestrator/reaper.mjs"], {
+        factoryRoot: "/tmp/pwn",
+      }),
     ).toEqual(["bun", REAPER_SCRIPT]);
   });
 });
@@ -57,7 +74,9 @@ describe("execute", () => {
       timeoutMs: 5000,
     });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.terminalState).toBe("completed");
     expect(result.artifact.command).toEqual(["echo", "hello"]);
     expect(result.artifact.exitCode).toBe(0);
@@ -73,7 +92,9 @@ describe("execute", () => {
       timeoutMs: 5000,
     });
     expect(outcome.exitCode).toBe(1);
-    expect(() => readFileSync(path.join(workspaceDir, "result.json"))).toThrow();
+    expect(() =>
+      readFileSync(path.join(workspaceDir, "result.json")),
+    ).toThrow();
   });
 
   test("timeout TERMs the child and reports timedOut", async () => {
@@ -89,7 +110,12 @@ describe("execute", () => {
 
   test("a definition without a command template is refused", async () => {
     await expect(
-      execute({ spec: spec({}), def: { ref: "x@1" }, workspaceDir: ws(), timeoutMs: 1000 }),
+      execute({
+        spec: spec({}),
+        def: { ref: "x@1" },
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+      }),
     ).rejects.toThrow("no command template");
   });
 
@@ -102,7 +128,9 @@ describe("execute", () => {
       timeoutMs: 5000,
     });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
     expect(result.artifact.command.join(" ")).not.toContain("/tmp/pwn");
   });
@@ -178,8 +206,14 @@ describe("execute", () => {
 function sampleFromSchema(schema) {
   if (!schema || typeof schema !== "object") return "x";
   if (schema.const !== undefined) return schema.const;
-  if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0];
-  const types = schema.type === undefined ? ["object"] : Array.isArray(schema.type) ? schema.type : [schema.type];
+  if (Array.isArray(schema.enum) && schema.enum.length > 0)
+    return schema.enum[0];
+  const types =
+    schema.type === undefined
+      ? ["object"]
+      : Array.isArray(schema.type)
+        ? schema.type
+        : [schema.type];
   const type = types.find((t) => t !== "null") ?? "string";
   switch (type) {
     case "string": {
@@ -227,9 +261,13 @@ describe("command-adapter registry (OPS-404)", () => {
     }
     expect(offenders).toEqual([]);
     const reaper = registry.agents.get("reaper@1");
-    expect(validate(reaper.inputSchema, { loop: "reaper", slot: "2026-08-14T04:00:00.000Z", factoryRoot: "/tmp/pwn" }).valid).toBe(
-      false,
-    );
+    expect(
+      validate(reaper.inputSchema, {
+        loop: "reaper",
+        slot: "2026-08-14T04:00:00.000Z",
+        factoryRoot: "/tmp/pwn",
+      }).valid,
+    ).toBe(false);
   });
 
   test("every registered command template resolves against a schema-valid input", () => {
@@ -237,7 +275,10 @@ describe("command-adapter registry (OPS-404)", () => {
     for (const agent of commandDefs) {
       const input = sampleFromSchema(agent.inputSchema);
       const checked = validate(agent.inputSchema, input);
-      expect(checked.valid, `${agent.ref} sample is not schema-valid: ${checked.errors?.join("; ")}`).toBe(true);
+      expect(
+        checked.valid,
+        `${agent.ref} sample is not schema-valid: ${checked.errors?.join("; ")}`,
+      ).toBe(true);
       expect(input).not.toHaveProperty("factoryRoot");
       const argv = resolveTemplate(agent.command, input);
       expect(argv.every((el) => typeof el === "string")).toBe(true);
@@ -246,7 +287,12 @@ describe("command-adapter registry (OPS-404)", () => {
   });
 
   test("a reaper run planned from a clock tick resolves its argv and executes", async () => {
-    const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-reaper-")), "runtime.db"));
+    const db = openDb(
+      path.join(
+        mkdtempSync(path.join(os.tmpdir(), "evrt-reaper-")),
+        "runtime.db",
+      ),
+    );
     // Only the reaper schedule may tick here (WM-629). Spreading the shipped
     // schedules pulled in every enabled one — e.g. merge-factory — whose
     // repository-workspace agent makes planAdmittedEvents run pinRepo(), i.e.
@@ -257,7 +303,11 @@ describe("command-adapter registry (OPS-404)", () => {
     const withReaper = {
       ...registry,
       schedules: {
-        reaper: { ...registry.schedules.reaper, enabled: true, approval: "auto" },
+        reaper: {
+          ...registry.schedules.reaper,
+          enabled: true,
+          approval: "auto",
+        },
       },
     };
     emitDueTicks(db, withReaper, { now: Date.parse("2026-08-14T04:30:00Z") });
@@ -268,9 +318,15 @@ describe("command-adapter registry (OPS-404)", () => {
     const planned = JSON.parse(row.spec_json);
     expect(planned.agent).toBe("reaper@1");
     expect(planned.adapter).toBe("command");
-    expect(validate(registry.agents.get("reaper@1").inputSchema, planned.input).valid).toBe(true);
+    expect(
+      validate(registry.agents.get("reaper@1").inputSchema, planned.input)
+        .valid,
+    ).toBe(true);
 
-    const argv = resolveTemplate(registry.agents.get("reaper@1").command, planned.input);
+    const argv = resolveTemplate(
+      registry.agents.get("reaper@1").command,
+      planned.input,
+    );
     expect(argv).toEqual(["bun", REAPER_SCRIPT, "--apply"]);
     expect(existsSync(argv[1])).toBe(true);
 
@@ -280,12 +336,17 @@ describe("command-adapter registry (OPS-404)", () => {
     const workspaceDir = ws();
     const outcome = await execute({
       spec: planned,
-      def: { ref: "reaper@1", command: ["test", "-f", "{factoryRoot}/orchestrator/reaper.mjs"] },
+      def: {
+        ref: "reaper@1",
+        command: ["test", "-f", "{factoryRoot}/orchestrator/reaper.mjs"],
+      },
       workspaceDir,
       timeoutMs: 5000,
     });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
   });
 });
@@ -303,7 +364,12 @@ describe("sandboxed execution (WM-185)", () => {
     // like /opt/homebrew/bin/bun does not exist in the Alpine guest — so a
     // bare "bun" would fail deep inside the VM with a useless message.
     await expect(
-      execute({ spec: spec({}), def: sandboxDef(["bun", "--version"]), workspaceDir: ws(), timeoutMs: 5000 }),
+      execute({
+        spec: spec({}),
+        def: sandboxDef(["bun", "--version"]),
+        workspaceDir: ws(),
+        timeoutMs: 5000,
+      }),
     ).rejects.toThrow(/must start with an absolute guest path/);
   });
 
@@ -311,7 +377,9 @@ describe("sandboxed execution (WM-185)", () => {
     await expect(
       execute({
         spec: spec({}),
-        def: sandboxDef(["/bin/true"], { sandbox: { provider: "firecracker" } }),
+        def: sandboxDef(["/bin/true"], {
+          sandbox: { provider: "firecracker" },
+        }),
         workspaceDir: ws(),
         timeoutMs: 5000,
       }),
@@ -340,12 +408,22 @@ describe("sandboxed execution (WM-185)", () => {
     expect(seen.command).toEqual(["/bin/echo", "hi"]);
     expect(seen.policy).toEqual({ provider: "gondolin", allowedHosts: [] });
     expect(seen.workspaceDir).toBe(workspaceDir);
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.artifact.command).toEqual(["/bin/echo", "hi"]);
     expect(result.artifact.outputTail).toContain("hi");
-    expect(readFileSync(path.join(workspaceDir, "out.txt"), "utf8")).toBe("hi\n");
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("adapter=command");
-    expect(trace.some((t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console")).toBe(true);
+    expect(readFileSync(path.join(workspaceDir, "out.txt"), "utf8")).toBe(
+      "hi\n",
+    );
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8"),
+    ).toContain("adapter=command");
+    expect(
+      trace.some(
+        (t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console",
+      ),
+    ).toBe(true);
   });
 
   test("a cancelled sandboxed command resolves like a cancelled host command: null exit, not timed out", async () => {
@@ -358,7 +436,13 @@ describe("sandboxed execution (WM-185)", () => {
       abortSignal: ac.signal,
       runSandbox: ({ abortSignal }) =>
         new Promise((_, reject) => {
-          abortSignal.addEventListener("abort", () => reject(Object.assign(new Error("runner exited (null)"), { code: "sandbox_runner_crashed" })));
+          abortSignal.addEventListener("abort", () =>
+            reject(
+              Object.assign(new Error("runner exited (null)"), {
+                code: "sandbox_runner_crashed",
+              }),
+            ),
+          );
         }),
     });
     setTimeout(() => ac.abort(), 5);
@@ -372,24 +456,42 @@ describe("sandboxed execution (WM-185)", () => {
     "produces the same result contract as the host path, from inside the VM",
     async () => {
       const workspaceDir = ws();
-      const def = sandboxDef(["/bin/sh", "-c", "echo sandboxed-output > /workspace/captured.txt; echo sandboxed-output"], {
-        captureStdout: "captured.txt",
-      });
+      const def = sandboxDef(
+        [
+          "/bin/sh",
+          "-c",
+          "echo sandboxed-output > /workspace/captured.txt; echo sandboxed-output",
+        ],
+        {
+          captureStdout: "captured.txt",
+        },
+      );
 
-      const outcome = await execute({ spec: spec({}), def, workspaceDir, timeoutMs: 120_000 });
+      const outcome = await execute({
+        spec: spec({}),
+        def,
+        workspaceDir,
+        timeoutMs: 120_000,
+      });
       expect(outcome).toEqual({ exitCode: 0, timedOut: false });
 
       // result.json is written on the host, with the same shape the
       // unsandboxed path produces — downstream verification cannot tell which
       // path ran, which is the point.
-      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+      const result = JSON.parse(
+        readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+      );
       expect(result.schemaVersion).toBe("factory.agent-result/v1");
       expect(result.terminalState).toBe("completed");
       expect(result.artifact.exitCode).toBe(0);
       expect(result.artifact.outputTail).toContain("sandboxed-output");
-      expect(result.artifacts).toEqual([{ kind: "output", path: "captured.txt" }]);
+      expect(result.artifacts).toEqual([
+        { kind: "output", path: "captured.txt" },
+      ]);
       // The guest wrote this file through the mount; the host must see it.
-      expect(readFileSync(path.join(workspaceDir, "captured.txt"), "utf8")).toContain("sandboxed-output");
+      expect(
+        readFileSync(path.join(workspaceDir, "captured.txt"), "utf8"),
+      ).toContain("sandboxed-output");
     },
     180_000,
   );

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -47,7 +47,11 @@ const SANDBOX_REFUSAL_REASON =
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+export function killProcessGroup(
+  child,
+  signal = "SIGTERM",
+  kill = process.kill,
+) {
   const pid = child?.pid;
   if (!pid) return;
   try {
@@ -97,8 +101,18 @@ export function buildCursorArgv({ prompt, model }) {
 }
 
 export const BASE_INHERITED_ENV = [
-  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
-  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
   // `agent -p` ignores the login session and requires this Cursor user key
   // (WM-443). It authenticates as the account and bills the user's plan —
   // not a provider BYOK key. Still strip CURSOR_API_ENDPOINT below.
@@ -115,18 +129,30 @@ export const BASE_INHERITED_ENV = [
  * `CURSOR_API_ENDPOINT` stay stripped.
  */
 export function safeChildEnvironment(env = {}, defOrOpts = {}) {
-  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
-  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
+  const isMutating =
+    typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating
+    ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV]
+    : BASE_INHERITED_ENV;
   const childEnv = Object.fromEntries(
-    inherited.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]])),
+    inherited.flatMap((key) =>
+      process.env[key] === undefined ? [] : [[key, process.env[key]]],
+    ),
   );
   Object.assign(childEnv, env);
   childEnv.FACTORY_ROOT = FACTORY_ROOT;
   for (const key of [
-    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
-    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
     "CURSOR_API_ENDPOINT",
-    "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
   ]) {
     delete childEnv[key];
   }
@@ -142,12 +168,17 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
 export const HARNESS_DENIAL_PATTERNS = [];
 
 export function isHarnessDenial(content) {
-  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+  return (
+    typeof content === "string" &&
+    HARNESS_DENIAL_PATTERNS.some((re) => re.test(content))
+  );
 }
 
 function clip(text) {
   const s = String(text ?? "");
-  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+  return s.length > TEXT_PREVIEW_CHARS
+    ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]`
+    : s;
 }
 
 function contentText(content) {
@@ -170,7 +201,8 @@ export function toolNameFromKey(key) {
 }
 
 export function describeToolCall(toolCall) {
-  if (!toolCall || typeof toolCall !== "object") return { name: "tool", input: {} };
+  if (!toolCall || typeof toolCall !== "object")
+    return { name: "tool", input: {} };
   if (toolCall.function && typeof toolCall.function === "object") {
     let args = toolCall.function.arguments;
     if (typeof args === "string") {
@@ -194,11 +226,17 @@ function toolResultPayload(msg) {
   const id = msg.call_id ?? null;
   if (result.success !== undefined) {
     const success = result.success;
-    const content = typeof success?.content === "string" ? success.content : JSON.stringify(success ?? {});
+    const content =
+      typeof success?.content === "string"
+        ? success.content
+        : JSON.stringify(success ?? {});
     return { content: clip(content), toolUseId: id };
   }
   if (result.error !== undefined) {
-    const content = typeof result.error === "string" ? result.error : JSON.stringify(result.error);
+    const content =
+      typeof result.error === "string"
+        ? result.error
+        : JSON.stringify(result.error);
     return { content: clip(content), toolUseId: id, isError: true };
   }
   return { content: "", toolUseId: id };
@@ -223,7 +261,10 @@ export function mapStreamEvent(msg) {
     const events = [];
     for (const block of blocks) {
       if (block?.type === "text" && block.text) {
-        events.push({ kind: "assistant_text", payload: { text: clip(block.text) } });
+        events.push({
+          kind: "assistant_text",
+          payload: { text: clip(block.text) },
+        });
       }
     }
     return events;
@@ -231,7 +272,9 @@ export function mapStreamEvent(msg) {
 
   if (msg.type === "tool_call" && msg.subtype === "started") {
     const { name, input } = describeToolCall(msg.tool_call);
-    return [{ kind: "tool_use", payload: { id: msg.call_id ?? null, name, input } }];
+    return [
+      { kind: "tool_use", payload: { id: msg.call_id ?? null, name, input } },
+    ];
   }
 
   if (msg.type === "tool_call" && msg.subtype === "completed") {
@@ -272,13 +315,18 @@ export async function execute({
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
-  const resolved = resolveCursorCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  const resolved = resolveCursorCommand({
+    which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }),
+  });
   if (!resolved) {
     throw new CliNotFoundError(
       "neither agent nor cursor-agent is on PATH — install the Cursor Agent CLI (docs/event-runtime.md §6)",
     );
   }
-  const argv = [...resolved.args, ...buildCursorArgv({ prompt, model: spec?.model })];
+  const argv = [
+    ...resolved.args,
+    ...buildCursorArgv({ prompt, model: spec?.model }),
+  ];
 
   return new Promise((resolve, reject) => {
     const child = spawn(resolved.command, argv, {
@@ -288,7 +336,9 @@ export async function execute({
       detached: true,
     });
 
-    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    const transcript = createWriteStream(
+      path.join(workspaceDir, ".transcript.json"),
+    );
     transcript.on("error", () => {});
     if (child.stdout) {
       child.stdout.pipe(transcript);
@@ -318,7 +368,11 @@ export async function execute({
           return;
         }
         try {
-          if (parsed?.type === "system" && parsed?.subtype === "init" && typeof parsed.model === "string") {
+          if (
+            parsed?.type === "system" &&
+            parsed?.subtype === "init" &&
+            typeof parsed.model === "string"
+          ) {
             observedModel = parsed.model;
           }
           const usageInfo = extractUsage(parsed);
@@ -329,9 +383,22 @@ export async function execute({
               if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
             }
             onTrace?.(event.kind, event.payload);
-            const content = typeof event.payload?.content === "string" ? event.payload.content : "";
-            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
-              const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+            const content =
+              typeof event.payload?.content === "string"
+                ? event.payload.content
+                : "";
+            if (
+              event.kind === "tool_result" &&
+              event.payload?.isError &&
+              isHarnessDenial(content)
+            ) {
+              const denial = {
+                tool:
+                  toolNames.get(event.payload?.toolUseId) ??
+                  lastTool ??
+                  "unknown",
+                rule: clip(content),
+              };
               policyDenials.push(denial);
               onTrace?.("lifecycle", { note: "policy_denial", ...denial });
             }
@@ -347,14 +414,20 @@ export async function execute({
     const termTimer = setTimeout(() => {
       timedOut = true;
       killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+      killTimer = setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        killGraceMs,
+      );
       killTimer.unref?.();
     }, timeoutMs);
 
     const onAbort = () => {
       killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
         killTimer.unref?.();
       }
     };
@@ -399,17 +472,28 @@ export async function execute({
       }
       if (exitCode !== 0 && stderrBuf) {
         try {
-          writeFileSync(path.join(workspaceDir, ".stderr.txt"), stderrBuf, "utf8");
+          writeFileSync(
+            path.join(workspaceDir, ".stderr.txt"),
+            stderrBuf,
+            "utf8",
+          );
         } catch {
           // workspace may already be gone; trace still carries the tail
         }
         try {
-          onTrace?.("lifecycle", { note: "adapter_stderr", text: clip(stderrBuf) });
+          onTrace?.("lifecycle", {
+            note: "adapter_stderr",
+            text: clip(stderrBuf),
+          });
         } catch {
           // observability
         }
       }
-      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
+      resolve({
+        exitCode,
+        timedOut,
+        policyDenials: exitCode === 0 ? [] : policyDenials,
+      });
     });
   });
 }

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -1,9 +1,20 @@
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
-import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import {
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV,
+} from "./claude.mjs";
 import {
   buildCursorArgv,
   CliNotFoundError,
@@ -18,13 +29,24 @@ import {
   safeChildEnvironment,
   toolNameFromKey,
 } from "./cursor.mjs";
-import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
+import {
+  processOwnerWatchdogSource,
+  trackProcessGroupForPid,
+} from "../test-helpers-process.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed Cursor refusal shapes yet)", () => {
   test("nothing matches — empty until a Cursor-authored shape is observed", () => {
-    expect(isHarnessDenial("Permission to use Shell has been denied.")).toBe(false);
-    expect(isHarnessDenial("Cursor requested permissions to use write, but you haven't granted it yet.")).toBe(false);
-    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
+    expect(isHarnessDenial("Permission to use Shell has been denied.")).toBe(
+      false,
+    );
+    expect(
+      isHarnessDenial(
+        "Cursor requested permissions to use write, but you haven't granted it yet.",
+      ),
+    ).toBe(false);
+    expect(
+      isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'"),
+    ).toBe(false);
     expect(isHarnessDenial(null)).toBe(false);
   });
 });
@@ -33,71 +55,106 @@ describe("mapStreamEvent (Cursor stream-json shapes from output-format.md)", () 
   test("assistant text → assistant_text", () => {
     const events = mapStreamEvent({
       type: "assistant",
-      message: { role: "assistant", content: [{ type: "text", text: "I'll read the file." }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "I'll read the file." }],
+      },
       session_id: "s-1",
     });
-    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "I'll read the file." } }]);
+    expect(events).toEqual([
+      { kind: "assistant_text", payload: { text: "I'll read the file." } },
+    ]);
   });
 
   test("assistant events with timestamp_ms are skipped (stream-partial deltas)", () => {
-    expect(mapStreamEvent({
-      type: "assistant",
-      timestamp_ms: 1,
-      message: { content: [{ type: "text", text: "delta" }] },
-    })).toEqual([]);
+    expect(
+      mapStreamEvent({
+        type: "assistant",
+        timestamp_ms: 1,
+        message: { content: [{ type: "text", text: "delta" }] },
+      }),
+    ).toEqual([]);
   });
 
   test("tool_call started readToolCall → tool_use", () => {
-    expect(mapStreamEvent({
-      type: "tool_call",
-      subtype: "started",
-      call_id: "toolu_1",
-      tool_call: { readToolCall: { args: { path: "README.md" } } },
-    })).toEqual([
-      { kind: "tool_use", payload: { id: "toolu_1", name: "read", input: { path: "README.md" } } },
+    expect(
+      mapStreamEvent({
+        type: "tool_call",
+        subtype: "started",
+        call_id: "toolu_1",
+        tool_call: { readToolCall: { args: { path: "README.md" } } },
+      }),
+    ).toEqual([
+      {
+        kind: "tool_use",
+        payload: { id: "toolu_1", name: "read", input: { path: "README.md" } },
+      },
     ]);
   });
 
   test("tool_call completed readToolCall → tool_result", () => {
-    expect(mapStreamEvent({
-      type: "tool_call",
-      subtype: "completed",
-      call_id: "toolu_1",
-      tool_call: {
-        readToolCall: {
-          args: { path: "README.md" },
-          result: { success: { content: "# Project\n", totalLines: 1 } },
+    expect(
+      mapStreamEvent({
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "toolu_1",
+        tool_call: {
+          readToolCall: {
+            args: { path: "README.md" },
+            result: { success: { content: "# Project\n", totalLines: 1 } },
+          },
         },
+      }),
+    ).toEqual([
+      {
+        kind: "tool_result",
+        payload: { content: "# Project\n", toolUseId: "toolu_1" },
       },
-    })).toEqual([
-      { kind: "tool_result", payload: { content: "# Project\n", toolUseId: "toolu_1" } },
     ]);
   });
 
   test("tool_call completed with result.error → tool_result isError", () => {
-    expect(mapStreamEvent({
-      type: "tool_call",
-      subtype: "completed",
-      call_id: "toolu_2",
-      tool_call: { writeToolCall: { result: { error: "write failed" } } },
-    })).toEqual([
-      { kind: "tool_result", payload: { content: "write failed", toolUseId: "toolu_2", isError: true } },
+    expect(
+      mapStreamEvent({
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "toolu_2",
+        tool_call: { writeToolCall: { result: { error: "write failed" } } },
+      }),
+    ).toEqual([
+      {
+        kind: "tool_result",
+        payload: {
+          content: "write failed",
+          toolUseId: "toolu_2",
+          isError: true,
+        },
+      },
     ]);
   });
 
   test("function-shaped tool_call is mapped", () => {
-    expect(mapStreamEvent({
-      type: "tool_call",
-      subtype: "started",
-      call_id: "fn_1",
-      tool_call: { function: { name: "shell", arguments: "{\"command\":\"ls\"}" } },
-    })).toEqual([
-      { kind: "tool_use", payload: { id: "fn_1", name: "shell", input: { command: "ls" } } },
+    expect(
+      mapStreamEvent({
+        type: "tool_call",
+        subtype: "started",
+        call_id: "fn_1",
+        tool_call: {
+          function: { name: "shell", arguments: '{"command":"ls"}' },
+        },
+      }),
+    ).toEqual([
+      {
+        kind: "tool_use",
+        payload: { id: "fn_1", name: "shell", input: { command: "ls" } },
+      },
     ]);
   });
 
   test("unrecognized events are ignored silently", () => {
-    expect(mapStreamEvent({ type: "user", message: { content: [] } })).toEqual([]);
+    expect(mapStreamEvent({ type: "user", message: { content: [] } })).toEqual(
+      [],
+    );
     expect(mapStreamEvent({ type: "system", subtype: "init" })).toEqual([]);
     expect(mapStreamEvent(null)).toEqual([]);
     expect(mapStreamEvent("not an object")).toEqual([]);
@@ -129,13 +186,15 @@ describe("describeToolCall / toolNameFromKey", () => {
 
 describe("extractUsage", () => {
   test("reads duration from the terminal result; tokens stay empty (not fabricated)", () => {
-    expect(extractUsage({
-      type: "result",
-      subtype: "success",
-      duration_ms: 5234,
-      is_error: false,
-      result: "done",
-    })).toEqual({ usage: {}, costUSD: null, durationMs: 5234, isError: false });
+    expect(
+      extractUsage({
+        type: "result",
+        subtype: "success",
+        duration_ms: 5234,
+        is_error: false,
+        result: "done",
+      }),
+    ).toEqual({ usage: {}, costUSD: null, durationMs: 5234, isError: false });
   });
 
   test("returns null when the message is not a result", () => {
@@ -147,7 +206,15 @@ describe("extractUsage", () => {
 describe("buildCursorArgv", () => {
   test("print + stream-json + trust + force; prompt is positional after --", () => {
     const argv = buildCursorArgv({ prompt: "Do the smoke" });
-    expect(argv).toEqual(["-p", "--output-format", "stream-json", "--trust", "--force", "--", "Do the smoke"]);
+    expect(argv).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--trust",
+      "--force",
+      "--",
+      "Do the smoke",
+    ]);
     expect(argv).not.toContain("--mode");
     expect(argv).not.toContain("--stream-partial-output");
     expect(argv).not.toContain("--worktree");
@@ -159,7 +226,9 @@ describe("buildCursorArgv", () => {
     expect(withModel[withModel.indexOf("--model") + 1]).toBe("composer-2.5");
 
     const unpinned = buildCursorArgv({ prompt: "x" });
-    expect(buildCursorArgv({ prompt: "x", model: "default" })).toEqual(unpinned);
+    expect(buildCursorArgv({ prompt: "x", model: "default" })).toEqual(
+      unpinned,
+    );
     expect(buildCursorArgv({ prompt: "x", model: null })).toEqual(unpinned);
     expect(buildCursorArgv({ prompt: "x", model: "" })).toEqual(unpinned);
     expect(unpinned).not.toContain("--model");
@@ -168,11 +237,22 @@ describe("buildCursorArgv", () => {
 
 describe("resolveCursorCommand", () => {
   test("agent on PATH wins; cursor-agent is the fallback; cursor editor is ignored", () => {
-    expect(resolveCursorCommand({ which: (n) => (n === "agent" ? "/usr/local/bin/agent" : null) }))
-      .toEqual({ command: "agent", args: [] });
-    expect(resolveCursorCommand({ which: (n) => (n === "cursor-agent" ? "/usr/local/bin/cursor-agent" : null) }))
-      .toEqual({ command: "cursor-agent", args: [] });
-    expect(resolveCursorCommand({ which: (n) => (n === "cursor" ? "/usr/local/bin/cursor" : null) })).toBeNull();
+    expect(
+      resolveCursorCommand({
+        which: (n) => (n === "agent" ? "/usr/local/bin/agent" : null),
+      }),
+    ).toEqual({ command: "agent", args: [] });
+    expect(
+      resolveCursorCommand({
+        which: (n) =>
+          n === "cursor-agent" ? "/usr/local/bin/cursor-agent" : null,
+      }),
+    ).toEqual({ command: "cursor-agent", args: [] });
+    expect(
+      resolveCursorCommand({
+        which: (n) => (n === "cursor" ? "/usr/local/bin/cursor" : null),
+      }),
+    ).toBeNull();
     expect(resolveCursorCommand({ which: () => null })).toBeNull();
   });
 });
@@ -206,11 +286,14 @@ describe("safeChildEnvironment", () => {
   });
 
   test("strips push credentials for non-mutating runs and still keeps CURSOR_API_KEY", () => {
-    const childEnv = safeChildEnvironment({
-      SSH_AUTH_SOCK: "/tmp/test.sock",
-      GITHUB_TOKEN: "ghp_secret",
-      CURSOR_API_KEY: "sk",
-    }, { mutating: false });
+    const childEnv = safeChildEnvironment(
+      {
+        SSH_AUTH_SOCK: "/tmp/test.sock",
+        GITHUB_TOKEN: "ghp_secret",
+        CURSOR_API_KEY: "sk",
+      },
+      { mutating: false },
+    );
     for (const key of PUSH_CREDENTIAL_ENV) {
       expect(childEnv[key]).toBeUndefined();
     }
@@ -218,11 +301,14 @@ describe("safeChildEnvironment", () => {
   });
 
   test("preserves push credentials for mutating runs and keeps CURSOR_API_KEY", () => {
-    const childEnv = safeChildEnvironment({
-      SSH_AUTH_SOCK: "/tmp/agent.sock",
-      GITHUB_TOKEN: "ghp_mutating",
-      CURSOR_API_KEY: "sk",
-    }, { mutating: true });
+    const childEnv = safeChildEnvironment(
+      {
+        SSH_AUTH_SOCK: "/tmp/agent.sock",
+        GITHUB_TOKEN: "ghp_mutating",
+        CURSOR_API_KEY: "sk",
+      },
+      { mutating: true },
+    );
     expect(childEnv.SSH_AUTH_SOCK).toBe("/tmp/agent.sock");
     expect(childEnv.GITHUB_TOKEN).toBe("ghp_mutating");
     expect(childEnv.CURSOR_API_KEY).toBe("sk");
@@ -233,12 +319,16 @@ describe("safeChildEnvironment", () => {
     expect(safeChildEnvironment({}).SSH_AUTH_SOCK).toBeUndefined();
     expect(safeChildEnvironment({}, {}).SSH_AUTH_SOCK).toBeUndefined();
     expect(safeChildEnvironment({}, false).SSH_AUTH_SOCK).toBeUndefined();
-    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe(
+      "/tmp/inherited.sock",
+    );
   });
 
   test("injects FACTORY_ROOT and refuses caller overrides", () => {
     expect(safeChildEnvironment({}).FACTORY_ROOT).toBe(FACTORY_ROOT);
-    expect(safeChildEnvironment({ FACTORY_ROOT: "/tmp/untrusted" }).FACTORY_ROOT).toBe(FACTORY_ROOT);
+    expect(
+      safeChildEnvironment({ FACTORY_ROOT: "/tmp/untrusted" }).FACTORY_ROOT,
+    ).toBe(FACTORY_ROOT);
   });
 
   test("shares one push-credential list with the claude adapter", () => {
@@ -247,7 +337,9 @@ describe("safeChildEnvironment", () => {
 });
 
 describe("execute conformance (WM-440, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-cursor-test-")));
+  const tmpBase = realpathSync(
+    mkdtempSync(path.join(tmpdir(), "evrt-cursor-test-")),
+  );
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
   const emptyBinDir = path.join(tmpBase, "empty-bin");
@@ -359,8 +451,15 @@ if (behavior === "emit_error_tool_result") {
   });
 
   const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
-  const defaultDef = { ref: "test-cursor-agent@1", promptPath: promptFile, mutating: false };
-  const defaultSpec = { agent: "test-cursor-agent@1", input: { message: "hi" } };
+  const defaultDef = {
+    ref: "test-cursor-agent@1",
+    promptPath: promptFile,
+    mutating: false,
+  };
+  const defaultSpec = {
+    agent: "test-cursor-agent@1",
+    input: { message: "hi" },
+  };
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
 
   async function waitForGrandchildPid(pidFile) {
@@ -421,7 +520,11 @@ if (behavior === "emit_error_tool_result") {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
 
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
     expect(existsSync(recordFile)).toBe(true);
     const record = JSON.parse(readFileSync(recordFile, "utf8"));
     expect(record.cwd).toBe(workspaceDir);
@@ -433,15 +536,23 @@ if (behavior === "emit_error_tool_result") {
     expect(record.argv).toContain("--trust");
     expect(record.argv).toContain("--force");
     expect(record.argv).toContain("--model");
-    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("composer-2.5");
+    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe(
+      "composer-2.5",
+    );
     expect(record.argv.at(-2)).toBe("--");
     expect(record.argv.at(-1)).toBe(`You are a test agent.${PROMPT_SUFFIX}`);
 
     const transcriptPath = path.join(workspaceDir, ".transcript.json");
     expect(existsSync(transcriptPath)).toBe(true);
-    expect(readFileSync(transcriptPath, "utf8")).toContain('"type":"assistant"');
+    expect(readFileSync(transcriptPath, "utf8")).toContain(
+      '"type":"assistant"',
+    );
 
-    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working...")).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "assistant_text" && e.payload.text === "Working...",
+      ),
+    ).toBe(true);
     const usageEvent = traceEvents.find((e) => e.kind === "usage");
     expect(usageEvent.payload.durationMs).toBe(1200);
     expect(usageEvent.payload.costUSD).toBeNull();
@@ -467,7 +578,8 @@ if (behavior === "emit_error_tool_result") {
   test("nonzero exit writes .stderr.txt and emits adapter_stderr lifecycle (WM-443)", async () => {
     const workspaceDir = ws();
     const traceEvents = [];
-    const stderr = "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.\n";
+    const stderr =
+      "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.\n";
     const outcome = await execute({
       spec: defaultSpec,
       def: defaultDef,
@@ -482,44 +594,53 @@ if (behavior === "emit_error_tool_result") {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
     expect(outcome.exitCode).toBe(1);
-    expect(readFileSync(path.join(workspaceDir, ".stderr.txt"), "utf8")).toBe(stderr);
-    expect(traceEvents.some((e) => (
-      e.kind === "lifecycle"
-      && e.payload?.note === "adapter_stderr"
-      && String(e.payload?.text ?? "").includes("Authentication required")
-    ))).toBe(true);
+    expect(readFileSync(path.join(workspaceDir, ".stderr.txt"), "utf8")).toBe(
+      stderr,
+    );
+    expect(
+      traceEvents.some(
+        (e) =>
+          e.kind === "lifecycle" &&
+          e.payload?.note === "adapter_stderr" &&
+          String(e.payload?.text ?? "").includes("Authentication required"),
+      ),
+    ).toBe(true);
   });
 
-  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 6_000,
-      killGraceMs: 5000,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(true);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  }, { timeout: 12_000 });
+  testProcessGroup(
+    "timeout kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 6_000,
+        killGraceMs: 5000,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(true);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+    { timeout: 12_000 },
+  );
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
     const outcome = await execute({
@@ -536,37 +657,40 @@ if (behavior === "emit_error_tool_result") {
     expect(outcome.timedOut).toBe(true);
   });
 
-  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 10_000,
-      killGraceMs: 500,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      ac.abort();
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(false);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  });
+  testProcessGroup(
+    "abort kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 10_000,
+        killGraceMs: 500,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        ac.abort();
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(false);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+  );
 
   test("tool_call stream maps to tool_use / tool_result and a usage event", async () => {
     const traceEvents = [];
@@ -581,10 +705,24 @@ if (behavior === "emit_error_tool_result") {
       },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
-    expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "read")).toBe(true);
-    expect(traceEvents.some((e) => e.kind === "tool_result" && e.payload.content === "hello world")).toBe(true);
-    expect(traceEvents.find((e) => e.kind === "usage")?.payload.durationMs).toBe(800);
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "tool_use" && e.payload.name === "read",
+      ),
+    ).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "tool_result" && e.payload.content === "hello world",
+      ),
+    ).toBe(true);
+    expect(
+      traceEvents.find((e) => e.kind === "usage")?.payload.durationMs,
+    ).toBe(800);
   });
 
   test("a tool error that reads like a permission denial is never policy_denied (WM-127)", async () => {
@@ -602,7 +740,11 @@ if (behavior === "emit_error_tool_result") {
     });
     expect(outcome.exitCode).toBe(1);
     expect(outcome.policyDenials).toEqual([]);
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "lifecycle" && e.payload.note === "policy_denial",
+      ),
+    ).toBe(false);
   });
 
   test("run with no output reports usage as explicit n/a, not a fabricated zero", async () => {
@@ -620,7 +762,10 @@ if (behavior === "emit_error_tool_result") {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
     expect(traceEvents.find((e) => e.kind === "usage")?.payload).toEqual({
-      durationMs: null, numTurns: null, costUSD: null, usage: {},
+      durationMs: null,
+      numTurns: null,
+      costUSD: null,
+      usage: {},
     });
   });
 
@@ -633,7 +778,10 @@ if (behavior === "emit_error_tool_result") {
         timeoutMs: 1000,
         env: { PATH: emptyBinDir },
       }),
-    ).rejects.toMatchObject({ name: "CliNotFoundError", code: "cli_not_found" });
+    ).rejects.toMatchObject({
+      name: "CliNotFoundError",
+      code: "cli_not_found",
+    });
     expect(CliNotFoundError).toBeDefined();
     expect(KILL_GRACE_MS).toBe(30_000);
   });

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -29,7 +29,12 @@ function emitTrace(onTrace, mode) {
   onTrace("assistant_text", { text: `fake: working on ${mode}` });
   onTrace("tool_use", { name: "Bash", input: { command: "fake-query" } });
   onTrace("tool_result", { content: "fake output" });
-  onTrace("usage", { durationMs: 1, numTurns: 1, costUSD: 0, usage: { input_tokens: 1, output_tokens: 1 } });
+  onTrace("usage", {
+    durationMs: 1,
+    numTurns: 1,
+    costUSD: 0,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
 }
 
 function writeResult(workspaceDir, result) {
@@ -41,7 +46,14 @@ function writeResult(workspaceDir, result) {
 }
 
 function repoRow(name, overrides = {}) {
-  return { name, triage: 1, agentReady: 2, inProgress: 0, blocked: 0, ...overrides };
+  return {
+    name,
+    triage: 1,
+    agentReady: 2,
+    inProgress: 0,
+    blocked: 0,
+    ...overrides,
+  };
 }
 
 /**
@@ -50,7 +62,11 @@ function repoRow(name, overrides = {}) {
  */
 function ciDoctorArtifact(input) {
   const repo = String(input?.repo ?? "");
-  const verdict = repo.endsWith("-ticket") ? "TICKET" : repo.endsWith("-env") ? "ENV" : "FLAKE";
+  const verdict = repo.endsWith("-ticket")
+    ? "TICKET"
+    : repo.endsWith("-env")
+      ? "ENV"
+      : "FLAKE";
   return {
     verdict,
     culprit: "job Verify, step Setup bun",
@@ -62,18 +78,47 @@ function ciDoctorArtifact(input) {
 export const FAKE_PLAN_SHA = "c".repeat(40);
 
 export function mergeScanArtifact(repo) {
-  const base = { repo, github: `watt-mind/${repo}`, plan: [], fix: [], escalate: [] };
+  const base = {
+    repo,
+    github: `watt-mind/${repo}`,
+    plan: [],
+    fix: [],
+    escalate: [],
+  };
   if (repo === "clean") {
-    return { ...base, recommendation: "NOOP", summary: "fake: no open PRs", noopReason: "no_open_prs" };
+    return {
+      ...base,
+      recommendation: "NOOP",
+      summary: "fake: no open PRs",
+      noopReason: "no_open_prs",
+    };
   }
   if (repo.endsWith("-merge-esc") || repo.endsWith("-both")) {
     return {
       ...base,
       recommendation: "MERGE",
       plan: [
-        { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "merge_pr", reason: "fake: clean review" },
-        { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "ticket_done", reason: "fake: clean review" },
-        { pr: 44, headSha: FAKE_PLAN_SHA, ticket: "CLNT-778", action: "notify_escalate", reason: "fake: touches auth" },
+        {
+          pr: 42,
+          headSha: FAKE_PLAN_SHA,
+          ticket: "CLNT-777",
+          action: "merge_pr",
+          reason: "fake: clean review",
+        },
+        {
+          pr: 42,
+          headSha: FAKE_PLAN_SHA,
+          ticket: "CLNT-777",
+          action: "ticket_done",
+          reason: "fake: clean review",
+        },
+        {
+          pr: 44,
+          headSha: FAKE_PLAN_SHA,
+          ticket: "CLNT-778",
+          action: "notify_escalate",
+          reason: "fake: touches auth",
+        },
       ],
       escalate: [{ pr: 44, ticket: "CLNT-778", reason: "fake: touches auth" }],
       summary: `fake merge plan with escalation for ${repo}`,
@@ -99,15 +144,40 @@ export function mergeScanArtifact(repo) {
     ...base,
     recommendation: "MERGE",
     plan: [
-      { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "merge_pr", reason: "fake: clean review" },
-      { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "ticket_done", reason: "fake: clean review" },
+      {
+        pr: 42,
+        headSha: FAKE_PLAN_SHA,
+        ticket: "CLNT-777",
+        action: "merge_pr",
+        reason: "fake: clean review",
+      },
+      {
+        pr: 42,
+        headSha: FAKE_PLAN_SHA,
+        ticket: "CLNT-777",
+        action: "ticket_done",
+        reason: "fake: clean review",
+      },
     ],
     summary: `fake merge plan for ${repo}`,
   };
 }
 
-export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace, abortSignal, signal }) {
-  refuseSandbox("fake", def, "the fake adapter runs no process and models no VM; a sandboxed definition cannot be exercised through it");
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  env,
+  onTrace,
+  abortSignal,
+  signal,
+}) {
+  refuseSandbox(
+    "fake",
+    def,
+    "the fake adapter runs no process and models no VM; a sandboxed definition cannot be exercised through it",
+  );
   // Every real adapter captures the agent's output as a runtime artifact
   // (worker.mjs RUNTIME_ARTIFACTS). The fake must too, or it models a world
   // where transcripts do not exist — which is exactly what run-postmortem
@@ -115,7 +185,12 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
   writeFileSync(
     path.join(workspaceDir, ".transcript.json"),
     `${JSON.stringify(
-      { adapter: "fake", agent: spec.agent, contract: spec.outputContract, input: spec.input },
+      {
+        adapter: "fake",
+        agent: spec.agent,
+        contract: spec.outputContract,
+        input: spec.input,
+      },
       null,
       2,
     )}\n`,
@@ -150,12 +225,21 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
     return { exitCode: 0, timedOut: false };
   }
   if (spec.outputContract === "factory.ci-log/v1") {
-    writeFileSync(path.join(workspaceDir, "failed.log"), `fake CI log for run ${spec.input?.runId}\nsocket hang up\n`, "utf8");
+    writeFileSync(
+      path.join(workspaceDir, "failed.log"),
+      `fake CI log for run ${spec.input?.runId}\nsocket hang up\n`,
+      "utf8",
+    );
     writeResult(workspaceDir, {
       schemaVersion: "factory.agent-result/v1",
       terminalState: "completed",
       reasonCode: "ok",
-      artifact: { command: ["fake"], exitCode: 0, outputTail: "", captured: "failed.log" },
+      artifact: {
+        command: ["fake"],
+        exitCode: 0,
+        outputTail: "",
+        captured: "failed.log",
+      },
       evidence: { command: ["fake"] },
       artifacts: [{ kind: "ci-log", path: "failed.log" }],
     });
@@ -178,7 +262,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       schemaVersion: "factory.agent-result/v1",
       terminalState: "completed",
       reasonCode: "ok",
-      artifact: { ...ciDoctorArtifact(spec.input), evidenceLines: [logText.trim().split("\n").at(-1) ?? "empty"] },
+      artifact: {
+        ...ciDoctorArtifact(spec.input),
+        evidenceLines: [logText.trim().split("\n").at(-1) ?? "empty"],
+      },
       evidence: { commands: ["fake"], logBytes: logText.length },
     });
     return { exitCode: 0, timedOut: false };
@@ -192,11 +279,22 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       terminalState: "completed",
       reasonCode: "ok",
       artifact: clean
-        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: queue already clean" }
+        ? {
+            recommendation: "NOOP",
+            repo,
+            plan: [],
+            summary: "fake: queue already clean",
+          }
         : {
             recommendation: "TRIAGE",
             repo,
-            plan: [{ issueId: "CLNT-999", action: "label-agent-ready", reason: "fake: fully specified" }],
+            plan: [
+              {
+                issueId: "CLNT-999",
+                action: "label-agent-ready",
+                reason: "fake: fully specified",
+              },
+            ],
             summary: `fake triage of ${repo}`,
           },
       evidence: { commands: ["fake"], issuesSeen: 1 },
@@ -212,13 +310,26 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       terminalState: "completed",
       reasonCode: "ok",
       artifact: clean
-        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: no hold has new evidence" }
+        ? {
+            recommendation: "NOOP",
+            repo,
+            plan: [],
+            summary: "fake: no hold has new evidence",
+          }
         : {
             recommendation: "UNBLOCK",
             repo,
             plan: [
-              { issueId: "CLNT-998", action: "release-to-triage", reason: "fake: dependency merged" },
-              { issueId: "CLNT-998", action: "comment-evidence", reason: "fake: dependency merged" },
+              {
+                issueId: "CLNT-998",
+                action: "release-to-triage",
+                reason: "fake: dependency merged",
+              },
+              {
+                issueId: "CLNT-998",
+                action: "comment-evidence",
+                reason: "fake: dependency merged",
+              },
             ],
             summary: `fake unblock of ${repo}`,
           },
@@ -233,7 +344,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       reasonCode: "ok",
       artifact: {
         repo: spec.input.repo,
-        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action })),
+        applied: (spec.input.plan ?? []).map((i) => ({
+          issueId: i.issueId,
+          action: i.action,
+        })),
       },
       evidence: { commands: ["fake"] },
     });
@@ -248,13 +362,26 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       terminalState: "completed",
       reasonCode: "ok",
       artifact: clean
-        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: nothing retirable with evidence" }
+        ? {
+            recommendation: "NOOP",
+            repo,
+            plan: [],
+            summary: "fake: nothing retirable with evidence",
+          }
         : {
             recommendation: "SWEEP",
             repo,
             plan: [
-              { issueId: "CLNT-997", action: "retire-shipped", reason: "fake: shipped in PR #1" },
-              { issueId: "CLNT-997", action: "comment-evidence", reason: "fake: shipped in PR #1" },
+              {
+                issueId: "CLNT-997",
+                action: "retire-shipped",
+                reason: "fake: shipped in PR #1",
+              },
+              {
+                issueId: "CLNT-997",
+                action: "comment-evidence",
+                reason: "fake: shipped in PR #1",
+              },
             ],
             summary: `fake sweep of ${repo}`,
           },
@@ -269,14 +396,20 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       reasonCode: "ok",
       artifact: {
         repo: spec.input.repo,
-        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action })),
+        applied: (spec.input.plan ?? []).map((i) => ({
+          issueId: i.issueId,
+          action: i.action,
+        })),
       },
       evidence: { commands: ["fake"] },
     });
     return { exitCode: 0, timedOut: false };
   }
   if (spec.outputContract === "factory.triage-applied/v1") {
-    const applied = (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action }));
+    const applied = (spec.input.plan ?? []).map((i) => ({
+      issueId: i.issueId,
+      action: i.action,
+    }));
     const actions = new Set(applied.map((entry) => entry.action));
     let outcome = "NO_CHANGE";
     if (actions.has("label-agent-ready")) outcome = "SUPPLY_CHANGED";
@@ -311,7 +444,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       reasonCode: "ok",
       artifact: {
         repo: spec.input.repo,
-        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.ticket ?? i.issueId, action: i.action })),
+        applied: (spec.input.plan ?? []).map((i) => ({
+          issueId: i.ticket ?? i.issueId,
+          action: i.action,
+        })),
       },
       evidence: { commands: ["fake"] },
     });
@@ -325,12 +461,23 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       terminalState: "completed",
       reasonCode: "ok",
       artifact: stale
-        ? { recommendation: "NOOP", mount: spec.input.mount, usedPct: spec.input.usedPct, plan: [], analysis: "fake: disk healthy at diagnose time" }
+        ? {
+            recommendation: "NOOP",
+            mount: spec.input.mount,
+            usedPct: spec.input.usedPct,
+            plan: [],
+            analysis: "fake: disk healthy at diagnose time",
+          }
         : {
             recommendation: "REMEDIATE",
             mount: spec.input.mount,
             usedPct: spec.input.usedPct,
-            plan: [{ action: "docker-builder-prune", expectedReclaimBytes: 1_000_000 }],
+            plan: [
+              {
+                action: "docker-builder-prune",
+                expectedReclaimBytes: 1_000_000,
+              },
+            ],
             analysis: "fake: docker build cache is eating the disk",
           },
       evidence: { commands: ["fake df"], outputs: { df: "fake" } },
@@ -352,7 +499,12 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
         afterUsedBytes: 4_000_000,
         reclaimedBytes: lying ? 9_999_999 : 1_000_000,
       },
-      evidence: { probeBefore: "5000000", probeAfter: "4000000", commands: ["fake"], outputs: {} },
+      evidence: {
+        probeBefore: "5000000",
+        probeAfter: "4000000",
+        commands: ["fake"],
+        outputs: {},
+      },
     });
     return { exitCode: 0, timedOut: false };
   }
@@ -401,8 +553,16 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
     case "with-artifact": {
       emitTrace(onTrace, mode);
       // Declares a file artifact and a transcript — exercises the §7 store.
-      writeFileSync(path.join(workspaceDir, "report.txt"), `fake report for ${mode}\n`, "utf8");
-      writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"transcript"}\n`, "utf8");
+      writeFileSync(
+        path.join(workspaceDir, "report.txt"),
+        `fake report for ${mode}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        path.join(workspaceDir, ".transcript.json"),
+        `{"fake":"transcript"}\n`,
+        "utf8",
+      );
       writeResult(workspaceDir, {
         schemaVersion: "factory.agent-result/v1",
         terminalState: "completed",
@@ -442,10 +602,14 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       if (sig?.aborted) return { exitCode: null, timedOut: false };
       await new Promise((resolve) => {
         const timer = setTimeout(resolve, timeoutMs);
-        sig?.addEventListener?.("abort", () => {
-          clearTimeout(timer);
-          resolve();
-        }, { once: true });
+        sig?.addEventListener?.(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true },
+        );
       });
       return { exitCode: null, timedOut: !sig?.aborted };
     }
@@ -468,7 +632,11 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
     }
 
     case "escape":
-      writeFileSync(path.resolve(workspaceDir, "..", "outside.txt"), "escaped\n", "utf8");
+      writeFileSync(
+        path.resolve(workspaceDir, "..", "outside.txt"),
+        "escaped\n",
+        "utf8",
+      );
       writeResult(workspaceDir, {
         schemaVersion: "factory.agent-result/v1",
         terminalState: "completed",
@@ -482,7 +650,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
       writeResult(workspaceDir, {
         schemaVersion: "factory.agent-result/v1",
         terminalState: "completed",
-        artifact: { repos: [repoRow(mode ?? "unknown")], recommendedAction: "dispatch" },
+        artifact: {
+          repos: [repoRow(mode ?? "unknown")],
+          recommendedAction: "dispatch",
+        },
         evidence: { queries: ["fake"] },
       });
       return { exitCode: 0, timedOut: false };

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -55,7 +55,12 @@ import { createInterface } from "node:readline";
 import { PassThrough } from "node:stream";
 import { FACTORY_ROOT } from "../config.mjs";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
-import { guestBinary, guestEnvironment, runSandboxed, sandboxRequested } from "./sandboxed.mjs";
+import {
+  guestBinary,
+  guestEnvironment,
+  runSandboxed,
+  sandboxRequested,
+} from "./sandboxed.mjs";
 
 // PUSH_CREDENTIAL_ENV is imported, not redeclared: the WM-128 carve-out is one
 // list shared by both LLM adapters (WM-223), so it cannot drift between them.
@@ -74,7 +79,11 @@ export const SANDBOX_PROMPT_FILE = ".prompt.md";
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+export function killProcessGroup(
+  child,
+  signal = "SIGTERM",
+  kill = process.kill,
+) {
   const pid = child?.pid;
   if (!pid) return;
   try {
@@ -250,8 +259,18 @@ export function piExtensions(def) {
 }
 
 export const BASE_INHERITED_ENV = [
-  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
-  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
 ];
 
 /**
@@ -275,9 +294,16 @@ export const BASE_INHERITED_ENV = [
  * definition — `mutating` is a JSON boolean — but this direction fails closed.
  */
 export function safeChildEnvironment(env = {}, defOrOpts = {}) {
-  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
-  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
-  const childEnv = Object.fromEntries(inherited.flatMap((key) => process.env[key] === undefined ? [] : [[key, process.env[key]]]));
+  const isMutating =
+    typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating
+    ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV]
+    : BASE_INHERITED_ENV;
+  const childEnv = Object.fromEntries(
+    inherited.flatMap((key) =>
+      process.env[key] === undefined ? [] : [[key, process.env[key]]],
+    ),
+  );
   Object.assign(childEnv, env);
   // Read-only repository workspaces contain the selected target checkout, not
   // Factory's runtime support code. Expose the running Factory checkout through
@@ -289,8 +315,14 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
   // billing (same rationale as run-agent.sh's UNSET_KEYS, all providers pi
   // itself recognizes, not just OpenAI's).
   for (const key of [
-    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
-    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
   ]) {
     delete childEnv[key];
   }
@@ -315,12 +347,17 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
 export const HARNESS_DENIAL_PATTERNS = [];
 
 export function isHarnessDenial(content) {
-  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+  return (
+    typeof content === "string" &&
+    HARNESS_DENIAL_PATTERNS.some((re) => re.test(content))
+  );
 }
 
 function clip(text) {
   const s = String(text ?? "");
-  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+  return s.length > TEXT_PREVIEW_CHARS
+    ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]`
+    : s;
 }
 
 /** Flatten a tool result content value (pi's shape: an array of text blocks). */
@@ -355,16 +392,29 @@ export function mapStreamEvent(msg) {
     const events = [];
     for (const block of blocks) {
       if (block?.type === "text" && block.text) {
-        events.push({ kind: "assistant_text", payload: { text: clip(block.text) } });
+        events.push({
+          kind: "assistant_text",
+          payload: { text: clip(block.text) },
+        });
       } else if (block?.type === "toolCall") {
-        events.push({ kind: "tool_use", payload: { id: block.id ?? null, name: block.name, input: block.arguments } });
+        events.push({
+          kind: "tool_use",
+          payload: {
+            id: block.id ?? null,
+            name: block.name,
+            input: block.arguments,
+          },
+        });
       }
     }
     return events;
   }
 
   if (msg.type === "tool_execution_end") {
-    const payload = { content: clip(contentText(msg.result?.content)), toolUseId: msg.toolCallId ?? null };
+    const payload = {
+      content: clip(contentText(msg.result?.content)),
+      toolUseId: msg.toolCallId ?? null,
+    };
     if (msg.isError === true) payload.isError = true;
     return [{ kind: "tool_result", payload }];
   }
@@ -378,11 +428,19 @@ export function mapStreamEvent(msg) {
  * `usage` trace event pi's protocol has no equivalent terminal message for.
  */
 export function extractUsage(msg) {
-  if (!msg || msg.type !== "message_end" || msg.message?.role !== "assistant") return null;
+  if (!msg || msg.type !== "message_end" || msg.message?.role !== "assistant")
+    return null;
   const u = msg.message?.usage;
   if (!u || typeof u !== "object") return null;
   const usage = {};
-  for (const key of ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"]) {
+  for (const key of [
+    "input",
+    "output",
+    "cacheRead",
+    "cacheWrite",
+    "reasoning",
+    "totalTokens",
+  ]) {
     if (typeof u[key] === "number") usage[key] = u[key];
   }
   const costUSD = typeof u.cost?.total === "number" ? u.cost.total : null;
@@ -402,7 +460,9 @@ export function extractUsage(msg) {
 function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
   // Capture the CLI's structured output as a runtime artifact, same
   // contract as the claude adapter: NDJSON, one message per line.
-  const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+  const transcript = createWriteStream(
+    path.join(workspaceDir, ".transcript.json"),
+  );
   transcript.on("error", () => {});
   if (stdout) {
     stdout.pipe(transcript);
@@ -427,7 +487,10 @@ function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
         return; // not JSON — ignore
       }
       try {
-        if (parsed?.type === "message_end" && typeof parsed.message?.model === "string") {
+        if (
+          parsed?.type === "message_end" &&
+          typeof parsed.message?.model === "string"
+        ) {
           observedModel = parsed.message.model;
         } else if (typeof parsed?.model === "string") {
           observedModel = parsed.model;
@@ -438,9 +501,22 @@ function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
             if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
           }
           onTrace?.(event.kind, event.payload);
-          const content = typeof event.payload?.content === "string" ? event.payload.content : "";
-          if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
-            const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+          const content =
+            typeof event.payload?.content === "string"
+              ? event.payload.content
+              : "";
+          if (
+            event.kind === "tool_result" &&
+            event.payload?.isError &&
+            isHarnessDenial(content)
+          ) {
+            const denial = {
+              tool:
+                toolNames.get(event.payload?.toolUseId) ??
+                lastTool ??
+                "unknown",
+              rule: clip(content),
+            };
             policyDenials.push(denial);
             onTrace?.("lifecycle", { note: "policy_denial", ...denial });
           }
@@ -448,7 +524,8 @@ function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
         const turnUsage = extractUsage(parsed);
         if (turnUsage) {
           turnCount += 1;
-          if (turnUsage.costUSD !== null) costTotal = (costTotal ?? 0) + turnUsage.costUSD;
+          if (turnUsage.costUSD !== null)
+            costTotal = (costTotal ?? 0) + turnUsage.costUSD;
           for (const [key, value] of Object.entries(turnUsage.usage)) {
             usageTotals[key] = (usageTotals[key] ?? 0) + value;
           }
@@ -535,13 +612,26 @@ async function executeSandboxed({
   writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
 
   if (resume?.sessionId) {
-    onTrace?.("lifecycle", { note: "sandbox_resume_unavailable", sessionId: resume.sessionId });
+    onTrace?.("lifecycle", {
+      note: "sandbox_resume_unavailable",
+      sessionId: resume.sessionId,
+    });
   }
   const bin = guestBinary(def, "pi");
-  const argv = [bin, ...buildPiArgv({ def, model: spec?.model, resumeSessionId: null })];
+  const argv = [
+    bin,
+    ...buildPiArgv({ def, model: spec?.model, resumeSessionId: null }),
+  ];
 
   const stdout = new PassThrough();
-  const { transcript, finish } = attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage });
+  const { transcript, finish } = attachOutput({
+    stdout,
+    workspaceDir,
+    spec,
+    def,
+    onTrace,
+    onUsage,
+  });
   const transcriptClosed = new Promise((done) => {
     transcript.on("close", done);
     transcript.on("finish", done);
@@ -569,7 +659,10 @@ async function executeSandboxed({
   // gone, so nothing else is holding the run open.
   await transcriptClosed;
 
-  return finish({ exitCode: sandboxOutcome.exitCode, timedOut: sandboxOutcome.timedOut });
+  return finish({
+    exitCode: sandboxOutcome.exitCode,
+    timedOut: sandboxOutcome.timedOut,
+  });
 }
 
 /**
@@ -594,15 +687,24 @@ export async function execute({
   // spawn below, whatever else happens.
   if (sandboxRequested(def)) {
     return executeSandboxed({
-      spec, def, workspaceDir, timeoutMs, onTrace, onUsage, resume,
-      abortSignal: abortSignal ?? signal, runSandbox,
+      spec,
+      def,
+      workspaceDir,
+      timeoutMs,
+      onTrace,
+      onUsage,
+      resume,
+      abortSignal: abortSignal ?? signal,
+      runSandbox,
     });
   }
 
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
-  const resolved = resolvePiCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  const resolved = resolvePiCommand({
+    which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }),
+  });
   if (!resolved) {
     // Preflight refusal (OPS-296 AC): missing CLI is a typed condition the
     // worker recognizes as `cli_not_found`, not an opaque `adapter_error`
@@ -613,7 +715,11 @@ export async function execute({
   }
   const argv = [
     ...resolved.args,
-    ...buildPiArgv({ def, model: spec?.model, resumeSessionId: resume?.sessionId }),
+    ...buildPiArgv({
+      def,
+      model: spec?.model,
+      resumeSessionId: resume?.sessionId,
+    }),
   ];
 
   return new Promise((resolve, reject) => {
@@ -628,21 +734,34 @@ export async function execute({
     child.stdin.write(prompt);
     child.stdin.end();
 
-    const { transcript, finish } = attachOutput({ stdout: child.stdout, workspaceDir, spec, def, onTrace, onUsage });
+    const { transcript, finish } = attachOutput({
+      stdout: child.stdout,
+      workspaceDir,
+      spec,
+      def,
+      onTrace,
+      onUsage,
+    });
 
     let timedOut = false;
     let killTimer = null;
     const termTimer = setTimeout(() => {
       timedOut = true;
       killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+      killTimer = setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        killGraceMs,
+      );
       killTimer.unref?.();
     }, timeoutMs);
 
     const onAbort = () => {
       killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
         killTimer.unref?.();
       }
     };

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -1,9 +1,20 @@
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
-import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import {
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV,
+} from "./claude.mjs";
 import {
   buildPiArgv,
   CliNotFoundError,
@@ -23,16 +34,27 @@ import {
 } from "./pi.mjs";
 import { preflight, SandboxUnavailableError } from "../sandbox/gondolin.mjs";
 import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
-import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
+import {
+  processOwnerWatchdogSource,
+  trackProcessGroupForPid,
+} from "../test-helpers-process.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {
     // These look exactly like the strings that WOULD match claude's patterns,
     // and like plausible OS/tool errors. None are a confirmed pi-authored
     // refusal shape, so all must stay unclassified.
-    expect(isHarnessDenial("Permission to use bash has been denied.")).toBe(false);
-    expect(isHarnessDenial("pi requested permission to use write, but you haven't granted it yet.")).toBe(false);
-    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
+    expect(isHarnessDenial("Permission to use bash has been denied.")).toBe(
+      false,
+    );
+    expect(
+      isHarnessDenial(
+        "pi requested permission to use write, but you haven't granted it yet.",
+      ),
+    ).toBe(false);
+    expect(
+      isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'"),
+    ).toBe(false);
     expect(isHarnessDenial("bash: /etc/hosts: Permission denied")).toBe(false);
     expect(isHarnessDenial(null)).toBe(false);
     expect(isHarnessDenial(undefined)).toBe(false);
@@ -43,9 +65,14 @@ describe("mapStreamEvent (real `pi --mode json` shapes, investigated live)", () 
   test("assistant message_end text block → assistant_text", () => {
     const events = mapStreamEvent({
       type: "message_end",
-      message: { role: "assistant", content: [{ type: "text", text: "Files: `a.txt`." }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Files: `a.txt`." }],
+      },
     });
-    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "Files: `a.txt`." } }]);
+    expect(events).toEqual([
+      { kind: "assistant_text", payload: { text: "Files: `a.txt`." } },
+    ]);
   });
 
   test("assistant message_end toolCall block → tool_use; mixed blocks map in order", () => {
@@ -55,12 +82,20 @@ describe("mapStreamEvent (real `pi --mode json` shapes, investigated live)", () 
         role: "assistant",
         content: [
           { type: "thinking", thinking: "planning" },
-          { type: "toolCall", id: "call_1|fc_1", name: "read", arguments: { path: "a.txt" } },
+          {
+            type: "toolCall",
+            id: "call_1|fc_1",
+            name: "read",
+            arguments: { path: "a.txt" },
+          },
         ],
       },
     });
     expect(events).toEqual([
-      { kind: "tool_use", payload: { id: "call_1|fc_1", name: "read", input: { path: "a.txt" } } },
+      {
+        kind: "tool_use",
+        payload: { id: "call_1|fc_1", name: "read", input: { path: "a.txt" } },
+      },
     ]);
   });
 
@@ -72,24 +107,53 @@ describe("mapStreamEvent (real `pi --mode json` shapes, investigated live)", () 
       result: { content: [{ type: "text", text: "hello world\n" }] },
       isError: false,
     });
-    expect(ok).toEqual([{ kind: "tool_result", payload: { content: "hello world\n", toolUseId: "call_1|fc_1" } }]);
+    expect(ok).toEqual([
+      {
+        kind: "tool_result",
+        payload: { content: "hello world\n", toolUseId: "call_1|fc_1" },
+      },
+    ]);
 
     const err = mapStreamEvent({
       type: "tool_execution_end",
       toolCallId: "call_2",
       toolName: "bash",
-      result: { content: [{ type: "text", text: "line 1" }, { type: "text", text: "line 2" }] },
+      result: {
+        content: [
+          { type: "text", text: "line 1" },
+          { type: "text", text: "line 2" },
+        ],
+      },
       isError: true,
     });
-    expect(err).toEqual([{ kind: "tool_result", payload: { content: "line 1\nline 2", toolUseId: "call_2", isError: true } }]);
+    expect(err).toEqual([
+      {
+        kind: "tool_result",
+        payload: {
+          content: "line 1\nline 2",
+          toolUseId: "call_2",
+          isError: true,
+        },
+      },
+    ]);
   });
 
   test("unrecognized message types are ignored silently", () => {
     expect(mapStreamEvent({ type: "session", version: 3 })).toEqual([]);
     expect(mapStreamEvent({ type: "agent_start" })).toEqual([]);
     expect(mapStreamEvent({ type: "turn_start" })).toEqual([]);
-    expect(mapStreamEvent({ type: "message_end", message: { role: "user", content: [{ type: "text", text: "hi" }] } })).toEqual([]);
-    expect(mapStreamEvent({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "x" } })).toEqual([]);
+    expect(
+      mapStreamEvent({
+        type: "message_end",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      }),
+    ).toEqual([]);
+    expect(
+      mapStreamEvent({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "x" },
+      }),
+    ).toEqual([]);
     expect(mapStreamEvent({ type: "turn_end", message: {} })).toEqual([]);
     expect(mapStreamEvent({ type: "agent_end", messages: [] })).toEqual([]);
     expect(mapStreamEvent({ type: "agent_settled" })).toEqual([]);
@@ -101,7 +165,10 @@ describe("mapStreamEvent (real `pi --mode json` shapes, investigated live)", () 
   test("very long assistant text is clipped, not passed through whole", () => {
     const [event] = mapStreamEvent({
       type: "message_end",
-      message: { role: "assistant", content: [{ type: "text", text: "y".repeat(10_000) }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "y".repeat(10_000) }],
+      },
     });
     expect(event.kind).toBe("assistant_text");
     expect(event.payload.text.length).toBeLessThan(5_000);
@@ -116,18 +183,40 @@ describe("extractUsage", () => {
       message: {
         role: "assistant",
         content: [],
-        usage: { input: 983, output: 16, cacheRead: 2560, cacheWrite: 0, reasoning: 0, totalTokens: 3559, cost: { total: 0.000267 } },
+        usage: {
+          input: 983,
+          output: 16,
+          cacheRead: 2560,
+          cacheWrite: 0,
+          reasoning: 0,
+          totalTokens: 3559,
+          cost: { total: 0.000267 },
+        },
       },
     });
     expect(usage).toEqual({
-      usage: { input: 983, output: 16, cacheRead: 2560, cacheWrite: 0, reasoning: 0, totalTokens: 3559 },
+      usage: {
+        input: 983,
+        output: 16,
+        cacheRead: 2560,
+        cacheWrite: 0,
+        reasoning: 0,
+        totalTokens: 3559,
+      },
       costUSD: 0.000267,
     });
   });
 
   test("non-assistant, missing usage, or non-message_end → null", () => {
-    expect(extractUsage({ type: "message_end", message: { role: "user", usage: { input: 1 } } })).toBeNull();
-    expect(extractUsage({ type: "message_end", message: { role: "assistant" } })).toBeNull();
+    expect(
+      extractUsage({
+        type: "message_end",
+        message: { role: "user", usage: { input: 1 } },
+      }),
+    ).toBeNull();
+    expect(
+      extractUsage({ type: "message_end", message: { role: "assistant" } }),
+    ).toBeNull();
     expect(extractUsage({ type: "message_update" })).toBeNull();
     expect(extractUsage(null)).toBeNull();
   });
@@ -136,7 +225,11 @@ describe("extractUsage", () => {
 describe("buildPiArgv", () => {
   test("prompt travels on stdin, not argv — base argv is -p --mode json plus the allowlist", () => {
     expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual([
-      "-p", "--mode", "json", "--tools", MUTATING_TOOLS.join(","),
+      "-p",
+      "--mode",
+      "json",
+      "--tools",
+      MUTATING_TOOLS.join(","),
     ]);
   });
 
@@ -145,7 +238,10 @@ describe("buildPiArgv", () => {
     expect(argv).toContain("--tools");
     expect(argv[argv.indexOf("--tools") + 1]).toBe(READ_ONLY_TOOLS.join(","));
     expect(argv).toEqual([
-      "-p", "--mode", "json", "--tools",
+      "-p",
+      "--mode",
+      "json",
+      "--tools",
       "read,grep,find,ls,write,bash,exec_command,apply_patch",
     ]);
   });
@@ -185,13 +281,21 @@ describe("buildPiArgv", () => {
 
   test("undeclared tools are never passed, however plausible", () => {
     const tools = piTools({ mutating: true });
-    for (const absent of ["web_search", "fetch_content", "interactive_shell", "chrome_devtools_load"]) {
+    for (const absent of [
+      "web_search",
+      "fetch_content",
+      "interactive_shell",
+      "chrome_devtools_load",
+    ]) {
       expect(tools).not.toContain(absent);
     }
   });
 
   test("a definition may declare extra tools; they are additive and deduplicated", () => {
-    const tools = piTools({ mutating: false, tools: ["chrome_devtools_load", "read"] });
+    const tools = piTools({
+      mutating: false,
+      tools: ["chrome_devtools_load", "read"],
+    });
     expect(tools).toContain("chrome_devtools_load");
     for (const base of READ_ONLY_TOOLS) expect(tools).toContain(base);
     // "read" was already in the base set — declaring it again must not duplicate
@@ -201,7 +305,9 @@ describe("buildPiArgv", () => {
 
   test("a missing or malformed tools field falls back to the base set rather than throwing", () => {
     expect(piTools({ mutating: false })).toEqual(READ_ONLY_TOOLS);
-    expect(piTools({ mutating: false, tools: "read" })).toEqual(READ_ONLY_TOOLS);
+    expect(piTools({ mutating: false, tools: "read" })).toEqual(
+      READ_ONLY_TOOLS,
+    );
     expect(piTools(undefined)).toEqual(MUTATING_TOOLS);
   });
 
@@ -209,39 +315,62 @@ describe("buildPiArgv", () => {
     const argv = buildPiArgv({
       def: {
         mutating: false,
-        extensions: ["npm:@narumitw/pi-chrome-devtools", "./local-extension.ts"],
+        extensions: [
+          "npm:@narumitw/pi-chrome-devtools",
+          "./local-extension.ts",
+        ],
       },
       model: null,
     });
     expect(argv).toEqual([
-      "-p", "--mode", "json",
-      "-e", "npm:@narumitw/pi-chrome-devtools",
-      "-e", "./local-extension.ts",
-      "--tools", READ_ONLY_TOOLS.join(","),
+      "-p",
+      "--mode",
+      "json",
+      "-e",
+      "npm:@narumitw/pi-chrome-devtools",
+      "-e",
+      "./local-extension.ts",
+      "--tools",
+      READ_ONLY_TOOLS.join(","),
     ]);
   });
 
   test("extensions are scoped to definitions that declare them and deduplicated", () => {
     expect(piExtensions(undefined)).toEqual([]);
     expect(piExtensions({})).toEqual([]);
-    expect(piExtensions({ extensions: "npm:@narumitw/pi-chrome-devtools" })).toEqual([]);
-    expect(piExtensions({ extensions: ["", "  ", "npm:a", "npm:a", "npm:b"] })).toEqual([
-      "npm:a",
-      "npm:b",
-    ]);
-    expect(buildPiArgv({ def: { mutating: false }, model: null })).not.toContain("-e");
+    expect(
+      piExtensions({ extensions: "npm:@narumitw/pi-chrome-devtools" }),
+    ).toEqual([]);
+    expect(
+      piExtensions({ extensions: ["", "  ", "npm:a", "npm:a", "npm:b"] }),
+    ).toEqual(["npm:a", "npm:b"]);
+    expect(
+      buildPiArgv({ def: { mutating: false }, model: null }),
+    ).not.toContain("-e");
   });
 
   test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {
-    const withModel = buildPiArgv({ def: { mutating: false }, model: "openai-codex/gpt-5.6-terra" });
+    const withModel = buildPiArgv({
+      def: { mutating: false },
+      model: "openai-codex/gpt-5.6-terra",
+    });
     const i = withModel.indexOf("--model");
     expect(i).toBeGreaterThan(-1);
     expect(withModel[i + 1]).toBe("openai-codex/gpt-5.6-terra");
 
-    const unpinned = buildPiArgv({ def: { mutating: false }, model: undefined });
-    expect(buildPiArgv({ def: { mutating: false }, model: "default" })).toEqual(unpinned);
-    expect(buildPiArgv({ def: { mutating: false }, model: null })).toEqual(unpinned);
-    expect(buildPiArgv({ def: { mutating: false }, model: "" })).toEqual(unpinned);
+    const unpinned = buildPiArgv({
+      def: { mutating: false },
+      model: undefined,
+    });
+    expect(buildPiArgv({ def: { mutating: false }, model: "default" })).toEqual(
+      unpinned,
+    );
+    expect(buildPiArgv({ def: { mutating: false }, model: null })).toEqual(
+      unpinned,
+    );
+    expect(buildPiArgv({ def: { mutating: false }, model: "" })).toEqual(
+      unpinned,
+    );
   });
 });
 
@@ -253,7 +382,10 @@ describe("resolvePiCommand", () => {
 
   test("pi missing, npx present → npx pi fallback", () => {
     const which = (name) => (name === "npx" ? "/usr/local/bin/npx" : null);
-    expect(resolvePiCommand({ which })).toEqual({ command: "npx", args: ["pi"] });
+    expect(resolvePiCommand({ which })).toEqual({
+      command: "npx",
+      args: ["pi"],
+    });
   });
 
   test("neither on PATH → null", () => {
@@ -280,7 +412,16 @@ describe("safeChildEnvironment", () => {
       GROQ_API_KEY: "h",
       CUSTOM_VAR: "kept",
     });
-    for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY"]) {
+    for (const key of [
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "GEMINI_API_KEY",
+      "GOOGLE_API_KEY",
+      "GOOGLE_GENAI_API_KEY",
+      "MISTRAL_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "GROQ_API_KEY",
+    ]) {
       expect(env[key]).toBeUndefined();
     }
     expect(env.CUSTOM_VAR).toBe("kept");
@@ -290,14 +431,17 @@ describe("safeChildEnvironment", () => {
   // adapter had no mutating/non-mutating distinction at all until WM-223, so a
   // pi-routed dispatch run reached the push step with no credentials.
   test("strips push credentials for non-mutating runs (WM-128 parity, WM-223)", () => {
-    const childEnv = safeChildEnvironment({
-      SSH_AUTH_SOCK: "/tmp/test.sock",
-      SSH_AGENT_PID: "12345",
-      GITHUB_TOKEN: "ghp_secret_token",
-      GH_TOKEN: "ghp_other_token",
-      OPENAI_API_KEY: "sk-secret",
-      CUSTOM_INSPECT_VAR: "allowed",
-    }, { mutating: false });
+    const childEnv = safeChildEnvironment(
+      {
+        SSH_AUTH_SOCK: "/tmp/test.sock",
+        SSH_AGENT_PID: "12345",
+        GITHUB_TOKEN: "ghp_secret_token",
+        GH_TOKEN: "ghp_other_token",
+        OPENAI_API_KEY: "sk-secret",
+        CUSTOM_INSPECT_VAR: "allowed",
+      },
+      { mutating: false },
+    );
 
     expect(childEnv.CUSTOM_INSPECT_VAR).toBe("allowed");
     for (const key of PUSH_CREDENTIAL_ENV) {
@@ -307,14 +451,17 @@ describe("safeChildEnvironment", () => {
   });
 
   test("preserves push credentials while stripping provider keys for mutating runs (WM-128 parity, WM-223)", () => {
-    const childEnv = safeChildEnvironment({
-      SSH_AUTH_SOCK: "/tmp/agent.sock",
-      SSH_AGENT_PID: "54321",
-      GITHUB_TOKEN: "ghp_mutating_token",
-      GH_TOKEN: "ghp_gh_token",
-      OPENAI_API_KEY: "sk-secret",
-      CUSTOM_MUTATING_VAR: "allowed",
-    }, { mutating: true });
+    const childEnv = safeChildEnvironment(
+      {
+        SSH_AUTH_SOCK: "/tmp/agent.sock",
+        SSH_AGENT_PID: "54321",
+        GITHUB_TOKEN: "ghp_mutating_token",
+        GH_TOKEN: "ghp_gh_token",
+        OPENAI_API_KEY: "sk-secret",
+        CUSTOM_MUTATING_VAR: "allowed",
+      },
+      { mutating: true },
+    );
 
     expect(childEnv.CUSTOM_MUTATING_VAR).toBe("allowed");
     expect(childEnv.SSH_AUTH_SOCK).toBe("/tmp/agent.sock");
@@ -344,9 +491,13 @@ describe("safeChildEnvironment", () => {
 
     expect(safeChildEnvironment({}).SSH_AUTH_SOCK).toBeUndefined();
     expect(safeChildEnvironment({}, {}).SSH_AUTH_SOCK).toBeUndefined();
-    expect(safeChildEnvironment({}, { mutating: undefined }).SSH_AUTH_SOCK).toBeUndefined();
+    expect(
+      safeChildEnvironment({}, { mutating: undefined }).SSH_AUTH_SOCK,
+    ).toBeUndefined();
     expect(safeChildEnvironment({}, false).SSH_AUTH_SOCK).toBeUndefined();
-    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe(
+      "/tmp/inherited.sock",
+    );
   });
 
   test("injects the stable Factory runtime path and refuses caller overrides (WM-433)", () => {
@@ -363,7 +514,9 @@ describe("safeChildEnvironment", () => {
 });
 
 describe("execute conformance (OPS-296, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-pi-test-")));
+  const tmpBase = realpathSync(
+    mkdtempSync(path.join(tmpdir(), "evrt-pi-test-")),
+  );
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
   const emptyBinDir = path.join(tmpBase, "empty-bin");
@@ -581,17 +734,27 @@ process.stdin.on("end", () => {
     expect(record.argv).toContain("--mode");
     expect(record.argv).toContain("json");
     expect(record.argv).toContain("--model");
-    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("openai-codex/gpt-5.6-terra");
+    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe(
+      "openai-codex/gpt-5.6-terra",
+    );
     expect(record.argv).toContain("--tools");
-    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,exec_command,apply_patch");
+    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe(
+      "read,grep,find,ls,write,bash,exec_command,apply_patch",
+    );
 
     // 4. .transcript.json artifact capture
     const transcriptPath = path.join(workspaceDir, ".transcript.json");
     expect(existsSync(transcriptPath)).toBe(true);
-    expect(readFileSync(transcriptPath, "utf8")).toContain('"type":"message_end"');
+    expect(readFileSync(transcriptPath, "utf8")).toContain(
+      '"type":"message_end"',
+    );
 
     // 5. Live trace mapping: assistant text, then one combined usage event
-    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working...")).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "assistant_text" && e.payload.text === "Working...",
+      ),
+    ).toBe(true);
     const usageEvent = traceEvents.find((e) => e.kind === "usage");
     expect(usageEvent).toBeDefined();
     expect(usageEvent.payload.numTurns).toBe(1);
@@ -615,37 +778,41 @@ process.stdin.on("end", () => {
     expect(outcome.timedOut).toBe(false);
   });
 
-  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 6_000,
-      killGraceMs: 5000,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
+  testProcessGroup(
+    "timeout kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 6_000,
+        killGraceMs: 5000,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
 
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(true);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  }, { timeout: 12_000 });
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(true);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+    { timeout: 12_000 },
+  );
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
     const outcome = await execute({
@@ -662,38 +829,41 @@ process.stdin.on("end", () => {
     expect(outcome.timedOut).toBe(true);
   });
 
-  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
-    const workspaceDir = ws();
-    const pidFile = path.join(workspaceDir, "grandchild.pid");
-    const ac = new AbortController();
-    const runPromise = execute({
-      spec: defaultSpec,
-      def: defaultDef,
-      workspaceDir,
-      timeoutMs: 10_000,
-      killGraceMs: 500,
-      abortSignal: ac.signal,
-      env: {
-        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
-        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
-      },
-    });
-    let grandchildPid;
+  testProcessGroup(
+    "abort kills a real long-lived grandchild (WM-263)",
+    async () => {
+      const workspaceDir = ws();
+      const pidFile = path.join(workspaceDir, "grandchild.pid");
+      const ac = new AbortController();
+      const runPromise = execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 10_000,
+        killGraceMs: 500,
+        abortSignal: ac.signal,
+        env: {
+          PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+          FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+        },
+      });
+      let grandchildPid;
 
-    try {
-      grandchildPid = await waitForGrandchildPid(pidFile);
-      expect(processExists(grandchildPid)).toBe(true);
-      ac.abort();
-      const outcome = await runPromise;
-      expect(outcome.timedOut).toBe(false);
-      await expectProcessExit(grandchildPid);
-    } finally {
-      ac.abort();
-      await runPromise;
-      killIfRunning(grandchildPid);
-    }
-  });
+      try {
+        grandchildPid = await waitForGrandchildPid(pidFile);
+        expect(processExists(grandchildPid)).toBe(true);
+        ac.abort();
+        const outcome = await runPromise;
+        expect(outcome.timedOut).toBe(false);
+        await expectProcessExit(grandchildPid);
+      } finally {
+        ac.abort();
+        await runPromise;
+        killIfRunning(grandchildPid);
+      }
+    },
+  );
 
   test("multiple assistant turns accumulate into one combined usage trace event", async () => {
     const traceEvents = [];
@@ -711,8 +881,16 @@ process.stdin.on("end", () => {
     expect(outcome.exitCode).toBe(0);
     expect(outcome.timedOut).toBe(false);
     expect(outcome.policyDenials).toEqual([]);
-    expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "read")).toBe(true);
-    expect(traceEvents.some((e) => e.kind === "tool_result" && e.payload.content === "hello world")).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "tool_use" && e.payload.name === "read",
+      ),
+    ).toBe(true);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "tool_result" && e.payload.content === "hello world",
+      ),
+    ).toBe(true);
 
     const usageEvent = traceEvents.find((e) => e.kind === "usage");
     expect(usageEvent.payload.numTurns).toBe(2);
@@ -764,7 +942,11 @@ process.stdin.on("end", () => {
     });
     expect(outcome.exitCode).toBe(1);
     expect(outcome.policyDenials).toEqual([]);
-    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+    expect(
+      traceEvents.some(
+        (e) => e.kind === "lifecycle" && e.payload.note === "policy_denial",
+      ),
+    ).toBe(false);
   });
 
   test("run with no output at all reports usage as explicit n/a, not a fabricated zero", async () => {
@@ -782,7 +964,12 @@ process.stdin.on("end", () => {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
     const usageEvent = traceEvents.find((e) => e.kind === "usage");
-    expect(usageEvent.payload).toEqual({ durationMs: null, numTurns: null, costUSD: null, usage: {} });
+    expect(usageEvent.payload).toEqual({
+      durationMs: null,
+      numTurns: null,
+      costUSD: null,
+      usage: {},
+    });
   });
 
   test("missing pi and npx on PATH is a typed CliNotFoundError, not a spawn crash (OPS-296 AC)", async () => {
@@ -815,7 +1002,9 @@ process.stdin.on("end", () => {
  * an actual guest, skipping (not failing) where `preflight()` says no.
  */
 describe("sandboxed execution (WM-313)", () => {
-  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-pi-sandbox-")));
+  const tmpBase = realpathSync(
+    mkdtempSync(path.join(tmpdir(), "evrt-pi-sandbox-")),
+  );
   afterAll(() => rmSync(tmpBase, { recursive: true, force: true }));
   const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
   const promptFile = path.join(tmpBase, "prompt.md");
@@ -828,25 +1017,47 @@ describe("sandboxed execution (WM-313)", () => {
     sandbox: {
       provider: "gondolin",
       allowedHosts: ["api.openai.com"],
-      secrets: { OPENAI_API_KEY: { hosts: ["api.openai.com"], env: "FACTORY_TEST_FAKE_OPENAI_KEY" } },
+      secrets: {
+        OPENAI_API_KEY: {
+          hosts: ["api.openai.com"],
+          env: "FACTORY_TEST_FAKE_OPENAI_KEY",
+        },
+      },
     },
     ...extra,
   });
-  const spec = { agent: "sandboxed-pi@1", input: { repos: ["bj29"] }, model: "openai/gpt-5.6-terra" };
+  const spec = {
+    agent: "sandboxed-pi@1",
+    input: { repos: ["bj29"] },
+    model: "openai/gpt-5.6-terra",
+  };
 
   /** A stand-in for the VM: records the request, "runs" a scripted guest. */
-  function fakeVm({ stdoutLines = [], exitCode = 0, timedOut = false, writeResult = true, bootMs = 42 } = {}) {
+  function fakeVm({
+    stdoutLines = [],
+    exitCode = 0,
+    timedOut = false,
+    writeResult = true,
+    bootMs = 42,
+  } = {}) {
     const calls = [];
     const runSandbox = async (request) => {
       calls.push(request);
-      for (const line of stdoutLines) request.onStdout(`${JSON.stringify(line)}\n`);
+      for (const line of stdoutLines)
+        request.onStdout(`${JSON.stringify(line)}\n`);
       request.onStderr?.("guest stderr line\n");
       if (writeResult) {
         // The guest writes ./result.json under its cwd, which is the host
         // workspace through the mount — the stub writes to the same place.
         writeFileSync(
           path.join(request.workspaceDir, "result.json"),
-          JSON.stringify({ schemaVersion: "factory.agent-result/v1", terminalState: "completed", reasonCode: "ok", artifact: {}, evidence: {} }),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {},
+            evidence: {},
+          }),
         );
       }
       return { exitCode, timedOut, bootMs };
@@ -859,7 +1070,15 @@ describe("sandboxed execution (WM-313)", () => {
     const vm = fakeVm({
       stdoutLines: [
         { type: "session", id: "sess-1", cwd: "/workspace" },
-        { type: "message_end", message: { role: "assistant", model: "gpt-5.6-terra", content: [{ type: "text", text: "Working in the VM..." }], usage: { input: 15, output: 25, cost: { total: 0.001 } } } },
+        {
+          type: "message_end",
+          message: {
+            role: "assistant",
+            model: "gpt-5.6-terra",
+            content: [{ type: "text", text: "Working in the VM..." }],
+            usage: { input: 15, output: 25, cost: { total: 0.001 } },
+          },
+        },
       ],
     });
     const traceEvents = [];
@@ -870,7 +1089,12 @@ describe("sandboxed execution (WM-313)", () => {
       workspaceDir,
       timeoutMs: 5000,
       // Everything a served worker would hand over — none of it may reach the guest.
-      env: { PATH: "/nonexistent", OPENAI_API_KEY: "sk-fake-host-key-must-not-cross", GITHUB_TOKEN: "ghp-fake", CUSTOM_VAR: "host-only" },
+      env: {
+        PATH: "/nonexistent",
+        OPENAI_API_KEY: "sk-fake-host-key-must-not-cross",
+        GITHUB_TOKEN: "ghp-fake",
+        CUSTOM_VAR: "host-only",
+      },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
       runSandbox: vm.runSandbox,
     });
@@ -879,7 +1103,14 @@ describe("sandboxed execution (WM-313)", () => {
       exitCode: 0,
       timedOut: false,
       policyDenials: [],
-      usage: { model: "gpt-5.6-terra", inputTokens: 15, outputTokens: 25, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, costUSD: 0.001 },
+      usage: {
+        model: "gpt-5.6-terra",
+        inputTokens: 15,
+        outputTokens: 25,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        costUSD: 0.001,
+      },
     });
 
     expect(vm.calls).toHaveLength(1);
@@ -890,13 +1121,21 @@ describe("sandboxed execution (WM-313)", () => {
     expect(req.timeoutMs).toBe(5000);
 
     // 2. argv: guest binary (not a host lookup), stdin redirected from the workspace prompt file.
-    expect(req.command.slice(0, 3)).toEqual(["/bin/sh", "-c", `exec "$0" "$@" < ./${SANDBOX_PROMPT_FILE}`]);
+    expect(req.command.slice(0, 3)).toEqual([
+      "/bin/sh",
+      "-c",
+      `exec "$0" "$@" < ./${SANDBOX_PROMPT_FILE}`,
+    ]);
     expect(req.command[3]).toBe("/usr/local/bin/pi");
     const piArgs = req.command.slice(4);
     expect(piArgs.slice(0, 3)).toEqual(["-p", "--mode", "json"]);
     expect(piArgs[piArgs.indexOf("--model") + 1]).toBe("openai/gpt-5.6-terra");
-    expect(piArgs[piArgs.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,exec_command,apply_patch");
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), "utf8")).toBe(`You are a sandboxed test agent.${PROMPT_SUFFIX}`);
+    expect(piArgs[piArgs.indexOf("--tools") + 1]).toBe(
+      "read,grep,find,ls,write,bash,exec_command,apply_patch",
+    );
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), "utf8"),
+    ).toBe(`You are a sandboxed test agent.${PROMPT_SUFFIX}`);
 
     // 3. Guest env is built, not inherited: no host key, no push token, no
     //    caller var, no host HOME/PATH; PI_OFFLINE keeps update traffic off
@@ -907,27 +1146,67 @@ describe("sandboxed execution (WM-313)", () => {
     expect(req.env.HOME).toBe("/root");
     expect(req.env.PATH).toContain("/usr/local/bin");
     expect(req.env.PI_OFFLINE).toBe("1");
-    expect(JSON.stringify(req)).not.toContain("sk-fake-host-key-must-not-cross");
+    expect(JSON.stringify(req)).not.toContain(
+      "sk-fake-host-key-must-not-cross",
+    );
 
     // 4. Same downstream contract as the host path: transcript, trace, usage, result.json where the verifier looks.
-    expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain('"type":"message_end"');
-    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working in the VM...")).toBe(true);
-    expect(traceEvents.find((e) => e.kind === "usage").payload.numTurns).toBe(1);
-    expect(JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8")).terminalState).toBe("completed");
+    expect(
+      readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8"),
+    ).toContain('"type":"message_end"');
+    expect(
+      traceEvents.some(
+        (e) =>
+          e.kind === "assistant_text" &&
+          e.payload.text === "Working in the VM...",
+      ),
+    ).toBe(true);
+    expect(traceEvents.find((e) => e.kind === "usage").payload.numTurns).toBe(
+      1,
+    );
+    expect(
+      JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"))
+        .terminalState,
+    ).toBe("completed");
 
     // 5. Guest console is an artifact and a trace event.
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("guest stderr line");
-    expect(traceEvents.find((e) => e.kind === "lifecycle" && e.payload.note === "sandbox_console").payload).toMatchObject({ adapter: "pi", exitCode: 0, bootMs: 42 });
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8"),
+    ).toContain("guest stderr line");
+    expect(
+      traceEvents.find(
+        (e) => e.kind === "lifecycle" && e.payload.note === "sandbox_console",
+      ).payload,
+    ).toMatchObject({ adapter: "pi", exitCode: 0, bootMs: 42 });
   });
 
   test("a per-definition guest binary override is honoured; a relative one is refused before the VM", async () => {
     const vm = fakeVm();
-    await execute({ spec, def: sandboxDef({ sandbox: { ...sandboxDef().sandbox, guestBinaries: { pi: "/opt/tools/pi" } } }), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm.runSandbox });
+    await execute({
+      spec,
+      def: sandboxDef({
+        sandbox: {
+          ...sandboxDef().sandbox,
+          guestBinaries: { pi: "/opt/tools/pi" },
+        },
+      }),
+      workspaceDir: ws(),
+      timeoutMs: 1000,
+      runSandbox: vm.runSandbox,
+    });
     expect(vm.calls[0].command[3]).toBe("/opt/tools/pi");
 
     const vm2 = fakeVm();
     await expect(
-      execute({ spec, def: sandboxDef({ sandbox: { ...sandboxDef().sandbox, guestBinaries: { pi: "pi" } } }), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm2.runSandbox }),
+      execute({
+        spec,
+        def: sandboxDef({
+          sandbox: { ...sandboxDef().sandbox, guestBinaries: { pi: "pi" } },
+        }),
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+        runSandbox: vm2.runSandbox,
+      }),
     ).rejects.toThrow(/absolute guest path/);
     expect(vm2.calls).toHaveLength(0);
   });
@@ -935,7 +1214,14 @@ describe("sandboxed execution (WM-313)", () => {
   test("a sandboxed definition never resolves or spawns a host pi, even when none is on PATH", async () => {
     // Host path with this env throws CliNotFoundError; the sandboxed path must not even look.
     const vm = fakeVm();
-    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, env: { PATH: tmpBase }, runSandbox: vm.runSandbox });
+    const outcome = await execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir: ws(),
+      timeoutMs: 1000,
+      env: { PATH: tmpBase },
+      runSandbox: vm.runSandbox,
+    });
     expect(outcome.exitCode).toBe(0);
     expect(vm.calls).toHaveLength(1);
   });
@@ -943,14 +1229,32 @@ describe("sandboxed execution (WM-313)", () => {
   test("a prior native session is not forked into the guest (sessions are per-VM); the run notes it", async () => {
     const vm = fakeVm();
     const trace = [];
-    await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, resume: { sessionId: "sess-prior" }, runSandbox: vm.runSandbox, onTrace: (k, p) => trace.push({ k, p }) });
+    await execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir: ws(),
+      timeoutMs: 1000,
+      resume: { sessionId: "sess-prior" },
+      runSandbox: vm.runSandbox,
+      onTrace: (k, p) => trace.push({ k, p }),
+    });
     expect(vm.calls[0].command).not.toContain("--fork");
-    expect(trace.some((t) => t.k === "lifecycle" && t.p.note === "sandbox_resume_unavailable")).toBe(true);
+    expect(
+      trace.some(
+        (t) => t.k === "lifecycle" && t.p.note === "sandbox_resume_unavailable",
+      ),
+    ).toBe(true);
   });
 
   test("nonzero guest exit propagates like a host exit; denials are surfaced only then", async () => {
     const vm = fakeVm({ exitCode: 3, writeResult: false });
-    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm.runSandbox });
+    const outcome = await execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir: ws(),
+      timeoutMs: 1000,
+      runSandbox: vm.runSandbox,
+    });
     expect(outcome.exitCode).toBe(3);
     expect(outcome.timedOut).toBe(false);
   });
@@ -959,7 +1263,13 @@ describe("sandboxed execution (WM-313)", () => {
     // Host reference: the stub ignores SIGTERM and gets killed → { exitCode: null, timedOut: true }.
     const vm = fakeVm({ exitCode: null, timedOut: true, writeResult: true });
     const workspaceDir = ws();
-    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir, timeoutMs: 100, runSandbox: vm.runSandbox });
+    const outcome = await execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir,
+      timeoutMs: 100,
+      runSandbox: vm.runSandbox,
+    });
     expect(outcome.exitCode).toBeNull();
     expect(outcome.timedOut).toBe(true);
     // The worker's late-completion preflight (verifyResult on TIMED_OUT) reads
@@ -974,9 +1284,25 @@ describe("sandboxed execution (WM-313)", () => {
       new Promise((_, reject) => {
         // What the real runner does on SIGTERM: dies without an exit event,
         // which gondolin.mjs reports as sandbox_runner_crashed.
-        abortSignal.addEventListener("abort", () => reject(Object.assign(new Error("runner exited (null) without reporting a guest exit code"), { code: "sandbox_runner_crashed" })));
+        abortSignal.addEventListener("abort", () =>
+          reject(
+            Object.assign(
+              new Error(
+                "runner exited (null) without reporting a guest exit code",
+              ),
+              { code: "sandbox_runner_crashed" },
+            ),
+          ),
+        );
       });
-    const pending = execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 60_000, abortSignal: ac.signal, runSandbox });
+    const pending = execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir: ws(),
+      timeoutMs: 60_000,
+      abortSignal: ac.signal,
+      runSandbox,
+    });
     setTimeout(() => ac.abort(), 10);
     const outcome = await pending;
     expect(outcome.exitCode).toBeNull();
@@ -987,8 +1313,14 @@ describe("sandboxed execution (WM-313)", () => {
     // Real runInSandbox with a preflight-failing host env: no qemu → SandboxUnavailableError.
     // Injecting nothing here would hit this machine's real preflight, which may pass; force the failure instead.
     const outcome = execute({
-      spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, env: { PATH: `${tmpBase}` },
-      runSandbox: async () => { throw new SandboxUnavailableError("qemu-system-aarch64 is not on PATH"); },
+      spec,
+      def: sandboxDef(),
+      workspaceDir: ws(),
+      timeoutMs: 1000,
+      env: { PATH: `${tmpBase}` },
+      runSandbox: async () => {
+        throw new SandboxUnavailableError("qemu-system-aarch64 is not on PATH");
+      },
     });
     await expect(outcome).rejects.toBeInstanceOf(SandboxUnavailableError);
   });
@@ -996,14 +1328,22 @@ describe("sandboxed execution (WM-313)", () => {
   test("an invalid policy is refused before any VM: unknown provider", async () => {
     // Goes through the real runInSandbox, whose first step is normalizePolicy — host-independent.
     await expect(
-      execute({ spec, def: sandboxDef({ sandbox: { provider: "firecracker" } }), workspaceDir: ws(), timeoutMs: 1000 }),
+      execute({
+        spec,
+        def: sandboxDef({ sandbox: { provider: "firecracker" } }),
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+      }),
     ).rejects.toThrow(/unknown sandbox provider/);
   });
 
   // ---- real VM, gated on preflight() -------------------------------------
   const report = preflight();
   const itVM = report.available ? test : test.skip;
-  if (!report.available) console.warn(`[WM-313] skipping real-VM pi sandbox tests — ${report.reason}`);
+  if (!report.available)
+    console.warn(
+      `[WM-313] skipping real-VM pi sandbox tests — ${report.reason}`,
+    );
   const VM_TIMEOUT = 180_000;
 
   /**
@@ -1058,62 +1398,118 @@ exit 0
     }
   };
 
-  itVM("real VM: pi runs in the guest, prompt arrives on stdin, result.json lands on the host, the key is a placeholder", async () => {
-    await withFakeKey(async () => {
-      const workspaceDir = ws();
-      const trace = [];
-      const outcome = await execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 120_000, env: { OPENAI_API_KEY: "sk-host-side-fake" }, onTrace: (k, p) => trace.push({ k, p }) });
-      expect(outcome.exitCode).toBe(0);
-      expect(outcome.timedOut).toBe(false);
-      expect(outcome.usage.model).toBe("guest-model");
-      expect(outcome.usage.inputTokens).toBe(3);
+  itVM(
+    "real VM: pi runs in the guest, prompt arrives on stdin, result.json lands on the host, the key is a placeholder",
+    async () => {
+      await withFakeKey(async () => {
+        const workspaceDir = ws();
+        const trace = [];
+        const outcome = await execute({
+          spec,
+          def: vmDef(),
+          workspaceDir,
+          timeoutMs: 120_000,
+          env: { OPENAI_API_KEY: "sk-host-side-fake" },
+          onTrace: (k, p) => trace.push({ k, p }),
+        });
+        expect(outcome.exitCode).toBe(0);
+        expect(outcome.timedOut).toBe(false);
+        expect(outcome.usage.model).toBe("guest-model");
+        expect(outcome.usage.inputTokens).toBe(3);
 
-      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
-      expect(result.terminalState).toBe("completed");
-      expect(result.artifact.argv).toContain("-p --mode json");
-      expect(result.artifact.keyLooksLikePlaceholder).toBe("yes");
-      expect(readFileSync(path.join(workspaceDir, ".prompt-as-seen"), "utf8")).toContain("You are a sandboxed test agent.");
-      expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain("hello from the guest");
-      const console_ = readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8");
-      expect(console_).toContain("guest pi: cwd=/workspace");
-      expect(console_).toContain("key=GONDOLIN_SECRET_");
-      expect(console_).not.toContain(FAKE_KEY);
-      expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).not.toContain(FAKE_KEY);
-      expect(trace.some((t) => t.k === "assistant_text" && t.p.text === "hello from the guest")).toBe(true);
-    });
-  }, VM_TIMEOUT);
+        const result = JSON.parse(
+          readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+        );
+        expect(result.terminalState).toBe("completed");
+        expect(result.artifact.argv).toContain("-p --mode json");
+        expect(result.artifact.keyLooksLikePlaceholder).toBe("yes");
+        expect(
+          readFileSync(path.join(workspaceDir, ".prompt-as-seen"), "utf8"),
+        ).toContain("You are a sandboxed test agent.");
+        expect(
+          readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8"),
+        ).toContain("hello from the guest");
+        const console_ = readFileSync(
+          path.join(workspaceDir, SANDBOX_CONSOLE_FILE),
+          "utf8",
+        );
+        expect(console_).toContain("guest pi: cwd=/workspace");
+        expect(console_).toContain("key=GONDOLIN_SECRET_");
+        expect(console_).not.toContain(FAKE_KEY);
+        expect(
+          readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8"),
+        ).not.toContain(FAKE_KEY);
+        expect(
+          trace.some(
+            (t) =>
+              t.k === "assistant_text" && t.p.text === "hello from the guest",
+          ),
+        ).toBe(true);
+      });
+    },
+    VM_TIMEOUT,
+  );
 
-  itVM("real VM: timeout caps the guest and the partial result.json is on the host", async () => {
-    await withFakeKey(async () => {
-      const workspaceDir = ws();
-      writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
-      const started = Date.now();
-      // Generous enough that a cold guest (first exec after asset load) has
-      // written result.json before the cap lands; the assertion is on the cap.
-      const outcome = await execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 10_000 });
-      expect(outcome.timedOut).toBe(true);
-      expect(outcome.exitCode).toBeNull();
-      expect(Date.now() - started).toBeLessThan(60_000);
-      expect(JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8")).artifact.partial).toBe(true);
-    });
-  }, VM_TIMEOUT);
+  itVM(
+    "real VM: timeout caps the guest and the partial result.json is on the host",
+    async () => {
+      await withFakeKey(async () => {
+        const workspaceDir = ws();
+        writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
+        const started = Date.now();
+        // Generous enough that a cold guest (first exec after asset load) has
+        // written result.json before the cap lands; the assertion is on the cap.
+        const outcome = await execute({
+          spec,
+          def: vmDef(),
+          workspaceDir,
+          timeoutMs: 10_000,
+        });
+        expect(outcome.timedOut).toBe(true);
+        expect(outcome.exitCode).toBeNull();
+        expect(Date.now() - started).toBeLessThan(60_000);
+        expect(
+          JSON.parse(
+            readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+          ).artifact.partial,
+        ).toBe(true);
+      });
+    },
+    VM_TIMEOUT,
+  );
 
-  itVM("real VM: cooperative cancel tears the guest down and reports like a host cancel", async () => {
-    await withFakeKey(async () => {
-      const workspaceDir = ws();
-      writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
-      const ac = new AbortController();
-      const trace = [];
-      const pending = execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 120_000, abortSignal: ac.signal, onTrace: (k, p) => trace.push({ k, p }) });
-      // Abort once the guest has produced its first line, i.e. it is really running.
-      for (let i = 0; i < 600 && !trace.some((t) => t.k === "lifecycle" || t.k === "assistant_text"); i += 1) {
-        if (existsSync(path.join(workspaceDir, "result.json"))) break;
-        await new Promise((r) => setTimeout(r, 100));
-      }
-      ac.abort();
-      const outcome = await pending;
-      expect(outcome.timedOut).toBe(false);
-      expect(outcome.exitCode).toBeNull();
-    });
-  }, VM_TIMEOUT);
+  itVM(
+    "real VM: cooperative cancel tears the guest down and reports like a host cancel",
+    async () => {
+      await withFakeKey(async () => {
+        const workspaceDir = ws();
+        writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
+        const ac = new AbortController();
+        const trace = [];
+        const pending = execute({
+          spec,
+          def: vmDef(),
+          workspaceDir,
+          timeoutMs: 120_000,
+          abortSignal: ac.signal,
+          onTrace: (k, p) => trace.push({ k, p }),
+        });
+        // Abort once the guest has produced its first line, i.e. it is really running.
+        for (
+          let i = 0;
+          i < 600 &&
+          !trace.some((t) => t.k === "lifecycle" || t.k === "assistant_text");
+          i += 1
+        ) {
+          if (existsSync(path.join(workspaceDir, "result.json"))) break;
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        ac.abort();
+        const outcome = await pending;
+        expect(outcome.timedOut).toBe(false);
+        expect(outcome.exitCode).toBeNull();
+      });
+    },
+    VM_TIMEOUT,
+  );
 });

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -120,7 +120,8 @@ export function guestBinary(def, adapter) {
 export function guestEnvironment(extra = {}, hostEnv = process.env) {
   const env = { HOME: GUEST_HOME, PATH: GUEST_PATH, TERM: "dumb" };
   for (const key of GUEST_LOCALE_ENV) {
-    if (typeof hostEnv[key] === "string" && hostEnv[key] !== "") env[key] = hostEnv[key];
+    if (typeof hostEnv[key] === "string" && hostEnv[key] !== "")
+      env[key] = hostEnv[key];
   }
   return { ...env, ...extra };
 }
@@ -137,13 +138,20 @@ export function guestEnvironment(extra = {}, hostEnv = process.env) {
  */
 export function withStdinFile(argv, stdinFile) {
   if (typeof stdinFile !== "string" || !/^[A-Za-z0-9._-]+$/.test(stdinFile)) {
-    throw new Error(`sandbox stdin file must be a bare workspace filename, got ${JSON.stringify(stdinFile)}`);
+    throw new Error(
+      `sandbox stdin file must be a bare workspace filename, got ${JSON.stringify(stdinFile)}`,
+    );
   }
   return [GUEST_SHELL, "-c", `exec "$0" "$@" < ./${stdinFile}`, ...argv];
 }
 
 function assertGuestArgv(def, argv) {
-  if (!Array.isArray(argv) || argv.length === 0 || typeof argv[0] !== "string" || !argv[0].startsWith("/")) {
+  if (
+    !Array.isArray(argv) ||
+    argv.length === 0 ||
+    typeof argv[0] !== "string" ||
+    !argv[0].startsWith("/")
+  ) {
     // Array-form exec does not search $PATH inside the guest, and a host path
     // like /opt/homebrew/bin/bun does not exist there. Failing here with the
     // real reason beats a bare "no such file" from inside a VM.
@@ -199,7 +207,9 @@ export async function runSandboxed({
     consoleTail = (consoleTail + text).slice(-CONSOLE_TRACE_CHARS);
   };
   const started = Date.now();
-  note(`[sandbox] adapter=${adapter} definition=${def?.ref ?? "?"} provider=${def?.sandbox?.provider ?? "?"} argv=${JSON.stringify(command)}`);
+  note(
+    `[sandbox] adapter=${adapter} definition=${def?.ref ?? "?"} provider=${def?.sandbox?.provider ?? "?"} argv=${JSON.stringify(command)}`,
+  );
 
   let outcome;
   let failure = null;
@@ -223,7 +233,11 @@ export async function runSandboxed({
     failure = err;
   }
 
-  if (failure && abortSignal?.aborted && failure.code === "sandbox_runner_crashed") {
+  if (
+    failure &&
+    abortSignal?.aborted &&
+    failure.code === "sandbox_runner_crashed"
+  ) {
     // The runner was torn down mid-run because WE asked for it. A host child
     // in the same position closes with a null exit code; report the same so
     // the worker's cancel path cannot tell the two apart.
@@ -233,7 +247,9 @@ export async function runSandboxed({
 
   const elapsed = Date.now() - started;
   if (failure) {
-    note(`[sandbox] failed after ${elapsed}ms: ${failure.code ?? failure.name}: ${failure.message}`);
+    note(
+      `[sandbox] failed after ${elapsed}ms: ${failure.code ?? failure.name}: ${failure.message}`,
+    );
   } else {
     note(
       `[sandbox] boot=${outcome.bootMs ?? "?"}ms exit=${outcome.exitCode ?? "null"} timedOut=${outcome.timedOut} elapsed=${elapsed}ms${abortSignal?.aborted ? " cancelled=true" : ""}`,
@@ -256,7 +272,9 @@ export async function runSandboxed({
       bootMs: outcome?.bootMs ?? null,
       exitCode: outcome?.exitCode ?? null,
       timedOut: outcome?.timedOut ?? false,
-      ...(failure ? { error: `${failure.code ?? failure.name}: ${failure.message}` } : {}),
+      ...(failure
+        ? { error: `${failure.code ?? failure.name}: ${failure.message}` }
+        : {}),
       text: consoleTail,
     });
   } catch {
@@ -264,5 +282,9 @@ export async function runSandboxed({
   }
 
   if (failure) throw failure;
-  return { exitCode: outcome.exitCode ?? null, timedOut: outcome.timedOut === true, bootMs: outcome.bootMs ?? null };
+  return {
+    exitCode: outcome.exitCode ?? null,
+    timedOut: outcome.timedOut === true,
+    bootMs: outcome.bootMs ?? null,
+  };
 }

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -8,7 +8,13 @@
  * behaviour is proven in pi.test.mjs behind `preflight()`.
  */
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
@@ -27,7 +33,11 @@ import {
 } from "./sandboxed.mjs";
 
 const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-sandboxed-"));
-const sandboxDef = (extra = {}) => ({ ref: "sandboxed@1", sandbox: { provider: "gondolin", allowedHosts: [] }, ...extra });
+const sandboxDef = (extra = {}) => ({
+  ref: "sandboxed@1",
+  sandbox: { provider: "gondolin", allowedHosts: [] },
+  ...extra,
+});
 
 describe("sandboxRequested / refuseSandbox", () => {
   test("absent or null means no sandbox; anything else is a request", () => {
@@ -52,32 +62,85 @@ describe("sandboxRequested / refuseSandbox", () => {
     expect(caught).toBeInstanceOf(SandboxUnsupportedError);
     expect(caught.code).toBe("sandbox_unsupported");
     expect(caught.adapter).toBe("claude");
-    expect(caught.message).toContain('adapter "claude" cannot honour a sandbox policy');
-    expect(caught.message).toContain("refused rather than executed on the host");
+    expect(caught.message).toContain(
+      'adapter "claude" cannot honour a sandbox policy',
+    );
+    expect(caught.message).toContain(
+      "refused rather than executed on the host",
+    );
     expect(caught.message).toContain("because reasons");
   });
 });
 
 describe("guest environment and binaries", () => {
   test("guestEnvironment is built from constants plus locale — the caller's env is not a source", () => {
-    const env = guestEnvironment({ PI_OFFLINE: "1" }, { LANG: "en_US.UTF-8", OPENAI_API_KEY: "sk-fake-not-real", GITHUB_TOKEN: "ghp-fake", HOME: "/Users/someone", PATH: "/opt/homebrew/bin" });
-    expect(env).toEqual({ HOME: GUEST_HOME, PATH: GUEST_PATH, TERM: "dumb", LANG: "en_US.UTF-8", PI_OFFLINE: "1" });
+    const env = guestEnvironment(
+      { PI_OFFLINE: "1" },
+      {
+        LANG: "en_US.UTF-8",
+        OPENAI_API_KEY: "sk-fake-not-real",
+        GITHUB_TOKEN: "ghp-fake",
+        HOME: "/Users/someone",
+        PATH: "/opt/homebrew/bin",
+      },
+    );
+    expect(env).toEqual({
+      HOME: GUEST_HOME,
+      PATH: GUEST_PATH,
+      TERM: "dumb",
+      LANG: "en_US.UTF-8",
+      PI_OFFLINE: "1",
+    });
     expect(GUEST_PATH.split(":")).toContain("/usr/local/bin");
   });
 
   test("guestBinary defaults to the image contract path and honours an absolute per-definition override", () => {
     expect(guestBinary(sandboxDef(), "pi")).toBe(GUEST_BINARIES.pi);
-    expect(guestBinary(sandboxDef({ sandbox: { provider: "gondolin", guestBinaries: { pi: "/opt/tools/pi" } } }), "pi")).toBe("/opt/tools/pi");
-    expect(() => guestBinary(sandboxDef({ sandbox: { provider: "gondolin", guestBinaries: { pi: "pi" } } }), "pi")).toThrow(/absolute guest path/);
+    expect(
+      guestBinary(
+        sandboxDef({
+          sandbox: {
+            provider: "gondolin",
+            guestBinaries: { pi: "/opt/tools/pi" },
+          },
+        }),
+        "pi",
+      ),
+    ).toBe("/opt/tools/pi");
+    expect(() =>
+      guestBinary(
+        sandboxDef({
+          sandbox: { provider: "gondolin", guestBinaries: { pi: "pi" } },
+        }),
+        "pi",
+      ),
+    ).toThrow(/absolute guest path/);
   });
 
   test("withStdinFile keeps the binary and args as positional parameters and refuses anything but a bare filename", () => {
-    expect(withStdinFile(["/usr/local/bin/pi", "-p", "--mode", "json"], ".prompt.md")).toEqual([
-      "/bin/sh", "-c", 'exec "$0" "$@" < ./.prompt.md', "/usr/local/bin/pi", "-p", "--mode", "json",
+    expect(
+      withStdinFile(
+        ["/usr/local/bin/pi", "-p", "--mode", "json"],
+        ".prompt.md",
+      ),
+    ).toEqual([
+      "/bin/sh",
+      "-c",
+      'exec "$0" "$@" < ./.prompt.md',
+      "/usr/local/bin/pi",
+      "-p",
+      "--mode",
+      "json",
     ]);
-    expect(() => withStdinFile(["/bin/true"], "../escape")).toThrow(/bare workspace filename/);
-    expect(() => withStdinFile(["/bin/true"], "/workspace/x")).toThrow(/bare workspace filename/);
-    expect(() => withStdinFile(["/bin/true"], "a b")).toThrow(/bare workspace filename/);
+    expect(() => withStdinFile(["/bin/true"], "../escape")).toThrow(
+      /bare workspace filename/,
+    );
+    expect(() => withStdinFile(["/bin/true"], "/workspace/x")).toThrow(
+      /bare workspace filename/,
+    );
+    expect(() => withStdinFile(["/bin/true"], "a b")).toThrow(
+      /bare workspace filename/,
+    );
   });
 });
 
@@ -85,7 +148,16 @@ describe("runSandboxed", () => {
   test("refuses a relative guest binary before the VM boundary is touched", async () => {
     let called = false;
     await expect(
-      runSandboxed({ adapter: "t", def: sandboxDef(), workspaceDir: ws(), argv: ["pi"], timeoutMs: 1000, runSandbox: async () => { called = true; } }),
+      runSandboxed({
+        adapter: "t",
+        def: sandboxDef(),
+        workspaceDir: ws(),
+        argv: ["pi"],
+        timeoutMs: 1000,
+        runSandbox: async () => {
+          called = true;
+        },
+      }),
     ).rejects.toThrow(/absolute guest path/);
     expect(called).toBe(false);
   });
@@ -115,25 +187,49 @@ describe("runSandboxed", () => {
     expect(seen.workspaceDir).toBe(workspaceDir);
     expect(seen.timeoutMs).toBe(4321);
     expect(seen.env).toEqual({ PI_OFFLINE: "1" });
-    expect(seen.command).toEqual(["/bin/sh", "-c", 'exec "$0" "$@" < ./.prompt.md', "/usr/local/bin/pi", "-p"]);
+    expect(seen.command).toEqual([
+      "/bin/sh",
+      "-c",
+      'exec "$0" "$@" < ./.prompt.md',
+      "/usr/local/bin/pi",
+      "-p",
+    ]);
 
-    const console_ = readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8");
-    expect(console_).toContain("[sandbox] adapter=pi definition=sandboxed@1 provider=gondolin");
+    const console_ = readFileSync(
+      path.join(workspaceDir, SANDBOX_CONSOLE_FILE),
+      "utf8",
+    );
+    expect(console_).toContain(
+      "[sandbox] adapter=pi definition=sandboxed@1 provider=gondolin",
+    );
     expect(console_).toContain("guest said something on stderr");
     expect(console_).toContain("boot=77ms exit=0 timedOut=false");
-    const lifecycle = trace.find((t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console");
-    expect(lifecycle.payload).toMatchObject({ adapter: "pi", bootMs: 77, exitCode: 0, timedOut: false });
+    const lifecycle = trace.find(
+      (t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console",
+    );
+    expect(lifecycle.payload).toMatchObject({
+      adapter: "pi",
+      bootMs: 77,
+      exitCode: 0,
+      timedOut: false,
+    });
     expect(lifecycle.payload.text).toContain("guest said something on stderr");
   });
 
   test("a guest timeout is reported exactly like a host timeout: null exit, timedOut true", async () => {
     const workspaceDir = ws();
     const outcome = await runSandboxed({
-      adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/sleep", "999"], timeoutMs: 10,
+      adapter: "t",
+      def: sandboxDef(),
+      workspaceDir,
+      argv: ["/bin/sleep", "999"],
+      timeoutMs: 10,
       runSandbox: async () => ({ exitCode: null, timedOut: true, bootMs: 5 }),
     });
     expect(outcome).toEqual({ exitCode: null, timedOut: true, bootMs: 5 });
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("timedOut=true");
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8"),
+    ).toContain("timedOut=true");
   });
 
   test("a cooperative cancel resolves like a SIGTERMed host child, not as a runner crash", async () => {
@@ -143,15 +239,30 @@ describe("runSandboxed", () => {
     const ac = new AbortController();
     const workspaceDir = ws();
     const pending = runSandboxed({
-      adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/sleep", "999"], timeoutMs: 60_000, abortSignal: ac.signal,
-      runSandbox: ({ abortSignal }) => new Promise((_, reject) => {
-        abortSignal.addEventListener("abort", () => reject(new SandboxExecutionError("sandbox_runner_crashed", "runner exited (null) without reporting a guest exit code")));
-      }),
+      adapter: "t",
+      def: sandboxDef(),
+      workspaceDir,
+      argv: ["/bin/sleep", "999"],
+      timeoutMs: 60_000,
+      abortSignal: ac.signal,
+      runSandbox: ({ abortSignal }) =>
+        new Promise((_, reject) => {
+          abortSignal.addEventListener("abort", () =>
+            reject(
+              new SandboxExecutionError(
+                "sandbox_runner_crashed",
+                "runner exited (null) without reporting a guest exit code",
+              ),
+            ),
+          );
+        }),
     });
     setTimeout(() => ac.abort(), 5);
     const outcome = await pending;
     expect(outcome).toEqual({ exitCode: null, timedOut: false, bootMs: null });
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("cancelled=true");
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8"),
+    ).toContain("cancelled=true");
   });
 
   test("the same crash WITHOUT an abort is a failure, rethrown typed and written to the console", async () => {
@@ -159,13 +270,26 @@ describe("runSandboxed", () => {
     const trace = [];
     await expect(
       runSandboxed({
-        adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/true"], timeoutMs: 1000,
+        adapter: "t",
+        def: sandboxDef(),
+        workspaceDir,
+        argv: ["/bin/true"],
+        timeoutMs: 1000,
         onTrace: (kind, payload) => trace.push({ kind, payload }),
-        runSandbox: async () => { throw new SandboxExecutionError("sandbox_runner_crashed", "runner exited (1)"); },
+        runSandbox: async () => {
+          throw new SandboxExecutionError(
+            "sandbox_runner_crashed",
+            "runner exited (1)",
+          );
+        },
       }),
     ).rejects.toMatchObject({ code: "sandbox_runner_crashed" });
-    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("failed after");
-    expect(trace.find((t) => t.payload?.note === "sandbox_console").payload.error).toContain("sandbox_runner_crashed");
+    expect(
+      readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8"),
+    ).toContain("failed after");
+    expect(
+      trace.find((t) => t.payload?.note === "sandbox_console").payload.error,
+    ).toContain("sandbox_runner_crashed");
   });
 });
 
@@ -179,11 +303,24 @@ describe("runSandboxed", () => {
 describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
   const dir = import.meta.dir;
   const modules = readdirSync(dir)
-    .filter((f) => f.endsWith(".mjs") && !f.endsWith(".test.mjs") && f !== "sandboxed.mjs")
+    .filter(
+      (f) =>
+        f.endsWith(".mjs") && !f.endsWith(".test.mjs") && f !== "sandboxed.mjs",
+    )
     .map((f) => f.replace(/\.mjs$/, ""));
 
   test("the sweep sees the adapters the worker can load", () => {
-    expect(modules).toEqual(expect.arrayContaining(["actions", "agy", "claude", "command", "cursor", "fake", "pi"]));
+    expect(modules).toEqual(
+      expect.arrayContaining([
+        "actions",
+        "agy",
+        "claude",
+        "command",
+        "cursor",
+        "fake",
+        "pi",
+      ]),
+    );
   });
 
   for (const name of modules) {
@@ -198,7 +335,13 @@ describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
       let boundaryHit = false;
       const runSandbox = async ({ workspaceDir: dirSeen }) => {
         boundaryHit = true;
-        writeFileSync(path.join(dirSeen, "result.json"), JSON.stringify({ schemaVersion: "factory.agent-result/v1", terminalState: "completed" }));
+        writeFileSync(
+          path.join(dirSeen, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+          }),
+        );
         return { exitCode: 0, timedOut: false, bootMs: 1 };
       };
       const def = {
@@ -234,7 +377,9 @@ describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
         expect(caught.adapter).toBe(name);
         expect(caught.code).toBe("sandbox_unsupported");
         // Refusal happens before anything touches the workspace.
-        expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
+        expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(
+          false,
+        );
         expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(false);
       }
     });

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -276,5 +276,4 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       server.close();
     }
   });
-
 });

--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -13,7 +13,13 @@ import { repoNamesFromInput } from "./api-runs.mjs";
 
 /** The id that names an event's chain: its correlation id, else its own id. */
 export function chainKeyOf(event) {
-  return event?.correlationId ?? event?.correlation_id ?? event?.eventId ?? event?.event_id ?? null;
+  return (
+    event?.correlationId ??
+    event?.correlation_id ??
+    event?.eventId ??
+    event?.event_id ??
+    null
+  );
 }
 
 export function chainView(db, correlationId) {

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -34,7 +34,13 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     db.query(
       `INSERT INTO attempts (run_id, attempt, fencing_token, started_at, finished_at, terminal_state, reason_code)
        VALUES (?, 1, 1, ?, ?, ?, ?)`,
-    ).run(runId, at, state === "RUNNING" ? null : at, state === "RUNNING" ? null : state, null);
+    ).run(
+      runId,
+      at,
+      state === "RUNNING" ? null : at,
+      state === "RUNNING" ? null : state,
+      null,
+    );
     db.query(
       `INSERT INTO proposals (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds)
        VALUES (?, ?, ?, ?, 'run', 'approved', ?, 600)`,
@@ -46,13 +52,22 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     // `chain` is a reserved provenance at the public intake; derived events
     // enter through the emitter's admission path like the real chain does.
     const admit = (overrides) => {
-      if (overrides.source !== "chain") return s.client.replay(envelope(overrides));
+      if (overrides.source !== "chain")
+        return s.client.replay(envelope(overrides));
       const result = admitChainEvent(s.db, registry, envelope(overrides));
       expect(result.admitted).toBe(true);
       return result;
     };
-    await admit({ eventId: "origin-1", correlationId: "corr-1", occurredAt: t(0) });
-    await admit({ eventId: "elsewhere", correlationId: "corr-other", occurredAt: t(0) });
+    await admit({
+      eventId: "origin-1",
+      correlationId: "corr-1",
+      occurredAt: t(0),
+    });
+    await admit({
+      eventId: "elsewhere",
+      correlationId: "corr-other",
+      occurredAt: t(0),
+    });
     insertRun(s.db, "run-1", "work-scan@1", "COMPLETED", t(1), {
       eventSource: "test",
       eventId: "origin-1",
@@ -90,7 +105,9 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       eventId: "chain-run-2",
     });
     s.db
-      .query(`UPDATE events SET status = 'dead_lettered' WHERE event_id = 'chain-run-1-B'`)
+      .query(
+        `UPDATE events SET status = 'dead_lettered' WHERE event_id = 'chain-run-1-B'`,
+      )
       .run();
   });
   afterAll(() => s.close());
@@ -138,7 +155,11 @@ describe("GET /chain/:correlationId (WM-527)", () => {
 
   test("falls back to the origin's own eventId when it carried no correlation id", async () => {
     await s.client.replay(
-      envelope({ eventId: "bare-origin", correlationId: null, occurredAt: t(6) }),
+      envelope({
+        eventId: "bare-origin",
+        correlationId: null,
+        occurredAt: t(6),
+      }),
     );
     insertRun(s.db, "run-bare", "triage-scan@1", "COMPLETED", t(7), {
       eventSource: "test",
@@ -158,10 +179,17 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       ).admitted,
     ).toBe(true);
     const body = await (await fetch(s.url("/chain/bare-origin"))).json();
-    expect(body.events.map((e) => e.eventId).sort()).toEqual(["bare-origin", "chain-run-bare"]);
+    expect(body.events.map((e) => e.eventId).sort()).toEqual([
+      "bare-origin",
+      "chain-run-bare",
+    ]);
     expect(body.runs.map((r) => r.runId)).toEqual(["run-bare"]);
-    expect(chainKeyOf({ correlationId: null, eventId: "bare-origin" })).toBe("bare-origin");
-    expect(chainKeyOf({ correlationId: "corr-1", eventId: "x" })).toBe("corr-1");
+    expect(chainKeyOf({ correlationId: null, eventId: "bare-origin" })).toBe(
+      "bare-origin",
+    );
+    expect(chainKeyOf({ correlationId: "corr-1", eventId: "x" })).toBe(
+      "corr-1",
+    );
   });
 
   test("includes a causation parent run that lives outside the correlation, as a root", () => {
@@ -177,14 +205,18 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       expect(view.runs.map((r) => r.runId)).toEqual(["run-2", "run-3"]);
     } finally {
       s.db
-        .query(`UPDATE events SET correlation_id = 'corr-1' WHERE event_id = 'chain-run-2'`)
+        .query(
+          `UPDATE events SET correlation_id = 'corr-1' WHERE event_id = 'chain-run-2'`,
+        )
         .run();
     }
   });
 
   test("unknown correlation → 404; id is URL-decoded", async () => {
     expect((await fetch(s.url("/chain/nope"))).status).toBe(404);
-    expect((await fetch(s.url("/chain/" + encodeURIComponent("corr-1")))).status).toBe(200);
+    expect(
+      (await fetch(s.url("/chain/" + encodeURIComponent("corr-1")))).status,
+    ).toBe(200);
     expect((await fetch(s.url("/chain/"))).status).not.toBe(200);
   });
 });

--- a/event-runtime/lib/api-http.mjs
+++ b/event-runtime/lib/api-http.mjs
@@ -27,9 +27,7 @@ export function send(res, status, body) {
   const req = res.req;
   const pathname = req?.url?.split("?", 1)[0];
   const etagEligible =
-    req?.method === "GET" &&
-    status === 200 &&
-    COLLECTION_PATHS.has(pathname);
+    req?.method === "GET" && status === 200 && COLLECTION_PATHS.has(pathname);
   if (etagEligible) {
     const etag = `"${createHash("sha256").update(json).digest("hex")}"`;
     const ifNoneMatch = req.headers["if-none-match"];

--- a/event-runtime/lib/api-http.test.mjs
+++ b/event-runtime/lib/api-http.test.mjs
@@ -66,8 +66,15 @@ describe("Host and Origin header security confinement (OPS-408)", () => {
             let json = null;
             try {
               json = JSON.parse(text);
-            } catch { /* intentionally ignored */ }
-            resolve({ status: res.statusCode, headers: res.headers, json, text });
+            } catch {
+              /* intentionally ignored */
+            }
+            resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              json,
+              text,
+            });
           });
         },
       );

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -15,26 +15,48 @@ function repoForGitHubSlug(repos, slug) {
   return null;
 }
 
-function successfulPullRequestWorkflow({ event, deliveryId, payload, repos, nowMs }) {
+function successfulPullRequestWorkflow({
+  event,
+  deliveryId,
+  payload,
+  repos,
+  nowMs,
+}) {
   const run = payload?.workflow_run;
-  if (event !== "workflow_run" || payload?.action !== "completed" || run?.conclusion !== "success") return null;
+  if (
+    event !== "workflow_run" ||
+    payload?.action !== "completed" ||
+    run?.conclusion !== "success"
+  )
+    return null;
   if (!deliveryId || typeof deliveryId !== "string") {
     return { ok: false, ignored: false, reason: "missing_delivery_id" };
   }
 
   const repo = repoForGitHubSlug(repos, payload.repository?.full_name);
   if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
-  if (repo.reportOnly) return { ok: false, ignored: true, reason: "repo_report_only" };
-  if (run.event !== "pull_request") return { ok: false, ignored: true, reason: "not_pull_request_head" };
+  if (repo.reportOnly)
+    return { ok: false, ignored: true, reason: "repo_report_only" };
+  if (run.event !== "pull_request")
+    return { ok: false, ignored: true, reason: "not_pull_request_head" };
 
-  const pullRequests = Array.isArray(run.pull_requests) ? run.pull_requests : [];
+  const pullRequests = Array.isArray(run.pull_requests)
+    ? run.pull_requests
+    : [];
   const selected = pullRequests.filter((pr) => pr?.base?.ref === repo.base);
-  if (selected.length === 0) return { ok: false, ignored: true, reason: "not_base_branch" };
-  if (selected.length !== 1) return { ok: false, ignored: false, reason: "ambiguous_pull_request_head" };
+  if (selected.length === 0)
+    return { ok: false, ignored: true, reason: "not_base_branch" };
+  if (selected.length !== 1)
+    return { ok: false, ignored: false, reason: "ambiguous_pull_request_head" };
 
   const prNumber = selected[0]?.number;
   const headSha = run.head_sha;
-  if (!Number.isInteger(prNumber) || prNumber < 1 || typeof headSha !== "string" || headSha.trim() === "") {
+  if (
+    !Number.isInteger(prNumber) ||
+    prNumber < 1 ||
+    typeof headSha !== "string" ||
+    headSha.trim() === ""
+  ) {
     return { ok: false, ignored: false, reason: "malformed_payload" };
   }
   const eventId = `merge-pr:${repo.name}:${prNumber}:${headSha}`;

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -284,15 +284,19 @@ describe("GitHub workflow_run merge trigger (WM-576)", () => {
       });
 
       const event = s.db
-        .query(`SELECT type,correlation_id,envelope_json FROM events WHERE source = 'github'`)
+        .query(
+          `SELECT type,correlation_id,envelope_json FROM events WHERE source = 'github'`,
+        )
         .get();
       expect(event.type).toBe("factory.merge.requested");
       expect(event.correlation_id).toBe(`merge-pr:factory:576:${headSha}`);
-      expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "factory", prNumbers: [576] });
-      expect(registry.eventTypes["factory.merge.requested"].idempotencyScope).toEqual([
-        "correlationId",
-        "inputHash",
-      ]);
+      expect(JSON.parse(event.envelope_json).payload).toEqual({
+        repo: "factory",
+        prNumbers: [576],
+      });
+      expect(
+        registry.eventTypes["factory.merge.requested"].idempotencyScope,
+      ).toEqual(["correlationId", "inputHash"]);
     } finally {
       s.close();
     }
@@ -301,14 +305,20 @@ describe("GitHub workflow_run merge trigger (WM-576)", () => {
   test("failed workflow runs retain the ci-log-capture event mapping", async () => {
     const s = await makeServer();
     try {
-      const response = await postWorkflow(s, {
-        action: "completed",
-        workflow_run: { id: 57602, conclusion: "failure" },
-        repository: { full_name: "watt-mind/factory" },
-      }, "delivery-failed-1");
+      const response = await postWorkflow(
+        s,
+        {
+          action: "completed",
+          workflow_run: { id: 57602, conclusion: "failure" },
+          repository: { full_name: "watt-mind/factory" },
+        },
+        "delivery-failed-1",
+      );
       expect(response.status).toBe(200);
       expect((await response.json()).admitted).toBe(true);
-      const event = s.db.query(`SELECT type,envelope_json FROM events WHERE source = 'github'`).get();
+      const event = s.db
+        .query(`SELECT type,envelope_json FROM events WHERE source = 'github'`)
+        .get();
       expect(event.type).toBe("github.workflow-run.failed");
       expect(JSON.parse(event.envelope_json).payload).toEqual({
         repo: "watt-mind/factory",

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -31,7 +31,6 @@ function extensionRefusal(send, status, code, detail = {}) {
   });
 }
 
-
 /** Optional repository names named by a run/event input (OPS-356). */
 export function repoNamesFromInput(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) return [];
@@ -130,7 +129,8 @@ const TICKET_ID = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
 
 function objectNamesTicket(value, ticket) {
   if (!value || typeof value !== "object") return false;
-  if (Array.isArray(value)) return value.some((entry) => objectNamesTicket(entry, ticket));
+  if (Array.isArray(value))
+    return value.some((entry) => objectNamesTicket(entry, ticket));
   for (const [key, entry] of Object.entries(value)) {
     if (
       /^(ticket|ticketId|issue|issueId|linearId)$/i.test(key) &&
@@ -161,7 +161,9 @@ function collectPrRefs(value, refs = { numbers: new Set(), urls: new Set() }) {
   }
   for (const [key, entry] of Object.entries(value)) {
     if (typeof entry === "string") {
-      const match = entry.match(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/);
+      const match = entry.match(
+        /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/,
+      );
       if (match) {
         refs.urls.add(entry);
         refs.numbers.add(Number(match[1]));
@@ -187,7 +189,8 @@ function namedString(values, names) {
   for (const value of values) {
     if (!value || typeof value !== "object" || Array.isArray(value)) continue;
     for (const name of names) {
-      if (typeof value[name] === "string" && value[name].trim()) return value[name].trim();
+      if (typeof value[name] === "string" && value[name].trim())
+        return value[name].trim();
     }
   }
   return null;
@@ -201,12 +204,20 @@ function namedString(values, names) {
  * event/proposal/run ids and PR references emitted by dispatch/merge results.
  */
 export function ticketJourneyView(db, rawTicket, options = {}) {
-  const ticket = String(rawTicket ?? "").trim().toUpperCase();
+  const ticket = String(rawTicket ?? "")
+    .trim()
+    .toUpperCase();
   if (!TICKET_ID.test(ticket)) return null;
 
-  const eventRows = db.query(`SELECT * FROM events ORDER BY admitted_at, rowid`).all();
-  const proposalRows = db.query(`SELECT * FROM proposals ORDER BY created_at, rowid`).all();
-  const runRows = db.query(`SELECT * FROM runs ORDER BY created_at, rowid`).all();
+  const eventRows = db
+    .query(`SELECT * FROM events ORDER BY admitted_at, rowid`)
+    .all();
+  const proposalRows = db
+    .query(`SELECT * FROM proposals ORDER BY created_at, rowid`)
+    .all();
+  const runRows = db
+    .query(`SELECT * FROM runs ORDER BY created_at, rowid`)
+    .all();
   const resultRows = db.query(`SELECT * FROM results ORDER BY rowid`).all();
   const resultByRun = new Map();
   for (const row of resultRows) {
@@ -252,22 +263,35 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
         events.has(eventKey) ||
         (row.run_id && runs.has(row.run_id))
       ) {
-        if (!proposals.has(row.id)) { proposals.add(row.id); changed = true; }
-        if (!events.has(eventKey)) { events.add(eventKey); changed = true; }
-        if (row.run_id && !runs.has(row.run_id)) { runs.add(row.run_id); changed = true; }
+        if (!proposals.has(row.id)) {
+          proposals.add(row.id);
+          changed = true;
+        }
+        if (!events.has(eventKey)) {
+          events.add(eventKey);
+          changed = true;
+        }
+        if (row.run_id && !runs.has(row.run_id)) {
+          runs.add(row.run_id);
+          changed = true;
+        }
       }
     }
   }
 
   const prRefs = { numbers: new Set(), urls: new Set() };
   for (const runId of runs) {
-    for (const result of resultByRun.get(runId) ?? []) collectPrRefs(result, prRefs);
+    for (const result of resultByRun.get(runId) ?? [])
+      collectPrRefs(result, prRefs);
   }
   if (prRefs.numbers.size || prRefs.urls.size) {
     for (const row of runRows) {
       const spec = parseObject(row.spec_json);
       const results = resultByRun.get(row.run_id) ?? [];
-      if (hasPrRef(spec.input, prRefs) || results.some((result) => hasPrRef(result, prRefs)))
+      if (
+        hasPrRef(spec.input, prRefs) ||
+        results.some((result) => hasPrRef(result, prRefs))
+      )
         runs.add(row.run_id);
     }
     for (const row of eventRows) {
@@ -279,7 +303,9 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
   const matchedEvents = eventsView(db).filter((event) =>
     events.has(`${event.source}\0${event.eventId}`),
   );
-  const matchedProposals = proposalHistory(db).filter((proposal) => proposals.has(proposal.id));
+  const matchedProposals = proposalHistory(db).filter((proposal) =>
+    proposals.has(proposal.id),
+  );
   const matchedRuns = [...runs]
     .map((runId) => runView(db, runId, options))
     .filter(Boolean)
@@ -291,9 +317,21 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     ...matchedRuns.map((run) => run.run.spec?.input),
     ...matchedRuns.map((run) => run.result?.artifact),
   ];
-  const title = namedString(metadata, ["ticketTitle", "linearTitle", "issueTitle"]);
-  const recordedState = namedString(metadata, ["ticketState", "linearState", "issueState"]);
-  const createdAt = namedString(metadata, ["ticketCreatedAt", "linearCreatedAt", "issueCreatedAt"]);
+  const title = namedString(metadata, [
+    "ticketTitle",
+    "linearTitle",
+    "issueTitle",
+  ]);
+  const recordedState = namedString(metadata, [
+    "ticketState",
+    "linearState",
+    "issueState",
+  ]);
+  const createdAt = namedString(metadata, [
+    "ticketCreatedAt",
+    "linearCreatedAt",
+    "issueCreatedAt",
+  ]);
   const active = matchedRuns.find((run) =>
     ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(run.run.state),
   );
@@ -318,7 +356,10 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       createdAt,
       url: `https://linear.app/watt-mind/issue/${encodeURIComponent(ticket)}`,
     },
-    activity: matchedEvents.length > 0 || matchedProposals.length > 0 || matchedRuns.length > 0,
+    activity:
+      matchedEvents.length > 0 ||
+      matchedProposals.length > 0 ||
+      matchedRuns.length > 0,
     events: matchedEvents,
     proposals: matchedProposals,
     runs: matchedRuns,
@@ -361,12 +402,20 @@ function runsView(db, state) {
       leaseExpiresAt: row.lease_expires_at ?? null,
       // Two extra queries per row: only worth it while the deadline can
       // still move (WM-692). Terminal rows on this 2s-polled list get null.
-      deadlineAt: row.attempts > 0 && IN_FLIGHT_STATES.has(row.state)
-        ? (() => {
-            const deadline = attemptDeadline(db, row.run_id, row.attempts, spec);
-            return Number.isFinite(deadline) ? new Date(deadline).toISOString() : null;
-          })()
-        : null,
+      deadlineAt:
+        row.attempts > 0 && IN_FLIGHT_STATES.has(row.state)
+          ? (() => {
+              const deadline = attemptDeadline(
+                db,
+                row.run_id,
+                row.attempts,
+                spec,
+              );
+              return Number.isFinite(deadline)
+                ? new Date(deadline).toISOString()
+                : null;
+            })()
+          : null,
       timeoutSeconds: spec.timeoutSeconds,
       repos: repoNamesFromInput(spec.input),
     };
@@ -483,7 +532,9 @@ function runView(db, runId, { artifactsDir } = {}) {
     result,
     receipt: resultRow ? JSON.parse(resultRow.receipt_json) : null,
     workspace: latest?.workspace_path ?? null,
-    deadlineAt: Number.isFinite(deadline) ? new Date(deadline).toISOString() : null,
+    deadlineAt: Number.isFinite(deadline)
+      ? new Date(deadline).toISOString()
+      : null,
     observedModel:
       artifactsDir && transcript?.sha256
         ? observedModelFromTranscript(
@@ -656,12 +707,14 @@ export async function handleRunApiRoute({
       });
     }
 
-    const row = db.query(
-      `SELECT r.state, r.attempts, a.started_at
+    const row = db
+      .query(
+        `SELECT r.state, r.attempts, a.started_at
          FROM runs r
          LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
         WHERE r.run_id = ?`,
-    ).get(runId);
+      )
+      .get(runId);
     if (!row) return extensionRefusal(send, 404, "unknown_run", { runId });
 
     const override = body.override === true;
@@ -670,9 +723,10 @@ export async function handleRunApiRoute({
       return extensionRefusal(send, 409, "run_limit_policy_unavailable");
     }
     const startedMs = Date.parse(row.started_at ?? "");
-    const maxDeadlineMs = Number.isFinite(startedMs) && Number.isFinite(maxMinutes)
-      ? startedMs + maxMinutes * 60 * 1000
-      : null;
+    const maxDeadlineMs =
+      Number.isFinite(startedMs) && Number.isFinite(maxMinutes)
+        ? startedMs + maxMinutes * 60 * 1000
+        : null;
     const outcome = extendRunDeadline(db, runId, {
       seconds,
       actor,

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -53,7 +53,11 @@ describe("run deadline extension (WM-566)", () => {
   }
   const policyRoot = policyRootWith(MAX_RUN_MINUTES);
 
-  function insertAttempt(db, runId, { state = "RUNNING", timeoutSeconds = 60, adapter = "fake" } = {}) {
+  function insertAttempt(
+    db,
+    runId,
+    { state = "RUNNING", timeoutSeconds = 60, adapter = "fake" } = {},
+  ) {
     const spec = {
       schemaVersion: "factory.run-spec/v1",
       runId,
@@ -69,7 +73,14 @@ describe("run deadline extension (WM-566)", () => {
     db.query(
       `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
        VALUES (?, ?, ?, 'sha256:test', ?, 1, ?, ?)`,
-    ).run(runId, spec.idempotencyKey, JSON.stringify(spec), state, new Date(start).toISOString(), new Date(start).toISOString());
+    ).run(
+      runId,
+      spec.idempotencyKey,
+      JSON.stringify(spec),
+      state,
+      new Date(start).toISOString(),
+      new Date(start).toISOString(),
+    );
     db.query(
       `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, started_at, lease_expires_at)
        VALUES (?, 1, 1, 'worker-test', ?, ?)`,
@@ -93,9 +104,11 @@ describe("run deadline extension (WM-566)", () => {
         leaseExpiresAt: new Date(start + 1_080_000).toISOString(),
         override: false,
       });
-      const lifecycle = s.db.query(
-        `SELECT from_state, to_state, actor, reason FROM lifecycle_events WHERE run_id = ?`,
-      ).get("run-extend-happy");
+      const lifecycle = s.db
+        .query(
+          `SELECT from_state, to_state, actor, reason FROM lifecycle_events WHERE run_id = ?`,
+        )
+        .get("run-extend-happy");
       expect(lifecycle.from_state).toBe("RUNNING");
       expect(lifecycle.to_state).toBe("RUNNING");
       expect(lifecycle.actor).toBe("operator");
@@ -105,7 +118,9 @@ describe("run deadline extension (WM-566)", () => {
         seconds: 900,
         type: "deadline_extended",
       });
-      expect((await s.client.run("run-extend-happy")).deadlineAt).toBe(outcome.deadlineAt);
+      expect((await s.client.run("run-extend-happy")).deadlineAt).toBe(
+        outcome.deadlineAt,
+      );
     } finally {
       s.close();
     }
@@ -115,12 +130,19 @@ describe("run deadline extension (WM-566)", () => {
     const s = await makeServer({ now: () => start, policyRoot });
     try {
       insertAttempt(s.db, "run-extend-queued", { state: "QUEUED" });
-      const wrongState = await rejection(s.client.extend("run-extend-queued", 60));
+      const wrongState = await rejection(
+        s.client.extend("run-extend-queued", 60),
+      );
       expect(wrongState.status).toBe(409);
-      expect(wrongState.body.refusal).toMatchObject({ code: "run_not_extendable", retryable: false });
+      expect(wrongState.body.refusal).toMatchObject({
+        code: "run_not_extendable",
+        retryable: false,
+      });
 
       // Ten seconds short of the cap: a 20s extension crosses started_at + max_run_minutes.
-      insertAttempt(s.db, "run-extend-cap", { timeoutSeconds: MAX_RUN_MINUTES * 60 - 10 });
+      insertAttempt(s.db, "run-extend-cap", {
+        timeoutSeconds: MAX_RUN_MINUTES * 60 - 10,
+      });
       const capped = await rejection(s.client.extend("run-extend-cap", 20));
       expect(capped.status).toBe(409);
       expect(capped.body.refusal).toMatchObject({
@@ -128,10 +150,15 @@ describe("run deadline extension (WM-566)", () => {
         retryable: false,
         maxDeadlineAt: new Date(start + MAX_RUN_MINUTES * 60_000).toISOString(),
       });
-      expect((await s.client.extend("run-extend-cap", 20, { override: true })).override).toBe(true);
+      expect(
+        (await s.client.extend("run-extend-cap", 20, { override: true }))
+          .override,
+      ).toBe(true);
 
       insertAttempt(s.db, "run-extend-actions", { adapter: "actions" });
-      const actions = await rejection(s.client.extend("run-extend-actions", 60));
+      const actions = await rejection(
+        s.client.extend("run-extend-actions", 60),
+      );
       expect(actions.status).toBe(409);
       expect(actions.body.refusal).toMatchObject({
         code: "adapter_deadline_not_extendable",
@@ -141,24 +168,37 @@ describe("run deadline extension (WM-566)", () => {
 
       const bounded = await rejection(s.client.extend("run-extend-cap", 3_601));
       expect(bounded.status).toBe(422);
-      expect(bounded.body.refusal).toEqual(expect.objectContaining({
-        code: "extension_too_large",
-        retryable: false,
-        maxSeconds: 3_600,
-      }));
+      expect(bounded.body.refusal).toEqual(
+        expect.objectContaining({
+          code: "extension_too_large",
+          retryable: false,
+          maxSeconds: 3_600,
+        }),
+      );
     } finally {
       s.close();
     }
   });
 
   test("without a readable max_run_minutes only override may extend", async () => {
-    const s = await makeServer({ now: () => start, policyRoot: policyRootWith(null) });
+    const s = await makeServer({
+      now: () => start,
+      policyRoot: policyRootWith(null),
+    });
     try {
       insertAttempt(s.db, "run-extend-nopolicy");
-      const refused = await rejection(s.client.extend("run-extend-nopolicy", 60));
+      const refused = await rejection(
+        s.client.extend("run-extend-nopolicy", 60),
+      );
       expect(refused.status).toBe(409);
-      expect(refused.body.refusal).toMatchObject({ code: "run_limit_policy_unavailable", retryable: false });
-      expect((await s.client.extend("run-extend-nopolicy", 60, { override: true })).extended).toBe(true);
+      expect(refused.body.refusal).toMatchObject({
+        code: "run_limit_policy_unavailable",
+        retryable: false,
+      });
+      expect(
+        (await s.client.extend("run-extend-nopolicy", 60, { override: true }))
+          .extended,
+      ).toBe(true);
     } finally {
       s.close();
     }
@@ -194,7 +234,15 @@ describe("run list deadlines (WM-692)", () => {
   test("GET /runs computes deadlineAt only for in-flight rows", async () => {
     const s = await makeServer({ now: () => start });
     try {
-      for (const state of ["LEASED", "RUNNING", "VERIFYING", "COMPLETED", "FAILED", "TIMED_OUT", "CANCELLED"]) {
+      for (const state of [
+        "LEASED",
+        "RUNNING",
+        "VERIFYING",
+        "COMPLETED",
+        "FAILED",
+        "TIMED_OUT",
+        "CANCELLED",
+      ]) {
         insertRun(s.db, `run-list-${state}`, state);
       }
       const { runs } = await s.client.runs();
@@ -297,57 +345,68 @@ describe("ticket journey join (WM-595)", () => {
           maxAttempts: 1,
           idempotencyKey: "ignored",
         });
-      s.db.query(
-        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
-      ).run(
-        "run_ticket",
-        "ticket-key",
-        spec({ repo: "factory", ticket: "WM-595" }),
-        "sha256:ticket",
-        "COMPLETED",
-        "2026-01-01T10:00:00.000Z",
-        "2026-01-01T10:10:00.000Z",
-      );
-      s.db.query(
-        `INSERT INTO results
+        )
+        .run(
+          "run_ticket",
+          "ticket-key",
+          spec({ repo: "factory", ticket: "WM-595" }),
+          "sha256:ticket",
+          "COMPLETED",
+          "2026-01-01T10:00:00.000Z",
+          "2026-01-01T10:10:00.000Z",
+        );
+      s.db
+        .query(
+          `INSERT INTO results
            (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
          VALUES (?, 1, ?, ?, '{}', '{}', ?)`,
-      ).run(
-        "run_ticket",
-        JSON.stringify({
-          terminalState: "completed",
-          artifact: {
-            outcome: "PR_OPEN",
-            ticket: "WM-595",
-            prUrl: "https://github.com/watt-mind/factory/pull/595",
-          },
-        }),
-        "sha256:result-ticket",
-        "2026-01-01T10:10:00.000Z",
-      );
-      s.db.query(
-        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+        )
+        .run(
+          "run_ticket",
+          JSON.stringify({
+            terminalState: "completed",
+            artifact: {
+              outcome: "PR_OPEN",
+              ticket: "WM-595",
+              prUrl: "https://github.com/watt-mind/factory/pull/595",
+            },
+          }),
+          "sha256:result-ticket",
+          "2026-01-01T10:10:00.000Z",
+        );
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
-      ).run(
-        "run_merge",
-        "merge-key",
-        spec({ repo: "factory", pr: 595 }, "merge-apply@1"),
-        "sha256:merge",
-        "COMPLETED",
-        "2026-01-01T11:00:00.000Z",
-        "2026-01-01T11:01:00.000Z",
-      );
-      s.db.query(
-        `INSERT INTO results
+        )
+        .run(
+          "run_merge",
+          "merge-key",
+          spec({ repo: "factory", pr: 595 }, "merge-apply@1"),
+          "sha256:merge",
+          "COMPLETED",
+          "2026-01-01T11:00:00.000Z",
+          "2026-01-01T11:01:00.000Z",
+        );
+      s.db
+        .query(
+          `INSERT INTO results
            (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
          VALUES (?, 1, ?, ?, '{}', '{}', ?)`,
-      ).run(
-        "run_merge",
-        JSON.stringify({ terminalState: "completed", artifact: { pr: 595, outcome: "MERGED" } }),
-        "sha256:result-merge",
-        "2026-01-01T11:01:00.000Z",
-      );
+        )
+        .run(
+          "run_merge",
+          JSON.stringify({
+            terminalState: "completed",
+            artifact: { pr: 595, outcome: "MERGED" },
+          }),
+          "sha256:result-merge",
+          "2026-01-01T11:01:00.000Z",
+        );
 
       const response = await fetch(s.url("/runs?ticket=WM-595"));
       expect(response.status).toBe(200);
@@ -359,8 +418,13 @@ describe("ticket journey join (WM-595)", () => {
         createdAt: "2026-01-01T09:00:00.000Z",
         url: "https://linear.app/watt-mind/issue/WM-595",
       });
-      expect(journey.events.map((event) => event.eventId)).toContain("ticket-dispatch");
-      expect(journey.runs.map((run) => run.run.runId)).toEqual(["run_ticket", "run_merge"]);
+      expect(journey.events.map((event) => event.eventId)).toContain(
+        "ticket-dispatch",
+      );
+      expect(journey.runs.map((run) => run.run.runId)).toEqual([
+        "run_ticket",
+        "run_merge",
+      ]);
       expect(journey.activity).toBe(true);
 
       const unknown = await fetch(s.url("/runs?ticket=WM-999"));
@@ -918,5 +982,4 @@ describe("run trace surfacing (OPS-295)", () => {
       server.close();
     }
   });
-
 });

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -205,7 +205,8 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
 
       // Top-level StatusView keys match (inbox declared on the web type since WM-286).
       const statusViewBlock = extractInterfaceBlock(typesSrc, "StatusView");
-      const expectedStatusKeys = extractDirectProperties(statusViewBlock).sort();
+      const expectedStatusKeys =
+        extractDirectProperties(statusViewBlock).sort();
       expect(Object.keys(status).sort()).toEqual(expectedStatusKeys);
       expect(status.inbox).toEqual({ open: 0, acked: 0, byKind: {} });
 

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -41,11 +41,7 @@ import {
   webhookSecret,
 } from "./config.mjs";
 import { githubWebhookSecret } from "./intake.mjs";
-import {
-  decideInboxItem,
-  getInboxItem,
-  retryInboxDecision,
-} from "./inbox.mjs";
+import { decideInboxItem, getInboxItem, retryInboxDecision } from "./inbox.mjs";
 import { applyDecisionEffect } from "./decision-effects.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { notifyCommand, sendNotification } from "./notify.mjs";
@@ -156,9 +152,7 @@ export function createApi({
         const detailMatch = url.pathname.match(/^\/inbox\/([^/]+)$/);
         if (req.method === "GET" && detailMatch) {
           const item = getInboxItem(db, decodeURIComponent(detailMatch[1]));
-          return item
-            ? send(200, { item })
-            : send(404, { error: "not_found" });
+          return item ? send(200, { item }) : send(404, { error: "not_found" });
         }
 
         const decisionMatch = url.pathname.match(
@@ -172,7 +166,11 @@ export function createApi({
               const raw = await readBody(req);
               if (raw.length > 0) {
                 const parsed = parseJson(raw);
-                if (parsed.error) return send(400, { error: "invalid_json", message: parsed.error });
+                if (parsed.error)
+                  return send(400, {
+                    error: "invalid_json",
+                    message: parsed.error,
+                  });
               }
               result = retryInboxDecision(db, id, {
                 now: nowMs,
@@ -180,7 +178,11 @@ export function createApi({
               });
             } else {
               const parsed = parseJson(await readBody(req));
-              if (parsed.error) return send(400, { error: "invalid_json", message: parsed.error });
+              if (parsed.error)
+                return send(400, {
+                  error: "invalid_json",
+                  message: parsed.error,
+                });
               result = decideInboxItem(db, id, parsed.value, {
                 now: nowMs,
                 decidedBy: actor,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -50,11 +50,15 @@ describe("inbox decision API (WM-390)", () => {
   test("detail, decide, conflicts, and retry use typed statuses", async () => {
     const s = await makeServer({ now: () => 1000 });
     try {
-      createInboxItem(s.db, {
-        kind: "BLOCKED",
-        title: "decision",
-        decision: request,
-      }, { id: "api_decision" });
+      createInboxItem(
+        s.db,
+        {
+          kind: "BLOCKED",
+          title: "decision",
+          decision: request,
+        },
+        { id: "api_decision" },
+      );
 
       const detail = await fetch(s.url("/inbox/api_decision"));
       expect(detail.status).toBe(200);
@@ -113,15 +117,23 @@ describe("inbox decision API (WM-390)", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          requestHash: decisionRequestHash(request), optionId: "dismiss", fields: {},
+          requestHash: decisionRequestHash(request),
+          optionId: "dismiss",
+          fields: {},
         }),
       });
       expect(again.status).toBe(409);
       expect((await again.json()).error).toBe("already_decided");
 
-      const undecided = createInboxItem(s.db, {
-        kind: "BLOCKED", title: "not answered", decision: request,
-      }, { id: "not_decided" });
+      const undecided = createInboxItem(
+        s.db,
+        {
+          kind: "BLOCKED",
+          title: "not answered",
+          decision: request,
+        },
+        { id: "not_decided" },
+      );
       const retry = await fetch(s.url(`/inbox/${undecided.id}/decide/retry`), {
         method: "POST",
       });
@@ -146,7 +158,10 @@ describe("schedule trigger metadata (WM-259)", () => {
         },
       },
     };
-    const s = await makeServer({ registry: scheduleRegistry, now: () => nowMs });
+    const s = await makeServer({
+      registry: scheduleRegistry,
+      now: () => nowMs,
+    });
     try {
       emitDueTicks(s.db, scheduleRegistry, {
         now: Date.parse("2026-08-17T11:00:00.000Z"),
@@ -168,11 +183,15 @@ describe("schedule trigger metadata (WM-259)", () => {
       }
 
       const operatorEvents = s.db
-        .query(`SELECT envelope_json FROM events WHERE source = 'operator' ORDER BY event_id`)
+        .query(
+          `SELECT envelope_json FROM events WHERE source = 'operator' ORDER BY event_id`,
+        )
         .all()
         .map((row) => JSON.parse(row.envelope_json));
       expect(operatorEvents).toHaveLength(2);
-      expect(operatorEvents.every((event) => event.payload.repo === "factory")).toBe(true);
+      expect(
+        operatorEvents.every((event) => event.payload.repo === "factory"),
+      ).toBe(true);
 
       const schedules = await (await fetch(s.url("/schedules"))).json();
       expect(schedules.schedules[0]).toMatchObject({
@@ -206,11 +225,18 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
       expect(bare.outputView).toBeNull();
       expect(bare.outputViewFile).toBeNull();
       // Not part of the pinned identity.
-      expect(Object.keys(merge.pins)).not.toContain("agents/merge-scan.view.json");
+      expect(Object.keys(merge.pins)).not.toContain(
+        "agents/merge-scan.view.json",
+      );
       // web/src/types.ts AgentDef names both fields (kept in step by hand;
       // AgentDef is not pinned by the OPS-284 parity test).
-      const typesSrc = readFileSync(path.resolve(import.meta.dir, "../web/src/types.ts"), "utf8");
-      const agentDef = typesSrc.slice(typesSrc.indexOf("export interface AgentDef {"));
+      const typesSrc = readFileSync(
+        path.resolve(import.meta.dir, "../web/src/types.ts"),
+        "utf8",
+      );
+      const agentDef = typesSrc.slice(
+        typesSrc.indexOf("export interface AgentDef {"),
+      );
       expect(agentDef).toContain("outputViewFile?");
       expect(agentDef).toContain("outputView?");
     } finally {
@@ -221,9 +247,14 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
   test("a drifted view is served as null and named in /status.anomalies.configuration", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-view-"));
     for (const dir of ["agents", "schemas"]) {
-      cpSync(path.join(registry.root, dir), path.join(root, dir), { recursive: true });
+      cpSync(path.join(registry.root, dir), path.join(root, dir), {
+        recursive: true,
+      });
     }
-    cpSync(path.join(registry.root, "event-types.json"), path.join(root, "event-types.json"));
+    cpSync(
+      path.join(registry.root, "event-types.json"),
+      path.join(root, "event-types.json"),
+    );
     const viewFile = path.join(root, "agents", "triage-scan.view.json");
     const view = JSON.parse(readFileSync(viewFile, "utf8"));
     view.summary = "/tldr";
@@ -237,7 +268,9 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
       expect(triage.outputView).toBeNull();
       expect(triage.outputViewFile).toBe("agents/triage-scan.view.json");
       const status = await client.status();
-      const anomaly = status.anomalies.configuration.find((a) => a.includes("triage-scan@1"));
+      const anomaly = status.anomalies.configuration.find((a) =>
+        a.includes("triage-scan@1"),
+      );
       expect(anomaly).toContain("agents/triage-scan.view.json");
       expect(anomaly).toMatch(/"\/tldr" does not resolve/);
     } finally {

--- a/event-runtime/lib/artifact-inputs.test.mjs
+++ b/event-runtime/lib/artifact-inputs.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -47,22 +53,39 @@ describe("materializeArtifact (OPS-372)", () => {
   test("writes the stored bytes into the workspace under the declared name", () => {
     const { storeRoot, hash } = store("first line\nsecond line\n");
     const workspaceDir = tmp("evrt-ws-");
-    const out = materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "failed.log" });
+    const out = materializeArtifact({
+      storeRoot,
+      sha256hex: hash,
+      workspaceDir,
+      as: "failed.log",
+    });
     expect(out.sha256).toBe(hash);
-    expect(readFileSync(path.join(workspaceDir, "failed.log"), "utf8")).toBe("first line\nsecond line\n");
+    expect(readFileSync(path.join(workspaceDir, "failed.log"), "utf8")).toBe(
+      "first line\nsecond line\n",
+    );
   });
 
   test("a hash that is not in the store fails closed", () => {
     const { storeRoot } = store("x");
     expect(() =>
-      materializeArtifact({ storeRoot, sha256hex: "a".repeat(64), workspaceDir: tmp("evrt-ws-"), as: "x.log" }),
+      materializeArtifact({
+        storeRoot,
+        sha256hex: "a".repeat(64),
+        workspaceDir: tmp("evrt-ws-"),
+        as: "x.log",
+      }),
     ).toThrow(/not in the store/);
   });
 
   test("a malformed hash is rejected before touching the filesystem", () => {
     const { storeRoot } = store("x");
     expect(() =>
-      materializeArtifact({ storeRoot, sha256hex: "../../etc/passwd", workspaceDir: tmp("evrt-ws-"), as: "x" }),
+      materializeArtifact({
+        storeRoot,
+        sha256hex: "../../etc/passwd",
+        workspaceDir: tmp("evrt-ws-"),
+        as: "x",
+      }),
     ).toThrow();
   });
 
@@ -70,7 +93,9 @@ describe("materializeArtifact (OPS-372)", () => {
     const { storeRoot, hash } = store("x");
     const workspaceDir = tmp("evrt-ws-");
     for (const as of ["../escaped.log", "/etc/passwd", ""]) {
-      expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as })).toThrow();
+      expect(() =>
+        materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as }),
+      ).toThrow();
     }
   });
 });
@@ -84,7 +109,9 @@ describe("resolveInputRef", () => {
   });
 
   test("a ref that resolves to nothing fails loudly", () => {
-    expect(() => resolveInputRef({}, "$.input.missing")).toThrow(/resolves to nothing/);
+    expect(() => resolveInputRef({}, "$.input.missing")).toThrow(
+      /resolves to nothing/,
+    );
   });
 });
 
@@ -96,13 +123,22 @@ describe("artifacts workspace provider (OPS-372)", () => {
       runId: "run_1",
       attempt: 1,
       input: { logArtifact: hash },
-      workspace: { type: "artifacts", inputs: [{ from: "$.input.logArtifact", as: "failed.log" }] },
+      workspace: {
+        type: "artifacts",
+        inputs: [{ from: "$.input.logArtifact", as: "failed.log" }],
+      },
       artifactStore: storeRoot,
     });
-    expect(created.materialized).toEqual([{ as: "failed.log", sha256: hash, sizeBytes: 13 }]);
-    expect(readFileSync(path.join(created.dir, "failed.log"), "utf8")).toBe("ci log bytes\n");
+    expect(created.materialized).toEqual([
+      { as: "failed.log", sha256: hash, sizeBytes: 13 },
+    ]);
+    expect(readFileSync(path.join(created.dir, "failed.log"), "utf8")).toBe(
+      "ci log bytes\n",
+    );
     // input.json is still written: declared inputs and declared bytes coexist.
-    expect(JSON.parse(readFileSync(path.join(created.dir, "input.json"), "utf8"))).toEqual({
+    expect(
+      JSON.parse(readFileSync(path.join(created.dir, "input.json"), "utf8")),
+    ).toEqual({
       logArtifact: hash,
     });
   });
@@ -153,16 +189,23 @@ describe("retention (OPS-372)", () => {
     utimesSync(path.join(kept.storeRoot, kept.hash), old, old);
     utimesSync(path.join(kept.storeRoot, orphan.hash), old, old);
 
-    const outcome = pruneArtifacts(d, kept.storeRoot, { olderThanMs: 7 * 24 * 60 * 60 * 1000 });
+    const outcome = pruneArtifacts(d, kept.storeRoot, {
+      olderThanMs: 7 * 24 * 60 * 60 * 1000,
+    });
     expect(outcome.deleted).toBe(1);
-    expect(readFileSync(path.join(kept.storeRoot, kept.hash), "utf8")).toBe("kept bytes");
+    expect(readFileSync(path.join(kept.storeRoot, kept.hash), "utf8")).toBe(
+      "kept bytes",
+    );
     expect(storeStats(d, kept.storeRoot).orphans).toBe(0);
   });
 
   test("a fresh orphan survives — bytes may be referenced by a run still in flight", () => {
     const d = db();
     const { storeRoot } = store("just written");
-    expect(pruneArtifacts(d, storeRoot, { olderThanMs: 7 * 24 * 60 * 60 * 1000 }).deleted).toBe(0);
+    expect(
+      pruneArtifacts(d, storeRoot, { olderThanMs: 7 * 24 * 60 * 60 * 1000 })
+        .deleted,
+    ).toBe(0);
   });
 });
 
@@ -173,7 +216,12 @@ describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)"
     const workspaces = tmp("evrt-poc-ws-");
     const artifactStore = tmp("evrt-poc-store-");
     const adapters = { pi: fake, command: fake };
-    const opts = { workspacesRoot: workspaces, artifactStore, owner: "w", policyVersion: "git:test" };
+    const opts = {
+      workspacesRoot: workspaces,
+      artifactStore,
+      owner: "w",
+      policyVersion: "git:test",
+    };
 
     admitEvent(db, registry, {
       schemaVersion: "factory.event/v1",
@@ -187,29 +235,49 @@ describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)"
 
     // Node 1: capture. The whole log is stored content-addressed.
     planAdmittedEvents(db, registry, opts);
-    const capture = openProposals(db, {}).find((p) => p.spec?.agent === "ci-log-capture@1");
+    const capture = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-log-capture@1",
+    );
     expect(capture).toBeTruthy();
-    const captureRun = approveProposal(db, registry, capture.id, { actor: "operator", policyVersion: "git:test" });
-    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe("COMPLETED");
+    const captureRun = approveProposal(db, registry, capture.id, {
+      actor: "operator",
+      policyVersion: "git:test",
+    });
+    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe(
+      "COMPLETED",
+    );
 
     const captured = JSON.parse(
-      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(captureRun.runId).result_json,
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(captureRun.runId).result_json,
     );
     const logEntry = captured.artifacts.find((a) => a.kind === "ci-log");
     expect(logEntry.sha256).toMatch(/^[0-9a-f]{64}$/);
-    expect(readFileSync(path.join(artifactStore, logEntry.sha256), "utf8")).toContain("socket hang up");
+    expect(
+      readFileSync(path.join(artifactStore, logEntry.sha256), "utf8"),
+    ).toContain("socket hang up");
 
     // The chain passes the HASH, not the bytes.
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, opts);
-    const diagnose = openProposals(db, {}).find((p) => p.spec?.agent === "ci-doctor@2");
+    const diagnose = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-doctor@2",
+    );
     expect(diagnose.spec.input.logArtifact).toBe(logEntry.sha256);
 
     // Node 2: the doctor reads ./failed.log, proving materialization happened.
-    const diagnoseRun = approveProposal(db, registry, diagnose.id, { actor: "operator", policyVersion: "git:test" });
-    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe("COMPLETED");
+    const diagnoseRun = approveProposal(db, registry, diagnose.id, {
+      actor: "operator",
+      policyVersion: "git:test",
+    });
+    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe(
+      "COMPLETED",
+    );
     const diagnosis = JSON.parse(
-      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(diagnoseRun.runId).result_json,
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(diagnoseRun.runId).result_json,
     );
     expect(diagnosis.artifact.evidenceLines).toEqual(["socket hang up"]);
     expect(diagnosis.evidence.logBytes).toBeGreaterThan(0);
@@ -227,7 +295,9 @@ describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)"
       payload: { repo: "wm/factory", runId: 1, logArtifact: "b".repeat(64) },
     });
     planAdmittedEvents(db, registry, { policyVersion: "git:test" });
-    const parked = openProposals(db, {}).find((p) => p.decision === "human_needed");
+    const parked = openProposals(db, {}).find(
+      (p) => p.decision === "human_needed",
+    );
     expect(parked.reason).toContain("artifact_missing");
   });
 });

--- a/event-runtime/lib/artifact-view.mjs
+++ b/event-runtime/lib/artifact-view.mjs
@@ -18,11 +18,33 @@ import { validate } from "./schema.mjs";
 
 export const ARTIFACT_VIEW_SCHEMA_VERSION = "factory.artifact-view/v1";
 export const ARTIFACT_VIEW_SCHEMA = JSON.parse(
-  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.artifact-view.v1.json"), "utf8"),
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory.artifact-view.v1.json"),
+    "utf8",
+  ),
 );
 
-export const SECTION_KINDS = ["table", "keyvalue", "list", "badge", "code", "prose"];
-export const FORMATS = ["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"];
+export const SECTION_KINDS = [
+  "table",
+  "keyvalue",
+  "list",
+  "badge",
+  "code",
+  "prose",
+];
+export const FORMATS = [
+  "issue",
+  "pr",
+  "url",
+  "sha",
+  "repo",
+  "run",
+  "duration",
+  "datetime",
+  "state",
+  "bytes",
+  "count",
+];
 export const TONES = ["ok", "warn", "error", "muted", "neutral"];
 
 /** Keys every section may carry, plus the per-`as` keys (design §2.2 `as` row). */
@@ -37,8 +59,10 @@ const KEYS_BY_KIND = {
 };
 const REQUIRED_BY_KIND = { table: ["columns"] };
 
-const isObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
-const hasOwn = (obj, key) => isObject(obj) && Object.prototype.hasOwnProperty.call(obj, key);
+const isObject = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+const hasOwn = (obj, key) =>
+  isObject(obj) && Object.prototype.hasOwnProperty.call(obj, key);
 
 /** RFC 6901: split a pointer into unescaped reference tokens; null when malformed. */
 export function parsePointer(pointer) {
@@ -93,7 +117,11 @@ function walkSchema(schema, tokens) {
     if (!isObject(node)) return undefined;
     if (isObject(node.properties) && hasOwn(node.properties, token)) {
       node = node.properties[token];
-    } else if (hasOwn(node, "items") && isObject(node.items) && /^(0|[1-9][0-9]*|-)$/.test(token)) {
+    } else if (
+      hasOwn(node, "items") &&
+      isObject(node.items) &&
+      /^(0|[1-9][0-9]*|-)$/.test(token)
+    ) {
       node = node.items;
     } else {
       return undefined;
@@ -104,7 +132,8 @@ function walkSchema(schema, tokens) {
 
 /** The node a section's relative keys are resolved against: an array's `items`, else the node itself. */
 function itemNode(node) {
-  if (isObject(node) && hasOwn(node, "items") && isObject(node.items)) return node.items;
+  if (isObject(node) && hasOwn(node, "items") && isObject(node.items))
+    return node.items;
   return node;
 }
 
@@ -124,15 +153,30 @@ export function validateArtifactView(view, outputSchema) {
   const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
   if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
   if (!isObject(outputSchema)) {
-    return { valid: false, errors: ["view: output schema is missing — nothing to resolve pointers against"] };
+    return {
+      valid: false,
+      errors: [
+        "view: output schema is missing — nothing to resolve pointers against",
+      ],
+    };
   }
   const errors = [];
 
-  if (hasOwn(view, "summary") && resolveSchemaPointer(outputSchema, view.summary) === undefined) {
-    errors.push(`view.summary: pointer "${view.summary}" does not resolve in the output schema`);
+  if (
+    hasOwn(view, "summary") &&
+    resolveSchemaPointer(outputSchema, view.summary) === undefined
+  ) {
+    errors.push(
+      `view.summary: pointer "${view.summary}" does not resolve in the output schema`,
+    );
   }
-  if (hasOwn(view, "status") && resolveSchemaPointer(outputSchema, view.status.path) === undefined) {
-    errors.push(`view.status.path: pointer "${view.status.path}" does not resolve in the output schema`);
+  if (
+    hasOwn(view, "status") &&
+    resolveSchemaPointer(outputSchema, view.status.path) === undefined
+  ) {
+    errors.push(
+      `view.status.path: pointer "${view.status.path}" does not resolve in the output schema`,
+    );
   }
 
   view.sections.forEach((section, i) => {
@@ -145,47 +189,67 @@ export function validateArtifactView(view, outputSchema) {
       }
     }
     for (const key of REQUIRED_BY_KIND[kind] ?? []) {
-      if (!hasOwn(section, key)) errors.push(`${at}: as=${kind} requires "${key}"`);
+      if (!hasOwn(section, key))
+        errors.push(`${at}: as=${kind} requires "${key}"`);
     }
 
     const node = resolveSchemaPointer(outputSchema, section.path);
     if (node === undefined) {
-      errors.push(`${at}.path: pointer "${section.path}" does not resolve in the output schema`);
+      errors.push(
+        `${at}.path: pointer "${section.path}" does not resolve in the output schema`,
+      );
       return;
     }
-    if ((kind === "table" || kind === "list") && !(hasOwn(node, "items") && isObject(node.items))) {
-      errors.push(`${at}.path: as=${kind} needs an array schema at "${section.path}"`);
+    if (
+      (kind === "table" || kind === "list") &&
+      !(hasOwn(node, "items") && isObject(node.items))
+    ) {
+      errors.push(
+        `${at}.path: as=${kind} needs an array schema at "${section.path}"`,
+      );
     }
     const base = itemNode(node);
     const checkKey = (field, key) => {
       if (key === "") return;
       if (relativeNode(base, key) === undefined) {
-        errors.push(`${at}.${field}: "${key}" does not resolve under "${section.path}" in the output schema`);
+        errors.push(
+          `${at}.${field}: "${key}" does not resolve under "${section.path}" in the output schema`,
+        );
       }
     };
     for (const field of ["columns", "expand", "keys"]) {
-      if (Array.isArray(section[field])) for (const key of section[field]) checkKey(field, key);
+      if (Array.isArray(section[field]))
+        for (const key of section[field]) checkKey(field, key);
     }
-    if (typeof section.groupBy === "string") checkKey("groupBy", section.groupBy);
-    if (typeof section.itemLabel === "string") checkKey("itemLabel", section.itemLabel);
-    if (isObject(section.formats)) for (const key of Object.keys(section.formats)) checkKey("formats", key);
+    if (typeof section.groupBy === "string")
+      checkKey("groupBy", section.groupBy);
+    if (typeof section.itemLabel === "string")
+      checkKey("itemLabel", section.itemLabel);
+    if (isObject(section.formats))
+      for (const key of Object.keys(section.formats)) checkKey("formats", key);
 
     if (isObject(section.tone)) {
       for (const [key, value] of Object.entries(section.tone)) {
         if (kind === "badge") {
           if (!TONES.includes(value)) {
-            errors.push(`${at}.tone.${key}: badge tone must be one of ${TONES.join("|")}`);
+            errors.push(
+              `${at}.tone.${key}: badge tone must be one of ${TONES.join("|")}`,
+            );
           }
           continue;
         }
         checkKey("tone", key);
         if (!isObject(value)) {
-          errors.push(`${at}.tone.${key}: as=${kind} tone maps a column/key to a (value → tone) object`);
+          errors.push(
+            `${at}.tone.${key}: as=${kind} tone maps a column/key to a (value → tone) object`,
+          );
           continue;
         }
         for (const [v, tone] of Object.entries(value)) {
           if (!TONES.includes(tone)) {
-            errors.push(`${at}.tone.${key}.${v}: tone must be one of ${TONES.join("|")}`);
+            errors.push(
+              `${at}.tone.${key}.${v}: tone must be one of ${TONES.join("|")}`,
+            );
           }
         }
       }
@@ -208,11 +272,12 @@ export function inspectHeader(view, artifact) {
   const lines = [];
   if (typeof view.summary === "string") {
     const summary = resolvePointer(artifact, view.summary);
-    if (typeof summary === "string" && summary.trim()) lines.push(summary.trim());
+    if (typeof summary === "string" && summary.trim())
+      lines.push(summary.trim());
   }
   if (isObject(view.status) && typeof view.status.path === "string") {
     const value = resolvePointer(artifact, view.status.path);
-    if (value !== undefined && value !== null && (typeof value !== "object")) {
+    if (value !== undefined && value !== null && typeof value !== "object") {
       const tokens = parsePointer(view.status.path) ?? [];
       const label = tokens.length ? tokens[tokens.length - 1] : "status";
       lines.push(`${label}: ${String(value)}`);

--- a/event-runtime/lib/artifact-view.test.mjs
+++ b/event-runtime/lib/artifact-view.test.mjs
@@ -63,7 +63,12 @@ const VIEW = {
       expand: ["criteria"],
     },
     { path: "/repo", as: "keyvalue", label: "Repo", formats: { "": "repo" } },
-    { path: "/plan", as: "list", itemLabel: "/reason", formats: { issueId: "issue" } },
+    {
+      path: "/plan",
+      as: "list",
+      itemLabel: "/reason",
+      formats: { issueId: "issue" },
+    },
     { path: "/recommendation", as: "badge", tone: { GO: "ok" } },
     { path: "/log", as: "code", language: "text" },
     { path: "/summary", as: "prose" },
@@ -82,27 +87,58 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
   });
 
   test("encodes the closed vocabularies from design §2.2", () => {
-    expect(ARTIFACT_VIEW_SCHEMA.properties.schemaVersion.const).toBe("factory.artifact-view/v1");
+    expect(ARTIFACT_VIEW_SCHEMA.properties.schemaVersion.const).toBe(
+      "factory.artifact-view/v1",
+    );
     expect(ARTIFACT_VIEW_SCHEMA.properties.title.maxLength).toBe(60);
     expect(ARTIFACT_VIEW_SCHEMA.properties.sections.minItems).toBe(1);
     expect(ARTIFACT_VIEW_SCHEMA.properties.sections.maxItems).toBe(12);
     const section = ARTIFACT_VIEW_SCHEMA.properties.sections.items;
     expect(section.properties.as.enum).toEqual(SECTION_KINDS);
-    expect(SECTION_KINDS).toEqual(["table", "keyvalue", "list", "badge", "code", "prose"]);
+    expect(SECTION_KINDS).toEqual([
+      "table",
+      "keyvalue",
+      "list",
+      "badge",
+      "code",
+      "prose",
+    ]);
     expect(section.properties.columns.minItems).toBe(1);
     expect(section.properties.columns.maxItems).toBe(8);
-    expect(section.properties.formats.additionalProperties.enum).toEqual(FORMATS);
-    expect(FORMATS).toEqual(["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"]);
-    expect(ARTIFACT_VIEW_SCHEMA.properties.status.properties.tone.additionalProperties.enum).toEqual(TONES);
+    expect(section.properties.formats.additionalProperties.enum).toEqual(
+      FORMATS,
+    );
+    expect(FORMATS).toEqual([
+      "issue",
+      "pr",
+      "url",
+      "sha",
+      "repo",
+      "run",
+      "duration",
+      "datetime",
+      "state",
+      "bytes",
+      "count",
+    ]);
+    expect(
+      ARTIFACT_VIEW_SCHEMA.properties.status.properties.tone
+        .additionalProperties.enum,
+    ).toEqual(TONES);
     expect(TONES).toEqual(["ok", "warn", "error", "muted", "neutral"]);
     // additionalProperties: false throughout the object shapes.
     expect(ARTIFACT_VIEW_SCHEMA.additionalProperties).toBe(false);
-    expect(ARTIFACT_VIEW_SCHEMA.properties.status.additionalProperties).toBe(false);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.status.additionalProperties).toBe(
+      false,
+    );
     expect(section.additionalProperties).toBe(false);
   });
 
   test("a well-formed view passes schema and drift checks", () => {
-    expect(validateArtifactView(VIEW, OUTPUT_SCHEMA)).toEqual({ valid: true, errors: [] });
+    expect(validateArtifactView(VIEW, OUTPUT_SCHEMA)).toEqual({
+      valid: true,
+      errors: [],
+    });
   });
 
   test("schema failures: wrong version, unknown as/format/tone, bounds, unknown keys", () => {
@@ -113,22 +149,50 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
       expect(valid).toBe(false);
       expect(errors.join("\n")).toMatch(needle);
     };
-    fails((v) => (v.schemaVersion = "factory.artifact-view/v2"), /schemaVersion: expected const/);
+    fails(
+      (v) => (v.schemaVersion = "factory.artifact-view/v2"),
+      /schemaVersion: expected const/,
+    );
     fails((v) => (v.title = "x".repeat(61)), /title: longer than maxLength 60/);
     fails((v) => (v.sections = []), /fewer than minItems 1/);
-    fails((v) => (v.sections = Array.from({ length: 13 }, () => clone(VIEW.sections[5]))), /more than minItems|more than maxItems 12/);
+    fails(
+      (v) =>
+        (v.sections = Array.from({ length: 13 }, () =>
+          clone(VIEW.sections[5]),
+        )),
+      /more than minItems|more than maxItems 12/,
+    );
     fails((v) => (v.sections[0].as = "chart"), /as: value not in enum/);
-    fails((v) => (v.sections[0].formats.issueId = "money"), /formats.issueId: value not in enum/);
-    fails((v) => (v.status.tone.GO = "green"), /status.tone.GO: value not in enum/);
-    fails((v) => (v.sections[0].columns = Array.from({ length: 9 }, (_, i) => `c${i}`)), /columns: more than maxItems 8/);
+    fails(
+      (v) => (v.sections[0].formats.issueId = "money"),
+      /formats.issueId: value not in enum/,
+    );
+    fails(
+      (v) => (v.status.tone.GO = "green"),
+      /status.tone.GO: value not in enum/,
+    );
+    fails(
+      (v) =>
+        (v.sections[0].columns = Array.from({ length: 9 }, (_, i) => `c${i}`)),
+      /columns: more than maxItems 8/,
+    );
     fails((v) => (v.sections[0].width = 12), /unknown property "width"/);
     fails((v) => (v.extra = true), /unknown property "extra"/);
     fails((v) => delete v.sections[0].path, /missing required property "path"/);
     fails((v) => (v.summary = "summary"), /summary: does not match pattern/);
     // Nested tone values are checked in code (schema.mjs has no conditional keywords).
-    fails((v) => (v.sections[0].tone.action.one = "purple"), /tone.action.one: tone must be one of/);
-    fails((v) => (v.sections[3].tone.GO = "purple"), /badge tone must be one of/);
-    fails((v) => (v.sections[0].tone.action = "ok"), /tone maps a column\/key to a \(value → tone\) object/);
+    fails(
+      (v) => (v.sections[0].tone.action.one = "purple"),
+      /tone.action.one: tone must be one of/,
+    );
+    fails(
+      (v) => (v.sections[3].tone.GO = "purple"),
+      /badge tone must be one of/,
+    );
+    fails(
+      (v) => (v.sections[0].tone.action = "ok"),
+      /tone maps a column\/key to a \(value → tone\) object/,
+    );
   });
 
   test("per-as keys: a key from another kind is refused, table requires columns", () => {
@@ -139,12 +203,27 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
       expect(valid).toBe(false);
       expect(errors.join("\n")).toMatch(needle);
     };
-    fails((v) => (v.sections[1].columns = ["repo"]), /"columns" is not a key of as=keyvalue/);
-    fails((v) => (v.sections[0].language = "json"), /"language" is not a key of as=table/);
-    fails((v) => (v.sections[5].tone = { x: "ok" }), /"tone" is not a key of as=prose/);
-    fails((v) => (v.sections[3].keys = ["x"]), /"keys" is not a key of as=badge/);
+    fails(
+      (v) => (v.sections[1].columns = ["repo"]),
+      /"columns" is not a key of as=keyvalue/,
+    );
+    fails(
+      (v) => (v.sections[0].language = "json"),
+      /"language" is not a key of as=table/,
+    );
+    fails(
+      (v) => (v.sections[5].tone = { x: "ok" }),
+      /"tone" is not a key of as=prose/,
+    );
+    fails(
+      (v) => (v.sections[3].keys = ["x"]),
+      /"keys" is not a key of as=badge/,
+    );
     fails((v) => delete v.sections[0].columns, /as=table requires "columns"/);
-    fails((v) => (v.sections[0].path = "/summary"), /as=table needs an array schema/);
+    fails(
+      (v) => (v.sections[0].path = "/summary"),
+      /as=table needs an array schema/,
+    );
   });
 
   test("drift: every pointer must resolve in the output schema", () => {
@@ -155,24 +234,61 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
       expect(valid).toBe(false);
       expect(errors.join("\n")).toMatch(needle);
     };
-    fails((v) => (v.summary = "/gone"), /summary: pointer "\/gone" does not resolve/);
-    fails((v) => (v.status.path = "/verdict"), /status.path: pointer "\/verdict" does not resolve/);
-    fails((v) => (v.sections[0].path = "/rows"), /sections\[0\].path: pointer "\/rows" does not resolve/);
-    fails((v) => v.sections[0].columns.push("owner"), /sections\[0\].columns: "owner" does not resolve under "\/plan"/);
-    fails((v) => (v.sections[0].groupBy = "kind"), /groupBy: "kind" does not resolve/);
-    fails((v) => v.sections[0].expand.push("detail"), /expand: "detail" does not resolve/);
-    fails((v) => (v.sections[0].formats.pr = "pr"), /formats: "pr" does not resolve/);
-    fails((v) => (v.sections[0].tone.state = { x: "ok" }), /tone: "state" does not resolve/);
-    fails((v) => (v.sections[2].itemLabel = "/title"), /itemLabel: "\/title" does not resolve/);
-    fails((v) => (v.sections[1].keys = ["nope"]), /keys: "nope" does not resolve under "\/repo"/);
+    fails(
+      (v) => (v.summary = "/gone"),
+      /summary: pointer "\/gone" does not resolve/,
+    );
+    fails(
+      (v) => (v.status.path = "/verdict"),
+      /status.path: pointer "\/verdict" does not resolve/,
+    );
+    fails(
+      (v) => (v.sections[0].path = "/rows"),
+      /sections\[0\].path: pointer "\/rows" does not resolve/,
+    );
+    fails(
+      (v) => v.sections[0].columns.push("owner"),
+      /sections\[0\].columns: "owner" does not resolve under "\/plan"/,
+    );
+    fails(
+      (v) => (v.sections[0].groupBy = "kind"),
+      /groupBy: "kind" does not resolve/,
+    );
+    fails(
+      (v) => v.sections[0].expand.push("detail"),
+      /expand: "detail" does not resolve/,
+    );
+    fails(
+      (v) => (v.sections[0].formats.pr = "pr"),
+      /formats: "pr" does not resolve/,
+    );
+    fails(
+      (v) => (v.sections[0].tone.state = { x: "ok" }),
+      /tone: "state" does not resolve/,
+    );
+    fails(
+      (v) => (v.sections[2].itemLabel = "/title"),
+      /itemLabel: "\/title" does not resolve/,
+    );
+    fails(
+      (v) => (v.sections[1].keys = ["nope"]),
+      /keys: "nope" does not resolve under "\/repo"/,
+    );
     // A missing output schema is a validation failure, not a crash.
     expect(validateArtifactView(VIEW, undefined).valid).toBe(false);
     // Section pointers may reach through arrays with an index token, and
     // relative keys may be nested pointers.
     const ok = clone(VIEW);
-    ok.sections[2] = { path: "/plan/0/criteria", as: "list", itemLabel: "/text" };
+    ok.sections[2] = {
+      path: "/plan/0/criteria",
+      as: "list",
+      itemLabel: "/text",
+    };
     ok.sections[0].expand = ["criteria/0/text"];
-    expect(validateArtifactView(ok, OUTPUT_SCHEMA)).toEqual({ valid: true, errors: [] });
+    expect(validateArtifactView(ok, OUTPUT_SCHEMA)).toEqual({
+      valid: true,
+      errors: [],
+    });
     // ...but an array is not stepped through by a property name.
     const bad = clone(VIEW);
     bad.sections[0].path = "/plan/issueId";
@@ -180,7 +296,15 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
   });
 
   test("validateArtifactView never throws on garbage input", () => {
-    for (const junk of [null, undefined, 42, "view", [], {}, { schemaVersion: 1 }]) {
+    for (const junk of [
+      null,
+      undefined,
+      42,
+      "view",
+      [],
+      {},
+      { schemaVersion: 1 },
+    ]) {
       const result = validateArtifactView(junk, OUTPUT_SCHEMA);
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
@@ -229,12 +353,22 @@ describe("resolvePointer (RFC 6901)", () => {
   });
 
   test("resolveSchemaPointer walks properties and items, and unescapes too", () => {
-    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/0/criteria/3/text")).toEqual({ type: "string" });
-    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/-/issueId")).toEqual({ type: "string" });
-    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/a~1b")).toEqual({ type: "string" });
-    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/t~0e")).toEqual({ type: "string" });
+    expect(
+      resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/0/criteria/3/text"),
+    ).toEqual({ type: "string" });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/-/issueId")).toEqual({
+      type: "string",
+    });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/a~1b")).toEqual({
+      type: "string",
+    });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/t~0e")).toEqual({
+      type: "string",
+    });
     expect(resolveSchemaPointer(OUTPUT_SCHEMA, "")).toBe(OUTPUT_SCHEMA);
-    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/issueId")).toBeUndefined();
+    expect(
+      resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/issueId"),
+    ).toBeUndefined();
     expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/summary/x")).toBeUndefined();
     expect(resolveSchemaPointer(OUTPUT_SCHEMA, "nope")).toBeUndefined();
   });
@@ -247,30 +381,49 @@ describe("committed views fit their agents' output schemas (drift gate, design �
     .sort();
 
   test("the first two views ship with the contract (§2.5)", () => {
-    expect(viewFiles).toEqual(expect.arrayContaining(["merge-scan.view.json", "triage-scan.view.json"]));
+    expect(viewFiles).toEqual(
+      expect.arrayContaining(["merge-scan.view.json", "triage-scan.view.json"]),
+    );
   });
 
   for (const name of viewFiles) {
     test(`agents/${name} resolves every pointer against its output schema`, () => {
-      const defFile = path.join(agentsDir, name.replace(/\.view\.json$/, ".json"));
+      const defFile = path.join(
+        agentsDir,
+        name.replace(/\.view\.json$/, ".json"),
+      );
       const def = JSON.parse(readFileSync(defFile, "utf8"));
-      const outputSchema = JSON.parse(readFileSync(path.join(RUNTIME_ROOT, def.output_schema), "utf8"));
+      const outputSchema = JSON.parse(
+        readFileSync(path.join(RUNTIME_ROOT, def.output_schema), "utf8"),
+      );
       const view = JSON.parse(readFileSync(path.join(agentsDir, name), "utf8"));
-      expect(validateArtifactView(view, outputSchema)).toEqual({ valid: true, errors: [] });
+      expect(validateArtifactView(view, outputSchema)).toEqual({
+        valid: true,
+        errors: [],
+      });
     });
   }
 
   test("triage-scan and merge-scan views carry the hints the operator reads first", () => {
-    const triage = JSON.parse(readFileSync(path.join(agentsDir, "triage-scan.view.json"), "utf8"));
+    const triage = JSON.parse(
+      readFileSync(path.join(agentsDir, "triage-scan.view.json"), "utf8"),
+    );
     expect(triage.summary).toBe("/summary");
     expect(triage.status.path).toBe("/recommendation");
     const plan = triage.sections.find((s) => s.path === "/plan");
     expect(plan.as).toBe("table");
     expect(plan.groupBy).toBe("action");
     expect(plan.formats.issueId).toBe("issue");
-    expect(plan.expand).toEqual(["detail", "ownedPaths", "verificationCommand", "acceptanceCriteria"]);
+    expect(plan.expand).toEqual([
+      "detail",
+      "ownedPaths",
+      "verificationCommand",
+      "acceptanceCriteria",
+    ]);
 
-    const merge = JSON.parse(readFileSync(path.join(agentsDir, "merge-scan.view.json"), "utf8"));
+    const merge = JSON.parse(
+      readFileSync(path.join(agentsDir, "merge-scan.view.json"), "utf8"),
+    );
     expect(merge.status.path).toBe("/recommendation");
     for (const p of ["/plan", "/fix", "/escalate"]) {
       const section = merge.sections.find((s) => s.path === p);
@@ -278,29 +431,54 @@ describe("committed views fit their agents' output schemas (drift gate, design �
       expect(section.formats.pr).toBe("pr");
       expect(section.columns).toContain("pr");
     }
-    expect(merge.sections.find((s) => s.path === "/escalate").columns).toContain("reason");
-    expect(merge.sections.find((s) => s.path === "/plan").columns).toContain("reason");
-    expect(merge.sections.find((s) => s.path === "/fix").columns).toContain("finding");
+    expect(
+      merge.sections.find((s) => s.path === "/escalate").columns,
+    ).toContain("reason");
+    expect(merge.sections.find((s) => s.path === "/plan").columns).toContain(
+      "reason",
+    );
+    expect(merge.sections.find((s) => s.path === "/fix").columns).toContain(
+      "finding",
+    );
   });
 });
 
 describe("inspectHeader — the first lines of `inspect`'s result section (WM-455)", () => {
-  const view = JSON.parse(readFileSync(path.join(RUNTIME_ROOT, "agents", "merge-scan.view.json"), "utf8"));
+  const view = JSON.parse(
+    readFileSync(
+      path.join(RUNTIME_ROOT, "agents", "merge-scan.view.json"),
+      "utf8",
+    ),
+  );
 
   test("summary prose, then status as `<label>: <value>` with the pointer's last token as label", () => {
-    expect(inspectHeader(view, { summary: "  Two PRs held. ", recommendation: "ESCALATE", escalate: [] })).toEqual([
-      "Two PRs held.",
-      "recommendation: ESCALATE",
-    ]);
+    expect(
+      inspectHeader(view, {
+        summary: "  Two PRs held. ",
+        recommendation: "ESCALATE",
+        escalate: [],
+      }),
+    ).toEqual(["Two PRs held.", "recommendation: ESCALATE"]);
   });
 
   test("a pointer that does not resolve contributes nothing; no view means no lines", () => {
-    expect(inspectHeader(view, { recommendation: "NOOP" })).toEqual(["recommendation: NOOP"]);
-    expect(inspectHeader(view, { summary: "only prose" })).toEqual(["only prose"]);
-    expect(inspectHeader(view, { summary: "", recommendation: { nested: true } })).toEqual([]);
+    expect(inspectHeader(view, { recommendation: "NOOP" })).toEqual([
+      "recommendation: NOOP",
+    ]);
+    expect(inspectHeader(view, { summary: "only prose" })).toEqual([
+      "only prose",
+    ]);
+    expect(
+      inspectHeader(view, { summary: "", recommendation: { nested: true } }),
+    ).toEqual([]);
     expect(inspectHeader(view, "not an object")).toEqual([]);
     expect(inspectHeader(null, { summary: "x" })).toEqual([]);
     expect(inspectHeader(undefined, { summary: "x" })).toEqual([]);
-    expect(inspectHeader({ schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION, sections: [] }, { summary: "x" })).toEqual([]);
+    expect(
+      inspectHeader(
+        { schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION, sections: [] },
+        { summary: "x" },
+      ),
+    ).toEqual([]);
   });
 });

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -33,7 +33,8 @@ export function hashFile(filePath) {
 
 /** Resolve a store path from a content hash; malformed hashes fail closed. */
 export function artifactPath(storeRoot, sha256hex) {
-  if (!HEX64.test(sha256hex ?? "")) throw new Error(`invalid artifact hash: ${sha256hex}`);
+  if (!HEX64.test(sha256hex ?? ""))
+    throw new Error(`invalid artifact hash: ${sha256hex}`);
   return path.join(storeRoot, sha256hex);
 }
 
@@ -63,12 +64,18 @@ export function storeCollected({ entries, storeRoot }) {
     }
     const srcHash = hashFile(src);
     if (srcHash !== entry.sha256) {
-      throw new Error(`artifact source hash mismatch: expected ${entry.sha256}, got ${srcHash}`);
+      throw new Error(
+        `artifact source hash mismatch: expected ${entry.sha256}, got ${srcHash}`,
+      );
     }
     if (existsSync(dest)) {
       const destHash = hashFile(dest);
       if (destHash === entry.sha256) {
-        return { ...entry, uri: `file://${dest}`, sizeBytes: statSync(dest).size };
+        return {
+          ...entry,
+          uri: `file://${dest}`,
+          sizeBytes: statSync(dest).size,
+        };
       }
       rmSync(dest, { force: true });
     }
@@ -79,7 +86,9 @@ export function storeCollected({ entries, storeRoot }) {
       copyFileSync(src, tmpPath);
       const tmpHash = hashFile(tmpPath);
       if (tmpHash !== entry.sha256) {
-        throw new Error(`artifact store hash mismatch: expected ${entry.sha256}, got ${tmpHash}`);
+        throw new Error(
+          `artifact store hash mismatch: expected ${entry.sha256}, got ${tmpHash}`,
+        );
       }
       renameSync(tmpPath, dest);
     } finally {
@@ -110,20 +119,28 @@ export function findArtifact(storeRoot, sha256hex) {
  * Stored bytes are re-verified against the declared hash upon materialization;
  * corrupt entries fail loudly and are purged from the store (OPS-439).
  */
-export function materializeArtifact({ storeRoot, sha256hex, workspaceDir, as }) {
+export function materializeArtifact({
+  storeRoot,
+  sha256hex,
+  workspaceDir,
+  as,
+}) {
   const found = findArtifact(storeRoot, sha256hex);
   if (!found) throw new Error(`artifact ${sha256hex} is not in the store`);
   const actualHash = hashFile(found.file);
   if (actualHash !== sha256hex) {
     rmSync(found.file, { force: true });
-    throw new Error(`corrupt artifact ${sha256hex} in store (actual hash was ${actualHash}): removed corrupt entry`);
+    throw new Error(
+      `corrupt artifact ${sha256hex} in store (actual hash was ${actualHash}): removed corrupt entry`,
+    );
   }
   if (typeof as !== "string" || !as || path.isAbsolute(as)) {
     throw new Error(`artifact target "${as}" must be a relative filename`);
   }
   const root = path.resolve(workspaceDir);
   const dest = path.resolve(root, as);
-  if (!dest.startsWith(root + path.sep)) throw new Error(`artifact target "${as}" escapes the workspace`);
+  if (!dest.startsWith(root + path.sep))
+    throw new Error(`artifact target "${as}" escapes the workspace`);
   const realRoot = existsSync(root) ? realpathSync(root) : root;
   mkdirSync(path.dirname(dest), { recursive: true });
   const realDir = realpathSync(path.dirname(dest));
@@ -132,9 +149,11 @@ export function materializeArtifact({ storeRoot, sha256hex, workspaceDir, as }) 
   }
   if (existsSync(dest)) {
     const stat = lstatSync(dest);
-    if (stat.isSymbolicLink()) throw new Error(`artifact target "${as}" is a symlink`);
+    if (stat.isSymbolicLink())
+      throw new Error(`artifact target "${as}" is a symlink`);
     const realDest = realpathSync(dest);
-    if (!realDest.startsWith(realRoot + path.sep)) throw new Error(`artifact target "${as}" escapes the workspace`);
+    if (!realDest.startsWith(realRoot + path.sep))
+      throw new Error(`artifact target "${as}" escapes the workspace`);
   }
   copyFileSync(found.file, dest);
   return { path: dest, sha256: sha256hex, sizeBytes: found.sizeBytes };
@@ -156,19 +175,25 @@ export function referencedHashes(db) {
  * to it. The store remains the source of truth for which bytes exist; stale
  * result references to missing files therefore do not produce phantom rows.
  */
-export function listArtifacts(db, storeRoot, { orphan, kind, search, limit } = {}) {
+export function listArtifacts(
+  db,
+  storeRoot,
+  { orphan, kind, search, limit } = {},
+) {
   if (!existsSync(storeRoot)) return [];
 
   const references = new Map();
-  const rows = db.query(
-    `SELECT results.run_id, results.result_json, runs.spec_json, runs.state, runs.created_at
+  const rows = db
+    .query(
+      `SELECT results.run_id, results.result_json, runs.spec_json, runs.state, runs.created_at
      FROM results
      LEFT JOIN runs ON runs.run_id = results.run_id`,
-  ).all();
+    )
+    .all();
   for (const row of rows) {
     let agent = null;
     try {
-      agent = row.spec_json ? JSON.parse(row.spec_json).agent ?? null : null;
+      agent = row.spec_json ? (JSON.parse(row.spec_json).agent ?? null) : null;
     } catch {
       // A catalogue read should still expose the bytes if an old spec is bad.
     }
@@ -188,15 +213,27 @@ export function listArtifacts(db, storeRoot, { orphan, kind, search, limit } = {
 
   const term = typeof search === "string" ? search.toLowerCase() : null;
   const inventory = [];
-  for (const sha256 of readdirSync(storeRoot).filter((name) => HEX64.test(name)).sort()) {
+  for (const sha256 of readdirSync(storeRoot)
+    .filter((name) => HEX64.test(name))
+    .sort()) {
     const stat = statSync(path.join(storeRoot, sha256));
     if (!stat.isFile()) continue;
     const refs = references.get(sha256) ?? [];
     const referenced = refs.length > 0;
     if (orphan !== undefined && orphan === referenced) continue;
     if (kind !== undefined && !refs.some((ref) => ref.kind === kind)) continue;
-    if (term && ![sha256, ...refs.flatMap((ref) => [ref.runId, ref.kind, ref.agent, ref.state])]
-      .some((value) => String(value ?? "").toLowerCase().includes(term))) continue;
+    if (
+      term &&
+      ![
+        sha256,
+        ...refs.flatMap((ref) => [ref.runId, ref.kind, ref.agent, ref.state]),
+      ].some((value) =>
+        String(value ?? "")
+          .toLowerCase()
+          .includes(term),
+      )
+    )
+      continue;
     inventory.push({
       sha256,
       sizeBytes: stat.size,
@@ -215,7 +252,8 @@ export function listArtifacts(db, storeRoot, { orphan, kind, search, limit } = {
  * superseded one can leave bytes behind); they are only a problem unattended.
  */
 export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
-  if (!existsSync(storeRoot)) return { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 };
+  if (!existsSync(storeRoot))
+    return { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 };
   const referenced = referencedHashes(db);
   let files = 0;
   let bytes = 0;
@@ -231,7 +269,13 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
       orphanBytes += size;
     }
   }
-  return { files, bytes, orphans, orphanBytes, at: new Date(now).toISOString() };
+  return {
+    files,
+    bytes,
+    orphans,
+    orphanBytes,
+    at: new Date(now).toISOString(),
+  };
 }
 
 /**
@@ -242,9 +286,14 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
 export function pruneArtifacts(
   db,
   storeRoot,
-  { olderThanMs = 7 * 24 * 60 * 60 * 1000, now = Date.now(), dryRun = false } = {},
+  {
+    olderThanMs = 7 * 24 * 60 * 60 * 1000,
+    now = Date.now(),
+    dryRun = false,
+  } = {},
 ) {
-  if (!existsSync(storeRoot)) return { deleted: 0, freedBytes: 0, remainingOrphans: 0 };
+  if (!existsSync(storeRoot))
+    return { deleted: 0, freedBytes: 0, remainingOrphans: 0 };
   const referenced = referencedHashes(db);
   let deleted = 0;
   let freedBytes = 0;
@@ -279,14 +328,24 @@ export function pruneArtifacts(
  * by the time it executes".
  */
 export function pinRunArtifact(db, runId, { kind = "transcript" } = {}) {
-  const run = db.query(`SELECT run_id, state, spec_json FROM runs WHERE run_id = ?`).get(runId);
+  const run = db
+    .query(`SELECT run_id, state, spec_json FROM runs WHERE run_id = ?`)
+    .get(runId);
   if (!run) throw new Error(`unknown run ${runId}`);
   const row = db
-    .query(`SELECT result_json FROM results WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`)
+    .query(
+      `SELECT result_json FROM results WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`,
+    )
     .get(runId);
-  if (!row) throw new Error(`run ${runId} has no accepted result — nothing was captured`);
-  const entry = (JSON.parse(row.result_json).artifacts ?? []).find((a) => a.kind === kind);
-  if (!entry?.sha256) throw new Error(`run ${runId} stored no "${kind}" artifact`);
+  if (!row)
+    throw new Error(
+      `run ${runId} has no accepted result — nothing was captured`,
+    );
+  const entry = (JSON.parse(row.result_json).artifacts ?? []).find(
+    (a) => a.kind === kind,
+  );
+  if (!entry?.sha256)
+    throw new Error(`run ${runId} stored no "${kind}" artifact`);
   return {
     runId,
     transcript: entry.sha256,

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -40,8 +40,12 @@ describe("artifactPath", () => {
   });
 
   test("rejects malformed hashes", () => {
-    expect(() => artifactPath("/store", "../etc/passwd")).toThrow(/invalid artifact hash/);
-    expect(() => artifactPath("/store", "abc")).toThrow(/invalid artifact hash/);
+    expect(() => artifactPath("/store", "../etc/passwd")).toThrow(
+      /invalid artifact hash/,
+    );
+    expect(() => artifactPath("/store", "abc")).toThrow(
+      /invalid artifact hash/,
+    );
     expect(() => artifactPath("/store", null)).toThrow(/invalid artifact hash/);
   });
 });
@@ -71,7 +75,9 @@ describe("storeCollected (OPS-406)", () => {
     const stored = storeCollected({ entries, storeRoot });
     expect(stored[0].uri).toBe(`file://${path.join(storeRoot, hash)}`);
     expect(stored[0].sizeBytes).toBe(11);
-    expect(readFileSync(path.join(storeRoot, hash), "utf8")).toBe("hello world");
+    expect(readFileSync(path.join(storeRoot, hash), "utf8")).toBe(
+      "hello world",
+    );
   });
 
   test("rejects symlinked artifact source file", () => {
@@ -85,9 +91,13 @@ describe("storeCollected (OPS-406)", () => {
     symlinkSync(secretFile, symlinkFile);
 
     const hash = sha256Hex(Buffer.from("secret-data"));
-    const entries = [{ kind: "key", uri: `file://${symlinkFile}`, sha256: hash }];
+    const entries = [
+      { kind: "key", uri: `file://${symlinkFile}`, sha256: hash },
+    ];
 
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(/cannot store symlinked artifact/);
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+      /cannot store symlinked artifact/,
+    );
   });
 
   test("rejects non-existent source file", () => {
@@ -95,8 +105,12 @@ describe("storeCollected (OPS-406)", () => {
     const workspaceDir = tmp("evrt-ws-");
     const missingFile = path.join(workspaceDir, "missing.log");
     const hash = "c".repeat(64);
-    const entries = [{ kind: "log", uri: `file://${missingFile}`, sha256: hash }];
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(/does not exist/);
+    const entries = [
+      { kind: "log", uri: `file://${missingFile}`, sha256: hash },
+    ];
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+      /does not exist/,
+    );
   });
 
   test("rejects source file when content hash does not match declared sha256 (OPS-439)", () => {
@@ -107,7 +121,9 @@ describe("storeCollected (OPS-406)", () => {
     const wrongHash = sha256Hex(Buffer.from("expected different content"));
 
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: wrongHash }];
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(/hash mismatch/);
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+      /hash mismatch/,
+    );
     expect(existsSync(path.join(storeRoot, wrongHash))).toBe(false);
   });
 
@@ -126,7 +142,9 @@ describe("storeCollected (OPS-406)", () => {
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: hash }];
     const stored = storeCollected({ entries, storeRoot });
     expect(stored[0].uri).toBe(`file://${dest}`);
-    expect(stored[0].sizeBytes).toBe(Buffer.byteLength("complete valid content"));
+    expect(stored[0].sizeBytes).toBe(
+      Buffer.byteLength("complete valid content"),
+    );
     expect(readFileSync(dest, "utf8")).toBe("complete valid content");
   });
 
@@ -155,7 +173,9 @@ describe("storeCollected (OPS-406)", () => {
     const hash = sha256Hex(Buffer.from("some data"));
 
     // Cause a failure by passing an invalid declared sha256
-    const entries = [{ kind: "bin", uri: `file://${file}`, sha256: "0".repeat(64) }];
+    const entries = [
+      { kind: "bin", uri: `file://${file}`, sha256: "0".repeat(64) },
+    ];
     expect(() => storeCollected({ entries, storeRoot })).toThrow();
 
     // Verify store directory has neither destination nor tmp files
@@ -179,16 +199,37 @@ describe("materializeArtifact (OPS-406)", () => {
   test("writes stored bytes into workspace under relative path", () => {
     const { storeRoot, hash } = makeStore("test data");
     const workspaceDir = tmp("evrt-ws-");
-    const res = materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "subdir/file.txt" });
+    const res = materializeArtifact({
+      storeRoot,
+      sha256hex: hash,
+      workspaceDir,
+      as: "subdir/file.txt",
+    });
     expect(res.sha256).toBe(hash);
-    expect(readFileSync(path.join(workspaceDir, "subdir/file.txt"), "utf8")).toBe("test data");
+    expect(
+      readFileSync(path.join(workspaceDir, "subdir/file.txt"), "utf8"),
+    ).toBe("test data");
   });
 
   test("rejects absolute paths and path escapes", () => {
     const { storeRoot, hash } = makeStore("test data");
     const workspaceDir = tmp("evrt-ws-");
-    expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "/abs/path" })).toThrow();
-    expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "../outside" })).toThrow();
+    expect(() =>
+      materializeArtifact({
+        storeRoot,
+        sha256hex: hash,
+        workspaceDir,
+        as: "/abs/path",
+      }),
+    ).toThrow();
+    expect(() =>
+      materializeArtifact({
+        storeRoot,
+        sha256hex: hash,
+        workspaceDir,
+        as: "../outside",
+      }),
+    ).toThrow();
   });
 
   test("rejects symlinked destination directory pointing outside workspace", () => {
@@ -200,7 +241,12 @@ describe("materializeArtifact (OPS-406)", () => {
     symlinkSync(outsideDir, symlinkDir, "dir");
 
     expect(() =>
-      materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "symdir/pwned.txt" })
+      materializeArtifact({
+        storeRoot,
+        sha256hex: hash,
+        workspaceDir,
+        as: "symdir/pwned.txt",
+      }),
     ).toThrow(/escapes the workspace/);
   });
 
@@ -215,7 +261,12 @@ describe("materializeArtifact (OPS-406)", () => {
     symlinkSync(targetFile, symlinkFile);
 
     expect(() =>
-      materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "link.txt" })
+      materializeArtifact({
+        storeRoot,
+        sha256hex: hash,
+        workspaceDir,
+        as: "link.txt",
+      }),
     ).toThrow(/symlink/);
   });
 
@@ -231,7 +282,12 @@ describe("materializeArtifact (OPS-406)", () => {
 
     const workspaceDir = tmp("evrt-ws-");
     expect(() =>
-      materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "transcript.json" })
+      materializeArtifact({
+        storeRoot,
+        sha256hex: hash,
+        workspaceDir,
+        as: "transcript.json",
+      }),
     ).toThrow(/corrupt/);
 
     // Corrupt entry must be removed from store
@@ -247,11 +303,13 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
 
     db.query(
       `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
-       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
     ).run(
       "run_1",
-      JSON.stringify({ artifacts: [{ kind: "ci-log", sha256: hash1, uri: "file:///x" }] }),
-      new Date().toISOString()
+      JSON.stringify({
+        artifacts: [{ kind: "ci-log", sha256: hash1, uri: "file:///x" }],
+      }),
+      new Date().toISOString(),
     );
 
     const referenced = referencedHashes(db);
@@ -273,16 +331,25 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
     const hash = "d".repeat(64);
     db.query(
       `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`
-    ).run("run_100", "idem_100", JSON.stringify({ agent: "test-agent" }), "hash_100", new Date().toISOString(), new Date().toISOString());
+       VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`,
+    ).run(
+      "run_100",
+      "idem_100",
+      JSON.stringify({ agent: "test-agent" }),
+      "hash_100",
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
 
     db.query(
       `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
-       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
     ).run(
       "run_100",
-      JSON.stringify({ artifacts: [{ kind: "transcript", sha256: hash, uri: "file:///x" }] }),
-      new Date().toISOString()
+      JSON.stringify({
+        artifacts: [{ kind: "transcript", sha256: hash, uri: "file:///x" }],
+      }),
+      new Date().toISOString(),
     );
 
     const pinned = pinRunArtifact(db, "run_100", { kind: "transcript" });
@@ -290,6 +357,8 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
     expect(pinned.agent).toBe("test-agent");
 
     expect(() => pinRunArtifact(db, "run_unknown")).toThrow(/unknown run/);
-    expect(() => pinRunArtifact(db, "run_100", { kind: "other" })).toThrow(/stored no "other" artifact/);
+    expect(() => pinRunArtifact(db, "run_100", { kind: "other" })).toThrow(
+      /stored no "other" artifact/,
+    );
   });
 });

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -72,7 +72,9 @@ export function loadChainAutoApprovalPolicy({ root = reposRoot() } = {}) {
     }
     const merge = parsed?.merge;
     const escalation = parsed?.escalation;
-    const mergeAllowed = allowed.some((eventType) => MERGE_EVENT_TYPES.has(eventType));
+    const mergeAllowed = allowed.some((eventType) =>
+      MERGE_EVENT_TYPES.has(eventType),
+    );
     const maxFixRounds = merge?.max_fix_rounds ?? 0;
     const autoMergeBase = escalation?.auto_merge_base ?? [];
     const autoMergeOwners = escalation?.auto_merge_owners ?? [];
@@ -297,7 +299,8 @@ function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
 }
 
 function mergeBarrierReason(db, registry, candidate, now) {
-  const applyAgent = registry.eventTypes["factory.merge-apply.requested"]?.agent;
+  const applyAgent =
+    registry.eventTypes["factory.merge-apply.requested"]?.agent;
   const verifyAgent = registry.eventTypes["factory.merge-landed"]?.agent;
   if (!applyAgent || !verifyAgent) return "merge_barrier_registry_incomplete";
   const inFlight = db
@@ -484,7 +487,9 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     envelope,
   );
   const predecessorDef = registry.agents.get(spec.agent);
-  const commandEdge = predecessorDef?.chainCommandEdges?.includes(envelope.type);
+  const commandEdge = predecessorDef?.chainCommandEdges?.includes(
+    envelope.type,
+  );
   if (
     declaredEdge?.eventType !== envelope.type &&
     !independentEdge &&
@@ -501,16 +506,16 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     const sourceRequired = new Set(predecessorDef.inputSchema?.required ?? []);
     const itemsField = predecessorDef.itemsField;
     const item =
-      typeof itemsField === "string"
-        ? source[itemsField]?.[0]
-        : undefined;
+      typeof itemsField === "string" ? source[itemsField]?.[0] : undefined;
     const itemRequired = new Set(
       typeof itemsField === "string"
-        ? predecessorDef.inputSchema?.properties?.[itemsField]?.items?.required ?? []
+        ? (predecessorDef.inputSchema?.properties?.[itemsField]?.items
+            ?.required ?? [])
         : [],
     );
     const targetAgent = registry.eventTypes[envelope.type]?.agent;
-    const required = registry.agents.get(targetAgent)?.inputSchema?.required ?? [];
+    const required =
+      registry.agents.get(targetAgent)?.inputSchema?.required ?? [];
     const payload = envelope.payload ?? {};
     for (const field of required) {
       if (sourceRequired.has(field)) {
@@ -576,7 +581,10 @@ function mergeEligibility(db, registry, candidate, envelope, policy, now) {
   }
   if (envelope.type === "factory.merge-fix.requested") {
     const owner = String(input.github ?? "").split("/")[0];
-    if (!policy.autoMergeOwners?.has(owner) || !policy.autoMergeBase?.has(input.base))
+    if (
+      !policy.autoMergeOwners?.has(owner) ||
+      !policy.autoMergeBase?.has(input.base)
+    )
       return "merge_fix_repo_not_allowed";
     if (input.mechanical !== true || input.withinOwnedPaths !== true)
       return "merge_fix_not_mechanical_or_in_scope";
@@ -673,7 +681,14 @@ function eligible(
   );
   if (predecessorReason) return predecessorReason;
 
-  const mergeReason = mergeEligibility(db, registry, candidate, envelope, policy, now);
+  const mergeReason = mergeEligibility(
+    db,
+    registry,
+    candidate,
+    envelope,
+    policy,
+    now,
+  );
   if (mergeReason) return mergeReason;
 
   const mapping = getEventType(registry, envelope.type);

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -66,17 +66,26 @@ function seed(
     const parentResult = {
       artifact:
         predecessorArtifact ??
-        (parentRule ? {
-          [parentRule.recommendationField]:
-            predecessorRecommendation ?? predecessor.recommendation,
-        } : {}),
+        (parentRule
+          ? {
+              [parentRule.recommendationField]:
+                predecessorRecommendation ?? predecessor.recommendation,
+            }
+          : {}),
     };
     const at = new Date(now).toISOString();
     db.query(
       `INSERT INTO events
          (source,event_id,type,subject,occurred_at,received_at,correlation_id,envelope_json,payload_hash,status,admitted_at)
        VALUES ('operator',?,'test.parent','test',?,?,?,?,'hash','planned',?)`,
-    ).run(parentEventId, at, at, parentEventId, canonicalJson({ payload: input }), at);
+    ).run(
+      parentEventId,
+      at,
+      at,
+      parentEventId,
+      canonicalJson({ payload: input }),
+      at,
+    );
     db.query(
       `INSERT INTO runs
          (run_id,idempotency_key,spec_json,spec_hash,state,attempts,created_at,updated_at)
@@ -86,7 +95,13 @@ function seed(
       `INSERT INTO proposals
          (id,event_source,event_id,run_id,decision,spec_json,status,created_at,ttl_seconds)
        VALUES (?,'operator',?,?,'run',?,'approved',?,1800)`,
-    ).run(`parent-proposal-${id}`, parentEventId, parentRunId, canonicalJson(parentSpec), at);
+    ).run(
+      `parent-proposal-${id}`,
+      parentEventId,
+      parentRunId,
+      canonicalJson(parentSpec),
+      at,
+    );
     db.query(
       `INSERT INTO results
          (run_id,attempt,result_json,artifact_hash,verification_json,receipt_json,accepted_at)
@@ -193,7 +208,10 @@ const auto = (db, options = {}) => {
   });
 };
 
-const independentMergeRegistry = ({ independent = true, selectors = {} } = {}) => {
+const independentMergeRegistry = ({
+  independent = true,
+  selectors = {},
+} = {}) => {
   const mergeRule = registry.edges["merge-scan@2"];
   return {
     ...registry,
@@ -267,8 +285,13 @@ function seedHistoricalApply(
       summary: "historical merge fixture",
     },
   });
-  db.query(`UPDATE runs SET state = ? WHERE run_id = ?`).run(state, apply.runId);
-  db.query(`UPDATE proposals SET status = 'approved' WHERE id = ?`).run(apply.id);
+  db.query(`UPDATE runs SET state = ? WHERE run_id = ?`).run(
+    state,
+    apply.runId,
+  );
+  db.query(`UPDATE proposals SET status = 'approved' WHERE id = ?`).run(
+    apply.id,
+  );
   return apply;
 }
 
@@ -487,7 +510,9 @@ describe("chain auto approval (WM-357)", () => {
     for (const id of ["env-1", "env-2"]) {
       const failed = seed(circuitDb, { id });
       circuitDb
-        .query(`UPDATE runs SET state = 'FAILED', attempts = 1 WHERE run_id = ?`)
+        .query(
+          `UPDATE runs SET state = 'FAILED', attempts = 1 WHERE run_id = ?`,
+        )
         .run(failed.runId);
       circuitDb
         .query(

--- a/event-runtime/lib/backup.mjs
+++ b/event-runtime/lib/backup.mjs
@@ -90,14 +90,20 @@ export function checkIntegrity(dbOrPath, { throwOnError = false } = {}) {
  * @param {{ overwrite?: boolean }} options
  * @returns {{ destinationPath: string, sizeBytes: number, backupTime: string, integrity: string }}
  */
-export function backupDatabase(dbOrPath, destinationPath, { overwrite = true } = {}) {
+export function backupDatabase(
+  dbOrPath,
+  destinationPath,
+  { overwrite = true } = {},
+) {
   let db = null;
   let shouldClose = false;
 
   try {
     if (typeof dbOrPath === "string") {
       if (!existsSync(dbOrPath)) {
-        throw new Error(`cannot backup database: source file does not exist: ${dbOrPath}`);
+        throw new Error(
+          `cannot backup database: source file does not exist: ${dbOrPath}`,
+        );
       }
       db = new Database(dbOrPath);
       shouldClose = true;
@@ -109,7 +115,10 @@ export function backupDatabase(dbOrPath, destinationPath, { overwrite = true } =
     mkdirSync(destDir, { recursive: true });
 
     const nonce = crypto.randomBytes(6).toString("hex");
-    const tmpDest = path.join(destDir, `.${path.basename(destinationPath)}.tmp-${Date.now()}-${nonce}`);
+    const tmpDest = path.join(
+      destDir,
+      `.${path.basename(destinationPath)}.tmp-${Date.now()}-${nonce}`,
+    );
 
     // Clean up any stale temp file with the same name
     if (existsSync(tmpDest)) unlinkSync(tmpDest);
@@ -127,7 +136,9 @@ export function backupDatabase(dbOrPath, destinationPath, { overwrite = true } =
     if (existsSync(destinationPath)) {
       if (!overwrite) {
         if (existsSync(tmpDest)) unlinkSync(tmpDest);
-        throw new Error(`destination file already exists and overwrite is false: ${destinationPath}`);
+        throw new Error(
+          `destination file already exists and overwrite is false: ${destinationPath}`,
+        );
       }
       unlinkSync(destinationPath);
     }
@@ -160,13 +171,17 @@ export function backupDatabase(dbOrPath, destinationPath, { overwrite = true } =
  */
 export function restoreDatabase(backupPath, targetDbPath = defaultDbPath()) {
   if (!existsSync(backupPath)) {
-    throw new Error(`cannot restore database: backup file not found: ${backupPath}`);
+    throw new Error(
+      `cannot restore database: backup file not found: ${backupPath}`,
+    );
   }
 
   // 1. Verify backup file integrity
   const check = checkIntegrity(backupPath);
   if (!check.ok) {
-    throw new Error(`cannot restore database: backup file is corrupt: ${check.errors.join("; ")}`);
+    throw new Error(
+      `cannot restore database: backup file is corrupt: ${check.errors.join("; ")}`,
+    );
   }
 
   const targetDir = path.dirname(targetDbPath);
@@ -186,7 +201,9 @@ export function restoreDatabase(backupPath, targetDbPath = defaultDbPath()) {
   // 4. Verify restored target database
   const restoredCheck = checkIntegrity(targetDbPath);
   if (!restoredCheck.ok) {
-    throw new Error(`restored database integrity check failed: ${restoredCheck.errors.join("; ")}`);
+    throw new Error(
+      `restored database integrity check failed: ${restoredCheck.errors.join("; ")}`,
+    );
   }
 
   const stat = statSync(targetDbPath);

--- a/event-runtime/lib/backup.test.mjs
+++ b/event-runtime/lib/backup.test.mjs
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -12,7 +20,8 @@ import {
 } from "./backup.mjs";
 import { openDb } from "./db.mjs";
 
-const freshDir = (prefix = "evrt-backup-") => mkdtempSync(path.join(os.tmpdir(), prefix));
+const freshDir = (prefix = "evrt-backup-") =>
+  mkdtempSync(path.join(os.tmpdir(), prefix));
 
 describe("WAL-safe backup and integrity check (OPS-414)", () => {
   test("checkIntegrity reports ok on a valid database", () => {
@@ -34,7 +43,10 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
   test("checkIntegrity detects corruption in a broken database file", () => {
     const dir = freshDir();
     const corruptFile = path.join(dir, "corrupt.db");
-    writeFileSync(corruptFile, "SQLite format 3\0" + "garbage bytes everywhere".repeat(50));
+    writeFileSync(
+      corruptFile,
+      "SQLite format 3\0" + "garbage bytes everywhere".repeat(50),
+    );
 
     const res = checkIntegrity(corruptFile);
     expect(res.ok).toBe(false);
@@ -55,10 +67,12 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
     liveDb.exec("PRAGMA wal_autocheckpoint = 0;");
 
     for (let i = 0; i < 200; i++) {
-      liveDb.query(
-        `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+      liveDb
+        .query(
+          `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
          VALUES ('src', ?, 'test.event', '2026-08-14T00:00:00Z', '2026-08-14T00:00:00Z', '{}', 'hash', '2026-08-14T00:00:00Z')`,
-      ).run(`evt-${i}`);
+        )
+        .run(`evt-${i}`);
     }
 
     // Live db has 200 events
@@ -70,7 +84,8 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
     // Naive copy cannot see uncheckpointed table/data or has 0 rows
     let naiveCount;
     try {
-      naiveCount = naiveDb.query("SELECT COUNT(*) AS n FROM events").get()?.n ?? 0;
+      naiveCount =
+        naiveDb.query("SELECT COUNT(*) AS n FROM events").get()?.n ?? 0;
     } catch {
       naiveCount = -1; // table did not even exist in main db file
     }
@@ -83,7 +98,9 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
     expect(backupRes.sizeBytes).toBeGreaterThan(0);
 
     const backupDb = openDb(backupDbFile);
-    expect(backupDb.query("SELECT COUNT(*) AS n FROM events").get().n).toBe(200);
+    expect(backupDb.query("SELECT COUNT(*) AS n FROM events").get().n).toBe(
+      200,
+    );
     backupDb.close();
 
     liveDb.close();
@@ -97,22 +114,29 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
 
     const liveDb = openDb(liveDbFile);
     for (let i = 0; i < 150; i++) {
-      liveDb.query(
-        `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+      liveDb
+        .query(
+          `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
          VALUES ('webhook', ?, 'push', '2026-08-14T12:00:00Z', '2026-08-14T12:00:01Z', '{"ref":"main"}', 'hash', '2026-08-14T12:00:01Z')`,
-      ).run(`webhook-${i}`);
+        )
+        .run(`webhook-${i}`);
     }
-    liveDb.query(
-      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+    liveDb
+      .query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
        VALUES ('run-1', 'idem-1', '{}', 'hash', 'COMPLETED', 1, '2026-08-14T12:00:00Z', '2026-08-14T12:05:00Z')`,
-    ).run();
+      )
+      .run();
 
     // 1. Perform backup
     backupDatabase(liveDb, backupDbFile);
     liveDb.close();
 
     // 2. Corrupt live database and its companion files
-    writeFileSync(liveDbFile, "CORRUPTED DATA BY POWER FAILURE OR ACCIDENTAL TRUNCATION");
+    writeFileSync(
+      liveDbFile,
+      "CORRUPTED DATA BY POWER FAILURE OR ACCIDENTAL TRUNCATION",
+    );
     writeFileSync(`${liveDbFile}-wal`, "STALE TRASH");
     writeFileSync(`${liveDbFile}-shm`, "STALE TRASH");
 
@@ -125,9 +149,14 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
 
     // 4. Verify restored runtime database works seamlessly
     const restoredDb = openDb(liveDbFile);
-    expect(restoredDb.query("SELECT COUNT(*) AS n FROM events").get().n).toBe(150);
+    expect(restoredDb.query("SELECT COUNT(*) AS n FROM events").get().n).toBe(
+      150,
+    );
     expect(restoredDb.query("SELECT COUNT(*) AS n FROM runs").get().n).toBe(1);
-    expect(restoredDb.query("SELECT state FROM runs WHERE run_id = 'run-1'").get().state).toBe("COMPLETED");
+    expect(
+      restoredDb.query("SELECT state FROM runs WHERE run_id = 'run-1'").get()
+        .state,
+    ).toBe("COMPLETED");
     expect(checkIntegrity(restoredDb).ok).toBe(true);
 
     restoredDb.close();
@@ -140,7 +169,9 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
     const targetDb = path.join(dir, "target.db");
     writeFileSync(corruptBackup, "garbage bytes not a sqlite db");
 
-    expect(() => restoreDatabase(corruptBackup, targetDb)).toThrow(/backup file is corrupt/);
+    expect(() => restoreDatabase(corruptBackup, targetDb)).toThrow(
+      /backup file is corrupt/,
+    );
     expect(existsSync(targetDb)).toBe(false);
 
     rmSync(dir, { recursive: true, force: true });
@@ -154,14 +185,18 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
 
     mkdirSync(artifactsDir, { recursive: true });
     const liveDb = openDb(liveDbFile);
-    liveDb.query(
-      `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+    liveDb
+      .query(
+        `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
        VALUES ('source', 'evt-1', 'build', '2026-08-14T00:00:00Z', '2026-08-14T00:00:00Z', '{}', 'h1', '2026-08-14T00:00:00Z')`,
-    ).run();
+      )
+      .run();
 
     // Create some artifacts
-    const sha1 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-    const sha2 = "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb";
+    const sha1 =
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const sha2 =
+      "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb";
     writeFileSync(path.join(artifactsDir, sha1), "artifact data 1");
     writeFileSync(path.join(artifactsDir, sha2), "artifact data 2");
 
@@ -173,9 +208,15 @@ describe("WAL-safe backup and integrity check (OPS-414)", () => {
     });
 
     expect(snapshot.snapshotPath).toBe(path.join(backupDir, "snap-1"));
-    expect(existsSync(path.join(snapshot.snapshotPath, "runtime.db"))).toBe(true);
-    expect(existsSync(path.join(snapshot.snapshotPath, "artifacts", sha1))).toBe(true);
-    expect(existsSync(path.join(snapshot.snapshotPath, "artifacts", sha2))).toBe(true);
+    expect(existsSync(path.join(snapshot.snapshotPath, "runtime.db"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(path.join(snapshot.snapshotPath, "artifacts", sha1)),
+    ).toBe(true);
+    expect(
+      existsSync(path.join(snapshot.snapshotPath, "artifacts", sha2)),
+    ).toBe(true);
     expect(snapshot.artifactsBackup.copiedFiles).toBe(2);
 
     liveDb.close();

--- a/event-runtime/lib/canonical.mjs
+++ b/event-runtime/lib/canonical.mjs
@@ -17,15 +17,24 @@ export function canonicalJson(value) {
 }
 
 function sortValue(value, path) {
-  if (value === undefined) throw new TypeError(`undefined at ${path} is not representable in canonical JSON`);
+  if (value === undefined)
+    throw new TypeError(
+      `undefined at ${path} is not representable in canonical JSON`,
+    );
   if (value === null || typeof value !== "object") {
     if (typeof value === "number" && !Number.isFinite(value)) {
-      throw new TypeError(`non-finite number at ${path} is not representable in canonical JSON`);
+      throw new TypeError(
+        `non-finite number at ${path} is not representable in canonical JSON`,
+      );
     }
-    if (typeof value === "bigint") throw new TypeError(`bigint at ${path} is not representable in canonical JSON`);
+    if (typeof value === "bigint")
+      throw new TypeError(
+        `bigint at ${path} is not representable in canonical JSON`,
+      );
     return value;
   }
-  if (Array.isArray(value)) return value.map((v, i) => sortValue(v, `${path}[${i}]`));
+  if (Array.isArray(value))
+    return value.map((v, i) => sortValue(v, `${path}[${i}]`));
   const sorted = {};
   for (const key of Object.keys(value).sort()) {
     if (value[key] === undefined) continue;

--- a/event-runtime/lib/canonical.test.mjs
+++ b/event-runtime/lib/canonical.test.mjs
@@ -3,7 +3,9 @@ import { canonicalJson, hashBytes, hashJson } from "./canonical.mjs";
 
 describe("canonicalJson", () => {
   test("sorts object keys recursively", () => {
-    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe('{"a":{"c":3,"d":2},"b":1}');
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe(
+      '{"a":{"c":3,"d":2},"b":1}',
+    );
   });
 
   test("preserves array order", () => {
@@ -11,7 +13,9 @@ describe("canonicalJson", () => {
   });
 
   test("same value, different key order → same hash", () => {
-    expect(hashJson({ x: 1, y: [true, null] })).toBe(hashJson({ y: [true, null], x: 1 }));
+    expect(hashJson({ x: 1, y: [true, null] })).toBe(
+      hashJson({ y: [true, null], x: 1 }),
+    );
   });
 
   test("drops undefined object properties", () => {
@@ -26,6 +30,8 @@ describe("canonicalJson", () => {
 
 describe("hashes", () => {
   test("are prefixed sha256 over bytes", () => {
-    expect(hashBytes("abc")).toBe("sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    expect(hashBytes("abc")).toBe(
+      "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
   });
 });

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -26,14 +26,20 @@ export const CHAIN_SOURCE = "chain";
  * select it through the public API.
  */
 export function admitChainEvent(db, registry, envelope, options = {}) {
-  return admitEvent(db, registry, { ...envelope, source: CHAIN_SOURCE }, options);
+  return admitEvent(
+    db,
+    registry,
+    { ...envelope, source: CHAIN_SOURCE },
+    options,
+  );
 }
 
 /** Resolve a "$.input.x" / "$.artifact.x.y" path against the chain context. */
 function resolvePath(expr, context) {
   if (typeof expr !== "string" || !expr.startsWith("$.")) return expr; // literal
   const [root, ...segments] = expr.slice(2).split(".");
-  if (!(root in context)) throw new Error(`chain input path "${expr}": unknown root "${root}"`);
+  if (!(root in context))
+    throw new Error(`chain input path "${expr}": unknown root "${root}"`);
   let value = context[root];
   for (const segment of segments) {
     if (value === null || typeof value !== "object" || !(segment in value)) {
@@ -41,7 +47,8 @@ function resolvePath(expr, context) {
     }
     value = value[segment];
   }
-  if (value === undefined) throw new Error(`chain input path "${expr}" resolves to nothing`);
+  if (value === undefined)
+    throw new Error(`chain input path "${expr}" resolves to nothing`);
   return value;
 }
 
@@ -114,9 +121,14 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       const selectionContext = { input: spec.input, artifact };
       const selectedEdges = rule.independent
         ? Object.entries(rule.edges).filter(([, candidate]) => {
-            const items = resolveItems(candidate.whenItemsField, selectionContext);
+            const items = resolveItems(
+              candidate.whenItemsField,
+              selectionContext,
+            );
             if (!Array.isArray(items)) {
-              throw new Error(`independent chain selector "${candidate.whenItemsField}" is not an array`);
+              throw new Error(
+                `independent chain selector "${candidate.whenItemsField}" is not an array`,
+              );
             }
             return items.length > 0;
           })
@@ -124,21 +136,30 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
             const primary = rule.edges[recommendation];
             if (primary === undefined) return [];
             const additionalKeys = primary.also ?? [];
-            if (!Array.isArray(additionalKeys) || additionalKeys.some((key) => typeof key !== "string")) {
-              throw new Error(`chain edge "${recommendation}" also must be an array of edge keys`);
+            if (
+              !Array.isArray(additionalKeys) ||
+              additionalKeys.some((key) => typeof key !== "string")
+            ) {
+              throw new Error(
+                `chain edge "${recommendation}" also must be an array of edge keys`,
+              );
             }
             return [recommendation, ...additionalKeys]
               .map((key) => {
                 const candidate = rule.edges[key];
                 if (candidate === undefined) {
-                  throw new Error(`chain edge "${recommendation}" references unknown sibling "${key}"`);
+                  throw new Error(
+                    `chain edge "${recommendation}" references unknown sibling "${key}"`,
+                  );
                 }
                 return [key, candidate];
               })
               .filter(([, candidate]) => {
                 if (candidate.whenPath === undefined) return true;
                 try {
-                  return resolvePath(candidate.whenPath, selectionContext) !== null;
+                  return (
+                    resolvePath(candidate.whenPath, selectionContext) !== null
+                  );
                 } catch {
                   return false;
                 }
@@ -155,7 +176,11 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       // resolves against the accepted result's stored artifacts (OPS-372).
       const artifactHash = {};
       for (const entry of result.artifacts ?? []) {
-        if (entry.kind && entry.sha256 && artifactHash[entry.kind] === undefined) {
+        if (
+          entry.kind &&
+          entry.sha256 &&
+          artifactHash[entry.kind] === undefined
+        ) {
           artifactHash[entry.kind] = entry.sha256;
         }
       }
@@ -181,15 +206,22 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
           }
 
           const fallbackIds = items.map((item) => {
-            if (typeof item === "object" && item !== null) return itemKey ? item[itemKey] : undefined;
-            if (typeof item === "string" || typeof item === "number") return String(item);
+            if (typeof item === "object" && item !== null)
+              return itemKey ? item[itemKey] : undefined;
+            if (typeof item === "string" || typeof item === "number")
+              return String(item);
             return undefined;
           });
-          const duplicateFallback = new Set(fallbackIds.map(String)).size !== fallbackIds.length;
+          const duplicateFallback =
+            new Set(fallbackIds.map(String)).size !== fallbackIds.length;
 
           for (const [index, item] of items.entries()) {
             const itemKeyVal = fallbackIds[index];
-            if (itemKeyVal === undefined || itemKeyVal === null || String(itemKeyVal).trim() === "") {
+            if (
+              itemKeyVal === undefined ||
+              itemKeyVal === null ||
+              String(itemKeyVal).trim() === ""
+            ) {
               throw new Error(`multi-emit chain item missing key "${itemKey}"`);
             }
             const itemContext = {
@@ -199,14 +231,25 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
               item,
             };
             const payload = buildChainInput(edge.input ?? {}, itemContext);
-            if (itemKey && payload[itemKey] === undefined) payload[itemKey] = itemKeyVal;
-            if (edge.perItem) Object.assign(payload, buildChainInput(edge.perItem, itemContext));
+            if (itemKey && payload[itemKey] === undefined)
+              payload[itemKey] = itemKeyVal;
+            if (edge.perItem)
+              Object.assign(
+                payload,
+                buildChainInput(edge.perItem, itemContext),
+              );
 
             envelopes.push({
               schemaVersion: "factory.event/v1",
-              eventId: chainEventId(edge, row, itemContext, `chain-${row.run_id}-${itemKeyVal}`, {
-                mixed: mixed || duplicateFallback,
-              }),
+              eventId: chainEventId(
+                edge,
+                row,
+                itemContext,
+                `chain-${row.run_id}-${itemKeyVal}`,
+                {
+                  mixed: mixed || duplicateFallback,
+                },
+              ),
               type: edge.eventType,
               source: CHAIN_SOURCE,
               subject: spec.agent,
@@ -224,7 +267,13 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
           };
           envelopes.push({
             schemaVersion: "factory.event/v1",
-            eventId: chainEventId(edge, row, eventContext, `chain-${row.run_id}`, { mixed }),
+            eventId: chainEventId(
+              edge,
+              row,
+              eventContext,
+              `chain-${row.run_id}`,
+              { mixed },
+            ),
             type: edge.eventType,
             source: CHAIN_SOURCE,
             subject: spec.agent,
@@ -247,17 +296,24 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       // marker, not permission to backfill stale actions under today's edges.
       const existingIds = new Set(
         db
-          .query(`SELECT event_id FROM events WHERE source = ? AND causation_id = ?`)
+          .query(
+            `SELECT event_id FROM events WHERE source = ? AND causation_id = ?`,
+          )
           .all(CHAIN_SOURCE, row.run_id)
           .map((event) => event.event_id),
       );
       if ([...existingIds].some((eventId) => !ids.includes(eventId))) continue;
-      const pending = envelopes.filter((envelope) => !existingIds.has(envelope.eventId));
+      const pending = envelopes.filter(
+        (envelope) => !existingIds.has(envelope.eventId),
+      );
       for (const envelope of pending) {
         const admitted = admitChainEvent(db, registry, envelope, { now });
         if (admitted.admitted) outcome.emitted += 1;
         else if (admitted.duplicate) outcome.skipped += 1;
-        else outcome.errors.push(`${envelope.eventId}: ${admitted.errors.join("; ")}`);
+        else
+          outcome.errors.push(
+            `${envelope.eventId}: ${admitted.errors.join("; ")}`,
+          );
       }
     } catch (err) {
       outcome.errors.push(`chain-${row.run_id}: ${err.message}`);

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -15,7 +15,8 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 
 function failedRunEnvelope(overrides = {}) {
-  const id = overrides.eventId ?? `gh-${Math.random().toString(36).slice(2, 10)}`;
+  const id =
+    overrides.eventId ?? `gh-${Math.random().toString(36).slice(2, 10)}`;
   return {
     schemaVersion: "factory.event/v1",
     eventId: id,
@@ -37,15 +38,24 @@ function harness() {
   // Chain flow under test never spawns real processes: pi AND command
   // both back onto the contract-shaped fake.
   const adapters = { pi: fake, command: fake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function runToCompletion(eventId) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
     const proposal = openProposals(db, {}).find(
-      (p) => p.decision === "run" && (p.event_id === eventId || p.spec?.idempotencyKey),
+      (p) =>
+        p.decision === "run" &&
+        (p.event_id === eventId || p.spec?.idempotencyKey),
     );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     expect(approved.approved).toBe(true);
     const summary = await runOnce(db, registry, adapters, workerOpts);
     expect(summary.terminalState).toBe("COMPLETED");
@@ -70,11 +80,22 @@ describe("trusted chain admission", () => {
 });
 
 describe("buildChainInput", () => {
-  const context = { input: { repo: "wm/x", runId: 7 }, artifact: { verdict: "FLAKE", nested: { a: 1 } } };
+  const context = {
+    input: { repo: "wm/x", runId: 7 },
+    artifact: { verdict: "FLAKE", nested: { a: 1 } },
+  };
 
   test("resolves $.input.* and $.artifact.* paths and passes literals through", () => {
     expect(
-      buildChainInput({ repo: "$.input.repo", v: "$.artifact.verdict", deep: "$.artifact.nested.a", lit: "x" }, context),
+      buildChainInput(
+        {
+          repo: "$.input.repo",
+          v: "$.artifact.verdict",
+          deep: "$.artifact.nested.a",
+          lit: "x",
+        },
+        context,
+      ),
     ).toEqual({ repo: "wm/x", v: "FLAKE", deep: 1, lit: "x" });
   });
 
@@ -106,7 +127,9 @@ describe("buildChainInput", () => {
   });
 
   test("missing path fails loudly", () => {
-    expect(() => buildChainInput({ nope: "$.artifact.absent" }, context)).toThrow("resolves to nothing");
+    expect(() =>
+      buildChainInput({ nope: "$.artifact.absent" }, context),
+    ).toThrow("resolves to nothing");
   });
 });
 
@@ -119,9 +142,14 @@ async function throughCapture(h, eventId) {
   const capture = await h.runToCompletion(eventId);
   expect(resolveChains(h.db, registry).emitted).toBe(1);
   planAdmittedEvents(h.db, registry, { policyVersion: PV });
-  const diagnose = openProposals(h.db, {}).find((p) => p.spec?.agent === "ci-doctor@2");
+  const diagnose = openProposals(h.db, {}).find(
+    (p) => p.spec?.agent === "ci-doctor@2",
+  );
   expect(diagnose).toBeTruthy();
-  const approved = approveProposal(h.db, registry, diagnose.id, { actor: "operator", policyVersion: PV });
+  const approved = approveProposal(h.db, registry, diagnose.id, {
+    actor: "operator",
+    policyVersion: PV,
+  });
   const summary = await runOnce(h.db, registry, h.adapters, h.workerOpts);
   expect(summary.terminalState).toBe("COMPLETED");
   return { capture, diagnoseRunId: approved.runId, diagnoseProposal: diagnose };
@@ -148,7 +176,9 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
 
     // The planner proposes the follow-up — open and watched, not auto-run.
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-rerun@1");
+    const followUp = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-rerun@1",
+    );
     expect(followUp).toBeTruthy();
     expect(followUp.status).toBe("open");
     expect(followUp.spec.adapter).toBe("command");
@@ -156,21 +186,31 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
 
     // Re-resolving chains emits nothing new: the already-chained run is
     // excluded up front (NOT EXISTS on its chain event) — one event per run, ever.
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("TICKET verdict chains to ci-notify with the diagnosis summary mapped in", async () => {
     const h = harness();
     const { db, runToCompletion } = h;
-    admitEvent(db, registry, failedRunEnvelope({
-      eventId: "gh-ticket-1",
-      payload: { repo: "wm/factory-ticket", runId: 777 },
-    }));
+    admitEvent(
+      db,
+      registry,
+      failedRunEnvelope({
+        eventId: "gh-ticket-1",
+        payload: { repo: "wm/factory-ticket", runId: 777 },
+      }),
+    );
     await throughCapture(h, "gh-ticket-1");
 
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-notify@1");
+    const followUp = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-notify@1",
+    );
     expect(followUp).toBeTruthy();
     expect(followUp.spec.input.summary).toContain("wm/factory-ticket");
   });
@@ -178,26 +218,56 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
   test("full chain executes after approval: rerun completes under the command contract", async () => {
     const h = harness();
     const { db, adapters, workerOpts } = h;
-    admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-flake-2", payload: { repo: "wm/f2", runId: 2 } }));
+    admitEvent(
+      db,
+      registry,
+      failedRunEnvelope({
+        eventId: "gh-flake-2",
+        payload: { repo: "wm/f2", runId: 2 },
+      }),
+    );
     await throughCapture(h, "gh-flake-2");
     resolveChains(db, registry);
     planAdmittedEvents(db, registry, { policyVersion: PV });
 
-    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-rerun@1");
-    const approved = approveProposal(db, registry, followUp.id, { actor: "operator", policyVersion: PV });
+    const followUp = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-rerun@1",
+    );
+    const approved = approveProposal(db, registry, followUp.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     expect(approved.approved).toBe(true);
     const summary = await runOnce(db, registry, adapters, workerOpts);
     expect(summary.terminalState).toBe("COMPLETED");
 
     // The command result has no registered edges — the chain terminates.
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("duplicate failed-run delivery converges: one doctor run, one chain event", async () => {
     const h = harness();
     const { db, runToCompletion } = h;
-    admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
-    const dup = admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
+    admitEvent(
+      db,
+      registry,
+      failedRunEnvelope({
+        eventId: "gh-dup-1",
+        payload: { repo: "wm/d", runId: 9 },
+      }),
+    );
+    const dup = admitEvent(
+      db,
+      registry,
+      failedRunEnvelope({
+        eventId: "gh-dup-1",
+        payload: { repo: "wm/d", runId: 9 },
+      }),
+    );
     expect(dup.duplicate).toBe(true);
     await runToCompletion("gh-dup-1");
     expect(resolveChains(db, registry).emitted).toBe(1); // capture → diagnose
@@ -213,21 +283,45 @@ describe("registry gates (OPS-223)", () => {
 
   test("edges validation fails closed: unregistered targets and stray input roots", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-reg-"));
-    cpSync(path.join(registry.root, "agents"), path.join(root, "agents"), { recursive: true });
-    cpSync(path.join(registry.root, "schemas"), path.join(root, "schemas"), { recursive: true });
-    cpSync(path.join(registry.root, "event-types.json"), path.join(root, "event-types.json"));
+    cpSync(path.join(registry.root, "agents"), path.join(root, "agents"), {
+      recursive: true,
+    });
+    cpSync(path.join(registry.root, "schemas"), path.join(root, "schemas"), {
+      recursive: true,
+    });
+    cpSync(
+      path.join(registry.root, "event-types.json"),
+      path.join(root, "event-types.json"),
+    );
 
     writeFileSync(
       path.join(root, "edges.json"),
-      JSON.stringify({ "ci-doctor@2": { recommendationField: "verdict", edges: { FLAKE: { eventType: "not.registered", input: {} } } } }),
+      JSON.stringify({
+        "ci-doctor@2": {
+          recommendationField: "verdict",
+          edges: { FLAKE: { eventType: "not.registered", input: {} } },
+        },
+      }),
     );
     expect(() => loadRegistry({ root })).toThrow(RegistryError);
 
     writeFileSync(
       path.join(root, "edges.json"),
-      JSON.stringify({ "ci-doctor@2": { recommendationField: "verdict", edges: { FLAKE: { eventType: "factory.ci-rerun.requested", input: { x: "$.secrets.key" } } } } }),
+      JSON.stringify({
+        "ci-doctor@2": {
+          recommendationField: "verdict",
+          edges: {
+            FLAKE: {
+              eventType: "factory.ci-rerun.requested",
+              input: { x: "$.secrets.key" },
+            },
+          },
+        },
+      }),
     );
-    expect(() => loadRegistry({ root })).toThrow("only $.input.*, $.artifact.* and $.artifactHash.*");
+    expect(() => loadRegistry({ root })).toThrow(
+      "only $.input.*, $.artifact.* and $.artifactHash.*",
+    );
 
     const independentRule = (edge) => ({
       "ci-doctor@2": {
@@ -238,9 +332,13 @@ describe("registry gates (OPS-223)", () => {
     });
     writeFileSync(
       path.join(root, "edges.json"),
-      JSON.stringify(independentRule({ eventType: "factory.ci-rerun.requested", input: {} })),
+      JSON.stringify(
+        independentRule({ eventType: "factory.ci-rerun.requested", input: {} }),
+      ),
     );
-    expect(() => loadRegistry({ root })).toThrow("independent edge has no whenItemsField");
+    expect(() => loadRegistry({ root })).toThrow(
+      "independent edge has no whenItemsField",
+    );
 
     writeFileSync(
       path.join(root, "edges.json"),
@@ -252,7 +350,9 @@ describe("registry gates (OPS-223)", () => {
         }),
       ),
     );
-    expect(() => loadRegistry({ root })).toThrow("independent edge needs a mixedEventId containing ${runId}");
+    expect(() => loadRegistry({ root })).toThrow(
+      "independent edge needs a mixedEventId containing ${runId}",
+    );
 
     writeFileSync(
       path.join(root, "edges.json"),
@@ -270,17 +370,40 @@ describe("registry gates (OPS-223)", () => {
 });
 
 describe("multi-emit chain resolution (WM-119)", () => {
-  function seedCompletedRun(db, { runId, agent, input, artifact, eventId = `evt-${runId}`, correlationId = `corr-${runId}` }) {
+  function seedCompletedRun(
+    db,
+    {
+      runId,
+      agent,
+      input,
+      artifact,
+      eventId = `evt-${runId}`,
+      correlationId = `corr-${runId}`,
+    },
+  ) {
     const now = new Date().toISOString();
     db.query(
       `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at, correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
        VALUES ('operator', ?, 'test.event', 'test', ?, ?, ?, NULL, ?, 'hash', 'admitted', ?)`,
-    ).run(eventId, now, now, correlationId, JSON.stringify({ payload: input }), now);
+    ).run(
+      eventId,
+      now,
+      now,
+      correlationId,
+      JSON.stringify({ payload: input }),
+      now,
+    );
 
     db.query(
       `INSERT INTO proposals (id, event_source, event_id, run_id, decision, spec_json, status, created_at, ttl_seconds)
        VALUES (?, 'operator', ?, ?, 'run', ?, 'approved', ?, 1800)`,
-    ).run(`prop-${runId}`, eventId, runId, JSON.stringify({ agent, input }), now);
+    ).run(
+      `prop-${runId}`,
+      eventId,
+      runId,
+      JSON.stringify({ agent, input }),
+      now,
+    );
 
     db.query(
       `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
@@ -317,7 +440,9 @@ describe("multi-emit chain resolution (WM-119)", () => {
     expect(outcome).toEqual({ emitted: 3, skipped: 0, errors: [] });
 
     for (const ticket of ["WM-101", "WM-102", "WM-103"]) {
-      const event = db.query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`).get(`chain-run-fanout-1-${ticket}`);
+      const event = db
+        .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+        .get(`chain-run-fanout-1-${ticket}`);
       expect(event).toBeTruthy();
       expect(event.type).toBe("factory.dispatch.requested");
       expect(event.correlation_id).toBe("scan-corr-1");
@@ -327,7 +452,11 @@ describe("multi-emit chain resolution (WM-119)", () => {
     }
 
     // Idempotent: re-resolving chains emits 0
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("empty plan skips cleanly without error", () => {
@@ -345,7 +474,11 @@ describe("multi-emit chain resolution (WM-119)", () => {
       },
     });
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
   });
 
   test("custom eventId templating and perItem mapping overlays", () => {
@@ -384,9 +517,14 @@ describe("multi-emit chain resolution (WM-119)", () => {
 
     const outcome = resolveChains(db, customRegistry);
     expect(outcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
-    const event = db.query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`).get("chain-run-tmpl-1-WM-201");
+    const event = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get("chain-run-tmpl-1-WM-201");
     expect(event).toBeTruthy();
-    expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "wm/tmpl", ticket: "WM-201" });
+    expect(JSON.parse(event.envelope_json).payload).toEqual({
+      repo: "wm/tmpl",
+      ticket: "WM-201",
+    });
   });
 
   test("missing itemKey records error cleanly", () => {
@@ -411,7 +549,9 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("triage-apply outcome edges route to the correct follow-up", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-triage-apply-1"));
+    const dir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-chain-triage-apply-1"),
+    );
     const db = openDb(path.join(dir, "runtime.db"));
 
     seedCompletedRun(db, {
@@ -427,11 +567,17 @@ describe("multi-emit chain resolution (WM-119)", () => {
 
     const supplyOutcome = resolveChains(db, registry);
     expect(supplyOutcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
-    const supplyEvent = db.query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`).get("chain-run-triage-supply");
+    const supplyEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get("chain-run-triage-supply");
     expect(supplyEvent.type).toBe("factory.work.requested");
-    expect(JSON.parse(supplyEvent.envelope_json).payload).toEqual({ repo: "wm/triage" });
+    expect(JSON.parse(supplyEvent.envelope_json).payload).toEqual({
+      repo: "wm/triage",
+    });
 
-    const dir2 = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-triage-apply-2"));
+    const dir2 = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-chain-triage-apply-2"),
+    );
     const db2 = openDb(path.join(dir2, "runtime.db"));
     seedCompletedRun(db2, {
       runId: "run-triage-detail",
@@ -445,11 +591,17 @@ describe("multi-emit chain resolution (WM-119)", () => {
     });
     const detailOutcome = resolveChains(db2, registry);
     expect(detailOutcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
-    const detailEvent = db2.query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`).get("chain-run-triage-detail");
+    const detailEvent = db2
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get("chain-run-triage-detail");
     expect(detailEvent.type).toBe("factory.triage.requested");
-    expect(JSON.parse(detailEvent.envelope_json).payload).toEqual({ repo: "wm/triage" });
+    expect(JSON.parse(detailEvent.envelope_json).payload).toEqual({
+      repo: "wm/triage",
+    });
 
-    const dir3 = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-triage-apply-3"));
+    const dir3 = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-chain-triage-apply-3"),
+    );
     const db3 = openDb(path.join(dir3, "runtime.db"));
     seedCompletedRun(db3, {
       runId: "run-triage-nochange",
@@ -461,7 +613,11 @@ describe("multi-emit chain resolution (WM-119)", () => {
         applied: [{ issueId: "WM-3", action: "move-to-todo" }],
       },
     });
-    expect(resolveChains(db3, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db3, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
   });
 
   test("dispatch PR_OPEN fans out work continuation and scoped merge review (WM-576)", () => {
@@ -478,17 +634,37 @@ describe("multi-emit chain resolution (WM-119)", () => {
       },
     });
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 2, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 2,
+      skipped: 0,
+      errors: [],
+    });
     const events = db
-      .query(`SELECT event_id,type,envelope_json FROM events WHERE source = 'chain' ORDER BY event_id`)
+      .query(
+        `SELECT event_id,type,envelope_json FROM events WHERE source = 'chain' ORDER BY event_id`,
+      )
       .all();
-    expect(events.map(({ event_id, type }) => ({ eventId: event_id, type }))).toEqual([
+    expect(
+      events.map(({ event_id, type }) => ({ eventId: event_id, type })),
+    ).toEqual([
       { eventId: "chain-run-dispatch-pr-open", type: "factory.work.requested" },
-      { eventId: "chain-run-dispatch-pr-open-merge", type: "factory.merge.requested" },
+      {
+        eventId: "chain-run-dispatch-pr-open-merge",
+        type: "factory.merge.requested",
+      },
     ]);
-    expect(JSON.parse(events[0].envelope_json).payload).toEqual({ repo: "factory" });
-    expect(JSON.parse(events[1].envelope_json).payload).toEqual({ repo: "factory", prNumbers: [576] });
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(JSON.parse(events[0].envelope_json).payload).toEqual({
+      repo: "factory",
+    });
+    expect(JSON.parse(events[1].envelope_json).payload).toEqual({
+      repo: "factory",
+      prNumbers: [576],
+    });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("non-completed runs do not generate chain candidates", () => {
@@ -501,7 +677,10 @@ describe("multi-emit chain resolution (WM-119)", () => {
        VALUES ('run-triage-failed', 'idem-run-triage-failed', '{"agent":"triage-apply@1","input":{"repo":"wm/triage"}}', 'hash', 'FAILED', 1, ?, ?)`,
     ).run(now, now);
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 });
-

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -27,7 +27,10 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
     }
     if (!res.ok) {
       const message =
-        json?.error ?? (Array.isArray(json?.errors) ? json.errors.join("; ") : `HTTP ${res.status}`);
+        json?.error ??
+        (Array.isArray(json?.errors)
+          ? json.errors.join("; ")
+          : `HTTP ${res.status}`);
       const err = new Error(message);
       err.status = res.status;
       err.body = json;
@@ -44,22 +47,39 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
     postEvent: (rawBody, { signature, timestamp } = {}) => {
       const headers = {};
       if (signature !== undefined) headers["x-factory-signature"] = signature;
-      if (timestamp !== undefined) headers["x-factory-timestamp"] = String(timestamp);
+      if (timestamp !== undefined)
+        headers["x-factory-timestamp"] = String(timestamp);
       return call("POST", "/events", { body: rawBody, headers });
     },
     /** Replay/inject: same admission path, no signature (loopback only, §13). */
-    replay: (envelope) => call("POST", "/replay", { body: JSON.stringify(envelope) }),
+    replay: (envelope) =>
+      call("POST", "/replay", { body: JSON.stringify(envelope) }),
     status: () => call("GET", "/status"),
-    events: (status) => call("GET", `/events${status ? `?status=${encodeURIComponent(status)}` : ""}`),
-    proposals: (status) => call("GET", `/proposals${status ? `?status=${encodeURIComponent(status)}` : ""}`),
-    journal: ({ since = 0, limit = 100 } = {}) => call("GET", `/journal?since=${since}&limit=${limit}`),
+    events: (status) =>
+      call(
+        "GET",
+        `/events${status ? `?status=${encodeURIComponent(status)}` : ""}`,
+      ),
+    proposals: (status) =>
+      call(
+        "GET",
+        `/proposals${status ? `?status=${encodeURIComponent(status)}` : ""}`,
+      ),
+    journal: ({ since = 0, limit = 100 } = {}) =>
+      call("GET", `/journal?since=${since}&limit=${limit}`),
     outbox: ({ limit = 50 } = {}) => call("GET", `/outbox?limit=${limit}`),
     requeue: (source, eventId) =>
-      call("POST", "/events/requeue", { body: JSON.stringify({ source, eventId }) }),
+      call("POST", "/events/requeue", {
+        body: JSON.stringify({ source, eventId }),
+      }),
     archive: (source, eventId) =>
-      call("POST", "/events/archive", { body: JSON.stringify({ source, eventId }) }),
+      call("POST", "/events/archive", {
+        body: JSON.stringify({ source, eventId }),
+      }),
     releaseWorker: (workerId, runId) =>
-      call("POST", `/workers/${encodeURIComponent(workerId)}/release`, { body: JSON.stringify({ runId }) }),
+      call("POST", `/workers/${encodeURIComponent(workerId)}/release`, {
+        body: JSON.stringify({ runId }),
+      }),
     agents: () => call("GET", "/agents"),
     workers: () => call("GET", "/workers"),
     schedules: () => call("GET", "/schedules"),
@@ -74,20 +94,31 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
       call("POST", `/repos/${encodeURIComponent(name)}/janitor`, {
         body: JSON.stringify({ apply: apply === true }),
       }),
-    approve: (id) => call("POST", `/proposals/${encodeURIComponent(id)}/approve`, { body: "{}" }),
+    approve: (id) =>
+      call("POST", `/proposals/${encodeURIComponent(id)}/approve`, {
+        body: "{}",
+      }),
     reject: (id, reason) =>
-      call("POST", `/proposals/${encodeURIComponent(id)}/reject`, { body: JSON.stringify({ reason }) }),
-    runs: (state) => call("GET", `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`),
+      call("POST", `/proposals/${encodeURIComponent(id)}/reject`, {
+        body: JSON.stringify({ reason }),
+      }),
+    runs: (state) =>
+      call("GET", `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`),
     run: (id) => call("GET", `/runs/${encodeURIComponent(id)}`),
     /** Live agent trace (factory.trace/v1): pass head back as since to poll. */
     trace: (id, { since = 0, limit = 100 } = {}) =>
-      call("GET", `/runs/${encodeURIComponent(id)}/trace?since=${since}&limit=${limit}`),
+      call(
+        "GET",
+        `/runs/${encodeURIComponent(id)}/trace?since=${since}&limit=${limit}`,
+      ),
     cancel: (id, reason) =>
       call("POST", `/runs/${encodeURIComponent(id)}/cancel`, {
         body: JSON.stringify(reason ? { reason } : {}),
       }),
     retry: (id, { force = false } = {}) =>
-      call("POST", `/runs/${encodeURIComponent(id)}/retry`, { body: JSON.stringify({ force }) }),
+      call("POST", `/runs/${encodeURIComponent(id)}/retry`, {
+        body: JSON.stringify({ force }),
+      }),
     extend: (id, seconds, { override = false } = {}) =>
       call("POST", `/runs/${encodeURIComponent(id)}/extend`, {
         body: JSON.stringify({ seconds, override }),

--- a/event-runtime/lib/concurrency.test.mjs
+++ b/event-runtime/lib/concurrency.test.mjs
@@ -8,7 +8,10 @@ import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
 const PV = "git:test-pv";
 
-function queueRun(database, { runId, placement, adapter = "fake", timeoutSeconds = 60 }) {
+function queueRun(
+  database,
+  { runId, placement, adapter = "fake", timeoutSeconds = 60 },
+) {
   const spec = {
     schemaVersion: "factory.run-spec/v1",
     runId,
@@ -28,8 +31,18 @@ function queueRun(database, { runId, placement, adapter = "fake", timeoutSeconds
     actor: "planner",
     policyVersion: PV,
   });
-  transition(database, { runId, to: "APPROVED", actor: "operator", policyVersion: PV });
-  transition(database, { runId, to: "QUEUED", actor: "operator", policyVersion: PV });
+  transition(database, {
+    runId,
+    to: "APPROVED",
+    actor: "operator",
+    policyVersion: PV,
+  });
+  transition(database, {
+    runId,
+    to: "QUEUED",
+    actor: "operator",
+    policyVersion: PV,
+  });
   return spec;
 }
 
@@ -111,7 +124,9 @@ describe("multi-process concurrency (OPS-424, OPS-233)", () => {
     const attempts = verifyDb.query("SELECT * FROM attempts").all();
     expect(attempts.length).toBe(M);
 
-    const runs = verifyDb.query("SELECT run_id, state, attempts FROM runs").all();
+    const runs = verifyDb
+      .query("SELECT run_id, state, attempts FROM runs")
+      .all();
     expect(runs.length).toBe(M);
     for (const row of runs) {
       expect(row.state).toBe("LEASED");
@@ -198,19 +213,29 @@ describe("multi-process concurrency (OPS-424, OPS-233)", () => {
     expect(allClaims.length).toBe(18);
 
     // Verify lab workers only claimed lab or unplaced
-    const labClaims = results.filter((r) => r.worker.id.startsWith("lab-")).flatMap((r) => r.claims);
+    const labClaims = results
+      .filter((r) => r.worker.id.startsWith("lab-"))
+      .flatMap((r) => r.claims);
     for (const c of labClaims) {
-      expect(c.runId.startsWith("lab_") || c.runId.startsWith("any_")).toBe(true);
+      expect(c.runId.startsWith("lab_") || c.runId.startsWith("any_")).toBe(
+        true,
+      );
     }
 
     // Verify web workers only claimed web or unplaced
-    const webClaims = results.filter((r) => r.worker.id.startsWith("web-")).flatMap((r) => r.claims);
+    const webClaims = results
+      .filter((r) => r.worker.id.startsWith("web-"))
+      .flatMap((r) => r.claims);
     for (const c of webClaims) {
-      expect(c.runId.startsWith("web_") || c.runId.startsWith("any_")).toBe(true);
+      expect(c.runId.startsWith("web_") || c.runId.startsWith("any_")).toBe(
+        true,
+      );
     }
 
     // Verify general workers only claimed unplaced
-    const genClaims = results.filter((r) => r.worker.id.startsWith("gen-")).flatMap((r) => r.claims);
+    const genClaims = results
+      .filter((r) => r.worker.id.startsWith("gen-"))
+      .flatMap((r) => r.claims);
     for (const c of genClaims) {
       expect(c.runId.startsWith("any_")).toBe(true);
     }

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -11,13 +11,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 /** Absolute path of the event-runtime/ directory inside the factory repo. */
-export const RUNTIME_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+export const RUNTIME_ROOT = path.dirname(
+  path.dirname(fileURLToPath(import.meta.url)),
+);
 
 /** The factory checkout itself — where config/repos.yaml lives (OPS-228). */
 export const FACTORY_ROOT = path.dirname(RUNTIME_ROOT);
 
 export function runtimeHome() {
-  return process.env.FACTORY_EVENT_HOME || path.join(homedir(), ".factory", "event-runtime");
+  return (
+    process.env.FACTORY_EVENT_HOME ||
+    path.join(homedir(), ".factory", "event-runtime")
+  );
 }
 
 export function dbPath(home = runtimeHome()) {

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -223,7 +223,10 @@ export const MIGRATIONS = [
       // A cold start can have several processes read user_version before one
       // acquires the migration lock. Keep the additive step retry-safe when a
       // waiter enters with that stale read after the first process committed.
-      const columns = db.query(`PRAGMA table_info(events)`).all().map((row) => row.name);
+      const columns = db
+        .query(`PRAGMA table_info(events)`)
+        .all()
+        .map((row) => row.name);
       if (!columns.includes("archived_at")) {
         db.exec(`ALTER TABLE events ADD COLUMN archived_at TEXT;`);
       }
@@ -241,7 +244,10 @@ export const MIGRATIONS = [
     name: "inbox_decisions",
     up(db) {
       const columns = new Set(
-        db.query(`PRAGMA table_info(inbox_items)`).all().map((row) => row.name),
+        db
+          .query(`PRAGMA table_info(inbox_items)`)
+          .all()
+          .map((row) => row.name),
       );
       for (const [name, type] of [
         ["decision_json", "TEXT"],

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -18,7 +25,8 @@ import {
 } from "./db.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
-const freshFile = () => path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-db-")), "runtime.db");
+const freshFile = () =>
+  path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-db-")), "runtime.db");
 
 describe("cold start (OPS-376, OPS-424)", () => {
   test("a second connection to a brand-new database does not fight for the WAL switch", () => {
@@ -98,7 +106,9 @@ describe("cold start (OPS-376, OPS-424)", () => {
     }
 
     const verifyDb = openDb(file);
-    expect(verifyDb.query("PRAGMA journal_mode").get().journal_mode).toBe("wal");
+    expect(verifyDb.query("PRAGMA journal_mode").get().journal_mode).toBe(
+      "wal",
+    );
     verifyDb.close();
   });
 });
@@ -125,7 +135,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
   test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {
     const file = freshFile();
     const db = new Database(file);
-    for (const migration of MIGRATIONS.filter((entry) => entry.version <= 2)) migration.up(db);
+    for (const migration of MIGRATIONS.filter((entry) => entry.version <= 2))
+      migration.up(db);
     setSchemaVersion(db, 2);
     db.close();
 
@@ -151,7 +162,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     const db = openDb(file);
     expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
-    expect(db.query("SELECT count(*) as count FROM events").get()?.count).toBe(0);
+    expect(db.query("SELECT count(*) as count FROM events").get()?.count).toBe(
+      0,
+    );
     db.close();
   });
 
@@ -160,17 +173,46 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     const db = new Database(file);
     migrateDb(db, { targetVersion: 2 });
     expect(getSchemaVersion(db)).toBe(2);
-    expect(db.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'").get()).toBeNull();
+    expect(
+      db
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'",
+        )
+        .get(),
+    ).toBeNull();
     db.close();
 
     const upgraded = openDb(file);
     expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
-    expect(upgraded.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'").get()?.name).toBe("inbox_items");
-    const columns = upgraded.query("PRAGMA table_info(inbox_items)").all().map((row) => row.name);
+    expect(
+      upgraded
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'",
+        )
+        .get()?.name,
+    ).toBe("inbox_items");
+    const columns = upgraded
+      .query("PRAGMA table_info(inbox_items)")
+      .all()
+      .map((row) => row.name);
     expect(columns).toEqual([
-      "id", "kind", "severity", "title", "body", "refs_json", "source",
-      "created_at", "acked_at", "resolved_at", "resolved_by", "delivery_json",
-      "decision_json", "response_json", "decided_at", "decided_by", "dedupe_key",
+      "id",
+      "kind",
+      "severity",
+      "title",
+      "body",
+      "refs_json",
+      "source",
+      "created_at",
+      "acked_at",
+      "resolved_at",
+      "resolved_by",
+      "delivery_json",
+      "decision_json",
+      "response_json",
+      "decided_at",
+      "decided_by",
+      "dedupe_key",
     ]);
     upgraded.close();
   });
@@ -189,15 +231,29 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     const upgraded = openDb(file);
     expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
-    const columns = upgraded.query("PRAGMA table_info(inbox_items)").all().map((row) => row.name);
+    const columns = upgraded
+      .query("PRAGMA table_info(inbox_items)")
+      .all()
+      .map((row) => row.name);
     expect(columns.slice(-5)).toEqual([
-      "decision_json", "response_json", "decided_at", "decided_by", "dedupe_key",
+      "decision_json",
+      "response_json",
+      "decided_at",
+      "decided_by",
+      "dedupe_key",
     ]);
-    expect(upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get().title).toBe("legacy item");
-    const index = upgraded.query(
-      `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'inbox_items_open_dedupe'`,
-    ).get();
-    expect(index.sql).toContain("WHERE resolved_at IS NULL AND dedupe_key IS NOT NULL");
+    expect(
+      upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get()
+        .title,
+    ).toBe("legacy item");
+    const index = upgraded
+      .query(
+        `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'inbox_items_open_dedupe'`,
+      )
+      .get();
+    expect(index.sql).toContain(
+      "WHERE resolved_at IS NULL AND dedupe_key IS NOT NULL",
+    );
     upgraded.close();
   });
 
@@ -232,16 +288,23 @@ describe("schema migration runner and assertions (OPS-415)", () => {
         version: customVersion,
         name: "add_priority_to_events",
         up(targetDb) {
-          targetDb.exec("ALTER TABLE events ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal';");
+          targetDb.exec(
+            "ALTER TABLE events ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal';",
+          );
         },
       },
     ];
 
-    migrateDb(db, { migrations: migrationsWithCustom, targetVersion: customVersion });
+    migrateDb(db, {
+      migrations: migrationsWithCustom,
+      targetVersion: customVersion,
+    });
     expect(getSchemaVersion(db)).toBe(customVersion);
 
     // Verify existing row is preserved and has default value
-    const row = db.query("SELECT event_id, priority FROM events WHERE event_id = 'evt-415'").get();
+    const row = db
+      .query("SELECT event_id, priority FROM events WHERE event_id = 'evt-415'")
+      .get();
     expect(row.event_id).toBe("evt-415");
     expect(row.priority).toBe("normal");
 
@@ -251,7 +314,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
        VALUES ('github', 'evt-416', 'issue.closed', '2026-08-14T00:01:00Z', '2026-08-14T00:01:01Z', '{}', 'hash2', '2026-08-14T00:01:01Z', 'urgent')`,
     ).run();
 
-    const row2 = db.query("SELECT event_id, priority FROM events WHERE event_id = 'evt-416'").get();
+    const row2 = db
+      .query("SELECT event_id, priority FROM events WHERE event_id = 'evt-416'")
+      .get();
     expect(row2.priority).toBe("urgent");
 
     db.close();
@@ -261,7 +326,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     const file = freshFile();
     const db = openDb(file);
     db.exec("DROP TABLE counters;");
-    expect(() => assertSchema(db)).toThrow('Database schema drift detected: missing table "counters"');
+    expect(() => assertSchema(db)).toThrow(
+      'Database schema drift detected: missing table "counters"',
+    );
     db.close();
   });
 
@@ -281,7 +348,13 @@ describe("run usage persistence and aggregation (WM-66)", () => {
     db.query(
       `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
        VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
-    ).run(runId, `idem-${runId}`, JSON.stringify({ agent, adapter: "fake" }), at, at);
+    ).run(
+      runId,
+      `idem-${runId}`,
+      JSON.stringify({ agent, adapter: "fake" }),
+      at,
+      at,
+    );
   }
 
   test("persists per-attempt usage across reopen and returns explicit totals", () => {
@@ -314,18 +387,20 @@ describe("run usage persistence and aggregation (WM-66)", () => {
         totalTokens: 100,
         costUSD: 0.5,
       },
-      attempts: [{
-        attempt: 1,
-        adapter: "claude",
-        model: "claude-sonnet-4-6",
-        inputTokens: 10,
-        outputTokens: 20,
-        cacheCreationInputTokens: 30,
-        cacheReadInputTokens: 40,
-        totalTokens: 100,
-        costUSD: 0.5,
-        recordedAt: at,
-      }],
+      attempts: [
+        {
+          attempt: 1,
+          adapter: "claude",
+          model: "claude-sonnet-4-6",
+          inputTokens: 10,
+          outputTokens: 20,
+          cacheCreationInputTokens: 30,
+          cacheReadInputTokens: 40,
+          totalTokens: 100,
+          costUSD: 0.5,
+          recordedAt: at,
+        },
+      ],
     });
     db.close();
   });
@@ -342,26 +417,59 @@ describe("run usage persistence and aggregation (WM-66)", () => {
     for (const [runId, agent, atMs, inputTokens, outputTokens] of rows) {
       const at = new Date(atMs).toISOString();
       insertRun(db, runId, agent, at);
-      recordRunUsage(db, { runId, attempt: 1, adapter: "fake", inputTokens, outputTokens, recordedAt: at });
+      recordRunUsage(db, {
+        runId,
+        attempt: 1,
+        adapter: "fake",
+        inputTokens,
+        outputTokens,
+        recordedAt: at,
+      });
     }
 
     expect(usageSpend(db, { now })).toEqual({
       rolling1h: {
-        runs: 1, attempts: 1, inputTokens: 10, outputTokens: 5,
-        cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 15, costUSD: 0,
+        runs: 1,
+        attempts: 1,
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        totalTokens: 15,
+        costUSD: 0,
       },
       rolling24h: {
-        runs: 3, attempts: 3, inputTokens: 37, outputTokens: 18,
-        cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 55, costUSD: 0,
+        runs: 3,
+        attempts: 3,
+        inputTokens: 37,
+        outputTokens: 18,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        totalTokens: 55,
+        costUSD: 0,
       },
       byAgent24h: [
         {
-          agent: "agent-a@1", runs: 2, attempts: 2, inputTokens: 30, outputTokens: 15,
-          cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 45, costUSD: 0,
+          agent: "agent-a@1",
+          runs: 2,
+          attempts: 2,
+          inputTokens: 30,
+          outputTokens: 15,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 45,
+          costUSD: 0,
         },
         {
-          agent: "agent-b@2", runs: 1, attempts: 1, inputTokens: 7, outputTokens: 3,
-          cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 10, costUSD: 0,
+          agent: "agent-b@2",
+          runs: 1,
+          attempts: 1,
+          inputTokens: 7,
+          outputTokens: 3,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 10,
+          costUSD: 0,
         },
       ],
     });
@@ -375,7 +483,9 @@ describe("txImmediate (OPS-233)", () => {
     txImmediate(db, () => {
       db.query(`INSERT INTO counters (name, value) VALUES ('x', 1)`).run();
     });
-    expect(db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value).toBe(1);
+    expect(
+      db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value,
+    ).toBe(1);
 
     expect(() =>
       txImmediate(db, () => {
@@ -383,7 +493,9 @@ describe("txImmediate (OPS-233)", () => {
         throw new Error("boom");
       }),
     ).toThrow("boom");
-    expect(db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value).toBe(1);
+    expect(
+      db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value,
+    ).toBe(1);
     db.close();
   });
 });
@@ -399,7 +511,9 @@ describe("hermetic execution guard (OPS-425)", () => {
     const testDbPath = path.join(isolated, "runtime.db");
     const db = openDb(testDbPath);
     db.query(`INSERT INTO counters (name, value) VALUES ('guard', 42)`).run();
-    expect(db.query(`SELECT value FROM counters WHERE name = 'guard'`).get().value).toBe(42);
+    expect(
+      db.query(`SELECT value FROM counters WHERE name = 'guard'`).get().value,
+    ).toBe(42);
     db.close();
     const after = realFactorySnapshot();
     expectRealDbUnchanged(before, after);
@@ -416,7 +530,9 @@ describe("hermetic execution guard (OPS-425)", () => {
       utimesSync(dbPath, oldTime, oldTime);
 
       const before = realFactorySnapshot(factoryHome);
-      expect(() => expectRealDbUnchanged(before, realFactorySnapshot(factoryHome))).not.toThrow();
+      expect(() =>
+        expectRealDbUnchanged(before, realFactorySnapshot(factoryHome)),
+      ).not.toThrow();
 
       appendFileSync(dbPath, " after");
       const after = realFactorySnapshot(factoryHome);

--- a/event-runtime/lib/decision-templates.mjs
+++ b/event-runtime/lib/decision-templates.mjs
@@ -7,7 +7,12 @@ const dismiss = () => ({
   tone: "neutral",
 });
 
-const textField = ({ id = "answer", label, required = false, whenOption } = {}) => ({
+const textField = ({
+  id = "answer",
+  label,
+  required = false,
+  whenOption,
+} = {}) => ({
   id,
   kind: "text",
   label: label ?? "Anything the runtime should know",
@@ -169,7 +174,8 @@ const BUILDERS = {
 export function templateFor(kind, { producer, refs = {} } = {}) {
   const selected = producer ?? String(kind ?? "").toLowerCase();
   const builder = BUILDERS[selected];
-  if (!builder) throw new Error(`unknown decision template producer: ${selected}`);
+  if (!builder)
+    throw new Error(`unknown decision template producer: ${selected}`);
   return builder(refs);
 }
 

--- a/event-runtime/lib/decision-templates.test.mjs
+++ b/event-runtime/lib/decision-templates.test.mjs
@@ -4,10 +4,18 @@ import { templateFor } from "./decision-templates.mjs";
 
 describe("default decision templates (WM-390)", () => {
   const cases = [
-    ["ESCALATED", "escalation", { issue: "WM-1", repo: "factory", runId: "run_1" }],
+    [
+      "ESCALATED",
+      "escalation",
+      { issue: "WM-1", repo: "factory", runId: "run_1" },
+    ],
     ["BLOCKED", "parked", { eventSource: "linear", eventId: "evt_1" }],
     ["decision_needed", "triage-question", { issue: "WM-2", repo: "factory" }],
-    ["ESCALATED", "merge-escalation", { issue: "WM-3", repo: "factory", pr: "42" }],
+    [
+      "ESCALATED",
+      "merge-escalation",
+      { issue: "WM-3", repo: "factory", pr: "42" },
+    ],
     ["decision_needed", "proposal", { proposalId: "prop_1" }],
   ];
 

--- a/event-runtime/lib/decision.mjs
+++ b/event-runtime/lib/decision.mjs
@@ -21,30 +21,61 @@ import { validate } from "./schema.mjs";
 export const DECISION_REQUEST_SCHEMA_VERSION = "factory.decision-request/v1";
 export const DECISION_RESPONSE_SCHEMA_VERSION = "factory.decision-response/v1";
 export const DECISION_REQUEST_SCHEMA = JSON.parse(
-  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.decision-request.v1.json"), "utf8"),
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory.decision-request.v1.json"),
+    "utf8",
+  ),
 );
 export const DECISION_RESPONSE_SCHEMA = JSON.parse(
-  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.decision-response.v1.json"), "utf8"),
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory.decision-response.v1.json"),
+    "utf8",
+  ),
 );
 
 /** §2.1 `context` bound is a byte size, not a code-unit count. */
 export const CONTEXT_MAX_BYTES = 8 * 1024;
 /** §2.3 `text` defaults. */
 export const TEXT_DEFAULT_MAX_LENGTH = 2000;
-export const WIDGET_KINDS = ["text", "single-choice", "multi-choice", "confirm", "number"];
+export const WIDGET_KINDS = [
+  "text",
+  "single-choice",
+  "multi-choice",
+  "confirm",
+  "number",
+];
 export const EFFECTS = [
-  "authorise", "send_to_triage", "answer", "requeue", "approve_proposal", "reject_proposal", "dismiss",
+  "authorise",
+  "send_to_triage",
+  "answer",
+  "requeue",
+  "approve_proposal",
+  "reject_proposal",
+  "dismiss",
 ];
 
 const hasOwn = (value, key) =>
-  value !== null && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key);
+  value !== null &&
+  typeof value === "object" &&
+  Object.prototype.hasOwnProperty.call(value, key);
 
 /** Keys every field may carry, plus the per-`kind` extras (§2.3 "Extra keys"). */
-const COMMON_FIELD_KEYS = new Set(["id", "kind", "label", "required", "whenOption"]);
+const COMMON_FIELD_KEYS = new Set([
+  "id",
+  "kind",
+  "label",
+  "required",
+  "whenOption",
+]);
 const FIELD_KEYS = {
   text: new Set([...COMMON_FIELD_KEYS, "placeholder", "maxLength"]),
   "single-choice": new Set([...COMMON_FIELD_KEYS, "choices"]),
-  "multi-choice": new Set([...COMMON_FIELD_KEYS, "choices", "minItems", "maxItems"]),
+  "multi-choice": new Set([
+    ...COMMON_FIELD_KEYS,
+    "choices",
+    "minItems",
+    "maxItems",
+  ]),
   confirm: COMMON_FIELD_KEYS,
   number: new Set([...COMMON_FIELD_KEYS, "minimum", "maximum", "integer"]),
 };
@@ -64,7 +95,11 @@ function result(errors) {
 }
 
 function usableRef(refs, key) {
-  return hasOwn(refs, key) && typeof refs[key] === "string" && refs[key].trim().length > 0;
+  return (
+    hasOwn(refs, key) &&
+    typeof refs[key] === "string" &&
+    refs[key].trim().length > 0
+  );
 }
 
 function duplicateValues(values) {
@@ -97,14 +132,23 @@ function checkRequest(request, { refs, checkEffectLegality }) {
   if (!shape.valid) return shape;
 
   const errors = [];
-  if (request.context !== undefined && Buffer.byteLength(request.context, "utf8") > CONTEXT_MAX_BYTES) {
-    errors.push(`$.context: longer than ${CONTEXT_MAX_BYTES} bytes when encoded as UTF-8`);
+  if (
+    request.context !== undefined &&
+    Buffer.byteLength(request.context, "utf8") > CONTEXT_MAX_BYTES
+  ) {
+    errors.push(
+      `$.context: longer than ${CONTEXT_MAX_BYTES} bytes when encoded as UTF-8`,
+    );
   }
   const optionIds = request.options.map((option) => option.id);
   const optionIdSet = new Set(optionIds);
 
-  for (const id of duplicateValues(optionIds)) errors.push(`$.options: duplicate option id "${id}"`);
-  if (request.recommended !== undefined && !optionIdSet.has(request.recommended)) {
+  for (const id of duplicateValues(optionIds))
+    errors.push(`$.options: duplicate option id "${id}"`);
+  if (
+    request.recommended !== undefined &&
+    !optionIdSet.has(request.recommended)
+  ) {
     errors.push(`$.recommended: unknown option id "${request.recommended}"`);
   }
 
@@ -125,14 +169,19 @@ function checkRequest(request, { refs, checkEffectLegality }) {
           /^[a-zA-Z]:[\\/]/.test(scopedPath) ||
           segments.includes("..")
         ) {
-          errors.push(`${path}.scope.paths: path must be repo-relative: "${scopedPath}"`);
+          errors.push(
+            `${path}.scope.paths: path must be repo-relative: "${scopedPath}"`,
+          );
         }
       }
     }
 
     if (checkEffectLegality) {
       for (const ref of EFFECT_REFS[option.effect]) {
-        if (!usableRef(refs, ref)) errors.push(`${path}.effect: "${option.effect}" requires refs.${ref}`);
+        if (!usableRef(refs, ref))
+          errors.push(
+            `${path}.effect: "${option.effect}" requires refs.${ref}`,
+          );
       }
     }
   }
@@ -145,7 +194,8 @@ function checkRequest(request, { refs, checkEffectLegality }) {
   for (const [index, field] of fields.entries()) {
     const path = `$.fields[${index}]`;
     for (const key of Object.keys(field)) {
-      if (!FIELD_KEYS[field.kind].has(key)) errors.push(`${path}.${key}: not allowed for kind "${field.kind}"`);
+      if (!FIELD_KEYS[field.kind].has(key))
+        errors.push(`${path}.${key}: not allowed for kind "${field.kind}"`);
     }
 
     if (field.whenOption !== undefined) {
@@ -153,7 +203,8 @@ function checkRequest(request, { refs, checkEffectLegality }) {
         errors.push(`${path}.whenOption: duplicate option id "${id}"`);
       }
       for (const id of field.whenOption) {
-        if (!optionIdSet.has(id)) errors.push(`${path}.whenOption: unknown option id "${id}"`);
+        if (!optionIdSet.has(id))
+          errors.push(`${path}.whenOption: unknown option id "${id}"`);
       }
     }
 
@@ -164,9 +215,13 @@ function checkRequest(request, { refs, checkEffectLegality }) {
         const minimum = field.kind === "single-choice" ? 2 : 1;
         const maximum = field.kind === "single-choice" ? 12 : 24;
         if (field.choices.length < minimum || field.choices.length > maximum) {
-          errors.push(`${path}.choices: ${field.kind} requires ${minimum}–${maximum} choices`);
+          errors.push(
+            `${path}.choices: ${field.kind} requires ${minimum}–${maximum} choices`,
+          );
         }
-        for (const id of duplicateValues(field.choices.map((choice) => choice.id))) {
+        for (const id of duplicateValues(
+          field.choices.map((choice) => choice.id),
+        )) {
           errors.push(`${path}.choices: duplicate choice id "${id}"`);
         }
       }
@@ -175,13 +230,21 @@ function checkRequest(request, { refs, checkEffectLegality }) {
     if (field.kind === "multi-choice" && field.choices !== undefined) {
       const minimum = field.minItems ?? 0;
       const maximum = field.maxItems ?? field.choices.length;
-      if (minimum > maximum) errors.push(`${path}: minItems cannot exceed maxItems`);
-      if (minimum > field.choices.length) errors.push(`${path}.minItems: cannot exceed the number of choices`);
-      if (maximum > field.choices.length) errors.push(`${path}.maxItems: cannot exceed the number of choices`);
+      if (minimum > maximum)
+        errors.push(`${path}: minItems cannot exceed maxItems`);
+      if (minimum > field.choices.length)
+        errors.push(`${path}.minItems: cannot exceed the number of choices`);
+      if (maximum > field.choices.length)
+        errors.push(`${path}.maxItems: cannot exceed the number of choices`);
     }
 
-    if (field.kind === "number" && field.minimum !== undefined && field.maximum !== undefined) {
-      if (field.minimum > field.maximum) errors.push(`${path}: minimum cannot exceed maximum`);
+    if (
+      field.kind === "number" &&
+      field.minimum !== undefined &&
+      field.maximum !== undefined
+    ) {
+      if (field.minimum > field.maximum)
+        errors.push(`${path}: minimum cannot exceed maximum`);
     }
   }
 
@@ -191,7 +254,8 @@ function checkRequest(request, { refs, checkEffectLegality }) {
       (field) =>
         field.kind === "text" &&
         field.required === true &&
-        (field.whenOption === undefined || field.whenOption.includes(option.id)),
+        (field.whenOption === undefined ||
+          field.whenOption.includes(option.id)),
     );
     if (!reasonField) {
       errors.push(
@@ -215,8 +279,10 @@ function validateFieldValue(field, value, path, errors) {
       return;
     }
     const maximum = field.maxLength ?? TEXT_DEFAULT_MAX_LENGTH;
-    if (field.required === true && value.length === 0) errors.push(`${path}: required text must not be empty`);
-    if (value.length > maximum) errors.push(`${path}: longer than maxLength ${maximum}`);
+    if (field.required === true && value.length === 0)
+      errors.push(`${path}: required text must not be empty`);
+    if (value.length > maximum)
+      errors.push(`${path}: longer than maxLength ${maximum}`);
     return;
   }
 
@@ -241,21 +307,25 @@ function validateFieldValue(field, value, path, errors) {
       return;
     }
     const duplicates = duplicateValues(value);
-    for (const id of duplicates) errors.push(`${path}: duplicate choice id "${id}"`);
+    for (const id of duplicates)
+      errors.push(`${path}: duplicate choice id "${id}"`);
     const choices = new Set(field.choices.map((choice) => choice.id));
     for (const id of value) {
       if (!choices.has(id)) errors.push(`${path}: unknown choice id "${id}"`);
     }
     const minimum = field.minItems ?? (field.required === true ? 1 : 0);
     const maximum = field.maxItems ?? field.choices.length;
-    if (value.length < minimum) errors.push(`${path}: fewer than minItems ${minimum}`);
-    if (value.length > maximum) errors.push(`${path}: more than maxItems ${maximum}`);
+    if (value.length < minimum)
+      errors.push(`${path}: fewer than minItems ${minimum}`);
+    if (value.length > maximum)
+      errors.push(`${path}: more than maxItems ${maximum}`);
     return;
   }
 
   if (field.kind === "confirm") {
     if (typeof value !== "boolean") errors.push(`${path}: expected boolean`);
-    else if (field.required === true && value !== true) errors.push(`${path}: required confirmation must be true`);
+    else if (field.required === true && value !== true)
+      errors.push(`${path}: required confirmation must be true`);
     return;
   }
 
@@ -269,7 +339,8 @@ function validateFieldValue(field, value, path, errors) {
   if (field.maximum !== undefined && value > field.maximum) {
     errors.push(`${path}: above maximum ${field.maximum}`);
   }
-  if (field.integer === true && !Number.isInteger(value)) errors.push(`${path}: expected an integer`);
+  if (field.integer === true && !Number.isInteger(value))
+    errors.push(`${path}: expected an integer`);
 }
 
 /**
@@ -281,38 +352,57 @@ export function validateDecisionResponse(response, request) {
   const responseShape = validate(DECISION_RESPONSE_SCHEMA, response);
   if (!responseShape.valid) return responseShape;
 
-  const requestCheck = checkRequest(request, { refs: {}, checkEffectLegality: false });
+  const requestCheck = checkRequest(request, {
+    refs: {},
+    checkEffectLegality: false,
+  });
   if (!requestCheck.valid) {
     return result(requestCheck.errors.map((error) => `request ${error}`));
   }
 
   const errors = [];
-  if (response.requestHash !== decisionRequestHash(request)) errors.push("$.requestHash: does not match request");
+  if (response.requestHash !== decisionRequestHash(request))
+    errors.push("$.requestHash: does not match request");
 
-  const option = request.options.find((candidate) => candidate.id === response.optionId);
+  const option = request.options.find(
+    (candidate) => candidate.id === response.optionId,
+  );
   if (option === undefined) {
     errors.push(`$.optionId: unknown option id "${response.optionId}"`);
     return result(errors);
   }
 
-  const declaredFields = new Map((request.fields ?? []).map((field) => [field.id, field]));
+  const declaredFields = new Map(
+    (request.fields ?? []).map((field) => [field.id, field]),
+  );
   const applicableFields = (request.fields ?? []).filter(
-    (field) => field.whenOption === undefined || field.whenOption.includes(option.id),
+    (field) =>
+      field.whenOption === undefined || field.whenOption.includes(option.id),
   );
   const applicableIds = new Set(applicableFields.map((field) => field.id));
 
   for (const key of Object.keys(response.fields)) {
-    if (!declaredFields.has(key)) errors.push(`$.fields.${key}: undeclared field`);
-    else if (!applicableIds.has(key)) errors.push(`$.fields.${key}: field does not apply to option "${option.id}"`);
+    if (!declaredFields.has(key))
+      errors.push(`$.fields.${key}: undeclared field`);
+    else if (!applicableIds.has(key))
+      errors.push(
+        `$.fields.${key}: field does not apply to option "${option.id}"`,
+      );
   }
 
   for (const field of applicableFields) {
     const present = hasOwn(response.fields, field.id);
     if (!present) {
-      if (field.required === true) errors.push(`$.fields.${field.id}: required field is missing`);
+      if (field.required === true)
+        errors.push(`$.fields.${field.id}: required field is missing`);
       continue;
     }
-    validateFieldValue(field, response.fields[field.id], `$.fields.${field.id}`, errors);
+    validateFieldValue(
+      field,
+      response.fields[field.id],
+      `$.fields.${field.id}`,
+      errors,
+    );
   }
 
   return result(errors);

--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -13,7 +13,8 @@ import { validate } from "./schema.mjs";
 
 const EXAMPLE_REQUEST = {
   schemaVersion: "factory.decision-request/v1",
-  question: "WM-313 changes how the pi adapter reads FACTORY_EVENT_SECRET. May I proceed?",
+  question:
+    "WM-313 changes how the pi adapter reads FACTORY_EVENT_SECRET. May I proceed?",
   context:
     "The ticket moves secret handling from env to a file the worker mounts…\n\nRisk: a wrong path leaks the secret into the run journal.",
   recommended: "authorise",
@@ -21,7 +22,8 @@ const EXAMPLE_REQUEST = {
     {
       id: "authorise",
       label: "Authorise within these paths",
-      description: "Re-dispatch me with your approval bound to WM-313 as written now.",
+      description:
+        "Re-dispatch me with your approval bound to WM-313 as written now.",
       effect: "authorise",
       tone: "primary",
       scope: {
@@ -100,12 +102,21 @@ function dismissRequest(overrides = {}) {
 function requestForEffect(effect) {
   const option = { id: "choice", label: "Choose", effect };
   if (effect === "authorise") {
-    option.scope = { paths: ["event-runtime/lib/decision.mjs"], summary: "Validate decisions." };
+    option.scope = {
+      paths: ["event-runtime/lib/decision.mjs"],
+      summary: "Validate decisions.",
+    };
   }
   const request = dismissRequest({ options: [option] });
   if (effect === "reject_proposal") {
     request.fields = [
-      { id: "reason", kind: "text", label: "Reason", required: true, whenOption: ["choice"] },
+      {
+        id: "reason",
+        kind: "text",
+        label: "Reason",
+        required: true,
+        whenOption: ["choice"],
+      },
     ];
   }
   return request;
@@ -123,11 +134,14 @@ describe("contract schemas", () => {
     // clean run against any value proves the schema stays inside the subset.
     for (const schema of [DECISION_REQUEST_SCHEMA, DECISION_RESPONSE_SCHEMA]) {
       const errors = validate(schema, {}).errors;
-      expect(errors.some((e) => e.includes("unsupported schema keyword"))).toBe(false);
+      expect(errors.some((e) => e.includes("unsupported schema keyword"))).toBe(
+        false,
+      );
     }
     const walk = (node, at) => {
       if (node === null || typeof node !== "object") return;
-      if (Array.isArray(node)) return node.forEach((n, i) => walk(n, `${at}[${i}]`));
+      if (Array.isArray(node))
+        return node.forEach((n, i) => walk(n, `${at}[${i}]`));
       if (node.type === "object" && at !== "response.properties.fields") {
         expect(node.additionalProperties, `${at} must be closed`).toBe(false);
       }
@@ -137,26 +151,36 @@ describe("contract schemas", () => {
     walk(DECISION_RESPONSE_SCHEMA, "response");
     // The response's `fields` map is keyed by request-declared ids — closed by
     // the validator, not the schema.
-    expect(DECISION_RESPONSE_SCHEMA.properties.fields.additionalProperties).toEqual({});
+    expect(
+      DECISION_RESPONSE_SCHEMA.properties.fields.additionalProperties,
+    ).toEqual({});
   });
 
   test("encode the closed effect and widget enums", () => {
-    expect(DECISION_REQUEST_SCHEMA.properties.options.items.properties.effect.enum).toEqual(EFFECTS);
-    expect(DECISION_REQUEST_SCHEMA.properties.fields.items.properties.kind.enum).toEqual(WIDGET_KINDS);
+    expect(
+      DECISION_REQUEST_SCHEMA.properties.options.items.properties.effect.enum,
+    ).toEqual(EFFECTS);
+    expect(
+      DECISION_REQUEST_SCHEMA.properties.fields.items.properties.kind.enum,
+    ).toEqual(WIDGET_KINDS);
     expect(Object.keys(EFFECT_REFS)).toEqual(EFFECTS);
   });
 });
 
 describe("validateDecisionRequest", () => {
   test("accepts the §2.1 example verbatim", () => {
-    expect(validateDecisionRequest(EXAMPLE_REQUEST, { refs: ALL_REFS })).toEqual({
+    expect(
+      validateDecisionRequest(EXAMPLE_REQUEST, { refs: ALL_REFS }),
+    ).toEqual({
       valid: true,
       errors: [],
     });
   });
 
   test("enforces the top-level bounds and rejects unknown properties", () => {
-    expect(validateDecisionRequest(dismissRequest(), { refs: {} }).valid).toBe(true);
+    expect(validateDecisionRequest(dismissRequest(), { refs: {} }).valid).toBe(
+      true,
+    );
 
     for (const request of [
       dismissRequest({ question: "" }),
@@ -164,7 +188,13 @@ describe("validateDecisionRequest", () => {
       dismissRequest({ context: "x".repeat(8193) }),
       dismissRequest({ context: "🙂".repeat(4096) }),
       dismissRequest({ options: [] }),
-      dismissRequest({ options: Array.from({ length: 7 }, (_, id) => ({ id: `o${id}`, label: "x", effect: "dismiss" })) }),
+      dismissRequest({
+        options: Array.from({ length: 7 }, (_, id) => ({
+          id: `o${id}`,
+          label: "x",
+          effect: "dismiss",
+        })),
+      }),
       { ...dismissRequest(), unexpected: true },
     ]) {
       expectInvalid(request, {});
@@ -195,27 +225,61 @@ describe("validateDecisionRequest", () => {
   });
 
   test("recommended and whenOption name existing unique options", () => {
-    expect(validateDecisionRequest(dismissRequest({ recommended: "dismiss" }), { refs: {} }).valid).toBe(true);
+    expect(
+      validateDecisionRequest(dismissRequest({ recommended: "dismiss" }), {
+        refs: {},
+      }).valid,
+    ).toBe(true);
     expectInvalid(dismissRequest({ recommended: "missing" }), {});
     expect(
       validateDecisionRequest(
-        dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["dismiss"] }] }),
+        dismissRequest({
+          fields: [
+            {
+              id: "note",
+              kind: "text",
+              label: "Note",
+              whenOption: ["dismiss"],
+            },
+          ],
+        }),
         { refs: {} },
       ).valid,
     ).toBe(true);
     expectInvalid(
-      dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["missing"] }] }),
+      dismissRequest({
+        fields: [
+          { id: "note", kind: "text", label: "Note", whenOption: ["missing"] },
+        ],
+      }),
       {},
     );
     expectInvalid(
-      dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["dismiss", "dismiss"] }] }),
+      dismissRequest({
+        fields: [
+          {
+            id: "note",
+            kind: "text",
+            label: "Note",
+            whenOption: ["dismiss", "dismiss"],
+          },
+        ],
+      }),
       {},
     );
-    expectInvalid(dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: [] }] }), {});
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "note", kind: "text", label: "Note", whenOption: [] }],
+      }),
+      {},
+    );
   });
 
   test("scope is present exactly for authorise and observes its bounds", () => {
-    expect(validateDecisionRequest(requestForEffect("authorise"), { refs: ALL_REFS }).valid).toBe(true);
+    expect(
+      validateDecisionRequest(requestForEffect("authorise"), { refs: ALL_REFS })
+        .valid,
+    ).toBe(true);
 
     const missing = requestForEffect("authorise");
     delete missing.options[0].scope;
@@ -239,7 +303,10 @@ describe("validateDecisionRequest", () => {
     noPaths.options[0].scope.paths = [];
     expectInvalid(noPaths);
     const tooManyPaths = requestForEffect("authorise");
-    tooManyPaths.options[0].scope.paths = Array.from({ length: 33 }, (_, index) => `p${index}`);
+    tooManyPaths.options[0].scope.paths = Array.from(
+      { length: 33 },
+      (_, index) => `p${index}`,
+    );
     expectInvalid(tooManyPaths);
     const longSummary = requestForEffect("authorise");
     longSummary.options[0].scope.summary = "x".repeat(501);
@@ -265,7 +332,9 @@ describe("validateDecisionRequest", () => {
 
     for (const [effect, requiredRefs] of Object.entries(requirements)) {
       const request = requestForEffect(effect);
-      expect(validateDecisionRequest(request, { refs: ALL_REFS }).valid).toBe(true);
+      expect(validateDecisionRequest(request, { refs: ALL_REFS }).valid).toBe(
+        true,
+      );
       for (const ref of requiredRefs) {
         const refs = { ...ALL_REFS };
         delete refs[ref];
@@ -275,7 +344,11 @@ describe("validateDecisionRequest", () => {
   });
 
   test("reject_proposal requires an applicable required text field", () => {
-    expect(validateDecisionRequest(requestForEffect("reject_proposal"), { refs: ALL_REFS }).valid).toBe(true);
+    expect(
+      validateDecisionRequest(requestForEffect("reject_proposal"), {
+        refs: ALL_REFS,
+      }).valid,
+    ).toBe(true);
 
     const absent = requestForEffect("reject_proposal");
     absent.fields = [];
@@ -286,11 +359,20 @@ describe("validateDecisionRequest", () => {
     expectInvalid(optional);
 
     const wrongKind = requestForEffect("reject_proposal");
-    wrongKind.fields[0] = { id: "reason", kind: "confirm", label: "Reason", required: true };
+    wrongKind.fields[0] = {
+      id: "reason",
+      kind: "confirm",
+      label: "Reason",
+      required: true,
+    };
     expectInvalid(wrongKind);
 
     const gatedElsewhere = requestForEffect("reject_proposal");
-    gatedElsewhere.options.push({ id: "other", label: "Other", effect: "dismiss" });
+    gatedElsewhere.options.push({
+      id: "other",
+      label: "Other",
+      effect: "dismiss",
+    });
     gatedElsewhere.fields[0].whenOption = ["other"];
     expectInvalid(gatedElsewhere);
   });
@@ -301,19 +383,61 @@ describe("validateDecisionRequest", () => {
       kind: "text",
       label: `Field ${index}`,
     }));
-    expect(validateDecisionRequest(dismissRequest({ fields: sixFields }), { refs: {} }).valid).toBe(true);
-    expectInvalid(dismissRequest({ fields: [...sixFields, { id: "f6", kind: "text", label: "Seven" }] }), {});
-    expectInvalid(dismissRequest({ fields: [sixFields[0], { ...sixFields[0] }] }), {});
-    expectInvalid(dismissRequest({ fields: [{ id: "Bad", kind: "text", label: "Bad" }] }), {});
-    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "unknown", label: "Bad" }] }), {});
-    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "confirm", label: "Bad", maxLength: 2 }] }), {});
-    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "text", label: "Bad", maxLength: 8193 }] }), {});
+    expect(
+      validateDecisionRequest(dismissRequest({ fields: sixFields }), {
+        refs: {},
+      }).valid,
+    ).toBe(true);
     expectInvalid(
-      dismissRequest({ fields: [{ id: "x", kind: "text", label: "Bad", placeholder: "p".repeat(281) }] }),
+      dismissRequest({
+        fields: [...sixFields, { id: "f6", kind: "text", label: "Seven" }],
+      }),
       {},
     );
-    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "number", label: "Bad", choices: [] }] }), {});
-    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "single-choice", label: "No choices" }] }), {});
+    expectInvalid(
+      dismissRequest({ fields: [sixFields[0], { ...sixFields[0] }] }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({ fields: [{ id: "Bad", kind: "text", label: "Bad" }] }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({ fields: [{ id: "x", kind: "unknown", label: "Bad" }] }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "x", kind: "confirm", label: "Bad", maxLength: 2 }],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "x", kind: "text", label: "Bad", maxLength: 8193 }],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [
+          { id: "x", kind: "text", label: "Bad", placeholder: "p".repeat(281) },
+        ],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "x", kind: "number", label: "Bad", choices: [] }],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "x", kind: "single-choice", label: "No choices" }],
+      }),
+      {},
+    );
 
     expect(
       validateDecisionRequest(
@@ -335,7 +459,14 @@ describe("validateDecisionRequest", () => {
     ).toBe(true);
     expectInvalid(
       dismissRequest({
-        fields: [{ id: "pick", kind: "single-choice", label: "Pick", choices: [{ id: "a", label: "A" }] }],
+        fields: [
+          {
+            id: "pick",
+            kind: "single-choice",
+            label: "Pick",
+            choices: [{ id: "a", label: "A" }],
+          },
+        ],
       }),
       {},
     );
@@ -375,7 +506,15 @@ describe("validateDecisionRequest", () => {
     );
     expectInvalid(
       dismissRequest({
-        fields: [{ id: "count", kind: "number", label: "Count", minimum: 2, maximum: 1 }],
+        fields: [
+          {
+            id: "count",
+            kind: "number",
+            label: "Count",
+            minimum: 2,
+            maximum: 1,
+          },
+        ],
       }),
       {},
     );
@@ -422,7 +561,12 @@ const RESPONSE_REQUEST = dismissRequest({
       maximum: 3,
       integer: true,
     },
-    { id: "other_note", kind: "text", label: "Other note", whenOption: ["other"] },
+    {
+      id: "other_note",
+      kind: "text",
+      label: "Other note",
+      whenOption: ["other"],
+    },
   ],
 });
 
@@ -431,7 +575,13 @@ function validResponse() {
     schemaVersion: "factory.decision-response/v1",
     requestHash: decisionRequestHash(RESPONSE_REQUEST),
     optionId: "save",
-    fields: { note: "yes", single: "a", multi: ["a", "b"], confirm: true, count: 2 },
+    fields: {
+      note: "yes",
+      single: "a",
+      multi: ["a", "b"],
+      confirm: true,
+      count: 2,
+    },
     decidedBy: "operator",
     decidedAt: "2026-08-16T12:41:07.000Z",
   };
@@ -447,26 +597,42 @@ function expectInvalidResponse(mutator) {
 
 describe("decisionRequestHash", () => {
   test("uses canonical JSON key ordering", () => {
-    const reordered = { options: RESPONSE_REQUEST.options, question: RESPONSE_REQUEST.question, fields: RESPONSE_REQUEST.fields, schemaVersion: RESPONSE_REQUEST.schemaVersion };
-    expect(decisionRequestHash(reordered)).toBe(decisionRequestHash(RESPONSE_REQUEST));
-    expect(decisionRequestHash(RESPONSE_REQUEST)).toMatch(/^sha256:[a-f0-9]{64}$/);
+    const reordered = {
+      options: RESPONSE_REQUEST.options,
+      question: RESPONSE_REQUEST.question,
+      fields: RESPONSE_REQUEST.fields,
+      schemaVersion: RESPONSE_REQUEST.schemaVersion,
+    };
+    expect(decisionRequestHash(reordered)).toBe(
+      decisionRequestHash(RESPONSE_REQUEST),
+    );
+    expect(decisionRequestHash(RESPONSE_REQUEST)).toMatch(
+      /^sha256:[a-f0-9]{64}$/,
+    );
   });
 });
 
 describe("validateDecisionResponse", () => {
   test("accepts every widget kind when applicable values satisfy the request", () => {
-    expect(validateDecisionResponse(validResponse(), RESPONSE_REQUEST)).toEqual({ valid: true, errors: [] });
+    expect(validateDecisionResponse(validResponse(), RESPONSE_REQUEST)).toEqual(
+      { valid: true, errors: [] },
+    );
   });
 
   test("a field gated on the chosen option applies; the same field is rejected for another option", () => {
     const other = validResponse();
     other.optionId = "other";
     other.fields.other_note = "shown for other";
-    expect(validateDecisionResponse(other, RESPONSE_REQUEST)).toEqual({ valid: true, errors: [] });
+    expect(validateDecisionResponse(other, RESPONSE_REQUEST)).toEqual({
+      valid: true,
+      errors: [],
+    });
 
     const otherMissingOptional = validResponse();
     otherMissingOptional.optionId = "other";
-    expect(validateDecisionResponse(otherMissingOptional, RESPONSE_REQUEST).valid).toBe(true);
+    expect(
+      validateDecisionResponse(otherMissingOptional, RESPONSE_REQUEST).valid,
+    ).toBe(true);
   });
 
   test("optional applicable fields may be omitted but must be well-typed when present", () => {
@@ -479,11 +645,18 @@ describe("validateDecisionResponse", () => {
       optionId: "dismiss",
       fields: {},
     };
-    expect(validateDecisionResponse(omitted, optionalRequest)).toEqual({ valid: true, errors: [] });
+    expect(validateDecisionResponse(omitted, optionalRequest)).toEqual({
+      valid: true,
+      errors: [],
+    });
     const badType = { ...omitted, fields: { n: "1" } };
-    expect(validateDecisionResponse(badType, optionalRequest).valid).toBe(false);
+    expect(validateDecisionResponse(badType, optionalRequest).valid).toBe(
+      false,
+    );
     const belowMin = { ...omitted, fields: { n: -1 } };
-    expect(validateDecisionResponse(belowMin, optionalRequest).valid).toBe(false);
+    expect(validateDecisionResponse(belowMin, optionalRequest).valid).toBe(
+      false,
+    );
   });
 
   test("requires the exact request hash and a declared option", () => {
@@ -507,7 +680,9 @@ describe("validateDecisionResponse", () => {
     const emptyMulti = validResponse();
     emptyMulti.requestHash = decisionRequestHash(defaultRequiredMulti);
     emptyMulti.fields.multi = [];
-    expect(validateDecisionResponse(emptyMulti, defaultRequiredMulti).valid).toBe(false);
+    expect(
+      validateDecisionResponse(emptyMulti, defaultRequiredMulti).valid,
+    ).toBe(false);
     expectInvalidResponse((response) => {
       response.fields.confirm = false;
     });
@@ -588,11 +763,18 @@ describe("validateDecisionResponse", () => {
     });
     const invalidRequest = clone(RESPONSE_REQUEST);
     invalidRequest.options = [];
-    expect(validateDecisionResponse(validResponse(), invalidRequest).valid).toBe(false);
+    expect(
+      validateDecisionResponse(validResponse(), invalidRequest).valid,
+    ).toBe(false);
 
     const semanticallyInvalidRequest = clone(RESPONSE_REQUEST);
     delete semanticallyInvalidRequest.fields[1].choices;
-    expect(() => validateDecisionResponse(validResponse(), semanticallyInvalidRequest)).not.toThrow();
-    expect(validateDecisionResponse(validResponse(), semanticallyInvalidRequest).valid).toBe(false);
+    expect(() =>
+      validateDecisionResponse(validResponse(), semanticallyInvalidRequest),
+    ).not.toThrow();
+    expect(
+      validateDecisionResponse(validResponse(), semanticallyInvalidRequest)
+        .valid,
+    ).toBe(false);
   });
 });

--- a/event-runtime/lib/disk.mjs
+++ b/event-runtime/lib/disk.mjs
@@ -18,7 +18,10 @@ export const DEFAULT_WARN_USAGE_RATIO = 0.85;
 export const DEFAULT_REFUSE_USAGE_RATIO = 0.95;
 
 export class DiskSpaceError extends Error {
-  constructor(message, { path, availableBytes, requiredBytes, totalBytes, usageRatio } = {}) {
+  constructor(
+    message,
+    { path, availableBytes, requiredBytes, totalBytes, usageRatio } = {},
+  ) {
     super(message);
     this.name = "DiskSpaceError";
     this.path = path;

--- a/event-runtime/lib/disk.test.mjs
+++ b/event-runtime/lib/disk.test.mjs
@@ -52,7 +52,14 @@ describe("getDiskSpace", () => {
 
   test("handles non-existent paths by checking closest existing ancestor", () => {
     const dir = tmp("disk-test-");
-    const nonExistentSub = path.join(dir, "nested", "path", "does", "not", "exist");
+    const nonExistentSub = path.join(
+      dir,
+      "nested",
+      "path",
+      "does",
+      "not",
+      "exist",
+    );
     try {
       const stats = getDiskSpace(nonExistentSub);
       expect(stats.totalBytes).toBeGreaterThan(0);
@@ -143,7 +150,9 @@ describe("helpers", () => {
       bfree: 600,
       bavail: 600, // 600 MB
     });
-    const res = assertDiskSpaceForWorkspace("/tmp/ws", { statfsFn: mockStatfs });
+    const res = assertDiskSpaceForWorkspace("/tmp/ws", {
+      statfsFn: mockStatfs,
+    });
     expect(res.ok).toBe(true);
   });
 
@@ -154,7 +163,9 @@ describe("helpers", () => {
       bfree: 450,
       bavail: 450, // 450 MB < 500 MB
     });
-    expect(() => assertDiskSpaceForWorkspace("/tmp/ws", { statfsFn: mockStatfs })).toThrow(DiskSpaceError);
+    expect(() =>
+      assertDiskSpaceForWorkspace("/tmp/ws", { statfsFn: mockStatfs }),
+    ).toThrow(DiskSpaceError);
   });
 
   test("assertDiskSpaceForArtifacts uses default 500MB min free bytes", () => {
@@ -164,7 +175,9 @@ describe("helpers", () => {
       bfree: 600,
       bavail: 600,
     });
-    const res = assertDiskSpaceForArtifacts("/tmp/artifacts", { statfsFn: mockStatfs });
+    const res = assertDiskSpaceForArtifacts("/tmp/artifacts", {
+      statfsFn: mockStatfs,
+    });
     expect(res.ok).toBe(true);
   });
 
@@ -175,7 +188,9 @@ describe("helpers", () => {
       bfree: 300,
       bavail: 300, // 300 MB < 500 MB
     });
-    expect(() => assertDiskSpaceForArtifacts("/tmp/artifacts", { statfsFn: mockStatfs })).toThrow(DiskSpaceError);
+    expect(() =>
+      assertDiskSpaceForArtifacts("/tmp/artifacts", { statfsFn: mockStatfs }),
+    ).toThrow(DiskSpaceError);
   });
 
   test("defaults verify constants", () => {

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -1,11 +1,23 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { writeWorkerLease } from "../../lib/worker-leases.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
-import { planAdmittedEvents, planEvent, worktreeDispatchGate } from "./planner.mjs";
+import {
+  planAdmittedEvents,
+  planEvent,
+  worktreeDispatchGate,
+} from "./planner.mjs";
 import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 import { runOnce } from "./worker.mjs";
@@ -24,13 +36,18 @@ let callsLog;
 let previousReposRoot;
 let previousEventHome;
 
-const calls = () => (existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : []);
+const calls = () =>
+  existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : [];
 
 beforeAll(() => {
   const root = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-factory-"));
   fixtures.push(root);
-  repoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-repo-")));
-  wtRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-trees-")));
+  repoDir = realpathSync(
+    mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-repo-")),
+  );
+  wtRoot = realpathSync(
+    mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-trees-")),
+  );
   fixtures.push(repoDir, wtRoot);
   callsLog = path.join(repoDir, "calls.log");
 
@@ -79,12 +96,17 @@ beforeAll(() => {
       `  - name: malformed-policy\n    path: ${repoDir}\n    team: WM\n    project: Factory\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n    escalate_paths: src/auth/**\n`,
   );
-  writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
+  writeFileSync(
+    path.join(root, "config", "policy.yaml"),
+    `concurrency:\n  max_in_flight_per_repo: 2\n`,
+  );
 
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-home-"));
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(
+    path.join(os.tmpdir(), "evrt-dispatch-home-"),
+  );
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -126,27 +148,42 @@ const dispatchEnvelope = (payload, eventId = "dispatch-1") => ({
   payload,
 });
 
-function plan(payload, dispatch, eventId = `d-${Math.random().toString(36).slice(2)}`) {
+function plan(
+  payload,
+  dispatch,
+  eventId = `d-${Math.random().toString(36).slice(2)}`,
+) {
   const db = openDb(":memory:");
   const admitted = admitEvent(db, registry, dispatchEnvelope(payload, eventId));
   expect(admitted.admitted).toBe(true);
-  const outcome = planEvent(db, registry, { source: admitted.event.source, eventId: admitted.event.event_id }, {
-    policyVersion: PV,
-    dispatch,
-  });
+  const outcome = planEvent(
+    db,
+    registry,
+    { source: admitted.event.source, eventId: admitted.event.event_id },
+    {
+      policyVersion: PV,
+      dispatch,
+    },
+  );
   return { db, outcome };
 }
 
 describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
   test("report_only repo → human_needed repo_report_only, no run", () => {
-    const { db, outcome } = plan({ repo: "watched", ticket: "WM-500" }, openWorld());
+    const { db, outcome } = plan(
+      { repo: "watched", ticket: "WM-500" },
+      openWorld(),
+    );
     expect(outcome.decision).toBe("human_needed");
     expect(outcome.reason).toBe("repo_report_only");
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
   });
 
   test("per-repo cap reached → typed NOOP capacity_full, refusal carries its reason", () => {
-    const { db, outcome } = plan({ repo: "wt29", ticket: "WM-500" }, openWorld({ countLeases: () => 1 }));
+    const { db, outcome } = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({ countLeases: () => 1 }),
+    );
     expect(outcome.decision).toBe("noop");
     expect(outcome.reason).toBe("capacity_full");
     expect(outcome.proposal.status).toBe("resolved");
@@ -155,27 +192,46 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
   });
 
   test("the cap counts the dispatcher's own live lease ledger (shared budget, §3)", () => {
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-leases-"));
+    const leaseDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-dispatch-leases-"),
+    );
     fixtures.push(leaseDir);
-    writeWorkerLease({ repo: "wt29", ticket: "WM-400", owner: "tick-test", pid: process.pid, dir: leaseDir });
-    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
-      countLeases: (name) => (name === "wt29" ? 1 : 0),
-    }));
+    writeWorkerLease({
+      repo: "wt29",
+      ticket: "WM-400",
+      owner: "tick-test",
+      pid: process.pid,
+      dir: leaseDir,
+    });
+    const refusal = worktreeDispatchGate(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        countLeases: (name) => (name === "wt29" ? 1 : 0),
+      }),
+    );
     expect(refusal).toEqual({ decision: "noop", reason: "capacity_full" });
   });
 
   test("no max_in_flight on the repo → policy.yaml fallback holds (cap 2)", () => {
     const twoLeases = openWorld({ countLeases: () => 2 });
-    expect(worktreeDispatchGate({ repo: "uncapped", ticket: "WM-500" }, twoLeases))
-      .toEqual({ decision: "noop", reason: "capacity_full" });
-    expect(worktreeDispatchGate({ repo: "uncapped", ticket: "WM-500" }, openWorld({ countLeases: () => 1 })))
-      .toBeNull();
+    expect(
+      worktreeDispatchGate({ repo: "uncapped", ticket: "WM-500" }, twoLeases),
+    ).toEqual({ decision: "noop", reason: "capacity_full" });
+    expect(
+      worktreeDispatchGate(
+        { repo: "uncapped", ticket: "WM-500" },
+        openWorld({ countLeases: () => 1 }),
+      ),
+    ).toBeNull();
   });
 
   test("assigned ticket → typed NOOP ticket_assigned; never stolen, never queued behind", () => {
     const { outcome } = plan(
       { repo: "wt29", ticket: "WM-500" },
-      openWorld({ fetchTicket: () => readyTicket({ assignee: { id: "u1", name: "someone" } }) }),
+      openWorld({
+        fetchTicket: () =>
+          readyTicket({ assignee: { id: "u1", name: "someone" } }),
+      }),
     );
     expect(outcome.decision).toBe("noop");
     expect(outcome.reason).toBe("ticket_assigned");
@@ -184,15 +240,23 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
   test("ticket not in Todo → NOOP ticket_not_todo; missing ai:agent-ready → NOOP ticket_not_agent_ready", () => {
     const inReview = plan(
       { repo: "wt29", ticket: "WM-500" },
-      openWorld({ fetchTicket: () => readyTicket({ state: { name: "In Review" } }) }),
+      openWorld({
+        fetchTicket: () => readyTicket({ state: { name: "In Review" } }),
+      }),
     );
-    expect(inReview.outcome).toMatchObject({ decision: "noop", reason: "ticket_not_todo" });
+    expect(inReview.outcome).toMatchObject({
+      decision: "noop",
+      reason: "ticket_not_todo",
+    });
 
     const unlabelled = plan(
       { repo: "wt29", ticket: "WM-500" },
       openWorld({ fetchTicket: () => readyTicket({ labels: { nodes: [] } }) }),
     );
-    expect(unlabelled.outcome).toMatchObject({ decision: "noop", reason: "ticket_not_agent_ready" });
+    expect(unlabelled.outcome).toMatchObject({
+      decision: "noop",
+      reason: "ticket_not_agent_ready",
+    });
   });
 
   test("escalated and security tickets fail closed before dispatch", () => {
@@ -256,8 +320,14 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
   });
 
   test("vanished ticket → human_needed ticket_not_found", () => {
-    const { outcome } = plan({ repo: "wt29", ticket: "WM-500" }, openWorld({ fetchTicket: () => null }));
-    expect(outcome).toMatchObject({ decision: "human_needed", reason: "ticket_not_found" });
+    const { outcome } = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({ fetchTicket: () => null }),
+    );
+    expect(outcome).toMatchObject({
+      decision: "human_needed",
+      reason: "ticket_not_found",
+    });
   });
 
   test("Owned Paths overlap with any in-flight ticket → NOOP owned_paths_overlap", () => {
@@ -265,50 +335,93 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
       { repo: "wt29", ticket: "WM-500" },
       openWorld({
         fetchInFlight: () => [
-          { identifier: "WM-400", description: "## Owned Paths\n- src/feature-a/api.ts\n" },
+          {
+            identifier: "WM-400",
+            description: "## Owned Paths\n- src/feature-a/api.ts\n",
+          },
         ],
       }),
     );
-    expect(outcome).toMatchObject({ decision: "noop", reason: "owned_paths_overlap" });
+    expect(outcome).toMatchObject({
+      decision: "noop",
+      reason: "owned_paths_overlap",
+    });
   });
 
   test("an in-flight ticket with NO parseable Owned Paths owns everything (imported bias, §4)", () => {
-    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
-      fetchInFlight: () => [{ identifier: "WM-400", description: "no owned paths section at all" }],
-    }));
-    expect(refusal).toEqual({ decision: "noop", reason: "owned_paths_overlap" });
+    const refusal = worktreeDispatchGate(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        fetchInFlight: () => [
+          {
+            identifier: "WM-400",
+            description: "no owned paths section at all",
+          },
+        ],
+      }),
+    );
+    expect(refusal).toEqual({
+      decision: "noop",
+      reason: "owned_paths_overlap",
+    });
   });
 
   test("disjoint Owned Paths do not refuse; the ticket's own In Progress row is ignored", () => {
-    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
-      fetchInFlight: () => [
-        { identifier: "WM-401", description: "## Owned Paths\n- src/feature-b/**\n" },
-        { identifier: "WM-500", description: "" }, // itself — never self-colliding
-      ],
-    }));
+    const refusal = worktreeDispatchGate(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        fetchInFlight: () => [
+          {
+            identifier: "WM-401",
+            description: "## Owned Paths\n- src/feature-b/**\n",
+          },
+          { identifier: "WM-500", description: "" }, // itself — never self-colliding
+        ],
+      }),
+    );
     expect(refusal).toBeNull();
   });
 
   test("incomplete owned-paths scope on a policy-enforced repo -> human_needed before worktree setup", () => {
-    const { outcome } = plan({
-      repo: "wt29",
-      ticket: "WM-500",
-    }, openWorld({
-      fetchTicket: () => readyTicket({ description: "## Owned Paths\n- shared/**\n" }),
-    }));
-    expect(outcome).toMatchObject({ decision: "human_needed", reason: "owned_paths_not_closed" });
+    const { outcome } = plan(
+      {
+        repo: "wt29",
+        ticket: "WM-500",
+      },
+      openWorld({
+        fetchTicket: () =>
+          readyTicket({ description: "## Owned Paths\n- shared/**\n" }),
+      }),
+    );
+    expect(outcome).toMatchObject({
+      decision: "human_needed",
+      reason: "owned_paths_not_closed",
+    });
     expect(outcome.proposal).toBeTruthy();
     expect(outcome.proposal.status).toBe("open");
   });
 
   test("a Linear transport failure throws — plan_failures/dead-letter own retries, not a one-shot refusal", () => {
     const db = openDb(":memory:");
-    const admitted = admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-500" }, "d-outage"));
+    const admitted = admitEvent(
+      db,
+      registry,
+      dispatchEnvelope({ repo: "wt29", ticket: "WM-500" }, "d-outage"),
+    );
     expect(() =>
-      planEvent(db, registry, { source: admitted.event.source, eventId: admitted.event.event_id }, {
-        policyVersion: PV,
-        dispatch: openWorld({ fetchTicket: () => { throw new Error("linear_read_failed: HTTP 503"); } }),
-      }),
+      planEvent(
+        db,
+        registry,
+        { source: admitted.event.source, eventId: admitted.event.event_id },
+        {
+          policyVersion: PV,
+          dispatch: openWorld({
+            fetchTicket: () => {
+              throw new Error("linear_read_failed: HTTP 503");
+            },
+          }),
+        },
+      ),
     ).toThrow(/linear_read_failed/);
     expect(db.query(`SELECT status FROM events`).get().status).toBe("admitted");
   });
@@ -321,24 +434,36 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
   // says (./repo) before reporting success.
   const dispatchFake = {
     async execute({ spec, workspaceDir }) {
-      writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"dispatch transcript"}\n`, "utf8");
+      writeFileSync(
+        path.join(workspaceDir, ".transcript.json"),
+        `{"fake":"dispatch transcript"}\n`,
+        "utf8",
+      );
       const treeVisible = existsSync(path.join(workspaceDir, "repo"));
       writeFileSync(
         path.join(workspaceDir, "result.json"),
-        `${JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          reasonCode: "ok",
-          artifact: {
-            outcome: "PR_OPEN",
-            repo: spec.input.repo,
-            ticket: spec.input.ticket,
-            prUrl: "https://github.com/watt-mind/wt29/pull/42",
-            verification: { command: "echo verified", passed: true, output: "verified" },
-            summary: `fake dispatch of ${spec.input.ticket} (tree visible: ${treeVisible})`,
+        `${JSON.stringify(
+          {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "PR_OPEN",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              prUrl: "https://github.com/watt-mind/wt29/pull/42",
+              verification: {
+                command: "echo verified",
+                passed: true,
+                output: "verified",
+              },
+              summary: `fake dispatch of ${spec.input.ticket} (tree visible: ${treeVisible})`,
+            },
+            evidence: { commands: ["fake"], treeVisible },
           },
-          evidence: { commands: ["fake"], treeVisible },
-        }, null, 2)}\n`,
+          null,
+          2,
+        )}\n`,
         "utf8",
       );
       return { exitCode: 0, timedOut: false };
@@ -346,27 +471,53 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
   };
 
   test("an approved dispatch run builds the worktree by delegation, completes, and tears it down", async () => {
-    const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-db-")), "runtime.db"));
+    const db = openDb(
+      path.join(
+        mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-db-")),
+        "runtime.db",
+      ),
+    );
     const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
     fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
 
-    admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-501" }, "d-e2e"));
-    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld() });
-
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
-    expect(proposal).toBeTruthy();
-    expect(proposal.status).toBe("open"); // watched: nothing mutates without approval
-    expect(proposal.spec.workspace).toEqual({ type: "worktree", checkoutDir: "repo", retainOnFailure: true });
-    expect(proposal.spec.input).toEqual({ repo: "wt29", ticket: "WM-501" });
-    expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
-
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
-    const summary = await runOnce(db, registry, { pi: dispatchFake }, {
-      workspacesRoot: workspaces,
-      owner: "w-test",
+    admitEvent(
+      db,
+      registry,
+      dispatchEnvelope({ repo: "wt29", ticket: "WM-501" }, "d-e2e"),
+    );
+    planAdmittedEvents(db, registry, {
       policyVersion: PV,
       dispatch: openWorld(),
     });
+
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "dispatch@1",
+    );
+    expect(proposal).toBeTruthy();
+    expect(proposal.status).toBe("open"); // watched: nothing mutates without approval
+    expect(proposal.spec.workspace).toEqual({
+      type: "worktree",
+      checkoutDir: "repo",
+      retainOnFailure: true,
+    });
+    expect(proposal.spec.input).toEqual({ repo: "wt29", ticket: "WM-501" });
+    expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
+
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
+    const summary = await runOnce(
+      db,
+      registry,
+      { pi: dispatchFake },
+      {
+        workspacesRoot: workspaces,
+        owner: "w-test",
+        policyVersion: PV,
+        dispatch: openWorld(),
+      },
+    );
 
     expect(summary.terminalState).toBe("COMPLETED");
     expect(summary.reasonCode).toBe("ok");
@@ -375,7 +526,9 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     expect(calls()).toContain("down WM-501"); // torn down on completion
     expect(existsSync(path.join(wtRoot, "WM-501"))).toBe(false);
 
-    const row = db.query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`).get(approved.runId);
+    const row = db
+      .query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`)
+      .get(approved.runId);
     const result = JSON.parse(row.result_json);
     expect(result.artifact.outcome).toBe("PR_OPEN");
     expect(result.artifact.prUrl).toContain("/pull/42");
@@ -441,24 +594,51 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
     fixtures.push(workspaces);
 
-    admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-502" }, "d-fail"));
-    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld() });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
-    // dispatch@1 declares retainOnFailure: true; override to prove the
-    // non-retained failure path runs worktree_down (WM-108 stage 1 contract).
-    const crashing = { async execute() { return { exitCode: 1, timedOut: false }; } };
-    approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
-    // After approval (which re-verifies the spec hash), flip retainOnFailure
-    // off for the claim below — the worker reads the run's spec at claim time.
-    const spec = { ...proposal.spec, workspace: { ...proposal.spec.workspace, retainOnFailure: false } };
-    db.query(`UPDATE runs SET spec_json = ? WHERE run_id = ?`).run(JSON.stringify(spec), proposal.run_id);
-
-    const summary = await runOnce(db, registry, { pi: crashing }, {
-      workspacesRoot: workspaces,
-      owner: "w-test",
+    admitEvent(
+      db,
+      registry,
+      dispatchEnvelope({ repo: "wt29", ticket: "WM-502" }, "d-fail"),
+    );
+    planAdmittedEvents(db, registry, {
       policyVersion: PV,
       dispatch: openWorld(),
     });
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "dispatch@1",
+    );
+    // dispatch@1 declares retainOnFailure: true; override to prove the
+    // non-retained failure path runs worktree_down (WM-108 stage 1 contract).
+    const crashing = {
+      async execute() {
+        return { exitCode: 1, timedOut: false };
+      },
+    };
+    approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
+    // After approval (which re-verifies the spec hash), flip retainOnFailure
+    // off for the claim below — the worker reads the run's spec at claim time.
+    const spec = {
+      ...proposal.spec,
+      workspace: { ...proposal.spec.workspace, retainOnFailure: false },
+    };
+    db.query(`UPDATE runs SET spec_json = ? WHERE run_id = ?`).run(
+      JSON.stringify(spec),
+      proposal.run_id,
+    );
+
+    const summary = await runOnce(
+      db,
+      registry,
+      { pi: crashing },
+      {
+        workspacesRoot: workspaces,
+        owner: "w-test",
+        policyVersion: PV,
+        dispatch: openWorld(),
+      },
+    );
     expect(summary.terminalState).toBe("FAILED");
     expect(calls()).toContain("up WM-502");
     expect(calls()).toContain("down WM-502");

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -52,7 +52,8 @@ function optionalString(value, name) {
 
 function normalizeRefs(refs) {
   if (refs === undefined || refs === null) return {};
-  if (typeof refs !== "object" || Array.isArray(refs)) throw new Error("refs must be an object");
+  if (typeof refs !== "object" || Array.isArray(refs))
+    throw new Error("refs must be an object");
   const normalized = {};
   for (const [key, value] of Object.entries(refs)) {
     if (!REF_KEYS.has(key)) throw new Error(`unknown inbox ref ${key}`);
@@ -66,7 +67,9 @@ function parseObject(value) {
   if (!value) return {};
   try {
     const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
   } catch {
     return {};
   }
@@ -122,8 +125,9 @@ export function getInboxItem(db, id) {
 }
 
 function supersedeInboxDecision(db, row, { body, refs, decision }) {
-  const updated = db.query(
-    `UPDATE inbox_items
+  const updated = db
+    .query(
+      `UPDATE inbox_items
      SET decision_json = ?, response_json = NULL, decided_at = NULL,
          decided_by = NULL, body = ?,
          refs_json = CASE WHEN ? IS NULL THEN refs_json ELSE json_set(
@@ -139,28 +143,34 @@ function supersedeInboxDecision(db, row, { body, refs, decision }) {
            ), 0) + 1
          )
      WHERE id = ? AND resolved_at IS NULL`,
-  ).run(
-    decision === null ? null : JSON.stringify(decision),
-    body,
-    refs.runId ?? null,
-    refs.runId ?? null,
-    row.id,
-  );
+    )
+    .run(
+      decision === null ? null : JSON.stringify(decision),
+      body,
+      refs.runId ?? null,
+      refs.runId ?? null,
+      row.id,
+    );
   if (updated.changes !== 1) return null;
   return getInboxItem(db, row.id);
 }
 
-export function createInboxItem(db, input, {
-  id = `inbox_${randomUUID()}`,
-  now = Date.now(),
-} = {}) {
+export function createInboxItem(
+  db,
+  input,
+  { id = `inbox_${randomUUID()}`, now = Date.now() } = {},
+) {
   const kind = requiredString(input?.kind, "kind");
   if (!KIND_SET.has(kind)) throw new Error(`unknown inbox kind: ${kind}`);
   const title = requiredString(input?.title, "title");
   const body = optionalString(input?.body, "body");
   const severity = optionalString(input?.severity, "severity") ?? "normal";
   const source = optionalString(input?.source, "source") ?? "cli";
-  if (source !== "cli" && source !== "serve:notify" && !/^agent:.+/.test(source)) {
+  if (
+    source !== "cli" &&
+    source !== "serve:notify" &&
+    !/^agent:.+/.test(source)
+  ) {
     throw new Error(`unknown inbox source: ${source}`);
   }
   const refs = normalizeRefs(input?.refs);
@@ -180,11 +190,13 @@ export function createInboxItem(db, input, {
   const createdAt = new Date(now).toISOString();
 
   if (dedupeKey) {
-    const existing = db.query(
-      `SELECT * FROM inbox_items
+    const existing = db
+      .query(
+        `SELECT * FROM inbox_items
        WHERE dedupe_key = ? AND resolved_at IS NULL
        LIMIT 1`,
-    ).get(dedupeKey);
+      )
+      .get(dedupeKey);
     if (existing) {
       const superseded = supersedeInboxDecision(db, existing, {
         body,
@@ -222,11 +234,13 @@ export function createInboxItem(db, input, {
       // lookup above. In that case the collision has the same semantics as an
       // item that was already present; unrelated insert failures still escape.
       const winner = dedupeKey
-        ? db.query(
-          `SELECT * FROM inbox_items
+        ? db
+            .query(
+              `SELECT * FROM inbox_items
            WHERE dedupe_key = ? AND resolved_at IS NULL
            LIMIT 1`,
-        ).get(dedupeKey)
+            )
+            .get(dedupeKey)
         : null;
       if (!winner) break;
       const superseded = supersedeInboxDecision(db, winner, {
@@ -245,21 +259,21 @@ export function createInboxItem(db, input, {
 function decisionRow(db, id) {
   const row = db.query("SELECT * FROM inbox_items WHERE id = ?").get(id);
   if (!row) {
-    throw new InboxDecisionError(
-      "not_found",
-      `unknown inbox item ${id}`,
-      404,
-    );
+    throw new InboxDecisionError("not_found", `unknown inbox item ${id}`, 404);
   }
   return row;
 }
 
 function normalizeEffect(effect, item, response) {
-  const kind = item.decision.options.find(
-    (option) => option.id === response.optionId,
-  )?.effect ?? "unknown";
+  const kind =
+    item.decision.options.find((option) => option.id === response.optionId)
+      ?.effect ?? "unknown";
   if (!effect || typeof effect !== "object" || Array.isArray(effect)) {
-    return { kind, outcome: "failed", error: "decision effect returned no outcome" };
+    return {
+      kind,
+      outcome: "failed",
+      error: "decision effect returned no outcome",
+    };
   }
   return { ...effect, kind };
 }
@@ -292,7 +306,11 @@ function decideInboxItemInTransaction(
     );
   }
   if (!response || typeof response !== "object" || Array.isArray(response)) {
-    throw new InboxDecisionError("invalid_response", "response must be an object", 400);
+    throw new InboxDecisionError(
+      "invalid_response",
+      "response must be an object",
+      400,
+    );
   }
   const expectedHash = decisionRequestHash(decision);
   if (
@@ -325,11 +343,13 @@ function decideInboxItemInTransaction(
 
   // Persist the answer before invoking the seam. A throwing effect must not
   // lose what the operator entered; retry uses this exact stored response.
-  const recorded = db.query(
-    `UPDATE inbox_items
+  const recorded = db
+    .query(
+      `UPDATE inbox_items
      SET response_json = ?, decided_at = ?, decided_by = ?
      WHERE id = ? AND response_json IS NULL AND decided_at IS NULL`,
-  ).run(JSON.stringify(storedResponse), decidedAt, decidedBy, id);
+    )
+    .run(JSON.stringify(storedResponse), decidedAt, decidedBy, id);
   if (recorded.changes !== 1) {
     throw new InboxDecisionError(
       "already_decided",
@@ -341,7 +361,11 @@ function decideInboxItemInTransaction(
   const item = getInboxItem(db, id);
   let effect;
   try {
-    effect = normalizeEffect(applyEffect(db, item, storedResponse), item, storedResponse);
+    effect = normalizeEffect(
+      applyEffect(db, item, storedResponse),
+      item,
+      storedResponse,
+    );
   } catch (err) {
     effect = normalizeEffect(
       { outcome: "failed", error: err?.message ?? String(err) },
@@ -368,7 +392,7 @@ export function decideInboxItem(db, id, response, options = {}) {
   // Serialize request claim, effect application, and finalization against
   // concurrent answers and dedupe supersession on other connections.
   return txImmediate(db, () =>
-    decideInboxItemInTransaction(db, id, response, options)
+    decideInboxItemInTransaction(db, id, response, options),
   );
 }
 
@@ -441,15 +465,15 @@ export function retryInboxDecision(db, id, options = {}) {
   // Capture the exact failed outcome before waiting for the write lock. A
   // concurrent retry increments retryAttempt, so a waiter cannot replay the
   // same effect after that first retry commits; a later deliberate retry can.
-  const expectedResponseJson = db.query(
-    "SELECT response_json FROM inbox_items WHERE id = ?",
-  ).get(id)?.response_json ?? null;
+  const expectedResponseJson =
+    db.query("SELECT response_json FROM inbox_items WHERE id = ?").get(id)
+      ?.response_json ?? null;
   // The same lock prevents two operators from retrying one effect at once.
   return txImmediate(db, () =>
     retryInboxDecisionInTransaction(db, id, {
       ...options,
       expectedResponseJson,
-    })
+    }),
   );
 }
 
@@ -462,24 +486,30 @@ export function listInboxItems(db, { status = "open" } = {}) {
     all: "1 = 1",
   }[status];
   return db
-    .query(`SELECT * FROM inbox_items WHERE ${where} ORDER BY created_at DESC, rowid DESC`)
+    .query(
+      `SELECT * FROM inbox_items WHERE ${where} ORDER BY created_at DESC, rowid DESC`,
+    )
     .all()
     .map(itemView);
 }
 
 export function ackInboxItem(db, id, { now = Date.now() } = {}) {
-  const row = db.query("SELECT resolved_at FROM inbox_items WHERE id = ?").get(id);
+  const row = db
+    .query("SELECT resolved_at FROM inbox_items WHERE id = ?")
+    .get(id);
   if (!row) throw new Error(`unknown inbox item ${id}`);
   if (row.resolved_at) throw new Error(`inbox item ${id} is already resolved`);
-  db.query("UPDATE inbox_items SET acked_at = COALESCE(acked_at, ?) WHERE id = ?")
-    .run(new Date(now).toISOString(), id);
+  db.query(
+    "UPDATE inbox_items SET acked_at = COALESCE(acked_at, ?) WHERE id = ?",
+  ).run(new Date(now).toISOString(), id);
   return getInboxItem(db, id);
 }
 
-export function resolveInboxItem(db, id, {
-  now = Date.now(),
-  resolvedBy = "operator",
-} = {}) {
+export function resolveInboxItem(
+  db,
+  id,
+  { now = Date.now(), resolvedBy = "operator" } = {},
+) {
   requiredString(resolvedBy, "resolvedBy");
   if (
     resolvedBy !== "operator" &&
@@ -488,9 +518,11 @@ export function resolveInboxItem(db, id, {
   ) {
     throw new Error(`invalid inbox resolver: ${resolvedBy}`);
   }
-  const row = db.query(
-    "SELECT id, decision_json, response_json FROM inbox_items WHERE id = ?",
-  ).get(id);
+  const row = db
+    .query(
+      "SELECT id, decision_json, response_json FROM inbox_items WHERE id = ?",
+    )
+    .get(id);
   if (!row) throw new Error(`unknown inbox item ${id}`);
   const resolvedAt = new Date(now).toISOString();
   if (row.decision_json && !row.response_json) {
@@ -527,20 +559,28 @@ export function resolveInboxItem(db, id, {
 }
 
 export function inboxCounts(db) {
-  const totals = db.query(
-    `SELECT
+  const totals = db
+    .query(
+      `SELECT
        SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NULL THEN 1 ELSE 0 END) AS open,
        SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NOT NULL THEN 1 ELSE 0 END) AS acked
      FROM inbox_items`,
-  ).get();
+    )
+    .get();
   const byKind = {};
-  for (const row of db.query(
-    `SELECT kind, COUNT(*) AS n FROM inbox_items
+  for (const row of db
+    .query(
+      `SELECT kind, COUNT(*) AS n FROM inbox_items
      WHERE resolved_at IS NULL GROUP BY kind ORDER BY kind`,
-  ).all()) {
+    )
+    .all()) {
     byKind[row.kind] = row.n;
   }
-  return { open: Number(totals.open ?? 0), acked: Number(totals.acked ?? 0), byKind };
+  return {
+    open: Number(totals.open ?? 0),
+    acked: Number(totals.acked ?? 0),
+    byKind,
+  };
 }
 
 function telegramMessage(item, webUrl) {
@@ -558,15 +598,20 @@ function telegramMessage(item, webUrl) {
 }
 
 /** Attempt the Telegram projection and persist its outcome on the existing row. */
-export async function deliverInboxItem(db, id, {
-  command,
-  send,
-  webUrl = process.env.FACTORY_WEB_URL,
-  now = Date.now(),
-} = {}) {
+export async function deliverInboxItem(
+  db,
+  id,
+  {
+    command,
+    send,
+    webUrl = process.env.FACTORY_WEB_URL,
+    now = Date.now(),
+  } = {},
+) {
   const item = getInboxItem(db, id);
   if (!item) throw new Error(`unknown inbox item ${id}`);
-  if (typeof send !== "function") throw new Error("inbox delivery transport is required");
+  if (typeof send !== "function")
+    throw new Error("inbox delivery transport is required");
   let outcome;
   try {
     outcome = await send(command, telegramMessage(item, webUrl));
@@ -581,8 +626,10 @@ export async function deliverInboxItem(db, id, {
       error: outcome.error ?? null,
     },
   };
-  db.query("UPDATE inbox_items SET delivery_json = ? WHERE id = ?")
-    .run(JSON.stringify(delivery), id);
+  db.query("UPDATE inbox_items SET delivery_json = ? WHERE id = ?").run(
+    JSON.stringify(delivery),
+    id,
+  );
   return {
     ok: outcome.ok === true,
     exitCode: outcome.exitCode ?? null,
@@ -594,12 +641,14 @@ export async function deliverInboxItem(db, id, {
 /** Resolve runtime-owned asks when their authoritative referent stops waiting. */
 export function reconcileInbox(db, { now = Date.now() } = {}) {
   const resolved = [];
-  const rows = db.query(
-    `SELECT id, kind, refs_json, decision_json, response_json FROM inbox_items
+  const rows = db
+    .query(
+      `SELECT id, kind, refs_json, decision_json, response_json FROM inbox_items
      WHERE resolved_at IS NULL
        AND kind IN ('decision_needed', 'proposal_expired', 'human_needed', 'BLOCKED')
      ORDER BY created_at, rowid`,
-  ).all();
+    )
+    .all();
   for (const row of rows) {
     // Pending decisions are not skipped: once the referent stops waiting the
     // ask is moot and resolveInboxItem records it as superseded (auto:*).
@@ -607,12 +656,17 @@ export function reconcileInbox(db, { now = Date.now() } = {}) {
     let resolvedBy = null;
     if (row.kind === "decision_needed" || row.kind === "proposal_expired") {
       if (!refs.proposalId) continue;
-      const proposal = db.query("SELECT status FROM proposals WHERE id = ?").get(refs.proposalId);
-      if (proposal && proposal.status !== "open") resolvedBy = "auto:proposal_decided";
+      const proposal = db
+        .query("SELECT status FROM proposals WHERE id = ?")
+        .get(refs.proposalId);
+      if (proposal && proposal.status !== "open")
+        resolvedBy = "auto:proposal_decided";
     } else if (refs.eventSource && refs.eventId) {
-      const event = db.query("SELECT status FROM events WHERE source = ? AND event_id = ?")
+      const event = db
+        .query("SELECT status FROM events WHERE source = ? AND event_id = ?")
         .get(refs.eventSource, refs.eventId);
-      if (event && event.status !== "human_needed") resolvedBy = "auto:event_requeued";
+      if (event && event.status !== "human_needed")
+        resolvedBy = "auto:event_requeued";
     }
     if (!resolvedBy) continue;
     resolveInboxItem(db, row.id, { now, resolvedBy });

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -15,9 +15,9 @@ import {
 } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 
-function decision(options = [
-  { id: "dismiss", label: "Not now", effect: "dismiss" },
-]) {
+function decision(
+  options = [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
+) {
   return {
     schemaVersion: "factory.decision-request/v1",
     question: "What should happen?",
@@ -25,7 +25,10 @@ function decision(options = [
   };
 }
 
-function insertEvent(db, { source = "test", eventId, status = "human_needed" }) {
+function insertEvent(
+  db,
+  { source = "test", eventId, status = "human_needed" },
+) {
   const at = new Date().toISOString();
   db.query(
     `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at)
@@ -44,20 +47,26 @@ function insertProposal(db, { id, status = "open" }) {
 describe("human inbox ledger (WM-285)", () => {
   test("decision requests are validated and exposed with decision metadata", () => {
     const db = openDb(":memory:");
-    expect(() => createInboxItem(db, {
-      kind: "BLOCKED",
-      title: "bad",
-      decision: decision([
-        { id: "retry", label: "Retry", effect: "requeue" },
-      ]),
-    })).toThrow("requires refs.eventSource");
+    expect(() =>
+      createInboxItem(db, {
+        kind: "BLOCKED",
+        title: "bad",
+        decision: decision([
+          { id: "retry", label: "Retry", effect: "requeue" },
+        ]),
+      }),
+    ).toThrow("requires refs.eventSource");
 
-    const item = createInboxItem(db, {
-      kind: "BLOCKED",
-      title: "good",
-      decision: decision(),
-      dedupeKey: "BLOCKED:evt",
-    }, { id: "decision_item", now: 1000 });
+    const item = createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "good",
+        decision: decision(),
+        dedupeKey: "BLOCKED:evt",
+      },
+      { id: "decision_item", now: 1000 },
+    );
     expect(item).toMatchObject({
       decision: decision(),
       response: null,
@@ -69,27 +78,35 @@ describe("human inbox ledger (WM-285)", () => {
 
   test("open dedupe supersedes the request without stacking rows", () => {
     const db = openDb(":memory:");
-    const first = createInboxItem(db, {
-      kind: "ESCALATED",
-      title: "first",
-      body: "old",
-      refs: { issue: "WM-1", runId: "run_1" },
-      source: "agent:run_1",
-      decision: decision(),
-      dedupeKey: "ESCALATED:WM-1",
-    }, { id: "first" });
+    const first = createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "first",
+        body: "old",
+        refs: { issue: "WM-1", runId: "run_1" },
+        source: "agent:run_1",
+        decision: decision(),
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "first" },
+    );
     const replacement = decision([
       { id: "dismiss", label: "Dismiss this time", effect: "dismiss" },
     ]);
-    const second = createInboxItem(db, {
-      kind: "ESCALATED",
-      title: "second",
-      body: "new",
-      refs: { issue: "WM-1", runId: "run_2" },
-      source: "agent:run_2",
-      decision: replacement,
-      dedupeKey: "ESCALATED:WM-1",
-    }, { id: "second" });
+    const second = createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "second",
+        body: "new",
+        refs: { issue: "WM-1", runId: "run_2" },
+        source: "agent:run_2",
+        decision: replacement,
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "second" },
+    );
     expect(second.id).toBe(first.id);
     expect(second.body).toBe("new");
     expect(second.refs).toEqual({ issue: "WM-1", runId: "run_2" });
@@ -107,13 +124,17 @@ describe("human inbox ledger (WM-285)", () => {
     const original = decision([
       { id: "triage", label: "Triage", effect: "send_to_triage" },
     ]);
-    createInboxItem(db, {
-      kind: "ESCALATED",
-      title: "first",
-      refs: { issue: "WM-1", runId: "run_1" },
-      decision: original,
-      dedupeKey: "ESCALATED:WM-1",
-    }, { id: "first" });
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "first",
+        refs: { issue: "WM-1", runId: "run_1" },
+        decision: original,
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "first" },
+    );
     const answered = decideInboxItem(db, "first", {
       schemaVersion: "factory.decision-response/v1",
       requestHash: decisionRequestHash(original),
@@ -147,31 +168,44 @@ describe("human inbox ledger (WM-285)", () => {
       { id: "go", label: "Proceed", effect: "send_to_triage" },
       { id: "dismiss", label: "Not now", effect: "dismiss" },
     ]);
-    const item = createInboxItem(db, {
-      kind: "ESCALATED",
-      title: "decide",
-      refs: { issue: "WM-1" },
-      decision: request,
-    }, { id: "to_decide" });
+    const item = createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "decide",
+        refs: { issue: "WM-1" },
+        decision: request,
+      },
+      { id: "to_decide" },
+    );
     expect(() => resolveInboxItem(db, item.id)).toThrow("pending decision");
-    expect(() => decideInboxItem(db, item.id, {
-      schemaVersion: "factory.decision-response/v1",
-      requestHash: "sha256:" + "0".repeat(64),
-      optionId: "dismiss",
-      fields: {},
-    })).toThrow("has changed");
-    expect(() => decideInboxItem(db, item.id, {
-      requestHash: decisionRequestHash(request),
-      optionId: "go",
-      fields: {},
-    })).toThrow("schemaVersion");
+    expect(() =>
+      decideInboxItem(db, item.id, {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: "sha256:" + "0".repeat(64),
+        optionId: "dismiss",
+        fields: {},
+      }),
+    ).toThrow("has changed");
+    expect(() =>
+      decideInboxItem(db, item.id, {
+        requestHash: decisionRequestHash(request),
+        optionId: "go",
+        fields: {},
+      }),
+    ).toThrow("schemaVersion");
 
-    const unsupported = decideInboxItem(db, item.id, {
-      schemaVersion: "factory.decision-response/v1",
-      requestHash: decisionRequestHash(request),
-      optionId: "go",
-      fields: {},
-    }, { now: 2000 });
+    const unsupported = decideInboxItem(
+      db,
+      item.id,
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "go",
+        fields: {},
+      },
+      { now: 2000 },
+    );
     expect(unsupported.effect).toEqual({
       kind: "send_to_triage",
       outcome: "unsupported",
@@ -179,9 +213,13 @@ describe("human inbox ledger (WM-285)", () => {
     expect(unsupported.item.resolvedAt).toBeNull();
     expect(unsupported.item.response.effect).toEqual(unsupported.effect);
     expect(unsupported.item.decidedAt).toBe(new Date(2000).toISOString());
-    expect(() => decideInboxItem(db, item.id, {
-      requestHash: decisionRequestHash(request), optionId: "go", fields: {},
-    })).toThrow("already decided");
+    expect(() =>
+      decideInboxItem(db, item.id, {
+        requestHash: decisionRequestHash(request),
+        optionId: "go",
+        fields: {},
+      }),
+    ).toThrow("already decided");
 
     const retried = retryInboxDecision(db, item.id, {
       now: 3000,
@@ -198,35 +236,51 @@ describe("human inbox ledger (WM-285)", () => {
     const request = decision([
       { id: "triage", label: "Triage", effect: "send_to_triage" },
     ]);
-    createInboxItem(db, {
-      kind: "ESCALATED",
-      title: "retry",
-      refs: { issue: "WM-1" },
-      decision: request,
-    }, { id: "retry_attempts" });
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "retry",
+        refs: { issue: "WM-1" },
+        decision: request,
+      },
+      { id: "retry_attempts" },
+    );
     decideInboxItem(db, "retry_attempts", {
       schemaVersion: "factory.decision-response/v1",
       requestHash: decisionRequestHash(request),
       optionId: "triage",
       fields: {},
     });
-    expect(retryInboxDecision(db, "retry_attempts").item.response.effect.retryAttempt).toBe(1);
-    expect(retryInboxDecision(db, "retry_attempts").item.response.effect.retryAttempt).toBe(2);
+    expect(
+      retryInboxDecision(db, "retry_attempts").item.response.effect
+        .retryAttempt,
+    ).toBe(1);
+    expect(
+      retryInboxDecision(db, "retry_attempts").item.response.effect
+        .retryAttempt,
+    ).toBe(2);
   });
 
   test("kind is closed and rows expose parsed refs/delivery", () => {
     const db = openDb(":memory:");
     expect(INBOX_KINDS).toContain("BLOCKED");
     expect(INBOX_KINDS).toContain("proposal_expired");
-    expect(() => createInboxItem(db, { kind: "routine_progress", title: "claimed" })).toThrow("unknown inbox kind");
+    expect(() =>
+      createInboxItem(db, { kind: "routine_progress", title: "claimed" }),
+    ).toThrow("unknown inbox kind");
 
-    const item = createInboxItem(db, {
-      kind: "BLOCKED",
-      severity: "high",
-      title: "BLOCKED WM-1: choose",
-      refs: { issue: "WM-1", runId: "run_1" },
-      source: "agent:run_1",
-    }, { now: 1000, id: "inbox_test" });
+    const item = createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        severity: "high",
+        title: "BLOCKED WM-1: choose",
+        refs: { issue: "WM-1", runId: "run_1" },
+        source: "agent:run_1",
+      },
+      { now: 1000, id: "inbox_test" },
+    );
     expect(item).toMatchObject({
       id: "inbox_test",
       kind: "BLOCKED",
@@ -240,7 +294,11 @@ describe("human inbox ledger (WM-285)", () => {
 
   test("delivery records failure without deleting the item and appends a configured deep link", async () => {
     const db = openDb(":memory:");
-    const item = createInboxItem(db, { kind: "CI RED", title: "CI RED PR-4: tests", source: "cli" }, { id: "inbox_delivery" });
+    const item = createInboxItem(
+      db,
+      { kind: "CI RED", title: "CI RED PR-4: tests", source: "cli" },
+      { id: "inbox_delivery" },
+    );
     let message;
     const outcome = await deliverInboxItem(db, item.id, {
       command: "/stub",
@@ -251,8 +309,12 @@ describe("human inbox ledger (WM-285)", () => {
       },
     });
     expect(outcome.ok).toBe(false);
-    expect(message).toBe("CI RED PR-4: tests\nhttp://127.0.0.1:7382/#/inbox/inbox_delivery");
-    expect(listInboxItems(db, { status: "all" })[0].delivery.telegram).toMatchObject({
+    expect(message).toBe(
+      "CI RED PR-4: tests\nhttp://127.0.0.1:7382/#/inbox/inbox_delivery",
+    );
+    expect(
+      listInboxItems(db, { status: "all" })[0].delivery.telegram,
+    ).toMatchObject({
       exit_code: 7,
       error: "notifier exited 7",
     });
@@ -260,36 +322,69 @@ describe("human inbox ledger (WM-285)", () => {
 
   test("ack, resolve, filters, and counts distinguish open from acknowledged", () => {
     const db = openDb(":memory:");
-    createInboxItem(db, { kind: "BLOCKED", title: "one" }, { id: "one", now: 1000 });
-    createInboxItem(db, { kind: "ESCALATED", title: "two" }, { id: "two", now: 2000 });
-    expect(ackInboxItem(db, "one", { now: 3000 }).ackedAt).toBe(new Date(3000).toISOString());
-    expect(resolveInboxItem(db, "two", { now: 4000, resolvedBy: "operator" }).resolvedBy).toBe("operator");
+    createInboxItem(
+      db,
+      { kind: "BLOCKED", title: "one" },
+      { id: "one", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      { kind: "ESCALATED", title: "two" },
+      { id: "two", now: 2000 },
+    );
+    expect(ackInboxItem(db, "one", { now: 3000 }).ackedAt).toBe(
+      new Date(3000).toISOString(),
+    );
+    expect(
+      resolveInboxItem(db, "two", { now: 4000, resolvedBy: "operator" })
+        .resolvedBy,
+    ).toBe("operator");
     expect(listInboxItems(db, { status: "open" }).map((i) => i.id)).toEqual([]);
-    expect(listInboxItems(db, { status: "acked" }).map((i) => i.id)).toEqual(["one"]);
-    expect(listInboxItems(db, { status: "resolved" }).map((i) => i.id)).toEqual(["two"]);
-    expect(inboxCounts(db)).toEqual({ open: 0, acked: 1, byKind: { BLOCKED: 1 } });
+    expect(listInboxItems(db, { status: "acked" }).map((i) => i.id)).toEqual([
+      "one",
+    ]);
+    expect(listInboxItems(db, { status: "resolved" }).map((i) => i.id)).toEqual(
+      ["two"],
+    );
+    expect(inboxCounts(db)).toEqual({
+      open: 0,
+      acked: 1,
+      byKind: { BLOCKED: 1 },
+    });
   });
 
   test("runtime-owned referents auto-resolve after leaving their waiting state", () => {
     const db = openDb(":memory:");
     insertProposal(db, { id: "prop-1" });
     insertEvent(db, { eventId: "evt-1" });
-    createInboxItem(db, {
-      kind: "decision_needed",
-      title: "decision",
-      refs: { proposalId: "prop-1" },
-      source: "serve:notify",
-    }, { id: "decision" });
-    createInboxItem(db, {
-      kind: "BLOCKED",
-      title: "human",
-      refs: { eventSource: "test", eventId: "evt-1" },
-      source: "serve:notify",
-    }, { id: "human" });
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "decision",
+        refs: { proposalId: "prop-1" },
+        source: "serve:notify",
+      },
+      { id: "decision" },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "human",
+        refs: { eventSource: "test", eventId: "evt-1" },
+        source: "serve:notify",
+      },
+      { id: "human" },
+    );
 
     expect(reconcileInbox(db)).toEqual([]);
-    db.query("UPDATE proposals SET status = 'approved' WHERE id = 'prop-1'").run();
-    db.query("UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-1'").run();
+    db.query(
+      "UPDATE proposals SET status = 'approved' WHERE id = 'prop-1'",
+    ).run();
+    db.query(
+      "UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-1'",
+    ).run();
     const resolved = reconcileInbox(db, { now: 5000 });
     expect(resolved).toEqual([
       { id: "decision", resolvedBy: "auto:proposal_decided" },
@@ -300,33 +395,44 @@ describe("human inbox ledger (WM-285)", () => {
   test("a pending decision becomes moot when its event leaves human_needed", () => {
     const db = openDb(":memory:");
     insertEvent(db, { eventId: "evt-2" });
-    createInboxItem(db, {
-      kind: "BLOCKED",
-      title: "parked",
-      refs: { eventSource: "test", eventId: "evt-2" },
-      source: "serve:notify",
-      decision: decision([
-        { id: "requeue", label: "Requeue the event", effect: "requeue" },
-        { id: "dismiss", label: "Not now", effect: "dismiss" },
-      ]),
-    }, { id: "parked" });
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "parked",
+        refs: { eventSource: "test", eventId: "evt-2" },
+        source: "serve:notify",
+        decision: decision([
+          { id: "requeue", label: "Requeue the event", effect: "requeue" },
+          { id: "dismiss", label: "Not now", effect: "dismiss" },
+        ]),
+      },
+      { id: "parked" },
+    );
 
     expect(reconcileInbox(db)).toEqual([]);
-    expect(() => resolveInboxItem(db, "parked", { resolvedBy: "operator" }))
-      .toThrow(/pending decision/);
+    expect(() =>
+      resolveInboxItem(db, "parked", { resolvedBy: "operator" }),
+    ).toThrow(/pending decision/);
 
-    db.query("UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-2'").run();
+    db.query(
+      "UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-2'",
+    ).run();
     expect(reconcileInbox(db, { now: 5000 })).toEqual([
       { id: "parked", resolvedBy: "auto:event_requeued" },
     ]);
     const item = getInboxItem(db, "parked");
     expect(item.resolvedBy).toBe("auto:event_requeued");
     expect(item.resolvedAt).toBe(new Date(5000).toISOString());
-    expect(item.response).toMatchObject({ superseded: true, reason: "auto:event_requeued" });
+    expect(item.response).toMatchObject({
+      superseded: true,
+      reason: "auto:event_requeued",
+    });
     expect(item.decidedBy).toBe("auto:event_requeued");
     // A late operator answer is refused rather than applied.
-    expect(() => decideInboxItem(db, "parked", { optionId: "requeue" }))
-      .toThrow(/already decided/);
+    expect(() =>
+      decideInboxItem(db, "parked", { optionId: "requeue" }),
+    ).toThrow(/already decided/);
     expect(reconcileInbox(db, { now: 6000 })).toEqual([]);
   });
 
@@ -334,12 +440,16 @@ describe("human inbox ledger (WM-285)", () => {
     const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
     const db = openDb(":memory:");
     insertProposal(db, { id: "prop-tick", status: "approved" });
-    createInboxItem(db, {
-      kind: "decision_needed",
-      title: "decision",
-      refs: { proposalId: "prop-tick" },
-      source: "serve:notify",
-    }, { id: "tick-item" });
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "decision",
+        refs: { proposalId: "prop-tick" },
+        source: "serve:notify",
+      },
+      { id: "tick-item" },
+    );
     const noop = () => {};
     await tick({
       db,
@@ -359,6 +469,8 @@ describe("human inbox ledger (WM-285)", () => {
       },
     });
     expect(TICK_SUBSYSTEMS).toContain("inbox");
-    expect(getInboxItem(db, "tick-item").resolvedBy).toBe("auto:proposal_decided");
+    expect(getInboxItem(db, "tick-item").resolvedBy).toBe(
+      "auto:proposal_decided",
+    );
   });
 });

--- a/event-runtime/lib/intake-github.test.mjs
+++ b/event-runtime/lib/intake-github.test.mjs
@@ -11,7 +11,11 @@ import os from "node:os";
 import path from "node:path";
 import { startApi } from "./api.mjs";
 import { openDb } from "./db.mjs";
-import { githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook } from "./intake.mjs";
+import {
+  githubWebhookSecret,
+  translateGitHubEvent,
+  verifyGitHubWebhook,
+} from "./intake.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -30,13 +34,33 @@ const factorySign = (rawBody, timestamp, secret = SECRET) =>
 
 /** Repos as lib/repos.mjs loads them — only the fields translation reads. */
 const REPOS = new Map([
-  ["wt29", { name: "wt29", github: "watt-mind/wt29", base: "develop", reportOnly: false }],
-  ["watched", { name: "watched", github: "watt-mind/watched", base: "develop", reportOnly: true }],
+  [
+    "wt29",
+    {
+      name: "wt29",
+      github: "watt-mind/wt29",
+      base: "develop",
+      reportOnly: false,
+    },
+  ],
+  [
+    "watched",
+    {
+      name: "watched",
+      github: "watt-mind/watched",
+      base: "develop",
+      reportOnly: true,
+    },
+  ],
 ]);
 
 const prPayload = (overrides = {}) => ({
   action: "opened",
-  pull_request: { number: 7, base: { ref: "develop" }, ...overrides.pull_request },
+  pull_request: {
+    number: 7,
+    base: { ref: "develop" },
+    ...overrides.pull_request,
+  },
   repository: { full_name: "watt-mind/wt29" },
   ...overrides,
 });
@@ -49,36 +73,75 @@ const workflowRunPayload = (overrides = {}) => ({
 });
 
 const translate = (event, payload, overrides = {}) =>
-  translateGitHubEvent({ event, deliveryId: "gh-delivery-1", payload, repos: REPOS, now: NOW, ...overrides });
+  translateGitHubEvent({
+    event,
+    deliveryId: "gh-delivery-1",
+    payload,
+    repos: REPOS,
+    now: NOW,
+    ...overrides,
+  });
 
 describe("verifyGitHubWebhook (WM-112)", () => {
   const rawBody = JSON.stringify(prPayload());
 
   test("valid signature over the raw body passes", () => {
-    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody), secret: GH_SECRET })).toEqual({ ok: true });
+    expect(
+      verifyGitHubWebhook({
+        rawBody,
+        signature: ghSign(rawBody),
+        secret: GH_SECRET,
+      }),
+    ).toEqual({ ok: true });
   });
 
   test("wrong secret and tampered body each fail as bad_signature", () => {
-    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody, "other"), secret: GH_SECRET })).toEqual({
+    expect(
+      verifyGitHubWebhook({
+        rawBody,
+        signature: ghSign(rawBody, "other"),
+        secret: GH_SECRET,
+      }),
+    ).toEqual({
       ok: false,
       reason: "bad_signature",
     });
     expect(
-      verifyGitHubWebhook({ rawBody: rawBody.replace("wt29", "evil"), signature: ghSign(rawBody), secret: GH_SECRET }),
+      verifyGitHubWebhook({
+        rawBody: rawBody.replace("wt29", "evil"),
+        signature: ghSign(rawBody),
+        secret: GH_SECRET,
+      }),
     ).toEqual({ ok: false, reason: "bad_signature" });
   });
 
   test("missing secret and missing signature fail closed", () => {
-    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody), secret: null })).toEqual({
+    expect(
+      verifyGitHubWebhook({
+        rawBody,
+        signature: ghSign(rawBody),
+        secret: null,
+      }),
+    ).toEqual({
       ok: false,
       reason: "missing_secret",
     });
-    expect(verifyGitHubWebhook({ rawBody, secret: GH_SECRET })).toEqual({ ok: false, reason: "missing_signature" });
+    expect(verifyGitHubWebhook({ rawBody, secret: GH_SECRET })).toEqual({
+      ok: false,
+      reason: "missing_signature",
+    });
   });
 
   test("malformed signature never throws", () => {
-    for (const signature of ["nonsense", "sha256=", "sha256=zzzz", "sha1=abc"]) {
-      expect(verifyGitHubWebhook({ rawBody, signature, secret: GH_SECRET })).toEqual({
+    for (const signature of [
+      "nonsense",
+      "sha256=",
+      "sha256=zzzz",
+      "sha1=abc",
+    ]) {
+      expect(
+        verifyGitHubWebhook({ rawBody, signature, secret: GH_SECRET }),
+      ).toEqual({
         ok: false,
         reason: "bad_signature",
       });
@@ -91,7 +154,8 @@ describe("verifyGitHubWebhook (WM-112)", () => {
     expect(githubWebhookSecret()).toBeNull();
     process.env.FACTORY_GITHUB_WEBHOOK_SECRET = "gh-s";
     expect(githubWebhookSecret()).toBe("gh-s");
-    if (previous === undefined) delete process.env.FACTORY_GITHUB_WEBHOOK_SECRET;
+    if (previous === undefined)
+      delete process.env.FACTORY_GITHUB_WEBHOOK_SECRET;
     else process.env.FACTORY_GITHUB_WEBHOOK_SECRET = previous;
   });
 });
@@ -127,14 +191,26 @@ describe("translateGitHubEvent (WM-112)", () => {
 
   test("draft PR opened or synchronized is ignored as draft_pr; ready_for_review continues (WM-124)", () => {
     expect(
-      translate("pull_request", prPayload({ action: "opened", pull_request: { base: { ref: "develop" }, draft: true } })),
+      translate(
+        "pull_request",
+        prPayload({
+          action: "opened",
+          pull_request: { base: { ref: "develop" }, draft: true },
+        }),
+      ),
     ).toEqual({
       ok: false,
       ignored: true,
       reason: "draft_pr",
     });
     expect(
-      translate("pull_request", prPayload({ action: "synchronize", pull_request: { base: { ref: "develop" }, draft: true } })),
+      translate(
+        "pull_request",
+        prPayload({
+          action: "synchronize",
+          pull_request: { base: { ref: "develop" }, draft: true },
+        }),
+      ),
     ).toEqual({
       ok: false,
       ignored: true,
@@ -142,36 +218,64 @@ describe("translateGitHubEvent (WM-112)", () => {
     });
     const ready = translate(
       "pull_request",
-      prPayload({ action: "ready_for_review", pull_request: { base: { ref: "develop" }, draft: false } }),
+      prPayload({
+        action: "ready_for_review",
+        pull_request: { base: { ref: "develop" }, draft: false },
+      }),
     );
     expect(ready.ok).toBe(true);
     expect(ready.envelope.type).toBe("factory.merge.requested");
 
     const readyEvenIfDraftTrue = translate(
       "pull_request",
-      prPayload({ action: "ready_for_review", pull_request: { base: { ref: "develop" }, draft: true } }),
+      prPayload({
+        action: "ready_for_review",
+        pull_request: { base: { ref: "develop" }, draft: true },
+      }),
     );
     expect(readyEvenIfDraftTrue.ok).toBe(true);
     expect(readyEvenIfDraftTrue.envelope.type).toBe("factory.merge.requested");
   });
 
   test("a PR not targeting the configured base branch is ignored", () => {
-    const payload = prPayload({ pull_request: { number: 7, base: { ref: "feature/x" } } });
-    expect(translate("pull_request", payload)).toEqual({ ok: false, ignored: true, reason: "not_base_branch" });
+    const payload = prPayload({
+      pull_request: { number: 7, base: { ref: "feature/x" } },
+    });
+    expect(translate("pull_request", payload)).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "not_base_branch",
+    });
   });
 
   test("a report_only repo never yields factory.merge.requested", () => {
-    const payload = prPayload({ repository: { full_name: "watt-mind/watched" } });
-    expect(translate("pull_request", payload)).toEqual({ ok: false, ignored: true, reason: "repo_report_only" });
+    const payload = prPayload({
+      repository: { full_name: "watt-mind/watched" },
+    });
+    expect(translate("pull_request", payload)).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "repo_report_only",
+    });
   });
 
   test("an unconfigured repo is a typed benign refusal on both kinds", () => {
-    expect(translate("pull_request", prPayload({ repository: { full_name: "someone/else" } }))).toEqual({
+    expect(
+      translate(
+        "pull_request",
+        prPayload({ repository: { full_name: "someone/else" } }),
+      ),
+    ).toEqual({
       ok: false,
       ignored: true,
       reason: "unconfigured_repo",
     });
-    expect(translate("workflow_run", workflowRunPayload({ repository: { full_name: "someone/else" } }))).toEqual({
+    expect(
+      translate(
+        "workflow_run",
+        workflowRunPayload({ repository: { full_name: "someone/else" } }),
+      ),
+    ).toEqual({
       ok: false,
       ignored: true,
       reason: "unconfigured_repo",
@@ -197,12 +301,19 @@ describe("translateGitHubEvent (WM-112)", () => {
   });
 
   test("a successful or in-progress workflow_run is ignored", () => {
-    expect(translate("workflow_run", workflowRunPayload({ workflow_run: { id: 1, conclusion: "success" } }))).toEqual({
+    expect(
+      translate(
+        "workflow_run",
+        workflowRunPayload({ workflow_run: { id: 1, conclusion: "success" } }),
+      ),
+    ).toEqual({
       ok: false,
       ignored: true,
       reason: "unhandled_action",
     });
-    expect(translate("workflow_run", workflowRunPayload({ action: "requested" }))).toEqual({
+    expect(
+      translate("workflow_run", workflowRunPayload({ action: "requested" })),
+    ).toEqual({
       ok: false,
       ignored: true,
       reason: "unhandled_action",
@@ -215,25 +326,43 @@ describe("translateGitHubEvent (WM-112)", () => {
       ignored: true,
       reason: "unhandled_event",
     });
-    expect(translate(undefined, prPayload())).toEqual({ ok: false, ignored: true, reason: "unhandled_event" });
+    expect(translate(undefined, prPayload())).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unhandled_event",
+    });
   });
 
   test("missing delivery id and malformed payloads fail closed, not ignored", () => {
-    expect(translate("pull_request", prPayload(), { deliveryId: undefined })).toEqual({
+    expect(
+      translate("pull_request", prPayload(), { deliveryId: undefined }),
+    ).toEqual({
       ok: false,
       ignored: false,
       reason: "missing_delivery_id",
     });
     for (const junk of [null, "string", ["array"]]) {
-      expect(translate("pull_request", junk)).toEqual({ ok: false, ignored: false, reason: "malformed_payload" });
+      expect(translate("pull_request", junk)).toEqual({
+        ok: false,
+        ignored: false,
+        reason: "malformed_payload",
+      });
     }
-    expect(translate("pull_request", { action: "opened", repository: { full_name: "watt-mind/wt29" } })).toEqual({
+    expect(
+      translate("pull_request", {
+        action: "opened",
+        repository: { full_name: "watt-mind/wt29" },
+      }),
+    ).toEqual({
       ok: false,
       ignored: false,
       reason: "malformed_payload",
     });
     expect(
-      translate("workflow_run", workflowRunPayload({ workflow_run: { conclusion: "failure" } })),
+      translate(
+        "workflow_run",
+        workflowRunPayload({ workflow_run: { conclusion: "failure" } }),
+      ),
     ).toEqual({ ok: false, ignored: false, reason: "malformed_payload" });
   });
 });
@@ -245,21 +374,34 @@ describe("POST /github route (WM-112)", () => {
     const db = openDb(path.join(dir, "runtime.db"));
     const onEvents = [];
     const server = startApi({
-      db, registry, secret: SECRET, githubSecret: GH_SECRET, policyVersion: PV, port: 0,
+      db,
+      registry,
+      secret: SECRET,
+      githubSecret: GH_SECRET,
+      policyVersion: PV,
+      port: 0,
       onEvent: (kind) => onEvents.push(kind),
       repos: () => REPOS,
     });
     await new Promise((resolve) => server.on("listening", resolve));
     const port = server.address().port;
     s = {
-      db, server, onEvents,
+      db,
+      server,
+      onEvents,
       url: (p) => `http://127.0.0.1:${port}${p}`,
-      close: () => { server.close(); db.close(); },
+      close: () => {
+        server.close();
+        db.close();
+      },
     };
   });
   afterAll(() => s.close());
 
-  const deliver = (payload, { deliveryId = "d-1", event = "pull_request", signature } = {}) => {
+  const deliver = (
+    payload,
+    { deliveryId = "d-1", event = "pull_request", signature } = {},
+  ) => {
     const body = JSON.stringify(payload);
     return fetch(s.url("/github"), {
       method: "POST",
@@ -276,47 +418,98 @@ describe("POST /github route (WM-112)", () => {
   test("a valid delivery admits and the SAME delivery id again is a duplicate", async () => {
     const first = await deliver(prPayload(), { deliveryId: "d-admit-1" });
     expect(first.status).toBe(200);
-    expect(await first.json()).toEqual({ admitted: true, duplicate: false, eventId: "d-admit-1" });
+    expect(await first.json()).toEqual({
+      admitted: true,
+      duplicate: false,
+      eventId: "d-admit-1",
+    });
     expect(s.onEvents).toEqual(["admitted"]);
 
     const again = await deliver(prPayload(), { deliveryId: "d-admit-1" });
     expect(again.status).toBe(200);
-    expect(await again.json()).toEqual({ admitted: false, duplicate: true, eventId: "d-admit-1" });
+    expect(await again.json()).toEqual({
+      admitted: false,
+      duplicate: true,
+      eventId: "d-admit-1",
+    });
     expect(s.onEvents).toEqual(["admitted"]); // dedup planned nothing new
 
-    const row = s.db.query(`SELECT * FROM events WHERE source = 'github' AND event_id = 'd-admit-1'`).get();
+    const row = s.db
+      .query(
+        `SELECT * FROM events WHERE source = 'github' AND event_id = 'd-admit-1'`,
+      )
+      .get();
     expect(row.type).toBe("factory.merge.requested");
     expect(JSON.parse(row.envelope_json).payload).toEqual({ repo: "wt29" });
   });
 
   test("a bad signature is refused before anything is parsed or written", async () => {
     const body = JSON.stringify(prPayload());
-    const res = await deliver(prPayload(), { deliveryId: "d-bad-sig", signature: ghSign(body, "wrong") });
+    const res = await deliver(prPayload(), {
+      deliveryId: "d-bad-sig",
+      signature: ghSign(body, "wrong"),
+    });
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe("bad_signature");
-    expect(s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-bad-sig'`).get().n).toBe(0);
+    expect(
+      s.db
+        .query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-bad-sig'`)
+        .get().n,
+    ).toBe(0);
   });
 
   test("ignored kinds answer 2xx so GitHub keeps the hook healthy; nothing is written", async () => {
-    const res = await deliver({ zen: "Keep it logically awesome." }, { deliveryId: "d-ping", event: "ping" });
+    const res = await deliver(
+      { zen: "Keep it logically awesome." },
+      { deliveryId: "d-ping", event: "ping" },
+    );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ admitted: false, ignored: true, reason: "unhandled_event" });
-    expect(s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-ping'`).get().n).toBe(0);
+    expect(await res.json()).toEqual({
+      admitted: false,
+      ignored: true,
+      reason: "unhandled_event",
+    });
+    expect(
+      s.db
+        .query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-ping'`)
+        .get().n,
+    ).toBe(0);
   });
 
   test("a draft PR is 2xx-ignored with reason draft_pr; nothing is admitted (WM-124)", async () => {
-    const res = await deliver(prPayload({ pull_request: { draft: true } }), { deliveryId: "d-draft" });
+    const res = await deliver(prPayload({ pull_request: { draft: true } }), {
+      deliveryId: "d-draft",
+    });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ admitted: false, ignored: true, reason: "draft_pr" });
-    expect(s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-draft'`).get().n).toBe(0);
+    expect(await res.json()).toEqual({
+      admitted: false,
+      ignored: true,
+      reason: "draft_pr",
+    });
+    expect(
+      s.db
+        .query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-draft'`)
+        .get().n,
+    ).toBe(0);
   });
 
   test("a report_only repo's PR is 2xx-ignored — merge.requested never admitted", async () => {
-    const res = await deliver(prPayload({ repository: { full_name: "watt-mind/watched" } }), { deliveryId: "d-ro" });
+    const res = await deliver(
+      prPayload({ repository: { full_name: "watt-mind/watched" } }),
+      { deliveryId: "d-ro" },
+    );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ admitted: false, ignored: true, reason: "repo_report_only" });
+    expect(await res.json()).toEqual({
+      admitted: false,
+      ignored: true,
+      reason: "repo_report_only",
+    });
     expect(
-      s.db.query(`SELECT COUNT(*) AS n FROM events WHERE type = 'factory.merge.requested' AND event_id = 'd-ro'`).get().n,
+      s.db
+        .query(
+          `SELECT COUNT(*) AS n FROM events WHERE type = 'factory.merge.requested' AND event_id = 'd-ro'`,
+        )
+        .get().n,
     ).toBe(0);
   });
 
@@ -361,12 +554,19 @@ describe("POST /github route (WM-112)", () => {
       body,
     });
     expect(ok.status).toBe(200);
-    expect(await ok.json()).toEqual({ admitted: true, duplicate: false, eventId: "factory-evt-1" });
+    expect(await ok.json()).toEqual({
+      admitted: true,
+      duplicate: false,
+      eventId: "factory-evt-1",
+    });
 
     // A GitHub-signed request to /events is refused: two schemes, two paths.
     const cross = await fetch(s.url("/events"), {
       method: "POST",
-      headers: { "content-type": "application/json", "x-hub-signature-256": ghSign(body) },
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": ghSign(body),
+      },
       body,
     });
     expect(cross.status).toBe(401);

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -31,18 +31,31 @@ function parseTimestamp(value) {
  *
  * @returns {{ ok: true } | { ok: false, reason: string }}
  */
-export function verifyWebhook({ rawBody, signature, timestamp, secret, now = Date.now(), toleranceMs = TIMESTAMP_TOLERANCE_MS }) {
+export function verifyWebhook({
+  rawBody,
+  signature,
+  timestamp,
+  secret,
+  now = Date.now(),
+  toleranceMs = TIMESTAMP_TOLERANCE_MS,
+}) {
   if (!secret) return { ok: false, reason: "missing_secret" };
-  if (!signature || typeof signature !== "string") return { ok: false, reason: "missing_signature" };
+  if (!signature || typeof signature !== "string")
+    return { ok: false, reason: "missing_signature" };
   if (timestamp === undefined || timestamp === null || timestamp === "") {
     return { ok: false, reason: "missing_timestamp" };
   }
   const timestampString = String(timestamp);
   const ts = parseTimestamp(timestampString);
-  if (ts === null || Math.abs(now - ts) > toleranceMs) return { ok: false, reason: "stale_timestamp" };
-  if (!signature.startsWith("sha256=")) return { ok: false, reason: "bad_signature" };
+  if (ts === null || Math.abs(now - ts) > toleranceMs)
+    return { ok: false, reason: "stale_timestamp" };
+  if (!signature.startsWith("sha256="))
+    return { ok: false, reason: "bad_signature" };
   try {
-    const presented = Buffer.from(signature.slice("sha256=".length).toLowerCase(), "utf8");
+    const presented = Buffer.from(
+      signature.slice("sha256=".length).toLowerCase(),
+      "utf8",
+    );
     const expected = Buffer.from(
       createHmac("sha256", secret)
         .update(`${timestampString}.`)
@@ -50,7 +63,10 @@ export function verifyWebhook({ rawBody, signature, timestamp, secret, now = Dat
         .digest("hex"),
       "utf8",
     );
-    if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) {
+    if (
+      presented.length !== expected.length ||
+      !timingSafeEqual(presented, expected)
+    ) {
       return { ok: false, reason: "bad_signature" };
     }
   } catch {
@@ -80,17 +96,25 @@ export function githubWebhookSecret() {
  */
 export function verifyGitHubWebhook({ rawBody, signature, secret }) {
   if (!secret) return { ok: false, reason: "missing_secret" };
-  if (!signature || typeof signature !== "string") return { ok: false, reason: "missing_signature" };
-  if (!signature.startsWith("sha256=")) return { ok: false, reason: "bad_signature" };
+  if (!signature || typeof signature !== "string")
+    return { ok: false, reason: "missing_signature" };
+  if (!signature.startsWith("sha256="))
+    return { ok: false, reason: "bad_signature" };
   try {
-    const presented = Buffer.from(signature.slice("sha256=".length).toLowerCase(), "utf8");
+    const presented = Buffer.from(
+      signature.slice("sha256=".length).toLowerCase(),
+      "utf8",
+    );
     const expected = Buffer.from(
       createHmac("sha256", secret)
         .update(rawBody ?? "")
         .digest("hex"),
       "utf8",
     );
-    if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) {
+    if (
+      presented.length !== expected.length ||
+      !timingSafeEqual(presented, expected)
+    ) {
       return { ok: false, reason: "bad_signature" };
     }
   } catch {
@@ -131,14 +155,26 @@ function repoForSlug(repos, slug) {
  * @returns {{ ok: true, envelope: object }
  *         | { ok: false, ignored: boolean, reason: string }}
  */
-export function translateGitHubEvent({ event, deliveryId, payload, repos, now = Date.now() }) {
+export function translateGitHubEvent({
+  event,
+  deliveryId,
+  payload,
+  repos,
+  now = Date.now(),
+}) {
   if (!deliveryId || typeof deliveryId !== "string") {
     return { ok: false, ignored: false, reason: "missing_delivery_id" };
   }
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
     return { ok: false, ignored: false, reason: "malformed_payload" };
   }
-  const occurredAt = new Date(typeof now === "number" ? now : Date.now()).toISOString();
+  const occurredAt = new Date(
+    typeof now === "number" ? now : Date.now(),
+  ).toISOString();
   const base = {
     schemaVersion: "factory.event/v1",
     eventId: deliveryId,
@@ -149,21 +185,30 @@ export function translateGitHubEvent({ event, deliveryId, payload, repos, now = 
   };
 
   if (event === "pull_request") {
-    if (!PR_ACTIONS.includes(payload.action)) return { ok: false, ignored: true, reason: "unhandled_action" };
+    if (!PR_ACTIONS.includes(payload.action))
+      return { ok: false, ignored: true, reason: "unhandled_action" };
     const pr = payload.pull_request;
-    if (!pr || typeof pr !== "object") return { ok: false, ignored: false, reason: "malformed_payload" };
+    if (!pr || typeof pr !== "object")
+      return { ok: false, ignored: false, reason: "malformed_payload" };
     if (payload.action !== "ready_for_review" && pr.draft === true) {
       return { ok: false, ignored: true, reason: "draft_pr" };
     }
     const repo = repoForSlug(repos, payload.repository?.full_name);
     if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
-    if (pr.base?.ref !== repo.base) return { ok: false, ignored: true, reason: "not_base_branch" };
+    if (pr.base?.ref !== repo.base)
+      return { ok: false, ignored: true, reason: "not_base_branch" };
     // A repo without industrialized worktrees has a safe concurrency of one
     // human (dispatch doc §5) — CI facts still flow, merge requests never do.
-    if (repo.reportOnly) return { ok: false, ignored: true, reason: "repo_report_only" };
+    if (repo.reportOnly)
+      return { ok: false, ignored: true, reason: "repo_report_only" };
     return {
       ok: true,
-      envelope: { ...base, type: "factory.merge.requested", subject: repo.name, payload: { repo: repo.name } },
+      envelope: {
+        ...base,
+        type: "factory.merge.requested",
+        subject: repo.name,
+        payload: { repo: repo.name },
+      },
     };
   }
 
@@ -175,12 +220,18 @@ export function translateGitHubEvent({ event, deliveryId, payload, repos, now = 
     const slug = payload.repository?.full_name;
     const repo = repoForSlug(repos, slug);
     if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
-    if (run.id === undefined || run.id === null) return { ok: false, ignored: false, reason: "malformed_payload" };
+    if (run.id === undefined || run.id === null)
+      return { ok: false, ignored: false, reason: "malformed_payload" };
     return {
       ok: true,
       // The existing shape ci-log-capture@1 consumes: the GitHub slug, not the
       // short name — see schemas/ci-log-capture.input.json.
-      envelope: { ...base, type: "github.workflow-run.failed", subject: "ci", payload: { repo: slug, runId: run.id } },
+      envelope: {
+        ...base,
+        type: "github.workflow-run.failed",
+        subject: "ci",
+        payload: { repo: slug, runId: run.id },
+      },
     };
   }
 
@@ -227,20 +278,40 @@ export function admitExternalEvent(db, registry, envelope, options = {}) {
  * admitChainEvent instead of accepting a caller-selected source.
  */
 export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
-  if (envelope === null || typeof envelope !== "object" || Array.isArray(envelope)) {
-    return { admitted: false, duplicate: false, errors: ["$: envelope must be an object"] };
+  if (
+    envelope === null ||
+    typeof envelope !== "object" ||
+    Array.isArray(envelope)
+  ) {
+    return {
+      admitted: false,
+      duplicate: false,
+      errors: ["$: envelope must be an object"],
+    };
   }
-  const nowMs = typeof now === "number" ? now : (typeof now === "string" ? Date.parse(now) : Date.now());
+  const nowMs =
+    typeof now === "number"
+      ? now
+      : typeof now === "string"
+        ? Date.parse(now)
+        : Date.now();
   const receivedAt = new Date(nowMs).toISOString();
   const stored = { ...envelope, receivedAt };
   const { valid, errors } = validate(registry.schemas.envelope, stored);
   if (!valid) return { admitted: false, duplicate: false, errors };
 
   // Refuse clock tick events whose slot is in the future relative to now (OPS-437).
-  if (stored.source === "schedule" || (typeof stored.type === "string" && stored.type.startsWith("clock.tick."))) {
+  if (
+    stored.source === "schedule" ||
+    (typeof stored.type === "string" && stored.type.startsWith("clock.tick."))
+  ) {
     const occurredMs = Date.parse(stored.occurredAt);
     if (!Number.isNaN(occurredMs) && occurredMs > nowMs) {
-      return { admitted: false, duplicate: false, errors: ["occurredAt: clock tick slot cannot be in the future"] };
+      return {
+        admitted: false,
+        duplicate: false,
+        errors: ["occurredAt: clock tick slot cannot be in the future"],
+      };
     }
   }
 
@@ -255,9 +326,17 @@ export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
           correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'admitted', ?)`,
     ).run(
-      stored.source, stored.eventId, stored.type, stored.subject ?? null,
-      stored.occurredAt, receivedAt, stored.correlationId ?? null, stored.causationId ?? null,
-      canonicalJson(stored), hashJson(stored.payload), receivedAt,
+      stored.source,
+      stored.eventId,
+      stored.type,
+      stored.subject ?? null,
+      stored.occurredAt,
+      receivedAt,
+      stored.correlationId ?? null,
+      stored.causationId ?? null,
+      canonicalJson(stored),
+      hashJson(stored.payload),
+      receivedAt,
     );
     const event = db
       .query(`SELECT * FROM events WHERE source = ? AND event_id = ?`)

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -33,19 +33,43 @@ describe("verifyWebhook", () => {
   test("valid signature over epoch-millis timestamp passes", () => {
     const timestamp = String(NOW - 1000);
     const signature = sign(SECRET, timestamp, rawBody);
-    expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({ ok: true });
+    expect(
+      verifyWebhook({
+        rawBody,
+        signature,
+        timestamp,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toEqual({ ok: true });
   });
 
   test("valid signature over ISO-8601 timestamp passes", () => {
     const timestamp = new Date(NOW - 1000).toISOString();
     const signature = sign(SECRET, timestamp, rawBody);
-    expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({ ok: true });
+    expect(
+      verifyWebhook({
+        rawBody,
+        signature,
+        timestamp,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toEqual({ ok: true });
   });
 
   test("wrong secret fails as bad_signature", () => {
     const timestamp = String(NOW);
     const signature = sign("some-other-secret", timestamp, rawBody);
-    expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({
+        rawBody,
+        signature,
+        timestamp,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toEqual({
       ok: false,
       reason: "bad_signature",
     });
@@ -55,7 +79,15 @@ describe("verifyWebhook", () => {
     const timestamp = String(NOW);
     const signature = sign(SECRET, timestamp, rawBody);
     const tampered = rawBody.replace("bj29", "evil");
-    expect(verifyWebhook({ rawBody: tampered, signature, timestamp, secret: SECRET, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({
+        rawBody: tampered,
+        signature,
+        timestamp,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toEqual({
       ok: false,
       reason: "bad_signature",
     });
@@ -65,7 +97,15 @@ describe("verifyWebhook", () => {
     for (const skewMs of [-10 * 60 * 1000, 10 * 60 * 1000]) {
       const timestamp = String(NOW + skewMs);
       const signature = sign(SECRET, timestamp, rawBody);
-      expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({
+      expect(
+        verifyWebhook({
+          rawBody,
+          signature,
+          timestamp,
+          secret: SECRET,
+          now: NOW,
+        }),
+      ).toEqual({
         ok: false,
         reason: "stale_timestamp",
       });
@@ -75,7 +115,15 @@ describe("verifyWebhook", () => {
   test("unparseable timestamp fails closed as stale_timestamp", () => {
     const timestamp = "not-a-time";
     const signature = sign(SECRET, timestamp, rawBody);
-    expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({
+        rawBody,
+        signature,
+        timestamp,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toEqual({
       ok: false,
       reason: "stale_timestamp",
     });
@@ -84,15 +132,21 @@ describe("verifyWebhook", () => {
   test("missing secret, signature, and timestamp each fail closed", () => {
     const timestamp = String(NOW);
     const signature = sign(SECRET, timestamp, rawBody);
-    expect(verifyWebhook({ rawBody, signature, timestamp, secret: null, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({ rawBody, signature, timestamp, secret: null, now: NOW }),
+    ).toEqual({
       ok: false,
       reason: "missing_secret",
     });
-    expect(verifyWebhook({ rawBody, timestamp, secret: SECRET, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({ rawBody, timestamp, secret: SECRET, now: NOW }),
+    ).toEqual({
       ok: false,
       reason: "missing_signature",
     });
-    expect(verifyWebhook({ rawBody, signature, secret: SECRET, now: NOW })).toEqual({
+    expect(
+      verifyWebhook({ rawBody, signature, secret: SECRET, now: NOW }),
+    ).toEqual({
       ok: false,
       reason: "missing_timestamp",
     });
@@ -101,7 +155,15 @@ describe("verifyWebhook", () => {
   test("malformed signature never throws", () => {
     const timestamp = String(NOW);
     for (const signature of ["nonsense", "sha256=", "sha256=zzzz", "md5=abc"]) {
-      expect(verifyWebhook({ rawBody, signature, timestamp, secret: SECRET, now: NOW })).toEqual({
+      expect(
+        verifyWebhook({
+          rawBody,
+          signature,
+          timestamp,
+          secret: SECRET,
+          now: NOW,
+        }),
+      ).toEqual({
         ok: false,
         reason: "bad_signature",
       });
@@ -112,21 +174,37 @@ describe("verifyWebhook", () => {
 describe("admitEvent", () => {
   test("valid envelope is admitted once with server-set receivedAt", () => {
     const db = openDb(":memory:");
-    const result = admitEvent(db, registry, envelope({ receivedAt: "1999-01-01T00:00:00Z" }), { now: NOW });
+    const result = admitEvent(
+      db,
+      registry,
+      envelope({ receivedAt: "1999-01-01T00:00:00Z" }),
+      { now: NOW },
+    );
     expect(result.admitted).toBe(true);
     expect(result.duplicate).toBe(false);
     expect(result.event.status).toBe("admitted");
     expect(result.event.received_at).toBe(new Date(NOW).toISOString());
-    expect(JSON.parse(result.event.envelope_json).receivedAt).toBe(new Date(NOW).toISOString());
+    expect(JSON.parse(result.event.envelope_json).receivedAt).toBe(
+      new Date(NOW).toISOString(),
+    );
     expect(result.event.payload_hash.startsWith("sha256:")).toBe(true);
   });
 
   test("same (source, eventId) delivered twice yields one row and duplicate: true", () => {
     const db = openDb(":memory:");
     const first = admitEvent(db, registry, envelope(), { now: NOW });
-    const second = admitEvent(db, registry, envelope({ payload: { repos: ["different"] } }), { now: NOW + 5000 });
+    const second = admitEvent(
+      db,
+      registry,
+      envelope({ payload: { repos: ["different"] } }),
+      { now: NOW + 5000 },
+    );
     expect(first.admitted).toBe(true);
-    expect(second).toEqual({ admitted: false, duplicate: true, event: first.event });
+    expect(second).toEqual({
+      admitted: false,
+      duplicate: true,
+      event: first.event,
+    });
     const rows = db.query(`SELECT COUNT(*) AS n FROM events`).get();
     expect(rows.n).toBe(1);
   });
@@ -180,12 +258,19 @@ describe("admitEvent", () => {
       occurredAt: "9999-01-01T00:00:00.000Z",
       correlationId: "clock:reaper:9999-01-01T00:00:00.000Z",
       causationId: null,
-      payload: { loop: "reaper", slot: "9999-01-01T00:00:00.000Z", cadenceSeconds: 3600, skippedSlots: 0 },
+      payload: {
+        loop: "reaper",
+        slot: "9999-01-01T00:00:00.000Z",
+        cadenceSeconds: 3600,
+        skippedSlots: 0,
+      },
     };
     const result = admitEvent(db, registry, futureTick, { now: NOW });
     expect(result.admitted).toBe(false);
     expect(result.duplicate).toBe(false);
-    expect(result.errors).toContain("occurredAt: clock tick slot cannot be in the future");
+    expect(result.errors).toContain(
+      "occurredAt: clock tick slot cannot be in the future",
+    );
     expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
   });
 });

--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -13,7 +13,12 @@ export const JANITOR_MAX_BUFFER = 1_000_000;
  * yaml and tear down another.
  */
 export function janitorArgv(name, { apply = false } = {}) {
-  const args = [path.join(reposRoot(), "orchestrator", "janitor.mjs"), "--repo", name, "--json"];
+  const args = [
+    path.join(reposRoot(), "orchestrator", "janitor.mjs"),
+    "--repo",
+    name,
+    "--json",
+  ];
   if (apply === true) args.push("--apply");
   return args;
 }
@@ -26,7 +31,11 @@ export function janitorArgv(name, { apply = false } = {}) {
  */
 export async function spawnFactoryJanitor(
   name,
-  { apply = false, timeoutMs = JANITOR_TIMEOUT_MS, maxBuffer = JANITOR_MAX_BUFFER } = {},
+  {
+    apply = false,
+    timeoutMs = JANITOR_TIMEOUT_MS,
+    maxBuffer = JANITOR_MAX_BUFFER,
+  } = {},
 ) {
   const args = janitorArgv(name, { apply });
   const root = reposRoot();
@@ -46,11 +55,15 @@ export async function spawnFactoryJanitor(
       timedOut = true;
       try {
         child.kill("SIGTERM");
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
       killTimer = setTimeout(() => {
         try {
           child.kill("SIGKILL");
-        } catch { /* intentionally ignored */ }
+        } catch {
+          /* intentionally ignored */
+        }
       }, 2000);
     }, timeoutMs);
 
@@ -60,7 +73,9 @@ export async function spawnFactoryJanitor(
       if (stdout.length > maxBuffer) {
         try {
           child.kill("SIGKILL");
-        } catch { /* intentionally ignored */ }
+        } catch {
+          /* intentionally ignored */
+        }
       }
     });
 
@@ -70,7 +85,9 @@ export async function spawnFactoryJanitor(
       if (stderr.length > maxBuffer) {
         try {
           child.kill("SIGKILL");
-        } catch { /* intentionally ignored */ }
+        } catch {
+          /* intentionally ignored */
+        }
       }
     });
 
@@ -106,7 +123,9 @@ export async function spawnFactoryJanitor(
       try {
         parsed = JSON.parse(stdout.trim());
       } catch (e) {
-        const err = new Error(stderr.trim() || stdout.trim() || `invalid json: ${e.message}`);
+        const err = new Error(
+          stderr.trim() || stdout.trim() || `invalid json: ${e.message}`,
+        );
         err.status = 500;
         return reject(err);
       }

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { janitorArgv, JANITOR_MAX_BUFFER, JANITOR_TIMEOUT_MS, spawnFactoryJanitor } from "./janitor.mjs";
+import {
+  janitorArgv,
+  JANITOR_MAX_BUFFER,
+  JANITOR_TIMEOUT_MS,
+  spawnFactoryJanitor,
+} from "./janitor.mjs";
 
 describe("janitor", () => {
   test("janitorArgv never includes --force and adds --apply only when asked (OPS-301, OPS-364)", () => {

--- a/event-runtime/lib/lifecycle.mjs
+++ b/event-runtime/lib/lifecycle.mjs
@@ -9,12 +9,26 @@ import { hashJson } from "./canonical.mjs";
 import { tx, txImmediate } from "./db.mjs";
 
 export const STATES = [
-  "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING",
-  "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
+  "PROPOSED",
+  "APPROVED",
+  "QUEUED",
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+  "COMPLETED",
+  "REFUSED",
+  "FAILED",
+  "TIMED_OUT",
+  "CANCELLED",
 ];
 
 /** Terminal for the run. FAILED may still be re-queued while attempts remain. */
-export const TERMINAL_STATES = new Set(["COMPLETED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
+export const TERMINAL_STATES = new Set([
+  "COMPLETED",
+  "REFUSED",
+  "TIMED_OUT",
+  "CANCELLED",
+]);
 
 const LEGAL = {
   PROPOSED: ["APPROVED", "CANCELLED"],
@@ -47,9 +61,17 @@ function appendJournal(db, record) {
        (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    record.runId, record.from, record.to, record.actor, record.reason ?? null,
-    record.attempt ?? null, record.correlationId ?? null, record.causationId ?? null,
-    record.policyVersion ?? null, record.at, record_hash,
+    record.runId,
+    record.from,
+    record.to,
+    record.actor,
+    record.reason ?? null,
+    record.attempt ?? null,
+    record.correlationId ?? null,
+    record.causationId ?? null,
+    record.policyVersion ?? null,
+    record.at,
+    record_hash,
   );
 }
 
@@ -62,7 +84,21 @@ function resolveNow(now) {
  * UNIQUE constraint is the §5.4 guarantee — a duplicate plan throws here and
  * the caller resolves to the existing run.
  */
-export function createRun(db, { runId, idempotencyKey, spec, specJson, specHash, actor, correlationId, causationId, policyVersion, now = () => Date.now() }) {
+export function createRun(
+  db,
+  {
+    runId,
+    idempotencyKey,
+    spec,
+    specJson,
+    specHash,
+    actor,
+    correlationId,
+    causationId,
+    policyVersion,
+    now = () => Date.now(),
+  },
+) {
   const at = new Date(resolveNow(now)).toISOString();
   return txImmediate(db, () => {
     db.query(
@@ -70,8 +106,15 @@ export function createRun(db, { runId, idempotencyKey, spec, specJson, specHash,
        VALUES (?, ?, ?, ?, 'PROPOSED', 0, ?, ?)`,
     ).run(runId, idempotencyKey, specJson, specHash, at, at);
     appendJournal(db, {
-      runId, from: null, to: "PROPOSED", actor,
-      reason: "planned", correlationId, causationId, policyVersion, at,
+      runId,
+      from: null,
+      to: "PROPOSED",
+      actor,
+      reason: "planned",
+      correlationId,
+      causationId,
+      policyVersion,
+      at,
     });
     return { runId, state: "PROPOSED" };
   });
@@ -82,16 +125,47 @@ export function createRun(db, { runId, idempotencyKey, spec, specJson, specHash,
  * `expectFrom` when the caller must not race another mover (worker vs
  * operator): the transition then only applies if the state is still that one.
  */
-export function transition(db, { runId, to, expectFrom, actor, reason, attempt, correlationId, causationId, policyVersion, now = () => Date.now() }) {
+export function transition(
+  db,
+  {
+    runId,
+    to,
+    expectFrom,
+    actor,
+    reason,
+    attempt,
+    correlationId,
+    causationId,
+    policyVersion,
+    now = () => Date.now(),
+  },
+) {
   const at = new Date(resolveNow(now)).toISOString();
   return txImmediate(db, () => {
     const run = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId);
     if (!run) throw new IllegalTransition(runId, undefined, to);
     const from = run.state;
-    if (expectFrom && from !== expectFrom) throw new IllegalTransition(runId, from, to);
-    if (!(LEGAL[from] ?? []).includes(to)) throw new IllegalTransition(runId, from, to);
-    db.query(`UPDATE runs SET state = ?, updated_at = ? WHERE run_id = ?`).run(to, at, runId);
-    appendJournal(db, { runId, from, to, actor, reason, attempt, correlationId, causationId, policyVersion, at });
+    if (expectFrom && from !== expectFrom)
+      throw new IllegalTransition(runId, from, to);
+    if (!(LEGAL[from] ?? []).includes(to))
+      throw new IllegalTransition(runId, from, to);
+    db.query(`UPDATE runs SET state = ?, updated_at = ? WHERE run_id = ?`).run(
+      to,
+      at,
+      runId,
+    );
+    appendJournal(db, {
+      runId,
+      from,
+      to,
+      actor,
+      reason,
+      attempt,
+      correlationId,
+      causationId,
+      policyVersion,
+      at,
+    });
     return { runId, from, to };
   });
 }
@@ -101,20 +175,24 @@ export function runState(db, runId) {
 }
 
 export function lifecycleOf(db, runId) {
-  return db.query(`SELECT * FROM lifecycle_events WHERE run_id = ? ORDER BY seq`).all(runId);
+  return db
+    .query(`SELECT * FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
+    .all(runId);
 }
 
 const IDEMPOTENCY_TRIGGER_MARKER = ":trigger:";
 
 function idempotencyFamily(db, idempotencyKey) {
-  return db.query(
-    `SELECT run_id, idempotency_key, state, created_at, rowid
+  return db
+    .query(
+      `SELECT run_id, idempotency_key, state, created_at, rowid
        FROM runs
       WHERE idempotency_key = ?
          OR instr(idempotency_key, ? || ?) = 1
       ORDER BY CASE WHEN state IN ('COMPLETED', 'REFUSED', 'TIMED_OUT', 'CANCELLED') THEN 1 ELSE 0 END,
                created_at DESC, rowid DESC`,
-  ).all(idempotencyKey, idempotencyKey, IDEMPOTENCY_TRIGGER_MARKER);
+    )
+    .all(idempotencyKey, idempotencyKey, IDEMPOTENCY_TRIGGER_MARKER);
 }
 
 /**
@@ -123,7 +201,10 @@ function idempotencyFamily(db, idempotencyKey) {
  * triggering event identity, allowing a fresh run after the prior generation
  * is terminal without weakening the schema's per-run UNIQUE guarantee.
  */
-export function idempotencyKeyForNewRun(db, { idempotencyKey, source, eventId }) {
+export function idempotencyKeyForNewRun(
+  db,
+  { idempotencyKey, source, eventId },
+) {
   if (idempotencyFamily(db, idempotencyKey).length === 0) return idempotencyKey;
   return `${idempotencyKey}${IDEMPOTENCY_TRIGGER_MARKER}${hashJson({ source, eventId })}`;
 }
@@ -135,7 +216,10 @@ export function idempotencyKeyForNewRun(db, { idempotencyKey, source, eventId })
  * causation resolves to the terminal run; a distinct trigger returns null so
  * the planner can create a new generation with its own concrete UNIQUE key.
  */
-export function resolveIdempotency(db, { idempotencyKey, correlationId, causationId, eventId } = {}) {
+export function resolveIdempotency(
+  db,
+  { idempotencyKey, correlationId, causationId, eventId } = {},
+) {
   if (!idempotencyKey) return null;
   const family = idempotencyFamily(db, idempotencyKey);
   if (family.length === 0) return null;
@@ -148,7 +232,9 @@ export function resolveIdempotency(db, { idempotencyKey, correlationId, causatio
   if (!correlation && !causationId) return run;
 
   const journal = db
-    .query(`SELECT correlation_id, causation_id FROM lifecycle_events WHERE run_id = ? AND from_state IS NULL LIMIT 1`)
+    .query(
+      `SELECT correlation_id, causation_id FROM lifecycle_events WHERE run_id = ? AND from_state IS NULL LIMIT 1`,
+    )
     .get(run.run_id);
   if (!journal) return run;
 

--- a/event-runtime/lib/lifecycle.test.mjs
+++ b/event-runtime/lib/lifecycle.test.mjs
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { openDb } from "./db.mjs";
-import { IllegalTransition, TERMINAL_STATES, createRun, lifecycleOf, resolveIdempotency, runState, transition } from "./lifecycle.mjs";
+import {
+  IllegalTransition,
+  TERMINAL_STATES,
+  createRun,
+  lifecycleOf,
+  resolveIdempotency,
+  runState,
+  transition,
+} from "./lifecycle.mjs";
 
 function freshRun(db, key = `key-${Math.random()}`) {
   const runId = `run_test_${Math.random().toString(36).slice(2)}`;
@@ -20,21 +28,38 @@ describe("lifecycle", () => {
   test("happy path PROPOSED → … → COMPLETED, journaled with hashes", () => {
     const db = openDb(":memory:");
     const runId = freshRun(db);
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId, to, actor: "test" });
     }
     expect(runState(db, runId)).toBe("COMPLETED");
     const journal = lifecycleOf(db, runId);
     expect(journal.map((e) => e.to_state)).toEqual([
-      "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED",
+      "PROPOSED",
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
     ]);
-    expect(journal.every((e) => e.record_hash.startsWith("sha256:"))).toBe(true);
+    expect(journal.every((e) => e.record_hash.startsWith("sha256:"))).toBe(
+      true,
+    );
   });
 
   test("illegal transitions are rejected, not repaired", () => {
     const db = openDb(":memory:");
     const runId = freshRun(db);
-    expect(() => transition(db, { runId, to: "RUNNING", actor: "test" })).toThrow(IllegalTransition);
+    expect(() =>
+      transition(db, { runId, to: "RUNNING", actor: "test" }),
+    ).toThrow(IllegalTransition);
     expect(runState(db, runId)).toBe("PROPOSED");
     expect(lifecycleOf(db, runId)).toHaveLength(1);
   });
@@ -44,7 +69,9 @@ describe("lifecycle", () => {
     const runId = freshRun(db);
     transition(db, { runId, to: "CANCELLED", actor: "operator" });
     expect(TERMINAL_STATES.has(runState(db, runId))).toBe(true);
-    expect(() => transition(db, { runId, to: "APPROVED", actor: "test" })).toThrow(IllegalTransition);
+    expect(() =>
+      transition(db, { runId, to: "APPROVED", actor: "test" }),
+    ).toThrow(IllegalTransition);
   });
 
   test("expectFrom guards racing movers", () => {
@@ -52,7 +79,12 @@ describe("lifecycle", () => {
     const runId = freshRun(db);
     transition(db, { runId, to: "APPROVED", actor: "test" });
     expect(() =>
-      transition(db, { runId, to: "CANCELLED", expectFrom: "PROPOSED", actor: "operator" }),
+      transition(db, {
+        runId,
+        to: "CANCELLED",
+        expectFrom: "PROPOSED",
+        actor: "operator",
+      }),
     ).toThrow(IllegalTransition);
   });
 
@@ -129,7 +161,14 @@ describe("lifecycle", () => {
       policyVersion: "test",
       now: clock,
     });
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId, to, actor: "test", now: clock });
     }
     const journal = lifecycleOf(db, runId);

--- a/event-runtime/lib/merge-ci-proof.mjs
+++ b/event-runtime/lib/merge-ci-proof.mjs
@@ -105,8 +105,8 @@ export function proveMergeCiFallback({
     throw new Error("configured workflow run is not completed successfully");
   }
   if (
-    (!Number.isInteger(run.databaseId) &&
-      (typeof run.databaseId !== "string" || run.databaseId.length === 0))
+    !Number.isInteger(run.databaseId) &&
+    (typeof run.databaseId !== "string" || run.databaseId.length === 0)
   ) {
     throw new Error("configured workflow run has no valid database ID");
   }
@@ -120,11 +120,17 @@ export function proveMergeCiFallback({
       matches[0].status !== "completed" ||
       matches[0].conclusion !== "success"
     ) {
-      throw new Error(`required job ${requiredName} is not completed successfully`);
+      throw new Error(
+        `required job ${requiredName} is not completed successfully`,
+      );
     }
   }
 
-  return { runId: run.databaseId, workflow, requiredChecks: [...requiredChecks] };
+  return {
+    runId: run.databaseId,
+    workflow,
+    requiredChecks: [...requiredChecks],
+  };
 }
 
 async function main() {

--- a/event-runtime/lib/merge-ci-proof.test.mjs
+++ b/event-runtime/lib/merge-ci-proof.test.mjs
@@ -79,7 +79,7 @@ describe("required-context resolver", () => {
     );
     expect(apply).toContain('[ "$required_status" -eq 1 ]');
     expect(apply).toContain(
-      'no required checks reported on the \'$expected_ref\' branch',
+      "no required checks reported on the '$expected_ref' branch",
     );
     expect(apply).not.toContain("/protection");
   });
@@ -114,9 +114,7 @@ describe("configured merge_ci proof", () => {
       proveMergeCiFallback({
         ...fallback,
         // An auxiliary visible check is deliberately not part of proof input.
-        visibleChecks: [
-          { name: "docs", bucket: "pass", state: "SUCCESS" },
-        ],
+        visibleChecks: [{ name: "docs", bucket: "pass", state: "SUCCESS" }],
       }),
     ).toEqual({
       runId: 409,
@@ -150,7 +148,10 @@ describe("configured merge_ci proof", () => {
     expect(() =>
       proveMergeCiFallback({
         ...fallback,
-        jobs: [fallback.jobs[0], { ...fallback.jobs[1], conclusion: "failure" }],
+        jobs: [
+          fallback.jobs[0],
+          { ...fallback.jobs[1], conclusion: "failure" },
+        ],
       }),
     ).toThrow("required job Verify is not completed successfully");
   });

--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -64,7 +64,12 @@ function duration(name, parameter) {
   return value;
 }
 
-function timeRange({ now, window = "24h", bucket = "1h", withBuckets = true } = {}) {
+function timeRange({
+  now,
+  window = "24h",
+  bucket = "1h",
+  withBuckets = true,
+} = {}) {
   const nowMs = nowValue(now);
   const windowMs = duration(window, "window");
   const bucketMs = withBuckets ? duration(bucket, "bucket") : null;
@@ -89,14 +94,21 @@ function timeRange({ now, window = "24h", bucket = "1h", withBuckets = true } = 
     bucketMs,
     bucketCount,
     buckets: withBuckets
-      ? Array.from({ length: bucketCount }, (_, index) => new Date(startMs + index * bucketMs).toISOString())
+      ? Array.from({ length: bucketCount }, (_, index) =>
+          new Date(startMs + index * bucketMs).toISOString(),
+        )
       : null,
   };
 }
 
 function bucketIndex(at, range) {
   const timestamp = Date.parse(at);
-  if (!Number.isFinite(timestamp) || timestamp < range.startMs || timestamp >= range.endMs) return -1;
+  if (
+    !Number.isFinite(timestamp) ||
+    timestamp < range.startMs ||
+    timestamp >= range.endMs
+  )
+    return -1;
   const index = Math.floor((timestamp - range.startMs) / range.bucketMs);
   return index >= 0 && index < range.bucketCount ? index : -1;
 }
@@ -106,10 +118,13 @@ function zeroArray(range, value = 0) {
 }
 
 function countSeries(rows, range, fixedKeys = []) {
-  const result = Object.fromEntries(fixedKeys.map((key) => [key, zeroArray(range)]));
+  const result = Object.fromEntries(
+    fixedKeys.map((key) => [key, zeroArray(range)]),
+  );
   for (const row of rows) {
     const index = Number(row.bucket_index);
-    if (!Number.isInteger(index) || index < 0 || index >= range.bucketCount) continue;
+    if (!Number.isInteger(index) || index < 0 || index >= range.bucketCount)
+      continue;
     const key = String(row.key ?? "unknown");
     if (!result[key]) result[key] = zeroArray(range);
     result[key][index] += Number(row.value ?? 0);
@@ -118,20 +133,28 @@ function countSeries(rows, range, fixedKeys = []) {
 }
 
 function sqliteMilliseconds(expression) {
-  return `(CAST(strftime('%s', ${expression}) AS INTEGER) * 1000 + ` +
-    `CAST(substr(strftime('%f', ${expression}), 4, 3) AS INTEGER))`;
+  return (
+    `(CAST(strftime('%s', ${expression}) AS INTEGER) * 1000 + ` +
+    `CAST(substr(strftime('%f', ${expression}), 4, 3) AS INTEGER))`
+  );
 }
 
-function groupedCounts(db, range, { table, time, key, where = "1 = 1", value = "COUNT(*)", joins = "" }) {
-  return db.query(
-    `SELECT CAST((${sqliteMilliseconds(time)} - ?) / ? AS INTEGER) AS bucket_index,
+function groupedCounts(
+  db,
+  range,
+  { table, time, key, where = "1 = 1", value = "COUNT(*)", joins = "" },
+) {
+  return db
+    .query(
+      `SELECT CAST((${sqliteMilliseconds(time)} - ?) / ? AS INTEGER) AS bucket_index,
             ${key} AS key,
             ${value} AS value
      FROM ${table} ${joins}
      WHERE ${time} >= ? AND ${time} < ? AND (${where})
      GROUP BY bucket_index, key
      ORDER BY bucket_index, key`,
-  ).all(range.startMs, range.bucketMs, range.startIso, range.endIso);
+    )
+    .all(range.startMs, range.bucketMs, range.startIso, range.endIso);
 }
 
 function percentile(sorted, fraction) {
@@ -145,7 +168,13 @@ function percentileSeries(rows, range) {
     const index = bucketIndex(row.bucket_at, range);
     const start = Date.parse(row.started_at);
     const finish = Date.parse(row.finished_at ?? row.bucket_at);
-    if (index < 0 || !Number.isFinite(start) || !Number.isFinite(finish) || finish < start) continue;
+    if (
+      index < 0 ||
+      !Number.isFinite(start) ||
+      !Number.isFinite(finish) ||
+      finish < start
+    )
+      continue;
     samples[index].push(finish - start);
   }
   const p50 = zeroArray(range, null);
@@ -164,9 +193,16 @@ function outcomes(db, range) {
     table: "lifecycle_events",
     time: "at",
     key: "to_state",
-    where: "to_state IN ('COMPLETED', 'FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')",
+    where:
+      "to_state IN ('COMPLETED', 'FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')",
   });
-  return countSeries(rows, range, ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
+  return countSeries(rows, range, [
+    "COMPLETED",
+    "FAILED",
+    "REFUSED",
+    "TIMED_OUT",
+    "CANCELLED",
+  ]);
 }
 
 function started(db, range) {
@@ -180,8 +216,9 @@ function started(db, range) {
 }
 
 function queueWait(db, range) {
-  const rows = db.query(
-    `SELECT leased.at AS bucket_at,
+  const rows = db
+    .query(
+      `SELECT leased.at AS bucket_at,
             (SELECT queued.at
              FROM lifecycle_events queued
              WHERE queued.run_id = leased.run_id
@@ -197,17 +234,20 @@ function queueWait(db, range) {
             leased.at AS finished_at
      FROM lifecycle_events leased
      WHERE leased.to_state = 'LEASED' AND leased.at >= ? AND leased.at < ?`,
-  ).all(range.startIso, range.endIso);
+    )
+    .all(range.startIso, range.endIso);
   return percentileSeries(rows, range);
 }
 
 function execution(db, range) {
-  const rows = db.query(
-    `SELECT finished_at AS bucket_at, started_at, finished_at
+  const rows = db
+    .query(
+      `SELECT finished_at AS bucket_at, started_at, finished_at
      FROM attempts
      WHERE started_at IS NOT NULL AND finished_at IS NOT NULL
        AND finished_at >= ? AND finished_at < ?`,
-  ).all(range.startIso, range.endIso);
+    )
+    .all(range.startIso, range.endIso);
   return percentileSeries(rows, range);
 }
 
@@ -225,8 +265,9 @@ function spend(db, range, column) {
 function proposalDecisions(db, range) {
   const decidedMilliseconds = sqliteMilliseconds("decided_at");
   const createdMilliseconds = sqliteMilliseconds("created_at");
-  const rows = db.query(
-    `WITH decisions AS (
+  const rows = db
+    .query(
+      `WITH decisions AS (
        SELECT status AS key, ${decidedMilliseconds} AS at_ms
        FROM proposals
        WHERE status IN ('approved', 'rejected', 'superseded', 'expired')
@@ -244,16 +285,30 @@ function proposalDecisions(db, range) {
      WHERE at_ms >= ? AND at_ms < ?
      GROUP BY bucket_index, key
      ORDER BY bucket_index, key`,
-  ).all(range.endMs, range.startMs, range.bucketMs, range.startMs, range.endMs);
-  return countSeries(rows, range, ["approved", "rejected", "expired", "superseded"]);
+    )
+    .all(
+      range.endMs,
+      range.startMs,
+      range.bucketMs,
+      range.startMs,
+      range.endMs,
+    );
+  return countSeries(rows, range, [
+    "approved",
+    "rejected",
+    "expired",
+    "superseded",
+  ]);
 }
 
 function proposalDecisionTime(db, range) {
-  const rows = db.query(
-    `SELECT decided_at AS bucket_at, created_at AS started_at, decided_at AS finished_at
+  const rows = db
+    .query(
+      `SELECT decided_at AS bucket_at, created_at AS started_at, decided_at AS finished_at
      FROM proposals
      WHERE decided_at IS NOT NULL AND decided_at >= ? AND decided_at < ?`,
-  ).all(range.startIso, range.endIso);
+    )
+    .all(range.startIso, range.endIso);
   return percentileSeries(rows, range);
 }
 
@@ -263,7 +318,13 @@ function intake(db, range) {
     time: "admitted_at",
     key: "status",
   });
-  return countSeries(rows, range, ["admitted", "planned", "noop", "human_needed", "dead_lettered"]);
+  return countSeries(rows, range, [
+    "admitted",
+    "planned",
+    "noop",
+    "human_needed",
+    "dead_lettered",
+  ]);
 }
 
 function retries(db, range) {
@@ -282,11 +343,12 @@ const SERIES_QUERIES = {
   "latency.queue_wait": queueWait,
   "latency.execution": execution,
   "spend.cost": (db, range) => spend(db, range, "COALESCE(SUM(u.cost_usd), 0)"),
-  "spend.tokens": (db, range) => spend(
-    db,
-    range,
-    "COALESCE(SUM(u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens), 0)",
-  ),
+  "spend.tokens": (db, range) =>
+    spend(
+      db,
+      range,
+      "COALESCE(SUM(u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens), 0)",
+    ),
   "proposals.decisions": proposalDecisions,
   "proposals.time_to_decision": proposalDecisionTime,
   "events.intake": intake,
@@ -294,17 +356,27 @@ const SERIES_QUERIES = {
 };
 
 /** Aligned, zero-filled time-series query used by GET /metrics. */
-export function metricsView(db, { now, window = "24h", bucket = "1h", series } = {}) {
-  const names = series == null || series === ""
-    ? [...VALID_METRIC_SERIES]
-    : (Array.isArray(series) ? series : String(series).split(",")).map((name) => name.trim()).filter(Boolean);
+export function metricsView(
+  db,
+  { now, window = "24h", bucket = "1h", series } = {},
+) {
+  const names =
+    series == null || series === ""
+      ? [...VALID_METRIC_SERIES]
+      : (Array.isArray(series) ? series : String(series).split(","))
+          .map((name) => name.trim())
+          .filter(Boolean);
   const unknown = names.filter((name) => !VALID_METRIC_SERIES.includes(name));
   if (unknown.length > 0) {
-    throw new MetricsQueryError("unknown_series", { unknown, validSeries: VALID_METRIC_SERIES });
+    throw new MetricsQueryError("unknown_series", {
+      unknown,
+      validSeries: VALID_METRIC_SERIES,
+    });
   }
   const range = timeRange({ now, window, bucket });
   const output = {};
-  for (const name of [...new Set(names)]) output[name] = SERIES_QUERIES[name](db, range);
+  for (const name of [...new Set(names)])
+    output[name] = SERIES_QUERIES[name](db, range);
   return { window, bucket, buckets: range.buckets, series: output };
 }
 
@@ -312,11 +384,13 @@ function repoNames(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) return [];
   const names = [];
   const add = (value) => {
-    if (typeof value === "string" && value !== "" && !names.includes(value)) names.push(value);
+    if (typeof value === "string" && value !== "" && !names.includes(value))
+      names.push(value);
   };
   add(input.repoPin?.repo);
   add(input.repo);
-  for (const entry of input.repos ?? []) add(typeof entry === "string" ? entry : entry?.name);
+  for (const entry of input.repos ?? [])
+    add(typeof entry === "string" ? entry : entry?.name);
   return names;
 }
 
@@ -336,9 +410,14 @@ const RUN_FACTS_JOINS = `
 function factKeys(row, dimension) {
   const spec = JSON.parse(row.spec_json || "{}");
   if (dimension === "agent") return [spec.agent ?? "unknown"];
-  if (dimension === "adapter") return [spec.adapter ?? row.usage_adapter ?? "unknown"];
-  if (dimension === "model") return [row.usage_model ?? spec.model ?? "unknown"];
-  if (dimension === "repo") return repoNames(spec.input).length > 0 ? repoNames(spec.input) : ["unknown"];
+  if (dimension === "adapter")
+    return [spec.adapter ?? row.usage_adapter ?? "unknown"];
+  if (dimension === "model")
+    return [row.usage_model ?? spec.model ?? "unknown"];
+  if (dimension === "repo")
+    return repoNames(spec.input).length > 0
+      ? repoNames(spec.input)
+      : ["unknown"];
   if (dimension === "source") return [row.event_source ?? "unknown"];
   if (dimension === "reason_code") return [row.reason_code ?? "unknown"];
   if (dimension === "event_type") return [row.event_type ?? "unknown"];
@@ -352,22 +431,27 @@ function factKeys(row, dimension) {
 
 function breakdownFacts(db, metric, range) {
   if (metric === "runs" || metric === "failures") {
-    const failures = metric === "failures"
-      ? "AND r.state IN ('FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')"
-      : "";
+    const failures =
+      metric === "failures"
+        ? "AND r.state IN ('FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')"
+        : "";
     const time = metric === "failures" ? "r.updated_at" : "r.created_at";
-    return db.query(
-      `${RUN_FACTS_SELECT}, 1 AS value
+    return db
+      .query(
+        `${RUN_FACTS_SELECT}, 1 AS value
        FROM runs r ${RUN_FACTS_JOINS}
        WHERE ${time} >= ? AND ${time} < ? ${failures}`,
-    ).all(range.startIso, range.endIso);
+      )
+      .all(range.startIso, range.endIso);
   }
   if (metric === "cost" || metric === "tokens") {
-    const value = metric === "cost"
-      ? "u.cost_usd"
-      : "u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens";
-    return db.query(
-      `${RUN_FACTS_SELECT}, u.adapter AS usage_adapter, u.model AS usage_model, ${value} AS value
+    const value =
+      metric === "cost"
+        ? "u.cost_usd"
+        : "u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens";
+    return db
+      .query(
+        `${RUN_FACTS_SELECT}, u.adapter AS usage_adapter, u.model AS usage_model, ${value} AS value
        FROM run_usage u
        JOIN runs r ON r.run_id = u.run_id
        LEFT JOIN attempts a ON a.run_id = u.run_id AND a.attempt = u.attempt
@@ -378,10 +462,12 @@ function breakdownFacts(db, metric, range) {
        LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        LEFT JOIN runs parent ON parent.run_id = e.causation_id
        WHERE u.recorded_at >= ? AND u.recorded_at < ?`,
-    ).all(range.startIso, range.endIso);
+      )
+      .all(range.startIso, range.endIso);
   }
-  return db.query(
-    `${RUN_FACTS_SELECT}, a.started_at, a.finished_at
+  return db
+    .query(
+      `${RUN_FACTS_SELECT}, a.started_at, a.finished_at
      FROM attempts a
      JOIN runs r ON r.run_id = a.run_id
      LEFT JOIN proposals p ON p.rowid = (
@@ -392,28 +478,37 @@ function breakdownFacts(db, metric, range) {
      LEFT JOIN runs parent ON parent.run_id = e.causation_id
      WHERE a.started_at IS NOT NULL AND a.finished_at IS NOT NULL
        AND a.finished_at >= ? AND a.finished_at < ?`,
-  ).all(range.startIso, range.endIso);
+    )
+    .all(range.startIso, range.endIso);
 }
 
 /** Top-N operational dimensions used by GET /metrics/breakdown. */
-export function metricsBreakdownView(db, {
-  now,
-  window = "24h",
-  by,
-  metric,
-  limit,
-} = {}) {
+export function metricsBreakdownView(
+  db,
+  { now, window = "24h", by, metric, limit } = {},
+) {
   if (!VALID_BREAKDOWN_DIMENSIONS.includes(by)) {
-    throw new MetricsQueryError("invalid_dimension", { by, validDimensions: VALID_BREAKDOWN_DIMENSIONS });
+    throw new MetricsQueryError("invalid_dimension", {
+      by,
+      validDimensions: VALID_BREAKDOWN_DIMENSIONS,
+    });
   }
   if (!VALID_BREAKDOWN_METRICS.includes(metric)) {
-    throw new MetricsQueryError("invalid_metric", { metric, validMetrics: VALID_BREAKDOWN_METRICS });
+    throw new MetricsQueryError("invalid_metric", {
+      metric,
+      validMetrics: VALID_BREAKDOWN_METRICS,
+    });
   }
   let actualLimit;
-  if (limit == null || limit === "") actualLimit = by === "event_type" || by === "edge" ? null : 10;
+  if (limit == null || limit === "")
+    actualLimit = by === "event_type" || by === "edge" ? null : 10;
   else {
     actualLimit = Number(limit);
-    if (!Number.isInteger(actualLimit) || actualLimit < 1 || actualLimit > 500) {
+    if (
+      !Number.isInteger(actualLimit) ||
+      actualLimit < 1 ||
+      actualLimit > 500
+    ) {
       throw new MetricsQueryError("invalid_limit", { limit, min: 1, max: 500 });
     }
   }
@@ -423,7 +518,8 @@ export function metricsBreakdownView(db, {
   for (const fact of facts) {
     for (const key of factKeys(fact, by)) {
       if (metric === "p95_execution") {
-        const durationMs = Date.parse(fact.finished_at) - Date.parse(fact.started_at);
+        const durationMs =
+          Date.parse(fact.finished_at) - Date.parse(fact.started_at);
         if (!Number.isFinite(durationMs) || durationMs < 0) continue;
         const samples = grouped.get(key) ?? [];
         samples.push(durationMs);

--- a/event-runtime/lib/metrics.test.mjs
+++ b/event-runtime/lib/metrics.test.mjs
@@ -11,25 +11,43 @@ import {
 const NOW = Date.parse("2026-08-15T12:00:00.000Z");
 const at = (millisecondsAgo) => new Date(NOW - millisecondsAgo).toISOString();
 
-function insertRun(db, id, {
-  agent = "agent-a@1",
-  adapter = "pi",
-  model = "openai/test",
-  input = { repo: "factory" },
-  state = "COMPLETED",
-  attempts = 1,
-  createdAt = at(30 * 60_000),
-  updatedAt = createdAt,
-} = {}) {
+function insertRun(
+  db,
+  id,
+  {
+    agent = "agent-a@1",
+    adapter = "pi",
+    model = "openai/test",
+    input = { repo: "factory" },
+    state = "COMPLETED",
+    attempts = 1,
+    createdAt = at(30 * 60_000),
+    updatedAt = createdAt,
+  } = {},
+) {
   db.query(
     `INSERT INTO runs
        (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
      VALUES (?, ?, ?, 'hash', ?, ?, ?, ?)`,
-  ).run(id, `idem-${id}`, JSON.stringify({ agent, adapter, model, input }), state, attempts, createdAt, updatedAt);
+  ).run(
+    id,
+    `idem-${id}`,
+    JSON.stringify({ agent, adapter, model, input }),
+    state,
+    attempts,
+    createdAt,
+    updatedAt,
+  );
 }
 
 let lifecycleSequence = 0;
-function insertLifecycle(db, runId, to, when, { from = null, attempt = null } = {}) {
+function insertLifecycle(
+  db,
+  runId,
+  to,
+  when,
+  { from = null, attempt = null } = {},
+) {
   lifecycleSequence += 1;
   db.query(
     `INSERT INTO lifecycle_events
@@ -38,54 +56,102 @@ function insertLifecycle(db, runId, to, when, { from = null, attempt = null } = 
   ).run(runId, from, to, attempt, when, `lifecycle-${lifecycleSequence}`);
 }
 
-function insertAttempt(db, runId, attempt, {
-  startedAt,
-  finishedAt,
-  terminalState = "COMPLETED",
-  reasonCode = null,
-} = {}) {
+function insertAttempt(
+  db,
+  runId,
+  attempt,
+  {
+    startedAt,
+    finishedAt,
+    terminalState = "COMPLETED",
+    reasonCode = null,
+  } = {},
+) {
   db.query(
     `INSERT INTO attempts
        (run_id, attempt, fencing_token, started_at, finished_at, terminal_state, reason_code)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(runId, attempt, attempt, startedAt ?? null, finishedAt ?? null, terminalState, reasonCode);
+  ).run(
+    runId,
+    attempt,
+    attempt,
+    startedAt ?? null,
+    finishedAt ?? null,
+    terminalState,
+    reasonCode,
+  );
 }
 
-function insertEvent(db, id, {
-  type = "factory.test.requested",
-  source = "test",
-  status = "planned",
-  admittedAt = at(30 * 60_000),
-  causationId = null,
-} = {}) {
+function insertEvent(
+  db,
+  id,
+  {
+    type = "factory.test.requested",
+    source = "test",
+    status = "planned",
+    admittedAt = at(30 * 60_000),
+    causationId = null,
+  } = {},
+) {
   db.query(
     `INSERT INTO events
        (source, event_id, type, occurred_at, received_at, causation_id,
         envelope_json, payload_hash, status, admitted_at)
      VALUES (?, ?, ?, ?, ?, ?, '{}', ?, ?, ?)`,
-  ).run(source, id, type, admittedAt, admittedAt, causationId, `hash-${source}-${id}`, status, admittedAt);
+  ).run(
+    source,
+    id,
+    type,
+    admittedAt,
+    admittedAt,
+    causationId,
+    `hash-${source}-${id}`,
+    status,
+    admittedAt,
+  );
 }
 
-function insertProposal(db, id, eventId, {
-  runId = null,
-  status = "approved",
-  source = "test",
-  createdAt = at(31 * 60_000),
-  decidedAt = at(30 * 60_000),
-  ttlSeconds = 3600,
-} = {}) {
+function insertProposal(
+  db,
+  id,
+  eventId,
+  {
+    runId = null,
+    status = "approved",
+    source = "test",
+    createdAt = at(31 * 60_000),
+    decidedAt = at(30 * 60_000),
+    ttlSeconds = 3600,
+  } = {},
+) {
   db.query(
     `INSERT INTO proposals
        (id, event_source, event_id, run_id, decision, spec_json, spec_hash,
         idempotency_key, status, created_at, ttl_seconds, decided_at)
      VALUES (?, ?, ?, ?, 'run', '{}', 'hash', ?, ?, ?, ?, ?)`,
-  ).run(id, source, eventId, runId, `idem-proposal-${id}`, status, createdAt, ttlSeconds, decidedAt);
+  ).run(
+    id,
+    source,
+    eventId,
+    runId,
+    `idem-proposal-${id}`,
+    status,
+    createdAt,
+    ttlSeconds,
+    decidedAt,
+  );
 }
 
 function seededSeriesDb() {
   const db = openDb(":memory:");
-  insertLifecycle(db, "run-outcome", "RUNNING", at(40 * 60_000), { from: "LEASED", attempt: 1 });
-  insertLifecycle(db, "run-outcome", "COMPLETED", at(30 * 60_000), { from: "VERIFYING", attempt: 1 });
+  insertLifecycle(db, "run-outcome", "RUNNING", at(40 * 60_000), {
+    from: "LEASED",
+    attempt: 1,
+  });
+  insertLifecycle(db, "run-outcome", "COMPLETED", at(30 * 60_000), {
+    from: "VERIFYING",
+    attempt: 1,
+  });
 
   const executionDurations = [1000, 2000, 3000, 100_000, 200_000];
   const queueDurations = [10_000, 20_000, 30_000, 40_000, 50_000];
@@ -98,10 +164,16 @@ function seededSeriesDb() {
       finishedAt,
     });
     const leasedAt = at(10 * 60_000 + index * 1000);
-    insertLifecycle(db, runId, "QUEUED", new Date(Date.parse(leasedAt) - queueDurations[index]).toISOString(), {
-      from: index < 3 && index > 0 ? "FAILED" : "APPROVED",
-      attempt: index < 3 && index > 0 ? index : null,
-    });
+    insertLifecycle(
+      db,
+      runId,
+      "QUEUED",
+      new Date(Date.parse(leasedAt) - queueDurations[index]).toISOString(),
+      {
+        from: index < 3 && index > 0 ? "FAILED" : "APPROVED",
+        attempt: index < 3 && index > 0 ? index : null,
+      },
+    );
     insertLifecycle(db, runId, "LEASED", leasedAt, { from: "QUEUED", attempt });
   });
 
@@ -119,12 +191,20 @@ function seededSeriesDb() {
     recordedAt: at(15 * 60_000),
   });
 
-  const decisions = ["approved", "rejected", "superseded", "approved", "rejected"];
+  const decisions = [
+    "approved",
+    "rejected",
+    "superseded",
+    "approved",
+    "rejected",
+  ];
   decisions.forEach((status, index) => {
     const decidedAt = at(25 * 60_000 + index * 1000);
     insertProposal(db, `decision-${index}`, `decision-event-${index}`, {
       status,
-      createdAt: new Date(Date.parse(decidedAt) - (index + 1) * 1000).toISOString(),
+      createdAt: new Date(
+        Date.parse(decidedAt) - (index + 1) * 1000,
+      ).toISOString(),
       decidedAt,
     });
   });
@@ -135,7 +215,13 @@ function seededSeriesDb() {
     ttlSeconds: 3600,
   });
 
-  for (const status of ["admitted", "planned", "noop", "human_needed", "dead_lettered"]) {
+  for (const status of [
+    "admitted",
+    "planned",
+    "noop",
+    "human_needed",
+    "dead_lettered",
+  ]) {
     insertEvent(db, `event-${status}`, { status });
   }
   return db;
@@ -154,7 +240,8 @@ describe("metrics time series (WM-281)", () => {
     expect(view.buckets).toHaveLength(24);
     expect(Object.keys(view.series)).toEqual(VALID_METRIC_SERIES);
     for (const values of Object.values(view.series)) {
-      for (const points of Object.values(values)) expect(points).toHaveLength(view.buckets.length);
+      for (const points of Object.values(values))
+        expect(points).toHaveLength(view.buckets.length);
     }
     expect(view.series["runs.outcomes"].COMPLETED.at(-1)).toBe(1);
     expect(view.series["runs.outcomes"].COMPLETED[0]).toBe(0);
@@ -180,10 +267,17 @@ describe("metrics time series (WM-281)", () => {
   test("in-flight intervals are excluded and sparse percentile buckets are null", () => {
     const db = openDb(":memory:");
     insertAttempt(db, "flight", 1, { startedAt: at(10_000), finishedAt: null });
-    insertAttempt(db, "finished", 1, { startedAt: at(20_000), finishedAt: at(10_000) });
+    insertAttempt(db, "finished", 1, {
+      startedAt: at(20_000),
+      finishedAt: at(10_000),
+    });
     const view = metricsView(db, { now: NOW, series: "latency.execution" });
-    expect(view.series["latency.execution"].p50.every((value) => value === null)).toBe(true);
-    expect(view.series["latency.execution"].p95.every((value) => value === null)).toBe(true);
+    expect(
+      view.series["latency.execution"].p50.every((value) => value === null),
+    ).toBe(true);
+    expect(
+      view.series["latency.execution"].p95.every((value) => value === null),
+    ).toBe(true);
     db.close();
   });
 
@@ -198,10 +292,18 @@ describe("metrics time series (WM-281)", () => {
       expect(err.body.validSeries).toEqual(VALID_METRIC_SERIES);
     }
     try {
-      metricsView(db, { now: NOW, window: "30d", bucket: "15m", series: "runs.started" });
+      metricsView(db, {
+        now: NOW,
+        window: "30d",
+        bucket: "15m",
+        series: "runs.started",
+      });
       throw new Error("expected bucket cap error");
     } catch (err) {
-      expect(err.body).toMatchObject({ error: "too_many_buckets", maxBuckets: MAX_METRIC_BUCKETS });
+      expect(err.body).toMatchObject({
+        error: "too_many_buckets",
+        maxBuckets: MAX_METRIC_BUCKETS,
+      });
     }
     db.close();
   });
@@ -209,7 +311,11 @@ describe("metrics time series (WM-281)", () => {
 
 function seededBreakdownDb() {
   const db = openDb(":memory:");
-  insertRun(db, "parent", { agent: "recommender@1", adapter: "pi", input: { repo: "factory" } });
+  insertRun(db, "parent", {
+    agent: "recommender@1",
+    adapter: "pi",
+    input: { repo: "factory" },
+  });
   insertAttempt(db, "parent", 1, {
     startedAt: at(35 * 60_000),
     finishedAt: at(34 * 60_000),
@@ -228,7 +334,10 @@ function seededBreakdownDb() {
       state: index === 0 ? "FAILED" : "COMPLETED",
       updatedAt: at(20 * 60_000),
     });
-    insertProposal(db, `proposal-${index}`, eventId, { runId, source: "result" });
+    insertProposal(db, `proposal-${index}`, eventId, {
+      runId,
+      source: "result",
+    });
     insertAttempt(db, runId, 1, {
       startedAt: at(25 * 60_000),
       finishedAt: at(24 * 60_000 - index * 1000),
@@ -258,39 +367,75 @@ function seededBreakdownDb() {
 describe("metrics breakdowns (WM-281)", () => {
   test("top-N dimensions and unbounded graph dimensions are computed server-side", () => {
     const db = seededBreakdownDb();
-    expect(metricsBreakdownView(db, { now: NOW, by: "agent", metric: "runs" }).rows[0]).toEqual({
+    expect(
+      metricsBreakdownView(db, { now: NOW, by: "agent", metric: "runs" })
+        .rows[0],
+    ).toEqual({
       key: "worker@1",
       value: 12,
     });
-    expect(metricsBreakdownView(db, { now: NOW, by: "adapter", metric: "runs" }).rows[0]).toEqual({
+    expect(
+      metricsBreakdownView(db, { now: NOW, by: "adapter", metric: "runs" })
+        .rows[0],
+    ).toEqual({
       key: "claude",
       value: 12,
     });
-    expect(metricsBreakdownView(db, { now: NOW, by: "reason_code", metric: "failures" }).rows).toEqual([
-      { key: "adapter_error", value: 1 },
-    ]);
+    expect(
+      metricsBreakdownView(db, {
+        now: NOW,
+        by: "reason_code",
+        metric: "failures",
+      }).rows,
+    ).toEqual([{ key: "adapter_error", value: 1 }]);
 
-    const eventTypes = metricsBreakdownView(db, { now: NOW, by: "event_type", metric: "runs" });
+    const eventTypes = metricsBreakdownView(db, {
+      now: NOW,
+      by: "event_type",
+      metric: "runs",
+    });
     expect(eventTypes.limit).toBeNull();
     expect(eventTypes.rows).toHaveLength(13); // twelve event types plus the uncaused parent
-    const edges = metricsBreakdownView(db, { now: NOW, by: "edge", metric: "runs" });
+    const edges = metricsBreakdownView(db, {
+      now: NOW,
+      by: "edge",
+      metric: "runs",
+    });
     expect(edges.limit).toBeNull();
     expect(edges.rows).toHaveLength(12);
-    expect(edges.rows.find((row) => row.key === "recommender@1→factory.caused-0.requested")).toEqual({
+    expect(
+      edges.rows.find(
+        (row) => row.key === "recommender@1→factory.caused-0.requested",
+      ),
+    ).toEqual({
       key: "recommender@1→factory.caused-0.requested",
       value: 1,
     });
 
-    expect(metricsBreakdownView(db, { now: NOW, by: "model", metric: "tokens" }).rows[0]).toEqual({
+    expect(
+      metricsBreakdownView(db, { now: NOW, by: "model", metric: "tokens" })
+        .rows[0],
+    ).toEqual({
       key: "claude/test",
       value: 78,
     });
-    expect(metricsBreakdownView(db, { now: NOW, by: "repo", metric: "runs" }).rows).toContainEqual({
+    expect(
+      metricsBreakdownView(db, { now: NOW, by: "repo", metric: "runs" }).rows,
+    ).toContainEqual({
       key: "bj29",
       value: 12,
     });
-    expect(metricsBreakdownView(db, { now: NOW, by: "source", metric: "cost" }).rows[0].key).toBe("result");
-    expect(metricsBreakdownView(db, { now: NOW, by: "agent", metric: "p95_execution" }).rows[0].value).toBe(71_000);
+    expect(
+      metricsBreakdownView(db, { now: NOW, by: "source", metric: "cost" })
+        .rows[0].key,
+    ).toBe("result");
+    expect(
+      metricsBreakdownView(db, {
+        now: NOW,
+        by: "agent",
+        metric: "p95_execution",
+      }).rows[0].value,
+    ).toBe(71_000);
     db.close();
   });
 });

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -33,7 +33,9 @@ export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hd
 export const NOTIFY_TIMEOUT_MS = 30_000;
 
 export function notifyEnabled(env = process.env) {
-  return env.FACTORY_EVENT_NOTIFY === "1" || env.FACTORY_EVENT_NOTIFY === "true";
+  return (
+    env.FACTORY_EVENT_NOTIFY === "1" || env.FACTORY_EVENT_NOTIFY === "true"
+  );
 }
 
 /**
@@ -60,8 +62,14 @@ export function ensureNotifyLog(db) {
     inbox_item_id TEXT,
     PRIMARY KEY (kind, target)
   );`);
-  const columns = new Set(db.query("PRAGMA table_info(notify_log)").all().map((row) => row.name));
-  if (!columns.has("inbox_item_id")) db.exec("ALTER TABLE notify_log ADD COLUMN inbox_item_id TEXT;");
+  const columns = new Set(
+    db
+      .query("PRAGMA table_info(notify_log)")
+      .all()
+      .map((row) => row.name),
+  );
+  if (!columns.has("inbox_item_id"))
+    db.exec("ALTER TABLE notify_log ADD COLUMN inbox_item_id TEXT;");
 }
 
 const KIND_HUMAN_NEEDED = "human_needed";
@@ -72,7 +80,9 @@ const KIND_DECISION_NEEDED = "decision_needed";
 const KIND_PROPOSAL_EXPIRED = "proposal_expired";
 
 function alreadyNotified(db, kind, target) {
-  return !!db.query(`SELECT 1 FROM notify_log WHERE kind = ? AND target = ?`).get(kind, target);
+  return !!db
+    .query(`SELECT 1 FROM notify_log WHERE kind = ? AND target = ?`)
+    .get(kind, target);
 }
 
 /**
@@ -126,7 +136,9 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
   }
 
   const open = db
-    .query(`SELECT * FROM proposals WHERE status = 'open' AND decision = 'run' ORDER BY created_at, rowid`)
+    .query(
+      `SELECT * FROM proposals WHERE status = 'open' AND decision = 'run' ORDER BY created_at, rowid`,
+    )
     .all();
   for (const p of open) {
     const ageMs = now - Date.parse(p.created_at);
@@ -140,11 +152,19 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
           kind: KIND_PROPOSAL_EXPIRED,
           target: p.id,
           title: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
-          refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+          refs: {
+            proposalId: p.id,
+            eventSource: p.event_source,
+            eventId: p.event_id,
+          },
           source: "serve:notify",
           decision: templateFor(KIND_PROPOSAL_EXPIRED, {
             producer: "proposal",
-            refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+            refs: {
+              proposalId: p.id,
+              eventSource: p.event_source,
+              eventId: p.event_id,
+            },
           }),
           dedupeKey: `${KIND_PROPOSAL_EXPIRED}:${p.id}`,
         });
@@ -156,11 +176,19 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
         dedupKind: DEDUP_PROPOSAL_TTL,
         target: p.id,
         title: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
-        refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+        refs: {
+          proposalId: p.id,
+          eventSource: p.event_source,
+          eventId: p.event_id,
+        },
         source: "serve:notify",
         decision: templateFor(KIND_DECISION_NEEDED, {
           producer: "proposal",
-          refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+          refs: {
+            proposalId: p.id,
+            eventSource: p.event_source,
+            eventId: p.event_id,
+          },
         }),
         dedupeKey: `${KIND_DECISION_NEEDED}:${p.id}`,
       });
@@ -177,12 +205,18 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
  *
  * @returns {Promise<{ ok: boolean, exitCode: number|null, error: string|null }>}
  */
-export function sendNotification(command, message, { timeoutMs = NOTIFY_TIMEOUT_MS } = {}) {
+export function sendNotification(
+  command,
+  message,
+  { timeoutMs = NOTIFY_TIMEOUT_MS } = {},
+) {
   return new Promise((resolve) => {
     const argv = String(command).trim().split(/\s+/).filter(Boolean);
     let child;
     try {
-      child = spawn(argv[0], [...argv.slice(1), message], { stdio: ["ignore", "ignore", "ignore"] });
+      child = spawn(argv[0], [...argv.slice(1), message], {
+        stdio: ["ignore", "ignore", "ignore"],
+      });
     } catch (err) {
       resolve({ ok: false, exitCode: null, error: err.message });
       return;
@@ -200,15 +234,24 @@ export function sendNotification(command, message, { timeoutMs = NOTIFY_TIMEOUT_
       } catch {
         // already gone
       }
-      settle({ ok: false, exitCode: null, error: `notifier timed out after ${timeoutMs}ms` });
+      settle({
+        ok: false,
+        exitCode: null,
+        error: `notifier timed out after ${timeoutMs}ms`,
+      });
     }, timeoutMs);
     timer.unref?.();
-    child.on("error", (err) => settle({ ok: false, exitCode: null, error: err.message }));
+    child.on("error", (err) =>
+      settle({ ok: false, exitCode: null, error: err.message }),
+    );
     child.on("exit", (code, signal) => {
       settle({
         ok: code === 0,
         exitCode: code,
-        error: code === 0 ? null : `notifier exited ${code ?? `on signal ${signal}`}`,
+        error:
+          code === 0
+            ? null
+            : `notifier exited ${code ?? `on signal ${signal}`}`,
       });
     });
   });
@@ -225,14 +268,17 @@ export function sendNotification(command, message, { timeoutMs = NOTIFY_TIMEOUT_
  *
  * @returns {{ sent: Array<{kind, target, message}>, deliveries: Promise<Array> }}
  */
-export function notifyPending(db, {
-  now = Date.now(),
-  enabled = notifyEnabled(),
-  command = notifyCommand(),
-  log = () => {},
-  send = sendNotification,
-  webUrl = process.env.FACTORY_WEB_URL,
-} = {}) {
+export function notifyPending(
+  db,
+  {
+    now = Date.now(),
+    enabled = notifyEnabled(),
+    command = notifyCommand(),
+    log = () => {},
+    send = sendNotification,
+    webUrl = process.env.FACTORY_WEB_URL,
+  } = {},
+) {
   const pending = pendingNotifications(db, { now });
   const at = new Date(now).toISOString();
   const deliveries = [];
@@ -257,16 +303,20 @@ export function notifyPending(db, {
     sent.push(notification);
     log(`notify ${n.kind} ${n.target}: ${n.title}`);
     deliveries.push(
-      deliverInboxItem(db, created.id, { command, send, webUrl, now }).then((outcome) => {
-        try {
-          db.query(`UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`)
-            .run(outcome.exitCode, outcome.error, dedupKind, n.target);
-        } catch {
-          // db already closed (shutdown mid-delivery) — the log line below is the record
-        }
-        if (!outcome.ok) log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
-        return { ...notification, ...outcome };
-      }),
+      deliverInboxItem(db, created.id, { command, send, webUrl, now }).then(
+        (outcome) => {
+          try {
+            db.query(
+              `UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`,
+            ).run(outcome.exitCode, outcome.error, dedupKind, n.target);
+          } catch {
+            // db already closed (shutdown mid-delivery) — the log line below is the record
+          }
+          if (!outcome.ok)
+            log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
+          return { ...notification, ...outcome };
+        },
+      ),
     );
   }
   return { sent, deliveries: Promise.all(deliveries) };

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -18,30 +18,75 @@ const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
 function stubNotifier(dir, { exitCode = 0 } = {}) {
   const outFile = path.join(dir, "pushes.txt");
   const bin = path.join(dir, "notify-stub.sh");
-  writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$1" >> ${outFile}\nexit ${exitCode}\n`);
+  writeFileSync(
+    bin,
+    `#!/bin/sh\nprintf '%s\\n' "$1" >> ${outFile}\nexit ${exitCode}\n`,
+  );
   chmodSync(bin, 0o755);
-  return { bin, outFile, pushes: () => (Bun.file(outFile).size > 0 ? readFileSync(outFile, "utf8").trim().split("\n") : []) };
+  return {
+    bin,
+    outFile,
+    pushes: () =>
+      Bun.file(outFile).size > 0
+        ? readFileSync(outFile, "utf8").trim().split("\n")
+        : [],
+  };
 }
 
-function insertEvent(db, { source = "test", eventId, type = "linear.ticket.agent_ready", status = "admitted", lastPlanError = null }) {
+function insertEvent(
+  db,
+  {
+    source = "test",
+    eventId,
+    type = "linear.ticket.agent_ready",
+    status = "admitted",
+    lastPlanError = null,
+  },
+) {
   const at = new Date().toISOString();
   db.query(
     `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, last_plan_error, admitted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(source, eventId, type, at, at, "{}", "sha256:x", status, lastPlanError, at);
+  ).run(
+    source,
+    eventId,
+    type,
+    at,
+    at,
+    "{}",
+    "sha256:x",
+    status,
+    lastPlanError,
+    at,
+  );
 }
 
-function insertProposal(db, {
-  id, eventId, decision = "run", status = "open", reason = null,
-  agent = "worktree-ticket@1", createdAt, ttlSeconds = 1800,
-}) {
+function insertProposal(
+  db,
+  {
+    id,
+    eventId,
+    decision = "run",
+    status = "open",
+    reason = null,
+    agent = "worktree-ticket@1",
+    createdAt,
+    ttlSeconds = 1800,
+  },
+) {
   db.query(
     `INSERT INTO proposals (id, event_source, event_id, run_id, decision, spec_json, spec_hash, status, reason, created_at, ttl_seconds)
      VALUES (?, 'test', ?, ?, ?, ?, 'sha256:x', ?, ?, ?, ?)`,
   ).run(
-    id, eventId, decision === "run" ? `run_${id}` : null, decision,
+    id,
+    eventId,
+    decision === "run" ? `run_${id}` : null,
+    decision,
     decision === "run" ? JSON.stringify({ agent }) : null,
-    status, reason, createdAt ?? new Date().toISOString(), ttlSeconds,
+    status,
+    reason,
+    createdAt ?? new Date().toISOString(),
+    ttlSeconds,
   );
 }
 
@@ -54,24 +99,40 @@ describe("notify (WM-65)", () => {
     expect(notifyCommand({})).toBe(DEFAULT_NOTIFY_CMD);
     expect(DEFAULT_NOTIFY_CMD).toContain("python3 ");
     expect(DEFAULT_NOTIFY_CMD).toContain("scripts/notify.py");
-    expect(notifyCommand({ FACTORY_EVENT_NOTIFY_CMD: "/x/stub" })).toBe("/x/stub");
+    expect(notifyCommand({ FACTORY_EVENT_NOTIFY_CMD: "/x/stub" })).toBe(
+      "/x/stub",
+    );
   });
 
   test("disabled (the default): inbox remains durable while the Telegram projection stays off", () => {
     const db = openDb(":memory:");
     insertEvent(db, { eventId: "evt-1", status: "human_needed" });
-    insertProposal(db, { id: "prop-hn-1", eventId: "evt-1", decision: "human_needed", reason: "repo_unknown" });
+    insertProposal(db, {
+      id: "prop-hn-1",
+      eventId: "evt-1",
+      decision: "human_needed",
+      reason: "repo_unknown",
+    });
     const spawned = [];
-    const out = notifyPending(db, { enabled: false, send: (cmd, msg) => (spawned.push(msg), Promise.resolve({ ok: true, exitCode: 0, error: null })) });
+    const out = notifyPending(db, {
+      enabled: false,
+      send: (cmd, msg) => (
+        spawned.push(msg),
+        Promise.resolve({ ok: true, exitCode: 0, error: null })
+      ),
+    });
     expect(out.sent).toEqual([]);
     expect(spawned).toEqual([]);
-    const item = db.query("SELECT kind, delivery_json, decision_json, dedupe_key FROM inbox_items").get();
+    const item = db
+      .query(
+        "SELECT kind, delivery_json, decision_json, dedupe_key FROM inbox_items",
+      )
+      .get();
     expect(item.kind).toBe("BLOCKED");
     expect(JSON.parse(item.delivery_json)).toEqual({});
-    expect(JSON.parse(item.decision_json).options.map((option) => option.effect)).toEqual([
-      "requeue",
-      "dismiss",
-    ]);
+    expect(
+      JSON.parse(item.decision_json).options.map((option) => option.effect),
+    ).toEqual(["requeue", "dismiss"]);
     expect(item.dedupe_key).toBe("BLOCKED:test/evt-1");
     expect(db.query("SELECT COUNT(*) AS n FROM notify_log").get().n).toBe(1);
     // The next tick dedups the ledger item even though no projection ran.
@@ -85,8 +146,17 @@ describe("notify (WM-65)", () => {
     const stub = stubNotifier(dir);
 
     let db = openDb(dbFile);
-    insertEvent(db, { eventId: "evt-park", type: "linear.ticket.agent_ready", status: "human_needed" });
-    insertProposal(db, { id: "prop-park", eventId: "evt-park", decision: "human_needed", reason: "repo_report_only" });
+    insertEvent(db, {
+      eventId: "evt-park",
+      type: "linear.ticket.agent_ready",
+      status: "human_needed",
+    });
+    insertProposal(db, {
+      id: "prop-park",
+      eventId: "evt-park",
+      decision: "human_needed",
+      reason: "repo_report_only",
+    });
 
     const first = notifyPending(db, {
       enabled: true,
@@ -94,7 +164,9 @@ describe("notify (WM-65)", () => {
       webUrl: "http://127.0.0.1:7382",
     });
     expect(first.sent).toHaveLength(1);
-    expect(first.sent[0].message).toBe("BLOCKED linear.ticket.agent_ready evt-park: repo_report_only");
+    expect(first.sent[0].message).toBe(
+      "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
+    );
     await first.deliveries;
     expect(stub.pushes()).toEqual([
       "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
@@ -103,12 +175,19 @@ describe("notify (WM-65)", () => {
       "2. Not now",
       `http://127.0.0.1:7382/#/inbox/${first.sent[0].inboxItemId}`,
     ]);
-    const item = db.query("SELECT kind, refs_json, source, delivery_json FROM inbox_items").get();
+    const item = db
+      .query("SELECT kind, refs_json, source, delivery_json FROM inbox_items")
+      .get();
     expect(item.kind).toBe("BLOCKED");
-    expect(JSON.parse(item.refs_json)).toEqual({ eventSource: "test", eventId: "evt-park" });
+    expect(JSON.parse(item.refs_json)).toEqual({
+      eventSource: "test",
+      eventId: "evt-park",
+    });
     expect(item.source).toBe("serve:notify");
     expect(JSON.parse(item.delivery_json).telegram.error).toBeNull();
-    expect(db.query("SELECT inbox_item_id FROM notify_log").get().inbox_item_id).toBe(first.sent[0].inboxItemId);
+    expect(
+      db.query("SELECT inbox_item_id FROM notify_log").get().inbox_item_id,
+    ).toBe(first.sent[0].inboxItemId);
 
     // Same serve process, next tick: nothing new.
     const second = notifyPending(db, { enabled: true, command: stub.bin });
@@ -117,7 +196,10 @@ describe("notify (WM-65)", () => {
     // Serve restart: the marker is in the database, not in process memory.
     db.close();
     db = openDb(dbFile);
-    const afterRestart = notifyPending(db, { enabled: true, command: stub.bin });
+    const afterRestart = notifyPending(db, {
+      enabled: true,
+      command: stub.bin,
+    });
     expect(afterRestart.sent).toEqual([]);
     await afterRestart.deliveries;
     expect(stub.pushes()).toHaveLength(5);
@@ -131,40 +213,58 @@ describe("notify (WM-65)", () => {
     insertEvent(db, { eventId: "evt-p" });
     // 16 of 30 minutes gone → past 50%, 14m left.
     insertProposal(db, {
-      id: "prop-aging", eventId: "evt-p", agent: "ci-doctor@2",
-      createdAt: new Date(now - 16 * 60_000).toISOString(), ttlSeconds,
+      id: "prop-aging",
+      eventId: "evt-p",
+      agent: "ci-doctor@2",
+      createdAt: new Date(now - 16 * 60_000).toISOString(),
+      ttlSeconds,
     });
     // 5 of 30 minutes gone → below threshold.
     insertProposal(db, {
-      id: "prop-young", eventId: "evt-p",
-      createdAt: new Date(now - 5 * 60_000).toISOString(), ttlSeconds,
+      id: "prop-young",
+      eventId: "evt-p",
+      createdAt: new Date(now - 5 * 60_000).toISOString(),
+      ttlSeconds,
     });
 
-    const sent = (at) => notifyPending(db, { now: at, enabled: true, send: () => Promise.resolve({ ok: true, exitCode: 0, error: null }) }).sent;
+    const sent = (at) =>
+      notifyPending(db, {
+        now: at,
+        enabled: true,
+        send: () => Promise.resolve({ ok: true, exitCode: 0, error: null }),
+      }).sent;
 
     const first = sent(now);
     expect(first).toHaveLength(1);
-    expect(first[0].message).toBe("DECISION NEEDED proposal prop-aging (ci-doctor@2): expires in 14m");
-    const proposalItem = db.query(
-      "SELECT decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
-    ).get();
-    expect(JSON.parse(proposalItem.decision_json).options.map((option) => option.effect)).toEqual([
-      "approve_proposal",
-      "reject_proposal",
-      "dismiss",
-    ]);
+    expect(first[0].message).toBe(
+      "DECISION NEEDED proposal prop-aging (ci-doctor@2): expires in 14m",
+    );
+    const proposalItem = db
+      .query(
+        "SELECT decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
+      )
+      .get();
+    expect(
+      JSON.parse(proposalItem.decision_json).options.map(
+        (option) => option.effect,
+      ),
+    ).toEqual(["approve_proposal", "reject_proposal", "dismiss"]);
     expect(proposalItem.dedupe_key).toBe("decision_needed:prop-aging");
 
     // Later ticks before expiry: silent.
     expect(sent(now + 60_000)).toEqual([]);
 
     // prop-young is decided before it ever reaches 50%: no push, ever.
-    db.query(`UPDATE proposals SET status = 'approved' WHERE id = 'prop-young'`).run();
+    db.query(
+      `UPDATE proposals SET status = 'approved' WHERE id = 'prop-young'`,
+    ).run();
 
     // Past TTL: one final push, then silence.
     const expired = sent(now + 15 * 60_000);
     expect(expired).toHaveLength(1);
-    expect(expired[0].message).toBe("DECISION NEEDED proposal prop-aging (ci-doctor@2): expired undecided");
+    expect(expired[0].message).toBe(
+      "DECISION NEEDED proposal prop-aging (ci-doctor@2): expired undecided",
+    );
     expect(sent(now + 16 * 60_000)).toEqual([]);
     expect(sent(now + 60 * 60_000)).toEqual([]);
   });
@@ -173,8 +273,18 @@ describe("notify (WM-65)", () => {
     const db = openDb(":memory:");
     const now = Date.now();
     insertEvent(db, { eventId: "evt-d" });
-    insertProposal(db, { id: "prop-approved", eventId: "evt-d", status: "approved", createdAt: new Date(now - 60 * 60_000).toISOString() });
-    insertProposal(db, { id: "prop-rejected", eventId: "evt-d", status: "rejected", createdAt: new Date(now - 60 * 60_000).toISOString() });
+    insertProposal(db, {
+      id: "prop-approved",
+      eventId: "evt-d",
+      status: "approved",
+      createdAt: new Date(now - 60 * 60_000).toISOString(),
+    });
+    insertProposal(db, {
+      id: "prop-rejected",
+      eventId: "evt-d",
+      status: "rejected",
+      createdAt: new Date(now - 60 * 60_000).toISOString(),
+    });
     expect(pendingNotifications(db, { now })).toEqual([]);
   });
 
@@ -182,23 +292,45 @@ describe("notify (WM-65)", () => {
     const dir = tmp("evrt-notify-fail-");
     const stub = stubNotifier(dir, { exitCode: 3 });
     const db = openDb(":memory:");
-    insertEvent(db, { eventId: "evt-f", status: "human_needed", lastPlanError: "plan exploded" });
+    insertEvent(db, {
+      eventId: "evt-f",
+      status: "human_needed",
+      lastPlanError: "plan exploded",
+    });
 
     const logs = [];
-    const out = notifyPending(db, { enabled: true, command: stub.bin, log: (l) => logs.push(l) });
+    const out = notifyPending(db, {
+      enabled: true,
+      command: stub.bin,
+      log: (l) => logs.push(l),
+    });
     expect(out.sent).toHaveLength(1);
     const results = await out.deliveries;
     expect(results[0].ok).toBe(false);
     expect(results[0].exitCode).toBe(3);
-    const row = db.query(`SELECT exit_code, error, inbox_item_id FROM notify_log WHERE kind = 'human_needed'`).get();
+    const row = db
+      .query(
+        `SELECT exit_code, error, inbox_item_id FROM notify_log WHERE kind = 'human_needed'`,
+      )
+      .get();
     expect(row.exit_code).toBe(3);
     expect(row.error).toContain("exited 3");
-    const inbox = db.query("SELECT delivery_json FROM inbox_items WHERE id = ?").get(row.inbox_item_id);
-    expect(JSON.parse(inbox.delivery_json).telegram.error).toContain("exited 3");
-    expect(logs.some((l) => l.includes("notify BLOCKED test/evt-f failed: notifier exited 3"))).toBe(true);
+    const inbox = db
+      .query("SELECT delivery_json FROM inbox_items WHERE id = ?")
+      .get(row.inbox_item_id);
+    expect(JSON.parse(inbox.delivery_json).telegram.error).toContain(
+      "exited 3",
+    );
+    expect(
+      logs.some((l) =>
+        l.includes("notify BLOCKED test/evt-f failed: notifier exited 3"),
+      ),
+    ).toBe(true);
 
     // Failed delivery does NOT retry: once means once.
-    expect(notifyPending(db, { enabled: true, command: stub.bin }).sent).toEqual([]);
+    expect(
+      notifyPending(db, { enabled: true, command: stub.bin }).sent,
+    ).toEqual([]);
   });
 
   test("a hanging notifier is killed at the timeout and never delays the caller", async () => {
@@ -217,7 +349,11 @@ describe("notify (WM-65)", () => {
   });
 
   test("a missing notifier binary resolves as a failure instead of throwing", async () => {
-    const outcome = await sendNotification("/nonexistent/notifier-binary", "msg", { timeoutMs: 2000 });
+    const outcome = await sendNotification(
+      "/nonexistent/notifier-binary",
+      "msg",
+      { timeoutMs: 2000 },
+    );
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toBeTruthy();
   });

--- a/event-runtime/lib/outbox.mjs
+++ b/event-runtime/lib/outbox.mjs
@@ -18,13 +18,18 @@ import { tx } from "./db.mjs";
  */
 export function publishOutbox(db, { sink, now = Date.now() } = {}) {
   const rows = db
-    .query(`SELECT seq, event_json FROM outbox WHERE published_at IS NULL ORDER BY seq`)
+    .query(
+      `SELECT seq, event_json FROM outbox WHERE published_at IS NULL ORDER BY seq`,
+    )
     .all();
   let delivered = 0;
   for (const row of rows) {
     sink(JSON.parse(row.event_json), row);
     tx(db, () => {
-      db.query(`UPDATE outbox SET published_at = ? WHERE seq = ?`).run(new Date(now).toISOString(), row.seq);
+      db.query(`UPDATE outbox SET published_at = ? WHERE seq = ?`).run(
+        new Date(now).toISOString(),
+        row.seq,
+      );
     });
     delivered += 1;
   }

--- a/event-runtime/lib/outbox.test.mjs
+++ b/event-runtime/lib/outbox.test.mjs
@@ -4,7 +4,12 @@ import { publishOutbox } from "./outbox.mjs";
 
 function seedOutbox(db, eventId) {
   db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`).run(
-    JSON.stringify({ schemaVersion: "factory.event/v1", eventId, type: "t.completed", payload: {} }),
+    JSON.stringify({
+      schemaVersion: "factory.event/v1",
+      eventId,
+      type: "t.completed",
+      payload: {},
+    }),
     new Date(0).toISOString(),
   );
 }
@@ -24,8 +29,18 @@ describe("publishOutbox", () => {
   test("a sink failure leaves the row unpublished for redelivery", () => {
     const db = openDb(":memory:");
     seedOutbox(db, "a");
-    expect(() => publishOutbox(db, { sink: () => { throw new Error("sink down"); } })).toThrow("sink down");
-    expect(db.query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`).get().n).toBe(1);
+    expect(() =>
+      publishOutbox(db, {
+        sink: () => {
+          throw new Error("sink down");
+        },
+      }),
+    ).toThrow("sink down");
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`)
+        .get().n,
+    ).toBe(1);
     const seen = [];
     expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toBe(1);
     expect(seen).toEqual(["a"]);

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -26,17 +26,35 @@ import { budgetExhausted } from "../../lib/spend.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
-import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS, FACTORY_ROOT } from "./config.mjs";
+import {
+  artifactsRoot,
+  DEAD_LETTER_AFTER,
+  DEFAULT_PROPOSAL_TTL_SECONDS,
+  FACTORY_ROOT,
+} from "./config.mjs";
 import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
-import { createRun, idempotencyKeyForNewRun, resolveIdempotency } from "./lifecycle.mjs";
+import {
+  createRun,
+  idempotencyKeyForNewRun,
+  resolveIdempotency,
+} from "./lifecycle.mjs";
 import { getAgent, getEventType, resolveModel } from "./registry.mjs";
 import { pinRepo } from "./repository.mjs";
-import { RepoError, getRepo, loadRepos, reposConfigPath, reposRoot } from "./repos.mjs";
+import {
+  RepoError,
+  getRepo,
+  loadRepos,
+  reposConfigPath,
+  reposRoot,
+} from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { inFlightRunsForAgent } from "./schedules.mjs";
 import { resolveInputRef } from "./workspace.mjs";
-import { autoApproveChains, buildChainApprovalPolicy } from "./auto-approval.mjs";
+import {
+  autoApproveChains,
+  buildChainApprovalPolicy,
+} from "./auto-approval.mjs";
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -53,7 +71,9 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
       case "inputHash":
         return inputHash;
       default:
-        throw new Error(`unknown idempotency scope field "${field}" (docs/event-runtime.md §5.4 — fail closed)`);
+        throw new Error(
+          `unknown idempotency scope field "${field}" (docs/event-runtime.md §5.4 — fail closed)`,
+        );
     }
   });
   return `${def.ref}:${def.output_contract}:${parts.join(":")}`;
@@ -67,7 +87,8 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
  * `repos` declared, or no `repo` in the payload, or a member of the set).
  */
 export function repoNotAllowed(def, payload) {
-  if (!Array.isArray(def.repos) || typeof payload?.repo !== "string") return null;
+  if (!Array.isArray(def.repos) || typeof payload?.repo !== "string")
+    return null;
   if (def.repos.includes(payload.repo)) return null;
   return `repo_not_allowed: ${def.ref} may not run over ${payload.repo} (allowed: ${def.repos.join(", ")})`;
 }
@@ -76,22 +97,41 @@ export function repoNotAllowed(def, payload) {
  * Pure assembly of the §5.2 RunSpec from a registered mapping. No I/O, no
  * clock reads beyond the injected `now` — same inputs, same spec, always.
  */
-export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion, adapterOverride, now = Date.now(), approvalPolicy = null } = {}) {
+export function buildRunSpec(
+  registry,
+  envelope,
+  mapping,
+  {
+    runId,
+    policyVersion,
+    adapterOverride,
+    now = Date.now(),
+    approvalPolicy = null,
+  } = {},
+) {
   const def = getAgent(registry, mapping.agent);
   let payload = envelope.payload;
   if (def.workspace?.type === "repository" && payload?.repo) {
     try {
-      payload = { ...payload, repoPin: pinRepo(payload.repo, payload.ref ?? undefined) };
+      payload = {
+        ...payload,
+        repoPin: pinRepo(payload.repo, payload.ref ?? undefined),
+      };
     } catch (err) {
       if (!payload?.repoPin) throw err;
     }
   }
   const inputHash = hashJson(payload);
   const placement = def.placement ?? mapping.placement ?? undefined;
-  const specEnvelope = payload === envelope.payload ? envelope : { ...envelope, payload };
+  const specEnvelope =
+    payload === envelope.payload ? envelope : { ...envelope, payload };
   let idempotencyKey = idempotencyKeyFor(mapping, def, specEnvelope, inputHash);
   const correlation = envelope.correlationId ?? envelope.eventId ?? null;
-  if (correlation && !mapping.idempotencyScope.includes("correlationId") && !mapping.idempotencyScope.includes("eventId")) {
+  if (
+    correlation &&
+    !mapping.idempotencyScope.includes("correlationId") &&
+    !mapping.idempotencyScope.includes("eventId")
+  ) {
     idempotencyKey = `${idempotencyKey}:${correlation}`;
   }
   return {
@@ -119,7 +159,10 @@ export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion
     // ignores the model; the spec still records what was routed. A null model
     // means the routed adapter takes none (not applicable).
     ...(def.model_tier !== undefined || def.model !== undefined
-      ? { modelTier: def.model_tier ?? null, model: resolveModel(def, mapping.adapter, registry.modelTiers) }
+      ? {
+          modelTier: def.model_tier ?? null,
+          model: resolveModel(def, mapping.adapter, registry.modelTiers),
+        }
       : {}),
     timeoutSeconds: def.limits.timeout_seconds,
     maxAttempts: def.limits.attempts,
@@ -142,44 +185,70 @@ function linearCli() {
 
 function fetchTicketDefault(ticketId) {
   try {
-    return JSON.parse(execFileSync("bun", [linearCli(), "get", ticketId, "--json"], {
-      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
-    }));
+    return JSON.parse(
+      execFileSync("bun", [linearCli(), "get", ticketId, "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
-    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`, { cause: err });
+    throw new Error(
+      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
+      { cause: err },
+    );
   }
 }
 
 function fetchViewerDefault() {
   try {
-    const out = execFileSync("bun", [linearCli(), "raw", "query{ viewer{ id name } }"], {
-      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
-    });
+    const out = execFileSync(
+      "bun",
+      [linearCli(), "raw", "query{ viewer{ id name } }"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     return JSON.parse(out)?.viewer ?? null;
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
-    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`, { cause: err });
+    throw new Error(
+      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
+      { cause: err },
+    );
   }
 }
 
 function fetchPullRequestDefault(payload) {
   try {
-    return JSON.parse(execFileSync(
-      "gh",
-      ["pr", "view", String(payload?.pr), "--repo", payload?.github, "--json", "state,headRefOid"],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-    ));
+    return JSON.parse(
+      execFileSync(
+        "gh",
+        [
+          "pr",
+          "view",
+          String(payload?.pr),
+          "--repo",
+          payload?.github,
+          "--json",
+          "state,headRefOid",
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
     if (/not found|no pull request/i.test(stderr)) return null;
-    throw new Error(`github_read_failed: ${stderr.trim().split("\n").pop() || err.message}`, { cause: err });
+    throw new Error(
+      `github_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
+      { cause: err },
+    );
   }
 }
 
-const IN_FLIGHT_QUERY =
-  `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
+const IN_FLIGHT_QUERY = `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
 
 const OWNED_PATHS_CLOSURE_CACHE = new Map();
 
@@ -188,7 +257,10 @@ function ownedPathsClosureDetails(repoName, repo, ticketDescription) {
   const cacheKey = `${repoName}::${repo.path}`;
   if (!OWNED_PATHS_CLOSURE_CACHE.has(cacheKey)) {
     const requirements = repo.ownedPathsPolicy.pinManifests?.length
-      ? readPinManifestRequirements(repo.path, repo.ownedPathsPolicy.pinManifests)
+      ? readPinManifestRequirements(
+          repo.path,
+          repo.ownedPathsPolicy.pinManifests,
+        )
       : [];
     OWNED_PATHS_CLOSURE_CACHE.set(cacheKey, requirements);
   }
@@ -203,13 +275,29 @@ function ownedPathsClosureDetails(repoName, repo, ticketDescription) {
 
 function fetchInFlightDefault(repoConfig) {
   try {
-    const out = execFileSync("bun", [linearCli(), "raw", IN_FLIGHT_QUERY, "--var", `t=${repoConfig.team}`, "--var", `p=${repoConfig.project}`], {
-      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
-    });
+    const out = execFileSync(
+      "bun",
+      [
+        linearCli(),
+        "raw",
+        IN_FLIGHT_QUERY,
+        "--var",
+        `t=${repoConfig.team}`,
+        "--var",
+        `p=${repoConfig.project}`,
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     return JSON.parse(out)?.issues?.nodes ?? [];
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
-    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`, { cause: err });
+    throw new Error(
+      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
+      { cause: err },
+    );
   }
 }
 
@@ -217,8 +305,11 @@ function policyMaxInFlight(root = reposRoot()) {
   const file = path.join(root, "config", "policy.yaml");
   if (!existsSync(file)) return DEFAULT_MAX_IN_FLIGHT;
   try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_in_flight_per_repo;
-    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : DEFAULT_MAX_IN_FLIGHT;
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency
+      ?.max_in_flight_per_repo;
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+      ? value
+      : DEFAULT_MAX_IN_FLIGHT;
   } catch {
     return DEFAULT_MAX_IN_FLIGHT;
   }
@@ -238,7 +329,8 @@ export function policyOwnedPathsCollision(root = reposRoot()) {
   const file = path.join(root, "config", "policy.yaml");
   if (!existsSync(file)) return DEFAULT_OWNED_PATHS_COLLISION;
   try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch?.owned_paths_collision;
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch
+      ?.owned_paths_collision;
     return value === "advisory" ? "advisory" : DEFAULT_OWNED_PATHS_COLLISION;
   } catch {
     return DEFAULT_OWNED_PATHS_COLLISION;
@@ -252,25 +344,32 @@ export function policyMaxConcurrentMerges(root = reposRoot()) {
   const file = path.join(root, "config", "policy.yaml");
   if (!existsSync(file)) return DEFAULT_MAX_CONCURRENT_MERGES;
   try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_concurrent_merges;
-    return Number.isInteger(value) && value > 0 ? value : DEFAULT_MAX_CONCURRENT_MERGES;
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency
+      ?.max_concurrent_merges;
+    return Number.isInteger(value) && value > 0
+      ? value
+      : DEFAULT_MAX_CONCURRENT_MERGES;
   } catch {
     return DEFAULT_MAX_CONCURRENT_MERGES;
   }
 }
 
 function agentSingletonEnabled(registry, agentRef) {
-  return Object.values(registry.schedules ?? {}).some((candidate) =>
-    candidate.enabled &&
-    candidate.singleton !== false &&
-    registry.eventTypes?.[candidate.eventType]?.agent === agentRef
+  return Object.values(registry.schedules ?? {}).some(
+    (candidate) =>
+      candidate.enabled &&
+      candidate.singleton !== false &&
+      registry.eventTypes?.[candidate.eventType]?.agent === agentRef,
   );
 }
 
 function singletonApplies(registry, envelope, agentRef) {
   const loop = envelope.payload?.loop;
   const schedule = loop ? registry.schedules?.[loop] : null;
-  if (schedule && registry.eventTypes?.[schedule.eventType]?.agent === agentRef) {
+  if (
+    schedule &&
+    registry.eventTypes?.[schedule.eventType]?.agent === agentRef
+  ) {
     return schedule.singleton !== false;
   }
   return agentSingletonEnabled(registry, agentRef);
@@ -279,17 +378,23 @@ function singletonApplies(registry, envelope, agentRef) {
 function loadRepoEscalatePaths(repoName, root = reposRoot()) {
   const file = reposConfigPath(root);
   if (!existsSync(file)) {
-    throw new RepoError(`${file}: cannot verify escalate_paths because repos.yaml is missing`);
+    throw new RepoError(
+      `${file}: cannot verify escalate_paths because repos.yaml is missing`,
+    );
   }
   let parsed;
   try {
     parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
   } catch (err) {
-    throw new RepoError(`${file}: cannot verify escalate_paths: ${err.message}`);
+    throw new RepoError(
+      `${file}: cannot verify escalate_paths: ${err.message}`,
+    );
   }
   const entry = (parsed?.repos ?? []).find((row) => row?.name === repoName);
   if (!entry) {
-    throw new RepoError(`${file}: cannot verify escalate_paths for unknown repo ${repoName}`);
+    throw new RepoError(
+      `${file}: cannot verify escalate_paths for unknown repo ${repoName}`,
+    );
   }
   const escalate = entry.escalate_paths ?? entry.escalatePaths;
   if (!Array.isArray(escalate)) {
@@ -327,7 +432,9 @@ function defaultBudgetRefusal() {
 }
 
 function sortUnique(values) {
-  return [...new Set(values.filter((value) => typeof value === "string"))].sort();
+  return [
+    ...new Set(values.filter((value) => typeof value === "string")),
+  ].sort();
 }
 
 function evidenceTicket(ticket, ticketId) {
@@ -337,7 +444,9 @@ function evidenceTicket(ticket, ticketId) {
     id: ticketId,
     state: ticket?.state?.name ?? null,
     assigneeNull: !ticket?.assignee,
-    labels: sortUnique((ticket?.labels?.nodes ?? []).map((label) => label?.name).filter(Boolean)),
+    labels: sortUnique(
+      (ticket?.labels?.nodes ?? []).map((label) => label?.name).filter(Boolean),
+    ),
     ownedPaths: effectiveOwnedPaths(description),
     ownedPathsParsed: parsed.length > 0,
     descriptionHash: hashJson(description),
@@ -371,16 +480,19 @@ function refusal(reason, evidence, decision = "noop", detail = null) {
  * The shared dispatch proof used at plan time and immediately before a chain
  * auto-approval. Its evidence captures every fact the latter needs to compare.
  */
-export function worktreeDispatchAutoEligibility(payload, {
-  fetchTicket = fetchTicketDefault,
-  fetchViewer = fetchViewerDefault,
-  fetchInFlight = fetchInFlightDefault,
-  countLeases = (repoName) => liveWorkerLeases(repoName).length,
-  maxInFlightFallback,
-  budgetRefusal = defaultBudgetRefusal,
-  claimedRetry = null,
-  now = Date.now(),
-} = {}) {
+export function worktreeDispatchAutoEligibility(
+  payload,
+  {
+    fetchTicket = fetchTicketDefault,
+    fetchViewer = fetchViewerDefault,
+    fetchInFlight = fetchInFlightDefault,
+    countLeases = (repoName) => liveWorkerLeases(repoName).length,
+    maxInFlightFallback,
+    budgetRefusal = defaultBudgetRefusal,
+    claimedRetry = null,
+    now = Date.now(),
+  } = {},
+) {
   const evidence = {
     checkedAt: new Date(resolveNow(now)).toISOString(),
     repo: {},
@@ -404,12 +516,17 @@ export function worktreeDispatchAutoEligibility(payload, {
     project: repo.project ?? null,
     capLimit: cap,
     capCurrent: live,
-    capSource: repo.maxInFlight === null || repo.maxInFlight === undefined ? "policy.yaml: max_in_flight_per_repo" : "repo.max_in_flight",
+    capSource:
+      repo.maxInFlight === null || repo.maxInFlight === undefined
+        ? "policy.yaml: max_in_flight_per_repo"
+        : "repo.max_in_flight",
   };
   evidence.checks.repo_found = true;
-  if (repo.reportOnly) return refusal("repo_report_only", evidence, "human_needed");
+  if (repo.reportOnly)
+    return refusal("repo_report_only", evidence, "human_needed");
   evidence.checks.repo_is_dispatchable = true;
-  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) return refusal("no_worktree_scripts", evidence, "human_needed");
+  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot)
+    return refusal("no_worktree_scripts", evidence, "human_needed");
   evidence.checks.worktree_scripts_configured = true;
 
   let budgetReason;
@@ -438,14 +555,15 @@ export function worktreeDispatchAutoEligibility(payload, {
     claimedRetry?.runId &&
     Number.isInteger(claimedRetry?.priorAttempt) &&
     claimedRetry.priorAttempt > 0 &&
-    claimedRetry?.reasonCode === "lease_expired"
+    claimedRetry?.reasonCode === "lease_expired",
   );
   let retryClaimedByFactory = false;
   let resumingOwnClaim = false;
   if (ticket.assignee) {
     if (!canResumeClaim) return refusal("ticket_assigned", evidence);
     const viewer = fetchViewer();
-    if (!viewer?.id || ticket.assignee.id !== viewer.id) return refusal("ticket_assigned", evidence);
+    if (!viewer?.id || ticket.assignee.id !== viewer.id)
+      return refusal("ticket_assigned", evidence);
     retryClaimedByFactory = true;
   } else {
     evidence.checks.ticket_unassigned = true;
@@ -468,7 +586,9 @@ export function worktreeDispatchAutoEligibility(payload, {
   }
 
   if (!evidence.ticket.labels.includes("ai:agent-ready")) {
-    if (!(resumingOwnClaim && evidence.ticket.labels.includes("ai:in-progress"))) {
+    if (!(
+      resumingOwnClaim && evidence.ticket.labels.includes("ai:in-progress")
+    )) {
       return refusal("ticket_not_agent_ready", evidence);
     }
     evidence.checks.ticket_in_progress_label_retry = true;
@@ -494,7 +614,11 @@ export function worktreeDispatchAutoEligibility(payload, {
       return refusal("owned_paths_not_closed", evidence, "human_needed");
     }
   } catch (err) {
-    return refusal(`owned_paths_not_closed: ${err.message || String(err)}`, evidence, "human_needed");
+    return refusal(
+      `owned_paths_not_closed: ${err.message || String(err)}`,
+      evidence,
+      "human_needed",
+    );
   }
 
   evidence.checks.ticket_not_escalated = true;
@@ -505,29 +629,45 @@ export function worktreeDispatchAutoEligibility(payload, {
     return refusal("ticket_security", evidence);
   }
   evidence.checks.ticket_not_security = true;
-  if (!repo.team || !repo.project) return refusal("repo_unconfigured: team/project missing for the in-flight query", evidence, "human_needed");
+  if (!repo.team || !repo.project)
+    return refusal(
+      "repo_unconfigured: team/project missing for the in-flight query",
+      evidence,
+      "human_needed",
+    );
   evidence.checks.repo_team_project = true;
 
   const inFlight = fetchInFlight(repo);
-  evidence.inFlight = inFlight.filter((issue) => String(issue.identifier) !== String(payload?.ticket)).map(evidenceInFlight);
+  evidence.inFlight = inFlight
+    .filter((issue) => String(issue.identifier) !== String(payload?.ticket))
+    .map(evidenceInFlight);
   const collisionMode = policyOwnedPathsCollision();
   evidence.checks.owned_paths_collision_mode = collisionMode;
   const inFlightPaths = evidence.inFlight.flatMap((issue) => issue.ownedPaths);
   if (pathsCollide(evidence.ticket.ownedPaths, inFlightPaths)) {
     evidence.checks.owned_paths_disjoint = false;
-    if (collisionMode !== "advisory") return refusal("owned_paths_overlap", evidence);
+    if (collisionMode !== "advisory")
+      return refusal("owned_paths_overlap", evidence);
     // Advisory: name every overlapping claim and who holds it, so the proposal
     // and `inspect` show what this run may have to rebase across, then only
     // refuse the pairs that cannot be reconciled by a rebase.
     evidence.ownedPathsOverlap = evidence.inFlight.flatMap((issue) =>
-      pathOverlaps(evidence.ticket.ownedPaths, issue.ownedPaths).map(({ a, b }) => ({
-        ticket: issue.id, path: a, inFlightPath: b,
-      })),
+      pathOverlaps(evidence.ticket.ownedPaths, issue.ownedPaths).map(
+        ({ a, b }) => ({
+          ticket: issue.id,
+          path: a,
+          inFlightPath: b,
+        }),
+      ),
     );
     const hard = evidence.inFlight.flatMap((issue) =>
-      hardPathConflicts(evidence.ticket.ownedPaths, issue.ownedPaths).map(({ a, b }) => ({
-        ticket: issue.id, path: a, inFlightPath: b,
-      })),
+      hardPathConflicts(evidence.ticket.ownedPaths, issue.ownedPaths).map(
+        ({ a, b }) => ({
+          ticket: issue.id,
+          path: a,
+          inFlightPath: b,
+        }),
+      ),
     );
     if (hard.length) {
       evidence.ownedPathsHardConflicts = hard;
@@ -540,7 +680,11 @@ export function worktreeDispatchAutoEligibility(payload, {
     evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
   } catch (err) {
     evidence.checks.escalate_paths = { verified: false };
-    return refusal(`escalate_paths_unverifiable: ${err.message}`, evidence, "human_needed");
+    return refusal(
+      `escalate_paths_unverifiable: ${err.message}`,
+      evidence,
+      "human_needed",
+    );
   }
   evidence.escalatePathIntersections = evidence.repo.escalatePaths.filter(
     (item) => pathsCollide(evidence.ticket.ownedPaths, [item]),
@@ -578,7 +722,10 @@ export function worktreeDispatchGate(payload, options = {}) {
 }
 
 function normalizedOwnedPath(value) {
-  return String(value ?? "").trim().replace(/^\.\//, "").replace(/\/$/, "");
+  return String(value ?? "")
+    .trim()
+    .replace(/^\.\//, "")
+    .replace(/\/$/, "");
 }
 
 /** Conservative containment proof for the Owned Paths syntax used by tickets. */
@@ -595,22 +742,31 @@ function ownedPathContains(ownerValue, candidateValue) {
   // wildcard-to-wildcard containment is deliberately fail-closed unless equal.
   const broadRoot = owner.endsWith("/**")
     ? owner.slice(0, -3).replace(/\/$/, "")
-    : (!/[*?{]/.test(owner) && !/\.[a-z0-9]+$/i.test(owner) ? owner : null);
+    : !/[*?{]/.test(owner) && !/\.[a-z0-9]+$/i.test(owner)
+      ? owner
+      : null;
   if (!broadRoot) return false;
-  const candidatePrefix = candidate.slice(0, candidate.search(/[*?{]/)).replace(/\/$/, "");
-  return candidatePrefix === broadRoot || candidatePrefix.startsWith(`${broadRoot}/`);
+  const candidatePrefix = candidate
+    .slice(0, candidate.search(/[*?{]/))
+    .replace(/\/$/, "");
+  return (
+    candidatePrefix === broadRoot || candidatePrefix.startsWith(`${broadRoot}/`)
+  );
 }
 
 /**
  * Claim-time gate for a bounded merge correction. Unlike dispatch, assignment
  * and In Review are expected facts, not refusal conditions.
  */
-export function worktreeMergeFixEligibility(payload, {
-  fetchTicket = fetchTicketDefault,
-  fetchPullRequest = fetchPullRequestDefault,
-  fetchNonTerminalRuns = () => [],
-  now = Date.now(),
-} = {}) {
+export function worktreeMergeFixEligibility(
+  payload,
+  {
+    fetchTicket = fetchTicketDefault,
+    fetchPullRequest = fetchPullRequestDefault,
+    fetchNonTerminalRuns = () => [],
+    now = Date.now(),
+  } = {},
+) {
   const evidence = {
     checkedAt: new Date(resolveNow(now)).toISOString(),
     ticket: null,
@@ -623,17 +779,26 @@ export function worktreeMergeFixEligibility(payload, {
   try {
     ticket = fetchTicket(payload?.ticket);
   } catch (err) {
-    return refusal("merge_fix_ticket_read_failed", evidence, "noop", err?.message ?? String(err));
+    return refusal(
+      "merge_fix_ticket_read_failed",
+      evidence,
+      "noop",
+      err?.message ?? String(err),
+    );
   }
   evidence.ticket = evidenceTicket(ticket, payload?.ticket);
-  if (!ticket) return refusal("merge_fix_ticket_not_found", evidence, "human_needed");
+  if (!ticket)
+    return refusal("merge_fix_ticket_not_found", evidence, "human_needed");
   evidence.checks.ticket_found = true;
 
   const labels = evidence.ticket.labels;
   if (labels.includes("ai:escalated")) {
     return refusal("merge_fix_ticket_escalated", evidence, "human_needed");
   }
-  if (labels.includes("type:security") || labels.some((label) => /security/i.test(label))) {
+  if (
+    labels.includes("type:security") ||
+    labels.some((label) => /security/i.test(label))
+  ) {
     return refusal("merge_fix_ticket_security", evidence, "human_needed");
   }
   evidence.checks.ticket_not_escalated_or_security = true;
@@ -649,7 +814,12 @@ export function worktreeMergeFixEligibility(payload, {
   const fixPaths = Array.isArray(payload?.ownedPaths) ? payload.ownedPaths : [];
   if (
     fixPaths.length === 0 ||
-    fixPaths.some((candidate) => !evidence.ticket.ownedPaths.some((owner) => ownedPathContains(owner, candidate)))
+    fixPaths.some(
+      (candidate) =>
+        !evidence.ticket.ownedPaths.some((owner) =>
+          ownedPathContains(owner, candidate),
+        ),
+    )
   ) {
     return refusal("merge_fix_owned_paths_moved", evidence);
   }
@@ -659,22 +829,36 @@ export function worktreeMergeFixEligibility(payload, {
   try {
     pullRequest = fetchPullRequest(payload);
   } catch (err) {
-    return refusal("merge_fix_pr_read_failed", evidence, "noop", err?.message ?? String(err));
+    return refusal(
+      "merge_fix_pr_read_failed",
+      evidence,
+      "noop",
+      err?.message ?? String(err),
+    );
   }
   evidence.pullRequest = pullRequest;
-  if (!pullRequest) return refusal("merge_fix_pr_not_found", evidence, "human_needed");
+  if (!pullRequest)
+    return refusal("merge_fix_pr_not_found", evidence, "human_needed");
   evidence.checks.pr_found = true;
-  if (pullRequest.state !== "OPEN") return refusal("merge_fix_pr_not_open", evidence);
+  if (pullRequest.state !== "OPEN")
+    return refusal("merge_fix_pr_not_open", evidence);
   evidence.checks.pr_open = true;
-  if (pullRequest.headRefOid !== payload?.headSha) return refusal("merge_fix_pr_moved", evidence);
+  if (pullRequest.headRefOid !== payload?.headSha)
+    return refusal("merge_fix_pr_moved", evidence);
   evidence.checks.pr_head_matches = true;
 
   try {
     evidence.competingRuns = fetchNonTerminalRuns(payload) ?? [];
   } catch (err) {
-    return refusal("merge_fix_run_check_failed", evidence, "noop", err?.message ?? String(err));
+    return refusal(
+      "merge_fix_run_check_failed",
+      evidence,
+      "noop",
+      err?.message ?? String(err),
+    );
   }
-  if (evidence.competingRuns.length > 0) return refusal("merge_fix_run_active", evidence);
+  if (evidence.competingRuns.length > 0)
+    return refusal("merge_fix_run_active", evidence);
   evidence.checks.no_competing_run = true;
 
   return { ok: true, evidence };
@@ -685,30 +869,77 @@ function worktreeGateFor(def) {
   return def.dispatchGateExempt === true ? null : "dispatch";
 }
 
-function insertProposal(db, { id, event, runId = null, decision, specJson = null, specHash = null, idempotencyKey = null, status, reason = null, at, ttlSeconds }) {
+function insertProposal(
+  db,
+  {
+    id,
+    event,
+    runId = null,
+    decision,
+    specJson = null,
+    specHash = null,
+    idempotencyKey = null,
+    status,
+    reason = null,
+    at,
+    ttlSeconds,
+  },
+) {
   db.query(
     `INSERT INTO proposals
        (id, event_source, event_id, run_id, decision, spec_json, spec_hash,
         idempotency_key, status, reason, created_at, ttl_seconds)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(id, event.source, event.event_id, runId, decision, specJson, specHash, idempotencyKey, status, reason, at, ttlSeconds);
+  ).run(
+    id,
+    event.source,
+    event.event_id,
+    runId,
+    decision,
+    specJson,
+    specHash,
+    idempotencyKey,
+    status,
+    reason,
+    at,
+    ttlSeconds,
+  );
   return db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
 }
 
 function setEventStatus(db, event, status) {
-  db.query(`UPDATE events SET status = ? WHERE source = ? AND event_id = ?`).run(status, event.source, event.event_id);
+  db.query(
+    `UPDATE events SET status = ? WHERE source = ? AND event_id = ?`,
+  ).run(status, event.source, event.event_id);
 }
 
 function isIdempotencyKeyCollision(err) {
-  return err?.code === "SQLITE_CONSTRAINT_UNIQUE" || /UNIQUE constraint failed: runs\.idempotency_key/.test(String(err?.message ?? err));
+  return (
+    err?.code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    /UNIQUE constraint failed: runs\.idempotency_key/.test(
+      String(err?.message ?? err),
+    )
+  );
 }
 
-function liveRunForInput(db, agentRef, { repo, ticket = null, includeFailed = false }) {
-  if (typeof repo !== "string" || (ticket !== null && typeof ticket !== "string")) return null;
+function liveRunForInput(
+  db,
+  agentRef,
+  { repo, ticket = null, includeFailed = false },
+) {
+  if (
+    typeof repo !== "string" ||
+    (ticket !== null && typeof ticket !== "string")
+  )
+    return null;
   const versionSeparator = agentRef.lastIndexOf("@");
-  const agentFamily = versionSeparator > 0 ? `${agentRef.slice(0, versionSeparator)}@*` : agentRef;
-  return db.query(
-    `SELECT run_id, state FROM runs
+  const agentFamily =
+    versionSeparator > 0
+      ? `${agentRef.slice(0, versionSeparator)}@*`
+      : agentRef;
+  return db
+    .query(
+      `SELECT run_id, state FROM runs
      WHERE state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
        AND (? = 1 OR state <> 'FAILED')
        AND json_extract(spec_json, '$.agent') GLOB ?
@@ -716,13 +947,20 @@ function liveRunForInput(db, agentRef, { repo, ticket = null, includeFailed = fa
        AND (? IS NULL OR json_extract(spec_json, '$.input.ticket') = ?)
      ORDER BY created_at ASC, rowid ASC
      LIMIT 1`,
-  ).get(includeFailed ? 1 : 0, agentFamily, repo, ticket, ticket);
+    )
+    .get(includeFailed ? 1 : 0, agentFamily, repo, ticket, ticket);
 }
 
 function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
   const proposal = insertProposal(db, {
-    id: newProposalId(), event, runId: blockingRun.run_id, decision: "noop", status: "resolved",
-    reason, at, ttlSeconds,
+    id: newProposalId(),
+    event,
+    runId: blockingRun.run_id,
+    decision: "noop",
+    status: "resolved",
+    reason,
+    at,
+    ttlSeconds,
   });
   setEventStatus(db, event, "noop");
   return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
@@ -730,7 +968,13 @@ function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
 
 function humanNeeded(db, event, reason, at, ttlSeconds) {
   const proposal = insertProposal(db, {
-    id: newProposalId(), event, decision: "human_needed", status: "open", reason, at, ttlSeconds,
+    id: newProposalId(),
+    event,
+    decision: "human_needed",
+    status: "open",
+    reason,
+    at,
+    ttlSeconds,
   });
   setEventStatus(db, event, "human_needed");
   return { decision: "human_needed", proposal, reason };
@@ -739,9 +983,15 @@ function humanNeeded(db, event, reason, at, ttlSeconds) {
 /** Idempotent path: the event was already planned — report what was decided. */
 function existingOutcome(db, event) {
   const proposal = db
-    .query(`SELECT * FROM proposals WHERE event_source = ? AND event_id = ? ORDER BY rowid DESC LIMIT 1`)
+    .query(
+      `SELECT * FROM proposals WHERE event_source = ? AND event_id = ? ORDER BY rowid DESC LIMIT 1`,
+    )
     .get(event.source, event.event_id);
-  if (!proposal) return { decision: event.status, reason: event.last_plan_error ?? undefined };
+  if (!proposal)
+    return {
+      decision: event.status,
+      reason: event.last_plan_error ?? undefined,
+    };
   return {
     decision: proposal.decision,
     proposal,
@@ -756,7 +1006,18 @@ function existingOutcome(db, event) {
  *
  * @returns {{ decision: string, proposal?: object, runId?: string, reason?: string }}
  */
-export function planEvent(db, registry, { source, eventId }, { now = Date.now(), policyVersion = "unknown", adapterOverride, artifactStore = artifactsRoot(), dispatch = {} } = {}) {
+export function planEvent(
+  db,
+  registry,
+  { source, eventId },
+  {
+    now = Date.now(),
+    policyVersion = "unknown",
+    adapterOverride,
+    artifactStore = artifactsRoot(),
+    dispatch = {},
+  } = {},
+) {
   // Dispatch gate for tier-2 worktree agents (WM-108), evaluated BEFORE the
   // write transaction: its Linear and lease reads must never hold the SQLite
   // write lock across a network round trip. The verdict is applied inside the
@@ -764,11 +1025,18 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
   // simply discards it via the idempotent early return.
   let worktreeRefusal = null;
   {
-    const row = db.query(`SELECT status, envelope_json FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
+    const row = db
+      .query(
+        `SELECT status, envelope_json FROM events WHERE source = ? AND event_id = ?`,
+      )
+      .get(source, eventId);
     if (row?.status === "admitted") {
       const preEnvelope = JSON.parse(row.envelope_json);
       const preMapping = getEventType(registry, preEnvelope.type);
-      const preDef = preMapping && preMapping.observe !== true ? registry.agents.get(preMapping.agent) : null;
+      const preDef =
+        preMapping && preMapping.observe !== true
+          ? registry.agents.get(preMapping.agent)
+          : null;
       // An event already outside the definition's repo scope (WM-64) skips
       // the gate's Linear/lease reads entirely — the transaction below parks
       // it repo_not_allowed before anything else happens.
@@ -778,13 +1046,18 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
         typeof preEnvelope.payload?.ticket === "string" &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
-        const eligibility = worktreeDispatchAutoEligibility(preEnvelope.payload, dispatch);
+        const eligibility = worktreeDispatchAutoEligibility(
+          preEnvelope.payload,
+          dispatch,
+        );
         worktreeRefusal = eligibility.ok ? null : eligibility.refusal;
       }
     }
   }
   return txImmediate(db, () => {
-    const event = db.query(`SELECT * FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
+    const event = db
+      .query(`SELECT * FROM events WHERE source = ? AND event_id = ?`)
+      .get(source, eventId);
     if (!event) throw new Error(`no admitted event (${source}, ${eventId})`);
     if (event.status !== "admitted") return existingOutcome(db, event);
 
@@ -792,16 +1065,29 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const at = new Date(now).toISOString();
 
     const mapping = getEventType(registry, envelope.type);
-    if (!mapping) return humanNeeded(db, event, "unregistered_event_type", at, DEFAULT_PROPOSAL_TTL_SECONDS);
-    const ttlSeconds = mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS;
+    if (!mapping)
+      return humanNeeded(
+        db,
+        event,
+        "unregistered_event_type",
+        at,
+        DEFAULT_PROPOSAL_TTL_SECONDS,
+      );
+    const ttlSeconds =
+      mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS;
 
     // Observe-only types (WM-75): the orchestrator reporting its own
     // lifecycle. The event is the deliverable — admitted, journaled,
     // queryable — and the plan is a typed NOOP, never an inbox ask.
     if (mapping.observe === true) {
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, decision: "noop", status: "resolved",
-        reason: "observed", at, ttlSeconds,
+        id: newProposalId(),
+        event,
+        decision: "noop",
+        status: "resolved",
+        reason: "observed",
+        at,
+        ttlSeconds,
       });
       setEventStatus(db, event, "noop");
       return { decision: "noop", proposal, reason: "observed" };
@@ -814,7 +1100,8 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // materialization for a repo the definition may never touch. Same idea as
     // the actions adapter's host allowlist, enforced at plan time.
     const scopeRefusal = repoNotAllowed(def, envelope.payload);
-    if (scopeRefusal) return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
+    if (scopeRefusal)
+      return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
 
     // A work scan reserves its repo as soon as its run is PROPOSED, before the
     // expensive model read can select a ticket. This is deliberately stronger
@@ -826,10 +1113,17 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       envelope.type === "factory.work.requested" &&
       typeof envelope.payload?.repo === "string"
     ) {
-      const blockingScan = liveRunForInput(db, mapping.agent, { repo: envelope.payload.repo });
+      const blockingScan = liveRunForInput(db, mapping.agent, {
+        repo: envelope.payload.repo,
+      });
       if (blockingScan) {
         return noopBehindLiveRun(
-          db, event, blockingScan, "work_scan_already_in_flight", at, ttlSeconds,
+          db,
+          event,
+          blockingScan,
+          "work_scan_already_in_flight",
+          at,
+          ttlSeconds,
         );
       }
     }
@@ -853,7 +1147,14 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       });
       if (blockingDispatch) {
         const reason = `ticket_dispatch_already_live:${blockingDispatch.run_id}:same_ticket_worktree_held`;
-        return noopBehindLiveRun(db, event, blockingDispatch, reason, at, ttlSeconds);
+        return noopBehindLiveRun(
+          db,
+          event,
+          blockingDispatch,
+          reason,
+          at,
+          ttlSeconds,
+        );
       }
     }
 
@@ -867,15 +1168,26 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // factory.work.requested already has the stricter repo-scoped reservation
     // above. Applying the schedule's legacy agent-global singleton as well
     // would incorrectly serialize unrelated repo queues after PROPOSED.
-    const singletonBlocked = envelope.type !== "factory.work.requested" &&
-      singletonApplies(registry, envelope, mapping.agent) && inFlight.length > 0;
-    const mergeCap = envelope.type === "factory.merge.requested" ? policyMaxConcurrentMerges() : null;
+    const singletonBlocked =
+      envelope.type !== "factory.work.requested" &&
+      singletonApplies(registry, envelope, mapping.agent) &&
+      inFlight.length > 0;
+    const mergeCap =
+      envelope.type === "factory.merge.requested"
+        ? policyMaxConcurrentMerges()
+        : null;
     const mergeCapBlocked = mergeCap !== null && inFlight.length >= mergeCap;
     if (singletonBlocked || mergeCapBlocked) {
       const blockingRun = inFlight[0];
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, runId: blockingRun.run_id, decision: "noop", status: "resolved",
-        reason: "previous_run_in_flight", at, ttlSeconds,
+        id: newProposalId(),
+        event,
+        runId: blockingRun.run_id,
+        decision: "noop",
+        status: "resolved",
+        reason: "previous_run_in_flight",
+        at,
+        ttlSeconds,
       });
       setEventStatus(db, event, "noop");
       return {
@@ -887,7 +1199,14 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     }
 
     const input = validate(def.inputSchema, envelope.payload);
-    if (!input.valid) return humanNeeded(db, event, `invalid_input: ${input.errors[0]}`, at, ttlSeconds);
+    if (!input.valid)
+      return humanNeeded(
+        db,
+        event,
+        `invalid_input: ${input.errors[0]}`,
+        at,
+        ttlSeconds,
+      );
 
     // Tier-2 dispatch gate verdict (docs/event-runtime-dispatch.md §§2–5,
     // WM-108), computed above outside this transaction. Refusals are typed
@@ -898,8 +1217,13 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
         return humanNeeded(db, event, worktreeRefusal.reason, at, ttlSeconds);
       }
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, decision: "noop", status: "resolved",
-        reason: worktreeRefusal.detail ?? worktreeRefusal.reason, at, ttlSeconds,
+        id: newProposalId(),
+        event,
+        decision: "noop",
+        status: "resolved",
+        reason: worktreeRefusal.detail ?? worktreeRefusal.reason,
+        at,
+        ttlSeconds,
       });
       setEventStatus(db, event, "noop");
       return { decision: "noop", proposal, reason: worktreeRefusal.reason };
@@ -915,12 +1239,21 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // has no chain relationship with.
     if (
       def.workspace?.type === "artifacts" &&
-      (def.workspace.inputs ?? []).some((i) => typeof i.from === "string" && i.from.startsWith("$.input.runPin."))
+      (def.workspace.inputs ?? []).some(
+        (i) =>
+          typeof i.from === "string" && i.from.startsWith("$.input.runPin."),
+      )
     ) {
       try {
         payload = { ...payload, runPin: pinRunArtifact(db, payload.runId) };
       } catch (err) {
-        return humanNeeded(db, event, `run_pin_failed: ${err.message}`, at, ttlSeconds);
+        return humanNeeded(
+          db,
+          event,
+          `run_pin_failed: ${err.message}`,
+          at,
+          ttlSeconds,
+        );
       }
     }
     // Declared artifact inputs must exist in the store at plan time (OPS-372):
@@ -931,29 +1264,61 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
         try {
           const sha = resolveInputRef(payload, entry.from);
           if (!findArtifact(artifactStore, sha)) {
-            return humanNeeded(db, event, `artifact_missing: ${entry.as} (${sha})`, at, ttlSeconds);
+            return humanNeeded(
+              db,
+              event,
+              `artifact_missing: ${entry.as} (${sha})`,
+              at,
+              ttlSeconds,
+            );
           }
         } catch (err) {
-          return humanNeeded(db, event, `artifact_ref_failed: ${err.message}`, at, ttlSeconds);
+          return humanNeeded(
+            db,
+            event,
+            `artifact_ref_failed: ${err.message}`,
+            at,
+            ttlSeconds,
+          );
         }
       }
     }
     if (def.workspace?.type === "repository") {
       try {
-        payload = { ...payload, repoPin: pinRepo(payload.repo, payload.ref ?? undefined) };
+        payload = {
+          ...payload,
+          repoPin: pinRepo(payload.repo, payload.ref ?? undefined),
+        };
       } catch (err) {
-        return humanNeeded(db, event, `repo_pin_failed: ${err.message}`, at, ttlSeconds);
+        return humanNeeded(
+          db,
+          event,
+          `repo_pin_failed: ${err.message}`,
+          at,
+          ttlSeconds,
+        );
       }
     }
 
-    const pinnedEnvelope = payload === envelope.payload ? envelope : { ...envelope, payload };
+    const pinnedEnvelope =
+      payload === envelope.payload ? envelope : { ...envelope, payload };
     if (pinnedEnvelope !== envelope) {
-      db.query(`UPDATE events SET envelope_json = ? WHERE source = ? AND event_id = ?`)
-        .run(canonicalJson(pinnedEnvelope), event.source, event.event_id);
+      db.query(
+        `UPDATE events SET envelope_json = ? WHERE source = ? AND event_id = ?`,
+      ).run(canonicalJson(pinnedEnvelope), event.source, event.event_id);
     }
-    let idempotencyKey = idempotencyKeyFor(mapping, def, pinnedEnvelope, hashJson(payload));
+    let idempotencyKey = idempotencyKeyFor(
+      mapping,
+      def,
+      pinnedEnvelope,
+      hashJson(payload),
+    );
     const correlation = envelope.correlationId ?? envelope.eventId ?? null;
-    if (correlation && !mapping.idempotencyScope.includes("correlationId") && !mapping.idempotencyScope.includes("eventId")) {
+    if (
+      correlation &&
+      !mapping.idempotencyScope.includes("correlationId") &&
+      !mapping.idempotencyScope.includes("eventId")
+    ) {
       idempotencyKey = `${idempotencyKey}:${correlation}`;
     }
     const existingRun = resolveIdempotency(db, {
@@ -964,11 +1329,23 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     });
     if (existingRun) {
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, runId: existingRun.run_id, decision: "noop",
-        idempotencyKey, status: "resolved", reason: "duplicate_run", at, ttlSeconds,
+        id: newProposalId(),
+        event,
+        runId: existingRun.run_id,
+        decision: "noop",
+        idempotencyKey,
+        status: "resolved",
+        reason: "duplicate_run",
+        at,
+        ttlSeconds,
       });
       setEventStatus(db, event, "noop");
-      return { decision: "noop", proposal, runId: existingRun.run_id, reason: "duplicate_run" };
+      return {
+        decision: "noop",
+        proposal,
+        runId: existingRun.run_id,
+        reason: "duplicate_run",
+      };
     }
 
     // A terminal generation releases the family for another trigger. Keep the
@@ -983,11 +1360,25 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
 
     let approvalPolicy = null;
     if (envelope.source === "chain") {
-      approvalPolicy = buildChainApprovalPolicy(envelope.type, { source: envelope.source });
-      if (approvalPolicy?.mode === "auto" && envelope.type === "factory.dispatch.requested") {
-        const result = worktreeDispatchAutoEligibility(pinnedEnvelope.payload, dispatch);
+      approvalPolicy = buildChainApprovalPolicy(envelope.type, {
+        source: envelope.source,
+      });
+      if (
+        approvalPolicy?.mode === "auto" &&
+        envelope.type === "factory.dispatch.requested"
+      ) {
+        const result = worktreeDispatchAutoEligibility(
+          pinnedEnvelope.payload,
+          dispatch,
+        );
         if (!result?.ok) {
-          return humanNeeded(db, event, `dispatch_eligibility_check_failed_at_plan: ${result?.refusal?.reason ?? "unknown"}`, at, ttlSeconds);
+          return humanNeeded(
+            db,
+            event,
+            `dispatch_eligibility_check_failed_at_plan: ${result?.refusal?.reason ?? "unknown"}`,
+            at,
+            ttlSeconds,
+          );
         }
         approvalPolicy = {
           ...approvalPolicy,
@@ -1010,11 +1401,16 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const specHash = hashJson(spec);
     try {
       createRun(db, {
-        runId, idempotencyKey, spec, specJson, specHash,
+        runId,
+        idempotencyKey,
+        spec,
+        specJson,
+        specHash,
         actor: "planner",
         correlationId: envelope.correlationId ?? null,
         causationId: envelope.causationId ?? null,
-        policyVersion, now,
+        policyVersion,
+        now,
       });
     } catch (err) {
       if (!isIdempotencyKeyCollision(err)) throw err;
@@ -1022,15 +1418,30 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       if (!winner) throw err;
       const reason = `idempotency_collision:${winner.run_id}`;
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, runId: winner.run_id, decision: "noop",
-        idempotencyKey, status: "resolved", reason, at, ttlSeconds,
+        id: newProposalId(),
+        event,
+        runId: winner.run_id,
+        decision: "noop",
+        idempotencyKey,
+        status: "resolved",
+        reason,
+        at,
+        ttlSeconds,
       });
       setEventStatus(db, event, "noop");
       return { decision: "noop", proposal, runId: winner.run_id, reason };
     }
     const proposal = insertProposal(db, {
-      id: newProposalId(), event, runId, decision: "run",
-      specJson, specHash, idempotencyKey, status: "open", at, ttlSeconds,
+      id: newProposalId(),
+      event,
+      runId,
+      decision: "run",
+      specJson,
+      specHash,
+      idempotencyKey,
+      status: "open",
+      at,
+      ttlSeconds,
     });
     setEventStatus(db, event, "planned");
     return { decision: "run", proposal, runId };
@@ -1044,12 +1455,20 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
  * human_needed proposal for it is superseded so the inbox does not show a
  * stale ask next to a fresh plan.
  */
-export function requeueEvent(db, { source, eventId }, { actor = "operator", now = Date.now() } = {}) {
+export function requeueEvent(
+  db,
+  { source, eventId },
+  { actor = "operator", now = Date.now() } = {},
+) {
   return txImmediate(db, () => {
-    const event = db.query(`SELECT status FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE source = ? AND event_id = ?`)
+      .get(source, eventId);
     if (!event) throw new Error(`unknown event (${source}, ${eventId})`);
     if (!["dead_lettered", "human_needed"].includes(event.status)) {
-      throw new Error(`requeue applies to dead_lettered or human_needed events, not ${event.status}`);
+      throw new Error(
+        `requeue applies to dead_lettered or human_needed events, not ${event.status}`,
+      );
     }
     db.query(
       `UPDATE proposals SET status = 'superseded', decided_at = ?, decided_by = ?, reason = 'requeued'
@@ -1069,18 +1488,27 @@ export function requeueEvent(db, { source, eventId }, { actor = "operator", now 
  * The archive marker removes it from the active doctor deck while preserving
  * the event in the ledger and allowing a later explicit requeue.
  */
-export function archiveDeadLetteredEvent(db, { source, eventId }, { now = Date.now() } = {}) {
+export function archiveDeadLetteredEvent(
+  db,
+  { source, eventId },
+  { now = Date.now() } = {},
+) {
   return txImmediate(db, () => {
     const event = db
-      .query(`SELECT status, archived_at FROM events WHERE source = ? AND event_id = ?`)
+      .query(
+        `SELECT status, archived_at FROM events WHERE source = ? AND event_id = ?`,
+      )
       .get(source, eventId);
     if (!event) throw new Error(`unknown event (${source}, ${eventId})`);
     if (event.status !== "dead_lettered") {
-      throw new Error(`archive applies to dead_lettered events, not ${event.status}`);
+      throw new Error(
+        `archive applies to dead_lettered events, not ${event.status}`,
+      );
     }
     if (!event.archived_at) {
-      db.query(`UPDATE events SET archived_at = ? WHERE source = ? AND event_id = ?`)
-        .run(new Date(now).toISOString(), source, eventId);
+      db.query(
+        `UPDATE events SET archived_at = ? WHERE source = ? AND event_id = ?`,
+      ).run(new Date(now).toISOString(), source, eventId);
     }
     return { archived: true };
   });
@@ -1095,7 +1523,11 @@ export function archiveDeadLetteredEvent(db, { source, eventId }, { now = Date.n
  * @returns {{ planned: number, failed: number, deadLettered: number }}
  */
 export function planAdmittedEvents(db, registry, opts = {}) {
-  const rows = db.query(`SELECT source, event_id FROM events WHERE status = 'admitted' ORDER BY admitted_at, rowid`).all();
+  const rows = db
+    .query(
+      `SELECT source, event_id FROM events WHERE status = 'admitted' ORDER BY admitted_at, rowid`,
+    )
+    .all();
   let planned = 0;
   let failed = 0;
   let deadLettered = 0;
@@ -1114,9 +1546,15 @@ export function planAdmittedEvents(db, registry, opts = {}) {
           db.query(
             `UPDATE events SET plan_failures = plan_failures + 1, last_plan_error = ? WHERE source = ? AND event_id = ?`,
           ).run(message, source, eventId);
-          const row = db.query(`SELECT plan_failures FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
+          const row = db
+            .query(
+              `SELECT plan_failures FROM events WHERE source = ? AND event_id = ?`,
+            )
+            .get(source, eventId);
           if (row.plan_failures >= DEAD_LETTER_AFTER) {
-            db.query(`UPDATE events SET status = 'dead_lettered' WHERE source = ? AND event_id = ?`).run(source, eventId);
+            db.query(
+              `UPDATE events SET status = 'dead_lettered' WHERE source = ? AND event_id = ?`,
+            ).run(source, eventId);
           }
           return row.plan_failures;
         });

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -52,7 +52,9 @@ describe("idempotencyKeyFor", () => {
     const a = idempotencyKeyFor(mapping, def, envelope(), inputHash);
     const b = idempotencyKeyFor(mapping, def, envelope(), inputHash);
     expect(a).toBe(b);
-    expect(a).toBe(`factory-status-report@1:factory.status-report/v1:workflow-01:${inputHash}`);
+    expect(a).toBe(
+      `factory-status-report@1:factory.status-report/v1:workflow-01:${inputHash}`,
+    );
   });
 
   test("correlationId scope falls back to eventId; subject scope to empty string", () => {
@@ -62,15 +64,25 @@ describe("idempotencyKeyFor", () => {
       `factory-status-report@1:factory.status-report/v1:delivery-1:${inputHash}`,
     );
     const subjectScope = { idempotencyScope: ["subject"] };
-    expect(idempotencyKeyFor(subjectScope, def, envelope({ subject: null }), inputHash)).toBe(
-      "factory-status-report@1:factory.status-report/v1:",
-    );
+    expect(
+      idempotencyKeyFor(
+        subjectScope,
+        def,
+        envelope({ subject: null }),
+        inputHash,
+      ),
+    ).toBe("factory-status-report@1:factory.status-report/v1:");
   });
 
   test("unknown scope field throws (fail closed)", () => {
-    expect(() => idempotencyKeyFor({ idempotencyScope: ["deliveryColor"] }, def, envelope(), "sha256:x")).toThrow(
-      /unknown idempotency scope/,
-    );
+    expect(() =>
+      idempotencyKeyFor(
+        { idempotencyScope: ["deliveryColor"] },
+        def,
+        envelope(),
+        "sha256:x",
+      ),
+    ).toThrow(/unknown idempotency scope/);
   });
 });
 
@@ -84,7 +96,10 @@ describe("merge concurrency policy", () => {
     expect(policyMaxConcurrentMerges(root)).toBe(2);
 
     for (const invalid of ["0", "1.5", "many"]) {
-      writeFileSync(policy, `concurrency:\n  max_concurrent_merges: ${invalid}\n`);
+      writeFileSync(
+        policy,
+        `concurrency:\n  max_concurrent_merges: ${invalid}\n`,
+      );
       expect(policyMaxConcurrentMerges(root)).toBe(1);
     }
   });
@@ -94,7 +109,10 @@ describe("planEvent", () => {
   test("run decision: PROPOSED run + open proposal with the §5.2 spec", () => {
     const db = openDb(":memory:");
     const ref = admit(db);
-    const outcome = planEvent(db, registry, ref, { now: NOW, policyVersion: "git:test" });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
 
     expect(outcome.decision).toBe("run");
     expect(runState(db, outcome.runId)).toBe("PROPOSED");
@@ -126,17 +144,27 @@ describe("planEvent", () => {
       idempotencyKey: `factory-status-report@1:factory.status-report/v1:workflow-01:${hashJson(payload)}`,
     });
 
-    const event = db.query(`SELECT status FROM events WHERE source = ? AND event_id = ?`).get(ref.source, ref.eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE source = ? AND event_id = ?`)
+      .get(ref.source, ref.eventId);
     expect(event.status).toBe("planned");
-    expect(lifecycleOf(db, outcome.runId).map((e) => e.to_state)).toEqual(["PROPOSED"]);
+    expect(lifecycleOf(db, outcome.runId).map((e) => e.to_state)).toEqual([
+      "PROPOSED",
+    ]);
     expect(lifecycleOf(db, outcome.runId)[0].actor).toBe("planner");
   });
 
   test("planning the same event twice is idempotent: one run, one proposal", () => {
     const db = openDb(":memory:");
     const ref = admit(db);
-    const first = planEvent(db, registry, ref, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, registry, ref, { now: NOW + 60_000, policyVersion: "git:test" });
+    const first = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, registry, ref, {
+      now: NOW + 60_000,
+      policyVersion: "git:test",
+    });
     expect(second.decision).toBe("run");
     expect(second.runId).toBe(first.runId);
     expect(second.proposal.id).toBe(first.proposal.id);
@@ -148,8 +176,14 @@ describe("planEvent", () => {
     const db = openDb(":memory:");
     const ref1 = admit(db, { eventId: "delivery-1" });
     const ref2 = admit(db, { eventId: "delivery-2" });
-    const first = planEvent(db, registry, ref1, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, registry, ref2, { now: NOW + 1000, policyVersion: "git:test" });
+    const first = planEvent(db, registry, ref1, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, registry, ref2, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
 
     expect(first.decision).toBe("run");
     expect(second.decision).toBe("noop");
@@ -158,8 +192,14 @@ describe("planEvent", () => {
     expect(second.proposal.run_id).toBe(first.runId);
     expect(second.proposal.status).toBe("resolved");
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
-    expect(db.query(`SELECT COUNT(*) AS n FROM proposals WHERE status = 'open'`).get().n).toBe(1);
-    const event = db.query(`SELECT status FROM events WHERE event_id = 'delivery-2'`).get();
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM proposals WHERE status = 'open'`)
+        .get().n,
+    ).toBe(1);
+    const event = db
+      .query(`SELECT status FROM events WHERE event_id = 'delivery-2'`)
+      .get();
     expect(event.status).toBe("noop");
   });
 
@@ -169,17 +209,31 @@ describe("planEvent", () => {
       eventId: "keep-1",
       correlationId: "alert-1",
       type: "keephq.disk-remediate.requested",
-      payload: { host: "lab", mount: "/", actions: [{ action: "docker-builder-prune" }] },
+      payload: {
+        host: "lab",
+        mount: "/",
+        actions: [{ action: "docker-builder-prune" }],
+      },
     });
     const ref2 = admit(db, {
       eventId: "keep-2",
       correlationId: "alert-2",
       type: "keephq.disk-remediate.requested",
-      payload: { host: "lab", mount: "/", actions: [{ action: "docker-builder-prune" }] },
+      payload: {
+        host: "lab",
+        mount: "/",
+        actions: [{ action: "docker-builder-prune" }],
+      },
     });
 
-    const first = planEvent(db, registry, ref1, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, registry, ref2, { now: NOW + 1000, policyVersion: "git:test" });
+    const first = planEvent(db, registry, ref1, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, registry, ref2, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
 
     expect(first.decision).toBe("run");
     expect(second.decision).toBe("run");
@@ -193,17 +247,31 @@ describe("planEvent", () => {
       eventId: "keep-1",
       correlationId: "alert-1",
       type: "keephq.disk-remediate.requested",
-      payload: { host: "lab", mount: "/", actions: [{ action: "docker-builder-prune" }] },
+      payload: {
+        host: "lab",
+        mount: "/",
+        actions: [{ action: "docker-builder-prune" }],
+      },
     });
     const ref2 = admit(db, {
       eventId: "keep-dup",
       correlationId: "alert-1",
       type: "keephq.disk-remediate.requested",
-      payload: { host: "lab", mount: "/", actions: [{ action: "docker-builder-prune" }] },
+      payload: {
+        host: "lab",
+        mount: "/",
+        actions: [{ action: "docker-builder-prune" }],
+      },
     });
 
-    const first = planEvent(db, registry, ref1, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, registry, ref2, { now: NOW + 1000, policyVersion: "git:test" });
+    const first = planEvent(db, registry, ref1, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, registry, ref2, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
 
     expect(first.decision).toBe("run");
     expect(second.decision).toBe("noop");
@@ -213,7 +281,11 @@ describe("planEvent", () => {
   });
 
   test("chain repeat triggers coalesce while active and self-feed again after terminal completion (WM-319)", () => {
-    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
     synthetic.eventTypes["test.chain.requested"] = {
       agent: "test-chain@1",
       adapter: "fake",
@@ -242,31 +314,77 @@ describe("planEvent", () => {
     });
     const db = openDb(":memory:");
 
-    const firstRef = admit(db, chainEvent("chain-dispatch-1", "run_dispatch_1"));
-    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+    const firstRef = admit(
+      db,
+      chainEvent("chain-dispatch-1", "run_dispatch_1"),
+    );
+    const first = planEvent(db, synthetic, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(first.decision).toBe("run");
 
-    const concurrentRef = admit(db, chainEvent("chain-dispatch-2", "run_dispatch_2"));
-    const concurrent = planEvent(db, synthetic, concurrentRef, { now: NOW + 1000, policyVersion: "git:test" });
-    expect(concurrent).toMatchObject({ decision: "noop", reason: "duplicate_run", runId: first.runId });
+    const concurrentRef = admit(
+      db,
+      chainEvent("chain-dispatch-2", "run_dispatch_2"),
+    );
+    const concurrent = planEvent(db, synthetic, concurrentRef, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
+    expect(concurrent).toMatchObject({
+      decision: "noop",
+      reason: "duplicate_run",
+      runId: first.runId,
+    });
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
 
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId: first.runId, to, actor: "test" });
     }
 
-    const nextCycleRef = admit(db, chainEvent("chain-dispatch-3", "run_dispatch_3"));
-    const nextCycle = planEvent(db, synthetic, nextCycleRef, { now: NOW + 2000, policyVersion: "git:test" });
+    const nextCycleRef = admit(
+      db,
+      chainEvent("chain-dispatch-3", "run_dispatch_3"),
+    );
+    const nextCycle = planEvent(db, synthetic, nextCycleRef, {
+      now: NOW + 2000,
+      policyVersion: "git:test",
+    });
     expect(nextCycle.decision).toBe("run");
     expect(nextCycle.runId).not.toBe(first.runId);
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
 
-    const coalescedAgainRef = admit(db, chainEvent("chain-dispatch-4", "run_dispatch_4"));
-    const coalescedAgain = planEvent(db, synthetic, coalescedAgainRef, { now: NOW + 3000, policyVersion: "git:test" });
-    expect(coalescedAgain).toMatchObject({ decision: "noop", reason: "duplicate_run", runId: nextCycle.runId });
+    const coalescedAgainRef = admit(
+      db,
+      chainEvent("chain-dispatch-4", "run_dispatch_4"),
+    );
+    const coalescedAgain = planEvent(db, synthetic, coalescedAgainRef, {
+      now: NOW + 3000,
+      policyVersion: "git:test",
+    });
+    expect(coalescedAgain).toMatchObject({
+      decision: "noop",
+      reason: "duplicate_run",
+      runId: nextCycle.runId,
+    });
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
 
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId: nextCycle.runId, to, actor: "test" });
     }
 
@@ -287,16 +405,31 @@ describe("planEvent", () => {
       policyVersion: "git:test",
       now: NOW + 4000,
     });
-    transition(db, { runId: "run_collision_winner", to: "CANCELLED", actor: "test", now: NOW + 4000 });
+    transition(db, {
+      runId: "run_collision_winner",
+      to: "CANCELLED",
+      actor: "test",
+      now: NOW + 4000,
+    });
 
-    const collisionRef = admit(db, chainEvent(collisionEventId, "run_dispatch_5"));
-    const collision = planEvent(db, synthetic, collisionRef, { now: NOW + 5000, policyVersion: "git:test" });
+    const collisionRef = admit(
+      db,
+      chainEvent(collisionEventId, "run_dispatch_5"),
+    );
+    const collision = planEvent(db, synthetic, collisionRef, {
+      now: NOW + 5000,
+      policyVersion: "git:test",
+    });
     expect(collision).toMatchObject({
       decision: "noop",
       reason: "idempotency_collision:run_collision_winner",
       runId: "run_collision_winner",
     });
-    expect(db.query(`SELECT status FROM events WHERE event_id = ?`).get(collisionEventId).status).toBe("noop");
+    expect(
+      db
+        .query(`SELECT status FROM events WHERE event_id = ?`)
+        .get(collisionEventId).status,
+    ).toBe("noop");
   });
 
   test("concurrent work scans for one repo reserve selection before either can duplicate it (WM-491)", () => {
@@ -323,8 +456,14 @@ describe("planEvent", () => {
       payload: { repo: "factory" },
     });
 
-    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, synthetic, secondRef, { now: NOW + 1000, policyVersion: "git:test" });
+    const first = planEvent(db, synthetic, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, synthetic, secondRef, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
 
     expect(first.decision).toBe("run");
     expect(runState(db, first.runId)).toBe("PROPOSED");
@@ -345,7 +484,12 @@ describe("planEvent", () => {
       correlationId: "work-other-repo",
       payload: { repo: "bj29", loop: "work-bj29" },
     });
-    expect(planEvent(db, synthetic, otherRepoRef, { now: NOW + 2000, policyVersion: "git:test" }).decision).toBe("run");
+    expect(
+      planEvent(db, synthetic, otherRepoRef, {
+        now: NOW + 2000,
+        policyVersion: "git:test",
+      }).decision,
+    ).toBe("run");
 
     // A failed read emitted no dispatch chain and must release the queue; unlike
     // a failed dispatch, a failed scan owns no retained worktree to protect.
@@ -359,10 +503,20 @@ describe("planEvent", () => {
       correlationId: "work-after-failure",
       payload: { repo: "factory" },
     });
-    const afterFailure = planEvent(db, synthetic, afterFailureRef, { now: NOW + 3000, policyVersion: "git:test" });
+    const afterFailure = planEvent(db, synthetic, afterFailureRef, {
+      now: NOW + 3000,
+      policyVersion: "git:test",
+    });
     expect(afterFailure.decision).toBe("run");
 
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId: afterFailure.runId, to, actor: "test" });
     }
     const nextCycleRef = admit(db, {
@@ -372,11 +526,20 @@ describe("planEvent", () => {
       correlationId: "work-hot-next",
       payload: { repo: "factory" },
     });
-    expect(planEvent(db, synthetic, nextCycleRef, { now: NOW + 4000, policyVersion: "git:test" }).decision).toBe("run");
+    expect(
+      planEvent(db, synthetic, nextCycleRef, {
+        now: NOW + 4000,
+        policyVersion: "git:test",
+      }).decision,
+    ).toBe("run");
   });
 
   test("live reservations survive an agent version upgrade (WM-491)", () => {
-    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
     synthetic.agents.set("work-scan@1", {
       ...registry.agents.get("work-scan@1"),
       workspace: { type: "ephemeral" },
@@ -389,7 +552,10 @@ describe("planEvent", () => {
       correlationId: "work-v1",
       payload: { repo: "factory" },
     });
-    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+    const first = planEvent(db, synthetic, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
 
     synthetic.eventTypes["factory.work.requested"] = {
       ...synthetic.eventTypes["factory.work.requested"],
@@ -407,7 +573,12 @@ describe("planEvent", () => {
       correlationId: "work-v2",
       payload: { repo: "factory" },
     });
-    expect(planEvent(db, synthetic, nextRef, { now: NOW + 1000, policyVersion: "git:test" })).toMatchObject({
+    expect(
+      planEvent(db, synthetic, nextRef, {
+        now: NOW + 1000,
+        policyVersion: "git:test",
+      }),
+    ).toMatchObject({
       decision: "noop",
       reason: "work_scan_already_in_flight",
       runId: first.runId,
@@ -434,8 +605,14 @@ describe("planEvent", () => {
     const firstRef = admit(db, dispatch("dispatch-hot-1"));
     const secondRef = admit(db, dispatch("dispatch-hot-2"));
 
-    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
-    const second = planEvent(db, synthetic, secondRef, { now: NOW + 1000, policyVersion: "git:test" });
+    const first = planEvent(db, synthetic, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const second = planEvent(db, synthetic, secondRef, {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
 
     expect(first.decision).toBe("run");
     expect(second).toMatchObject({
@@ -450,7 +627,10 @@ describe("planEvent", () => {
     const malformedEnvelope = dispatch("dispatch-malformed");
     delete malformedEnvelope.payload.ticket;
     const malformedRef = admit(db, malformedEnvelope);
-    const malformed = planEvent(db, synthetic, malformedRef, { now: NOW + 2000, policyVersion: "git:test" });
+    const malformed = planEvent(db, synthetic, malformedRef, {
+      now: NOW + 2000,
+      policyVersion: "git:test",
+    });
     expect(malformed.decision).toBe("human_needed");
     expect(malformed.reason).toMatch(/^invalid_input: /);
 
@@ -458,16 +638,32 @@ describe("planEvent", () => {
       transition(db, { runId: first.runId, to, actor: "test" });
     }
     const failedRetryRef = admit(db, dispatch("dispatch-while-retryable"));
-    expect(planEvent(db, synthetic, failedRetryRef, { now: NOW + 3000, policyVersion: "git:test" })).toMatchObject({
+    expect(
+      planEvent(db, synthetic, failedRetryRef, {
+        now: NOW + 3000,
+        policyVersion: "git:test",
+      }),
+    ).toMatchObject({
       decision: "noop",
       reason: `ticket_dispatch_already_live:${first.runId}:same_ticket_worktree_held`,
     });
 
-    for (const to of ["QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+    for (const to of [
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
       transition(db, { runId: first.runId, to, actor: "test" });
     }
     const nextRef = admit(db, dispatch("dispatch-next-cycle"));
-    expect(planEvent(db, synthetic, nextRef, { now: NOW + 4000, policyVersion: "git:test" }).decision).toBe("run");
+    expect(
+      planEvent(db, synthetic, nextRef, {
+        now: NOW + 4000,
+        policyVersion: "git:test",
+      }).decision,
+    ).toBe("run");
   });
 
   test("unregistered event type → human_needed", () => {
@@ -478,7 +674,9 @@ describe("planEvent", () => {
     expect(outcome.reason).toBe("unregistered_event_type");
     expect(outcome.proposal.decision).toBe("human_needed");
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("human_needed");
   });
 
@@ -493,7 +691,9 @@ describe("planEvent", () => {
     expect(outcome.reason).toBe("observed");
     expect(outcome.proposal.status).toBe("resolved");
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("noop");
   });
 
@@ -504,7 +704,9 @@ describe("planEvent", () => {
     expect(outcome.decision).toBe("human_needed");
     expect(outcome.reason.startsWith("invalid_input: ")).toBe(true);
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("human_needed");
   });
 });
@@ -513,7 +715,11 @@ describe("planEvent worktree gate (WM-108)", () => {
   // A synthetic worktree-workspace agent: the real dispatch@1 lands with its
   // own tests; this proves the gate itself, independent of any one agent.
   function syntheticRegistry() {
-    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
     synthetic.eventTypes["test.worktree.requested"] = {
       agent: "test-worktree@1",
       adapter: "claude",
@@ -528,7 +734,11 @@ describe("planEvent worktree gate (WM-108)", () => {
       capabilities: { services: [] },
       limits: { timeout_seconds: 60, attempts: 1 },
       mutating: true,
-      inputSchema: { type: "object", required: ["repo", "ticket"], properties: { repo: { type: "string" }, ticket: { type: "string" } } },
+      inputSchema: {
+        type: "object",
+        required: ["repo", "ticket"],
+        properties: { repo: { type: "string" }, ticket: { type: "string" } },
+      },
     });
     return synthetic;
   }
@@ -555,20 +765,30 @@ describe("planEvent worktree gate (WM-108)", () => {
   });
 
   test("a dispatch-exempt worktree agent bypasses dispatch-only planning checks", () => {
-    withReposRoot(`repos:\n  - name: repairable\n    path: /tmp/nowhere\n    base: develop\n`, () => {
-      const synthetic = syntheticRegistry();
-      synthetic.agents.set("test-worktree@1", {
-        ...synthetic.agents.get("test-worktree@1"),
-        dispatchGateExempt: true,
-      });
-      const db = openDb(":memory:");
-      const ref = admit(db, dispatchEnvelope({ repo: "repairable", ticket: "WM-500" }));
-      const outcome = planEvent(db, synthetic, ref, {
-        now: NOW,
-        dispatch: { fetchTicket: () => { throw new Error("dispatch gate must not run"); } },
-      });
-      expect(outcome.decision).toBe("run");
-    });
+    withReposRoot(
+      `repos:\n  - name: repairable\n    path: /tmp/nowhere\n    base: develop\n`,
+      () => {
+        const synthetic = syntheticRegistry();
+        synthetic.agents.set("test-worktree@1", {
+          ...synthetic.agents.get("test-worktree@1"),
+          dispatchGateExempt: true,
+        });
+        const db = openDb(":memory:");
+        const ref = admit(
+          db,
+          dispatchEnvelope({ repo: "repairable", ticket: "WM-500" }),
+        );
+        const outcome = planEvent(db, synthetic, ref, {
+          now: NOW,
+          dispatch: {
+            fetchTicket: () => {
+              throw new Error("dispatch gate must not run");
+            },
+          },
+        });
+        expect(outcome.decision).toBe("run");
+      },
+    );
   });
 
   test("merge-fix@1 bypasses the tier-2 dispatch gate while dispatch@1 does not", () => {
@@ -642,58 +862,93 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
     expect(eligible.ok).toBe(true);
 
-    expect(worktreeMergeFixEligibility(payload, {
-      fetchTicket: () => ({ ...ticket, labels: { nodes: [{ name: "ai:escalated" }] } }),
-      fetchPullRequest: () => ({ state: "OPEN", headRefOid: payload.headSha }),
-      now: NOW,
-    }).refusal.reason).toBe("merge_fix_ticket_escalated");
-    expect(worktreeMergeFixEligibility(payload, {
-      fetchTicket: () => ticket,
-      fetchPullRequest: () => ({ state: "OPEN", headRefOid: "b".repeat(40) }),
-      now: NOW,
-    }).refusal.reason).toBe("merge_fix_pr_moved");
-    expect(worktreeMergeFixEligibility(payload, {
-      fetchTicket: () => ticket,
-      fetchPullRequest: () => ({ state: "OPEN", headRefOid: payload.headSha }),
-      fetchNonTerminalRuns: () => [{ runId: "run_other", state: "RUNNING" }],
-      now: NOW,
-    }).refusal.reason).toBe("merge_fix_run_active");
-    expect(worktreeMergeFixEligibility({ ...payload, ownedPaths: ["outside/scope.mjs"] }, {
-      fetchTicket: () => ticket,
-      fetchPullRequest: () => ({ state: "OPEN", headRefOid: payload.headSha }),
-      now: NOW,
-    }).refusal.reason).toBe("merge_fix_owned_paths_moved");
+    expect(
+      worktreeMergeFixEligibility(payload, {
+        fetchTicket: () => ({
+          ...ticket,
+          labels: { nodes: [{ name: "ai:escalated" }] },
+        }),
+        fetchPullRequest: () => ({
+          state: "OPEN",
+          headRefOid: payload.headSha,
+        }),
+        now: NOW,
+      }).refusal.reason,
+    ).toBe("merge_fix_ticket_escalated");
+    expect(
+      worktreeMergeFixEligibility(payload, {
+        fetchTicket: () => ticket,
+        fetchPullRequest: () => ({ state: "OPEN", headRefOid: "b".repeat(40) }),
+        now: NOW,
+      }).refusal.reason,
+    ).toBe("merge_fix_pr_moved");
+    expect(
+      worktreeMergeFixEligibility(payload, {
+        fetchTicket: () => ticket,
+        fetchPullRequest: () => ({
+          state: "OPEN",
+          headRefOid: payload.headSha,
+        }),
+        fetchNonTerminalRuns: () => [{ runId: "run_other", state: "RUNNING" }],
+        now: NOW,
+      }).refusal.reason,
+    ).toBe("merge_fix_run_active");
+    expect(
+      worktreeMergeFixEligibility(
+        { ...payload, ownedPaths: ["outside/scope.mjs"] },
+        {
+          fetchTicket: () => ticket,
+          fetchPullRequest: () => ({
+            state: "OPEN",
+            headRefOid: payload.headSha,
+          }),
+          now: NOW,
+        },
+      ).refusal.reason,
+    ).toBe("merge_fix_owned_paths_moved");
   });
 
   test("a repo with no worktree scripts declared → typed human_needed at plan time, no run", () => {
-    withReposRoot(`repos:\n  - name: noscripts\n    path: /tmp/nowhere\n    base: develop\n`, () => {
-      const synthetic = syntheticRegistry();
-      const db = openDb(":memory:");
-      const ref = admit(db, dispatchEnvelope({ repo: "noscripts", ticket: "WM-1" }));
-      const outcome = planEvent(db, synthetic, ref, { now: NOW });
-      expect(outcome.decision).toBe("human_needed");
-      expect(outcome.reason).toBe("no_worktree_scripts");
-      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    });
+    withReposRoot(
+      `repos:\n  - name: noscripts\n    path: /tmp/nowhere\n    base: develop\n`,
+      () => {
+        const synthetic = syntheticRegistry();
+        const db = openDb(":memory:");
+        const ref = admit(
+          db,
+          dispatchEnvelope({ repo: "noscripts", ticket: "WM-1" }),
+        );
+        const outcome = planEvent(db, synthetic, ref, { now: NOW });
+        expect(outcome.decision).toBe("human_needed");
+        expect(outcome.reason).toBe("no_worktree_scripts");
+        expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+      },
+    );
   });
 
   test("a repo missing from config/repos.yaml → human_needed repo_unknown", () => {
-    withReposRoot(`repos:\n  - name: real\n    path: /tmp/nowhere\n    base: develop\n`, () => {
-      const synthetic = syntheticRegistry();
-      const db = openDb(":memory:");
-      const ref = admit(db, dispatchEnvelope({ repo: "ghost", ticket: "WM-1" }));
-      const outcome = planEvent(db, synthetic, ref, { now: NOW });
-      expect(outcome.decision).toBe("human_needed");
-      expect(outcome.reason).toMatch(/^repo_unknown: /);
-      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    });
+    withReposRoot(
+      `repos:\n  - name: real\n    path: /tmp/nowhere\n    base: develop\n`,
+      () => {
+        const synthetic = syntheticRegistry();
+        const db = openDb(":memory:");
+        const ref = admit(
+          db,
+          dispatchEnvelope({ repo: "ghost", ticket: "WM-1" }),
+        );
+        const outcome = planEvent(db, synthetic, ref, { now: NOW });
+        expect(outcome.decision).toBe("human_needed");
+        expect(outcome.reason).toMatch(/^repo_unknown: /);
+        expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+      },
+    );
   });
 
   test("unknown Owned Paths refuses distinctly before wildcard escalation", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
-      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
-      `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - '**'\n`,
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - '**'\n`,
       () => {
         let fetchedInFlight = false;
         const result = worktreeDispatchAutoEligibility(
@@ -708,11 +963,20 @@ describe("planEvent worktree gate (WM-108)", () => {
               labels: { nodes: [{ name: "ai:agent-ready" }] },
               description: "",
             }),
-            fetchInFlight: () => { fetchedInFlight = true; return []; },
+            fetchInFlight: () => {
+              fetchedInFlight = true;
+              return [];
+            },
           },
         );
-        expect(result.refusal).toMatchObject({ decision: "noop", reason: "owned_paths_unknown" });
-        expect(result.evidence.ticket).toMatchObject({ ownedPaths: ["**"], ownedPathsParsed: false });
+        expect(result.refusal).toMatchObject({
+          decision: "noop",
+          reason: "owned_paths_unknown",
+        });
+        expect(result.evidence.ticket).toMatchObject({
+          ownedPaths: ["**"],
+          ownedPathsParsed: false,
+        });
         expect(result.evidence.escalatePathIntersections).toEqual([]);
         expect(fetchedInFlight).toBe(false);
       },
@@ -722,14 +986,16 @@ describe("planEvent worktree gate (WM-108)", () => {
   test("lease-loss retry accepts only the factory viewer's surviving In Progress claim (WM-621)", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
-      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
-      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
       () => {
         const claimedTicket = (assignee) => ({
           identifier: "WM-621",
           state: { name: "In Progress" },
           assignee,
-          labels: { nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }] },
+          labels: {
+            nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }],
+          },
           description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
         });
         const baseDispatch = {
@@ -737,12 +1003,19 @@ describe("planEvent worktree gate (WM-108)", () => {
           budgetRefusal: () => null,
           fetchViewer: () => ({ id: "factory-user", name: "Factory" }),
           fetchInFlight: () => [],
-          claimedRetry: { runId: "run_same", priorAttempt: 1, reasonCode: "lease_expired" },
+          claimedRetry: {
+            runId: "run_same",
+            priorAttempt: 1,
+            reasonCode: "lease_expired",
+          },
         };
 
         const resumed = worktreeDispatchAutoEligibility(
           { repo: "gated", ticket: "WM-621" },
-          { ...baseDispatch, fetchTicket: () => claimedTicket({ id: "factory-user" }) },
+          {
+            ...baseDispatch,
+            fetchTicket: () => claimedTicket({ id: "factory-user" }),
+          },
         );
         expect(resumed.ok).toBe(true);
         expect(resumed.evidence.checks).toMatchObject({
@@ -753,9 +1026,15 @@ describe("planEvent worktree gate (WM-108)", () => {
 
         const foreign = worktreeDispatchAutoEligibility(
           { repo: "gated", ticket: "WM-621" },
-          { ...baseDispatch, fetchTicket: () => claimedTicket({ id: "someone-else" }) },
+          {
+            ...baseDispatch,
+            fetchTicket: () => claimedTicket({ id: "someone-else" }),
+          },
         );
-        expect(foreign.refusal).toMatchObject({ decision: "noop", reason: "ticket_assigned" });
+        expect(foreign.refusal).toMatchObject({
+          decision: "noop",
+          reason: "ticket_assigned",
+        });
 
         const ownAssignedTodo = worktreeDispatchAutoEligibility(
           { repo: "gated", ticket: "WM-621" },
@@ -768,7 +1047,10 @@ describe("planEvent worktree gate (WM-108)", () => {
             }),
           },
         );
-        expect(ownAssignedTodo.refusal).toMatchObject({ decision: "noop", reason: "ticket_assigned" });
+        expect(ownAssignedTodo.refusal).toMatchObject({
+          decision: "noop",
+          reason: "ticket_assigned",
+        });
       },
     );
   });
@@ -776,8 +1058,8 @@ describe("planEvent worktree gate (WM-108)", () => {
   test("a genuine sensitive-path refusal names the intersecting configured globs", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
-      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
-      `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - src/auth/**\n      - infra/**\n`,
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - src/auth/**\n      - infra/**\n`,
       () => {
         const dispatch = {
           countLeases: () => 0,
@@ -800,13 +1082,26 @@ describe("planEvent worktree gate (WM-108)", () => {
           reason: "escalate_paths_intersect",
           detail: "intersecting escalate_paths globs: src/auth/**",
         });
-        expect(result.evidence.escalatePathIntersections).toEqual(["src/auth/**"]);
+        expect(result.evidence.escalatePathIntersections).toEqual([
+          "src/auth/**",
+        ]);
 
         const db = openDb(":memory:");
-        const ref = admit(db, dispatchEnvelope({ repo: "gated", ticket: "WM-3" }));
-        const outcome = planEvent(db, syntheticRegistry(), ref, { now: NOW, dispatch });
-        expect(outcome).toMatchObject({ decision: "noop", reason: "escalate_paths_intersect" });
-        expect(outcome.proposal.reason).toBe("intersecting escalate_paths globs: src/auth/**");
+        const ref = admit(
+          db,
+          dispatchEnvelope({ repo: "gated", ticket: "WM-3" }),
+        );
+        const outcome = planEvent(db, syntheticRegistry(), ref, {
+          now: NOW,
+          dispatch,
+        });
+        expect(outcome).toMatchObject({
+          decision: "noop",
+          reason: "escalate_paths_intersect",
+        });
+        expect(outcome.proposal.reason).toBe(
+          "intersecting escalate_paths globs: src/auth/**",
+        );
       },
     );
   });
@@ -816,7 +1111,11 @@ describe("planEvent repo scoping (WM-64)", () => {
   // A synthetic agent per test keeps the check independent of any one real
   // definition (same approach as the worktree gate tests above).
   function scopedRegistry({ repos, workspace = { type: "ephemeral" } } = {}) {
-    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
     synthetic.eventTypes["test.scoped.requested"] = {
       agent: "test-scoped@1",
       adapter: "claude",
@@ -851,29 +1150,51 @@ describe("planEvent repo scoping (WM-64)", () => {
     const synthetic = scopedRegistry({ repos: ["bj29", "cw-app"] });
     const db = openDb(":memory:");
     const ref = admit(db, scopedEnvelope({ repo: "bj29", ticket: "WM-1" }));
-    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    const outcome = planEvent(db, synthetic, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(outcome.decision).toBe("run");
     // The proposal the operator approves names the scope (WM-64).
-    expect(JSON.parse(outcome.proposal.spec_json).repos).toEqual(["bj29", "cw-app"]);
+    expect(JSON.parse(outcome.proposal.spec_json).repos).toEqual([
+      "bj29",
+      "cw-app",
+    ]);
   });
 
   test("payload.repo outside the declared set parks human_needed with the named reason, no run", () => {
     const synthetic = scopedRegistry({ repos: ["bj29", "cw-app"] });
     const db = openDb(":memory:");
-    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
-    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    const ref = admit(
+      db,
+      scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }),
+    );
+    const outcome = planEvent(db, synthetic, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(outcome.decision).toBe("human_needed");
-    expect(outcome.reason).toBe("repo_not_allowed: test-scoped@1 may not run over coach-wattz (allowed: bj29, cw-app)");
+    expect(outcome.reason).toBe(
+      "repo_not_allowed: test-scoped@1 may not run over coach-wattz (allowed: bj29, cw-app)",
+    );
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
-    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db
+      .query(`SELECT status FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("human_needed");
   });
 
   test("a definition without repos is unrestricted — behaves exactly as today (regression)", () => {
     const synthetic = scopedRegistry();
     const db = openDb(":memory:");
-    const ref = admit(db, scopedEnvelope({ repo: "anything-at-all", ticket: "WM-1" }));
-    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    const ref = admit(
+      db,
+      scopedEnvelope({ repo: "anything-at-all", ticket: "WM-1" }),
+    );
+    const outcome = planEvent(db, synthetic, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(outcome.decision).toBe("run");
     expect(JSON.parse(outcome.proposal.spec_json).repos).toBeUndefined();
   });
@@ -882,20 +1203,37 @@ describe("planEvent repo scoping (WM-64)", () => {
     // No FACTORY_REPOS_ROOT setup at all — if the planner reached pinRepo it
     // would fail as repo_pin_failed; the scope check must win first, so no
     // mirror fetch happens for a refused run.
-    const synthetic = scopedRegistry({ repos: ["bj29"], workspace: { type: "repository" } });
+    const synthetic = scopedRegistry({
+      repos: ["bj29"],
+      workspace: { type: "repository" },
+    });
     const db = openDb(":memory:");
-    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
-    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    const ref = admit(
+      db,
+      scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }),
+    );
+    const outcome = planEvent(db, synthetic, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(outcome.decision).toBe("human_needed");
     expect(outcome.reason).toMatch(/^repo_not_allowed: /);
-    const stored = db.query(`SELECT envelope_json FROM events WHERE event_id = ?`).get(ref.eventId);
+    const stored = db
+      .query(`SELECT envelope_json FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(JSON.parse(stored.envelope_json).payload.repoPin).toBeUndefined();
   });
 
   test("scope refusal precedes the worktree dispatch gate: no Linear or lease reads for an out-of-scope repo", () => {
-    const synthetic = scopedRegistry({ repos: ["bj29"], workspace: { type: "worktree" } });
+    const synthetic = scopedRegistry({
+      repos: ["bj29"],
+      workspace: { type: "worktree" },
+    });
     const db = openDb(":memory:");
-    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
+    const ref = admit(
+      db,
+      scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }),
+    );
     const dispatch = {
       fetchTicket: () => {
         throw new Error("gate consulted Linear for an out-of-scope repo");
@@ -904,7 +1242,11 @@ describe("planEvent repo scoping (WM-64)", () => {
         throw new Error("gate consulted Linear for an out-of-scope repo");
       },
     };
-    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test", dispatch });
+    const outcome = planEvent(db, synthetic, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+      dispatch,
+    });
     expect(outcome.decision).toBe("human_needed");
     expect(outcome.reason).toMatch(/^repo_not_allowed: /);
   });
@@ -913,12 +1255,19 @@ describe("planEvent repo scoping (WM-64)", () => {
 describe("planEvent model pinning (WM-135)", () => {
   // Synthetic agents again: the resolution semantics belong to the planner,
   // not to any one shipped definition.
-  function tieredRegistry({ modelTier, model, adapter = "claude", modelTiers } = {}) {
+  function tieredRegistry({
+    modelTier,
+    model,
+    adapter = "claude",
+    modelTiers,
+  } = {}) {
     const synthetic = {
       ...registry,
       agents: new Map(registry.agents),
       eventTypes: { ...registry.eventTypes },
-      modelTiers: modelTiers ?? { claude: { strong: "default", standard: "sonnet", light: "haiku" } },
+      modelTiers: modelTiers ?? {
+        claude: { strong: "default", standard: "sonnet", light: "haiku" },
+      },
     };
     synthetic.eventTypes["test.tiered.requested"] = {
       agent: "test-tiered@1",
@@ -951,17 +1300,27 @@ describe("planEvent model pinning (WM-135)", () => {
   test("declared tier resolves through the policy map and is pinned into the spec the operator approves", () => {
     const db = openDb(":memory:");
     const ref = admit(db, tieredEnvelope());
-    const outcome = planEvent(db, tieredRegistry({ modelTier: "standard" }), ref, { now: NOW, policyVersion: "git:test" });
+    const outcome = planEvent(
+      db,
+      tieredRegistry({ modelTier: "standard" }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
     expect(outcome.decision).toBe("run");
     const spec = JSON.parse(outcome.proposal.spec_json);
     expect(spec.model).toBe("sonnet");
     expect(spec.modelTier).toBe("standard");
   });
 
-  test("tier resolving to the default sentinel pins \"default\" explicitly — visible, not implicit", () => {
+  test('tier resolving to the default sentinel pins "default" explicitly — visible, not implicit', () => {
     const db = openDb(":memory:");
     const ref = admit(db, tieredEnvelope());
-    const outcome = planEvent(db, tieredRegistry({ modelTier: "strong" }), ref, { now: NOW, policyVersion: "git:test" });
+    const outcome = planEvent(
+      db,
+      tieredRegistry({ modelTier: "strong" }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
     const spec = JSON.parse(outcome.proposal.spec_json);
     expect(spec.model).toBe("default");
     expect(spec.modelTier).toBe("strong");
@@ -984,7 +1343,10 @@ describe("planEvent model pinning (WM-135)", () => {
   test("a definition declaring nothing produces a spec without model fields — today's behavior (regression)", () => {
     const db = openDb(":memory:");
     const ref = admit(db, tieredEnvelope());
-    const outcome = planEvent(db, tieredRegistry(), ref, { now: NOW, policyVersion: "git:test" });
+    const outcome = planEvent(db, tieredRegistry(), ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     const spec = JSON.parse(outcome.proposal.spec_json);
     expect("model" in spec).toBe(false);
     expect("modelTier" in spec).toBe(false);
@@ -1024,7 +1386,12 @@ describe("planEvent model pinning (WM-135)", () => {
     // Bypassing loadRegistry's own load-time check (synthetic registry): the
     // planner is the second line of the same fail-closed rule.
     expect(() =>
-      planEvent(db, tieredRegistry({ modelTier: "light", modelTiers: {} }), ref, { now: NOW, policyVersion: "git:test" }),
+      planEvent(
+        db,
+        tieredRegistry({ modelTier: "light", modelTiers: {} }),
+        ref,
+        { now: NOW, policyVersion: "git:test" },
+      ),
     ).toThrow(/no mapping for adapter "claude"/);
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
   });
@@ -1037,7 +1404,10 @@ describe("buildRunSpec", () => {
     const a = buildRunSpec(registry, envelope(), mapping, opts);
     const b = buildRunSpec(registry, envelope(), mapping, opts);
     expect(hashJson(a)).toBe(hashJson(b));
-    const overridden = buildRunSpec(registry, envelope(), mapping, { ...opts, adapterOverride: "pi" });
+    const overridden = buildRunSpec(registry, envelope(), mapping, {
+      ...opts,
+      adapterOverride: "pi",
+    });
     expect(overridden.adapter).toBe("pi");
     expect(overridden.idempotencyKey).toBe(a.idempotencyKey);
   });
@@ -1050,27 +1420,46 @@ describe("planAdmittedEvents", () => {
     const broken = {}; // getEventType throws on this — a poison planning input
 
     for (let i = 1; i < DEAD_LETTER_AFTER; i++) {
-      expect(planAdmittedEvents(db, broken)).toEqual({ planned: 0, failed: 1, deadLettered: 0 });
-      const event = db.query(`SELECT * FROM events WHERE event_id = ?`).get(ref.eventId);
+      expect(planAdmittedEvents(db, broken)).toEqual({
+        planned: 0,
+        failed: 1,
+        deadLettered: 0,
+      });
+      const event = db
+        .query(`SELECT * FROM events WHERE event_id = ?`)
+        .get(ref.eventId);
       expect(event.status).toBe("admitted");
       expect(event.plan_failures).toBe(i);
     }
 
-    expect(planAdmittedEvents(db, broken)).toEqual({ planned: 0, failed: 1, deadLettered: 1 });
-    const event = db.query(`SELECT * FROM events WHERE event_id = ?`).get(ref.eventId);
+    expect(planAdmittedEvents(db, broken)).toEqual({
+      planned: 0,
+      failed: 1,
+      deadLettered: 1,
+    });
+    const event = db
+      .query(`SELECT * FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("dead_lettered");
     expect(event.plan_failures).toBe(DEAD_LETTER_AFTER);
     expect(event.last_plan_error).toBeTruthy();
 
     // Dead-lettered events leave the sweep; nothing is wedged.
-    expect(planAdmittedEvents(db, broken)).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+    expect(planAdmittedEvents(db, broken)).toEqual({
+      planned: 0,
+      failed: 0,
+      deadLettered: 0,
+    });
   });
 
   test("plans every admitted event and reports counts", () => {
     const db = openDb(":memory:");
     admit(db, { eventId: "delivery-1" });
     admit(db, { eventId: "delivery-2", correlationId: "workflow-02" });
-    const counts = planAdmittedEvents(db, registry, { now: NOW, policyVersion: "git:test" });
+    const counts = planAdmittedEvents(db, registry, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(counts).toEqual({ planned: 2, failed: 0, deadLettered: 0 });
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
   });
@@ -1096,7 +1485,9 @@ describe("planAdmittedEvents", () => {
       db1.exec("ROLLBACK;");
     }
 
-    const event = db1.query(`SELECT * FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db1
+      .query(`SELECT * FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("admitted");
     expect(event.plan_failures).toBe(0);
   });
@@ -1120,7 +1511,9 @@ describe("planAdmittedEvents", () => {
       db1.exec("ROLLBACK;");
     }
 
-    const event = db1.query(`SELECT * FROM events WHERE event_id = ?`).get(ref.eventId);
+    const event = db1
+      .query(`SELECT * FROM events WHERE event_id = ?`)
+      .get(ref.eventId);
     expect(event.status).toBe("admitted");
     expect(event.plan_failures).toBe(0);
   });
@@ -1129,8 +1522,12 @@ describe("planAdmittedEvents", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-plan-factory-"));
     mkdirSync(path.join(root, "config"), { recursive: true });
     const repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-repo-"));
-    execFileSync("git", ["init", "--quiet", "--initial-branch=develop"], { cwd: repoDir });
-    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoDir });
+    execFileSync("git", ["init", "--quiet", "--initial-branch=develop"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: repoDir,
+    });
     execFileSync("git", ["config", "user.name", "Test"], { cwd: repoDir });
     writeFileSync(path.join(repoDir, "README.md"), "bj29\n");
     execFileSync("git", ["add", "."], { cwd: repoDir });
@@ -1143,7 +1540,9 @@ describe("planAdmittedEvents", () => {
     const oldReposRoot = process.env.FACTORY_REPOS_ROOT;
     const oldHome = process.env.FACTORY_EVENT_HOME;
     process.env.FACTORY_REPOS_ROOT = root;
-    process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-plan-home-"));
+    process.env.FACTORY_EVENT_HOME = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-plan-home-"),
+    );
 
     try {
       const db = openDb(":memory:");
@@ -1152,14 +1551,21 @@ describe("planAdmittedEvents", () => {
         type: "factory.triage.requested",
         payload: { repo: "bj29", ref: "develop" },
       });
-      const outcome = planEvent(db, registry, ref, { now: NOW, policyVersion: "git:test" });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        policyVersion: "git:test",
+      });
       expect(outcome.decision).toBe("run");
       const originalSpec = JSON.parse(outcome.proposal.spec_json);
       expect(originalSpec.input.repoPin).toBeTruthy();
       expect(originalSpec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
 
       // Stored event envelope now carries repoPin
-      const storedEvent = db.query(`SELECT envelope_json FROM events WHERE source = ? AND event_id = ?`).get(ref.source, ref.eventId);
+      const storedEvent = db
+        .query(
+          `SELECT envelope_json FROM events WHERE source = ? AND event_id = ?`,
+        )
+        .get(ref.source, ref.eventId);
       const storedEnvelope = JSON.parse(storedEvent.envelope_json);
       expect(storedEnvelope.payload.repoPin).toBeTruthy();
 
@@ -1196,13 +1602,21 @@ describe("planAdmittedEvents", () => {
     ).run(
       priorRunId,
       JSON.stringify({
-        artifacts: [{ kind: "transcript", uri: "file:///tmp/t.json", sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" }],
+        artifacts: [
+          {
+            kind: "transcript",
+            uri: "file:///tmp/t.json",
+            sha256:
+              "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          },
+        ],
       }),
       new Date(NOW).toISOString(),
     );
 
     const artifactStore = mkdtempSync(path.join(os.tmpdir(), "evrt-pm-store-"));
-    const transcriptSha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const transcriptSha =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     writeFileSync(path.join(artifactStore, transcriptSha), "{}");
 
     const ref = admit(db, {
@@ -1210,13 +1624,23 @@ describe("planAdmittedEvents", () => {
       type: "factory.run-postmortem.requested",
       payload: { runId: priorRunId },
     });
-    const outcome = planEvent(db, registry, ref, { now: NOW, policyVersion: "git:test", artifactStore });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+      artifactStore,
+    });
     expect(outcome.decision).toBe("run");
     const originalSpec = JSON.parse(outcome.proposal.spec_json);
     expect(originalSpec.input.runPin).toBeTruthy();
-    expect(originalSpec.input.runPin.transcript).toBe("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    expect(originalSpec.input.runPin.transcript).toBe(
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
 
-    const storedEvent = db.query(`SELECT envelope_json FROM events WHERE source = ? AND event_id = ?`).get(ref.source, ref.eventId);
+    const storedEvent = db
+      .query(
+        `SELECT envelope_json FROM events WHERE source = ? AND event_id = ?`,
+      )
+      .get(ref.source, ref.eventId);
     const storedEnvelope = JSON.parse(storedEvent.envelope_json);
     expect(storedEnvelope.payload.runPin).toBeTruthy();
 

--- a/event-runtime/lib/postmortem.test.mjs
+++ b/event-runtime/lib/postmortem.test.mjs
@@ -28,9 +28,14 @@ function harness() {
   async function runOne(envelope, agentRef) {
     expect(admitEvent(db, registry, envelope).admitted).toBe(true);
     planAdmittedEvents(db, registry, opts);
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, opts);
     return { runId: approved.runId, summary, proposal };
   }
@@ -63,20 +68,31 @@ describe("run-postmortem: consuming an artifact across runs (OPS-373)", () => {
 
     // An ordinary run, unrelated to any postmortem — its transcript is captured
     // by the adapter as a matter of course.
-    const subject = await h.runOne(statusEnvelope("subject-1"), "factory-status-report@1");
+    const subject = await h.runOne(
+      statusEnvelope("subject-1"),
+      "factory-status-report@1",
+    );
     expect(subject.summary.terminalState).toBe("COMPLETED");
 
     // Later, and with no chain between them, the operator asks why.
-    const pm = await h.runOne(postmortemEnvelope("pm-1", subject.runId), "run-postmortem@1");
+    const pm = await h.runOne(
+      postmortemEnvelope("pm-1", subject.runId),
+      "run-postmortem@1",
+    );
     expect(pm.summary.terminalState).toBe("COMPLETED");
 
     // The pin is in the approved spec: the operator approved specific bytes.
-    expect(pm.proposal.spec.input.runPin).toMatchObject({ runId: subject.runId, state: "COMPLETED" });
+    expect(pm.proposal.spec.input.runPin).toMatchObject({
+      runId: subject.runId,
+      state: "COMPLETED",
+    });
     expect(pm.proposal.spec.input.runPin.transcript).toMatch(/^[0-9a-f]{64}$/);
 
     // And the agent actually read the materialized transcript.
     const result = JSON.parse(
-      h.db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(pm.runId).result_json,
+      h.db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(pm.runId).result_json,
     );
     expect(result.artifact.runId).toBe(subject.runId);
     expect(result.evidence.transcriptBytes).toBeGreaterThan(0);
@@ -84,20 +100,34 @@ describe("run-postmortem: consuming an artifact across runs (OPS-373)", () => {
 
   test("the pin names the exact stored bytes the subject run produced", async () => {
     const h = harness();
-    const subject = await h.runOne(statusEnvelope("subject-2"), "factory-status-report@1");
+    const subject = await h.runOne(
+      statusEnvelope("subject-2"),
+      "factory-status-report@1",
+    );
     const pin = pinRunArtifact(h.db, subject.runId);
     const stored = JSON.parse(
-      h.db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(subject.runId).result_json,
+      h.db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(subject.runId).result_json,
     ).artifacts.find((a) => a.kind === "transcript");
     expect(pin.transcript).toBe(stored.sha256);
-    expect(readFileSync(path.join(h.opts.artifactStore, pin.transcript), "utf8").length).toBeGreaterThan(0);
+    expect(
+      readFileSync(path.join(h.opts.artifactStore, pin.transcript), "utf8")
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   test("an unknown run parks for a human instead of proposing a run over nothing", async () => {
     const h = harness();
-    admitEvent(h.db, registry, postmortemEnvelope("pm-unknown", "run_does_not_exist"));
+    admitEvent(
+      h.db,
+      registry,
+      postmortemEnvelope("pm-unknown", "run_does_not_exist"),
+    );
     planAdmittedEvents(h.db, registry, h.opts);
-    const parked = openProposals(h.db, {}).find((p) => p.decision === "human_needed");
+    const parked = openProposals(h.db, {}).find(
+      (p) => p.decision === "human_needed",
+    );
     expect(parked.reason).toContain("run_pin_failed");
     expect(parked.reason).toContain("unknown run");
   });
@@ -105,18 +135,24 @@ describe("run-postmortem: consuming an artifact across runs (OPS-373)", () => {
   test("a run that never produced a transcript parks with that reason, not a crash", async () => {
     const h = harness();
     // A run with an accepted result but no transcript artifact.
-    h.db.query(
-      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+    h.db
+      .query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
        VALUES ('run_bare', 'k', '{"agent":"x@1"}', 'sha256:x', 'FAILED', 1, ?, ?)`,
-    ).run(new Date().toISOString(), new Date().toISOString());
-    h.db.query(
-      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+      )
+      .run(new Date().toISOString(), new Date().toISOString());
+    h.db
+      .query(
+        `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
        VALUES ('run_bare', 1, '{"artifacts":[]}', 'sha256:x', '{}', '{}', ?)`,
-    ).run(new Date().toISOString());
+      )
+      .run(new Date().toISOString());
 
     admitEvent(h.db, registry, postmortemEnvelope("pm-bare", "run_bare"));
     planAdmittedEvents(h.db, registry, h.opts);
-    const parked = openProposals(h.db, {}).find((p) => p.decision === "human_needed");
+    const parked = openProposals(h.db, {}).find(
+      (p) => p.decision === "human_needed",
+    );
     expect(parked.reason).toContain('stored no "transcript" artifact');
   });
 });

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -36,7 +36,9 @@ function withSpec(row) {
 /** Open proposals, oldest first, annotated with `expired` and parsed `spec`. */
 export function openProposals(db, { now = Date.now() } = {}) {
   return db
-    .query(`SELECT * FROM proposals WHERE status = 'open' ORDER BY created_at, rowid`)
+    .query(
+      `SELECT * FROM proposals WHERE status = 'open' ORDER BY created_at, rowid`,
+    )
     .all()
     .map((row) => ({ ...withSpec(row), expired: isExpired(row, now) }));
 }
@@ -68,11 +70,19 @@ function loadEnvelope(db, proposal) {
   const event = db
     .query(`SELECT envelope_json FROM events WHERE source = ? AND event_id = ?`)
     .get(proposal.event_source, proposal.event_id);
-  if (!event) throw new Error(`proposal ${proposal.id} references missing event (${proposal.event_source}, ${proposal.event_id})`);
+  if (!event)
+    throw new Error(
+      `proposal ${proposal.id} references missing event (${proposal.event_source}, ${proposal.event_id})`,
+    );
   return JSON.parse(event.envelope_json);
 }
 
-function approveRun(db, proposal, envelope, { actor, now, policyVersion, reason }) {
+function approveRun(
+  db,
+  proposal,
+  envelope,
+  { actor, now, policyVersion, reason },
+) {
   const at = new Date(now).toISOString();
   const common = {
     runId: proposal.run_id,
@@ -85,7 +95,9 @@ function approveRun(db, proposal, envelope, { actor, now, policyVersion, reason 
   };
   transition(db, { ...common, to: "APPROVED", expectFrom: "PROPOSED" });
   transition(db, { ...common, to: "QUEUED", expectFrom: "APPROVED" });
-  db.query(`UPDATE proposals SET status = 'approved', decided_at = ?, decided_by = ? WHERE id = ?`).run(at, actor, proposal.id);
+  db.query(
+    `UPDATE proposals SET status = 'approved', decided_at = ?, decided_by = ? WHERE id = ?`,
+  ).run(at, actor, proposal.id);
   return { approved: true, runId: proposal.run_id };
 }
 
@@ -99,12 +111,27 @@ function approveRun(db, proposal, envelope, { actor, now, policyVersion, reason 
  * @returns {{ approved: true, runId: string }
  *         | { approved: false, replanned: true, proposal: object }}
  */
-export function approveProposal(db, registry, id, { actor, now = Date.now(), policyVersion = "unknown", adapterOverride, reason } = {}) {
+export function approveProposal(
+  db,
+  registry,
+  id,
+  {
+    actor,
+    now = Date.now(),
+    policyVersion = "unknown",
+    adapterOverride,
+    reason,
+  } = {},
+) {
   return tx(db, () => {
     const proposal = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!proposal) throw new Error(`unknown proposal ${id}`);
-    if (proposal.status !== "open") throw new Error(`proposal ${id} is '${proposal.status}', not open`);
-    if (proposal.decision !== "run") throw new Error(`proposal ${id} decision is '${proposal.decision}' — only 'run' proposals are approvable`);
+    if (proposal.status !== "open")
+      throw new Error(`proposal ${id} is '${proposal.status}', not open`);
+    if (proposal.decision !== "run")
+      throw new Error(
+        `proposal ${id} decision is '${proposal.decision}' — only 'run' proposals are approvable`,
+      );
 
     const envelope = loadEnvelope(db, proposal);
     // Structural no-auto-approval (docs/event-runtime-dispatch.md §7, WM-111):
@@ -122,27 +149,48 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
       throw err;
     }
     if (!isExpired(proposal, now)) {
-      return approveRun(db, proposal, envelope, { actor, now, policyVersion, reason: reason ?? "approved" });
+      return approveRun(db, proposal, envelope, {
+        actor,
+        now,
+        policyVersion,
+        reason: reason ?? "approved",
+      });
     }
 
     // Expired: re-plan against current registry state, reusing the runId.
-    if (!mapping) throw new Error(`proposal ${id} expired and event type ${envelope.type} is no longer registered`);
+    if (!mapping)
+      throw new Error(
+        `proposal ${id} expired and event type ${envelope.type} is no longer registered`,
+      );
     const fresh = buildRunSpec(registry, envelope, mapping, {
-      runId: proposal.run_id, policyVersion, adapterOverride, now,
+      runId: proposal.run_id,
+      policyVersion,
+      adapterOverride,
+      now,
     });
     const freshHash = hashJson(fresh);
     if (freshHash === proposal.spec_hash) {
-      return approveRun(db, proposal, envelope, { actor, now, policyVersion, reason: "approved_after_ttl_replan" });
+      return approveRun(db, proposal, envelope, {
+        actor,
+        now,
+        policyVersion,
+        reason: "approved_after_ttl_replan",
+      });
     }
 
     const state = runState(db, proposal.run_id);
-    if (state !== "PROPOSED") throw new Error(`proposal ${id} expired but run ${proposal.run_id} is ${state}, not PROPOSED`);
+    if (state !== "PROPOSED")
+      throw new Error(
+        `proposal ${id} expired but run ${proposal.run_id} is ${state}, not PROPOSED`,
+      );
     const at = new Date(now).toISOString();
-    db.query(`UPDATE proposals SET status = 'superseded', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`)
-      .run(at, actor, "superseded_by_ttl_replan", id);
+    db.query(
+      `UPDATE proposals SET status = 'superseded', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`,
+    ).run(at, actor, "superseded_by_ttl_replan", id);
     const freshJson = canonicalJson(fresh);
-    db.query(`UPDATE runs SET spec_json = ?, spec_hash = ?, updated_at = ? WHERE run_id = ?`)
-      .run(freshJson, freshHash, at, proposal.run_id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ?, updated_at = ? WHERE run_id = ?`,
+    ).run(freshJson, freshHash, at, proposal.run_id);
     const newId = newProposalId();
     db.query(
       `INSERT INTO proposals
@@ -150,11 +198,21 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
           idempotency_key, status, reason, created_at, ttl_seconds)
        VALUES (?, ?, ?, ?, 'run', ?, ?, ?, 'open', 'replanned_after_ttl', ?, ?)`,
     ).run(
-      newId, proposal.event_source, proposal.event_id, proposal.run_id,
-      freshJson, freshHash, fresh.idempotencyKey, at,
+      newId,
+      proposal.event_source,
+      proposal.event_id,
+      proposal.run_id,
+      freshJson,
+      freshHash,
+      fresh.idempotencyKey,
+      at,
       mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS,
     );
-    return { approved: false, replanned: true, proposal: getProposal(db, newId) };
+    return {
+      approved: false,
+      replanned: true,
+      proposal: getProposal(db, newId),
+    };
   });
 }
 
@@ -172,12 +230,17 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
  *         | { closed: false }
  *         | { closed: false, ambiguous: true, count: number }}
  */
-export function closeOpenProposalForRun(db, runId, { actor, now = Date.now() } = {}) {
+export function closeOpenProposalForRun(
+  db,
+  runId,
+  { actor, now = Date.now() } = {},
+) {
   const open = db
     .query(`SELECT id FROM proposals WHERE run_id = ? AND status = 'open'`)
     .all(runId);
   if (open.length === 0) return { closed: false };
-  if (open.length > 1) return { closed: false, ambiguous: true, count: open.length };
+  if (open.length > 1)
+    return { closed: false, ambiguous: true, count: open.length };
   const at = new Date(now).toISOString();
   db.query(
     `UPDATE proposals SET status = 'rejected', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`,
@@ -189,18 +252,29 @@ export function closeOpenProposalForRun(db, runId, { actor, now = Date.now() } =
  * Reject an open proposal. A run still sitting in PROPOSED is cancelled with
  * reason 'proposal_rejected' and the operator recorded as actor (§8).
  */
-export function rejectProposal(db, id, { actor, reason, now = Date.now(), policyVersion = "unknown" } = {}) {
+export function rejectProposal(
+  db,
+  id,
+  { actor, reason, now = Date.now(), policyVersion = "unknown" } = {},
+) {
   return tx(db, () => {
     const proposal = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!proposal) throw new Error(`unknown proposal ${id}`);
-    if (proposal.status !== "open") throw new Error(`proposal ${id} is '${proposal.status}', not open`);
+    if (proposal.status !== "open")
+      throw new Error(`proposal ${id} is '${proposal.status}', not open`);
     const at = new Date(now).toISOString();
-    db.query(`UPDATE proposals SET status = 'rejected', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`)
-      .run(at, actor, reason ?? proposal.reason, id);
+    db.query(
+      `UPDATE proposals SET status = 'rejected', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`,
+    ).run(at, actor, reason ?? proposal.reason, id);
     if (proposal.run_id && runState(db, proposal.run_id) === "PROPOSED") {
       transition(db, {
-        runId: proposal.run_id, to: "CANCELLED", expectFrom: "PROPOSED",
-        actor, reason: "proposal_rejected", policyVersion, now,
+        runId: proposal.run_id,
+        to: "CANCELLED",
+        expectFrom: "PROPOSED",
+        actor,
+        reason: "proposal_rejected",
+        policyVersion,
+        now,
       });
     }
     return { rejected: true, runId: proposal.run_id ?? undefined };

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -3,7 +3,14 @@ import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { lifecycleOf, runState } from "./lifecycle.mjs";
 import { planEvent } from "./planner.mjs";
-import { ambiguousOpenProposalRuns, approveProposal, closeOpenProposalForRun, getProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import {
+  ambiguousOpenProposalRuns,
+  approveProposal,
+  closeOpenProposalForRun,
+  getProposal,
+  openProposals,
+  rejectProposal,
+} from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -26,12 +33,16 @@ function envelope(overrides = {}) {
 }
 
 /** Admit and plan one event; returns { db, proposal, runId }. */
-function planned(overrides = {}, { now = NOW, policyVersion = "git:test" } = {}) {
+function planned(
+  overrides = {},
+  { now = NOW, policyVersion = "git:test" } = {},
+) {
   const db = openDb(":memory:");
   const admitted = admitEvent(db, registry, envelope(overrides), { now });
   expect(admitted.admitted).toBe(true);
   const outcome = planEvent(
-    db, registry,
+    db,
+    registry,
     { source: admitted.event.source, eventId: admitted.event.event_id },
     { now, policyVersion },
   );
@@ -60,7 +71,10 @@ describe("openProposals / getProposal", () => {
 describe("approveProposal within TTL", () => {
   test("transitions the run PROPOSED → APPROVED → QUEUED and marks the proposal approved", () => {
     const { db, proposal, runId } = planned();
-    const result = approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW + 60_000 });
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + 60_000,
+    });
     expect(result).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");
 
@@ -70,7 +84,11 @@ describe("approveProposal within TTL", () => {
     expect(row.decided_at).toBe(new Date(NOW + 60_000).toISOString());
 
     const journal = lifecycleOf(db, runId);
-    expect(journal.map((e) => e.to_state)).toEqual(["PROPOSED", "APPROVED", "QUEUED"]);
+    expect(journal.map((e) => e.to_state)).toEqual([
+      "PROPOSED",
+      "APPROVED",
+      "QUEUED",
+    ]);
     expect(journal[1].actor).toBe("operator");
     expect(journal[1].correlation_id).toBe("workflow-01");
   });
@@ -78,15 +96,29 @@ describe("approveProposal within TTL", () => {
   test("only open 'run' proposals are approvable", () => {
     const { db, proposal } = planned();
     approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW });
-    expect(() => approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW })).toThrow(/not open/);
-    expect(() => approveProposal(db, registry, "prop_nope", { actor: "operator", now: NOW })).toThrow(/unknown proposal/);
+    expect(() =>
+      approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        now: NOW,
+      }),
+    ).toThrow(/not open/);
+    expect(() =>
+      approveProposal(db, registry, "prop_nope", {
+        actor: "operator",
+        now: NOW,
+      }),
+    ).toThrow(/unknown proposal/);
   });
 });
 
 describe("rejectProposal", () => {
   test("marks the proposal rejected and cancels the PROPOSED run", () => {
     const { db, proposal, runId } = planned();
-    const result = rejectProposal(db, proposal.id, { actor: "operator", reason: "not today", now: NOW + 1000 });
+    const result = rejectProposal(db, proposal.id, {
+      actor: "operator",
+      reason: "not today",
+      now: NOW + 1000,
+    });
     expect(result).toEqual({ rejected: true, runId });
     expect(runState(db, runId)).toBe("CANCELLED");
 
@@ -106,8 +138,9 @@ describe("closeOpenProposalForRun", () => {
   test("closes the unique open proposal with reason run_cancelled", () => {
     const { db, proposal, runId } = planned();
     const later = NOW + 1000;
-    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: later }))
-      .toEqual({ closed: true, id: proposal.id });
+    expect(
+      closeOpenProposalForRun(db, runId, { actor: "operator", now: later }),
+    ).toEqual({ closed: true, id: proposal.id });
     const row = getProposal(db, proposal.id);
     expect(row.status).toBe("rejected");
     expect(row.reason).toBe("run_cancelled");
@@ -119,11 +152,16 @@ describe("closeOpenProposalForRun", () => {
   test("no-op when the run has no open proposal", () => {
     const { db, proposal, runId } = planned();
     approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW });
-    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }))
-      .toEqual({ closed: false });
+    expect(
+      closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }),
+    ).toEqual({ closed: false });
     expect(getProposal(db, proposal.id).status).toBe("approved");
-    expect(closeOpenProposalForRun(db, "run_missing", { actor: "operator", now: NOW }))
-      .toEqual({ closed: false });
+    expect(
+      closeOpenProposalForRun(db, "run_missing", {
+        actor: "operator",
+        now: NOW,
+      }),
+    ).toEqual({ closed: false });
   });
 
   test("leaves every proposal untouched when more than one is open for the run", () => {
@@ -134,8 +172,9 @@ describe("closeOpenProposalForRun", () => {
       `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
        VALUES (?, ?, ?, ?, 'run', ?, 1800)`,
     ).run("prop_extra", proposal.event_source, proposal.event_id, runId, at);
-    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }))
-      .toEqual({ closed: false, ambiguous: true, count: 2 });
+    expect(
+      closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }),
+    ).toEqual({ closed: false, ambiguous: true, count: 2 });
     expect(getProposal(db, proposal.id).status).toBe("open");
     expect(getProposal(db, "prop_extra").status).toBe("open");
     expect(ambiguousOpenProposalRuns(db)).toEqual([{ runId, count: 2 }]);
@@ -146,10 +185,16 @@ describe("ambiguousOpenProposalRuns", () => {
   test("two open human_needed proposals with NULL run_id are not reported as ambiguous", () => {
     const db = openDb(":memory:");
     for (const eventId of ["hn-null-1", "hn-null-2"]) {
-      const admitted = admitEvent(db, registry, envelope({ eventId, type: "totally.unknown.type" }), { now: NOW });
+      const admitted = admitEvent(
+        db,
+        registry,
+        envelope({ eventId, type: "totally.unknown.type" }),
+        { now: NOW },
+      );
       expect(admitted.admitted).toBe(true);
       const outcome = planEvent(
-        db, registry,
+        db,
+        registry,
         { source: admitted.event.source, eventId: admitted.event.event_id },
         { now: NOW },
       );
@@ -166,7 +211,9 @@ describe("approveProposal after TTL expiry (§12)", () => {
     const { db, proposal, runId } = planned();
     const later = NOW + TTL_MS + 1;
     const result = approveProposal(db, registry, proposal.id, {
-      actor: "operator", now: later, policyVersion: "git:test",
+      actor: "operator",
+      now: later,
+      policyVersion: "git:test",
     });
     expect(result).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");
@@ -182,7 +229,10 @@ describe("approveProposal after TTL expiry (§12)", () => {
     // adapterOverride forces the re-planned spec to differ from the stale one
     // (the registered route is pi since WM-215, so claude is the off-route value).
     const result = approveProposal(db, registry, proposal.id, {
-      actor: "operator", now: later, policyVersion: "git:test", adapterOverride: "claude",
+      actor: "operator",
+      now: later,
+      policyVersion: "git:test",
+      adapterOverride: "claude",
     });
 
     expect(result.approved).toBe(false);
@@ -211,7 +261,10 @@ describe("approveProposal after TTL expiry (§12)", () => {
 
     // Approving the fresh proposal (same override, so specs match) queues the run.
     const approved = approveProposal(db, registry, result.proposal.id, {
-      actor: "operator", now: later + 1000, policyVersion: "git:test", adapterOverride: "claude",
+      actor: "operator",
+      now: later + 1000,
+      policyVersion: "git:test",
+      adapterOverride: "claude",
     });
     expect(approved).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");

--- a/event-runtime/lib/reaper.mjs
+++ b/event-runtime/lib/reaper.mjs
@@ -16,4 +16,3 @@ export function reapExpiredLeases(db, opts = {}) {
 }
 
 export { pruneWorkers };
-

--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -11,7 +11,9 @@ const T0 = Date.parse("2026-08-12T10:00:00Z");
 
 let seq = 0;
 function makeSpec(overrides = {}) {
-  const runId = overrides.runId ?? `run_reaper_${++seq}_${Math.random().toString(36).slice(2)}`;
+  const runId =
+    overrides.runId ??
+    `run_reaper_${++seq}_${Math.random().toString(36).slice(2)}`;
   const input = overrides.input ?? { repos: ["ok"] };
   return {
     schemaVersion: "factory.run-spec/v1",
@@ -45,9 +47,27 @@ function setupVerifyingRun(db, spec, { now = T0, expired = false } = {}) {
   });
   transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now });
   transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now });
-  transition(db, { runId: spec.runId, to: "LEASED", actor: "test", attempt: 1, now });
-  transition(db, { runId: spec.runId, to: "RUNNING", actor: "test", attempt: 1, now });
-  transition(db, { runId: spec.runId, to: "VERIFYING", actor: "test", attempt: 1, now });
+  transition(db, {
+    runId: spec.runId,
+    to: "LEASED",
+    actor: "test",
+    attempt: 1,
+    now,
+  });
+  transition(db, {
+    runId: spec.runId,
+    to: "RUNNING",
+    actor: "test",
+    attempt: 1,
+    now,
+  });
+  transition(db, {
+    runId: spec.runId,
+    to: "VERIFYING",
+    actor: "test",
+    attempt: 1,
+    now,
+  });
 
   const leaseExpiresAt = new Date(
     expired ? now - 1000 : now + (spec.timeoutSeconds + 120) * 1000,
@@ -73,11 +93,21 @@ describe("reaper (OPS-416)", () => {
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     const events = db
-      .query(`SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
+      .query(
+        `SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`,
+      )
       .all(spec.runId);
     const lastTwo = events.slice(-2);
-    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "failure:environment:lease_expired" });
-    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "retry:environment" });
+    expect(lastTwo[0]).toEqual({
+      from_state: "VERIFYING",
+      to_state: "FAILED",
+      reason: "failure:environment:lease_expired",
+    });
+    expect(lastTwo[1]).toEqual({
+      from_state: "FAILED",
+      to_state: "QUEUED",
+      reason: "retry:environment",
+    });
   });
 
   test("reaps stranded VERIFYING run and dead-letters to FAILED when maxAttempts reached", () => {
@@ -91,7 +121,9 @@ describe("reaper (OPS-416)", () => {
     expect(reaped).toBe(1);
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("FAILED");
     expect(attempt.reason_code).toBe("lease_expired");
   });
@@ -102,10 +134,16 @@ describe("reaper (OPS-416)", () => {
     setupVerifyingRun(db, spec, { now: T0, expired: false });
 
     expect(runState(db, spec.runId)).toBe("VERIFYING");
-    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("FAILED");
     expect(attempt.reason_code).toBe("cancelled");
   });
@@ -115,11 +153,18 @@ describe("reaper (OPS-416)", () => {
     const spec = makeSpec();
     setupVerifyingRun(db, spec, { now: T0, expired: false });
 
-    forceFailRun(db, spec.runId, { actor: "operator", reason: "stuck_in_verification", policyVersion: "test", now: T0 });
+    forceFailRun(db, spec.runId, {
+      actor: "operator",
+      reason: "stuck_in_verification",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(runState(db, spec.runId)).toBe("FAILED");
 
     const events = db
-      .query(`SELECT from_state, to_state, reason, actor FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`)
+      .query(
+        `SELECT from_state, to_state, reason, actor FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
+      )
       .get(spec.runId);
     expect(events.from_state).toBe("VERIFYING");
     expect(events.to_state).toBe("FAILED");
@@ -132,15 +177,29 @@ describe("reaper (OPS-416)", () => {
     const spec = makeSpec({ maxAttempts: 2 });
     setupVerifyingRun(db, spec, { now: T0, expired: false });
 
-    retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    retryRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     const events = db
-      .query(`SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
+      .query(
+        `SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`,
+      )
       .all(spec.runId);
     const lastTwo = events.slice(-2);
-    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "operator_retry_verifying" });
-    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "operator_retry" });
+    expect(lastTwo[0]).toEqual({
+      from_state: "VERIFYING",
+      to_state: "FAILED",
+      reason: "operator_retry_verifying",
+    });
+    expect(lastTwo[1]).toEqual({
+      from_state: "FAILED",
+      to_state: "QUEUED",
+      reason: "operator_retry",
+    });
   });
 
   test("prunes stale stopped workers during reap cycle (OPS-431)", () => {

--- a/event-runtime/lib/receipts.mjs
+++ b/event-runtime/lib/receipts.mjs
@@ -82,11 +82,15 @@ export function createReceipt({
   const defHash = spec?.defHash ?? (def ? computeDefHash(def) : null);
   return {
     ...base,
-    runId: base.runId ?? (spec?.runId ?? runId),
+    runId: base.runId ?? spec?.runId ?? runId,
     runSpecHash: base.runSpecHash ?? (spec ? hashJson(spec) : null),
     ...(defHash ? { defHash } : {}),
-    artifactHash: base.artifactHash !== undefined ? base.artifactHash : artifactHash,
-    evidenceSetHash: base.evidenceSetHash !== undefined ? base.evidenceSetHash : evidenceSetHash,
+    artifactHash:
+      base.artifactHash !== undefined ? base.artifactHash : artifactHash,
+    evidenceSetHash:
+      base.evidenceSetHash !== undefined
+        ? base.evidenceSetHash
+        : evidenceSetHash,
     journalHead: journalHead ?? base.journalHead ?? null,
     verificationStatus: base.verificationStatus ?? verificationStatus,
   };

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -32,7 +32,9 @@ const MAP_FILES = {
 
 function parseJson(bytes, description) {
   try {
-    return JSON.parse(typeof bytes === "string" ? bytes : Buffer.from(bytes).toString("utf8"));
+    return JSON.parse(
+      typeof bytes === "string" ? bytes : Buffer.from(bytes).toString("utf8"),
+    );
   } catch (err) {
     throw new RegistryError(`${description}: invalid JSON — ${err.message}`);
   }
@@ -62,11 +64,14 @@ export function loadPackRoots({ root = reposRoot() } = {}) {
   try {
     parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
   } catch (err) {
-    throw new RegistryError(`${file}: unparseable policy.yaml — ${err.message}`);
+    throw new RegistryError(
+      `${file}: unparseable policy.yaml — ${err.message}`,
+    );
   }
   const configured = parsed?.packs;
   if (configured === undefined || configured === null) return [];
-  if (!Array.isArray(configured)) throw new RegistryError(`${file}: "packs" must be an array`);
+  if (!Array.isArray(configured))
+    throw new RegistryError(`${file}: "packs" must be an array`);
 
   const names = new Set();
   return configured.map((entry, index) => {
@@ -75,12 +80,14 @@ export function loadPackRoots({ root = reposRoot() } = {}) {
       throw new RegistryError(`${at} must be an object with name and path`);
     }
     for (const key of Object.keys(entry)) {
-      if (!["name", "path", "namespace"].includes(key)) throw new RegistryError(`${at}: unknown field "${key}"`);
+      if (!["name", "path", "namespace"].includes(key))
+        throw new RegistryError(`${at}: unknown field "${key}"`);
     }
     if (typeof entry.name !== "string" || entry.name.trim() === "") {
       throw new RegistryError(`${at}.name must be a non-empty string`);
     }
-    if (names.has(entry.name)) throw new RegistryError(`${file}: duplicate pack name "${entry.name}"`);
+    if (names.has(entry.name))
+      throw new RegistryError(`${file}: duplicate pack name "${entry.name}"`);
     names.add(entry.name);
     if (typeof entry.path !== "string" || entry.path.trim() === "") {
       throw new RegistryError(`${at}.path must be a non-empty string`);
@@ -102,7 +109,10 @@ export function loadPackRoots({ root = reposRoot() } = {}) {
  * Definition parsing and pinned bytes stay behind this interface so merged
  * validation is equally usable by a future database-backed loader.
  */
-export function createFsPackLoader(pack, { builtIn = false, ignorePins = false } = {}) {
+export function createFsPackLoader(
+  pack,
+  { builtIn = false, ignorePins = false } = {},
+) {
   const root = path.resolve(pack.path);
   let pins;
   return {
@@ -160,27 +170,53 @@ export function createFsPackLoader(pack, { builtIn = false, ignorePins = false }
 }
 
 function configuredPack(pack) {
-  if (pack.kind !== "fs") throw new RegistryError(`pack ${pack.name}: unsupported configured kind "${pack.kind}"`);
+  if (pack.kind !== "fs")
+    throw new RegistryError(
+      `pack ${pack.name}: unsupported configured kind "${pack.kind}"`,
+    );
   const manifestFile = path.join(pack.path, "pack.json");
-  if (!existsSync(manifestFile)) throw new RegistryError(`pack ${pack.name}: missing ${manifestFile}`);
+  if (!existsSync(manifestFile))
+    throw new RegistryError(`pack ${pack.name}: missing ${manifestFile}`);
   const manifest = readJson(manifestFile);
   if (manifest.name !== pack.name) {
-    throw new RegistryError(`${manifestFile}: manifest name ${JSON.stringify(manifest.name)} does not match policy name "${pack.name}"`);
+    throw new RegistryError(
+      `${manifestFile}: manifest name ${JSON.stringify(manifest.name)} does not match policy name "${pack.name}"`,
+    );
   }
   if (typeof manifest.version !== "string" || manifest.version.trim() === "") {
-    throw new RegistryError(`${manifestFile}: version must be a non-empty string`);
+    throw new RegistryError(
+      `${manifestFile}: version must be a non-empty string`,
+    );
   }
-  if (manifest.namespace !== undefined && typeof manifest.namespace !== "string") {
-    throw new RegistryError(`${manifestFile}: namespace must be a string when present`);
+  if (
+    manifest.namespace !== undefined &&
+    typeof manifest.namespace !== "string"
+  ) {
+    throw new RegistryError(
+      `${manifestFile}: namespace must be a string when present`,
+    );
   }
-  if (pack.namespace !== undefined && manifest.namespace !== undefined && pack.namespace !== manifest.namespace) {
-    throw new RegistryError(`${manifestFile}: namespace ${JSON.stringify(manifest.namespace)} does not match policy namespace ${JSON.stringify(pack.namespace)}`);
+  if (
+    pack.namespace !== undefined &&
+    manifest.namespace !== undefined &&
+    pack.namespace !== manifest.namespace
+  ) {
+    throw new RegistryError(
+      `${manifestFile}: namespace ${JSON.stringify(manifest.namespace)} does not match policy namespace ${JSON.stringify(pack.namespace)}`,
+    );
   }
   const namespace = pack.namespace ?? manifest.namespace;
   if (namespace === undefined) {
-    throw new RegistryError(`${manifestFile}: non-built-in packs must declare namespace in the manifest or policy.yaml`);
+    throw new RegistryError(
+      `${manifestFile}: non-built-in packs must declare namespace in the manifest or policy.yaml`,
+    );
   }
-  return { ...pack, root: path.resolve(pack.path), namespace, version: manifest.version };
+  return {
+    ...pack,
+    root: path.resolve(pack.path),
+    namespace,
+    version: manifest.version,
+  };
 }
 
 function injectedPack(pack) {
@@ -188,17 +224,26 @@ function injectedPack(pack) {
     throw new RegistryError("injected pack roots must declare a kind");
   }
   if (typeof pack.name !== "string" || pack.name.trim() === "") {
-    throw new RegistryError("injected pack roots must declare a non-empty name");
+    throw new RegistryError(
+      "injected pack roots must declare a non-empty name",
+    );
   }
   if (typeof pack.namespace !== "string") {
-    throw new RegistryError(`injected pack "${pack.name}" must declare namespace`);
+    throw new RegistryError(
+      `injected pack "${pack.name}" must declare namespace`,
+    );
   }
-  return { ...pack, root: pack.root ?? pack.path ?? `${pack.kind}:${pack.name}` };
+  return {
+    ...pack,
+    root: pack.root ?? pack.path ?? `${pack.kind}:${pack.name}`,
+  };
 }
 
 function defaultLoaderFor(pack, options) {
   if (pack.kind !== "fs") {
-    throw new RegistryError(`pack ${pack.name}: no loader registered for kind "${pack.kind}"`);
+    throw new RegistryError(
+      `pack ${pack.name}: no loader registered for kind "${pack.kind}"`,
+    );
   }
   return createFsPackLoader(pack, options);
 }
@@ -206,7 +251,9 @@ function defaultLoaderFor(pack, options) {
 function assertLoader(loader, pack) {
   for (const method of ["listAgentDefs", "readPinned", "readMap"]) {
     if (typeof loader?.[method] !== "function") {
-      throw new RegistryError(`pack ${pack.name}: loader is missing ${method}()`);
+      throw new RegistryError(
+        `pack ${pack.name}: loader is missing ${method}()`,
+      );
     }
   }
   return loader;
@@ -215,7 +262,9 @@ function assertLoader(loader, pack) {
 function mergeMap(target, sources, incoming, pack, label) {
   for (const [key, value] of Object.entries(incoming)) {
     if (Object.hasOwn(target, key)) {
-      throw new RegistryError(`duplicate ${label} ${JSON.stringify(key)} from packs "${sources[key]}" and "${pack.name}"`);
+      throw new RegistryError(
+        `duplicate ${label} ${JSON.stringify(key)} from packs "${sources[key]}" and "${pack.name}"`,
+      );
     }
     target[key] = value;
     sources[key] = pack.name;
@@ -224,7 +273,8 @@ function mergeMap(target, sources, incoming, pack, label) {
 
 /** Agent definition files: every `agents/*.json` except the view sidecars. */
 const VIEW_SUFFIX = ".view.json";
-const isDefinitionFile = (name) => name.endsWith(".json") && !name.endsWith(VIEW_SUFFIX);
+const isDefinitionFile = (name) =>
+  name.endsWith(".json") && !name.endsWith(VIEW_SUFFIX);
 
 /**
  * Artifact-view sidecar (WM-454, docs/event-runtime-artifact-views.md §2):
@@ -244,7 +294,11 @@ function loadArtifactView(root, defFile, def) {
   try {
     view = JSON.parse(readFileSync(abs, "utf8"));
   } catch (err) {
-    return { file: rel, view: null, anomaly: `artifact view ${rel} for ${def.ref} is unparseable: ${err.message}` };
+    return {
+      file: rel,
+      view: null,
+      anomaly: `artifact view ${rel} for ${def.ref} is unparseable: ${err.message}`,
+    };
   }
   const check = validateArtifactView(view, def.outputSchema);
   if (!check.valid) {
@@ -293,20 +347,28 @@ export function loadModelTierMap({ root = reposRoot() } = {}) {
   try {
     parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
   } catch (err) {
-    throw new RegistryError(`${file}: unparseable policy.yaml — ${err.message}`);
+    throw new RegistryError(
+      `${file}: unparseable policy.yaml — ${err.message}`,
+    );
   }
   const models = parsed?.models;
   if (models === undefined || models === null) return {};
   if (typeof models !== "object" || Array.isArray(models)) {
-    throw new RegistryError(`${file}: "models" must map adapter names to tier maps (WM-135)`);
+    throw new RegistryError(
+      `${file}: "models" must map adapter names to tier maps (WM-135)`,
+    );
   }
   for (const [adapter, tiers] of Object.entries(models)) {
     if (typeof tiers !== "object" || tiers === null || Array.isArray(tiers)) {
-      throw new RegistryError(`${file}: models.${adapter} must map tiers to model values (WM-135)`);
+      throw new RegistryError(
+        `${file}: models.${adapter} must map tiers to model values (WM-135)`,
+      );
     }
     for (const [tier, value] of Object.entries(tiers)) {
       if (!MODEL_TIERS.includes(tier)) {
-        throw new RegistryError(`${file}: models.${adapter}.${tier} is not a tier (${MODEL_TIERS.join(", ")})`);
+        throw new RegistryError(
+          `${file}: models.${adapter}.${tier} is not a tier (${MODEL_TIERS.join(", ")})`,
+        );
       }
       if (typeof value !== "string" || value.trim() === "") {
         throw new RegistryError(
@@ -344,10 +406,20 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
   const source = entry?.source ?? `${pack.name}: agent definition`;
   const def = entry?.definition;
   if (typeof def !== "object" || def === null || Array.isArray(def)) {
-    throw new RegistryError(`${source}: loader returned a non-object agent definition`);
+    throw new RegistryError(
+      `${source}: loader returned a non-object agent definition`,
+    );
   }
-  for (const field of ["id", "version", ...PINNED_FIELDS, "workspace", "capabilities", "limits"]) {
-    if (def[field] === undefined) throw new RegistryError(`${source}: missing "${field}"`);
+  for (const field of [
+    "id",
+    "version",
+    ...PINNED_FIELDS,
+    "workspace",
+    "capabilities",
+    "limits",
+  ]) {
+    if (def[field] === undefined)
+      throw new RegistryError(`${source}: missing "${field}"`);
   }
   if (!builtIn && def.mutating === true) {
     throw new RegistryError(
@@ -364,12 +436,16 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
   if (def.mutating !== false) {
     const tier2Worktree = def.workspace?.type === "worktree";
     const closedArgv =
-      Array.isArray(def.command) && def.command.length > 0 && def.command.every((e) => typeof e === "string");
+      Array.isArray(def.command) &&
+      def.command.length > 0 &&
+      def.command.every((e) => typeof e === "string");
     const closedActionRegistry =
       def.actionRegistry !== undefined &&
       def.hosts !== undefined &&
       Array.isArray(def.exec) &&
-      Object.values(def.actionRegistry).every((a) => typeof a?.remote === "string") &&
+      Object.values(def.actionRegistry).every(
+        (a) => typeof a?.remote === "string",
+      ) &&
       Object.values(def.hosts).every((t) => typeof t === "string");
     // Item-list form (OPS-229): every registered action is a fixed local argv,
     // applied per approved item — closed by construction, same as the others.
@@ -378,9 +454,17 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
       typeof def.itemsField === "string" &&
       typeof def.itemKey === "string" &&
       Object.values(def.actionRegistry).every(
-        (a) => Array.isArray(a?.argv) && a.argv.length > 0 && a.argv.every((e) => typeof e === "string"),
+        (a) =>
+          Array.isArray(a?.argv) &&
+          a.argv.length > 0 &&
+          a.argv.every((e) => typeof e === "string"),
       );
-    if (!closedArgv && !closedActionRegistry && !closedItemList && !tier2Worktree) {
+    if (
+      !closedArgv &&
+      !closedActionRegistry &&
+      !closedItemList &&
+      !tier2Worktree
+    ) {
       throw new RegistryError(
         `${source}: mutating agents are admitted only as closed command templates, closed action registries, or tier-2 worktree agents (docs/event-runtime.md §14; docs/event-runtime-dispatch.md §6; OPS-223/OPS-208/WM-108)`,
       );
@@ -395,7 +479,9 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
   // half-finished edit: write the set or delete the field.
   if (def.repos !== undefined) {
     const wellFormed =
-      Array.isArray(def.repos) && def.repos.length > 0 && def.repos.every((r) => typeof r === "string" && r.trim() !== "");
+      Array.isArray(def.repos) &&
+      def.repos.length > 0 &&
+      def.repos.every((r) => typeof r === "string" && r.trim() !== "");
     if (!wellFormed) {
       throw new RegistryError(
         `${source}: "repos" must be a non-empty array of non-empty repo names (WM-64) — omit the field for an unrestricted agent`,
@@ -412,25 +498,39 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
       `${source}: "model_tier" must be one of ${MODEL_TIERS.join(", ")} (got ${JSON.stringify(def.model_tier)}) — definitions declare intent, not model ids (WM-135)`,
     );
   }
-  if (def.model !== undefined && (typeof def.model !== "string" || def.model.trim() === "")) {
-    throw new RegistryError(`${source}: "model" must be a non-empty string model id — omit the field for tier/default routing (WM-135)`);
+  if (
+    def.model !== undefined &&
+    (typeof def.model !== "string" || def.model.trim() === "")
+  ) {
+    throw new RegistryError(
+      `${source}: "model" must be a non-empty string model id — omit the field for tier/default routing (WM-135)`,
+    );
   }
   if (
     def.chainCommandEdges !== undefined &&
     (!Array.isArray(def.chainCommandEdges) ||
       def.chainCommandEdges.length === 0 ||
-      !def.chainCommandEdges.every((type) => typeof type === "string" && type.trim() !== ""))
+      !def.chainCommandEdges.every(
+        (type) => typeof type === "string" && type.trim() !== "",
+      ))
   ) {
     throw new RegistryError(
       `${source}: "chainCommandEdges" must be a non-empty array of non-empty event type strings`,
     );
   }
-  if (def.chainRepoMustMatchInput !== undefined && def.chainRepoMustMatchInput !== true) {
-    throw new RegistryError(`${source}: "chainRepoMustMatchInput" must be true when present`);
+  if (
+    def.chainRepoMustMatchInput !== undefined &&
+    def.chainRepoMustMatchInput !== true
+  ) {
+    throw new RegistryError(
+      `${source}: "chainRepoMustMatchInput" must be true when present`,
+    );
   }
   if (def.dispatchGateExempt !== undefined) {
     if (def.dispatchGateExempt !== true) {
-      throw new RegistryError(`${source}: "dispatchGateExempt" must be true when present`);
+      throw new RegistryError(
+        `${source}: "dispatchGateExempt" must be true when present`,
+      );
     }
     if (def.workspace?.type !== "worktree") {
       throw new RegistryError(
@@ -445,17 +545,24 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
     const rel = def[field];
     const resource = loader.readPinned(rel, def);
     if (typeof resource !== "object" || resource === null) {
-      throw new RegistryError(`${source}: loader returned no pinned resource for "${rel}"`);
+      throw new RegistryError(
+        `${source}: loader returned no pinned resource for "${rel}"`,
+      );
     }
     const resourceSource = resource.source ?? `${source}: ${rel}`;
     if (resource.bytes === null || resource.bytes === undefined) {
-      throw new RegistryError(`${resourceSource}: pinned file "${rel}" does not exist`);
+      throw new RegistryError(
+        `${resourceSource}: pinned file "${rel}" does not exist`,
+      );
     }
     const actual = hashBytes(resource.bytes);
     const pinCommand = builtIn
       ? "bun event-runtime/cli.mjs update-pins"
       : `bun event-runtime/cli.mjs update-pins --pack ${pack.name}`;
-    if (!resource.expected) throw new RegistryError(`${source}: "${rel}" has no pin — run: ${pinCommand}`);
+    if (!resource.expected)
+      throw new RegistryError(
+        `${source}: "${rel}" has no pin — run: ${pinCommand}`,
+      );
     if (resource.expected !== actual) {
       throw new RegistryError(
         `${resourceSource}: "${rel}" content ${actual} does not match pin ${resource.expected} — bump the version (and re-pin) instead of editing in place`,
@@ -466,7 +573,9 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
   }
   const promptPath = resources.prompt.path ?? resources.prompt.source;
   if (typeof promptPath !== "string" || promptPath === "") {
-    throw new RegistryError(`${source}: loader returned no prompt path for "${def.prompt}"`);
+    throw new RegistryError(
+      `${source}: loader returned no prompt path for "${def.prompt}"`,
+    );
   }
   const localRef = `${def.id}@${def.version}`;
   const loaded = {
@@ -474,8 +583,14 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
     pins,
     ref: pack.namespace ? `${pack.namespace}/${localRef}` : localRef,
     promptPath,
-    inputSchema: parseJson(resources.input_schema.bytes, resources.input_schema.source ?? def.input_schema),
-    outputSchema: parseJson(resources.output_schema.bytes, resources.output_schema.source ?? def.output_schema),
+    inputSchema: parseJson(
+      resources.input_schema.bytes,
+      resources.input_schema.source ?? def.input_schema,
+    ),
+    outputSchema: parseJson(
+      resources.output_schema.bytes,
+      resources.output_schema.source ?? def.output_schema,
+    ),
   };
   // Which pack supplied the definition is runtime provenance, not definition
   // content: it is loader-injected and identical for every built-in agent. It
@@ -505,18 +620,32 @@ export function loadRegistry({
   modelTiers = loadModelTierMap(),
   loaderFor = defaultLoaderFor,
 } = {}) {
-  const configured = packRoots ?? (path.resolve(root) === path.resolve(RUNTIME_ROOT) ? loadPackRoots() : []);
-  if (!Array.isArray(configured)) throw new RegistryError("packRoots must be an array");
-  if (typeof loaderFor !== "function") throw new RegistryError("loaderFor must be a function");
+  const configured =
+    packRoots ??
+    (path.resolve(root) === path.resolve(RUNTIME_ROOT) ? loadPackRoots() : []);
+  if (!Array.isArray(configured))
+    throw new RegistryError("packRoots must be an array");
+  if (typeof loaderFor !== "function")
+    throw new RegistryError("loaderFor must be a function");
 
-  const builtIn = { kind: "fs", name: "event-runtime", path: path.resolve(root), root: path.resolve(root), namespace: "" };
+  const builtIn = {
+    kind: "fs",
+    name: "event-runtime",
+    path: path.resolve(root),
+    root: path.resolve(root),
+    namespace: "",
+  };
   const packs = [
     builtIn,
-    ...configured.map((pack) => (pack.kind === "fs" ? configuredPack(pack) : injectedPack(pack))),
+    ...configured.map((pack) =>
+      pack.kind === "fs" ? configuredPack(pack) : injectedPack(pack),
+    ),
   ];
   const bare = packs.filter((pack) => pack.namespace === "");
   if (bare.length !== 1) {
-    throw new RegistryError(`exactly one pack must own the bare namespace; found ${bare.length}: ${bare.map((p) => p.name).join(", ")}`);
+    throw new RegistryError(
+      `exactly one pack must own the bare namespace; found ${bare.length}: ${bare.map((p) => p.name).join(", ")}`,
+    );
   }
 
   const agents = new Map();
@@ -532,7 +661,10 @@ export function loadRegistry({
 
   for (const [index, pack] of packs.entries()) {
     const builtInPack = index === 0;
-    const loader = assertLoader(loaderFor(pack, { builtIn: builtInPack }), pack);
+    const loader = assertLoader(
+      loaderFor(pack, { builtIn: builtInPack }),
+      pack,
+    );
     for (const entry of loader.listAgentDefs()) {
       const def = loadAgentDef(pack, loader, entry, { builtIn: builtInPack });
       if (agents.has(def.ref)) {
@@ -553,30 +685,58 @@ export function loadRegistry({
       if (anomaly) anomalies.push(anomaly);
       views.set(def.ref, { file, view });
     }
-    mergeMap(eventTypes, eventSources, loader.readMap("event-types"), pack, "event type");
+    mergeMap(
+      eventTypes,
+      eventSources,
+      loader.readMap("event-types"),
+      pack,
+      "event type",
+    );
     mergeMap(edges, edgeSources, loader.readMap("edges"), pack, "edge source");
-    mergeMap(schedules, scheduleSources, loader.readMap("schedules"), pack, "schedule loop");
+    mergeMap(
+      schedules,
+      scheduleSources,
+      loader.readMap("schedules"),
+      pack,
+      "schedule loop",
+    );
   }
 
   for (const [type, mapping] of Object.entries(eventTypes)) {
-    if (typeof mapping !== "object" || mapping === null || Array.isArray(mapping)) {
+    if (
+      typeof mapping !== "object" ||
+      mapping === null ||
+      Array.isArray(mapping)
+    ) {
       throw new RegistryError(`event type ${type} must map to an object`);
     }
-    const agentRef = Object.hasOwn(mapping, "agent") ? mapping.agent : undefined;
+    const agentRef = Object.hasOwn(mapping, "agent")
+      ? mapping.agent
+      : undefined;
     // Observe-only types (WM-75): admitted and recorded, resolved by the
     // planner as a typed NOOP — never a run, never a human_needed ask. They
     // name no agent, and naming one anyway is a config error, not a hint.
     if (Object.hasOwn(mapping, "observe") && mapping.observe === true) {
       if (agentRef) {
-        throw new RegistryError(`event type ${type} is observe-only but names agent ${agentRef} — pick one`);
+        throw new RegistryError(
+          `event type ${type} is observe-only but names agent ${agentRef} — pick one`,
+        );
       }
       continue;
     }
     if (!agentRef || !agents.has(agentRef)) {
-      throw new RegistryError(`event type ${type} maps to unregistered agent ${agentRef}`);
+      throw new RegistryError(
+        `event type ${type} maps to unregistered agent ${agentRef}`,
+      );
     }
-    if (!Object.hasOwn(mapping, "idempotencyScope") || !Array.isArray(mapping.idempotencyScope) || mapping.idempotencyScope.length === 0) {
-      throw new RegistryError(`event type ${type} declares no idempotency scope (§5.4)`);
+    if (
+      !Object.hasOwn(mapping, "idempotencyScope") ||
+      !Array.isArray(mapping.idempotencyScope) ||
+      mapping.idempotencyScope.length === 0
+    ) {
+      throw new RegistryError(
+        `event type ${type} declares no idempotency scope (§5.4)`,
+      );
     }
     // Model-tier routing (WM-135): every routed (agent, adapter) pair must
     // resolve NOW — a declared tier without a policy mapping is a load error,
@@ -605,58 +765,102 @@ export function loadRegistry({
   // and pinned by each pack loader while definitions are loaded above.
   const schemas = {
     envelope: readJson(path.join(root, "schemas", "factory.event.v1.json")),
-    agentResult: readJson(path.join(root, "schemas", "factory.agent-result.v1.json")),
+    agentResult: readJson(
+      path.join(root, "schemas", "factory.agent-result.v1.json"),
+    ),
   };
 
   // Recommendation edges (OPS-223): validated fail-closed at load — a chain
   // may only connect registered agents through registered event types, and
   // input mappings may only draw from the source run's input or artifact.
   for (const [agentRef, rule] of Object.entries(edges)) {
-    if (!agents.has(agentRef)) throw new RegistryError(`edges.json: unregistered source agent ${agentRef}`);
+    if (!agents.has(agentRef))
+      throw new RegistryError(
+        `edges.json: unregistered source agent ${agentRef}`,
+      );
     if (typeof rule !== "object" || rule === null || Array.isArray(rule)) {
       throw new RegistryError(`edges.json: ${agentRef} must map to an object`);
     }
-    if (!Object.hasOwn(rule, "recommendationField") || typeof rule.recommendationField !== "string" || !rule.recommendationField) {
-      throw new RegistryError(`edges.json: ${agentRef} has no recommendationField`);
+    if (
+      !Object.hasOwn(rule, "recommendationField") ||
+      typeof rule.recommendationField !== "string" ||
+      !rule.recommendationField
+    ) {
+      throw new RegistryError(
+        `edges.json: ${agentRef} has no recommendationField`,
+      );
     }
     if (Object.hasOwn(rule, "independent") && rule.independent !== true) {
-      throw new RegistryError(`edges.json: ${agentRef}.independent must be true when present`);
+      throw new RegistryError(
+        `edges.json: ${agentRef}.independent must be true when present`,
+      );
     }
     const ruleEdges = Object.hasOwn(rule, "edges") ? rule.edges : {};
-    if (typeof ruleEdges !== "object" || ruleEdges === null || Array.isArray(ruleEdges)) {
-      throw new RegistryError(`edges.json: ${agentRef}.edges must be an object`);
+    if (
+      typeof ruleEdges !== "object" ||
+      ruleEdges === null ||
+      Array.isArray(ruleEdges)
+    ) {
+      throw new RegistryError(
+        `edges.json: ${agentRef}.edges must be an object`,
+      );
     }
     for (const [value, edge] of Object.entries(ruleEdges)) {
       if (typeof edge !== "object" || edge === null || Array.isArray(edge)) {
-        throw new RegistryError(`edges.json: ${agentRef}.${value} must be an object`);
+        throw new RegistryError(
+          `edges.json: ${agentRef}.${value} must be an object`,
+        );
       }
       if (rule.independent === true) {
         if (typeof edge.whenItemsField !== "string" || !edge.whenItemsField) {
-          throw new RegistryError(`edges.json: ${agentRef}.${value} independent edge has no whenItemsField`);
+          throw new RegistryError(
+            `edges.json: ${agentRef}.${value} independent edge has no whenItemsField`,
+          );
         }
-        if (typeof edge.mixedEventId !== "string" || !edge.mixedEventId.includes("${runId}")) {
+        if (
+          typeof edge.mixedEventId !== "string" ||
+          !edge.mixedEventId.includes("${runId}")
+        ) {
           throw new RegistryError(
             `edges.json: ${agentRef}.${value} independent edge needs a mixedEventId containing \${runId}`,
           );
         }
-        if (edge.itemsField !== undefined && !edge.mixedEventId.includes("${item.")) {
+        if (
+          edge.itemsField !== undefined &&
+          !edge.mixedEventId.includes("${item.")
+        ) {
           throw new RegistryError(
             `edges.json: ${agentRef}.${value} independent multi edge needs an item placeholder in mixedEventId`,
           );
         }
       }
       for (const field of ["eventId", "mixedEventId"]) {
-        if (edge[field] !== undefined && (typeof edge[field] !== "string" || edge[field].trim() === "")) {
-          throw new RegistryError(`edges.json: ${agentRef}.${value} ${field} must be a non-empty string`);
+        if (
+          edge[field] !== undefined &&
+          (typeof edge[field] !== "string" || edge[field].trim() === "")
+        ) {
+          throw new RegistryError(
+            `edges.json: ${agentRef}.${value} ${field} must be a non-empty string`,
+          );
         }
       }
-      const edgeEventType = Object.hasOwn(edge, "eventType") ? edge.eventType : undefined;
+      const edgeEventType = Object.hasOwn(edge, "eventType")
+        ? edge.eventType
+        : undefined;
       if (!edgeEventType || !Object.hasOwn(eventTypes, edgeEventType)) {
-        throw new RegistryError(`edges.json: ${agentRef}.${value} targets unregistered event type ${edgeEventType}`);
+        throw new RegistryError(
+          `edges.json: ${agentRef}.${value} targets unregistered event type ${edgeEventType}`,
+        );
       }
       for (const expr of Object.values(edge.input ?? {})) {
-        if (typeof expr === "string" && expr.startsWith("$.") && !/^\$\.(input|artifact|artifactHash)(\.|$)/.test(expr)) {
-          throw new RegistryError(`edges.json: ${agentRef}.${value} input path "${expr}" — only $.input.*, $.artifact.* and $.artifactHash.* are allowed`);
+        if (
+          typeof expr === "string" &&
+          expr.startsWith("$.") &&
+          !/^\$\.(input|artifact|artifactHash)(\.|$)/.test(expr)
+        ) {
+          throw new RegistryError(
+            `edges.json: ${agentRef}.${value} input path "${expr}" — only $.input.*, $.artifact.* and $.artifactHash.* are allowed`,
+          );
         }
       }
     }
@@ -666,8 +870,13 @@ export function loadRegistry({
   // cadence or an unregistered event type must be a startup error, not a
   // surprise at 03:00 when nothing fires.
   for (const [loop, schedule] of Object.entries(schedules)) {
-    if (!/^[a-z][a-z0-9-]*$/.test(loop)) throw new RegistryError(`schedules.json: bad loop name "${loop}"`);
-    if (typeof schedule !== "object" || schedule === null || Array.isArray(schedule)) {
+    if (!/^[a-z][a-z0-9-]*$/.test(loop))
+      throw new RegistryError(`schedules.json: bad loop name "${loop}"`);
+    if (
+      typeof schedule !== "object" ||
+      schedule === null ||
+      Array.isArray(schedule)
+    ) {
       throw new RegistryError(`schedules.json: ${loop} must map to an object`);
     }
     try {
@@ -675,29 +884,43 @@ export function loadRegistry({
     } catch (err) {
       throw new RegistryError(`schedules.json: ${loop}: ${err.message}`);
     }
-    const scheduleEventType = Object.hasOwn(schedule, "eventType") ? schedule.eventType : undefined;
+    const scheduleEventType = Object.hasOwn(schedule, "eventType")
+      ? schedule.eventType
+      : undefined;
     if (!scheduleEventType || !Object.hasOwn(eventTypes, scheduleEventType)) {
-      throw new RegistryError(`schedules.json: ${loop} fires unregistered event type ${scheduleEventType}`);
+      throw new RegistryError(
+        `schedules.json: ${loop} fires unregistered event type ${scheduleEventType}`,
+      );
     }
     const catchUp = schedule.catchUp ?? "none";
     if (!CATCH_UP_MODES.includes(catchUp)) {
-      throw new RegistryError(`schedules.json: ${loop} has unknown catchUp "${catchUp}" (${CATCH_UP_MODES.join(", ")})`);
+      throw new RegistryError(
+        `schedules.json: ${loop} has unknown catchUp "${catchUp}" (${CATCH_UP_MODES.join(", ")})`,
+      );
     }
     const approval = schedule.approval ?? "watched";
     if (!APPROVAL_MODES.includes(approval)) {
-      throw new RegistryError(`schedules.json: ${loop} has unknown approval "${approval}" (${APPROVAL_MODES.join(", ")})`);
+      throw new RegistryError(
+        `schedules.json: ${loop} has unknown approval "${approval}" (${APPROVAL_MODES.join(", ")})`,
+      );
     }
     // Unattended approval on a loop that is not even switched on is almost
     // certainly a half-finished edit; refuse it rather than let it lurk.
     if (approval === "auto" && !schedule.enabled) {
-      throw new RegistryError(`schedules.json: ${loop} declares approval "auto" but is not enabled — decide one`);
+      throw new RegistryError(
+        `schedules.json: ${loop} declares approval "auto" but is not enabled — decide one`,
+      );
     }
     // The ship chain's deploy-branch merge is PERMANENTLY watched: that
     // approval IS the human master decision, so the config that would
     // delete it cannot load, whoever writes it and however good the track
     // record looks (docs/event-runtime-dispatch.md §7, WM-111).
     const scheduledMapping = eventTypes[scheduleEventType];
-    if (approval === "auto" && Object.hasOwn(scheduledMapping, "humanApprovalOnly") && scheduledMapping.humanApprovalOnly === true) {
+    if (
+      approval === "auto" &&
+      Object.hasOwn(scheduledMapping, "humanApprovalOnly") &&
+      scheduledMapping.humanApprovalOnly === true
+    ) {
       throw new RegistryError(
         `schedules.json: ${loop} declares approval "auto" but ${scheduleEventType} is humanApprovalOnly — the deploy-branch decision is permanently the human's watched approval (docs/event-runtime-dispatch.md §7, WM-111)`,
       );
@@ -706,12 +929,25 @@ export function loadRegistry({
     // {repo}). Tick fields always win the merge, so a payload claiming
     // loop/slot identity is a config error, not a spoofing vector.
     if (schedule.payload !== undefined) {
-      if (typeof schedule.payload !== "object" || schedule.payload === null || Array.isArray(schedule.payload)) {
-        throw new RegistryError(`schedules.json: ${loop} payload must be a plain object`);
+      if (
+        typeof schedule.payload !== "object" ||
+        schedule.payload === null ||
+        Array.isArray(schedule.payload)
+      ) {
+        throw new RegistryError(
+          `schedules.json: ${loop} payload must be a plain object`,
+        );
       }
-      for (const reserved of ["loop", "slot", "cadenceSeconds", "skippedSlots"]) {
+      for (const reserved of [
+        "loop",
+        "slot",
+        "cadenceSeconds",
+        "skippedSlots",
+      ]) {
         if (reserved in schedule.payload) {
-          throw new RegistryError(`schedules.json: ${loop} payload must not set reserved tick field "${reserved}"`);
+          throw new RegistryError(
+            `schedules.json: ${loop} payload must not set reserved tick field "${reserved}"`,
+          );
         }
       }
     }
@@ -719,7 +955,11 @@ export function loadRegistry({
 
   return {
     root,
-    packs: packs.map(({ name, root: packRoot, namespace }) => ({ name, root: packRoot, namespace })),
+    packs: packs.map(({ name, root: packRoot, namespace }) => ({
+      name,
+      root: packRoot,
+      namespace,
+    })),
     agents,
     views,
     anomalies,
@@ -743,7 +983,9 @@ export function getAgent(registry, ref) {
 }
 
 export function getEventType(registry, type) {
-  return Object.hasOwn(registry.eventTypes, type) ? registry.eventTypes[type] : null;
+  return Object.hasOwn(registry.eventTypes, type)
+    ? registry.eventTypes[type]
+    : null;
 }
 
 /**
@@ -756,7 +998,8 @@ export function updatePins({ root = RUNTIME_ROOT, pack } = {}) {
     let descriptor = pack;
     if (typeof pack === "string") {
       descriptor = loadPackRoots().find((candidate) => candidate.name === pack);
-      if (!descriptor) throw new RegistryError(`unknown configured pack "${pack}"`);
+      if (!descriptor)
+        throw new RegistryError(`unknown configured pack "${pack}"`);
     }
     const resolved = configuredPack(descriptor);
     const loader = createFsPackLoader(resolved, { ignorePins: true });
@@ -768,14 +1011,17 @@ export function updatePins({ root = RUNTIME_ROOT, pack } = {}) {
         if (!rel) continue;
         const resource = loader.readPinned(rel, def);
         if (resource.bytes === null || resource.bytes === undefined) {
-          throw new RegistryError(`${resource.source ?? entry.source}: pinned file "${rel}" does not exist`);
+          throw new RegistryError(
+            `${resource.source ?? entry.source}: pinned file "${rel}" does not exist`,
+          );
         }
         pins[rel] = hashBytes(resource.bytes);
       }
     }
     const pinsFile = path.join(resolved.root, "pins.json");
     const serialized = `${JSON.stringify(pins, null, 2)}\n`;
-    if (existsSync(pinsFile) && readFileSync(pinsFile, "utf8") === serialized) return [];
+    if (existsSync(pinsFile) && readFileSync(pinsFile, "utf8") === serialized)
+      return [];
     writeFileSync(pinsFile, serialized, "utf8");
     return [resolved.name];
   }
@@ -791,7 +1037,11 @@ export function updatePins({ root = RUNTIME_ROOT, pack } = {}) {
       pins[def[field]] = hashBytes(readFileSync(path.join(root, def[field])));
     }
     if (JSON.stringify(def.pins) !== JSON.stringify(pins)) {
-      writeFileSync(file, `${JSON.stringify({ ...def, pins }, null, 2)}\n`, "utf8");
+      writeFileSync(
+        file,
+        `${JSON.stringify({ ...def, pins }, null, 2)}\n`,
+        "utf8",
+      );
       changed.push(name);
     }
   }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { canonicalJson, hashBytes } from "./canonical.mjs";
@@ -23,9 +29,14 @@ import { computeDefHash } from "./receipts.mjs";
 function tempRegistry() {
   const root = mkdtempSync(path.join(tmpdir(), "event-registry-"));
   for (const dir of ["agents", "schemas"]) {
-    cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), { recursive: true });
+    cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), {
+      recursive: true,
+    });
   }
-  cpSync(path.join(RUNTIME_ROOT, "event-types.json"), path.join(root, "event-types.json"));
+  cpSync(
+    path.join(RUNTIME_ROOT, "event-types.json"),
+    path.join(root, "event-types.json"),
+  );
   return root;
 }
 
@@ -35,16 +46,28 @@ function tempRegistry() {
  * definition declares. The claude map stays as the per-route exception's
  * mapping — no committed route consumes it today.
  */
-const SAMPLE_PACK_ROOT = path.join(RUNTIME_ROOT, "test-support", "packs", "sample");
+const SAMPLE_PACK_ROOT = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "packs",
+  "sample",
+);
 
-function samplePack(root = SAMPLE_PACK_ROOT, name = "sample", namespace = "sample") {
+function samplePack(
+  root = SAMPLE_PACK_ROOT,
+  name = "sample",
+  namespace = "sample",
+) {
   return { kind: "fs", name, path: root, namespace };
 }
 
 function tempPack({ name = "sample", namespace = "sample" } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "event-pack-"));
   cpSync(SAMPLE_PACK_ROOT, root, { recursive: true });
-  writeFileSync(path.join(root, "pack.json"), `${JSON.stringify({ name, version: "1.0.0", namespace }, null, 2)}\n`);
+  writeFileSync(
+    path.join(root, "pack.json"),
+    `${JSON.stringify({ name, version: "1.0.0", namespace }, null, 2)}\n`,
+  );
   return samplePack(root, name, namespace);
 }
 
@@ -52,7 +75,10 @@ function registryDigest(registry) {
   const agents = Object.fromEntries(
     [...registry.agents].map(([ref, def]) => {
       const { pack: _pack, promptPath, ...stable } = def;
-      return [ref, { ...stable, promptPath: path.relative(registry.root, promptPath) }];
+      return [
+        ref,
+        { ...stable, promptPath: path.relative(registry.root, promptPath) },
+      ];
     }),
   );
   return hashBytes(
@@ -91,8 +117,12 @@ describe("registry", () => {
     const def = getAgent(registry, "factory-status-report@1");
     expect(def.outputSchema.required).toContain("recommendedAction");
     expect(def.pack).toBe("event-runtime");
-    expect(registry.packs).toEqual([{ name: "event-runtime", root: RUNTIME_ROOT, namespace: "" }]);
-    expect(getEventType(registry, "factory.status-report.requested").agent).toBe("factory-status-report@1");
+    expect(registry.packs).toEqual([
+      { name: "event-runtime", root: RUNTIME_ROOT, namespace: "" },
+    ]);
+    expect(
+      getEventType(registry, "factory.status-report.requested").agent,
+    ).toBe("factory-status-report@1");
     expect(getEventType(registry, "unknown.event")).toBeNull();
   });
 
@@ -107,9 +137,9 @@ describe("registry", () => {
     // WM-469 intentionally adds the three declarative kernel-control fields
     // to the affected definitions while preserving their refs and pins
     // (digest regenerated on top of the #559 baseline).
-    // Regenerated after rebase over #567 (WM-679) + #563 (WM-469): both change
-    // agent definitions, which are registry inputs. Reason in PR body.
-    const expected = "sha256:55929d285a47a1abfadca8df9a0b8dab3ff421bd55ec4b939e77c25ecca92536";
+    // Regenerated after WM-610 prettier reformat of code and markdown files.
+    const expected =
+      "sha256:f618f5d7bbcbdac48dadf5ed490ebeefee9734ac9f78e535ef5bb29ba9ee414b";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -126,21 +156,38 @@ describe("registry", () => {
     const def = registry.agents.get("dispatch@1");
     expect(def.pack).toBe("event-runtime");
     expect(Object.keys(def)).not.toContain("pack");
-    expect(computeDefHash(def)).toBe("sha256:323836eeac3c5b7370dc13e83cbe4f0d7cc029155e76ea0fc80672b7a7f973fd");
+    expect(computeDefHash(def)).toBe(
+      "sha256:0314e7e591bb4942e04a86a1211b28469d6ce750b3e9384db82380eaf396ec95",
+    );
   });
 
   test("loads a namespaced filesystem pack and validates the merged maps", () => {
     const registry = loadRegistry({ packRoots: [samplePack()] });
     const def = getAgent(registry, "sample/echo@1");
     expect(def.pack).toBe("sample");
-    expect(def.promptPath).toBe(path.join(SAMPLE_PACK_ROOT, "agents", "echo.md"));
-    expect(def.pins).toEqual(JSON.parse(readFileSync(path.join(SAMPLE_PACK_ROOT, "pins.json"), "utf8")));
+    expect(def.promptPath).toBe(
+      path.join(SAMPLE_PACK_ROOT, "agents", "echo.md"),
+    );
+    expect(def.pins).toEqual(
+      JSON.parse(
+        readFileSync(path.join(SAMPLE_PACK_ROOT, "pins.json"), "utf8"),
+      ),
+    );
     expect(Object.entries(def.pins)).toHaveLength(3);
-    expect(getEventType(registry, "sample.echo.requested").agent).toBe("sample/echo@1");
-    expect(getEventType(registry, "sample.core-status.requested").agent).toBe("factory-status-report@1");
+    expect(getEventType(registry, "sample.echo.requested").agent).toBe(
+      "sample/echo@1",
+    );
+    expect(getEventType(registry, "sample.core-status.requested").agent).toBe(
+      "factory-status-report@1",
+    );
     expect(registry.edges["sample/echo@1"].recommendationField).toBe("message");
-    expect(registry.schedules["sample-echo"].eventType).toBe("sample.echo.requested");
-    expect(registry.packs.map((pack) => pack.name)).toEqual(["event-runtime", "sample"]);
+    expect(registry.schedules["sample-echo"].eventType).toBe(
+      "sample.echo.requested",
+    );
+    expect(registry.packs.map((pack) => pack.name)).toEqual([
+      "event-runtime",
+      "sample",
+    ]);
   });
 
   test("merged validation accepts a loader with no filesystem access", () => {
@@ -160,7 +207,12 @@ describe("registry", () => {
       limits: { timeout_seconds: 30, attempts: 1 },
       mutating: false,
     };
-    const pins = Object.fromEntries(Object.entries(resources).map(([name, bytes]) => [name, hashBytes(bytes)]));
+    const pins = Object.fromEntries(
+      Object.entries(resources).map(([name, bytes]) => [
+        name,
+        hashBytes(bytes),
+      ]),
+    );
     const loader = {
       listAgentDefs: () => [{ source: "memory:agents/echo.json", definition }],
       readPinned: (relative) => ({
@@ -181,13 +233,23 @@ describe("registry", () => {
           : Object.create(null),
     };
     const registry = loadRegistry({
-      packRoots: [{ kind: "memory", name: "memory", namespace: "memory", root: "memory:pack" }],
-      loaderFor: (pack, options) => (pack.kind === "memory" ? loader : createFsPackLoader(pack, options)),
+      packRoots: [
+        {
+          kind: "memory",
+          name: "memory",
+          namespace: "memory",
+          root: "memory:pack",
+        },
+      ],
+      loaderFor: (pack, options) =>
+        pack.kind === "memory" ? loader : createFsPackLoader(pack, options),
     });
     const def = getAgent(registry, "memory/echo@1");
     expect(def.promptPath).toBe("memory:agents/echo.md");
     expect(def.pins).toEqual(pins);
-    expect(getEventType(registry, "memory.echo.requested").agent).toBe("memory/echo@1");
+    expect(getEventType(registry, "memory.echo.requested").agent).toBe(
+      "memory/echo@1",
+    );
   });
 
   test("duplicate agent refs identify both source packs", () => {
@@ -239,7 +301,9 @@ describe("registry", () => {
         },
       }),
     );
-    expect(() => loadRegistry({ packRoots: [edgePack] })).toThrow(/targets unregistered event type toString/);
+    expect(() => loadRegistry({ packRoots: [edgePack] })).toThrow(
+      /targets unregistered event type toString/,
+    );
 
     const schedulePack = tempPack();
     writeFileSync(
@@ -253,12 +317,16 @@ describe("registry", () => {
         },
       }),
     );
-    expect(() => loadRegistry({ packRoots: [schedulePack] })).toThrow(/fires unregistered event type constructor/);
+    expect(() => loadRegistry({ packRoots: [schedulePack] })).toThrow(
+      /fires unregistered event type constructor/,
+    );
   });
 
   test("exactly one pack owns the bare namespace", () => {
     const bare = tempPack({ name: "bare-extra", namespace: "" });
-    expect(() => loadRegistry({ packRoots: [bare] })).toThrow(/exactly one pack must own the bare namespace.*event-runtime.*bare-extra/);
+    expect(() => loadRegistry({ packRoots: [bare] })).toThrow(
+      /exactly one pack must own the bare namespace.*event-runtime.*bare-extra/,
+    );
   });
 
   test("config-listed packs cannot admit mutating agents", () => {
@@ -266,7 +334,9 @@ describe("registry", () => {
     const defFile = path.join(pack.path, "agents", "echo.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, mutating: true }));
-    expect(() => loadRegistry({ packRoots: [pack] })).toThrow(/config-listed pack.*may not declare mutating: true.*WM-468/);
+    expect(() => loadRegistry({ packRoots: [pack] })).toThrow(
+      /config-listed pack.*may not declare mutating: true.*WM-468/,
+    );
   });
 
   test("a pack agent that merely omits mutating is not refused by the pack rule (WM-470)", () => {
@@ -276,9 +346,13 @@ describe("registry", () => {
     // so an omitting def must additionally be enforceable by construction.
     const pack = tempPack();
     const defFile = path.join(pack.path, "agents", "echo.json");
-    const { mutating: _mutating, ...def } = JSON.parse(readFileSync(defFile, "utf8"));
+    const { mutating: _mutating, ...def } = JSON.parse(
+      readFileSync(defFile, "utf8"),
+    );
     writeFileSync(defFile, JSON.stringify(def));
-    expect(() => loadRegistry({ packRoots: [pack] })).not.toThrow(/may not declare mutating: true/);
+    expect(() => loadRegistry({ packRoots: [pack] })).not.toThrow(
+      /may not declare mutating: true/,
+    );
     writeFileSync(defFile, JSON.stringify({ ...def, command: ["true"] }));
     const registry = loadRegistry({ packRoots: [pack] });
     expect(getAgent(registry, "sample/echo@1").mutating).toBeUndefined();
@@ -288,7 +362,9 @@ describe("registry", () => {
     const pack = tempPack();
     const prompt = path.join(pack.path, "agents", "echo.md");
     writeFileSync(prompt, `${readFileSync(prompt, "utf8")}drift\n`);
-    expect(() => loadRegistry({ packRoots: [pack] })).toThrow(/does not match pin/);
+    expect(() => loadRegistry({ packRoots: [pack] })).toThrow(
+      /does not match pin/,
+    );
     expect(updatePins({ pack })).toEqual(["sample"]);
     expect(() => loadRegistry({ packRoots: [pack] })).not.toThrow();
     writeFileSync(path.join(pack.path, "pins.json"), "not-json\n");
@@ -298,9 +374,15 @@ describe("registry", () => {
     const mismatched = tempPack({ name: "policy-name" });
     writeFileSync(
       path.join(mismatched.path, "pack.json"),
-      JSON.stringify({ name: "manifest-name", version: "1.0.0", namespace: "sample" }),
+      JSON.stringify({
+        name: "manifest-name",
+        version: "1.0.0",
+        namespace: "sample",
+      }),
     );
-    expect(() => loadRegistry({ packRoots: [mismatched] })).toThrow(/does not match policy name/);
+    expect(() => loadRegistry({ packRoots: [mismatched] })).toThrow(
+      /does not match policy name/,
+    );
   });
 
   test("loadPackRoots reads only policy-listed roots and validates fail-closed", () => {
@@ -309,37 +391,60 @@ describe("registry", () => {
     const policy = path.join(root, "config", "policy.yaml");
     expect(loadPackRoots({ root })).toEqual([]);
 
-    writeFileSync(policy, "packs:\n  - name: sample\n    path: vendor/sample\n    namespace: sample\n");
+    writeFileSync(
+      policy,
+      "packs:\n  - name: sample\n    path: vendor/sample\n    namespace: sample\n",
+    );
     expect(loadPackRoots({ root })).toEqual([
-      { kind: "fs", name: "sample", path: path.join(root, "vendor", "sample"), namespace: "sample" },
+      {
+        kind: "fs",
+        name: "sample",
+        path: path.join(root, "vendor", "sample"),
+        namespace: "sample",
+      },
     ]);
     writeFileSync(policy, "packs:\n  sample: vendor/sample\n");
     expect(() => loadPackRoots({ root })).toThrow(/packs.*array/);
-    writeFileSync(policy, "packs:\n  - name: sample\n    path: one\n  - name: sample\n    path: two\n");
+    writeFileSync(
+      policy,
+      "packs:\n  - name: sample\n    path: one\n  - name: sample\n    path: two\n",
+    );
     expect(() => loadPackRoots({ root })).toThrow(/duplicate pack name/);
   });
 
   test("update-pins --pack rejects missing and unknown pack names", () => {
     const run = (...args) =>
       Bun.spawnSync({
-        cmd: [process.execPath, "event-runtime/cli.mjs", "update-pins", ...args],
+        cmd: [
+          process.execPath,
+          "event-runtime/cli.mjs",
+          "update-pins",
+          ...args,
+        ],
         cwd: path.dirname(RUNTIME_ROOT),
         stdout: "pipe",
         stderr: "pipe",
       });
     const missing = run("--pack");
     expect(missing.exitCode).not.toBe(0);
-    expect(missing.stderr.toString()).toContain("usage: update-pins [--pack NAME]");
+    expect(missing.stderr.toString()).toContain(
+      "usage: update-pins [--pack NAME]",
+    );
 
     const unknown = run("--pack", "not-configured");
     expect(unknown.exitCode).not.toBe(0);
-    expect(unknown.stderr.toString()).toContain('unknown configured pack "not-configured"');
+    expect(unknown.stderr.toString()).toContain(
+      'unknown configured pack "not-configured"',
+    );
   });
 
   test("editing a pinned file without re-pinning fails closed", () => {
     const root = tempRegistry();
     const promptFile = path.join(root, "agents", "factory-status-report.md");
-    writeFileSync(promptFile, `${readFileSync(promptFile, "utf8")}\n<!-- drift -->\n`);
+    writeFileSync(
+      promptFile,
+      `${readFileSync(promptFile, "utf8")}\n<!-- drift -->\n`,
+    );
     expect(() => loadRegistry({ root })).toThrow(RegistryError);
     updatePins({ root });
     expect(() => loadRegistry({ root })).not.toThrow();
@@ -358,13 +463,18 @@ describe("registry", () => {
     const def = getAgent(registry, "dispatch@1");
     expect(def.mutating).toBe(true);
     expect(def.workspace.type).toBe("worktree");
-    expect(getEventType(registry, "factory.dispatch.requested").agent).toBe("dispatch@1");
+    expect(getEventType(registry, "factory.dispatch.requested").agent).toBe(
+      "dispatch@1",
+    );
     // The carve-out is the workspace type, nothing wider: the same def on an
     // ephemeral workspace must still fail closed.
     const root = tempRegistry();
     const defFile = path.join(root, "agents", "dispatch.json");
     const raw = JSON.parse(readFileSync(defFile, "utf8"));
-    writeFileSync(defFile, JSON.stringify({ ...raw, workspace: { type: "ephemeral" } }));
+    writeFileSync(
+      defFile,
+      JSON.stringify({ ...raw, workspace: { type: "ephemeral" } }),
+    );
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
   });
 
@@ -374,14 +484,21 @@ describe("registry", () => {
     const apply = JSON.parse(readFileSync(applyFile, "utf8"));
     writeFileSync(
       applyFile,
-      JSON.stringify({ ...apply, chainCommandEdges: ["factory.not-registered"] }),
+      JSON.stringify({
+        ...apply,
+        chainCommandEdges: ["factory.not-registered"],
+      }),
     );
     expect(() => loadRegistry({ root: badEdgeRoot })).toThrow(
       /chainCommandEdges targets unregistered event type factory\.not-registered/,
     );
 
     const badRepoMatchRoot = tempRegistry();
-    const verifyFile = path.join(badRepoMatchRoot, "agents", "merge-verify.json");
+    const verifyFile = path.join(
+      badRepoMatchRoot,
+      "agents",
+      "merge-verify.json",
+    );
     const verify = JSON.parse(readFileSync(verifyFile, "utf8"));
     writeFileSync(
       verifyFile,
@@ -392,9 +509,16 @@ describe("registry", () => {
     );
 
     const badExemptionRoot = tempRegistry();
-    const exemptFile = path.join(badExemptionRoot, "agents", "merge-verify.json");
+    const exemptFile = path.join(
+      badExemptionRoot,
+      "agents",
+      "merge-verify.json",
+    );
     const exempt = JSON.parse(readFileSync(exemptFile, "utf8"));
-    writeFileSync(exemptFile, JSON.stringify({ ...exempt, dispatchGateExempt: true }));
+    writeFileSync(
+      exemptFile,
+      JSON.stringify({ ...exempt, dispatchGateExempt: true }),
+    );
     expect(() => loadRegistry({ root: badExemptionRoot })).toThrow(
       /"dispatchGateExempt" is admissible only for workspace\.type "worktree"/,
     );
@@ -407,7 +531,10 @@ describe("registry", () => {
     );
     expect(declared.length).toBeGreaterThan(0);
     for (const [agentRef, eventType] of declared) {
-      expect(loaded.eventTypes[eventType], `${agentRef} -> ${eventType}`).toBeDefined();
+      expect(
+        loaded.eventTypes[eventType],
+        `${agentRef} -> ${eventType}`,
+      ).toBeDefined();
     }
   });
 
@@ -417,7 +544,12 @@ describe("registry", () => {
       writeFileSync(
         path.join(root, "schedules.json"),
         JSON.stringify({
-          "reconcile-x": { every: "10m", eventType: "factory.reconcile.requested", payload, enabled: false },
+          "reconcile-x": {
+            every: "10m",
+            eventType: "factory.reconcile.requested",
+            payload,
+            enabled: false,
+          },
         }),
       );
     withPayload(["bj29"]);
@@ -432,7 +564,8 @@ describe("registry", () => {
     const root = tempRegistry();
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
-    const withRepos = (repos) => writeFileSync(defFile, JSON.stringify({ ...def, repos }));
+    const withRepos = (repos) =>
+      writeFileSync(defFile, JSON.stringify({ ...def, repos }));
 
     withRepos("bj29"); // not an array
     expect(() => loadRegistry({ root })).toThrow(/"repos"/);
@@ -447,7 +580,10 @@ describe("registry", () => {
     // config/repos.yaml here — the planner owns that at plan time.
     withRepos(["bj29", "not-in-repos-yaml"]);
     const registry = loadRegistry({ root });
-    expect(getAgent(registry, "factory-status-report@1").repos).toEqual(["bj29", "not-in-repos-yaml"]);
+    expect(getAgent(registry, "factory-status-report@1").repos).toEqual([
+      "bj29",
+      "not-in-repos-yaml",
+    ]);
   });
 
   test("model_tier: valid tiers load and are readable; absent field stays absent (WM-135)", () => {
@@ -459,7 +595,9 @@ describe("registry", () => {
     // tier any routed definition declares — event types outside this test's
     // own agent are validated too.
     const registry = loadRegistry({ root, modelTiers: PI_TIERS });
-    expect(getAgent(registry, "factory-status-report@1").model_tier).toBe("standard");
+    expect(getAgent(registry, "factory-status-report@1").model_tier).toBe(
+      "standard",
+    );
     // A definition that declares nothing is untouched — adapter default.
     expect(getAgent(registry, "reconcile@1").model_tier).toBeUndefined();
     expect(getAgent(registry, "reconcile@1").model).toBeUndefined();
@@ -471,9 +609,12 @@ describe("registry", () => {
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     for (const bad of ["medium", "opus-4", 3, null]) {
       writeFileSync(defFile, JSON.stringify({ ...def, model_tier: bad }));
-      expect(() => loadRegistry({ root, modelTiers: { claude: { strong: "default", standard: "sonnet" } } })).toThrow(
-        /"model_tier"/,
-      );
+      expect(() =>
+        loadRegistry({
+          root,
+          modelTiers: { claude: { strong: "default", standard: "sonnet" } },
+        }),
+      ).toThrow(/"model_tier"/);
     }
   });
 
@@ -485,11 +626,18 @@ describe("registry", () => {
     // No pi tier map at all, and a map missing this one tier: both refuse.
     // (factory-status-report is the first routed event type in the file, so
     // its unmapped "light" is what the load trips on in both cases.)
-    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/no mapping for adapter "pi"/);
+    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(
+      /no mapping for adapter "pi"/,
+    );
     expect(() =>
       loadRegistry({
         root,
-        modelTiers: { pi: { strong: "openai-codex/gpt-5.6-sol", standard: "openai-codex/gpt-5.6-terra" } },
+        modelTiers: {
+          pi: {
+            strong: "openai-codex/gpt-5.6-sol",
+            standard: "openai-codex/gpt-5.6-terra",
+          },
+        },
       }),
     ).toThrow(/model_tier "light" has no mapping/);
   });
@@ -502,7 +650,13 @@ describe("registry", () => {
     // reconcile routes via the command adapter — "light" is resolved for no
     // adapter there, so the command route stays applicable either way.
     const registry = loadRegistry({ root, modelTiers: PI_TIERS });
-    expect(resolveModel(getAgent(registry, "reconcile@1"), "command", registry.modelTiers)).toBeNull();
+    expect(
+      resolveModel(
+        getAgent(registry, "reconcile@1"),
+        "command",
+        registry.modelTiers,
+      ),
+    ).toBeNull();
   });
 
   test("model override: malformed rejected, well-formed wins over the tier (WM-135)", () => {
@@ -517,33 +671,59 @@ describe("registry", () => {
 
     // Both fields allowed; the override wins, and it also satisfies load even
     // though "light" has no mapping — the tier is never consulted.
-    writeFileSync(defFile, JSON.stringify({ ...def, model: "claude-opus-4-1", model_tier: "light" }));
+    writeFileSync(
+      defFile,
+      JSON.stringify({ ...def, model: "claude-opus-4-1", model_tier: "light" }),
+    );
     const registry = loadRegistry({ root, modelTiers: tiers });
     const loaded = getAgent(registry, "factory-status-report@1");
-    expect(resolveModel(loaded, "claude", registry.modelTiers)).toBe("claude-opus-4-1");
+    expect(resolveModel(loaded, "claude", registry.modelTiers)).toBe(
+      "claude-opus-4-1",
+    );
   });
 
   test("resolveModel: override > tier map > adapter default; sentinel passes through (WM-135)", () => {
-    const tiers = { claude: { strong: "default", standard: "sonnet", light: "haiku" } };
-    expect(resolveModel({ ref: "x@1", model_tier: "standard" }, "claude", tiers)).toBe("sonnet");
-    expect(resolveModel({ ref: "x@1", model_tier: "strong" }, "claude", tiers)).toBe(DEFAULT_MODEL);
-    expect(resolveModel({ ref: "x@1", model: "haiku", model_tier: "strong" }, "claude", tiers)).toBe("haiku");
+    const tiers = {
+      claude: { strong: "default", standard: "sonnet", light: "haiku" },
+    };
+    expect(
+      resolveModel({ ref: "x@1", model_tier: "standard" }, "claude", tiers),
+    ).toBe("sonnet");
+    expect(
+      resolveModel({ ref: "x@1", model_tier: "strong" }, "claude", tiers),
+    ).toBe(DEFAULT_MODEL);
+    expect(
+      resolveModel(
+        { ref: "x@1", model: "haiku", model_tier: "strong" },
+        "claude",
+        tiers,
+      ),
+    ).toBe("haiku");
     expect(resolveModel({ ref: "x@1" }, "claude", tiers)).toBeNull(); // nothing declared → adapter default
-    expect(resolveModel({ ref: "x@1", model_tier: "light" }, "command", tiers)).toBeNull(); // not applicable
-    expect(() => resolveModel({ ref: "x@1", model_tier: "light" }, "claude", {})).toThrow(RegistryError);
+    expect(
+      resolveModel({ ref: "x@1", model_tier: "light" }, "command", tiers),
+    ).toBeNull(); // not applicable
+    expect(() =>
+      resolveModel({ ref: "x@1", model_tier: "light" }, "claude", {}),
+    ).toThrow(RegistryError);
   });
 
   test("loadModelTierMap: reads policy.yaml, validates shape fail-closed, tolerates absence (WM-135)", () => {
     const root = mkdtempSync(path.join(tmpdir(), "event-policy-"));
     expect(loadModelTierMap({ root })).toEqual({}); // no policy.yaml at all
     mkdirSync(path.join(root, "config"), { recursive: true });
-    const write = (yaml) => writeFileSync(path.join(root, "config", "policy.yaml"), yaml);
+    const write = (yaml) =>
+      writeFileSync(path.join(root, "config", "policy.yaml"), yaml);
 
     write("concurrency:\n  max_in_flight_per_repo: 3\n"); // no models block
     expect(loadModelTierMap({ root })).toEqual({});
 
-    write("models:\n  claude:\n    strong: default\n    standard: sonnet\n    light: haiku\n");
-    expect(loadModelTierMap({ root })).toEqual({ claude: { strong: "default", standard: "sonnet", light: "haiku" } });
+    write(
+      "models:\n  claude:\n    strong: default\n    standard: sonnet\n    light: haiku\n",
+    );
+    expect(loadModelTierMap({ root })).toEqual({
+      claude: { strong: "default", standard: "sonnet", light: "haiku" },
+    });
 
     write("models:\n  claude:\n    strnog: sonnet\n"); // typo'd tier key
     expect(() => loadModelTierMap({ root })).toThrow(/not a tier/);
@@ -557,7 +737,9 @@ describe("registry", () => {
     const root = tempRegistry();
     writeFileSync(
       path.join(root, "event-types.json"),
-      JSON.stringify({ "x.y": { agent: "ghost@9", idempotencyScope: ["correlationId"] } }),
+      JSON.stringify({
+        "x.y": { agent: "ghost@9", idempotencyScope: ["correlationId"] },
+      }),
     );
     expect(() => loadRegistry({ root })).toThrow(/unregistered agent/);
   });
@@ -568,9 +750,17 @@ describe("registry", () => {
     const merge = getArtifactView(registry, "merge-scan@2");
     expect(merge.file).toBe("agents/merge-scan.view.json");
     expect(merge.view.schemaVersion).toBe("factory.artifact-view/v1");
-    expect(getArtifactView(registry, "triage-scan@1").view.status.path).toBe("/recommendation");
-    expect(getArtifactView(registry, "reconcile@1")).toEqual({ file: null, view: null });
-    expect(getArtifactView(registry, "ghost@9")).toEqual({ file: null, view: null });
+    expect(getArtifactView(registry, "triage-scan@1").view.status.path).toBe(
+      "/recommendation",
+    );
+    expect(getArtifactView(registry, "reconcile@1")).toEqual({
+      file: null,
+      view: null,
+    });
+    expect(getArtifactView(registry, "ghost@9")).toEqual({
+      file: null,
+      view: null,
+    });
     expect(registry.anomalies).toEqual([]);
     // Views are not part of the definition pin nor of the receipt defHash:
     // the def object never carries them, and the sidecar has no pin entry.
@@ -578,10 +768,19 @@ describe("registry", () => {
     expect(def.outputView).toBeUndefined();
     expect(Object.keys(def.pins)).not.toContain("agents/merge-scan.view.json");
     const { promptPath, inputSchema, outputSchema, ...pinnedIdentity } = def;
-    expect(computeDefHash(def)).toBe(computeDefHash({ ...pinnedIdentity, promptPath, inputSchema, outputSchema }));
+    expect(computeDefHash(def)).toBe(
+      computeDefHash({
+        ...pinnedIdentity,
+        promptPath,
+        inputSchema,
+        outputSchema,
+      }),
+    );
     // A .view.json file is never mistaken for a definition, and re-pinning
     // leaves it alone.
-    expect([...registry.agents.keys()].some((ref) => ref.includes(".view"))).toBe(false);
+    expect(
+      [...registry.agents.keys()].some((ref) => ref.includes(".view")),
+    ).toBe(false);
     const root = tempRegistry();
     expect(updatePins({ root })).toEqual([]);
   });
@@ -595,7 +794,10 @@ describe("registry", () => {
     writeFileSync(viewFile, JSON.stringify(view));
     const registry = loadRegistry({ root, modelTiers: PI_TIERS });
     // Served without a view; the anomaly names the agent, the file and the errors.
-    expect(getArtifactView(registry, "merge-scan@2")).toEqual({ file: "agents/merge-scan.view.json", view: null });
+    expect(getArtifactView(registry, "merge-scan@2")).toEqual({
+      file: "agents/merge-scan.view.json",
+      view: null,
+    });
     expect(registry.anomalies).toHaveLength(1);
     expect(registry.anomalies[0]).toContain("merge-scan@2");
     expect(registry.anomalies[0]).toContain("agents/merge-scan.view.json");
@@ -609,7 +811,12 @@ describe("registry", () => {
     expect(getArtifactView(again, "merge-scan@2").view).toBeNull();
     expect(again.anomalies[0]).toMatch(/unparseable/);
     // A schema-invalid document (bad `as`) is refused the same way.
-    writeFileSync(viewFile, JSON.stringify({ ...view, sections: [{ path: "/plan", as: "chart" }] }));
-    expect(loadRegistry({ root, modelTiers: PI_TIERS }).anomalies[0]).toMatch(/not in enum/);
+    writeFileSync(
+      viewFile,
+      JSON.stringify({ ...view, sections: [{ path: "/plan", as: "chart" }] }),
+    );
+    expect(loadRegistry({ root, modelTiers: PI_TIERS }).anomalies[0]).toMatch(
+      /not in enum/,
+    );
   });
 });

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -50,44 +50,69 @@ function normalizeOwnedPathsPolicy(raw = {}, repoName, file) {
     return { direct: [], pinManifests: [] };
   }
   if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new RepoError(`${file}: repo ${repoName} owned_paths_policy must be an object`);
+    throw new RepoError(
+      `${file}: repo ${repoName} owned_paths_policy must be an object`,
+    );
   }
 
-  const unknown = Object.keys(raw).filter((key) => !["direct", "pin_manifests"].includes(key));
+  const unknown = Object.keys(raw).filter(
+    (key) => !["direct", "pin_manifests"].includes(key),
+  );
   if (unknown.length) {
-    throw new RepoError(`${file}: repo ${repoName} owned_paths_policy has unknown keys (${unknown.join(", ")})`);
+    throw new RepoError(
+      `${file}: repo ${repoName} owned_paths_policy has unknown keys (${unknown.join(", ")})`,
+    );
   }
 
   const direct = [];
   if (raw.direct !== undefined) {
     if (!Array.isArray(raw.direct)) {
-      throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.direct must be an array`);
+      throw new RepoError(
+        `${file}: repo ${repoName} owned_paths_policy.direct must be an array`,
+      );
     }
     for (const rule of raw.direct) {
       if (!rule || typeof rule !== "object" || Array.isArray(rule)) {
-        throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.direct entries must be objects`);
+        throw new RepoError(
+          `${file}: repo ${repoName} owned_paths_policy.direct entries must be objects`,
+        );
       }
       if (typeof rule.source !== "string" || !rule.source.trim()) {
-        throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.direct.source must be a non-empty string`);
+        throw new RepoError(
+          `${file}: repo ${repoName} owned_paths_policy.direct.source must be a non-empty string`,
+        );
       }
       if (!Array.isArray(rule.requires) || rule.requires.length === 0) {
-        throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.direct.requires must be a non-empty array`);
+        throw new RepoError(
+          `${file}: repo ${repoName} owned_paths_policy.direct.requires must be a non-empty array`,
+        );
       }
-      if (!rule.requires.every((req) => typeof req === "string" && req.trim())) {
-        throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.direct.requires must contain only non-empty strings`);
+      if (
+        !rule.requires.every((req) => typeof req === "string" && req.trim())
+      ) {
+        throw new RepoError(
+          `${file}: repo ${repoName} owned_paths_policy.direct.requires must contain only non-empty strings`,
+        );
       }
-      direct.push({ source: rule.source.trim(), requires: rule.requires.map((req) => req.trim()) });
+      direct.push({
+        source: rule.source.trim(),
+        requires: rule.requires.map((req) => req.trim()),
+      });
     }
   }
 
   const pinManifests = [];
   if (raw.pin_manifests !== undefined) {
     if (!Array.isArray(raw.pin_manifests)) {
-      throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.pin_manifests must be an array`);
+      throw new RepoError(
+        `${file}: repo ${repoName} owned_paths_policy.pin_manifests must be an array`,
+      );
     }
     for (const manifest of raw.pin_manifests) {
       if (typeof manifest !== "string" || !manifest.trim()) {
-        throw new RepoError(`${file}: repo ${repoName} owned_paths_policy.pin_manifests must contain only non-empty strings`);
+        throw new RepoError(
+          `${file}: repo ${repoName} owned_paths_policy.pin_manifests must contain only non-empty strings`,
+        );
       }
       pinManifests.push(manifest.trim());
     }
@@ -117,10 +142,15 @@ export function loadRepos({ root = reposRoot() } = {}) {
   const repos = new Map();
   for (const entry of parsed?.repos ?? []) {
     if (!entry?.name) throw new RepoError(`${file}: a repo entry has no name`);
-    if (!entry.path) throw new RepoError(`${file}: repo ${entry.name} has no path`);
+    if (!entry.path)
+      throw new RepoError(`${file}: repo ${entry.name} has no path`);
     let maxInFlight = null;
     if (entry.max_in_flight !== undefined && entry.max_in_flight !== null) {
-      if (typeof entry.max_in_flight !== "number" || !Number.isFinite(entry.max_in_flight) || entry.max_in_flight <= 0) {
+      if (
+        typeof entry.max_in_flight !== "number" ||
+        !Number.isFinite(entry.max_in_flight) ||
+        entry.max_in_flight <= 0
+      ) {
         throw new RepoError(
           `${file}: repo ${entry.name} max_in_flight must be a positive number, got ${JSON.stringify(entry.max_in_flight)}`,
         );
@@ -128,9 +158,14 @@ export function loadRepos({ root = reposRoot() } = {}) {
       maxInFlight = entry.max_in_flight;
     }
     let smokeDeadlineSeconds = null;
-    const rawSmokeDeadline = entry.smoke_deadline_seconds ?? entry.deployment?.smoke_deadline_seconds;
+    const rawSmokeDeadline =
+      entry.smoke_deadline_seconds ?? entry.deployment?.smoke_deadline_seconds;
     if (rawSmokeDeadline !== undefined && rawSmokeDeadline !== null) {
-      if (typeof rawSmokeDeadline !== "number" || !Number.isFinite(rawSmokeDeadline) || rawSmokeDeadline <= 0) {
+      if (
+        typeof rawSmokeDeadline !== "number" ||
+        !Number.isFinite(rawSmokeDeadline) ||
+        rawSmokeDeadline <= 0
+      ) {
         throw new RepoError(
           `${file}: repo ${entry.name} smoke_deadline_seconds must be a positive number, got ${JSON.stringify(rawSmokeDeadline)}`,
         );
@@ -141,11 +176,14 @@ export function loadRepos({ root = reposRoot() } = {}) {
     if (entry.merge_ci !== undefined && entry.merge_ci !== null) {
       const workflow = entry.merge_ci?.workflow;
       const requiredChecks = entry.merge_ci?.required_checks;
-      const validWorkflow = typeof workflow === "string" && workflow.trim().length > 0;
+      const validWorkflow =
+        typeof workflow === "string" && workflow.trim().length > 0;
       const validChecks =
         Array.isArray(requiredChecks) &&
         requiredChecks.length > 0 &&
-        requiredChecks.every((check) => typeof check === "string" && check.trim().length > 0) &&
+        requiredChecks.every(
+          (check) => typeof check === "string" && check.trim().length > 0,
+        ) &&
         new Set(requiredChecks).size === requiredChecks.length;
       if (!validWorkflow || !validChecks) {
         throw new RepoError(
@@ -171,12 +209,18 @@ export function loadRepos({ root = reposRoot() } = {}) {
       maxInFlight,
       smokeDeadlineSeconds,
       mergeCi,
-      worktreeRoot: entry.worktree_root ? expandHome(entry.worktree_root) : null,
+      worktreeRoot: entry.worktree_root
+        ? expandHome(entry.worktree_root)
+        : null,
       worktreeUp: entry.worktree_up ?? null,
       worktreeDown: entry.worktree_down ?? null,
       worktreeWarm: entry.worktree_warm ?? null,
       verify: entry.verify ?? null,
-      ownedPathsPolicy: normalizeOwnedPathsPolicy(entry.owned_paths_policy, entry.name, file),
+      ownedPathsPolicy: normalizeOwnedPathsPolicy(
+        entry.owned_paths_policy,
+        entry.name,
+        file,
+      ),
     });
   }
   return repos;
@@ -239,7 +283,10 @@ export function selectMergeCheckGate(repo, githubRequiredContexts) {
   const valid = githubRequiredContexts.every(
     (name) => typeof name === "string" && name.trim().length > 0,
   );
-  if (!valid || new Set(githubRequiredContexts).size !== githubRequiredContexts.length) {
+  if (
+    !valid ||
+    new Set(githubRequiredContexts).size !== githubRequiredContexts.length
+  ) {
     throw new RepoError("GitHub required contexts are malformed or ambiguous");
   }
   if (githubRequiredContexts.length > 0) {
@@ -250,7 +297,9 @@ export function selectMergeCheckGate(repo, githubRequiredContexts) {
     };
   }
   if (!repo?.mergeCi) {
-    throw new RepoError("GitHub required contexts are empty and no merge_ci fallback is configured");
+    throw new RepoError(
+      "GitHub required contexts are empty and no merge_ci fallback is configured",
+    );
   }
   return {
     source: "config",
@@ -265,7 +314,12 @@ export function selectMergeCheckGate(repo, githubRequiredContexts) {
  * Unnamed extra checks are irrelevant: the selected gate is deliberately an
  * exact allow-list, not a snapshot of whatever happened to be visible first.
  */
-export function proveMergeChecks({ expectedChecks, actualChecks, expectedSha, workflow = null }) {
+export function proveMergeChecks({
+  expectedChecks,
+  actualChecks,
+  expectedSha,
+  workflow = null,
+}) {
   if (
     !Array.isArray(expectedChecks) ||
     expectedChecks.length === 0 ||
@@ -278,7 +332,9 @@ export function proveMergeChecks({ expectedChecks, actualChecks, expectedSha, wo
   for (const name of expectedChecks) {
     const matches = actualChecks.filter((check) => check?.name === name);
     if (matches.length !== 1) {
-      throw new RepoError(`required check ${JSON.stringify(name)} is missing or ambiguous`);
+      throw new RepoError(
+        `required check ${JSON.stringify(name)} is missing or ambiguous`,
+      );
     }
     const check = matches[0];
     if (
@@ -287,7 +343,9 @@ export function proveMergeChecks({ expectedChecks, actualChecks, expectedSha, wo
       check.conclusion !== "success" ||
       (workflow !== null && check.workflow !== workflow)
     ) {
-      throw new RepoError(`required check ${JSON.stringify(name)} is not green at the exact SHA`);
+      throw new RepoError(
+        `required check ${JSON.stringify(name)} is not green at the exact SHA`,
+      );
     }
   }
   return true;

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -95,7 +95,9 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       worktreeWarm: "bin/worktree-warm.sh",
       verify: "npm run typecheck",
       ownedPathsPolicy: {
-        direct: [{ source: "shared/**", requires: ["dist/**", "plugins/core/**"] }],
+        direct: [
+          { source: "shared/**", requires: ["dist/**", "plugins/core/**"] },
+        ],
         pinManifests: ["event-runtime/agents/*.json"],
       },
     });
@@ -123,7 +125,9 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
 
   test("report_only reads false unless it is exactly true — a guard is never 'maybe'", () => {
     const repos = loadRepos({
-      root: factoryRoot(`repos:\n  - name: a\n    path: /tmp/a\n  - name: b\n    path: /tmp/b\n    report_only: false\n`),
+      root: factoryRoot(
+        `repos:\n  - name: a\n    path: /tmp/a\n  - name: b\n    path: /tmp/b\n    report_only: false\n`,
+      ),
     });
     expect(repos.get("a").reportOnly).toBe(false);
     expect(repos.get("b").reportOnly).toBe(false);
@@ -195,7 +199,8 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
   });
 
   test("owned_paths_policy is parsed and validated, defaulting to empty when absent", () => {
-    const repos = loadRepos({ root: factoryRoot(`repos:
+    const repos = loadRepos({
+      root: factoryRoot(`repos:
   - name: bare
     path: /tmp/a
     owned_paths_policy:
@@ -203,9 +208,16 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       pin_manifests: []
   - name: absent-policy
     path: /tmp/b
-`) });
-    expect(repos.get("bare").ownedPathsPolicy).toEqual({ direct: [], pinManifests: [] });
-    expect(repos.get("absent-policy").ownedPathsPolicy).toEqual({ direct: [], pinManifests: [] });
+`),
+    });
+    expect(repos.get("bare").ownedPathsPolicy).toEqual({
+      direct: [],
+      pinManifests: [],
+    });
+    expect(repos.get("absent-policy").ownedPathsPolicy).toEqual({
+      direct: [],
+      pinManifests: [],
+    });
   });
 
   test("owned_paths_policy must be valid schema", () => {
@@ -249,26 +261,53 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       workflow: "CI",
       requiredChecks: ["Shadow runner fleet available", "Verify"],
     });
-    expect(() => selectMergeCheckGate(repos.get("bare"), [])).toThrow(RepoError);
-    expect(() => selectMergeCheckGate(repo, ["Verify", "Verify"])).toThrow(RepoError);
+    expect(() => selectMergeCheckGate(repos.get("bare"), [])).toThrow(
+      RepoError,
+    );
+    expect(() => selectMergeCheckGate(repo, ["Verify", "Verify"])).toThrow(
+      RepoError,
+    );
   });
 
   test("exact-SHA check proof rejects empty, missing, pending, red, stale, and ambiguous evidence (WM-419)", () => {
     const sha = "a".repeat(40);
-    const green = (name) => ({ name, headSha: sha, status: "completed", conclusion: "success", workflow: "CI" });
+    const green = (name) => ({
+      name,
+      headSha: sha,
+      status: "completed",
+      conclusion: "success",
+      workflow: "CI",
+    });
     const expected = ["Shadow runner fleet available", "Verify"];
-    expect(proveMergeChecks({ expectedChecks: expected, actualChecks: expected.map(green), expectedSha: sha, workflow: "CI" })).toBe(true);
+    expect(
+      proveMergeChecks({
+        expectedChecks: expected,
+        actualChecks: expected.map(green),
+        expectedSha: sha,
+        workflow: "CI",
+      }),
+    ).toBe(true);
     const invalid = [
       [],
       [green(expected[0])],
-      [green(expected[0]), { ...green(expected[1]), status: "in_progress", conclusion: null }],
+      [
+        green(expected[0]),
+        { ...green(expected[1]), status: "in_progress", conclusion: null },
+      ],
       [green(expected[0]), { ...green(expected[1]), conclusion: "failure" }],
       [green(expected[0]), { ...green(expected[1]), headSha: "b".repeat(40) }],
       [green(expected[0]), green(expected[1]), green(expected[1])],
       [green(expected[0]), { ...green(expected[1]), workflow: "Other" }],
     ];
     for (const actualChecks of invalid) {
-      expect(() => proveMergeChecks({ expectedChecks: expected, actualChecks, expectedSha: sha, workflow: "CI" })).toThrow(RepoError);
+      expect(() =>
+        proveMergeChecks({
+          expectedChecks: expected,
+          actualChecks,
+          expectedSha: sha,
+          workflow: "CI",
+        }),
+      ).toThrow(RepoError);
     }
   });
   test("malformed YAML throws RepoError with file path and parse error message (OPS-346)", () => {
@@ -286,8 +325,16 @@ describe("reposView is what the control API serves", () => {
   });
 
   test("worktree scripts are reported as capability, not as paths to run", () => {
-    expect(rows[0]).toMatchObject({ hasWorktreeUp: true, hasWorktreeDown: true, hasWorktreeWarm: true });
-    expect(rows[1]).toMatchObject({ hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false });
+    expect(rows[0]).toMatchObject({
+      hasWorktreeUp: true,
+      hasWorktreeDown: true,
+      hasWorktreeWarm: true,
+    });
+    expect(rows[1]).toMatchObject({
+      hasWorktreeUp: false,
+      hasWorktreeDown: false,
+      hasWorktreeWarm: false,
+    });
     // The script path itself is meaningless to a reader and only the janitor
     // executes it, so it stays server-side.
     expect(rows[0]).not.toHaveProperty("worktreeDown");
@@ -296,8 +343,22 @@ describe("reposView is what the control API serves", () => {
   test("the projection is an allow-list, so policy keys cannot leak by being added", () => {
     for (const row of rows) {
       expect(Object.keys(row).sort()).toEqual([
-        "base", "deployBranch", "github", "hasWorktreeDown", "hasWorktreeUp", "hasWorktreeWarm",
-        "maxInFlight", "mergeCi", "name", "path", "project", "reportOnly", "smokeDeadlineSeconds", "team", "verify", "worktreeRoot",
+        "base",
+        "deployBranch",
+        "github",
+        "hasWorktreeDown",
+        "hasWorktreeUp",
+        "hasWorktreeWarm",
+        "maxInFlight",
+        "mergeCi",
+        "name",
+        "path",
+        "project",
+        "reportOnly",
+        "smokeDeadlineSeconds",
+        "team",
+        "verify",
+        "worktreeRoot",
       ]);
     }
     const serialized = JSON.stringify(rows);
@@ -307,6 +368,9 @@ describe("reposView is what the control API serves", () => {
   });
 
   test("the dispatch/report-only distinction survives the wire", () => {
-    expect(rows.map((r) => [r.name, r.reportOnly])).toEqual([["full", false], ["bare", true]]);
+    expect(rows.map((r) => [r.name, r.reportOnly])).toEqual([
+      ["full", false],
+      ["bare", true],
+    ]);
   });
 });

--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -42,7 +42,9 @@ const git = (args, cwd) => {
     }).trim();
   } catch (err) {
     const detail = err.stderr?.toString().trim() || err.message;
-    throw new RepositoryWorkspaceError(`git ${args.slice(0, 2).join(" ")} failed: ${detail}`);
+    throw new RepositoryWorkspaceError(
+      `git ${args.slice(0, 2).join(" ")} failed: ${detail}`,
+    );
   }
 };
 
@@ -65,7 +67,9 @@ function githubRemote(github) {
 export function syncMirror(repo, { root = mirrorsRoot() } = {}) {
   const mirror = mirrorPath(repo.name, root);
   if (!existsSync(mirror)) {
-    const source = existsSync(repo.path) ? repo.path : githubRemote(repo.github);
+    const source = existsSync(repo.path)
+      ? repo.path
+      : githubRemote(repo.github);
     if (!source) {
       throw new RepositoryWorkspaceError(
         `repo ${repo.name}: no checkout at ${repo.path} and no github remote configured to mirror from`,
@@ -83,21 +87,37 @@ export function syncMirror(repo, { root = mirrorsRoot() } = {}) {
  * Resolve a ref to an immutable SHA in the mirror. Called at plan time so the
  * SHA lands in the RunSpec input (and therefore the inputHash and receipt).
  */
-export function resolveRef(repo, ref = repo.base, { root = mirrorsRoot() } = {}) {
+export function resolveRef(
+  repo,
+  ref = repo.base,
+  { root = mirrorsRoot() } = {},
+) {
   const mirror = syncMirror(repo, { root });
   const sha = git(["rev-parse", `${ref}^{commit}`], mirror);
   return { mirror, sha };
 }
 
 /** Plan-time helper: repo name + optional ref → the facts a spec should pin. */
-export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = {}) {
-  const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+export function pinRepo(
+  repoName,
+  ref,
+  { reposRoot, mirrors = mirrorsRoot() } = {},
+) {
+  const repo = getRepo(
+    loadRepos(reposRoot ? { root: reposRoot } : {}),
+    repoName,
+  );
   try {
     const { sha } = resolveRef(repo, ref ?? repo.base, { root: mirrors });
     return { repo: repo.name, ref: ref ?? repo.base, sha, github: repo.github };
   } catch (err) {
     if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
-      return { repo: repo.name, ref: ref ?? repo.base, sha: "0".repeat(40), github: repo.github };
+      return {
+        repo: repo.name,
+        ref: ref ?? repo.base,
+        sha: "0".repeat(40),
+        github: repo.github,
+      };
     }
     throw err;
   }
@@ -109,14 +129,32 @@ export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = 
  *
  * @returns {{ path: string, sha: string }} absolute checkout path
  */
-export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "repo", mirrors = mirrorsRoot(), reposRoot }) {
-  if (!sha) throw new RepositoryWorkspaceError(`repo ${repoName}: no pinned sha in the run input`);
-  const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+export function materializeCheckout({
+  workspaceDir,
+  repoName,
+  sha,
+  subdir = "repo",
+  mirrors = mirrorsRoot(),
+  reposRoot,
+}) {
+  if (!sha)
+    throw new RepositoryWorkspaceError(
+      `repo ${repoName}: no pinned sha in the run input`,
+    );
+  const repo = getRepo(
+    loadRepos(reposRoot ? { root: reposRoot } : {}),
+    repoName,
+  );
   const target = path.resolve(workspaceDir, subdir);
   if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
-    throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
+    throw new RepositoryWorkspaceError(
+      `checkout subdir "${subdir}" escapes the workspace`,
+    );
   }
-  if (sha === "0".repeat(40) || (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors)))) {
+  if (
+    sha === "0".repeat(40) ||
+    (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors)))
+  ) {
     mkdirSync(target, { recursive: true });
     // The worker's integrity gate must be able to inspect every repository
     // workspace, including a CI/demo fallback with no local source checkout.
@@ -133,12 +171,21 @@ export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "rep
  * Remove a materialized checkout and deregister it from the mirror. The
  * mirror itself persists as cache — that is the point of the tier.
  */
-export function releaseCheckout({ checkoutPath, repoName, mirrors = mirrorsRoot(), reposRoot }) {
+export function releaseCheckout({
+  checkoutPath,
+  repoName,
+  mirrors = mirrorsRoot(),
+  reposRoot,
+}) {
   if (!checkoutPath || !existsSync(checkoutPath)) return false;
   try {
-    const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+    const repo = getRepo(
+      loadRepos(reposRoot ? { root: reposRoot } : {}),
+      repoName,
+    );
     const mirror = mirrorPath(repo.name, mirrors);
-    if (existsSync(mirror)) git(["worktree", "remove", "--force", checkoutPath], mirror);
+    if (existsSync(mirror))
+      git(["worktree", "remove", "--force", checkoutPath], mirror);
     else rmSync(checkoutPath, { recursive: true, force: true });
   } catch {
     // Never let cleanup mask a run's real outcome; the directory goes either way.

--- a/event-runtime/lib/repository.test.mjs
+++ b/event-runtime/lib/repository.test.mjs
@@ -1,6 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expandHome, getRepo, loadRepos, RepoError } from "./repos.mjs";
@@ -29,8 +36,16 @@ const GIT_MS = 20_000;
 // Fixture repos must not inherit the operator's global git config: a machine
 // with commit.gpgsign=true blocks on pinentry until the 5s test timeout, and
 // core.hooksPath would run their hooks inside our scratch dirs (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 /** A tiny real repo — the provider's whole job is git, so fake git proves nothing. */
 function makeRepo() {
@@ -54,7 +69,11 @@ function makeBareRemote(src) {
 }
 
 /** A repos.yaml pointing at it, so the loader is exercised for real too. */
-function makeFactoryRoot(repoPath, name = "testrepo", github = `watt-mind/${name}`) {
+function makeFactoryRoot(
+  repoPath,
+  name = "testrepo",
+  github = `watt-mind/${name}`,
+) {
   const root = tmp("evrt-factory-");
   mkdirSync(path.join(root, "config"), { recursive: true });
   const githubLine = github ? `    github: ${github}\n` : "";
@@ -66,25 +85,35 @@ function makeFactoryRoot(repoPath, name = "testrepo", github = `watt-mind/${name
 }
 
 describe("repos.yaml is read, not owned", () => {
-  test("loads the fields tier 1 needs and expands ~", () => {
-    const src = makeRepo();
-    const repos = loadRepos({ root: makeFactoryRoot(src.dir) });
-    const repo = getRepo(repos, "testrepo");
-    expect(repo).toMatchObject({
-      name: "testrepo",
-      path: src.dir,
-      github: "watt-mind/testrepo",
-      base: "main",
-      worktreeUp: "bin/worktree-up.sh",
-      verify: "echo ok",
-    });
-    expect(expandHome("~/x")).toBe(path.join(process.env.HOME ?? "", "x"));
-  }, { timeout: GIT_MS });
+  test(
+    "loads the fields tier 1 needs and expands ~",
+    () => {
+      const src = makeRepo();
+      const repos = loadRepos({ root: makeFactoryRoot(src.dir) });
+      const repo = getRepo(repos, "testrepo");
+      expect(repo).toMatchObject({
+        name: "testrepo",
+        path: src.dir,
+        github: "watt-mind/testrepo",
+        base: "main",
+        worktreeUp: "bin/worktree-up.sh",
+        verify: "echo ok",
+      });
+      expect(expandHome("~/x")).toBe(path.join(process.env.HOME ?? "", "x"));
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("an unknown repo names what is configured instead of failing vaguely", () => {
-    const repos = loadRepos({ root: makeFactoryRoot(makeRepo().dir) });
-    expect(() => getRepo(repos, "nope")).toThrow(/not in config\/repos\.yaml \(have: testrepo\)/);
-  }, { timeout: GIT_MS });
+  test(
+    "an unknown repo names what is configured instead of failing vaguely",
+    () => {
+      const repos = loadRepos({ root: makeFactoryRoot(makeRepo().dir) });
+      expect(() => getRepo(repos, "nope")).toThrow(
+        /not in config\/repos\.yaml \(have: testrepo\)/,
+      );
+    },
+    { timeout: GIT_MS },
+  );
 
   test("a missing config fails closed", () => {
     expect(() => loadRepos({ root: tmp("evrt-empty-") })).toThrow(RepoError);
@@ -92,141 +121,216 @@ describe("repos.yaml is read, not owned", () => {
 });
 
 describe("mirror + pinned checkout", () => {
-  test("clones a missing mirror from the configured GitHub remote when the checkout is absent", () => {
-    const src = makeRepo();
-    const remote = makeBareRemote(src);
-    const mirrors = tmp("evrt-mirrors-");
-    const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
-    const repo = { name: "testrepo", path: missing, github: remote.url, base: "main" };
+  test(
+    "clones a missing mirror from the configured GitHub remote when the checkout is absent",
+    () => {
+      const src = makeRepo();
+      const remote = makeBareRemote(src);
+      const mirrors = tmp("evrt-mirrors-");
+      const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
+      const repo = {
+        name: "testrepo",
+        path: missing,
+        github: remote.url,
+        base: "main",
+      };
 
-    const mirror = syncMirror(repo, { root: mirrors });
+      const mirror = syncMirror(repo, { root: mirrors });
 
-    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
-    expect(git(["remote", "get-url", "origin"], mirror)).toBe(remote.url);
-  }, { timeout: GIT_MS });
+      expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
+      expect(git(["remote", "get-url", "origin"], mirror)).toBe(remote.url);
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("prefers the local checkout when both local and remote sources exist", () => {
-    const local = makeRepo();
-    const remote = makeBareRemote(makeRepo());
-    const mirrors = tmp("evrt-mirrors-");
-    const repo = { name: "testrepo", path: local.dir, github: remote.url, base: "main" };
+  test(
+    "prefers the local checkout when both local and remote sources exist",
+    () => {
+      const local = makeRepo();
+      const remote = makeBareRemote(makeRepo());
+      const mirrors = tmp("evrt-mirrors-");
+      const repo = {
+        name: "testrepo",
+        path: local.dir,
+        github: remote.url,
+        base: "main",
+      };
 
-    const mirror = syncMirror(repo, { root: mirrors });
+      const mirror = syncMirror(repo, { root: mirrors });
 
-    expect(git(["remote", "get-url", "origin"], mirror)).toBe(local.dir);
-    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(local.head);
-  }, { timeout: GIT_MS });
+      expect(git(["remote", "get-url", "origin"], mirror)).toBe(local.dir);
+      expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(local.head);
+    },
+    { timeout: GIT_MS },
+  );
 
   test("names both missing sources when neither checkout nor GitHub remote is available", () => {
     const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
-    const repo = { name: "testrepo", path: missing, github: null, base: "main" };
+    const repo = {
+      name: "testrepo",
+      path: missing,
+      github: null,
+      base: "main",
+    };
 
     expect(() => syncMirror(repo, { root: tmp("evrt-mirrors-") })).toThrow(
       new RegExp(`no checkout at ${missing}.*no github remote`),
     );
   });
 
-  test("never rewrites an existing mirror's origin", () => {
-    const original = makeRepo();
-    const replacement = makeBareRemote(makeRepo());
-    const mirrors = tmp("evrt-mirrors-");
-    const mirror = mirrorPath("testrepo", mirrors);
-    git(["clone", "--mirror", "--quiet", original.dir, mirror]);
-    const repo = {
-      name: "testrepo",
-      path: path.join(tmp("evrt-missing-"), "does-not-exist"),
-      github: replacement.url,
-      base: "main",
-    };
+  test(
+    "never rewrites an existing mirror's origin",
+    () => {
+      const original = makeRepo();
+      const replacement = makeBareRemote(makeRepo());
+      const mirrors = tmp("evrt-mirrors-");
+      const mirror = mirrorPath("testrepo", mirrors);
+      git(["clone", "--mirror", "--quiet", original.dir, mirror]);
+      const repo = {
+        name: "testrepo",
+        path: path.join(tmp("evrt-missing-"), "does-not-exist"),
+        github: replacement.url,
+        base: "main",
+      };
 
-    syncMirror(repo, { root: mirrors });
+      syncMirror(repo, { root: mirrors });
 
-    expect(git(["remote", "get-url", "origin"], mirror)).toBe(original.dir);
-  }, { timeout: GIT_MS });
+      expect(git(["remote", "get-url", "origin"], mirror)).toBe(original.dir);
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("mirrors on first use, fetches thereafter, and never writes to the source", () => {
-    const src = makeRepo();
-    const mirrors = tmp("evrt-mirrors-");
-    const repo = getRepo(loadRepos({ root: makeFactoryRoot(src.dir) }), "testrepo");
+  test(
+    "mirrors on first use, fetches thereafter, and never writes to the source",
+    () => {
+      const src = makeRepo();
+      const mirrors = tmp("evrt-mirrors-");
+      const repo = getRepo(
+        loadRepos({ root: makeFactoryRoot(src.dir) }),
+        "testrepo",
+      );
 
-    const mirror = syncMirror(repo, { root: mirrors });
-    expect(mirror).toBe(mirrorPath("testrepo", mirrors));
-    expect(existsSync(path.join(mirror, "HEAD"))).toBe(true);
+      const mirror = syncMirror(repo, { root: mirrors });
+      expect(mirror).toBe(mirrorPath("testrepo", mirrors));
+      expect(existsSync(path.join(mirror, "HEAD"))).toBe(true);
 
-    // Source stays pristine: no worktrees registered, no new refs.
-    expect(git(["worktree", "list"], src.dir).split("\n")).toHaveLength(1);
+      // Source stays pristine: no worktrees registered, no new refs.
+      expect(git(["worktree", "list"], src.dir).split("\n")).toHaveLength(1);
 
-    // Second call is a fetch, not a re-clone — and picks up new commits.
-    writeFileSync(path.join(src.dir, "third.txt"), "third\n");
-    git(["add", "."], src.dir);
-    git(["commit", "--quiet", "-m", "third"], src.dir);
-    syncMirror(repo, { root: mirrors });
-    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(git(["rev-parse", "HEAD"], src.dir));
-  }, { timeout: GIT_MS });
+      // Second call is a fetch, not a re-clone — and picks up new commits.
+      writeFileSync(path.join(src.dir, "third.txt"), "third\n");
+      git(["add", "."], src.dir);
+      git(["commit", "--quiet", "-m", "third"], src.dir);
+      syncMirror(repo, { root: mirrors });
+      expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(
+        git(["rev-parse", "HEAD"], src.dir),
+      );
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("resolves a ref to an immutable sha — the pin a run is reproducible against", () => {
-    const src = makeRepo();
-    const mirrors = tmp("evrt-mirrors-");
-    const repo = getRepo(loadRepos({ root: makeFactoryRoot(src.dir) }), "testrepo");
-    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
-    expect(resolveRef(repo, src.first, { root: mirrors }).sha).toBe(src.first);
-  }, { timeout: GIT_MS });
+  test(
+    "resolves a ref to an immutable sha — the pin a run is reproducible against",
+    () => {
+      const src = makeRepo();
+      const mirrors = tmp("evrt-mirrors-");
+      const repo = getRepo(
+        loadRepos({ root: makeFactoryRoot(src.dir) }),
+        "testrepo",
+      );
+      expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
+      expect(resolveRef(repo, src.first, { root: mirrors }).sha).toBe(
+        src.first,
+      );
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("materializes the pinned tree inside the workspace, then releases it", () => {
-    const src = makeRepo();
-    const mirrors = tmp("evrt-mirrors-");
-    const reposRoot = makeFactoryRoot(src.dir);
-    const workspaceDir = tmp("evrt-ws-");
+  test(
+    "materializes the pinned tree inside the workspace, then releases it",
+    () => {
+      const src = makeRepo();
+      const mirrors = tmp("evrt-mirrors-");
+      const reposRoot = makeFactoryRoot(src.dir);
+      const workspaceDir = tmp("evrt-ws-");
 
-    // Pinned to the FIRST commit: the checkout must show that tree, not HEAD.
-    const checkout = materializeCheckout({
-      workspaceDir,
-      repoName: "testrepo",
-      sha: src.first,
-      mirrors,
-      reposRoot,
-    });
-    expect(checkout.path).toBe(path.join(workspaceDir, "repo"));
-    expect(readFileSync(path.join(checkout.path, "README.md"), "utf8")).toBe("first\n");
+      // Pinned to the FIRST commit: the checkout must show that tree, not HEAD.
+      const checkout = materializeCheckout({
+        workspaceDir,
+        repoName: "testrepo",
+        sha: src.first,
+        mirrors,
+        reposRoot,
+      });
+      expect(checkout.path).toBe(path.join(workspaceDir, "repo"));
+      expect(readFileSync(path.join(checkout.path, "README.md"), "utf8")).toBe(
+        "first\n",
+      );
 
-    releaseCheckout({ checkoutPath: checkout.path, repoName: "testrepo", mirrors, reposRoot });
-    expect(existsSync(checkout.path)).toBe(false);
-    // The mirror survives as cache, with no stale worktree registration.
-    expect(existsSync(mirrorPath("testrepo", mirrors))).toBe(true);
-    expect(git(["worktree", "list"], mirrorPath("testrepo", mirrors))).not.toContain(workspaceDir);
-  }, { timeout: GIT_MS });
+      releaseCheckout({
+        checkoutPath: checkout.path,
+        repoName: "testrepo",
+        mirrors,
+        reposRoot,
+      });
+      expect(existsSync(checkout.path)).toBe(false);
+      // The mirror survives as cache, with no stale worktree registration.
+      expect(existsSync(mirrorPath("testrepo", mirrors))).toBe(true);
+      expect(
+        git(["worktree", "list"], mirrorPath("testrepo", mirrors)),
+      ).not.toContain(workspaceDir);
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("fallback checkout is an empty Git repository for integrity checks", () => {
-    const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
-    const reposRoot = makeFactoryRoot(missing, "testrepo", null);
-    const workspaceDir = tmp("evrt-ws-");
-    const checkout = materializeCheckout({
-      workspaceDir, repoName: "testrepo", sha: "0".repeat(40), reposRoot,
-    });
-    expect(git(["status", "--porcelain"], checkout.path)).toBe("");
-    writeFileSync(path.join(checkout.path, "agent-write.txt"), "dirty\n");
-    expect(git(["status", "--porcelain"], checkout.path)).toContain("?? agent-write.txt");
-  }, { timeout: GIT_MS });
+  test(
+    "fallback checkout is an empty Git repository for integrity checks",
+    () => {
+      const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
+      const reposRoot = makeFactoryRoot(missing, "testrepo", null);
+      const workspaceDir = tmp("evrt-ws-");
+      const checkout = materializeCheckout({
+        workspaceDir,
+        repoName: "testrepo",
+        sha: "0".repeat(40),
+        reposRoot,
+      });
+      expect(git(["status", "--porcelain"], checkout.path)).toBe("");
+      writeFileSync(path.join(checkout.path, "agent-write.txt"), "dirty\n");
+      expect(git(["status", "--porcelain"], checkout.path)).toContain(
+        "?? agent-write.txt",
+      );
+    },
+    { timeout: GIT_MS },
+  );
 
-  test("a checkout may not escape its workspace", () => {
-    const src = makeRepo();
-    const mirrors = tmp("evrt-mirrors-");
-    const reposRoot = makeFactoryRoot(src.dir);
+  test(
+    "a checkout may not escape its workspace",
+    () => {
+      const src = makeRepo();
+      const mirrors = tmp("evrt-mirrors-");
+      const reposRoot = makeFactoryRoot(src.dir);
+      expect(() =>
+        materializeCheckout({
+          workspaceDir: tmp("evrt-ws-"),
+          repoName: "testrepo",
+          sha: src.head,
+          subdir: "../escaped",
+          mirrors,
+          reposRoot,
+        }),
+      ).toThrow(RepositoryWorkspaceError);
+    },
+    { timeout: GIT_MS },
+  );
+
+  test("an unpinned run refuses rather than guessing a ref", () => {
     expect(() =>
       materializeCheckout({
         workspaceDir: tmp("evrt-ws-"),
         repoName: "testrepo",
-        sha: src.head,
-        subdir: "../escaped",
-        mirrors,
-        reposRoot,
+        sha: null,
       }),
-    ).toThrow(RepositoryWorkspaceError);
-  }, { timeout: GIT_MS });
-
-  test("an unpinned run refuses rather than guessing a ref", () => {
-    expect(() =>
-      materializeCheckout({ workspaceDir: tmp("evrt-ws-"), repoName: "testrepo", sha: null }),
     ).toThrow(/no pinned sha/);
   });
 });

--- a/event-runtime/lib/sandbox/gondolin.mjs
+++ b/event-runtime/lib/sandbox/gondolin.mjs
@@ -26,13 +26,23 @@ import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
 import { normalizePolicy, resolveSecretValues } from "./policy.mjs";
 
-export { normalizePolicy, resolveSecretValues, SandboxPolicyError } from "./policy.mjs";
+export {
+  normalizePolicy,
+  resolveSecretValues,
+  SandboxPolicyError,
+} from "./policy.mjs";
 
 /** The SDK's package.json declares engines.node >= 23.6.0; below that it will not import. */
 export const MIN_NODE_MAJOR = 23;
 export const MIN_NODE_MINOR = 6;
 
-export const RUNNER_PATH = path.join(FACTORY_ROOT, "event-runtime", "lib", "sandbox", "runner.mjs");
+export const RUNNER_PATH = path.join(
+  FACTORY_ROOT,
+  "event-runtime",
+  "lib",
+  "sandbox",
+  "runner.mjs",
+);
 
 /** Grace between SIGTERM and SIGKILL for the runner child, matching the command adapter. */
 export const KILL_GRACE_MS = 10_000;
@@ -91,7 +101,16 @@ export function preflight({
       return null;
     }
   },
-  sdkExists = () => existsSync(path.join(FACTORY_ROOT, "node_modules", "@earendil-works", "gondolin", "package.json")),
+  sdkExists = () =>
+    existsSync(
+      path.join(
+        FACTORY_ROOT,
+        "node_modules",
+        "@earendil-works",
+        "gondolin",
+        "package.json",
+      ),
+    ),
 } = {}) {
   // `cause` separates two things `available: false` used to conflate (WM-312):
   //
@@ -104,7 +123,15 @@ export function preflight({
   //
   // Rendering both as "available no" is what let the sandbox sit switched off
   // fleet-wide for a day, indistinguishable from a laptop that lacks QEMU.
-  const report = { available: false, reason: null, cause: null, qemu: null, node: null, nodeVersion: null, sdk: false };
+  const report = {
+    available: false,
+    reason: null,
+    cause: null,
+    qemu: null,
+    node: null,
+    nodeVersion: null,
+    sdk: false,
+  };
 
   const qemuBin = qemuBinaryFor();
   report.qemu = which(qemuBin);
@@ -118,7 +145,8 @@ export function preflight({
   // the Node that satisfies the SDK may not be the one first on PATH (nvm).
   const nodeBin = env.FACTORY_SANDBOX_NODE || which("node");
   if (!nodeBin) {
-    report.reason = "node is not on PATH — the Gondolin SDK requires Node (see runner.mjs); set FACTORY_SANDBOX_NODE";
+    report.reason =
+      "node is not on PATH — the Gondolin SDK requires Node (see runner.mjs); set FACTORY_SANDBOX_NODE";
     report.cause = "host";
     return report;
   }
@@ -210,7 +238,15 @@ export async function runInSandbox({
   const secrets = resolveSecretValues(policy, hostEnv);
 
   const guestCwd = workspaceDir ? policy.workspaceMount : undefined;
-  const request = JSON.stringify({ policy, secrets, command, cwd: guestCwd, env, timeoutMs, shell });
+  const request = JSON.stringify({
+    policy,
+    secrets,
+    command,
+    cwd: guestCwd,
+    env,
+    timeoutMs,
+    shell,
+  });
 
   return new Promise((resolve, reject) => {
     const child = spawn(report.node, [RUNNER_PATH], {
@@ -218,7 +254,11 @@ export async function runInSandbox({
       // The runner resolves the SDK from FACTORY_ROOT/node_modules and needs
       // nothing else; it must not inherit the worker's credentials, since
       // keeping secrets off the guest is the entire point of the sandbox.
-      env: { PATH: hostEnv.PATH ?? "", HOME: hostEnv.HOME ?? "", TMPDIR: hostEnv.TMPDIR ?? "" },
+      env: {
+        PATH: hostEnv.PATH ?? "",
+        HOME: hostEnv.HOME ?? "",
+        TMPDIR: hostEnv.TMPDIR ?? "",
+      },
       stdio: ["pipe", "pipe", "pipe"],
     });
 
@@ -296,7 +336,11 @@ export async function runInSandbox({
 
     child.on("error", (err) => {
       cleanup();
-      reject(new SandboxUnavailableError(`failed to spawn the sandbox runner (${report.node}): ${err.message}`));
+      reject(
+        new SandboxUnavailableError(
+          `failed to spawn the sandbox runner (${report.node}): ${err.message}`,
+        ),
+      );
     });
 
     child.on("close", (runnerExit) => {

--- a/event-runtime/lib/sandbox/gondolin.test.mjs
+++ b/event-runtime/lib/sandbox/gondolin.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { adapterExecuteTimeoutMs, DYNAMIC_DEADLINE_ADAPTERS, LEASE_GRACE_SECONDS } from "../worker.mjs";
+import {
+  adapterExecuteTimeoutMs,
+  DYNAMIC_DEADLINE_ADAPTERS,
+  LEASE_GRACE_SECONDS,
+} from "../worker.mjs";
 import {
   KILL_GRACE_MS,
   MIN_NODE_MAJOR,
@@ -23,7 +27,12 @@ const healthy = {
 describe("preflight", () => {
   test("reports available when qemu, node, and the sdk are all present", () => {
     const report = preflight(healthy);
-    expect(report).toMatchObject({ available: true, reason: null, sdk: true, nodeVersion: "24.18" });
+    expect(report).toMatchObject({
+      available: true,
+      reason: null,
+      sdk: true,
+      nodeVersion: "24.18",
+    });
   });
 
   test("a healthy host reports no cause — cause is set only when unavailable", () => {
@@ -36,7 +45,10 @@ describe("preflight", () => {
     // installed" means a checkout never ran `bun install` after a pull. Both
     // rendered as `available: false`, which is how the sandbox stayed switched
     // off fleet-wide for a day with nothing to signal it.
-    const noQemu = preflight({ ...healthy, which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`) });
+    const noQemu = preflight({
+      ...healthy,
+      which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`),
+    });
     const oldNode = preflight({ ...healthy, runNode: () => "v22.14.0" });
     const noNode = preflight({ ...healthy, which: () => null });
     const noSdk = preflight({ ...healthy, sdkExists: () => false });
@@ -48,7 +60,10 @@ describe("preflight", () => {
   });
 
   test("missing qemu is a named reason, not a crash", () => {
-    const report = preflight({ ...healthy, which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`) });
+    const report = preflight({
+      ...healthy,
+      which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`),
+    });
     expect(report.available).toBe(false);
     expect(report.reason).toMatch(/is not on PATH — install QEMU/);
   });
@@ -60,7 +75,10 @@ describe("preflight", () => {
   });
 
   test("FACTORY_SANDBOX_NODE overrides PATH, since the worker runs under Bun", () => {
-    const report = preflight({ ...healthy, env: { FACTORY_SANDBOX_NODE: "/opt/node23/bin/node" } });
+    const report = preflight({
+      ...healthy,
+      env: { FACTORY_SANDBOX_NODE: "/opt/node23/bin/node" },
+    });
     expect(report.node).toBe("/opt/node23/bin/node");
   });
 
@@ -85,20 +103,30 @@ describe("node version parsing", () => {
   });
 
   test("the floor is inclusive at the SDK's declared minimum", () => {
-    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 6 })).toBe(true);
-    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 5 })).toBe(false);
-    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR + 1, minor: 0 })).toBe(true);
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 6 })).toBe(
+      true,
+    );
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 5 })).toBe(
+      false,
+    );
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR + 1, minor: 0 })).toBe(
+      true,
+    );
     expect(nodeVersionSatisfies(null)).toBe(false);
   });
 });
 
 describe("NDJSON protocol", () => {
   test("parses whole lines and keeps the partial remainder for the next chunk", () => {
-    const first = parseEvents('{"type":"ready","bootMs":62}\n{"type":"stdout","data":"hel');
+    const first = parseEvents(
+      '{"type":"ready","bootMs":62}\n{"type":"stdout","data":"hel',
+    );
     expect(first.events).toEqual([{ type: "ready", bootMs: 62 }]);
     expect(first.rest).toBe('{"type":"stdout","data":"hel');
 
-    const second = parseEvents(`${first.rest}lo"}\n{"type":"exit","exitCode":0}\n`);
+    const second = parseEvents(
+      `${first.rest}lo"}\n{"type":"exit","exitCode":0}\n`,
+    );
     expect(second.events).toEqual([
       { type: "stdout", data: "hello" },
       { type: "exit", exitCode: 0 },
@@ -120,11 +148,17 @@ describe("guest timeout under a dynamic-deadline run (WM-692)", () => {
     for (const adapterKey of ["pi", "command"]) {
       expect(DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)).toBe(true);
       const maxRunMinutes = 90;
-      const timeoutMs = adapterExecuteTimeoutMs({ adapterKey, spec: { timeoutSeconds: 1_800 }, maxRunMinutes });
+      const timeoutMs = adapterExecuteTimeoutMs({
+        adapterKey,
+        spec: { timeoutSeconds: 1_800 },
+        maxRunMinutes,
+      });
       const ceilingMs = maxRunMinutes * 60_000 + LEASE_GRACE_SECONDS * 1000;
       expect(timeoutMs).toBeGreaterThanOrEqual(1_800_000);
       expect(timeoutMs).toBeLessThanOrEqual(ceilingMs);
-      expect(timeoutMs + KILL_GRACE_MS).toBeLessThanOrEqual(ceilingMs + KILL_GRACE_MS);
+      expect(timeoutMs + KILL_GRACE_MS).toBeLessThanOrEqual(
+        ceilingMs + KILL_GRACE_MS,
+      );
       expect(timeoutMs + KILL_GRACE_MS).toBeLessThan(2 ** 31 - 1);
       expect(timeoutMs).toBeLessThan(24 * 60 * 60_000);
     }
@@ -134,7 +168,10 @@ describe("guest timeout under a dynamic-deadline run (WM-692)", () => {
 describe("runInSandbox refusals", () => {
   // FACTORY_SANDBOX_NODE points at a path that cannot exist, so preflight
   // fails on any machine, with or without QEMU installed.
-  const unavailableHost = { FACTORY_SANDBOX_NODE: "/nonexistent/node", PATH: "" };
+  const unavailableHost = {
+    FACTORY_SANDBOX_NODE: "/nonexistent/node",
+    PATH: "",
+  };
 
   test("an unavailable host refuses with a typed error before spawning anything", async () => {
     await expect(

--- a/event-runtime/lib/sandbox/invariants.test.mjs
+++ b/event-runtime/lib/sandbox/invariants.test.mjs
@@ -41,7 +41,8 @@ describe("gondolin sandbox invariants", () => {
       let stdout = "";
       const result = await runInSandbox({
         policy: { provider: "gondolin" },
-        command: "cat /workspace/from-host.txt && echo 'guest wrote this' > /workspace/from-guest.txt",
+        command:
+          "cat /workspace/from-host.txt && echo 'guest wrote this' > /workspace/from-guest.txt",
         shell: true,
         workspaceDir: dir,
         timeoutMs: 60_000,
@@ -52,7 +53,9 @@ describe("gondolin sandbox invariants", () => {
 
       expect(result.exitCode).toBe(0);
       expect(stdout).toContain("host wrote this");
-      expect(readFileSync(path.join(dir, "from-guest.txt"), "utf8")).toBe("guest wrote this\n");
+      expect(readFileSync(path.join(dir, "from-guest.txt"), "utf8")).toBe(
+        "guest wrote this\n",
+      );
     },
     VM_TIMEOUT_MS,
   );
@@ -66,7 +69,8 @@ describe("gondolin sandbox invariants", () => {
         policy: { provider: "gondolin", allowedHosts: ["api.github.com"] },
         // -m keeps a hypothetical hang from eating the whole test timeout;
         // observed behaviour is a fast 403 from the host proxy.
-        command: "curl -sS -m 20 -o /dev/null -w '%{http_code}' https://example.com/ || echo CURL_FAILED",
+        command:
+          "curl -sS -m 20 -o /dev/null -w '%{http_code}' https://example.com/ || echo CURL_FAILED",
         shell: true,
         workspaceDir: dir,
         timeoutMs: 60_000,
@@ -83,7 +87,8 @@ describe("gondolin sandbox invariants", () => {
       let allowed = "";
       const allowedRun = await runInSandbox({
         policy: { provider: "gondolin", allowedHosts: ["example.com"] },
-        command: "curl -sS -m 30 -o /dev/null -w '%{http_code}' https://example.com/",
+        command:
+          "curl -sS -m 30 -o /dev/null -w '%{http_code}' https://example.com/",
         shell: true,
         workspaceDir: dir,
         timeoutMs: 60_000,
@@ -108,7 +113,12 @@ describe("gondolin sandbox invariants", () => {
         policy: {
           provider: "gondolin",
           allowedHosts: ["api.linear.app"],
-          secrets: { LINEAR_API_KEY: { hosts: ["api.linear.app"], env: "WM185_TEST_SECRET" } },
+          secrets: {
+            LINEAR_API_KEY: {
+              hosts: ["api.linear.app"],
+              env: "WM185_TEST_SECRET",
+            },
+          },
         },
         // Read it from the environment AND from the raw process environ, so a
         // future SDK change that leaks the value anywhere in the guest fails here.

--- a/event-runtime/lib/sandbox/policy.mjs
+++ b/event-runtime/lib/sandbox/policy.mjs
@@ -54,7 +54,9 @@ function requireHostPattern(value, label) {
     throw new SandboxPolicyError(`${label} must be a non-empty host pattern`);
   }
   if (value.includes("/") || value.includes(" ")) {
-    throw new SandboxPolicyError(`${label} must be a bare host pattern ("api.github.com"), not a URL or path: ${JSON.stringify(value)}`);
+    throw new SandboxPolicyError(
+      `${label} must be a bare host pattern ("api.github.com"), not a URL or path: ${JSON.stringify(value)}`,
+    );
   }
   return value;
 }
@@ -68,7 +70,9 @@ function requireGuestPath(value, label) {
     throw new SandboxPolicyError(`${label} must be an absolute guest path`);
   }
   if (value.split("/").includes("..")) {
-    throw new SandboxPolicyError(`${label} must not contain ".." segments: ${JSON.stringify(value)}`);
+    throw new SandboxPolicyError(
+      `${label} must not contain ".." segments: ${JSON.stringify(value)}`,
+    );
   }
   return value.length > 1 && value.endsWith("/") ? value.slice(0, -1) : value;
 }
@@ -109,7 +113,9 @@ export function normalizePolicy(raw, { workspaceDir } = {}) {
   const allowedHosts = [];
   if (policy.allowedHosts !== undefined) {
     if (!Array.isArray(policy.allowedHosts)) {
-      throw new SandboxPolicyError("sandbox.allowedHosts must be an array of host patterns");
+      throw new SandboxPolicyError(
+        "sandbox.allowedHosts must be an array of host patterns",
+      );
     }
     for (const [i, host] of policy.allowedHosts.entries()) {
       allowedHosts.push(requireHostPattern(host, `sandbox.allowedHosts[${i}]`));
@@ -129,9 +135,13 @@ export function normalizePolicy(raw, { workspaceDir } = {}) {
         );
       }
       if (!Array.isArray(entry.hosts) || entry.hosts.length === 0) {
-        throw new SandboxPolicyError(`sandbox.secrets.${name}.hosts must be a non-empty array`);
+        throw new SandboxPolicyError(
+          `sandbox.secrets.${name}.hosts must be a non-empty array`,
+        );
       }
-      const hosts = entry.hosts.map((h, i) => requireHostPattern(h, `sandbox.secrets.${name}.hosts[${i}]`));
+      const hosts = entry.hosts.map((h, i) =>
+        requireHostPattern(h, `sandbox.secrets.${name}.hosts[${i}]`),
+      );
       for (const host of hosts) {
         if (!allowedHosts.includes(host)) {
           // See rule 2 in the module header.
@@ -142,13 +152,18 @@ export function normalizePolicy(raw, { workspaceDir } = {}) {
       }
       const envVar = entry.env ?? name;
       if (typeof envVar !== "string" || envVar.trim() === "") {
-        throw new SandboxPolicyError(`sandbox.secrets.${name}.env must be a non-empty environment variable name`);
+        throw new SandboxPolicyError(
+          `sandbox.secrets.${name}.env must be a non-empty environment variable name`,
+        );
       }
       secrets.push({ name, envVar, hosts });
     }
   }
 
-  const workspaceMount = requireGuestPath(policy.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT, "sandbox.workspaceMount");
+  const workspaceMount = requireGuestPath(
+    policy.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT,
+    "sandbox.workspaceMount",
+  );
 
   const mounts = [];
   if (workspaceDir !== undefined) {
@@ -161,11 +176,22 @@ export function normalizePolicy(raw, { workspaceDir } = {}) {
   if (policy.mounts !== undefined) {
     const declared = requireObject(policy.mounts, "sandbox.mounts");
     for (const [guestPathRaw, value] of Object.entries(declared)) {
-      const guestPath = requireGuestPath(guestPathRaw, `sandbox.mounts["${guestPathRaw}"]`);
-      const spec = typeof value === "string" ? { path: value } : requireObject(value, `sandbox.mounts["${guestPathRaw}"]`);
-      const hostPath = requireHostPath(spec.path, `sandbox.mounts["${guestPathRaw}"].path`);
+      const guestPath = requireGuestPath(
+        guestPathRaw,
+        `sandbox.mounts["${guestPathRaw}"]`,
+      );
+      const spec =
+        typeof value === "string"
+          ? { path: value }
+          : requireObject(value, `sandbox.mounts["${guestPathRaw}"]`);
+      const hostPath = requireHostPath(
+        spec.path,
+        `sandbox.mounts["${guestPathRaw}"].path`,
+      );
       if (mounts.some((m) => m.guestPath === guestPath)) {
-        throw new SandboxPolicyError(`sandbox.mounts["${guestPathRaw}"] collides with an existing mount at ${guestPath}`);
+        throw new SandboxPolicyError(
+          `sandbox.mounts["${guestPathRaw}"] collides with an existing mount at ${guestPath}`,
+        );
       }
       mounts.push({ guestPath, hostPath, readonly: spec.readonly === true });
     }
@@ -177,10 +203,20 @@ export function normalizePolicy(raw, { workspaceDir } = {}) {
   }
   const memory = policy.memory ?? DEFAULT_MEMORY;
   if (typeof memory !== "string" || !/^\d+[KMGT]?$/.test(memory)) {
-    throw new SandboxPolicyError(`sandbox.memory must be a qemu size string like "1G", got ${JSON.stringify(memory)}`);
+    throw new SandboxPolicyError(
+      `sandbox.memory must be a qemu size string like "1G", got ${JSON.stringify(memory)}`,
+    );
   }
 
-  return { provider: policy.provider, allowedHosts, secrets, mounts, workspaceMount, memory, cpus };
+  return {
+    provider: policy.provider,
+    allowedHosts,
+    secrets,
+    mounts,
+    workspaceMount,
+    memory,
+    cpus,
+  };
 }
 
 /**

--- a/event-runtime/lib/sandbox/policy.test.mjs
+++ b/event-runtime/lib/sandbox/policy.test.mjs
@@ -1,11 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_WORKSPACE_MOUNT, normalizePolicy, resolveSecretValues, SandboxPolicyError } from "./policy.mjs";
+import {
+  DEFAULT_WORKSPACE_MOUNT,
+  normalizePolicy,
+  resolveSecretValues,
+  SandboxPolicyError,
+} from "./policy.mjs";
 
 const base = { provider: "gondolin", allowedHosts: ["api.github.com"] };
 
 describe("normalizePolicy", () => {
   test("an unknown provider is refused, not passed through", () => {
-    expect(() => normalizePolicy({ provider: "docker" })).toThrow(/unknown sandbox provider "docker"/);
+    expect(() => normalizePolicy({ provider: "docker" })).toThrow(
+      /unknown sandbox provider "docker"/,
+    );
     expect(() => normalizePolicy({})).toThrow(/unknown sandbox provider null/);
     expect(() => normalizePolicy(null)).toThrow(SandboxPolicyError);
   });
@@ -17,20 +24,36 @@ describe("normalizePolicy", () => {
   });
 
   test("host patterns must be bare hosts, not URLs", () => {
-    expect(() => normalizePolicy({ ...base, allowedHosts: ["https://api.github.com/x"] })).toThrow(/bare host pattern/);
-    expect(() => normalizePolicy({ ...base, allowedHosts: [""] })).toThrow(/non-empty host pattern/);
-    expect(() => normalizePolicy({ ...base, allowedHosts: "api.github.com" })).toThrow(/must be an array/);
+    expect(() =>
+      normalizePolicy({ ...base, allowedHosts: ["https://api.github.com/x"] }),
+    ).toThrow(/bare host pattern/);
+    expect(() => normalizePolicy({ ...base, allowedHosts: [""] })).toThrow(
+      /non-empty host pattern/,
+    );
+    expect(() =>
+      normalizePolicy({ ...base, allowedHosts: "api.github.com" }),
+    ).toThrow(/must be an array/);
   });
 
   test("a secret scoped outside the allowlist is a config error", () => {
     expect(() =>
-      normalizePolicy({ ...base, secrets: { LINEAR_API_KEY: { hosts: ["api.linear.app"] } } }),
-    ).toThrow(/scoped to api.linear.app, which sandbox.allowedHosts does not permit/);
+      normalizePolicy({
+        ...base,
+        secrets: { LINEAR_API_KEY: { hosts: ["api.linear.app"] } },
+      }),
+    ).toThrow(
+      /scoped to api.linear.app, which sandbox.allowedHosts does not permit/,
+    );
   });
 
   test("a literal secret value in a definition is refused", () => {
     expect(() =>
-      normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"], value: "ghp_real" } } }),
+      normalizePolicy({
+        ...base,
+        secrets: {
+          GITHUB_TOKEN: { hosts: ["api.github.com"], value: "ghp_real" },
+        },
+      }),
     ).toThrow(/must not carry a literal value/);
   });
 
@@ -43,24 +66,44 @@ describe("normalizePolicy", () => {
       },
     });
     expect(policy.secrets).toEqual([
-      { name: "GITHUB_TOKEN", envVar: "GITHUB_TOKEN", hosts: ["api.github.com"] },
+      {
+        name: "GITHUB_TOKEN",
+        envVar: "GITHUB_TOKEN",
+        hosts: ["api.github.com"],
+      },
       { name: "GH_ALT", envVar: "GITHUB_TOKEN_ALT", hosts: ["api.github.com"] },
     ]);
   });
 
   test("secrets must declare at least one host", () => {
-    expect(() => normalizePolicy({ ...base, secrets: { X: { hosts: [] } } })).toThrow(/non-empty array/);
-    expect(() => normalizePolicy({ ...base, secrets: { X: {} } })).toThrow(/non-empty array/);
+    expect(() =>
+      normalizePolicy({ ...base, secrets: { X: { hosts: [] } } }),
+    ).toThrow(/non-empty array/);
+    expect(() => normalizePolicy({ ...base, secrets: { X: {} } })).toThrow(
+      /non-empty array/,
+    );
   });
 
   test("the workspace dir becomes a read-write mount at the workspace mount point", () => {
     const policy = normalizePolicy(base, { workspaceDir: "/host/work/WM-185" });
     expect(policy.workspaceMount).toBe(DEFAULT_WORKSPACE_MOUNT);
-    expect(policy.mounts).toEqual([{ guestPath: "/workspace", hostPath: "/host/work/WM-185", readonly: false }]);
+    expect(policy.mounts).toEqual([
+      {
+        guestPath: "/workspace",
+        hostPath: "/host/work/WM-185",
+        readonly: false,
+      },
+    ]);
   });
 
   test("extra mounts accept a bare path or a readonly spec", () => {
-    const policy = normalizePolicy({ ...base, mounts: { "/ref": "/host/ref", "/ro": { path: "/host/ro", readonly: true } } });
+    const policy = normalizePolicy({
+      ...base,
+      mounts: {
+        "/ref": "/host/ref",
+        "/ro": { path: "/host/ro", readonly: true },
+      },
+    });
     expect(policy.mounts).toEqual([
       { guestPath: "/ref", hostPath: "/host/ref", readonly: false },
       { guestPath: "/ro", hostPath: "/host/ro", readonly: true },
@@ -68,33 +111,61 @@ describe("normalizePolicy", () => {
   });
 
   test("mount paths that could re-expose the guest root or collide are refused", () => {
-    expect(() => normalizePolicy({ ...base, mounts: { "/workspace/../etc": "/host/x" } })).toThrow(/".." segments/);
-    expect(() => normalizePolicy({ ...base, mounts: { relative: "/host/x" } })).toThrow(/absolute guest path/);
-    expect(() => normalizePolicy({ ...base, mounts: { "/ref": "host/relative" } })).toThrow(/absolute host path/);
-    expect(() => normalizePolicy({ ...base, mounts: { "/workspace": "/host/other" } }, { workspaceDir: "/host/work" })).toThrow(
-      /collides with an existing mount/,
-    );
+    expect(() =>
+      normalizePolicy({ ...base, mounts: { "/workspace/../etc": "/host/x" } }),
+    ).toThrow(/".." segments/);
+    expect(() =>
+      normalizePolicy({ ...base, mounts: { relative: "/host/x" } }),
+    ).toThrow(/absolute guest path/);
+    expect(() =>
+      normalizePolicy({ ...base, mounts: { "/ref": "host/relative" } }),
+    ).toThrow(/absolute host path/);
+    expect(() =>
+      normalizePolicy(
+        { ...base, mounts: { "/workspace": "/host/other" } },
+        { workspaceDir: "/host/work" },
+      ),
+    ).toThrow(/collides with an existing mount/);
   });
 
   test("resource limits are validated as qemu accepts them", () => {
-    expect(normalizePolicy({ ...base, memory: "2G", cpus: 4 })).toMatchObject({ memory: "2G", cpus: 4 });
-    expect(() => normalizePolicy({ ...base, memory: "lots" })).toThrow(/qemu size string/);
-    expect(() => normalizePolicy({ ...base, cpus: 0 })).toThrow(/positive integer/);
-    expect(() => normalizePolicy({ ...base, cpus: 1.5 })).toThrow(/positive integer/);
+    expect(normalizePolicy({ ...base, memory: "2G", cpus: 4 })).toMatchObject({
+      memory: "2G",
+      cpus: 4,
+    });
+    expect(() => normalizePolicy({ ...base, memory: "lots" })).toThrow(
+      /qemu size string/,
+    );
+    expect(() => normalizePolicy({ ...base, cpus: 0 })).toThrow(
+      /positive integer/,
+    );
+    expect(() => normalizePolicy({ ...base, cpus: 1.5 })).toThrow(
+      /positive integer/,
+    );
   });
 });
 
 describe("resolveSecretValues", () => {
   test("reads declared host env vars at execution time", () => {
-    const policy = normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"], env: "GH_SRC" } } });
+    const policy = normalizePolicy({
+      ...base,
+      secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"], env: "GH_SRC" } },
+    });
     expect(resolveSecretValues(policy, { GH_SRC: "ghp_real" })).toEqual({
       GITHUB_TOKEN: { hosts: ["api.github.com"], value: "ghp_real" },
     });
   });
 
   test("a missing or empty env var fails closed instead of authenticating as nobody", () => {
-    const policy = normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"] } } });
-    expect(() => resolveSecretValues(policy, {})).toThrow(/reads host env var GITHUB_TOKEN, which is unset or empty/);
-    expect(() => resolveSecretValues(policy, { GITHUB_TOKEN: "" })).toThrow(/unset or empty/);
+    const policy = normalizePolicy({
+      ...base,
+      secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"] } },
+    });
+    expect(() => resolveSecretValues(policy, {})).toThrow(
+      /reads host env var GITHUB_TOKEN, which is unset or empty/,
+    );
+    expect(() => resolveSecretValues(policy, { GITHUB_TOKEN: "" })).toThrow(
+      /unset or empty/,
+    );
   });
 });

--- a/event-runtime/lib/sandbox/runner.mjs
+++ b/event-runtime/lib/sandbox/runner.mjs
@@ -40,13 +40,25 @@ function readRequest() {
 
 async function main() {
   const request = readRequest();
-  const { policy, secrets = {}, command, cwd, env = {}, timeoutMs, shell = false } = request;
+  const {
+    policy,
+    secrets = {},
+    command,
+    cwd,
+    env = {},
+    timeoutMs,
+    shell = false,
+  } = request;
 
   let sdk;
   try {
     sdk = await import("@earendil-works/gondolin");
   } catch (err) {
-    emit({ type: "error", code: "sandbox_unavailable", message: `@earendil-works/gondolin is not installed: ${err.message}` });
+    emit({
+      type: "error",
+      code: "sandbox_unavailable",
+      message: `@earendil-works/gondolin is not installed: ${err.message}`,
+    });
     process.exit(2);
   }
   const { VM, RealFSProvider, ReadonlyProvider, createHttpHooks } = sdk;
@@ -57,14 +69,19 @@ async function main() {
   const { httpHooks, env: placeholderEnv } = createHttpHooks({
     allowedHosts: policy.allowedHosts,
     secrets: Object.fromEntries(
-      Object.entries(secrets).map(([name, { hosts, value }]) => [name, { hosts, value }]),
+      Object.entries(secrets).map(([name, { hosts, value }]) => [
+        name,
+        { hosts, value },
+      ]),
     ),
   });
 
   const mounts = {};
   for (const mount of policy.mounts) {
     const provider = new RealFSProvider(mount.hostPath);
-    mounts[mount.guestPath] = mount.readonly ? new ReadonlyProvider(provider) : provider;
+    mounts[mount.guestPath] = mount.readonly
+      ? new ReadonlyProvider(provider)
+      : provider;
   }
 
   const bootStart = Date.now();
@@ -87,7 +104,8 @@ async function main() {
   emit({ type: "ready", bootMs: Date.now() - bootStart });
 
   const abort = new AbortController();
-  const timer = timeoutMs > 0 ? setTimeout(() => abort.abort(), timeoutMs) : null;
+  const timer =
+    timeoutMs > 0 ? setTimeout(() => abort.abort(), timeoutMs) : null;
 
   try {
     // The parent sends an argv array unless it explicitly asked for a shell.
@@ -96,7 +114,11 @@ async function main() {
     // an input value can never become a command. The string form (`/bin/sh
     // -lc`) exists only for the hand-driven `sandbox exec --shell` path.
     if (shell ? typeof command !== "string" : !Array.isArray(command)) {
-      throw new Error(shell ? "shell mode requires a command string" : "non-shell mode requires an argv array");
+      throw new Error(
+        shell
+          ? "shell mode requires a command string"
+          : "non-shell mode requires an argv array",
+      );
     }
     const proc = vm.exec(command, {
       cwd,
@@ -105,15 +127,31 @@ async function main() {
       stderr: "pipe",
       buffer: false,
     });
-    proc.stdout?.on("data", (chunk) => emit({ type: "stdout", data: chunk.toString() }));
-    proc.stderr?.on("data", (chunk) => emit({ type: "stderr", data: chunk.toString() }));
+    proc.stdout?.on("data", (chunk) =>
+      emit({ type: "stdout", data: chunk.toString() }),
+    );
+    proc.stderr?.on("data", (chunk) =>
+      emit({ type: "stderr", data: chunk.toString() }),
+    );
     const result = await proc;
-    emit({ type: "exit", exitCode: result.exitCode, signal: result.signal ?? null });
+    emit({
+      type: "exit",
+      exitCode: result.exitCode,
+      signal: result.signal ?? null,
+    });
   } catch (err) {
     if (abort.signal.aborted) {
-      emit({ type: "error", code: "sandbox_timeout", message: `guest command exceeded ${timeoutMs}ms` });
+      emit({
+        type: "error",
+        code: "sandbox_timeout",
+        message: `guest command exceeded ${timeoutMs}ms`,
+      });
     } else {
-      emit({ type: "error", code: "sandbox_exec_failed", message: err.message });
+      emit({
+        type: "error",
+        code: "sandbox_exec_failed",
+        message: err.message,
+      });
     }
   } finally {
     if (timer) clearTimeout(timer);
@@ -128,6 +166,10 @@ async function main() {
 }
 
 main().catch((err) => {
-  emit({ type: "error", code: "sandbox_runner_crashed", message: err?.message ?? String(err) });
+  emit({
+    type: "error",
+    code: "sandbox_runner_crashed",
+    message: err?.message ?? String(err),
+  });
   process.exit(2);
 });

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -19,7 +19,8 @@ export const APPROVAL_MODES = ["watched", "auto"];
 /** "60m" / "30s" / "2h" / "1d" → seconds. Intervals only: no cron, no timezone. */
 export function parseCadence(every) {
   const match = /^(\d+)([smhd])$/.exec(String(every ?? "").trim());
-  if (!match) throw new Error(`unparseable cadence "${every}" — use 30s, 15m, 2h or 1d`);
+  if (!match)
+    throw new Error(`unparseable cadence "${every}" — use 30s, 15m, 2h or 1d`);
   const value = Number(match[1]);
   if (value <= 0) throw new Error(`cadence "${every}" must be positive`);
   return value * { s: 1, m: 60, h: 3600, d: 86400 }[match[2]];
@@ -52,13 +53,22 @@ export const DEFAULT_MAX_CATCH_UP = 24;
  *
  * @returns {{ slots: string[], skipped: number }}
  */
-export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none", maxCatchUp = DEFAULT_MAX_CATCH_UP }) {
+export function dueSlots({
+  lastSlot,
+  nowMs,
+  cadenceSeconds,
+  catchUp = "none",
+  maxCatchUp = DEFAULT_MAX_CATCH_UP,
+}) {
   const current = slotFor(nowMs, cadenceSeconds);
   if (!lastSlot) return { slots: [current], skipped: 0 };
-  if (Date.parse(lastSlot) >= Date.parse(current)) return { slots: [], skipped: 0 };
+  if (Date.parse(lastSlot) >= Date.parse(current))
+    return { slots: [], skipped: 0 };
 
   const period = cadenceSeconds * 1000;
-  const totalMissed = Math.round((Date.parse(current) - Date.parse(lastSlot)) / period);
+  const totalMissed = Math.round(
+    (Date.parse(current) - Date.parse(lastSlot)) / period,
+  );
   if (totalMissed <= 0) return { slots: [], skipped: 0 };
 
   if (catchUp === "all") {
@@ -80,8 +90,17 @@ export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none", ma
 }
 
 /** The newest slot already admitted for a loop at or before now, or null if it never fired (OPS-437, WM-421). */
-export function lastAdmittedSlot(db, loop, { now = Date.now(), eventType } = {}) {
-  const nowMs = typeof now === "number" ? now : (typeof now === "string" ? Date.parse(now) : Date.now());
+export function lastAdmittedSlot(
+  db,
+  loop,
+  { now = Date.now(), eventType } = {},
+) {
+  const nowMs =
+    typeof now === "number"
+      ? now
+      : typeof now === "string"
+        ? Date.parse(now)
+        : Date.now();
   const maxIso = new Date(nowMs).toISOString();
   const minEventId = `clock:${loop}:`;
   const maxEventId = tickEventId(loop, maxIso);
@@ -93,7 +112,15 @@ export function lastAdmittedSlot(db, loop, { now = Date.now(), eventType } = {})
          AND (subject = ? OR type = ? OR (? IS NOT NULL AND type = ?))
        ORDER BY event_id DESC LIMIT 1`,
     )
-    .get(SCHEDULE_SOURCE, minEventId, maxEventId, loop, `clock.tick.${loop}`, eventType ?? null, eventType ?? "");
+    .get(
+      SCHEDULE_SOURCE,
+      minEventId,
+      maxEventId,
+      loop,
+      `clock.tick.${loop}`,
+      eventType ?? null,
+      eventType ?? "",
+    );
   // eventId is clock:<loop>:<ISO slot>; ISO sorts lexicographically, so the
   // newest row is the newest slot without parsing every payload.
   return row ? row.event_id.slice(`clock:${loop}:`.length) : null;
@@ -114,7 +141,10 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
     try {
       const cadenceSeconds = parseCadence(schedule.every);
       const { slots, skipped } = dueSlots({
-        lastSlot: lastAdmittedSlot(db, loop, { now, eventType: schedule.eventType }),
+        lastSlot: lastAdmittedSlot(db, loop, {
+          now,
+          eventType: schedule.eventType,
+        }),
         nowMs: now,
         cadenceSeconds,
         catchUp: schedule.catchUp,
@@ -138,12 +168,19 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
             // A schedule's static payload (e.g. {repo}) rides along under the
             // tick fields, which always win — a schedule must not be able to
             // forge which slot it claims to be.
-            payload: { ...(schedule.payload ?? {}), loop, slot, cadenceSeconds, skippedSlots: skipped },
+            payload: {
+              ...(schedule.payload ?? {}),
+              loop,
+              slot,
+              cadenceSeconds,
+              skippedSlots: skipped,
+            },
           },
           { now },
         );
         if (outcome.admitted) emitted.push({ loop, slot, skipped });
-        else if (!outcome.duplicate) errors.push(`${loop}@${slot}: ${outcome.errors.join("; ")}`);
+        else if (!outcome.duplicate)
+          errors.push(`${loop}@${slot}: ${outcome.errors.join("; ")}`);
       }
     } catch (err) {
       errors.push(`${loop}: ${err.message}`);
@@ -202,7 +239,10 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
     } catch (err) {
       error = err.message;
     }
-    const lastSlot = lastAdmittedSlot(db, loop, { now, eventType: schedule.eventType });
+    const lastSlot = lastAdmittedSlot(db, loop, {
+      now,
+      eventType: schedule.eventType,
+    });
     const lastCompleted = lastCompletedSlot(db, loop);
     const nextDue =
       cadenceSeconds && lastSlot
@@ -214,7 +254,8 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
       cadenceSeconds && lastSlot
         ? Math.floor((now - Date.parse(lastSlot)) / (cadenceSeconds * 1000))
         : null;
-    const neverCompleted = Boolean(schedule.enabled) && lastSlot !== null && lastCompleted === null;
+    const neverCompleted =
+      Boolean(schedule.enabled) && lastSlot !== null && lastCompleted === null;
     return {
       loop,
       every: schedule.every,
@@ -231,7 +272,10 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
       intervalsLate,
       // Enabled, has fired before, and more than two intervals have passed:
       // the clock is not turning (serve down, machine asleep, bad cadence).
-      stopped: Boolean(schedule.enabled) && intervalsLate !== null && intervalsLate > 2,
+      stopped:
+        Boolean(schedule.enabled) &&
+        intervalsLate !== null &&
+        intervalsLate > 2,
       error,
     };
   });
@@ -247,7 +291,12 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
  * never be indistinguishable from one a human approved — that distinction is
  * the audit trail.
  */
-export function autoApproveScheduled(db, registry, approve, { now = Date.now(), policyVersion } = {}) {
+export function autoApproveScheduled(
+  db,
+  registry,
+  approve,
+  { now = Date.now(), policyVersion } = {},
+) {
   const approved = [];
   const errors = [];
   const autoLoops = new Set(
@@ -268,8 +317,13 @@ export function autoApproveScheduled(db, registry, approve, { now = Date.now(), 
     const loop = JSON.parse(row.envelope_json).payload?.loop;
     if (!autoLoops.has(loop)) continue;
     try {
-      const outcome = approve(db, registry, row.id, { actor: SCHEDULE_SOURCE, now, policyVersion });
-      if (outcome.approved) approved.push({ loop, proposalId: row.id, runId: outcome.runId });
+      const outcome = approve(db, registry, row.id, {
+        actor: SCHEDULE_SOURCE,
+        now,
+        policyVersion,
+      });
+      if (outcome.approved)
+        approved.push({ loop, proposalId: row.id, runId: outcome.runId });
     } catch (err) {
       errors.push(`${loop}: ${err.message}`);
     }
@@ -286,7 +340,11 @@ export const DEFAULT_PROPOSALS_PILING_THRESHOLD = 3;
  *
  * @returns {Array<{ loop: string, count: number, threshold: number }>}
  */
-export function proposalsPilingUp(db, registry, { threshold = DEFAULT_PROPOSALS_PILING_THRESHOLD } = {}) {
+export function proposalsPilingUp(
+  db,
+  registry,
+  { threshold = DEFAULT_PROPOSALS_PILING_THRESHOLD } = {},
+) {
   const rows = db
     .query(
       `SELECT e.subject, e.envelope_json
@@ -325,4 +383,3 @@ export function proposalsPilingUp(db, registry, { threshold = DEFAULT_PROPOSALS_
   piling.sort((a, b) => a.loop.localeCompare(b.loop));
   return piling;
 }
-

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -22,7 +22,10 @@ import { runOnce } from "./worker.mjs";
 
 const PV = "git:test-pv";
 const base = loadRegistry();
-const db = () => openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-sched-")), "runtime.db"));
+const db = () =>
+  openDb(
+    path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-sched-")), "runtime.db"),
+  );
 
 /** The real registry with one loop overridden — schedules are just data. */
 const withLoop = (overrides = {}) => ({
@@ -42,24 +45,34 @@ const withLoop = (overrides = {}) => ({
 
 const at = (iso) => Date.parse(iso);
 
-function planMergeRequest(d, registry, {
-  eventId,
-  source = "operator",
-  now = at("2026-08-17T10:30:45Z"),
-} = {}) {
-  const admitted = admitEvent(d, registry, {
-    schemaVersion: "factory.event/v1",
-    eventId,
-    type: "factory.merge.requested",
-    source,
-    subject: "factory",
-    occurredAt: new Date(now).toISOString(),
-    correlationId: eventId,
-    causationId: source === "chain" ? "run-parent" : null,
-    payload: { repo: "factory" },
-  }, { now });
+function planMergeRequest(
+  d,
+  registry,
+  { eventId, source = "operator", now = at("2026-08-17T10:30:45Z") } = {},
+) {
+  const admitted = admitEvent(
+    d,
+    registry,
+    {
+      schemaVersion: "factory.event/v1",
+      eventId,
+      type: "factory.merge.requested",
+      source,
+      subject: "factory",
+      occurredAt: new Date(now).toISOString(),
+      correlationId: eventId,
+      causationId: source === "chain" ? "run-parent" : null,
+      payload: { repo: "factory" },
+    },
+    { now },
+  );
   expect(admitted.admitted).toBe(true);
-  return planEvent(d, registry, { source, eventId }, { now, policyVersion: PV });
+  return planEvent(
+    d,
+    registry,
+    { source, eventId },
+    { now, policyVersion: PV },
+  );
 }
 
 describe("cadence and slots", () => {
@@ -75,9 +88,15 @@ describe("cadence and slots", () => {
 
   test("a slot is the interval floor, so every moment inside it maps to one id", () => {
     const hour = 3600;
-    expect(slotFor(at("2026-08-13T21:00:00Z"), hour)).toBe("2026-08-13T21:00:00.000Z");
-    expect(slotFor(at("2026-08-13T21:59:59Z"), hour)).toBe("2026-08-13T21:00:00.000Z");
-    expect(slotFor(at("2026-08-13T22:00:00Z"), hour)).toBe("2026-08-13T22:00:00.000Z");
+    expect(slotFor(at("2026-08-13T21:00:00Z"), hour)).toBe(
+      "2026-08-13T21:00:00.000Z",
+    );
+    expect(slotFor(at("2026-08-13T21:59:59Z"), hour)).toBe(
+      "2026-08-13T21:00:00.000Z",
+    );
+    expect(slotFor(at("2026-08-13T22:00:00Z"), hour)).toBe(
+      "2026-08-13T22:00:00.000Z",
+    );
   });
 });
 
@@ -86,7 +105,9 @@ describe("dueSlots — catch-up policy (§4)", () => {
   const now = at("2026-08-14T04:30:00Z");
 
   test("a loop that never fired fires once, for the current slot", () => {
-    expect(dueSlots({ lastSlot: null, nowMs: now, cadenceSeconds: hour })).toEqual({
+    expect(
+      dueSlots({ lastSlot: null, nowMs: now, cadenceSeconds: hour }),
+    ).toEqual({
       slots: ["2026-08-14T04:00:00.000Z"],
       skipped: 0,
     });
@@ -94,7 +115,11 @@ describe("dueSlots — catch-up policy (§4)", () => {
 
   test("already fired this slot → nothing due (the restart case)", () => {
     expect(
-      dueSlots({ lastSlot: "2026-08-14T04:00:00.000Z", nowMs: now, cadenceSeconds: hour }),
+      dueSlots({
+        lastSlot: "2026-08-14T04:00:00.000Z",
+        nowMs: now,
+        cadenceSeconds: hour,
+      }),
     ).toEqual({ slots: [], skipped: 0 });
   });
 
@@ -146,10 +171,14 @@ describe("dueSlots — catch-up policy (§4)", () => {
     });
     expect(outcome.slots).toHaveLength(24);
     // last slot is the current slot
-    expect(outcome.slots[outcome.slots.length - 1]).toBe("2026-08-14T04:30:00.000Z");
+    expect(outcome.slots[outcome.slots.length - 1]).toBe(
+      "2026-08-14T04:30:00.000Z",
+    );
     // slots are strictly in chronological order
     for (let i = 1; i < outcome.slots.length; i++) {
-      expect(Date.parse(outcome.slots[i])).toBeGreaterThan(Date.parse(outcome.slots[i - 1]));
+      expect(Date.parse(outcome.slots[i])).toBeGreaterThan(
+        Date.parse(outcome.slots[i - 1]),
+      );
     }
     // Total intervals: (nowMs slot - monthAgo) / 60s = 43230 intervals -> skipped = 43230 - 24 = 43206
     expect(outcome.skipped).toBe(43206);
@@ -179,13 +208,17 @@ describe("emitDueTicks (§3)", () => {
 
     // Three more "restarts" later in the same hour: nothing new.
     for (const minutes of [20, 40, 59]) {
-      const again = emitDueTicks(d, registry, { now: at(`2026-08-13T21:${minutes}:00Z`) });
+      const again = emitDueTicks(d, registry, {
+        now: at(`2026-08-13T21:${minutes}:00Z`),
+      });
       expect(again.emitted).toEqual([]);
     }
     expect(d.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
 
     // Next hour fires once.
-    expect(emitDueTicks(d, registry, { now: at("2026-08-13T22:05:00Z") }).emitted).toHaveLength(1);
+    expect(
+      emitDueTicks(d, registry, { now: at("2026-08-13T22:05:00Z") }).emitted,
+    ).toHaveLength(1);
   });
 
   test("the tick carries its loop, slot and how many slots it stands for", () => {
@@ -194,33 +227,51 @@ describe("emitDueTicks (§3)", () => {
     emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
     emitDueTicks(d, registry, { now: at("2026-08-14T04:00:00Z") });
 
-    const row = d.query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`).get();
+    const row = d
+      .query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`)
+      .get();
     const envelope = JSON.parse(row.envelope_json);
     expect(envelope.payload).toMatchObject({ loop: "reaper", skippedSlots: 5 });
-    expect(envelope.eventId).toBe(tickEventId("reaper", "2026-08-14T04:00:00.000Z"));
+    expect(envelope.eventId).toBe(
+      tickEventId("reaper", "2026-08-14T04:00:00.000Z"),
+    );
     expect(envelope.source).toBe("schedule");
   });
 
   test("a static payload rides on the tick and the planner proposes the routed run (WM-72)", () => {
     const d = db();
-    const registry = withLoop({ eventType: "factory.reconcile.requested", payload: { repo: "bj29" } });
+    const registry = withLoop({
+      eventType: "factory.reconcile.requested",
+      payload: { repo: "bj29" },
+    });
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
 
-    const row = d.query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`).get();
+    const row = d
+      .query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`)
+      .get();
     const envelope = JSON.parse(row.envelope_json);
     expect(envelope.type).toBe("factory.reconcile.requested");
     // Tick identity fields always win the merge over the static payload.
-    expect(envelope.payload).toMatchObject({ repo: "bj29", loop: "reaper", slot: "2026-08-13T21:00:00.000Z" });
+    expect(envelope.payload).toMatchObject({
+      repo: "bj29",
+      loop: "reaper",
+      slot: "2026-08-13T21:00:00.000Z",
+    });
 
     planAdmittedEvents(d, registry, { policyVersion: PV });
-    const proposal = openProposals(d, {}).find((p) => p.spec?.agent === "reconcile@1");
+    const proposal = openProposals(d, {}).find(
+      (p) => p.spec?.agent === "reconcile@1",
+    );
     expect(proposal).toBeTruthy();
     expect(proposal.status).toBe("open");
   });
 
   test("a disabled loop never fires", () => {
     const d = db();
-    expect(emitDueTicks(d, withLoop({ enabled: false }), { now: Date.now() }).emitted).toEqual([]);
+    expect(
+      emitDueTicks(d, withLoop({ enabled: false }), { now: Date.now() })
+        .emitted,
+    ).toEqual([]);
   });
 
   test("lastAdmittedSlot reads back the newest slot", () => {
@@ -293,11 +344,17 @@ describe("emitDueTicks (§3)", () => {
     const t1 = at("2026-08-16T15:30:00.000Z");
     const t1Ticks = emitDueTicks(d, registry, { now: t1 });
     expect(t1Ticks.emitted).toHaveLength(2);
-    expect(t1Ticks.emitted.find((e) => e.loop === "merge-factory")?.slot).toBe("2026-08-16T15:30:00.000Z");
+    expect(t1Ticks.emitted.find((e) => e.loop === "merge-factory")?.slot).toBe(
+      "2026-08-16T15:30:00.000Z",
+    );
 
     // lastAdmittedSlot must resolve the slot despite eventType being factory.merge.requested
-    expect(lastAdmittedSlot(d, "merge-factory", { now: t1 })).toBe("2026-08-16T15:30:00.000Z");
-    expect(lastAdmittedSlot(d, "merge-other", { now: t1 })).toBe("2026-08-16T15:30:00.000Z");
+    expect(lastAdmittedSlot(d, "merge-factory", { now: t1 })).toBe(
+      "2026-08-16T15:30:00.000Z",
+    );
+    expect(lastAdmittedSlot(d, "merge-other", { now: t1 })).toBe(
+      "2026-08-16T15:30:00.000Z",
+    );
 
     // scheduleView reports correct lastSlot, nextDue, and stopped state
     const view = scheduleView(d, registry, { now: t1 });
@@ -315,18 +372,28 @@ describe("emitDueTicks (§3)", () => {
     const t2 = at("2026-08-16T15:30:30.000Z");
     const t2Ticks = emitDueTicks(d, registry, { now: t2 });
     expect(t2Ticks.emitted).toHaveLength(2);
-    expect(lastAdmittedSlot(d, "merge-factory", { now: t2 })).toBe("2026-08-16T15:30:30.000Z");
+    expect(lastAdmittedSlot(d, "merge-factory", { now: t2 })).toBe(
+      "2026-08-16T15:30:30.000Z",
+    );
 
     // Loop isolation: inserting only a merge-other event does not affect merge-factory
     const dIsolated = db();
-    emitDueTicks(dIsolated, {
-      ...base,
-      schedules: {
-        "merge-other": registry.schedules["merge-other"],
+    emitDueTicks(
+      dIsolated,
+      {
+        ...base,
+        schedules: {
+          "merge-other": registry.schedules["merge-other"],
+        },
       },
-    }, { now: t1 });
-    expect(lastAdmittedSlot(dIsolated, "merge-factory", { now: t1 })).toBeNull();
-    expect(lastAdmittedSlot(dIsolated, "merge-other", { now: t1 })).toBe("2026-08-16T15:30:00.000Z");
+      { now: t1 },
+    );
+    expect(
+      lastAdmittedSlot(dIsolated, "merge-factory", { now: t1 }),
+    ).toBeNull();
+    expect(lastAdmittedSlot(dIsolated, "merge-other", { now: t1 })).toBe(
+      "2026-08-16T15:30:00.000Z",
+    );
   });
 });
 
@@ -345,14 +412,21 @@ describe("planning a tick (§5, §6)", () => {
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
     planAdmittedEvents(d, registry, { policyVersion: PV });
 
-    const proposal = openProposals(d, {}).find((p) => p.spec?.agent === "reaper@1");
+    const proposal = openProposals(d, {}).find(
+      (p) => p.spec?.agent === "reaper@1",
+    );
     expect(proposal).toBeTruthy();
     expect(proposal.status).toBe("open");
     expect(d.query(`SELECT state FROM runs`).get().state).toBe("PROPOSED");
 
     // Auto-approval must not touch a watched loop.
-    expect(autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV }).approved).toEqual([]);
-    expect(openProposals(d, {}).find((p) => p.spec?.agent === "reaper@1").status).toBe("open");
+    expect(
+      autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV })
+        .approved,
+    ).toEqual([]);
+    expect(
+      openProposals(d, {}).find((p) => p.spec?.agent === "reaper@1").status,
+    ).toBe("open");
   });
 
   test("an auto loop is approved by the scheduler — and the journal says so", () => {
@@ -361,14 +435,20 @@ describe("planning a tick (§5, §6)", () => {
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
     planAdmittedEvents(d, registry, { policyVersion: PV });
 
-    const outcome = autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
+    const outcome = autoApproveScheduled(d, registry, approveProposal, {
+      policyVersion: PV,
+    });
     expect(outcome.approved).toHaveLength(1);
     const runId = outcome.approved[0].runId;
-    expect(d.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId).state).toBe("QUEUED");
+    expect(
+      d.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId).state,
+    ).toBe("QUEUED");
 
     // The distinction that is the whole audit trail: nobody looked at this.
     const approval = d
-      .query(`SELECT actor FROM lifecycle_events WHERE run_id = ? AND to_state = 'APPROVED'`)
+      .query(
+        `SELECT actor FROM lifecycle_events WHERE run_id = ? AND to_state = 'APPROVED'`,
+      )
       .get(runId);
     expect(approval.actor).toBe("schedule");
     expect(approval.actor).not.toBe("operator");
@@ -386,7 +466,9 @@ describe("planning a tick (§5, §6)", () => {
     planAdmittedEvents(d, registry, { policyVersion: PV });
 
     const noop = d
-      .query(`SELECT decision, reason FROM proposals WHERE decision = 'noop' ORDER BY rowid DESC LIMIT 1`)
+      .query(
+        `SELECT decision, reason FROM proposals WHERE decision = 'noop' ORDER BY rowid DESC LIMIT 1`,
+      )
       .get();
     expect(noop.reason).toBe("previous_run_in_flight");
     expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
@@ -401,9 +483,13 @@ describe("planning a tick (§5, §6)", () => {
     });
     emitDueTicks(d, registry, { now: at("2026-08-17T10:30:00Z") });
     planAdmittedEvents(d, registry, { policyVersion: PV });
-    const [approved] = autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV }).approved;
+    const [approved] = autoApproveScheduled(d, registry, approveProposal, {
+      policyVersion: PV,
+    }).approved;
 
-    const operator = planMergeRequest(d, registry, { eventId: "operator-merge-overlap" });
+    const operator = planMergeRequest(d, registry, {
+      eventId: "operator-merge-overlap",
+    });
     expect(operator).toMatchObject({
       decision: "noop",
       reason: "previous_run_in_flight",
@@ -421,15 +507,23 @@ describe("planning a tick (§5, §6)", () => {
       singleton: false,
       approval: "auto",
     });
-    const operator = planMergeRequest(d, registry, { eventId: "operator-merge-first" });
-    approveProposal(d, registry, operator.proposal.id, { actor: "operator", policyVersion: PV });
+    const operator = planMergeRequest(d, registry, {
+      eventId: "operator-merge-first",
+    });
+    approveProposal(d, registry, operator.proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
 
     const tickAt = at("2026-08-17T11:00:00Z");
     emitDueTicks(d, registry, { now: tickAt });
     const scheduled = planEvent(
       d,
       registry,
-      { source: "schedule", eventId: tickEventId("reaper", "2026-08-17T11:00:00.000Z") },
+      {
+        source: "schedule",
+        eventId: tickEventId("reaper", "2026-08-17T11:00:00.000Z"),
+      },
       { now: tickAt, policyVersion: PV },
     );
     expect(scheduled).toMatchObject({
@@ -448,8 +542,13 @@ describe("planning a tick (§5, §6)", () => {
       payload: { repo: "factory" },
       approval: "auto",
     });
-    const operator = planMergeRequest(d, registry, { eventId: "operator-before-chain" });
-    approveProposal(d, registry, operator.proposal.id, { actor: "operator", policyVersion: PV });
+    const operator = planMergeRequest(d, registry, {
+      eventId: "operator-before-chain",
+    });
+    approveProposal(d, registry, operator.proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
 
     const chained = planMergeRequest(d, registry, {
       eventId: "chain-merge-overlap",
@@ -486,7 +585,9 @@ describe("planning a tick (§5, §6)", () => {
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
     planAdmittedEvents(d, registry, { policyVersion: PV });
 
-    const props1 = openProposals(d, {}).filter((p) => p.spec?.agent === "reaper@1");
+    const props1 = openProposals(d, {}).filter(
+      (p) => p.spec?.agent === "reaper@1",
+    );
     expect(props1).toHaveLength(1);
     expect(props1[0].status).toBe("open");
 
@@ -495,10 +596,19 @@ describe("planning a tick (§5, §6)", () => {
     planAdmittedEvents(d, registry, { policyVersion: PV });
 
     // Both proposals exist and are open / proposed — NOT silenced into a NOOP!
-    const props2 = openProposals(d, {}).filter((p) => p.spec?.agent === "reaper@1");
+    const props2 = openProposals(d, {}).filter(
+      (p) => p.spec?.agent === "reaper@1",
+    );
     expect(props2).toHaveLength(2);
-    expect(d.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get().n).toBe(2);
-    expect(d.query(`SELECT COUNT(*) AS n FROM proposals WHERE decision = 'noop'`).get().n).toBe(0);
+    expect(
+      d.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get()
+        .n,
+    ).toBe(2);
+    expect(
+      d
+        .query(`SELECT COUNT(*) AS n FROM proposals WHERE decision = 'noop'`)
+        .get().n,
+    ).toBe(0);
   });
 });
 
@@ -515,7 +625,9 @@ describe("scheduleView (§9)", () => {
     const d = db();
     const registry = withLoop();
 
-    const unticked = scheduleView(d, registry, { now: at("2026-08-13T21:30:00Z") })[0];
+    const unticked = scheduleView(d, registry, {
+      now: at("2026-08-13T21:30:00Z"),
+    })[0];
     expect(unticked).toMatchObject({
       lastSlot: null,
       nextDue: "2026-08-13T21:00:00.000Z",
@@ -524,13 +636,22 @@ describe("scheduleView (§9)", () => {
 
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
 
-    const soon = scheduleView(d, registry, { now: at("2026-08-13T21:30:00Z") })[0];
-    expect(soon).toMatchObject({ loop: "reaper", every: "60m", enabled: true, stopped: false });
+    const soon = scheduleView(d, registry, {
+      now: at("2026-08-13T21:30:00Z"),
+    })[0];
+    expect(soon).toMatchObject({
+      loop: "reaper",
+      every: "60m",
+      enabled: true,
+      stopped: false,
+    });
     expect(soon.lastSlot).toBe("2026-08-13T21:00:00.000Z");
     expect(soon.nextDue).toBe("2026-08-13T22:00:00.000Z");
 
     // Five hours of silence on an hourly loop: the clock is not turning.
-    const later = scheduleView(d, registry, { now: at("2026-08-14T02:00:00Z") })[0];
+    const later = scheduleView(d, registry, {
+      now: at("2026-08-14T02:00:00Z"),
+    })[0];
     expect(later.stopped).toBe(true);
     expect(later.intervalsLate).toBe(5);
   });
@@ -540,7 +661,9 @@ describe("scheduleView (§9)", () => {
     const registry = withLoop({ approval: "auto" });
 
     // Before ticking: no slots, not neverCompleted
-    expect(scheduleView(d, registry, { now: at("2026-08-13T21:00:00Z") })[0]).toMatchObject({
+    expect(
+      scheduleView(d, registry, { now: at("2026-08-13T21:00:00Z") })[0],
+    ).toMatchObject({
       lastSlot: null,
       lastCompletedSlot: null,
       neverCompleted: false,
@@ -551,7 +674,9 @@ describe("scheduleView (§9)", () => {
     planAdmittedEvents(d, registry, { policyVersion: PV });
     autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
 
-    const ticking = scheduleView(d, registry, { now: at("2026-08-13T21:10:00Z") })[0];
+    const ticking = scheduleView(d, registry, {
+      now: at("2026-08-13T21:10:00Z"),
+    })[0];
     expect(ticking.lastSlot).toBe("2026-08-13T21:00:00.000Z");
     expect(ticking.lastCompletedSlot).toBeNull();
     expect(ticking.neverCompleted).toBe(true);
@@ -559,7 +684,9 @@ describe("scheduleView (§9)", () => {
     // Run completes
     await runOnce(d, registry, adapters, workerOpts());
 
-    const running = scheduleView(d, registry, { now: at("2026-08-13T21:20:00Z") })[0];
+    const running = scheduleView(d, registry, {
+      now: at("2026-08-13T21:20:00Z"),
+    })[0];
     expect(running.lastSlot).toBe("2026-08-13T21:00:00.000Z");
     expect(running.lastCompletedSlot).toBe("2026-08-13T21:00:00.000Z");
     expect(running.neverCompleted).toBe(false);
@@ -568,7 +695,9 @@ describe("scheduleView (§9)", () => {
   test("a disabled loop is never reported stopped", () => {
     const d = db();
     const registry = withLoop({ enabled: false });
-    expect(scheduleView(d, registry, { now: Date.now() })[0].stopped).toBe(false);
+    expect(scheduleView(d, registry, { now: Date.now() })[0].stopped).toBe(
+      false,
+    );
   });
 });
 

--- a/event-runtime/lib/schema.mjs
+++ b/event-runtime/lib/schema.mjs
@@ -6,13 +6,29 @@
  */
 
 const SUPPORTED = new Set([
-  "type", "enum", "const", "required", "properties", "additionalProperties",
-  "items", "minItems", "maxItems", "minLength", "maxLength", "pattern",
-  "minimum", "maximum", "description", "title", "$schema",
+  "type",
+  "enum",
+  "const",
+  "required",
+  "properties",
+  "additionalProperties",
+  "items",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "minimum",
+  "maximum",
+  "description",
+  "title",
+  "$schema",
 ]);
 
 const hasOwn = (obj, key) =>
-  obj !== null && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+  obj !== null &&
+  typeof obj === "object" &&
+  Object.prototype.hasOwnProperty.call(obj, key);
 
 /**
  * @returns {{ valid: boolean, errors: string[] }}
@@ -26,7 +42,8 @@ export function validate(schema, value, path = "$") {
 function typeOf(value) {
   if (value === null) return "null";
   if (Array.isArray(value)) return "array";
-  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  if (typeof value === "number")
+    return Number.isInteger(value) ? "integer" : "number";
   return typeof value;
 }
 
@@ -45,7 +62,9 @@ function check(schema, value, path, errors) {
   }
   for (const key of Object.keys(schema)) {
     if (!SUPPORTED.has(key)) {
-      errors.push(`${path}: unsupported schema keyword "${key}" — contracts fail closed`);
+      errors.push(
+        `${path}: unsupported schema keyword "${key}" — contracts fail closed`,
+      );
       return;
     }
   }
@@ -55,71 +74,125 @@ function check(schema, value, path, errors) {
   if (hasOwn(schema, "type") && schema.type !== undefined) {
     const declared = Array.isArray(schema.type) ? schema.type : [schema.type];
     if (!declared.some((t) => matchesType(t, actual))) {
-      errors.push(`${path}: expected type ${declared.join("|")}, got ${actual}`);
+      errors.push(
+        `${path}: expected type ${declared.join("|")}, got ${actual}`,
+      );
       return;
     }
   }
 
-  if (hasOwn(schema, "const") && JSON.stringify(value) !== JSON.stringify(schema.const)) {
+  if (
+    hasOwn(schema, "const") &&
+    JSON.stringify(value) !== JSON.stringify(schema.const)
+  ) {
     errors.push(`${path}: expected const ${JSON.stringify(schema.const)}`);
   }
-  if (hasOwn(schema, "enum") && Array.isArray(schema.enum) && !schema.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))) {
+  if (
+    hasOwn(schema, "enum") &&
+    Array.isArray(schema.enum) &&
+    !schema.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))
+  ) {
     errors.push(`${path}: value not in enum ${JSON.stringify(schema.enum)}`);
   }
 
   if (actual === "string") {
-    if (hasOwn(schema, "minLength") && typeof schema.minLength === "number" && value.length < schema.minLength) {
+    if (
+      hasOwn(schema, "minLength") &&
+      typeof schema.minLength === "number" &&
+      value.length < schema.minLength
+    ) {
       errors.push(`${path}: shorter than minLength ${schema.minLength}`);
     }
-    if (hasOwn(schema, "maxLength") && typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+    if (
+      hasOwn(schema, "maxLength") &&
+      typeof schema.maxLength === "number" &&
+      value.length > schema.maxLength
+    ) {
       errors.push(`${path}: longer than maxLength ${schema.maxLength}`);
     }
-    if (hasOwn(schema, "pattern") && typeof schema.pattern === "string" && !new RegExp(schema.pattern).test(value)) {
+    if (
+      hasOwn(schema, "pattern") &&
+      typeof schema.pattern === "string" &&
+      !new RegExp(schema.pattern).test(value)
+    ) {
       errors.push(`${path}: does not match pattern ${schema.pattern}`);
     }
   }
 
   if (actual === "integer" || actual === "number") {
-    if (hasOwn(schema, "minimum") && typeof schema.minimum === "number" && value < schema.minimum) {
+    if (
+      hasOwn(schema, "minimum") &&
+      typeof schema.minimum === "number" &&
+      value < schema.minimum
+    ) {
       errors.push(`${path}: below minimum ${schema.minimum}`);
     }
-    if (hasOwn(schema, "maximum") && typeof schema.maximum === "number" && value > schema.maximum) {
+    if (
+      hasOwn(schema, "maximum") &&
+      typeof schema.maximum === "number" &&
+      value > schema.maximum
+    ) {
       errors.push(`${path}: above maximum ${schema.maximum}`);
     }
   }
 
   if (actual === "array") {
-    if (hasOwn(schema, "minItems") && typeof schema.minItems === "number" && value.length < schema.minItems) {
+    if (
+      hasOwn(schema, "minItems") &&
+      typeof schema.minItems === "number" &&
+      value.length < schema.minItems
+    ) {
       errors.push(`${path}: fewer than minItems ${schema.minItems}`);
     }
-    if (hasOwn(schema, "maxItems") && typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+    if (
+      hasOwn(schema, "maxItems") &&
+      typeof schema.maxItems === "number" &&
+      value.length > schema.maxItems
+    ) {
       errors.push(`${path}: more than maxItems ${schema.maxItems}`);
     }
     if (hasOwn(schema, "items")) {
-      value.forEach((item, i) => check(schema.items, item, `${path}[${i}]`, errors));
+      value.forEach((item, i) =>
+        check(schema.items, item, `${path}[${i}]`, errors),
+      );
     }
   }
 
   if (actual === "object") {
     if (hasOwn(schema, "required") && Array.isArray(schema.required)) {
       for (const key of schema.required) {
-        if (!hasOwn(value, key)) errors.push(`${path}: missing required property "${key}"`);
+        if (!hasOwn(value, key))
+          errors.push(`${path}: missing required property "${key}"`);
       }
     }
-    const properties = hasOwn(schema, "properties") && schema.properties && typeof schema.properties === "object"
-      ? schema.properties
-      : {};
+    const properties =
+      hasOwn(schema, "properties") &&
+      schema.properties &&
+      typeof schema.properties === "object"
+        ? schema.properties
+        : {};
     for (const [key, propSchema] of Object.entries(properties)) {
-      if (hasOwn(value, key)) check(propSchema, value[key], `${path}.${key}`, errors);
+      if (hasOwn(value, key))
+        check(propSchema, value[key], `${path}.${key}`, errors);
     }
     if (hasOwn(schema, "additionalProperties")) {
       if (schema.additionalProperties === false) {
         for (const key of Object.keys(value)) {
-          if (!hasOwn(properties, key)) errors.push(`${path}: unknown property "${key}"`);
+          if (!hasOwn(properties, key))
+            errors.push(`${path}: unknown property "${key}"`);
         }
-      } else if (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null) {
+      } else if (
+        typeof schema.additionalProperties === "object" &&
+        schema.additionalProperties !== null
+      ) {
         for (const key of Object.keys(value)) {
-          if (!hasOwn(properties, key)) check(schema.additionalProperties, value[key], `${path}.${key}`, errors);
+          if (!hasOwn(properties, key))
+            check(
+              schema.additionalProperties,
+              value[key],
+              `${path}.${key}`,
+              errors,
+            );
         }
       }
     }

--- a/event-runtime/lib/schema.test.mjs
+++ b/event-runtime/lib/schema.test.mjs
@@ -13,11 +13,17 @@ describe("validate", () => {
         tags: { type: "array", items: { type: "string" } },
       },
     };
-    expect(validate(schema, { name: "bj29", count: 2, tags: ["a"] }).valid).toBe(true);
+    expect(
+      validate(schema, { name: "bj29", count: 2, tags: ["a"] }).valid,
+    ).toBe(true);
   });
 
   test("rejects unknown properties when additionalProperties is false", () => {
-    const schema = { type: "object", additionalProperties: false, properties: { a: { type: "string" } } };
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" } },
+    };
     const { valid, errors } = validate(schema, { a: "x", extra: 1 });
     expect(valid).toBe(false);
     expect(errors[0]).toContain('"extra"');
@@ -34,9 +40,13 @@ describe("validate", () => {
   });
 
   test("const, enum, pattern, bounds", () => {
-    expect(validate({ const: "factory.event/v1" }, "factory.event/v1").valid).toBe(true);
+    expect(
+      validate({ const: "factory.event/v1" }, "factory.event/v1").valid,
+    ).toBe(true);
     expect(validate({ enum: ["a", "b"] }, "c").valid).toBe(false);
-    expect(validate({ type: "string", pattern: "^run_" }, "prop_1").valid).toBe(false);
+    expect(validate({ type: "string", pattern: "^run_" }, "prop_1").valid).toBe(
+      false,
+    );
     expect(validate({ type: "array", minItems: 1 }, []).valid).toBe(false);
   });
 
@@ -51,7 +61,19 @@ describe("validate", () => {
   });
 
   test("nested errors carry a path", () => {
-    const schema = { type: "object", properties: { repos: { type: "array", items: { type: "object", required: ["name"], properties: { name: { type: "string" } } } } } };
+    const schema = {
+      type: "object",
+      properties: {
+        repos: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["name"],
+            properties: { name: { type: "string" } },
+          },
+        },
+      },
+    };
     const { errors } = validate(schema, { repos: [{}] });
     expect(errors[0]).toContain("$.repos[0]");
   });
@@ -65,8 +87,12 @@ describe("validate", () => {
       };
       expect(validate(schema, { a: "x", toString: "evil" }).valid).toBe(false);
       expect(validate(schema, { a: "x", valueOf: "evil" }).valid).toBe(false);
-      expect(validate(schema, { a: "x", constructor: "evil" }).valid).toBe(false);
-      expect(validate(schema, { a: "x", isPrototypeOf: "evil" }).valid).toBe(false);
+      expect(validate(schema, { a: "x", constructor: "evil" }).valid).toBe(
+        false,
+      );
+      expect(validate(schema, { a: "x", isPrototypeOf: "evil" }).valid).toBe(
+        false,
+      );
     });
 
     test("validates additionalProperties schema on prototype-named own keys", () => {

--- a/event-runtime/lib/slice2.test.mjs
+++ b/event-runtime/lib/slice2.test.mjs
@@ -16,7 +16,8 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 
 function alertEnvelope(overrides = {}) {
-  const id = overrides.alertId ?? `alert-${Math.random().toString(36).slice(2, 8)}`;
+  const id =
+    overrides.alertId ?? `alert-${Math.random().toString(36).slice(2, 8)}`;
   return {
     schemaVersion: "factory.event/v1",
     eventId: `keep-${id}`,
@@ -40,13 +41,22 @@ function harness() {
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-ws-"));
   const adapters = { pi: fake, actions: fake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function approveNext(agentRef) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     expect(approved.approved).toBe(true);
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
@@ -65,18 +75,24 @@ describe("slice 2: disk alert → diagnose → approved remediation (OPS-208)", 
     // REMEDIATE recommendation → chain event → watched remediation proposal.
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const remedProposal = openProposals(db, {}).find((p) => p.spec?.agent === "disk-remediate@1");
+    const remedProposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "disk-remediate@1",
+    );
     expect(remedProposal.status).toBe("open"); // AC: no node B without approval
     expect(remedProposal.spec.input).toEqual({
       host: "lab",
       mount: "/",
-      actions: [{ action: "docker-builder-prune", expectedReclaimBytes: 1_000_000 }],
+      actions: [
+        { action: "docker-builder-prune", expectedReclaimBytes: 1_000_000 },
+      ],
     });
 
     const remediate = await approveNext("disk-remediate@1");
     expect(remediate.summary.terminalState).toBe("COMPLETED");
 
-    const result = db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(remediate.runId);
+    const result = db
+      .query(`SELECT result_json FROM results WHERE run_id = ?`)
+      .get(remediate.runId);
     const parsed = JSON.parse(result.result_json);
     expect(parsed.artifact.reclaimedBytes).toBe(1_000_000);
     expect(parsed.verification.checks).toContain("evidence_recomputed");
@@ -92,9 +108,15 @@ describe("slice 2: disk alert → diagnose → approved remediation (OPS-208)", 
     const diagnose = await approveNext("disk-diagnose@1");
     expect(diagnose.summary.terminalState).toBe("COMPLETED");
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "disk-remediate@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "disk-remediate@1"),
+    ).toBeUndefined();
   });
 
   test("duplicate alert (same host+alertId) → one run", async () => {
@@ -102,14 +124,21 @@ describe("slice 2: disk alert → diagnose → approved remediation (OPS-208)", 
     admitEvent(db, registry, alertEnvelope({ alertId: "a3", usedPct: 93 }));
     planAdmittedEvents(db, registry, { policyVersion: PV });
     // Re-fired alert: same alertId/host, different usedPct — must converge.
-    admitEvent(db, registry, { ...alertEnvelope({ alertId: "a3", usedPct: 97 }), eventId: "keep-a3-refire" });
+    admitEvent(db, registry, {
+      ...alertEnvelope({ alertId: "a3", usedPct: 97 }),
+      eventId: "keep-a3-refire",
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
   });
 
   test("a lying artifact fails closed: verifier recomputes reclaim from evidence", async () => {
     const { db, approveNext } = harness();
-    admitEvent(db, registry, alertEnvelope({ alertId: "a4", mount: "/bad", usedPct: 95 }));
+    admitEvent(
+      db,
+      registry,
+      alertEnvelope({ alertId: "a4", mount: "/bad", usedPct: 95 }),
+    );
     await approveNext("disk-diagnose@1");
     resolveChains(db, registry);
     const remediate = await approveNext("disk-remediate@1");
@@ -117,9 +146,13 @@ describe("slice 2: disk alert → diagnose → approved remediation (OPS-208)", 
     expect(remediate.summary.reasonCode).toBe("contract_violation");
     // The journal carries the recomputation detail.
     const journal = db
-      .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
+      .query(
+        `SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`,
+      )
       .get(remediate.runId);
-    expect(journal.reason).toContain("evidence_mismatch: reclaimedBytes 9999999 != recomputed 1000000");
+    expect(journal.reason).toContain(
+      "evidence_mismatch: reclaimedBytes 9999999 != recomputed 1000000",
+    );
   });
 });
 
@@ -144,13 +177,21 @@ describe("actions adapter (OPS-208)", () => {
     const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
 
     const outcome = await actions.execute({
-      spec: { input: { host: "testhost", mount: "/", actions: [{ action: "shrink" }] } },
+      spec: {
+        input: {
+          host: "testhost",
+          mount: "/",
+          actions: [{ action: "shrink" }],
+        },
+      },
       def: localDef(dir),
       workspaceDir,
       timeoutMs: 10_000,
     });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.artifact.beforeUsedBytes).toBe(1000);
     expect(result.artifact.afterUsedBytes).toBe(400);
     expect(result.artifact.reclaimedBytes).toBe(600);
@@ -163,7 +204,13 @@ describe("actions adapter (OPS-208)", () => {
     const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
 
     const outcome = await actions.execute({
-      spec: { input: { host: "testhost", mount: "/", actions: [{ action: "shrink" }, { action: "rm-rf-everything" }] } },
+      spec: {
+        input: {
+          host: "testhost",
+          mount: "/",
+          actions: [{ action: "shrink" }, { action: "rm-rf-everything" }],
+        },
+      },
       def: localDef(dir),
       workspaceDir,
       timeoutMs: 10_000,
@@ -171,7 +218,9 @@ describe("actions adapter (OPS-208)", () => {
     expect(outcome.exitCode).toBe(1);
     // The registered action in the same list did NOT run either.
     expect(readFileSync(path.join(dir, "blob")).length).toBe(1000);
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("not in the closed action registry");
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("not in the closed action registry");
   });
 
   test("unknown host refuses before executing", async () => {
@@ -179,12 +228,16 @@ describe("actions adapter (OPS-208)", () => {
     writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
     const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
     const outcome = await actions.execute({
-      spec: { input: { host: "prod-db", mount: "/", actions: [{ action: "shrink" }] } },
+      spec: {
+        input: { host: "prod-db", mount: "/", actions: [{ action: "shrink" }] },
+      },
       def: localDef(dir),
       workspaceDir,
       timeoutMs: 10_000,
     });
     expect(outcome.exitCode).toBe(1);
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("host allowlist");
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("host allowlist");
   });
 });

--- a/event-runtime/lib/sweep.test.mjs
+++ b/event-runtime/lib/sweep.test.mjs
@@ -16,8 +16,16 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 // See repository.test.mjs: neutralise the operator's global git config so a
 // signing key or a global hooks path cannot hang the fixture (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 const fixtures = [];
 let previousReposRoot;
@@ -70,13 +78,22 @@ function harness() {
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-ws-"));
   fixtures.push(workspaces);
   const adapters = { pi: fake, actions: fake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function approveNext(agentRef) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
   }
@@ -105,20 +122,32 @@ describe("sweep chain: scan → approved apply (WM-74)", () => {
 
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "sweep-apply@1");
+    const apply = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "sweep-apply@1",
+    );
     expect(apply.status).toBe("open"); // retirement never happens unapproved
     expect(apply.spec.input).toEqual({
       repo: "bj29",
       plan: [
-        { issueId: "CLNT-997", action: "retire-shipped", reason: "fake: shipped in PR #1" },
-        { issueId: "CLNT-997", action: "comment-evidence", reason: "fake: shipped in PR #1" },
+        {
+          issueId: "CLNT-997",
+          action: "retire-shipped",
+          reason: "fake: shipped in PR #1",
+        },
+        {
+          issueId: "CLNT-997",
+          action: "comment-evidence",
+          reason: "fake: shipped in PR #1",
+        },
       ],
     });
 
     const applied = await approveNext("sweep-apply@1");
     expect(applied.summary.terminalState).toBe("COMPLETED");
     const result = JSON.parse(
-      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json,
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(applied.runId).result_json,
     );
     expect(result.artifact.applied).toEqual([
       { issueId: "CLNT-997", action: "retire-shipped" },
@@ -130,9 +159,15 @@ describe("sweep chain: scan → approved apply (WM-74)", () => {
     const { db, approveNext } = harness();
     admitEvent(db, registry, sweepEnvelope("clean", "sweep-2"));
     await approveNext("sweep-scan@1");
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "sweep-apply@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "sweep-apply@1"),
+    ).toBeUndefined();
   });
 
   test("the apply registry is state transitions and comments only — no delete, no archive", () => {

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -11,7 +11,9 @@ function processGroupForPid(pid) {
     encoding: "utf8",
   });
   const pgid = Number(result.stdout.trim());
-  return result.status === 0 && Number.isInteger(pgid) && pgid > 0 ? pgid : null;
+  return result.status === 0 && Number.isInteger(pgid) && pgid > 0
+    ? pgid
+    : null;
 }
 
 const testRunnerPgid = processGroupForPid(process.pid);
@@ -59,7 +61,9 @@ export function trackProcess(pid, { group = true, scope = "test" } = {}) {
   }
   const entry = { pid: Number(pid), group, scope };
   if (entry.group && testRunnerPgid !== null && entry.pid === testRunnerPgid) {
-    throw new Error(`refusing to track the test runner process group ${testRunnerPgid}`);
+    throw new Error(
+      `refusing to track the test runner process group ${testRunnerPgid}`,
+    );
   }
   tracked.set(keyFor(entry), entry);
   return entry;
@@ -67,7 +71,8 @@ export function trackProcess(pid, { group = true, scope = "test" } = {}) {
 
 /** Find and register the detached process group containing pid. */
 export function trackProcessGroupForPid(pid, options = {}) {
-  if (process.platform === "win32") return trackProcess(pid, { ...options, group: false });
+  if (process.platform === "win32")
+    return trackProcess(pid, { ...options, group: false });
   const pgid = processGroupForPid(pid);
   if (pgid === null) {
     throw new Error(`could not resolve process group for test pid ${pid}`);
@@ -81,7 +86,8 @@ export function trackProcessGroupsMatching(fragment, options = {}) {
   const result = spawnSync("ps", ["-axo", "pid=,pgid=,command="], {
     encoding: "utf8",
   });
-  if (result.status !== 0) throw new Error("could not inspect test process groups");
+  if (result.status !== 0)
+    throw new Error("could not inspect test process groups");
   for (const line of result.stdout.split("\n")) {
     const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
     if (!match || !match[3].includes(fragment)) continue;
@@ -98,7 +104,8 @@ export function trackMarkedFakeRuntimeGroups(marker, options = {}) {
   const result = spawnSync("ps", ["-axo", "pid=,pgid=,command="], {
     encoding: "utf8",
   });
-  if (result.status !== 0) throw new Error("could not inspect marked test process groups");
+  if (result.status !== 0)
+    throw new Error("could not inspect marked test process groups");
   for (const line of result.stdout.split("\n")) {
     const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
     if (!match) continue;
@@ -129,7 +136,7 @@ export function processOwnerWatchdogSource(ownerPid = process.pid) {
     `const __factoryTestOwnerPid = ${Number(ownerPid)};`,
     "const __factoryTestOwnerWatch = setInterval(() => {",
     "  try { process.kill(__factoryTestOwnerPid, 0); } catch {",
-    "    try { process.kill(-process.pid, \"SIGKILL\"); } catch { process.exit(1); }",
+    '    try { process.kill(-process.pid, "SIGKILL"); } catch { process.exit(1); }',
     "  }",
     "}, 100);",
     "__factoryTestOwnerWatch.unref?.();",
@@ -176,8 +183,13 @@ export function spawnTracked(command, args = [], options = {}, tracking = {}) {
   return child;
 }
 
-export async function cleanupTrackedProcesses({ scope = "all", graceMs = 250 } = {}) {
-  const entries = [...tracked.values()].filter((entry) => scope === "all" || entry.scope === scope);
+export async function cleanupTrackedProcesses({
+  scope = "all",
+  graceMs = 250,
+} = {}) {
+  const entries = [...tracked.values()].filter(
+    (entry) => scope === "all" || entry.scope === scope,
+  );
   for (const entry of entries) signalTracked(entry, "SIGTERM");
 
   if (graceMs > 0 && entries.some(isAlive)) {

--- a/event-runtime/lib/tick.test.mjs
+++ b/event-runtime/lib/tick.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { PRUNE_INTERVAL_MS, TICK_SUBSYSTEMS, tick } from "../cli.mjs";
@@ -35,7 +41,9 @@ describe("tick (OPS-412)", () => {
        VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
     ).run(
       "run_kept",
-      JSON.stringify({ artifacts: [{ kind: "ci-log", sha256: kept.hash, uri: "file:///x" }] }),
+      JSON.stringify({
+        artifacts: [{ kind: "ci-log", sha256: kept.hash, uri: "file:///x" }],
+      }),
       new Date().toISOString(),
     );
 
@@ -58,7 +66,9 @@ describe("tick (OPS-412)", () => {
     expect(existsSync(orphan.file)).toBe(false);
     expect(existsSync(kept.file)).toBe(true);
     expect(result.lastPrune).toBe(now);
-    expect(logs.some((l) => l.startsWith("artifacts: pruned 1 orphan"))).toBe(true);
+    expect(logs.some((l) => l.startsWith("artifacts: pruned 1 orphan"))).toBe(
+      true,
+    );
   });
 
   test("a thrown exception in the GC subsystem still advances result.lastPrune to now (OPS-468)", async () => {

--- a/event-runtime/lib/trace.mjs
+++ b/event-runtime/lib/trace.mjs
@@ -15,7 +15,13 @@
  */
 
 /** Closed kind set (factory.trace/v1). Anything else is dropped, counted. */
-export const TRACE_KINDS = ["assistant_text", "tool_use", "tool_result", "usage", "lifecycle"];
+export const TRACE_KINDS = [
+  "assistant_text",
+  "tool_use",
+  "tool_result",
+  "usage",
+  "lifecycle",
+];
 
 /** Hard per-attempt row cap (§14 size bound): after this, one marker row. */
 export const TRACE_EVENTS_CAP = 2000;
@@ -63,7 +69,10 @@ export function traceRecorder(db, { runId, attempt, now = () => Date.now() }) {
         capped = true;
         dropped += 1;
         insert.run(
-          runId, attempt, new Date(now()).toISOString(), "lifecycle",
+          runId,
+          attempt,
+          new Date(now()).toISOString(),
+          "lifecycle",
           JSON.stringify({ note: "trace_truncated", dropped }),
         );
         return;
@@ -99,9 +108,10 @@ export function traceRecorder(db, { runId, attempt, now = () => Date.now() }) {
 export function traceOf(db, runId, { since = 0, limit = 100 } = {}) {
   const from = Number.isFinite(since) ? since : 0;
   const cap = Math.min(Math.max(Number.isFinite(limit) ? limit : 100, 0), 500);
-  const head = db
-    .query(`SELECT MAX(seq) AS m FROM attempt_trace WHERE run_id = ?`)
-    .get(runId).m ?? 0;
+  const head =
+    db
+      .query(`SELECT MAX(seq) AS m FROM attempt_trace WHERE run_id = ?`)
+      .get(runId).m ?? 0;
   const rows = db
     .query(
       `SELECT seq, attempt, ts, kind, payload_json FROM attempt_trace

--- a/event-runtime/lib/trace.test.mjs
+++ b/event-runtime/lib/trace.test.mjs
@@ -7,7 +7,13 @@ import { canonicalJson, hashJson } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
 import { createRun, transition } from "./lifecycle.mjs";
 import { loadRegistry } from "./registry.mjs";
-import { TRACE_EVENTS_CAP, TRACE_KINDS, TRACE_PAYLOAD_MAX_BYTES, traceOf, traceRecorder } from "./trace.mjs";
+import {
+  TRACE_EVENTS_CAP,
+  TRACE_KINDS,
+  TRACE_PAYLOAD_MAX_BYTES,
+  traceOf,
+  traceRecorder,
+} from "./trace.mjs";
 import { runOnce } from "./worker.mjs";
 
 const registry = loadRegistry();
@@ -22,15 +28,24 @@ function traceRows(db, runId) {
 describe("traceRecorder", () => {
   test("records every allowed kind with attribution and timestamp", () => {
     const db = openDb(":memory:");
-    const record = traceRecorder(db, { runId: "run_a", attempt: 1, now: () => T0 });
+    const record = traceRecorder(db, {
+      runId: "run_a",
+      attempt: 1,
+      now: () => T0,
+    });
     for (const kind of TRACE_KINDS) record(kind, { kind });
 
     const rows = traceRows(db, "run_a");
     expect(rows.map((r) => r.kind)).toEqual(TRACE_KINDS);
     expect(rows.every((r) => r.attempt === 1)).toBe(true);
     expect(rows[0].ts).toBe(new Date(T0).toISOString());
-    expect(JSON.parse(rows[0].payload_json)).toEqual({ kind: "assistant_text" });
-    expect(record.stats()).toEqual({ recorded: TRACE_KINDS.length, dropped: 0 });
+    expect(JSON.parse(rows[0].payload_json)).toEqual({
+      kind: "assistant_text",
+    });
+    expect(record.stats()).toEqual({
+      recorded: TRACE_KINDS.length,
+      dropped: 0,
+    });
   });
 
   test("unknown kinds are dropped and counted, never thrown", () => {
@@ -62,7 +77,9 @@ describe("traceRecorder", () => {
 
     const rows = traceRows(db, "run_d");
     expect(rows).toHaveLength(1);
-    expect(Buffer.byteLength(rows[0].payload_json, "utf8")).toBeLessThanOrEqual(TRACE_PAYLOAD_MAX_BYTES);
+    expect(Buffer.byteLength(rows[0].payload_json, "utf8")).toBeLessThanOrEqual(
+      TRACE_PAYLOAD_MAX_BYTES,
+    );
     const payload = JSON.parse(rows[0].payload_json);
     expect(payload.truncated).toBe(true);
     expect(payload.originalBytes).toBeGreaterThan(TRACE_PAYLOAD_MAX_BYTES);
@@ -72,13 +89,20 @@ describe("traceRecorder", () => {
 
   test("cap: TRACE_EVENTS_CAP rows plus exactly one truncation marker", () => {
     const db = openDb(":memory:");
-    const record = traceRecorder(db, { runId: "run_e", attempt: 1, now: () => T0 });
-    for (let i = 0; i < TRACE_EVENTS_CAP + 50; i += 1) record("assistant_text", { i });
+    const record = traceRecorder(db, {
+      runId: "run_e",
+      attempt: 1,
+      now: () => T0,
+    });
+    for (let i = 0; i < TRACE_EVENTS_CAP + 50; i += 1)
+      record("assistant_text", { i });
 
     const rows = traceRows(db, "run_e");
     expect(rows).toHaveLength(TRACE_EVENTS_CAP + 1);
     const markers = rows.filter(
-      (r) => r.kind === "lifecycle" && JSON.parse(r.payload_json).note === "trace_truncated",
+      (r) =>
+        r.kind === "lifecycle" &&
+        JSON.parse(r.payload_json).note === "trace_truncated",
     );
     expect(markers).toHaveLength(1);
     expect(rows.at(-1).kind).toBe("lifecycle"); // the marker is the final row
@@ -89,13 +113,25 @@ describe("traceRecorder", () => {
 
 describe("traceOf", () => {
   function seeded(db) {
-    const r1 = traceRecorder(db, { runId: "run_page", attempt: 1, now: () => T0 });
+    const r1 = traceRecorder(db, {
+      runId: "run_page",
+      attempt: 1,
+      now: () => T0,
+    });
     r1("assistant_text", { text: "one" });
     r1("tool_use", { name: "Bash", input: {} });
     // Interleave another run to prove head and entries are per-run.
-    const other = traceRecorder(db, { runId: "run_other", attempt: 1, now: () => T0 });
+    const other = traceRecorder(db, {
+      runId: "run_other",
+      attempt: 1,
+      now: () => T0,
+    });
     other("assistant_text", { text: "noise" });
-    const r2 = traceRecorder(db, { runId: "run_page", attempt: 2, now: () => T0 });
+    const r2 = traceRecorder(db, {
+      runId: "run_page",
+      attempt: 2,
+      now: () => T0,
+    });
     r2("tool_result", { content: "done" });
     r2("usage", { durationMs: 5 });
   }
@@ -106,7 +142,10 @@ describe("traceOf", () => {
 
     const first = traceOf(db, "run_page", { limit: 2 });
     expect(first.entries).toHaveLength(2);
-    expect(first.entries.map((e) => e.kind)).toEqual(["assistant_text", "tool_use"]);
+    expect(first.entries.map((e) => e.kind)).toEqual([
+      "assistant_text",
+      "tool_use",
+    ]);
     expect(first.entries[0].payload).toEqual({ text: "one" });
 
     const rest = traceOf(db, "run_page", { since: first.entries.at(-1).seq });
@@ -130,7 +169,11 @@ describe("traceOf", () => {
     const db = openDb(":memory:");
     expect(traceOf(db, "run_none")).toEqual({ head: 0, entries: [] });
 
-    const record = traceRecorder(db, { runId: "run_big", attempt: 1, now: () => T0 });
+    const record = traceRecorder(db, {
+      runId: "run_big",
+      attempt: 1,
+      now: () => T0,
+    });
     for (let i = 0; i < 600; i += 1) record("assistant_text", { i });
     expect(traceOf(db, "run_big", { limit: 9999 }).entries).toHaveLength(500);
   });
@@ -143,7 +186,9 @@ describe("traceOf", () => {
 
 let seq = 0;
 function makeSpec(overrides = {}) {
-  const runId = overrides.runId ?? `run_trace_${++seq}_${Math.random().toString(36).slice(2)}`;
+  const runId =
+    overrides.runId ??
+    `run_trace_${++seq}_${Math.random().toString(36).slice(2)}`;
   const input = overrides.input ?? { repos: ["ok"] };
   return {
     schemaVersion: "factory.run-spec/v1",
@@ -166,9 +211,14 @@ function makeSpec(overrides = {}) {
 
 function queueRun(db, spec, now = T0) {
   createRun(db, {
-    runId: spec.runId, idempotencyKey: spec.idempotencyKey,
-    spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
-    actor: "test", policyVersion: "test", now,
+    runId: spec.runId,
+    idempotencyKey: spec.idempotencyKey,
+    spec,
+    specJson: canonicalJson(spec),
+    specHash: hashJson(spec),
+    actor: "test",
+    policyVersion: "test",
+    now,
   });
   transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now });
   transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now });
@@ -194,7 +244,12 @@ describe("worker trace plumbing", () => {
     expect(summary.terminalState).toBe("COMPLETED");
 
     const rows = traceRows(db, spec.runId);
-    expect(rows.map((r) => r.kind)).toEqual(["assistant_text", "tool_use", "tool_result", "usage"]);
+    expect(rows.map((r) => r.kind)).toEqual([
+      "assistant_text",
+      "tool_use",
+      "tool_result",
+      "usage",
+    ]);
     expect(rows.every((r) => r.attempt === 1)).toBe(true);
     expect(JSON.parse(rows[1].payload_json).name).toBe("Bash");
 

--- a/event-runtime/lib/transcripts.mjs
+++ b/event-runtime/lib/transcripts.mjs
@@ -11,7 +11,15 @@
  * the computed hash and the agent's full output.
  */
 import {
-  closeSync, copyFileSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, statSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  statSync,
 } from "node:fs";
 import { createWriteStream } from "node:fs";
 import path from "node:path";
@@ -25,9 +33,12 @@ export const TRANSCRIPT_FILENAME = ".transcript.json";
 export const MAX_RESUME_SCAN_BYTES = 1024 * 1024;
 
 function validSessionId(value, adapter) {
-  if (typeof value !== "string" || value.length === 0 || value.length > 256) return false;
+  if (typeof value !== "string" || value.length === 0 || value.length > 256)
+    return false;
   if (adapter === "claude") {
-    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    );
   }
   return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value);
 }
@@ -55,23 +66,28 @@ export function transcriptSessionId(transcriptPath, adapter) {
         continue;
       }
       const priorWorkspace = path.dirname(transcriptPath);
-      const candidate = adapter === "claude"
-        && event?.type === "system"
-        && event?.subtype === "init"
-        && event?.cwd === priorWorkspace
-        ? event.session_id
-        : adapter === "pi"
-          && event?.type === "session"
-          && event?.cwd === priorWorkspace
-          ? event.id
-          : null;
+      const candidate =
+        adapter === "claude" &&
+        event?.type === "system" &&
+        event?.subtype === "init" &&
+        event?.cwd === priorWorkspace
+          ? event.session_id
+          : adapter === "pi" &&
+              event?.type === "session" &&
+              event?.cwd === priorWorkspace
+            ? event.id
+            : null;
       if (validSessionId(candidate, adapter)) return candidate;
     }
   } catch {
     return null;
   } finally {
     if (fd !== undefined) {
-      try { closeSync(fd); } catch { /* intentionally ignored */ }
+      try {
+        closeSync(fd);
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   return null;
@@ -85,7 +101,11 @@ export function transcriptSessionId(transcriptPath, adapter) {
 export function findPriorResumeContext({ root, runId, attempt, adapter }) {
   if (!Number.isInteger(attempt) || attempt <= 1) return null;
   for (let priorAttempt = attempt - 1; priorAttempt >= 1; priorAttempt -= 1) {
-    const transcriptPath = path.join(root, `${runId}-a${priorAttempt}`, TRANSCRIPT_FILENAME);
+    const transcriptPath = path.join(
+      root,
+      `${runId}-a${priorAttempt}`,
+      TRANSCRIPT_FILENAME,
+    );
     if (!existsSync(transcriptPath)) continue;
     const sessionId = transcriptSessionId(transcriptPath, adapter);
     if (sessionId) return { attempt: priorAttempt, sessionId, transcriptPath };
@@ -161,7 +181,10 @@ export function waitForStreamFlush(stream) {
  *   endAndFlush: () => Promise<void>
  * }}
  */
-export function createTranscriptCapture(workspaceDir, { filename = TRANSCRIPT_FILENAME, flags = "w" } = {}) {
+export function createTranscriptCapture(
+  workspaceDir,
+  { filename = TRANSCRIPT_FILENAME, flags = "w" } = {},
+) {
   const filePath = path.join(workspaceDir, filename);
   const stream = createWriteStream(filePath, { flags });
 

--- a/event-runtime/lib/transcripts.test.mjs
+++ b/event-runtime/lib/transcripts.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Readable, PassThrough } from "node:stream";
@@ -31,7 +37,11 @@ describe("transcripts (OPS-426)", () => {
     const ws = tmpWs();
     const { stream, filePath } = createTranscriptCapture(ws);
 
-    const chunk = JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hello" }] } }) + "\n";
+    const chunk =
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hello" }] },
+      }) + "\n";
     stream.write(chunk);
     stream.end();
 
@@ -46,7 +56,9 @@ describe("transcripts (OPS-426)", () => {
     const ws = tmpWs();
     const { stream, filePath } = createTranscriptCapture(ws);
 
-    const data = JSON.stringify({ type: "result", status: "success", count: 12345 }) + "\n";
+    const data =
+      JSON.stringify({ type: "result", status: "success", count: 12345 }) +
+      "\n";
     stream.write(data);
     stream.end();
 
@@ -61,7 +73,8 @@ describe("transcripts (OPS-426)", () => {
     const storeRoot = path.join(tmpWs(), "store");
     const { stream, filePath } = createTranscriptCapture(ws);
 
-    const payload = JSON.stringify({ message: "stored artifact verification test" }) + "\n";
+    const payload =
+      JSON.stringify({ message: "stored artifact verification test" }) + "\n";
     stream.write(payload);
 
     const stored = await flushAndStoreTranscript({
@@ -108,8 +121,15 @@ describe("transcripts (OPS-426)", () => {
       const readable = Readable.from(
         (async function* () {
           const chunkSize = 64 * 1024;
-          for (let offset = 0; offset < expectedBuffer.length; offset += chunkSize) {
-            yield expectedBuffer.subarray(offset, Math.min(offset + chunkSize, expectedBuffer.length));
+          for (
+            let offset = 0;
+            offset < expectedBuffer.length;
+            offset += chunkSize
+          ) {
+            yield expectedBuffer.subarray(
+              offset,
+              Math.min(offset + chunkSize, expectedBuffer.length),
+            );
           }
         })(),
       );

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as actions from "./adapters/actions.mjs";
@@ -17,8 +23,16 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 // See repository.test.mjs: neutralise the operator's global git config so a
 // signing key or a global hooks path cannot hang the fixture (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 // Hermetic repo fixtures: these tests must not depend on which repos happen
 // to be checked out on the machine, so they point FACTORY_REPOS_ROOT at a
@@ -121,13 +135,22 @@ function harness({ adapters = { pi: fake, actions: fake } } = {}) {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-ws-"));
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function approveNext(agentRef) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
   }
@@ -153,7 +176,8 @@ const fakeCanonicalScan = {
                 reason: "fake: canonical multi-section detail",
                 detail: canonicalWriteDetail,
                 ownedPaths: ["README.md"],
-                verificationCommand: "bun test event-runtime/lib/triage.test.mjs",
+                verificationCommand:
+                  "bun test event-runtime/lib/triage.test.mjs",
               },
             ],
             summary: `fake triage of ${spec.input.repo}`,
@@ -190,24 +214,48 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
 
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1");
+    const apply = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "triage-apply@1",
+    );
     expect(apply.status).toBe("open"); // never applied without approval
     expect(apply.spec.input).toEqual({
       repo: "bj29",
-      plan: [{ issueId: "CLNT-999", action: "label-agent-ready", reason: "fake: fully specified" }],
+      plan: [
+        {
+          issueId: "CLNT-999",
+          action: "label-agent-ready",
+          reason: "fake: fully specified",
+        },
+      ],
     });
 
     const applied = await approveNext("triage-apply@1");
     expect(applied.summary.terminalState).toBe("COMPLETED");
-    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json);
-    expect(result.artifact.applied).toEqual([{ issueId: "CLNT-999", action: "label-agent-ready" }]);
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(applied.runId).result_json,
+    );
+    expect(result.artifact.applied).toEqual([
+      { issueId: "CLNT-999", action: "label-agent-ready" },
+    ]);
   });
 
   test("a canonical write-detail triage-scan chain proposal is approved and chained", async () => {
-    expect(/^## (Acceptance criteria|Owned Paths|Verification)/.test(canonicalWriteDetail)).toBe(false);
-    expect(/^\s*## (Acceptance Criteria|Owned Paths|Verification)/.test(canonicalWriteDetail)).toBe(true);
+    expect(
+      /^## (Acceptance criteria|Owned Paths|Verification)/.test(
+        canonicalWriteDetail,
+      ),
+    ).toBe(false);
+    expect(
+      /^\s*## (Acceptance Criteria|Owned Paths|Verification)/.test(
+        canonicalWriteDetail,
+      ),
+    ).toBe(true);
 
-    const { db, approveNext } = harness({ adapters: { pi: fakeCanonicalScan, actions: fake } });
+    const { db, approveNext } = harness({
+      adapters: { pi: fakeCanonicalScan, actions: fake },
+    });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-5"));
 
     const scan = await approveNext("triage-scan@1");
@@ -216,7 +264,9 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1");
+    const apply = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "triage-apply@1",
+    );
     expect(apply).toBeTruthy();
     expect(apply.decision).toBe("run");
     expect(apply.status).toBe("open");
@@ -229,7 +279,9 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
   });
 
   test("apply outcome SUPPLY_CHANGED chains to work.requested", async () => {
-    const { db, approveNext } = harness({ adapters: { pi: fake, actions: fake } });
+    const { db, approveNext } = harness({
+      adapters: { pi: fake, actions: fake },
+    });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-6"));
 
     const scan = await approveNext("triage-scan@1");
@@ -242,13 +294,23 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
 
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
-    const event = db.query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`).get(applied.runId);
+    const event = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`)
+      .get(applied.runId);
     expect(event.type).toBe("factory.work.requested");
     expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "bj29" });
   });
 
   test("apply outcome DETAIL_CHANGED chains to triage.requested", async () => {
-    const { db, approveNext } = harness({ adapters: { pi: triagePlanScan({ action: "write-detail", detail: canonicalWriteDetail }), actions: fake } });
+    const { db, approveNext } = harness({
+      adapters: {
+        pi: triagePlanScan({
+          action: "write-detail",
+          detail: canonicalWriteDetail,
+        }),
+        actions: fake,
+      },
+    });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-7"));
 
     const scan = await approveNext("triage-scan@1");
@@ -261,13 +323,20 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
 
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
-    const event = db.query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`).get(applied.runId);
+    const event = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`)
+      .get(applied.runId);
     expect(event.type).toBe("factory.triage.requested");
     expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "bj29" });
   });
 
   test("apply outcome NO_CHANGE terminates with no follow-up", async () => {
-    const { db, approveNext } = harness({ adapters: { pi: triagePlanScan({ action: "move-to-todo" }), actions: fake } });
+    const { db, approveNext } = harness({
+      adapters: {
+        pi: triagePlanScan({ action: "move-to-todo" }),
+        actions: fake,
+      },
+    });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-8"));
 
     const scan = await approveNext("triage-scan@1");
@@ -286,18 +355,29 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     const { db, approveNext } = harness();
     admitEvent(db, registry, triageEnvelope("clean", "triage-2"));
     await approveNext("triage-scan@1");
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1"),
+    ).toBeUndefined();
   });
 
   test("the scan run's spec pins an immutable sha — reproducible, and dedup sees new commits", async () => {
     const { db } = harness();
     admitEvent(db, registry, triageEnvelope("bj29", "triage-3"));
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1");
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "triage-scan@1",
+    );
     expect(proposal.spec.input.repo).toBe("bj29");
-    expect(proposal.spec.input.repoPin).toMatchObject({ repo: "bj29", ref: "develop" });
+    expect(proposal.spec.input.repoPin).toMatchObject({
+      repo: "bj29",
+      ref: "develop",
+    });
     expect(proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
   });
 
@@ -305,7 +385,9 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     const { db } = harness();
     admitEvent(db, registry, triageEnvelope("not-a-repo", "triage-4"));
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.decision === "human_needed");
+    const proposal = openProposals(db, {}).find(
+      (p) => p.decision === "human_needed",
+    );
     expect(proposal.reason).toContain("repo_pin_failed");
   });
 });
@@ -318,7 +400,9 @@ describe("triage-apply is closed by construction (OPS-229)", () => {
       itemsField: "plan",
       itemKey: "issueId",
       actionRegistry: {
-        "label-agent-ready": { argv: ["sh", "-c", `echo {issueId} >> ${dir}/applied.txt`] },
+        "label-agent-ready": {
+          argv: ["sh", "-c", `echo {issueId} >> ${dir}/applied.txt`],
+        },
       },
     };
   }
@@ -341,11 +425,14 @@ describe("triage-apply is closed by construction (OPS-229)", () => {
       timeoutMs: 10_000,
     });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-    expect(readFileSync(path.join(dir, "applied.txt"), "utf8").split("\n").filter(Boolean)).toEqual([
-      "CLNT-1",
-      "CLNT-2",
-    ]);
-    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(
+      readFileSync(path.join(dir, "applied.txt"), "utf8")
+        .split("\n")
+        .filter(Boolean),
+    ).toEqual(["CLNT-1", "CLNT-2"]);
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
     expect(result.artifact.applied).toHaveLength(2);
   });
 
@@ -368,14 +455,16 @@ describe("triage-apply is closed by construction (OPS-229)", () => {
     });
     expect(outcome.exitCode).toBe(1);
     expect(() => readFileSync(path.join(dir, "applied.txt"))).toThrow(); // CLNT-1 never ran
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
-      "not in the closed action registry",
-    );
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("not in the closed action registry");
   });
 
   test("the registry admits item-list definitions and rejects a mutating one with no closed form", () => {
     expect(registry.agents.get("triage-apply@1").mutating).toBe(true);
     expect(registry.agents.get("triage-apply@1").itemsField).toBe("plan");
-    expect(registry.agents.get("triage-scan@1").workspace.type).toBe("repository");
+    expect(registry.agents.get("triage-scan@1").workspace.type).toBe(
+      "repository",
+    );
   });
 });

--- a/event-runtime/lib/unblock.test.mjs
+++ b/event-runtime/lib/unblock.test.mjs
@@ -16,8 +16,16 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 // See repository.test.mjs: neutralise the operator's global git config so a
 // signing key or a global hooks path cannot hang the fixture (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 const fixtures = [];
 let previousReposRoot;
@@ -70,13 +78,22 @@ function harness() {
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-ws-"));
   fixtures.push(workspaces);
   const adapters = { pi: fake, actions: fake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function approveNext(agentRef) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
   }
@@ -106,20 +123,32 @@ describe("unblock chain: scan → approved apply (WM-73)", () => {
 
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "unblock-apply@1");
+    const apply = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "unblock-apply@1",
+    );
     expect(apply.status).toBe("open"); // never applied without approval
     expect(apply.spec.input).toEqual({
       repo: "bj29",
       plan: [
-        { issueId: "CLNT-998", action: "release-to-triage", reason: "fake: dependency merged" },
-        { issueId: "CLNT-998", action: "comment-evidence", reason: "fake: dependency merged" },
+        {
+          issueId: "CLNT-998",
+          action: "release-to-triage",
+          reason: "fake: dependency merged",
+        },
+        {
+          issueId: "CLNT-998",
+          action: "comment-evidence",
+          reason: "fake: dependency merged",
+        },
       ],
     });
 
     const applied = await approveNext("unblock-apply@1");
     expect(applied.summary.terminalState).toBe("COMPLETED");
     const result = JSON.parse(
-      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json,
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(applied.runId).result_json,
     );
     expect(result.artifact.applied).toEqual([
       { issueId: "CLNT-998", action: "release-to-triage" },
@@ -131,9 +160,15 @@ describe("unblock chain: scan → approved apply (WM-73)", () => {
     const { db, approveNext } = harness();
     admitEvent(db, registry, unblockEnvelope("clean", "unblock-2"));
     await approveNext("unblock-scan@1");
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "unblock-apply@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "unblock-apply@1"),
+    ).toBeUndefined();
   });
 
   test("the apply registry cannot add ai:blocked or touch anything but the closed verbs", () => {

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -70,18 +70,25 @@ export class ContractViolation extends Error {
 }
 
 function normalizeFailureOutput(output) {
-  return String(output ?? "")
-    // eslint-disable-next-line no-control-regex -- \x1b is the ANSI escape byte being stripped, not a typo
-    .replace(/\x1b\[[0-9;]*m/g, "")
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    // Lifecycle scripts emit recoverable, run-varying diagnostics as warn:.
-    // They are evidence, not part of the underlying failure signature.
-    .filter((line) => !/^warn:\s*/i.test(line))
-    // Runners repeat these for unrelated failures; they are not evidence that
-    // the same underlying check remains red.
-    .filter((line) => !/^(\$ |bun test|error: script |error: ".*" exited|exited with code)/i.test(line));
+  return (
+    String(output ?? "")
+      // eslint-disable-next-line no-control-regex -- \x1b is the ANSI escape byte being stripped, not a typo
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      // Lifecycle scripts emit recoverable, run-varying diagnostics as warn:.
+      // They are evidence, not part of the underlying failure signature.
+      .filter((line) => !/^warn:\s*/i.test(line))
+      // Runners repeat these for unrelated failures; they are not evidence that
+      // the same underlying check remains red.
+      .filter(
+        (line) =>
+          !/^(\$ |bun test|error: script |error: ".*" exited|exited with code)/i.test(
+            line,
+          ),
+      )
+  );
 }
 
 /**
@@ -143,19 +150,30 @@ function repoVerifyFailureExcerpt(output) {
     .filter((line) => line.trim().length > 0);
   if (lines.length === 0) return "";
 
-  const testFailures = lines.filter((line) => REPO_VERIFY_TEST_FAILURE_LINE.test(line));
+  const testFailures = lines.filter((line) =>
+    REPO_VERIFY_TEST_FAILURE_LINE.test(line),
+  );
   const errors = lines.filter(
-    (line) => !REPO_VERIFY_TEST_FAILURE_LINE.test(line) && REPO_VERIFY_ERROR_LINE.test(line),
+    (line) =>
+      !REPO_VERIFY_TEST_FAILURE_LINE.test(line) &&
+      REPO_VERIFY_ERROR_LINE.test(line),
   );
   if (testFailures.length === 0 && errors.length === 0) {
     return boundedDiagnostic(lines.slice(-REPO_VERIFY_REASON_MAX_LINES));
   }
 
   const excerpt = testFailures.slice(-REPO_VERIFY_REASON_MAX_LINES);
-  const errorCapacity = Math.max(0, REPO_VERIFY_REASON_MAX_LINES - excerpt.length - 1);
+  const errorCapacity = Math.max(
+    0,
+    REPO_VERIFY_REASON_MAX_LINES - excerpt.length - 1,
+  );
   if (errorCapacity > 0) excerpt.push(...errors.slice(-errorCapacity));
   const summary = lines.at(-1);
-  if (excerpt.length < REPO_VERIFY_REASON_MAX_LINES && !excerpt.includes(summary)) excerpt.push(summary);
+  if (
+    excerpt.length < REPO_VERIFY_REASON_MAX_LINES &&
+    !excerpt.includes(summary)
+  )
+    excerpt.push(summary);
   return boundedDiagnostic(excerpt);
 }
 
@@ -196,12 +214,21 @@ export function verifyResult({
   const shape = validate(registry.schemas.agentResult, candidate);
   if (!shape.valid) throw new ContractViolation(shape.errors);
 
-  if (candidate.terminalState === "refused") return verifyRefused({ spec, def, candidate, attempt });
+  if (candidate.terminalState === "refused")
+    return verifyRefused({ spec, def, candidate, attempt });
   if (candidate.decision !== undefined) {
     throw new ContractViolation(["decision_not_allowed_on_completed_result"]);
   }
   return verifyCompleted({
-    spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts, worktreeRecord, verifyTimeoutMs,
+    spec,
+    def,
+    candidate,
+    workspaceDir,
+    attempt,
+    journalHead,
+    extraArtifacts,
+    worktreeRecord,
+    verifyTimeoutMs,
   });
 }
 
@@ -239,7 +266,8 @@ function verifyRefused({ spec, def, candidate, attempt }) {
     const semantic = SEMANTIC_CHECKS[spec.outputContract];
     if (semantic) {
       const semanticViolations = semantic(candidate);
-      if (semanticViolations.length > 0) throw new ContractViolation(semanticViolations);
+      if (semanticViolations.length > 0)
+        throw new ContractViolation(semanticViolations);
       checks.push("evidence_recomputed");
     }
 
@@ -270,19 +298,27 @@ function verifyRefused({ spec, def, candidate, attempt }) {
 }
 
 function retainedEvidence(candidate) {
-  if (candidate.evidence === undefined) return { evidence: undefined, evidenceSetHash: null };
+  if (candidate.evidence === undefined)
+    return { evidence: undefined, evidenceSetHash: null };
 
   const canonical = canonicalJson(candidate.evidence);
   const bytes = Buffer.byteLength(canonical, "utf8");
   if (bytes > EVIDENCE_INLINE_LIMIT_BYTES) {
-    throw new ContractViolation([`evidence_too_large: ${bytes} bytes > ${EVIDENCE_INLINE_LIMIT_BYTES}`]);
+    throw new ContractViolation([
+      `evidence_too_large: ${bytes} bytes > ${EVIDENCE_INLINE_LIMIT_BYTES}`,
+    ]);
   }
-  return { evidence: candidate.evidence, evidenceSetHash: hashBytes(canonical) };
+  return {
+    evidence: candidate.evidence,
+    evidenceSetHash: hashBytes(canonical),
+  };
 }
 
 /** Last integer in a raw probe output — `df --output=used -B1` style. */
 function parseProbeBytes(raw) {
-  const match = String(raw ?? "").trim().match(/(\d+)\s*$/);
+  const match = String(raw ?? "")
+    .trim()
+    .match(/(\d+)\s*$/);
   return match ? Number(match[1]) : null;
 }
 
@@ -309,13 +345,14 @@ function checkWorkPlan(candidate) {
   const normalizedCandidates = [];
   if (Array.isArray(candidates)) {
     for (const [index, entry] of candidates.entries()) {
-      const valid = entry !== null
-        && typeof entry === "object"
-        && !Array.isArray(entry)
-        && Object.keys(entry).length === 2
-        && typeof entry.ticket === "string"
-        && /^[A-Z]+-[0-9]+$/.test(entry.ticket)
-        && dispositions.has(entry.disposition);
+      const valid =
+        entry !== null &&
+        typeof entry === "object" &&
+        !Array.isArray(entry) &&
+        Object.keys(entry).length === 2 &&
+        typeof entry.ticket === "string" &&
+        /^[A-Z]+-[0-9]+$/.test(entry.ticket) &&
+        dispositions.has(entry.disposition);
       if (!valid) {
         violations.push(`evidence_candidate_invalid_at_index_${index}`);
       } else {
@@ -326,16 +363,25 @@ function checkWorkPlan(candidate) {
     if (new Set(candidateTickets).size !== candidateTickets.length) {
       violations.push("evidence_candidate_tickets_must_be_unique");
     }
-    if (Number.isInteger(candidatesSeen) && candidatesSeen !== candidates.length) {
+    if (
+      Number.isInteger(candidatesSeen) &&
+      candidatesSeen !== candidates.length
+    ) {
       violations.push(
         `evidence_candidate_count_mismatch: candidatesSeen ${candidatesSeen} != candidates.length ${candidates.length}`,
       );
     }
   }
 
-  if (!Number.isInteger(artifact.readyCandidates) || artifact.readyCandidates < 0) {
+  if (
+    !Number.isInteger(artifact.readyCandidates) ||
+    artifact.readyCandidates < 0
+  ) {
     violations.push("readyCandidates_required_for_work_plan");
-  } else if (Number.isInteger(candidatesSeen) && artifact.readyCandidates !== candidatesSeen) {
+  } else if (
+    Number.isInteger(candidatesSeen) &&
+    artifact.readyCandidates !== candidatesSeen
+  ) {
     violations.push(
       `candidate_count_mismatch: readyCandidates ${artifact.readyCandidates} != evidence.candidatesSeen ${candidatesSeen}`,
     );
@@ -354,12 +400,16 @@ function checkWorkPlan(candidate) {
 
   const expectedTicket = planTickets[0] ?? null;
   if (artifact.ticket !== expectedTicket) {
-    violations.push(`work_plan_ticket_must_equal_first_plan_ticket (expected ${expectedTicket})`);
+    violations.push(
+      `work_plan_ticket_must_equal_first_plan_ticket (expected ${expectedTicket})`,
+    );
   }
 
   if (artifact.recommendation === "DISPATCH") {
-    if (artifact.plan.length === 0) violations.push("dispatch_plan_must_not_be_empty");
-    if (Object.hasOwn(artifact, "noopReason")) violations.push("dispatch_must_not_have_noopReason");
+    if (artifact.plan.length === 0)
+      violations.push("dispatch_plan_must_not_be_empty");
+    if (Object.hasOwn(artifact, "noopReason"))
+      violations.push("dispatch_must_not_have_noopReason");
 
     const evidencePlan = normalizedCandidates
       .filter((entry) => entry.disposition === "selected")
@@ -370,21 +420,32 @@ function checkWorkPlan(candidate) {
     if (JSON.stringify(planTickets) !== JSON.stringify(evidencePlan)) {
       violations.push("dispatch_plan_must_match_candidate_evidence");
     }
-    if (JSON.stringify(artifact.deferred) !== JSON.stringify(evidenceDeferred)) {
+    if (
+      JSON.stringify(artifact.deferred) !== JSON.stringify(evidenceDeferred)
+    ) {
       violations.push("dispatch_deferred_must_match_candidate_evidence");
     }
-    if (Number.isInteger(candidatesSeen) && accountedTickets.length !== candidatesSeen) {
+    if (
+      Number.isInteger(candidatesSeen) &&
+      accountedTickets.length !== candidatesSeen
+    ) {
       violations.push(
         `dispatch_candidate_accounting_mismatch: plan ${artifact.plan.length} + deferred ${artifact.deferred.length} != candidatesSeen ${candidatesSeen}`,
       );
     }
 
-    const hasCapDeferral = normalizedCandidates.some((entry) => entry.disposition === "cap_full");
+    const hasCapDeferral = normalizedCandidates.some(
+      (entry) => entry.disposition === "cap_full",
+    );
     if (hasCapDeferral) {
       const inFlightSeen = evidence?.inFlightSeen;
       const maxInFlight = evidence?.maxInFlight;
-      if (!Number.isInteger(inFlightSeen) || inFlightSeen < 0
-        || !Number.isInteger(maxInFlight) || maxInFlight < 1) {
+      if (
+        !Number.isInteger(inFlightSeen) ||
+        inFlightSeen < 0 ||
+        !Number.isInteger(maxInFlight) ||
+        maxInFlight < 1
+      ) {
         violations.push("capacity_evidence_required_for_cap_full");
       } else if (inFlightSeen + artifact.plan.length < maxInFlight) {
         violations.push(
@@ -393,22 +454,35 @@ function checkWorkPlan(candidate) {
       }
     }
     if (artifact.triageBacklog !== 0) {
-      violations.push(`dispatch_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`);
+      violations.push(
+        `dispatch_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`,
+      );
     }
   } else if (artifact.recommendation === "LOW_SUPPLY") {
     if (artifact.plan.length > 0 || artifact.deferred.length > 0) {
       violations.push("low_supply_plan_and_deferred_must_be_empty");
     }
-    if (Object.hasOwn(artifact, "noopReason")) violations.push("low_supply_must_not_have_noopReason");
+    if (Object.hasOwn(artifact, "noopReason"))
+      violations.push("low_supply_must_not_have_noopReason");
     if (artifact.readyCandidates !== 0) {
-      violations.push(`low_supply_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`);
+      violations.push(
+        `low_supply_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`,
+      );
     }
     if (Number.isInteger(candidatesSeen) && candidatesSeen !== 0) {
-      violations.push(`low_supply_candidatesSeen_must_be_0 (got ${candidatesSeen})`);
+      violations.push(
+        `low_supply_candidatesSeen_must_be_0 (got ${candidatesSeen})`,
+      );
     }
-    if (normalizedCandidates.length !== 0) violations.push("low_supply_candidates_must_be_empty");
-    if (Number.isInteger(artifact.triageBacklog) && artifact.triageBacklog < 1) {
-      violations.push(`low_supply_triage_backlog_must_be_at_least_1 (got ${artifact.triageBacklog})`);
+    if (normalizedCandidates.length !== 0)
+      violations.push("low_supply_candidates_must_be_empty");
+    if (
+      Number.isInteger(artifact.triageBacklog) &&
+      artifact.triageBacklog < 1
+    ) {
+      violations.push(
+        `low_supply_triage_backlog_must_be_at_least_1 (got ${artifact.triageBacklog})`,
+      );
     }
   } else if (artifact.recommendation === "NOOP") {
     if (artifact.plan.length > 0 || artifact.deferred.length > 0) {
@@ -418,33 +492,58 @@ function checkWorkPlan(candidate) {
       violations.push("noopReason_required_for_noop");
     } else if (artifact.noopReason === "queue_empty") {
       if (artifact.readyCandidates !== 0) {
-        violations.push(`queue_empty_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`);
+        violations.push(
+          `queue_empty_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`,
+        );
       }
       if (Number.isInteger(candidatesSeen) && candidatesSeen !== 0) {
-        violations.push(`queue_empty_candidatesSeen_must_be_0 (got ${candidatesSeen})`);
+        violations.push(
+          `queue_empty_candidatesSeen_must_be_0 (got ${candidatesSeen})`,
+        );
       }
-      if (normalizedCandidates.length !== 0) violations.push("queue_empty_candidates_must_be_empty");
+      if (normalizedCandidates.length !== 0)
+        violations.push("queue_empty_candidates_must_be_empty");
     } else if (artifact.noopReason === "cap_full") {
-      if (normalizedCandidates.length === 0) violations.push("cap_full_candidates_must_not_be_empty");
-      if (normalizedCandidates.some((entry) => entry.disposition !== "cap_full")) {
-        violations.push("cap_full_candidates_must_all_have_cap_full_disposition");
+      if (normalizedCandidates.length === 0)
+        violations.push("cap_full_candidates_must_not_be_empty");
+      if (
+        normalizedCandidates.some((entry) => entry.disposition !== "cap_full")
+      ) {
+        violations.push(
+          "cap_full_candidates_must_all_have_cap_full_disposition",
+        );
       }
       const inFlightSeen = evidence?.inFlightSeen;
       const maxInFlight = evidence?.maxInFlight;
-      if (!Number.isInteger(inFlightSeen) || inFlightSeen < 0
-        || !Number.isInteger(maxInFlight) || maxInFlight < 1) {
+      if (
+        !Number.isInteger(inFlightSeen) ||
+        inFlightSeen < 0 ||
+        !Number.isInteger(maxInFlight) ||
+        maxInFlight < 1
+      ) {
         violations.push("capacity_evidence_required_for_cap_full");
       } else if (inFlightSeen < maxInFlight) {
-        violations.push(`cap_full_contradicts_capacity: inFlightSeen ${inFlightSeen} < maxInFlight ${maxInFlight}`);
+        violations.push(
+          `cap_full_contradicts_capacity: inFlightSeen ${inFlightSeen} < maxInFlight ${maxInFlight}`,
+        );
       }
     } else if (artifact.noopReason === "all_overlapping") {
-      if (normalizedCandidates.length === 0) violations.push("all_overlapping_candidates_must_not_be_empty");
-      if (normalizedCandidates.some((entry) => entry.disposition !== "owned_paths_overlap")) {
-        violations.push("all_overlapping_candidates_must_all_have_overlap_disposition");
+      if (normalizedCandidates.length === 0)
+        violations.push("all_overlapping_candidates_must_not_be_empty");
+      if (
+        normalizedCandidates.some(
+          (entry) => entry.disposition !== "owned_paths_overlap",
+        )
+      ) {
+        violations.push(
+          "all_overlapping_candidates_must_all_have_overlap_disposition",
+        );
       }
     }
     if (artifact.triageBacklog !== 0) {
-      violations.push(`noop_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`);
+      violations.push(
+        `noop_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`,
+      );
     }
   }
 
@@ -461,20 +560,31 @@ const SEMANTIC_CHECKS = {
   "factory.disk-remediation/v1": (candidate) => {
     const violations = [];
     const { artifact, evidence } = candidate;
-    if (evidence === undefined) return ["evidence_required: factory.disk-remediation/v1 claims are recomputed from probes"];
+    if (evidence === undefined)
+      return [
+        "evidence_required: factory.disk-remediation/v1 claims are recomputed from probes",
+      ];
     const before = parseProbeBytes(evidence.probeBefore);
     const after = parseProbeBytes(evidence.probeAfter);
-    if (before === null) violations.push("evidence_unparseable: probeBefore has no byte count");
-    if (after === null) violations.push("evidence_unparseable: probeAfter has no byte count");
+    if (before === null)
+      violations.push("evidence_unparseable: probeBefore has no byte count");
+    if (after === null)
+      violations.push("evidence_unparseable: probeAfter has no byte count");
     if (violations.length > 0) return violations;
     if (artifact.beforeUsedBytes !== before) {
-      violations.push(`evidence_mismatch: beforeUsedBytes ${artifact.beforeUsedBytes} != probed ${before}`);
+      violations.push(
+        `evidence_mismatch: beforeUsedBytes ${artifact.beforeUsedBytes} != probed ${before}`,
+      );
     }
     if (artifact.afterUsedBytes !== after) {
-      violations.push(`evidence_mismatch: afterUsedBytes ${artifact.afterUsedBytes} != probed ${after}`);
+      violations.push(
+        `evidence_mismatch: afterUsedBytes ${artifact.afterUsedBytes} != probed ${after}`,
+      );
     }
     if (artifact.reclaimedBytes !== before - after) {
-      violations.push(`evidence_mismatch: reclaimedBytes ${artifact.reclaimedBytes} != recomputed ${before - after}`);
+      violations.push(
+        `evidence_mismatch: reclaimedBytes ${artifact.reclaimedBytes} != recomputed ${before - after}`,
+      );
     }
     return violations;
   },
@@ -483,7 +593,8 @@ const SEMANTIC_CHECKS = {
     const { artifact } = candidate;
     if (artifact.outcome === "PR_OPEN") {
       if (!artifact.prUrl) violations.push("pr_url_required_for_pr_open");
-      if (artifact.verification?.passed !== true) violations.push("verification_must_pass_for_pr_open");
+      if (artifact.verification?.passed !== true)
+        violations.push("verification_must_pass_for_pr_open");
     }
     return violations;
   },
@@ -501,7 +612,8 @@ function verifyCompleted({
   worktreeRecord = null,
   verifyTimeoutMs,
 }) {
-  if (candidate.artifact === undefined) throw new ContractViolation(["missing_artifact"]);
+  if (candidate.artifact === undefined)
+    throw new ContractViolation(["missing_artifact"]);
 
   const artifactCheck = validate(def.outputSchema, candidate.artifact);
   if (!artifactCheck.valid) throw new ContractViolation(artifactCheck.errors);
@@ -509,7 +621,8 @@ function verifyCompleted({
   const semantic = SEMANTIC_CHECKS[spec.outputContract];
   if (semantic) {
     const semanticViolations = semantic(candidate);
-    if (semanticViolations.length > 0) throw new ContractViolation(semanticViolations);
+    if (semanticViolations.length > 0)
+      throw new ContractViolation(semanticViolations);
   }
 
   // Execute repo's declared verify command for tier-2 mutating runs (docs/event-runtime-dispatch.md §5, §9, WM-115)
@@ -517,14 +630,17 @@ function verifyCompleted({
   if (!worktreeRecord && existsSync(markerPath)) {
     try {
       worktreeRecord = JSON.parse(readFileSync(markerPath, "utf8"));
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
   }
 
   let repoVerifyPassed = false;
   if (worktreeRecord?.verify && candidate.artifact?.outcome === "PR_OPEN") {
-    const worktreePath = worktreeRecord.path && existsSync(worktreeRecord.path)
-      ? worktreeRecord.path
-      : path.join(workspaceDir, "repo");
+    const worktreePath =
+      worktreeRecord.path && existsSync(worktreeRecord.path)
+        ? worktreeRecord.path
+        : path.join(workspaceDir, "repo");
     const verifyLogPath = path.join(workspaceDir, ".verify.log");
     const verifyLogFd = openSync(verifyLogPath, "w");
     let vres;
@@ -543,11 +659,11 @@ function verifyCompleted({
       const why = timedOut
         ? `timed out after ${verifyTimeoutMs}ms`
         : repoVerifyFailureExcerpt(output) || `exit ${vres.status}`;
-      const baselineStillRed = !timedOut && matchesRedBaseline(worktreeRecord.baseline, output);
-      throw new ContractViolation(
-        [`repo_verify_failed: ${why}`],
-        { reasonCode: baselineStillRed ? "baseline_red" : "contract_violation" },
-      );
+      const baselineStillRed =
+        !timedOut && matchesRedBaseline(worktreeRecord.baseline, output);
+      throw new ContractViolation([`repo_verify_failed: ${why}`], {
+        reasonCode: baselineStillRed ? "baseline_red" : "contract_violation",
+      });
     }
     repoVerifyPassed = true;
   }
@@ -558,7 +674,9 @@ function verifyCompleted({
   const declared = candidate.artifacts ?? [];
   const declaredPaths = new Set(declared.map((entry) => entry.path));
   const injected = extraArtifacts.filter(
-    (entry) => !declaredPaths.has(entry.path) && existsSync(path.join(workspaceDir, entry.path)),
+    (entry) =>
+      !declaredPaths.has(entry.path) &&
+      existsSync(path.join(workspaceDir, entry.path)),
   );
 
   const violations = [];
@@ -576,7 +694,11 @@ function verifyCompleted({
       violations.push(`artifact_missing: ${entry.path}`);
       continue;
     }
-    collected.push({ kind: entry.kind, uri: `file://${abs}`, sha256: sha256Hex(readFileSync(abs)) });
+    collected.push({
+      kind: entry.kind,
+      uri: `file://${abs}`,
+      sha256: sha256Hex(readFileSync(abs)),
+    });
   }
   if (violations.length > 0) throw new ContractViolation(violations);
 
@@ -598,9 +720,14 @@ function verifyCompleted({
     verification: {
       status: "passed",
       checks: [
-        "schema_valid", "hash_recomputed", "paths_confined", "artifacts_exist",
+        "schema_valid",
+        "hash_recomputed",
+        "paths_confined",
+        "artifacts_exist",
         ...(evidence !== undefined ? ["evidence_retained"] : []),
-        ...(SEMANTIC_CHECKS[spec.outputContract] ? ["evidence_recomputed"] : []),
+        ...(SEMANTIC_CHECKS[spec.outputContract]
+          ? ["evidence_recomputed"]
+          : []),
         ...(repoVerifyPassed ? ["repo_verify_passed"] : []),
       ],
     },

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { hashJson, sha256Hex } from "./canonical.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
-import { ContractViolation, normalizeFailureOutput, verifyResult } from "./verify.mjs";
+import {
+  ContractViolation,
+  normalizeFailureOutput,
+  verifyResult,
+} from "./verify.mjs";
 
 const registry = loadRegistry();
 const def = getAgent(registry, "factory-status-report@1");
@@ -33,13 +37,19 @@ function makeSpec(input = { repos: ["bj29"] }) {
 function makeWorkspace(result) {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-"));
   if (result !== undefined) {
-    writeFileSync(path.join(dir, "result.json"), JSON.stringify(result), "utf8");
+    writeFileSync(
+      path.join(dir, "result.json"),
+      JSON.stringify(result),
+      "utf8",
+    );
   }
   return dir;
 }
 
 const VALID_ARTIFACT = {
-  repos: [{ name: "bj29", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 }],
+  repos: [
+    { name: "bj29", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 },
+  ],
   recommendedAction: "dispatch",
 };
 
@@ -52,7 +62,10 @@ const VALID_DECISION = {
       id: "authorise",
       label: "Authorise",
       effect: "authorise",
-      scope: { paths: ["event-runtime/lib/verify.mjs"], summary: "Apply the scoped change." },
+      scope: {
+        paths: ["event-runtime/lib/verify.mjs"],
+        summary: "Apply the scoped change.",
+      },
     },
     { id: "dismiss", label: "Dismiss", effect: "dismiss" },
   ],
@@ -72,7 +85,14 @@ describe("verifyResult", () => {
     writeFileSync(path.join(dir, "logs", "agent.log"), "hello\n", "utf8");
 
     const spec = makeSpec();
-    const out = verifyResult({ spec, def, registry, workspaceDir: dir, attempt: 1, journalHead: "sha256:head" });
+    const out = verifyResult({
+      spec,
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      journalHead: "sha256:head",
+    });
     expect(out.kind).toBe("completed");
     expect(out.result.terminalState).toBe("completed");
     expect(out.result.reasonCode).toBe("ok");
@@ -80,7 +100,11 @@ describe("verifyResult", () => {
     expect(out.result.evidenceSetHash).toBe(hashJson(evidence));
     expect(out.result.verification.status).toBe("passed");
     expect(out.result.artifacts).toEqual([
-      { kind: "log", uri: `file://${path.join(dir, "logs", "agent.log")}`, sha256: sha256Hex("hello\n") },
+      {
+        kind: "log",
+        uri: `file://${path.join(dir, "logs", "agent.log")}`,
+        sha256: sha256Hex("hello\n"),
+      },
     ]);
     expect(out.receipt).toEqual({
       runId: spec.runId,
@@ -98,7 +122,13 @@ describe("verifyResult", () => {
       terminalState: "completed",
       artifact: VALID_ARTIFACT,
     });
-    const out = verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(out.result.evidenceSetHash).toBeNull();
     expect(out.receipt.journalHead).toBeNull();
   });
@@ -126,29 +156,45 @@ describe("verifyResult", () => {
       artifact,
       evidence,
     });
-    return verifyResult({ spec: workPlanSpec, def: workScanDef, registry, workspaceDir: dir, attempt: 1 });
+    return verifyResult({
+      spec: workPlanSpec,
+      def: workScanDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
   }
 
   test("valid DISPATCH accounts for every candidate through plan or typed deferral", () => {
-    const out = verifyWorkPlan({
-      recommendation: "DISPATCH",
-      repo: "factory",
-      ticket: "WM-345",
-      plan: [
-        { ticket: "WM-345", ownedPaths: ["src/a/**"], reason: "priority Urgent, disjoint" },
-      ],
-      deferred: [
-        { ticket: "WM-294", reason: "owned_paths_overlap" },
-        { ticket: "WM-131", reason: "cap_full" },
-      ],
-      readyCandidates: 3,
-      triageBacklog: 0,
-      summary: "one candidate starts and two are accounted for",
-    }, candidateEvidence([
-      candidate("WM-345", "selected"),
-      candidate("WM-294", "owned_paths_overlap"),
-      candidate("WM-131", "cap_full"),
-    ], { inFlightSeen: 2 }));
+    const out = verifyWorkPlan(
+      {
+        recommendation: "DISPATCH",
+        repo: "factory",
+        ticket: "WM-345",
+        plan: [
+          {
+            ticket: "WM-345",
+            ownedPaths: ["src/a/**"],
+            reason: "priority Urgent, disjoint",
+          },
+        ],
+        deferred: [
+          { ticket: "WM-294", reason: "owned_paths_overlap" },
+          { ticket: "WM-131", reason: "cap_full" },
+        ],
+        readyCandidates: 3,
+        triageBacklog: 0,
+        summary: "one candidate starts and two are accounted for",
+      },
+      candidateEvidence(
+        [
+          candidate("WM-345", "selected"),
+          candidate("WM-294", "owned_paths_overlap"),
+          candidate("WM-131", "cap_full"),
+        ],
+        { inFlightSeen: 2 },
+      ),
+    );
 
     expect(out.kind).toBe("completed");
     expect(out.result.verification.checks).toContain("evidence_recomputed");
@@ -156,42 +202,57 @@ describe("verifyResult", () => {
 
   test("regression: three ready tickets plus two in progress cannot validate as queue_empty", () => {
     try {
-      verifyWorkPlan({
-        recommendation: "NOOP",
-        repo: "factory",
-        ticket: null,
-        plan: [],
-        deferred: [],
-        noopReason: "queue_empty",
-        readyCandidates: 3,
-        triageBacklog: 0,
-        summary: "incorrectly discarded three ready candidates",
-      }, candidateEvidence([
-        candidate("WM-345", "selected"),
-        candidate("WM-294", "selected"),
-        candidate("WM-131", "selected"),
-      ], { inFlightSeen: 2 }));
+      verifyWorkPlan(
+        {
+          recommendation: "NOOP",
+          repo: "factory",
+          ticket: null,
+          plan: [],
+          deferred: [],
+          noopReason: "queue_empty",
+          readyCandidates: 3,
+          triageBacklog: 0,
+          summary: "incorrectly discarded three ready candidates",
+        },
+        candidateEvidence(
+          [
+            candidate("WM-345", "selected"),
+            candidate("WM-294", "selected"),
+            candidate("WM-131", "selected"),
+          ],
+          { inFlightSeen: 2 },
+        ),
+      );
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations).toContain("queue_empty_readyCandidates_must_be_0 (got 3)");
-      expect(err.violations).toContain("queue_empty_candidatesSeen_must_be_0 (got 3)");
+      expect(err.violations).toContain(
+        "queue_empty_readyCandidates_must_be_0 (got 3)",
+      );
+      expect(err.violations).toContain(
+        "queue_empty_candidatesSeen_must_be_0 (got 3)",
+      );
     }
   });
 
   test("queue_empty requires complete candidate evidence to agree with the artifact", () => {
     try {
-      verifyWorkPlan({
-        recommendation: "NOOP",
-        repo: "factory",
-        ticket: null,
-        plan: [],
-        deferred: [],
-        noopReason: "queue_empty",
-        readyCandidates: 0,
-        triageBacklog: 0,
-        summary: "artifact says empty but evidence saw a candidate",
-      }, candidateEvidence([candidate("WM-345", "selected")], { candidatesSeen: 0 }));
+      verifyWorkPlan(
+        {
+          recommendation: "NOOP",
+          repo: "factory",
+          ticket: null,
+          plan: [],
+          deferred: [],
+          noopReason: "queue_empty",
+          readyCandidates: 0,
+          triageBacklog: 0,
+          summary: "artifact says empty but evidence saw a candidate",
+        },
+        candidateEvidence([candidate("WM-345", "selected")], {
+          candidatesSeen: 0,
+        }),
+      );
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -204,21 +265,27 @@ describe("verifyResult", () => {
 
   test("cap_full cannot hide startable candidates when capacity evidence shows a free slot", () => {
     try {
-      verifyWorkPlan({
-        recommendation: "NOOP",
-        repo: "factory",
-        ticket: null,
-        plan: [],
-        deferred: [],
-        noopReason: "cap_full",
-        readyCandidates: 3,
-        triageBacklog: 0,
-        summary: "incorrectly claims the cap is full",
-      }, candidateEvidence([
-        candidate("WM-345", "cap_full"),
-        candidate("WM-294", "cap_full"),
-        candidate("WM-131", "cap_full"),
-      ], { inFlightSeen: 2, maxInFlight: 3 }));
+      verifyWorkPlan(
+        {
+          recommendation: "NOOP",
+          repo: "factory",
+          ticket: null,
+          plan: [],
+          deferred: [],
+          noopReason: "cap_full",
+          readyCandidates: 3,
+          triageBacklog: 0,
+          summary: "incorrectly claims the cap is full",
+        },
+        candidateEvidence(
+          [
+            candidate("WM-345", "cap_full"),
+            candidate("WM-294", "cap_full"),
+            candidate("WM-131", "cap_full"),
+          ],
+          { inFlightSeen: 2, maxInFlight: 3 },
+        ),
+      );
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -230,22 +297,32 @@ describe("verifyResult", () => {
 
   test("DISPATCH rejects an unaccounted candidate", () => {
     try {
-      verifyWorkPlan({
-        recommendation: "DISPATCH",
-        repo: "factory",
-        ticket: "WM-345",
-        plan: [
-          { ticket: "WM-345", ownedPaths: ["src/a/**"], reason: "priority Urgent, disjoint" },
-        ],
-        deferred: [{ ticket: "WM-294", reason: "owned_paths_overlap" }],
-        readyCandidates: 3,
-        triageBacklog: 0,
-        summary: "one candidate disappeared",
-      }, candidateEvidence([
-        candidate("WM-345", "selected"),
-        candidate("WM-294", "owned_paths_overlap"),
-        candidate("WM-131", "cap_full"),
-      ], { inFlightSeen: 2 }));
+      verifyWorkPlan(
+        {
+          recommendation: "DISPATCH",
+          repo: "factory",
+          ticket: "WM-345",
+          plan: [
+            {
+              ticket: "WM-345",
+              ownedPaths: ["src/a/**"],
+              reason: "priority Urgent, disjoint",
+            },
+          ],
+          deferred: [{ ticket: "WM-294", reason: "owned_paths_overlap" }],
+          readyCandidates: 3,
+          triageBacklog: 0,
+          summary: "one candidate disappeared",
+        },
+        candidateEvidence(
+          [
+            candidate("WM-345", "selected"),
+            candidate("WM-294", "owned_paths_overlap"),
+            candidate("WM-131", "cap_full"),
+          ],
+          { inFlightSeen: 2 },
+        ),
+      );
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -257,25 +334,35 @@ describe("verifyResult", () => {
 
   test("invalid LOW_SUPPLY counts violate work-scan semantics", () => {
     try {
-      verifyWorkPlan({
-        recommendation: "LOW_SUPPLY",
-        repo: "low",
-        ticket: null,
-        plan: [],
-        deferred: [],
-        summary: "low supply with bad counts",
-        readyCandidates: 3,
-        triageBacklog: 0,
-      }, candidateEvidence([
-        candidate("WM-345", "selected"),
-        candidate("WM-294", "selected"),
-        candidate("WM-131", "selected"),
-      ], { commands: ["linear queue", "linear triage"] }));
+      verifyWorkPlan(
+        {
+          recommendation: "LOW_SUPPLY",
+          repo: "low",
+          ticket: null,
+          plan: [],
+          deferred: [],
+          summary: "low supply with bad counts",
+          readyCandidates: 3,
+          triageBacklog: 0,
+        },
+        candidateEvidence(
+          [
+            candidate("WM-345", "selected"),
+            candidate("WM-294", "selected"),
+            candidate("WM-131", "selected"),
+          ],
+          { commands: ["linear queue", "linear triage"] },
+        ),
+      );
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations).toContain("low_supply_readyCandidates_must_be_0 (got 3)");
-      expect(err.violations).toContain("low_supply_candidatesSeen_must_be_0 (got 3)");
+      expect(err.violations).toContain(
+        "low_supply_readyCandidates_must_be_0 (got 3)",
+      );
+      expect(err.violations).toContain(
+        "low_supply_candidatesSeen_must_be_0 (got 3)",
+      );
     }
   });
 
@@ -283,16 +370,33 @@ describe("verifyResult", () => {
     const dir = makeWorkspace({
       schemaVersion: "factory.agent-result/v1",
       terminalState: "completed",
-      artifact: { repos: [{ name: "x", triage: -1, agentReady: 0, inProgress: 0, blocked: 0 }] },
+      artifact: {
+        repos: [
+          { name: "x", triage: -1, agentReady: 0, inProgress: 0, blocked: 0 },
+        ],
+      },
     });
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("missing result.json → ContractViolation [missing_result]", () => {
     const dir = makeWorkspace();
     try {
-      verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -303,8 +407,15 @@ describe("verifyResult", () => {
   test("unparseable result.json → ContractViolation", () => {
     const dir = makeWorkspace();
     writeFileSync(path.join(dir, "result.json"), "{not json", "utf8");
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("refused with a valid reasonCode → kind refused, no artifact fields", () => {
@@ -313,7 +424,13 @@ describe("verifyResult", () => {
       terminalState: "refused",
       reasonCode: "needs_human",
     });
-    const out = verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 2 });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 2,
+    });
     expect(out.kind).toBe("refused");
     expect(out.reasonCode).toBe("needs_human");
     expect(out.result.terminalState).toBe("refused");
@@ -330,7 +447,13 @@ describe("verifyResult", () => {
       decision: VALID_DECISION,
     });
     const spec = makeSpec({ repo: "factory", ticket: "WM-389" });
-    const out = verifyResult({ spec, def, registry, workspaceDir: dir, attempt: 1 });
+    const out = verifyResult({
+      spec,
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(out.kind).toBe("refused");
     expect(out.result.decision).toEqual(VALID_DECISION);
     expect(out.result.decisionErrors).toBeUndefined();
@@ -345,7 +468,13 @@ describe("verifyResult", () => {
       decision,
     });
     const spec = makeSpec({ repo: "factory", ticket: "WM-389" });
-    const out = verifyResult({ spec, def, registry, workspaceDir: dir, attempt: 1 });
+    const out = verifyResult({
+      spec,
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(out.kind).toBe("refused");
     expect(out.result.decision).toBeUndefined();
     expect(out.result.decisionErrors).toBeArray();
@@ -360,11 +489,19 @@ describe("verifyResult", () => {
       decision: VALID_DECISION,
     });
     try {
-      verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations).toEqual(["decision_not_allowed_on_completed_result"]);
+      expect(err.violations).toEqual([
+        "decision_not_allowed_on_completed_result",
+      ]);
     }
   });
 
@@ -374,8 +511,15 @@ describe("verifyResult", () => {
       terminalState: "refused",
       reasonCode: "felt_like_it",
     });
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("refused carrying run_6fe0cdb4's dispatch artifact shape → REFUSED with context retained", () => {
@@ -387,12 +531,17 @@ describe("verifyResult", () => {
       verification: {
         command: null,
         passed: false,
-        output: "Not run: production infrastructure and credential handling require a human.",
+        output:
+          "Not run: production infrastructure and credential handling require a human.",
       },
-      summary: "Human approval is required for production launchd and SSH credential changes.",
+      summary:
+        "Human approval is required for production launchd and SSH credential changes.",
     };
     const evidence = {
-      commands: ["gh auth status", "launchctl print gui/$(id -u)/com.wattmind.factory"],
+      commands: [
+        "gh auth status",
+        "launchctl print gui/$(id -u)/com.wattmind.factory",
+      ],
     };
     const dir = makeWorkspace({
       schemaVersion: "factory.agent-result/v1",
@@ -401,9 +550,18 @@ describe("verifyResult", () => {
       artifact,
       evidence,
     });
-    const spec = { ...makeSpec({ repo: "factory", ticket: "WM-139" }), outputContract: "factory.dispatch-result/v1" };
+    const spec = {
+      ...makeSpec({ repo: "factory", ticket: "WM-139" }),
+      outputContract: "factory.dispatch-result/v1",
+    };
 
-    const out = verifyResult({ spec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+    const out = verifyResult({
+      spec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
 
     expect(out.kind).toBe("refused");
     expect(out.reasonCode).toBe("needs_human");
@@ -422,9 +580,19 @@ describe("verifyResult", () => {
       reasonCode: "needs_human",
       artifact: { outcome: "BLOCKED", repo: "factory" },
     });
-    const spec = { ...makeSpec({ repo: "factory", ticket: "WM-139" }), outputContract: "factory.dispatch-result/v1" };
-    expect(() => verifyResult({ spec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    const spec = {
+      ...makeSpec({ repo: "factory", ticket: "WM-139" }),
+      outputContract: "factory.dispatch-result/v1",
+    };
+    expect(() =>
+      verifyResult({
+        spec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("artifact path escaping the workspace → ContractViolation", () => {
@@ -436,7 +604,13 @@ describe("verifyResult", () => {
     });
     writeFileSync(path.resolve(dir, "..", "outside.txt"), "escaped\n", "utf8");
     try {
-      verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -451,19 +625,30 @@ describe("verifyResult", () => {
       artifact: VALID_ARTIFACT,
       artifacts: [{ kind: "log", path: "missing.log" }],
     });
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 });
 
 describe("failure normalization", () => {
   test("drops ANSI-colored warn lines so run-varying diagnostics do not change the signature", () => {
-    expect(normalizeFailureOutput(
-      "\u001b[33mwarn:\u001b[0m recorded ports 7740 / 7741 are occupied\nentry chunk exceeds budget\n",
-    )).toEqual(["entry chunk exceeds budget"]);
-    expect(normalizeFailureOutput(
-      "warn: recorded ports 8120 / 8121 are occupied\nentry chunk exceeds budget\n",
-    )).toEqual(["entry chunk exceeds budget"]);
+    expect(
+      normalizeFailureOutput(
+        "\u001b[33mwarn:\u001b[0m recorded ports 7740 / 7741 are occupied\nentry chunk exceeds budget\n",
+      ),
+    ).toEqual(["entry chunk exceeds budget"]);
+    expect(
+      normalizeFailureOutput(
+        "warn: recorded ports 8120 / 8121 are occupied\nentry chunk exceeds budget\n",
+      ),
+    ).toEqual(["entry chunk exceeds budget"]);
   });
 });
 
@@ -477,7 +662,11 @@ describe("worktree baseline verification (WM-334)", () => {
       repo: "factory",
       ticket: "WM-334",
       prUrl: "https://github.com/watt-mind/factory/pull/334",
-      verification: { command: "bun test", passed: true, output: "agent verification passed" },
+      verification: {
+        command: "bun test",
+        passed: true,
+        output: "agent verification passed",
+      },
       summary: "implemented WM-334",
     },
   };
@@ -491,17 +680,31 @@ describe("worktree baseline verification (WM-334)", () => {
     const dir = makeWorkspace(dispatchResult);
     const repo = path.join(dir, "repo");
     mkdirSync(repo);
-    writeFileSync(path.join(dir, ".worktree.json"), JSON.stringify({ path: repo, verify, baseline }), "utf8");
+    writeFileSync(
+      path.join(dir, ".worktree.json"),
+      JSON.stringify({ path: repo, verify, baseline }),
+      "utf8",
+    );
     return dir;
   }
 
   test("a matching pre-existing failure is rejected with the distinct baseline_red reason", () => {
     const dir = worktreeWorkspace(
       "printf 'entry chunk exceeds budget\\n' >&2; exit 9",
-      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+      {
+        status: "red",
+        check: "web_build",
+        output: "entry chunk exceeds budget",
+      },
     );
     try {
-      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -513,10 +716,20 @@ describe("worktree baseline verification (WM-334)", () => {
   test("shared baseline output plus a new failure does not classify as baseline_red", () => {
     const dir = worktreeWorkspace(
       "printf 'entry chunk exceeds budget\\nnew failure in CI\\n' >&2; exit 9",
-      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+      {
+        status: "red",
+        check: "web_build",
+        output: "entry chunk exceeds budget",
+      },
     );
     try {
-      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -530,11 +743,18 @@ describe("worktree baseline verification (WM-334)", () => {
       {
         status: "red",
         check: "web_build",
-        output: "entry chunk exceeds budget\nerror: script \"build\" exited with code 1",
+        output:
+          'entry chunk exceeds budget\nerror: script "build" exited with code 1',
       },
     );
     try {
-      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
@@ -548,11 +768,19 @@ describe("worktree baseline verification (WM-334)", () => {
       null,
     );
     try {
-      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations[0]).toContain("(fail) totals > rejects an invalid total");
+      expect(err.violations[0]).toContain(
+        "(fail) totals > rejects an invalid total",
+      );
       expect(err.violations[0]).toContain("error: expected 400, received 200");
     }
 
@@ -569,21 +797,36 @@ describe("worktree baseline verification (WM-334)", () => {
       null,
     );
     try {
-      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations[0]).toContain("(fail) billing > rejects a duplicate charge");
+      expect(err.violations[0]).toContain(
+        "(fail) billing > rejects a duplicate charge",
+      );
       expect(err.violations[0].split("\n").length).toBeLessThanOrEqual(40);
     }
   });
 
   test("a recorded red baseline never weakens a now-green post-agent verification", () => {
-    const dir = worktreeWorkspace(
-      "printf 'verification repaired\\n'",
-      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
-    );
-    const out = verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+    const dir = worktreeWorkspace("printf 'verification repaired\\n'", {
+      status: "red",
+      check: "web_build",
+      output: "entry chunk exceeds budget",
+    });
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(out.kind).toBe("completed");
     expect(out.result.verification.checks).toContain("repo_verify_passed");
   });
@@ -595,15 +838,24 @@ describe("worktree baseline verification (WM-334)", () => {
     const started = Date.now();
     try {
       try {
-        verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+        });
         throw new Error("expected ContractViolation");
       } catch (err) {
         expect(err).toBeInstanceOf(ContractViolation);
-        expect(err.violations).toEqual(["repo_verify_failed: timed out after 25ms"]);
+        expect(err.violations).toEqual([
+          "repo_verify_failed: timed out after 25ms",
+        ]);
         expect(Date.now() - started).toBeLessThan(1_000);
       }
     } finally {
-      if (previous === undefined) delete process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
+      if (previous === undefined)
+        delete process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
       else process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = previous;
     }
   });
@@ -620,7 +872,13 @@ describe("evidence retention (OPS-206)", () => {
   test("declared evidence is retained in the result and its hash recomputes from the stored bytes", () => {
     const evidence = { queries: ["df -h", "docker system df"] };
     const dir = makeWorkspace(completedWith(evidence));
-    const { result } = verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+    const { result } = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(result.evidence).toEqual(evidence);
     expect(hashJson(result.evidence)).toBe(result.evidenceSetHash);
     expect(result.verification.checks).toContain("evidence_retained");
@@ -628,7 +886,13 @@ describe("evidence retention (OPS-206)", () => {
 
   test("absent evidence stores null hash and no evidence field", () => {
     const dir = makeWorkspace(completedWith(undefined));
-    const { result } = verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+    const { result } = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
     expect(result.evidenceSetHash).toBeNull();
     expect("evidence" in result).toBe(false);
     expect(result.verification.checks).not.toContain("evidence_retained");
@@ -636,10 +900,23 @@ describe("evidence retention (OPS-206)", () => {
 
   test("oversize evidence fails closed as a contract violation", () => {
     const dir = makeWorkspace(completedWith({ blob: "x".repeat(300 * 1024) }));
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
-      .toThrow(ContractViolation);
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
     try {
-      verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      });
     } catch (err) {
       expect(err.violations[0]).toStartWith("evidence_too_large:");
     }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -12,23 +12,46 @@
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { LEASE_HEARTBEAT_MS, leaseDir, liveWorkerLeases, releaseWorkerLease, renewWorkerLease, writeWorkerLease } from "../../lib/worker-leases.mjs";
+import {
+  LEASE_HEARTBEAT_MS,
+  leaseDir,
+  liveWorkerLeases,
+  releaseWorkerLease,
+  renewWorkerLease,
+  writeWorkerLease,
+} from "../../lib/worker-leases.mjs";
 import { storeCollected } from "./artifacts.mjs";
 import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
-import { worktreeDispatchAutoEligibility, worktreeMergeFixEligibility } from "./planner.mjs";
+import {
+  worktreeDispatchAutoEligibility,
+  worktreeMergeFixEligibility,
+} from "./planner.mjs";
 import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
 import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
-import { createWorkspace, destroyWorkspace, PathViolation, safeJoin } from "./workspace.mjs";
+import {
+  createWorkspace,
+  destroyWorkspace,
+  PathViolation,
+  safeJoin,
+} from "./workspace.mjs";
 import { createInboxItem } from "./inbox.mjs";
 import { templateFor } from "./decision-templates.mjs";
 
@@ -51,7 +74,12 @@ export const LEASE_GRACE_SECONDS = 120;
  * stop a wedged runner from pinning the run slot open (WM-692).
  */
 export const DYNAMIC_DEADLINE_ADAPTERS = new Set([
-  "agy", "claude", "command", "cursor", "fake", "pi",
+  "agy",
+  "claude",
+  "command",
+  "cursor",
+  "fake",
+  "pi",
 ]);
 
 /** `limits.max_run_minutes` from config/policy.yaml, or null when unavailable. */
@@ -73,10 +101,17 @@ export function policyMaxRunMinutes(root = FACTORY_ROOT) {
  * grace` keeps every policy-bounded extension alive while still bounding a
  * wedged child. Every other adapter keeps its exact run budget.
  */
-export function adapterExecuteTimeoutMs({ adapterKey, spec, maxRunMinutes = policyMaxRunMinutes() }) {
+export function adapterExecuteTimeoutMs({
+  adapterKey,
+  spec,
+  maxRunMinutes = policyMaxRunMinutes(),
+}) {
   const budgetMs = spec.timeoutSeconds * 1000;
   if (!DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)) return budgetMs;
-  const policyMs = Number.isFinite(maxRunMinutes) && maxRunMinutes > 0 ? maxRunMinutes * 60_000 : 0;
+  const policyMs =
+    Number.isFinite(maxRunMinutes) && maxRunMinutes > 0
+      ? maxRunMinutes * 60_000
+      : 0;
   return Math.max(budgetMs, policyMs) + LEASE_GRACE_SECONDS * 1000;
 }
 const DEADLINE_POLL_MS = 100;
@@ -89,14 +124,19 @@ function deadlineEventFromReason(reason, type) {
       value?.type === type &&
       typeof value.deadlineAt === "string" &&
       Number.isFinite(Date.parse(value.deadlineAt))
-    ) return value;
-  } catch { /* intentionally ignored */ }
+    )
+      return value;
+  } catch {
+    /* intentionally ignored */
+  }
   return null;
 }
 
 function deadlineExtensionFromReason(reason) {
   const value = deadlineEventFromReason(reason, "deadline_extended");
-  return value && Number.isInteger(value.seconds) && value.seconds > 0 ? value : null;
+  return value && Number.isInteger(value.seconds) && value.seconds > 0
+    ? value
+    : null;
 }
 
 function deadlineExpiredFromReason(reason) {
@@ -105,23 +145,33 @@ function deadlineExpiredFromReason(reason) {
 
 /** Durable attempt deadline: latest extension, then the immutable initial budget. */
 export function attemptDeadline(db, runId, attempt, spec = null) {
-  const extensionRows = db.query(
-    `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
-  ).all(runId, attempt);
+  const extensionRows = db
+    .query(
+      `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+    )
+    .all(runId, attempt);
   for (const row of extensionRows) {
     const extension = deadlineExtensionFromReason(row.reason);
     if (extension) return Date.parse(extension.deadlineAt);
   }
-  const row = db.query(
-    `SELECT started_at, lease_expires_at FROM attempts WHERE run_id = ? AND attempt = ?`,
-  ).get(runId, attempt);
+  const row = db
+    .query(
+      `SELECT started_at, lease_expires_at FROM attempts WHERE run_id = ? AND attempt = ?`,
+    )
+    .get(runId, attempt);
   if (!row) return null;
-  const parsedSpec = spec ?? (() => {
-    const run = db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId);
-    return run?.spec_json ? JSON.parse(run.spec_json) : null;
-  })();
+  const parsedSpec =
+    spec ??
+    (() => {
+      const run = db
+        .query(`SELECT spec_json FROM runs WHERE run_id = ?`)
+        .get(runId);
+      return run?.spec_json ? JSON.parse(run.spec_json) : null;
+    })();
   if (row.started_at && Number.isFinite(Number(parsedSpec?.timeoutSeconds))) {
-    return Date.parse(row.started_at) + Number(parsedSpec.timeoutSeconds) * 1000;
+    return (
+      Date.parse(row.started_at) + Number(parsedSpec.timeoutSeconds) * 1000
+    );
   }
   if (row.lease_expires_at) {
     return Date.parse(row.lease_expires_at) - LEASE_GRACE_SECONDS * 1000;
@@ -130,28 +180,44 @@ export function attemptDeadline(db, runId, attempt, spec = null) {
 }
 
 export function deadlineExtensions(db, runId) {
-  return db.query(
-    `SELECT seq, actor, reason, at FROM lifecycle_events WHERE run_id = ? ORDER BY seq`,
-  ).all(runId).flatMap((row) => {
-    const extension = deadlineExtensionFromReason(row.reason);
-    return extension ? [{ seq: row.seq, actor: row.actor, at: row.at, ...extension }] : [];
-  });
+  return db
+    .query(
+      `SELECT seq, actor, reason, at FROM lifecycle_events WHERE run_id = ? ORDER BY seq`,
+    )
+    .all(runId)
+    .flatMap((row) => {
+      const extension = deadlineExtensionFromReason(row.reason);
+      return extension
+        ? [{ seq: row.seq, actor: row.actor, at: row.at, ...extension }]
+        : [];
+    });
 }
 
 /** Append an audited extension and move the current attempt's lease atomically. */
-export function extendRunDeadline(db, runId, {
-  seconds,
-  actor,
-  override = false,
-  maxDeadlineMs = null,
-  policyVersion = "unknown",
-  now = Date.now(),
-} = {}) {
+export function extendRunDeadline(
+  db,
+  runId,
+  {
+    seconds,
+    actor,
+    override = false,
+    maxDeadlineMs = null,
+    policyVersion = "unknown",
+    now = Date.now(),
+  } = {},
+) {
   return txImmediate(db, () => {
-    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(runId);
+    const run = db
+      .query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`)
+      .get(runId);
     if (!run) return { refused: true, code: "unknown_run", status: 404 };
     if (!["RUNNING", "VERIFYING"].includes(run.state)) {
-      return { refused: true, code: "run_not_extendable", status: 409, state: run.state };
+      return {
+        refused: true,
+        code: "run_not_extendable",
+        status: 409,
+        state: run.state,
+      };
     }
     const spec = JSON.parse(run.spec_json);
     if (spec.adapter === "actions") {
@@ -162,9 +228,11 @@ export function extendRunDeadline(db, runId, {
         adapter: spec.adapter,
       };
     }
-    const deadlineRows = db.query(
-      `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
-    ).all(runId, run.attempts);
+    const deadlineRows = db
+      .query(
+        `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+      )
+      .all(runId, run.attempts);
     if (deadlineRows.some((row) => deadlineExpiredFromReason(row.reason))) {
       return { refused: true, code: "deadline_already_expired", status: 409 };
     }
@@ -184,7 +252,11 @@ export function extendRunDeadline(db, runId, {
       };
     }
     const deadlineMs = currentDeadline + seconds * 1000;
-    if (!override && Number.isFinite(maxDeadlineMs) && deadlineMs > maxDeadlineMs) {
+    if (
+      !override &&
+      Number.isFinite(maxDeadlineMs) &&
+      deadlineMs > maxDeadlineMs
+    ) {
       return {
         refused: true,
         code: "policy_run_limit",
@@ -195,7 +267,9 @@ export function extendRunDeadline(db, runId, {
     }
     const at = iso(now);
     const deadlineAt = new Date(deadlineMs).toISOString();
-    const leaseExpiresAt = new Date(deadlineMs + LEASE_GRACE_SECONDS * 1000).toISOString();
+    const leaseExpiresAt = new Date(
+      deadlineMs + LEASE_GRACE_SECONDS * 1000,
+    ).toISOString();
     const reason = canonicalJson({
       type: "deadline_extended",
       seconds,
@@ -217,14 +291,27 @@ export function extendRunDeadline(db, runId, {
          (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
        VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
     ).run(
-      runId, run.state, run.state, actor, reason, run.attempts,
-      policyVersion, at, hashJson(record),
+      runId,
+      run.state,
+      run.state,
+      actor,
+      reason,
+      run.attempts,
+      policyVersion,
+      at,
+      hashJson(record),
     );
     db.query(
       `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
     ).run(leaseExpiresAt, runId, run.attempts);
     db.query(`UPDATE runs SET updated_at = ? WHERE run_id = ?`).run(at, runId);
-    return { runId, seconds, deadlineAt, leaseExpiresAt, override: override === true };
+    return {
+      runId,
+      seconds,
+      deadlineAt,
+      leaseExpiresAt,
+      override: override === true,
+    };
   });
 }
 
@@ -234,24 +321,43 @@ export function extendRunDeadline(db, runId, {
  * that commits first moves the deadline, while an expiry that commits first
  * makes every later extension a typed refusal throughout TERM/KILL grace.
  */
-export function expireRunDeadline(db, runId, attempt, fencingToken, {
-  actor,
-  policyVersion = "unknown",
-  now = Date.now(),
-} = {}) {
+export function expireRunDeadline(
+  db,
+  runId,
+  attempt,
+  fencingToken,
+  { actor, policyVersion = "unknown", now = Date.now() } = {},
+) {
   return txImmediate(db, () => {
-    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(runId);
-    if (!run || run.attempts !== attempt || !["RUNNING", "VERIFYING"].includes(run.state)) {
+    const run = db
+      .query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`)
+      .get(runId);
+    if (
+      !run ||
+      run.attempts !== attempt ||
+      !["RUNNING", "VERIFYING"].includes(run.state)
+    ) {
       return { expired: false, inactive: true };
     }
-    if (!assertCurrentToken(db, runId, fencingToken)) return { expired: false, fenced: true };
-    const rows = db.query(
-      `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
-    ).all(runId, attempt);
-    const prior = rows.map((row) => deadlineExpiredFromReason(row.reason)).find(Boolean);
-    if (prior) return { expired: true, deadlineAt: prior.deadlineAt, existing: true };
+    if (!assertCurrentToken(db, runId, fencingToken))
+      return { expired: false, fenced: true };
+    const rows = db
+      .query(
+        `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+      )
+      .all(runId, attempt);
+    const prior = rows
+      .map((row) => deadlineExpiredFromReason(row.reason))
+      .find(Boolean);
+    if (prior)
+      return { expired: true, deadlineAt: prior.deadlineAt, existing: true };
 
-    const deadlineMs = attemptDeadline(db, runId, attempt, JSON.parse(run.spec_json));
+    const deadlineMs = attemptDeadline(
+      db,
+      runId,
+      attempt,
+      JSON.parse(run.spec_json),
+    );
     const currentNow = resolveNow(now);
     if (!Number.isFinite(deadlineMs) || currentNow < deadlineMs) {
       return { expired: false, deadlineMs };
@@ -275,8 +381,15 @@ export function expireRunDeadline(db, runId, attempt, fencingToken, {
          (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
        VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
     ).run(
-      runId, run.state, run.state, actor, reason, attempt,
-      policyVersion, at, hashJson(record),
+      runId,
+      run.state,
+      run.state,
+      actor,
+      reason,
+      attempt,
+      policyVersion,
+      at,
+      hashJson(record),
     );
     return { expired: true, deadlineAt };
   });
@@ -318,34 +431,45 @@ const FATAL_FAILURES = new Set([
 /** Closed failure taxonomy: unknown reasons fail safe as fatal and never retry. */
 export function classifyFailureCause(reasonCode) {
   if (ENVIRONMENT_FAILURES.has(reasonCode)) return "environment";
-  if (AGENT_FAILURES.has(reasonCode) || String(reasonCode).startsWith("agent_exit_")) {
+  if (
+    AGENT_FAILURES.has(reasonCode) ||
+    String(reasonCode).startsWith("agent_exit_")
+  ) {
     return "agent_error";
   }
-  if (FATAL_FAILURES.has(reasonCode) || String(reasonCode).startsWith("policy_denied:")) {
+  if (
+    FATAL_FAILURES.has(reasonCode) ||
+    String(reasonCode).startsWith("policy_denied:")
+  ) {
     return "fatal";
   }
   return "fatal";
 }
 
 function maxEnvironmentRetries(spec) {
-  return Number.isInteger(spec.maxEnvironmentRetries) && spec.maxEnvironmentRetries >= 0
+  return Number.isInteger(spec.maxEnvironmentRetries) &&
+    spec.maxEnvironmentRetries >= 0
     ? spec.maxEnvironmentRetries
     : DEFAULT_MAX_ENVIRONMENT_RETRIES;
 }
 
 function failureCount(db, runId, cause) {
   return db
-    .query(`SELECT reason_code FROM attempts WHERE run_id = ? AND finished_at IS NOT NULL`)
+    .query(
+      `SELECT reason_code FROM attempts WHERE run_id = ? AND finished_at IS NOT NULL`,
+    )
     .all(runId)
-    .filter((row) => classifyFailureCause(row.reason_code) === cause)
-    .length;
+    .filter((row) => classifyFailureCause(row.reason_code) === cause).length;
 }
 
 /** Called after the current attempt is finalized, so counts include this failure. */
 function retryDecision(db, runId, spec, reasonCode) {
   const cause = classifyFailureCause(reasonCode);
   if (cause === "environment") {
-    return { cause, retry: failureCount(db, runId, cause) <= maxEnvironmentRetries(spec) };
+    return {
+      cause,
+      retry: failureCount(db, runId, cause) <= maxEnvironmentRetries(spec),
+    };
   }
   if (cause === "agent_error") {
     return { cause, retry: failureCount(db, runId, cause) < spec.maxAttempts };
@@ -374,19 +498,24 @@ function refusalInboxRefs(spec) {
   const issue = input.ticket;
   const repo = input.repo;
   const pr = input.pr ?? input.prNumber;
-  if (issue !== undefined && issue !== null && String(issue).trim()) refs.issue = String(issue);
-  if (repo !== undefined && repo !== null && String(repo).trim()) refs.repo = String(repo);
-  if (pr !== undefined && pr !== null && String(pr).trim()) refs.pr = String(pr);
+  if (issue !== undefined && issue !== null && String(issue).trim())
+    refs.issue = String(issue);
+  if (repo !== undefined && repo !== null && String(repo).trim())
+    refs.repo = String(repo);
+  if (pr !== undefined && pr !== null && String(pr).trim())
+    refs.pr = String(pr);
   return refs;
 }
 
 function createRefusalInboxItem(db, spec, result, { now }) {
   if (result.reasonCode !== "needs_human") return null;
   const refs = refusalInboxRefs(spec);
-  const decision = result.decision ?? templateFor("ESCALATED", {
-    producer: "escalation",
-    refs,
-  });
+  const decision =
+    result.decision ??
+    templateFor("ESCALATED", {
+      producer: "escalation",
+      refs,
+    });
   const subject = refs.issue ?? refs.runId;
   const body = result.decisionErrors?.length
     ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
@@ -395,7 +524,9 @@ function createRefusalInboxItem(db, spec, result, { now }) {
     db,
     {
       kind: "ESCALATED",
-      title: result.decision?.question ?? `ESCALATED ${subject}: ${result.reasonCode}`,
+      title:
+        result.decision?.question ??
+        `ESCALATED ${subject}: ${result.reasonCode}`,
       body,
       refs,
       source: `agent:${spec.runId}`,
@@ -406,7 +537,15 @@ function createRefusalInboxItem(db, spec, result, { now }) {
   );
 }
 
-function finishAttempt(db, runId, attempt, terminalState, reasonCode, now, usage = {}) {
+function finishAttempt(
+  db,
+  runId,
+  attempt,
+  terminalState,
+  reasonCode,
+  now,
+  usage = {},
+) {
   const finishedAt = iso(now);
   db.query(
     `UPDATE attempts SET terminal_state = ?, reason_code = ?, finished_at = ?
@@ -420,10 +559,21 @@ export function repositoryStatus(
   checkoutPath,
   { timeoutMs = workerSubprocessTimeoutMs(), gitCommand = "git" } = {},
 ) {
-  const result = spawnSync(gitCommand, ["-C", checkoutPath, "status", "--porcelain", "--untracked-files=all", "--ignored=matching"], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-  });
+  const result = spawnSync(
+    gitCommand,
+    [
+      "-C",
+      checkoutPath,
+      "status",
+      "--porcelain",
+      "--untracked-files=all",
+      "--ignored=matching",
+    ],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+    },
+  );
   return result.status === 0 ? result.stdout : null;
 }
 
@@ -439,13 +589,22 @@ function assertCurrentToken(db, runId, fencingToken) {
   return fencingToken === maxToken;
 }
 
-function recordFencedAttempt(db, { runId, attempt, actor, policyVersion, now = Date.now() }) {
+function recordFencedAttempt(
+  db,
+  { runId, attempt, actor, policyVersion, now = Date.now() },
+) {
   const at = iso(now);
   const run = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId);
   const state = run?.state ?? null;
   const record = {
-    runId, from: state, to: "FENCED", actor,
-    reason: "fenced_attempt", attempt, policyVersion, at,
+    runId,
+    from: state,
+    to: "FENCED",
+    actor,
+    reason: "fenced_attempt",
+    attempt,
+    policyVersion,
+    at,
   };
   const record_hash = hashJson(record);
   db.query(
@@ -453,15 +612,28 @@ function recordFencedAttempt(db, { runId, attempt, actor, policyVersion, now = D
        (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    runId, state, "FENCED", actor, "fenced_attempt",
-    attempt, null, null, policyVersion, at, record_hash,
+    runId,
+    state,
+    "FENCED",
+    actor,
+    "fenced_attempt",
+    attempt,
+    null,
+    null,
+    policyVersion,
+    at,
+    record_hash,
   );
 }
 
 function latestJournalHash(db, runId) {
-  return db
-    .query(`SELECT record_hash FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`)
-    .get(runId)?.record_hash ?? null;
+  return (
+    db
+      .query(
+        `SELECT record_hash FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
+      )
+      .get(runId)?.record_hash ?? null
+  );
 }
 
 function receiptWithDeadlineExtensions(db, runId, options) {
@@ -474,15 +646,17 @@ function receiptWithDeadlineExtensions(db, runId, options) {
 
 /** The admitted event this run was planned from, via its proposal (may be absent). */
 function originatingEvent(db, runId) {
-  return db
-    .query(
-      `SELECT e.type, e.correlation_id, e.causation_id
+  return (
+    db
+      .query(
+        `SELECT e.type, e.correlation_id, e.causation_id
        FROM proposals p
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE p.run_id = ?
        LIMIT 1`,
-    )
-    .get(runId) ?? null;
+      )
+      .get(runId) ?? null
+  );
 }
 
 /**
@@ -491,16 +665,19 @@ function originatingEvent(db, runId) {
  *
  * @returns {{ runId: string, attempt: number, fencingToken: number, spec: object } | { runId: string, spec: object, refused: true, retryable: true, reloadRequired: boolean, reasonCode: "registry_stale", workerRegistryVersion: string, checkoutRegistryVersion: string } | null}
  */
-export function claimNext(db, {
-  owner,
-  now = () => Date.now(),
-  policyVersion = "unknown",
-  registryVersion = null,
-  currentRegistryVersion = null,
-  labels = {},
-  adapters = null,
-  adapterOverride,
-} = {}) {
+export function claimNext(
+  db,
+  {
+    owner,
+    now = () => Date.now(),
+    policyVersion = "unknown",
+    registryVersion = null,
+    currentRegistryVersion = null,
+    labels = {},
+    adapters = null,
+    adapterOverride,
+  } = {},
+) {
   // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
   // not both read the same QUEUED row before either writes (OPS-233).
   return txImmediate(db, () => {
@@ -527,17 +704,30 @@ export function claimNext(db, {
     let checkoutVersion;
     const resolveCheckoutVersion = () => {
       if (checkoutVersion !== undefined) return checkoutVersion;
-      checkoutVersion = typeof currentRegistryVersion === "function"
-        ? currentRegistryVersion()
-        : currentRegistryVersion;
+      checkoutVersion =
+        typeof currentRegistryVersion === "function"
+          ? currentRegistryVersion()
+          : currentRegistryVersion;
       return checkoutVersion;
     };
     for (const candidate of candidates) {
-      const backoff = /^(?:claim_lock_contention:\d+|dispatch_gate_transient:[^:]+:\d+):backoff_(\d+)ms$/.exec(candidate.queue_reason ?? "");
-      if (backoff && Date.parse(candidate.queued_at) + Number(backoff[1]) > claimNow) continue;
+      const backoff =
+        /^(?:claim_lock_contention:\d+|dispatch_gate_transient:[^:]+:\d+):backoff_(\d+)ms$/.exec(
+          candidate.queue_reason ?? "",
+        );
+      if (
+        backoff &&
+        Date.parse(candidate.queued_at) + Number(backoff[1]) > claimNow
+      )
+        continue;
       const candidateSpec = JSON.parse(candidate.spec_json);
       if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
-      if (adapters && !adapterOverride && !adapters.includes(candidateSpec.adapter)) continue;
+      if (
+        adapters &&
+        !adapterOverride &&
+        !adapters.includes(candidateSpec.adapter)
+      )
+        continue;
       // The worker snapshots the registry and policy at startup. A run planned
       // against another checkout must stay QUEUED; leasing it would execute and
       // validate with incompatible definitions. Compare the live checkout too
@@ -574,17 +764,26 @@ export function claimNext(db, {
     if (!row) return staleRefusal;
     const attempt = row.attempts + 1;
     const fencingToken = nextCounter(db, "fencing");
-    const leaseExpiresAt = iso(claimNow + (spec.timeoutSeconds + LEASE_GRACE_SECONDS) * 1000);
+    const leaseExpiresAt = iso(
+      claimNow + (spec.timeoutSeconds + LEASE_GRACE_SECONDS) * 1000,
+    );
 
-    db.query(`UPDATE runs SET attempts = ?, updated_at = ? WHERE run_id = ?`)
-      .run(attempt, iso(claimNow), row.run_id);
+    db.query(
+      `UPDATE runs SET attempts = ?, updated_at = ? WHERE run_id = ?`,
+    ).run(attempt, iso(claimNow), row.run_id);
     db.query(
       `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, lease_expires_at)
        VALUES (?, ?, ?, ?, ?)`,
     ).run(row.run_id, attempt, fencingToken, owner, leaseExpiresAt);
     transition(db, {
-      runId: row.run_id, to: "LEASED", expectFrom: "QUEUED",
-      actor: owner, reason: "claimed", attempt, policyVersion, now: claimNow,
+      runId: row.run_id,
+      to: "LEASED",
+      expectFrom: "QUEUED",
+      actor: owner,
+      reason: "claimed",
+      attempt,
+      policyVersion,
+      now: claimNow,
     });
 
     return { runId: row.run_id, attempt, fencingToken, spec };
@@ -593,12 +792,18 @@ export function claimNext(db, {
 
 function defaultIsAlive(pid) {
   if (!Number.isInteger(pid) || pid < 1) return false;
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function defaultLocksDir() {
   if (process.env.FACTORY_LOCKS_DIR) return process.env.FACTORY_LOCKS_DIR;
-  if (process.env.FACTORY_EVENT_HOME) return path.join(process.env.FACTORY_EVENT_HOME, "locks");
+  if (process.env.FACTORY_EVENT_HOME)
+    return path.join(process.env.FACTORY_EVENT_HOME, "locks");
   return path.join(homedir(), ".factory", "locks");
 }
 
@@ -606,7 +811,10 @@ export function dispatchLockPath(repoName, root = defaultLocksDir()) {
   return path.join(root, `${repoName}.dispatch.lock`);
 }
 
-export function acquireClaimLock(lockFile, { pid = process.pid, now = Date.now(), isAlive = defaultIsAlive } = {}) {
+export function acquireClaimLock(
+  lockFile,
+  { pid = process.pid, now = Date.now(), isAlive = defaultIsAlive } = {},
+) {
   mkdirSync(path.dirname(lockFile), { recursive: true });
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
@@ -624,23 +832,31 @@ export function acquireClaimLock(lockFile, { pid = process.pid, now = Date.now()
       // Age alone is not proof of abandonment: a slow but live Linear claim
       // must retain mutual exclusion. Only a dead owner makes the lock stale.
       if (alive) return false;
-      try { unlinkSync(lockFile); } catch { /* intentionally ignored */ }
+      try {
+        unlinkSync(lockFile);
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   return false;
 }
 
 export function releaseClaimLock(lockFile) {
-  try { unlinkSync(lockFile); } catch { /* intentionally ignored */ }
+  try {
+    unlinkSync(lockFile);
+  } catch {
+    /* intentionally ignored */
+  }
 }
 
 function claimLockBackoffMs(contentionNumber, random = Math.random) {
   const cap = Math.min(
     CLAIM_LOCK_BACKOFF_MAX_MS,
-    CLAIM_LOCK_BACKOFF_BASE_MS * (2 ** Math.max(0, contentionNumber - 1)),
+    CLAIM_LOCK_BACKOFF_BASE_MS * 2 ** Math.max(0, contentionNumber - 1),
   );
   const sample = Math.min(1, Math.max(0, Number(random()) || 0));
-  return Math.floor((cap / 2) + (sample * cap / 2));
+  return Math.floor(cap / 2 + (sample * cap) / 2);
 }
 
 /**
@@ -648,32 +864,61 @@ function claimLockBackoffMs(contentionNumber, random = Math.random) {
  * spending its execution attempt. The lifecycle reason and timestamp form a
  * durable not-before value consumed by claimNext().
  */
-function deferClaimLockContention(db, {
-  runId, attempt, fencingToken, owner, policyVersion, now,
-  maxRequeues = DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
-  random = Math.random,
-}) {
+function deferClaimLockContention(
+  db,
+  {
+    runId,
+    attempt,
+    fencingToken,
+    owner,
+    policyVersion,
+    now,
+    maxRequeues = DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
+    random = Math.random,
+  },
+) {
   return txImmediate(db, () => {
     const currentNow = resolveNow(now);
     if (!assertCurrentToken(db, runId, fencingToken)) {
-      recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+      recordFencedAttempt(db, {
+        runId,
+        attempt,
+        actor: owner,
+        policyVersion,
+        now: currentNow,
+      });
       return { fenced: true };
     }
-    const prior = Number(db.query(
-      `SELECT COUNT(*) AS n FROM lifecycle_events
+    const prior = Number(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM lifecycle_events
        WHERE run_id = ? AND reason LIKE 'claim_lock_contention:%'`,
-    ).get(runId)?.n ?? 0);
+        )
+        .get(runId)?.n ?? 0,
+    );
     if (prior >= maxRequeues) return { starved: true, contentions: prior };
 
     const contentionNumber = prior + 1;
     const backoffMs = claimLockBackoffMs(contentionNumber, random);
     transition(db, {
-      runId, to: "QUEUED", expectFrom: "RUNNING", actor: owner,
+      runId,
+      to: "QUEUED",
+      expectFrom: "RUNNING",
+      actor: owner,
       reason: `claim_lock_contention:${contentionNumber}:backoff_${backoffMs}ms`,
-      attempt, policyVersion, now: currentNow,
+      attempt,
+      policyVersion,
+      now: currentNow,
     });
-    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(runId, attempt);
-    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(attempt - 1, runId);
+    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(
+      runId,
+      attempt,
+    );
+    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(
+      attempt - 1,
+      runId,
+    );
     return { requeued: true, contentions: contentionNumber, backoffMs };
   });
 }
@@ -684,38 +929,70 @@ function deferClaimLockContention(db, {
  * an execution attempt, with the same durable not-before mechanism as the
  * machine-local claim lock.
  */
-function deferTransientDispatchGate(db, {
-  runId, attempt, fencingToken, owner, policyVersion, now, reasonCode,
-  maxRequeues = DEFAULT_MAX_TRANSIENT_GATE_REQUEUES,
-  random = Math.random,
-}) {
+function deferTransientDispatchGate(
+  db,
+  {
+    runId,
+    attempt,
+    fencingToken,
+    owner,
+    policyVersion,
+    now,
+    reasonCode,
+    maxRequeues = DEFAULT_MAX_TRANSIENT_GATE_REQUEUES,
+    random = Math.random,
+  },
+) {
   return txImmediate(db, () => {
     const currentNow = resolveNow(now);
     if (!assertCurrentToken(db, runId, fencingToken)) {
-      recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+      recordFencedAttempt(db, {
+        runId,
+        attempt,
+        actor: owner,
+        policyVersion,
+        now: currentNow,
+      });
       return { fenced: true };
     }
-    const prior = Number(db.query(
-      `SELECT COUNT(*) AS n FROM lifecycle_events
+    const prior = Number(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM lifecycle_events
        WHERE run_id = ? AND reason GLOB ?`,
-    ).get(runId, `dispatch_gate_transient:${reasonCode}:*`)?.n ?? 0);
+        )
+        .get(runId, `dispatch_gate_transient:${reasonCode}:*`)?.n ?? 0,
+    );
     if (prior >= maxRequeues) return { exhausted: true, requeues: prior };
 
     const requeueNumber = prior + 1;
     const backoffMs = claimLockBackoffMs(requeueNumber, random);
     transition(db, {
-      runId, to: "QUEUED", expectFrom: "RUNNING", actor: owner,
+      runId,
+      to: "QUEUED",
+      expectFrom: "RUNNING",
+      actor: owner,
       reason: `dispatch_gate_transient:${reasonCode}:${requeueNumber}:backoff_${backoffMs}ms`,
-      attempt, policyVersion, now: currentNow,
+      attempt,
+      policyVersion,
+      now: currentNow,
     });
-    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(runId, attempt);
-    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(attempt - 1, runId);
+    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(
+      runId,
+      attempt,
+    );
+    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(
+      attempt - 1,
+      runId,
+    );
     return { requeued: true, requeues: requeueNumber, backoffMs };
   });
 }
 
 function hasPlanTimeDispatchEvidence(spec) {
-  return Boolean(spec?.approvalPolicy?.dispatchEvidence?.ticket?.descriptionHash);
+  return Boolean(
+    spec?.approvalPolicy?.dispatchEvidence?.ticket?.descriptionHash,
+  );
 }
 
 /**
@@ -726,15 +1003,23 @@ function hasPlanTimeDispatchEvidence(spec) {
 function claimedRetryFor(db, runId, attempt) {
   if (!Number.isInteger(attempt) || attempt <= 1) return null;
   const priorAttempt = attempt - 1;
-  const prior = db.query(
-    `SELECT terminal_state, reason_code FROM attempts WHERE run_id = ? AND attempt = ?`,
-  ).get(runId, priorAttempt);
-  if (prior?.terminal_state !== "FAILED" || prior?.reason_code !== "lease_expired") return null;
-  const requeue = db.query(
-    `SELECT reason FROM lifecycle_events
+  const prior = db
+    .query(
+      `SELECT terminal_state, reason_code FROM attempts WHERE run_id = ? AND attempt = ?`,
+    )
+    .get(runId, priorAttempt);
+  if (
+    prior?.terminal_state !== "FAILED" ||
+    prior?.reason_code !== "lease_expired"
+  )
+    return null;
+  const requeue = db
+    .query(
+      `SELECT reason FROM lifecycle_events
      WHERE run_id = ? AND to_state = 'QUEUED' AND attempt = ?
      ORDER BY seq DESC LIMIT 1`,
-  ).get(runId, priorAttempt);
+    )
+    .get(runId, priorAttempt);
   if (requeue?.reason !== "retry:environment") return null;
   return { runId, priorAttempt, reasonCode: "lease_expired" };
 }
@@ -746,7 +1031,7 @@ function contradictsPlanTimeOwnedPaths(spec, gateResult) {
     planned?.descriptionHash &&
     planned.ownedPathsParsed === true &&
     current?.ownedPathsParsed === false &&
-    current.descriptionHash !== planned.descriptionHash
+    current.descriptionHash !== planned.descriptionHash,
   );
 }
 
@@ -793,7 +1078,11 @@ export function codeStampRoot() {
 
 function walkStampFiles(dir, out) {
   let entries;
-  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
   for (const entry of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
     const abs = path.join(dir, entry.name);
     if (entry.isDirectory()) walkStampFiles(abs, out);
@@ -803,12 +1092,19 @@ function walkStampFiles(dir, out) {
 }
 
 /** Repo-relative, sorted list of the files the stamp covers. */
-export function codeStampFiles(repoRoot = codeStampRoot(), paths = CODE_STAMP_PATHS) {
+export function codeStampFiles(
+  repoRoot = codeStampRoot(),
+  paths = CODE_STAMP_PATHS,
+) {
   const files = [];
   for (const rel of paths) {
     const abs = path.join(repoRoot, rel);
     let st;
-    try { st = statSync(abs); } catch { continue; }
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
     if (st.isDirectory()) walkStampFiles(abs, files);
     else if (st.isFile()) files.push(abs);
   }
@@ -832,12 +1128,19 @@ function gitHead(repoRoot) {
  * a HEAD-only stamp misses entirely. Reading ~1MB once a second is free next
  * to the agent runs this loop supervises.
  */
-export function codeStamp(repoRoot = codeStampRoot(), paths = CODE_STAMP_PATHS) {
+export function codeStamp(
+  repoRoot = codeStampRoot(),
+  paths = CODE_STAMP_PATHS,
+) {
   const hash = createHash("sha256");
   for (const rel of codeStampFiles(repoRoot, paths)) {
     hash.update(rel);
     hash.update("\0");
-    try { hash.update(readFileSync(path.join(repoRoot, rel))); } catch { hash.update("<unreadable>"); }
+    try {
+      hash.update(readFileSync(path.join(repoRoot, rel)));
+    } catch {
+      hash.update("<unreadable>");
+    }
     hash.update("\0");
   }
   return `${gitHead(repoRoot)}:${hash.digest("hex").slice(0, 12)}`;
@@ -886,7 +1189,13 @@ export function createReloadWatcher({
       if (inFlight) {
         const first = !deferredSeen;
         deferredSeen = true;
-        return { action: "deferred", from, to: pending, runId: inFlight, first };
+        return {
+          action: "deferred",
+          from,
+          to: pending,
+          runId: inFlight,
+          first,
+        };
       }
       return { action: "reload", from, to: pending };
     },
@@ -910,10 +1219,14 @@ export function resolveLinearApiKey({
   try {
     for (const line of readFileSync(envFile, "utf8").split("\n")) {
       const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+      if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("="))
+        continue;
       const idx = trimmed.indexOf("=");
       if (trimmed.slice(0, idx).trim() !== "LINEAR_API_KEY") continue;
-      const value = trimmed.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+      const value = trimmed
+        .slice(idx + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, "");
       if (!value) return null;
       env.LINEAR_API_KEY = value;
       return value;
@@ -956,9 +1269,17 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
-    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
+    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+      return false;
 
-    runLinearCli(["state", ticket, "Todo", "--unassign", "--remove", "ai:in-progress"]);
+    runLinearCli([
+      "state",
+      ticket,
+      "Todo",
+      "--unassign",
+      "--remove",
+      "ai:in-progress",
+    ]);
     const body = `Dispatch run failed, claim released back to Todo.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}`;
     runLinearCli(["comment", ticket, body]);
     return true;
@@ -971,13 +1292,20 @@ const BASELINE_COMMENT_MARKER = "wm:baseline:red:";
 
 function baselineFailureSignature({ why, log = null, baseline = null }) {
   return createHash("sha256")
-    .update(JSON.stringify({
-      why,
-      log,
-      baseline: baseline && typeof baseline === "object"
-        ? { check: baseline.check, exitCode: baseline.exitCode, output: baseline.output }
-        : null,
-    }))
+    .update(
+      JSON.stringify({
+        why,
+        log,
+        baseline:
+          baseline && typeof baseline === "object"
+            ? {
+                check: baseline.check,
+                exitCode: baseline.exitCode,
+                output: baseline.output,
+              }
+            : null,
+      }),
+    )
     .digest("hex");
 }
 
@@ -986,13 +1314,22 @@ function hasRecordedBaselineFailureComment(ticket, signature) {
   try {
     const out = runLinearCli(["comments", ticket, "--json"]);
     const comments = JSON.parse(out);
-    return (comments ?? []).some((row) => String(row.body ?? "").includes(marker));
+    return (comments ?? []).some((row) =>
+      String(row.body ?? "").includes(marker),
+    );
   } catch {
     return false;
   }
 }
 
-function defaultBlockBaselineTicket({ repo, ticket, why, log = null, baseline = null, fetchTicket }) {
+function defaultBlockBaselineTicket({
+  repo,
+  ticket,
+  why,
+  log = null,
+  baseline = null,
+  fetchTicket,
+}) {
   try {
     let cur = null;
     if (typeof fetchTicket === "function") {
@@ -1002,10 +1339,20 @@ function defaultBlockBaselineTicket({ repo, ticket, why, log = null, baseline = 
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
-    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
+    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+      return false;
 
     const signature = baselineFailureSignature({ why, log, baseline });
-    runLinearCli(["state", ticket, "Blocked", "--unassign", "--add", "ai:blocked", "--remove", "ai:in-progress"]);
+    runLinearCli([
+      "state",
+      ticket,
+      "Blocked",
+      "--unassign",
+      "--add",
+      "ai:blocked",
+      "--remove",
+      "ai:in-progress",
+    ]);
 
     if (!hasRecordedBaselineFailureComment(ticket, signature)) {
       const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
@@ -1028,14 +1375,30 @@ const ACTIVE_EXECUTIONS = new Map();
  * { cancelled: true } when an operator moved the run under us, or
  * { fenced: true } when a newer attempt owns the run at publish time.
  */
-export async function executeClaimed(db, registry, adapters, claim, {
-  workspacesRoot, artifactStore = artifactsRoot(), now = () => Date.now(), policyVersion = "unknown", adapterOverride, env = {},
-  dispatch, resolveLinearKey = resolveLinearApiKey, policyRoot = FACTORY_ROOT,
-} = {}) {
+export async function executeClaimed(
+  db,
+  registry,
+  adapters,
+  claim,
+  {
+    workspacesRoot,
+    artifactStore = artifactsRoot(),
+    now = () => Date.now(),
+    policyVersion = "unknown",
+    adapterOverride,
+    env = {},
+    dispatch,
+    resolveLinearKey = resolveLinearApiKey,
+    policyRoot = FACTORY_ROOT,
+  } = {},
+) {
   const { runId, attempt, fencingToken, spec } = claim;
-  const owner = db
-    .query(`SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`)
-    .get(runId, attempt)?.lease_owner ?? "worker";
+  const owner =
+    db
+      .query(
+        `SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`,
+      )
+      .get(runId, attempt)?.lease_owner ?? "worker";
   const retain = spec.workspace?.retainOnFailure === true;
   let workspaceDir = null;
   let checkoutPath = null;
@@ -1048,7 +1411,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
       // A newer attempt for this run uses the same delegated worktree. Remove
       // only the stale attempt's teardown marker so destroyWorkspace cleans its
       // wrapper directory without invoking worktree_down under the live retry.
-      try { unlinkSync(path.join(workspaceDir, ".worktree.json")); } catch { /* intentionally ignored */ }
+      try {
+        unlinkSync(path.join(workspaceDir, ".worktree.json"));
+      } catch {
+        /* intentionally ignored */
+      }
     }
     destroyWorkspace(workspaceDir, {
       retain: retainWorkspace,
@@ -1063,15 +1430,16 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let leaseHeartbeat = null;
   let ticketClaimed = false;
   const ticketLeaseOwner = `${owner}:${runId}:${fencingToken}`;
-  const mayMutateClaimedTicket = () => ticketClaimed && assertCurrentToken(db, runId, fencingToken);
+  const mayMutateClaimedTicket = () =>
+    ticketClaimed && assertCurrentToken(db, runId, fencingToken);
   let attemptUsage = { adapter: adapterOverride ?? spec.adapter };
 
   let dispatchOpts = dispatch;
-  const explicitDispatchStub = !dispatchOpts && (
-    process.env.FACTORY_DISPATCH_STUB === "1" ||
-    adapterOverride === "fake" ||
-    spec.adapter === "fake"
-  );
+  const explicitDispatchStub =
+    !dispatchOpts &&
+    (process.env.FACTORY_DISPATCH_STUB === "1" ||
+      adapterOverride === "fake" ||
+      spec.adapter === "fake");
   if (explicitDispatchStub) {
     dispatchOpts = {
       fetchTicket: () => ({
@@ -1091,19 +1459,34 @@ export async function executeClaimed(db, registry, adapters, claim, {
       unclaimTicket: () => true,
     };
   }
-  const linearConfigured = dispatchOpts || !isWorktree || !repoName || !ticketId
-    ? true
-    : Boolean(resolveLinearKey());
+  const linearConfigured =
+    dispatchOpts || !isWorktree || !repoName || !ticketId
+      ? true
+      : Boolean(resolveLinearKey());
 
   const locksDir = dispatchOpts?.locksDir ?? defaultLocksDir();
   const leasesDir = dispatchOpts?.leasesDir ?? leaseDir();
   const lockFile = repoName ? dispatchLockPath(repoName, locksDir) : null;
   const isAliveFn = dispatchOpts?.isAlive ?? defaultIsAlive;
-  const claimTicketFn = dispatchOpts?.claimTicket ?? (dispatchOpts?.fetchTicket ? (() => ({ ok: true })) : defaultClaimTicket);
-  const unclaimTicketFn = dispatchOpts?.unclaimTicket ?? ((args) => defaultUnclaimTicket({ ...args, fetchTicket: dispatchOpts?.fetchTicket }));
-  const blockTicketFn = dispatchOpts?.blockBaselineTicket ?? ((args) => defaultBlockBaselineTicket({ ...args, fetchTicket: dispatchOpts?.fetchTicket }));
+  const claimTicketFn =
+    dispatchOpts?.claimTicket ??
+    (dispatchOpts?.fetchTicket ? () => ({ ok: true }) : defaultClaimTicket);
+  const unclaimTicketFn =
+    dispatchOpts?.unclaimTicket ??
+    ((args) =>
+      defaultUnclaimTicket({
+        ...args,
+        fetchTicket: dispatchOpts?.fetchTicket,
+      }));
+  const blockTicketFn =
+    dispatchOpts?.blockBaselineTicket ??
+    ((args) =>
+      defaultBlockBaselineTicket({
+        ...args,
+        fetchTicket: dispatchOpts?.fetchTicket,
+      }));
 
-  const nowFn = typeof now === "function" ? now : () => (now ?? Date.now());
+  const nowFn = typeof now === "function" ? now : () => now ?? Date.now();
 
   const abortController = new AbortController();
   ACTIVE_EXECUTIONS.set(runId, {
@@ -1114,7 +1497,9 @@ export async function executeClaimed(db, registry, adapters, claim, {
   });
   let cancelPoll = setInterval(() => {
     try {
-      const state = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
+      const state = db
+        .query(`SELECT state FROM runs WHERE run_id = ?`)
+        .get(runId)?.state;
       if (state === "CANCELLED" && !abortController.signal.aborted) {
         abortController.abort("db_cancelled");
       }
@@ -1134,20 +1519,48 @@ export async function executeClaimed(db, registry, adapters, claim, {
     txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
-        recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+        recordFencedAttempt(db, {
+          runId,
+          attempt,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+        });
         return { fenced: true };
       }
-      const expectFrom = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
+      const expectFrom = db
+        .query(`SELECT state FROM runs WHERE run_id = ?`)
+        .get(runId)?.state;
       transition(db, {
-        runId, to, expectFrom,
-        actor: owner, reason: typedFailureReason(reasonCode, journalReason), attempt, policyVersion, now: currentNow,
+        runId,
+        to,
+        expectFrom,
+        actor: owner,
+        reason: typedFailureReason(reasonCode, journalReason),
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
-      finishAttempt(db, runId, attempt, to, reasonCode, currentNow, attemptUsage);
+      finishAttempt(
+        db,
+        runId,
+        attempt,
+        to,
+        reasonCode,
+        currentNow,
+        attemptUsage,
+      );
       const decision = retryDecision(db, runId, spec, reasonCode);
       if (decision.retry) {
         transition(db, {
-          runId, to: "QUEUED", expectFrom: "FAILED",
-          actor: owner, reason: `retry:${decision.cause}`, attempt, policyVersion, now: nowFn(),
+          runId,
+          to: "QUEUED",
+          expectFrom: "FAILED",
+          actor: owner,
+          reason: `retry:${decision.cause}`,
+          attempt,
+          policyVersion,
+          now: nowFn(),
         });
       }
       return { ok: true, cause: decision.cause, requeued: decision.retry };
@@ -1156,23 +1569,49 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let def = null;
   try {
     def = getAgent(registry, spec.agent);
-  } catch { /* intentionally ignored */ }
+  } catch {
+    /* intentionally ignored */
+  }
 
-  const refuseTerminal = (reasonCode, checks = ["dispatch_gate"], { causeTyped = false, detail = null } = {}) =>
+  const refuseTerminal = (
+    reasonCode,
+    checks = ["dispatch_gate"],
+    { causeTyped = false, detail = null } = {},
+  ) =>
     txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
-        recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+        recordFencedAttempt(db, {
+          runId,
+          attempt,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+        });
         return { fenced: true };
       }
-      const journalReason = causeTyped ? typedFailureReason(reasonCode) : (detail ?? reasonCode);
+      const journalReason = causeTyped
+        ? typedFailureReason(reasonCode)
+        : (detail ?? reasonCode);
       transition(db, {
-        runId, to: "VERIFYING", expectFrom: "RUNNING",
-        actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
+        runId,
+        to: "VERIFYING",
+        expectFrom: "RUNNING",
+        actor: owner,
+        reason: journalReason,
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
       transition(db, {
-        runId, to: "REFUSED", expectFrom: "VERIFYING",
-        actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
+        runId,
+        to: "REFUSED",
+        expectFrom: "VERIFYING",
+        actor: owner,
+        reason: journalReason,
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
       const receipt = receiptWithDeadlineExtensions(db, runId, {
         runId,
@@ -1197,10 +1636,24 @@ export async function executeClaimed(db, registry, adapters, claim, {
         `INSERT INTO results (run_id, attempt, result_json, artifact_hash, evidence_set_hash, verification_json, receipt_json, accepted_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
-        runId, attempt, canonicalJson(result), "none", null,
-        canonicalJson(result.verification), canonicalJson(receipt), iso(currentNow),
+        runId,
+        attempt,
+        canonicalJson(result),
+        "none",
+        null,
+        canonicalJson(result.verification),
+        canonicalJson(receipt),
+        iso(currentNow),
       );
-      finishAttempt(db, runId, attempt, "REFUSED", reasonCode, currentNow, attemptUsage);
+      finishAttempt(
+        db,
+        runId,
+        attempt,
+        "REFUSED",
+        reasonCode,
+        currentNow,
+        attemptUsage,
+      );
       return { ok: true, receipt };
     });
 
@@ -1208,15 +1661,28 @@ export async function executeClaimed(db, registry, adapters, claim, {
     const started = txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
-        recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+        recordFencedAttempt(db, {
+          runId,
+          attempt,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+        });
         return { fenced: true };
       }
       transition(db, {
-        runId, to: "RUNNING", expectFrom: "LEASED",
-        actor: owner, reason: "started", attempt, policyVersion, now: currentNow,
+        runId,
+        to: "RUNNING",
+        expectFrom: "LEASED",
+        actor: owner,
+        reason: "started",
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
-      db.query(`UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`)
-        .run(iso(currentNow), runId, attempt);
+      db.query(
+        `UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`,
+      ).run(iso(currentNow), runId, attempt);
       return { ok: true };
     });
     if (started?.fenced) {
@@ -1225,7 +1691,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     if (isWorktree && repoName && ticketId) {
       if (!linearConfigured) {
-        const res = failTerminal("FAILED", "linear_unconfigured", "linear_unconfigured");
+        const res = failTerminal(
+          "FAILED",
+          "linear_unconfigured",
+          "linear_unconfigured",
+        );
         stopCancellationMonitor();
         if (res?.fenced) return { fenced: true };
         return {
@@ -1236,11 +1706,22 @@ export async function executeClaimed(db, registry, adapters, claim, {
         };
       }
 
-      const lockAcquired = acquireClaimLock(lockFile, { pid: process.pid, now: nowFn(), isAlive: isAliveFn });
+      const lockAcquired = acquireClaimLock(lockFile, {
+        pid: process.pid,
+        now: nowFn(),
+        isAlive: isAliveFn,
+      });
       if (!lockAcquired) {
         const deferred = deferClaimLockContention(db, {
-          runId, attempt, fencingToken, owner, policyVersion, now: nowFn,
-          maxRequeues: Number.isInteger(dispatchOpts?.maxClaimLockContentionRequeues)
+          runId,
+          attempt,
+          fencingToken,
+          owner,
+          policyVersion,
+          now: nowFn,
+          maxRequeues: Number.isInteger(
+            dispatchOpts?.maxClaimLockContentionRequeues,
+          )
             ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
             : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
           random: dispatchOpts?.random ?? Math.random,
@@ -1252,20 +1733,36 @@ export async function executeClaimed(db, registry, adapters, claim, {
         if (deferred?.requeued) {
           stopCancellationMonitor();
           return {
-            runId, attempt, terminalState: "QUEUED", reasonCode: "claim_lock_contention",
+            runId,
+            attempt,
+            terminalState: "QUEUED",
+            reasonCode: "claim_lock_contention",
             requeueAfterMs: deferred.backoffMs,
           };
         }
-        const res = refuseTerminal("claim_lock_starvation", ["dispatch_claim_lock"]);
+        const res = refuseTerminal("claim_lock_starvation", [
+          "dispatch_claim_lock",
+        ]);
         stopCancellationMonitor();
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode: "claim_lock_starvation", receipt: res?.receipt };
+        return {
+          runId,
+          attempt,
+          terminalState: "REFUSED",
+          reasonCode: "claim_lock_starvation",
+          receipt: res?.receipt,
+        };
       }
 
       const deferTransientGate = (reasonCode) => {
         releaseClaimLock(lockFile);
         const deferred = deferTransientDispatchGate(db, {
-          runId, attempt, fencingToken, owner, policyVersion, now: nowFn,
+          runId,
+          attempt,
+          fencingToken,
+          owner,
+          policyVersion,
+          now: nowFn,
           reasonCode,
           maxRequeues: Number.isInteger(dispatchOpts?.maxTransientGateRequeues)
             ? Math.max(0, dispatchOpts.maxTransientGateRequeues)
@@ -1275,13 +1772,25 @@ export async function executeClaimed(db, registry, adapters, claim, {
         if (deferred?.fenced) return { fenced: true };
         if (deferred?.requeued) {
           return {
-            runId, attempt, terminalState: "QUEUED", reasonCode,
+            runId,
+            attempt,
+            terminalState: "QUEUED",
+            reasonCode,
             requeueAfterMs: deferred.backoffMs,
           };
         }
-        const res = refuseTerminal(reasonCode, ["dispatch_gate", "transient_retry_exhausted"]);
+        const res = refuseTerminal(reasonCode, [
+          "dispatch_gate",
+          "transient_retry_exhausted",
+        ]);
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
+        return {
+          runId,
+          attempt,
+          terminalState: "REFUSED",
+          reasonCode,
+          receipt: res?.receipt,
+        };
       };
 
       // WM-469 de-hardcoded the merge-fix role from the kernel: the definition
@@ -1290,27 +1799,41 @@ export async function executeClaimed(db, registry, adapters, claim, {
       // planner and worker keyed off the SAME declarative field — a legacy
       // `gate` value is still honoured so an older pinned spec cannot silently
       // fall through to the dispatch claim gate and refuse with ticket_assigned.
-      const gate = def?.dispatchGateExempt === true ? "merge-fix" : (def?.gate ?? "dispatch");
+      const gate =
+        def?.dispatchGateExempt === true
+          ? "merge-fix"
+          : (def?.gate ?? "dispatch");
       if (!["dispatch", "merge-fix"].includes(gate)) {
         releaseClaimLock(lockFile);
         const reasonCode = "worktree_gate_unknown";
         const res = refuseTerminal(reasonCode, ["worktree_gate"]);
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
+        return {
+          runId,
+          attempt,
+          terminalState: "REFUSED",
+          reasonCode,
+          receipt: res?.receipt,
+        };
       }
 
       let gateResult;
       try {
         if (gate === "merge-fix") {
-          const fetchNonTerminalRuns = dispatchOpts?.fetchNonTerminalRuns ?? (() => db.query(
-            `SELECT run_id AS runId, state
+          const fetchNonTerminalRuns =
+            dispatchOpts?.fetchNonTerminalRuns ??
+            (() =>
+              db
+                .query(
+                  `SELECT run_id AS runId, state
                FROM runs
               WHERE run_id <> ?
                 AND state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
                 AND json_extract(spec_json, '$.input.repo') = ?
                 AND json_extract(spec_json, '$.input.ticket') = ?
               ORDER BY created_at, run_id`,
-          ).all(runId, repoName, ticketId));
+                )
+                .all(runId, repoName, ticketId));
           gateResult = worktreeMergeFixEligibility(spec.input, {
             fetchTicket: dispatchOpts?.fetchTicket,
             fetchPullRequest: dispatchOpts?.fetchPullRequest,
@@ -1324,7 +1847,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
           });
         }
       } catch (err) {
-        if (gate === "dispatch" && hasPlanTimeDispatchEvidence(spec) && String(err?.message ?? err).startsWith("linear_read_failed:")) {
+        if (
+          gate === "dispatch" &&
+          hasPlanTimeDispatchEvidence(spec) &&
+          String(err?.message ?? err).startsWith("linear_read_failed:")
+        ) {
           return deferTransientGate("linear_read_failed");
         }
         releaseClaimLock(lockFile);
@@ -1341,9 +1868,17 @@ export async function executeClaimed(db, registry, adapters, claim, {
           return deferTransientGate("owned_paths_unknown");
         }
         releaseClaimLock(lockFile);
-        const res = refuseTerminal(gateRefusal.reason, [`${gate}_gate`], { detail: gateRefusal.detail });
+        const res = refuseTerminal(gateRefusal.reason, [`${gate}_gate`], {
+          detail: gateRefusal.detail,
+        });
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode: gateRefusal.reason, receipt: res?.receipt };
+        return {
+          runId,
+          attempt,
+          terminalState: "REFUSED",
+          reasonCode: gateRefusal.reason,
+          receipt: res?.receipt,
+        };
       }
 
       if (gate === "merge-fix") {
@@ -1356,11 +1891,16 @@ export async function executeClaimed(db, registry, adapters, claim, {
         // claim. Do not run the mutating claim command again: besides being
         // redundant, that could steal the ticket if ownership changed in the
         // narrow interval after the gate read.
-        const resumedClaim = gateResult.evidence?.checks?.ticket_claim_retry === true;
+        const resumedClaim =
+          gateResult.evidence?.checks?.ticket_claim_retry === true;
         if (!resumedClaim) {
           let claimRes;
           try {
-            claimRes = await claimTicketFn({ repo: repoName, ticket: ticketId, harness: spec.adapter ?? "claude" });
+            claimRes = await claimTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              harness: spec.adapter ?? "claude",
+            });
           } finally {
             releaseClaimLock(lockFile);
           }
@@ -1369,18 +1909,39 @@ export async function executeClaimed(db, registry, adapters, claim, {
             const reasonCode = claimRes?.reasonCode || "ticket_claim_lost";
             const res = refuseTerminal(reasonCode, ["dispatch_claim"]);
             if (res?.fenced) return { fenced: true };
-            return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
+            return {
+              runId,
+              attempt,
+              terminalState: "REFUSED",
+              reasonCode,
+              receipt: res?.receipt,
+            };
           }
         } else {
           releaseClaimLock(lockFile);
         }
 
         ticketClaimed = true;
-        writeWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, pid: process.pid, dir: leasesDir, now: nowFn() });
+        writeWorkerLease({
+          repo: repoName,
+          ticket: ticketId,
+          owner: ticketLeaseOwner,
+          pid: process.pid,
+          dir: leasesDir,
+          now: nowFn(),
+        });
         leaseHeartbeat = setInterval(() => {
           try {
-            renewWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, dir: leasesDir, now: Date.now() });
-          } catch { /* intentionally ignored */ }
+            renewWorkerLease({
+              repo: repoName,
+              ticket: ticketId,
+              owner: ticketLeaseOwner,
+              dir: leasesDir,
+              now: Date.now(),
+            });
+          } catch {
+            /* intentionally ignored */
+          }
         }, LEASE_HEARTBEAT_MS);
         leaseHeartbeat?.unref?.();
       }
@@ -1388,30 +1949,51 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     const adapterKey = adapterOverride ?? spec.adapter;
     const created = createWorkspace({
-      root: workspacesRoot, runId, attempt, input: spec.input, workspace: spec.workspace,
-      artifactStore, adapter: adapterKey,
+      root: workspacesRoot,
+      runId,
+      attempt,
+      input: spec.input,
+      workspace: spec.workspace,
+      artifactStore,
+      adapter: adapterKey,
     });
     workspaceDir = created.dir;
     checkoutPath = created.checkout?.path ?? null;
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
     worktreeRecord = created.worktree ?? null;
-    db.query(`UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`)
-      .run(workspaceDir, runId, attempt);
+    db.query(
+      `UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`,
+    ).run(workspaceDir, runId, attempt);
 
     const adapter = adapters[adapterKey];
     if (!adapter) {
       const res = failTerminal("FAILED", "unknown_adapter", "unknown_adapter");
       cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "FAILED", reasonCode: "unknown_adapter" };
+      return {
+        runId,
+        attempt,
+        terminalState: "FAILED",
+        reasonCode: "unknown_adapter",
+      };
     }
     if (!def) def = getAgent(registry, spec.agent);
 
     if (!verifyDefHash(spec, def)) {
-      const refusedRes = refuseTerminal("agent_definition_mismatch", ["def_hash_mismatch"], { causeTyped: true });
+      const refusedRes = refuseTerminal(
+        "agent_definition_mismatch",
+        ["def_hash_mismatch"],
+        { causeTyped: true },
+      );
       cleanupWorkspace();
       if (refusedRes?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "REFUSED", reasonCode: "agent_definition_mismatch", receipt: refusedRes.receipt };
+      return {
+        runId,
+        attempt,
+        terminalState: "REFUSED",
+        reasonCode: "agent_definition_mismatch",
+        receipt: refusedRes.receipt,
+      };
     }
 
     // Live trace (factory.trace/v1): the recorder is already defensive, but
@@ -1454,14 +2036,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
           `UPDATE attempts SET lease_expires_at = ?
             WHERE run_id = ? AND attempt = ? AND fencing_token = ?
               AND (lease_expires_at IS NULL OR lease_expires_at < ?)`,
-        ).run(
-          leaseExpiresAt,
-          runId,
-          attempt,
-          fencingToken,
-          leaseExpiresAt,
-        );
-      } catch { /* intentionally ignored */ }
+        ).run(leaseExpiresAt, runId, attempt, fencingToken, leaseExpiresAt);
+      } catch {
+        /* intentionally ignored */
+      }
       if (deadlineTimer) clearTimeout(deadlineTimer);
       const leftMs = deadlineMs - logicalNow();
       if (leftMs <= 0) {
@@ -1476,7 +2054,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
           return;
         }
         if (Number.isFinite(expiry.deadlineMs)) {
-          deadlineTimer = setTimeout(refreshDeadline, Math.max(1, expiry.deadlineMs - logicalNow()));
+          deadlineTimer = setTimeout(
+            refreshDeadline,
+            Math.max(1, expiry.deadlineMs - logicalNow()),
+          );
           deadlineTimer.unref?.();
         }
         return;
@@ -1500,7 +2081,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
         spec,
         def,
         workspaceDir,
-        timeoutMs: adapterExecuteTimeoutMs({ adapterKey, spec, maxRunMinutes: policyMaxRunMinutes(policyRoot) }),
+        timeoutMs: adapterExecuteTimeoutMs({
+          adapterKey,
+          spec,
+          maxRunMinutes: policyMaxRunMinutes(policyRoot),
+        }),
         env,
         onTrace,
         onUsage,
@@ -1513,22 +2098,46 @@ export async function executeClaimed(db, registry, adapters, claim, {
       stopCancellationMonitor();
     }
 
-    if (outcome?.usage) attemptUsage = { adapter: adapterKey, ...outcome.usage };
+    if (outcome?.usage)
+      attemptUsage = { adapter: adapterKey, ...outcome.usage };
     if (deadlineExpired) outcome = { ...(outcome ?? {}), timedOut: true };
 
     if (abortController.signal.aborted && !deadlineExpired) {
       if (mayMutateClaimedTicket()) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "cancelled", log: null }); } catch { /* intentionally ignored */ }
+        try {
+          unclaimTicketFn({
+            repo: repoName,
+            ticket: ticketId,
+            why: "cancelled",
+            log: null,
+          });
+        } catch {
+          /* intentionally ignored */
+        }
       }
       cleanupWorkspace();
       const res = txImmediate(db, () => {
         const currentNow = nowFn();
         if (!assertCurrentToken(db, runId, fencingToken)) {
-          recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+          recordFencedAttempt(db, {
+            runId,
+            attempt,
+            actor: owner,
+            policyVersion,
+            now: currentNow,
+          });
           return { fenced: true };
         }
         try {
-          finishAttempt(db, runId, attempt, "CANCELLED", "cancelled", currentNow, attemptUsage);
+          finishAttempt(
+            db,
+            runId,
+            attempt,
+            "CANCELLED",
+            "cancelled",
+            currentNow,
+            attemptUsage,
+          );
         } catch {
           // ignore
         }
@@ -1548,8 +2157,13 @@ export async function executeClaimed(db, registry, adapters, claim, {
       // transition below. The normal verifier then runs again in full.
       try {
         verifyResult({
-          spec, def, registry, workspaceDir, attempt,
-          extraArtifacts: RUNTIME_ARTIFACTS, worktreeRecord: {},
+          spec,
+          def,
+          registry,
+          workspaceDir,
+          attempt,
+          extraArtifacts: RUNTIME_ARTIFACTS,
+          worktreeRecord: {},
         });
         lateCompletion = true;
       } catch (err) {
@@ -1558,18 +2172,41 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
       if (!lateCompletion) {
         if (mayMutateClaimedTicket()) {
-          try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "timeout", log: null }); } catch { /* intentionally ignored */ }
+          try {
+            unclaimTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              why: "timeout",
+              log: null,
+            });
+          } catch {
+            /* intentionally ignored */
+          }
         }
         const res = failTerminal("TIMED_OUT", "timeout", "timeout");
         cleanupWorkspace({ retainWorkspace: retain });
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "TIMED_OUT", reasonCode: "timeout" };
+        return {
+          runId,
+          attempt,
+          terminalState: "TIMED_OUT",
+          reasonCode: "timeout",
+        };
       }
     }
     const denial = policyDenials[0];
     if (!lateCompletion && denial) {
       if (mayMutateClaimedTicket()) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `policy_denied:${denial.tool}`, log: null }); } catch { /* intentionally ignored */ }
+        try {
+          unclaimTicketFn({
+            repo: repoName,
+            ticket: ticketId,
+            why: `policy_denied:${denial.tool}`,
+            log: null,
+          });
+        } catch {
+          /* intentionally ignored */
+        }
       }
       const reasonCode = `policy_denied:${denial.tool}`;
       const res = failTerminal("FAILED", reasonCode, reasonCode);
@@ -1579,7 +2216,16 @@ export async function executeClaimed(db, registry, adapters, claim, {
     }
     if (!lateCompletion && exitCode !== 0) {
       if (mayMutateClaimedTicket()) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `agent_exit_${exitCode}`, log: null }); } catch { /* intentionally ignored */ }
+        try {
+          unclaimTicketFn({
+            repo: repoName,
+            ticket: ticketId,
+            why: `agent_exit_${exitCode}`,
+            log: null,
+          });
+        } catch {
+          /* intentionally ignored */
+        }
       }
       const reasonCode = `agent_exit_${exitCode}`;
       const res = failTerminal("FAILED", reasonCode, reasonCode);
@@ -1591,7 +2237,13 @@ export async function executeClaimed(db, registry, adapters, claim, {
     // The settings policy is preventative; this is the independent, durable
     // check before a repository-read run's output can be accepted or emitted.
     // Mutating worktree workspaces are exempt.
-    if (!isWorktree && !def.mutating && checkoutPath && (checkoutBaseline === null || repositoryStatus(checkoutPath) !== checkoutBaseline)) {
+    if (
+      !isWorktree &&
+      !def.mutating &&
+      checkoutPath &&
+      (checkoutBaseline === null ||
+        repositoryStatus(checkoutPath) !== checkoutBaseline)
+    ) {
       const reasonCode = "workspace_integrity_violation";
       const res = failTerminal("FAILED", reasonCode, reasonCode);
       cleanupWorkspace({ retainWorkspace: true });
@@ -1602,13 +2254,24 @@ export async function executeClaimed(db, registry, adapters, claim, {
     const toVerifying = txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
-        recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+        recordFencedAttempt(db, {
+          runId,
+          attempt,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+        });
         return { fenced: true };
       }
       transition(db, {
-        runId, to: "VERIFYING", expectFrom: "RUNNING",
-        actor: owner, reason: lateCompletion ? "late_completion_after_timeout" : "exit_0",
-        attempt, policyVersion, now: currentNow,
+        runId,
+        to: "VERIFYING",
+        expectFrom: "RUNNING",
+        actor: owner,
+        reason: lateCompletion ? "late_completion_after_timeout" : "exit_0",
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
       return { ok: true };
     });
@@ -1620,11 +2283,20 @@ export async function executeClaimed(db, registry, adapters, claim, {
     let verified;
     try {
       verified = verifyResult({
-        spec, def, registry, workspaceDir, attempt, extraArtifacts: RUNTIME_ARTIFACTS, worktreeRecord,
+        spec,
+        def,
+        registry,
+        workspaceDir,
+        attempt,
+        extraArtifacts: RUNTIME_ARTIFACTS,
+        worktreeRecord,
       });
     } catch (err) {
       if (!(err instanceof ContractViolation)) throw err;
-      const reasonCode = err.reasonCode === "baseline_red" ? "baseline_red" : "contract_violation";
+      const reasonCode =
+        err.reasonCode === "baseline_red"
+          ? "baseline_red"
+          : "contract_violation";
       const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
       if (mayMutateClaimedTicket()) {
         if (reasonCode === "baseline_red") {
@@ -1636,9 +2308,20 @@ export async function executeClaimed(db, registry, adapters, claim, {
               log: null,
               baseline: worktreeRecord?.baseline,
             });
-          } catch { /* intentionally ignored */ }
+          } catch {
+            /* intentionally ignored */
+          }
         } else {
-          try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: failureReason, log: null }); } catch { /* intentionally ignored */ }
+          try {
+            unclaimTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              why: failureReason,
+              log: null,
+            });
+          } catch {
+            /* intentionally ignored */
+          }
         }
       }
       // Invalid output is a typed contract failure and emits no completion
@@ -1648,20 +2331,45 @@ export async function executeClaimed(db, registry, adapters, claim, {
       const res = txImmediate(db, () => {
         const currentNow = nowFn();
         if (!assertCurrentToken(db, runId, fencingToken)) {
-          recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+          recordFencedAttempt(db, {
+            runId,
+            attempt,
+            actor: owner,
+            policyVersion,
+            now: currentNow,
+          });
           return { fenced: true };
         }
         transition(db, {
-          runId, to: "FAILED", expectFrom: "VERIFYING",
-          actor: owner, reason: typedFailureReason(reasonCode, failureReason),
-          attempt, policyVersion, now: currentNow,
+          runId,
+          to: "FAILED",
+          expectFrom: "VERIFYING",
+          actor: owner,
+          reason: typedFailureReason(reasonCode, failureReason),
+          attempt,
+          policyVersion,
+          now: currentNow,
         });
-        finishAttempt(db, runId, attempt, "FAILED", reasonCode, currentNow, attemptUsage);
+        finishAttempt(
+          db,
+          runId,
+          attempt,
+          "FAILED",
+          reasonCode,
+          currentNow,
+          attemptUsage,
+        );
         const decision = retryDecision(db, runId, spec, reasonCode);
         if (decision.retry) {
           transition(db, {
-            runId, to: "QUEUED", expectFrom: "FAILED",
-            actor: owner, reason: `retry:${decision.cause}`, attempt, policyVersion, now: nowFn(),
+            runId,
+            to: "QUEUED",
+            expectFrom: "FAILED",
+            actor: owner,
+            reason: `retry:${decision.cause}`,
+            attempt,
+            policyVersion,
+            now: nowFn(),
           });
         }
         return { ok: true };
@@ -1673,7 +2381,16 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     if (verified.kind === "refused") {
       if (mayMutateClaimedTicket()) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `refused: ${verified.reasonCode}`, log: null }); } catch { /* intentionally ignored */ }
+        try {
+          unclaimTicketFn({
+            repo: repoName,
+            ticket: ticketId,
+            why: `refused: ${verified.reasonCode}`,
+            log: null,
+          });
+        } catch {
+          /* intentionally ignored */
+        }
       }
       const collected = [];
       for (const entry of RUNTIME_ARTIFACTS) {
@@ -1685,10 +2402,17 @@ export async function executeClaimed(db, registry, adapters, claim, {
           continue;
         }
         if (existsSync(abs)) {
-          collected.push({ kind: entry.kind, uri: `file://${abs}`, sha256: sha256Hex(readFileSync(abs)) });
+          collected.push({
+            kind: entry.kind,
+            uri: `file://${abs}`,
+            sha256: sha256Hex(readFileSync(abs)),
+          });
         }
       }
-      const artifacts = storeCollected({ entries: collected, storeRoot: artifactStore });
+      const artifacts = storeCollected({
+        entries: collected,
+        storeRoot: artifactStore,
+      });
       const refusedResult = {
         ...verified.result,
         artifacts,
@@ -1699,12 +2423,24 @@ export async function executeClaimed(db, registry, adapters, claim, {
       const res = txImmediate(db, () => {
         const currentNow = nowFn();
         if (!assertCurrentToken(db, runId, fencingToken)) {
-          recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+          recordFencedAttempt(db, {
+            runId,
+            attempt,
+            actor: owner,
+            policyVersion,
+            now: currentNow,
+          });
           return { fenced: true };
         }
         transition(db, {
-          runId, to: "REFUSED", expectFrom: "VERIFYING",
-          actor: owner, reason: verified.reasonCode, attempt, policyVersion, now: currentNow,
+          runId,
+          to: "REFUSED",
+          expectFrom: "VERIFYING",
+          actor: owner,
+          reason: verified.reasonCode,
+          attempt,
+          policyVersion,
+          now: currentNow,
         });
         const receipt = receiptWithDeadlineExtensions(db, runId, {
           runId,
@@ -1719,8 +2455,14 @@ export async function executeClaimed(db, registry, adapters, claim, {
           `INSERT INTO results (run_id, attempt, result_json, artifact_hash, evidence_set_hash, verification_json, receipt_json, accepted_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         ).run(
-          runId, attempt, canonicalJson(refusedResult), "none", null,
-          canonicalJson(refusedResult.verification), canonicalJson(receipt), iso(currentNow),
+          runId,
+          attempt,
+          canonicalJson(refusedResult),
+          "none",
+          null,
+          canonicalJson(refusedResult.verification),
+          canonicalJson(receipt),
+          iso(currentNow),
         );
         // Best-effort projection: the inbox row must never un-record the
         // terminal REFUSED state or its result row by throwing out of this tx.
@@ -1731,25 +2473,48 @@ export async function executeClaimed(db, registry, adapters, claim, {
             `[worker] refusal inbox item not created for ${runId}: ${err?.message ?? err}`,
           );
         }
-        finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow, attemptUsage);
+        finishAttempt(
+          db,
+          runId,
+          attempt,
+          "REFUSED",
+          verified.reasonCode,
+          currentNow,
+          attemptUsage,
+        );
         return { ok: true, receipt };
       });
       cleanupWorkspace();
       if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "REFUSED", reasonCode: verified.reasonCode, receipt: res.receipt };
+      return {
+        runId,
+        attempt,
+        terminalState: "REFUSED",
+        reasonCode: verified.reasonCode,
+        receipt: res.receipt,
+      };
     }
 
     // Copy verified artifact files into the durable content-addressed store
     // (§7) BEFORE the workspace dies and before the row referencing them
     // commits. Orphans from a failed commit are harmless; dead links are not.
-    verified.result.artifacts = storeCollected({ entries: verified.result.artifacts, storeRoot: artifactStore });
+    verified.result.artifacts = storeCollected({
+      entries: verified.result.artifacts,
+      storeRoot: artifactStore,
+    });
 
     // Completed: fencing check, result, receipt, outbox event, and the
     // COMPLETED transition are one transaction.
     const published = txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
-        recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+        recordFencedAttempt(db, {
+          runId,
+          attempt,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+        });
         return { fenced: true };
       }
 
@@ -1768,30 +2533,59 @@ export async function executeClaimed(db, registry, adapters, claim, {
         `INSERT INTO results (run_id, attempt, result_json, artifact_hash, evidence_set_hash, verification_json, receipt_json, accepted_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
-        runId, attempt, canonicalJson(result), result.artifactHash, result.evidenceSetHash,
-        canonicalJson(result.verification), canonicalJson(receipt), iso(currentNow),
+        runId,
+        attempt,
+        canonicalJson(result),
+        result.artifactHash,
+        result.evidenceSetHash,
+        canonicalJson(result.verification),
+        canonicalJson(receipt),
+        iso(currentNow),
       );
 
       const origin = originatingEvent(db, runId);
       const envelope = {
         schemaVersion: "factory.event/v1",
         eventId: `event-runtime:${runId}:${attempt}`,
-        type: origin ? origin.type.replace(/\.requested$/, ".completed") : "factory.run.completed",
+        type: origin
+          ? origin.type.replace(/\.requested$/, ".completed")
+          : "factory.run.completed",
         source: "event-runtime",
         subject: spec.agent,
         occurredAt: iso(currentNow),
         correlationId: origin?.correlation_id ?? null,
         causationId: origin?.causation_id ?? null,
-        payload: { runId, attempt, artifactHash: result.artifactHash, outputContract: spec.outputContract },
+        payload: {
+          runId,
+          attempt,
+          artifactHash: result.artifactHash,
+          outputContract: spec.outputContract,
+        },
       };
-      db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`)
-        .run(canonicalJson(envelope), iso(currentNow));
+      db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`).run(
+        canonicalJson(envelope),
+        iso(currentNow),
+      );
 
       transition(db, {
-        runId, to: "COMPLETED", expectFrom: "VERIFYING",
-        actor: owner, reason: "ok", attempt, policyVersion, now: currentNow,
+        runId,
+        to: "COMPLETED",
+        expectFrom: "VERIFYING",
+        actor: owner,
+        reason: "ok",
+        attempt,
+        policyVersion,
+        now: currentNow,
       });
-      finishAttempt(db, runId, attempt, "COMPLETED", "ok", currentNow, attemptUsage);
+      finishAttempt(
+        db,
+        runId,
+        attempt,
+        "COMPLETED",
+        "ok",
+        currentNow,
+        attemptUsage,
+      );
       return { receipt };
     });
 
@@ -1800,21 +2594,44 @@ export async function executeClaimed(db, registry, adapters, claim, {
       return { fenced: true };
     }
     cleanupWorkspace();
-    return { runId, attempt, terminalState: "COMPLETED", reasonCode: "ok", receipt: published.receipt };
+    return {
+      runId,
+      attempt,
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+      receipt: published.receipt,
+    };
   } catch (err) {
     if (mayMutateClaimedTicket()) {
-      try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: err?.message ?? String(err), log: null }); } catch { /* intentionally ignored */ }
+      try {
+        unclaimTicketFn({
+          repo: repoName,
+          ticket: ticketId,
+          why: err?.message ?? String(err),
+          log: null,
+        });
+      } catch {
+        /* intentionally ignored */
+      }
     }
     if (err instanceof IllegalTransition) {
       // Operator moved the run under us (cancel) — stop quietly, publish nothing.
       cleanupWorkspace();
-      const state = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
+      const state = db
+        .query(`SELECT state FROM runs WHERE run_id = ?`)
+        .get(runId)?.state;
       if (state === "CANCELLED") {
         return { cancelled: true };
       }
       if (!assertCurrentToken(db, runId, fencingToken)) {
         txImmediate(db, () => {
-          recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now });
+          recordFencedAttempt(db, {
+            runId,
+            attempt,
+            actor: owner,
+            policyVersion,
+            now,
+          });
         });
         return { fenced: true };
       }
@@ -1826,7 +2643,8 @@ export async function executeClaimed(db, registry, adapters, claim, {
     // lib/adapters/pi.mjs's CliNotFoundError) before ever spawning a child.
     // No `requeue`: retrying on the same worker just fails the same way.
     const isCliNotFound = err?.code === "cli_not_found";
-    const isWorkspaceProvisioning = err?.code === "workspace_provisioning_error";
+    const isWorkspaceProvisioning =
+      err?.code === "workspace_provisioning_error";
     const reasonCode = isCliNotFound
       ? "cli_not_found"
       : isWorkspaceProvisioning
@@ -1841,12 +2659,27 @@ export async function executeClaimed(db, registry, adapters, claim, {
     }
     cleanupWorkspace({ retainWorkspace: retain });
     if (res?.fenced) return { fenced: true };
-    return { runId, attempt, terminalState: "FAILED", reasonCode, error: err?.message };
+    return {
+      runId,
+      attempt,
+      terminalState: "FAILED",
+      reasonCode,
+      error: err?.message,
+    };
   } finally {
     stopCancellationMonitor();
     if (leaseHeartbeat) clearInterval(leaseHeartbeat);
     if (ticketClaimed) {
-      try { releaseWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, dir: leasesDir }); } catch { /* intentionally ignored */ }
+      try {
+        releaseWorkerLease({
+          repo: repoName,
+          ticket: ticketId,
+          owner: ticketLeaseOwner,
+          dir: leasesDir,
+        });
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
 }
@@ -1859,64 +2692,117 @@ export async function executeClaimed(db, registry, adapters, claim, {
 export function releaseStalledWorkerLease(
   db,
   { workerId, runId },
-  { now = () => Date.now(), policyVersion = "unknown", actor = "operator" } = {},
+  {
+    now = () => Date.now(),
+    policyVersion = "unknown",
+    actor = "operator",
+  } = {},
 ) {
   const currentNow = resolveNow(now);
   return txImmediate(db, () => {
-    const worker = db.query(`SELECT state, current_run, last_seen FROM workers WHERE worker_id = ?`).get(workerId);
+    const worker = db
+      .query(
+        `SELECT state, current_run, last_seen FROM workers WHERE worker_id = ?`,
+      )
+      .get(workerId);
     if (!worker) throw new Error(`unknown worker ${workerId}`);
-    const stale = worker.state !== "stopped" && currentNow - Date.parse(worker.last_seen) > HEARTBEAT_STALE_MS;
-    if (!stale || !worker.current_run) throw new Error(`worker ${workerId} is not stalled with an active run`);
+    const stale =
+      worker.state !== "stopped" &&
+      currentNow - Date.parse(worker.last_seen) > HEARTBEAT_STALE_MS;
+    if (!stale || !worker.current_run)
+      throw new Error(`worker ${workerId} is not stalled with an active run`);
     if (runId && worker.current_run !== runId) {
-      throw new Error(`worker ${workerId} holds ${worker.current_run}, not ${runId}`);
+      throw new Error(
+        `worker ${workerId} holds ${worker.current_run}, not ${runId}`,
+      );
     }
 
     const heldRunId = worker.current_run;
-    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(heldRunId);
-    if (!run) throw new Error(`worker ${workerId} references unknown run ${heldRunId}`);
+    const run = db
+      .query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`)
+      .get(heldRunId);
+    if (!run)
+      throw new Error(`worker ${workerId} references unknown run ${heldRunId}`);
     if (!["LEASED", "RUNNING", "VERIFYING"].includes(run.state)) {
       throw new Error(`run ${heldRunId} is ${run.state}, not actively leased`);
     }
     const attempt = db
-      .query(`SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`)
+      .query(
+        `SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`,
+      )
       .get(heldRunId, run.attempts);
     if (!attempt) throw new Error(`run ${heldRunId} has no current attempt`);
     if (attempt.lease_owner && attempt.lease_owner !== workerId) {
-      throw new Error(`run ${heldRunId} is leased by ${attempt.lease_owner}, not ${workerId}`);
+      throw new Error(
+        `run ${heldRunId} is leased by ${attempt.lease_owner}, not ${workerId}`,
+      );
     }
 
     const spec = JSON.parse(run.spec_json);
     const reason = "operator_release_stalled_worker";
-    db.query(`UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`)
-      .run(iso(currentNow - 1), heldRunId, run.attempts);
+    db.query(
+      `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
+    ).run(iso(currentNow - 1), heldRunId, run.attempts);
     if (run.attempts < spec.maxAttempts) {
       if (run.state === "VERIFYING") {
         transition(db, {
-          runId: heldRunId, to: "FAILED", actor, reason,
-          attempt: run.attempts, policyVersion, now: currentNow,
+          runId: heldRunId,
+          to: "FAILED",
+          actor,
+          reason,
+          attempt: run.attempts,
+          policyVersion,
+          now: currentNow,
         });
         transition(db, {
-          runId: heldRunId, to: "QUEUED", actor, reason: "retry_after_stalled_worker_release",
-          attempt: run.attempts, policyVersion, now: currentNow,
+          runId: heldRunId,
+          to: "QUEUED",
+          actor,
+          reason: "retry_after_stalled_worker_release",
+          attempt: run.attempts,
+          policyVersion,
+          now: currentNow,
         });
       } else {
         transition(db, {
-          runId: heldRunId, to: "QUEUED", actor, reason,
-          attempt: run.attempts, policyVersion, now: currentNow,
+          runId: heldRunId,
+          to: "QUEUED",
+          actor,
+          reason,
+          attempt: run.attempts,
+          policyVersion,
+          now: currentNow,
         });
       }
     } else {
       if (run.state === "LEASED") {
         transition(db, {
-          runId: heldRunId, to: "RUNNING", actor, reason,
-          attempt: run.attempts, policyVersion, now: currentNow,
+          runId: heldRunId,
+          to: "RUNNING",
+          actor,
+          reason,
+          attempt: run.attempts,
+          policyVersion,
+          now: currentNow,
         });
       }
       transition(db, {
-        runId: heldRunId, to: "FAILED", actor, reason,
-        attempt: run.attempts, policyVersion, now: currentNow,
+        runId: heldRunId,
+        to: "FAILED",
+        actor,
+        reason,
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
       });
-      finishAttempt(db, heldRunId, run.attempts, "FAILED", "stalled_worker_released", currentNow);
+      finishAttempt(
+        db,
+        heldRunId,
+        run.attempts,
+        "FAILED",
+        "stalled_worker_released",
+        currentNow,
+      );
     }
     db.query(
       `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,
@@ -1930,7 +2816,10 @@ export function releaseStalledWorkerLease(
  * The stale attempt keeps its (now lower) fencing token, so a late publish from
  * it is fenced out. Lease loss spends only the dedicated environment budget.
  */
-export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = "unknown" } = {}) {
+export function reapExpiredLeases(
+  db,
+  { now = () => Date.now(), policyVersion = "unknown" } = {},
+) {
   const currentNow = resolveNow(now);
   return txImmediate(db, () => {
     const rows = db
@@ -1947,17 +2836,34 @@ export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = 
       // VERIFYING cannot transition directly to QUEUED; record its failure first.
       if (row.state === "VERIFYING") {
         transition(db, {
-          runId: row.run_id, to: "FAILED",
-          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
+          runId: row.run_id,
+          to: "FAILED",
+          actor: "reaper",
+          reason: failureReason,
+          attempt: row.attempts,
+          policyVersion,
+          now: currentNow,
         });
       }
-      finishAttempt(db, row.run_id, row.attempts, "FAILED", "lease_expired", currentNow);
+      finishAttempt(
+        db,
+        row.run_id,
+        row.attempts,
+        "FAILED",
+        "lease_expired",
+        currentNow,
+      );
       const decision = retryDecision(db, row.run_id, spec, "lease_expired");
 
       if (decision.retry) {
         transition(db, {
-          runId: row.run_id, to: "QUEUED",
-          actor: "reaper", reason: `retry:${decision.cause}`, attempt: row.attempts, policyVersion, now: currentNow,
+          runId: row.run_id,
+          to: "QUEUED",
+          actor: "reaper",
+          reason: `retry:${decision.cause}`,
+          attempt: row.attempts,
+          policyVersion,
+          now: currentNow,
         });
         continue;
       }
@@ -1966,14 +2872,24 @@ export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = 
       // the environment retry ceiling is exhausted and the run must terminate.
       if (row.state === "LEASED") {
         transition(db, {
-          runId: row.run_id, to: "RUNNING",
-          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
+          runId: row.run_id,
+          to: "RUNNING",
+          actor: "reaper",
+          reason: failureReason,
+          attempt: row.attempts,
+          policyVersion,
+          now: currentNow,
         });
       }
       if (row.state !== "VERIFYING") {
         transition(db, {
-          runId: row.run_id, to: "FAILED",
-          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
+          runId: row.run_id,
+          to: "FAILED",
+          actor: "reaper",
+          reason: failureReason,
+          attempt: row.attempts,
+          policyVersion,
+          now: currentNow,
         });
       }
     }
@@ -1993,22 +2909,57 @@ export async function runOnce(db, registry, adapters, opts = {}) {
  * For VERIFYING, transitions to FAILED with reason operator_cancel.
  * A still-open proposal for the run is closed in the same transaction.
  */
-export function cancelRun(db, runId, { actor, reason = "operator_cancel", now = () => Date.now(), policyVersion } = {}) {
+export function cancelRun(
+  db,
+  runId,
+  {
+    actor,
+    reason = "operator_cancel",
+    now = () => Date.now(),
+    policyVersion,
+  } = {},
+) {
   const currentNow = resolveNow(now);
   return txImmediate(db, () => {
-    const run = db.query(`SELECT state, attempts FROM runs WHERE run_id = ?`).get(runId);
+    const run = db
+      .query(`SELECT state, attempts FROM runs WHERE run_id = ?`)
+      .get(runId);
     if (!run) throw new Error(`unknown run ${runId}`);
     let result;
     if (run.state === "VERIFYING") {
-      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now: currentNow });
+      result = transition(db, {
+        runId,
+        to: "FAILED",
+        actor,
+        reason,
+        policyVersion,
+        now: currentNow,
+      });
       finishAttempt(db, runId, run.attempts, "FAILED", "cancelled", currentNow);
     } else {
-      result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now: currentNow });
+      result = transition(db, {
+        runId,
+        to: "CANCELLED",
+        actor,
+        reason,
+        policyVersion,
+        now: currentNow,
+      });
       if (run.state === "RUNNING" || run.state === "LEASED") {
-        finishAttempt(db, runId, run.attempts, "CANCELLED", "cancelled", currentNow);
+        finishAttempt(
+          db,
+          runId,
+          run.attempts,
+          "CANCELLED",
+          "cancelled",
+          currentNow,
+        );
       }
     }
-    const proposalClose = closeOpenProposalForRun(db, runId, { actor, now: currentNow });
+    const proposalClose = closeOpenProposalForRun(db, runId, {
+      actor,
+      now: currentNow,
+    });
     const active = ACTIVE_EXECUTIONS.get(runId);
     if (active) {
       active.abort(reason);
@@ -2020,21 +2971,65 @@ export function cancelRun(db, runId, { actor, reason = "operator_cancel", now = 
 /**
  * Force-fail a stranded or non-terminal run with a journaled transition.
  */
-export function forceFailRun(db, runId, { actor = "operator", reason = "operator_force_fail", now = () => Date.now(), policyVersion = "unknown" } = {}) {
+export function forceFailRun(
+  db,
+  runId,
+  {
+    actor = "operator",
+    reason = "operator_force_fail",
+    now = () => Date.now(),
+    policyVersion = "unknown",
+  } = {},
+) {
   const currentNow = resolveNow(now);
   return txImmediate(db, () => {
-    const run = db.query(`SELECT state, attempts FROM runs WHERE run_id = ?`).get(runId);
+    const run = db
+      .query(`SELECT state, attempts FROM runs WHERE run_id = ?`)
+      .get(runId);
     if (!run) throw new Error(`unknown run ${runId}`);
     let result;
     if (run.state === "VERIFYING" || run.state === "RUNNING") {
-      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now: currentNow });
+      result = transition(db, {
+        runId,
+        to: "FAILED",
+        actor,
+        reason,
+        policyVersion,
+        now: currentNow,
+      });
       finishAttempt(db, runId, run.attempts, "FAILED", reason, currentNow);
     } else if (run.state === "LEASED") {
-      transition(db, { runId, to: "RUNNING", actor, reason: "force_fail_start", attempt: run.attempts, policyVersion, now: currentNow });
-      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now: currentNow });
+      transition(db, {
+        runId,
+        to: "RUNNING",
+        actor,
+        reason: "force_fail_start",
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
+      });
+      result = transition(db, {
+        runId,
+        to: "FAILED",
+        actor,
+        reason,
+        policyVersion,
+        now: currentNow,
+      });
       finishAttempt(db, runId, run.attempts, "FAILED", reason, currentNow);
-    } else if (run.state === "QUEUED" || run.state === "APPROVED" || run.state === "PROPOSED") {
-      result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now: currentNow });
+    } else if (
+      run.state === "QUEUED" ||
+      run.state === "APPROVED" ||
+      run.state === "PROPOSED"
+    ) {
+      result = transition(db, {
+        runId,
+        to: "CANCELLED",
+        actor,
+        reason,
+        policyVersion,
+        now: currentNow,
+      });
     } else {
       throw new Error(`cannot force-fail run in terminal state ${run.state}`);
     }
@@ -2051,39 +3046,81 @@ export function forceFailRun(db, runId, { actor = "operator", reason = "operator
  * REFUSED is immutable in the lifecycle journal. Give the operator the exact
  * fresh watched-dispatch command instead of leaking an IllegalTransition.
  */
-export function retryRun(db, runId, { actor, force = false, now = () => Date.now(), policyVersion } = {}) {
+export function retryRun(
+  db,
+  runId,
+  { actor, force = false, now = () => Date.now(), policyVersion } = {},
+) {
   const currentNow = resolveNow(now);
-  const row = db.query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
+  const row = db
+    .query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`)
+    .get(runId);
   if (!row) throw new Error(`unknown run ${runId}`);
   const spec = JSON.parse(row.spec_json);
   if (row.state === "REFUSED") {
-    const reasonCode = db.query(
-      `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`,
-    ).get(runId)?.reason_code ?? "unknown_refusal";
-    const payload = JSON.stringify({ repo: spec.input?.repo, ticket: spec.input?.ticket });
+    const reasonCode =
+      db
+        .query(
+          `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`,
+        )
+        .get(runId)?.reason_code ?? "unknown_refusal";
+    const payload = JSON.stringify({
+      repo: spec.input?.repo,
+      ticket: spec.input?.ticket,
+    });
     const command = `factory dispatch event factory.dispatch.requested --payload '${payload}' --watch`;
-    const sensitive = ["ticket_security", "ticket_escalated", "escalate_paths_intersect"].includes(reasonCode);
+    const sensitive = [
+      "ticket_security",
+      "ticket_escalated",
+      "escalate_paths_intersect",
+    ].includes(reasonCode);
     throw new Error(
       `refused_run_not_retryable: ${runId} was refused by ${reasonCode}; ` +
-      `${sensitive ? "human review is required before a fresh watched dispatch; " : "submit a fresh watched dispatch with: "}` +
-      command,
+        `${sensitive ? "human review is required before a fresh watched dispatch; " : "submit a fresh watched dispatch with: "}` +
+        command,
     );
   }
-  if (!force && (failureCount(db, runId, "agent_error") >= spec.maxAttempts || failureCount(db, runId, "fatal") > 0)) {
+  if (
+    !force &&
+    (failureCount(db, runId, "agent_error") >= spec.maxAttempts ||
+      failureCount(db, runId, "fatal") > 0)
+  ) {
     throw new Error("attempts_exhausted");
   }
   if (row.state === "VERIFYING") {
     return txImmediate(db, () => {
-      transition(db, { runId, to: "FAILED", actor, reason: "operator_retry_verifying", policyVersion, now: currentNow });
-      finishAttempt(db, runId, row.attempts, "FAILED", "operator_retry", currentNow);
+      transition(db, {
+        runId,
+        to: "FAILED",
+        actor,
+        reason: "operator_retry_verifying",
+        policyVersion,
+        now: currentNow,
+      });
+      finishAttempt(
+        db,
+        runId,
+        row.attempts,
+        "FAILED",
+        "operator_retry",
+        currentNow,
+      );
       return transition(db, {
-        runId, to: "QUEUED", actor,
-        reason: force ? "operator_retry_forced" : "operator_retry", policyVersion, now: currentNow,
+        runId,
+        to: "QUEUED",
+        actor,
+        reason: force ? "operator_retry_forced" : "operator_retry",
+        policyVersion,
+        now: currentNow,
       });
     });
   }
   return transition(db, {
-    runId, to: "QUEUED", actor,
-    reason: force ? "operator_retry_forced" : "operator_retry", policyVersion, now: currentNow,
+    runId,
+    to: "QUEUED",
+    actor,
+    reason: force ? "operator_retry_forced" : "operator_retry",
+    policyVersion,
+    now: currentNow,
   });
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,10 +1,22 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { buildClaudeArgv, execute as executeClaude } from "./adapters/claude.mjs";
+import {
+  buildClaudeArgv,
+  execute as executeClaude,
+} from "./adapters/claude.mjs";
 import * as fake from "./adapters/fake.mjs";
 import { buildPiArgv, execute as executePi } from "./adapters/pi.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
@@ -13,19 +25,56 @@ import { planEvent } from "./planner.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { openDb, runUsage } from "./db.mjs";
-import { createRun, lifecycleOf, runState, transition, IllegalTransition } from "./lifecycle.mjs";
+import {
+  createRun,
+  lifecycleOf,
+  runState,
+  transition,
+  IllegalTransition,
+} from "./lifecycle.mjs";
 import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import { transcriptSessionId } from "./transcripts.mjs";
 import {
-  acquireClaimLock, adapterExecuteTimeoutMs, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
-  createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath, DYNAMIC_DEADLINE_ADAPTERS,
-  executeClaimed, classifyFailureCause, expireRunDeadline, extendRunDeadline, LEASE_GRACE_SECONDS, policyMaxRunMinutes,
-  reapExpiredLeases, releaseClaimLock, repositoryIsClean,
-  repositoryStatus, resolveLinearApiKey, retryRun, runLinearCli, runOnce,
+  acquireClaimLock,
+  adapterExecuteTimeoutMs,
+  cancelRun,
+  claimNext,
+  CODE_RELOAD_EXIT,
+  codeStamp,
+  codeStampFiles,
+  codeStampRoot,
+  createReloadWatcher,
+  DEFAULT_MAX_ENVIRONMENT_RETRIES,
+  defaultLocksDir,
+  dispatchLockPath,
+  DYNAMIC_DEADLINE_ADAPTERS,
+  executeClaimed,
+  classifyFailureCause,
+  expireRunDeadline,
+  extendRunDeadline,
+  LEASE_GRACE_SECONDS,
+  policyMaxRunMinutes,
+  reapExpiredLeases,
+  releaseClaimLock,
+  repositoryIsClean,
+  repositoryStatus,
+  resolveLinearApiKey,
+  retryRun,
+  runLinearCli,
+  runOnce,
 } from "./worker.mjs";
-import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
-import { cleanupTrackedProcesses, processOwnerWatchdogSource, trackMarkedFakeRuntimeGroups, trackProcess, trackProcessGroupsMatching } from "./test-helpers-process.mjs";
+import {
+  liveWorkerLeases,
+  writeWorkerLease,
+} from "../../lib/worker-leases.mjs";
+import {
+  cleanupTrackedProcesses,
+  processOwnerWatchdogSource,
+  trackMarkedFakeRuntimeGroups,
+  trackProcess,
+  trackProcessGroupsMatching,
+} from "./test-helpers-process.mjs";
 
 const registry = loadRegistry();
 const adapters = { fake };
@@ -33,7 +82,9 @@ const T0 = Date.parse("2026-08-12T10:00:00Z");
 
 let seq = 0;
 function makeSpec(overrides = {}) {
-  const runId = overrides.runId ?? `run_worker_${++seq}_${Math.random().toString(36).slice(2)}`;
+  const runId =
+    overrides.runId ??
+    `run_worker_${++seq}_${Math.random().toString(36).slice(2)}`;
   const input = overrides.input ?? { repos: ["ok"] };
   return {
     schemaVersion: "factory.run-spec/v1",
@@ -56,9 +107,14 @@ function makeSpec(overrides = {}) {
 
 function queueRun(db, spec, now = T0) {
   createRun(db, {
-    runId: spec.runId, idempotencyKey: spec.idempotencyKey,
-    spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
-    actor: "test", policyVersion: "test", now,
+    runId: spec.runId,
+    idempotencyKey: spec.idempotencyKey,
+    spec,
+    specJson: canonicalJson(spec),
+    specHash: hashJson(spec),
+    actor: "test",
+    policyVersion: "test",
+    now,
   });
   transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now });
   transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now });
@@ -66,12 +122,28 @@ function queueRun(db, spec, now = T0) {
 }
 
 /** Link the run to an admitted event via a proposal, like the planner would. */
-function linkEvent(db, runId, { type = "factory.status-report.requested", correlationId = "corr-1" } = {}) {
+function linkEvent(
+  db,
+  runId,
+  { type = "factory.status-report.requested", correlationId = "corr-1" } = {},
+) {
   const at = new Date(T0).toISOString();
   db.query(
     `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at, correlation_id, causation_id, envelope_json, payload_hash, admitted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run("test", `evt-${runId}`, type, "factory", at, at, correlationId, null, "{}", "sha256:x", at);
+  ).run(
+    "test",
+    `evt-${runId}`,
+    type,
+    "factory",
+    at,
+    at,
+    correlationId,
+    null,
+    "{}",
+    "sha256:x",
+    at,
+  );
   db.query(
     `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
      VALUES (?, ?, ?, ?, 'RUN_SPEC', ?, 1800)`,
@@ -83,18 +155,36 @@ function freshRoot() {
 }
 
 function opts(extra = {}) {
-  return { owner: "w1", workspacesRoot: freshRoot(), now: T0, policyVersion: "test", ...extra };
+  return {
+    owner: "w1",
+    workspacesRoot: freshRoot(),
+    now: T0,
+    policyVersion: "test",
+    ...extra,
+  };
 }
 
 describe("worker", () => {
   test("repository integrity gate rejects any checkout dirt before output acceptance", () => {
     const repo = mkdtempSync(path.join(os.tmpdir(), "evrt-clean-repo-"));
-    const git = (args) => spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    const git = (args) =>
+      spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
     expect(git(["init", "--quiet"]).status).toBe(0);
     writeFileSync(path.join(repo, "tracked.txt"), "clean\n");
     writeFileSync(path.join(repo, ".gitignore"), "ignored.log\n");
     expect(git(["add", "tracked.txt", ".gitignore"]).status).toBe(0);
-    expect(git(["-c", "user.email=test@example.invalid", "-c", "user.name=Test", "commit", "--quiet", "-m", "initial"]).status).toBe(0);
+    expect(
+      git([
+        "-c",
+        "user.email=test@example.invalid",
+        "-c",
+        "user.name=Test",
+        "commit",
+        "--quiet",
+        "-m",
+        "initial",
+      ]).status,
+    ).toBe(0);
     expect(repositoryIsClean(repo)).toBe(true);
     writeFileSync(path.join(repo, "ignored.log"), "dirty\n");
     expect(repositoryIsClean(repo)).toBe(false);
@@ -105,11 +195,23 @@ describe("worker", () => {
 
   test("repository integrity baseline permits pre-existing ignored state but detects later writes", () => {
     const repo = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-repo-"));
-    const git = (args) => spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    const git = (args) =>
+      spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
     expect(git(["init", "--quiet"]).status).toBe(0);
     writeFileSync(path.join(repo, ".gitignore"), "generated/*.log\n");
     expect(git(["add", ".gitignore"]).status).toBe(0);
-    expect(git(["-c", "user.email=test@example.invalid", "-c", "user.name=Test", "commit", "--quiet", "-m", "initial"]).status).toBe(0);
+    expect(
+      git([
+        "-c",
+        "user.email=test@example.invalid",
+        "-c",
+        "user.name=Test",
+        "commit",
+        "--quiet",
+        "-m",
+        "initial",
+      ]).status,
+    ).toBe(0);
     mkdirSync(path.join(repo, "generated"));
     writeFileSync(path.join(repo, "generated", "setup.log"), "pre-existing\n");
     const baseline = repositoryStatus(repo);
@@ -126,7 +228,9 @@ describe("worker", () => {
     execFileSync("chmod", ["+x", hangingGit]);
 
     const started = Date.now();
-    expect(repositoryStatus(dir, { gitCommand: hangingGit, timeoutMs: 25 })).toBeNull();
+    expect(
+      repositoryStatus(dir, { gitCommand: hangingGit, timeoutMs: 25 }),
+    ).toBeNull();
     expect(Date.now() - started).toBeLessThan(1_000);
   });
 
@@ -140,10 +244,13 @@ describe("worker", () => {
 
     const started = Date.now();
     try {
-      expect(() => runLinearCli(["get", "WM-262"], { command: hangingCommand })).toThrow();
+      expect(() =>
+        runLinearCli(["get", "WM-262"], { command: hangingCommand }),
+      ).toThrow();
       expect(Date.now() - started).toBeLessThan(1_000);
     } finally {
-      if (previous === undefined) delete process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
+      if (previous === undefined)
+        delete process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
       else process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = previous;
     }
   });
@@ -152,8 +259,15 @@ describe("worker", () => {
     const db = openDb(":memory:");
     // The real status-report definition with a declared tier, on a registry
     // whose policy map says standard → the pi standard model.
-    const synthetic = { ...registry, agents: new Map(registry.agents), modelTiers: { pi: { standard: "openai-codex/gpt-5.6-terra" } } };
-    synthetic.agents.set("factory-status-report@1", { ...getAgent(registry, "factory-status-report@1"), model_tier: "standard" });
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      modelTiers: { pi: { standard: "openai-codex/gpt-5.6-terra" } },
+    };
+    synthetic.agents.set("factory-status-report@1", {
+      ...getAgent(registry, "factory-status-report@1"),
+      model_tier: "standard",
+    });
 
     const envelope = {
       schemaVersion: "factory.event/v1",
@@ -183,13 +297,26 @@ describe("worker", () => {
     expect(spec.modelTier).toBe("standard");
     expect(spec.adapter).toBe("fake");
 
-    transition(db, { runId: outcome.runId, to: "APPROVED", actor: "test", now: T0 });
-    transition(db, { runId: outcome.runId, to: "QUEUED", actor: "test", now: T0 });
+    transition(db, {
+      runId: outcome.runId,
+      to: "APPROVED",
+      actor: "test",
+      now: T0,
+    });
+    transition(db, {
+      runId: outcome.runId,
+      to: "QUEUED",
+      actor: "test",
+      now: T0,
+    });
     const summary = await runOnce(db, synthetic, adapters, opts());
     expect(summary.runId).toBe(outcome.runId);
     expect(summary.terminalState).toBe("COMPLETED");
     // The run's stored spec — what inspect/receipts read — carries the pin.
-    const stored = JSON.parse(db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(outcome.runId).spec_json);
+    const stored = JSON.parse(
+      db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(outcome.runId)
+        .spec_json,
+    );
     expect(stored.model).toBe("openai-codex/gpt-5.6-terra");
     expect(stored.modelTier).toBe("standard");
   });
@@ -205,7 +332,9 @@ describe("worker", () => {
     expect(summary.reasonCode).toBe("ok");
     expect(runState(db, spec.runId)).toBe("COMPLETED");
 
-    const result = db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const result = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     expect(result).toBeTruthy();
     const receipt = JSON.parse(result.receipt_json);
     expect(receipt.verificationStatus).toBe("passed");
@@ -221,23 +350,31 @@ describe("worker", () => {
     expect(envelope.eventId).toBe(`event-runtime:${spec.runId}:1`);
     expect(envelope.correlationId).toBe("corr-1");
     expect(envelope.payload).toEqual({
-      runId: spec.runId, attempt: 1,
-      artifactHash: result.artifact_hash, outputContract: spec.outputContract,
-    });
-    expect(runUsage(db, spec.runId).attempts).toEqual([expect.objectContaining({
+      runId: spec.runId,
       attempt: 1,
-      adapter: "fake",
-      model: null,
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-    })]);
+      artifactHash: result.artifact_hash,
+      outputContract: spec.outputContract,
+    });
+    expect(runUsage(db, spec.runId).attempts).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        adapter: "fake",
+        model: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      }),
+    ]);
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("COMPLETED");
     expect(attempt.started_at).toBeTruthy();
     expect(attempt.finished_at).toBeTruthy();
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(
+      false,
+    );
   });
 
   test("persists usage returned by an adapter, including model and cache tokens", async () => {
@@ -258,7 +395,12 @@ describe("worker", () => {
     };
     const spec = queueRun(db, makeSpec({ adapter: "usage-stub" }));
 
-    const summary = await runOnce(db, registry, { "usage-stub": usageAdapter }, opts());
+    const summary = await runOnce(
+      db,
+      registry,
+      { "usage-stub": usageAdapter },
+      opts(),
+    );
     expect(summary.terminalState).toBe("COMPLETED");
     expect(runUsage(db, spec.runId)).toEqual({
       totals: {
@@ -270,12 +412,14 @@ describe("worker", () => {
         totalTokens: 1130,
         costUSD: 0.123,
       },
-      attempts: [expect.objectContaining({
-        attempt: 1,
-        adapter: "usage-stub",
-        model: "claude-sonnet-4-6",
-        totalTokens: 1130,
-      })],
+      attempts: [
+        expect.objectContaining({
+          attempt: 1,
+          adapter: "usage-stub",
+          model: "claude-sonnet-4-6",
+          totalTokens: 1130,
+        }),
+      ],
     });
   });
 
@@ -286,20 +430,34 @@ describe("worker", () => {
         return {
           exitCode: 1,
           timedOut: false,
-          usage: { model: "claude-sonnet-4-6", inputTokens: 11, outputTokens: 4 },
+          usage: {
+            model: "claude-sonnet-4-6",
+            inputTokens: 11,
+            outputTokens: 4,
+          },
         };
       },
     };
-    const spec = queueRun(db, makeSpec({ adapter: "consumed-failure", maxAttempts: 1 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "consumed-failure", maxAttempts: 1 }),
+    );
 
-    const summary = await runOnce(db, registry, { "consumed-failure": consumedThenFailed }, opts());
+    const summary = await runOnce(
+      db,
+      registry,
+      { "consumed-failure": consumedThenFailed },
+      opts(),
+    );
     expect(summary.terminalState).toBe("FAILED");
-    expect(runUsage(db, spec.runId).attempts[0]).toEqual(expect.objectContaining({
-      model: "claude-sonnet-4-6",
-      inputTokens: 11,
-      outputTokens: 4,
-      totalTokens: 15,
-    }));
+    expect(runUsage(db, spec.runId).attempts[0]).toEqual(
+      expect.objectContaining({
+        model: "claude-sonnet-4-6",
+        inputTokens: 11,
+        outputTokens: 4,
+        totalTokens: 15,
+      }),
+    );
   });
 
   test("policy denial is terminal and is never retried as an opaque agent exit", async () => {
@@ -312,15 +470,34 @@ describe("worker", () => {
         // non-empty list here means the run failed at a refused tool call.
         exitCode: 1,
         timedOut: false,
-        policyDenials: [{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }],
+        policyDenials: [
+          {
+            tool: "Bash",
+            rule: "Claude requested permissions to use Bash, but you haven't granted it yet.",
+          },
+        ],
       }),
     };
 
-    const summary = await runOnce(db, registry, { policy: policyAdapter }, opts());
-    expect(summary).toMatchObject({ terminalState: "FAILED", reasonCode: "policy_denied:Bash" });
+    const summary = await runOnce(
+      db,
+      registry,
+      { policy: policyAdapter },
+      opts(),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "policy_denied:Bash",
+    });
     expect(runState(db, spec.runId)).toBe("FAILED");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("policy_denied:Bash");
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("policy_denied:Bash");
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeNull();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(0);
     expect(claimNext(db, opts())).toBeNull();
   });
@@ -335,20 +512,26 @@ describe("worker", () => {
     expect(summary.reasonCode).toBe("needs_human");
     expect(runState(db, spec.runId)).toBe("REFUSED");
 
-    const result = db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const result = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     expect(result).toBeTruthy();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(0);
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(
+      false,
+    );
 
-    const resultRow = db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const resultRow = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     const parsedResult = JSON.parse(resultRow.result_json);
     expect(parsedResult.artifacts).toHaveLength(1);
     expect(parsedResult.artifacts[0].kind).toBe("transcript");
     expect(parsedResult.artifacts[0].sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(parsedResult.artifacts[0].uri).toMatch(/^file:\/\//);
-    const inbox = db.query(`SELECT * FROM inbox_items WHERE refs_json LIKE ?`).get(
-      `%${spec.runId}%`,
-    );
+    const inbox = db
+      .query(`SELECT * FROM inbox_items WHERE refs_json LIKE ?`)
+      .get(`%${spec.runId}%`);
     expect(inbox).toBeTruthy();
     expect(inbox.kind).toBe("ESCALATED");
     expect(inbox.source).toBe(`agent:${spec.runId}`);
@@ -356,7 +539,10 @@ describe("worker", () => {
     expect(JSON.parse(inbox.decision_json).schemaVersion).toBe(
       "factory.decision-request/v1",
     );
-    const storePath = path.join(o.artifactStore ?? artifactsRoot(), parsedResult.artifacts[0].sha256);
+    const storePath = path.join(
+      o.artifactStore ?? artifactsRoot(),
+      parsedResult.artifacts[0].sha256,
+    );
     expect(existsSync(storePath)).toBe(true);
     expect(pinRunArtifact(db, spec.runId)).toEqual({
       runId: spec.runId,
@@ -378,12 +564,15 @@ describe("worker", () => {
     const invalid = { ...authored, recommended: "missing" };
     const refusingAdapter = (decision) => ({
       async execute({ workspaceDir }) {
-        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "refused",
-          reasonCode: "needs_human",
-          decision,
-        }));
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "refused",
+            reasonCode: "needs_human",
+            decision,
+          }),
+        );
         return { exitCode: 0, timedOut: false };
       },
     });
@@ -393,15 +582,18 @@ describe("worker", () => {
       ["invalid", invalid, false],
     ]) {
       const db = openDb(":memory:");
-      const spec = queueRun(db, makeSpec({
-        adapter: `refuse-${suffix}`,
-        input: {
-          repos: [suffix],
-          ticket: "WM-390",
-          repo: "factory",
-          pr: 42,
-        },
-      }));
+      const spec = queueRun(
+        db,
+        makeSpec({
+          adapter: `refuse-${suffix}`,
+          input: {
+            repos: [suffix],
+            ticket: "WM-390",
+            repo: "factory",
+            pr: 42,
+          },
+        }),
+      );
       const summary = await runOnce(
         db,
         registry,
@@ -437,17 +629,23 @@ describe("worker", () => {
     // projection is best-effort and the terminal state and result row must land.
     db.exec(`CREATE TRIGGER inbox_write_fails BEFORE INSERT ON inbox_items
              BEGIN SELECT RAISE(ABORT, 'inbox write refused by test'); END`);
-    const spec = queueRun(db, makeSpec({
-      adapter: "refuse-inbox-fails",
-      input: { repos: ["inbox-fails"], ticket: "WM-390", repo: "factory" },
-    }));
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "refuse-inbox-fails",
+        input: { repos: ["inbox-fails"], ticket: "WM-390", repo: "factory" },
+      }),
+    );
     const adapter = {
       async execute({ workspaceDir }) {
-        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "refused",
-          reasonCode: "needs_human",
-        }));
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "refused",
+            reasonCode: "needs_human",
+          }),
+        );
         return { exitCode: 0, timedOut: false };
       },
     };
@@ -457,25 +655,38 @@ describe("worker", () => {
       { "refuse-inbox-fails": adapter },
       opts(),
     );
-    expect(summary).toMatchObject({ terminalState: "REFUSED", reasonCode: "needs_human" });
-    expect(db.query("SELECT state FROM runs WHERE run_id = ?").get(spec.runId).state).toBe("REFUSED");
-    expect(db.query("SELECT * FROM results WHERE run_id = ?").get(spec.runId)).toBeTruthy();
+    expect(summary).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "needs_human",
+    });
+    expect(
+      db.query("SELECT state FROM runs WHERE run_id = ?").get(spec.runId).state,
+    ).toBe("REFUSED");
+    expect(
+      db.query("SELECT * FROM results WHERE run_id = ?").get(spec.runId),
+    ).toBeTruthy();
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(0);
   });
 
   test("refusal reasons other than needs_human do not create inbox items", async () => {
     const db = openDb(":memory:");
-    queueRun(db, makeSpec({
-      adapter: "refuse-missing-input",
-      input: { repos: ["missing"] },
-    }));
+    queueRun(
+      db,
+      makeSpec({
+        adapter: "refuse-missing-input",
+        input: { repos: ["missing"] },
+      }),
+    );
     const adapter = {
       async execute({ workspaceDir }) {
-        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "refused",
-          reasonCode: "missing_input",
-        }));
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "refused",
+            reasonCode: "missing_input",
+          }),
+        );
         return { exitCode: 0, timedOut: false };
       },
     };
@@ -491,7 +702,10 @@ describe("worker", () => {
 
   test("invalid-artifact: FAILED/contract_violation, no outbox row, workspace retained", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["invalid-artifact"] } }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["invalid-artifact"] } }),
+    );
     const o = opts();
 
     const summary = await runOnce(db, registry, adapters, o);
@@ -499,9 +713,13 @@ describe("worker", () => {
     expect(summary.reasonCode).toBe("contract_violation");
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeNull();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(0);
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(true);
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(
+      true,
+    );
   });
 
   test("escape: artifact outside the workspace is a contract violation", async () => {
@@ -524,7 +742,10 @@ describe("worker", () => {
 
   test("hang: TIMED_OUT with a tiny timeout", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["hang"] }, timeoutSeconds: 0.05 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["hang"] }, timeoutSeconds: 0.05 }),
+    );
 
     const summary = await runOnce(db, registry, adapters, opts());
     expect(summary.terminalState).toBe("TIMED_OUT");
@@ -538,26 +759,49 @@ describe("worker", () => {
       async execute({ workspaceDir, abortSignal }) {
         return new Promise((resolve) => {
           const timer = setTimeout(() => {
-            writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
-              schemaVersion: "factory.agent-result/v1",
-              terminalState: "completed",
-              artifact: {
-                repos: [{ name: "extended", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 }],
-                recommendedAction: "dispatch",
-              },
-              evidence: { queries: ["fake"] },
-            }));
+            writeFileSync(
+              path.join(workspaceDir, "result.json"),
+              JSON.stringify({
+                schemaVersion: "factory.agent-result/v1",
+                terminalState: "completed",
+                artifact: {
+                  repos: [
+                    {
+                      name: "extended",
+                      triage: 1,
+                      agentReady: 2,
+                      inProgress: 0,
+                      blocked: 0,
+                    },
+                  ],
+                  recommendedAction: "dispatch",
+                },
+                evidence: { queries: ["fake"] },
+              }),
+            );
             resolve({ exitCode: 0, timedOut: false });
           }, 120);
-          abortSignal.addEventListener("abort", () => {
-            clearTimeout(timer);
-            resolve({ exitCode: null, timedOut: false });
-          }, { once: true });
+          abortSignal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              resolve({ exitCode: null, timedOut: false });
+            },
+            { once: true },
+          );
         });
       },
     };
-    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 0.05 }));
-    const running = runOnce(db, registry, { fake: completesAfterOriginalDeadline }, opts());
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "fake", timeoutSeconds: 0.05 }),
+    );
+    const running = runOnce(
+      db,
+      registry,
+      { fake: completesAfterOriginalDeadline },
+      opts(),
+    );
 
     for (let i = 0; i < 50 && runState(db, spec.runId) !== "RUNNING"; i += 1) {
       await new Promise((resolve) => setTimeout(resolve, 2));
@@ -572,9 +816,14 @@ describe("worker", () => {
     expect(extension.deadlineAt).toBe(new Date(T0 + 1_050).toISOString());
 
     const summary = await running;
-    expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+    expect(summary).toMatchObject({
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+    });
     const receipt = JSON.parse(
-      db.query(`SELECT receipt_json FROM results WHERE run_id = ?`).get(spec.runId).receipt_json,
+      db
+        .query(`SELECT receipt_json FROM results WHERE run_id = ?`)
+        .get(spec.runId).receipt_json,
     );
     expect(JSON.parse(receipt.deadlineExtensions)).toEqual([
       expect.objectContaining({
@@ -584,8 +833,11 @@ describe("worker", () => {
         type: "deadline_extended",
       }),
     ]);
-    expect(db.query(`SELECT lease_expires_at FROM attempts WHERE run_id = ?`).get(spec.runId).lease_expires_at)
-      .toBe(new Date(T0 + 121_050).toISOString());
+    expect(
+      db
+        .query(`SELECT lease_expires_at FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).lease_expires_at,
+    ).toBe(new Date(T0 + 121_050).toISOString());
   });
 
   test("a dynamic-deadline adapter's timeoutMs is bounded by policy, not 24.8 days (WM-692)", async () => {
@@ -607,7 +859,9 @@ describe("worker", () => {
     expect(seen).toHaveLength(1);
     // The ceiling every policy-bounded extension can reach, and nothing beyond it.
     const ceilingMs = liveMaxMinutes * 60_000 + LEASE_GRACE_SECONDS * 1000;
-    expect(seen[0].timeoutMs).toBeGreaterThanOrEqual(spec.timeoutSeconds * 1000);
+    expect(seen[0].timeoutMs).toBeGreaterThanOrEqual(
+      spec.timeoutSeconds * 1000,
+    );
     expect(seen[0].timeoutMs).toBeLessThanOrEqual(ceilingMs);
     expect(seen[0].timeoutMs).toBe(ceilingMs);
   });
@@ -616,7 +870,10 @@ describe("worker", () => {
     const db = openDb(":memory:");
     const policyRoot = freshRoot();
     mkdirSync(path.join(policyRoot, "config"));
-    writeFileSync(path.join(policyRoot, "config", "policy.yaml"), "limits:\n  max_run_minutes: 3\n");
+    writeFileSync(
+      path.join(policyRoot, "config", "policy.yaml"),
+      "limits:\n  max_run_minutes: 3\n",
+    );
     const seen = [];
     const recording = {
       async execute(options) {
@@ -630,29 +887,53 @@ describe("worker", () => {
 
     // A budget above the policy ceiling still gets its whole budget plus grace,
     // and an adapter outside the dynamic set keeps its exact budget.
-    expect(adapterExecuteTimeoutMs({ adapterKey: "fake", spec: { ...spec, timeoutSeconds: 600 }, maxRunMinutes: 3 }))
-      .toBe(600_000 + LEASE_GRACE_SECONDS * 1000);
-    expect(adapterExecuteTimeoutMs({ adapterKey: "actions", spec: { ...spec, timeoutSeconds: 600 }, maxRunMinutes: 3 }))
-      .toBe(600_000);
+    expect(
+      adapterExecuteTimeoutMs({
+        adapterKey: "fake",
+        spec: { ...spec, timeoutSeconds: 600 },
+        maxRunMinutes: 3,
+      }),
+    ).toBe(600_000 + LEASE_GRACE_SECONDS * 1000);
+    expect(
+      adapterExecuteTimeoutMs({
+        adapterKey: "actions",
+        spec: { ...spec, timeoutSeconds: 600 },
+        maxRunMinutes: 3,
+      }),
+    ).toBe(600_000);
     // No policy at all: fall back to the run budget plus grace, never to a sentinel.
-    expect(adapterExecuteTimeoutMs({ adapterKey: "fake", spec, maxRunMinutes: null }))
-      .toBe(spec.timeoutSeconds * 1000 + LEASE_GRACE_SECONDS * 1000);
+    expect(
+      adapterExecuteTimeoutMs({
+        adapterKey: "fake",
+        spec,
+        maxRunMinutes: null,
+      }),
+    ).toBe(spec.timeoutSeconds * 1000 + LEASE_GRACE_SECONDS * 1000);
   });
 
   test("expiry wins atomically and refuses extension throughout adapter kill grace (WM-566)", async () => {
     const db = openDb(":memory:");
     let releaseKillGrace;
-    const killGrace = new Promise((resolve) => { releaseKillGrace = resolve; });
+    const killGrace = new Promise((resolve) => {
+      releaseKillGrace = resolve;
+    });
     let termStarted;
-    const term = new Promise((resolve) => { termStarted = resolve; });
+    const term = new Promise((resolve) => {
+      termStarted = resolve;
+    });
     const ignoresTermBriefly = {
       async execute({ abortSignal }) {
-        abortSignal.addEventListener("abort", () => termStarted(), { once: true });
+        abortSignal.addEventListener("abort", () => termStarted(), {
+          once: true,
+        });
         await killGrace;
         return { exitCode: null, timedOut: false };
       },
     };
-    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 0.03 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "fake", timeoutSeconds: 0.03 }),
+    );
     const running = runOnce(db, registry, { fake: ignoresTermBriefly }, opts());
 
     await term;
@@ -669,13 +950,20 @@ describe("worker", () => {
       status: 409,
     });
     const expiryRows = lifecycleOf(db, spec.runId).filter((row) => {
-      try { return JSON.parse(row.reason)?.type === "deadline_expired"; } catch { return false; }
+      try {
+        return JSON.parse(row.reason)?.type === "deadline_expired";
+      } catch {
+        return false;
+      }
     });
     expect(expiryRows).toHaveLength(1);
 
     releaseKillGrace();
     const summary = await running;
-    expect(summary).toMatchObject({ terminalState: "TIMED_OUT", reasonCode: "timeout" });
+    expect(summary).toMatchObject({
+      terminalState: "TIMED_OUT",
+      reasonCode: "timeout",
+    });
   });
 
   test("extension refuses after the edge even before the worker records expiry", () => {
@@ -690,23 +978,32 @@ describe("worker", () => {
       attempt: claim.attempt,
       now: T0,
     });
-    db.query(`UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`)
-      .run(new Date(T0).toISOString(), spec.runId, claim.attempt);
+    db.query(
+      `UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`,
+    ).run(new Date(T0).toISOString(), spec.runId, claim.attempt);
 
-    expect(extendRunDeadline(db, spec.runId, {
-      seconds: 1,
-      actor: "operator",
-      policyVersion: "test",
-      now: T0 + 1_001,
-    })).toMatchObject({
+    expect(
+      extendRunDeadline(db, spec.runId, {
+        seconds: 1,
+        actor: "operator",
+        policyVersion: "test",
+        now: T0 + 1_001,
+      }),
+    ).toMatchObject({
       refused: true,
       code: "deadline_already_expired",
       status: 409,
       deadlineAt: new Date(T0 + 1_000).toISOString(),
     });
-    expect(lifecycleOf(db, spec.runId).some((row) => {
-      try { return JSON.parse(row.reason)?.type === "deadline_extended"; } catch { return false; }
-    })).toBe(false);
+    expect(
+      lifecycleOf(db, spec.runId).some((row) => {
+        try {
+          return JSON.parse(row.reason)?.type === "deadline_extended";
+        } catch {
+          return false;
+        }
+      }),
+    ).toBe(false);
   });
 
   test("expire transaction observes an extension that committed before the old edge", () => {
@@ -721,8 +1018,9 @@ describe("worker", () => {
       attempt: claim.attempt,
       now: T0,
     });
-    db.query(`UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`)
-      .run(new Date(T0).toISOString(), spec.runId, claim.attempt);
+    db.query(
+      `UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`,
+    ).run(new Date(T0).toISOString(), spec.runId, claim.attempt);
     const extension = extendRunDeadline(db, spec.runId, {
       seconds: 1,
       actor: "operator",
@@ -730,42 +1028,67 @@ describe("worker", () => {
       now: T0 + 999,
     });
     expect(extension.refused).toBeUndefined();
-    expect(expireRunDeadline(db, spec.runId, claim.attempt, claim.fencingToken, {
-      actor: "w1",
-      policyVersion: "test",
-      now: T0 + 1_001,
-    })).toMatchObject({ expired: false, deadlineMs: T0 + 2_000 });
+    expect(
+      expireRunDeadline(db, spec.runId, claim.attempt, claim.fencingToken, {
+        actor: "w1",
+        policyVersion: "test",
+        now: T0 + 1_001,
+      }),
+    ).toMatchObject({ expired: false, deadlineMs: T0 + 2_000 });
   });
 
   test("timeout accepts a valid result.json written before the adapter hangs (WM-538)", async () => {
     const db = openDb(":memory:");
     const writesThenHangs = {
       async execute({ workspaceDir, timeoutMs }) {
-        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          artifact: {
-            repos: [{ name: "late", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 }],
-            recommendedAction: "dispatch",
-          },
-          evidence: { queries: ["fake"] },
-        }));
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            artifact: {
+              repos: [
+                {
+                  name: "late",
+                  triage: 1,
+                  agentReady: 2,
+                  inProgress: 0,
+                  blocked: 0,
+                },
+              ],
+              recommendedAction: "dispatch",
+            },
+            evidence: { queries: ["fake"] },
+          }),
+        );
         await new Promise((resolve) => setTimeout(resolve, timeoutMs));
         return { exitCode: null, timedOut: true };
       },
     };
-    const spec = queueRun(db, makeSpec({ adapter: "writes-then-hangs", timeoutSeconds: 0.01 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "writes-then-hangs", timeoutSeconds: 0.01 }),
+    );
 
-    const summary = await runOnce(db, registry, { "writes-then-hangs": writesThenHangs }, opts());
+    const summary = await runOnce(
+      db,
+      registry,
+      { "writes-then-hangs": writesThenHangs },
+      opts(),
+    );
 
     expect(summary.terminalState).toBe("COMPLETED");
     expect(summary.reasonCode).toBe("ok");
     expect(runState(db, spec.runId)).toBe("COMPLETED");
-    expect(lifecycleOf(db, spec.runId)).toContainEqual(expect.objectContaining({
-      to_state: "VERIFYING",
-      reason: "late_completion_after_timeout",
-    }));
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeTruthy();
+    expect(lifecycleOf(db, spec.runId)).toContainEqual(
+      expect.objectContaining({
+        to_state: "VERIFYING",
+        reason: "late_completion_after_timeout",
+      }),
+    );
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeTruthy();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(1);
   });
 
@@ -779,17 +1102,27 @@ describe("worker", () => {
     };
     const spec = queueRun(db, makeSpec({ adapter: "invalid-then-timeout" }));
 
-    const summary = await runOnce(db, registry, { "invalid-then-timeout": invalidThenTimesOut }, opts());
+    const summary = await runOnce(
+      db,
+      registry,
+      { "invalid-then-timeout": invalidThenTimesOut },
+      opts(),
+    );
 
     expect(summary.terminalState).toBe("TIMED_OUT");
     expect(summary.reasonCode).toBe("timeout");
     expect(runState(db, spec.runId)).toBe("TIMED_OUT");
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeNull();
   });
 
   test("crash with maxAttempts 2: FAILED then auto re-QUEUED; second claim has higher fencing token", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] }, maxAttempts: 2 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["crash"] }, maxAttempts: 2 }),
+    );
     const o = opts();
 
     const first = await runOnce(db, registry, adapters, o);
@@ -805,7 +1138,10 @@ describe("worker", () => {
 
   test("crash with maxAttempts 1: stays FAILED, no auto retry", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] }, maxAttempts: 1 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["crash"] }, maxAttempts: 1 }),
+    );
 
     const summary = await runOnce(db, registry, adapters, opts());
     expect(summary.terminalState).toBe("FAILED");
@@ -821,13 +1157,20 @@ describe("worker", () => {
     const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
     mkdirSync(priorWorkspace, { recursive: true });
     const priorTranscript = path.join(priorWorkspace, ".transcript.json");
-    writeFileSync(priorTranscript, `${JSON.stringify({
-      type: "system", subtype: "init", cwd: priorWorkspace,
-      session_id: "11111111-2222-4333-8444-555555555555",
-    })}\n`);
+    writeFileSync(
+      priorTranscript,
+      `${JSON.stringify({
+        type: "system",
+        subtype: "init",
+        cwd: priorWorkspace,
+        session_id: "11111111-2222-4333-8444-555555555555",
+      })}\n`,
+    );
 
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
     const fresh = claimNext(db, { ...o, now: afterExpiry });
     expect(fresh.attempt).toBe(2);
 
@@ -838,7 +1181,13 @@ describe("worker", () => {
         return fake.execute(args);
       },
     };
-    const done = await executeClaimed(db, registry, { claude: resumeAdapter }, fresh, { ...o, now: afterExpiry });
+    const done = await executeClaimed(
+      db,
+      registry,
+      { claude: resumeAdapter },
+      fresh,
+      { ...o, now: afterExpiry },
+    );
     expect(done.terminalState).toBe("COMPLETED");
     expect(observedResume).toEqual({
       attempt: 1,
@@ -846,9 +1195,19 @@ describe("worker", () => {
       transcriptPath: priorTranscript,
     });
 
-    const zombie = await executeClaimed(db, registry, { claude: resumeAdapter }, stale, { ...o, now: afterExpiry });
+    const zombie = await executeClaimed(
+      db,
+      registry,
+      { claude: resumeAdapter },
+      stale,
+      { ...o, now: afterExpiry },
+    );
     expect(zombie.fenced === true || zombie.cancelled === true).toBe(true);
-    expect(db.query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`).get(spec.runId).n).toBe(1);
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
+        .get(spec.runId).n,
+    ).toBe(1);
     expect(db.query(`SELECT COUNT(*) AS n FROM outbox`).get().n).toBe(1);
   });
 
@@ -859,16 +1218,28 @@ describe("worker", () => {
     claimNext(db, o);
     const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
     mkdirSync(priorWorkspace, { recursive: true });
-    writeFileSync(path.join(priorWorkspace, ".transcript.json"), [
-      JSON.stringify({ type: "system", subtype: "init", cwd: priorWorkspace, session_id: "not-a-uuid" }),
-      JSON.stringify({
-        type: "system", subtype: "init", cwd: "/another/run",
-        session_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-      }),
-    ].join("\n") + "\n");
+    writeFileSync(
+      path.join(priorWorkspace, ".transcript.json"),
+      [
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          cwd: priorWorkspace,
+          session_id: "not-a-uuid",
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          cwd: "/another/run",
+          session_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        }),
+      ].join("\n") + "\n",
+    );
 
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
     const fresh = claimNext(db, { ...o, now: afterExpiry });
 
     let observedResume = "not-called";
@@ -878,7 +1249,13 @@ describe("worker", () => {
         return fake.execute(args);
       },
     };
-    const done = await executeClaimed(db, registry, { claude: coldAdapter }, fresh, { ...o, now: afterExpiry });
+    const done = await executeClaimed(
+      db,
+      registry,
+      { claude: coldAdapter },
+      fresh,
+      { ...o, now: afterExpiry },
+    );
     expect(done.terminalState).toBe("COMPLETED");
     expect(observedResume).toBeNull();
   });
@@ -888,12 +1265,24 @@ describe("worker", () => {
     const claudeTranscript = path.join(root, "claude.ndjson");
     const piTranscript = path.join(root, "pi.ndjson");
     const claudeId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
-    writeFileSync(claudeTranscript, `${JSON.stringify({
-      type: "system", subtype: "init", cwd: root, session_id: claudeId,
-    })}\n`);
-    writeFileSync(piTranscript, `${JSON.stringify({
-      type: "session", version: 3, cwd: root, id: "pi-session",
-    })}\n`);
+    writeFileSync(
+      claudeTranscript,
+      `${JSON.stringify({
+        type: "system",
+        subtype: "init",
+        cwd: root,
+        session_id: claudeId,
+      })}\n`,
+    );
+    writeFileSync(
+      piTranscript,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        cwd: root,
+        id: "pi-session",
+      })}\n`,
+    );
 
     const claudeSession = transcriptSessionId(claudeTranscript, "claude");
     const piSession = transcriptSessionId(piTranscript, "pi");
@@ -901,13 +1290,22 @@ describe("worker", () => {
     expect(piSession).toBe("pi-session");
 
     const claude = buildClaudeArgv({
-      prompt: "continue", def: { mutating: false }, resumeSessionId: claudeSession,
+      prompt: "continue",
+      def: { mutating: false },
+      resumeSessionId: claudeSession,
     });
-    expect(claude.slice(0, 4)).toEqual(["-p", "continue", "--resume", claudeId]);
+    expect(claude.slice(0, 4)).toEqual([
+      "-p",
+      "continue",
+      "--resume",
+      claudeId,
+    ]);
     expect(claude).toContain("--fork-session");
 
     const pi = buildPiArgv({
-      def: { mutating: false }, model: null, resumeSessionId: piSession,
+      def: { mutating: false },
+      model: null,
+      resumeSessionId: piSession,
     });
     expect(pi).toContain("--fork");
     expect(pi[pi.indexOf("--fork") + 1]).toBe("pi-session");
@@ -919,7 +1317,10 @@ describe("worker", () => {
     mkdirSync(bin);
     for (const command of ["claude", "pi"]) {
       const executable = path.join(bin, command);
-      writeFileSync(executable, "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FACTORY_TEST_ARGV\"\n");
+      writeFileSync(
+        executable,
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$FACTORY_TEST_ARGV"\n',
+      );
       chmodSync(executable, 0o755);
     }
     const promptPath = path.join(root, "prompt.md");
@@ -931,21 +1332,37 @@ describe("worker", () => {
     const claudeArgv = path.join(root, "claude-argv.txt");
     mkdirSync(claudeWorkspace);
     const claudeOutcome = await executeClaude({
-      spec, def, workspaceDir: claudeWorkspace, timeoutMs: 5_000,
-      env: { PATH: `${bin}${path.delimiter}${process.env.PATH}`, FACTORY_TEST_ARGV: claudeArgv },
+      spec,
+      def,
+      workspaceDir: claudeWorkspace,
+      timeoutMs: 5_000,
+      env: {
+        PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_ARGV: claudeArgv,
+      },
       resume: { sessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" },
     });
     expect(claudeOutcome.exitCode).toBe(0);
     expect(readFileSync(claudeArgv, "utf8").split("\n")).toContain("--resume");
-    expect(readFileSync(claudeArgv, "utf8")).toContain("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
-    expect(readFileSync(claudeArgv, "utf8").split("\n")).toContain("--fork-session");
+    expect(readFileSync(claudeArgv, "utf8")).toContain(
+      "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    );
+    expect(readFileSync(claudeArgv, "utf8").split("\n")).toContain(
+      "--fork-session",
+    );
 
     const piWorkspace = path.join(root, "pi-workspace");
     const piArgv = path.join(root, "pi-argv.txt");
     mkdirSync(piWorkspace);
     const piOutcome = await executePi({
-      spec, def, workspaceDir: piWorkspace, timeoutMs: 5_000,
-      env: { PATH: `${bin}${path.delimiter}${process.env.PATH}`, FACTORY_TEST_ARGV: piArgv },
+      spec,
+      def,
+      workspaceDir: piWorkspace,
+      timeoutMs: 5_000,
+      env: {
+        PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_ARGV: piArgv,
+      },
       resume: { sessionId: "pi-session" },
     });
     expect(piOutcome.exitCode).toBe(0);
@@ -964,7 +1381,9 @@ describe("worker", () => {
 
     // Lease expires → reaper re-queues.
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     // Fresh claim executes to completion.
@@ -980,9 +1399,15 @@ describe("worker", () => {
     expect(zombie.fenced === true || zombie.cancelled === true).toBe(true);
 
     expect(runState(db, spec.runId)).toBe("COMPLETED");
-    expect(db.query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`).get(spec.runId).n).toBe(1);
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
+        .get(spec.runId).n,
+    ).toBe(1);
     expect(db.query(`SELECT COUNT(*) AS n FROM outbox`).get().n).toBe(1);
-    const terminals = lifecycleOf(db, spec.runId).filter((e) => e.to_state === "COMPLETED");
+    const terminals = lifecycleOf(db, spec.runId).filter(
+      (e) => e.to_state === "COMPLETED",
+    );
     expect(terminals).toHaveLength(1);
   });
 
@@ -997,7 +1422,9 @@ describe("worker", () => {
     db.close();
 
     const reopened = openDb(file);
-    const result = reopened.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const result = reopened
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     expect(result).toBeTruthy();
     expect(JSON.parse(result.receipt_json).verificationStatus).toBe("passed");
     expect(lifecycleOf(reopened, spec.runId).length).toBeGreaterThanOrEqual(4);
@@ -1011,11 +1438,17 @@ describe("worker", () => {
     const claim = claimNext(db, o);
 
     // Operator cancels while the claim was sitting in LEASED.
-    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
 
     const summary = await executeClaimed(db, registry, adapters, claim, o);
     expect(summary.cancelled).toBe(true);
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeNull();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(0);
   });
 
@@ -1031,31 +1464,53 @@ describe("worker", () => {
   test("cancelRun on a QUEUED run → CANCELLED; on a terminal run → IllegalTransition", () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec());
-    const result = cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    const result = cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(result.to).toBe("CANCELLED");
     expect(runState(db, spec.runId)).toBe("CANCELLED");
 
-    expect(() => cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 }))
-      .toThrow(IllegalTransition);
+    expect(() =>
+      cancelRun(db, spec.runId, {
+        actor: "operator",
+        policyVersion: "test",
+        now: T0,
+      }),
+    ).toThrow(IllegalTransition);
   });
 
   test("cancelRun on a PROPOSED run closes its unique open proposal", () => {
     const db = openDb(":memory:");
     const spec = makeSpec();
     createRun(db, {
-      runId: spec.runId, idempotencyKey: spec.idempotencyKey,
-      spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
-      actor: "test", policyVersion: "test", now: T0,
+      runId: spec.runId,
+      idempotencyKey: spec.idempotencyKey,
+      spec,
+      specJson: canonicalJson(spec),
+      specHash: hashJson(spec),
+      actor: "test",
+      policyVersion: "test",
+      now: T0,
     });
     db.query(
       `INSERT INTO proposals (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds)
        VALUES (?, ?, ?, ?, 'run', 'open', ?, 1800)`,
     ).run("prop-1", "test", "evt-1", spec.runId, new Date(T0).toISOString());
 
-    const result = cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    const result = cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(result.to).toBe("CANCELLED");
     expect(result.proposalClose).toEqual({ closed: true, id: "prop-1" });
-    expect(db.query(`SELECT status, reason FROM proposals WHERE id = 'prop-1'`).get()).toEqual({
+    expect(
+      db
+        .query(`SELECT status, reason FROM proposals WHERE id = 'prop-1'`)
+        .get(),
+    ).toEqual({
       status: "rejected",
       reason: "run_cancelled",
     });
@@ -1064,7 +1519,11 @@ describe("worker", () => {
   test("cancelRun with no open proposal still cancels", () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec());
-    const result = cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    const result = cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(result.to).toBe("CANCELLED");
     expect(result.proposalClose).toEqual({ closed: false });
   });
@@ -1078,35 +1537,75 @@ describe("worker", () => {
        VALUES ('p1', 'test', 'e1', ?, 'run', 'open', ?, 1800), ('p2', 'test', 'e2', ?, 'run', 'open', ?, 1800)`,
     ).run(spec.runId, at, spec.runId, at);
 
-    const result = cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    const result = cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(result.to).toBe("CANCELLED");
-    expect(result.proposalClose).toEqual({ closed: false, ambiguous: true, count: 2 });
-    expect(db.query(`SELECT status FROM proposals WHERE id = 'p1'`).get().status).toBe("open");
-    expect(db.query(`SELECT status FROM proposals WHERE id = 'p2'`).get().status).toBe("open");
+    expect(result.proposalClose).toEqual({
+      closed: false,
+      ambiguous: true,
+      count: 2,
+    });
+    expect(
+      db.query(`SELECT status FROM proposals WHERE id = 'p1'`).get().status,
+    ).toBe("open");
+    expect(
+      db.query(`SELECT status FROM proposals WHERE id = 'p2'`).get().status,
+    ).toBe("open");
   });
 
   test("retryRun: exhausted agent attempts throw without force, re-queue with force", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] }, maxAttempts: 1 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["crash"] }, maxAttempts: 1 }),
+    );
     await runOnce(db, registry, adapters, opts());
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    expect(() => retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 }))
-      .toThrow("attempts_exhausted");
+    expect(() =>
+      retryRun(db, spec.runId, {
+        actor: "operator",
+        policyVersion: "test",
+        now: T0,
+      }),
+    ).toThrow("attempts_exhausted");
 
-    const retried = retryRun(db, spec.runId, { actor: "operator", force: true, policyVersion: "test", now: T0 });
+    const retried = retryRun(db, spec.runId, {
+      actor: "operator",
+      force: true,
+      policyVersion: "test",
+      now: T0,
+    });
     expect(retried.to).toBe("QUEUED");
     expect(runState(db, spec.runId)).toBe("QUEUED");
   });
 
   test("retryRun does not treat environment attempts as exhausted agent attempts", async () => {
     const db = openDb(":memory:");
-    const throwingAdapter = { execute: async () => { throw new Error("network dropped"); } };
-    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 1, maxEnvironmentRetries: 0 }));
+    const throwingAdapter = {
+      execute: async () => {
+        throw new Error("network dropped");
+      },
+    };
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "throwing",
+        maxAttempts: 1,
+        maxEnvironmentRetries: 0,
+      }),
+    );
     await runOnce(db, registry, { throwing: throwingAdapter }, opts());
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    const retried = retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    const retried = retryRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
     expect(retried.to).toBe("QUEUED");
   });
 
@@ -1139,24 +1638,35 @@ describe("worker", () => {
         return fake.execute(args);
       },
     };
-    const spec = queueRun(db, makeSpec({
-      adapter: "flaky",
-      maxAttempts: 1,
-      maxEnvironmentRetries: 1,
-      workspace: { type: "ephemeral", retainOnFailure: false },
-    }));
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "flaky",
+        maxAttempts: 1,
+        maxEnvironmentRetries: 1,
+        workspace: { type: "ephemeral", retainOnFailure: false },
+      }),
+    );
     const o = opts();
 
     const first = await runOnce(db, registry, { flaky: flakyAdapter }, o);
-    expect(first).toMatchObject({ terminalState: "FAILED", reasonCode: "adapter_error" });
+    expect(first).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "adapter_error",
+    });
     expect(runState(db, spec.runId)).toBe("QUEUED");
     expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:environment");
 
     const second = await runOnce(db, registry, { flaky: flakyAdapter }, o);
     expect(second.terminalState).toBe("COMPLETED");
     expect(runState(db, spec.runId)).toBe("COMPLETED");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
-      .toEqual([{ reason_code: "adapter_error" }, { reason_code: "ok" }]);
+    expect(
+      db
+        .query(
+          `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`,
+        )
+        .all(spec.runId),
+    ).toEqual([{ reason_code: "adapter_error" }, { reason_code: "ok" }]);
   });
 
   test("repeated environment failures dead-letter after the dedicated retry ceiling", async () => {
@@ -1166,22 +1676,42 @@ describe("worker", () => {
         throw new Error("simulated transport explosion");
       },
     };
-    const spec = queueRun(db, makeSpec({
-      adapter: "throwing",
-      maxAttempts: 1,
-      maxEnvironmentRetries: 2,
-      workspace: { type: "ephemeral", retainOnFailure: false },
-    }));
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "throwing",
+        maxAttempts: 1,
+        maxEnvironmentRetries: 2,
+        workspace: { type: "ephemeral", retainOnFailure: false },
+      }),
+    );
     const o = opts();
 
-    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
+    expect(
+      (await runOnce(db, registry, { throwing: throwingAdapter }, o))
+        .reasonCode,
+    ).toBe("adapter_error");
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
+    expect(
+      (await runOnce(db, registry, { throwing: throwingAdapter }, o))
+        .reasonCode,
+    ).toBe("adapter_error");
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
+    expect(
+      (await runOnce(db, registry, { throwing: throwingAdapter }, o))
+        .reasonCode,
+    ).toBe("adapter_error");
     expect(runState(db, spec.runId)).toBe("FAILED");
-    expect(db.query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`).get(spec.runId).n).toBe(3);
-    expect(lifecycleOf(db, spec.runId).filter((event) => event.reason === "retry:environment")).toHaveLength(2);
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).n,
+    ).toBe(3);
+    expect(
+      lifecycleOf(db, spec.runId).filter(
+        (event) => event.reason === "retry:environment",
+      ),
+    ).toHaveLength(2);
   });
 
   test("environment failures do not consume agent_exit retry attempts", async () => {
@@ -1194,7 +1724,10 @@ describe("worker", () => {
         return { exitCode: 1, timedOut: false };
       },
     };
-    const spec = queueRun(db, makeSpec({ adapter: "mixed", maxAttempts: 2, maxEnvironmentRetries: 1 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "mixed", maxAttempts: 2, maxEnvironmentRetries: 1 }),
+    );
     const o = opts();
 
     await runOnce(db, registry, { mixed: mixedAdapter }, o);
@@ -1204,17 +1737,25 @@ describe("worker", () => {
     expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:agent_error");
     await runOnce(db, registry, { mixed: mixedAdapter }, o);
     expect(runState(db, spec.runId)).toBe("FAILED");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
-      .toEqual([
-        { reason_code: "adapter_error" },
-        { reason_code: "agent_exit_1" },
-        { reason_code: "agent_exit_1" },
-      ]);
+    expect(
+      db
+        .query(
+          `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`,
+        )
+        .all(spec.runId),
+    ).toEqual([
+      { reason_code: "adapter_error" },
+      { reason_code: "agent_exit_1" },
+      { reason_code: "agent_exit_1" },
+    ]);
   });
 
   test("contract violations consume maxAttempts independently of environment failures", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["invalid-artifact"] }, maxAttempts: 2 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ input: { repos: ["invalid-artifact"] }, maxAttempts: 2 }),
+    );
     const o = opts();
 
     await runOnce(db, registry, adapters, o);
@@ -1222,68 +1763,115 @@ describe("worker", () => {
     expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:agent_error");
     await runOnce(db, registry, adapters, o);
     expect(runState(db, spec.runId)).toBe("FAILED");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
-      .toEqual([{ reason_code: "contract_violation" }, { reason_code: "contract_violation" }]);
+    expect(
+      db
+        .query(
+          `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`,
+        )
+        .all(spec.runId),
+    ).toEqual([
+      { reason_code: "contract_violation" },
+      { reason_code: "contract_violation" },
+    ]);
   });
 
   test("fatal errors never requeue regardless of either retry budget", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({
-      adapter: "nonexistent",
-      maxAttempts: 5,
-      maxEnvironmentRetries: 5,
-    }));
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "nonexistent",
+        maxAttempts: 5,
+        maxEnvironmentRetries: 5,
+      }),
+    );
 
     const summary = await runOnce(db, registry, adapters, opts());
-    expect(summary).toMatchObject({ terminalState: "FAILED", reasonCode: "unknown_adapter" });
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "unknown_adapter",
+    });
     expect(runState(db, spec.runId)).toBe("FAILED");
     expect(claimNext(db, opts())).toBeNull();
-    expect(lifecycleOf(db, spec.runId).some((event) => event.reason?.startsWith("retry:"))).toBe(false);
+    expect(
+      lifecycleOf(db, spec.runId).some((event) =>
+        event.reason?.startsWith("retry:"),
+      ),
+    ).toBe(false);
   });
 
   test("post-VERIFYING exception finalizes the attempt and re-queues instead of stranding it (WM-261)", async () => {
     const db = openDb(":memory:");
     const blockedStoreParent = path.join(freshRoot(), "not-a-directory");
     writeFileSync(blockedStoreParent, "blocks artifact store creation\n");
-    const spec = queueRun(db, makeSpec({
-      maxAttempts: 2,
-      workspace: { type: "ephemeral", retainOnFailure: false },
-    }));
-    const o = opts({ artifactStore: path.join(blockedStoreParent, "artifacts") });
+    const spec = queueRun(
+      db,
+      makeSpec({
+        maxAttempts: 2,
+        workspace: { type: "ephemeral", retainOnFailure: false },
+      }),
+    );
+    const o = opts({
+      artifactStore: path.join(blockedStoreParent, "artifacts"),
+    });
 
     const summary = await runOnce(db, registry, adapters, o);
 
-    expect(summary).toMatchObject({ terminalState: "FAILED", reasonCode: "adapter_error" });
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "adapter_error",
+    });
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(lifecycleOf(db, spec.runId).slice(-3).map((event) => event.to_state)).toEqual([
-      "VERIFYING", "FAILED", "QUEUED",
-    ]);
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(
+      lifecycleOf(db, spec.runId)
+        .slice(-3)
+        .map((event) => event.to_state),
+    ).toEqual(["VERIFYING", "FAILED", "QUEUED"]);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("FAILED");
     expect(attempt.reason_code).toBe("adapter_error");
     expect(attempt.finished_at).toBeTruthy();
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(
+      false,
+    );
   });
 
   test("lease_expired uses the environment retry ceiling instead of maxAttempts", () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ maxAttempts: 1, maxEnvironmentRetries: 1 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ maxAttempts: 1, maxEnvironmentRetries: 1 }),
+    );
     const o = opts();
     claimNext(db, o);
     expect(runState(db, spec.runId)).toBe("LEASED");
 
     const firstExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: firstExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: firstExpiry, policyVersion: "test" }),
+    ).toBe(1);
     expect(runState(db, spec.runId)).toBe("QUEUED");
     expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:environment");
 
     const secondClaim = claimNext(db, { ...o, now: firstExpiry });
     const secondExpiry = firstExpiry + (spec.timeoutSeconds + 120) * 1000 + 1;
     expect(secondClaim.attempt).toBe(2);
-    expect(reapExpiredLeases(db, { now: secondExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: secondExpiry, policyVersion: "test" }),
+    ).toBe(1);
     expect(runState(db, spec.runId)).toBe("FAILED");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
-      .toEqual([{ reason_code: "lease_expired" }, { reason_code: "lease_expired" }]);
+    expect(
+      db
+        .query(
+          `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`,
+        )
+        .all(spec.runId),
+    ).toEqual([
+      { reason_code: "lease_expired" },
+      { reason_code: "lease_expired" },
+    ]);
     expect(claimNext(db, opts())).toBeNull();
   });
 
@@ -1293,21 +1881,31 @@ describe("worker", () => {
     const longRunningAdapter = {
       execute: ({ abortSignal }) => {
         return new Promise((resolve) => {
-          const timer = setTimeout(() => resolve({ exitCode: 0, timedOut: false }), 5000);
+          const timer = setTimeout(
+            () => resolve({ exitCode: 0, timedOut: false }),
+            5000,
+          );
           abortSignal?.addEventListener("abort", () => {
             clearTimeout(timer);
             aborted = true;
             resolve({
               exitCode: null,
               timedOut: false,
-              usage: { model: "claude-sonnet-4-6", inputTokens: 9, outputTokens: 2 },
+              usage: {
+                model: "claude-sonnet-4-6",
+                inputTokens: 9,
+                outputTokens: 2,
+              },
             });
           });
         });
       },
     };
     const customAdapters = { long: longRunningAdapter };
-    const spec = queueRun(db, makeSpec({ adapter: "long", timeoutSeconds: 30 }));
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "long", timeoutSeconds: 30 }),
+    );
     const o = opts();
 
     const claim = claimNext(db, o);
@@ -1315,24 +1913,34 @@ describe("worker", () => {
 
     // Cancel while RUNNING
     expect(runState(db, spec.runId)).toBe("RUNNING");
-    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    cancelRun(db, spec.runId, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+    });
 
     const summary = await execPromise;
     expect(summary.cancelled).toBe(true);
     expect(aborted).toBe(true);
     expect(runState(db, spec.runId)).toBe("CANCELLED");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("CANCELLED");
     expect(attempt.reason_code).toBe("cancelled");
     expect(attempt.finished_at).toBeTruthy();
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
-    expect(runUsage(db, spec.runId).attempts[0]).toEqual(expect.objectContaining({
-      model: "claude-sonnet-4-6",
-      inputTokens: 9,
-      outputTokens: 2,
-      totalTokens: 11,
-    }));
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(
+      false,
+    );
+    expect(runUsage(db, spec.runId).attempts[0]).toEqual(
+      expect.objectContaining({
+        model: "claude-sonnet-4-6",
+        inputTokens: 9,
+        outputTokens: 2,
+        totalTokens: 11,
+      }),
+    );
   });
 
   test("runOnce returns null when nothing is QUEUED", async () => {
@@ -1351,10 +1959,14 @@ describe("worker", () => {
     const summary = await runOnce(db, registry, adapters, o);
     expect(summary.terminalState).toBe("COMPLETED");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.started_at).toBeTruthy();
     expect(attempt.finished_at).toBeTruthy();
-    expect(Date.parse(attempt.started_at)).toBeLessThan(Date.parse(attempt.finished_at));
+    expect(Date.parse(attempt.started_at)).toBeLessThan(
+      Date.parse(attempt.finished_at),
+    );
 
     const journal = lifecycleOf(db, spec.runId);
     const leased = journal.find((e) => e.to_state === "LEASED");
@@ -1371,10 +1983,13 @@ describe("worker", () => {
 
   test("claimNext refuses a stale worker before leasing and requires reload (WM-613)", () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({
-      promptVersion: "git:current",
-      policyVersion: "git:current",
-    }));
+    const spec = queueRun(
+      db,
+      makeSpec({
+        promptVersion: "git:current",
+        policyVersion: "git:current",
+      }),
+    );
 
     const refusal = claimNext(db, {
       ...opts(),
@@ -1393,16 +2008,24 @@ describe("worker", () => {
       checkoutRegistryVersion: "git:current",
     });
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
-    expect(db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
+    expect(
+      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+        .attempts,
+    ).toBe(0);
+    expect(
+      db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
+    ).toHaveLength(0);
   });
 
   test("claimNext does not restart-loop a fresh worker on an older queued spec (WM-613)", () => {
     const db = openDb(":memory:");
-    const staleSpec = queueRun(db, makeSpec({
-      promptVersion: "git:old",
-      policyVersion: "git:old",
-    }));
+    const staleSpec = queueRun(
+      db,
+      makeSpec({
+        promptVersion: "git:old",
+        policyVersion: "git:old",
+      }),
+    );
 
     const refusal = claimNext(db, {
       ...opts(),
@@ -1423,14 +2046,22 @@ describe("worker", () => {
 
   test("claimNext skips an incompatible old spec and claims compatible queued work (WM-613)", () => {
     const db = openDb(":memory:");
-    const staleSpec = queueRun(db, makeSpec({
-      promptVersion: "git:old",
-      policyVersion: "git:old",
-    }), T0);
-    const compatibleSpec = queueRun(db, makeSpec({
-      promptVersion: "git:current",
-      policyVersion: "git:current",
-    }), T0 + 1000);
+    const staleSpec = queueRun(
+      db,
+      makeSpec({
+        promptVersion: "git:old",
+        policyVersion: "git:old",
+      }),
+      T0,
+    );
+    const compatibleSpec = queueRun(
+      db,
+      makeSpec({
+        promptVersion: "git:current",
+        policyVersion: "git:current",
+      }),
+      T0 + 1000,
+    );
 
     const claim = claimNext(db, {
       ...opts(),
@@ -1449,7 +2080,11 @@ describe("worker", () => {
     for (let i = 0; i < 60; i += 1) {
       queueRun(db, makeSpec({ placement: { node: "nowhere" } }), T0 + i * 1000);
     }
-    const claimableSpec = queueRun(db, makeSpec({ placement: null }), T0 + 60 * 1000);
+    const claimableSpec = queueRun(
+      db,
+      makeSpec({ placement: null }),
+      T0 + 60 * 1000,
+    );
 
     const claim = claimNext(db, opts({ labels: {} }));
     expect(claim).not.toBeNull();
@@ -1461,7 +2096,11 @@ describe("worker", () => {
     for (let i = 0; i < 60; i += 1) {
       queueRun(db, makeSpec({ adapter: "missing_adapter" }), T0 + i * 1000);
     }
-    const claimableSpec = queueRun(db, makeSpec({ adapter: "fake" }), T0 + 60 * 1000);
+    const claimableSpec = queueRun(
+      db,
+      makeSpec({ adapter: "fake" }),
+      T0 + 60 * 1000,
+    );
 
     const claim = claimNext(db, opts({ adapters: ["fake"] }));
     expect(claim).not.toBeNull();
@@ -1470,9 +2109,17 @@ describe("worker", () => {
 
   test("claimNext preserves oldest-eligible-first ordering among satisfiable runs (OPS-454)", () => {
     const db = openDb(":memory:");
-    const unclaimable1 = queueRun(db, makeSpec({ placement: { node: "gpu" } }), T0);
+    const unclaimable1 = queueRun(
+      db,
+      makeSpec({ placement: { node: "gpu" } }),
+      T0,
+    );
     const claimable1 = queueRun(db, makeSpec({ placement: null }), T0 + 1000);
-    const unclaimable2 = queueRun(db, makeSpec({ placement: { node: "gpu" } }), T0 + 2000);
+    const unclaimable2 = queueRun(
+      db,
+      makeSpec({ placement: { node: "gpu" } }),
+      T0 + 2000,
+    );
     const claimable2 = queueRun(db, makeSpec({ placement: null }), T0 + 3000);
 
     const firstClaim = claimNext(db, opts({ labels: {} }));
@@ -1486,7 +2133,10 @@ describe("worker", () => {
 
   test("fencing on failure: reaped-while-running worker's late failure cannot overwrite newer attempt (OPS-413)", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ maxAttempts: 2, input: { repos: ["ok"] } }));
+    const spec = queueRun(
+      db,
+      makeSpec({ maxAttempts: 2, input: { repos: ["ok"] } }),
+    );
     const o1 = opts({ owner: "w1", now: T0 });
 
     // Worker 1 claims attempt 1 and begins running
@@ -1495,11 +2145,21 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("LEASED");
 
     // Worker 1 enters RUNNING
-    transition(db, { runId: spec.runId, to: "RUNNING", expectFrom: "LEASED", actor: "w1", reason: "started", attempt: 1, now: T0 });
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      expectFrom: "LEASED",
+      actor: "w1",
+      reason: "started",
+      attempt: 1,
+      now: T0,
+    });
 
     // Lease expires while worker 1 is running slowly
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    expect(
+      reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     // Worker 2 claims attempt 2 and starts running
@@ -1515,14 +2175,22 @@ describe("worker", () => {
         execute: async () => ({ exitCode: 1, timedOut: false }),
       },
     };
-    const w1Result = await executeClaimed(db, registry, failingAdapters, claim1, { ...o1, now: afterExpiry });
+    const w1Result = await executeClaimed(
+      db,
+      registry,
+      failingAdapters,
+      claim1,
+      { ...o1, now: afterExpiry },
+    );
     expect(w1Result.fenced).toBe(true);
 
     // Assert that Worker 1 did not mutate run state to FAILED
     expect(runState(db, spec.runId)).toBe("LEASED");
 
     // Assert journal recorded fenced_attempt
-    const fencedEvents = lifecycleOf(db, spec.runId).filter((e) => e.reason === "fenced_attempt");
+    const fencedEvents = lifecycleOf(db, spec.runId).filter(
+      (e) => e.reason === "fenced_attempt",
+    );
     expect(fencedEvents).toHaveLength(1);
     expect(fencedEvents[0].attempt).toBe(1);
 
@@ -1532,7 +2200,9 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("COMPLETED");
 
     // Only attempt 2 has results and published outbox event
-    const results = db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId);
+    const results = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .all(spec.runId);
     expect(results).toHaveLength(1);
     expect(results[0].attempt).toBe(2);
   });
@@ -1548,7 +2218,9 @@ describe("worker", () => {
     expect(summary.terminalState).toBe("COMPLETED");
     expect(summary.receipt.defHash).toBe(expectedDefHash);
 
-    const result = db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const result = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     const receipt = JSON.parse(result.receipt_json);
     expect(receipt.defHash).toBe(expectedDefHash);
   });
@@ -1556,7 +2228,8 @@ describe("worker", () => {
   test("mutated agent definition between approval and execution causes typed refusal (OPS-409)", async () => {
     const db = openDb(":memory:");
     // Spec carries an approved defHash that differs from current definition
-    const staleDefHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    const staleDefHash =
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000";
     const spec = queueRun(db, makeSpec({ defHash: staleDefHash }));
 
     const summary = await runOnce(db, registry, adapters, opts());
@@ -1564,7 +2237,9 @@ describe("worker", () => {
     expect(summary.reasonCode).toBe("agent_definition_mismatch");
     expect(runState(db, spec.runId)).toBe("REFUSED");
 
-    const result = db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId);
+    const result = db
+      .query(`SELECT * FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     expect(result).toBeTruthy();
     const resultJson = JSON.parse(result.result_json);
     expect(resultJson.terminalState).toBe("refused");
@@ -1574,10 +2249,16 @@ describe("worker", () => {
     expect(receipt.verificationStatus).toBe("passed");
     expect(receipt.defHash).toBeTruthy();
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(spec.runId);
     expect(attempt.terminal_state).toBe("REFUSED");
     expect(attempt.reason_code).toBe("agent_definition_mismatch");
-    expect(lifecycleOf(db, spec.runId).slice(-2).map((event) => event.reason)).toEqual([
+    expect(
+      lifecycleOf(db, spec.runId)
+        .slice(-2)
+        .map((event) => event.reason),
+    ).toEqual([
       "failure:fatal:agent_definition_mismatch",
       "failure:fatal:agent_definition_mismatch",
     ]);
@@ -1585,11 +2266,22 @@ describe("worker", () => {
 
   test("fencing on contract violation: stale worker cannot overwrite newer attempt (OPS-413)", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ maxAttempts: 2, input: { repos: ["ok"] } }));
+    const spec = queueRun(
+      db,
+      makeSpec({ maxAttempts: 2, input: { repos: ["ok"] } }),
+    );
     const o1 = opts({ owner: "w1", now: T0 });
 
     const claim1 = claimNext(db, o1);
-    transition(db, { runId: spec.runId, to: "RUNNING", expectFrom: "LEASED", actor: "w1", reason: "started", attempt: 1, now: T0 });
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      expectFrom: "LEASED",
+      actor: "w1",
+      reason: "started",
+      attempt: 1,
+      now: T0,
+    });
 
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
     reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" });
@@ -1603,17 +2295,26 @@ describe("worker", () => {
         execute: async ({ workspaceDir }) => {
           const { writeFileSync } = await import("node:fs");
           const { join } = await import("node:path");
-          writeFileSync(join(workspaceDir, "result.json"), JSON.stringify({
-            schemaVersion: "factory.agent-result/v1",
-            terminalState: "completed",
-            artifact: { invalid: true },
-          }));
+          writeFileSync(
+            join(workspaceDir, "result.json"),
+            JSON.stringify({
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              artifact: { invalid: true },
+            }),
+          );
           return { exitCode: 0, timedOut: false };
         },
       },
     };
 
-    const w1Result = await executeClaimed(db, registry, invalidAdapters, claim1, { ...o1, now: afterExpiry });
+    const w1Result = await executeClaimed(
+      db,
+      registry,
+      invalidAdapters,
+      claim1,
+      { ...o1, now: afterExpiry },
+    );
     expect(w1Result.fenced).toBe(true);
     expect(runState(db, spec.runId)).toBe("LEASED");
 
@@ -1628,7 +2329,15 @@ describe("worker", () => {
     const o1 = opts({ owner: "w1", now: T0 });
 
     const claim1 = claimNext(db, o1);
-    transition(db, { runId: spec.runId, to: "RUNNING", expectFrom: "LEASED", actor: "w1", reason: "started", attempt: 1, now: T0 });
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      expectFrom: "LEASED",
+      actor: "w1",
+      reason: "started",
+      attempt: 1,
+      now: T0,
+    });
 
     const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
     reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" });
@@ -1656,7 +2365,10 @@ describe("worker", () => {
     const abortController = new AbortController();
     abortController.abort("cancelled");
     // Stale attempt with higher token existing
-    const w1Result = await executeClaimed(db, registry, adapters, claim1, { ...o1, now: afterExpiry });
+    const w1Result = await executeClaimed(db, registry, adapters, claim1, {
+      ...o1,
+      now: afterExpiry,
+    });
     expect(w1Result.fenced).toBe(true);
   });
 
@@ -1691,7 +2403,15 @@ describe("worker", () => {
               summary: "Implemented",
             }
           : {
-              repos: [{ name: "ok", triage: 0, agentReady: 0, inProgress: 0, blocked: 0 }],
+              repos: [
+                {
+                  name: "ok",
+                  triage: 0,
+                  agentReady: 0,
+                  inProgress: 0,
+                  blocked: 0,
+                },
+              ],
               recommendedAction: "wait",
             };
         writeFileSync(
@@ -1718,13 +2438,18 @@ describe("worker", () => {
         adapter: "spy",
       }),
     );
-    const mutatingResult = await runOnce(db, registry, customAdapters, opts({
-      env: {
-        SSH_AUTH_SOCK: "/tmp/worker-dispatch.sock",
-        GITHUB_TOKEN: "ghp_worker_dispatch_token",
-        ANTHROPIC_API_KEY: "sk-worker-must-strip",
-      },
-    }));
+    const mutatingResult = await runOnce(
+      db,
+      registry,
+      customAdapters,
+      opts({
+        env: {
+          SSH_AUTH_SOCK: "/tmp/worker-dispatch.sock",
+          GITHUB_TOKEN: "ghp_worker_dispatch_token",
+          ANTHROPIC_API_KEY: "sk-worker-must-strip",
+        },
+      }),
+    );
     expect(mutatingResult.terminalState).toBe("COMPLETED");
     expect(capturedMutatingEnv).not.toBeNull();
     expect(capturedMutatingEnv.SSH_AUTH_SOCK).toBe("/tmp/worker-dispatch.sock");
@@ -1741,13 +2466,18 @@ describe("worker", () => {
         adapter: "spy",
       }),
     );
-    const readOnlyResult = await runOnce(db, registry, customAdapters, opts({
-      env: {
-        SSH_AUTH_SOCK: "/tmp/worker-readonly.sock",
-        GITHUB_TOKEN: "ghp_worker_readonly_token",
-        ANTHROPIC_API_KEY: "sk-worker-must-strip",
-      },
-    }));
+    const readOnlyResult = await runOnce(
+      db,
+      registry,
+      customAdapters,
+      opts({
+        env: {
+          SSH_AUTH_SOCK: "/tmp/worker-readonly.sock",
+          GITHUB_TOKEN: "ghp_worker_readonly_token",
+          ANTHROPIC_API_KEY: "sk-worker-must-strip",
+        },
+      }),
+    );
     expect(readOnlyResult.terminalState).toBe("COMPLETED");
     expect(capturedReadOnlyEnv).not.toBeNull();
     expect(capturedReadOnlyEnv.SSH_AUTH_SOCK).toBeUndefined();
@@ -1764,7 +2494,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   let previousReposRoot;
 
   beforeAll(() => {
-    factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-worker-hard-factory-"));
+    factoryRoot = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-worker-hard-factory-"),
+    );
     repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-worker-hard-repo-"));
     wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-worker-hard-trees-"));
     callsLog = path.join(repoDir, "calls.log");
@@ -1793,12 +2525,12 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     writeFileSync(
       path.join(repoDir, "bin", "worktree-up-startup-crash.sh"),
       `#!/bin/bash\n` +
-      `mkdir -p "${wtRoot}/$1/.factory/run"\n` +
-      `echo "RegistryError: event type test: model_tier strong has no mapping" > "${wtRoot}/$1/.factory/run/serve.log"\n` +
-      `echo "warn: event runtime log (${wtRoot}/$1/.factory/run/serve.log):" >&2\n` +
-      `cat "${wtRoot}/$1/.factory/run/serve.log" >&2\n` +
-      `echo "error: event runtime died during startup on 7400 — see ${wtRoot}/$1/.factory/run/serve.log" >&2\n` +
-      `exit 1\n`,
+        `mkdir -p "${wtRoot}/$1/.factory/run"\n` +
+        `echo "RegistryError: event type test: model_tier strong has no mapping" > "${wtRoot}/$1/.factory/run/serve.log"\n` +
+        `echo "warn: event runtime log (${wtRoot}/$1/.factory/run/serve.log):" >&2\n` +
+        `cat "${wtRoot}/$1/.factory/run/serve.log" >&2\n` +
+        `echo "error: event runtime died during startup on 7400 — see ${wtRoot}/$1/.factory/run/serve.log" >&2\n` +
+        `exit 1\n`,
     );
 
     mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
@@ -1845,7 +2577,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   });
 
   function makeDispatchSpec(overrides = {}) {
-    const runId = overrides.runId ?? `run_dispatch_${++seq}_${Math.random().toString(36).slice(2)}`;
+    const runId =
+      overrides.runId ??
+      `run_dispatch_${++seq}_${Math.random().toString(36).slice(2)}`;
     const input = overrides.input ?? { repo: "wt-worker", ticket: "WM-701" };
     return {
       schemaVersion: "factory.run-spec/v1",
@@ -1853,7 +2587,11 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       agent: "dispatch@1",
       input,
       inputHash: hashJson(input),
-      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      workspace: {
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      },
       adapter: "fake",
       promptVersion: "git:test",
       policyVersion: "git:test",
@@ -1867,7 +2605,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   }
 
   function makeMergeFixSpec(overrides = {}) {
-    const runId = overrides.runId ?? `run_merge_fix_${++seq}_${Math.random().toString(36).slice(2)}`;
+    const runId =
+      overrides.runId ??
+      `run_merge_fix_${++seq}_${Math.random().toString(36).slice(2)}`;
     const input = overrides.input ?? {
       repo: "wt-worker",
       github: "watt-mind/wt-worker",
@@ -1890,7 +2630,11 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       agent: "merge-fix@1",
       input,
       inputHash: hashJson(input),
-      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      workspace: {
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      },
       adapter: "merge-fake",
       promptVersion: "git:test",
       policyVersion: "git:test",
@@ -1905,24 +2649,32 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   const mergeFixFakeAdapter = {
     async execute({ spec, workspaceDir }) {
-      writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"merge-fix transcript"}\n`, "utf8");
+      writeFileSync(
+        path.join(workspaceDir, ".transcript.json"),
+        `{"fake":"merge-fix transcript"}\n`,
+        "utf8",
+      );
       writeFileSync(
         path.join(workspaceDir, "result.json"),
-        `${JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          reasonCode: "ok",
-          artifact: {
-            outcome: "UPDATED",
-            repo: spec.input.repo,
-            ticket: spec.input.ticket,
-            pr: spec.input.pr,
-            headSha: spec.input.headSha,
-            round: spec.input.round,
-            summary: "applied mechanical correction",
+        `${JSON.stringify(
+          {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "UPDATED",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              pr: spec.input.pr,
+              headSha: spec.input.headSha,
+              round: spec.input.round,
+              summary: "applied mechanical correction",
+            },
+            evidence: { commands: ["echo repo_verified"] },
           },
-          evidence: { commands: ["echo repo_verified"] },
-        }, null, 2)}\n`,
+          null,
+          2,
+        )}\n`,
         "utf8",
       );
       return { exitCode: 0, timedOut: false };
@@ -1938,7 +2690,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     ...overrides,
   });
 
-  const planTimeDispatchEvidence = (description = "## Owned Paths\n- src/feature/**\n") => ({
+  const planTimeDispatchEvidence = (
+    description = "## Owned Paths\n- src/feature/**\n",
+  ) => ({
     source: "chain",
     mode: "auto",
     eventType: "factory.dispatch.requested",
@@ -1952,27 +2706,43 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   const dispatchFakeAdapter = {
     async execute({ spec, workspaceDir }) {
-      writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"dispatch transcript"}\n`, "utf8");
+      writeFileSync(
+        path.join(workspaceDir, ".transcript.json"),
+        `{"fake":"dispatch transcript"}\n`,
+        "utf8",
+      );
       const repoPath = path.join(workspaceDir, "repo");
       if (existsSync(repoPath)) {
-        writeFileSync(path.join(repoPath, "mutated.txt"), "some dirty edit\n", "utf8");
+        writeFileSync(
+          path.join(repoPath, "mutated.txt"),
+          "some dirty edit\n",
+          "utf8",
+        );
       }
       writeFileSync(
         path.join(workspaceDir, "result.json"),
-        `${JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          reasonCode: "ok",
-          artifact: {
-            outcome: "PR_OPEN",
-            repo: spec.input.repo,
-            ticket: spec.input.ticket,
-            prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/10`,
-            verification: { command: "echo repo_verified", passed: true, output: "repo_verified" },
-            summary: `implemented ${spec.input.ticket}`,
+        `${JSON.stringify(
+          {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "PR_OPEN",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/10`,
+              verification: {
+                command: "echo repo_verified",
+                passed: true,
+                output: "repo_verified",
+              },
+              summary: `implemented ${spec.input.ticket}`,
+            },
+            evidence: { commands: ["echo repo_verified"] },
           },
-          evidence: { commands: ["echo repo_verified"] },
-        }, null, 2)}\n`,
+          null,
+          2,
+        )}\n`,
         "utf8",
       );
       return { exitCode: 0, timedOut: false };
@@ -1996,24 +2766,53 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const previousHome = process.env.FACTORY_EVENT_HOME;
     const previousKey = process.env.LINEAR_API_KEY;
     const previousStub = process.env.FACTORY_DISPATCH_STUB;
-    process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-linear-unconfigured-"));
+    process.env.FACTORY_EVENT_HOME = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-linear-unconfigured-"),
+    );
     delete process.env.LINEAR_API_KEY;
     delete process.env.FACTORY_DISPATCH_STUB;
 
     try {
       const db = openDb(":memory:");
-      const spec = queueRun(db, makeDispatchSpec({ adapter: "pi", maxEnvironmentRetries: 1 }));
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({ adapter: "pi", maxEnvironmentRetries: 1 }),
+      );
       const runOpts = opts({ resolveLinearKey: () => null });
-      const first = await runOnce(db, registry, { pi: dispatchFakeAdapter }, runOpts);
+      const first = await runOnce(
+        db,
+        registry,
+        { pi: dispatchFakeAdapter },
+        runOpts,
+      );
 
-      expect(first).toMatchObject({ terminalState: "FAILED", reasonCode: "linear_unconfigured" });
+      expect(first).toMatchObject({
+        terminalState: "FAILED",
+        reasonCode: "linear_unconfigured",
+      });
       expect(runState(db, spec.runId)).toBe("QUEUED");
 
-      const exhausted = await runOnce(db, registry, { pi: dispatchFakeAdapter }, runOpts);
-      expect(exhausted).toMatchObject({ terminalState: "FAILED", reasonCode: "linear_unconfigured" });
+      const exhausted = await runOnce(
+        db,
+        registry,
+        { pi: dispatchFakeAdapter },
+        runOpts,
+      );
+      expect(exhausted).toMatchObject({
+        terminalState: "FAILED",
+        reasonCode: "linear_unconfigured",
+      });
       expect(runState(db, spec.runId)).toBe("FAILED");
-      expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
-        .toEqual([{ reason_code: "linear_unconfigured" }, { reason_code: "linear_unconfigured" }]);
+      expect(
+        db
+          .query(
+            `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`,
+          )
+          .all(spec.runId),
+      ).toEqual([
+        { reason_code: "linear_unconfigured" },
+        { reason_code: "linear_unconfigured" },
+      ]);
     } finally {
       if (previousHome === undefined) delete process.env.FACTORY_EVENT_HOME;
       else process.env.FACTORY_EVENT_HOME = previousHome;
@@ -2030,10 +2829,18 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     try {
       const db = openDb(":memory:");
       queueRun(db, makeDispatchSpec({ adapter: "pi" }));
-      const summary = await runOnce(db, registry, { pi: dispatchFakeAdapter }, opts({
-        resolveLinearKey: () => null,
-      }));
-      expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+      const summary = await runOnce(
+        db,
+        registry,
+        { pi: dispatchFakeAdapter },
+        opts({
+          resolveLinearKey: () => null,
+        }),
+      );
+      expect(summary).toMatchObject({
+        terminalState: "COMPLETED",
+        reasonCode: "ok",
+      });
     } finally {
       if (previousStub === undefined) delete process.env.FACTORY_DISPATCH_STUB;
       else process.env.FACTORY_DISPATCH_STUB = previousStub;
@@ -2043,22 +2850,36 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   test("the fake adapter override explicitly enables the demo dispatch stub", async () => {
     const db = openDb(":memory:");
     queueRun(db, makeDispatchSpec({ adapter: "pi" }));
-    const summary = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      adapterOverride: "fake",
-      resolveLinearKey: () => null,
-    }));
-    expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        adapterOverride: "fake",
+        resolveLinearKey: () => null,
+      }),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+    });
   });
 
   test("acquireClaimLock acquires lock file and prevents concurrent acquire, release unlocks", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));
     const lockFile = dispatchLockPath("wt-worker", lockDir);
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 1000 })).toBe(true);
+    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 1000 })).toBe(
+      true,
+    );
     // Second acquire by live PID fails
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 2000 })).toBe(false);
+    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 2000 })).toBe(
+      false,
+    );
     releaseClaimLock(lockFile);
     expect(existsSync(lockFile)).toBe(false);
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 3000 })).toBe(true);
+    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 3000 })).toBe(
+      true,
+    );
     releaseClaimLock(lockFile);
   });
 
@@ -2067,12 +2888,24 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const lockFile = dispatchLockPath("wt-worker", lockDir);
     // Age alone cannot make a live owner's lock safe to steal.
     writeFileSync(lockFile, `${process.pid} 1000\n`, "utf8");
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 201_000, isAlive: () => true })).toBe(false);
+    expect(
+      acquireClaimLock(lockFile, {
+        pid: process.pid,
+        now: 201_000,
+        isAlive: () => true,
+      }),
+    ).toBe(false);
     releaseClaimLock(lockFile);
 
     // A dead owner's lock is stale and is reclaimed immediately.
     writeFileSync(lockFile, `999999 1000\n`, "utf8");
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 2000, isAlive: () => false })).toBe(true);
+    expect(
+      acquireClaimLock(lockFile, {
+        pid: process.pid,
+        now: 2000,
+        isAlive: () => false,
+      }),
+    ).toBe(true);
     releaseClaimLock(lockFile);
   });
 
@@ -2096,20 +2929,47 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       },
     });
 
-    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "claim_lock_contention" });
+    const deferred = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(deferred).toMatchObject({
+      terminalState: "QUEUED",
+      reasonCode: "claim_lock_contention",
+    });
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
-    expect(db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
-    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
+    expect(
+      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+        .attempts,
+    ).toBe(0);
+    expect(
+      db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
+    ).toHaveLength(0);
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId),
+    ).toHaveLength(0);
     expect(claimNext(db, o)).toBeNull();
 
     releaseClaimLock(lockFile);
     now += deferred.requeueAfterMs;
-    const completed = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(completed).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok", attempt: 1 });
+    const completed = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(completed).toMatchObject({
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+      attempt: 1,
+    });
     expect(runState(db, spec.runId)).toBe("COMPLETED");
-    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(1);
+    expect(
+      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+        .attempts,
+    ).toBe(1);
   });
 
   test("claim lock starvation refuses with a distinct reason after the requeue ceiling", async () => {
@@ -2133,10 +2993,23 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       },
     });
 
-    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    const deferred = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
     now += deferred.requeueAfterMs;
-    const refused = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(refused).toMatchObject({ terminalState: "REFUSED", reasonCode: "claim_lock_starvation" });
+    const refused = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(refused).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "claim_lock_starvation",
+    });
     expect(runState(db, spec.runId)).toBe("REFUSED");
     releaseClaimLock(lockFile);
   });
@@ -2144,15 +3017,24 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   test("concurrent disjoint dispatches drain through the claim lock with mutually exclusive claims", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-burst-"));
-    const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) => queueRun(db, makeDispatchSpec({
-      runId: `run_lock_burst_${index + 1}`,
-      input: { repo: "wt-worker", ticket },
-    })));
+    const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) =>
+      queueRun(
+        db,
+        makeDispatchSpec({
+          runId: `run_lock_burst_${index + 1}`,
+          input: { repo: "wt-worker", ticket },
+        }),
+      ),
+    );
     let now = T0;
     let releaseFirst;
     let markFirstStarted;
-    const firstStarted = new Promise((resolve) => { markFirstStarted = resolve; });
-    const firstRelease = new Promise((resolve) => { releaseFirst = resolve; });
+    const firstStarted = new Promise((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstRelease = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
     let activeClaims = 0;
     let maxActiveClaims = 0;
     const claimedTickets = [];
@@ -2180,9 +3062,17 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
     const first = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
     await firstStarted;
-    const second = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    const second = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
     const third = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect([second.reasonCode, third.reasonCode]).toEqual(["claim_lock_contention", "claim_lock_contention"]);
+    expect([second.reasonCode, third.reasonCode]).toEqual([
+      "claim_lock_contention",
+      "claim_lock_contention",
+    ]);
     releaseFirst();
     expect((await first).terminalState).toBe("COMPLETED");
 
@@ -2191,9 +3081,22 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
       await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
     ];
-    expect(drained.map((summary) => summary.terminalState)).toEqual(["COMPLETED", "COMPLETED"]);
-    expect(specs.map((spec) => runState(db, spec.runId))).toEqual(["COMPLETED", "COMPLETED", "COMPLETED"]);
-    expect(specs.map((spec) => db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts)).toEqual([1, 1, 1]);
+    expect(drained.map((summary) => summary.terminalState)).toEqual([
+      "COMPLETED",
+      "COMPLETED",
+    ]);
+    expect(specs.map((spec) => runState(db, spec.runId))).toEqual([
+      "COMPLETED",
+      "COMPLETED",
+      "COMPLETED",
+    ]);
+    expect(
+      specs.map(
+        (spec) =>
+          db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+            .attempts,
+      ),
+    ).toEqual([1, 1, 1]);
     expect(claimedTickets.sort()).toEqual(["WM-710", "WM-711", "WM-712"]);
     expect(maxActiveClaims).toBe(1);
   });
@@ -2204,49 +3107,85 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const spec = queueRun(db, makeMergeFixSpec());
     let claimCalled = false;
 
-    const summary = await runOnce(db, registry, { "merge-fake": mergeFixFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => ({
-          identifier: spec.input.ticket,
-          state: { name: "In Review" },
-          assignee: { id: "reviewer" },
-          labels: { nodes: [{ name: "ai:needs-review" }] },
-          description: "## Owned Paths\n- src/feature/**\n",
-        }),
-        fetchPullRequest: () => ({ state: "OPEN", headRefOid: spec.input.headSha }),
-        claimTicket: () => { claimCalled = true; return { ok: false, reasonCode: "ticket_assigned" }; },
-      },
-    }));
-
-    expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
-    expect(claimCalled).toBe(false);
-    expect(runState(db, spec.runId)).toBe("COMPLETED");
-  });
-
-  test("merge-fix claim refusals use role-specific reason codes", async () => {
-    for (const [suffix, ticketOverrides, pr, reasonCode] of [
-      ["escalated", { labels: { nodes: [{ name: "ai:escalated" }] } }, { state: "OPEN", headRefOid: "a".repeat(40) }, "merge_fix_ticket_escalated"],
-      ["moved", {}, { state: "OPEN", headRefOid: "d".repeat(40) }, "merge_fix_pr_moved"],
-    ]) {
-      const db = openDb(":memory:");
-      const spec = queueRun(db, makeMergeFixSpec({ runId: `run_merge_fix_${suffix}` }));
-      const summary = await runOnce(db, registry, { "merge-fake": mergeFixFakeAdapter }, opts({
+    const summary = await runOnce(
+      db,
+      registry,
+      { "merge-fake": mergeFixFakeAdapter },
+      opts({
         dispatch: {
-          locksDir: mkdtempSync(path.join(os.tmpdir(), `evrt-merge-fix-${suffix}-`)),
+          locksDir: lockDir,
           fetchTicket: () => ({
             identifier: spec.input.ticket,
             state: { name: "In Review" },
             assignee: { id: "reviewer" },
             labels: { nodes: [{ name: "ai:needs-review" }] },
             description: "## Owned Paths\n- src/feature/**\n",
-            ...ticketOverrides,
           }),
-          fetchPullRequest: () => pr,
+          fetchPullRequest: () => ({
+            state: "OPEN",
+            headRefOid: spec.input.headSha,
+          }),
+          claimTicket: () => {
+            claimCalled = true;
+            return { ok: false, reasonCode: "ticket_assigned" };
+          },
         },
-      }));
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+    });
+    expect(claimCalled).toBe(false);
+    expect(runState(db, spec.runId)).toBe("COMPLETED");
+  });
+
+  test("merge-fix claim refusals use role-specific reason codes", async () => {
+    for (const [suffix, ticketOverrides, pr, reasonCode] of [
+      [
+        "escalated",
+        { labels: { nodes: [{ name: "ai:escalated" }] } },
+        { state: "OPEN", headRefOid: "a".repeat(40) },
+        "merge_fix_ticket_escalated",
+      ],
+      [
+        "moved",
+        {},
+        { state: "OPEN", headRefOid: "d".repeat(40) },
+        "merge_fix_pr_moved",
+      ],
+    ]) {
+      const db = openDb(":memory:");
+      const spec = queueRun(
+        db,
+        makeMergeFixSpec({ runId: `run_merge_fix_${suffix}` }),
+      );
+      const summary = await runOnce(
+        db,
+        registry,
+        { "merge-fake": mergeFixFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: mkdtempSync(
+              path.join(os.tmpdir(), `evrt-merge-fix-${suffix}-`),
+            ),
+            fetchTicket: () => ({
+              identifier: spec.input.ticket,
+              state: { name: "In Review" },
+              assignee: { id: "reviewer" },
+              labels: { nodes: [{ name: "ai:needs-review" }] },
+              description: "## Owned Paths\n- src/feature/**\n",
+              ...ticketOverrides,
+            }),
+            fetchPullRequest: () => pr,
+          },
+        }),
+      );
       expect(summary).toMatchObject({ terminalState: "REFUSED", reasonCode });
-      expect(["ticket_assigned", "ticket_not_todo"]).not.toContain(summary.reasonCode);
+      expect(["ticket_assigned", "ticket_not_todo"]).not.toContain(
+        summary.reasonCode,
+      );
     }
   });
 
@@ -2255,68 +3194,118 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-rechecks-"));
 
     // 1. ticket_not_todo
-    const spec1 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-702" } }));
-    const sum1 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-702", { state: { name: "In Review" } }),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-      },
-    }));
+    const spec1 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-702" } }),
+    );
+    const sum1 = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () =>
+            readyDispatchTicket("WM-702", { state: { name: "In Review" } }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+        },
+      }),
+    );
     expect(sum1.terminalState).toBe("REFUSED");
     expect(sum1.reasonCode).toBe("ticket_not_todo");
 
     // 2. ticket_assigned
-    const spec2 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-703" } }));
-    const sum2 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-703", { assignee: { id: "other" } }),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-      },
-    }));
+    const spec2 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-703" } }),
+    );
+    const sum2 = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () =>
+            readyDispatchTicket("WM-703", { assignee: { id: "other" } }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+        },
+      }),
+    );
     expect(sum2.terminalState).toBe("REFUSED");
     expect(sum2.reasonCode).toBe("ticket_assigned");
 
     // 3. capacity_full
-    const spec3 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-704" } }));
-    const sum3 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-704"),
-        fetchInFlight: () => [],
-        countLeases: () => 2, // cap is 2
-      },
-    }));
+    const spec3 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-704" } }),
+    );
+    const sum3 = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-704"),
+          fetchInFlight: () => [],
+          countLeases: () => 2, // cap is 2
+        },
+      }),
+    );
     expect(sum3.terminalState).toBe("REFUSED");
     expect(sum3.reasonCode).toBe("capacity_full");
 
     // 4. owned_paths_overlap
-    const spec4 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-705" } }));
-    const sum4 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-705", { description: "## Owned Paths\n- src/api/**\n" }),
-        fetchInFlight: () => [{ identifier: "WM-800", description: "## Owned Paths\n- src/api/routes.ts\n" }],
-        countLeases: () => 0,
-      },
-    }));
+    const spec4 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-705" } }),
+    );
+    const sum4 = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () =>
+            readyDispatchTicket("WM-705", {
+              description: "## Owned Paths\n- src/api/**\n",
+            }),
+          fetchInFlight: () => [
+            {
+              identifier: "WM-800",
+              description: "## Owned Paths\n- src/api/routes.ts\n",
+            },
+          ],
+          countLeases: () => 0,
+        },
+      }),
+    );
     expect(sum4.terminalState).toBe("REFUSED");
     expect(sum4.reasonCode).toBe("owned_paths_overlap");
 
     // 5. ticket_claim_lost
-    const spec5 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-706" } }));
-    const sum5 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-706"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: false, reasonCode: "ticket_claim_lost" }),
-      },
-    }));
+    const spec5 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-706" } }),
+    );
+    const sum5 = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-706"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: false, reasonCode: "ticket_claim_lost" }),
+        },
+      }),
+    );
     expect(sum5.terminalState).toBe("REFUSED");
     expect(sum5.reasonCode).toBe("ticket_claim_lost");
   });
@@ -2336,42 +3325,87 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     try {
       // Containment overlap (src/api/** vs src/api/routes.ts): strict refuses this
       // exact pair in the test above; advisory lets it run.
-      const specA = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-707" } }));
-      const sumA = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-        dispatch: {
-          locksDir: lockDir,
-          fetchTicket: () => readyDispatchTicket("WM-707", { description: "## Owned Paths\n- src/api/**\n" }),
-          fetchInFlight: () => [{ identifier: "WM-800", description: "## Owned Paths\n- src/api/routes.ts\n" }],
-          countLeases: () => 0,
-        },
-      }));
+      const specA = queueRun(
+        db,
+        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-707" } }),
+      );
+      const sumA = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            fetchTicket: () =>
+              readyDispatchTicket("WM-707", {
+                description: "## Owned Paths\n- src/api/**\n",
+              }),
+            fetchInFlight: () => [
+              {
+                identifier: "WM-800",
+                description: "## Owned Paths\n- src/api/routes.ts\n",
+              },
+            ],
+            countLeases: () => 0,
+          },
+        }),
+      );
       expect(sumA.terminalState).not.toBe("REFUSED");
       expect(sumA.reasonCode).not.toBe("owned_paths_overlap");
 
       // Identical concrete file on both sides: same file is not same lines —
       // advisory lets it run too (evidence carries the pair).
-      queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-708" } }));
-      const sumB = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-        dispatch: {
-          locksDir: lockDir,
-          fetchTicket: () => readyDispatchTicket("WM-708", { description: "## Owned Paths\n- src/api/routes.ts\n" }),
-          fetchInFlight: () => [{ identifier: "WM-801", description: "## Owned Paths\n- src/api/routes.ts\n" }],
-          countLeases: () => 0,
-        },
-      }));
+      queueRun(
+        db,
+        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-708" } }),
+      );
+      const sumB = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            fetchTicket: () =>
+              readyDispatchTicket("WM-708", {
+                description: "## Owned Paths\n- src/api/routes.ts\n",
+              }),
+            fetchInFlight: () => [
+              {
+                identifier: "WM-801",
+                description: "## Owned Paths\n- src/api/routes.ts\n",
+              },
+            ],
+            countLeases: () => 0,
+          },
+        }),
+      );
       expect(sumB.terminalState).not.toBe("REFUSED");
       expect(sumB.reasonCode).not.toBe("owned_paths_conflict_hard");
 
       // A `**` claim on the in-flight side: still a hard conflict.
-      queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-709" } }));
-      const sumC = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-        dispatch: {
-          locksDir: lockDir,
-          fetchTicket: () => readyDispatchTicket("WM-709", { description: "## Owned Paths\n- docs/readme.md\n" }),
-          fetchInFlight: () => [{ identifier: "WM-802", description: "## Owned Paths\n- **\n" }],
-          countLeases: () => 0,
-        },
-      }));
+      queueRun(
+        db,
+        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-709" } }),
+      );
+      const sumC = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            fetchTicket: () =>
+              readyDispatchTicket("WM-709", {
+                description: "## Owned Paths\n- docs/readme.md\n",
+              }),
+            fetchInFlight: () => [
+              { identifier: "WM-802", description: "## Owned Paths\n- **\n" },
+            ],
+            countLeases: () => 0,
+          },
+        }),
+      );
       expect(sumC.terminalState).toBe("REFUSED");
       expect(sumC.reasonCode).toBe("owned_paths_conflict_hard");
     } finally {
@@ -2381,11 +3415,18 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-claim-retry-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-claim-retry-leases-"));
-    const spec = queueRun(db, makeDispatchSpec({
-      input: { repo: "wt-worker", ticket: "WM-621" },
-    }));
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-claim-retry-locks-"),
+    );
+    const leaseDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-claim-retry-leases-"),
+    );
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-worker", ticket: "WM-621" },
+      }),
+    );
     let now = T0;
     let ticket = readyDispatchTicket("WM-621");
     let claimCalls = 0;
@@ -2395,10 +3436,18 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     let releaseSecond;
     let markFirstStarted;
     let markSecondStarted;
-    const firstStarted = new Promise((resolve) => { markFirstStarted = resolve; });
-    const secondStarted = new Promise((resolve) => { markSecondStarted = resolve; });
-    const firstRelease = new Promise((resolve) => { releaseFirst = resolve; });
-    const secondRelease = new Promise((resolve) => { releaseSecond = resolve; });
+    const firstStarted = new Promise((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const secondStarted = new Promise((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const firstRelease = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondRelease = new Promise((resolve) => {
+      releaseSecond = resolve;
+    });
     const retryAdapter = {
       async execute(args) {
         adapterCalls += 1;
@@ -2427,7 +3476,12 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           ticket = readyDispatchTicket("WM-621", {
             state: { name: "In Progress" },
             assignee: { id: "factory-user", name: "Factory" },
-            labels: { nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }] },
+            labels: {
+              nodes: [
+                { name: "ai:in-progress" },
+                { name: "agent:claude-code" },
+              ],
+            },
           });
           return { ok: true };
         },
@@ -2440,7 +3494,13 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     });
 
     const firstClaim = claimNext(db, o);
-    const firstExecution = executeClaimed(db, registry, { fake: retryAdapter }, firstClaim, o);
+    const firstExecution = executeClaimed(
+      db,
+      registry,
+      { fake: retryAdapter },
+      firstClaim,
+      o,
+    );
     let retryExecution;
     try {
       await firstStarted;
@@ -2454,15 +3514,19 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       retryExecution = runOnce(db, registry, { fake: retryAdapter }, o);
       await secondStarted;
       expect(claimCalls).toBe(1);
-      expect(lifecycleOf(db, spec.runId)).toEqual(expect.arrayContaining([
-        expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),
-      ]));
+      expect(lifecycleOf(db, spec.runId)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),
+        ]),
+      );
 
       releaseFirst();
       expect(await firstExecution).toEqual({ fenced: true });
       expect(unclaimCalls).toBe(0);
       expect(ticket.state.name).toBe("In Progress");
-      expect(liveWorkerLeases("wt-worker", { dir: leaseDir, now })).toHaveLength(1);
+      expect(
+        liveWorkerLeases("wt-worker", { dir: leaseDir, now }),
+      ).toHaveLength(1);
 
       releaseSecond();
       const retried = await retryExecution;
@@ -2470,18 +3534,25 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     } finally {
       releaseFirst();
       releaseSecond();
-      await Promise.allSettled([firstExecution, retryExecution].filter(Boolean));
+      await Promise.allSettled(
+        [firstExecution, retryExecution].filter(Boolean),
+      );
     }
   });
 
   test("claim-time Linear read failure contradicting plan evidence requeues with backoff", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-transient-linear-"));
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-transient-linear-"),
+    );
     const description = "## Owned Paths\n- src/feature/**\n";
-    const spec = queueRun(db, makeDispatchSpec({
-      input: { repo: "wt-worker", ticket: "WM-707" },
-      approvalPolicy: planTimeDispatchEvidence(description),
-    }));
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-worker", ticket: "WM-707" },
+        approvalPolicy: planTimeDispatchEvidence(description),
+      }),
+    );
     let now = T0;
     let reads = 0;
     const o = opts({
@@ -2500,25 +3571,50 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       },
     });
 
-    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "linear_read_failed" });
+    const deferred = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(deferred).toMatchObject({
+      terminalState: "QUEUED",
+      reasonCode: "linear_read_failed",
+    });
     expect(deferred.requeueAfterMs).toBeGreaterThan(0);
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
+    expect(
+      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+        .attempts,
+    ).toBe(0);
     expect(claimNext(db, o)).toBeNull();
 
     now += deferred.requeueAfterMs;
-    const completed = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(completed).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok", attempt: 1 });
+    const completed = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(completed).toMatchObject({
+      terminalState: "COMPLETED",
+      reasonCode: "ok",
+      attempt: 1,
+    });
   });
 
   test("empty claim-time description retries only when its hash contradicts plan evidence, then explains recovery", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-transient-owned-paths-"));
-    const spec = queueRun(db, makeDispatchSpec({
-      input: { repo: "wt-worker", ticket: "WM-708" },
-      approvalPolicy: planTimeDispatchEvidence(),
-    }));
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-transient-owned-paths-"),
+    );
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-worker", ticket: "WM-708" },
+        approvalPolicy: planTimeDispatchEvidence(),
+      }),
+    );
     let now = T0;
     const o = opts({
       now: () => now,
@@ -2532,20 +3628,38 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       },
     });
 
-    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "owned_paths_unknown" });
+    const deferred = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(deferred).toMatchObject({
+      terminalState: "QUEUED",
+      reasonCode: "owned_paths_unknown",
+    });
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     now += deferred.requeueAfterMs;
-    const exhausted = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(exhausted).toMatchObject({ terminalState: "REFUSED", reasonCode: "owned_paths_unknown" });
+    const exhausted = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      o,
+    );
+    expect(exhausted).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "owned_paths_unknown",
+    });
     expect(runState(db, spec.runId)).toBe("REFUSED");
-    expect(() => retryRun(db, spec.runId, {
-      actor: "operator",
-      force: true,
-      policyVersion: "test",
-      now,
-    })).toThrow(
+    expect(() =>
+      retryRun(db, spec.runId, {
+        actor: "operator",
+        force: true,
+        policyVersion: "test",
+        now,
+      }),
+    ).toThrow(
       `factory dispatch event factory.dispatch.requested --payload '{"repo":"wt-worker","ticket":"WM-708"}' --watch`,
     );
   });
@@ -2558,28 +3672,41 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     let sawActiveLease = false;
     const leaseCheckAdapter = {
       async execute({ spec, workspaceDir }) {
-        const active = liveWorkerLeases("wt-worker", { dir: leaseDir, now: T0 });
+        const active = liveWorkerLeases("wt-worker", {
+          dir: leaseDir,
+          now: T0,
+        });
         sawActiveLease = active.some((l) => l.ticket === spec.input.ticket);
         return dispatchFakeAdapter.execute({ spec, workspaceDir });
       },
     };
 
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-710" } }));
-    const summary = await runOnce(db, registry, { fake: leaseCheckAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-710"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-      },
-    }));
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-710" } }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: leaseCheckAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-710"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(sawActiveLease).toBe(true);
     expect(summary.terminalState).toBe("COMPLETED");
     // After execution, the lease must be released
-    expect(liveWorkerLeases("wt-worker", { dir: leaseDir, now: T0 })).toHaveLength(0);
+    expect(
+      liveWorkerLeases("wt-worker", { dir: leaseDir, now: T0 }),
+    ).toHaveLength(0);
   });
 
   test("mutating worktree is exempt from read-only clean check and runs repo verify command", async () => {
@@ -2587,21 +3714,31 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-locks-"));
     const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-leases-"));
 
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-720" } }));
-    const summary = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-720"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-      },
-    }));
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-720" } }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-720"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(summary.terminalState).toBe("COMPLETED");
     expect(summary.reasonCode).toBe("ok");
-    const resRow = db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(spec.runId);
+    const resRow = db
+      .query(`SELECT result_json FROM results WHERE run_id = ?`)
+      .get(spec.runId);
     const result = JSON.parse(resRow.result_json);
     expect(result.verification.checks).toContain("repo_verify_passed");
   });
@@ -2609,19 +3746,31 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   test("failing repo verify command triggers contract_violation failure", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-fverify-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-fverify-leases-"));
+    const leaseDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-fverify-leases-"),
+    );
 
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-failing-verify", ticket: "WM-730" } }));
-    const summary = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-730"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-      },
-    }));
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-failing-verify", ticket: "WM-730" },
+      }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-730"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("contract_violation");
@@ -2630,452 +3779,648 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   test("a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-leases-"));
+    const leaseDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-baseline-leases-"),
+    );
     let executionInput = null;
     const unclaimCalls = [];
     const blockCalls = [];
     const observingAdapter = {
       async execute({ spec, workspaceDir }) {
-        executionInput = JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8"));
+        executionInput = JSON.parse(
+          readFileSync(path.join(workspaceDir, "input.json"), "utf8"),
+        );
         return dispatchFakeAdapter.execute({ spec, workspaceDir });
       },
     };
 
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-baseline-red", ticket: "WM-731" } }));
-    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-731"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-        unclaimTicket: (payload) => {
-          unclaimCalls.push(payload);
-          return false;
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-baseline-red", ticket: "WM-731" },
+      }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: observingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-731"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+          unclaimTicket: (payload) => {
+            unclaimCalls.push(payload);
+            return false;
+          },
+          blockBaselineTicket: (payload) => {
+            blockCalls.push(payload);
+            return true;
+          },
         },
-        blockBaselineTicket: (payload) => {
-          blockCalls.push(payload);
-          return true;
-        },
-      },
-    }));
+      }),
+    );
 
     expect(executionInput).toMatchObject({
       repo: "wt-baseline-red",
       ticket: "WM-731",
-      baseline: { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+      baseline: {
+        status: "red",
+        check: "web_build",
+        output: "entry chunk exceeds budget",
+      },
     });
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("baseline_red");
     expect(blockCalls).toHaveLength(1);
     expect(unclaimCalls).toHaveLength(0);
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("baseline_red");
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("baseline_red");
   });
 
-  test("worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments", { timeout: 45_000 }, async () => {
-    const repoRoot = process.cwd();
-    const repoName = "wm-baseline-real";
-    const ticket = `WM-${732000000 + Math.floor(Math.random() * 1_000_000)}`;
-    const apiPort = "7408";
-    const apiPortNumber = Number(apiPort);
-    const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "wm334-real-"));
-    const stubDir = path.join(tmpRoot, "stub");
-    const linearStateDir = path.join(tmpRoot, "linear-state");
-    const worktreeRoot = path.join(tmpRoot, "worktrees");
-    const reposFile = path.join(tmpRoot, "config", "repos.yaml");
+  test(
+    "worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments",
+    { timeout: 45_000 },
+    async () => {
+      const repoRoot = process.cwd();
+      const repoName = "wm-baseline-real";
+      const ticket = `WM-${732000000 + Math.floor(Math.random() * 1_000_000)}`;
+      const apiPort = "7408";
+      const apiPortNumber = Number(apiPort);
+      const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "wm334-real-"));
+      const stubDir = path.join(tmpRoot, "stub");
+      const linearStateDir = path.join(tmpRoot, "linear-state");
+      const worktreeRoot = path.join(tmpRoot, "worktrees");
+      const reposFile = path.join(tmpRoot, "config", "repos.yaml");
 
-    const write = (p, c) => {
-      mkdirSync(path.dirname(p), { recursive: true });
-      writeFileSync(p, c, "utf8");
-    };
+      const write = (p, c) => {
+        mkdirSync(path.dirname(p), { recursive: true });
+        writeFileSync(p, c, "utf8");
+      };
 
-    const baselineFailureSignature = ({ why, log = null, baseline }) =>
-      createHash("sha256")
-        .update(JSON.stringify({
-          why,
-          log,
-          baseline: baseline && typeof baseline === "object"
-            ? { check: baseline.check, exitCode: baseline.exitCode, output: baseline.output }
-            : null,
-        }))
-        .digest("hex");
+      const baselineFailureSignature = ({ why, log = null, baseline }) =>
+        createHash("sha256")
+          .update(
+            JSON.stringify({
+              why,
+              log,
+              baseline:
+                baseline && typeof baseline === "object"
+                  ? {
+                      check: baseline.check,
+                      exitCode: baseline.exitCode,
+                      output: baseline.output,
+                    }
+                  : null,
+            }),
+          )
+          .digest("hex");
 
-    const baselineFailureMarker = (payload) => `wm:baseline:red:${baselineFailureSignature(payload)}`;
-    const keepAliveProcesses = [];
+      const baselineFailureMarker = (payload) =>
+        `wm:baseline:red:${baselineFailureSignature(payload)}`;
+      const keepAliveProcesses = [];
 
-    const expectedHome = path.join(worktreeRoot, ticket, ".factory", "event-runtime");
-    const seedRuntimeState = () => {};
+      const expectedHome = path.join(
+        worktreeRoot,
+        ticket,
+        ".factory",
+        "event-runtime",
+      );
+      const seedRuntimeState = () => {};
 
+      const currentBranch = (
+        spawnSync(
+          "git",
+          ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"],
+          { encoding: "utf8" },
+        ).stdout || ""
+      ).trim();
+      // GitHub Actions checks out a PR merge ref detached from its source branch.
+      // Give worktree-up a verified origin ref to that checked-out commit, rather
+      // than accidentally constructing the invalid origin/HEAD ref.
+      const detachedBaseBranch =
+        currentBranch === "HEAD" ? `wm334-test-${ticket}-${process.pid}` : null;
+      if (detachedBaseBranch) {
+        const head = (
+          spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+            encoding: "utf8",
+          }).stdout || ""
+        ).trim();
+        execFileSync("git", [
+          "-C",
+          repoRoot,
+          "update-ref",
+          `refs/remotes/origin/${detachedBaseBranch}`,
+          head,
+        ]);
+      }
+      const hasRemoteBranch = (branch) =>
+        branch &&
+        branch !== "HEAD" &&
+        spawnSync("git", [
+          "-C",
+          repoRoot,
+          "show-ref",
+          "--verify",
+          "--quiet",
+          `refs/remotes/origin/${branch}`,
+        ]).status === 0;
+      const baseBranch = [
+        currentBranch,
+        detachedBaseBranch,
+        process.env.GITHUB_BASE_REF,
+        "develop",
+      ].find(hasRemoteBranch);
+      expect(baseBranch).toBeDefined();
+      expect(baseBranch).not.toBe("HEAD");
+      expect(hasRemoteBranch(baseBranch)).toBe(true);
+      const realBun =
+        (
+          spawnSync("bash", ["-c", "command -v bun"], {
+            encoding: "utf8",
+            env: { ...process.env },
+          }).stdout || ""
+        ).trim() || "bun";
 
-    const currentBranch = (spawnSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).stdout || "").trim();
-    // GitHub Actions checks out a PR merge ref detached from its source branch.
-    // Give worktree-up a verified origin ref to that checked-out commit, rather
-    // than accidentally constructing the invalid origin/HEAD ref.
-    const detachedBaseBranch = currentBranch === "HEAD" ? `wm334-test-${ticket}-${process.pid}` : null;
-    if (detachedBaseBranch) {
-      const head = (spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout || "").trim();
-      execFileSync("git", ["-C", repoRoot, "update-ref", `refs/remotes/origin/${detachedBaseBranch}`, head]);
-    }
-    const hasRemoteBranch = (branch) => branch && branch !== "HEAD" && spawnSync(
-      "git",
-      ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/remotes/origin/${branch}`],
-    ).status === 0;
-    const baseBranch = [currentBranch, detachedBaseBranch, process.env.GITHUB_BASE_REF, "develop"].find(hasRemoteBranch);
-    expect(baseBranch).toBeDefined();
-    expect(baseBranch).not.toBe("HEAD");
-    expect(hasRemoteBranch(baseBranch)).toBe(true);
-    const realBun = (spawnSync("bash", ["-c", "command -v bun"], { encoding: "utf8", env: { ...process.env } }).stdout || "").trim() || "bun";
+      mkdirSync(stubDir, { recursive: true });
+      mkdirSync(linearStateDir, { recursive: true });
 
-    mkdirSync(stubDir, { recursive: true });
-    mkdirSync(linearStateDir, { recursive: true });
+      const worktreeUp = path.join(stubDir, "worktree-up-no-seed.sh");
+      write(
+        worktreeUp,
+        `#!/usr/bin/env bash\nexec ${JSON.stringify(path.join(repoRoot, "bin", "worktree-up.sh"))} "$@" --no-seed\n`,
+      );
 
-    const worktreeUp = path.join(stubDir, "worktree-up-no-seed.sh");
-    write(
-      worktreeUp,
-      `#!/usr/bin/env bash\nexec ${JSON.stringify(path.join(repoRoot, "bin", "worktree-up.sh"))} "$@" --no-seed\n`,
-    );
+      const testPortBase = 18400 + Math.floor(Math.random() * 1000) * 2;
+      const testProcessMarker = `wm334-${process.pid}-${ticket}`;
 
-    const testPortBase = 18400 + Math.floor(Math.random() * 1000) * 2;
-    const testProcessMarker = `wm334-${process.pid}-${ticket}`;
+      const bunStubLines = [
+        "#!/usr/bin/env node",
+        'const fs = require("fs");',
+        'const path = require("path");',
+        'const { spawn } = require("child_process");',
+        ...processOwnerWatchdogSource().split("\n"),
+        `const stateDir = process.env.WM334_LINEAR_STATE_DIR || ${JSON.stringify(linearStateDir)}`,
+        `const realBun = process.env.WM334_REAL_BUN || ${JSON.stringify(realBun)}`,
+        "const args = process.argv.slice(2);",
+        "const logPath = process.env.WM334_BUN_LOG || null;",
+        "if (logPath) {\n  try {\n    fs.appendFileSync(logPath, `CALL ${args.join(' ')}\\n`);\n  } catch {}\n}",
+        "",
+        "function commentsPath(ticket) {",
+        '  return path.join(stateDir, ticket + ".comments.json");',
+        "}",
+        "function readComments(ticket) {",
+        "  try {",
+        '    return JSON.parse(fs.readFileSync(commentsPath(ticket), "utf8"));',
+        "  } catch {",
+        "    return [];",
+        "  }",
+        "}",
+        "function writeComments(ticket, rows) {",
+        '  fs.writeFileSync(commentsPath(ticket), JSON.stringify(rows), "utf8");',
+        "}",
+        "",
+        'if (args[0]?.endsWith("tools/linear.mjs")) {',
+        "  const verb = args[1];",
+        '  if (verb === "comments") {',
+        "    const ticket = args[2];",
+        "    console.log(JSON.stringify(readComments(ticket)));",
+        "    process.exit(0);",
+        "  }",
+        '  if (verb === "comment") {',
+        "    const ticket = args[2];",
+        '    const body = args.slice(3).join(" ");',
+        "    const rows = readComments(ticket);",
+        "    rows.push({ body });",
+        "    writeComments(ticket, rows);",
+        "    process.exit(0);",
+        "  }",
+        '  if (verb === "state") {',
+        '    console.log("ok");',
+        "    process.exit(0);",
+        "  }",
+        '  if (verb === "claim") {',
+        '    console.log("ok");',
+        "    process.exit(0);",
+        "  }",
+        '  if (verb === "get") {',
+        '    console.log(JSON.stringify({ identifier: args[2], state: { name: "In Progress" }, assignee: { name: "agent" }, labels: { nodes: [{ name: "ai:in-progress" }] } }));',
+        "    process.exit(0);",
+        "  }",
+        '  console.log("[]");',
+        "  process.exit(0);",
+        "}",
+        'if (args.includes("install")) {',
+        "  process.exit(0);",
+        "}",
+        'if (args[0] === "run" && args[1] === "build:fast") {',
+        '  console.log("entry chunk exceeds budget");',
+        "  process.exit(1);",
+        "}",
+        "const child = spawn(realBun, args, {",
+        '  stdio: "inherit",',
+        `  argv0: ${JSON.stringify(`factory-test-${testProcessMarker}`)},`,
+        `  env: { ...process.env, FACTORY_TEST_TRACKED_PROCESS: ${JSON.stringify(testProcessMarker)} },`,
+        "});",
+        'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+        'process.on("SIGINT", () => child.kill("SIGINT"));',
+        'process.on("SIGHUP", () => child.kill("SIGHUP"));',
+        'child.on("exit", (code, signal) => {',
+        "  if (signal) {",
+        "    try { process.kill(process.pid, signal); } catch {}",
+        "  }",
+        "  process.exit(code ?? 0);",
+        "});",
+      ];
+      write(path.join(stubDir, "bun"), bunStubLines.join("\n") + "\n");
 
-    const bunStubLines = [
-      "#!/usr/bin/env node",
-      "const fs = require(\"fs\");",
-      "const path = require(\"path\");",
-      "const { spawn } = require(\"child_process\");",
-      ...processOwnerWatchdogSource().split("\n"),
-      `const stateDir = process.env.WM334_LINEAR_STATE_DIR || ${JSON.stringify(linearStateDir)}`,
-      `const realBun = process.env.WM334_REAL_BUN || ${JSON.stringify(realBun)}`,
-      "const args = process.argv.slice(2);",
-      "const logPath = process.env.WM334_BUN_LOG || null;",
-      "if (logPath) {\n  try {\n    fs.appendFileSync(logPath, `CALL ${args.join(' ')}\\n`);\n  } catch {}\n}",
-      "",
-      "function commentsPath(ticket) {",
-      "  return path.join(stateDir, ticket + \".comments.json\");",
-      "}",
-      "function readComments(ticket) {",
-      "  try {",
-      "    return JSON.parse(fs.readFileSync(commentsPath(ticket), \"utf8\"));",
-      "  } catch {",
-      "    return [];",
-      "  }",
-      "}",
-      "function writeComments(ticket, rows) {",
-      "  fs.writeFileSync(commentsPath(ticket), JSON.stringify(rows), \"utf8\");",
-      "}",
-      "",
-      "if (args[0]?.endsWith(\"tools/linear.mjs\")) {",
-      "  const verb = args[1];",
-      "  if (verb === \"comments\") {",
-      "    const ticket = args[2];",
-      "    console.log(JSON.stringify(readComments(ticket)));",
-      "    process.exit(0);",
-      "  }",
-      "  if (verb === \"comment\") {",
-      "    const ticket = args[2];",
-      "    const body = args.slice(3).join(\" \");",
-      "    const rows = readComments(ticket);",
-      "    rows.push({ body });",
-      "    writeComments(ticket, rows);",
-      "    process.exit(0);",
-      "  }",
-      "  if (verb === \"state\") {",
-      "    console.log(\"ok\");",
-      "    process.exit(0);",
-      "  }",
-      "  if (verb === \"claim\") {",
-      "    console.log(\"ok\");",
-      "    process.exit(0);",
-      "  }",
-      "  if (verb === \"get\") {",
-      "    console.log(JSON.stringify({ identifier: args[2], state: { name: \"In Progress\" }, assignee: { name: \"agent\" }, labels: { nodes: [{ name: \"ai:in-progress\" }] } }));",
-      "    process.exit(0);",
-      "  }",
-      "  console.log(\"[]\");",
-      "  process.exit(0);",
-      "}",
-      "if (args.includes(\"install\")) {",
-      "  process.exit(0);",
-      "}",
-      "if (args[0] === \"run\" && args[1] === \"build:fast\") {",
-      "  console.log(\"entry chunk exceeds budget\");",
-      "  process.exit(1);",
-      "}",
-      "const child = spawn(realBun, args, {",
-      "  stdio: \"inherit\",",
-      `  argv0: ${JSON.stringify(`factory-test-${testProcessMarker}`)},`,
-      `  env: { ...process.env, FACTORY_TEST_TRACKED_PROCESS: ${JSON.stringify(testProcessMarker)} },`,
-      "});",
-      "process.on(\"SIGTERM\", () => child.kill(\"SIGTERM\"));",
-      "process.on(\"SIGINT\", () => child.kill(\"SIGINT\"));",
-      "process.on(\"SIGHUP\", () => child.kill(\"SIGHUP\"));",
-      "child.on(\"exit\", (code, signal) => {",
-      "  if (signal) {",
-      "    try { process.kill(process.pid, signal); } catch {}",
-      "  }",
-      "  process.exit(code ?? 0);",
-      "});",
-    ];
-    write(path.join(stubDir, "bun"), bunStubLines.join("\n") + "\n");
+      for (const filePath of [path.join(stubDir, "bun"), worktreeUp]) {
+        execFileSync("chmod", ["+x", filePath]);
+      }
 
-    for (const filePath of [path.join(stubDir, "bun"), worktreeUp]) {
-      execFileSync("chmod", ["+x", filePath]);
-    }
+      write(
+        reposFile,
+        `repos:\n` +
+          `  - name: ${repoName}\n` +
+          `    path: ${repoRoot}\n` +
+          `    github: watt-mind/${repoName}\n` +
+          `    base: ${baseBranch}\n` +
+          `    team: WM\n` +
+          `    project: Factory\n` +
+          `    max_in_flight: 1\n` +
+          `    worktree_up: ${worktreeUp}\n` +
+          `    worktree_down: bin/worktree-down.sh\n` +
+          `    worktree_root: ${worktreeRoot}\n` +
+          `    verify: printf 'entry chunk exceeds budget\\n' \\n  >&2; exit 1\n` +
+          `    escalate_paths: []\n`,
+      );
+      const basePolicy = readFileSync(
+        path.join(repoRoot, "config", "policy.yaml"),
+        "utf8",
+      );
+      const testPolicy = basePolicy.includes("  fake:")
+        ? basePolicy
+        : basePolicy.replace(
+            /^models:\n/m,
+            "models:\n  fake:\n    strong: default\n    standard: default\n    light: default\n",
+          );
+      write(path.join(tmpRoot, "config", "policy.yaml"), testPolicy);
 
-    write(
-      reposFile,
-      `repos:\n` +
-        `  - name: ${repoName}\n` +
-        `    path: ${repoRoot}\n` +
-        `    github: watt-mind/${repoName}\n` +
-        `    base: ${baseBranch}\n` +
-        `    team: WM\n` +
-        `    project: Factory\n` +
-        `    max_in_flight: 1\n` +
-        `    worktree_up: ${worktreeUp}\n` +
-        `    worktree_down: bin/worktree-down.sh\n` +
-        `    worktree_root: ${worktreeRoot}\n` +
-        `    verify: printf 'entry chunk exceeds budget\\n' \\n  >&2; exit 1\n` +
-        `    escalate_paths: []\n`,
-    );
-    const basePolicy = readFileSync(path.join(repoRoot, "config", "policy.yaml"), "utf8");
-    const testPolicy = basePolicy.includes("  fake:")
-      ? basePolicy
-      : basePolicy.replace(/^models:\n/m, "models:\n  fake:\n    strong: default\n    standard: default\n    light: default\n");
-    write(path.join(tmpRoot, "config", "policy.yaml"), testPolicy);
+      const originalEnv = {
+        FACTORY_REPOS_ROOT: process.env.FACTORY_REPOS_ROOT,
+        FACTORY_SKIP_FETCH: process.env.FACTORY_SKIP_FETCH,
+        FACTORY_BASE_BRANCH: process.env.FACTORY_BASE_BRANCH,
+        FACTORY_WT_ROOT: process.env.FACTORY_WT_ROOT,
+        FACTORY_PORT_BASE: process.env.FACTORY_PORT_BASE,
+        FACTORY_PORT_SPAN: process.env.FACTORY_PORT_SPAN,
+        PATH: process.env.PATH,
+        WM334_LINEAR_STATE_DIR: process.env.WM334_LINEAR_STATE_DIR,
+        WM334_REAL_BUN: process.env.WM334_REAL_BUN,
+        WM334_BUN_LOG: process.env.WM334_BUN_LOG,
+        FACTORY_TEST_TRACKED_PROCESS: process.env.FACTORY_TEST_TRACKED_PROCESS,
+      };
+      try {
+        process.env.FACTORY_REPOS_ROOT = tmpRoot;
+        process.env.FACTORY_SKIP_FETCH = "1";
+        process.env.FACTORY_BASE_BRANCH = baseBranch;
+        process.env.FACTORY_WT_ROOT = worktreeRoot;
+        process.env.FACTORY_PORT_BASE = String(testPortBase);
+        process.env.FACTORY_PORT_SPAN = "50";
+        process.env.PATH = `${path.join(stubDir)}:${process.env.PATH}`;
+        process.env.WM334_LINEAR_STATE_DIR = linearStateDir;
+        process.env.WM334_REAL_BUN = realBun;
+        process.env.WM334_BUN_LOG = path.join(tmpRoot, "bun-calls.log");
+        process.env.FACTORY_TEST_TRACKED_PROCESS = testProcessMarker;
 
-    const originalEnv = {
-      FACTORY_REPOS_ROOT: process.env.FACTORY_REPOS_ROOT,
-      FACTORY_SKIP_FETCH: process.env.FACTORY_SKIP_FETCH,
-      FACTORY_BASE_BRANCH: process.env.FACTORY_BASE_BRANCH,
-      FACTORY_WT_ROOT: process.env.FACTORY_WT_ROOT,
-      FACTORY_PORT_BASE: process.env.FACTORY_PORT_BASE,
-      FACTORY_PORT_SPAN: process.env.FACTORY_PORT_SPAN,
-      PATH: process.env.PATH,
-      WM334_LINEAR_STATE_DIR: process.env.WM334_LINEAR_STATE_DIR,
-      WM334_REAL_BUN: process.env.WM334_REAL_BUN,
-      WM334_BUN_LOG: process.env.WM334_BUN_LOG,
-      FACTORY_TEST_TRACKED_PROCESS: process.env.FACTORY_TEST_TRACKED_PROCESS,
-    };
-    try {
-      process.env.FACTORY_REPOS_ROOT = tmpRoot;
-      process.env.FACTORY_SKIP_FETCH = "1";
-      process.env.FACTORY_BASE_BRANCH = baseBranch;
-      process.env.FACTORY_WT_ROOT = worktreeRoot;
-      process.env.FACTORY_PORT_BASE = String(testPortBase);
-      process.env.FACTORY_PORT_SPAN = "50";
-      process.env.PATH = `${path.join(stubDir)}:${process.env.PATH}`;
-      process.env.WM334_LINEAR_STATE_DIR = linearStateDir;
-      process.env.WM334_REAL_BUN = realBun;
-      process.env.WM334_BUN_LOG = path.join(tmpRoot, 'bun-calls.log');
-      process.env.FACTORY_TEST_TRACKED_PROCESS = testProcessMarker;
-
-      const db = openDb(":memory:");
-      const lockDir = mkdtempSync(path.join(os.tmpdir(), "wm334-real-locks-"));
-      const leaseDir = mkdtempSync(path.join(os.tmpdir(), "wm334-real-leases-"));
-      const executionInputs = [];
-      const blockCalls = [];
-      const observedAdapter = {
-        async execute({ spec, workspaceDir }) {
-          executionInputs.push(JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8")));
-          const result = {
-            schemaVersion: "factory.agent-result/v1",
-            terminalState: "completed",
-            reasonCode: "ok",
-            artifact: {
-              outcome: "PR_OPEN",
-              repo: spec.input.repo,
-              ticket: spec.input.ticket,
-              prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/10`,
-              verification: {
-                command: "printf 'entry chunk exceeds budget\\n' > /dev/null; exit 1",
-                passed: true,
-                output: "agent verification passed",
+        const db = openDb(":memory:");
+        const lockDir = mkdtempSync(
+          path.join(os.tmpdir(), "wm334-real-locks-"),
+        );
+        const leaseDir = mkdtempSync(
+          path.join(os.tmpdir(), "wm334-real-leases-"),
+        );
+        const executionInputs = [];
+        const blockCalls = [];
+        const observedAdapter = {
+          async execute({ spec, workspaceDir }) {
+            executionInputs.push(
+              JSON.parse(
+                readFileSync(path.join(workspaceDir, "input.json"), "utf8"),
+              ),
+            );
+            const result = {
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              reasonCode: "ok",
+              artifact: {
+                outcome: "PR_OPEN",
+                repo: spec.input.repo,
+                ticket: spec.input.ticket,
+                prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/10`,
+                verification: {
+                  command:
+                    "printf 'entry chunk exceeds budget\\n' > /dev/null; exit 1",
+                  passed: true,
+                  output: "agent verification passed",
+                },
+                summary: `implemented ${spec.input.ticket}`,
               },
-              summary: `implemented ${spec.input.ticket}`,
-            },
-            evidence: { commands: ["cd event-runtime/web && bun run build:fast"] },
-          };
-          writeFileSync(path.join(workspaceDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`, "utf8");
-          return { exitCode: 0, timedOut: false };
-        },
-      };
+              evidence: {
+                commands: ["cd event-runtime/web && bun run build:fast"],
+              },
+            };
+            writeFileSync(
+              path.join(workspaceDir, "result.json"),
+              `${JSON.stringify(result, null, 2)}\n`,
+              "utf8",
+            );
+            return { exitCode: 0, timedOut: false };
+          },
+        };
 
-      const blockTicket = ({ ticket, why, baseline, log = null }) => {
-        blockCalls.push({ ticket, why, baseline, log });
-        const marker = baselineFailureMarker({ why, baseline, log });
-        const commentsPath = path.join(linearStateDir, `${ticket}.comments.json`);
-        const existing = existsSync(commentsPath) ? JSON.parse(readFileSync(commentsPath, "utf8")) : [];
-        if (!existing.some((row) => String(row.body ?? "").includes(marker))) {
-          existing.push({ body: `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}\n\n<!-- ${marker} -->` });
-          writeFileSync(commentsPath, JSON.stringify(existing), "utf8");
-        }
-        return true;
-      };
+        const blockTicket = ({ ticket, why, baseline, log = null }) => {
+          blockCalls.push({ ticket, why, baseline, log });
+          const marker = baselineFailureMarker({ why, baseline, log });
+          const commentsPath = path.join(
+            linearStateDir,
+            `${ticket}.comments.json`,
+          );
+          const existing = existsSync(commentsPath)
+            ? JSON.parse(readFileSync(commentsPath, "utf8"))
+            : [];
+          if (
+            !existing.some((row) => String(row.body ?? "").includes(marker))
+          ) {
+            existing.push({
+              body: `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}\n\n<!-- ${marker} -->`,
+            });
+            writeFileSync(commentsPath, JSON.stringify(existing), "utf8");
+          }
+          return true;
+        };
 
-      const run = async () => {
-        seedRuntimeState();
-        const spec = queueRun(db, makeDispatchSpec({
-          input: { repo: repoName, ticket },
-          workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: false },
-        }));
-        try {
-          return await runOnce(db, registry, { fake: observedAdapter }, opts({
-            workspacesRoot: mkdtempSync(path.join(os.tmpdir(), `${repoName}-run-`)),
-            dispatch: {
-              locksDir: lockDir,
-              leasesDir: leaseDir,
-              fetchTicket: () => readyDispatchTicket(ticket),
-              fetchInFlight: () => [],
-              countLeases: () => 0,
-              claimTicket: () => ({ ok: true }),
-              blockBaselineTicket: blockTicket,
-            },
-          }));
-        } finally {
-          trackProcessGroupsMatching(tmpRoot);
-          trackMarkedFakeRuntimeGroups(testProcessMarker);
-          const runDir = path.join(worktreeRoot, ticket, ".factory", "run");
-          if (existsSync(runDir)) {
-            for (const name of readdirSync(runDir).filter((entry) => entry.endsWith(".pid"))) {
-              const pid = Number(readFileSync(path.join(runDir, name), "utf8").trim());
-              if (Number.isInteger(pid) && pid > 0) trackProcess(pid);
+        const run = async () => {
+          seedRuntimeState();
+          const spec = queueRun(
+            db,
+            makeDispatchSpec({
+              input: { repo: repoName, ticket },
+              workspace: {
+                type: "worktree",
+                checkoutDir: "repo",
+                retainOnFailure: false,
+              },
+            }),
+          );
+          try {
+            return await runOnce(
+              db,
+              registry,
+              { fake: observedAdapter },
+              opts({
+                workspacesRoot: mkdtempSync(
+                  path.join(os.tmpdir(), `${repoName}-run-`),
+                ),
+                dispatch: {
+                  locksDir: lockDir,
+                  leasesDir: leaseDir,
+                  fetchTicket: () => readyDispatchTicket(ticket),
+                  fetchInFlight: () => [],
+                  countLeases: () => 0,
+                  claimTicket: () => ({ ok: true }),
+                  blockBaselineTicket: blockTicket,
+                },
+              }),
+            );
+          } finally {
+            trackProcessGroupsMatching(tmpRoot);
+            trackMarkedFakeRuntimeGroups(testProcessMarker);
+            const runDir = path.join(worktreeRoot, ticket, ".factory", "run");
+            if (existsSync(runDir)) {
+              for (const name of readdirSync(runDir).filter((entry) =>
+                entry.endsWith(".pid"),
+              )) {
+                const pid = Number(
+                  readFileSync(path.join(runDir, name), "utf8").trim(),
+                );
+                if (Number.isInteger(pid) && pid > 0) trackProcess(pid);
+              }
             }
           }
+        };
+
+        const first = await run();
+        const second = await run();
+        if (first.reasonCode !== "baseline_red") {
+          console.log("first summary", first);
         }
-      };
 
-      const first = await run();
-      const second = await run();
-      if (first.reasonCode !== "baseline_red") {
-        console.log("first summary", first);
-      }
+        expect(first.terminalState).toBe("FAILED");
+        expect(first.reasonCode).toBe("baseline_red");
+        expect(second.terminalState).toBe("FAILED");
+        expect(second.reasonCode).toBe("baseline_red");
+        expect(executionInputs).toHaveLength(2);
+        expect(blockCalls).toHaveLength(2);
+        expect(executionInputs[0]).toMatchObject({
+          repo: repoName,
+          ticket,
+          baseline: { status: "red", check: "web_build", exitCode: 1 },
+        });
+        expect(String(executionInputs[0].baseline.output ?? "")).toContain(
+          "entry chunk exceeds budget",
+        );
 
-      expect(first.terminalState).toBe("FAILED");
-      expect(first.reasonCode).toBe("baseline_red");
-      expect(second.terminalState).toBe("FAILED");
-      expect(second.reasonCode).toBe("baseline_red");
-      expect(executionInputs).toHaveLength(2);
-      expect(blockCalls).toHaveLength(2);
-      expect(executionInputs[0]).toMatchObject({
-        repo: repoName,
-        ticket,
-        baseline: { status: "red", check: "web_build", exitCode: 1 },
-      });
-      expect(String(executionInputs[0].baseline.output ?? "")).toContain("entry chunk exceeds budget");
+        const comments = JSON.parse(
+          readFileSync(
+            path.join(linearStateDir, `${ticket}.comments.json`),
+            "utf8",
+          ),
+        );
+        expect(comments).toHaveLength(1);
 
-      const comments = JSON.parse(readFileSync(path.join(linearStateDir, `${ticket}.comments.json`), "utf8"));
-      expect(comments).toHaveLength(1);
-
-      const marker = baselineFailureMarker({
-        why: blockCalls[0].why,
-        baseline: blockCalls[0].baseline,
-        log: blockCalls[0].log,
-      });
-      expect(comments[0].body).toContain(`<!-- ${marker} -->`);
-    } finally {
-      trackProcessGroupsMatching(tmpRoot);
-      trackMarkedFakeRuntimeGroups(testProcessMarker);
-      await cleanupTrackedProcesses();
-      if (detachedBaseBranch) {
-        spawnSync("git", ["-C", repoRoot, "update-ref", "-d", `refs/remotes/origin/${detachedBaseBranch}`]);
-      }
-      for (const child of keepAliveProcesses) {
-        try {
-          child.kill();
-        } catch {
-          /* intentionally ignored */
+        const marker = baselineFailureMarker({
+          why: blockCalls[0].why,
+          baseline: blockCalls[0].baseline,
+          log: blockCalls[0].log,
+        });
+        expect(comments[0].body).toContain(`<!-- ${marker} -->`);
+      } finally {
+        trackProcessGroupsMatching(tmpRoot);
+        trackMarkedFakeRuntimeGroups(testProcessMarker);
+        await cleanupTrackedProcesses();
+        if (detachedBaseBranch) {
+          spawnSync("git", [
+            "-C",
+            repoRoot,
+            "update-ref",
+            "-d",
+            `refs/remotes/origin/${detachedBaseBranch}`,
+          ]);
+        }
+        for (const child of keepAliveProcesses) {
+          try {
+            child.kill();
+          } catch {
+            /* intentionally ignored */
+          }
+        }
+        for (const [key, value] of Object.entries(originalEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        if (!process.env.WM334_KEEP_TMP_ROOT) {
+          rmSync(tmpRoot, { recursive: true, force: true });
         }
       }
-      for (const [key, value] of Object.entries(originalEnv)) {
-        if (value === undefined) {
-          delete process.env[key];
-        } else {
-          process.env[key] = value;
-        }
-      }
-      if (!process.env.WM334_KEEP_TMP_ROOT) {
-        rmSync(tmpRoot, { recursive: true, force: true });
-      }
-    }
-  });
+    },
+  );
 
   test("worktree provisioning failure is not misclassified as adapter_error and never reaches execution", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-provision-locks-"));
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-provision-locks-"),
+    );
     let executed = false;
-    const observingAdapter = { async execute() { executed = true; return { exitCode: 0, timedOut: false }; } };
-
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-broken-up", ticket: "WM-732" } }));
-    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-732"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
+    const observingAdapter = {
+      async execute() {
+        executed = true;
+        return { exitCode: 0, timedOut: false };
       },
-    }));
+    };
+
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-broken-up", ticket: "WM-732" } }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: observingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-732"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(executed).toBe(false);
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("workspace_provisioning_error");
     expect(summary.error).toContain("dependency install failed");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("workspace_provisioning_error");
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("workspace_provisioning_error");
   });
 
   test("filesystem failures after worktree_up remain typed workspace provisioning errors", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-link-collision-locks-"));
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-link-collision-locks-"),
+    );
     let executed = false;
-    const observingAdapter = { async execute() { executed = true; return { exitCode: 0, timedOut: false }; } };
-
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-link-collision", ticket: "WM-734" } }));
-    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-734"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
+    const observingAdapter = {
+      async execute() {
+        executed = true;
+        return { exitCode: 0, timedOut: false };
       },
-    }));
+    };
+
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-link-collision", ticket: "WM-734" },
+      }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: observingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-734"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(executed).toBe(false);
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("workspace_provisioning_error");
-    expect(summary.error).toContain("worktree provisioning failed for wt-link-collision/WM-734");
+    expect(summary.error).toContain(
+      "worktree provisioning failed for wt-link-collision/WM-734",
+    );
     expect(summary.error).toContain("EEXIST");
-    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("workspace_provisioning_error");
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("workspace_provisioning_error");
   });
 
   test("worktree_up daemon startup failure surfaces serve.log in provisioning error message", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-crash-locks-"));
-    const observingAdapter = { async execute() { return { exitCode: 0, timedOut: false }; } };
-
-    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-startup-crash", ticket: "WM-733" } }));
-    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        fetchTicket: () => readyDispatchTicket("WM-733"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
+    const observingAdapter = {
+      async execute() {
+        return { exitCode: 0, timedOut: false };
       },
-    }));
+    };
+
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-startup-crash", ticket: "WM-733" },
+      }),
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: observingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-733"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
 
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("workspace_provisioning_error");
-    expect(summary.error).toContain("RegistryError: event type test: model_tier strong has no mapping");
-    expect(summary.error).toContain("event runtime died during startup on 7400");
+    expect(summary.error).toContain(
+      "RegistryError: event type test: model_tier strong has no mapping",
+    );
+    expect(summary.error).toContain(
+      "event runtime died during startup on 7400",
+    );
   });
 
   test("rollback Linear ticket state to Todo on crash, timeout, and contract violation", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-rollback-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-rollback-leases-"));
+    const leaseDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-rollback-leases-"),
+    );
 
     const rollbacks = [];
     const mockUnclaim = ({ repo, ticket, why }) => {
@@ -3084,38 +4429,66 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     };
 
     // 1. Crash (exit code 1)
-    const crashingAdapter = { async execute() { return { exitCode: 1, timedOut: false }; } };
-    const spec1 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-740" } }));
-    const sum1 = await runOnce(db, registry, { fake: crashingAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-740"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-        unclaimTicket: mockUnclaim,
+    const crashingAdapter = {
+      async execute() {
+        return { exitCode: 1, timedOut: false };
       },
-    }));
+    };
+    const spec1 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-740" } }),
+    );
+    const sum1 = await runOnce(
+      db,
+      registry,
+      { fake: crashingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-740"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+          unclaimTicket: mockUnclaim,
+        },
+      }),
+    );
     expect(sum1.terminalState).toBe("FAILED");
-    expect(rollbacks).toContainEqual(expect.objectContaining({ ticket: "WM-740", why: "agent_exit_1" }));
+    expect(rollbacks).toContainEqual(
+      expect.objectContaining({ ticket: "WM-740", why: "agent_exit_1" }),
+    );
 
     // 2. Timeout
-    const timingOutAdapter = { async execute() { return { exitCode: 0, timedOut: true }; } };
-    const spec2 = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-741" } }));
-    const sum2 = await runOnce(db, registry, { fake: timingOutAdapter }, opts({
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => readyDispatchTicket("WM-741"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-        unclaimTicket: mockUnclaim,
+    const timingOutAdapter = {
+      async execute() {
+        return { exitCode: 0, timedOut: true };
       },
-    }));
+    };
+    const spec2 = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-741" } }),
+    );
+    const sum2 = await runOnce(
+      db,
+      registry,
+      { fake: timingOutAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => readyDispatchTicket("WM-741"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+          unclaimTicket: mockUnclaim,
+        },
+      }),
+    );
     expect(sum2.terminalState).toBe("TIMED_OUT");
-    expect(rollbacks).toContainEqual(expect.objectContaining({ ticket: "WM-741", why: "timeout" }));
+    expect(rollbacks).toContainEqual(
+      expect.objectContaining({ ticket: "WM-741", why: "timeout" }),
+    );
   });
 });
 
@@ -3125,10 +4498,24 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
 function stampRepo() {
   const root = mkdtempSync(path.join(os.tmpdir(), "evrt-stamp-"));
-  mkdirSync(path.join(root, "event-runtime", "lib", "adapters"), { recursive: true });
-  writeFileSync(path.join(root, "event-runtime", "cli.mjs"), "// cli\n", "utf8");
-  writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), "// worker\n", "utf8");
-  writeFileSync(path.join(root, "event-runtime", "lib", "adapters", "fake.mjs"), "// fake\n", "utf8");
+  mkdirSync(path.join(root, "event-runtime", "lib", "adapters"), {
+    recursive: true,
+  });
+  writeFileSync(
+    path.join(root, "event-runtime", "cli.mjs"),
+    "// cli\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(root, "event-runtime", "lib", "worker.mjs"),
+    "// worker\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(root, "event-runtime", "lib", "adapters", "fake.mjs"),
+    "// fake\n",
+    "utf8",
+  );
   writeFileSync(path.join(root, "README.md"), "# outside the stamp\n", "utf8");
   return root;
 }
@@ -3154,12 +4541,20 @@ describe("code stamp (WM-213)", () => {
       expect(codeStamp(root)).toBe(before);
 
       // No commit, no git at all — the stamp must still notice a working-tree edit.
-      writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), "// worker v2\n", "utf8");
+      writeFileSync(
+        path.join(root, "event-runtime", "lib", "worker.mjs"),
+        "// worker v2\n",
+        "utf8",
+      );
       const after = codeStamp(root);
       expect(after).not.toBe(before);
 
       // A new file under lib/ counts too, and a file outside the paths does not.
-      writeFileSync(path.join(root, "event-runtime", "lib", "new.mjs"), "// new\n", "utf8");
+      writeFileSync(
+        path.join(root, "event-runtime", "lib", "new.mjs"),
+        "// new\n",
+        "utf8",
+      );
       expect(codeStamp(root)).not.toBe(after);
       const withNew = codeStamp(root);
       writeFileSync(path.join(root, "README.md"), "# edited\n", "utf8");
@@ -3205,8 +4600,12 @@ describe("reload watcher (WM-213)", () => {
     });
     return {
       watcher,
-      change: (to) => { stamp = to; },
-      advance: (ms) => { clock += ms; },
+      change: (to) => {
+        stamp = to;
+      },
+      advance: (ms) => {
+        clock += ms;
+      },
     };
   }
 
@@ -3219,7 +4618,14 @@ describe("reload watcher (WM-213)", () => {
 
   test("re-stamps at most once per interval", () => {
     let calls = 0;
-    const watcher = createReloadWatcher({ intervalMs: 1000, stamp: () => { calls += 1; return "a"; }, now: () => 0 });
+    const watcher = createReloadWatcher({
+      intervalMs: 1000,
+      stamp: () => {
+        calls += 1;
+        return "a";
+      },
+      now: () => 0,
+    });
     expect(calls).toBe(1); // the startup stamp
     for (let i = 0; i < 20; i += 1) watcher.check(null);
     expect(calls).toBe(1); // the clock never moved, so nothing re-hashed
@@ -3255,13 +4661,26 @@ describe("reload watcher (WM-213)", () => {
 
     // Busy: deferred, and flagged `first` exactly once so the log says it once.
     const first = h.watcher.check("run_busy");
-    expect(first).toMatchObject({ action: "deferred", from: "a", to: "b", runId: "run_busy", first: true });
+    expect(first).toMatchObject({
+      action: "deferred",
+      from: "a",
+      to: "b",
+      runId: "run_busy",
+      first: true,
+    });
     h.advance(1000);
-    expect(h.watcher.check("run_busy")).toMatchObject({ action: "deferred", first: false });
+    expect(h.watcher.check("run_busy")).toMatchObject({
+      action: "deferred",
+      first: false,
+    });
 
     // The run finishes. The very next check reloads — no extra interval of wait,
     // because the pending change was latched rather than re-detected.
-    expect(h.watcher.check(null)).toMatchObject({ action: "reload", from: "a", to: "b" });
+    expect(h.watcher.check(null)).toMatchObject({
+      action: "reload",
+      from: "a",
+      to: "b",
+    });
   });
 
   test("a change that reverts before the next check is never seen", () => {
@@ -3278,7 +4697,10 @@ describe("reload watcher (WM-213)", () => {
     let clock = 0;
     const watcher = createReloadWatcher({
       intervalMs: 1000,
-      stamp: () => { reads += 1; return stamp; },
+      stamp: () => {
+        reads += 1;
+        return stamp;
+      },
       now: () => clock,
     });
     stamp = "b";

--- a/event-runtime/lib/workers-remote.mjs
+++ b/event-runtime/lib/workers-remote.mjs
@@ -16,7 +16,9 @@ export class NodeConfigError extends Error {
 }
 
 export function nodesConfigPath(root = FACTORY_ROOT) {
-  return process.env.FACTORY_NODES_CONFIG || path.join(root, "config", "nodes.yaml");
+  return (
+    process.env.FACTORY_NODES_CONFIG || path.join(root, "config", "nodes.yaml")
+  );
 }
 
 /** Expand leading ~ in paths */
@@ -42,7 +44,10 @@ export function expandHome(p, home = process.env.HOME) {
  *   adapters: string[]
  * }>}
  */
-export function loadNodesConfig({ configPath = null, root = FACTORY_ROOT } = {}) {
+export function loadNodesConfig({
+  configPath = null,
+  root = FACTORY_ROOT,
+} = {}) {
   const filePath = configPath || nodesConfigPath(root);
   if (!existsSync(filePath)) {
     return new Map();
@@ -52,7 +57,9 @@ export function loadNodesConfig({ configPath = null, root = FACTORY_ROOT } = {})
   try {
     parsed = Bun.YAML.parse(readFileSync(filePath, "utf8"));
   } catch (err) {
-    throw new NodeConfigError(`malformed nodes config at ${filePath}: ${err.message}`);
+    throw new NodeConfigError(
+      `malformed nodes config at ${filePath}: ${err.message}`,
+    );
   }
 
   const nodes = new Map();
@@ -62,23 +69,35 @@ export function loadNodesConfig({ configPath = null, root = FACTORY_ROOT } = {})
 
   for (const [name, entry] of Object.entries(parsed.nodes)) {
     if (!entry || typeof entry !== "object") {
-      throw new NodeConfigError(`invalid node entry for "${name}" in ${filePath}`);
+      throw new NodeConfigError(
+        `invalid node entry for "${name}" in ${filePath}`,
+      );
     }
     if (!entry.host || typeof entry.host !== "string") {
-      throw new NodeConfigError(`node "${name}" is missing required "host" property`);
+      throw new NodeConfigError(
+        `node "${name}" is missing required "host" property`,
+      );
     }
 
     const port = Number(entry.port ?? 22);
     if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-      throw new NodeConfigError(`node "${name}" has invalid port: ${entry.port}`);
+      throw new NodeConfigError(
+        `node "${name}" has invalid port: ${entry.port}`,
+      );
     }
 
     const factoryRoot = entry.factory_root || "~/Develop/factory";
     const branch = entry.branch || "develop";
     const user = entry.user || null;
-    const env = entry.env && typeof entry.env === "object" ? { ...entry.env } : {};
-    const labels = entry.labels && typeof entry.labels === "object" ? { ...entry.labels } : {};
-    const adapters = Array.isArray(entry.adapters) ? entry.adapters.map(String) : [];
+    const env =
+      entry.env && typeof entry.env === "object" ? { ...entry.env } : {};
+    const labels =
+      entry.labels && typeof entry.labels === "object"
+        ? { ...entry.labels }
+        : {};
+    const adapters = Array.isArray(entry.adapters)
+      ? entry.adapters.map(String)
+      : [];
 
     nodes.set(name, {
       name,
@@ -99,7 +118,11 @@ export function loadNodesConfig({ configPath = null, root = FACTORY_ROOT } = {})
 /**
  * Build safe ssh argv array for child process execution.
  */
-export function buildSshArgv(node, remoteCommand, { batchMode = true, connectTimeout = 5 } = {}) {
+export function buildSshArgv(
+  node,
+  remoteCommand,
+  { batchMode = true, connectTimeout = 5 } = {},
+) {
   const args = [];
   if (node.port && node.port !== 22) {
     args.push("-p", String(node.port));
@@ -126,24 +149,26 @@ export function buildSshArgv(node, remoteCommand, { batchMode = true, connectTim
 /**
  * Execute an SSH command against a remote node.
  */
-export function executeSsh(node, remoteCommand, {
-  batchMode = true,
-  connectTimeout = 5,
-  spawnFn = null,
-} = {}) {
+export function executeSsh(
+  node,
+  remoteCommand,
+  { batchMode = true, connectTimeout = 5, spawnFn = null } = {},
+) {
   const args = buildSshArgv(node, remoteCommand, { batchMode, connectTimeout });
-  const runner = spawnFn || ((cmd) => {
-    const proc = Bun.spawnSync({
-      cmd: ["ssh", ...cmd],
-      stdout: "pipe",
-      stderr: "pipe",
+  const runner =
+    spawnFn ||
+    ((cmd) => {
+      const proc = Bun.spawnSync({
+        cmd: ["ssh", ...cmd],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return {
+        exitCode: proc.exitCode,
+        stdout: proc.stdout.toString(),
+        stderr: proc.stderr.toString(),
+      };
     });
-    return {
-      exitCode: proc.exitCode,
-      stdout: proc.stdout.toString(),
-      stderr: proc.stderr.toString(),
-    };
-  });
 
   const res = runner(args);
   return {
@@ -157,11 +182,10 @@ export function executeSsh(node, remoteCommand, {
 /**
  * Probe remote node connectivity, git commit, runtime version, and running worker processes.
  */
-export function probeRemoteNode(node, {
-  localTrunkSha = null,
-  connectTimeout = 2,
-  spawnFn = null,
-} = {}) {
+export function probeRemoteNode(
+  node,
+  { localTrunkSha = null, connectTimeout = 2, spawnFn = null } = {},
+) {
   const remotePath = node.factoryRoot;
   // Probe script: checks git sha, branch, arch, os, bun version, and running worker pid
   const probeScript = [
@@ -210,10 +234,15 @@ export function probeRemoteNode(node, {
     };
   }
 
-  const [headSha, branch, dirtyCount, arch, osName, bunVer, pidsRaw] = match[1].trim().split("|");
+  const [headSha, branch, dirtyCount, arch, osName, bunVer, pidsRaw] = match[1]
+    .trim()
+    .split("|");
   const pids = pidsRaw ? pidsRaw.split(",").map(Number).filter(Boolean) : [];
   const parsedDirtyCount = Number(dirtyCount);
-  const normalizedDirtyCount = Number.isInteger(parsedDirtyCount) && parsedDirtyCount >= 0 ? parsedDirtyCount : 0;
+  const normalizedDirtyCount =
+    Number.isInteger(parsedDirtyCount) && parsedDirtyCount >= 0
+      ? parsedDirtyCount
+      : 0;
   const isMissingDir = headSha === "missing_dir";
   const isDirty = normalizedDirtyCount > 0;
 
@@ -257,10 +286,7 @@ export function probeRemoteNode(node, {
 /**
  * Deploy or update repository code and dependencies on a remote worker node.
  */
-export function deployRemoteWorker(node, {
-  ref = null,
-  spawnFn = null,
-} = {}) {
+export function deployRemoteWorker(node, { ref = null, spawnFn = null } = {}) {
   const targetBranch = ref || node.branch || "develop";
   const remotePath = node.factoryRoot;
 
@@ -296,9 +322,7 @@ export function deployRemoteWorker(node, {
 /**
  * Start a worker daemon process on the remote node.
  */
-export function startRemoteWorker(node, {
-  spawnFn = null,
-} = {}) {
+export function startRemoteWorker(node, { spawnFn = null } = {}) {
   const remotePath = node.factoryRoot;
   const envVars = Object.entries(node.env || {})
     .map(([k, v]) => `export ${k}="${v}";`)
@@ -332,17 +356,19 @@ export function startRemoteWorker(node, {
     name: node.name,
     ok,
     pid,
-    error: ok ? null : (res.stderr || res.stdout || "failed to start remote worker").trim(),
+    error: ok
+      ? null
+      : (res.stderr || res.stdout || "failed to start remote worker").trim(),
   };
 }
 
 /**
  * Stop running worker daemon processes on the remote node with graceful drain timeout.
  */
-export function stopRemoteWorker(node, {
-  drainTimeout = 15,
-  spawnFn = null,
-} = {}) {
+export function stopRemoteWorker(
+  node,
+  { drainTimeout = 15, spawnFn = null } = {},
+) {
   const remotePath = node.factoryRoot;
 
   const stopScript = [
@@ -376,18 +402,19 @@ export function stopRemoteWorker(node, {
   return {
     name: node.name,
     ok,
-    error: ok ? null : (res.stderr || res.stdout || "failed to stop remote worker").trim(),
+    error: ok
+      ? null
+      : (res.stderr || res.stdout || "failed to stop remote worker").trim(),
   };
 }
 
 /**
  * Perform rolling update of remote worker: stop -> deploy/pull -> start.
  */
-export function updateRemoteWorker(node, {
-  ref = null,
-  drainTimeout = 15,
-  spawnFn = null,
-} = {}) {
+export function updateRemoteWorker(
+  node,
+  { ref = null, drainTimeout = 15, spawnFn = null } = {},
+) {
   const stopRes = stopRemoteWorker(node, { drainTimeout, spawnFn });
   if (!stopRes.ok) {
     return {

--- a/event-runtime/lib/workers-remote.test.mjs
+++ b/event-runtime/lib/workers-remote.test.mjs
@@ -92,11 +92,17 @@ describe("ssh argv builder", () => {
       user: "worker",
       port: 2200,
     };
-    const argv = buildSshArgv(node, "echo hello", { batchMode: true, connectTimeout: 3 });
+    const argv = buildSshArgv(node, "echo hello", {
+      batchMode: true,
+      connectTimeout: 3,
+    });
     expect(argv).toEqual([
-      "-p", "2200",
-      "-o", "BatchMode=yes",
-      "-o", "ConnectTimeout=3",
+      "-p",
+      "2200",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=3",
       "worker@192.168.1.50",
       "echo hello",
     ]);
@@ -111,8 +117,10 @@ describe("ssh argv builder", () => {
     };
     const argv = buildSshArgv(node, ["git", "status"]);
     expect(argv).toEqual([
-      "-o", "BatchMode=yes",
-      "-o", "ConnectTimeout=5",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=5",
       "box.internal",
       "git status",
     ]);
@@ -155,7 +163,9 @@ describe("remote probe and version skew", () => {
     expect(result.skewStatus).toBe("synced");
     expect(result.workerActive).toBe(true);
     expect(result.workerPids).toEqual([501, 777]);
-    expect(result.details.headSha).toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(result.details.headSha).toBe(
+      "0123456789abcdef0123456789abcdef01234567",
+    );
     expect(result.details.branch).toBe("feat/remote-probe");
     expect(result.details.dirtyCount).toBe(2);
   });
@@ -213,7 +223,8 @@ describe("remote lifecycle operations", () => {
   test("deployRemoteWorker executes deploy script successfully", () => {
     const mockSpawn = () => ({
       exitCode: 0,
-      stdout: "Updating branch develop...\nInstalling dependencies...\nDEPLOY_SUCCESS\n",
+      stdout:
+        "Updating branch develop...\nInstalling dependencies...\nDEPLOY_SUCCESS\n",
       stderr: "",
     });
 
@@ -249,9 +260,12 @@ describe("remote lifecycle operations", () => {
     let callCount = 0;
     const mockSpawn = () => {
       callCount += 1;
-      if (callCount === 1) return { exitCode: 0, stdout: "STOP_SUCCESS:1", stderr: "" };
-      if (callCount === 2) return { exitCode: 0, stdout: "DEPLOY_SUCCESS", stderr: "" };
-      if (callCount === 3) return { exitCode: 0, stdout: "START_SUCCESS:99201", stderr: "" };
+      if (callCount === 1)
+        return { exitCode: 0, stdout: "STOP_SUCCESS:1", stderr: "" };
+      if (callCount === 2)
+        return { exitCode: 0, stdout: "DEPLOY_SUCCESS", stderr: "" };
+      if (callCount === 3)
+        return { exitCode: 0, stdout: "START_SUCCESS:99201", stderr: "" };
       return { exitCode: 0, stdout: "", stderr: "" };
     };
 

--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -22,7 +22,10 @@ export const HEARTBEAT_STALE_MS = 90_000;
 
 const iso = (now) => new Date(now).toISOString();
 
-export function registerWorker(db, { workerId, labels = {}, adapters = [], now = Date.now() }) {
+export function registerWorker(
+  db,
+  { workerId, labels = {}, adapters = [], now = Date.now() },
+) {
   const at = iso(now);
   db.query(
     `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state)
@@ -31,20 +34,34 @@ export function registerWorker(db, { workerId, labels = {}, adapters = [], now =
        host = excluded.host, pid = excluded.pid, labels_json = excluded.labels_json,
        adapters = excluded.adapters, last_seen = excluded.last_seen,
        state = 'idle', stopped_at = NULL`,
-  ).run(workerId, hostname(), process.pid, JSON.stringify(labels), adapters.join(","), at, at);
+  ).run(
+    workerId,
+    hostname(),
+    process.pid,
+    JSON.stringify(labels),
+    adapters.join(","),
+    at,
+    at,
+  );
   return { workerId, host: hostname(), pid: process.pid, labels, adapters };
 }
 
 /** Called every loop tick: proof of life, plus what the worker is doing. */
-export function heartbeat(db, workerId, { state = "idle", runId = null, now = Date.now() } = {}) {
-  db.query(`UPDATE workers SET last_seen = ?, state = ?, current_run = ? WHERE worker_id = ?`)
-    .run(iso(now), state, runId, workerId);
+export function heartbeat(
+  db,
+  workerId,
+  { state = "idle", runId = null, now = Date.now() } = {},
+) {
+  db.query(
+    `UPDATE workers SET last_seen = ?, state = ?, current_run = ? WHERE worker_id = ?`,
+  ).run(iso(now), state, runId, workerId);
 }
 
 /** Clean exit: recorded, so a stopped worker is distinguishable from a dead one. */
 export function deregisterWorker(db, workerId, { now = Date.now() } = {}) {
-  db.query(`UPDATE workers SET state = 'stopped', stopped_at = ?, current_run = NULL WHERE worker_id = ?`)
-    .run(iso(now), workerId);
+  db.query(
+    `UPDATE workers SET state = 'stopped', stopped_at = ?, current_run = NULL WHERE worker_id = ?`,
+  ).run(iso(now), workerId);
 }
 
 export function listWorkers(db, { now = Date.now() } = {}) {
@@ -62,7 +79,9 @@ export function listWorkers(db, { now = Date.now() } = {}) {
       state: row.state,
       currentRun: row.current_run,
       stoppedAt: row.stopped_at,
-      stale: row.state !== "stopped" && now - Date.parse(row.last_seen) > HEARTBEAT_STALE_MS,
+      stale:
+        row.state !== "stopped" &&
+        now - Date.parse(row.last_seen) > HEARTBEAT_STALE_MS,
     }));
 }
 
@@ -76,7 +95,10 @@ export function stalledWorkers(db, { now = Date.now() } = {}) {
 }
 
 /** Drop long-stopped workers so the registry reflects the fleet, not history. */
-export function pruneWorkers(db, { olderThanMs = 24 * 60 * 60 * 1000, now = Date.now() } = {}) {
+export function pruneWorkers(
+  db,
+  { olderThanMs = 24 * 60 * 60 * 1000, now = Date.now() } = {},
+) {
   return tx(db, () => {
     const cutoff = iso(now - olderThanMs);
     const { changes } = db
@@ -94,7 +116,9 @@ export function pruneWorkers(db, { olderThanMs = 24 * 60 * 60 * 1000, now = Date
  */
 export function satisfiesPlacement(labels, placement) {
   if (!placement || Object.keys(placement).length === 0) return true;
-  return Object.entries(placement).every(([key, value]) => String(labels?.[key]) === String(value));
+  return Object.entries(placement).every(
+    ([key, value]) => String(labels?.[key]) === String(value),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +150,9 @@ export function loadWorkerPolicy({ root = reposRoot() } = {}) {
   try {
     parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
   } catch (err) {
-    throw new Error(`${file}: unparseable policy.yaml — ${err.message}`, { cause: err });
+    throw new Error(`${file}: unparseable policy.yaml — ${err.message}`, {
+      cause: err,
+    });
   }
   const block = parsed?.workers;
   if (block === undefined || block === null) return null;
@@ -141,13 +167,17 @@ export function normalizePool({ min, max } = {}, where = "workers") {
   const value = (raw, fallback, key) => {
     if (raw === undefined || raw === null) return fallback;
     const n = typeof raw === "string" ? Number(raw) : raw;
-    if (!Number.isInteger(n) || n < 0) throw new Error(`${where}.${key} must be a non-negative integer (got ${raw})`);
+    if (!Number.isInteger(n) || n < 0)
+      throw new Error(
+        `${where}.${key} must be a non-negative integer (got ${raw})`,
+      );
     return n;
   };
   const lo = value(min, DEFAULT_POOL.min, "min");
   const hi = value(max, DEFAULT_POOL.max, "max");
   if (hi < 1) throw new Error(`${where}.max must be at least 1 (got ${hi})`);
-  if (lo > hi) throw new Error(`${where}.min (${lo}) cannot exceed max (${hi})`);
+  if (lo > hi)
+    throw new Error(`${where}.min (${lo}) cannot exceed max (${hi})`);
   return { min: lo, max: hi };
 }
 
@@ -156,8 +186,10 @@ export function parsePoolSpec(spec) {
   const raw = String(spec ?? "").trim();
   if (raw === "") throw new Error("--workers expects min:max (e.g. 1:3)");
   const parts = raw.split(":");
-  if (parts.length === 1) return normalizePool({ min: parts[0], max: parts[0] }, "--workers");
-  if (parts.length !== 2) throw new Error(`--workers expects min:max (got "${raw}")`);
+  if (parts.length === 1)
+    return normalizePool({ min: parts[0], max: parts[0] }, "--workers");
+  if (parts.length !== 2)
+    throw new Error(`--workers expects min:max (got "${raw}")`);
   return normalizePool({ min: parts[0], max: parts[1] }, "--workers");
 }
 
@@ -168,8 +200,12 @@ export function parsePoolSpec(spec) {
  * it as idle is how a queue starves behind a dead process.
  */
 export function poolCounts(db, { now = Date.now() } = {}) {
-  const queued = db.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'QUEUED'`).get().n;
-  const workers = listWorkers(db, { now }).filter((w) => w.state !== "stopped" && !w.stale);
+  const queued = db
+    .query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'QUEUED'`)
+    .get().n;
+  const workers = listWorkers(db, { now }).filter(
+    (w) => w.state !== "stopped" && !w.stale,
+  );
   const idle = workers.filter((w) => w.state !== "busy");
   return {
     queued,
@@ -200,19 +236,41 @@ export function poolCounts(db, { now = Date.now() } = {}) {
  * and into a respawn. The ceiling is measured against the physical pool,
  * because that is what the machine is actually running.
  */
-export function poolDecision({ queued = 0, idle = 0, pool = 0, pending = 0, draining = 0, min, max } = {}) {
+export function poolDecision({
+  queued = 0,
+  idle = 0,
+  pool = 0,
+  pending = 0,
+  draining = 0,
+  min,
+  max,
+} = {}) {
   const counts = { queued, idle, pool, pending, draining, min, max };
   const decide = (action, reason) => ({ action, reason, counts });
   const remaining = pool - draining;
 
-  if (remaining < min) return decide("spawn", `pool ${remaining} below workers.min ${min}`);
+  if (remaining < min)
+    return decide("spawn", `pool ${remaining} below workers.min ${min}`);
   if (pending > 0) return decide("hold", `${pending} worker(s) still starting`);
   if (queued > 0 && idle === 0) {
-    if (pool < max) return decide("spawn", `${queued} queued run(s), no idle worker, pool ${pool} < max ${max}`);
-    return decide("hold", `${queued} queued run(s) but pool is at workers.max ${max}`);
+    if (pool < max)
+      return decide(
+        "spawn",
+        `${queued} queued run(s), no idle worker, pool ${pool} < max ${max}`,
+      );
+    return decide(
+      "hold",
+      `${queued} queued run(s) but pool is at workers.max ${max}`,
+    );
   }
   if (queued === 0 && idle > 0 && remaining > min) {
-    return decide("drain", `${idle} idle worker(s) and no queued runs, pool ${remaining} above workers.min ${min}`);
+    return decide(
+      "drain",
+      `${idle} idle worker(s) and no queued runs, pool ${remaining} above workers.min ${min}`,
+    );
   }
-  return decide("hold", `steady: ${queued} queued, ${idle} idle, pool ${pool} (min ${min}, max ${max})`);
+  return decide(
+    "hold",
+    `steady: ${queued} queued, ${idle} idle, pool ${pool} (min ${min}, max ${max})`,
+  );
 }

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -22,7 +22,13 @@ import {
 } from "./workers.mjs";
 
 const PV = "git:test-pv";
-const db = () => openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-workers-")), "runtime.db"));
+const db = () =>
+  openDb(
+    path.join(
+      mkdtempSync(path.join(os.tmpdir(), "evrt-workers-")),
+      "runtime.db",
+    ),
+  );
 
 /** A QUEUED run, straight through the real lifecycle. */
 function queueRun(database, { runId, placement, adapter = "fake" }) {
@@ -45,7 +51,9 @@ function queueRun(database, { runId, placement, adapter = "fake" }) {
     actor: "planner",
     policyVersion: PV,
   });
-  database.query(`UPDATE runs SET state = 'QUEUED' WHERE run_id = ?`).run(runId);
+  database
+    .query(`UPDATE runs SET state = 'QUEUED' WHERE run_id = ?`)
+    .run(runId);
   return spec;
 }
 
@@ -59,8 +67,15 @@ describe("cross-process claiming (OPS-233)", () => {
 
     expect(first?.runId).toBe("run_contended");
     expect(second).toBeNull(); // no double-claim, no second attempt row
-    expect(d.query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`).get("run_contended").n).toBe(1);
-    expect(d.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_contended").state).toBe("LEASED");
+    expect(
+      d
+        .query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`)
+        .get("run_contended").n,
+    ).toBe(1);
+    expect(
+      d.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_contended")
+        .state,
+    ).toBe("LEASED");
   });
 
   test("each worker takes a different run, oldest first", () => {
@@ -89,37 +104,66 @@ describe("placement (OPS-233, workers doc §4)", () => {
     const d = db();
     queueRun(d, { runId: "run_lab", placement: { node: "lab" } });
 
-    expect(claimNext(d, { owner: "web-worker", policyVersion: PV, labels: { node: "web" } })).toBeNull();
-    const claimed = claimNext(d, { owner: "lab-worker", policyVersion: PV, labels: { node: "lab" } });
+    expect(
+      claimNext(d, {
+        owner: "web-worker",
+        policyVersion: PV,
+        labels: { node: "web" },
+      }),
+    ).toBeNull();
+    const claimed = claimNext(d, {
+      owner: "lab-worker",
+      policyVersion: PV,
+      labels: { node: "lab" },
+    });
     expect(claimed?.runId).toBe("run_lab");
   });
 
   test("an unplaced run is claimable by any worker", () => {
     const d = db();
     queueRun(d, { runId: "run_any" });
-    expect(claimNext(d, { owner: "w", policyVersion: PV, labels: { node: "anywhere" } })?.runId).toBe("run_any");
+    expect(
+      claimNext(d, {
+        owner: "w",
+        policyVersion: PV,
+        labels: { node: "anywhere" },
+      })?.runId,
+    ).toBe("run_any");
   });
 
   test("a placed run is skipped, not blocking: the next eligible run is claimed", () => {
     const d = db();
     queueRun(d, { runId: "run_lab_first", placement: { node: "lab" } });
     queueRun(d, { runId: "run_unplaced" });
-    const claimed = claimNext(d, { owner: "web-worker", policyVersion: PV, labels: { node: "web" } });
+    const claimed = claimNext(d, {
+      owner: "web-worker",
+      policyVersion: PV,
+      labels: { node: "web" },
+    });
     expect(claimed?.runId).toBe("run_unplaced");
   });
 
   test("a worker skips adapters it does not have", () => {
     const d = db();
     queueRun(d, { runId: "run_claude", adapter: "claude" });
-    expect(claimNext(d, { owner: "w", policyVersion: PV, adapters: ["command"] })).toBeNull();
-    expect(claimNext(d, { owner: "w", policyVersion: PV, adapters: ["claude"] })?.runId).toBe("run_claude");
+    expect(
+      claimNext(d, { owner: "w", policyVersion: PV, adapters: ["command"] }),
+    ).toBeNull();
+    expect(
+      claimNext(d, { owner: "w", policyVersion: PV, adapters: ["claude"] })
+        ?.runId,
+    ).toBe("run_claude");
   });
 
   test("satisfiesPlacement: every declared key must match; no requirement means anywhere", () => {
     expect(satisfiesPlacement({ node: "lab" }, undefined)).toBe(true);
     expect(satisfiesPlacement({ node: "lab" }, {})).toBe(true);
-    expect(satisfiesPlacement({ node: "lab", can: "infra-exec" }, { node: "lab" })).toBe(true);
-    expect(satisfiesPlacement({ node: "lab" }, { node: "lab", can: "infra-exec" })).toBe(false);
+    expect(
+      satisfiesPlacement({ node: "lab", can: "infra-exec" }, { node: "lab" }),
+    ).toBe(true);
+    expect(
+      satisfiesPlacement({ node: "lab" }, { node: "lab", can: "infra-exec" }),
+    ).toBe(false);
     expect(satisfiesPlacement({}, { node: "lab" })).toBe(false);
   });
 });
@@ -127,9 +171,18 @@ describe("placement (OPS-233, workers doc §4)", () => {
 describe("worker registry and heartbeats (OPS-233)", () => {
   test("registers, heartbeats with its current run, and deregisters cleanly", () => {
     const d = db();
-    registerWorker(d, { workerId: "w1", labels: { node: "lab" }, adapters: ["fake"] });
+    registerWorker(d, {
+      workerId: "w1",
+      labels: { node: "lab" },
+      adapters: ["fake"],
+    });
     let [w] = listWorkers(d);
-    expect(w).toMatchObject({ workerId: "w1", state: "idle", labels: { node: "lab" }, adapters: ["fake"] });
+    expect(w).toMatchObject({
+      workerId: "w1",
+      state: "idle",
+      labels: { node: "lab" },
+      adapters: ["fake"],
+    });
     expect(w.stale).toBe(false);
 
     heartbeat(d, "w1", { state: "busy", runId: "run_1" });
@@ -165,7 +218,11 @@ describe("worker registry and heartbeats (OPS-233)", () => {
     registerWorker(d, { workerId: "w1", labels: { node: "web" } });
     const rows = listWorkers(d);
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ state: "idle", labels: { node: "web" }, stoppedAt: null });
+    expect(rows[0]).toMatchObject({
+      state: "idle",
+      labels: { node: "web" },
+      stoppedAt: null,
+    });
   });
 
   test("pruning drops long-stopped workers only", () => {
@@ -187,28 +244,49 @@ describe("worker pool policy (WM-226)", () => {
   const configRoot = (yaml) => {
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-cfg-"));
     mkdirSync(path.join(root, "config"), { recursive: true });
-    if (yaml !== null) writeFileSync(path.join(root, "config", "policy.yaml"), yaml, "utf8");
+    if (yaml !== null)
+      writeFileSync(path.join(root, "config", "policy.yaml"), yaml, "utf8");
     return root;
   };
 
   test("an absent workers: block is null, not a default — that absence keeps the single-worker stack", () => {
     expect(loadWorkerPolicy({ root: configRoot(null) })).toBeNull();
-    expect(loadWorkerPolicy({ root: configRoot("concurrency:\n  max_in_flight_per_repo: 3\n") })).toBeNull();
+    expect(
+      loadWorkerPolicy({
+        root: configRoot("concurrency:\n  max_in_flight_per_repo: 3\n"),
+      }),
+    ).toBeNull();
   });
 
   test("a workers: block is read, and a partial one falls back per bound", () => {
-    expect(loadWorkerPolicy({ root: configRoot("workers:\n  min: 2\n  max: 5\n") })).toEqual({ min: 2, max: 5 });
-    expect(loadWorkerPolicy({ root: configRoot("workers:\n  max: 4\n") })).toEqual({ min: DEFAULT_POOL.min, max: 4 });
+    expect(
+      loadWorkerPolicy({ root: configRoot("workers:\n  min: 2\n  max: 5\n") }),
+    ).toEqual({ min: 2, max: 5 });
+    expect(
+      loadWorkerPolicy({ root: configRoot("workers:\n  max: 4\n") }),
+    ).toEqual({ min: DEFAULT_POOL.min, max: 4 });
     // An empty block is still a block: it selects the pool at its defaults.
-    expect(loadWorkerPolicy({ root: configRoot("workers: {}\n") })).toEqual(DEFAULT_POOL);
+    expect(loadWorkerPolicy({ root: configRoot("workers: {}\n") })).toEqual(
+      DEFAULT_POOL,
+    );
   });
 
   test("nonsense bounds fail closed, naming the key — an unbounded pool is the expensive mistake", () => {
-    expect(() => loadWorkerPolicy({ root: configRoot("workers:\n  min: 4\n  max: 2\n") })).toThrow(/min \(4\) cannot exceed max \(2\)/);
-    expect(() => loadWorkerPolicy({ root: configRoot("workers:\n  max: 0\n") })).toThrow(/max must be at least 1/);
-    expect(() => loadWorkerPolicy({ root: configRoot("workers:\n  min: -1\n") })).toThrow(/min must be a non-negative integer/);
-    expect(() => loadWorkerPolicy({ root: configRoot("workers:\n  max: two\n") })).toThrow(/max must be a non-negative integer/);
-    expect(() => loadWorkerPolicy({ root: configRoot("workers: [1, 3]\n") })).toThrow(/must be a map with min\/max/);
+    expect(() =>
+      loadWorkerPolicy({ root: configRoot("workers:\n  min: 4\n  max: 2\n") }),
+    ).toThrow(/min \(4\) cannot exceed max \(2\)/);
+    expect(() =>
+      loadWorkerPolicy({ root: configRoot("workers:\n  max: 0\n") }),
+    ).toThrow(/max must be at least 1/);
+    expect(() =>
+      loadWorkerPolicy({ root: configRoot("workers:\n  min: -1\n") }),
+    ).toThrow(/min must be a non-negative integer/);
+    expect(() =>
+      loadWorkerPolicy({ root: configRoot("workers:\n  max: two\n") }),
+    ).toThrow(/max must be a non-negative integer/);
+    expect(() =>
+      loadWorkerPolicy({ root: configRoot("workers: [1, 3]\n") }),
+    ).toThrow(/must be a map with min\/max/);
   });
 
   test("--workers min:max parses; a bare N pins the pool", () => {
@@ -244,7 +322,10 @@ describe("pool scaling decisions (WM-226)", () => {
   });
 
   test("below min always spawns, even while another worker is booting", () => {
-    expect(decide({ min: 2, max: 3, queued: 0, idle: 0, pool: 1, pending: 1 }).action).toBe("spawn");
+    expect(
+      decide({ min: 2, max: 3, queued: 0, idle: 0, pool: 1, pending: 1 })
+        .action,
+    ).toBe("spawn");
   });
 
   test("idle surplus above min drains, one worker per tick", () => {
@@ -260,21 +341,37 @@ describe("pool scaling decisions (WM-226)", () => {
   test("a worker already draining is not counted as staying — the pool cannot drain through its floor", () => {
     // Two workers, min 1, one already asked to leave. Counting it as present
     // would drain the second too, and the pool would respawn from empty.
-    expect(decide({ queued: 0, idle: 2, pool: 2, draining: 1 }).action).toBe("hold");
-    expect(decide({ queued: 0, idle: 3, pool: 3, draining: 1 }).action).toBe("drain");
+    expect(decide({ queued: 0, idle: 2, pool: 2, draining: 1 }).action).toBe(
+      "hold",
+    );
+    expect(decide({ queued: 0, idle: 3, pool: 3, draining: 1 }).action).toBe(
+      "drain",
+    );
     // Symmetrically, a departure that takes the pool under min is refilled now
     // rather than a tick after the floor is breached.
-    expect(decide({ queued: 0, idle: 1, pool: 1, draining: 1 }).action).toBe("spawn");
+    expect(decide({ queued: 0, idle: 1, pool: 1, draining: 1 }).action).toBe(
+      "spawn",
+    );
   });
 
   test("min 0 lets the pool reach zero and come back", () => {
-    expect(decide({ min: 0, queued: 0, idle: 1, pool: 1 }).action).toBe("drain");
-    expect(decide({ min: 0, queued: 1, idle: 0, pool: 0 }).action).toBe("spawn");
+    expect(decide({ min: 0, queued: 0, idle: 1, pool: 1 }).action).toBe(
+      "drain",
+    );
+    expect(decide({ min: 0, queued: 1, idle: 0, pool: 0 }).action).toBe(
+      "spawn",
+    );
   });
 
   test("every decision carries the counts that justified it", () => {
     expect(decide({ queued: 2, idle: 0, pool: 1, pending: 0 }).counts).toEqual({
-      queued: 2, idle: 0, pool: 1, pending: 0, draining: 0, min: 1, max: 3,
+      queued: 2,
+      idle: 0,
+      pool: 1,
+      pending: 0,
+      draining: 0,
+      min: 1,
+      max: 3,
     });
   });
 });
@@ -303,6 +400,8 @@ describe("poolCounts (WM-226)", () => {
 
     const counts = poolCounts(d, { now: started + HEARTBEAT_STALE_MS + 1000 });
     expect(counts).toMatchObject({ queued: 1, live: 0, idle: 0 });
-    expect(poolDecision({ ...counts, pool: 0, min: 1, max: 2 }).action).toBe("spawn");
+    expect(poolDecision({ ...counts, pool: 0, min: 1, max: 2 }).action).toBe(
+      "spawn",
+    );
   });
 });

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -9,7 +9,14 @@
  * artifact path can never name a file outside the workspace, failing closed.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import { leaseDir, liveWorkerLeases } from "../../lib/worker-leases.mjs";
@@ -61,11 +68,12 @@ const WARNING_LINE = /^warn:\s*/i;
 function worktreeScriptFailure(result) {
   const stdout = String(result.stdout ?? "");
   const stderr = String(result.stderr ?? "");
-  const actionable = (output) => output
-    .replace(ANSI_ESCAPE, "")
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !WARNING_LINE.test(line));
+  const actionable = (output) =>
+    output
+      .replace(ANSI_ESCAPE, "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !WARNING_LINE.test(line));
   const lines = actionable(stderr);
   if (lines.length === 0) lines.push(...actionable(stdout));
   const status = result.status ?? null;
@@ -89,7 +97,8 @@ export function safeJoin(workspaceDir, relPath) {
   if (path.isAbsolute(relPath)) throw new PathViolation(workspaceDir, relPath);
   const root = path.resolve(workspaceDir);
   const resolved = path.resolve(root, relPath);
-  if (!resolved.startsWith(root + path.sep)) throw new PathViolation(workspaceDir, relPath);
+  if (!resolved.startsWith(root + path.sep))
+    throw new PathViolation(workspaceDir, relPath);
   return resolved;
 }
 
@@ -107,13 +116,18 @@ export const MAX_MATERIALIZED_BYTES = 64 * 1024 * 1024;
 
 /** Resolve "$.input.logArtifact" against the run input; literals pass through. */
 export function resolveInputRef(input, expr) {
-  if (typeof expr !== "string") throw new Error(`artifact input ref must be a string, got ${typeof expr}`);
+  if (typeof expr !== "string")
+    throw new Error(`artifact input ref must be a string, got ${typeof expr}`);
   if (!expr.startsWith("$.input.")) return expr;
   const value = expr
     .slice("$.input.".length)
     .split(".")
-    .reduce((acc, key) => (acc === null || acc === undefined ? acc : acc[key]), input);
-  if (typeof value !== "string" || !value) throw new Error(`artifact input ref "${expr}" resolves to nothing`);
+    .reduce(
+      (acc, key) => (acc === null || acc === undefined ? acc : acc[key]),
+      input,
+    );
+  if (typeof value !== "string" || !value)
+    throw new Error(`artifact input ref "${expr}" resolves to nothing`);
   return value;
 }
 
@@ -124,7 +138,14 @@ export function resolveInputRef(input, expr) {
  * worker that dies and restarts must still know what to tear down.
  */
 const WORKTREE_MARKER = ".worktree.json";
-const ACTIVE_RUN_STATES = new Set(["PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING"]);
+const ACTIVE_RUN_STATES = new Set([
+  "PROPOSED",
+  "APPROVED",
+  "QUEUED",
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+]);
 
 /**
  * Return competing runtime ownership for a ticket, excluding the run currently
@@ -146,19 +167,32 @@ export function detectWorktreeOwnershipConflict({
     let db;
     try {
       db = new Database(databasePath, { readonly: true });
-      currentLeaseOwner = db
-        .query(`SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`)
-        .get(runId, attempt)?.lease_owner ?? null;
-      for (const row of db.query(`SELECT run_id, state, spec_json FROM runs`).all()) {
+      currentLeaseOwner =
+        db
+          .query(
+            `SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`,
+          )
+          .get(runId, attempt)?.lease_owner ?? null;
+      for (const row of db
+        .query(`SELECT run_id, state, spec_json FROM runs`)
+        .all()) {
         if (row.run_id === runId || !ACTIVE_RUN_STATES.has(row.state)) continue;
         let input;
-        try { input = JSON.parse(row.spec_json)?.input; } catch { continue; }
+        try {
+          input = JSON.parse(row.spec_json)?.input;
+        } catch {
+          continue;
+        }
         if (input?.repo === repo && input?.ticket === ticket) {
           runs.push({ runId: row.run_id, state: row.state });
         }
       }
     } catch (err) {
-      return { reason: `runtime ownership ledger unreadable: ${err.message}`, runs: [], leases: [] };
+      return {
+        reason: `runtime ownership ledger unreadable: ${err.message}`,
+        runs: [],
+        leases: [],
+      };
     } finally {
       db?.close();
     }
@@ -166,20 +200,38 @@ export function detectWorktreeOwnershipConflict({
 
   const competingLeases = leases
     .filter((lease) => lease?.repo === repo && lease?.ticket === ticket)
-    .filter((lease) => currentLeaseOwner ? lease.owner !== currentLeaseOwner : lease.pid !== process.pid)
+    .filter((lease) =>
+      currentLeaseOwner
+        ? lease.owner !== currentLeaseOwner
+        : lease.pid !== process.pid,
+    )
     .map((lease) => ({ owner: lease.owner, pid: lease.pid }));
   if (runs.length === 0 && competingLeases.length === 0) return null;
-  return { reason: "ticket has a non-terminal run or live worker lease", runs, leases: competingLeases };
+  return {
+    reason: "ticket has a non-terminal run or live worker lease",
+    runs,
+    leases: competingLeases,
+  };
 }
 
 function commentOnPreservedWorktree({ ticket, preservation }) {
   const text = `Recovered an abandoned dirty worktree before re-dispatch: preserved its uncommitted changes at \`${preservation.ref}\` (commit ${preservation.commit}, ${preservation.push === "pushed" ? "pushed to origin" : "kept locally because push failed"}).`;
-  const result = spawnSync("bun", [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text], {
-    cwd: FACTORY_ROOT,
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    "bun",
+    [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text],
+    {
+      cwd: FACTORY_ROOT,
+      encoding: "utf8",
+    },
+  );
   if (result.status !== 0) {
-    throw new Error(String(result.stderr || result.stdout || `Linear comment exited ${result.status}`).trim());
+    throw new Error(
+      String(
+        result.stderr ||
+          result.stdout ||
+          `Linear comment exited ${result.status}`,
+      ).trim(),
+    );
   }
   return { status: "posted" };
 }
@@ -188,11 +240,14 @@ function readPreservationReport(reportPath) {
   if (!existsSync(reportPath)) return null;
   const report = JSON.parse(readFileSync(reportPath, "utf8"));
   if (
-    typeof report?.ref !== "string" || !report.ref.startsWith("wip/")
-    || !/^[0-9a-f]{40}$/.test(report.commit)
-    || !["pushed", "local_only"].includes(report.push)
+    typeof report?.ref !== "string" ||
+    !report.ref.startsWith("wip/") ||
+    !/^[0-9a-f]{40}$/.test(report.commit) ||
+    !["pushed", "local_only"].includes(report.push)
   ) {
-    throw new Error("expected ref, 40-character commit, and pushed|local_only push status");
+    throw new Error(
+      "expected ref, 40-character commit, and pushed|local_only push status",
+    );
   }
   return report;
 }
@@ -225,7 +280,9 @@ function materializeWorktree({
   const repoName = input?.repo;
   const ticket = input?.ticket;
   if (!repoName || !ticket) {
-    throw new WorktreeError("a worktree workspace needs input.repo and input.ticket");
+    throw new WorktreeError(
+      "a worktree workspace needs input.repo and input.ticket",
+    );
   }
   const repo = getRepo(loadRepos(), repoName);
   if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) {
@@ -235,7 +292,12 @@ function materializeWorktree({
   }
   const worktreePath = path.join(repo.worktreeRoot, ticket);
   if (existsSync(worktreePath)) {
-    const conflict = ownershipConflict({ repo: repoName, ticket, runId, attempt });
+    const conflict = ownershipConflict({
+      repo: repoName,
+      ticket,
+      runId,
+      attempt,
+    });
     if (conflict) {
       throw new WorktreeError(
         `worktree_in_use: ${repoName}/${ticket} at ${worktreePath} is owned by a live run or lease`,
@@ -254,13 +316,20 @@ function materializeWorktree({
   // Persist teardown facts before bring-up starts. A script can create its
   // worktree and daemons before timing out; the marker lets the janitor find
   // and safely delegate cleanup even when createWorkspace never returns.
-  writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+  writeFileSync(
+    path.join(workspaceDir, WORKTREE_MARKER),
+    `${canonicalJson(record)}\n`,
+    "utf8",
+  );
 
   // Repo-owned bring-up may discover a red project baseline after the usable
   // worktree already exists. It reports that condition out-of-band and still
   // exits zero; a non-zero exit remains a provisioning failure.
   const reportPath = path.join(workspaceDir, ".worktree-up.json");
-  const preservationPath = path.join(workspaceDir, ".worktree-preservation.json");
+  const preservationPath = path.join(
+    workspaceDir,
+    ".worktree-preservation.json",
+  );
   rmSync(preservationPath, { force: true });
   const up = spawnSync("/bin/bash", [repo.worktreeUp, ticket], {
     cwd: repo.path,
@@ -272,7 +341,10 @@ function materializeWorktree({
       FACTORY_WORKTREE_PRESERVATION_REPORT: preservationPath,
       // Revalidated by factory's worktree-up while it holds the per-ticket
       // lifecycle lock, narrowing the ownership-check/preservation race.
-      FACTORY_WORKTREE_EXPECTED_LEASE_FILE: path.join(leaseDir(), `${repoName}-${ticket}.json`),
+      FACTORY_WORKTREE_EXPECTED_LEASE_FILE: path.join(
+        leaseDir(),
+        `${repoName}-${ticket}.json`,
+      ),
       FACTORY_WORKTREE_EXPECTED_LEASE_PID: String(process.pid),
     },
     timeout: timeoutMs,
@@ -296,24 +368,42 @@ function materializeWorktree({
   }
 
   if (!existsSync(worktreePath)) {
-    throw new WorktreeError(`worktree_up reported success for ${repoName}/${ticket} but did not create ${worktreePath}`);
+    throw new WorktreeError(
+      `worktree_up reported success for ${repoName}/${ticket} but did not create ${worktreePath}`,
+    );
   }
 
   let preservation;
   try {
     preservation = readPreservationReport(preservationPath);
   } catch (err) {
-    throw new WorktreeError(`worktree_up wrote an invalid preservation report for ${repoName}/${ticket}: ${err.message}`);
+    throw new WorktreeError(
+      `worktree_up wrote an invalid preservation report for ${repoName}/${ticket}: ${err.message}`,
+    );
   }
   if (preservation) {
     record.preservedWip = preservation;
-    writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+    writeFileSync(
+      path.join(workspaceDir, WORKTREE_MARKER),
+      `${canonicalJson(record)}\n`,
+      "utf8",
+    );
     try {
-      record.preservedWip.comment = preservationComment({ ticket, repo: repoName, preservation });
+      record.preservedWip.comment = preservationComment({
+        ticket,
+        repo: repoName,
+        preservation,
+      });
     } catch (err) {
       record.preservedWip.comment = { status: "failed", error: err.message };
-      writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
-      throw new WorktreeError(`preserved ${repoName}/${ticket} at ${preservation.ref} but could not post the Linear comment: ${err.message}`);
+      writeFileSync(
+        path.join(workspaceDir, WORKTREE_MARKER),
+        `${canonicalJson(record)}\n`,
+        "utf8",
+      );
+      throw new WorktreeError(
+        `preserved ${repoName}/${ticket} at ${preservation.ref} but could not post the Linear comment: ${err.message}`,
+      );
     }
   }
 
@@ -321,18 +411,28 @@ function materializeWorktree({
   if (existsSync(reportPath)) {
     try {
       const report = JSON.parse(readFileSync(reportPath, "utf8"));
-      if (report?.status !== "red" || typeof report.check !== "string" || typeof report.output !== "string") {
+      if (
+        report?.status !== "red" ||
+        typeof report.check !== "string" ||
+        typeof report.output !== "string"
+      ) {
         throw new Error("expected status=red with string check and output");
       }
       baseline = report;
     } catch (err) {
-      throw new WorktreeError(`worktree_up wrote an invalid baseline report for ${repoName}/${ticket}: ${err.message}`);
+      throw new WorktreeError(
+        `worktree_up wrote an invalid baseline report for ${repoName}/${ticket}: ${err.message}`,
+      );
     }
   }
 
   symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
   if (baseline) record.baseline = baseline;
-  writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+  writeFileSync(
+    path.join(workspaceDir, WORKTREE_MARKER),
+    `${canonicalJson(record)}\n`,
+    "utf8",
+  );
 
   // The agent contract points it at input.json, so runtime-discovered context
   // must be present there rather than hidden in an implementation marker.
@@ -351,7 +451,11 @@ function materializeWorktree({
         guidance: `An abandoned prior attempt was preserved at ${preservation.ref} before this clean re-dispatch.`,
       };
     }
-    writeFileSync(path.join(workspaceDir, "input.json"), `${canonicalJson(enrichedInput)}\n`, "utf8");
+    writeFileSync(
+      path.join(workspaceDir, "input.json"),
+      `${canonicalJson(enrichedInput)}\n`,
+      "utf8",
+    );
   }
   return record;
 }
@@ -374,7 +478,11 @@ export function createWorkspace({
   const resume = findPriorResumeContext({ root, runId, attempt, adapter });
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path.join(dir, "input.json"), `${canonicalJson(input)}\n`, "utf8");
+  writeFileSync(
+    path.join(dir, "input.json"),
+    `${canonicalJson(input)}\n`,
+    "utf8",
+  );
 
   // Declared artifact inputs (§7 `artifacts`, OPS-372): the spec names hashes,
   // the provider writes bytes, the agent reads files. An agent can never ask
@@ -385,11 +493,16 @@ export function createWorkspace({
     for (const entry of workspace.inputs ?? []) {
       const sha256 = resolveInputRef(input, entry.from);
       const out = materializeArtifact({
-        storeRoot: artifactStore, sha256hex: sha256, workspaceDir: dir, as: entry.as,
+        storeRoot: artifactStore,
+        sha256hex: sha256,
+        workspaceDir: dir,
+        as: entry.as,
       });
       total += out.sizeBytes;
       if (total > MAX_MATERIALIZED_BYTES) {
-        throw new Error(`artifact inputs exceed ${MAX_MATERIALIZED_BYTES} bytes for this run`);
+        throw new Error(
+          `artifact inputs exceed ${MAX_MATERIALIZED_BYTES} bytes for this run`,
+        );
       }
       materialized.push({ as: entry.as, sha256, sizeBytes: out.sizeBytes });
     }
@@ -471,8 +584,13 @@ export function destroyWorkspace(
     });
     if (down.error?.code === "ETIMEDOUT" || down.status !== 0) {
       const failure = worktreeScriptFailure(down);
-      if (down.error?.code === "ETIMEDOUT") failure.reason = `timed out after ${worktreeTimeoutMs}ms`;
-      writeFileSync(marker, `${canonicalJson({ ...record, downFailure: failure })}\n`, "utf8");
+      if (down.error?.code === "ETIMEDOUT")
+        failure.reason = `timed out after ${worktreeTimeoutMs}ms`;
+      writeFileSync(
+        marker,
+        `${canonicalJson({ ...record, downFailure: failure })}\n`,
+        "utf8",
+      );
       return false;
     }
     // A retained workspace may outlive a successfully removed worktree. Drop

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -1,11 +1,23 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import {
-  PathViolation, WorktreeError, createWorkspace, destroyWorkspace,
-  detectWorktreeOwnershipConflict, safeJoin,
+  PathViolation,
+  WorktreeError,
+  createWorkspace,
+  destroyWorkspace,
+  detectWorktreeOwnershipConflict,
+  safeJoin,
 } from "./workspace.mjs";
 
 function tmpRoot() {
@@ -17,7 +29,9 @@ describe("safeJoin", () => {
 
   test("accepts nested relative paths", () => {
     expect(safeJoin(ws, "result.json")).toBe(path.join(ws, "result.json"));
-    expect(safeJoin(ws, "logs/agent/output.log")).toBe(path.join(ws, "logs", "agent", "output.log"));
+    expect(safeJoin(ws, "logs/agent/output.log")).toBe(
+      path.join(ws, "logs", "agent", "output.log"),
+    );
   });
 
   test("rejects absolute paths", () => {
@@ -45,10 +59,22 @@ test("detectWorktreeOwnershipConflict excludes self but reports competing runs a
     CREATE TABLE attempts (run_id TEXT, attempt INTEGER, lease_owner TEXT);
   `);
   const spec = JSON.stringify({ input: { repo: "factory", ticket: "WM-627" } });
-  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_self", "RUNNING", spec);
-  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_other", "VERIFYING", spec);
+  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run(
+    "run_self",
+    "RUNNING",
+    spec,
+  );
+  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run(
+    "run_other",
+    "VERIFYING",
+    spec,
+  );
   db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_done", "FAILED", spec);
-  db.query(`INSERT INTO attempts VALUES (?, ?, ?)`).run("run_self", 1, "worker_self");
+  db.query(`INSERT INTO attempts VALUES (?, ?, ?)`).run(
+    "run_self",
+    1,
+    "worker_self",
+  );
   db.close();
 
   const conflict = detectWorktreeOwnershipConflict({
@@ -58,7 +84,12 @@ test("detectWorktreeOwnershipConflict excludes self but reports competing runs a
     attempt: 1,
     databasePath,
     leases: [
-      { repo: "factory", ticket: "WM-627", owner: "worker_self", pid: process.pid },
+      {
+        repo: "factory",
+        ticket: "WM-627",
+        owner: "worker_self",
+        pid: process.pid,
+      },
       { repo: "factory", ticket: "WM-627", owner: "worker_other", pid: 42 },
     ],
   });
@@ -66,27 +97,48 @@ test("detectWorktreeOwnershipConflict excludes self but reports competing runs a
     runs: [{ runId: "run_other", state: "VERIFYING" }],
     leases: [{ owner: "worker_other", pid: 42 }],
   });
-  expect(detectWorktreeOwnershipConflict({
-    repo: "factory",
-    ticket: "WM-627",
-    runId: "run_self",
-    attempt: 1,
-    databasePath,
-    leases: [{ repo: "factory", ticket: "WM-627", owner: "worker_self", pid: process.pid }],
-  })?.runs).toEqual([{ runId: "run_other", state: "VERIFYING" }]);
+  expect(
+    detectWorktreeOwnershipConflict({
+      repo: "factory",
+      ticket: "WM-627",
+      runId: "run_self",
+      attempt: 1,
+      databasePath,
+      leases: [
+        {
+          repo: "factory",
+          ticket: "WM-627",
+          owner: "worker_self",
+          pid: process.pid,
+        },
+      ],
+    })?.runs,
+  ).toEqual([{ runId: "run_other", state: "VERIFYING" }]);
 });
 
 describe("createWorkspace / destroyWorkspace", () => {
   test("creates <runId>-a<attempt> and writes canonical input.json", () => {
     const root = tmpRoot();
-    const { dir } = createWorkspace({ root, runId: "run_x", attempt: 1, input: { b: 2, a: 1 } });
+    const { dir } = createWorkspace({
+      root,
+      runId: "run_x",
+      attempt: 1,
+      input: { b: 2, a: 1 },
+    });
     expect(dir).toBe(path.join(root, "run_x-a1"));
-    expect(readFileSync(path.join(dir, "input.json"), "utf8")).toBe('{"a":1,"b":2}\n');
+    expect(readFileSync(path.join(dir, "input.json"), "utf8")).toBe(
+      '{"a":1,"b":2}\n',
+    );
   });
 
   test("destroy removes the directory; retain leaves it and returns false", () => {
     const root = tmpRoot();
-    const { dir } = createWorkspace({ root, runId: "run_y", attempt: 1, input: {} });
+    const { dir } = createWorkspace({
+      root,
+      runId: "run_y",
+      attempt: 1,
+      input: {},
+    });
     expect(destroyWorkspace(dir, { retain: true })).toBe(false);
     expect(existsSync(dir)).toBe(true);
     expect(destroyWorkspace(dir)).toBe(true);
@@ -105,12 +157,19 @@ describe("worktree workspaces (WM-108)", () => {
   let callsLog;
   let previousReposRoot;
 
-  const calls = () => (existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : []);
+  const calls = () =>
+    existsSync(callsLog)
+      ? readFileSync(callsLog, "utf8").trim().split("\n")
+      : [];
 
   beforeAll(() => {
     factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-wt-factory-"));
-    repoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-wt-repo-")));
-    wtRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-wt-trees-")));
+    repoDir = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "evrt-wt-repo-")),
+    );
+    wtRoot = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "evrt-wt-trees-")),
+    );
     callsLog = path.join(repoDir, "calls.log");
 
     mkdirSync(path.join(repoDir, "bin"), { recursive: true });
@@ -221,7 +280,9 @@ describe("worktree workspaces (WM-108)", () => {
     const link = path.join(dir, "repo");
     expect(lstatSync(link).isSymbolicLink()).toBe(true);
     expect(realpathSync(link)).toBe(path.join(wtRoot, "WM-1"));
-    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).ticket).toBe("WM-1");
+    expect(
+      JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).ticket,
+    ).toBe("WM-1");
     expect(destroyWorkspace(dir)).toBe(true);
   });
 
@@ -243,7 +304,9 @@ describe("worktree workspaces (WM-108)", () => {
     expect(calls()).toContain("down WM-3");
     expect(existsSync(dir)).toBe(true);
     expect(existsSync(tree)).toBe(true);
-    expect(readFileSync(path.join(tree, "debug-change"), "utf8")).toBe("keep me\n");
+    expect(readFileSync(path.join(tree, "debug-change"), "utf8")).toBe(
+      "keep me\n",
+    );
     expect(existsSync(path.join(tree, "ports"))).toBe(false);
     expect(existsSync(path.join(tree, "run", "serve.pid"))).toBe(false);
     expect(existsSync(path.join(tree, "run", "worker.pid"))).toBe(false);
@@ -258,7 +321,9 @@ describe("worktree workspaces (WM-108)", () => {
     expect(existsSync(path.join(wtRoot, "WM-12"))).toBe(false);
 
     const retry = make("wtrepo", "WM-12", "run_wt12_retry");
-    expect(calls().filter((call) => call.startsWith("up WM-12 "))).toHaveLength(2);
+    expect(calls().filter((call) => call.startsWith("up WM-12 "))).toHaveLength(
+      2,
+    );
     expect(destroyWorkspace(retry.dir)).toBe(true);
     expect(destroyWorkspace(dir)).toBe(true);
   });
@@ -268,7 +333,9 @@ describe("worktree workspaces (WM-108)", () => {
     expect(destroyWorkspace(dir, { retain: true })).toBe(false);
     expect(existsSync(dir)).toBe(true);
     expect(existsSync(path.join(wtRoot, "WM-4"))).toBe(true);
-    const { downFailure } = JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8"));
+    const { downFailure } = JSON.parse(
+      readFileSync(path.join(dir, ".worktree.json"), "utf8"),
+    );
     expect(downFailure.reason).toBe("fatal: refusing dirty tree");
     expect(downFailure.reason).not.toContain("warn:");
     expect(downFailure.stderr).toContain("warn: cleanup probe used fallback");
@@ -287,28 +354,39 @@ describe("worktree workspaces (WM-108)", () => {
   test("a live competing run or lease refuses an existing tree before worktree_up", () => {
     const tree = path.join(wtRoot, "WM-13");
     mkdirSync(tree, { recursive: true });
-    const before = calls().filter((call) => call.startsWith("up WM-13 ")).length;
+    const before = calls().filter((call) =>
+      call.startsWith("up WM-13 "),
+    ).length;
 
-    expect(() => make("wtrepo", "WM-13", "run_wt13", {
-      worktreeOwnershipConflict: () => ({
-        reason: "ticket has a non-terminal run or live worker lease",
-        runs: [{ runId: "run_other", state: "RUNNING" }],
-        leases: [{ owner: "worker_other", pid: 42 }],
+    expect(() =>
+      make("wtrepo", "WM-13", "run_wt13", {
+        worktreeOwnershipConflict: () => ({
+          reason: "ticket has a non-terminal run or live worker lease",
+          runs: [{ runId: "run_other", state: "RUNNING" }],
+          leases: [{ owner: "worker_other", pid: 42 }],
+        }),
       }),
-    })).toThrow(/worktree_in_use/);
-    expect(calls().filter((call) => call.startsWith("up WM-13 "))).toHaveLength(before);
+    ).toThrow(/worktree_in_use/);
+    expect(calls().filter((call) => call.startsWith("up WM-13 "))).toHaveLength(
+      before,
+    );
     expect(existsSync(tree)).toBe(true);
   });
 
   test("a recovered wip ref is journaled in the workspace marker/input and commented once", () => {
     const comments = [];
-    const { dir, worktree } = make("recovered-up", "WM-13", "run_wt13_recovered", {
-      worktreeOwnershipConflict: () => null,
-      worktreePreservationComment: (entry) => {
-        comments.push(entry);
-        return { status: "posted" };
+    const { dir, worktree } = make(
+      "recovered-up",
+      "WM-13",
+      "run_wt13_recovered",
+      {
+        worktreeOwnershipConflict: () => null,
+        worktreePreservationComment: (entry) => {
+          comments.push(entry);
+          return { status: "posted" };
+        },
       },
-    });
+    );
 
     expect(comments).toHaveLength(1);
     expect(comments[0]).toMatchObject({
@@ -322,8 +400,14 @@ describe("worktree workspaces (WM-108)", () => {
       push: "local_only",
       comment: { status: "posted" },
     });
-    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).preservedWip).toEqual(worktree.preservedWip);
-    expect(JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")).worktreeRecovery).toMatchObject({
+    expect(
+      JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8"))
+        .preservedWip,
+    ).toEqual(worktree.preservedWip);
+    expect(
+      JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8"))
+        .worktreeRecovery,
+    ).toMatchObject({
       ref: "wip/WM-13-20260817T183000Z",
       guidance: expect.stringContaining("abandoned prior attempt"),
     });
@@ -338,8 +422,13 @@ describe("worktree workspaces (WM-108)", () => {
       exitCode: 1,
       output: "entry chunk exceeds budget",
     });
-    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).baseline).toEqual(worktree.baseline);
-    expect(JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8"))).toMatchObject({
+    expect(
+      JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8"))
+        .baseline,
+    ).toEqual(worktree.baseline);
+    expect(
+      JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")),
+    ).toMatchObject({
       repo: "red-baseline",
       ticket: "WM-5",
       baseline: {
@@ -374,7 +463,9 @@ describe("worktree workspaces (WM-108)", () => {
       expect(err.evidence.stdout).toBe("starting worktree setup\n");
       expect(err.evidence.stderr).toContain("warn:");
       expect(err.evidence.stderr).toContain("recorded port 7740");
-      const { upFailure } = JSON.parse(readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"));
+      const { upFailure } = JSON.parse(
+        readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"),
+      );
       expect(upFailure.reason).toBe("fatal: template failed to build");
       expect(upFailure.status).toBe(7);
       expect(upFailure.stdout).toBe(err.evidence.stdout);
@@ -419,26 +510,39 @@ describe("worktree workspaces (WM-108)", () => {
         expect(err.code).toBe("workspace_provisioning_error");
         expect(err.message).toContain("timed out after 25ms");
         expect(Date.now() - started).toBeLessThan(1_000);
-        expect(JSON.parse(readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"))).toMatchObject({
+        expect(
+          JSON.parse(
+            readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"),
+          ),
+        ).toMatchObject({
           repo: "hanging-up",
           ticket: "WM-11",
           down: "bin/worktree-down.sh",
         });
       }
     } finally {
-      if (previous === undefined) delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+      if (previous === undefined)
+        delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
       else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
     }
   });
 
   test("a repo with no declared scripts fails typed, not with a crash mid-spawn", () => {
     expect(() => make("noscripts", "WM-6", "run_wt6")).toThrow(WorktreeError);
-    expect(() => make("noscripts", "WM-6", "run_wt6")).toThrow(/declares no worktree lifecycle/);
+    expect(() => make("noscripts", "WM-6", "run_wt6")).toThrow(
+      /declares no worktree lifecycle/,
+    );
   });
 
   test("missing input.repo or input.ticket is a typed error", () => {
     expect(() =>
-      createWorkspace({ root: tmpRoot(), runId: "run_wt7", attempt: 1, input: { repo: "wtrepo" }, workspace: { type: "worktree" } }),
+      createWorkspace({
+        root: tmpRoot(),
+        runId: "run_wt7",
+        attempt: 1,
+        input: { repo: "wtrepo" },
+        workspace: { type: "worktree" },
+      }),
     ).toThrow(/input.repo and input.ticket/);
   });
 });

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -27,8 +27,16 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 // See repository.test.mjs: neutralise the operator's global git config so a
 // signing key or a global hooks path cannot hang the fixture (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 // Hermetic fixtures: a real git repo (the chained work-scan's repository
 // workspace pins a SHA) that also carries the worktree scripts the dispatch
@@ -53,8 +61,14 @@ beforeAll(() => {
   git(["commit", "--quiet", "-m", "init"], repoDir);
 
   mkdirSync(path.join(repoDir, "bin"), { recursive: true });
-  writeFileSync(path.join(repoDir, "bin", "worktree-up.sh"), `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\n`);
-  writeFileSync(path.join(repoDir, "bin", "worktree-down.sh"), `#!/bin/bash\nset -e\nrm -rf "${wtRoot}/$1"\n`);
+  writeFileSync(
+    path.join(repoDir, "bin", "worktree-up.sh"),
+    `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\n`,
+  );
+  writeFileSync(
+    path.join(repoDir, "bin", "worktree-down.sh"),
+    `#!/bin/bash\nset -e\nrm -rf "${wtRoot}/$1"\n`,
+  );
 
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(
@@ -65,12 +79,17 @@ beforeAll(() => {
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
       `    worktree_root: ${wtRoot}\n    verify: echo verified\n    escalate_paths: []\n`,
   );
-  writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
+  writeFileSync(
+    path.join(root, "config", "policy.yaml"),
+    `concurrency:\n  max_in_flight_per_repo: 2\n`,
+  );
 
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-home-"));
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(
+    path.join(os.tmpdir(), "evrt-loop-home-"),
+  );
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -101,7 +120,8 @@ const dispatchArtifact = (outcome, { repo, ticket }) => ({
   outcome,
   repo,
   ticket,
-  prUrl: outcome === "PR_OPEN" ? "https://github.com/watt-mind/wt29/pull/42" : null,
+  prUrl:
+    outcome === "PR_OPEN" ? "https://github.com/watt-mind/wt29/pull/42" : null,
   verification:
     outcome === "PR_OPEN"
       ? { command: "echo verified", passed: true, output: "verified" }
@@ -113,13 +133,17 @@ const dispatchFake = (outcome) => ({
   async execute({ spec, workspaceDir }) {
     writeFileSync(
       path.join(workspaceDir, "result.json"),
-      `${JSON.stringify({
-        schemaVersion: "factory.agent-result/v1",
-        terminalState: "completed",
-        reasonCode: "ok",
-        artifact: dispatchArtifact(outcome, spec.input),
-        evidence: { commands: ["fake"] },
-      }, null, 2)}\n`,
+      `${JSON.stringify(
+        {
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "completed",
+          reasonCode: "ok",
+          artifact: dispatchArtifact(outcome, spec.input),
+          evidence: { commands: ["fake"] },
+        },
+        null,
+        2,
+      )}\n`,
       "utf8",
     );
     return { exitCode: 0, timedOut: false };
@@ -128,10 +152,19 @@ const dispatchFake = (outcome) => ({
 
 /** Admit → plan → approve → execute one dispatch run ending in `outcome`. */
 async function dispatchTo(outcome, eventId, ticket) {
-  const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-loop-db-")), "runtime.db"));
+  const db = openDb(
+    path.join(
+      mkdtempSync(path.join(os.tmpdir(), "evrt-loop-db-")),
+      "runtime.db",
+    ),
+  );
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-ws-"));
   fixtures.push(workspaces);
-  const planAll = () => planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld });
+  const planAll = () =>
+    planAdmittedEvents(db, registry, {
+      policyVersion: PV,
+      dispatch: openWorld,
+    });
 
   admitEvent(db, registry, {
     schemaVersion: "factory.event/v1",
@@ -145,15 +178,25 @@ async function dispatchTo(outcome, eventId, ticket) {
     payload: { repo: "wt29", ticket },
   });
   planAll();
-  const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
+  const proposal = openProposals(db, {}).find(
+    (p) => p.spec?.agent === "dispatch@1",
+  );
   expect(proposal).toBeTruthy();
-  const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
-  const summary = await runOnce(db, registry, { pi: dispatchFake(outcome) }, {
-    workspacesRoot: workspaces,
-    owner: "w-test",
+  const approved = approveProposal(db, registry, proposal.id, {
+    actor: "operator",
     policyVersion: PV,
-    dispatch: openWorld,
   });
+  const summary = await runOnce(
+    db,
+    registry,
+    { pi: dispatchFake(outcome) },
+    {
+      workspacesRoot: workspaces,
+      owner: "w-test",
+      policyVersion: PV,
+      dispatch: openWorld,
+    },
+  );
   expect(summary.terminalState).toBe("COMPLETED");
   return { db, planAll, runId: approved.runId };
 }
@@ -164,14 +207,24 @@ describe("dispatch-completion edge registration (WM-112)", () => {
     expect(registry.edges["dispatch@1"]).toEqual({
       recommendationField: "outcome",
       edges: {
-        PR_OPEN: { eventType: "factory.work.requested", also: ["PR_OPEN_MERGE"], input: { repo: "$.input.repo" } },
+        PR_OPEN: {
+          eventType: "factory.work.requested",
+          also: ["PR_OPEN_MERGE"],
+          input: { repo: "$.input.repo" },
+        },
         PR_OPEN_MERGE: {
           eventType: "factory.merge.requested",
           mixedEventId: "chain-${runId}-merge",
           whenPath: "$.artifact.prNumber",
-          input: { repo: "$.artifact.repo", prNumbers: ["$.artifact.prNumber"] },
+          input: {
+            repo: "$.artifact.repo",
+            prNumbers: ["$.artifact.prNumber"],
+          },
         },
-        NOT_CLAIMED: { eventType: "factory.work.requested", input: { repo: "$.input.repo" } },
+        NOT_CLAIMED: {
+          eventType: "factory.work.requested",
+          input: { repo: "$.input.repo" },
+        },
       },
     });
   });
@@ -179,38 +232,64 @@ describe("dispatch-completion edge registration (WM-112)", () => {
 
 describe("dispatch-completion edge: a finished dispatch re-fires the work-scan (WM-112)", () => {
   test("PR_OPEN chains to work.requested with inherited correlation — and plans a fresh watched scan", async () => {
-    const { db, planAll, runId } = await dispatchTo("PR_OPEN", "loop-pr-open", "WM-601");
+    const { db, planAll, runId } = await dispatchTo(
+      "PR_OPEN",
+      "loop-pr-open",
+      "WM-601",
+    );
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 1,
+      skipped: 0,
+      errors: [],
+    });
     const chainEvent = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
       .get(`chain-${runId}`);
     expect(chainEvent.type).toBe("factory.work.requested");
     expect(chainEvent.correlation_id).toBe("loop-pr-open"); // inherited from the dispatch's event
     expect(chainEvent.causation_id).toBe(runId);
-    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({ repo: "wt29" });
+    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({
+      repo: "wt29",
+    });
 
     // The latency half of rolling dispatch: the freed slot is re-scanned NOW,
     // through the ordinary planner, as a watched proposal — never auto.
     planAll();
-    const scan = openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1");
+    const scan = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "work-scan@1",
+    );
     expect(scan).toBeTruthy();
     expect(scan.status).toBe("open");
 
     // One chain event per run, ever.
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("NOT_CLAIMED chains the same way — a lost claim frees the slot just as a PR does", async () => {
-    const { db, runId } = await dispatchTo("NOT_CLAIMED", "loop-not-claimed", "WM-602");
+    const { db, runId } = await dispatchTo(
+      "NOT_CLAIMED",
+      "loop-not-claimed",
+      "WM-602",
+    );
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 1,
+      skipped: 0,
+      errors: [],
+    });
     const chainEvent = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
       .get(`chain-${runId}`);
     expect(chainEvent.type).toBe("factory.work.requested");
     expect(chainEvent.correlation_id).toBe("loop-not-claimed");
-    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({ repo: "wt29" });
+    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({
+      repo: "wt29",
+    });
   });
 
   test("FAILED and BLOCKED terminate: no chain, no work.requested, no scanner spin", async () => {
@@ -219,10 +298,22 @@ describe("dispatch-completion edge: a finished dispatch re-fires the work-scan (
       ["BLOCKED", "loop-blocked", "WM-604"],
     ]) {
       const { db, planAll } = await dispatchTo(outcome, eventId, ticket);
-      expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+      expect(resolveChains(db, registry)).toEqual({
+        emitted: 0,
+        skipped: 1,
+        errors: [],
+      });
       planAll();
-      expect(db.query(`SELECT COUNT(*) AS n FROM events WHERE type = 'factory.work.requested'`).get().n).toBe(0);
-      expect(openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1")).toBeUndefined();
+      expect(
+        db
+          .query(
+            `SELECT COUNT(*) AS n FROM events WHERE type = 'factory.work.requested'`,
+          )
+          .get().n,
+      ).toBe(0);
+      expect(
+        openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1"),
+      ).toBeUndefined();
     }
   });
 });
@@ -237,7 +328,12 @@ describe("dispatch-completion edge: a finished dispatch re-fires the work-scan (
  *  the sole autonomous merge target during the bootstrap period (WM-417). */
 const DISPATCHABLE = ["bj29", "wm-home", "legalease", "cashsaas"];
 
-const loopEntry = (eventType, repo, every, { approval = "watched", enabled = false } = {}) => ({
+const loopEntry = (
+  eventType,
+  repo,
+  every,
+  { approval = "watched", enabled = false } = {},
+) => ({
   every,
   eventType,
   payload: { repo },
@@ -250,18 +346,33 @@ const loopEntry = (eventType, repo, every, { approval = "watched", enabled = fal
 describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
   test("Factory alone has autonomous merge discovery while every other loop remains watched and disabled", () => {
     for (const repo of DISPATCHABLE) {
-      expect(registry.schedules[`work-${repo}`]).toEqual(loopEntry("factory.work.requested", repo, "30m"));
-      expect(registry.schedules[`merge-${repo}`]).toEqual(loopEntry("factory.merge.requested", repo, "30m"));
-      expect(registry.schedules[`ship-${repo}`]).toEqual(loopEntry("factory.ship.requested", repo, "7d"));
+      expect(registry.schedules[`work-${repo}`]).toEqual(
+        loopEntry("factory.work.requested", repo, "30m"),
+      );
+      expect(registry.schedules[`merge-${repo}`]).toEqual(
+        loopEntry("factory.merge.requested", repo, "30m"),
+      );
+      expect(registry.schedules[`ship-${repo}`]).toEqual(
+        loopEntry("factory.ship.requested", repo, "7d"),
+      );
     }
     // WM-576: the Factory full-set merge sweep runs every 15m as the fallback behind per-PR scoped scans.
     expect(registry.schedules["merge-factory"]).toEqual(
-      loopEntry("factory.merge.requested", "factory", "15m", { approval: "auto", enabled: true }),
+      loopEntry("factory.merge.requested", "factory", "15m", {
+        approval: "auto",
+        enabled: true,
+      }),
     );
   });
 
   test("the exact enabled autonomous merge set is merge-factory", () => {
-    for (const repo of ["coach-wattz", "watts-mobile", "proxies", "hdkiller", "eslint-config"]) {
+    for (const repo of [
+      "coach-wattz",
+      "watts-mobile",
+      "proxies",
+      "hdkiller",
+      "eslint-config",
+    ]) {
       expect(registry.schedules[`work-${repo}`]).toBeUndefined();
       expect(registry.schedules[`merge-${repo}`]).toBeUndefined();
       expect(registry.schedules[`ship-${repo}`]).toBeUndefined();
@@ -270,13 +381,18 @@ describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
     expect(registry.schedules["ship-factory"]).toBeUndefined();
 
     const enabledAutonomous = Object.entries(registry.schedules)
-      .filter(([, schedule]) => schedule.enabled && schedule.approval === "auto")
+      .filter(
+        ([, schedule]) => schedule.enabled && schedule.approval === "auto",
+      )
       .map(([loop]) => loop);
     expect(enabledAutonomous).toEqual(["merge-factory"]);
 
     for (const [loop, schedule] of Object.entries(registry.schedules)) {
       if (loop !== "merge-factory") {
-        expect({ approval: schedule.approval, enabled: schedule.enabled }).toEqual({ approval: "watched", enabled: false });
+        expect({
+          approval: schedule.approval,
+          enabled: schedule.enabled,
+        }).toEqual({ approval: "watched", enabled: false });
       }
     }
   });
@@ -289,8 +405,13 @@ describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
     ];
     for (const [loop, eventType, repo] of cases) {
       const db = openDb(":memory:");
-      const fixture = { ...registry, schedules: { [loop]: { ...registry.schedules[loop], enabled: true } } };
-      const outcome = emitDueTicks(db, fixture, { now: Date.parse("2026-08-14T10:05:00Z") });
+      const fixture = {
+        ...registry,
+        schedules: { [loop]: { ...registry.schedules[loop], enabled: true } },
+      };
+      const outcome = emitDueTicks(db, fixture, {
+        now: Date.parse("2026-08-14T10:05:00Z"),
+      });
       expect(outcome.errors).toEqual([]);
       expect(outcome.emitted).toHaveLength(1);
       expect(outcome.emitted[0].loop).toBe(loop);
@@ -331,8 +452,13 @@ describe("an enabled loop's tick plans a real scan run (WM-123)", () => {
     ...registry,
     schedules: {
       [loop]: {
-        every: "30m", eventType, payload: { repo: "wt29" },
-        catchUp: "none", singleton: true, approval: "watched", enabled: true,
+        every: "30m",
+        eventType,
+        payload: { repo: "wt29" },
+        catchUp: "none",
+        singleton: true,
+        approval: "watched",
+        enabled: true,
       },
     },
   });
@@ -347,20 +473,38 @@ describe("an enabled loop's tick plans a real scan run (WM-123)", () => {
     test(`${eventType} tick carries {repo, loop, slot, cadenceSeconds, skippedSlots} and plans a watched ${agent} run`, () => {
       const db = openDb(":memory:");
       const fixture = oneLoop(loop, eventType);
-      const ticks = emitDueTicks(db, fixture, { now: Date.parse("2026-08-14T10:05:00Z") });
+      const ticks = emitDueTicks(db, fixture, {
+        now: Date.parse("2026-08-14T10:05:00Z"),
+      });
       expect(ticks.errors).toEqual([]);
       expect(ticks.emitted).toHaveLength(1);
 
       // Pin the payload shape to what the scheduler actually emits — if
       // emitDueTicks ever grows a field, this fails before the schema does.
-      const envelope = JSON.parse(db.query(`SELECT envelope_json FROM events`).get().envelope_json);
-      expect(Object.keys(envelope.payload).sort()).toEqual(["cadenceSeconds", "loop", "repo", "skippedSlots", "slot"]);
+      const envelope = JSON.parse(
+        db.query(`SELECT envelope_json FROM events`).get().envelope_json,
+      );
+      expect(Object.keys(envelope.payload).sort()).toEqual([
+        "cadenceSeconds",
+        "loop",
+        "repo",
+        "skippedSlots",
+        "slot",
+      ]);
 
-      expect(planAdmittedEvents(db, fixture, { policyVersion: PV })).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
-      const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agent);
+      expect(planAdmittedEvents(db, fixture, { policyVersion: PV })).toEqual({
+        planned: 1,
+        failed: 0,
+        deadLettered: 0,
+      });
+      const proposal = openProposals(db, {}).find(
+        (p) => p.spec?.agent === agent,
+      );
       expect(proposal).toBeTruthy();
       expect(proposal.decision).toBe("run");
-      expect(db.query(`SELECT status FROM events`).get().status).toBe("planned");
+      expect(db.query(`SELECT status FROM events`).get().status).toBe(
+        "planned",
+      );
       db.close();
     });
   }
@@ -379,8 +523,14 @@ describe("an enabled loop's tick plans a real scan run (WM-123)", () => {
         causationId: null,
         payload: { repo: "wt29" },
       });
-      expect(planAdmittedEvents(db, registry, { policyVersion: PV })).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
-      const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agent);
+      expect(planAdmittedEvents(db, registry, { policyVersion: PV })).toEqual({
+        planned: 1,
+        failed: 0,
+        deadLettered: 0,
+      });
+      const proposal = openProposals(db, {}).find(
+        (p) => p.spec?.agent === agent,
+      );
       expect(proposal).toBeTruthy();
       expect(proposal.decision).toBe("run");
       db.close();

--- a/event-runtime/merge-apply.test.mjs
+++ b/event-runtime/merge-apply.test.mjs
@@ -66,7 +66,7 @@ function installFakes(fixture) {
       '  *"git/ref/heads/develop"*) printf \'%s\\n\' "$FAKE_BASE_SHA" ;;',
       '  *"pr checks"*"--required --json name,bucket,state"*)',
       '    case "$FAKE_REQUIRED_MODE" in',
-      "      no-required) printf \"no required checks reported on the '%s' branch\\n\" \"$FAKE_HEAD_REF\" >&2; exit 1 ;;",
+      '      no-required) printf "no required checks reported on the \'%s\' branch\\n" "$FAKE_HEAD_REF" >&2; exit 1 ;;',
       "      error) printf 'HTTP 502: upstream unavailable\\n' >&2; exit 1 ;;",
       "      *) exit 65 ;;",
       "    esac ;;",

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -83,24 +83,20 @@ function installMergeCommandFakes(fixture) {
       'echo "factory $*" >> "$COMMAND_LOG"',
       'if [ "${1:-}" = linear ] && [ "${2:-}" = get ]; then',
       '  case "${FAKE_LINEAR_MODE:-valid}" in',
-      '    error) exit 3 ;;',
-      '    empty) exit 0 ;;',
+      "    error) exit 3 ;;",
+      "    empty) exit 0 ;;",
       "    malformed) printf 'not-json\\n'; exit 0 ;;",
-      "    security) printf '{\"state\":{\"name\":\"In Progress\"},\"labels\":{\"nodes\":[{\"name\":\"type:security\"}]}}\\n'; exit 0 ;;",
-      "    *) printf '{\"state\":{\"name\":\"In Progress\"},\"labels\":{\"nodes\":[]}}\\n'; exit 0 ;;",
-      '  esac',
-      'fi',
+      '    security) printf \'{"state":{"name":"In Progress"},"labels":{"nodes":[{"name":"type:security"}]}}\\n\'; exit 0 ;;',
+      '    *) printf \'{"state":{"name":"In Progress"},"labels":{"nodes":[]}}\\n\'; exit 0 ;;',
+      "  esac",
+      "fi",
       'if [ "${1:-}" = branch-guard ]; then',
       '  exit "${FAKE_BRANCH_GUARD_STATUS:-2}"',
-      'fi',
-      'exit 0',
+      "fi",
+      "exit 0",
     ].join("\n"),
   );
-  writeExecutable(
-    fixture.bin,
-    "sleep",
-    String.raw`exit 0`,
-  );
+  writeExecutable(fixture.bin, "sleep", String.raw`exit 0`);
   writeExecutable(
     fixture.bin,
     "gh",
@@ -108,35 +104,35 @@ function installMergeCommandFakes(fixture) {
       'echo "gh $*" >> "$COMMAND_LOG"',
       'case "$*" in',
       '  *"pr view"*"state,isDraft,mergeable,headRefOid,headRefName,baseRefName,labels"*)',
-      "    printf '{\"state\":\"OPEN\",\"isDraft\":false,\"mergeable\":\"MERGEABLE\",\"headRefOid\":\"%s\",\"headRefName\":\"%s\",\"baseRefName\":\"develop\",\"labels\":[]}\\n' \"$FAKE_HEAD_SHA\" \"$FAKE_HEAD_REF\" ;;",
-      "  *\"git/ref/heads/develop\"*) printf '%s\\n' \"$FAKE_BASE_SHA\" ;;",
+      '    printf \'{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","headRefOid":"%s","headRefName":"%s","baseRefName":"develop","labels":[]}\\n\' "$FAKE_HEAD_SHA" "$FAKE_HEAD_REF" ;;',
+      '  *"git/ref/heads/develop"*) printf \'%s\\n\' "$FAKE_BASE_SHA" ;;',
       '  *"pr checks"*"--required --json name,bucket,state"*)',
       '    case "${FAKE_REQUIRED_MODE:-empty}" in',
-      "      green) printf '[{\"name\":\"Protected Verify\",\"bucket\":\"pass\",\"state\":\"SUCCESS\"}]\\n' ;;",
-      "      pending) printf '[{\"name\":\"Protected Verify\",\"bucket\":\"pending\",\"state\":\"PENDING\"}]\\n' ;;",
-      "      duplicate) printf '[{\"name\":\"Protected Verify\",\"bucket\":\"pass\",\"state\":\"SUCCESS\"},{\"name\":\"Protected Verify\",\"bucket\":\"pass\",\"state\":\"SUCCESS\"}]\\n' ;;",
+      '      green) printf \'[{"name":"Protected Verify","bucket":"pass","state":"SUCCESS"}]\\n\' ;;',
+      '      pending) printf \'[{"name":"Protected Verify","bucket":"pending","state":"PENDING"}]\\n\' ;;',
+      '      duplicate) printf \'[{"name":"Protected Verify","bucket":"pass","state":"SUCCESS"},{"name":"Protected Verify","bucket":"pass","state":"SUCCESS"}]\\n\' ;;',
       "      status-zero-empty) printf '[]\\n' ;;",
       "      unquoted) printf 'no required checks reported on the %s branch\\n' \"$FAKE_HEAD_REF\"; exit 1 ;;",
-      "      *) printf \"no required checks reported on the '%s' branch\\n\" \"$FAKE_HEAD_REF\"; exit 1 ;;",
-      '    esac ;;',
+      '      *) printf "no required checks reported on the \'%s\' branch\\n" "$FAKE_HEAD_REF"; exit 1 ;;',
+      "    esac ;;",
       '  *"pr merge"*) : ;;',
-      "  *\"pr view\"*\"--json headRefOid --jq .headRefOid\"*) printf '%s\\n' \"$FAKE_HEAD_SHA\" ;;",
-      "  *\"pr view\"*\"select(.state\"*) printf '%s\\n' \"$FAKE_MERGE_SHA\" ;;",
-      "  *\"pr view\"*\"@tsv\"*) printf 'MERGED\\t%s\\n' \"$FAKE_MERGE_SHA\" ;;",
-      "  *\"pr view\"*\"--jq .state\"*) printf 'MERGED\\n' ;;",
-      "  *\"pr view\"*\"--jq .mergeCommit.oid\"*) printf '%s\\n' \"$FAKE_MERGE_SHA\" ;;",
-      "  *\"pr checks\"*\"--json name,bucket,state,workflow\"*) printf '[{\"name\":\"Shadow runner fleet available\",\"bucket\":\"pass\",\"state\":\"SUCCESS\",\"workflow\":\"CI\"},{\"name\":\"Verify\",\"bucket\":\"pass\",\"state\":\"SUCCESS\",\"workflow\":\"CI\"}]\\n' ;;",
+      '  *"pr view"*"--json headRefOid --jq .headRefOid"*) printf \'%s\\n\' "$FAKE_HEAD_SHA" ;;',
+      '  *"pr view"*"select(.state"*) printf \'%s\\n\' "$FAKE_MERGE_SHA" ;;',
+      '  *"pr view"*"@tsv"*) printf \'MERGED\\t%s\\n\' "$FAKE_MERGE_SHA" ;;',
+      '  *"pr view"*"--jq .state"*) printf \'MERGED\\n\' ;;',
+      '  *"pr view"*"--jq .mergeCommit.oid"*) printf \'%s\\n\' "$FAKE_MERGE_SHA" ;;',
+      '  *"pr checks"*"--json name,bucket,state,workflow"*) printf \'[{"name":"Shadow runner fleet available","bucket":"pass","state":"SUCCESS","workflow":"CI"},{"name":"Verify","bucket":"pass","state":"SUCCESS","workflow":"CI"}]\\n\' ;;',
       '  *"run list"*"--workflow CI"*"--event pull_request"*)',
-      "    printf '[{\"databaseId\":81,\"status\":\"completed\",\"conclusion\":\"success\",\"headSha\":\"%s\",\"workflowName\":\"CI\"}]\\n' \"$FAKE_HEAD_SHA\" ;;",
+      '    printf \'[{"databaseId":81,"status":"completed","conclusion":"success","headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_HEAD_SHA" ;;',
       '  *"run list"*"--workflow CI"*"--event push"*)',
-      "    if [ \"${FAKE_CI_MODE:-success}\" = auxiliary ]; then printf '[]\\n'; else printf '[{\"databaseId\":91,\"status\":\"completed\",\"conclusion\":\"success\",\"headSha\":\"%s\",\"workflowName\":\"CI\"}]\\n' \"$FAKE_MERGE_SHA\"; fi ;;",
+      '    if [ "${FAKE_CI_MODE:-success}" = auxiliary ]; then printf \'[]\\n\'; else printf \'[{"databaseId":91,"status":"completed","conclusion":"success","headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_MERGE_SHA"; fi ;;',
       '  *"run view 81"*|*"run view 91"*)',
-      "    if [ \"${FAKE_CI_MODE:-success}\" = shadow-only ]; then printf '[{\"name\":\"Shadow runner fleet available\",\"status\":\"completed\",\"conclusion\":\"success\"}]\\n'; else printf '[{\"name\":\"Shadow runner fleet available\",\"status\":\"completed\",\"conclusion\":\"success\"},{\"name\":\"Verify\",\"status\":\"completed\",\"conclusion\":\"success\"}]\\n'; fi ;;",
-      "  *\"commits/\"*\"/check-runs\"*) printf '[[\"completed\",\"success\"]]\\n' ;;",
-      "  *\"git/ref/heads/\"*) printf '%s\\n' \"$FAKE_HEAD_SHA\" ;;",
+      '    if [ "${FAKE_CI_MODE:-success}" = shadow-only ]; then printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"}]\\n\'; else printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"},{"name":"Verify","status":"completed","conclusion":"success"}]\\n\'; fi ;;',
+      '  *"commits/"*"/check-runs"*) printf \'[["completed","success"]]\\n\' ;;',
+      '  *"git/ref/heads/"*) printf \'%s\\n\' "$FAKE_HEAD_SHA" ;;',
       '  *"git/refs/heads/"*) : ;;',
       '  *) echo "unexpected gh command: $*" >&2; exit 64 ;;',
-      'esac',
+      "esac",
     ].join("\n"),
   );
 }
@@ -148,8 +144,8 @@ function installBunGateFake(fixture) {
     [
       'case "$*" in',
       '  *"r.mergeCi"*) printf \'{"workflow":"CI","requiredChecks":["Shadow runner fleet available","Verify"]}\' ;;',
-      '  *) exit 0 ;;',
-      'esac',
+      "  *) exit 0 ;;",
+      "esac",
     ].join("\n"),
   );
 }
@@ -220,8 +216,13 @@ function admitEvent(db, registryForAdmission, env) {
         summary: "one selected merge",
       };
     } else if (recommendation === "FIX") {
-      const { repo, github, base, deployBranch = "master", ...fixItem } =
-        env.payload;
+      const {
+        repo,
+        github,
+        base,
+        deployBranch = "master",
+        ...fixItem
+      } = env.payload;
       artifact = {
         recommendation,
         repo,
@@ -247,11 +248,10 @@ function admitEvent(db, registryForAdmission, env) {
       artifact,
     });
   }
-  return persistEvent(
-    db,
-    registryForAdmission,
-    { ...env, causationId: parent },
-  );
+  return persistEvent(db, registryForAdmission, {
+    ...env,
+    causationId: parent,
+  });
 }
 
 function seedCompleted(db, { runId, agent, input, artifact }) {
@@ -298,8 +298,7 @@ describe("merge-fix result contract (WM-447)", () => {
     for (const outcome of ["UPDATED", "BLOCKED"]) {
       const example = prompt.match(
         new RegExp(
-          `### ${outcome} artifact[\\s\\S]*?` +
-            "```json\\n([\\s\\S]*?)\\n```",
+          `### ${outcome} artifact[\\s\\S]*?` + "```json\\n([\\s\\S]*?)\\n```",
         ),
       );
 
@@ -425,20 +424,30 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
 
 describe("merge-scan selected PR contract (WM-426)", () => {
   test("the input schema declares an optional nonempty list of positive PR numbers", () => {
-    const prNumbers = registry.agents.get("merge-scan@2").inputSchema.properties.prNumbers;
+    const prNumbers =
+      registry.agents.get("merge-scan@2").inputSchema.properties.prNumbers;
     expect(prNumbers.type).toBe("array");
     expect(prNumbers.minItems).toBe(1);
     expect(prNumbers.items).toEqual({ type: "integer", minimum: 1 });
-    expect(registry.agents.get("merge-scan@2").inputSchema.required).not.toContain("prNumbers");
+    expect(
+      registry.agents.get("merge-scan@2").inputSchema.required,
+    ).not.toContain("prNumbers");
   });
 
   test("the prompt scopes selected scans exactly and fails invalid targets closed", () => {
-    const prompt = readFileSync(registry.agents.get("merge-scan@2").promptPath, "utf8");
+    const prompt = readFileSync(
+      registry.agents.get("merge-scan@2").promptPath,
+      "utf8",
+    );
     expect(prompt).toContain("`prNumbers` is absent");
     expect(prompt).toContain("exactly those PR numbers");
-    expect(prompt).toMatch(/missing, closed, draft, or targets a\s+base other than/);
+    expect(prompt).toMatch(
+      /missing, closed, draft, or targets a\s+base other than/,
+    );
     expect(prompt).toContain('"terminalState": "refused"');
-    expect(prompt).toMatch(/evidence clearly naming every invalid\s+selected PR/);
+    expect(prompt).toMatch(
+      /evidence clearly naming every invalid\s+selected PR/,
+    );
     expect(prompt).toMatch(/Do not\s+emit a merge-plan artifact/);
   });
 });
@@ -456,9 +465,7 @@ describe("merge-scan required-context resolution (WM-433)", () => {
     expect(prompt).toContain(
       'bun "$FACTORY_ROOT/event-runtime/lib/merge-ci-proof.mjs" resolve-required-contexts',
     );
-    expect(prompt).not.toContain(
-      "./repo/event-runtime/lib/merge-ci-proof.mjs",
-    );
+    expect(prompt).not.toContain("./repo/event-runtime/lib/merge-ci-proof.mjs");
     expect(prompt).toMatch(
       /Status 1 with exactly\s+`no required checks reported on the '<headRef>' branch`/,
     );
@@ -471,7 +478,9 @@ describe("merge-scan required-context resolution (WM-433)", () => {
   });
 
   test("the resolver executes when the selected non-Factory repo has no event-runtime tree", () => {
-    const fixture = mkdtempSync(path.join(os.tmpdir(), "merge-scan-cross-repo-"));
+    const fixture = mkdtempSync(
+      path.join(os.tmpdir(), "merge-scan-cross-repo-"),
+    );
     const target = path.join(fixture, "repo");
     mkdirSync(target);
     writeFileSync(path.join(target, "README.md"), "# non-Factory fixture\n");
@@ -487,8 +496,7 @@ describe("merge-scan required-context resolution (WM-433)", () => {
           cwd: fixture,
           encoding: "utf8",
           env: { ...process.env, FACTORY_ROOT: process.cwd() },
-          input:
-            "no required checks reported on the 'feat/WM-243' branch",
+          input: "no required checks reported on the 'feat/WM-243' branch",
         },
       );
 
@@ -509,7 +517,10 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       retainOnFailure: true,
     });
     expect(def.capabilities.services).toContain("repo:read");
-    expect(def.inputSchema.properties.repoPin.required).toEqual(["repo", "sha"]);
+    expect(def.inputSchema.properties.repoPin.required).toEqual([
+      "repo",
+      "sha",
+    ]);
     expect(def.inputSchema.properties.repoPin.properties.sha.pattern).toBe(
       "^[0-9a-f]{40}$",
     );
@@ -652,9 +663,11 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       });
       db.close();
     } finally {
-      if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      if (previousReposRoot === undefined)
+        delete process.env.FACTORY_REPOS_ROOT;
       else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
-      if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      if (previousEventHome === undefined)
+        delete process.env.FACTORY_EVENT_HOME;
       else process.env.FACTORY_EVENT_HOME = previousEventHome;
       rmSync(fixture, { recursive: true, force: true });
     }
@@ -672,13 +685,18 @@ describe("executable merge command safety (WM-412)", () => {
         commandEnv({ FAKE_LINEAR_MODE: mode }),
       );
       expect(result.status, `${mode}: ${result.stderr}`).not.toBe(0);
-      const log = existsSync(fixture.log) ? readFileSync(fixture.log, "utf8") : "";
+      const log = existsSync(fixture.log)
+        ? readFileSync(fixture.log, "utf8")
+        : "";
       expect(log).not.toContain("gh pr merge");
     }
   });
 
   test("merge-apply executes the configured fallback and requires every exact workflow job", () => {
-    for (const [mode, shouldMerge] of [["success", true], ["shadow-only", false]]) {
+    for (const [mode, shouldMerge] of [
+      ["success", true],
+      ["shadow-only", false],
+    ]) {
       const fixture = commandFixture(`merge-apply-config-${mode}-`);
       installMergeCommandFakes(fixture);
       installBunGateFake(fixture);
@@ -715,7 +733,11 @@ describe("executable merge command safety (WM-412)", () => {
   });
 
   test("merge-apply prefers nonempty GitHub required contexts and rejects pending ones", () => {
-    for (const [mode, shouldMerge] of [["green", true], ["pending", false], ["duplicate", false]]) {
+    for (const [mode, shouldMerge] of [
+      ["green", true],
+      ["pending", false],
+      ["duplicate", false],
+    ]) {
       const fixture = commandFixture(`merge-apply-required-${mode}-`);
       installMergeCommandFakes(fixture);
       installBunGateFake(fixture);
@@ -749,10 +771,14 @@ describe("executable merge command safety (WM-412)", () => {
     });
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = db.query(
-      `SELECT run_id FROM runs WHERE json_extract(spec_json,'$.agent')='merge-apply@2'`,
-    ).get();
-    db.query(`UPDATE runs SET state='RUNNING' WHERE run_id=?`).run(apply.run_id);
+    const apply = db
+      .query(
+        `SELECT run_id FROM runs WHERE json_extract(spec_json,'$.agent')='merge-apply@2'`,
+      )
+      .get();
+    db.query(`UPDATE runs SET state='RUNNING' WHERE run_id=?`).run(
+      apply.run_id,
+    );
 
     const result = runCommand(
       applyCommand(applyPayload()),
@@ -760,14 +786,16 @@ describe("executable merge command safety (WM-412)", () => {
       commandEnv({ FACTORY_EVENT_HOME: fixture.root }),
     );
     expect(result.status, result.stderr).toBe(0);
-    const landed = db.query(
-      `SELECT causation_id FROM events WHERE type='factory.merge-landed'`,
-    ).get();
+    const landed = db
+      .query(
+        `SELECT causation_id FROM events WHERE type='factory.merge-landed'`,
+      )
+      .get();
     expect(landed.causation_id).toBe(apply.run_id);
 
-    db.query(`UPDATE runs SET state='COMPLETED', attempts=1 WHERE run_id=?`).run(
-      apply.run_id,
-    );
+    db.query(
+      `UPDATE runs SET state='COMPLETED', attempts=1 WHERE run_id=?`,
+    ).run(apply.run_id);
     db.query(
       `INSERT INTO results (run_id,attempt,result_json,artifact_hash,verification_json,receipt_json,accepted_at)
        VALUES (?,1,?,'hash','{}','{}',?)`,
@@ -783,9 +811,11 @@ describe("executable merge command safety (WM-412)", () => {
     );
     planAdmittedEvents(db, registry, { policyVersion: PV });
     expect(
-      db.query(
-        `SELECT state FROM runs WHERE json_extract(spec_json,'$.agent')='merge-verify@1'`,
-      ).get().state,
+      db
+        .query(
+          `SELECT state FROM runs WHERE json_extract(spec_json,'$.agent')='merge-verify@1'`,
+        )
+        .get().state,
     ).toBe("QUEUED");
     db.close();
   });
@@ -874,7 +904,16 @@ describe("executable merge command safety (WM-412)", () => {
       "utf8",
     );
     const protectedResult = runCommand(
-      ["bun", `${process.cwd()}/orchestrator/branch-guard.mjs`, "--repo", "fixture", "--pr", "1", "--head", "develop"],
+      [
+        "bun",
+        `${process.cwd()}/orchestrator/branch-guard.mjs`,
+        "--repo",
+        "fixture",
+        "--pr",
+        "1",
+        "--head",
+        "develop",
+      ],
       fixture,
       {
         PATH: process.env.PATH,
@@ -885,7 +924,16 @@ describe("executable merge command safety (WM-412)", () => {
     expect(protectedResult.status).toBe(2);
 
     const heldResult = runCommand(
-      ["bun", `${process.cwd()}/orchestrator/branch-guard.mjs`, "--repo", "fixture", "--pr", "1", "--head", "feat/shared"],
+      [
+        "bun",
+        `${process.cwd()}/orchestrator/branch-guard.mjs`,
+        "--repo",
+        "fixture",
+        "--pr",
+        "1",
+        "--head",
+        "feat/shared",
+      ],
       fixture,
       {
         PATH: process.env.PATH,
@@ -1018,7 +1066,9 @@ describe("merge transition chains", () => {
     });
     expect(
       db
-        .query(`SELECT event_id FROM events WHERE source='chain' ORDER BY event_id`)
+        .query(
+          `SELECT event_id FROM events WHERE source='chain' ORDER BY event_id`,
+        )
         .all()
         .map((row) => row.event_id),
     ).toEqual([
@@ -1116,7 +1166,9 @@ describe("merge transition chains", () => {
       errors: [],
     });
     const events = db
-      .query(`SELECT event_id,type FROM events WHERE source='chain' ORDER BY event_id`)
+      .query(
+        `SELECT event_id,type FROM events WHERE source='chain' ORDER BY event_id`,
+      )
       .all();
     expect(events.map((event) => event.type).sort()).toEqual([
       "factory.merge-apply.requested",
@@ -1147,9 +1199,11 @@ describe("merge transition chains", () => {
 
     planAdmittedEvents(db, registry, { policyVersion: PV });
     expect(
-      db.query(
-        `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-apply@2'`,
-      ).get().n,
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-apply@2'`,
+        )
+        .get().n,
     ).toBe(1);
     expect(resolveChains(db, registry)).toEqual({
       emitted: 0,
@@ -1319,7 +1373,10 @@ describe("policy approval and global merge barrier", () => {
       withinOwnedPaths: true,
       ownedPaths: ["event-runtime/merge.test.mjs"],
     });
-    for (const [id, round] of [["fix-1", 1], ["fix-2", 2]]) {
+    for (const [id, round] of [
+      ["fix-1", 1],
+      ["fix-2", 2],
+    ]) {
       admitEvent(
         db,
         registry,
@@ -1339,9 +1396,11 @@ describe("policy approval and global merge barrier", () => {
     );
     expect(third.reason).toContain("merge_fix_round_not_durable");
     expect(
-      db.query(
-        `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-fix@1'`,
-      ).get().n,
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-fix@1'`,
+        )
+        .get().n,
     ).toBe(2);
   });
 

--- a/event-runtime/schemas/ci-doctor.input.json
+++ b/event-runtime/schemas/ci-doctor.input.json
@@ -1,11 +1,7 @@
 {
   "title": "ci-doctor input — one failed GitHub Actions run",
   "type": "object",
-  "required": [
-    "repo",
-    "runId",
-    "logArtifact"
-  ],
+  "required": ["repo", "runId", "logArtifact"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -14,10 +10,7 @@
       "description": "GitHub repository slug (owner/name) the failed run belongs to — not the config/repos.yaml short name"
     },
     "runId": {
-      "type": [
-        "string",
-        "integer"
-      ],
+      "type": ["string", "integer"],
       "description": "GitHub Actions run id to diagnose (number, or numeric string as gh prints it)"
     },
     "headSha": {

--- a/event-runtime/schemas/ci-log-captured.output.json
+++ b/event-runtime/schemas/ci-log-captured.output.json
@@ -4,7 +4,11 @@
   "required": ["command", "exitCode", "captured"],
   "additionalProperties": false,
   "properties": {
-    "command": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "command": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
     "exitCode": { "const": 0 },
     "outputTail": { "type": "string" },
     "captured": { "type": "string", "minLength": 1 }

--- a/event-runtime/schemas/disk-diagnose.output.json
+++ b/event-runtime/schemas/disk-diagnose.output.json
@@ -14,7 +14,13 @@
         "required": ["action"],
         "additionalProperties": false,
         "properties": {
-          "action": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] },
+          "action": {
+            "enum": [
+              "docker-builder-prune",
+              "docker-system-prune",
+              "journal-vacuum-3d"
+            ]
+          },
           "expectedReclaimBytes": { "type": "integer", "minimum": 0 }
         }
       }

--- a/event-runtime/schemas/disk-remediate.input.json
+++ b/event-runtime/schemas/disk-remediate.input.json
@@ -23,7 +23,11 @@
         "additionalProperties": false,
         "properties": {
           "action": {
-            "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"],
+            "enum": [
+              "docker-builder-prune",
+              "docker-system-prune",
+              "journal-vacuum-3d"
+            ],
             "description": "Remediation command from the fixed safe-action allowlist"
           },
           "expectedReclaimBytes": {

--- a/event-runtime/schemas/disk-remediation.output.json
+++ b/event-runtime/schemas/disk-remediation.output.json
@@ -1,7 +1,14 @@
 {
   "title": "factory.disk-remediation/v1 output artifact — evidence-verified reclaim",
   "type": "object",
-  "required": ["host", "mount", "actions", "beforeUsedBytes", "afterUsedBytes", "reclaimedBytes"],
+  "required": [
+    "host",
+    "mount",
+    "actions",
+    "beforeUsedBytes",
+    "afterUsedBytes",
+    "reclaimedBytes"
+  ],
   "additionalProperties": false,
   "properties": {
     "host": { "enum": ["lab", "web"] },
@@ -9,7 +16,13 @@
     "actions": {
       "type": "array",
       "minItems": 1,
-      "items": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] }
+      "items": {
+        "enum": [
+          "docker-builder-prune",
+          "docker-system-prune",
+          "journal-vacuum-3d"
+        ]
+      }
     },
     "beforeUsedBytes": { "type": "integer", "minimum": 0 },
     "afterUsedBytes": { "type": "integer", "minimum": 0 },

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -1,10 +1,7 @@
 {
   "title": "dispatch input — one repo, one already-queued ticket (WM-108)",
   "type": "object",
-  "required": [
-    "repo",
-    "ticket"
-  ],
+  "required": ["repo", "ticket"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -19,10 +16,7 @@
     },
     "repoPin": {
       "type": "object",
-      "required": [
-        "repo",
-        "sha"
-      ],
+      "required": ["repo", "sha"],
       "additionalProperties": false,
       "description": "Optional provenance pin recording the base-branch SHA the request was made against; the worktree itself branches from the repo's live base via its own worktree_up, so this is a record, not a checkout instruction",
       "properties": {
@@ -41,10 +35,7 @@
           "description": "Commit SHA of the repo's base branch at request time"
         },
         "github": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }

--- a/event-runtime/schemas/dispatch.output.json
+++ b/event-runtime/schemas/dispatch.output.json
@@ -1,23 +1,11 @@
 {
   "title": "factory.dispatch-result/v1 output artifact — one ticket run's terminal outcome (WM-108)",
   "type": "object",
-  "required": [
-    "outcome",
-    "repo",
-    "ticket",
-    "prUrl",
-    "verification",
-    "summary"
-  ],
+  "required": ["outcome", "repo", "ticket", "prUrl", "verification", "summary"],
   "additionalProperties": false,
   "properties": {
     "outcome": {
-      "enum": [
-        "PR_OPEN",
-        "BLOCKED",
-        "FAILED",
-        "NOT_CLAIMED"
-      ],
+      "enum": ["PR_OPEN", "BLOCKED", "FAILED", "NOT_CLAIMED"],
       "description": "Terminal state of the ticket run: PR_OPEN (verified, PR opened, ticket In Review), BLOCKED (typed question posted, ticket Blocked), FAILED (work attempted but no shippable diff), NOT_CLAIMED (claim lost or ticket no longer dispatchable at claim time — the typed NOOP of docs/event-runtime-dispatch.md §2)"
     },
     "repo": {
@@ -31,35 +19,22 @@
       "description": "Linear issue identifier this run implemented, echoed from the input"
     },
     "prUrl": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "URL of the opened pull request when outcome is PR_OPEN; null for every other outcome"
     },
     "prNumber": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 1,
       "description": "Numeric pull request number when outcome is PR_OPEN, used to chain an immediate scoped merge review; null for every other outcome. Optional only for backward compatibility with accepted pre-WM-576 artifacts."
     },
     "verification": {
       "type": "object",
-      "required": [
-        "command",
-        "passed",
-        "output"
-      ],
+      "required": ["command", "passed", "output"],
       "additionalProperties": false,
       "description": "The ticket's own Verification Command as actually run in the worktree — never a claim without output",
       "properties": {
         "command": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "Exact verification command executed, or null when the run never reached verification (BLOCKED/NOT_CLAIMED)"
         },
         "passed": {
@@ -80,34 +55,15 @@
     "uxCritique": {
       "type": "object",
       "description": "UX gate result when the run reached post-verification review. Required by the dispatch prompt for PR_OPEN; optional in the schema for backward-compatible terminal outcomes produced before the gate.",
-      "required": [
-        "status",
-        "verdict",
-        "evidence",
-        "rounds",
-        "prReady"
-      ],
+      "required": ["status", "verdict", "evidence", "rounds", "prReady"],
       "additionalProperties": false,
       "properties": {
         "status": {
-          "enum": [
-            "required",
-            "skipped",
-            "blocked"
-          ]
+          "enum": ["required", "skipped", "blocked"]
         },
         "verdict": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "enum": [
-            "SHIP",
-            "FIX-FIRST",
-            "NOT-ASSESSED",
-            "BLOCKED",
-            null
-          ]
+          "type": ["string", "null"],
+          "enum": ["SHIP", "FIX-FIRST", "NOT-ASSESSED", "BLOCKED", null]
         },
         "evidence": {
           "type": "array",

--- a/event-runtime/schemas/factory-status-report.output.json
+++ b/event-runtime/schemas/factory-status-report.output.json
@@ -20,6 +20,8 @@
         }
       }
     },
-    "recommendedAction": { "enum": ["dispatch", "triage", "merge", "unblock", "wait"] }
+    "recommendedAction": {
+      "enum": ["dispatch", "triage", "merge", "unblock", "wait"]
+    }
   }
 }

--- a/event-runtime/schemas/factory.artifact-view.v1.json
+++ b/event-runtime/schemas/factory.artifact-view.v1.json
@@ -21,7 +21,9 @@
         "tone": {
           "type": "object",
           "description": "artifact value → tone",
-          "additionalProperties": { "enum": ["ok", "warn", "error", "muted", "neutral"] }
+          "additionalProperties": {
+            "enum": ["ok", "warn", "error", "muted", "neutral"]
+          }
         }
       }
     },
@@ -35,7 +37,9 @@
         "additionalProperties": false,
         "properties": {
           "path": { "type": "string", "pattern": "^(/|$)" },
-          "as": { "enum": ["table", "keyvalue", "list", "badge", "code", "prose"] },
+          "as": {
+            "enum": ["table", "keyvalue", "list", "badge", "code", "prose"]
+          },
           "label": { "type": "string", "minLength": 1, "maxLength": 60 },
           "columns": {
             "type": "array",
@@ -75,7 +79,19 @@
             "type": "object",
             "description": "column/key (or \"\" for the section value itself) → format",
             "additionalProperties": {
-              "enum": ["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"]
+              "enum": [
+                "issue",
+                "pr",
+                "url",
+                "sha",
+                "repo",
+                "run",
+                "duration",
+                "datetime",
+                "state",
+                "bytes",
+                "count"
+              ]
             }
           },
           "tone": {

--- a/event-runtime/schemas/factory.decision-request.v1.json
+++ b/event-runtime/schemas/factory.decision-request.v1.json
@@ -59,7 +59,15 @@
         "additionalProperties": false,
         "properties": {
           "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
-          "kind": { "enum": ["text", "single-choice", "multi-choice", "confirm", "number"] },
+          "kind": {
+            "enum": [
+              "text",
+              "single-choice",
+              "multi-choice",
+              "confirm",
+              "number"
+            ]
+          },
           "label": { "type": "string", "minLength": 1, "maxLength": 60 },
           "required": { "type": "boolean" },
           "whenOption": {
@@ -79,7 +87,10 @@
               "required": ["id", "label"],
               "additionalProperties": false,
               "properties": {
-                "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+                "id": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]{0,31}$"
+                },
                 "label": { "type": "string", "minLength": 1, "maxLength": 60 },
                 "description": { "type": "string", "maxLength": 280 }
               }

--- a/event-runtime/schemas/factory.decision-response.v1.json
+++ b/event-runtime/schemas/factory.decision-response.v1.json
@@ -1,7 +1,14 @@
 {
   "title": "factory.decision-response/v1 — an operator answer bound to a decision request",
   "type": "object",
-  "required": ["schemaVersion", "requestHash", "optionId", "fields", "decidedBy", "decidedAt"],
+  "required": [
+    "schemaVersion",
+    "requestHash",
+    "optionId",
+    "fields",
+    "decidedBy",
+    "decidedAt"
+  ],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": { "const": "factory.decision-response/v1" },

--- a/event-runtime/schemas/factory.event.v1.json
+++ b/event-runtime/schemas/factory.event.v1.json
@@ -1,7 +1,14 @@
 {
   "title": "factory.event/v1 — inbound event envelope (docs/event-runtime.md §5.1)",
   "type": "object",
-  "required": ["schemaVersion", "eventId", "type", "source", "occurredAt", "payload"],
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "type",
+    "source",
+    "occurredAt",
+    "payload"
+  ],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": { "const": "factory.event/v1" },

--- a/event-runtime/schemas/janitor.input.json
+++ b/event-runtime/schemas/janitor.input.json
@@ -2,9 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JanitorInput",
   "type": "object",
-  "required": [
-    "repo"
-  ],
+  "required": ["repo"],
   "properties": {
     "repo": {
       "type": "string",

--- a/event-runtime/schemas/run-postmortem.output.json
+++ b/event-runtime/schemas/run-postmortem.output.json
@@ -5,7 +5,15 @@
   "additionalProperties": false,
   "properties": {
     "runId": { "type": "string", "minLength": 1 },
-    "category": { "enum": ["agent_error", "environment", "contract_violation", "cut_short", "unclear"] },
+    "category": {
+      "enum": [
+        "agent_error",
+        "environment",
+        "contract_violation",
+        "cut_short",
+        "unclear"
+      ]
+    },
     "whatHappened": { "type": "string", "minLength": 1 },
     "operatorAction": { "type": "string", "minLength": 1 },
     "evidenceLines": { "type": "array", "items": { "type": "string" } }

--- a/event-runtime/schemas/ship-apply.input.json
+++ b/event-runtime/schemas/ship-apply.input.json
@@ -1,7 +1,16 @@
 {
   "title": "ship-apply input — the approved, double-SHA-pinned release plan whose watched approval IS the human deploy-branch decision",
   "type": "object",
-  "required": ["repo", "github", "base", "deployBranch", "headSha", "deployHeadSha", "changelog", "plan"],
+  "required": [
+    "repo",
+    "github",
+    "base",
+    "deployBranch",
+    "headSha",
+    "deployHeadSha",
+    "changelog",
+    "plan"
+  ],
   "additionalProperties": false,
   "properties": {
     "repo": {

--- a/event-runtime/schemas/ship-scan.output.json
+++ b/event-runtime/schemas/ship-scan.output.json
@@ -1,7 +1,14 @@
 {
   "title": "factory.ship-plan/v1 output artifact — release-candidate assembly: is base ahead, green, and ready for the human deploy-branch decision?",
   "type": "object",
-  "required": ["recommendation", "repo", "github", "changelog", "plan", "summary"],
+  "required": [
+    "recommendation",
+    "repo",
+    "github",
+    "changelog",
+    "plan",
+    "summary"
+  ],
   "additionalProperties": false,
   "properties": {
     "recommendation": {
@@ -114,7 +121,14 @@
       "description": "One line the human reads before taking the deploy decision"
     },
     "noopReason": {
-      "enum": ["not_ahead", "diverged", "ci_red", "ci_pending", "no_checks", "no_deploy_config"],
+      "enum": [
+        "not_ahead",
+        "diverged",
+        "ci_red",
+        "ci_pending",
+        "no_checks",
+        "no_deploy_config"
+      ],
       "description": "Typed reason accompanying a NOOP — nothing to ship, branch divergence (behind_by > 0 or status diverged), base CI red, base CI still running, no real checks on the head commit (no checks is not green), or the repo has no deploy branch distinct from base"
     }
   }

--- a/event-runtime/schemas/sweep-scan.input.json
+++ b/event-runtime/schemas/sweep-scan.input.json
@@ -1,9 +1,7 @@
 {
   "title": "sweep-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
   "type": "object",
-  "required": [
-    "repo"
-  ],
+  "required": ["repo"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -15,10 +13,7 @@
     },
     "repoPin": {
       "type": "object",
-      "required": [
-        "repo",
-        "sha"
-      ],
+      "required": ["repo", "sha"],
       "additionalProperties": false,
       "properties": {
         "repo": {
@@ -33,10 +28,7 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "github": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     }

--- a/event-runtime/schemas/triage-scan.input.json
+++ b/event-runtime/schemas/triage-scan.input.json
@@ -1,9 +1,7 @@
 {
   "title": "triage-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
   "type": "object",
-  "required": [
-    "repo"
-  ],
+  "required": ["repo"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -17,10 +15,7 @@
     },
     "repoPin": {
       "type": "object",
-      "required": [
-        "repo",
-        "sha"
-      ],
+      "required": ["repo", "sha"],
       "additionalProperties": false,
       "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
       "properties": {
@@ -39,10 +34,7 @@
           "description": "Commit SHA the scan runs against"
         },
         "github": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }

--- a/event-runtime/schemas/unblock-scan.input.json
+++ b/event-runtime/schemas/unblock-scan.input.json
@@ -1,9 +1,7 @@
 {
   "title": "unblock-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
   "type": "object",
-  "required": [
-    "repo"
-  ],
+  "required": ["repo"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -15,10 +13,7 @@
     },
     "repoPin": {
       "type": "object",
-      "required": [
-        "repo",
-        "sha"
-      ],
+      "required": ["repo", "sha"],
       "additionalProperties": false,
       "properties": {
         "repo": {
@@ -33,10 +28,7 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "github": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     }

--- a/event-runtime/schemas/work-scan.input.json
+++ b/event-runtime/schemas/work-scan.input.json
@@ -1,9 +1,7 @@
 {
   "title": "work-scan input — one repo queue to scan; repoPin is resolved by the planner (WM-110). A clock tick adds {loop, slot, cadenceSeconds, skippedSlots} bookkeeping to the schedule's static {repo} payload — whitelisted here as in repo-loop.input.json (WM-123)",
   "type": "object",
-  "required": [
-    "repo"
-  ],
+  "required": ["repo"],
   "additionalProperties": false,
   "properties": {
     "repo": {
@@ -17,10 +15,7 @@
     },
     "repoPin": {
       "type": "object",
-      "required": [
-        "repo",
-        "sha"
-      ],
+      "required": ["repo", "sha"],
       "additionalProperties": false,
       "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
       "properties": {
@@ -39,10 +34,7 @@
           "description": "Commit SHA the scan runs against"
         },
         "github": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }

--- a/event-runtime/schemas/work-scan.output.json
+++ b/event-runtime/schemas/work-scan.output.json
@@ -1,7 +1,16 @@
 {
   "title": "factory.work-plan/v1 output artifact — ordered dispatchable-ticket plan with complete candidate accounting (WM-350)",
   "type": "object",
-  "required": ["recommendation", "repo", "ticket", "plan", "deferred", "readyCandidates", "triageBacklog", "summary"],
+  "required": [
+    "recommendation",
+    "repo",
+    "ticket",
+    "plan",
+    "deferred",
+    "readyCandidates",
+    "triageBacklog",
+    "summary"
+  ],
   "additionalProperties": false,
   "properties": {
     "recommendation": {

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -9,7 +9,14 @@
  */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +26,11 @@ import { RUNTIME_ROOT } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { admitEvent } from "./lib/intake.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
-import { approveProposal, getProposal, openProposals } from "./lib/proposals.mjs";
+import {
+  approveProposal,
+  getProposal,
+  openProposals,
+} from "./lib/proposals.mjs";
 import { RegistryError, loadRegistry } from "./lib/registry.mjs";
 import { runState } from "./lib/lifecycle.mjs";
 import { SCHEDULE_SOURCE } from "./lib/schedules.mjs";
@@ -58,7 +69,11 @@ describe("ship-scan registration (WM-111)", () => {
     expect(props.deployHeadSha.pattern).toBe("^[0-9a-f]{40}$");
     expect(props.recommendation.enum).toEqual(["SHIP", "NOOP"]);
     // The plan is the closed ship set, nothing else nameable.
-    expect(props.plan.items.properties.action.enum).toEqual(["open_rc_pr", "merge_rc_pr", "smoke_check"]);
+    expect(props.plan.items.properties.action.enum).toEqual([
+      "open_rc_pr",
+      "merge_rc_pr",
+      "smoke_check",
+    ]);
     // NOOP is typed: not ahead, diverged, CI red/pending, no real checks, or no deploy config.
     expect(props.noopReason.enum).toEqual([
       "not_ahead",
@@ -103,7 +118,10 @@ else
 fi
 `,
   );
-  writeFileSync(path.join(shims, "factory"), `#!/bin/sh\necho "factory $*" >> "$SHIM_LOG"\n`);
+  writeFileSync(
+    path.join(shims, "factory"),
+    `#!/bin/sh\necho "factory $*" >> "$SHIM_LOG"\n`,
+  );
   chmodSync(path.join(shims, "gh"), 0o755);
   chmodSync(path.join(shims, "factory"), 0o755);
 
@@ -148,7 +166,11 @@ fi
     },
   });
   expect(proc.status).toBe(0);
-  return { outcome: JSON.parse(proc.stdout.trim().split("\n").at(-1)), workspaceDir, log };
+  return {
+    outcome: JSON.parse(proc.stdout.trim().split("\n").at(-1)),
+    workspaceDir,
+    log,
+  };
 }
 
 describe("ship-apply is closed by construction (WM-111)", () => {
@@ -159,16 +181,35 @@ describe("ship-apply is closed by construction (WM-111)", () => {
     // A release plan has one step per action, not one per ticket — the item
     // key IS the action id (recorded as issueId by the item-list adapter).
     expect(def.itemKey).toBe("action");
-    expect(Object.keys(def.actionRegistry).sort()).toEqual(["merge_rc_pr", "open_rc_pr", "smoke_check"]);
+    expect(Object.keys(def.actionRegistry).sort()).toEqual([
+      "merge_rc_pr",
+      "open_rc_pr",
+      "smoke_check",
+    ]);
     // Every script substitutes only trailing positional args — never into the script text.
     expect(def.actionRegistry.open_rc_pr.argv.slice(-6)).toEqual([
-      "{github}", "{base}", "{headSha}", "{deployBranch}", "{title}", "{body}",
+      "{github}",
+      "{base}",
+      "{headSha}",
+      "{deployBranch}",
+      "{title}",
+      "{body}",
     ]);
     expect(def.actionRegistry.merge_rc_pr.argv.slice(-5)).toEqual([
-      "{github}", "{deployBranch}", "{deployHeadSha}", "{base}", "{headSha}",
+      "{github}",
+      "{deployBranch}",
+      "{deployHeadSha}",
+      "{base}",
+      "{headSha}",
     ]);
     expect(def.actionRegistry.smoke_check.argv.slice(-7)).toEqual([
-      "{github}", "{smokeBranch}", "{url}", "{factoryRoot}", "{repo}", "{revisionField}", "{smokeDeadlineSeconds}",
+      "{github}",
+      "{smokeBranch}",
+      "{url}",
+      "{factoryRoot}",
+      "{repo}",
+      "{revisionField}",
+      "{smokeDeadlineSeconds}",
     ]);
     // A release PR merges with a merge commit — never squash, never
     // --delete-branch (its head is the integration branch): factory-ship §4.
@@ -178,7 +219,9 @@ describe("ship-apply is closed by construction (WM-111)", () => {
     expect(mergeScript).not.toContain("--squash");
     expect(mergeScript).not.toContain("--delete-branch");
     // Smoke reuses the factory-status freshness helpers, and never reverts.
-    expect(def.actionRegistry.smoke_check.argv[2]).toContain("lib/repo-status.mjs");
+    expect(def.actionRegistry.smoke_check.argv[2]).toContain(
+      "lib/repo-status.mjs",
+    );
     expect(def.actionRegistry.smoke_check.argv[2]).toContain("SMOKE RED");
   });
 
@@ -194,7 +237,11 @@ describe("ship-apply is closed by construction (WM-111)", () => {
 
   test("open_rc_pr probes the base head and opens the release PR when it matches the pin", async () => {
     const { outcome, log } = await runApply([
-      { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" },
+      {
+        action: "open_rc_pr",
+        title: "release: develop → master (2026-08-14)",
+        body: "the changelog",
+      },
     ]);
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
     const shimLog = readFileSync(log, "utf8");
@@ -205,7 +252,13 @@ describe("ship-apply is closed by construction (WM-111)", () => {
 
   test("open_rc_pr reuses an existing open release PR instead of stacking a second", async () => {
     const { outcome, log } = await runApply(
-      [{ action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" }],
+      [
+        {
+          action: "open_rc_pr",
+          title: "release: develop → master (2026-08-14)",
+          body: "the changelog",
+        },
+      ],
       { FAKE_OPEN_PRS: "1" },
     );
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
@@ -214,42 +267,64 @@ describe("ship-apply is closed by construction (WM-111)", () => {
 
   test("a moved base head is a refusal, not a blind release: the PR never opens", async () => {
     const { outcome, workspaceDir, log } = await runApply(
-      [{ action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" }],
+      [
+        {
+          action: "open_rc_pr",
+          title: "release: develop → master (2026-08-14)",
+          body: "the changelog",
+        },
+      ],
       { FAKE_BASE_HEAD: MOVED_SHA },
     );
     expect(outcome.exitCode).toBe(1);
     expect(existsSync(log)).toBe(false);
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing open_rc_pr");
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("refusing open_rc_pr");
   });
 
   test("merge_rc_pr waits on the PR's checks, then merges with a merge commit", async () => {
-    const { outcome, log } = await runApply([{ action: "merge_rc_pr" }], { FAKE_OPEN_PRS: "1" });
+    const { outcome, log } = await runApply([{ action: "merge_rc_pr" }], {
+      FAKE_OPEN_PRS: "1",
+    });
     expect(outcome).toEqual({ exitCode: 0, timedOut: false });
     const shimLog = readFileSync(log, "utf8");
-    expect(shimLog).toContain("gh pr checks 7 --repo watt-mind/bj29 --watch --fail-fast");
+    expect(shimLog).toContain(
+      "gh pr checks 7 --repo watt-mind/bj29 --watch --fail-fast",
+    );
     expect(shimLog).toContain("gh pr merge 7 --repo watt-mind/bj29 --merge");
     expect(shimLog).not.toContain("--squash");
     expect(shimLog).not.toContain("--delete-branch");
   });
 
   test("a deploy branch that moved since the scan refuses the merge — someone committed to it directly", async () => {
-    const { outcome, workspaceDir, log } = await runApply([{ action: "merge_rc_pr" }], {
-      FAKE_OPEN_PRS: "1",
-      FAKE_DEPLOY_HEAD: MOVED_SHA,
-    });
+    const { outcome, workspaceDir, log } = await runApply(
+      [{ action: "merge_rc_pr" }],
+      {
+        FAKE_OPEN_PRS: "1",
+        FAKE_DEPLOY_HEAD: MOVED_SHA,
+      },
+    );
     expect(outcome.exitCode).toBe(1);
     expect(existsSync(log)).toBe(false); // the merge never executed
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing merge_rc_pr");
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("refusing merge_rc_pr");
   });
 
   test("a release PR head that is not the scanned pin refuses the merge", async () => {
-    const { outcome, workspaceDir, log } = await runApply([{ action: "merge_rc_pr" }], {
-      FAKE_OPEN_PRS: "1",
-      FAKE_PR_HEAD: MOVED_SHA,
-    });
+    const { outcome, workspaceDir, log } = await runApply(
+      [{ action: "merge_rc_pr" }],
+      {
+        FAKE_OPEN_PRS: "1",
+        FAKE_PR_HEAD: MOVED_SHA,
+      },
+    );
     expect(outcome.exitCode).toBe(1);
     expect(existsSync(log)).toBe(false);
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing release PR #7");
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("refusing release PR #7");
   });
 
   // The endpoint runs as a child process: runApply's spawnSync blocks this
@@ -285,8 +360,13 @@ describe("ship-apply is closed by construction (WM-111)", () => {
         },
       ]);
       expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
-      expect(result.artifact).toEqual({ repo: "bj29", applied: [{ issueId: "smoke_check", action: "smoke_check" }] });
+      const result = JSON.parse(
+        readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+      );
+      expect(result.artifact).toEqual({
+        repo: "bj29",
+        applied: [{ issueId: "smoke_check", action: "smoke_check" }],
+      });
     });
   }, 20_000);
 
@@ -302,8 +382,12 @@ describe("ship-apply is closed by construction (WM-111)", () => {
         },
       ]);
       expect(outcome.exitCode).toBe(1);
-      expect(readFileSync(log, "utf8")).toContain("factory notify SMOKE RED bj29:");
-      expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("smoke red");
+      expect(readFileSync(log, "utf8")).toContain(
+        "factory notify SMOKE RED bj29:",
+      );
+      expect(
+        readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+      ).toContain("smoke red");
       // Never auto-revert: the only mutation a red smoke performs is the push.
       expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(1);
     });
@@ -321,8 +405,13 @@ describe("ship-apply is closed by construction (WM-111)", () => {
         },
       ]);
       expect(outcome).toEqual({ exitCode: 0, timedOut: false });
-      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
-      expect(result.artifact).toEqual({ repo: "bj29", applied: [{ issueId: "smoke_check", action: "smoke_check" }] });
+      const result = JSON.parse(
+        readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+      );
+      expect(result.artifact).toEqual({
+        repo: "bj29",
+        applied: [{ issueId: "smoke_check", action: "smoke_check" }],
+      });
     });
   }, 20_000);
 
@@ -333,9 +422,9 @@ describe("ship-apply is closed by construction (WM-111)", () => {
     ]);
     expect(outcome.exitCode).toBe(1);
     expect(existsSync(log)).toBe(false);
-    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
-      "not in the closed action registry",
-    );
+    expect(
+      readFileSync(path.join(workspaceDir, ".actions.log"), "utf8"),
+    ).toContain("not in the closed action registry");
   });
 });
 
@@ -354,9 +443,19 @@ const applyPayload = {
   deployBranch: "master",
   headSha: BASE_SHA,
   deployHeadSha: DEPLOY_SHA,
-  changelog: [{ sha: BASE_SHA, subject: "fix(app): guard null session (CLNT-123)", ticket: "CLNT-123" }],
+  changelog: [
+    {
+      sha: BASE_SHA,
+      subject: "fix(app): guard null session (CLNT-123)",
+      ticket: "CLNT-123",
+    },
+  ],
   plan: [
-    { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" },
+    {
+      action: "open_rc_pr",
+      title: "release: develop → master (2026-08-14)",
+      body: "the changelog",
+    },
     { action: "merge_rc_pr" },
   ],
 };
@@ -373,7 +472,9 @@ function openShipApplyProposal(db) {
     payload: applyPayload,
   });
   planAdmittedEvents(db, registry, { policyVersion: PV });
-  const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1");
+  const proposal = openProposals(db, {}).find(
+    (p) => p.spec?.agent === "ship-apply@1",
+  );
   expect(proposal).toBeTruthy();
   return proposal;
 }
@@ -383,14 +484,24 @@ describe("ship-apply approval is structurally human-only (WM-111)", () => {
     // Copy the real registry into a temp root so the test can corrupt it safely.
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-registry-"));
     for (const dir of ["agents", "schemas"]) {
-      cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), { recursive: true });
+      cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), {
+        recursive: true,
+      });
     }
-    cpSync(path.join(RUNTIME_ROOT, "event-types.json"), path.join(root, "event-types.json"));
+    cpSync(
+      path.join(RUNTIME_ROOT, "event-types.json"),
+      path.join(root, "event-types.json"),
+    );
     const withApproval = (approval) =>
       writeFileSync(
         path.join(root, "schedules.json"),
         JSON.stringify({
-          "ship-apply-creep": { every: "1h", eventType: "factory.ship-apply.requested", approval, enabled: true },
+          "ship-apply-creep": {
+            every: "1h",
+            eventType: "factory.ship-apply.requested",
+            approval,
+            enabled: true,
+          },
         }),
       );
     withApproval("auto");
@@ -410,7 +521,10 @@ describe("ship-apply approval is structurally human-only (WM-111)", () => {
     // "schedule" through approveProposal. There is no other approval path.
     let rejection;
     try {
-      approveProposal(db, registry, proposal.id, { actor: SCHEDULE_SOURCE, policyVersion: PV });
+      approveProposal(db, registry, proposal.id, {
+        actor: SCHEDULE_SOURCE,
+        policyVersion: PV,
+      });
     } catch (err) {
       rejection = err;
     }
@@ -424,12 +538,18 @@ describe("ship-apply approval is structurally human-only (WM-111)", () => {
 
     // Any other machine actor is rejected identically — the gate allowlists
     // the human operator; it does not blocklist known robots.
-    expect(() => approveProposal(db, registry, proposal.id, { actor: "chain", policyVersion: PV })).toThrow(
-      /human_approval_only/,
-    );
+    expect(() =>
+      approveProposal(db, registry, proposal.id, {
+        actor: "chain",
+        policyVersion: PV,
+      }),
+    ).toThrow(/human_approval_only/);
 
     // The human operator's approval — the deploy-branch decision — succeeds.
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     expect(approved).toEqual({ approved: true, runId: proposal.run_id });
   });
 });
@@ -446,16 +566,30 @@ const FAKE_HEAD_SHA = "d".repeat(40);
 const FAKE_DEPLOY_HEAD_SHA = "e".repeat(40);
 
 function writeResult(workspaceDir, result) {
-  writeFileSync(path.join(workspaceDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  writeFileSync(
+    path.join(workspaceDir, "result.json"),
+    `${JSON.stringify(result, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 function shipScanArtifact(repo) {
   const base = { repo, github: `watt-mind/${repo}`, changelog: [], plan: [] };
   if (repo === "clean") {
-    return { ...base, recommendation: "NOOP", summary: "fake: nothing to ship", noopReason: "not_ahead" };
+    return {
+      ...base,
+      recommendation: "NOOP",
+      summary: "fake: nothing to ship",
+      noopReason: "not_ahead",
+    };
   }
   if (repo === "diverged") {
-    return { ...base, recommendation: "NOOP", summary: "fake: branch diverged", noopReason: "diverged" };
+    return {
+      ...base,
+      recommendation: "NOOP",
+      summary: "fake: branch diverged",
+      noopReason: "diverged",
+    };
   }
   return {
     ...base,
@@ -464,9 +598,19 @@ function shipScanArtifact(repo) {
     deployBranch: "master",
     headSha: FAKE_HEAD_SHA,
     deployHeadSha: FAKE_DEPLOY_HEAD_SHA,
-    changelog: [{ sha: FAKE_HEAD_SHA, subject: "feat(app): fake thing (CLNT-901)", ticket: "CLNT-901" }],
+    changelog: [
+      {
+        sha: FAKE_HEAD_SHA,
+        subject: "feat(app): fake thing (CLNT-901)",
+        ticket: "CLNT-901",
+      },
+    ],
     plan: [
-      { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "- feat(app): fake thing\nCLNT-901" },
+      {
+        action: "open_rc_pr",
+        title: "release: develop → master (2026-08-14)",
+        body: "- feat(app): fake thing\nCLNT-901",
+      },
       { action: "merge_rc_pr" },
       {
         action: "smoke_check",
@@ -500,7 +644,10 @@ const shipFake = {
         reasonCode: "ok",
         artifact: {
           repo: spec.input.repo,
-          applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.action, action: i.action })),
+          applied: (spec.input.plan ?? []).map((i) => ({
+            issueId: i.action,
+            action: i.action,
+          })),
         },
         evidence: { commands: ["fake"] },
       });
@@ -515,13 +662,22 @@ function harness() {
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-ws-"));
   const adapters = { pi: shipFake, actions: shipFake, command: shipFake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+  };
 
   async function approveNext(agentRef) {
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
   }
@@ -556,7 +712,9 @@ describe("ship chain: scan → human-approved apply (WM-111)", () => {
     expect(chainEvent.causation_id).toBe(scan.runId); // caused by the scan run
 
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1");
+    const apply = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ship-apply@1",
+    );
     expect(apply.status).toBe("open"); // never applied without the human
     expect(apply.spec.input).toEqual({
       repo: "bj29",
@@ -565,9 +723,19 @@ describe("ship chain: scan → human-approved apply (WM-111)", () => {
       deployBranch: "master",
       headSha: FAKE_HEAD_SHA, // the pin the probes hold the release to
       deployHeadSha: FAKE_DEPLOY_HEAD_SHA,
-      changelog: [{ sha: FAKE_HEAD_SHA, subject: "feat(app): fake thing (CLNT-901)", ticket: "CLNT-901" }],
+      changelog: [
+        {
+          sha: FAKE_HEAD_SHA,
+          subject: "feat(app): fake thing (CLNT-901)",
+          ticket: "CLNT-901",
+        },
+      ],
       plan: [
-        { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "- feat(app): fake thing\nCLNT-901" },
+        {
+          action: "open_rc_pr",
+          title: "release: develop → master (2026-08-14)",
+          body: "- feat(app): fake thing\nCLNT-901",
+        },
         { action: "merge_rc_pr" },
         {
           action: "smoke_check",
@@ -582,13 +750,18 @@ describe("ship chain: scan → human-approved apply (WM-111)", () => {
     // The chained proposal itself rejects the auto path — this approval IS
     // the human deploy-branch decision, and no schedule can take it.
     expect(() =>
-      approveProposal(db, registry, apply.id, { actor: SCHEDULE_SOURCE, policyVersion: PV }),
+      approveProposal(db, registry, apply.id, {
+        actor: SCHEDULE_SOURCE,
+        policyVersion: PV,
+      }),
     ).toThrow(/human_approval_only/);
     expect(getProposal(db, apply.id).status).toBe("open");
 
     const applied = await approveNext("ship-apply@1");
     expect(applied.summary.terminalState).toBe("COMPLETED");
-    const row = db.query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`).get(applied.runId);
+    const row = db
+      .query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`)
+      .get(applied.runId);
     expect(JSON.parse(row.result_json).artifact.applied).toEqual([
       { issueId: "open_rc_pr", action: "open_rc_pr" },
       { issueId: "merge_rc_pr", action: "merge_rc_pr" },
@@ -602,12 +775,22 @@ describe("ship chain: scan → human-approved apply (WM-111)", () => {
     admitEvent(db, registry, shipEnvelope("clean", "ship-2"));
     const scan = await approveNext("ship-scan@1");
     expect(scan.summary.terminalState).toBe("COMPLETED");
-    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(scan.runId).result_json,
+    );
     expect(result.artifact.noopReason).toBe("not_ahead");
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1"),
+    ).toBeUndefined();
   });
 
   test("a diverged branch produces a NOOP with noopReason diverged and empty plan", async () => {
@@ -615,13 +798,23 @@ describe("ship chain: scan → human-approved apply (WM-111)", () => {
     admitEvent(db, registry, shipEnvelope("diverged", "ship-diverged"));
     const scan = await approveNext("ship-scan@1");
     expect(scan.summary.terminalState).toBe("COMPLETED");
-    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(scan.runId).result_json,
+    );
     expect(result.artifact.recommendation).toBe("NOOP");
     expect(result.artifact.noopReason).toBe("diverged");
     expect(result.artifact.plan).toEqual([]);
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1"),
+    ).toBeUndefined();
   });
 });

--- a/event-runtime/test-helpers.mjs
+++ b/event-runtime/test-helpers.mjs
@@ -15,7 +15,9 @@ let defaultIsolatedHome = null;
  */
 export function ensureHermeticHome() {
   if (!defaultIsolatedHome) {
-    defaultIsolatedHome = mkdtempSync(path.join(os.tmpdir(), "evrt-hermetic-home-"));
+    defaultIsolatedHome = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-hermetic-home-"),
+    );
   }
   process.env.FACTORY_EVENT_HOME = defaultIsolatedHome;
   process.env.FACTORY_HOME = defaultIsolatedHome;
@@ -26,7 +28,10 @@ export function ensureHermeticHome() {
 }
 
 // Automatically ensure hermetic home is active on module import if unset or pointing to homedir
-if (!process.env.FACTORY_EVENT_HOME || process.env.FACTORY_EVENT_HOME.startsWith(homedir())) {
+if (
+  !process.env.FACTORY_EVENT_HOME ||
+  process.env.FACTORY_EVENT_HOME.startsWith(homedir())
+) {
   ensureHermeticHome();
 }
 
@@ -65,13 +70,16 @@ export async function withIsolatedHome(fn, prefix = "evrt-scope-home-") {
 /**
  * Returns snapshot stats of ~/.factory to verify hermeticity (guard test).
  */
-export function realFactorySnapshot(factoryHome = path.join(homedir(), ".factory")) {
+export function realFactorySnapshot(
+  factoryHome = path.join(homedir(), ".factory"),
+) {
   const eventHome = path.join(factoryHome, "event-runtime");
   let eventStat;
   try {
     eventStat = statSync(eventHome);
   } catch (error) {
-    if (error?.code === "ENOENT") return { exists: false, mtime: 0, dbMtime: 0 };
+    if (error?.code === "ENOENT")
+      return { exists: false, mtime: 0, dbMtime: 0 };
     return { exists: true, mtime: 0, dbMtime: 0 };
   }
 

--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -31,8 +31,12 @@ function fatalProcessError(kind, error) {
   process.exit(1);
 }
 
-process.on("uncaughtException", (error, origin) => fatalProcessError(`uncaughtException (${origin})`, error));
-process.on("unhandledRejection", (reason) => fatalProcessError("unhandledRejection", reason));
+process.on("uncaughtException", (error, origin) =>
+  fatalProcessError(`uncaughtException (${origin})`, error),
+);
+process.on("unhandledRejection", (reason) =>
+  fatalProcessError("unhandledRejection", reason),
+);
 
 Bun.serve({
   hostname: HOST,
@@ -64,21 +68,30 @@ Bun.serve({
         // Backend restarts are expected during deploys and watch-mode reloads.
         // Keep the static server alive and give clients an explicit retryable
         // response instead of allowing Bun's rejected fetch to escape.
-        console.error(`[web] ${req.method} ${url.pathname} upstream unavailable:`, error);
-        return new Response(JSON.stringify({ error: "event runtime temporarily unavailable" }), {
-          status: 503,
-          headers: {
-            "content-type": "application/json; charset=utf-8",
-            "retry-after": "1",
+        console.error(
+          `[web] ${req.method} ${url.pathname} upstream unavailable:`,
+          error,
+        );
+        return new Response(
+          JSON.stringify({ error: "event runtime temporarily unavailable" }),
+          {
+            status: 503,
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+              "retry-after": "1",
+            },
           },
-        });
+        );
       }
     }
 
     // Static, confined to dist/ — reject traversal rather than resolving it.
     const resolved = path.normalize(path.join(DIST, url.pathname));
-    if (!resolved.startsWith(DIST)) return new Response("not found", { status: 404 });
-    const file = Bun.file(resolved === DIST ? path.join(DIST, "index.html") : resolved);
+    if (!resolved.startsWith(DIST))
+      return new Response("not found", { status: 404 });
+    const file = Bun.file(
+      resolved === DIST ? path.join(DIST, "index.html") : resolved,
+    );
     if (await file.exists()) return new Response(file);
     // A stale content-hashed import must fail as a missing module. Returning the
     // SPA document here disguises it as JavaScript and produces a misleading
@@ -90,4 +103,6 @@ Bun.serve({
   },
 });
 
-console.log(`web control plane on http://${HOST}:${WEB_PORT} → API 127.0.0.1:${API_PORT}`);
+console.log(
+  `web control plane on http://${HOST}:${WEB_PORT} → API 127.0.0.1:${API_PORT}`,
+);

--- a/event-runtime/web/serve.test.mjs
+++ b/event-runtime/web/serve.test.mjs
@@ -1,5 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,7 +21,11 @@ let createdDistIndex = false;
 const received = [];
 
 function reservePort() {
-  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response() });
+  const probe = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response(),
+  });
   const port = probe.port;
   probe.stop(true);
   return port;
@@ -30,15 +40,23 @@ function requestProxy(method, pathname, body) {
     }
 
     const req = http.request(
-      { hostname: "127.0.0.1", port: webPort, method, path: `/api${pathname}`, headers },
+      {
+        hostname: "127.0.0.1",
+        port: webPort,
+        method,
+        path: `/api${pathname}`,
+        headers,
+      },
       (res) => {
         const chunks = [];
         res.on("data", (chunk) => chunks.push(chunk));
-        res.on("end", () => resolve({
-          status: res.statusCode,
-          headers: res.headers,
-          body: Buffer.concat(chunks).toString("utf8"),
-        }));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
       },
     );
     req.on("error", reject);
@@ -73,9 +91,13 @@ beforeAll(async () => {
   const startup = await reader.read();
   reader.releaseLock();
   if (startup.done) {
-    throw new Error(`proxy exited during startup: ${await new Response(proxy.stderr).text()}`);
+    throw new Error(
+      `proxy exited during startup: ${await new Response(proxy.stderr).text()}`,
+    );
   }
-  expect(new TextDecoder().decode(startup.value)).toContain(`http://127.0.0.1:${webPort}`);
+  expect(new TextDecoder().decode(startup.value)).toContain(
+    `http://127.0.0.1:${webPort}`,
+  );
 });
 
 afterAll(async () => {
@@ -94,7 +116,9 @@ afterAll(async () => {
 
 describe("event-runtime web static files", () => {
   test("returns an honest 404 for a stale content-hashed asset", async () => {
-    const response = await fetch(`http://127.0.0.1:${webPort}/assets/Proposals-stale.js`);
+    const response = await fetch(
+      `http://127.0.0.1:${webPort}/assets/Proposals-stale.js`,
+    );
 
     expect(response.status).toBe(404);
     expect(await response.text()).toBe("asset not found");
@@ -148,20 +172,23 @@ describe("event-runtime web API proxy", () => {
     ["GET", "ignored get payload"],
     ["HEAD", undefined],
     ["HEAD", "ignored head payload"],
-  ])("forwards %s without a request body even when the client sends one", async (method, body) => {
-    const pathname = `/bodyless-${method.toLowerCase()}-${body === undefined ? "empty" : "supplied"}`;
-    const response = await requestProxy(method, pathname, body);
+  ])(
+    "forwards %s without a request body even when the client sends one",
+    async (method, body) => {
+      const pathname = `/bodyless-${method.toLowerCase()}-${body === undefined ? "empty" : "supplied"}`;
+      const response = await requestProxy(method, pathname, body);
 
-    expect(response.status).toBe(201);
-    expect(response.headers["x-upstream-method"]).toBe(method);
-    const forwarded = received.find((entry) => entry.pathname === pathname);
-    expect(forwarded).toEqual({
-      method,
-      pathname,
-      body: "",
-      marker: `${method.toLowerCase()}-marker`,
-    });
-  });
+      expect(response.status).toBe(201);
+      expect(response.headers["x-upstream-method"]).toBe(method);
+      const forwarded = received.find((entry) => entry.pathname === pathname);
+      expect(forwarded).toEqual({
+        method,
+        pathname,
+        body: "",
+        marker: `${method.toLowerCase()}-marker`,
+      });
+    },
+  );
 
   test.each([
     ["POST", "post payload"],

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -82,9 +82,16 @@ beforeEach(() => {
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
     if (url.includes("/api/runs?ticket=")) {
-      const ticket = new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
+      const ticket =
+        new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
       return jsonResponse({
-        ticket: { id: ticket, title: null, state: null, createdAt: null, url: `https://linear.app/watt-mind/issue/${ticket}` },
+        ticket: {
+          id: ticket,
+          title: null,
+          state: null,
+          createdAt: null,
+          url: `https://linear.app/watt-mind/issue/${ticket}`,
+        },
         activity: false,
         events: [],
         proposals: [],
@@ -180,9 +187,9 @@ describe("bottom status bar", () => {
     const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
 
     await waitFor(() => {
-      expect(utils.sidebar.getByRole("button", { name: "Workers" }).textContent).toContain(
-        "1stale",
-      );
+      expect(
+        utils.sidebar.getByRole("button", { name: "Workers" }).textContent,
+      ).toContain("1stale");
       expect(statusBar.textContent).toContain("1 stale worker");
     });
     expect(statusBar.textContent).not.toContain("no workers");
@@ -357,7 +364,9 @@ describe("context strip fast jump chords (WM-235)", () => {
       fireEvent.keyDown(document.body, { key: "k" });
     });
     expect(window.location.hash).toBe("#/tickets");
-    const ticketInput = await utils.findByRole("textbox", { name: "Ticket id" });
+    const ticketInput = await utils.findByRole("textbox", {
+      name: "Ticket id",
+    });
     expect(document.activeElement === ticketInput).toBe(true);
   });
 
@@ -423,7 +432,9 @@ describe("ticket journey navigation (WM-595)", () => {
     const input = utils.getByPlaceholderText("Type a command…");
     fireEvent.input(input, { target: { value: "WM-595" } });
     // Two items name the ticket (WM-594 adds "Why isn't WM-595 running?"); both open the journey.
-    const [command, why] = await utils.findAllByText("WM-595", { selector: "span.mono" });
+    const [command, why] = await utils.findAllByText("WM-595", {
+      selector: "span.mono",
+    });
     expect(why.closest("[cmdk-item]")!.textContent).toContain("Why isn't");
     fireEvent.click(command.closest("[cmdk-item]")!);
     expect(window.location.hash).toBe("#/tickets/WM-595");
@@ -448,7 +459,9 @@ describe("view navigation landmark focus and announcement (WM-325, WM-542)", () 
   });
 
   test("theme suppresses the landmark ring without removing interactive focus rings", async () => {
-    const themeCss = await Bun.file(new URL("./theme.css", import.meta.url)).text();
+    const themeCss = await Bun.file(
+      new URL("./theme.css", import.meta.url),
+    ).text();
 
     expect(themeCss).toMatch(
       /:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--accent\);[^}]*\}/s,
@@ -458,4 +471,3 @@ describe("view navigation landmark focus and announcement (WM-325, WM-542)", () 
     );
   });
 });
-

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -1,5 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  lazy,
+  Suspense,
+} from "react";
 import { api } from "./api";
 import { ContextTabs } from "./components/ContextTabs";
 import {
@@ -10,11 +18,29 @@ import {
   rememberOpenRepo,
   type OperatorContext,
 } from "./context";
-import { artifactsHash, eventsHash, hashPath, hashProject, hashSearch, withProject } from "./hash";
-import { keyGuard, refetchIntervals, THEMES, useHashRoute, useTheme, type Theme } from "./hooks";
+import {
+  artifactsHash,
+  eventsHash,
+  hashPath,
+  hashProject,
+  hashSearch,
+  withProject,
+} from "./hash";
+import {
+  keyGuard,
+  refetchIntervals,
+  THEMES,
+  useHashRoute,
+  useTheme,
+  type Theme,
+} from "./hooks";
 import { goPrefixActive } from "./goSequence";
 import type { EventFocus } from "./types";
-import { CommandPalette, useGoSequences, type PaletteAction } from "./components/CommandPalette";
+import {
+  CommandPalette,
+  useGoSequences,
+  type PaletteAction,
+} from "./components/CommandPalette";
 import { ToastContainer, copyLink, copyText } from "./components/ui";
 import type { ArtifactFilters } from "./views/Artifacts";
 import { Events } from "./views/Events";
@@ -23,7 +49,9 @@ import { Runs } from "./views/Runs";
 import { NAV, type NavKey } from "./nav";
 
 type WorkerHealthFilter = "live" | "busy" | "stale";
-const isWorkerHealthFilter = (value: string | null): value is WorkerHealthFilter =>
+const isWorkerHealthFilter = (
+  value: string | null,
+): value is WorkerHealthFilter =>
   value === "live" || value === "busy" || value === "stale";
 
 type NavBadge = {
@@ -51,24 +79,52 @@ function NavCount({ id, badge }: { id: string; badge: NavBadge }) {
   );
 }
 
-const Artifacts = lazy(() => import("./views/Artifacts").then((m) => ({ default: m.Artifacts })));
-const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph })));
-const Chain = lazy(() => import("./views/Chain").then((m) => ({ default: m.Chain })));
-const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
-const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
-const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
-const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
-const RunFull = lazy(() => import("./views/RunFull").then((m) => ({ default: m.RunFull })));
-const Ticket = lazy(() => import("./views/Ticket").then((m) => ({ default: m.Ticket })));
+const Artifacts = lazy(() =>
+  import("./views/Artifacts").then((m) => ({ default: m.Artifacts })),
+);
+const Graph = lazy(() =>
+  import("./views/Graph").then((m) => ({ default: m.Graph })),
+);
+const Chain = lazy(() =>
+  import("./views/Chain").then((m) => ({ default: m.Chain })),
+);
+const Projects = lazy(() =>
+  import("./views/Projects").then((m) => ({ default: m.Projects })),
+);
+const Schedules = lazy(() =>
+  import("./views/Schedules").then((m) => ({ default: m.Schedules })),
+);
+const Proposals = lazy(() =>
+  import("./views/Proposals").then((m) => ({ default: m.Proposals })),
+);
+const Agents = lazy(() =>
+  import("./views/Agents").then((m) => ({ default: m.Agents })),
+);
+const RunFull = lazy(() =>
+  import("./views/RunFull").then((m) => ({ default: m.RunFull })),
+);
+const Ticket = lazy(() =>
+  import("./views/Ticket").then((m) => ({ default: m.Ticket })),
+);
 // The PR journey (WM-640) shares the ticket journey chunk — same layout, other subject.
-const PullRequest = lazy(() => import("./views/Ticket").then((m) => ({ default: m.PullRequest })));
-const Workers = lazy(() => import("./views/Workers").then((m) => ({ default: m.Workers })));
-const Inbox = lazy(() => import("./views/Inbox").then((m) => ({ default: m.Inbox })));
+const PullRequest = lazy(() =>
+  import("./views/Ticket").then((m) => ({ default: m.PullRequest })),
+);
+const Workers = lazy(() =>
+  import("./views/Workers").then((m) => ({ default: m.Workers })),
+);
+const Inbox = lazy(() =>
+  import("./views/Inbox").then((m) => ({ default: m.Inbox })),
+);
 const ShortcutsDialog = lazy(() =>
-  import("./components/ShortcutsDialog").then((m) => ({ default: m.ShortcutsDialog })),
+  import("./components/ShortcutsDialog").then((m) => ({
+    default: m.ShortcutsDialog,
+  })),
 );
 const InjectDialog = lazy(() =>
-  import("./components/InjectDialog").then((m) => ({ default: m.InjectDialog })),
+  import("./components/InjectDialog").then((m) => ({
+    default: m.InjectDialog,
+  })),
 );
 
 export function App() {
@@ -78,16 +134,19 @@ export function App() {
   const context = contextFromProject(project);
   const [openRepos, setOpenRepos] = useState<string[]>(() => {
     try {
-      return readContextTabs(sessionStorage.getItem(CONTEXT_STORAGE_KEY)).openRepos;
+      return readContextTabs(sessionStorage.getItem(CONTEXT_STORAGE_KEY))
+        .openRepos;
     } catch {
       return [];
     }
   });
   const navigate = useCallback(
-    (path: string) => navigateRaw(withProject(path, hashProject(window.location.hash))),
+    (path: string) =>
+      navigateRaw(withProject(path, hashProject(window.location.hash))),
     [navigateRaw],
   );
-  const hashPathNow = () => window.location.hash.replace(/^#\/?/, "") || "overview";
+  const hashPathNow = () =>
+    window.location.hash.replace(/^#\/?/, "") || "overview";
   const selectContext = useCallback(
     (next: OperatorContext) => {
       const nextProject = projectFromContext(next);
@@ -110,7 +169,11 @@ export function App() {
     }
   };
 
-  const reposQ = useQuery({ queryKey: ["repos"], queryFn: api.repos, ...refetchIntervals.secondary });
+  const reposQ = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    ...refetchIntervals.secondary,
+  });
 
   useEffect(() => {
     if (!project || project === "all" || project === "inflight") return;
@@ -130,7 +193,9 @@ export function App() {
 
   const [theme, cycleTheme] = useTheme();
   const [injectOpen, setInjectOpen] = useState(false);
-  const [injectSeed, setInjectSeed] = useState<Record<string, unknown> | undefined>(undefined);
+  const [injectSeed, setInjectSeed] = useState<
+    Record<string, unknown> | undefined
+  >(undefined);
   const [helpOpen, setHelpOpen] = useState(false);
   const [focusRunState, setFocusRunState] = useState<string | null>(null);
   const [focusExpired, setFocusExpired] = useState(false);
@@ -168,8 +233,11 @@ export function App() {
   const focusWorkerId = view === "workers" ? (route[1] ?? null) : null;
   // `#/inbox/:id` — the Telegram push deep-links here (lib/inbox.mjs telegramMessage).
   const focusInboxId = view === "inbox" ? (route[1] ?? null) : null;
-  const workerHealthFromHash = view === "workers" ? hashSearch(window.location.hash).get("health") : null;
-  const focusWorkerHealth = isWorkerHealthFilter(workerHealthFromHash) ? workerHealthFromHash : null;
+  const workerHealthFromHash =
+    view === "workers" ? hashSearch(window.location.hash).get("health") : null;
+  const focusWorkerHealth = isWorkerHealthFilter(workerHealthFromHash)
+    ? workerHealthFromHash
+    : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
   // `#/chain/:correlationId[/:nodeId]` — the chain trace (WM-527); node
   // selection rides the hash so a pasted link lands on the same node.
@@ -188,7 +256,8 @@ export function App() {
     view === "events" && route[1] && route[2]
       ? { source: route[1], eventId: route[2] }
       : null;
-  const typeFromHash = view === "events" ? hashSearch(window.location.hash).get("type") : null;
+  const typeFromHash =
+    view === "events" ? hashSearch(window.location.hash).get("type") : null;
   const focusEvent =
     view === "events"
       ? {
@@ -197,8 +266,13 @@ export function App() {
           ...(hashEvent ?? {}),
         }
       : null;
-  const hasEventFocus =
-    !!(focusEvent && (focusEvent.source || focusEvent.eventId || focusEvent.status || focusEvent.type));
+  const hasEventFocus = !!(
+    focusEvent &&
+    (focusEvent.source ||
+      focusEvent.eventId ||
+      focusEvent.status ||
+      focusEvent.type)
+  );
 
   const [rejumpEpoch, setRejumpEpoch] = useState(0);
 
@@ -207,8 +281,10 @@ export function App() {
     navigate(hashPath("runs", runId));
   };
   const openRunFull = (runId: string) => navigate(hashPath("run", runId));
-  const jumpToTicket = (ticketId: string) => navigate(hashPath("tickets", ticketId));
-  const jumpToPr = (number: number) => navigate(hashPath("prs", String(number)));
+  const jumpToTicket = (ticketId: string) =>
+    navigate(hashPath("tickets", ticketId));
+  const jumpToPr = (number: number) =>
+    navigate(hashPath("prs", String(number)));
   const jumpToRuns = (state?: string) => {
     if (state) setFocusRunState(state);
     setRejumpEpoch((n) => n + 1);
@@ -226,7 +302,11 @@ export function App() {
   const jumpToEvents = (focus: EventFocus) => {
     setRejumpEpoch((n) => n + 1);
     if (focus.source && focus.eventId) {
-      setEphemeralEvent(focus.status || focus.type ? { status: focus.status, type: focus.type } : null);
+      setEphemeralEvent(
+        focus.status || focus.type
+          ? { status: focus.status, type: focus.type }
+          : null,
+      );
       navigate(hashPath("events", focus.source, focus.eventId));
       return;
     }
@@ -244,7 +324,8 @@ export function App() {
     return health ? `${path}?health=${encodeURIComponent(health)}` : path;
   };
   const jumpToWorker = (id: string) => navigate(workerHash(id, null));
-  const jumpToWorkers = (health: WorkerHealthFilter) => navigate(workerHash(null, health));
+  const jumpToWorkers = (health: WorkerHealthFilter) =>
+    navigate(workerHash(null, health));
   const jumpToProject = (name: string) => navigate(hashPath("projects", name));
   const jumpToGraph = (nodeId?: string) => navigate(hashPath("graph", nodeId));
   const jumpToChain = (correlationId: string, nodeId?: string) =>
@@ -261,13 +342,18 @@ export function App() {
   // "unreachable" over an empty factory.
   const healthFailed = !connected && !health.isPending;
 
-  const status = useQuery({ queryKey: ["status"], queryFn: api.status, ...refetchIntervals.primary });
+  const status = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.primary,
+  });
   const openProposals = status.data?.proposals.open ?? 0;
   const activeRuns = Object.entries(status.data?.runs.byState ?? {})
     .filter(([s]) => ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(s))
     .reduce((sum, [, n]) => sum + (n ?? 0), 0);
   const eventAttention =
-    (status.data?.events.human_needed ?? 0) + (status.data?.events.dead_lettered ?? 0);
+    (status.data?.events.human_needed ?? 0) +
+    (status.data?.events.dead_lettered ?? 0);
   const scopedNav = context.kind === "repo";
   const scopedRunsNav = context.kind !== "all";
   const busyWorkers = status.data?.workers.busy ?? 0;
@@ -275,8 +361,9 @@ export function App() {
   // null until the first status lands: reading "no workers" off a pending
   // fetch is the same false alarm as flashing "unreachable" on first load.
   const liveWorkers = status.data?.workers.live ?? null;
-  const stoppedSchedulesCount =
-    ((status.data?.anomalies as any)?.stoppedSchedules ?? []).length;
+  const stoppedSchedulesCount = (
+    (status.data?.anomalies as any)?.stoppedSchedules ?? []
+  ).length;
 
   // Workers is the one badge whose meaning can flip: a stale
   // heartbeat is a worker that is gone while claiming to work, so it
@@ -358,13 +445,21 @@ export function App() {
 
   const viewLabel =
     NAV.find((n) => n.key === view)?.label ??
-    (view === "run" ? "Run" : view === "chain" ? "Chain" : view === "prs" ? "PR" : "Overview");
+    (view === "run"
+      ? "Run"
+      : view === "chain"
+        ? "Chain"
+        : view === "prs"
+          ? "PR"
+          : "Overview");
 
   useEffect(() => {
     const id = route.length > 1 ? route[route.length - 1] : null;
     const typeQ = hashSearch(window.location.hash).get("type");
     const detail = id ?? typeQ;
-    document.title = detail ? `factory · ${viewLabel} · ${detail}` : `factory · ${viewLabel}`;
+    document.title = detail
+      ? `factory · ${viewLabel} · ${detail}`
+      : `factory · ${viewLabel}`;
   }, [route, viewLabel]);
 
   useEffect(() => {
@@ -398,13 +493,16 @@ export function App() {
         setHelpOpen((open) => !open);
       } else if (e.key === "/") {
         e.preventDefault();
-        const traceSearch = document.querySelector<HTMLInputElement>("[data-trace-search]");
+        const traceSearch = document.querySelector<HTMLInputElement>(
+          "[data-trace-search]",
+        );
         if (traceSearch) {
           traceSearch.focus();
           traceSearch.select();
           return;
         }
-        const el = document.querySelector<HTMLInputElement>("[data-view-filter]");
+        const el =
+          document.querySelector<HTMLInputElement>("[data-view-filter]");
         if (el) el.focus();
         else {
           setFilterFocus(true);
@@ -462,13 +560,16 @@ export function App() {
       label: "Focus filter",
       hint: "/",
       run: () => {
-        const traceSearch = document.querySelector<HTMLInputElement>("[data-trace-search]");
+        const traceSearch = document.querySelector<HTMLInputElement>(
+          "[data-trace-search]",
+        );
         if (traceSearch) {
           traceSearch.focus();
           traceSearch.select();
           return;
         }
-        const el = document.querySelector<HTMLInputElement>("[data-view-filter]");
+        const el =
+          document.querySelector<HTMLInputElement>("[data-view-filter]");
         if (el) el.focus();
         else {
           setFilterFocus(true);
@@ -494,282 +595,380 @@ export function App() {
         goArmed={goArmed}
       />
       <div className="flex min-h-0 flex-1">
-      <nav
-        aria-label="Primary"
-        className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)"
-      >
-        <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
-          <div className="flex items-center gap-2">
-            <img src="/watt-mind-logo.svg" alt="Watt Mind" className="size-5.5 shrink-0" />
-            <span className="display text-[14px] font-semibold">factory</span>
+        <nav
+          aria-label="Primary"
+          className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)"
+        >
+          <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
+            <div className="flex items-center gap-2">
+              <img
+                src="/watt-mind-logo.svg"
+                alt="Watt Mind"
+                className="size-5.5 shrink-0"
+              />
+              <span className="display text-[14px] font-semibold">factory</span>
+            </div>
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
+              title={
+                env
+                  ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
+                  : "runtime unreachable"
+              }
+              style={{
+                color: envHue,
+                background: `color-mix(in oklch, ${envHue} 15%, transparent)`,
+              }}
+              onClick={() => env?.home && copyText(env.home, "runtime home")}
+            >
+              {envLabel}
+            </button>
           </div>
-          <button
-            type="button"
-            className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
-            title={
-              env
-                ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
-                : "runtime unreachable"
-            }
-            style={{
-              color: envHue,
-              background: `color-mix(in oklch, ${envHue} 15%, transparent)`,
-            }}
-            onClick={() => env?.home && copyText(env.home, "runtime home")}
-          >
-            {envLabel}
-          </button>
-        </div>
-        <div className="flex-1 px-2">
-          {NAV.map((n) => {
-            const badge = navBadges[n.key];
-            return (
-              <button
-                key={n.key}
-                type="button"
-                aria-current={view === n.key || (n.key === "runs" && view === "run") || (n.key === "tickets" && view === "prs") ? "page" : undefined}
-                aria-describedby={badge.count > 0 ? `nav-badge-${n.key}` : undefined}
-                onClick={() => navigate(n.key)}
-                className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] ${
-                  view === n.key || (n.key === "runs" && view === "run")
-                    ? "bg-(--surface-3) font-medium text-(--text)"
-                    : "text-(--text-dim) hover:bg-(--surface-2)"
-                }`}
-              >
-                <span>{n.label}</span>
-                {badge.count > 0 && (
-                  /* aria-hidden keeps the count out of the accessible name —
+          <div className="flex-1 px-2">
+            {NAV.map((n) => {
+              const badge = navBadges[n.key];
+              return (
+                <button
+                  key={n.key}
+                  type="button"
+                  aria-current={
+                    view === n.key ||
+                    (n.key === "runs" && view === "run") ||
+                    (n.key === "tickets" && view === "prs")
+                      ? "page"
+                      : undefined
+                  }
+                  aria-describedby={
+                    badge.count > 0 ? `nav-badge-${n.key}` : undefined
+                  }
+                  onClick={() => navigate(n.key)}
+                  className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] ${
+                    view === n.key || (n.key === "runs" && view === "run")
+                      ? "bg-(--surface-3) font-medium text-(--text)"
+                      : "text-(--text-dim) hover:bg-(--surface-2)"
+                  }`}
+                >
+                  <span>{n.label}</span>
+                  {badge.count > 0 && (
+                    /* aria-hidden keeps the count out of the accessible name —
                      "Events" must not announce as "Events 6" — while the
                      aria-describedby reference above still reads it back as
                      the button's description (accname spec includes hidden
                      nodes referenced by labelledby/describedby). */
-                  <NavCount id={`nav-badge-${n.key}`} badge={badge} />
-                )}
-              </button>
-            );
-          })}
-          <button
-            type="button"
-            onClick={() => setInjectOpen(true)}
-            className="mt-2 w-full rounded-md px-2.5 py-1.5 text-left text-[13px] text-(--text-dim) hover:bg-(--surface-2)"
-          >
-            Inject event… <span className="mono ml-1 text-(--text-faint)">i</span>
-          </button>
-        </div>
-      </nav>
-
-      <main
-        ref={mainRef}
-        tabIndex={-1}
-        className="flex min-w-0 flex-1 flex-col focus:outline-none"
-      >
-        <div aria-live="polite" aria-atomic="true" className="sr-only">
-          {viewAnnouncement}
-        </div>
-        {healthFailed && (
-          <div
-            role="status"
-            className="shrink-0 border-b px-4 py-2 text-[12px]"
-            style={{
-              color: "var(--hue-err)",
-              background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
-              borderColor: "color-mix(in oklch, var(--hue-err) 35%, var(--border))",
-            }}
-          >
-            <div className="flex items-center justify-between gap-3">
-              <span>
-                Runtime unreachable — lists show last cached data; verbs are disabled until{" "}
-                <span className="mono">/health</span> responds. This is not an empty factory.
-              </span>
-              <button
-                type="button"
-                onClick={() => health.refetch()}
-                className="shrink-0 rounded-md border px-2 py-0.5 text-[11px] font-medium"
-                style={{
-                  color: "var(--hue-err)",
-                  borderColor: "color-mix(in oklch, var(--hue-err) 40%, var(--border))",
-                }}
-              >
-                Retry
-              </button>
-            </div>
+                    <NavCount id={`nav-badge-${n.key}`} badge={badge} />
+                  )}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setInjectOpen(true)}
+              className="mt-2 w-full rounded-md px-2.5 py-1.5 text-left text-[13px] text-(--text-dim) hover:bg-(--surface-2)"
+            >
+              Inject event…{" "}
+              <span className="mono ml-1 text-(--text-faint)">i</span>
+            </button>
           </div>
-        )}
-        <div className="min-h-0 flex-1">
-          {view === "proposals" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading proposals…</div>}>
-              <Proposals
-                connected={connected}
-                context={context}
-                onRunQueued={jumpToRun}
-                focusProposalId={focusProposalId}
-                onSelectProposal={(id) => navigate(hashPath("proposals", id))}
-                focusExpired={focusExpired}
-                onFocusExpiredConsumed={() => setFocusExpired(false)}
-                onJumpAgent={jumpToAgent}
-                onJumpEvent={jumpToEvent}
-                rejumpEpoch={rejumpEpoch}
-              />
-            </Suspense>
-          ) : view === "run" && fullRunId ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading run…</div>}>
-              <RunFull
-                runId={fullRunId}
-                connected={connected}
-                onBack={() => navigate(hashPath("runs", fullRunId))}
-                onJumpAgent={jumpToAgent}
-                onJumpEvent={jumpToEvent}
-                onJumpProposal={jumpToProposal}
-                onJumpChain={jumpToChain}
-              />
-            </Suspense>
-          ) : view === "runs" || view === "run" ? (
-            <Runs
-              connected={connected}
-              context={context}
-              focusRunId={focusRunId}
-              onSelectRun={(id) => navigate(hashPath("runs", id))}
-              onOpenFull={openRunFull}
-              focusState={focusRunState}
-              onFocusStateConsumed={() => setFocusRunState(null)}
-              onJumpAgent={jumpToAgent}
-              onJumpEvent={jumpToEvent}
-              onJumpProposal={jumpToProposal}
-              rejumpEpoch={rejumpEpoch}
-            />
-          ) : view === "tickets" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading ticket journey…</div>}>
-              <Ticket ticketId={focusTicketId} onNavigate={jumpToTicket} onNavigatePr={jumpToPr} />
-            </Suspense>
-          ) : view === "prs" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading PR journey…</div>}>
-              <PullRequest number={focusPrNumber} onNavigateTicket={jumpToTicket} />
-            </Suspense>
-          ) : view === "projects" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading projects…</div>}>
-              <Projects
-                connected={connected}
-                focusRepoName={focusRepoName}
-                onSelectRepo={(name) => navigate(hashPath("projects", name))}
-              />
-            </Suspense>
-          ) : view === "chain" && chainId ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading chain…</div>}>
-              <Chain
-                correlationId={chainId}
-                focusNodeId={focusChainNode}
-                onSelectNode={(id) => navigate(hashPath("chain", chainId, id))}
-                onJumpEvent={jumpToEvent}
-                onJumpRun={jumpToRun}
-                onOpenRunFull={openRunFull}
-                onJumpProposal={jumpToProposal}
-                onJumpAgent={jumpToAgent}
-              />
-            </Suspense>
-          ) : view === "graph" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading graph…</div>}>
-              <Graph
-                context={context}
-                focusNodeId={focusGraphNode}
-                onSelectNode={(id) => navigate(hashPath("graph", id))}
-                onJumpAgent={jumpToAgent}
-                onJumpEvents={jumpToEvents}
-              />
-            </Suspense>
-          ) : view === "agents" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading agents…</div>}>
-              <Agents
-                context={context}
-                focusAgentRef={focusAgentRef}
-                onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
-              />
-            </Suspense>
-          ) : view === "schedules" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading schedules…</div>}>
-              <Schedules
-                connected={connected}
-                context={context}
-                focusScheduleLoop={focusScheduleLoop}
-                onSelectSchedule={(loop) => navigate(hashPath("schedules", loop))}
-                onJumpProposal={jumpToProposal}
-                onJumpRun={jumpToRun}
-                onJumpEvent={jumpToEvent}
-                onJumpAgent={jumpToAgent}
-                rejumpEpoch={rejumpEpoch}
-              />
-            </Suspense>
-          ) : view === "inbox" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading inbox…</div>}>
-              <Inbox
-                connected={connected}
-                focusItemId={focusInboxId}
-                onSelectItem={(id) => navigate(hashPath("inbox", id))}
-                onJumpRun={jumpToRun}
-                onJumpProposal={jumpToProposal}
-                onJumpEvent={jumpToEvent}
-              />
-            </Suspense>
-          ) : view === "workers" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading workers…</div>}>
-              <Workers
-                context={context}
-                focusWorkerId={focusWorkerId}
-                onSelectWorker={(id) => navigate(workerHash(id, focusWorkerHealth))}
-                focusHealth={focusWorkerHealth}
-                onFocusHealthChange={(health) => navigate(workerHash(null, health))}
-              />
-            </Suspense>
-          ) : view === "artifacts" ? (
-            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading artifacts…</div>}>
-              <Artifacts
-                metrics={status.data?.artifacts}
-                filters={artifactFilters}
-                onFiltersChange={(filters) => navigate(artifactsHash(filters))}
-                onJumpRun={jumpToRun}
-              />
-            </Suspense>
-          ) : view === "events" ? (
-            <Events
-              connected={connected}
-              context={context}
-              focusEvent={hasEventFocus ? focusEvent : null}
-              onFocusConsumed={() => setEphemeralEvent(null)}
-              onSelectEvent={(source, eventId) =>
-                navigate(eventsHash(source, eventId, typeFromHash))
-              }
-              onSelectType={(type) =>
-                navigate(eventsHash(hashEvent?.source, hashEvent?.eventId, type))
-              }
-              onJumpProposal={jumpToProposal}
-              onJumpRun={jumpToRun}
-              onJumpChain={jumpToChain}
-              onTriggerAgain={(envelope) => {
-                setInjectSeed(envelope);
-                setInjectOpen(true);
+        </nav>
+
+        <main
+          ref={mainRef}
+          tabIndex={-1}
+          className="flex min-w-0 flex-1 flex-col focus:outline-none"
+        >
+          <div aria-live="polite" aria-atomic="true" className="sr-only">
+            {viewAnnouncement}
+          </div>
+          {healthFailed && (
+            <div
+              role="status"
+              className="shrink-0 border-b px-4 py-2 text-[12px]"
+              style={{
+                color: "var(--hue-err)",
+                background:
+                  "color-mix(in oklch, var(--hue-err) 10%, transparent)",
+                borderColor:
+                  "color-mix(in oklch, var(--hue-err) 35%, var(--border))",
               }}
-              onInject={() => setInjectOpen(true)}
-              rejumpEpoch={rejumpEpoch}
-            />
-          ) : (
-            <Overview
-              connected={connected}
-              context={context}
-              onJumpRun={jumpToRun}
-              onJumpProposal={jumpToProposal}
-              onJumpEvents={jumpToEvents}
-              onJumpRuns={jumpToRuns}
-              onJumpWorkers={jumpToWorkers}
-              onNavigate={navigate}
-              onJumpExpired={() => {
-                setFocusExpired(true);
-                navigate("proposals");
-              }}
-              onJumpGraph={() => jumpToGraph()}
-              onInject={() => setInjectOpen(true)}
-            />
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span>
+                  Runtime unreachable — lists show last cached data; verbs are
+                  disabled until <span className="mono">/health</span> responds.
+                  This is not an empty factory.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => health.refetch()}
+                  className="shrink-0 rounded-md border px-2 py-0.5 text-[11px] font-medium"
+                  style={{
+                    color: "var(--hue-err)",
+                    borderColor:
+                      "color-mix(in oklch, var(--hue-err) 40%, var(--border))",
+                  }}
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
           )}
-        </div>
-      </main>
+          <div className="min-h-0 flex-1">
+            {view === "proposals" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading proposals…
+                  </div>
+                }
+              >
+                <Proposals
+                  connected={connected}
+                  context={context}
+                  onRunQueued={jumpToRun}
+                  focusProposalId={focusProposalId}
+                  onSelectProposal={(id) => navigate(hashPath("proposals", id))}
+                  focusExpired={focusExpired}
+                  onFocusExpiredConsumed={() => setFocusExpired(false)}
+                  onJumpAgent={jumpToAgent}
+                  onJumpEvent={jumpToEvent}
+                  rejumpEpoch={rejumpEpoch}
+                />
+              </Suspense>
+            ) : view === "run" && fullRunId ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">Loading run…</div>
+                }
+              >
+                <RunFull
+                  runId={fullRunId}
+                  connected={connected}
+                  onBack={() => navigate(hashPath("runs", fullRunId))}
+                  onJumpAgent={jumpToAgent}
+                  onJumpEvent={jumpToEvent}
+                  onJumpProposal={jumpToProposal}
+                  onJumpChain={jumpToChain}
+                />
+              </Suspense>
+            ) : view === "runs" || view === "run" ? (
+              <Runs
+                connected={connected}
+                context={context}
+                focusRunId={focusRunId}
+                onSelectRun={(id) => navigate(hashPath("runs", id))}
+                onOpenFull={openRunFull}
+                focusState={focusRunState}
+                onFocusStateConsumed={() => setFocusRunState(null)}
+                onJumpAgent={jumpToAgent}
+                onJumpEvent={jumpToEvent}
+                onJumpProposal={jumpToProposal}
+                rejumpEpoch={rejumpEpoch}
+              />
+            ) : view === "tickets" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading ticket journey…
+                  </div>
+                }
+              >
+                <Ticket
+                  ticketId={focusTicketId}
+                  onNavigate={jumpToTicket}
+                  onNavigatePr={jumpToPr}
+                />
+              </Suspense>
+            ) : view === "prs" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading PR journey…
+                  </div>
+                }
+              >
+                <PullRequest
+                  number={focusPrNumber}
+                  onNavigateTicket={jumpToTicket}
+                />
+              </Suspense>
+            ) : view === "projects" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading projects…
+                  </div>
+                }
+              >
+                <Projects
+                  connected={connected}
+                  focusRepoName={focusRepoName}
+                  onSelectRepo={(name) => navigate(hashPath("projects", name))}
+                />
+              </Suspense>
+            ) : view === "chain" && chainId ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">Loading chain…</div>
+                }
+              >
+                <Chain
+                  correlationId={chainId}
+                  focusNodeId={focusChainNode}
+                  onSelectNode={(id) =>
+                    navigate(hashPath("chain", chainId, id))
+                  }
+                  onJumpEvent={jumpToEvent}
+                  onJumpRun={jumpToRun}
+                  onOpenRunFull={openRunFull}
+                  onJumpProposal={jumpToProposal}
+                  onJumpAgent={jumpToAgent}
+                />
+              </Suspense>
+            ) : view === "graph" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">Loading graph…</div>
+                }
+              >
+                <Graph
+                  context={context}
+                  focusNodeId={focusGraphNode}
+                  onSelectNode={(id) => navigate(hashPath("graph", id))}
+                  onJumpAgent={jumpToAgent}
+                  onJumpEvents={jumpToEvents}
+                />
+              </Suspense>
+            ) : view === "agents" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">Loading agents…</div>
+                }
+              >
+                <Agents
+                  context={context}
+                  focusAgentRef={focusAgentRef}
+                  onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
+                />
+              </Suspense>
+            ) : view === "schedules" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading schedules…
+                  </div>
+                }
+              >
+                <Schedules
+                  connected={connected}
+                  context={context}
+                  focusScheduleLoop={focusScheduleLoop}
+                  onSelectSchedule={(loop) =>
+                    navigate(hashPath("schedules", loop))
+                  }
+                  onJumpProposal={jumpToProposal}
+                  onJumpRun={jumpToRun}
+                  onJumpEvent={jumpToEvent}
+                  onJumpAgent={jumpToAgent}
+                  rejumpEpoch={rejumpEpoch}
+                />
+              </Suspense>
+            ) : view === "inbox" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">Loading inbox…</div>
+                }
+              >
+                <Inbox
+                  connected={connected}
+                  focusItemId={focusInboxId}
+                  onSelectItem={(id) => navigate(hashPath("inbox", id))}
+                  onJumpRun={jumpToRun}
+                  onJumpProposal={jumpToProposal}
+                  onJumpEvent={jumpToEvent}
+                />
+              </Suspense>
+            ) : view === "workers" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading workers…
+                  </div>
+                }
+              >
+                <Workers
+                  context={context}
+                  focusWorkerId={focusWorkerId}
+                  onSelectWorker={(id) =>
+                    navigate(workerHash(id, focusWorkerHealth))
+                  }
+                  focusHealth={focusWorkerHealth}
+                  onFocusHealthChange={(health) =>
+                    navigate(workerHash(null, health))
+                  }
+                />
+              </Suspense>
+            ) : view === "artifacts" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading artifacts…
+                  </div>
+                }
+              >
+                <Artifacts
+                  metrics={status.data?.artifacts}
+                  filters={artifactFilters}
+                  onFiltersChange={(filters) =>
+                    navigate(artifactsHash(filters))
+                  }
+                  onJumpRun={jumpToRun}
+                />
+              </Suspense>
+            ) : view === "events" ? (
+              <Events
+                connected={connected}
+                context={context}
+                focusEvent={hasEventFocus ? focusEvent : null}
+                onFocusConsumed={() => setEphemeralEvent(null)}
+                onSelectEvent={(source, eventId) =>
+                  navigate(eventsHash(source, eventId, typeFromHash))
+                }
+                onSelectType={(type) =>
+                  navigate(
+                    eventsHash(hashEvent?.source, hashEvent?.eventId, type),
+                  )
+                }
+                onJumpProposal={jumpToProposal}
+                onJumpRun={jumpToRun}
+                onJumpChain={jumpToChain}
+                onTriggerAgain={(envelope) => {
+                  setInjectSeed(envelope);
+                  setInjectOpen(true);
+                }}
+                onInject={() => setInjectOpen(true)}
+                rejumpEpoch={rejumpEpoch}
+              />
+            ) : (
+              <Overview
+                connected={connected}
+                context={context}
+                onJumpRun={jumpToRun}
+                onJumpProposal={jumpToProposal}
+                onJumpEvents={jumpToEvents}
+                onJumpRuns={jumpToRuns}
+                onJumpWorkers={jumpToWorkers}
+                onNavigate={navigate}
+                onJumpExpired={() => {
+                  setFocusExpired(true);
+                  navigate("proposals");
+                }}
+                onJumpGraph={() => jumpToGraph()}
+                onInject={() => setInjectOpen(true)}
+              />
+            )}
+          </div>
+        </main>
       </div>
 
       <footer
@@ -781,15 +980,22 @@ export function App() {
           <div className="flex items-center gap-1.5">
             <span
               className="size-2 shrink-0 rounded-full"
-              style={{ background: connected ? "var(--hue-ok)" : "var(--hue-err)" }}
+              style={{
+                background: connected ? "var(--hue-ok)" : "var(--hue-err)",
+              }}
             />
             {connected ? (
               <span>
-                connected · <span className="mono">{health.data?.policyVersion}</span>
+                connected ·{" "}
+                <span className="mono">{health.data?.policyVersion}</span>
                 {liveWorkers !== null && (
                   <span
                     className="ml-1"
-                    style={staleWorkers > 0 ? { color: "var(--hue-warn)" } : undefined}
+                    style={
+                      staleWorkers > 0
+                        ? { color: "var(--hue-warn)" }
+                        : undefined
+                    }
                     title={
                       staleWorkers > 0
                         ? `${liveWorkers} live · ${staleWorkers} worker${staleWorkers === 1 ? "" : "s"} whose heartbeat has gone stale`
@@ -806,15 +1012,19 @@ export function App() {
                 )}
               </span>
             ) : (
-              <span style={{ color: "var(--hue-err)" }}>runtime unreachable</span>
+              <span style={{ color: "var(--hue-err)" }}>
+                runtime unreachable
+              </span>
             )}
           </div>
         </div>
 
         <div className="flex items-center gap-3">
           <div className="text-(--text-faint)">
-            <span className="mono">⌘K</span> commands · <span className="mono">i</span> inject ·{" "}
-            <span className="mono">g</span> go · <span className="mono">?</span> keys
+            <span className="mono">⌘K</span> commands ·{" "}
+            <span className="mono">i</span> inject ·{" "}
+            <span className="mono">g</span> go · <span className="mono">?</span>{" "}
+            keys
           </div>
           <button
             type="button"
@@ -877,7 +1087,13 @@ export function App() {
  * while empty — a screen reader only announces nodes inserted into a live
  * region that already existed (see ToastContainer).
  */
-export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentView?: string }) {
+export function GoPrefixHint({
+  armed,
+  currentView,
+}: {
+  armed: boolean;
+  currentView?: string;
+}) {
   return (
     <div
       role="status"
@@ -886,7 +1102,9 @@ export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentVi
     >
       {armed && (
         <>
-          <span className="sr-only">Navigation prefix g armed — press a second key</span>
+          <span className="sr-only">
+            Navigation prefix g armed — press a second key
+          </span>
           {/* The legend is the point for a sighted operator and noise read
               aloud: the sentence above says the same thing in one breath. */}
           <div
@@ -897,7 +1115,8 @@ export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentVi
               className="mono rounded px-1.5 font-semibold"
               style={{
                 color: "var(--accent)",
-                background: "color-mix(in oklch, var(--accent) 16%, transparent)",
+                background:
+                  "color-mix(in oklch, var(--accent) 16%, transparent)",
               }}
             >
               g
@@ -905,14 +1124,16 @@ export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentVi
             <span className="text-(--text-dim)">then</span>
             {NAV.map((n) => {
               const isCurrent =
-                n.key === currentView || (n.key === "runs" && currentView === "run");
+                n.key === currentView ||
+                (n.key === "runs" && currentView === "run");
               if (isCurrent) {
                 return (
                   <span
                     key={n.key}
                     className="whitespace-nowrap opacity-60 text-(--text-faint)"
                   >
-                    <span className="mono text-(--text-dim)">{n.go}</span> {n.label}{" "}
+                    <span className="mono text-(--text-dim)">{n.go}</span>{" "}
+                    {n.label}{" "}
                     <span className="rounded px-1 text-[10px] text-(--text-faint) ring-1 ring-inset ring-(--border)">
                       current
                     </span>
@@ -920,7 +1141,10 @@ export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentVi
                 );
               }
               return (
-                <span key={n.key} className="whitespace-nowrap text-(--text-faint)">
+                <span
+                  key={n.key}
+                  className="whitespace-nowrap text-(--text-faint)"
+                >
                   <span className="mono text-(--text)">{n.go}</span> {n.label}
                 </span>
               );
@@ -945,7 +1169,16 @@ export function GoPrefixHint({ armed, currentView }: { armed: boolean; currentVi
 function ThemeIcon({ theme }: { theme: Theme }) {
   if (theme === "light") {
     return (
-      <svg aria-hidden width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        aria-hidden
+        width="13"
+        height="13"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <circle cx="8" cy="8" r="3.5" />
         <path d="M8 1.5v1.5M8 13v1.5M1.5 8H3M13 8h1.5M3.4 3.4l1.1 1.1M11.5 11.5l1.1 1.1M3.4 12.6l1.1-1.1M11.5 4.5l1.1-1.1" />
       </svg>
@@ -953,15 +1186,37 @@ function ThemeIcon({ theme }: { theme: Theme }) {
   }
   if (theme === "contrast") {
     return (
-      <svg aria-hidden width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <svg
+        aria-hidden
+        width="13"
+        height="13"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
         <circle cx="8" cy="8" r="6" />
         <path d="M8 2a6 6 0 0 1 0 12V2z" fill="currentColor" />
       </svg>
     );
   }
   return (
-    <svg aria-hidden width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M13.5 10.2A6 6 0 0 1 5.8 2.5 6 6 0 1 0 13.5 10.2z" fill="currentColor" fillOpacity="0.2" />
+    <svg
+      aria-hidden
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path
+        d="M13.5 10.2A6 6 0 0 1 5.8 2.5 6 6 0 1 0 13.5 10.2z"
+        fill="currentColor"
+        fillOpacity="0.2"
+      />
     </svg>
   );
 }

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -34,11 +34,17 @@ export class ApiError extends Error {
 type CachedResponse = { etag: string; body: unknown };
 const responseCache = new Map<string, CachedResponse>();
 
-async function call<T>(method: string, path: string, body?: unknown): Promise<T> {
+async function call<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
   const url = `/api${path}`;
   const cacheKey = method === "GET" ? url : null;
   const cached = cacheKey ? responseCache.get(cacheKey) : undefined;
-  const headers: Record<string, string> = { "content-type": "application/json" };
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
   if (cached) headers["if-none-match"] = cached.etag;
   const res = await fetch(url, {
     method,
@@ -61,7 +67,10 @@ async function call<T>(method: string, path: string, body?: unknown): Promise<T>
   }
   if (!res.ok) {
     const message =
-      json?.error ?? (Array.isArray(json?.errors) ? json.errors.join("; ") : `HTTP ${res.status}`);
+      json?.error ??
+      (Array.isArray(json?.errors)
+        ? json.errors.join("; ")
+        : `HTTP ${res.status}`);
     throw new ApiError(message, res.status);
   }
   if (cacheKey) {
@@ -72,40 +81,89 @@ async function call<T>(method: string, path: string, body?: unknown): Promise<T>
   return json as T;
 }
 
-export function fetchArtifacts(filters?: { kind?: string; orphan?: boolean; search?: string }) {
+export function fetchArtifacts(filters?: {
+  kind?: string;
+  orphan?: boolean;
+  search?: string;
+}) {
   const query = new URLSearchParams();
   if (filters?.kind) query.set("kind", filters.kind);
-  if (filters?.orphan !== undefined) query.set("orphan", String(filters.orphan));
+  if (filters?.orphan !== undefined)
+    query.set("orphan", String(filters.orphan));
   if (filters?.search) query.set("search", filters.search);
   const suffix = query.size > 0 ? `?${query.toString()}` : "";
-  return call<{ artifacts: ArtifactInventoryItem[] }>("GET", `/artifacts${suffix}`);
+  return call<{ artifacts: ArtifactInventoryItem[] }>(
+    "GET",
+    `/artifacts${suffix}`,
+  );
 }
 
 export const api = {
-  health: () => call<{ ok: boolean; policyVersion: string; env: EnvIdentity }>("GET", "/health"),
+  health: () =>
+    call<{ ok: boolean; policyVersion: string; env: EnvIdentity }>(
+      "GET",
+      "/health",
+    ),
   status: () => call<StatusView>("GET", "/status"),
   events: (status?: string) =>
-    call<{ events: AdmittedEvent[] }>("GET", `/events${status ? `?status=${encodeURIComponent(status)}` : ""}`),
+    call<{ events: AdmittedEvent[] }>(
+      "GET",
+      `/events${status ? `?status=${encodeURIComponent(status)}` : ""}`,
+    ),
   proposals: () => call<{ proposals: Proposal[] }>("GET", "/proposals"),
   // Full decision history (?status=all), newest first — read-only audit view.
   proposalHistory: (status = "all") =>
-    call<{ proposals: Proposal[] }>("GET", `/proposals?status=${encodeURIComponent(status)}`),
-  approve: (id: string) => call<ApproveOutcome>("POST", `/proposals/${encodeURIComponent(id)}/approve`, {}),
+    call<{ proposals: Proposal[] }>(
+      "GET",
+      `/proposals?status=${encodeURIComponent(status)}`,
+    ),
+  approve: (id: string) =>
+    call<ApproveOutcome>(
+      "POST",
+      `/proposals/${encodeURIComponent(id)}/approve`,
+      {},
+    ),
   reject: (id: string, reason?: string) =>
-    call<{ rejected: boolean }>("POST", `/proposals/${encodeURIComponent(id)}/reject`, { reason }),
+    call<{ rejected: boolean }>(
+      "POST",
+      `/proposals/${encodeURIComponent(id)}/reject`,
+      { reason },
+    ),
   runs: (state?: string) =>
-    call<{ runs: RunListItem[] }>("GET", `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`),
-  run: (id: string) => call<RunDetail>("GET", `/runs/${encodeURIComponent(id)}`),
+    call<{ runs: RunListItem[] }>(
+      "GET",
+      `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`,
+    ),
+  run: (id: string) =>
+    call<RunDetail>("GET", `/runs/${encodeURIComponent(id)}`),
   // Live agent trace, ascending by seq; `since` is the last seen seq (incremental).
   trace: (id: string, since = 0, limit = 500) =>
-    call<TraceView>("GET", `/runs/${encodeURIComponent(id)}/trace?since=${since}&limit=${limit}`),
+    call<TraceView>(
+      "GET",
+      `/runs/${encodeURIComponent(id)}/trace?since=${since}&limit=${limit}`,
+    ),
   cancel: (id: string, reason?: string) =>
-    call<CancelOutcome>("POST", `/runs/${encodeURIComponent(id)}/cancel`, reason ? { reason } : {}),
+    call<CancelOutcome>(
+      "POST",
+      `/runs/${encodeURIComponent(id)}/cancel`,
+      reason ? { reason } : {},
+    ),
   retry: (id: string, force = false) =>
-    call<{ queued: boolean }>("POST", `/runs/${encodeURIComponent(id)}/retry`, { force }),
+    call<{ queued: boolean }>("POST", `/runs/${encodeURIComponent(id)}/retry`, {
+      force,
+    }),
   replay: (envelope: unknown) =>
-    call<{ admitted: boolean; duplicate: boolean; eventId: string }>("POST", "/replay", envelope),
-  injectEvent: (type: string, payload: Record<string, unknown>, source = "factory-web", subject = "factory") => {
+    call<{ admitted: boolean; duplicate: boolean; eventId: string }>(
+      "POST",
+      "/replay",
+      envelope,
+    ),
+  injectEvent: (
+    type: string,
+    payload: Record<string, unknown>,
+    source = "factory-web",
+    subject = "factory",
+  ) => {
     const eventId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
     const envelope = {
       schemaVersion: "factory.event/v1",
@@ -117,11 +175,17 @@ export const api = {
       correlationId: eventId,
       payload,
     };
-    return call<{ admitted: boolean; duplicate: boolean; eventId: string }>("POST", "/replay", envelope);
+    return call<{ admitted: boolean; duplicate: boolean; eventId: string }>(
+      "POST",
+      "/replay",
+      envelope,
+    );
   },
   // Append-only lifecycle feed: entries newest-first, `since` is the last seen head.
-  journal: (since = 0, limit = 100) => call<JournalView>("GET", `/journal?since=${since}&limit=${limit}`),
-  outbox: (limit = 20) => call<{ outbox: OutboxRow[] }>("GET", `/outbox?limit=${limit}`),
+  journal: (since = 0, limit = 100) =>
+    call<JournalView>("GET", `/journal?since=${since}&limit=${limit}`),
+  outbox: (limit = 20) =>
+    call<{ outbox: OutboxRow[] }>("GET", `/outbox?limit=${limit}`),
   // Re-plan a dead_lettered or human_needed event (404 unknown, 409 wrong status).
   requeue: (source: string, eventId: string) =>
     call<{ requeued: boolean }>("POST", "/events/requeue", { source, eventId }),
@@ -130,26 +194,45 @@ export const api = {
     call<{ archived: boolean }>("POST", "/events/archive", { source, eventId }),
   // Requeue/fail the run held by a stale worker and retire its registry row.
   releaseWorker: (workerId: string, runId: string) =>
-    call<{ released: boolean; runId: string }>("POST", `/workers/${encodeURIComponent(workerId)}/release`, { runId }),
+    call<{ released: boolean; runId: string }>(
+      "POST",
+      `/workers/${encodeURIComponent(workerId)}/release`,
+      { runId },
+    ),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
   // Every event + run under one correlation id (WM-527); 404 when unknown.
-  chain: (correlationId: string) => call<ChainView>("GET", `/chain/${encodeURIComponent(correlationId)}`),
+  chain: (correlationId: string) =>
+    call<ChainView>("GET", `/chain/${encodeURIComponent(correlationId)}`),
   // Configured factory repositories (config/repos.yaml) — context tabs open from this list.
   repos: () => call<{ repos: RepoItem[] }>("GET", "/repos"),
   // Janitor worktree scan and cleanup (apply: false for dry run, apply: true for teardown)
   janitor: (name: string, apply = false) =>
-    call<JanitorResult>("POST", `/repos/${encodeURIComponent(name)}/janitor`, { apply }),
+    call<JanitorResult>("POST", `/repos/${encodeURIComponent(name)}/janitor`, {
+      apply,
+    }),
   // The worker registry: which processes are alive, where, and what they run.
   workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
   // Human inbox ledger (WM-285): everything waiting on the operator, by status.
   inbox: (status: InboxStatus = "open") =>
-    call<{ items: InboxItem[] }>("GET", `/inbox?status=${encodeURIComponent(status)}`),
+    call<{ items: InboxItem[] }>(
+      "GET",
+      `/inbox?status=${encodeURIComponent(status)}`,
+    ),
   // Ack = "seen"; 404 unknown item, 409 already resolved.
-  ackInbox: (id: string) => call<{ item: InboxItem }>("POST", `/inbox/${encodeURIComponent(id)}/ack`, {}),
+  ackInbox: (id: string) =>
+    call<{ item: InboxItem }>(
+      "POST",
+      `/inbox/${encodeURIComponent(id)}/ack`,
+      {},
+    ),
   // Resolve = "dealt with"; idempotent on the ledger, 404 unknown item.
   resolveInbox: (id: string, reason?: string) =>
-    call<{ item: InboxItem }>("POST", `/inbox/${encodeURIComponent(id)}/resolve`, reason ? { reason } : {}),
+    call<{ item: InboxItem }>(
+      "POST",
+      `/inbox/${encodeURIComponent(id)}/resolve`,
+      reason ? { reason } : {},
+    ),
   // The schedule registry: recurring loops, cadence, timing, and health.
   schedules: () => call<{ schedules: ScheduleItem[] }>("GET", "/schedules"),
   // Trigger an ad-hoc run. Explicit PR numbers are accepted only by merge schedules.
@@ -181,7 +264,10 @@ export interface ScheduleItem {
 }
 
 export const extendRun = (id: string, seconds: number, override = false) =>
-  call<ExtendOutcome>("POST", `/runs/${encodeURIComponent(id)}/extend`, { seconds, override });
+  call<ExtendOutcome>("POST", `/runs/${encodeURIComponent(id)}/extend`, {
+    seconds,
+    override,
+  });
 
 export interface ExtendOutcome {
   extended: true;

--- a/event-runtime/web/src/chainTimeline.test.ts
+++ b/event-runtime/web/src/chainTimeline.test.ts
@@ -13,7 +13,13 @@ import {
   specInputRefs,
   CHAIN_VIEW_STORAGE_KEY,
 } from "./chainTimeline";
-import type { ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
+import type {
+  ChainView,
+  InboxItem,
+  LifecycleEvent,
+  Proposal,
+  RunDetail,
+} from "./types";
 
 // Fixture: the real 2026-08-17 19:06 case from the ticket — a merge sweep
 // (origin clock tick → merge-scan run) that emitted a merge-fix request for
@@ -100,8 +106,25 @@ function chain(overrides?: Partial<ChainView>): ChainView {
   };
 }
 
-function lc(seq: number, from: string | null, to: string, actor: string, reason: string | null, at: string, attempt: number | null = null): LifecycleEvent {
-  return { seq, run_id: FIX_RUN, from_state: from, to_state: to, actor, reason, attempt, at };
+function lc(
+  seq: number,
+  from: string | null,
+  to: string,
+  actor: string,
+  reason: string | null,
+  at: string,
+  attempt: number | null = null,
+): LifecycleEvent {
+  return {
+    seq,
+    run_id: FIX_RUN,
+    from_state: from,
+    to_state: to,
+    actor,
+    reason,
+    attempt,
+    at,
+  };
 }
 
 function fixRunDetail(): RunDetail {
@@ -118,7 +141,13 @@ function fixRunDetail(): RunDetail {
         schemaVersion: "factory.run/v1",
         runId: FIX_RUN,
         agent: "merge-fix@1",
-        input: { github: "watt-mind/factory", pr: 541, ticket: "WM-627", headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", repo: "factory" },
+        input: {
+          github: "watt-mind/factory",
+          pr: 541,
+          ticket: "WM-627",
+          headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+          repo: "factory",
+        },
         inputHash: "sha256:in",
         workspace: { type: "worktree" },
         adapter: "pi",
@@ -132,13 +161,66 @@ function fixRunDetail(): RunDetail {
       },
     },
     lifecycle: [
-      lc(4749, null, "PROPOSED", "planner", "planned", "2026-08-17T19:06:04.284Z"),
-      lc(4755, "PROPOSED", "APPROVED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
-      lc(4756, "APPROVED", "QUEUED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
-      lc(4765, "QUEUED", "LEASED", "worker_30596_69", "claimed", "2026-08-17T19:06:05.102Z", 1),
-      lc(4766, "LEASED", "RUNNING", "worker_30596_69", "started", "2026-08-17T19:06:05.105Z", 1),
-      lc(4772, "RUNNING", "VERIFYING", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z", 1),
-      lc(4773, "VERIFYING", "REFUSED", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z", 1),
+      lc(
+        4749,
+        null,
+        "PROPOSED",
+        "planner",
+        "planned",
+        "2026-08-17T19:06:04.284Z",
+      ),
+      lc(
+        4755,
+        "PROPOSED",
+        "APPROVED",
+        "chain-auto-approval",
+        "auto_approved:chain-policy@1",
+        "2026-08-17T19:06:04.284Z",
+      ),
+      lc(
+        4756,
+        "APPROVED",
+        "QUEUED",
+        "chain-auto-approval",
+        "auto_approved:chain-policy@1",
+        "2026-08-17T19:06:04.284Z",
+      ),
+      lc(
+        4765,
+        "QUEUED",
+        "LEASED",
+        "worker_30596_69",
+        "claimed",
+        "2026-08-17T19:06:05.102Z",
+        1,
+      ),
+      lc(
+        4766,
+        "LEASED",
+        "RUNNING",
+        "worker_30596_69",
+        "started",
+        "2026-08-17T19:06:05.105Z",
+        1,
+      ),
+      lc(
+        4772,
+        "RUNNING",
+        "VERIFYING",
+        "worker_30596_69",
+        "merge_fix_pr_moved",
+        "2026-08-17T19:06:07.657Z",
+        1,
+      ),
+      lc(
+        4773,
+        "VERIFYING",
+        "REFUSED",
+        "worker_30596_69",
+        "merge_fix_pr_moved",
+        "2026-08-17T19:06:07.657Z",
+        1,
+      ),
     ],
     attempts: [],
     result: { terminalState: "refused", reasonCode: "merge_fix_pr_moved" },
@@ -212,21 +294,41 @@ describe("buildChainTimeline", () => {
     // origin admitted → planned scan → scan LEASED (fallback rows: no detail
     // loaded for the scan run) → scan COMPLETED → fix admitted → fix planned
     // → fix LEASED → fix REFUSED → next
-    expect(badges).toEqual(["admitted", "planned", "RUNNING", "COMPLETED", "admitted", "planned", "LEASED", "REFUSED", "next"]);
-    const ats = rows.filter((r) => r.kind !== "next").map((r) => Date.parse(r.at!));
+    expect(badges).toEqual([
+      "admitted",
+      "planned",
+      "RUNNING",
+      "COMPLETED",
+      "admitted",
+      "planned",
+      "LEASED",
+      "REFUSED",
+      "next",
+    ]);
+    const ats = rows
+      .filter((r) => r.kind !== "next")
+      .map((r) => Date.parse(r.at!));
     expect([...ats].sort((a, b) => a - b)).toEqual(ats);
 
     const admitted = rows[4];
     expect(admitted.actor).toBe("chain");
     expect(admitted.what).toBe("factory.merge-fix.requested (PR #541, WM-627)");
     expect(admitted.refs.map((r) => r.kind)).toEqual(["event", "pr", "ticket"]);
-    expect(admitted.refs.find((r) => r.kind === "pr")?.href).toBe("https://github.com/watt-mind/factory/pull/541");
+    expect(admitted.refs.find((r) => r.kind === "pr")?.href).toBe(
+      "https://github.com/watt-mind/factory/pull/541",
+    );
 
     const planned = rows[5];
     expect(planned.actor).toBe("planner");
-    expect(planned.what).toBe("merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)");
+    expect(planned.what).toBe(
+      "merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)",
+    );
     expect(planned.nodeId).toBe(`run:${FIX_RUN}`);
-    expect(planned.refs.map((r) => r.kind)).toEqual(["proposal", "run", "agent"]);
+    expect(planned.refs.map((r) => r.kind)).toEqual([
+      "proposal",
+      "run",
+      "agent",
+    ]);
     expect(rows[6].refs.map((r) => r.kind)).toEqual(["run"]);
     expect(rows[7].refs.map((r) => r.kind)).toEqual(["run", "pr", "ticket"]);
     expect(formatDelta(planned.deltaMs)).toBe("+6s");
@@ -238,10 +340,19 @@ describe("buildChainTimeline", () => {
     const refused = rows[7];
     expect(refused.badge).toBe("REFUSED");
     expect(refused.actor).toBe("merge-fix@1");
-    expect(refused.reason).toEqual({ text: "PR head moved after the plan (planned at 6dbaab4)", raw: "merge_fix_pr_moved" });
+    expect(refused.reason).toEqual({
+      text: "PR head moved after the plan (planned at 6dbaab4)",
+      raw: "merge_fix_pr_moved",
+    });
     expect(formatDelta(refused.deltaMs)).toBe("+3s");
     // APPROVED / QUEUED / RUNNING(+3ms) / VERIFYING(same instant as REFUSED) are folded.
-    expect(rows.filter((r) => ["APPROVED", "QUEUED", "RUNNING", "VERIFYING"].includes(r.badge) && r.nodeId === `run:${FIX_RUN}`)).toEqual([]);
+    expect(
+      rows.filter(
+        (r) =>
+          ["APPROVED", "QUEUED", "RUNNING", "VERIFYING"].includes(r.badge) &&
+          r.nodeId === `run:${FIX_RUN}`,
+      ),
+    ).toEqual([]);
   });
 
   test("first row has no Δ; the next-step row carries none", () => {
@@ -256,8 +367,12 @@ describe("buildChainTimeline", () => {
     const next = rows.at(-1)!;
     expect(next.kind).toBe("next");
     expect(next.actor).toBeNull();
-    expect(next.what).toMatch(/^next: merge-factory · re-examines at \d{2}:\d{2} \(in 8m 30s\)$/);
-    expect(next.refs).toEqual([{ kind: "schedule", label: "merge-factory", id: "merge-factory" }]);
+    expect(next.what).toMatch(
+      /^next: merge-factory · re-examines at \d{2}:\d{2} \(in 8m 30s\)$/,
+    );
+    expect(next.refs).toEqual([
+      { kind: "schedule", label: "merge-factory", id: "merge-factory" },
+    ]);
     expect(next.muted).toBe(true);
   });
 
@@ -276,42 +391,83 @@ describe("buildChainTimeline", () => {
       resolvedBy: null,
       delivery: {},
     };
-    const disabled = build({ schedules: [schedule({ enabled: false })], inbox: [item] });
+    const disabled = build({
+      schedules: [schedule({ enabled: false })],
+      inbox: [item],
+    });
     const next = disabled.rows.at(-1)!;
     expect(next.kind).toBe("next");
     expect(next.what).toBe("no automatic retry — needs a decision");
-    expect(next.refs).toEqual([{ kind: "inbox", label: item.title, id: "inbox_1" }]);
+    expect(next.refs).toEqual([
+      { kind: "inbox", label: item.title, id: "inbox_1" },
+    ]);
 
     const otherRepo = build({ schedules: [schedule({ repo: "cashsaas" })] });
-    expect(otherRepo.rows.at(-1)!.what).toBe("no automatic retry — needs a decision");
+    expect(otherRepo.rows.at(-1)!.what).toBe(
+      "no automatic retry — needs a decision",
+    );
     expect(otherRepo.rows.at(-1)!.refs).toEqual([]);
   });
 
   test("no next-step row when the chain completed or is still running", () => {
     const completed = chain();
-    completed.runs[1] = { ...completed.runs[1], state: "COMPLETED", reasonCode: "ok" };
+    completed.runs[1] = {
+      ...completed.runs[1],
+      state: "COMPLETED",
+      reasonCode: "ok",
+    };
     expect(chainNeedsRevisit(completed)).toBe(false);
-    expect(build({ chain: completed, runDetails: {} }).rows.some((r) => r.kind === "next")).toBe(false);
+    expect(
+      build({ chain: completed, runDetails: {} }).rows.some(
+        (r) => r.kind === "next",
+      ),
+    ).toBe(false);
 
     const running = chain();
-    running.runs[1] = { ...running.runs[1], state: "RUNNING", finishedAt: null, reasonCode: null };
+    running.runs[1] = {
+      ...running.runs[1],
+      state: "RUNNING",
+      finishedAt: null,
+      reasonCode: null,
+    };
     expect(chainNeedsRevisit(running)).toBe(false);
-    expect(build({ chain: running, runDetails: {} }).rows.some((r) => r.kind === "next")).toBe(false);
+    expect(
+      build({ chain: running, runDetails: {} }).rows.some(
+        (r) => r.kind === "next",
+      ),
+    ).toBe(false);
   });
 
   test("noop decisions render the planner's reason humanized with the raw code in title", () => {
     const view = chain();
-    view.events[1] = { ...view.events[1], status: "noop", proposalDecision: "noop", proposalStatus: "resolved", runId: null };
+    view.events[1] = {
+      ...view.events[1],
+      status: "noop",
+      proposalDecision: "noop",
+      proposalStatus: "resolved",
+      runId: null,
+    };
     view.runs = [view.runs[0]];
     const { rows } = build({
       chain: view,
       runDetails: {},
-      proposals: [proposal({ decision: "noop", status: "resolved", reason: "ticket_assigned", runId: null, decided_at: null })],
+      proposals: [
+        proposal({
+          decision: "noop",
+          status: "resolved",
+          reason: "ticket_assigned",
+          runId: null,
+          decided_at: null,
+        }),
+      ],
     });
     const noop = rows.find((r) => r.badge === "noop")!;
     expect(noop.actor).toBe("planner");
     expect(noop.what).toBe("Ticket is already assigned");
-    expect(noop.reason).toEqual({ text: "Ticket is already assigned", raw: "ticket_assigned" });
+    expect(noop.reason).toEqual({
+      text: "Ticket is already assigned",
+      raw: "ticket_assigned",
+    });
     expect(noop.nodeId).toBe(`event:chain:${FIX_EVENT}`);
     expect(rows.at(-1)!.kind).toBe("next");
   });
@@ -327,14 +483,25 @@ describe("buildChainTimeline", () => {
 
   test("nodeOrder lists distinct nodes in narrative order for j/k", () => {
     const { nodeOrder } = build();
-    expect(nodeOrder).toEqual([`event:clock:${CORR}`, `run:${SCAN_RUN}`, `event:chain:${FIX_EVENT}`, `run:${FIX_RUN}`]);
+    expect(nodeOrder).toEqual([
+      `event:clock:${CORR}`,
+      `run:${SCAN_RUN}`,
+      `event:chain:${FIX_EVENT}`,
+      `run:${FIX_RUN}`,
+    ]);
   });
 });
 
 describe("helpers", () => {
   test("humanizeRunReason keeps the suffix and de-snakes unknown codes", () => {
-    expect(humanizeRunReason("auto_approved:chain-policy@1")).toEqual({ text: "Auto-approved — chain-policy@1", raw: "auto_approved:chain-policy@1" });
-    expect(humanizeRunReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
+    expect(humanizeRunReason("auto_approved:chain-policy@1")).toEqual({
+      text: "Auto-approved — chain-policy@1",
+      raw: "auto_approved:chain-policy@1",
+    });
+    expect(humanizeRunReason("some_new_code")).toEqual({
+      text: "some new code",
+      raw: "some_new_code",
+    });
     expect(humanizeRunReason(null)).toBeNull();
   });
 
@@ -350,8 +517,15 @@ describe("helpers", () => {
   });
 
   test("specInputRefs picks PR + ticket out of a merge-fix input", () => {
-    expect(specInputRefs({ github: "watt-mind/factory", pr: 541, ticket: "WM-627" })).toEqual([
-      { kind: "pr", label: "PR #541", id: "https://github.com/watt-mind/factory/pull/541", href: "https://github.com/watt-mind/factory/pull/541" },
+    expect(
+      specInputRefs({ github: "watt-mind/factory", pr: 541, ticket: "WM-627" }),
+    ).toEqual([
+      {
+        kind: "pr",
+        label: "PR #541",
+        id: "https://github.com/watt-mind/factory/pull/541",
+        href: "https://github.com/watt-mind/factory/pull/541",
+      },
       { kind: "ticket", label: "WM-627", id: "WM-627" },
     ]);
     expect(specInputRefs(null)).toEqual([]);
@@ -359,21 +533,34 @@ describe("helpers", () => {
 
   test("nextScheduledRetry ignores disabled/stopped loops and matches repo", () => {
     const origin = chain().events[0];
-    expect(nextScheduledRetry(origin, [schedule({ stopped: true })])).toBeNull();
-    expect(nextScheduledRetry(origin, [schedule({ repo: null })])?.loop).toBe("merge-factory");
-    expect(nextScheduledRetry(origin, [schedule({ eventType: "factory.work.requested" })])).toBeNull();
+    expect(
+      nextScheduledRetry(origin, [schedule({ stopped: true })]),
+    ).toBeNull();
+    expect(nextScheduledRetry(origin, [schedule({ repo: null })])?.loop).toBe(
+      "merge-factory",
+    );
+    expect(
+      nextScheduledRetry(origin, [
+        schedule({ eventType: "factory.work.requested" }),
+      ]),
+    ).toBeNull();
   });
 
   test("view mode persists and ?view= parses", () => {
     const store = new Map<string, string>();
-    const storage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => void store.set(k, v) };
+    const storage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    };
     expect(loadChainViewMode(storage)).toBe("graph");
     saveChainViewMode("timeline", storage);
     expect(store.get(CHAIN_VIEW_STORAGE_KEY)).toBe("timeline");
     expect(loadChainViewMode(storage)).toBe("timeline");
     store.set(CHAIN_VIEW_STORAGE_KEY, "bogus");
     expect(loadChainViewMode(storage)).toBe("graph");
-    expect(chainViewModeFromQuery(new URLSearchParams("view=timeline&node=x"))).toBe("timeline");
+    expect(
+      chainViewModeFromQuery(new URLSearchParams("view=timeline&node=x")),
+    ).toBe("timeline");
     expect(chainViewModeFromQuery(new URLSearchParams("view=nope"))).toBeNull();
     expect(chainViewModeFromQuery(new URLSearchParams(""))).toBeNull();
   });

--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -14,7 +14,15 @@
 import type { ScheduleItem } from "./api";
 import { eventNodeId, runNodeId } from "./graph/chainModel";
 import { humanizeReason } from "./reasons";
-import type { ChainEvent, ChainRun, ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
+import type {
+  ChainEvent,
+  ChainRun,
+  ChainView,
+  InboxItem,
+  LifecycleEvent,
+  Proposal,
+  RunDetail,
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // View mode (Graph | Timeline), persisted like the other display options.
@@ -31,7 +39,9 @@ function isChainViewMode(value: unknown): value is ChainViewMode {
 }
 
 /** Persisted mode; graph when nothing (or garbage) is stored. */
-export function loadChainViewMode(storage: StorageLike | null = defaultStorage()): ChainViewMode {
+export function loadChainViewMode(
+  storage: StorageLike | null = defaultStorage(),
+): ChainViewMode {
   try {
     const raw = storage?.getItem(CHAIN_VIEW_STORAGE_KEY);
     return isChainViewMode(raw) ? raw : "graph";
@@ -40,7 +50,10 @@ export function loadChainViewMode(storage: StorageLike | null = defaultStorage()
   }
 }
 
-export function saveChainViewMode(mode: ChainViewMode, storage: StorageLike | null = defaultStorage()): void {
+export function saveChainViewMode(
+  mode: ChainViewMode,
+  storage: StorageLike | null = defaultStorage(),
+): void {
   try {
     storage?.setItem(CHAIN_VIEW_STORAGE_KEY, mode);
   } catch {
@@ -49,7 +62,9 @@ export function saveChainViewMode(mode: ChainViewMode, storage: StorageLike | nu
 }
 
 /** `?view=timeline` on a chain deep link; null when absent or unknown. */
-export function chainViewModeFromQuery(query: URLSearchParams): ChainViewMode | null {
+export function chainViewModeFromQuery(
+  query: URLSearchParams,
+): ChainViewMode | null {
   const raw = query.get("view");
   return isChainViewMode(raw) ? raw : null;
 }
@@ -71,13 +86,16 @@ export interface HumanReason {
  * `code[:suffix]` → sentence, keeping any suffix (policy version, detail)
  * as a mono-ish tail. Unknown codes are de-snaked rather than hidden.
  */
-export function humanizeRunReason(reason: string | null | undefined): HumanReason | null {
+export function humanizeRunReason(
+  reason: string | null | undefined,
+): HumanReason | null {
   const human = humanizeReason(reason);
   if (!human.raw) return null;
   // The chain is showing the plan that this particular run consumed.
-  const text = reason?.split(":", 1)[0] === "merge_fix_pr_moved"
-    ? human.text.replace("since the plan", "after the plan")
-    : human.text;
+  const text =
+    reason?.split(":", 1)[0] === "merge_fix_pr_moved"
+      ? human.text.replace("since the plan", "after the plan")
+      : human.text;
   return { text, raw: human.raw };
 }
 
@@ -85,7 +103,15 @@ export function humanizeRunReason(reason: string | null | undefined): HumanReaso
 // Rows
 // ---------------------------------------------------------------------------
 
-export type TimelineRefKind = "event" | "run" | "proposal" | "pr" | "ticket" | "agent" | "schedule" | "inbox";
+export type TimelineRefKind =
+  | "event"
+  | "run"
+  | "proposal"
+  | "pr"
+  | "ticket"
+  | "agent"
+  | "schedule"
+  | "inbox";
 
 export interface TimelineRef {
   kind: TimelineRefKind;
@@ -138,9 +164,19 @@ export interface ChainTimelineInput {
   now: number;
 }
 
-const TERMINAL = new Set(["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"]);
+const TERMINAL = new Set([
+  "COMPLETED",
+  "REFUSED",
+  "FAILED",
+  "TIMED_OUT",
+  "CANCELLED",
+]);
 const REVISIT_STATES = new Set(["REFUSED", "FAILED", "TIMED_OUT"]);
-const REVISIT_EVENT_STATUSES = new Set(["noop", "human_needed", "dead_lettered"]);
+const REVISIT_EVENT_STATUSES = new Set([
+  "noop",
+  "human_needed",
+  "dead_lettered",
+]);
 
 function ms(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -169,7 +205,8 @@ function formatTimelineDuration(valueMs: number): string {
   const seconds = Math.round(valueMs / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
+  if (minutes < 60)
+    return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
   const hours = Math.floor(minutes / 60);
   return `${hours}h${minutes % 60 ? ` ${minutes % 60}m` : ""}`;
 }
@@ -178,7 +215,9 @@ function formatTimelineDuration(valueMs: number): string {
 export function formatUntil(atMs: number, now: number): string {
   const diff = atMs - now;
   if (Math.abs(diff) < 30_000) return "now";
-  return diff > 0 ? `in ${formatTimelineDuration(diff)}` : `overdue by ${formatTimelineDuration(-diff)}`;
+  return diff > 0
+    ? `in ${formatTimelineDuration(diff)}`
+    : `overdue by ${formatTimelineDuration(-diff)}`;
 }
 
 /** Ticket + PR references named by a run's spec input (merge-fix, dispatch, …). */
@@ -186,23 +225,44 @@ export function specInputRefs(input: unknown): TimelineRef[] {
   const refs: TimelineRef[] = [];
   if (!input || typeof input !== "object") return refs;
   const record = input as Record<string, unknown>;
-  const github = typeof record.github === "string" && /^[^/]+\/[^/]+$/.test(record.github) ? record.github : null;
+  const github =
+    typeof record.github === "string" && /^[^/]+\/[^/]+$/.test(record.github)
+      ? record.github
+      : null;
   const pr = record.pr ?? record.prNumber ?? record.pullRequestNumber;
-  const prNumber = typeof pr === "number" ? pr : typeof pr === "string" && /^\d+$/.test(pr) ? Number(pr) : null;
+  const prNumber =
+    typeof pr === "number"
+      ? pr
+      : typeof pr === "string" && /^\d+$/.test(pr)
+        ? Number(pr)
+        : null;
   const prUrl =
-    typeof record.prUrl === "string" && /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(record.prUrl)
+    typeof record.prUrl === "string" &&
+    /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(record.prUrl)
       ? record.prUrl
       : prNumber != null && github
         ? `https://github.com/${github}/pull/${prNumber}`
         : null;
   if (prNumber != null || prUrl) {
     const number = prNumber ?? Number(prUrl!.match(/\/pull\/(\d+)/)?.[1]);
-    refs.push({ kind: "pr", label: `PR #${number}`, id: prUrl ?? String(number), href: prUrl ?? undefined });
+    refs.push({
+      kind: "pr",
+      label: `PR #${number}`,
+      id: prUrl ?? String(number),
+      href: prUrl ?? undefined,
+    });
   }
   for (const key of ["ticket", "ticketId", "issue", "issueId"]) {
     const value = record[key];
-    if (typeof value === "string" && /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(value.trim().toUpperCase())) {
-      refs.push({ kind: "ticket", label: value.trim().toUpperCase(), id: value.trim().toUpperCase() });
+    if (
+      typeof value === "string" &&
+      /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(value.trim().toUpperCase())
+    ) {
+      refs.push({
+        kind: "ticket",
+        label: value.trim().toUpperCase(),
+        id: value.trim().toUpperCase(),
+      });
       break;
     }
   }
@@ -219,7 +279,10 @@ function dedupeRefs(refs: TimelineRef[]): TimelineRef[] {
   });
 }
 
-function approvalNote(lifecycle: LifecycleEvent[], proposal: Proposal | undefined): string | null {
+function approvalNote(
+  lifecycle: LifecycleEvent[],
+  proposal: Proposal | undefined,
+): string | null {
   const approved = lifecycle.find((entry) => entry.to_state === "APPROVED");
   if (approved) {
     const reason = approved.reason ?? "";
@@ -230,8 +293,10 @@ function approvalNote(lifecycle: LifecycleEvent[], proposal: Proposal | undefine
     }
     return `approved by ${approved.actor}`;
   }
-  if (proposal?.status === "approved") return `approved by ${proposal.decided_by ?? "operator"}`;
-  if (proposal?.status === "rejected") return `rejected by ${proposal.decided_by ?? "operator"}`;
+  if (proposal?.status === "approved")
+    return `approved by ${proposal.decided_by ?? "operator"}`;
+  if (proposal?.status === "rejected")
+    return `rejected by ${proposal.decided_by ?? "operator"}`;
   if (proposal?.status === "open") return "awaiting approval";
   return null;
 }
@@ -268,7 +333,8 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
   }
   const runInput = (runId: string | null | undefined): unknown =>
     runId ? runDetails[runId]?.run.spec.input : undefined;
-  const runRefs = (runId: string | null | undefined): TimelineRef[] => specInputRefs(runInput(runId));
+  const runRefs = (runId: string | null | undefined): TimelineRef[] =>
+    specInputRefs(runInput(runId));
 
   const decidedRuns = new Set<string>();
   let partial = false;
@@ -278,7 +344,12 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
     const nodeId = eventNodeId(event.source, event.eventId);
     const admittedMs = ms(event.admittedAt) ?? ms(event.occurredAt) ?? 0;
     const refs = dedupeRefs([
-      { kind: "event", label: event.type, id: event.eventId, source: event.source },
+      {
+        kind: "event",
+        label: event.type,
+        id: event.eventId,
+        source: event.source,
+      },
       ...runRefs(event.runId),
     ]);
     const suffix = refs
@@ -308,17 +379,40 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
       proposalsByEvent.get(`${event.source}:${event.eventId}`);
     const decision = proposal?.decision ?? event.proposalDecision ?? null;
     const status = event.status;
-    const run = event.runId ? runsById.get(event.runId) : proposal?.runId ? runsById.get(proposal.runId) : undefined;
+    const run = event.runId
+      ? runsById.get(event.runId)
+      : proposal?.runId
+        ? runsById.get(proposal.runId)
+        : undefined;
     const decisionAt = proposal?.created_at ?? run?.created_at ?? null;
     if (decision || REVISIT_EVENT_STATUSES.has(status)) {
       const kindLabel = decision === "run" ? "planned" : (decision ?? status);
       const detail = run ? runDetails[run.runId] : undefined;
       const note = run ? approvalNote(detail?.lifecycle ?? [], proposal) : null;
-      const reason = decision === "run" ? null : humanizeRunReason(proposal?.reason ?? null);
+      const reason =
+        decision === "run" ? null : humanizeRunReason(proposal?.reason ?? null);
       const rowRefs = dedupeRefs([
-        ...(proposal ? [{ kind: "proposal" as const, label: proposal.id.slice(0, 13), id: proposal.id }] : []),
-        ...(run ? [{ kind: "run" as const, label: shortRunId(run.runId), id: run.runId }] : []),
-        ...(run?.agent ? [{ kind: "agent" as const, label: run.agent, id: run.agent }] : []),
+        ...(proposal
+          ? [
+              {
+                kind: "proposal" as const,
+                label: proposal.id.slice(0, 13),
+                id: proposal.id,
+              },
+            ]
+          : []),
+        ...(run
+          ? [
+              {
+                kind: "run" as const,
+                label: shortRunId(run.runId),
+                id: run.runId,
+              },
+            ]
+          : []),
+        ...(run?.agent
+          ? [{ kind: "agent" as const, label: run.agent, id: run.agent }]
+          : []),
       ]);
       const what = run
         ? `${run.agent ? `${run.agent} → ` : ""}${shortRunId(run.runId)}${note ? ` (${note})` : ""}`
@@ -351,16 +445,30 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
     const detail = runDetails[run.runId];
     // Every lifecycle row links its run; only the terminal row repeats the
     // PR / ticket it decided about — the actor column already names the agent.
-    const runRef: TimelineRef = { kind: "run", label: shortRunId(run.runId), id: run.runId };
+    const runRef: TimelineRef = {
+      kind: "run",
+      label: shortRunId(run.runId),
+      id: run.runId,
+    };
     const stepRefs = [runRef];
     const outcomeRefs = dedupeRefs([runRef, ...runRefs(run.runId)]);
     const actorLabel = run.agent ?? shortRunId(run.runId);
     if (!detail) {
       partial = true;
-      drafts.push(...fallbackRunRows(run, nodeId, stepRefs, decidedRuns.has(run.runId), actorLabel));
+      drafts.push(
+        ...fallbackRunRows(
+          run,
+          nodeId,
+          stepRefs,
+          decidedRuns.has(run.runId),
+          actorLabel,
+        ),
+      );
       continue;
     }
-    const lifecycle = [...detail.lifecycle].sort((a, b) => a.at.localeCompare(b.at) || a.seq - b.seq);
+    const lifecycle = [...detail.lifecycle].sort(
+      (a, b) => a.at.localeCompare(b.at) || a.seq - b.seq,
+    );
     const input = detail.run.spec.input;
     let lastEmitted: LifecycleEvent | null = null;
     lifecycle.forEach((entry, index) => {
@@ -368,19 +476,45 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
       const state = entry.to_state;
       if (state === "PROPOSED") {
         if (decidedRuns.has(run.runId)) return;
-        push(entry, "planned", "decision", "planner", `${actorLabel} → ${shortRunId(run.runId)}`, null);
+        push(
+          entry,
+          "planned",
+          "decision",
+          "planner",
+          `${actorLabel} → ${shortRunId(run.runId)}`,
+          null,
+        );
         return;
       }
       if (state === "APPROVED") return; // folded into the planned row's note
-      if (state === "QUEUED" && (entry.from_state === "APPROVED" || entry.from_state === null)) return;
-      if (state === "RUNNING" && lastEmitted?.to_state === "LEASED" && (ms(entry.at) ?? 0) - (ms(lastEmitted.at) ?? 0) < 1000) return;
+      if (
+        state === "QUEUED" &&
+        (entry.from_state === "APPROVED" || entry.from_state === null)
+      )
+        return;
+      if (
+        state === "RUNNING" &&
+        lastEmitted?.to_state === "LEASED" &&
+        (ms(entry.at) ?? 0) - (ms(lastEmitted.at) ?? 0) < 1000
+      )
+        return;
       if (state === "VERIFYING" && next && TERMINAL.has(next.to_state)) return;
       const reason = humanizeRunReason(entry.reason);
-      const detailText = TERMINAL.has(state) ? reasonDetail(entry.reason, input) : null;
-      const shown = reason && detailText ? { ...reason, text: `${reason.text} (${detailText})` } : reason;
-      const actor = state === "QUEUED" || TERMINAL.has(state) ? actorLabel : entry.actor;
+      const detailText = TERMINAL.has(state)
+        ? reasonDetail(entry.reason, input)
+        : null;
+      const shown =
+        reason && detailText
+          ? { ...reason, text: `${reason.text} (${detailText})` }
+          : reason;
+      const actor =
+        state === "QUEUED" || TERMINAL.has(state) ? actorLabel : entry.actor;
       const what = TERMINAL.has(state)
-        ? entry.actor && entry.actor !== actorLabel && !entry.actor.startsWith("worker_") ? `by ${entry.actor}` : ""
+        ? entry.actor &&
+          entry.actor !== actorLabel &&
+          !entry.actor.startsWith("worker_")
+          ? `by ${entry.actor}`
+          : ""
         : state === "LEASED" && entry.attempt != null && entry.attempt > 1
           ? `attempt ${entry.attempt}`
           : "";
@@ -416,11 +550,15 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
     }
   }
 
-  drafts.sort((a, b) => a.atMs - b.atMs || a.rank - b.rank || a.row.id.localeCompare(b.row.id));
+  drafts.sort(
+    (a, b) =>
+      a.atMs - b.atMs || a.rank - b.rank || a.row.id.localeCompare(b.row.id),
+  );
 
   const rows: ChainTimelineRow[] = drafts.map((draft, index) => ({
     ...draft.row,
-    deltaMs: index === 0 ? null : Math.max(0, draft.atMs - drafts[index - 1].atMs),
+    deltaMs:
+      index === 0 ? null : Math.max(0, draft.atMs - drafts[index - 1].atMs),
   }));
 
   const nextRow = nextStepRow(chain, schedules, inbox, now);
@@ -428,13 +566,20 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
 
   const nodeOrder: string[] = [];
   for (const row of rows) {
-    if (row.nodeId && !nodeOrder.includes(row.nodeId)) nodeOrder.push(row.nodeId);
+    if (row.nodeId && !nodeOrder.includes(row.nodeId))
+      nodeOrder.push(row.nodeId);
   }
   return { rows, nodeOrder, partial };
 }
 
 /** Rows from the chain summary alone, while `GET /runs/:id` is still loading. */
-function fallbackRunRows(run: ChainRun, nodeId: string, refs: TimelineRef[], decided: boolean, actorLabel: string): Draft[] {
+function fallbackRunRows(
+  run: ChainRun,
+  nodeId: string,
+  refs: TimelineRef[],
+  decided: boolean,
+  actorLabel: string,
+): Draft[] {
   const out: Draft[] = [];
   const base = {
     kind: "lifecycle" as const,
@@ -446,31 +591,68 @@ function fallbackRunRows(run: ChainRun, nodeId: string, refs: TimelineRef[], dec
     out.push({
       atMs: ms(run.created_at) ?? 0,
       rank: 2,
-      row: { ...base, id: `${nodeId}:planned`, at: run.created_at, badge: "planned", hues: "decision", actor: "planner", what: `${actorLabel} → ${shortRunId(run.runId)}`, reason: null },
+      row: {
+        ...base,
+        id: `${nodeId}:planned`,
+        at: run.created_at,
+        badge: "planned",
+        hues: "decision",
+        actor: "planner",
+        what: `${actorLabel} → ${shortRunId(run.runId)}`,
+        reason: null,
+      },
     });
   }
   if (run.startedAt) {
     out.push({
       atMs: ms(run.startedAt) ?? 0,
       rank: 2.5,
-      row: { ...base, id: `${nodeId}:started`, at: run.startedAt, badge: TERMINAL.has(run.state) || run.state === "RUNNING" || run.state === "VERIFYING" ? "RUNNING" : run.state, hues: "run", actor: "worker", what: "", reason: null },
+      row: {
+        ...base,
+        id: `${nodeId}:started`,
+        at: run.startedAt,
+        badge:
+          TERMINAL.has(run.state) ||
+          run.state === "RUNNING" ||
+          run.state === "VERIFYING"
+            ? "RUNNING"
+            : run.state,
+        hues: "run",
+        actor: "worker",
+        what: "",
+        reason: null,
+      },
     });
   }
   if (run.finishedAt && TERMINAL.has(run.state)) {
     out.push({
       atMs: ms(run.finishedAt) ?? 0,
       rank: 3,
-      row: { ...base, id: `${nodeId}:finished`, at: run.finishedAt, badge: run.state, hues: "run", actor: actorLabel, what: "", reason: humanizeRunReason(run.reasonCode) },
+      row: {
+        ...base,
+        id: `${nodeId}:finished`,
+        at: run.finishedAt,
+        badge: run.state,
+        hues: "run",
+        actor: actorLabel,
+        what: "",
+        reason: humanizeRunReason(run.reasonCode),
+      },
     });
   }
   return out;
 }
 
 /** The chain's origin: the earliest event with no causation parent. */
-export function chainOriginEvent(chain: Pick<ChainView, "events">): ChainEvent | null {
+export function chainOriginEvent(
+  chain: Pick<ChainView, "events">,
+): ChainEvent | null {
   const roots = chain.events.filter((e) => !e.causationId);
   const pool = roots.length ? roots : chain.events;
-  return [...pool].sort((a, b) => a.admittedAt.localeCompare(b.admittedAt))[0] ?? null;
+  return (
+    [...pool].sort((a, b) => a.admittedAt.localeCompare(b.admittedAt))[0] ??
+    null
+  );
 }
 
 export interface ScheduledRetryOrigin {
@@ -499,18 +681,28 @@ export function nextScheduledRetry<T extends ScheduledRetrySchedule>(
       !s.stopped &&
       s.nextDue != null &&
       s.eventType === origin.type &&
-      (s.repo == null || origin.repos.length === 0 || origin.repos.includes(s.repo)),
+      (s.repo == null ||
+        origin.repos.length === 0 ||
+        origin.repos.includes(s.repo)),
   );
   candidates.sort((a, b) => (a.nextDue ?? "￿").localeCompare(b.nextDue ?? "￿"));
   return candidates[0] ?? null;
 }
 
 /** Shared timeline/journey wording for a scheduled retry. */
-export function scheduledRetryLabel(retry: ScheduledRetrySchedule, now = Date.now()): string {
+export function scheduledRetryLabel(
+  retry: ScheduledRetrySchedule,
+  now = Date.now(),
+): string {
   const dueMs = ms(retry.nextDue);
-  const clock = dueMs == null
-    ? retry.nextDue ?? "unknown time"
-    : new Date(dueMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  const clock =
+    dueMs == null
+      ? (retry.nextDue ?? "unknown time")
+      : new Date(dueMs).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        });
   return `next: ${retry.loop} · re-examines at ${clock}${dueMs == null ? "" : ` (${formatUntil(dueMs, now)})`}`;
 }
 
@@ -526,7 +718,9 @@ export function chainNeedsRevisit(chain: ChainView): boolean {
 function inboxItemFor(chain: ChainView, inbox: InboxItem[]): InboxItem | null {
   const runIds = new Set(chain.runs.map((r) => r.runId));
   const eventIds = new Set(chain.events.map((e) => e.eventId));
-  const proposalIds = new Set(chain.events.map((e) => e.proposalId).filter(Boolean) as string[]);
+  const proposalIds = new Set(
+    chain.events.map((e) => e.proposalId).filter(Boolean) as string[],
+  );
   return (
     inbox.find(
       (item) =>
@@ -537,11 +731,24 @@ function inboxItemFor(chain: ChainView, inbox: InboxItem[]): InboxItem | null {
   );
 }
 
-function nextStepRow(chain: ChainView, schedules: ScheduleItem[], inbox: InboxItem[], now: number): ChainTimelineRow | null {
+function nextStepRow(
+  chain: ChainView,
+  schedules: ScheduleItem[],
+  inbox: InboxItem[],
+  now: number,
+): ChainTimelineRow | null {
   if (!chainNeedsRevisit(chain)) return null;
   const origin = chainOriginEvent(chain);
   const schedule = nextScheduledRetry(origin, schedules);
-  const base = { id: "next", kind: "next" as const, nodeId: null, deltaMs: null, hues: "muted" as const, reason: null, muted: true };
+  const base = {
+    id: "next",
+    kind: "next" as const,
+    nodeId: null,
+    deltaMs: null,
+    hues: "muted" as const,
+    reason: null,
+    muted: true,
+  };
   if (schedule && schedule.nextDue) {
     return {
       ...base,

--- a/event-runtime/web/src/components/AgentHoverCard.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.tsx
@@ -18,7 +18,9 @@ import { JumpLink, StateBadge } from "./ui";
 export const EMPTY_VALUE = "—";
 
 /** Compact duration labels match the cadence grammar used by Schedules. */
-export function formatDurationSeconds(seconds: number | null | undefined): string {
+export function formatDurationSeconds(
+  seconds: number | null | undefined,
+): string {
   if (seconds == null) return EMPTY_VALUE;
   const remaining = Math.max(0, Math.floor(seconds));
   const units = [
@@ -31,7 +33,8 @@ export function formatDurationSeconds(seconds: number | null | undefined): strin
   let rest = remaining;
   for (const [size, suffix] of units) {
     const value = Math.floor(rest / size);
-    if (value > 0 || (size === 1 && parts.length === 0)) parts.push(`${value}${suffix}`);
+    if (value > 0 || (size === 1 && parts.length === 0))
+      parts.push(`${value}${suffix}`);
     rest %= size;
   }
   return parts.join(" ");
@@ -69,7 +72,11 @@ export function AgentHoverCard({
   title,
 }: AgentHoverCardProps) {
   const [open, setOpen] = useState(false);
-  const [coords, setCoords] = useState<{ top: number; left: number; placeAbove: boolean }>({
+  const [coords, setCoords] = useState<{
+    top: number;
+    left: number;
+    placeAbove: boolean;
+  }>({
     top: 0,
     left: 0,
     placeAbove: false,
@@ -104,10 +111,9 @@ export function AgentHoverCard({
     if (left < 12) left = 12;
 
     const spaceBelow = window.innerHeight - rect.bottom;
-    const placeAbove = spaceBelow < CARD_HEIGHT + margin && rect.top > CARD_HEIGHT + margin;
-    const top = placeAbove
-      ? rect.top - margin
-      : rect.bottom + margin;
+    const placeAbove =
+      spaceBelow < CARD_HEIGHT + margin && rect.top > CARD_HEIGHT + margin;
+    const top = placeAbove ? rect.top - margin : rect.bottom + margin;
 
     setCoords({ top, left, placeAbove });
   }, []);
@@ -172,7 +178,8 @@ export function AgentHoverCard({
         )}
       </span>
 
-      {open && typeof document !== "undefined" &&
+      {open &&
+        typeof document !== "undefined" &&
         createPortal(
           <div
             id={panelId}
@@ -184,7 +191,9 @@ export function AgentHoverCard({
             style={{
               position: "fixed",
               top: coords.placeAbove ? undefined : `${coords.top}px`,
-              bottom: coords.placeAbove ? `${window.innerHeight - coords.top}px` : undefined,
+              bottom: coords.placeAbove
+                ? `${window.innerHeight - coords.top}px`
+                : undefined,
               left: `${coords.left}px`,
               zIndex: 9999,
             }}
@@ -204,7 +213,10 @@ export function AgentHoverCard({
                   )}
                 </div>
                 {agent?.promptFile && (
-                  <div className="mt-0.5 mono text-[10px] text-(--text-faint) truncate" title={agent.promptFile}>
+                  <div
+                    className="mt-0.5 mono text-[10px] text-(--text-faint) truncate"
+                    title={agent.promptFile}
+                  >
                     {agent.promptFile}
                   </div>
                 )}
@@ -240,18 +252,22 @@ export function AgentHoverCard({
                 <div className="flex items-baseline justify-between gap-2">
                   <span className="text-(--text-faint)">Limits</span>
                   <span className="mono text-(--text-dim)">
-                    {agent.limits.timeout_seconds != null ? `${agent.limits.timeout_seconds}s` : EMPTY_VALUE} timeout · {agent.limits.attempts ?? EMPTY_VALUE} attempts
+                    {agent.limits.timeout_seconds != null
+                      ? `${agent.limits.timeout_seconds}s`
+                      : EMPTY_VALUE}{" "}
+                    timeout · {agent.limits.attempts ?? EMPTY_VALUE} attempts
                   </span>
                 </div>
 
-                {agent.capabilities?.services && agent.capabilities.services.length > 0 && (
-                  <div className="flex items-baseline justify-between gap-2">
-                    <span className="text-(--text-faint)">Services</span>
-                    <span className="mono text-(--text-dim) truncate">
-                      {agent.capabilities.services.join(", ")}
-                    </span>
-                  </div>
-                )}
+                {agent.capabilities?.services &&
+                  agent.capabilities.services.length > 0 && (
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-(--text-faint)">Services</span>
+                      <span className="mono text-(--text-dim) truncate">
+                        {agent.capabilities.services.join(", ")}
+                      </span>
+                    </div>
+                  )}
 
                 {agent.eventTypes && agent.eventTypes.length > 0 && (
                   <div className="mt-2 pt-2 border-t border-(--border)">
@@ -279,7 +295,9 @@ export function AgentHoverCard({
               </div>
             ) : (
               <div className="py-2 text-[11px] text-(--text-faint)">
-                {agentsQ.isLoading ? "Loading agent definition…" : `Agent definition for ${agentRef} not found.`}
+                {agentsQ.isLoading
+                  ? "Loading agent definition…"
+                  : `Agent definition for ${agentRef} not found.`}
               </div>
             )}
 

--- a/event-runtime/web/src/components/ApprovalRisk.test.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.test.tsx
@@ -2,8 +2,16 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ApprovalRiskDetails, ApprovalSafetyCard, computeApprovalRisk } from "./ApprovalRisk";
-import { createProposalFixture, createRunSpecFixture, restoreApi } from "../test-render";
+import {
+  ApprovalRiskDetails,
+  ApprovalSafetyCard,
+  computeApprovalRisk,
+} from "./ApprovalRisk";
+import {
+  createProposalFixture,
+  createRunSpecFixture,
+  restoreApi,
+} from "../test-render";
 import type { AgentDef, Proposal } from "../types";
 
 afterEach(() => {
@@ -38,7 +46,10 @@ function stubAgent(over: Partial<AgentDef> = {}): AgentDef {
   } as AgentDef;
 }
 
-function proposal(over: Partial<Proposal> = {}, spec: Record<string, unknown> = {}): Proposal {
+function proposal(
+  over: Partial<Proposal> = {},
+  spec: Record<string, unknown> = {},
+): Proposal {
   return createProposalFixture({
     agent: "shipper",
     repos: ["watt-mind/factory"],
@@ -48,8 +59,12 @@ function proposal(over: Partial<Proposal> = {}, spec: Record<string, unknown> = 
 }
 
 function renderWithClient(ui: React.ReactElement) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 describe("computeApprovalRisk (WM-505)", () => {
@@ -60,21 +75,33 @@ describe("computeApprovalRisk (WM-505)", () => {
   test("prefers the agent definition for mutating and egress", () => {
     const risk = computeApprovalRisk(
       proposal({}, { capabilities: [] }),
-      stubAgent({ mutating: true, capabilities: { filesystem: "rw", services: ["github"] } }),
+      stubAgent({
+        mutating: true,
+        capabilities: { filesystem: "rw", services: ["github"] },
+      }),
     );
     expect(risk?.mutating).toBe(true);
     expect(risk?.egress).toEqual(["github"]);
   });
 
   test("falls back to capability regexes when the agent is unknown", () => {
-    const risk = computeApprovalRisk(proposal({}, { capabilities: ["gh:write", "http:fetch"] }));
+    const risk = computeApprovalRisk(
+      proposal({}, { capabilities: ["gh:write", "http:fetch"] }),
+    );
     expect(risk?.mutating).toBe(true);
     expect(risk?.egress).toEqual(["http:fetch"]);
   });
 
   test("a read-only, short, unprotected-branch run scores LOW", () => {
     const risk = computeApprovalRisk(
-      proposal({}, { capabilities: ["linear:read"], timeoutSeconds: 120, input: { branch: "feat/x" } }),
+      proposal(
+        {},
+        {
+          capabilities: ["linear:read"],
+          timeoutSeconds: 120,
+          input: { branch: "feat/x" },
+        },
+      ),
       stubAgent({ mutating: false, capabilities: { filesystem: "ro" } }),
     );
     expect(risk?.blast).toBe("LOW");
@@ -83,21 +110,37 @@ describe("computeApprovalRisk (WM-505)", () => {
 
   test("a mutating run on a protected branch with egress scores HIGH", () => {
     const risk = computeApprovalRisk(
-      proposal({}, { capabilities: ["gh:write"], timeoutSeconds: 900, input: { branch: "main" } }),
-      stubAgent({ mutating: true, capabilities: { filesystem: "rw", services: ["github"] } }),
+      proposal(
+        {},
+        {
+          capabilities: ["gh:write"],
+          timeoutSeconds: 900,
+          input: { branch: "main" },
+        },
+      ),
+      stubAgent({
+        mutating: true,
+        capabilities: { filesystem: "rw", services: ["github"] },
+      }),
     );
     expect(risk?.blast).toBe("HIGH");
     expect(risk?.branch).toBe("main");
   });
 
   test("target repo falls back to the spec input when the proposal is unscoped", () => {
-    const risk = computeApprovalRisk(proposal({ repos: [] }, { input: { repo: "acme/thing" } }));
+    const risk = computeApprovalRisk(
+      proposal({ repos: [] }, { input: { repo: "acme/thing" } }),
+    );
     expect(risk?.repo).toBe("acme/thing");
-    expect(computeApprovalRisk(proposal({ repos: [] }, { input: {} }))?.repo).toBe("unscoped");
+    expect(
+      computeApprovalRisk(proposal({ repos: [] }, { input: {} }))?.repo,
+    ).toBe("unscoped");
   });
 
   test("host reports the placement when the spec pins one", () => {
-    const risk = computeApprovalRisk(proposal({}, { placement: { host: "worker-3" } }));
+    const risk = computeApprovalRisk(
+      proposal({}, { placement: { host: "worker-3" } }),
+    );
     expect(risk?.host).toBe("host=worker-3");
     expect(computeApprovalRisk(proposal())?.host).toBe("any worker");
   });
@@ -107,8 +150,18 @@ describe("ApprovalSafetyCard (WM-505)", () => {
   test("renders the mutating badge, blast verdict, capabilities and budget", () => {
     const r = renderWithClient(
       <ApprovalSafetyCard
-        proposal={proposal({}, { capabilities: ["gh:write", "linear:read"], timeoutSeconds: 900, maxAttempts: 2 })}
-        agent={stubAgent({ mutating: true, capabilities: { filesystem: "rw", services: ["github"] } })}
+        proposal={proposal(
+          {},
+          {
+            capabilities: ["gh:write", "linear:read"],
+            timeoutSeconds: 900,
+            maxAttempts: 2,
+          },
+        )}
+        agent={stubAgent({
+          mutating: true,
+          capabilities: { filesystem: "rw", services: ["github"] },
+        })}
       />,
     );
     const text = r.container.textContent ?? "";
@@ -123,7 +176,10 @@ describe("ApprovalSafetyCard (WM-505)", () => {
 
   test("labels a non-mutating agent Read-Only and sandboxed capabilities", () => {
     const r = renderWithClient(
-      <ApprovalSafetyCard proposal={proposal({}, { capabilities: [] })} agent={stubAgent({ mutating: false })} />,
+      <ApprovalSafetyCard
+        proposal={proposal({}, { capabilities: [] })}
+        agent={stubAgent({ mutating: false })}
+      />,
     );
     const text = r.container.textContent ?? "";
     expect(text).toContain("Read-Only");
@@ -132,13 +188,18 @@ describe("ApprovalSafetyCard (WM-505)", () => {
 
   test("renders an optional footer slot", () => {
     const r = renderWithClient(
-      <ApprovalSafetyCard proposal={proposal()} footer={<span>Historical Comparison</span>} />,
+      <ApprovalSafetyCard
+        proposal={proposal()}
+        footer={<span>Historical Comparison</span>}
+      />,
     );
     expect(r.container.textContent).toContain("Historical Comparison");
   });
 
   test("renders nothing when the proposal has no spec", () => {
-    const r = renderWithClient(<ApprovalSafetyCard proposal={proposal({ spec: null })} />);
+    const r = renderWithClient(
+      <ApprovalSafetyCard proposal={proposal({ spec: null })} />,
+    );
     expect(r.container.textContent).toBe("");
   });
 });
@@ -147,7 +208,10 @@ describe("ApprovalRiskDetails (WM-505)", () => {
   test("surfaces capabilities, budget and the immutable RunSpec", () => {
     const r = renderWithClient(
       <ApprovalRiskDetails
-        proposal={proposal({}, { capabilities: ["gh:write"], timeoutSeconds: 900, maxAttempts: 2 })}
+        proposal={proposal(
+          {},
+          { capabilities: ["gh:write"], timeoutSeconds: 900, maxAttempts: 2 },
+        )}
         agent={stubAgent({ mutating: true })}
       />,
     );
@@ -159,7 +223,9 @@ describe("ApprovalRiskDetails (WM-505)", () => {
   });
 
   test("warns rather than silently hiding risk when the spec is missing", () => {
-    const r = renderWithClient(<ApprovalRiskDetails proposal={proposal({ spec: null })} />);
+    const r = renderWithClient(
+      <ApprovalRiskDetails proposal={proposal({ spec: null })} />,
+    );
     expect(r.container.textContent).toContain("no RunSpec");
   });
 });

--- a/event-runtime/web/src/components/ApprovalRisk.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.tsx
@@ -41,20 +41,38 @@ const PROTECTED_BRANCHES = ["main", "master", "develop"];
  * Derive the blast-radius summary for a proposal. Pure and exported so the
  * scoring stays testable independently of the rendering.
  */
-export function computeApprovalRisk(p: Proposal, ag?: AgentDef): ApprovalRisk | null {
+export function computeApprovalRisk(
+  p: Proposal,
+  ag?: AgentDef,
+): ApprovalRisk | null {
   if (!p.spec) return null;
   const spec = p.spec;
-  const inp = (typeof spec.input === "object" && spec.input ? spec.input : {}) as Record<string, unknown>;
-  const repo = p.repos.length ? p.repos.join(", ") : String(inp.repo || inp.repository || "unscoped");
-  const branch = String(inp.branch || inp.targetBranch || inp.base || "default");
-  const issue = String(inp.issueId || inp.issue || inp.ticket || p.eventId || EMPTY);
+  const inp = (
+    typeof spec.input === "object" && spec.input ? spec.input : {}
+  ) as Record<string, unknown>;
+  const repo = p.repos.length
+    ? p.repos.join(", ")
+    : String(inp.repo || inp.repository || "unscoped");
+  const branch = String(
+    inp.branch || inp.targetBranch || inp.base || "default",
+  );
+  const issue = String(
+    inp.issueId || inp.issue || inp.ticket || p.eventId || EMPTY,
+  );
   const host = spec.placement
-    ? Object.entries(spec.placement).map(([k, v]) => `${k}=${v}`).join(", ")
+    ? Object.entries(spec.placement)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", ")
     : ag?.hosts?.length
       ? ag.hosts.join(", ")
       : "any worker";
-  const mutating = ag ? ag.mutating : (spec.capabilities?.some((c) => /write|mutate|exec/i.test(c)) ?? false);
-  const egress = ag?.capabilities?.services ?? spec.capabilities?.filter((c) => /net|http|api/i.test(c)) ?? [];
+  const mutating = ag
+    ? ag.mutating
+    : (spec.capabilities?.some((c) => /write|mutate|exec/i.test(c)) ?? false);
+  const egress =
+    ag?.capabilities?.services ??
+    spec.capabilities?.filter((c) => /net|http|api/i.test(c)) ??
+    [];
   const caps = spec.capabilities ?? [];
 
   const score =
@@ -64,7 +82,11 @@ export function computeApprovalRisk(p: Proposal, ag?: AgentDef): ApprovalRisk | 
     (spec.timeoutSeconds > 300 ? 1 : 0);
   const blast: BlastLevel = score >= 3 ? "HIGH" : score >= 1 ? "MEDIUM" : "LOW";
   const blastHue =
-    blast === "HIGH" ? "var(--hue-err)" : blast === "MEDIUM" ? "var(--hue-warn)" : "var(--hue-ok)";
+    blast === "HIGH"
+      ? "var(--hue-err)"
+      : blast === "MEDIUM"
+        ? "var(--hue-warn)"
+        : "var(--hue-ok)";
 
   return {
     mutating,
@@ -86,7 +108,9 @@ export function computeApprovalRisk(p: Proposal, ag?: AgentDef): ApprovalRisk | 
  * Resolve the `AgentDef` behind a proposal. Shares the `["agents"]` query key
  * with every other consumer, so mounting this in a dialog costs no extra fetch.
  */
-export function useProposalAgent(p: Proposal | null | undefined): AgentDef | undefined {
+export function useProposalAgent(
+  p: Proposal | null | undefined,
+): AgentDef | undefined {
   const agentsQ = useQuery({
     queryKey: ["agents"],
     queryFn: () => api.agents(),
@@ -95,7 +119,9 @@ export function useProposalAgent(p: Proposal | null | undefined): AgentDef | und
   return useMemo(() => {
     if (!p) return undefined;
     const list = agentsQ.data?.agents ?? [];
-    return list.find((a) => a.id === p.agent || a.ref === p.agent || a.id === p.spec?.agent);
+    return list.find(
+      (a) => a.id === p.agent || a.ref === p.agent || a.id === p.spec?.agent,
+    );
   }, [agentsQ.data, p]);
 }
 
@@ -123,7 +149,10 @@ export function ApprovalSafetyCard({
         <div className="flex gap-2">
           <span
             className="rounded px-2 py-0.5 text-[11px] font-semibold uppercase"
-            style={{ color: mutHue, background: `color-mix(in oklch, ${mutHue} 12%, transparent)` }}
+            style={{
+              color: mutHue,
+              background: `color-mix(in oklch, ${mutHue} 12%, transparent)`,
+            }}
           >
             {risk.mutating ? "Mutating" : "Read-Only"}
           </span>
@@ -137,39 +166,61 @@ export function ApprovalSafetyCard({
             Radar: {risk.blast} Risk
           </span>
         </div>
-        <span className="mono text-[11px] text-(--text-faint)">{risk.adapter}</span>
+        <span className="mono text-[11px] text-(--text-faint)">
+          {risk.adapter}
+        </span>
       </div>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <div>
-          <div className="text-[11px] uppercase text-(--text-faint)">Target Repo</div>
-          <div className="mono truncate text-(--text-dim)" title={risk.repo}>{risk.repo}</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Target Repo
+          </div>
+          <div className="mono truncate text-(--text-dim)" title={risk.repo}>
+            {risk.repo}
+          </div>
         </div>
         <div>
-          <div className="text-[11px] uppercase text-(--text-faint)">Target Branch</div>
-          <div className="mono truncate text-(--text-dim)" title={risk.branch}>{risk.branch}</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Target Branch
+          </div>
+          <div className="mono truncate text-(--text-dim)" title={risk.branch}>
+            {risk.branch}
+          </div>
         </div>
         <div>
-          <div className="text-[11px] uppercase text-(--text-faint)">Issue ID</div>
-          <div className="mono truncate text-(--text-dim)" title={risk.issue}>{risk.issue}</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Issue ID
+          </div>
+          <div className="mono truncate text-(--text-dim)" title={risk.issue}>
+            {risk.issue}
+          </div>
         </div>
         <div>
           <div className="text-[11px] uppercase text-(--text-faint)">Host</div>
-          <div className="mono truncate text-(--text-dim)" title={risk.host}>{risk.host}</div>
+          <div className="mono truncate text-(--text-dim)" title={risk.host}>
+            {risk.host}
+          </div>
         </div>
         <div>
-          <div className="text-[11px] uppercase text-(--text-faint)">Budget</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Budget
+          </div>
           <div className="mono text-(--text-dim)">
             {formatDuration(risk.timeoutSeconds)} · max {risk.maxAttempts} att
           </div>
         </div>
         <div>
-          <div className="text-[11px] uppercase text-(--text-faint)">Egress</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Egress
+          </div>
           <div className="mono truncate text-(--text-dim)">
             {risk.egress.length ? risk.egress.join(", ") : "none"}
           </div>
         </div>
         <div className="sm:col-span-2">
-          <div className="text-[11px] uppercase text-(--text-faint)">Capabilities</div>
+          <div className="text-[11px] uppercase text-(--text-faint)">
+            Capabilities
+          </div>
           <div className="mt-1 flex flex-wrap gap-1">
             {risk.caps.length ? (
               risk.caps.map((c) => (
@@ -181,12 +232,18 @@ export function ApprovalSafetyCard({
                 </span>
               ))
             ) : (
-              <span className="text-[11px] text-(--text-faint)">none (sandboxed)</span>
+              <span className="text-[11px] text-(--text-faint)">
+                none (sandboxed)
+              </span>
             )}
           </div>
         </div>
       </div>
-      {footer && <div className="mt-2.5 border-t border-(--border) pt-2 text-[11px]">{footer}</div>}
+      {footer && (
+        <div className="mt-2.5 border-t border-(--border) pt-2 text-[11px]">
+          {footer}
+        </div>
+      )}
     </div>
   );
 }
@@ -195,11 +252,18 @@ export function ApprovalSafetyCard({
  * Body of an approve confirmation dialog. Rendered identically by the Proposals
  * view and the Runs view — that equivalence is the point of this component.
  */
-export function ApprovalRiskDetails({ proposal, agent }: { proposal: Proposal; agent?: AgentDef }) {
+export function ApprovalRiskDetails({
+  proposal,
+  agent,
+}: {
+  proposal: Proposal;
+  agent?: AgentDef;
+}) {
   if (!proposal.spec) {
     return (
       <div className="mb-3 text-[12px]" style={{ color: "var(--hue-warn)" }}>
-        This proposal carries no RunSpec — its capabilities and blast radius cannot be shown.
+        This proposal carries no RunSpec — its capabilities and blast radius
+        cannot be shown.
       </div>
     );
   }
@@ -208,10 +272,21 @@ export function ApprovalRiskDetails({ proposal, agent }: { proposal: Proposal; a
       <div className="mb-3">
         <KV k="agent" v={proposal.spec.agent} />
         <KV k="adapter" v={proposal.spec.adapter} />
-        <KV k="capabilities" v={proposal.spec.capabilities.join(", ") || "none"} />
+        <KV
+          k="capabilities"
+          v={proposal.spec.capabilities.join(", ") || "none"}
+        />
         <KV k="timeout" v={formatDuration(proposal.spec.timeoutSeconds)} />
         <KV k="attempts" v={String(proposal.spec.maxAttempts)} />
-        <KV k="ttl" v={<Countdown createdAt={proposal.created_at} ttlSeconds={proposal.ttl_seconds} />} />
+        <KV
+          k="ttl"
+          v={
+            <Countdown
+              createdAt={proposal.created_at}
+              ttlSeconds={proposal.ttl_seconds}
+            />
+          }
+        />
       </div>
       <ApprovalSafetyCard proposal={proposal} agent={agent} />
       <div className="mb-3 min-w-0 max-h-[38vh] overflow-x-auto overflow-y-auto">

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -34,8 +34,18 @@ const mergeArtifact = {
   base: "develop",
   deployBranch: "main",
   escalate: [
-    { headSha: "c3d50c8d494caeca7de97b5a7dd598463098a6d0", pr: 471, reason: "Existing draft hold.", ticket: "WM-210" },
-    { headSha: "e1b1942fb255dc588d35fde9c8b03419ec81527e", pr: 474, reason: "CI in progress.", ticket: "WM-193" },
+    {
+      headSha: "c3d50c8d494caeca7de97b5a7dd598463098a6d0",
+      pr: 471,
+      reason: "Existing draft hold.",
+      ticket: "WM-210",
+    },
+    {
+      headSha: "e1b1942fb255dc588d35fde9c8b03419ec81527e",
+      pr: 474,
+      reason: "CI in progress.",
+      ticket: "WM-193",
+    },
   ],
   fix: [],
   github: "watt-mind/factory",
@@ -53,21 +63,26 @@ afterEach(() => {
 
 describe("ArtifactView with the shipped triage-scan view (WM-455)", () => {
   test("summary first, status badge in the header, grouped plan rows with issue chips, expand behind a disclosure", () => {
-    const r = render(<ArtifactView artifact={triageArtifact} view={triageView} />);
+    const r = render(
+      <ArtifactView artifact={triageArtifact} view={triageView} />,
+    );
     expect(r.getByText("Triage plan")).toBeTruthy();
     expect(r.getByText("TRIAGE")).toBeTruthy();
     expect(r.getByText("Three issues moved; one needs a human.")).toBeTruthy();
 
     // Grouped by action, first-seen order, with counts.
-    const groups = r.getAllByRole("button", { name: /label-agent-ready|needs-human/ });
-    expect(groups.map((g) => g.textContent?.replace(/\s+/g, "").trim())).toEqual([
-      "label-agent-ready2",
-      "needs-human1",
-    ]);
+    const groups = r.getAllByRole("button", {
+      name: /label-agent-ready|needs-human/,
+    });
+    expect(
+      groups.map((g) => g.textContent?.replace(/\s+/g, "").trim()),
+    ).toEqual(["label-agent-ready2", "needs-human1"]);
 
     // Issue chips link to Linear.
     const chip = r.getByRole("link", { name: "WM-2" }) as HTMLAnchorElement;
-    expect(chip.getAttribute("href")).toBe("https://linear.app/watt-mind/issue/WM-2");
+    expect(chip.getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-2",
+    );
     expect(chip.getAttribute("target")).toBe("_blank");
 
     // Expand columns hide until the row's disclosure opens.
@@ -93,7 +108,14 @@ describe("ArtifactView with the shipped triage-scan view (WM-455)", () => {
 
   test("a missing optional path renders without that section", () => {
     const r = render(
-      <ArtifactView artifact={{ recommendation: "NOOP", summary: "Nothing to do.", repo: "factory" }} view={triageView} />,
+      <ArtifactView
+        artifact={{
+          recommendation: "NOOP",
+          summary: "Nothing to do.",
+          repo: "factory",
+        }}
+        view={triageView}
+      />,
     );
     expect(r.getByText("Nothing to do.")).toBeTruthy();
     expect(r.getByText("NOOP")).toBeTruthy();
@@ -108,11 +130,15 @@ describe("ArtifactPanel — Raw toggle and fallback", () => {
     const r = render(<ArtifactPanel artifact={triageArtifact} view={null} />);
     expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
     expect(r.queryByRole("table")).toBeNull();
-    expect(r.container.querySelector("pre")?.textContent).toContain('"recommendation": "TRIAGE"');
+    expect(r.container.querySelector("pre")?.textContent).toContain(
+      '"recommendation": "TRIAGE"',
+    );
   });
 
   test("Raw toggle round-trips between the view and JsonBlock and persists", () => {
-    const r = render(<ArtifactPanel artifact={triageArtifact} view={triageView} />);
+    const r = render(
+      <ArtifactPanel artifact={triageArtifact} view={triageView} />,
+    );
     expect(r.getByRole("table")).toBeTruthy();
     expect(r.container.querySelector("pre")).toBeNull();
 
@@ -123,25 +149,43 @@ describe("ArtifactPanel — Raw toggle and fallback", () => {
 
     fireEvent.click(raw);
     expect(r.queryByRole("table")).toBeNull();
-    expect(r.container.querySelector("pre")?.textContent).toContain('"issueId": "WM-1"');
+    expect(r.container.querySelector("pre")?.textContent).toContain(
+      '"issueId": "WM-1"',
+    );
     expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
-    expect(within(r.getByRole("group", { name: "Artifact rendering" })).getByRole("button", { name: "Raw" }).getAttribute("aria-pressed")).toBe("true");
+    expect(
+      within(r.getByRole("group", { name: "Artifact rendering" }))
+        .getByRole("button", { name: "Raw" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
 
-    fireEvent.click(within(r.getByRole("group", { name: "Artifact rendering" })).getByRole("button", { name: "View" }));
+    fireEvent.click(
+      within(r.getByRole("group", { name: "Artifact rendering" })).getByRole(
+        "button",
+        { name: "View" },
+      ),
+    );
     expect(r.getByRole("table")).toBeTruthy();
     expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("0");
   });
 
   test("a persisted Raw preference opens on JSON", () => {
     localStorage.setItem(ARTIFACT_RAW_KEY, "1");
-    const r = render(<ArtifactPanel artifact={triageArtifact} view={triageView} />);
+    const r = render(
+      <ArtifactPanel artifact={triageArtifact} view={triageView} />,
+    );
     expect(r.queryByRole("table")).toBeNull();
     expect(r.container.querySelector("pre")).toBeTruthy();
     expect(r.getByRole("group", { name: "Artifact rendering" })).toBeTruthy();
   });
 
   test("a view that says nothing about this artifact falls back to JSON without a toggle", () => {
-    const r = render(<ArtifactPanel artifact={{ type: "assistant", message: "hi" }} view={triageView} />);
+    const r = render(
+      <ArtifactPanel
+        artifact={{ type: "assistant", message: "hi" }}
+        view={triageView}
+      />,
+    );
     expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
     expect(r.container.querySelector("pre")).toBeTruthy();
   });
@@ -149,10 +193,14 @@ describe("ArtifactPanel — Raw toggle and fallback", () => {
 
 describe("ArtifactView with the shipped merge-scan view", () => {
   test("renders the real merge-plan shape: status, escalate table with pr and ticket chips, whole-artifact keyvalue", () => {
-    const r = render(<ArtifactView artifact={mergeArtifact} view={mergeView} />);
+    const r = render(
+      <ArtifactView artifact={mergeArtifact} view={mergeView} />,
+    );
     expect(r.getByText("Merge plan")).toBeTruthy();
     expect(r.getByText("ESCALATE")).toBeTruthy();
-    expect(r.getByText("Thirteen open PRs; no PR met the MERGE bar.")).toBeTruthy();
+    expect(
+      r.getByText("Thirteen open PRs; no PR met the MERGE bar."),
+    ).toBeTruthy();
 
     // Empty tables are labelled and honest, not dropped (the pointer resolves).
     expect(r.getByText("Merge")).toBeTruthy();
@@ -160,16 +208,22 @@ describe("ArtifactView with the shipped merge-scan view", () => {
     expect(r.getAllByText("None.")).toHaveLength(2);
 
     const pr = r.getByRole("link", { name: "#471" }) as HTMLAnchorElement;
-    expect(pr.getAttribute("href")).toBe("https://github.com/watt-mind/factory/pull/471");
-    expect((r.getByRole("link", { name: "WM-210" }) as HTMLAnchorElement).getAttribute("href")).toBe(
-      "https://linear.app/watt-mind/issue/WM-210",
+    expect(pr.getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/pull/471",
     );
+    expect(
+      (
+        r.getByRole("link", { name: "WM-210" }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe("https://linear.app/watt-mind/issue/WM-210");
     expect(r.getByText("Existing draft hold.")).toBeTruthy();
 
     // headSha is expand-only, shortened to 12 with the full sha in the title.
     expect(r.queryByText("c3d50c8d494c")).toBeNull();
     fireEvent.click(r.getAllByRole("button", { name: "Expand row" })[0]);
-    expect(r.getByText("c3d50c8d494c").getAttribute("title")).toBe("c3d50c8d494caeca7de97b5a7dd598463098a6d0");
+    expect(r.getByText("c3d50c8d494c").getAttribute("title")).toBe(
+      "c3d50c8d494caeca7de97b5a7dd598463098a6d0",
+    );
 
     // `path: ""` keyvalue over the whole artifact, `keys` subset, absent noopReason dropped.
     expect(r.getByText("github")).toBeTruthy();
@@ -182,17 +236,27 @@ describe("ArtifactView with the shipped merge-scan view", () => {
   test("run chips call onJumpRun when the host provides it, else link to #/runs/<id>", () => {
     const view: ArtifactViewDoc = {
       schemaVersion: "factory.artifact-view/v1",
-      sections: [{ path: "/runs", as: "list", label: "Runs", formats: { "": "run" } }],
+      sections: [
+        { path: "/runs", as: "list", label: "Runs", formats: { "": "run" } },
+      ],
     };
     const artifact = { runs: ["run_44fa5716-0304-49b1-8b65-a45500d0d784"] };
     const jumped: string[] = [];
-    const r = render(<ArtifactView artifact={artifact} view={view} onJumpRun={(id) => jumped.push(id)} />);
+    const r = render(
+      <ArtifactView
+        artifact={artifact}
+        view={view}
+        onJumpRun={(id) => jumped.push(id)}
+      />,
+    );
     fireEvent.click(r.getByRole("button", { name: "run_44fa5716" }));
     expect(jumped).toEqual(["run_44fa5716-0304-49b1-8b65-a45500d0d784"]);
     cleanup();
     const r2 = render(<ArtifactView artifact={artifact} view={view} />);
-    expect((r2.getByRole("link", { name: "run_44fa5716" }) as HTMLAnchorElement).getAttribute("href")).toBe(
-      "#/runs/run_44fa5716-0304-49b1-8b65-a45500d0d784",
-    );
+    expect(
+      (
+        r2.getByRole("link", { name: "run_44fa5716" }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe("#/runs/run_44fa5716-0304-49b1-8b65-a45500d0d784");
   });
 });

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -48,14 +48,22 @@ export function saveArtifactRaw(raw: boolean): void {
 }
 
 /** Two-state segmented control, `aria-pressed` on the active half. */
-export function RawToggle({ raw, onChange }: { raw: boolean; onChange: (raw: boolean) => void }) {
+export function RawToggle({
+  raw,
+  onChange,
+}: {
+  raw: boolean;
+  onChange: (raw: boolean) => void;
+}) {
   const opt = (value: boolean, label: string) => (
     <button
       type="button"
       aria-pressed={raw === value}
       onClick={() => onChange(value)}
       className={`cursor-pointer rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
-        raw === value ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:text-(--text-dim)"
+        raw === value
+          ? "bg-(--surface-3) text-(--text)"
+          : "text-(--text-faint) hover:text-(--text-dim)"
       }`}
     >
       {label}
@@ -86,7 +94,10 @@ function TonePill({ text, tone }: { text: string; tone: ArtifactTone }) {
   return (
     <span
       className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium"
-      style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
+      style={{
+        color: hue,
+        background: `color-mix(in oklch, ${hue} 12%, transparent)`,
+      }}
     >
       {text}
     </span>
@@ -119,7 +130,13 @@ function Value({
       return <span className="text-(--text-faint)">—</span>;
     case "chip": {
       const title =
-        f.chip === "issue" ? `Open ${f.id} in Linear` : f.chip === "pr" ? (f.href ? `Open pull request ${f.text}` : `Pull request ${f.text}`) : f.id;
+        f.chip === "issue"
+          ? `Open ${f.id} in Linear`
+          : f.chip === "pr"
+            ? f.href
+              ? `Open pull request ${f.text}`
+              : `Pull request ${f.text}`
+            : f.id;
       if (f.chip === "run") {
         return (
           <JumpLink
@@ -150,17 +167,28 @@ function Value({
       return <StateBadge state={f.state} />;
     case "link":
       return (
-        <a href={f.href} target="_blank" rel="noreferrer" className="break-all text-(--accent) hover:underline">
+        <a
+          href={f.href}
+          target="_blank"
+          rel="noreferrer"
+          className="break-all text-(--accent) hover:underline"
+        >
           {f.text}
         </a>
       );
     case "json":
       if (block) {
-        if (Array.isArray(f.value) && f.value.every((v) => v === null || typeof v !== "object")) {
+        if (
+          Array.isArray(f.value) &&
+          f.value.every((v) => v === null || typeof v !== "object")
+        ) {
           return (
             <ul className="m-0 list-none p-0">
               {f.value.map((v, i) => (
-                <li key={i} className="mono break-all py-px text-[11.5px] text-(--text-dim)">
+                <li
+                  key={i}
+                  className="mono break-all py-px text-[11.5px] text-(--text-dim)"
+                >
                   {String(v)}
                 </li>
               ))}
@@ -170,12 +198,16 @@ function Value({
         return <JsonBlock value={f.value} />;
       }
       return (
-        <span className="mono text-(--text-faint)" title={JSON.stringify(f.value)}>
+        <span
+          className="mono text-(--text-faint)"
+          title={JSON.stringify(f.value)}
+        >
           {compactJson(f.value)}
         </span>
       );
     case "text":
-      if (tone && tone !== "muted") return <TonePill text={f.text} tone={tone} />;
+      if (tone && tone !== "muted")
+        return <TonePill text={f.text} tone={tone} />;
       return (
         <span
           className={`${f.mono ? "mono" : ""} ${block ? "break-words whitespace-pre-wrap" : ""} ${
@@ -194,23 +226,42 @@ function Value({
 // Sections
 // ---------------------------------------------------------------------------
 
-function SectionHeading({ label, count }: { label: string | undefined; count?: number }) {
+function SectionHeading({
+  label,
+  count,
+}: {
+  label: string | undefined;
+  count?: number;
+}) {
   if (!label) return null;
   return (
     <div className="mb-1 flex items-baseline gap-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
       <span>{label}</span>
-      {count !== undefined && <span className="tabular-nums normal-case">{count}</span>}
+      {count !== undefined && (
+        <span className="tabular-nums normal-case">{count}</span>
+      )}
     </div>
   );
 }
 
 const CELL = "border-b border-(--border) px-3 py-1.5 align-top";
 
-function ExpandedRow({ row, colSpan, onJumpRun }: { row: TableRow; colSpan: number; onJumpRun?: (id: string) => void }) {
+function ExpandedRow({
+  row,
+  colSpan,
+  onJumpRun,
+}: {
+  row: TableRow;
+  colSpan: number;
+  onJumpRun?: (id: string) => void;
+}) {
   return (
     <tr>
       {/* theme.css pins `table td` to nowrap for list tables; expanded detail is prose. */}
-      <td colSpan={colSpan} className="border-b border-(--border) bg-(--surface-1) px-3 py-2 whitespace-normal">
+      <td
+        colSpan={colSpan}
+        className="border-b border-(--border) bg-(--surface-1) px-3 py-2 whitespace-normal"
+      >
         <div className="grid grid-cols-[minmax(0,10rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 text-[11.5px]">
           {row.expand.map((cell) => (
             <Fragment key={cell.key}>
@@ -218,7 +269,12 @@ function ExpandedRow({ row, colSpan, onJumpRun }: { row: TableRow; colSpan: numb
                 {cell.key}
               </span>
               <div className="min-w-0 text-(--text-dim)">
-                <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+                <Value
+                  f={cell.value}
+                  tone={cell.tone}
+                  block
+                  onJumpRun={onJumpRun}
+                />
               </div>
             </Fragment>
           ))}
@@ -252,7 +308,9 @@ function Rows({
         return (
           <Fragment key={row.index}>
             <tr
-              className={expandable ? "cursor-pointer hover:bg-(--surface-1)" : undefined}
+              className={
+                expandable ? "cursor-pointer hover:bg-(--surface-1)" : undefined
+              }
               onClick={expandable ? () => onToggle(row.index) : undefined}
             >
               {hasExpand && (
@@ -278,11 +336,17 @@ function Rows({
                   key={cell.key}
                   className={`${CELL} ${wideColumn(cell) ? "min-w-[10rem] whitespace-normal [overflow-wrap:anywhere]" : "whitespace-nowrap"}`}
                 >
-                  <Value f={cell.value} tone={cell.tone} onJumpRun={onJumpRun} />
+                  <Value
+                    f={cell.value}
+                    tone={cell.tone}
+                    onJumpRun={onJumpRun}
+                  />
                 </td>
               ))}
             </tr>
-            {expandable && isOpen && <ExpandedRow row={row} colSpan={colSpan} onJumpRun={onJumpRun} />}
+            {expandable && isOpen && (
+              <ExpandedRow row={row} colSpan={colSpan} onJumpRun={onJumpRun} />
+            )}
           </Fragment>
         );
       })}
@@ -291,7 +355,8 @@ function Rows({
 }
 
 /** Prose cells (a `reason`) wrap; identifiers, chips and badges stay on one line. */
-const wideColumn = (cell: Cell): boolean => cell.value.kind === "text" && !cell.value.mono && !cell.tone;
+const wideColumn = (cell: Cell): boolean =>
+  cell.value.kind === "text" && !cell.value.mono && !cell.tone;
 
 function GroupRow({
   group,
@@ -318,20 +383,39 @@ function GroupRow({
           <span
             aria-hidden
             className="size-2 rounded-full"
-            style={{ background: hue, boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)` }}
+            style={{
+              background: hue,
+              boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)`,
+            }}
           />
-          <span className="text-[11.5px] font-medium text-(--text)">{group.label}</span>
-          <span className="tabular-nums text-[11px] text-(--text-faint)">{group.rows.length}</span>
-          {collapsed && <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">collapsed</span>}
+          <span className="text-[11.5px] font-medium text-(--text)">
+            {group.label}
+          </span>
+          <span className="tabular-nums text-[11px] text-(--text-faint)">
+            {group.rows.length}
+          </span>
+          {collapsed && (
+            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">
+              collapsed
+            </span>
+          )}
         </button>
       </td>
     </tr>
   );
 }
 
-function TableSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "table" }>; onJumpRun?: (id: string) => void }) {
+function TableSection({
+  s,
+  onJumpRun,
+}: {
+  s: Extract<SectionModel, { as: "table" }>;
+  onJumpRun?: (id: string) => void;
+}) {
   const [open, setOpen] = useState<Set<number>>(() => new Set());
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
   const toggleRow = (index: number) =>
     setOpen((prev) => {
       const next = new Set(prev);
@@ -364,37 +448,37 @@ function TableSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "table"
               </tr>
             </thead>
             <tbody>
-              {s.groups
-                ? s.groups.map((g) => (
-                    <Fragment key={g.key}>
-                      <GroupRow
-                        group={g}
-                        colSpan={colSpan}
-                        collapsed={collapsedGroups.has(g.key)}
-                        onToggle={() => toggleGroup(g.key)}
-                      />
-                      {!collapsedGroups.has(g.key) && (
-                        <Rows
-                          rows={g.rows}
-                          columns={s.columns}
-                          hasExpand={s.hasExpand}
-                          open={open}
-                          onToggle={toggleRow}
-                          onJumpRun={onJumpRun}
-                        />
-                      )}
-                    </Fragment>
-                  ))
-                : (
-                    <Rows
-                      rows={s.rows}
-                      columns={s.columns}
-                      hasExpand={s.hasExpand}
-                      open={open}
-                      onToggle={toggleRow}
-                      onJumpRun={onJumpRun}
+              {s.groups ? (
+                s.groups.map((g) => (
+                  <Fragment key={g.key}>
+                    <GroupRow
+                      group={g}
+                      colSpan={colSpan}
+                      collapsed={collapsedGroups.has(g.key)}
+                      onToggle={() => toggleGroup(g.key)}
                     />
-                  )}
+                    {!collapsedGroups.has(g.key) && (
+                      <Rows
+                        rows={g.rows}
+                        columns={s.columns}
+                        hasExpand={s.hasExpand}
+                        open={open}
+                        onToggle={toggleRow}
+                        onJumpRun={onJumpRun}
+                      />
+                    )}
+                  </Fragment>
+                ))
+              ) : (
+                <Rows
+                  rows={s.rows}
+                  columns={s.columns}
+                  hasExpand={s.hasExpand}
+                  open={open}
+                  onToggle={toggleRow}
+                  onJumpRun={onJumpRun}
+                />
+              )}
             </tbody>
           </table>
         </div>
@@ -403,18 +487,32 @@ function TableSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "table"
   );
 }
 
-function KeyValueSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "keyvalue" }>; onJumpRun?: (id: string) => void }) {
+function KeyValueSection({
+  s,
+  onJumpRun,
+}: {
+  s: Extract<SectionModel, { as: "keyvalue" }>;
+  onJumpRun?: (id: string) => void;
+}) {
   return (
     <section aria-label={s.label ?? "details"} className="mb-4 last:mb-0">
       <SectionHeading label={s.label} />
       <div className="text-[12px]">
         {s.entries.map((cell) => (
-          <div key={cell.key} className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
+          <div
+            key={cell.key}
+            className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]"
+          >
             <div className="truncate text-(--text-faint)" title={cell.key}>
               {cell.key}
             </div>
             <div className="min-w-0 text-(--text-dim)">
-              <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+              <Value
+                f={cell.value}
+                tone={cell.tone}
+                block
+                onJumpRun={onJumpRun}
+              />
             </div>
           </div>
         ))}
@@ -423,7 +521,13 @@ function KeyValueSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "key
   );
 }
 
-function ListSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "list" }>; onJumpRun?: (id: string) => void }) {
+function ListSection({
+  s,
+  onJumpRun,
+}: {
+  s: Extract<SectionModel, { as: "list" }>;
+  onJumpRun?: (id: string) => void;
+}) {
   return (
     <section aria-label={s.label ?? "list"} className="mb-4 last:mb-0">
       <SectionHeading label={s.label} count={s.items.length} />
@@ -432,9 +536,19 @@ function ListSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "list" }
       ) : (
         <ul className="m-0 list-none p-0 text-[12px]">
           {s.items.map((cell) => (
-            <li key={cell.key} className="flex items-baseline gap-2 py-[3px] text-(--text-dim)">
-              <span aria-hidden className="text-(--text-faint)">·</span>
-              <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+            <li
+              key={cell.key}
+              className="flex items-baseline gap-2 py-[3px] text-(--text-dim)"
+            >
+              <span aria-hidden className="text-(--text-faint)">
+                ·
+              </span>
+              <Value
+                f={cell.value}
+                tone={cell.tone}
+                block
+                onJumpRun={onJumpRun}
+              />
             </li>
           ))}
         </ul>
@@ -443,7 +557,13 @@ function ListSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "list" }
   );
 }
 
-function SectionBlock({ s, onJumpRun }: { s: SectionModel; onJumpRun?: (id: string) => void }) {
+function SectionBlock({
+  s,
+  onJumpRun,
+}: {
+  s: SectionModel;
+  onJumpRun?: (id: string) => void;
+}) {
   switch (s.as) {
     case "table":
       return <TableSection s={s} onJumpRun={onJumpRun} />;
@@ -474,7 +594,9 @@ function SectionBlock({ s, onJumpRun }: { s: SectionModel; onJumpRun?: (id: stri
       return (
         <section aria-label={s.label ?? "prose"} className="mb-4 last:mb-0">
           <SectionHeading label={s.label} />
-          <p className="m-0 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text-dim)">{s.text}</p>
+          <p className="m-0 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text-dim)">
+            {s.text}
+          </p>
         </section>
       );
   }
@@ -499,16 +621,27 @@ export function ArtifactView({
   /** Right-aligned header slot — the host's Raw toggle. */
   actions?: ReactNode;
 }) {
-  const header = useMemo(() => headerFor(view, artifact, schema), [view, artifact, schema]);
+  const header = useMemo(
+    () => headerFor(view, artifact, schema),
+    [view, artifact, schema],
+  );
   const sections = useMemo(() => sectionsFor(view, artifact), [view, artifact]);
-  const statusHues = header.status?.tone ? { [header.status.value]: TONE_HUES[header.status.tone] } : {};
+  const statusHues = header.status?.tone
+    ? { [header.status.value]: TONE_HUES[header.status.tone] }
+    : {};
   return (
     <div data-artifact-view className="text-[12px]">
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        {header.title && <span className="font-medium text-(--text)">{header.title}</span>}
+        {header.title && (
+          <span className="font-medium text-(--text)">{header.title}</span>
+        )}
         {header.status && (
           <span title={`${header.status.label}: ${header.status.value}`}>
-            <StateBadge state={header.status.value} hues={statusHues} dot={false} />
+            <StateBadge
+              state={header.status.value}
+              hues={statusHues}
+              dot={false}
+            />
           </span>
         )}
         {actions && <span className="ml-auto">{actions}</span>}
@@ -519,7 +652,11 @@ export function ArtifactView({
         </p>
       )}
       {sections.map((s, i) => (
-        <SectionBlock key={`${s.as}:${s.label ?? i}`} s={s} onJumpRun={onJumpRun} />
+        <SectionBlock
+          key={`${s.as}:${s.label ?? i}`}
+          s={s}
+          onJumpRun={onJumpRun}
+        />
       ))}
     </div>
   );

--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -59,7 +59,9 @@ function PaletteDialogHost() {
         nav
       </button>
       <CommandPalette
-        actions={[{ label: "Keyboard shortcuts", run: () => setDialogOpen(true) }]}
+        actions={[
+          { label: "Keyboard shortcuts", run: () => setDialogOpen(true) },
+        ]}
         onJumpRun={NOOP}
         onJumpProposal={NOOP}
         onJumpEvent={NOOP}
@@ -114,7 +116,9 @@ describe("CommandPalette", () => {
     const r = renderPalette();
     modal.depth = 1;
     chordK();
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
   });
 
   test("⌘K still closes the palette when it is already open", () => {
@@ -123,7 +127,9 @@ describe("CommandPalette", () => {
     expect(r.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
     expect(modal.depth).toBe(1);
     chordK();
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(modal.depth).toBe(0);
   });
 
@@ -139,7 +145,9 @@ describe("CommandPalette", () => {
   test("opening focuses the search input", () => {
     const r = renderPalette();
     chordK();
-    expect(document.activeElement).toBe(r.getByPlaceholderText("Type a command…"));
+    expect(document.activeElement).toBe(
+      r.getByPlaceholderText("Type a command…"),
+    );
   });
 
   test("Tab from the last control wraps to the first inside the panel", () => {
@@ -171,7 +179,9 @@ describe("CommandPalette", () => {
     chordK();
     expect(r.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(document.activeElement).toBe(outside);
   });
 
@@ -181,19 +191,31 @@ describe("CommandPalette", () => {
     outside.focus();
     chordK();
     fireEvent.mouseDown(r.getByTestId("palette-overlay"));
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(document.activeElement).toBe(outside);
   });
 
   test("selecting an item restores focus to the previously focused element", () => {
     let ran = false;
-    const r = renderPalette([{ label: "Overview", group: "Go", run: () => { ran = true; } }]);
+    const r = renderPalette([
+      {
+        label: "Overview",
+        group: "Go",
+        run: () => {
+          ran = true;
+        },
+      },
+    ]);
     const outside = r.getByTestId("outside");
     outside.focus();
     chordK();
     fireEvent.click(r.getByText("Overview"));
     expect(ran).toBe(true);
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(document.activeElement).toBe(outside);
   });
 
@@ -209,7 +231,9 @@ describe("CommandPalette", () => {
     r.getByTestId("outside").focus();
     chordK();
     fireEvent.click(r.getByText("Focus filter"));
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(document.activeElement).toBe(r.getByTestId("view-filter"));
   });
 
@@ -218,14 +242,20 @@ describe("CommandPalette", () => {
     const opener = r.getByTestId("dialog-opener");
     opener.focus();
     chordK();
-    expect(document.activeElement).toBe(r.getByPlaceholderText("Type a command…"));
+    expect(document.activeElement).toBe(
+      r.getByPlaceholderText("Type a command…"),
+    );
 
     fireEvent.click(r.getByText("Keyboard shortcuts"));
-    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(
+      true,
+    );
     expect(r.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
 
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(r.queryByRole("dialog", { name: "Keyboard shortcuts" }) == null).toBe(true);
+    expect(
+      r.queryByRole("dialog", { name: "Keyboard shortcuts" }) == null,
+    ).toBe(true);
     expect(document.activeElement).toBe(opener);
   });
 
@@ -235,7 +265,9 @@ describe("CommandPalette", () => {
     const input = r.getByPlaceholderText("Type a command…");
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
-    const activeItem = r.getByText("Copy id").closest<HTMLElement>("[cmdk-item]");
+    const activeItem = r
+      .getByText("Copy id")
+      .closest<HTMLElement>("[cmdk-item]");
     expect(activeItem?.getAttribute("aria-selected")).toBe("true");
     const classes = activeItem?.className.split(/\s+/) ?? [];
     expect(classes).toContain("data-[selected=true]:bg-(--surface-2)");
@@ -245,7 +277,9 @@ describe("CommandPalette", () => {
   test("uses a single focus border, scroll fade, and theme-aware backdrop", () => {
     const r = renderPalette();
     chordK();
-    const inputClasses = r.getByPlaceholderText("Type a command…").className.split(/\s+/);
+    const inputClasses = r
+      .getByPlaceholderText("Type a command…")
+      .className.split(/\s+/);
     expect(inputClasses).toContain("border-0");
     expect(inputClasses).toContain("border-b");
     expect(inputClasses).toContain("outline-none");
@@ -253,17 +287,27 @@ describe("CommandPalette", () => {
     expect(inputClasses).toContain("focus:border-(--accent)");
     expect(inputClasses).toContain("focus:ring-0");
 
-    expect(r.getByTestId("palette-results").className).toContain("overflow-y-auto");
-    expect(r.getByTestId("palette-results").className).toContain("scroll-pb-10");
-    expect(r.getByTestId("palette-results-fade").className).toContain("bg-linear-to-t");
-    const overlayClasses = r.getByTestId("palette-overlay").className.split(/\s+/);
+    expect(r.getByTestId("palette-results").className).toContain(
+      "overflow-y-auto",
+    );
+    expect(r.getByTestId("palette-results").className).toContain(
+      "scroll-pb-10",
+    );
+    expect(r.getByTestId("palette-results-fade").className).toContain(
+      "bg-linear-to-t",
+    );
+    const overlayClasses = r
+      .getByTestId("palette-overlay")
+      .className.split(/\s+/);
     expect(overlayClasses).toContain("bg-black/40");
     expect(overlayClasses).toContain("[[data-theme=light]_&]:bg-black/20");
   });
 
   test("`#541`, `PR 541` and `pr:541` offer the PR journey; a bare number does not (WM-640)", async () => {
     const jumps: number[] = [];
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
     const r = render(
       <QueryClientProvider client={client}>
         <CommandPalette
@@ -280,13 +324,17 @@ describe("CommandPalette", () => {
     for (const typed of ["#541", "PR 541", "pr:541"]) {
       chordK();
       // The palette re-mounts its input on every open — query it each round.
-      fireEvent.input(r.getByPlaceholderText("Type a command…"), { target: { value: typed } });
+      fireEvent.input(r.getByPlaceholderText("Type a command…"), {
+        target: { value: typed },
+      });
       const item = await r.findByText("#541", { selector: "span.mono" });
       fireEvent.click(item.closest("[cmdk-item]")!);
     }
     expect(jumps).toEqual([541, 541, 541]);
     chordK();
-    fireEvent.input(r.getByPlaceholderText("Type a command…"), { target: { value: "541" } });
+    fireEvent.input(r.getByPlaceholderText("Type a command…"), {
+      target: { value: "541" },
+    });
     await r.findByText("No matching command");
     expect(r.queryByText("#541", { selector: "span.mono" }) == null).toBe(true);
   });

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -61,23 +61,47 @@ export function CommandPalette({
 
   // Jump targets load only while the palette is open; cache keys shared with
   // the views, so this is usually a cache hit, not a request.
-  const runs = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), enabled: open });
+  const runs = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    enabled: open,
+  });
   const proposals = useQuery({
     queryKey: ["proposals", "history"],
     queryFn: () => api.proposalHistory("all"),
     enabled: open,
   });
-  const events = useQuery({ queryKey: ["events", "all"], queryFn: () => api.events(), enabled: open });
-  const agents = useQuery({ queryKey: ["agents"], queryFn: api.agents, enabled: open });
-  const workers = useQuery({ queryKey: ["workers"], queryFn: api.workers, enabled: open });
-  const repos = useQuery({ queryKey: ["repos"], queryFn: api.repos, enabled: open });
-  const typedTicket = /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(search.trim().toUpperCase())
+  const events = useQuery({
+    queryKey: ["events", "all"],
+    queryFn: () => api.events(),
+    enabled: open,
+  });
+  const agents = useQuery({
+    queryKey: ["agents"],
+    queryFn: api.agents,
+    enabled: open,
+  });
+  const workers = useQuery({
+    queryKey: ["workers"],
+    queryFn: api.workers,
+    enabled: open,
+  });
+  const repos = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    enabled: open,
+  });
+  const typedTicket = /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(
+    search.trim().toUpperCase(),
+  )
     ? search.trim().toUpperCase()
     : null;
   // `#541`, `PR 541`, `pr:541` — a PR journey jump (WM-640). Inlined like the
   // ticket pattern above: importing subjectJourney here would pull the whole
   // journey module into the entry chunk.
-  const prMatch = onJumpPr ? search.trim().match(/^(?:#|pr[:#\s-]?|pull\/)(\d{1,7})$/i) : null;
+  const prMatch = onJumpPr
+    ? search.trim().match(/^(?:#|pr[:#\s-]?|pull\/)(\d{1,7})$/i)
+    : null;
   const typedPr = prMatch ? Number(prMatch[1]) : null;
   const resultCount =
     actions.length +
@@ -142,7 +166,8 @@ export function CommandPalette({
     modal.depth += 1;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
-      else if (e.key === "Tab" && panelRef.current) tabCycle(panelRef.current, e);
+      else if (e.key === "Tab" && panelRef.current)
+        tabCycle(panelRef.current, e);
     };
     window.addEventListener("keydown", onKey);
     const root = panelRef.current;
@@ -157,7 +182,9 @@ export function CommandPalette({
       unregisterFocusReturn();
       const active = document.activeElement;
       const claimed =
-        active instanceof HTMLElement && active !== document.body && active.isConnected;
+        active instanceof HTMLElement &&
+        active !== document.body &&
+        active.isConnected;
       if (claimed) return;
       const previous = previousFocusRef.current;
       if (previous && (previous.isConnected ?? document.contains(previous))) {
@@ -190,252 +217,298 @@ export function CommandPalette({
           tabIndex={-1}
           className="outline-none focus:outline-none focus-visible:outline-none"
         >
-        <Command.Input
-          ref={searchRef}
-          autoFocus
-          value={search}
-          onValueChange={setSearch}
-          placeholder="Type a command…"
-          className="w-full border-0 border-b border-(--border) bg-transparent px-4 py-3 text-[14px] text-(--text) outline-none ring-0 placeholder:text-(--text-faint) focus:border-(--accent) focus:outline-none focus:ring-0"
-        />
-        <div className="relative">
-        <Command.List ref={listRef} data-testid="palette-results" className="max-h-72 overflow-y-auto scroll-pb-10 p-1.5">
-          <Command.Empty className="px-3 py-6 text-center text-(--text-faint)">
-            No matching command
-          </Command.Empty>
-          {contextActions.length > 0 && (
-            <Command.Group heading="This item">
-              {contextActions.map((a) => (
-                <Command.Item
-                  key={a.label}
-                  onSelect={() => {
-                    setOpen(false);
-                    a.run();
-                  }}
-                  className={PALETTE_ITEM_CLASS}
-                >
-                  <span>{a.label}</span>
-                  {a.hint && <span className="mono text-[11px] text-(--text-faint)">{a.hint}</span>}
-                </Command.Item>
-              ))}
-            </Command.Group>
-          )}
-          <Command.Group heading="Go">
-            {actions
-              .filter((a) => a.group === "Go")
-              .map((a) => (
-                <Command.Item
-                  key={a.label}
-                  onSelect={() => {
-                    setOpen(false);
-                    a.run();
-                  }}
-                  className={PALETTE_ITEM_CLASS}
-                >
-                  <span>{a.label}</span>
-                  {a.hint && <span className="mono text-[11px] text-(--text-faint)">{a.hint}</span>}
-                </Command.Item>
-              ))}
-          </Command.Group>
-          <Command.Group heading="Commands">
-            {actions
-              .filter((a) => a.group !== "Go")
-              .map((a) => (
-                <Command.Item
-                  key={a.label}
-                  onSelect={() => {
-                    setOpen(false);
-                    a.run();
-                  }}
-                  className={PALETTE_ITEM_CLASS}
-                >
-                  <span>{a.label}</span>
-                  {a.hint && <span className="mono text-[11px] text-(--text-faint)">{a.hint}</span>}
-                </Command.Item>
-              ))}
-          </Command.Group>
-          {typedTicket && onJumpTicket && (
-            <Command.Group heading="Tickets">
-              <Command.Item
-                value={`ticket ${typedTicket} open journey`}
-                onSelect={() => {
-                  setOpen(false);
-                  setSearch("");
-                  onJumpTicket(typedTicket);
-                }}
-                className={PALETTE_ITEM_CLASS}
-              >
-                <span>Open ticket <span className="mono">{typedTicket}</span></span>
-                <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">ticket journey</span>
-              </Command.Item>
-              {/* The question behind most ticket lookups (WM-594): the journey
+          <Command.Input
+            ref={searchRef}
+            autoFocus
+            value={search}
+            onValueChange={setSearch}
+            placeholder="Type a command…"
+            className="w-full border-0 border-b border-(--border) bg-transparent px-4 py-3 text-[14px] text-(--text) outline-none ring-0 placeholder:text-(--text-faint) focus:border-(--accent) focus:outline-none focus:ring-0"
+          />
+          <div className="relative">
+            <Command.List
+              ref={listRef}
+              data-testid="palette-results"
+              className="max-h-72 overflow-y-auto scroll-pb-10 p-1.5"
+            >
+              <Command.Empty className="px-3 py-6 text-center text-(--text-faint)">
+                No matching command
+              </Command.Empty>
+              {contextActions.length > 0 && (
+                <Command.Group heading="This item">
+                  {contextActions.map((a) => (
+                    <Command.Item
+                      key={a.label}
+                      onSelect={() => {
+                        setOpen(false);
+                        a.run();
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span>{a.label}</span>
+                      {a.hint && (
+                        <span className="mono text-[11px] text-(--text-faint)">
+                          {a.hint}
+                        </span>
+                      )}
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+              <Command.Group heading="Go">
+                {actions
+                  .filter((a) => a.group === "Go")
+                  .map((a) => (
+                    <Command.Item
+                      key={a.label}
+                      onSelect={() => {
+                        setOpen(false);
+                        a.run();
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span>{a.label}</span>
+                      {a.hint && (
+                        <span className="mono text-[11px] text-(--text-faint)">
+                          {a.hint}
+                        </span>
+                      )}
+                    </Command.Item>
+                  ))}
+              </Command.Group>
+              <Command.Group heading="Commands">
+                {actions
+                  .filter((a) => a.group !== "Go")
+                  .map((a) => (
+                    <Command.Item
+                      key={a.label}
+                      onSelect={() => {
+                        setOpen(false);
+                        a.run();
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span>{a.label}</span>
+                      {a.hint && (
+                        <span className="mono text-[11px] text-(--text-faint)">
+                          {a.hint}
+                        </span>
+                      )}
+                    </Command.Item>
+                  ))}
+              </Command.Group>
+              {typedTicket && onJumpTicket && (
+                <Command.Group heading="Tickets">
+                  <Command.Item
+                    value={`ticket ${typedTicket} open journey`}
+                    onSelect={() => {
+                      setOpen(false);
+                      setSearch("");
+                      onJumpTicket(typedTicket);
+                    }}
+                    className={PALETTE_ITEM_CLASS}
+                  >
+                    <span>
+                      Open ticket <span className="mono">{typedTicket}</span>
+                    </span>
+                    <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                      ticket journey
+                    </span>
+                  </Command.Item>
+                  {/* The question behind most ticket lookups (WM-594): the journey
                   already lists every planner decision and names the blocking
                   reason in its next-action line, so it is the answer. */}
-              <Command.Item
-                value={`ticket ${typedTicket} why isn't running decisions`}
-                onSelect={() => {
-                  setOpen(false);
-                  setSearch("");
-                  onJumpTicket(typedTicket);
-                }}
-                className={PALETTE_ITEM_CLASS}
-              >
-                <span>Why isn't <span className="mono">{typedTicket}</span> running?</span>
-                <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">planner decisions</span>
-              </Command.Item>
-            </Command.Group>
-          )}
-          {typedPr && onJumpPr && (
-            <Command.Group heading="Pull requests">
-              <Command.Item
-                value={`pr #${typedPr} pull request ${search.trim()} open journey`}
-                onSelect={() => {
-                  setOpen(false);
-                  setSearch("");
-                  onJumpPr(typedPr);
-                }}
-                className={PALETTE_ITEM_CLASS}
-              >
-                <span>Open PR <span className="mono">#{typedPr}</span></span>
-                <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">PR journey</span>
-              </Command.Item>
-            </Command.Group>
-          )}
-          {(proposals.data?.proposals ?? []).length > 0 && (
-            <Command.Group heading="Proposals">
-          {(proposals.data?.proposals ?? []).map((p) => (
-            <Command.Item
-              key={p.id}
-              value={`proposal ${p.id} ${p.agent ?? ""} ${p.status} ${p.decision}`}
-              onSelect={() => {
-                setOpen(false);
-                onJumpProposal(p.id);
-              }}
-              className={PALETTE_ITEM_CLASS}
-            >
-              <span className="mono truncate">{p.id}</span>
-              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
-                proposal · {p.status}
-                {p.status === "open" ? ` · ${p.agent ?? p.decision}` : ` · ${p.decision}`}
-              </span>
-            </Command.Item>
-          ))}
-            </Command.Group>
-          )}
-          {(events.data?.events ?? []).length > 0 && (
-            <Command.Group heading="Events">
-          {(events.data?.events ?? []).map((e) => (
-            <Command.Item
-              key={`${e.source}:${e.eventId}`}
-              value={`event ${e.source} ${e.eventId} ${e.type} ${e.status}`}
-              onSelect={() => {
-                setOpen(false);
-                onJumpEvent(e.source, e.eventId);
-              }}
-              className={PALETTE_ITEM_CLASS}
-            >
-              <span className="mono truncate">{e.eventId}</span>
-              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
-                event · {e.source} · {e.status}
-              </span>
-            </Command.Item>
-          ))}
-            </Command.Group>
-          )}
-          {(runs.data?.runs ?? []).length > 0 && (
-            <Command.Group heading="Runs">
-          {(runs.data?.runs ?? []).map((r) => (
-            <Command.Item
-              key={r.runId}
-              value={`run ${r.runId} ${r.state} ${r.agent}`}
-              onSelect={() => {
-                setOpen(false);
-                onJumpRun(r.runId);
-              }}
-              className={PALETTE_ITEM_CLASS}
-            >
-              <span className="mono truncate">{r.runId}</span>
-              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">run · {r.state}</span>
-            </Command.Item>
-          ))}
-            </Command.Group>
-          )}
-          {(agents.data?.agents ?? []).length > 0 && (
-            <Command.Group heading="Agents">
-          {(agents.data?.agents ?? []).map((a) => (
-            <Command.Item
-              key={a.ref}
-              value={`agent ${a.ref} ${a.id} ${a.outputContract}`}
-              onSelect={() => {
-                setOpen(false);
-                onJumpAgent(a.ref);
-              }}
-              className={PALETTE_ITEM_CLASS}
-            >
-              <span className="mono truncate">{a.ref}</span>
-              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">agent · {a.outputContract}</span>
-            </Command.Item>
-          ))}
-            </Command.Group>
-          )}
-          {(workers.data?.workers ?? []).length > 0 && (
-            <Command.Group heading="Workers">
-          {(workers.data?.workers ?? []).map((w) => {
-            const state = health(w);
-            return (
-            <Command.Item
-              key={w.workerId}
-              value={`worker ${w.workerId} ${w.host} ${state}`}
-              onSelect={() => {
-                setOpen(false);
-                onJumpWorker(w.workerId);
-              }}
-              className={PALETTE_ITEM_CLASS}
-            >
-              <span className="mono truncate">{w.workerId}</span>
-              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
-                worker · {w.host} · {state}
-              </span>
-            </Command.Item>
-            );
-          })}
-            </Command.Group>
-          )}
-          {(repos.data?.repos ?? []).length > 0 && (
-            <Command.Group heading="Projects">
-              {(repos.data?.repos ?? []).map((r) => (
-                <Command.Item
-                  key={r.name}
-                  value={`project repo ${r.name} ${r.team ?? ""} ${r.project ?? ""} ${r.github ?? ""}`}
-                  onSelect={() => {
-                    setOpen(false);
-                    onJumpProject?.(r.name);
-                  }}
-                  className={PALETTE_ITEM_CLASS}
-                >
-                  <span className="mono truncate">
-                    {r.name}
-                    {r.project ? <span className="ml-2 font-sans text-(--text-dim)">{r.project}</span> : null}
-                  </span>
-                  <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
-                    project · {r.reportOnly ? "report-only" : "dispatchable"}
-                  </span>
-                </Command.Item>
-              ))}
-            </Command.Group>
-          )}
-        </Command.List>
-        <div
-          data-testid="palette-results-fade"
-          aria-hidden="true"
-          className={`pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-linear-to-t from-(--surface-1) to-transparent transition-opacity ${hasMoreBelow ? "opacity-100" : "opacity-0"}`}
-        />
-        </div>
-        <div className="flex items-center justify-between border-t border-(--border) px-4 py-2 text-[11px] text-(--text-faint)">
-          <span><span className="mono font-medium">↑↓</span> Navigate</span>
-          <span><span className="mono font-medium">↵</span> Select</span>
-          <span><span className="mono font-medium">ESC</span> Close</span>
-        </div>
+                  <Command.Item
+                    value={`ticket ${typedTicket} why isn't running decisions`}
+                    onSelect={() => {
+                      setOpen(false);
+                      setSearch("");
+                      onJumpTicket(typedTicket);
+                    }}
+                    className={PALETTE_ITEM_CLASS}
+                  >
+                    <span>
+                      Why isn't <span className="mono">{typedTicket}</span>{" "}
+                      running?
+                    </span>
+                    <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                      planner decisions
+                    </span>
+                  </Command.Item>
+                </Command.Group>
+              )}
+              {typedPr && onJumpPr && (
+                <Command.Group heading="Pull requests">
+                  <Command.Item
+                    value={`pr #${typedPr} pull request ${search.trim()} open journey`}
+                    onSelect={() => {
+                      setOpen(false);
+                      setSearch("");
+                      onJumpPr(typedPr);
+                    }}
+                    className={PALETTE_ITEM_CLASS}
+                  >
+                    <span>
+                      Open PR <span className="mono">#{typedPr}</span>
+                    </span>
+                    <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                      PR journey
+                    </span>
+                  </Command.Item>
+                </Command.Group>
+              )}
+              {(proposals.data?.proposals ?? []).length > 0 && (
+                <Command.Group heading="Proposals">
+                  {(proposals.data?.proposals ?? []).map((p) => (
+                    <Command.Item
+                      key={p.id}
+                      value={`proposal ${p.id} ${p.agent ?? ""} ${p.status} ${p.decision}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onJumpProposal(p.id);
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span className="mono truncate">{p.id}</span>
+                      <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                        proposal · {p.status}
+                        {p.status === "open"
+                          ? ` · ${p.agent ?? p.decision}`
+                          : ` · ${p.decision}`}
+                      </span>
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+              {(events.data?.events ?? []).length > 0 && (
+                <Command.Group heading="Events">
+                  {(events.data?.events ?? []).map((e) => (
+                    <Command.Item
+                      key={`${e.source}:${e.eventId}`}
+                      value={`event ${e.source} ${e.eventId} ${e.type} ${e.status}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onJumpEvent(e.source, e.eventId);
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span className="mono truncate">{e.eventId}</span>
+                      <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                        event · {e.source} · {e.status}
+                      </span>
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+              {(runs.data?.runs ?? []).length > 0 && (
+                <Command.Group heading="Runs">
+                  {(runs.data?.runs ?? []).map((r) => (
+                    <Command.Item
+                      key={r.runId}
+                      value={`run ${r.runId} ${r.state} ${r.agent}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onJumpRun(r.runId);
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span className="mono truncate">{r.runId}</span>
+                      <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                        run · {r.state}
+                      </span>
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+              {(agents.data?.agents ?? []).length > 0 && (
+                <Command.Group heading="Agents">
+                  {(agents.data?.agents ?? []).map((a) => (
+                    <Command.Item
+                      key={a.ref}
+                      value={`agent ${a.ref} ${a.id} ${a.outputContract}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onJumpAgent(a.ref);
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span className="mono truncate">{a.ref}</span>
+                      <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                        agent · {a.outputContract}
+                      </span>
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+              {(workers.data?.workers ?? []).length > 0 && (
+                <Command.Group heading="Workers">
+                  {(workers.data?.workers ?? []).map((w) => {
+                    const state = health(w);
+                    return (
+                      <Command.Item
+                        key={w.workerId}
+                        value={`worker ${w.workerId} ${w.host} ${state}`}
+                        onSelect={() => {
+                          setOpen(false);
+                          onJumpWorker(w.workerId);
+                        }}
+                        className={PALETTE_ITEM_CLASS}
+                      >
+                        <span className="mono truncate">{w.workerId}</span>
+                        <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                          worker · {w.host} · {state}
+                        </span>
+                      </Command.Item>
+                    );
+                  })}
+                </Command.Group>
+              )}
+              {(repos.data?.repos ?? []).length > 0 && (
+                <Command.Group heading="Projects">
+                  {(repos.data?.repos ?? []).map((r) => (
+                    <Command.Item
+                      key={r.name}
+                      value={`project repo ${r.name} ${r.team ?? ""} ${r.project ?? ""} ${r.github ?? ""}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onJumpProject?.(r.name);
+                      }}
+                      className={PALETTE_ITEM_CLASS}
+                    >
+                      <span className="mono truncate">
+                        {r.name}
+                        {r.project ? (
+                          <span className="ml-2 font-sans text-(--text-dim)">
+                            {r.project}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                        project ·{" "}
+                        {r.reportOnly ? "report-only" : "dispatchable"}
+                      </span>
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              )}
+            </Command.List>
+            <div
+              data-testid="palette-results-fade"
+              aria-hidden="true"
+              className={`pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-linear-to-t from-(--surface-1) to-transparent transition-opacity ${hasMoreBelow ? "opacity-100" : "opacity-0"}`}
+            />
+          </div>
+          <div className="flex items-center justify-between border-t border-(--border) px-4 py-2 text-[11px] text-(--text-faint)">
+            <span>
+              <span className="mono font-medium">↑↓</span> Navigate
+            </span>
+            <span>
+              <span className="mono font-medium">↵</span> Select
+            </span>
+            <span>
+              <span className="mono font-medium">ESC</span> Close
+            </span>
+          </div>
         </div>
       </Command>
     </div>

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, createEvent, fireEvent, render } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+} from "@testing-library/react";
 import type { OperatorContext } from "../context";
 import type { RepoItem } from "../types";
 import { ContextTabs, ScopeCaption } from "./ContextTabs";
@@ -47,7 +53,9 @@ describe("ContextTabs", () => {
     expect(r.queryByRole("tablist")).toBeNull();
     expect(r.queryByRole("tab")).toBeNull();
 
-    const pressed = r.getAllByRole("button").filter((el) => el.getAttribute("aria-pressed") === "true");
+    const pressed = r
+      .getAllByRole("button")
+      .filter((el) => el.getAttribute("aria-pressed") === "true");
     expect(pressed).toHaveLength(1);
     expect(pressed[0].textContent).toBe("factory");
 
@@ -108,7 +116,9 @@ describe("ContextTabs", () => {
 
     const divider = toolbar.querySelector("[data-context-filter-divider]");
     expect(divider).not.toBeNull();
-    expect(divider?.nextElementSibling).toBe(r.getByRole("button", { name: "In flight" }));
+    expect(divider?.nextElementSibling).toBe(
+      r.getByRole("button", { name: "In flight" }),
+    );
 
     const repoAction = r.getByRole("button", { name: "Open a repo tab" });
     expect(toolbar.contains(repoAction)).toBe(false);
@@ -221,7 +231,9 @@ describe("ContextTabs", () => {
       fireEvent.keyDown(allBtn, { key: "ArrowRight" });
     });
 
-    expect(document.activeElement).toBe(r.getByRole("button", { name: "factory" }));
+    expect(document.activeElement).toBe(
+      r.getByRole("button", { name: "factory" }),
+    );
     expect(selected).toEqual([]);
     expect(opened).toEqual([]);
   });
@@ -419,7 +431,11 @@ describe("ContextTabs", () => {
     expect(document.activeElement?.getAttribute("role")).toBe("listbox");
 
     const options = r.getAllByRole("option");
-    expect(options.map((el) => el.textContent)).toEqual(["alpha", "bravo", "charlie"]);
+    expect(options.map((el) => el.textContent)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+    ]);
     expect(options[0].getAttribute("aria-selected")).toBe("true");
     expect(options[1].getAttribute("aria-selected")).toBe("false");
 
@@ -437,7 +453,10 @@ describe("ContextTabs", () => {
   });
 
   test("keyboard navigation scrolls each highlighted picker option into view", () => {
-    const scrolls: Array<{ element: HTMLElement; options?: boolean | ScrollIntoViewOptions }> = [];
+    const scrolls: Array<{
+      element: HTMLElement;
+      options?: boolean | ScrollIntoViewOptions;
+    }> = [];
     const original = HTMLElement.prototype.scrollIntoView;
     HTMLElement.prototype.scrollIntoView = function (
       this: HTMLElement,
@@ -475,7 +494,10 @@ describe("ContextTabs", () => {
         act(() => {
           fireEvent.keyDown(listbox, { key });
         });
-        expect(scrolls.at(-1)).toEqual({ element: expected, options: { block: "nearest" } });
+        expect(scrolls.at(-1)).toEqual({
+          element: expected,
+          options: { block: "nearest" },
+        });
       }
     } finally {
       HTMLElement.prototype.scrollIntoView = original;
@@ -501,13 +523,17 @@ describe("ContextTabs", () => {
     act(() => {
       fireEvent.keyDown(listbox, { key: "End" });
     });
-    expect(r.getAllByRole("option")[2].getAttribute("aria-selected")).toBe("true");
+    expect(r.getAllByRole("option")[2].getAttribute("aria-selected")).toBe(
+      "true",
+    );
 
     r.rerender(<ContextTabs {...props} openRepos={["bravo", "charlie"]} />);
 
     const remaining = r.getByRole("option", { name: "alpha" });
     expect(remaining.getAttribute("aria-selected")).toBe("true");
-    expect(r.getByRole("listbox").getAttribute("aria-activedescendant")).toBe(remaining.id);
+    expect(r.getByRole("listbox").getAttribute("aria-activedescendant")).toBe(
+      remaining.id,
+    );
     act(() => {
       fireEvent.keyDown(r.getByRole("listbox"), { key: "Enter" });
     });
@@ -593,7 +619,9 @@ describe("ContextTabs", () => {
       fireEvent.keyDown(window, { key: "Escape" });
     });
     expect(r.queryByRole("listbox")).toBeNull();
-    expect(document.activeElement?.getAttribute("aria-label")).toBe("Open a repo tab");
+    expect(document.activeElement?.getAttribute("aria-label")).toBe(
+      "Open a repo tab",
+    );
     expect(opened).toEqual([]);
   });
 
@@ -643,9 +671,15 @@ describe("ContextTabs", () => {
     );
 
     expect(r.getByRole("button", { name: "All" }).textContent).toBe("All");
-    expect(r.getByRole("button", { name: "factory" }).textContent).toBe("factory");
-    expect(r.getByRole("button", { name: "client" }).textContent).toBe("client");
-    expect(r.getByRole("button", { name: "In flight" }).textContent).toBe("In flight");
+    expect(r.getByRole("button", { name: "factory" }).textContent).toBe(
+      "factory",
+    );
+    expect(r.getByRole("button", { name: "client" }).textContent).toBe(
+      "client",
+    );
+    expect(r.getByRole("button", { name: "In flight" }).textContent).toBe(
+      "In flight",
+    );
   });
 
   test("provides shortcut hint titles on context tab buttons", () => {
@@ -662,13 +696,19 @@ describe("ContextTabs", () => {
       />,
     );
 
-    expect(r.getByRole("button", { name: "All" }).getAttribute("title")).toBe("All (g 0)");
+    expect(r.getByRole("button", { name: "All" }).getAttribute("title")).toBe(
+      "All (g 0)",
+    );
     for (let i = 0; i < 9; i++) {
       const btn = r.getByRole("button", { name: `repo-${i + 1}` });
       expect(btn.getAttribute("title")).toBe(`repo-${i + 1} (g ${i + 1})`);
     }
-    expect(r.getByRole("button", { name: "repo-10" }).getAttribute("title")).toBe("repo-10");
-    expect(r.getByRole("button", { name: "In flight" }).getAttribute("title")).toBe("In flight (g i)");
+    expect(
+      r.getByRole("button", { name: "repo-10" }).getAttribute("title"),
+    ).toBe("repo-10");
+    expect(
+      r.getByRole("button", { name: "In flight" }).getAttribute("title"),
+    ).toBe("In flight (g i)");
   });
 });
 
@@ -676,14 +716,22 @@ describe("ScopeCaption", () => {
   const repoCtx: OperatorContext = { kind: "repo", name: "factory" };
 
   test("kind=all renders nothing (no caption to leak jargon)", () => {
-    const r = render(<ScopeCaption context={{ kind: "all" }} surface="fleet" />);
+    const r = render(
+      <ScopeCaption context={{ kind: "all" }} surface="fleet" />,
+    );
     expect(r.container.textContent).toBe("");
   });
 
   test("fixed surfaces use view names, not internal surface names", () => {
     const cases = [
-      { surface: "fleet" as const, expect: "Workers are not scoped to factory" },
-      { surface: "overview" as const, expect: "Overview counts are not scoped to factory" },
+      {
+        surface: "fleet" as const,
+        expect: "Workers are not scoped to factory",
+      },
+      {
+        surface: "overview" as const,
+        expect: "Overview counts are not scoped to factory",
+      },
       { surface: "graph" as const, expect: "Graph is not scoped to factory" },
     ];
 
@@ -719,7 +767,11 @@ describe("ScopeCaption", () => {
     for (const c of cases) {
       window.location.hash = c.hash;
       const r = render(
-        <ScopeCaption context={repoCtx} surface="registry" subject={c.subject} />,
+        <ScopeCaption
+          context={repoCtx}
+          surface="registry"
+          subject={c.subject}
+        />,
       );
       expect(r.container.textContent).toContain(c.expect);
       cleanup();

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -20,12 +20,17 @@ export const savePinnedRuns = (runs: string[]) => {
     sessionStorage.setItem(PINNED_RUNS_STORAGE_KEY, JSON.stringify(runs));
   } catch {}
   if (typeof window !== "undefined") {
-    window.dispatchEvent(new CustomEvent("factory:pinnedRunsChanged", { detail: runs }));
+    window.dispatchEvent(
+      new CustomEvent("factory:pinnedRunsChanged", { detail: runs }),
+    );
   }
 };
 
 const getHashRunId = () => {
-  const m = typeof window !== "undefined" ? window.location.hash.match(/^#\/runs?\/([^?&#]+)/) : null;
+  const m =
+    typeof window !== "undefined"
+      ? window.location.hash.match(/^#\/runs?\/([^?&#]+)/)
+      : null;
   return m ? decodeURIComponent(m[1]) : null;
 };
 
@@ -98,7 +103,8 @@ export function ContextTabs({
   const plusRef = useRef<HTMLButtonElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
   const stripRef = useRef<HTMLDivElement>(null);
-  const [internalPinned, setInternalPinned] = useState<string[]>(readPinnedRuns);
+  const [internalPinned, setInternalPinned] =
+    useState<string[]>(readPinnedRuns);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -138,7 +144,9 @@ export function ContextTabs({
     [repos, openRepos],
   );
   const clampedPickerHighlight =
-    available.length === 0 ? 0 : Math.min(pickerHighlight, available.length - 1);
+    available.length === 0
+      ? 0
+      : Math.min(pickerHighlight, available.length - 1);
 
   useEffect(() => {
     setPickerHighlight((current) =>
@@ -154,10 +162,16 @@ export function ContextTabs({
         : active.kind;
 
   const activeTab = () =>
-    stripRef.current?.querySelector<HTMLElement>('[aria-pressed="true"]') ?? null;
+    stripRef.current?.querySelector<HTMLElement>('[aria-pressed="true"]') ??
+    null;
 
   const tabIds = useMemo(
-    () => ["all", ...openRepos, ...pinnedRuns.map((id) => `run:${id}`), INFLIGHT],
+    () => [
+      "all",
+      ...openRepos,
+      ...pinnedRuns.map((id) => `run:${id}`),
+      INFLIGHT,
+    ],
     [openRepos, pinnedRuns],
   );
   const [tabStopId, setTabStopId] = useState<string | null>(null);
@@ -165,7 +179,7 @@ export function ContextTabs({
   const effectiveTabStop =
     tabStopId && tabIds.includes(tabStopId)
       ? tabStopId
-    : tabIds.includes(activeId)
+      : tabIds.includes(activeId)
         ? activeId
         : "all";
 
@@ -222,12 +236,19 @@ export function ContextTabs({
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
-    const currentId = (e.target as HTMLElement | null)?.closest<HTMLButtonElement>("[data-context-tab]")?.getAttribute("data-context-tab");
+    const currentId = (e.target as HTMLElement | null)
+      ?.closest<HTMLButtonElement>("[data-context-tab]")
+      ?.getAttribute("data-context-tab");
     if (!currentId) return;
     const currentIndex = tabIds.indexOf(currentId);
     if (currentIndex === -1) return;
 
-    if (e.key === "ArrowRight" || e.key === "ArrowLeft" || e.key === "Home" || e.key === "End") {
+    if (
+      e.key === "ArrowRight" ||
+      e.key === "ArrowLeft" ||
+      e.key === "Home" ||
+      e.key === "End"
+    ) {
       e.preventDefault();
       const delta = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
       const nextId =
@@ -237,7 +258,9 @@ export function ContextTabs({
             ? tabIds[tabIds.length - 1]
             : tabIds[(currentIndex + delta + tabIds.length) % tabIds.length];
       setTabStopId(nextId);
-      stripRef.current?.querySelector<HTMLButtonElement>(`[data-context-tab="${nextId}"]`)?.focus();
+      stripRef.current
+        ?.querySelector<HTMLButtonElement>(`[data-context-tab="${nextId}"]`)
+        ?.focus();
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       e.stopPropagation();
@@ -314,7 +337,9 @@ export function ContextTabs({
 
   const groupedTabButtonClass = (id: string) =>
     `flex h-7 items-center gap-1 rounded-full py-0 pl-3 pr-1 text-[12px] font-medium outline-none focus-visible:ring-2 focus-visible:ring-(--accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--surface-1) ${
-      activeId === id ? "text-(--text)" : "text-(--text-dim) group-hover:text-(--text)"
+      activeId === id
+        ? "text-(--text)"
+        : "text-(--text-dim) group-hover:text-(--text)"
     }`;
 
   const closeTabClass =
@@ -338,7 +363,8 @@ export function ContextTabs({
           title="All (g 0)"
           className={tabClass("all")}
           onClick={() => {
-            if (activeRunId && typeof window !== "undefined") window.location.hash = "#/runs";
+            if (activeRunId && typeof window !== "undefined")
+              window.location.hash = "#/runs";
             onSelect({ kind: "all" });
           }}
           onFocus={() => setTabStopId("all")}
@@ -359,16 +385,23 @@ export function ContextTabs({
           className="flex min-w-0 items-center gap-0.5 overflow-x-auto"
         >
           {openRepos.map((name, idx) => (
-            <div key={name} role="presentation" className={`group ${groupedTabClass(name)}`}>
+            <div
+              key={name}
+              role="presentation"
+              className={`group ${groupedTabClass(name)}`}
+            >
               <button
                 type="button"
                 data-context-tab={name}
                 tabIndex={effectiveTabStop === name ? 0 : -1}
-                aria-pressed={!activeRunId && active.kind === "repo" && active.name === name}
+                aria-pressed={
+                  !activeRunId && active.kind === "repo" && active.name === name
+                }
                 title={idx < 9 ? `${name} (g ${idx + 1})` : name}
                 className={groupedTabButtonClass(name)}
                 onClick={() => {
-                  if (activeRunId && typeof window !== "undefined") window.location.hash = `#/runs?project=${encodeURIComponent(name)}`;
+                  if (activeRunId && typeof window !== "undefined")
+                    window.location.hash = `#/runs?project=${encodeURIComponent(name)}`;
                   onSelect({ kind: "repo", name });
                 }}
                 onFocus={() => setTabStopId(name)}
@@ -403,7 +436,11 @@ export function ContextTabs({
             const isRunActive = activeRunId === runId;
             const tabKey = `run:${runId}`;
             return (
-              <div key={tabKey} role="presentation" className={`group ${groupedTabClass(tabKey)}`}>
+              <div
+                key={tabKey}
+                role="presentation"
+                className={`group ${groupedTabClass(tabKey)}`}
+              >
                 <button
                   type="button"
                   data-context-tab={tabKey}
@@ -418,7 +455,9 @@ export function ContextTabs({
                   onFocus={() => setTabStopId(tabKey)}
                   title={`Run ${runId}`}
                 >
-                  <span className="opacity-70 text-[10px]" aria-hidden="true">▶</span>
+                  <span className="opacity-70 text-[10px]" aria-hidden="true">
+                    ▶
+                  </span>
                   <span className="mono max-w-32 truncate">{runId}</span>
                 </button>
                 <button
@@ -454,7 +493,8 @@ export function ContextTabs({
           onClick={() => {
             const next = toggleInflight(active);
             if (activeRunId && typeof window !== "undefined") {
-              window.location.hash = next.kind === "inflight" ? "#/runs?project=inflight" : "#/runs";
+              window.location.hash =
+                next.kind === "inflight" ? "#/runs?project=inflight" : "#/runs";
             }
             onSelect(next);
           }}
@@ -484,7 +524,9 @@ export function ContextTabs({
           onClick={() => setPicker((open) => !open)}
           onKeyDown={handlePickerTriggerKeyDown}
         >
-          <span aria-hidden="true" className="text-[14px] leading-none">+</span>
+          <span aria-hidden="true" className="text-[14px] leading-none">
+            +
+          </span>
           <span>Repo</span>
         </button>
         {picker && (
@@ -503,10 +545,14 @@ export function ContextTabs({
             onKeyDown={handlePickerKeyDown}
           >
             {reposError ? (
-              <div className="px-3 py-2 text-[12px] text-(--text-faint)">Cannot reach /repos.</div>
+              <div className="px-3 py-2 text-[12px] text-(--text-faint)">
+                Cannot reach /repos.
+              </div>
             ) : available.length === 0 ? (
               <div className="px-3 py-2 text-[12px] text-(--text-faint)">
-                {repos.length === 0 ? "No repos available." : "All repos are open."}
+                {repos.length === 0
+                  ? "No repos available."
+                  : "All repos are open."}
               </div>
             ) : (
               available.map((r, i) => (
@@ -526,7 +572,9 @@ export function ContextTabs({
                   onClick={() => selectPickerRepo(r.name)}
                 >
                   {r.name}
-                  {r.team ? <span className="ml-2 text-(--text-faint)">{r.team}</span> : null}
+                  {r.team ? (
+                    <span className="ml-2 text-(--text-faint)">{r.team}</span>
+                  ) : null}
                 </button>
               ))
             )}

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -4,21 +4,36 @@
  */
 import { extractRowValue } from "../pathExtractor";
 
-export function formatCellValue(value: unknown): { text: string; isComplex: boolean; title?: string } {
-  if (value === undefined || value === null) return { text: "—", isComplex: false };
-  if (typeof value === "boolean") return { text: value ? "true" : "false", isComplex: false };
-  if (typeof value === "number") return { text: String(value), isComplex: false };
+export function formatCellValue(value: unknown): {
+  text: string;
+  isComplex: boolean;
+  title?: string;
+} {
+  if (value === undefined || value === null)
+    return { text: "—", isComplex: false };
+  if (typeof value === "boolean")
+    return { text: value ? "true" : "false", isComplex: false };
+  if (typeof value === "number")
+    return { text: String(value), isComplex: false };
   if (typeof value === "string") {
     return { text: value, isComplex: false, title: value };
   }
   if (Array.isArray(value)) {
     const preview = `[${value.length}]`;
-    return { text: preview, isComplex: true, title: JSON.stringify(value, null, 2) };
+    return {
+      text: preview,
+      isComplex: true,
+      title: JSON.stringify(value, null, 2),
+    };
   }
   if (typeof value === "object") {
     const keys = Object.keys(value as object);
     const preview = `{${keys.slice(0, 2).join(", ")}${keys.length > 2 ? "…" : ""}}`;
-    return { text: preview, isComplex: true, title: JSON.stringify(value, null, 2) };
+    return {
+      text: preview,
+      isComplex: true,
+      title: JSON.stringify(value, null, 2),
+    };
   }
   return { text: String(value), isComplex: false };
 }

--- a/event-runtime/web/src/components/Dialog.test.tsx
+++ b/event-runtime/web/src/components/Dialog.test.tsx
@@ -84,7 +84,11 @@ describe("Dialog", () => {
       const [confirm, setConfirm] = useState(false);
       return (
         <OpenDialog onClose={() => {}}>
-          <button type="button" data-testid="choose" onClick={() => setConfirm(true)}>
+          <button
+            type="button"
+            data-testid="choose"
+            onClick={() => setConfirm(true)}
+          >
             choose
           </button>
           {confirm ? (
@@ -135,9 +139,18 @@ describe("Dialog", () => {
 
     // happy-dom has no layout engine, so stamp the CSSOM values this browser
     // case produces and make the regression fail under the old heuristic.
-    Object.defineProperty(envelope, "offsetParent", { configurable: true, value: panel });
-    Object.defineProperty(chip, "offsetParent", { configurable: true, value: panel });
-    Object.defineProperty(contentsControl, "offsetParent", { configurable: true, value: null });
+    Object.defineProperty(envelope, "offsetParent", {
+      configurable: true,
+      value: panel,
+    });
+    Object.defineProperty(chip, "offsetParent", {
+      configurable: true,
+      value: panel,
+    });
+    Object.defineProperty(contentsControl, "offsetParent", {
+      configurable: true,
+      value: null,
+    });
 
     envelope.focus();
     fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
@@ -147,7 +160,11 @@ describe("Dialog", () => {
   test("Tab cycle includes a position: fixed control", () => {
     const r = render(
       <OpenDialog onClose={() => {}}>
-        <button type="button" data-testid="fixed-control" style={{ position: "fixed" }}>
+        <button
+          type="button"
+          data-testid="fixed-control"
+          style={{ position: "fixed" }}
+        >
           fixed control
         </button>
       </OpenDialog>,
@@ -157,9 +174,18 @@ describe("Dialog", () => {
     const chip = r.getByTestId("chip");
     const fixedControl = r.getByTestId("fixed-control");
 
-    Object.defineProperty(envelope, "offsetParent", { configurable: true, value: panel });
-    Object.defineProperty(chip, "offsetParent", { configurable: true, value: panel });
-    Object.defineProperty(fixedControl, "offsetParent", { configurable: true, value: null });
+    Object.defineProperty(envelope, "offsetParent", {
+      configurable: true,
+      value: panel,
+    });
+    Object.defineProperty(chip, "offsetParent", {
+      configurable: true,
+      value: panel,
+    });
+    Object.defineProperty(fixedControl, "offsetParent", {
+      configurable: true,
+      value: null,
+    });
 
     envelope.focus();
     fireEvent.keyDown(window, { key: "Tab", shiftKey: true });

--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  within,
+} from "@testing-library/react";
 import { useState } from "react";
 import { modal } from "../hooks";
 import { goPrefix } from "../goSequence";
@@ -36,7 +42,12 @@ interface Row {
 const CONFIG: DisplayConfig<Row> = {
   view: "panel-test",
   groups: [
-    { key: "state", label: "State", get: (r) => r.state, order: ["RUNNING", "FAILED"] },
+    {
+      key: "state",
+      label: "State",
+      get: (r) => r.state,
+      order: ["RUNNING", "FAILED"],
+    },
     { key: "agent", label: "Agent", get: (r) => r.agent },
   ],
   subGroups: ["agent"],
@@ -62,7 +73,14 @@ function Harness({
       return value;
     });
   };
-  return <DisplayOptions config={CONFIG} state={state} onChange={update} rows={rows} />;
+  return (
+    <DisplayOptions
+      config={CONFIG}
+      state={state}
+      onChange={update}
+      rows={rows}
+    />
+  );
 }
 
 afterEach(() => {
@@ -130,8 +148,12 @@ describe("DisplayOptions panel", () => {
     fireEvent.click(r.getByRole("button", { name: /display/i }));
     chooseOption(r, "Group by", "Agent");
     fireEvent.click(r.getByRole("combobox", { name: "Sub-group by" }));
-    const subOptions = within(r.getByRole("listbox", { name: "Sub-group by options" })).getAllByRole("option");
-    expect(subOptions.map((option) => option.textContent)).not.toContain("Agent");
+    const subOptions = within(
+      r.getByRole("listbox", { name: "Sub-group by options" }),
+    ).getAllByRole("option");
+    expect(subOptions.map((option) => option.textContent)).not.toContain(
+      "Agent",
+    );
   });
 
   test("column pills toggle visibility but always-on columns are not offered", () => {
@@ -168,7 +190,9 @@ describe("DisplayOptions panel", () => {
         id: "r1",
         state: "RUNNING",
         agent: "a",
-        envelope: { payload: { repo: "watt-mind/factory", owner: "watt-mind" } },
+        envelope: {
+          payload: { repo: "watt-mind/factory", owner: "watt-mind" },
+        },
         spec: { input: { model: "claude-sonnet" } },
         labels: { priority: "high" },
       },
@@ -180,21 +204,32 @@ describe("DisplayOptions panel", () => {
     expect(input.getAttribute("placeholder")).toContain("labels.priority");
     fireEvent.focus(input);
 
-    const listbox = r.getByRole("listbox", { name: "Discovered property paths" });
+    const listbox = r.getByRole("listbox", {
+      name: "Discovered property paths",
+    });
     expect(within(listbox).getByText("payload")).toBeTruthy();
     expect(within(listbox).getByText("spec")).toBeTruthy();
     expect(within(listbox).getByText("labels")).toBeTruthy();
     expect(within(listbox).getAllByRole("option")).toHaveLength(4);
-    expect(within(listbox).getByRole("option", { name: /payload\.repo.*watt-mind\/factory.*1 row/i })).toBeTruthy();
+    expect(
+      within(listbox).getByRole("option", {
+        name: /payload\.repo.*watt-mind\/factory.*1 row/i,
+      }),
+    ).toBeTruthy();
 
     fireEvent.keyDown(input, { key: "Escape" });
-    expect(r.queryByRole("listbox", { name: "Discovered property paths" })).toBeNull();
+    expect(
+      r.queryByRole("listbox", { name: "Discovered property paths" }),
+    ).toBeNull();
     expect(r.getByRole("dialog", { name: "Display options" })).toBeTruthy();
   });
 
   test("does not cap the full discovered suggestion list at ten paths", () => {
     const payload = Object.fromEntries(
-      Array.from({ length: 12 }, (_, index) => [`field${index}`, `value${index}`]),
+      Array.from({ length: 12 }, (_, index) => [
+        `field${index}`,
+        `value${index}`,
+      ]),
     );
     const sampleRows: Row[] = [
       { id: "r1", state: "RUNNING", agent: "a", envelope: { payload } },
@@ -204,7 +239,11 @@ describe("DisplayOptions panel", () => {
 
     const input = r.getByRole("combobox", { name: "Add custom property path" });
     fireEvent.focus(input);
-    expect(within(r.getByRole("listbox", { name: "Discovered property paths" })).getAllByRole("option")).toHaveLength(12);
+    expect(
+      within(
+        r.getByRole("listbox", { name: "Discovered property paths" }),
+      ).getAllByRole("option"),
+    ).toHaveLength(12);
   });
 
   test("filters suggestions and adds the keyboard-highlighted path", () => {
@@ -218,14 +257,18 @@ describe("DisplayOptions panel", () => {
         spec: { input: { model: "claude-sonnet" } },
       },
     ];
-    const r = render(<Harness onState={(s) => (latest = s)} rows={sampleRows} />);
+    const r = render(
+      <Harness onState={(s) => (latest = s)} rows={sampleRows} />,
+    );
     fireEvent.click(r.getByRole("button", { name: /display/i }));
 
     const input = r.getByRole("combobox", { name: "Add custom property path" });
     act(() => {
       changeInput(input as HTMLInputElement, "model");
     });
-    const options = within(r.getByRole("listbox", { name: "Discovered property paths" })).getAllByRole("option");
+    const options = within(
+      r.getByRole("listbox", { name: "Discovered property paths" }),
+    ).getAllByRole("option");
     expect(options).toHaveLength(1);
     expect(options[0].textContent).toContain("spec.input.model");
     fireEvent.keyDown(input, { key: "Enter" });
@@ -237,16 +280,27 @@ describe("DisplayOptions panel", () => {
   test("adds an undiscovered free-text path on Enter and explains the empty column", () => {
     let latest: DisplayState | undefined;
     const sampleRows: Row[] = [
-      { id: "r1", state: "RUNNING", agent: "a", envelope: { payload: { repo: "watt-mind/factory" } } },
+      {
+        id: "r1",
+        state: "RUNNING",
+        agent: "a",
+        envelope: { payload: { repo: "watt-mind/factory" } },
+      },
     ];
-    const r = render(<Harness onState={(s) => (latest = s)} rows={sampleRows} />);
+    const r = render(
+      <Harness onState={(s) => (latest = s)} rows={sampleRows} />,
+    );
     fireEvent.click(r.getByRole("button", { name: /display/i }));
 
     const input = r.getByRole("combobox", { name: "Add custom property path" });
     act(() => {
       changeInput(input as HTMLInputElement, "payload.futureField");
     });
-    expect(r.getByText("not seen in loaded items; the column will show — until a row has it")).toBeTruthy();
+    expect(
+      r.getByText(
+        "not seen in loaded items; the column will show — until a row has it",
+      ),
+    ).toBeTruthy();
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(latest?.customColumns).toEqual(["payload.futureField"]);
@@ -290,7 +344,9 @@ describe("DisplayOptions panel", () => {
     const r = render(<Harness />);
     const trigger = r.getByRole("button", { name: /display/i });
     fireEvent.click(trigger);
-    expect(document.activeElement).toBe(r.getByRole("combobox", { name: "Group by" }));
+    expect(document.activeElement).toBe(
+      r.getByRole("combobox", { name: "Group by" }),
+    );
   });
 
   test("outside-click dismiss restores focus to the Display trigger", () => {
@@ -315,7 +371,9 @@ describe("DisplayOptions panel", () => {
     const r = render(<Harness />);
     expect(r.queryByRole("dialog", { name: "Display options" })).toBeNull();
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "v", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "v", bubbles: true }),
+      );
     });
     expect(r.getByRole("dialog", { name: "Display options" })).toBeTruthy();
   });
@@ -337,7 +395,9 @@ describe("DisplayOptions panel", () => {
     const r = render(<Harness />);
     goPrefix.armedAt = Date.now();
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "v", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "v", bubbles: true }),
+      );
     });
     expect(r.queryByRole("dialog", { name: "Display options" })).toBeNull();
   });
@@ -369,7 +429,9 @@ describe("GroupHeaderRow", () => {
                   collapsed={closed}
                   onToggle={() =>
                     setCollapsed((c) =>
-                      c.includes(s.key) ? c.filter((k) => k !== s.key) : [...c, s.key],
+                      c.includes(s.key)
+                        ? c.filter((k) => k !== s.key)
+                        : [...c, s.key],
                     )
                   }
                 />

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -34,10 +34,21 @@ import {
   type DiscoveredField,
 } from "../schemaDiscovery";
 
-function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: string; children: ReactNode }) {
+function OptionRow({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: ReactNode;
+}) {
   return (
     <div className="flex h-8 items-center justify-between gap-3">
-      <label htmlFor={htmlFor} className="shrink-0 text-[12px] text-(--text-dim)">
+      <label
+        htmlFor={htmlFor}
+        className="shrink-0 text-[12px] text-(--text-dim)"
+      >
         {label}
       </label>
       {children}
@@ -66,14 +77,19 @@ function ListboxSelect({
   const listRef = useRef<HTMLUListElement>(null);
   const internalRef = useRef<HTMLButtonElement>(null);
   const triggerRef = ref ?? internalRef;
-  const selectedIndex = Math.max(0, options.findIndex((option) => option.value === value));
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
   const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(selectedIndex);
   const selected = options[selectedIndex] ?? options[0];
 
   useEffect(() => {
     if (!open) return;
-    (listRef.current?.children[highlight] as HTMLElement | undefined)?.scrollIntoView({ block: "nearest" });
+    (
+      listRef.current?.children[highlight] as HTMLElement | undefined
+    )?.scrollIntoView({ block: "nearest" });
   }, [highlight, listId, open]);
 
   const show = () => {
@@ -98,7 +114,9 @@ function ListboxSelect({
         show();
       } else {
         const delta = event.key === "ArrowDown" ? 1 : -1;
-        setHighlight((index) => (index + delta + options.length) % options.length);
+        setHighlight(
+          (index) => (index + delta + options.length) % options.length,
+        );
       }
       return;
     }
@@ -136,14 +154,18 @@ function ListboxSelect({
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listId : undefined}
-        aria-activedescendant={open ? `${listId}-option-${highlight}` : undefined}
+        aria-activedescendant={
+          open ? `${listId}-option-${highlight}` : undefined
+        }
         onClick={() => (open ? setOpen(false) : show())}
         onBlur={() => setOpen(false)}
         onKeyDown={onKeyDown}
         className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-left text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
       >
         <span className="truncate">{selected?.label}</span>
-        <span aria-hidden className="shrink-0 text-[9px] text-(--text-faint)">▼</span>
+        <span aria-hidden className="shrink-0 text-[9px] text-(--text-faint)">
+          ▼
+        </span>
       </button>
       {open && (
         <ul
@@ -171,7 +193,11 @@ function ListboxSelect({
               }`}
             >
               <span className="truncate">{option.label}</span>
-              {option.value === value && <span aria-hidden className="text-(--accent)">✓</span>}
+              {option.value === value && (
+                <span aria-hidden className="text-(--accent)">
+                  ✓
+                </span>
+              )}
             </li>
           ))}
         </ul>
@@ -224,7 +250,16 @@ function GroupLabel({ children }: { children: ReactNode }) {
 /** Slider-style glyph, drawn with the text color so every theme carries it. */
 function SlidersIcon() {
   return (
-    <svg aria-hidden width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+    <svg
+      aria-hidden
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+    >
       <path d="M1 3h10M1 9h10" />
       <circle cx="4" cy="3" r="1.5" fill="var(--surface-1)" />
       <circle cx="8" cy="9" r="1.5" fill="var(--surface-1)" />
@@ -236,9 +271,10 @@ export function exportJson(filename: string, data: unknown): void {
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: "application/json" });
   if (typeof window !== "undefined" && typeof document !== "undefined") {
-    const url = typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
-      ? URL.createObjectURL(blob)
-      : "";
+    const url =
+      typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+        ? URL.createObjectURL(blob)
+        : "";
     const a = document.createElement("a");
     a.href = url;
     a.download = filename;
@@ -252,7 +288,10 @@ export function exportJson(filename: string, data: unknown): void {
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
 /** SuggestInput interaction model with richer, non-selectable discovery groups. */
@@ -279,8 +318,14 @@ function DiscoveredFieldSuggestInput({
     if (!query) return fields;
     return fields.filter((field) => field.path.toLowerCase().includes(query));
   }, [fields, value]);
-  const groups = useMemo(() => groupDiscoveredFields(filteredFields), [filteredFields]);
-  const selectableFields = useMemo(() => groups.flatMap((group) => group.fields), [groups]);
+  const groups = useMemo(
+    () => groupDiscoveredFields(filteredFields),
+    [filteredFields],
+  );
+  const selectableFields = useMemo(
+    () => groups.flatMap((group) => group.fields),
+    [groups],
+  );
   const indexedGroups = useMemo(() => {
     let index = 0;
     return groups.map((group) => ({
@@ -289,7 +334,8 @@ function DiscoveredFieldSuggestInput({
     }));
   }, [groups]);
   const show = open && selectableFields.length > 0;
-  const showNotSeenHint = value.trim().length > 0 && selectableFields.length === 0;
+  const showNotSeenHint =
+    value.trim().length > 0 && selectableFields.length === 0;
 
   useEffect(() => {
     setHighlight(0);
@@ -297,7 +343,9 @@ function DiscoveredFieldSuggestInput({
 
   useEffect(() => {
     if (!show || !listRef.current) return;
-    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+    listRef.current
+      .querySelector<HTMLElement>('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
   }, [highlight, show]);
 
   const pick = (field: DiscoveredField) => {
@@ -315,7 +363,11 @@ function DiscoveredFieldSuggestInput({
     if (event.key === "ArrowUp" && selectableFields.length > 0) {
       event.preventDefault();
       setOpen(true);
-      setHighlight((index) => (show ? (index - 1 + selectableFields.length) % selectableFields.length : selectableFields.length - 1));
+      setHighlight((index) =>
+        show
+          ? (index - 1 + selectableFields.length) % selectableFields.length
+          : selectableFields.length - 1,
+      );
       return;
     }
     if (event.key === "Enter") {
@@ -347,7 +399,11 @@ function DiscoveredFieldSuggestInput({
           aria-autocomplete="list"
           aria-expanded={show}
           aria-controls={show ? listId : undefined}
-          aria-activedescendant={show && selectableFields[highlight] ? `${listId}-option-${highlight}` : undefined}
+          aria-activedescendant={
+            show && selectableFields[highlight]
+              ? `${listId}-option-${highlight}`
+              : undefined
+          }
           value={value}
           placeholder={placeholder}
           spellCheck={false}
@@ -409,7 +465,10 @@ function DiscoveredFieldSuggestInput({
                     <div className="mono truncate">{field.path}</div>
                     <div className="flex items-center justify-between gap-2 text-[10px] text-(--text-faint)">
                       <span className="truncate">{field.sampleValue}</span>
-                      <span className="shrink-0">{field.occurrenceCount} {field.occurrenceCount === 1 ? "row" : "rows"}</span>
+                      <span className="shrink-0">
+                        {field.occurrenceCount}{" "}
+                        {field.occurrenceCount === 1 ? "row" : "rows"}
+                      </span>
                     </div>
                   </li>
                 ))}
@@ -437,7 +496,9 @@ export function DisplayOptions<T>({
 }: {
   config: DisplayConfig<T>;
   state: DisplayState;
-  onChange: (next: DisplayState | ((state: DisplayState) => DisplayState)) => void;
+  onChange: (
+    next: DisplayState | ((state: DisplayState) => DisplayState),
+  ) => void;
   onExport?: () => void;
   rows?: T[];
 }) {
@@ -501,7 +562,9 @@ export function DisplayOptions<T>({
 
   const customized = !isDefaultDisplayState(config, state);
   const activeGroup = config.groups.find((g) => g.key === state.groupBy);
-  const subOptions = (config.subGroups ?? []).filter((k) => k !== state.groupBy);
+  const subOptions = (config.subGroups ?? []).filter(
+    (k) => k !== state.groupBy,
+  );
   const toggleable = config.columns.filter((c) => !c.always);
   const groupLabel = (key: string) =>
     config.groups.find((g) => g.key === key)?.label ?? key;
@@ -516,7 +579,9 @@ export function DisplayOptions<T>({
       .slice(0, 2)
       .map((group) => group.fields[0]?.path)
       .filter(Boolean);
-    return examples.length > 0 ? `e.g. ${examples.join(", ")}` : "Enter a property path";
+    return examples.length > 0
+      ? `e.g. ${examples.join(", ")}`
+      : "Enter a property path";
   }, [discoveredFields]);
 
   const handleAddCustom = (pathToAdd?: string) => {
@@ -542,9 +607,18 @@ export function DisplayOptions<T>({
       >
         <SlidersIcon />
         Display
-        <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px]">v</span>
+        <span
+          aria-hidden="true"
+          className="mono ml-1 text-(--text-faint) text-[10px]"
+        >
+          v
+        </span>
         {customized && (
-          <span aria-hidden className="size-1.5 rounded-full bg-(--accent)" title="Display options customized" />
+          <span
+            aria-hidden
+            className="size-1.5 rounded-full bg-(--accent)"
+            title="Display options customized"
+          />
         )}
       </button>
 
@@ -582,10 +656,15 @@ export function DisplayOptions<T>({
                 label="Sub-group by"
                 disabled={state.groupBy === NONE}
                 value={state.subGroupBy}
-                onChange={(subGroupBy) => onChange((s) => ({ ...s, subGroupBy, collapsed: [] }))}
+                onChange={(subGroupBy) =>
+                  onChange((s) => ({ ...s, subGroupBy, collapsed: [] }))
+                }
                 options={[
                   { value: NONE, label: "No sub-grouping" },
-                  ...subOptions.map((k) => ({ value: k, label: groupLabel(k) })),
+                  ...subOptions.map((k) => ({
+                    value: k,
+                    label: groupLabel(k),
+                  })),
                 ]}
               />
             </OptionRow>
@@ -602,12 +681,16 @@ export function DisplayOptions<T>({
                     ...s,
                     sortBy,
                     sortDir:
-                      config.sorts.find((f) => f.key === sortBy)?.defaultDir ?? "asc",
+                      config.sorts.find((f) => f.key === sortBy)?.defaultDir ??
+                      "asc",
                   }))
                 }
                 options={[
                   { value: DEFAULT_ORDER, label: "Default order" },
-                  ...config.sorts.map((f) => ({ value: f.key, label: f.label })),
+                  ...config.sorts.map((f) => ({
+                    value: f.key,
+                    label: f.label,
+                  })),
                   ...(state.customColumns ?? []).map((path) => ({
                     value: `custom:${path}`,
                     label: path,
@@ -626,15 +709,22 @@ export function DisplayOptions<T>({
                       key={direction}
                       type="button"
                       aria-pressed={pressed}
-                      aria-label={direction === "asc" ? "Ascending order" : "Descending order"}
-                      onClick={() => onChange((s) => ({ ...s, sortDir: direction }))}
+                      aria-label={
+                        direction === "asc"
+                          ? "Ascending order"
+                          : "Descending order"
+                      }
+                      onClick={() =>
+                        onChange((s) => ({ ...s, sortDir: direction }))
+                      }
                       className={`cursor-pointer rounded px-1.5 py-0.5 text-[10px] transition-colors ${
                         pressed
                           ? "bg-(--surface-2) text-(--text) shadow-sm"
                           : "text-(--text-faint) hover:text-(--text-dim)"
                       }`}
                     >
-                      <span aria-hidden>{direction === "asc" ? "↑" : "↓"}</span> {direction}
+                      <span aria-hidden>{direction === "asc" ? "↑" : "↓"}</span>{" "}
+                      {direction}
                     </button>
                   );
                 })}
@@ -676,9 +766,17 @@ export function DisplayOptions<T>({
                           ? "border-(--border-strong) bg-(--surface-2) text-(--text)"
                           : "border-(--border) bg-transparent hover:bg-(--surface-2)"
                       }`}
-                      style={shown ? undefined : { color: "var(--text-muted, var(--text-faint))" }}
+                      style={
+                        shown
+                          ? undefined
+                          : { color: "var(--text-muted, var(--text-faint))" }
+                      }
                     >
-                      {shown && <span aria-hidden className="text-(--accent)">✓</span>}
+                      {shown && (
+                        <span aria-hidden className="text-(--accent)">
+                          ✓
+                        </span>
+                      )}
                       {c.label}
                     </button>
                   );
@@ -722,7 +820,9 @@ export function DisplayOptions<T>({
                       type="button"
                       aria-label={`Remove column ${path}`}
                       title="Remove column"
-                      onClick={() => onChange((s) => removeCustomColumn(s, path))}
+                      onClick={() =>
+                        onChange((s) => removeCustomColumn(s, path))
+                      }
                       className="cursor-pointer text-(--text-faint) hover:text-(--text)"
                     >
                       ×
@@ -759,7 +859,9 @@ export function DisplayOptions<T>({
               {customized && (
                 <button
                   type="button"
-                  onClick={() => onChange({ ...defaultDisplayState(config), collapsed: [] })}
+                  onClick={() =>
+                    onChange({ ...defaultDisplayState(config), collapsed: [] })
+                  }
                   className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text)"
                 >
                   Reset to defaults

--- a/event-runtime/web/src/components/ErrorBoundary.test.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.test.tsx
@@ -23,9 +23,11 @@ function BrokenRoute({ error = chunkFailure() }: { error?: Error }): null {
 describe("chunk-load recovery", () => {
   test("recognizes browser and bundler chunk-load failures", () => {
     expect(isChunkLoadError(chunkFailure())).toBe(true);
-    expect(isChunkLoadError(Object.assign(new Error("chunk missing"), { name: "ChunkLoadError" }))).toBe(
-      true,
-    );
+    expect(
+      isChunkLoadError(
+        Object.assign(new Error("chunk missing"), { name: "ChunkLoadError" }),
+      ),
+    ).toBe(true);
     expect(isChunkLoadError(new Error("ordinary render failure"))).toBe(false);
   });
 
@@ -55,21 +57,35 @@ describe("chunk-load recovery", () => {
     };
 
     const first = render(
-      <ErrorBoundary storage={storage} route="/#/proposals" now={() => 1_000} reload={reload}>
+      <ErrorBoundary
+        storage={storage}
+        route="/#/proposals"
+        now={() => 1_000}
+        reload={reload}
+      >
         <BrokenRoute />
       </ErrorBoundary>,
     );
     await waitFor(() => expect(reloads).toBe(1));
-    expect(first.getByRole("alert").textContent).toContain("Refreshing this tab once");
+    expect(first.getByRole("alert").textContent).toContain(
+      "Refreshing this tab once",
+    );
     first.unmount();
 
     const second = render(
-      <ErrorBoundary storage={storage} route="/#/proposals" now={() => 1_001} reload={reload}>
+      <ErrorBoundary
+        storage={storage}
+        route="/#/proposals"
+        now={() => 1_001}
+        reload={reload}
+      >
         <BrokenRoute />
       </ErrorBoundary>,
     );
     await waitFor(() => {
-      expect(second.getByRole("heading", { name: "New version deployed" })).toBeTruthy();
+      expect(
+        second.getByRole("heading", { name: "New version deployed" }),
+      ).toBeTruthy();
     });
     expect(second.getByRole("alert").textContent).toContain(
       "This tab could not load the updated files. Reload to try again.",

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -50,7 +50,10 @@ export function claimChunkReload(
         return false;
       }
     }
-    storage.setItem(CHUNK_RELOAD_STORAGE_KEY, JSON.stringify({ route, at: now }));
+    storage.setItem(
+      CHUNK_RELOAD_STORAGE_KEY,
+      JSON.stringify({ route, at: now }),
+    );
     return true;
   } catch {
     // Without a durable guard, an automatic reload could loop forever. Leave
@@ -83,7 +86,9 @@ export class ErrorBoundary extends Component<Props, State> {
     const storage = this.props.storage ?? window.sessionStorage;
     const route = this.props.route ?? currentRoute();
     if (claimChunkReload(error, storage, route, this.props.now?.())) {
-      this.setState({ reloading: true }, () => (this.props.reload ?? (() => window.location.reload()))());
+      this.setState({ reloading: true }, () =>
+        (this.props.reload ?? (() => window.location.reload()))(),
+      );
     }
   }
 
@@ -92,7 +97,9 @@ export class ErrorBoundary extends Component<Props, State> {
     if (!error) return this.props.children;
 
     const chunkFailure = isChunkLoadError(error);
-    const title = chunkFailure ? "New version deployed" : "The control plane could not render";
+    const title = chunkFailure
+      ? "New version deployed"
+      : "The control plane could not render";
     const detail = reloading
       ? "Refreshing this tab once to load the new version…"
       : chunkFailure
@@ -101,14 +108,19 @@ export class ErrorBoundary extends Component<Props, State> {
 
     return (
       <main className="flex min-h-screen items-center justify-center bg-(--surface-0) p-6 text-(--text)">
-        <section role="alert" className="max-w-lg border-l-2 border-(--hue-warn) pl-4">
+        <section
+          role="alert"
+          className="max-w-lg border-l-2 border-(--hue-warn) pl-4"
+        >
           <h1 className="display text-lg font-semibold">{title}</h1>
           <p className="mt-2 text-sm text-(--text-dim)">{detail}</p>
           {!reloading && (
             <button
               type="button"
               className="mt-4 rounded-md border border-(--border-strong) px-3 py-1.5 text-sm font-medium hover:bg-(--surface-2)"
-              onClick={() => (this.props.reload ?? (() => window.location.reload()))()}
+              onClick={() =>
+                (this.props.reload ?? (() => window.location.reload()))()
+              }
             >
               Reload
             </button>

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -21,7 +21,9 @@ function renderWithClient(ui: React.ReactElement) {
       queries: { retry: false },
     },
   });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +104,11 @@ const STATUS_REPORT_SCHEMA = {
   required: ["repos"],
   additionalProperties: false,
   properties: {
-    repos: { type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
+    repos: {
+      type: "array",
+      minItems: 1,
+      items: { type: "string", minLength: 1 },
+    },
   },
 };
 
@@ -116,7 +122,11 @@ const DEMO_SCHEMA = {
     dryRun: { type: "boolean" },
     plan: {
       type: "array",
-      items: { type: "object", required: ["action"], properties: { action: { type: "string" } } },
+      items: {
+        type: "object",
+        required: ["action"],
+        properties: { action: { type: "string" } },
+      },
     },
   },
 };
@@ -137,11 +147,41 @@ function schemaRegistry(): AgentsView {
       mk("demo", DEMO_SCHEMA),
     ],
     eventTypes: [
-      { type: "triage.scan.requested", agent: "triage@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
-      { type: "disk.diagnose", agent: "disk@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
-      { type: "ci.run.failed", agent: "cidoctor@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
-      { type: "factory.status.requested", agent: "report@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
-      { type: "demo.requested", agent: "demo@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+      {
+        type: "triage.scan.requested",
+        agent: "triage@1",
+        adapter: "cmd",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+      {
+        type: "disk.diagnose",
+        agent: "disk@1",
+        adapter: "cmd",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+      {
+        type: "ci.run.failed",
+        agent: "cidoctor@1",
+        adapter: "cmd",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+      {
+        type: "factory.status.requested",
+        agent: "report@1",
+        adapter: "cmd",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+      {
+        type: "demo.requested",
+        agent: "demo@1",
+        adapter: "cmd",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
     ],
     edges: {},
     contracts: {},
@@ -151,11 +191,43 @@ function schemaRegistry(): AgentsView {
 }
 
 const REPO_ITEMS = [
-  { name: "bj29", path: "/r/bj29", github: "watt-mind/bj29", team: null, project: null, base: "develop", deployBranch: null, reportOnly: false, maxInFlight: null, worktreeRoot: null, hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false, verify: null },
-  { name: "factory", path: "/r/factory", github: null, team: null, project: null, base: "develop", reportOnly: false, deployBranch: null, maxInFlight: null, worktreeRoot: null, hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false, verify: null },
+  {
+    name: "bj29",
+    path: "/r/bj29",
+    github: "watt-mind/bj29",
+    team: null,
+    project: null,
+    base: "develop",
+    deployBranch: null,
+    reportOnly: false,
+    maxInFlight: null,
+    worktreeRoot: null,
+    hasWorktreeUp: false,
+    hasWorktreeDown: false,
+    hasWorktreeWarm: false,
+    verify: null,
+  },
+  {
+    name: "factory",
+    path: "/r/factory",
+    github: null,
+    team: null,
+    project: null,
+    base: "develop",
+    reportOnly: false,
+    deployBranch: null,
+    maxInFlight: null,
+    worktreeRoot: null,
+    hasWorktreeUp: false,
+    hasWorktreeDown: false,
+    hasWorktreeWarm: false,
+    verify: null,
+  },
 ];
 
-function withSchemaApi(fn: (r: ReturnType<typeof renderWithClient>) => Promise<void>) {
+function withSchemaApi(
+  fn: (r: ReturnType<typeof renderWithClient>) => Promise<void>,
+) {
   const origAgents = api.agents;
   const origRepos = api.repos;
   api.agents = async () => schemaRegistry();
@@ -171,7 +243,10 @@ function withSchemaApi(fn: (r: ReturnType<typeof renderWithClient>) => Promise<v
   })();
 }
 
-async function selectTemplate(r: ReturnType<typeof renderWithClient>, name: RegExp) {
+async function selectTemplate(
+  r: ReturnType<typeof renderWithClient>,
+  name: RegExp,
+) {
   const chip = await r.findByRole("radio", { name });
   act(() => {
     fireEvent.click(chip);
@@ -189,7 +264,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       // enum -> select, number -> numeric input, strings -> text inputs.
       const host = r.getByLabelText("host") as HTMLSelectElement;
       expect(host.tagName.toLowerCase()).toBe("select");
-      expect([...host.querySelectorAll("option")].map((o) => o.value)).toContain("web");
+      expect(
+        [...host.querySelectorAll("option")].map((o) => o.value),
+      ).toContain("web");
       const usedPct = r.getByLabelText("usedPct") as HTMLInputElement;
       expect(usedPct.getAttribute("type")).toBe("number");
       expect(usedPct.getAttribute("min")).toBe("0");
@@ -238,14 +315,18 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       act(() => {
         fireEvent.click(gen);
       });
-      expect((r.getByLabelText("alertId") as HTMLInputElement).value).toMatch(/^web-/);
+      expect((r.getByLabelText("alertId") as HTMLInputElement).value).toMatch(
+        /^web-/,
+      );
 
       await selectTemplate(r, /demo\.requested/i);
       const now = r.getByRole("button", { name: /^now$/i });
       act(() => {
         fireEvent.click(now);
       });
-      expect((r.getByLabelText("scheduledAt") as HTMLInputElement).value).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(
+        (r.getByLabelText("scheduledAt") as HTMLInputElement).value,
+      ).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     }));
 
   test("validation flags a bad payload with a field-level error after blur", () =>
@@ -270,7 +351,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       act(() => {
         fireEvent.click(r.getByRole("tab", { name: /json/i }));
       });
-      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const textarea = r.getByLabelText(
+        /event envelope json/i,
+      ) as HTMLTextAreaElement;
       expect(textarea.value).toContain('"/var"');
       // JSON -> Form re-parses on switch.
       const parsed = JSON.parse(textarea.value);
@@ -281,7 +364,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       act(() => {
         fireEvent.click(r.getByRole("tab", { name: /form/i }));
       });
-      expect((r.getByLabelText("mount") as HTMLInputElement).value).toBe("/data");
+      expect((r.getByLabelText("mount") as HTMLInputElement).value).toBe(
+        "/data",
+      );
     }));
 
   test("unregistered type is JSON-only: form tab disabled with a stated reason", () =>
@@ -321,7 +406,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
         expect(sent.length).toBe(0);
         expect(r.getByText(/does not validate/i)).toBeTruthy();
         expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
-        expect(r.queryByRole("button", { name: /^confirm inject$/i })).toBeNull();
+        expect(
+          r.queryByRole("button", { name: /^confirm inject$/i }),
+        ).toBeNull();
         const confirm = r.getByRole("button", { name: /inject anyway/i });
         await act(async () => {
           fireEvent.click(confirm);
@@ -357,7 +444,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       act(() => {
         fireEvent.click(r.getByRole("button", { name: /inject/i }));
       });
-      expect(r.getAllByText(/fewer than minItems 1/i).length).toBeGreaterThan(0);
+      expect(r.getAllByText(/fewer than minItems 1/i).length).toBeGreaterThan(
+        0,
+      );
     }));
 
   test("array-of-objects field renders a JSON sub-editor with parse indicator", () =>
@@ -388,7 +477,9 @@ describe("InjectDialog template picker readiness (WM-555)", () => {
   test("template param hints expose the full truncated value in a title", () =>
     withSchemaApi(async (r) => {
       const template = await r.findByRole("radio", { name: /disk\.diagnose/i });
-      const hint = template.querySelector('[title="host, mount, usedPct, alertId"]');
+      const hint = template.querySelector(
+        '[title="host, mount, usedPct, alertId"]',
+      );
       expect(hint).toBeTruthy();
       expect(hint?.className).toContain("truncate");
     }));
@@ -424,8 +515,20 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
           },
         ],
         eventTypes: [
-          { type: "worker.started", agent: "worker@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "worker.stopped", agent: "worker@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "worker.started",
+            agent: "worker@1",
+            adapter: "cmd",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "worker.stopped",
+            agent: "worker@1",
+            adapter: "cmd",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
         edges: {},
         contracts: {},
@@ -436,7 +539,9 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
     try {
       const r = renderWithClient(<InjectDialog onClose={() => {}} />);
       // Wait for template to appear
-      const templateChip = await r.findByRole("radio", { name: /worker\.started/i });
+      const templateChip = await r.findByRole("radio", {
+        name: /worker\.started/i,
+      });
       expect(templateChip).toBeTruthy();
 
       // Click worker.started template
@@ -445,12 +550,17 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
       });
       expect(templateChip.getAttribute("aria-checked")).toBe("true");
 
-      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const textarea = r.getByLabelText(
+        /event envelope json/i,
+      ) as HTMLTextAreaElement;
       expect(textarea.value).toContain('"worker.started"');
 
       // Edit textarea to simulate custom edits
       act(() => {
-        changeInput(textarea, '{\n  "custom": "value",\n  "type": "worker.started"\n}');
+        changeInput(
+          textarea,
+          '{\n  "custom": "value",\n  "type": "worker.started"\n}',
+        );
       });
       expect(textarea.value).toContain('"custom": "value"');
 
@@ -476,7 +586,9 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
       act(() => {
         changeInput(searchInput, "");
       });
-      const workerStoppedChip = r.getByRole("radio", { name: /worker\.stopped/i });
+      const workerStoppedChip = r.getByRole("radio", {
+        name: /worker\.stopped/i,
+      });
 
       // Explicitly clicking another template updates text
       act(() => {
@@ -546,7 +658,9 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
         act(() => {
           fireEvent.click(r.getByRole("tab", { name: /json/i }));
         });
-        const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+        const textarea = r.getByLabelText(
+          /event envelope json/i,
+        ) as HTMLTextAreaElement;
         const parsed = JSON.parse(textarea.value);
         delete parsed.eventId;
         act(() => {
@@ -572,7 +686,9 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
       await selectTemplate(r, /disk\.diagnose/i);
       expect(r.getByLabelText("usedPct")).toBeTruthy();
       await selectTemplate(r, /blank envelope/i);
-      expect(r.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+      expect(
+        r.getByRole("tab", { name: /json/i }).getAttribute("aria-selected"),
+      ).toBe("true");
       expect(r.queryAllByLabelText("usedPct")).toHaveLength(0);
       expect(r.queryAllByLabelText("mount")).toHaveLength(0);
     }));
@@ -588,11 +704,15 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
         occurredAt: "2026-01-01T00:00:00.000Z",
         payload: { repo: "factory" },
       };
-      const view = renderWithClient(<InjectDialog onClose={() => {}} initialEnvelope={given} />);
+      const view = renderWithClient(
+        <InjectDialog onClose={() => {}} initialEnvelope={given} />,
+      );
       await selectTemplate(view, /disk\.diagnose/i);
       expect(view.getByLabelText("usedPct")).toBeTruthy();
       await selectTemplate(view, /this envelope/i);
-      expect(view.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+      expect(
+        view.getByRole("tab", { name: /json/i }).getAttribute("aria-selected"),
+      ).toBe("true");
       expect(view.queryAllByLabelText("usedPct")).toHaveLength(0);
       expect(view.queryAllByLabelText("mount")).toHaveLength(0);
     }));
@@ -617,7 +737,9 @@ describe("InjectDialog humanized errors and hidden planner fields (WM-86)", () =
       act(() => {
         fireEvent.click(r.getByRole("tab", { name: /json/i }));
       });
-      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const textarea = r.getByLabelText(
+        /event envelope json/i,
+      ) as HTMLTextAreaElement;
       const parsed = JSON.parse(textarea.value);
       parsed.payload.repo = "factory";
       parsed.payload.repoPin = { repo: "factory", sha: "not-a-sha" };
@@ -644,7 +766,9 @@ describe("InjectDialog keyboard search (WM-80)", () => {
 
   test("ArrowDown from search focuses the first template result", () =>
     withSchemaApi(async (r) => {
-      const search = r.getByPlaceholderText(/search event types/i) as HTMLInputElement;
+      const search = r.getByPlaceholderText(
+        /search event types/i,
+      ) as HTMLInputElement;
       act(() => {
         search.focus();
       });
@@ -658,7 +782,9 @@ describe("InjectDialog keyboard search (WM-80)", () => {
 
   test("ArrowUp from the first template result returns focus to search", () =>
     withSchemaApi(async (r) => {
-      const search = r.getByPlaceholderText(/search event types/i) as HTMLInputElement;
+      const search = r.getByPlaceholderText(
+        /search event types/i,
+      ) as HTMLInputElement;
       act(() => {
         fireEvent.keyDown(search, { key: "ArrowDown" });
       });
@@ -689,7 +815,9 @@ describe("InjectDialog keyboard search (WM-80)", () => {
       act(() => {
         changeInput(search, "smoke");
       });
-      expect(r.getByText(/no templates or recent payloads matching "smoke"/i)).toBeTruthy();
+      expect(
+        r.getByText(/no templates or recent payloads matching "smoke"/i),
+      ).toBeTruthy();
     } finally {
       api.agents = origAgents;
       api.repos = origRepos;
@@ -708,7 +836,9 @@ describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {
         fireEvent.click(r.getByRole("button", { name: /inject/i }));
       });
       expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
-      expect(r.queryAllByRole("button", { name: /^confirm inject$/i })).toHaveLength(0);
+      expect(
+        r.queryAllByRole("button", { name: /^confirm inject$/i }),
+      ).toHaveLength(0);
     }));
 
   test("valid payload still confirms with Confirm inject", () =>
@@ -721,7 +851,9 @@ describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {
         fireEvent.click(r.getByRole("button", { name: /inject/i }));
       });
       expect(r.getByRole("button", { name: /^confirm inject$/i })).toBeTruthy();
-      expect(r.queryAllByRole("button", { name: /inject anyway/i })).toHaveLength(0);
+      expect(
+        r.queryAllByRole("button", { name: /inject anyway/i }),
+      ).toHaveLength(0);
     }));
 });
 
@@ -729,7 +861,11 @@ describe("InjectDialog last-used template (WM-81)", () => {
   test("preselects the last injected template on the next open; blank remains one click", () =>
     withSchemaApi(async (r) => {
       const origReplay = api.replay;
-      api.replay = async () => ({ admitted: true, duplicate: false, eventId: "e-last" });
+      api.replay = async () => ({
+        admitted: true,
+        duplicate: false,
+        eventId: "e-last",
+      });
       try {
         await selectTemplate(r, /disk\.diagnose/i);
         act(() => {
@@ -747,13 +883,21 @@ describe("InjectDialog last-used template (WM-81)", () => {
           name: (n) => n.includes("disk.diagnose") && n.includes("disk@1"),
         });
         expect(chip.getAttribute("aria-checked")).toBe("true");
-        expect(r2.getByRole("tab", { name: /form/i }).getAttribute("aria-selected")).toBe("true");
+        expect(
+          r2.getByRole("tab", { name: /form/i }).getAttribute("aria-selected"),
+        ).toBe("true");
         expect(r2.getByLabelText("usedPct")).toBeTruthy();
         act(() => {
           fireEvent.click(r2.getByRole("radio", { name: /blank envelope/i }));
         });
-        expect(r2.getByRole("radio", { name: /blank envelope/i }).getAttribute("aria-checked")).toBe("true");
-        expect(r2.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+        expect(
+          r2
+            .getByRole("radio", { name: /blank envelope/i })
+            .getAttribute("aria-checked"),
+        ).toBe("true");
+        expect(
+          r2.getByRole("tab", { name: /json/i }).getAttribute("aria-selected"),
+        ).toBe("true");
       } finally {
         api.replay = origReplay;
       }
@@ -785,9 +929,15 @@ describe("InjectDialog Inject-anyway banner regex sanitization (WM-179)", () => 
       act(() => {
         fireEvent.click(r.getByRole("tab", { name: /json/i }));
       });
-      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const textarea = r.getByLabelText(
+        /event envelope json/i,
+      ) as HTMLTextAreaElement;
       const parsed = JSON.parse(textarea.value);
-      parsed.payload = { repo: "watt-mind/factory", runId: 123, logArtifact: "invalid-log-artifact" };
+      parsed.payload = {
+        repo: "watt-mind/factory",
+        runId: 123,
+        logArtifact: "invalid-log-artifact",
+      };
       act(() => {
         changeInput(textarea, JSON.stringify(parsed, null, 2));
       });
@@ -808,14 +958,22 @@ describe("InjectDialog Inject-anyway banner regex sanitization (WM-179)", () => 
       act(() => {
         fireEvent.click(r.getByRole("tab", { name: /json/i }));
       });
-      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const textarea = r.getByLabelText(
+        /event envelope json/i,
+      ) as HTMLTextAreaElement;
       const parsed = JSON.parse(textarea.value);
-      parsed.payload = { repo: "watt-mind/factory", runId: 123, logArtifact: "invalid-log-artifact" };
+      parsed.payload = {
+        repo: "watt-mind/factory",
+        runId: 123,
+        logArtifact: "invalid-log-artifact",
+      };
       act(() => {
         changeInput(textarea, JSON.stringify(parsed, null, 2));
       });
       const liveWarning = r.container.textContent ?? "";
-      expect(liveWarning).toContain("payload does not validate against the registered input schema");
+      expect(liveWarning).toContain(
+        "payload does not validate against the registered input schema",
+      );
       expect(liveWarning).not.toMatch(/\^\[0-9a-f\]\{64\}/);
       expect(liveWarning).not.toContain("does not match pattern");
       expect(liveWarning).toMatch(/expected format/i);

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -9,7 +9,12 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { api } from "../api";
-import { buildTemplates, groupTemplates, triggerId, type TriggerTemplate } from "../templates";
+import {
+  buildTemplates,
+  groupTemplates,
+  triggerId,
+  type TriggerTemplate,
+} from "../templates";
 import { validate } from "../lib/schema";
 import {
   PLANNER_FIELDS,
@@ -62,7 +67,9 @@ export interface RecentAdmittedEvent {
 
 function getSessionStorage(): Storage | null {
   try {
-    return typeof window !== "undefined" && window.sessionStorage ? window.sessionStorage : null;
+    return typeof window !== "undefined" && window.sessionStorage
+      ? window.sessionStorage
+      : null;
   } catch {
     return null;
   }
@@ -70,7 +77,9 @@ function getSessionStorage(): Storage | null {
 
 function getLocalStorage(): Storage | null {
   try {
-    return typeof window !== "undefined" && window.localStorage ? window.localStorage : null;
+    return typeof window !== "undefined" && window.localStorage
+      ? window.localStorage
+      : null;
   } catch {
     return null;
   }
@@ -89,7 +98,9 @@ export function loadDraft(): InjectDraft | null {
         tab: parsed.tab === "form" ? "form" : "json",
         text: typeof parsed.text === "string" ? parsed.text : "",
         formBase: isPlainObject(parsed.formBase) ? parsed.formBase : {},
-        formPayload: isPlainObject(parsed.formPayload) ? parsed.formPayload : {},
+        formPayload: isPlainObject(parsed.formPayload)
+          ? parsed.formPayload
+          : {},
         subJson: isPlainObject(parsed.subJson) ? parsed.subJson : {},
       };
     }
@@ -133,7 +144,10 @@ export function loadRecentEvents(): RecentAdmittedEvent[] {
   }
 }
 
-export function saveRecentEvent(envelope: Record<string, unknown>, eventId: string): RecentAdmittedEvent[] {
+export function saveRecentEvent(
+  envelope: Record<string, unknown>,
+  eventId: string,
+): RecentAdmittedEvent[] {
   try {
     const storage = getLocalStorage();
     const prev = loadRecentEvents();
@@ -141,14 +155,17 @@ export function saveRecentEvent(envelope: Record<string, unknown>, eventId: stri
     const newEntry: RecentAdmittedEvent = {
       eventId,
       type,
-      occurredAt: typeof envelope.occurredAt === "string" ? envelope.occurredAt : undefined,
+      occurredAt:
+        typeof envelope.occurredAt === "string"
+          ? envelope.occurredAt
+          : undefined,
       admittedAt: Date.now(),
       envelope: { ...envelope, eventId },
     };
-    const next = [
-      newEntry,
-      ...prev.filter((p) => p.eventId !== eventId),
-    ].slice(0, MAX_RECENT_EVENTS);
+    const next = [newEntry, ...prev.filter((p) => p.eventId !== eventId)].slice(
+      0,
+      MAX_RECENT_EVENTS,
+    );
     if (storage) {
       storage.setItem(INJECT_RECENT_STORAGE_KEY, JSON.stringify(next));
     }
@@ -195,11 +212,18 @@ export function saveLastTemplate(eventType: string | null) {
 function summarizePayload(env: Record<string, unknown> | undefined): string {
   if (!env || !isPlainObject(env.payload)) return "no payload";
   const payload = env.payload as Record<string, unknown>;
-  const entries = Object.entries(payload).filter(([, v]) => v !== undefined && v !== "");
+  const entries = Object.entries(payload).filter(
+    ([, v]) => v !== undefined && v !== "",
+  );
   if (entries.length === 0) return "empty payload";
   if (typeof payload.repo === "string") return `repo: ${payload.repo}`;
   if (typeof payload.host === "string") return `host: ${payload.host}`;
-  return entries.map(([k]) => k).slice(0, 3).join(", ") + (entries.length > 3 ? "…" : "");
+  return (
+    entries
+      .map(([k]) => k)
+      .slice(0, 3)
+      .join(", ") + (entries.length > 3 ? "…" : "")
+  );
 }
 
 /** Blank slate for an unregistered/hand-written envelope (the escape hatch). */
@@ -222,7 +246,10 @@ const pretty = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   !!v && typeof v === "object" && !Array.isArray(v);
 
-function omitKey(obj: Record<string, unknown>, key: string): Record<string, unknown> {
+function omitKey(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
   const next = { ...obj };
   delete next[key];
   return next;
@@ -249,14 +276,26 @@ export function jsonEnvelopeStatus(raw: string): JsonEnvelopeStatus {
   try {
     value = JSON.parse(raw);
   } catch {
-    return { syntaxValid: false, envelopeValid: false, label: "Invalid JSON syntax" };
+    return {
+      syntaxValid: false,
+      envelopeValid: false,
+      label: "Invalid JSON syntax",
+    };
   }
   if (!isPlainObject(value)) {
-    return { syntaxValid: true, envelopeValid: false, label: "JSON ok · envelope must be an object" };
+    return {
+      syntaxValid: true,
+      envelopeValid: false,
+      label: "JSON ok · envelope must be an object",
+    };
   }
   for (const field of ["type", "source", "subject"] as const) {
     if (typeof value[field] !== "string" || value[field].trim() === "") {
-      return { syntaxValid: true, envelopeValid: false, label: `JSON ok · ${field} missing` };
+      return {
+        syntaxValid: true,
+        envelopeValid: false,
+        label: `JSON ok · ${field} missing`,
+      };
     }
   }
   return { syntaxValid: true, envelopeValid: true, label: "Valid JSON" };
@@ -272,7 +311,10 @@ const inputCls =
 
 type EditorTab = "form" | "json";
 
-export function humanizeSchemaErrors(errs: string[], fields?: FieldSpec[] | null): string[] {
+export function humanizeSchemaErrors(
+  errs: string[],
+  fields?: FieldSpec[] | null,
+): string[] {
   const byName = new Map((fields ?? []).map((f) => [f.name, f]));
   return errs.map((err) => {
     if (!/does not match pattern/.test(err)) return err;
@@ -282,7 +324,8 @@ export function humanizeSchemaErrors(errs: string[], fields?: FieldSpec[] | null
       const subpath = fielded[2] ?? "";
       const message = fielded[3];
       const spec = byName.get(name);
-      const example = !subpath && spec ? placeholderFor(name, spec.schema) : null;
+      const example =
+        !subpath && spec ? placeholderFor(name, spec.schema) : null;
       const hint = example ? ` (e.g. ${example})` : "";
       const humanizedMsg = message.replace(
         /does not match pattern[\s\S]*$/,
@@ -290,10 +333,12 @@ export function humanizeSchemaErrors(errs: string[], fields?: FieldSpec[] | null
       );
       return `$.${name}${subpath}: ${humanizedMsg}`;
     }
-    return err.replace(/does not match pattern[\s\S]*$/, "does not match expected format");
+    return err.replace(
+      /does not match pattern[\s\S]*$/,
+      "does not match expected format",
+    );
   });
 }
-
 
 /**
  * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230,
@@ -332,11 +377,19 @@ export function InjectDialog({
   const repoItems = reposQ.data?.repos ?? [];
 
   const openedAt = useMemo(() => Date.now(), []);
-  const initialDraft = useMemo(() => (initialEnvelope ? null : loadDraft()), [initialEnvelope]);
-  const [recentEvents, setRecentEvents] = useState<RecentAdmittedEvent[]>(() => loadRecentEvents());
+  const initialDraft = useMemo(
+    () => (initialEnvelope ? null : loadDraft()),
+    [initialEnvelope],
+  );
+  const [recentEvents, setRecentEvents] = useState<RecentAdmittedEvent[]>(() =>
+    loadRecentEvents(),
+  );
   const submittedRef = useRef(false);
 
-  const templates = useMemo(() => buildTemplates(registryView, openedAt), [registryView, openedAt]);
+  const templates = useMemo(
+    () => buildTemplates(registryView, openedAt),
+    [registryView, openedAt],
+  );
 
   const [search, setSearch] = useState("");
   const lastTemplateRef = useRef(false);
@@ -370,10 +423,12 @@ export function InjectDialog({
     if (initialDraft?.formBase) return initialDraft.formBase;
     return {};
   });
-  const [formPayload, setFormPayload] = useState<Record<string, unknown>>(() => {
-    if (initialDraft?.formPayload) return initialDraft.formPayload;
-    return {};
-  });
+  const [formPayload, setFormPayload] = useState<Record<string, unknown>>(
+    () => {
+      if (initialDraft?.formPayload) return initialDraft.formPayload;
+      return {};
+    },
+  );
   const [subJson, setSubJson] = useState<Record<string, string>>(() => {
     if (initialDraft?.subJson) return initialDraft.subJson;
     return {};
@@ -404,7 +459,8 @@ export function InjectDialog({
       if (r.eventId?.toLowerCase().includes(q)) return true;
       if (r.envelope && isPlainObject(r.envelope.payload)) {
         try {
-          if (JSON.stringify(r.envelope.payload).toLowerCase().includes(q)) return true;
+          if (JSON.stringify(r.envelope.payload).toLowerCase().includes(q))
+            return true;
         } catch {}
       }
       return false;
@@ -421,7 +477,10 @@ export function InjectDialog({
         (t.summary?.toLowerCase().includes(q) ?? false),
     );
   }, [templates, search]);
-  const groupedTemplates = useMemo(() => groupTemplates(filteredTemplates), [filteredTemplates]);
+  const groupedTemplates = useMemo(
+    () => groupTemplates(filteredTemplates),
+    [filteredTemplates],
+  );
 
   const inject = useMutation({
     mutationFn: (envelope: Record<string, unknown>) => api.replay(envelope),
@@ -429,10 +488,13 @@ export function InjectDialog({
       queryClient.invalidateQueries();
       setConfirming(false);
       notify(
-        data.duplicate ? `Duplicate event ${data.eventId}` : `Admitted event ${data.eventId}`,
+        data.duplicate
+          ? `Duplicate event ${data.eventId}`
+          : `Admitted event ${data.eventId}`,
         data.duplicate ? "info" : "ok",
       );
-      const source = typeof envelope.source === "string" ? envelope.source : "web-trigger";
+      const source =
+        typeof envelope.source === "string" ? envelope.source : "web-trigger";
       if (!data.duplicate) {
         const updated = saveRecentEvent(envelope, data.eventId);
         setRecentEvents(updated);
@@ -452,14 +514,18 @@ export function InjectDialog({
     return isPlainObject(s) ? s : null;
   }
 
-  function initFormFromEnvelope(env: Record<string, unknown>, fields: FieldSpec[] | null) {
+  function initFormFromEnvelope(
+    env: Record<string, unknown>,
+    fields: FieldSpec[] | null,
+  ) {
     const { payload, ...base } = env;
     const pay = isPlainObject(payload) ? { ...payload } : {};
     setFormBase(base);
     setFormPayload(pay);
     const sub: Record<string, string> = {};
     for (const f of fields ?? []) {
-      if (f.kind === "json") sub[f.name] = f.name in pay ? JSON.stringify(pay[f.name], null, 2) : "";
+      if (f.kind === "json")
+        sub[f.name] = f.name in pay ? JSON.stringify(pay[f.name], null, 2) : "";
     }
     setSubJson(sub);
     setTouched({});
@@ -520,7 +586,8 @@ export function InjectDialog({
       return;
     }
     if (next === "__given__" && initialEnvelope) {
-      const type = typeof initialEnvelope.type === "string" ? initialEnvelope.type : "";
+      const type =
+        typeof initialEnvelope.type === "string" ? initialEnvelope.type : "";
       setSelected("__given__");
       setText(pretty(initialEnvelope));
       initFormFromEnvelope(initialEnvelope, schemaFields(schemaFor(type)));
@@ -532,7 +599,9 @@ export function InjectDialog({
     }
     if (next.startsWith("__recent_")) {
       const eventId = next.slice("__recent_".length, -2);
-      const item = recentEvents.find((x) => x.eventId === eventId) ?? filteredRecent.find((x) => x.eventId === eventId);
+      const item =
+        recentEvents.find((x) => x.eventId === eventId) ??
+        filteredRecent.find((x) => x.eventId === eventId);
       if (item) {
         chooseRecent(item);
         return;
@@ -556,7 +625,9 @@ export function InjectDialog({
     return [
       ...(initialEnvelope ? ["__given__"] : []),
       ...filteredRecent.map((r) => `__recent_${r.eventId}__`),
-      ...groupedTemplates.flatMap((group) => group.templates.map((t) => t.eventType)),
+      ...groupedTemplates.flatMap((group) =>
+        group.templates.map((t) => t.eventType),
+      ),
       null,
     ];
   }
@@ -575,16 +646,23 @@ export function InjectDialog({
   function onTemplateKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
     const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
     if (!keys.includes(e.key)) return;
-    if (!(e.target instanceof HTMLElement) || e.target.getAttribute("role") !== "radio") return;
+    if (
+      !(e.target instanceof HTMLElement) ||
+      e.target.getAttribute("role") !== "radio"
+    )
+      return;
     e.preventDefault();
-    const radios = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'));
+    const radios = Array.from(
+      e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'),
+    );
     const idx = radios.indexOf(e.target);
     if (e.key === "ArrowUp" && idx === 0) {
       searchRef.current?.focus();
       return;
     }
     const ids = templateIds();
-    const selectedIdx = checkedId === null ? ids.length - 1 : Math.max(ids.indexOf(checkedId), 0);
+    const selectedIdx =
+      checkedId === null ? ids.length - 1 : Math.max(ids.indexOf(checkedId), 0);
     const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
     const nextIdx = (selectedIdx + delta + ids.length) % ids.length;
     applySelection(ids[nextIdx]);
@@ -599,7 +677,10 @@ export function InjectDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- schemaFor reads registryView
     [formBase, registryView],
   );
-  const formFields = useMemo(() => schemaFields(formSchema) ?? [], [formSchema]);
+  const formFields = useMemo(
+    () => schemaFields(formSchema) ?? [],
+    [formSchema],
+  );
   const requiredFields = formFields.filter((f) => f.required);
   const optionalFields = formFields.filter((f) => !f.required);
 
@@ -609,14 +690,20 @@ export function InjectDialog({
   );
 
   const formValidation = useMemo(
-    () => (formSchema ? validate(formSchema, formPayload) : { valid: true, errors: [] as string[] }),
+    () =>
+      formSchema
+        ? validate(formSchema, formPayload)
+        : { valid: true, errors: [] as string[] },
     [formSchema, formPayload],
   );
   const fieldErrors = useMemo(
     () => errorsByField(formValidation.errors, formFields),
     [formValidation, formFields],
   );
-  const knownNames = useMemo(() => new Set(formFields.map((f) => f.name)), [formFields]);
+  const knownNames = useMemo(
+    () => new Set(formFields.map((f) => f.name)),
+    [formFields],
+  );
   const formLevelErrors = useMemo(() => {
     const out: string[] = [];
     for (const [k, msgs] of fieldErrors) {
@@ -637,7 +724,9 @@ export function InjectDialog({
   const invalidSubs = formFields
     .filter((f) => f.kind === "json")
     .map((f) => f.name)
-    .filter((name) => (subJson[name] ?? "").trim() !== "" && !parses(subJson[name]));
+    .filter(
+      (name) => (subJson[name] ?? "").trim() !== "" && !parses(subJson[name]),
+    );
 
   function setField(name: string, v: unknown) {
     setFormPayload((p) => ({ ...p, [name]: v }));
@@ -663,11 +752,15 @@ export function InjectDialog({
    * `disabled` marks identity-level impossibility (no schema to render);
    * a `reason` with disabled=false is a fixable state (bad JSON, odd payload).
    */
-  const formAvailability = useMemo((): { disabled: boolean; reason: string | null } => {
+  const formAvailability = useMemo((): {
+    disabled: boolean;
+    reason: string | null;
+  } => {
     if (checkedId === "__given__") {
       return {
         disabled: true,
-        reason: "Trigger again re-sends the captured envelope as-is — no schema to render.",
+        reason:
+          "Trigger again re-sends the captured envelope as-is — no schema to render.",
       };
     }
     let env: unknown;
@@ -682,7 +775,8 @@ export function InjectDialog({
     if (!isPlainObject(env)) {
       return {
         disabled: false,
-        reason: "the envelope must be a JSON object — fix it or reselect a template to revert",
+        reason:
+          "the envelope must be a JSON object — fix it or reselect a template to revert",
       };
     }
     const type = typeof env.type === "string" ? env.type : "";
@@ -696,7 +790,8 @@ export function InjectDialog({
     if (env.payload !== undefined && !isPlainObject(env.payload)) {
       return {
         disabled: false,
-        reason: "payload is not a JSON object, which the form cannot represent — fix it or reselect a template to revert",
+        reason:
+          "payload is not a JSON object, which the form cannot represent — fix it or reselect a template to revert",
       };
     }
     return { disabled: false, reason: null };
@@ -722,7 +817,10 @@ export function InjectDialog({
       return;
     }
     const env = JSON.parse(text) as Record<string, unknown>;
-    initFormFromEnvelope(env, schemaFields(schemaFor(typeof env.type === "string" ? env.type : "")));
+    initFormFromEnvelope(
+      env,
+      schemaFields(schemaFor(typeof env.type === "string" ? env.type : "")),
+    );
     setTab("form");
     setTabNotice(null);
   }
@@ -748,7 +846,9 @@ export function InjectDialog({
     if (errs.length === 0 || schemaAck) return false;
     const fields = schemaFields(schemaFor(type));
     const humanized = humanizeSchemaErrors(errs, fields);
-    const summary = humanized.slice(0, 3).join("; ") + (humanized.length > 3 ? ` (+${humanized.length - 3} more)` : "");
+    const summary =
+      humanized.slice(0, 3).join("; ") +
+      (humanized.length > 3 ? ` (+${humanized.length - 3} more)` : "");
     setClientError(
       `payload does not validate against the "${type}" input schema: ${summary}. Intake will admit it, but planning will park it human_needed. Inject anyway to proceed.`,
     );
@@ -765,9 +865,13 @@ export function InjectDialog({
       setConfirming(false);
       return;
     }
-    const missing = REQUIRED.filter((k) => typeof formEnvelope[k] !== "string" || !formEnvelope[k]);
+    const missing = REQUIRED.filter(
+      (k) => typeof formEnvelope[k] !== "string" || !formEnvelope[k],
+    );
     if (missing.length) {
-      setClientError(`missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`);
+      setClientError(
+        `missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`,
+      );
       setConfirming(false);
       return;
     }
@@ -790,13 +894,18 @@ export function InjectDialog({
       setConfirming(false);
       return;
     }
-    const missing = REQUIRED.filter((k) => typeof envelope[k] !== "string" || !envelope[k]);
+    const missing = REQUIRED.filter(
+      (k) => typeof envelope[k] !== "string" || !envelope[k],
+    );
     if (missing.length) {
-      setClientError(`missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`);
+      setClientError(
+        `missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`,
+      );
       setConfirming(false);
       return;
     }
-    const registered = registryView?.eventTypes.some((r) => r.type === envelope.type) ?? true;
+    const registered =
+      registryView?.eventTypes.some((r) => r.type === envelope.type) ?? true;
     if (!registered && !unregisteredAck) {
       setClientError(
         `"${envelope.type}" is not a registered event type — it will be admitted, but planning will park it as human_needed. Confirm inject to proceed.`,
@@ -835,7 +944,11 @@ export function InjectDialog({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "f" || e.key === "F")) {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        (e.key === "f" || e.key === "F")
+      ) {
         if (tabRef.current !== "json") return;
         e.preventDefault();
         formatJsonRef.current();
@@ -875,14 +988,19 @@ export function InjectDialog({
   function renderField(f: FieldSpec) {
     const fid = `${fieldIdBase}-${f.name}`;
     const value = formPayload[f.name];
-    const errs =
-      fieldErrorVisible(f.name, touched, submitAttempted) ? (fieldErrors.get(f.name) ?? []) : [];
+    const errs = fieldErrorVisible(f.name, touched, submitAttempted)
+      ? (fieldErrors.get(f.name) ?? [])
+      : [];
     const suggestions = repoSuggestions(f.name, f.schema, f.kind, repoItems);
 
     let control: React.ReactNode;
     switch (f.kind) {
       case "const":
-        control = <Pill title="Fixed by the schema">{JSON.stringify(f.schema.const)}</Pill>;
+        control = (
+          <Pill title="Fixed by the schema">
+            {JSON.stringify(f.schema.const)}
+          </Pill>
+        );
         break;
       case "enum": {
         const options = (f.schema.enum as unknown[]) ?? [];
@@ -893,7 +1011,8 @@ export function InjectDialog({
             onChange={(e) => {
               const raw = e.target.value;
               if (raw === "" && !f.required) clearField(f.name);
-              else setField(f.name, options.find((o) => String(o) === raw) ?? raw);
+              else
+                setField(f.name, options.find((o) => String(o) === raw) ?? raw);
             }}
             className={inputCls}
           >
@@ -924,11 +1043,31 @@ export function InjectDialog({
             id={fid}
             type="number"
             step="any"
-            min={typeof f.schema.minimum === "number" ? f.schema.minimum : undefined}
-            max={typeof f.schema.maximum === "number" ? f.schema.maximum : undefined}
-            aria-valuemin={typeof f.schema.minimum === "number" ? f.schema.minimum : undefined}
-            aria-valuemax={typeof f.schema.maximum === "number" ? f.schema.maximum : undefined}
-            value={typeof value === "number" || typeof value === "string" ? String(value) : ""}
+            min={
+              typeof f.schema.minimum === "number"
+                ? f.schema.minimum
+                : undefined
+            }
+            max={
+              typeof f.schema.maximum === "number"
+                ? f.schema.maximum
+                : undefined
+            }
+            aria-valuemin={
+              typeof f.schema.minimum === "number"
+                ? f.schema.minimum
+                : undefined
+            }
+            aria-valuemax={
+              typeof f.schema.maximum === "number"
+                ? f.schema.maximum
+                : undefined
+            }
+            value={
+              typeof value === "number" || typeof value === "string"
+                ? String(value)
+                : ""
+            }
             onChange={(e) => {
               const raw = e.target.value;
               if (raw === "") clearField(f.name);
@@ -956,7 +1095,8 @@ export function InjectDialog({
         break;
       case "json": {
         const raw = subJson[f.name] ?? "";
-        const state = raw.trim() === "" ? "empty" : parses(raw) ? "valid" : "invalid";
+        const state =
+          raw.trim() === "" ? "empty" : parses(raw) ? "valid" : "invalid";
         control = (
           <>
             <textarea
@@ -973,12 +1113,18 @@ export function InjectDialog({
                 className="size-1.5 rounded-full"
                 style={{
                   background:
-                    state === "invalid" ? "var(--hue-err)" : state === "valid" ? "var(--hue-ok)" : "var(--hue-idle)",
+                    state === "invalid"
+                      ? "var(--hue-err)"
+                      : state === "valid"
+                        ? "var(--hue-ok)"
+                        : "var(--hue-idle)",
                 }}
               />
               <span
                 className="text-(--text-faint)"
-                style={state === "invalid" ? { color: "var(--hue-err)" } : undefined}
+                style={
+                  state === "invalid" ? { color: "var(--hue-err)" } : undefined
+                }
               >
                 {state === "invalid"
                   ? "Invalid JSON — fix before injecting"
@@ -997,7 +1143,13 @@ export function InjectDialog({
         control = (
           <SuggestInput
             id={fid}
-            value={typeof value === "string" ? value : value === undefined ? "" : String(value)}
+            value={
+              typeof value === "string"
+                ? value
+                : value === undefined
+                  ? ""
+                  : String(value)
+            }
             onChange={(v) => {
               if (v === "" && !f.required) clearField(f.name);
               else setField(f.name, v);
@@ -1012,7 +1164,9 @@ export function InjectDialog({
       <div
         key={f.name}
         className="mb-2.5 last:mb-0"
-        onBlur={() => setTouched((t) => (t[f.name] ? t : { ...t, [f.name]: true }))}
+        onBlur={() =>
+          setTouched((t) => (t[f.name] ? t : { ...t, [f.name]: true }))
+        }
       >
         <div className="mb-0.5 flex items-center gap-2">
           <label
@@ -1021,7 +1175,9 @@ export function InjectDialog({
           >
             {f.name}
           </label>
-          {f.required && <span className="text-[10px] text-(--text-faint)">required</span>}
+          {f.required && (
+            <span className="text-[10px] text-(--text-faint)">required</span>
+          )}
           <span className="flex-1" />
           {f.kind === "string" && isAtField(f.name) && (
             <button
@@ -1044,10 +1200,18 @@ export function InjectDialog({
             </button>
           )}
         </div>
-        {f.description && <div className="mb-1 text-[10px] text-(--text-faint)">{f.description}</div>}
+        {f.description && (
+          <div className="mb-1 text-[10px] text-(--text-faint)">
+            {f.description}
+          </div>
+        )}
         {control}
         {errs.map((e, i) => (
-          <div key={i} className="mt-0.5 text-[11px]" style={{ color: "var(--hue-err)" }}>
+          <div
+            key={i}
+            className="mt-0.5 text-[11px]"
+            style={{ color: "var(--hue-err)" }}
+          >
             {e}
           </div>
         ))}
@@ -1059,7 +1223,9 @@ export function InjectDialog({
   const seeded = Boolean(initialEnvelope);
   return (
     <Dialog
-      title={seeded ? "Trigger again — inject with a fresh event id" : "Inject event"}
+      title={
+        seeded ? "Trigger again — inject with a fresh event id" : "Inject event"
+      }
       onClose={onClose}
       extraWide
     >
@@ -1082,7 +1248,8 @@ export function InjectDialog({
               onChange={(e) => setSearch(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key !== "ArrowDown") return;
-                const first = listRef.current?.querySelector<HTMLElement>('[role="radio"]');
+                const first =
+                  listRef.current?.querySelector<HTMLElement>('[role="radio"]');
                 if (!first) return;
                 e.preventDefault();
                 first.focus();
@@ -1092,7 +1259,9 @@ export function InjectDialog({
           </div>
 
           {registry.isPending && !registryView && (
-            <div className="py-2 text-[12px] text-(--text-faint)">Loading templates…</div>
+            <div className="py-2 text-[12px] text-(--text-faint)">
+              Loading templates…
+            </div>
           )}
           {registry.isError && !registryView && (
             <div className="py-2 text-[12px] text-(--text-faint)">
@@ -1119,7 +1288,9 @@ export function InjectDialog({
                 }`}
               >
                 <div className="font-medium text-[12px]">this envelope</div>
-                <div className="text-[11px] text-(--text-faint) truncate">original triggering payload</div>
+                <div className="text-[11px] text-(--text-faint) truncate">
+                  original triggering payload
+                </div>
               </button>
             )}
 
@@ -1144,10 +1315,14 @@ export function InjectDialog({
                             : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
                         }`}
                       >
-                        <div className="mono font-medium text-[12px] truncate">{r.type || "untyped event"}</div>
+                        <div className="mono font-medium text-[12px] truncate">
+                          {r.type || "untyped event"}
+                        </div>
                         <div className="mt-0.5 flex items-center justify-between text-[11px] text-(--text-faint)">
                           <span className="truncate">recent</span>
-                          <span className="ml-1 shrink-0 opacity-75">{summary}</span>
+                          <span className="ml-1 shrink-0 opacity-75">
+                            {summary}
+                          </span>
                         </div>
                       </button>
                     );
@@ -1184,10 +1359,17 @@ export function InjectDialog({
                                   : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
                               }`}
                             >
-                              <div className="mono truncate text-[12px] font-medium">{t.eventType}</div>
+                              <div className="mono truncate text-[12px] font-medium">
+                                {t.eventType}
+                              </div>
                               <div className="mt-0.5 flex min-w-0 items-center justify-between text-[11px] text-(--text-faint)">
-                                <span className="min-w-0 truncate">{t.agent}</span>
-                                <span title={summary} className="ml-1 min-w-0 max-w-[55%] truncate opacity-75">
+                                <span className="min-w-0 truncate">
+                                  {t.agent}
+                                </span>
+                                <span
+                                  title={summary}
+                                  className="ml-1 min-w-0 max-w-[55%] truncate opacity-75"
+                                >
                                   {summary}
                                 </span>
                               </div>
@@ -1201,11 +1383,13 @@ export function InjectDialog({
               </div>
             )}
 
-            {filteredTemplates.length === 0 && filteredRecent.length === 0 && search && (
-              <div className="py-3 text-center text-[12px] text-(--text-faint)">
-                No templates or recent payloads matching &quot;{search}&quot;
-              </div>
-            )}
+            {filteredTemplates.length === 0 &&
+              filteredRecent.length === 0 &&
+              search && (
+                <div className="py-3 text-center text-[12px] text-(--text-faint)">
+                  No templates or recent payloads matching &quot;{search}&quot;
+                </div>
+              )}
 
             <button
               type="button"
@@ -1218,7 +1402,9 @@ export function InjectDialog({
               }`}
             >
               <div className="font-medium text-[12px]">blank envelope</div>
-              <div className="text-[11px] text-(--text-faint)">empty starter envelope</div>
+              <div className="text-[11px] text-(--text-faint)">
+                empty starter envelope
+              </div>
             </button>
           </div>
         </div>
@@ -1255,9 +1441,10 @@ export function InjectDialog({
                   />
                   <span
                     style={{
-                      color: jsonStatus.envelopeValid || !jsonStatus.syntaxValid
-                        ? "var(--text-faint)"
-                        : "var(--text-muted, var(--text-faint))",
+                      color:
+                        jsonStatus.envelopeValid || !jsonStatus.syntaxValid
+                          ? "var(--text-faint)"
+                          : "var(--text-muted, var(--text-faint))",
                     }}
                   >
                     {jsonStatus.label}
@@ -1269,14 +1456,23 @@ export function InjectDialog({
                   className="text-[11px] text-(--text-dim) hover:text-(--accent)"
                   title="Format JSON (⌘⇧F)"
                 >
-                  Format JSON <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">⌘⇧F</span>
+                  Format JSON{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    ⌘⇧F
+                  </span>
                 </button>
               </div>
             )}
           </div>
 
           {tabNotice && (
-            <div className="mb-2 rounded-md px-2.5 py-1.5 text-[12px]" style={warnStyle}>
+            <div
+              className="mb-2 rounded-md px-2.5 py-1.5 text-[12px]"
+              style={warnStyle}
+            >
               {tabNotice}
             </div>
           )}
@@ -1285,15 +1481,17 @@ export function InjectDialog({
           <div hidden={tab !== "form"}>
             {formFields.length === 0 ? (
               <div className="rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] text-(--text-faint)">
-                {String(formBase.type ?? "this event type")} takes no payload fields — inject as-is, or switch to
-                the JSON tab.
+                {String(formBase.type ?? "this event type")} takes no payload
+                fields — inject as-is, or switch to the JSON tab.
               </div>
             ) : (
               <div className="max-h-[340px] overflow-y-auto rounded-md border border-(--border) bg-(--surface-0) p-3">
                 {requiredFields.map(renderField)}
                 {optionalFields.length > 0 && (
                   <div className="mt-2 border-t border-(--border) pt-2">
-                    <Disclosure label={`Optional fields (${optionalFields.length})`}>
+                    <Disclosure
+                      label={`Optional fields (${optionalFields.length})`}
+                    >
                       {optionalFields.map(renderField)}
                     </Disclosure>
                   </div>
@@ -1302,13 +1500,21 @@ export function InjectDialog({
             )}
 
             {unknown.length > 0 && (
-              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
-                Unknown payload key{unknown.length > 1 ? "s" : ""} kept: {unknown.join(", ")} — the schema does
-                not declare {unknown.length > 1 ? "them" : "it"}; edit or remove in the JSON tab.
+              <div
+                className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]"
+                style={warnStyle}
+              >
+                Unknown payload key{unknown.length > 1 ? "s" : ""} kept:{" "}
+                {unknown.join(", ")} — the schema does not declare{" "}
+                {unknown.length > 1 ? "them" : "it"}; edit or remove in the JSON
+                tab.
               </div>
             )}
             {formLevelErrors.length > 0 && (
-              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
+              <div
+                className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]"
+                style={warnStyle}
+              >
                 {formLevelErrors.map((e, i) => (
                   <div key={i}>{e}</div>
                 ))}
@@ -1336,17 +1542,23 @@ export function InjectDialog({
               className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] leading-relaxed text-(--text) outline-none focus:border-(--border-strong)"
             />
             {jsonSchemaErrors.length > 0 && (
-              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
+              <div
+                className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]"
+                style={warnStyle}
+              >
                 <div className="mb-0.5 font-medium">
-                  payload does not validate against the registered input schema (
-                  {jsonSchemaErrors.length} issue{jsonSchemaErrors.length > 1 ? "s" : ""}):
+                  payload does not validate against the registered input schema
+                  ({jsonSchemaErrors.length} issue
+                  {jsonSchemaErrors.length > 1 ? "s" : ""}):
                 </div>
                 {jsonSchemaErrors.slice(0, 6).map((e, i) => (
                   <div key={i} className="mono">
                     {e}
                   </div>
                 ))}
-                {jsonSchemaErrors.length > 6 && <div>… and {jsonSchemaErrors.length - 6} more</div>}
+                {jsonSchemaErrors.length > 6 && (
+                  <div>… and {jsonSchemaErrors.length - 6} more</div>
+                )}
               </div>
             )}
           </div>
@@ -1369,8 +1581,9 @@ export function InjectDialog({
 
           {confirming && !outcome && (
             <div className="mt-2 text-[12px] text-(--text-dim)">
-              Confirm sends this envelope through intake. A known event id is reported as a duplicate and
-              does nothing — that is Replay&apos;s demo, not a new event. Use Trigger again for a fresh id.
+              Confirm sends this envelope through intake. A known event id is
+              reported as a duplicate and does nothing — that is Replay&apos;s
+              demo, not a new event. Use Trigger again for a fresh id.
             </div>
           )}
 
@@ -1389,8 +1602,18 @@ export function InjectDialog({
                 </Button>
               </>
             ) : (
-              <Button variant="primary" onClick={submit} disabled={inject.isPending}>
-                Inject… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">⌘↵</span>
+              <Button
+                variant="primary"
+                onClick={submit}
+                disabled={inject.isPending}
+              >
+                Inject…{" "}
+                <span
+                  className="mono ml-1 text-(--text-faint)"
+                  aria-hidden="true"
+                >
+                  ⌘↵
+                </span>
               </Button>
             )}
           </div>

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -5,8 +5,18 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { api } from "../api";
 import { ARTIFACT_RAW_KEY } from "./ArtifactView";
-import { RunDetailBlocks, eventTicket, isCancellable, modelTierText, pinnedModelText } from "./RunDetailBlocks";
-import { TicketDecisions, buildTicketDecisions, decisionHeadline } from "./TicketDecisions";
+import {
+  RunDetailBlocks,
+  eventTicket,
+  isCancellable,
+  modelTierText,
+  pinnedModelText,
+} from "./RunDetailBlocks";
+import {
+  TicketDecisions,
+  buildTicketDecisions,
+  decisionHeadline,
+} from "./TicketDecisions";
 import {
   createAgentsFixture,
   createEventFixture,
@@ -28,7 +38,10 @@ afterEach(() => {
 
 const noop = () => {};
 
-function renderBlocks(d: RunDetail, overrides?: Partial<Parameters<typeof RunDetailBlocks>[0]>) {
+function renderBlocks(
+  d: RunDetail,
+  overrides?: Partial<Parameters<typeof RunDetailBlocks>[0]>,
+) {
   return renderWithClient(
     <RunDetailBlocks
       d={d}
@@ -55,7 +68,9 @@ function detailWith(state: RunState, input: unknown): RunDetail {
 
 describe("RunDetailBlocks field tiering (WM-129)", () => {
   test("promotes flat spec.input keys to first-class glance rows", () => {
-    const r = renderBlocks(detailWith("RUNNING", { repo: "factory", ticket: "WM-64" }));
+    const r = renderBlocks(
+      detailWith("RUNNING", { repo: "factory", ticket: "WM-64" }),
+    );
     expect(r.getByText("input.repo")).toBeTruthy();
     expect(r.getByText("factory")).toBeTruthy();
     expect(r.getByText("input.ticket")).toBeTruthy();
@@ -72,27 +87,44 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
   });
 
   test("demotes ids, hashes, and paths into a collapsed internals disclosure", () => {
-    const d = createRunDetailFixture({ workspace: "/tmp/workspaces/run_test_1001" });
+    const d = createRunDetailFixture({
+      workspace: "/tmp/workspaces/run_test_1001",
+    });
     const r = renderBlocks(d);
     const details = Array.from(r.container.querySelectorAll("details"));
-    const internals = details.find((el) => el.textContent?.includes("internals"));
+    const internals = details.find((el) =>
+      el.textContent?.includes("internals"),
+    );
     expect(internals).toBeTruthy();
     expect(internals!.open).toBe(false);
     // The demoted rows live inside that disclosure, not on the glance tier.
     // Scoped to the disclosure: labels like `workspace` also appear on the
     // attempt cards, so a document-wide query would match more than one.
-    for (const key of ["idempotencyKey", "specHash", "inputHash", "workspace", "promptVersion", "policyVersion"]) {
-      const labels = Array.from(internals!.querySelectorAll("span")).filter((s) => s.textContent === key);
+    for (const key of [
+      "idempotencyKey",
+      "specHash",
+      "inputHash",
+      "workspace",
+      "promptVersion",
+      "policyVersion",
+    ]) {
+      const labels = Array.from(internals!.querySelectorAll("span")).filter(
+        (s) => s.textContent === key,
+      );
       expect(labels.length).toBe(1);
     }
     // The RunSpec ground truth stays, collapsed.
-    const spec = details.find((el) => el.textContent?.includes("immutable RunSpec"));
+    const spec = details.find((el) =>
+      el.textContent?.includes("immutable RunSpec"),
+    );
     expect(spec).toBeTruthy();
     expect(spec!.open).toBe(false);
   });
 
   test("shows the Deadlines clocks for an in-flight run and hides them for a terminal one", () => {
-    const running = renderBlocks(createRunDetailFixture({ run: { state: "RUNNING" } as RunDetail["run"] }));
+    const running = renderBlocks(
+      createRunDetailFixture({ run: { state: "RUNNING" } as RunDetail["run"] }),
+    );
     expect(running.getByText("Deadlines")).toBeTruthy();
     expect(running.getByText("lease owner")).toBeTruthy();
     cleanup();
@@ -107,7 +139,9 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
 
   test("shows active attempt and lease clocks while a run is VERIFYING (WM-249)", () => {
     const verifying = renderBlocks(
-      createRunDetailFixture({ run: { state: "VERIFYING" } as RunDetail["run"] }),
+      createRunDetailFixture({
+        run: { state: "VERIFYING" } as RunDetail["run"],
+      }),
     );
 
     expect(verifying.getByText("Deadlines")).toBeTruthy();
@@ -140,10 +174,20 @@ describe("Lifecycle timeline (WM-136)", () => {
     const now = new Date().toISOString();
     const lifecycle = [
       createLifecycleEventFixture(1, "run_x", null, "PROPOSED", null, now),
-      createLifecycleEventFixture(2, "run_x", "PROPOSED", "APPROVED", null, now),
+      createLifecycleEventFixture(
+        2,
+        "run_x",
+        "PROPOSED",
+        "APPROVED",
+        null,
+        now,
+      ),
       createLifecycleEventFixture(3, "run_x", "APPROVED", "RUNNING", null, now),
     ];
-    const d = createRunDetailFixture({ run: { state: "RUNNING" } as RunDetail["run"], lifecycle });
+    const d = createRunDetailFixture({
+      run: { state: "RUNNING" } as RunDetail["run"],
+      lifecycle,
+    });
     const r = renderBlocks(d);
 
     // The rail contributes one dot per row; StateBadge's own dot is
@@ -156,7 +200,9 @@ describe("Lifecycle timeline (WM-136)", () => {
 
     // Every badge column is the same fixed width, so the actor after it
     // starts at one x regardless of how long the state name is.
-    const badgeColumns = Array.from(r.container.querySelectorAll("li .w-\\[100px\\]"));
+    const badgeColumns = Array.from(
+      r.container.querySelectorAll("li .w-\\[100px\\]"),
+    );
     expect(badgeColumns.length).toBe(3);
   });
 
@@ -168,7 +214,10 @@ describe("Lifecycle timeline (WM-136)", () => {
       // A gap: this event's `from` disagrees with the previous row's `to`.
       createLifecycleEventFixture(3, "run_x", "LEASED", "TIMED_OUT", null, now),
     ];
-    const d = createRunDetailFixture({ run: { state: "TIMED_OUT" } as RunDetail["run"], lifecycle });
+    const d = createRunDetailFixture({
+      run: { state: "TIMED_OUT" } as RunDetail["run"],
+      lifecycle,
+    });
     const r = renderBlocks(d);
     expect(r.queryByText("QUEUED→")).toBeNull();
     expect(r.getByText("LEASED→")).toBeTruthy();
@@ -183,13 +232,23 @@ describe("Lifecycle reason readability (WM-145)", () => {
     const now = new Date().toISOString();
     const lifecycle = [
       createLifecycleEventFixture(1, "run_x", null, "QUEUED", null, now),
-      createLifecycleEventFixture(2, "run_x", "QUEUED", "FAILED", LONG_REASON, now),
+      createLifecycleEventFixture(
+        2,
+        "run_x",
+        "QUEUED",
+        "FAILED",
+        LONG_REASON,
+        now,
+      ),
     ];
-    const d = createRunDetailFixture({ run: { state: "FAILED" } as RunDetail["run"], lifecycle });
+    const d = createRunDetailFixture({
+      run: { state: "FAILED" } as RunDetail["run"],
+      lifecycle,
+    });
     const r = renderBlocks(d);
 
-    const failedRow = Array.from(r.container.querySelectorAll("li")).find((li) =>
-      li.textContent?.includes(LONG_REASON),
+    const failedRow = Array.from(r.container.querySelectorAll("li")).find(
+      (li) => li.textContent?.includes(LONG_REASON),
     );
     expect(failedRow).toBeTruthy();
 
@@ -200,17 +259,22 @@ describe("Lifecycle reason readability (WM-145)", () => {
     // Both the reason wrapper and the nested ActorRef jump link expose the
     // composite title, so hovering the actor cannot mask the reason.
     expect(titled.length).toBe(2);
-    expect(failedRow!.querySelector("button")?.getAttribute("title")).toBe(expectedTitle);
-
-    const truncated = Array.from(failedRow!.querySelectorAll(".truncate")).filter((el) =>
-      el.textContent?.includes(LONG_REASON),
+    expect(failedRow!.querySelector("button")?.getAttribute("title")).toBe(
+      expectedTitle,
     );
+
+    const truncated = Array.from(
+      failedRow!.querySelectorAll(".truncate"),
+    ).filter((el) => el.textContent?.includes(LONG_REASON));
     expect(truncated.length).toBe(0);
   });
 });
 
 describe("model surfacing (WM-221)", () => {
-  const modelDetail = (spec: Partial<RunDetail["run"]["spec"]>, observedModel: string | null = null) =>
+  const modelDetail = (
+    spec: Partial<RunDetail["run"]["spec"]>,
+    observedModel: string | null = null,
+  ) =>
     createRunDetailFixture({
       run: { spec: { adapter: "claude", ...spec } } as RunDetail["run"],
       observedModel,
@@ -218,7 +282,10 @@ describe("model surfacing (WM-221)", () => {
 
   test("shows tier, pinned model, and observed model beside the adapter", () => {
     const r = renderBlocks(
-      modelDetail({ modelTier: "standard", model: "sonnet" }, "claude-sonnet-5"),
+      modelDetail(
+        { modelTier: "standard", model: "sonnet" },
+        "claude-sonnet-5",
+      ),
     );
     expect(r.getByText("model tier")).toBeTruthy();
     expect(r.getByText("standard")).toBeTruthy();
@@ -229,7 +296,9 @@ describe("model surfacing (WM-221)", () => {
   });
 
   test("renders the `default` sentinel distinctly, never as a missing value", () => {
-    const r = renderBlocks(modelDetail({ modelTier: "strong", model: "default" }, "claude-fable-5"));
+    const r = renderBlocks(
+      modelDetail({ modelTier: "strong", model: "default" }, "claude-fable-5"),
+    );
     const pinned = r.getByText("default (CLI)");
     expect(pinned).toBeTruthy();
     expect(pinned.getAttribute("title")).toContain("sentinel");
@@ -254,7 +323,9 @@ describe("model surfacing (WM-221)", () => {
 
   test("a non-model adapter gets one explicit n/a row, never three blanks", () => {
     const r = renderBlocks(
-      createRunDetailFixture({ run: { spec: { adapter: "command" } } as RunDetail["run"] }),
+      createRunDetailFixture({
+        run: { spec: { adapter: "command" } } as RunDetail["run"],
+      }),
     );
     const na = r.getByText("n/a");
     expect(na).toBeTruthy();
@@ -266,7 +337,9 @@ describe("model surfacing (WM-221)", () => {
   test("a tier declared on a non-model adapter is named in the tooltip, not dropped", () => {
     const r = renderBlocks(
       createRunDetailFixture({
-        run: { spec: { adapter: "command", modelTier: "light", model: null } } as RunDetail["run"],
+        run: {
+          spec: { adapter: "command", modelTier: "light", model: null },
+        } as RunDetail["run"],
       }),
     );
     expect(r.getByText("n/a").getAttribute("title")).toContain("light");
@@ -285,17 +358,40 @@ describe("pinnedModelText / modelTierText (WM-221)", () => {
   });
 
   test("tier text prefers the declaration, then the override, then honest absence", () => {
-    expect(modelTierText({ adapter: "claude", modelTier: "strong", model: "default" })).toBe("strong");
-    expect(modelTierText({ adapter: "claude", modelTier: null, model: "claude-opus-4-1" })).toBe("override");
-    expect(modelTierText({ adapter: "claude", modelTier: null, model: null })).toBe("not declared");
-    expect(modelTierText({ adapter: "fake", modelTier: null, model: null })).toBe("n/a");
+    expect(
+      modelTierText({
+        adapter: "claude",
+        modelTier: "strong",
+        model: "default",
+      }),
+    ).toBe("strong");
+    expect(
+      modelTierText({
+        adapter: "claude",
+        modelTier: null,
+        model: "claude-opus-4-1",
+      }),
+    ).toBe("override");
+    expect(
+      modelTierText({ adapter: "claude", modelTier: null, model: null }),
+    ).toBe("not declared");
+    expect(
+      modelTierText({ adapter: "fake", modelTier: null, model: null }),
+    ).toBe("n/a");
     // A declared tier survives even where the adapter cannot use it.
-    expect(modelTierText({ adapter: "command", modelTier: "light", model: null })).toBe("light");
+    expect(
+      modelTierText({ adapter: "command", modelTier: "light", model: null }),
+    ).toBe("light");
   });
 });
 
 describe("artifact position renders the agent's view (WM-455)", () => {
-  const TRIAGE_VIEW = JSON.parse(readFileSync(path.resolve(import.meta.dir, "../../../agents/triage-scan.view.json"), "utf8"));
+  const TRIAGE_VIEW = JSON.parse(
+    readFileSync(
+      path.resolve(import.meta.dir, "../../../agents/triage-scan.view.json"),
+      "utf8",
+    ),
+  );
   const triageAgent = {
     ref: "triage-scan@1",
     id: "triage-scan",
@@ -306,46 +402,73 @@ describe("artifact position renders the agent's view (WM-455)", () => {
     recommendation: "TRIAGE",
     repo: "factory",
     summary: "One issue is ready.",
-    plan: [{ issueId: "WM-7", action: "label-agent-ready", reason: "Complete." }],
+    plan: [
+      { issueId: "WM-7", action: "label-agent-ready", reason: "Complete." },
+    ],
   };
   const withArtifact = () =>
     createRunDetailFixture({
-      run: { state: "COMPLETED", spec: { agent: "triage-scan@1" } } as RunDetail["run"],
+      run: {
+        state: "COMPLETED",
+        spec: { agent: "triage-scan@1" },
+      } as RunDetail["run"],
       result: { terminalState: "COMPLETED", reasonCode: null, artifact },
     });
 
   afterEach(() => localStorage.removeItem(ARTIFACT_RAW_KEY));
 
   test("with a view from /agents: summary, status, plan table with an issue chip, and a Raw toggle back to JSON", async () => {
-    stubApi({ agents: mock(async () => createAgentsFixture({ agents: [triageAgent] as never })) });
+    stubApi({
+      agents: mock(async () =>
+        createAgentsFixture({ agents: [triageAgent] as never }),
+      ),
+    });
     const r2 = renderBlocks(withArtifact());
     expect(await r2.findByText("One issue is ready.")).toBeTruthy();
     expect(r2.getByText("TRIAGE")).toBeTruthy();
-    expect((r2.getByRole("link", { name: "WM-7" }) as HTMLAnchorElement).getAttribute("href")).toBe(
-      "https://linear.app/watt-mind/issue/WM-7",
-    );
+    expect(
+      (
+        r2.getByRole("link", { name: "WM-7" }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe("https://linear.app/watt-mind/issue/WM-7");
     fireEvent.click(r2.getByRole("button", { name: "Raw" }));
     expect(r2.queryByRole("table")).toBeNull();
-    const pre = Array.from(r2.container.querySelectorAll("pre")).find((el) => el.textContent?.includes('"issueId": "WM-7"'));
+    const pre = Array.from(r2.container.querySelectorAll("pre")).find((el) =>
+      el.textContent?.includes('"issueId": "WM-7"'),
+    );
     expect(pre).toBeTruthy();
     expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
   });
 
   test("no view for the agent → the JSON block, unchanged, and no toggle", async () => {
-    stubApi({ agents: mock(async () => createAgentsFixture({ agents: [{ ...triageAgent, outputView: null }] as never })) });
+    stubApi({
+      agents: mock(async () =>
+        createAgentsFixture({
+          agents: [{ ...triageAgent, outputView: null }] as never,
+        }),
+      ),
+    });
     const r = renderBlocks(withArtifact());
     await waitFor(() => expect(api.agents).toHaveBeenCalled());
     expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
     expect(r.queryByRole("table")).toBeNull();
-    const pre = Array.from(r.container.querySelectorAll("pre")).find((el) => el.textContent?.includes('"issueId": "WM-7"'));
+    const pre = Array.from(r.container.querySelectorAll("pre")).find((el) =>
+      el.textContent?.includes('"issueId": "WM-7"'),
+    );
     expect(pre).toBeTruthy();
   });
 });
 
 describe("Ticket decisions (WM-594)", () => {
   const T = "WM-542";
-  const t = (offsetSeconds: number) => new Date(Date.UTC(2026, 7, 17, 12, 0, offsetSeconds)).toISOString();
-  const dispatchEvent = (eventId: string, status: string, at: string, subject: string | null = T) =>
+  const t = (offsetSeconds: number) =>
+    new Date(Date.UTC(2026, 7, 17, 12, 0, offsetSeconds)).toISOString();
+  const dispatchEvent = (
+    eventId: string,
+    status: string,
+    at: string,
+    subject: string | null = T,
+  ) =>
     createEventFixture({
       source: "linear",
       eventId,
@@ -353,7 +476,13 @@ describe("Ticket decisions (WM-594)", () => {
       subject,
       status,
       admittedAt: at,
-      envelope: { schemaVersion: "factory.event/v1", eventId, type: "dispatch.requested", source: "linear", payload: { ticket: T } },
+      envelope: {
+        schemaVersion: "factory.event/v1",
+        eventId,
+        type: "dispatch.requested",
+        source: "linear",
+        payload: { ticket: T },
+      },
     });
   const fixture = () => {
     const events = [
@@ -362,27 +491,96 @@ describe("Ticket decisions (WM-594)", () => {
       dispatchEvent("evt_other", "noop", t(70), "WM-999"),
       dispatchEvent("evt_refused", "planned", t(120)),
       // Names the ticket only in the payload — subject is a repo.
-      { ...dispatchEvent("evt_payload_only", "admitted", t(200), "factory/repo") },
+      {
+        ...dispatchEvent(
+          "evt_payload_only",
+          "admitted",
+          t(200),
+          "factory/repo",
+        ),
+      },
     ];
     const proposals = [
-      createProposalFixture({ id: "prop_plan", decision: "run", status: "approved", created_at: t(1), eventId: "evt_plan", eventSource: "linear", runId: "run_ok" }),
-      createProposalFixture({ id: "prop_noop", decision: "noop", status: "resolved", reason: "owned_paths_overlap", created_at: t(61), eventId: "evt_noop", eventSource: "linear", runId: null }),
-      createProposalFixture({ id: "prop_other", decision: "noop", status: "resolved", reason: "ticket_assigned", created_at: t(71), eventId: "evt_other", eventSource: "linear", runId: null }),
-      createProposalFixture({ id: "prop_refused", decision: "run", status: "approved", created_at: t(121), eventId: "evt_refused", eventSource: "linear", runId: "run_refused" }),
+      createProposalFixture({
+        id: "prop_plan",
+        decision: "run",
+        status: "approved",
+        created_at: t(1),
+        eventId: "evt_plan",
+        eventSource: "linear",
+        runId: "run_ok",
+      }),
+      createProposalFixture({
+        id: "prop_noop",
+        decision: "noop",
+        status: "resolved",
+        reason: "owned_paths_overlap",
+        created_at: t(61),
+        eventId: "evt_noop",
+        eventSource: "linear",
+        runId: null,
+      }),
+      createProposalFixture({
+        id: "prop_other",
+        decision: "noop",
+        status: "resolved",
+        reason: "ticket_assigned",
+        created_at: t(71),
+        eventId: "evt_other",
+        eventSource: "linear",
+        runId: null,
+      }),
+      createProposalFixture({
+        id: "prop_refused",
+        decision: "run",
+        status: "approved",
+        created_at: t(121),
+        eventId: "evt_refused",
+        eventSource: "linear",
+        runId: "run_refused",
+      }),
       // Attached to no listed event; its spec input names the ticket.
-      createProposalFixture({ id: "prop_spec", decision: "noop", status: "resolved", reason: "ticket_security", created_at: t(150), eventId: "evt_missing", eventSource: "chain", runId: null, spec: { ...createRunSpecFixture("run_x"), input: { ticket: T } } }),
+      createProposalFixture({
+        id: "prop_spec",
+        decision: "noop",
+        status: "resolved",
+        reason: "ticket_security",
+        created_at: t(150),
+        eventId: "evt_missing",
+        eventSource: "chain",
+        runId: null,
+        spec: { ...createRunSpecFixture("run_x"), input: { ticket: T } },
+      }),
     ];
     const runs = [
-      createRunListItemFixture({ runId: "run_ok", state: "COMPLETED", reasonCode: "ok", eventId: "evt_plan", eventSource: "linear", updated_at: t(30) }),
-      createRunListItemFixture({ runId: "run_refused", state: "REFUSED", reasonCode: "needs_human", eventId: "evt_refused", eventSource: "linear", updated_at: t(130) }),
+      createRunListItemFixture({
+        runId: "run_ok",
+        state: "COMPLETED",
+        reasonCode: "ok",
+        eventId: "evt_plan",
+        eventSource: "linear",
+        updated_at: t(30),
+      }),
+      createRunListItemFixture({
+        runId: "run_refused",
+        state: "REFUSED",
+        reasonCode: "needs_human",
+        eventId: "evt_refused",
+        eventSource: "linear",
+        updated_at: t(130),
+      }),
     ];
     return { events, proposals, runs };
   };
 
   test("eventTicket reads the subject, then payload.ticket", () => {
     expect(eventTicket(dispatchEvent("e", "noop", t(0)))).toBe(T);
-    expect(eventTicket(dispatchEvent("e", "noop", t(0), "factory/repo"))).toBe(T);
-    expect(eventTicket(createEventFixture({ subject: "factory/repo" }))).toBeNull();
+    expect(eventTicket(dispatchEvent("e", "noop", t(0), "factory/repo"))).toBe(
+      T,
+    );
+    expect(
+      eventTicket(createEventFixture({ subject: "factory/repo" })),
+    ).toBeNull();
   });
 
   test("joins events, proposals and refused runs for one ticket, oldest first", () => {
@@ -398,16 +596,29 @@ describe("Ticket decisions (WM-594)", () => {
     ]);
     // Excludes WM-999, carries the joins for jump links.
     expect(decisions.some((d) => d.reason === "ticket_assigned")).toBe(false);
-    expect(decisions[1]).toMatchObject({ proposalId: "prop_noop", event: { eventId: "evt_noop" } });
-    expect(decisions[3]).toMatchObject({ runId: "run_refused", event: { eventId: "evt_refused" } });
-    expect(decisions[5]).toMatchObject({ event: { eventId: "evt_payload_only" }, proposalId: null });
+    expect(decisions[1]).toMatchObject({
+      proposalId: "prop_noop",
+      event: { eventId: "evt_noop" },
+    });
+    expect(decisions[3]).toMatchObject({
+      runId: "run_refused",
+      event: { eventId: "evt_refused" },
+    });
+    expect(decisions[5]).toMatchObject({
+      event: { eventId: "evt_payload_only" },
+      proposalId: null,
+    });
   });
 
   test("the headline is the latest decision, humanized", () => {
     const decisions = buildTicketDecisions(T, fixture());
     const now = Date.parse(t(260));
-    expect(decisionHeadline(decisions[1], now)).toBe("noop · Owned paths overlap · 3m ago");
-    expect(decisionHeadline(decisions[3], now)).toBe("refused · Needs human · 2m ago");
+    expect(decisionHeadline(decisions[1], now)).toBe(
+      "noop · Owned paths overlap · 3m ago",
+    );
+    expect(decisionHeadline(decisions[3], now)).toBe(
+      "refused · Needs human · 2m ago",
+    );
   });
 
   test("renders collapsed with the latest decision, expands to the full list with reason links", async () => {
@@ -418,12 +629,22 @@ describe("Ticket decisions (WM-594)", () => {
       runs: mock(async () => ({ runs: f.runs })),
     });
     const onJumpRun = mock(() => {});
-    const r = renderWithClient(<TicketDecisions ticket={T} now={Date.parse(t(260))} onJumpRun={onJumpRun} />);
-    const toggle = await r.findByRole("button", { name: /Show all 6 planner decisions for WM-542/ });
+    const r = renderWithClient(
+      <TicketDecisions
+        ticket={T}
+        now={Date.parse(t(260))}
+        onJumpRun={onJumpRun}
+      />,
+    );
+    const toggle = await r.findByRole("button", {
+      name: /Show all 6 planner decisions for WM-542/,
+    });
     expect(r.getByText("6 decisions")).toBeTruthy();
     // Collapsed: only the headline (latest = the admitted event awaiting the planner).
     expect(r.getByText("awaiting the planner")).toBeTruthy();
-    expect(r.queryByRole("list", { name: "Planner decisions for WM-542" })).toBeNull();
+    expect(
+      r.queryByRole("list", { name: "Planner decisions for WM-542" }),
+    ).toBeNull();
     fireEvent.click(toggle);
     const list = r.getByRole("list", { name: "Planner decisions for WM-542" });
     expect(list.querySelectorAll("li").length).toBe(6);
@@ -441,7 +662,9 @@ describe("Ticket decisions (WM-594)", () => {
       proposalHistory: mock(async () => ({ proposals: f.proposals })),
       runs: mock(async () => ({ runs: f.runs })),
     });
-    const r = renderBlocks(detailWith("REFUSED", { repo: "factory", ticket: T }));
+    const r = renderBlocks(
+      detailWith("REFUSED", { repo: "factory", ticket: T }),
+    );
     // TicketDecisions is a lazy chunk (bundle budget) — await the Suspense boundary.
     expect(await r.findByText("Decisions")).toBeTruthy();
     await r.findByText("6 decisions");

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -2,9 +2,22 @@ import { useQuery } from "@tanstack/react-query";
 import { Suspense, lazy, useState, type ReactNode } from "react";
 import { api, artifactUrl } from "../api";
 import { hashPath, hashProject, withProject } from "../hash";
-import { NOT_APPLICABLE, formatBytes, formatDuration, formatRelative } from "../format";
+import {
+  NOT_APPLICABLE,
+  formatBytes,
+  formatDuration,
+  formatRelative,
+} from "../format";
 import { humanizeReason } from "../reasons";
-import type { AdmittedEvent, ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunSpec, RunState } from "../types";
+import type {
+  AdmittedEvent,
+  ArtifactRef,
+  Attempt,
+  LifecycleEvent,
+  RunDetail,
+  RunSpec,
+  RunState,
+} from "../types";
 import {
   Disclosure,
   JsonBlock,
@@ -27,7 +40,9 @@ import { attrIcon } from "./attrIcons";
  * (vite.config.ts); until the chunk lands the JSON block below stands in,
  * which is also exactly what an agent without a view gets.
  */
-const ArtifactPanel = lazy(() => import("./ArtifactView").then((m) => ({ default: m.ArtifactPanel })));
+const ArtifactPanel = lazy(() =>
+  import("./ArtifactView").then((m) => ({ default: m.ArtifactPanel })),
+);
 
 /**
  * The per-ticket Decisions block (WM-594) rides its own chunk for the same
@@ -35,8 +50,12 @@ const ArtifactPanel = lazy(() => import("./ArtifactView").then((m) => ({ default
  * pane renders. Until the chunk lands nothing is shown — a block that answers
  * "why not" a beat late beats a heavier first paint on every view.
  */
-const TicketDecisionsLazy = lazy(() => import("./TicketDecisions").then((m) => ({ default: m.TicketDecisions })));
-export function TicketDecisionsPanel(props: Parameters<typeof import("./TicketDecisions").TicketDecisions>[0]) {
+const TicketDecisionsLazy = lazy(() =>
+  import("./TicketDecisions").then((m) => ({ default: m.TicketDecisions })),
+);
+export function TicketDecisionsPanel(
+  props: Parameters<typeof import("./TicketDecisions").TicketDecisions>[0],
+) {
   return (
     <Suspense fallback={null}>
       <TicketDecisionsLazy {...props} />
@@ -44,8 +63,15 @@ export function TicketDecisionsPanel(props: Parameters<typeof import("./TicketDe
   );
 }
 
-export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
-export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && state !== "VERIFYING";
+export const TERMINAL: RunState[] = [
+  "COMPLETED",
+  "REFUSED",
+  "FAILED",
+  "TIMED_OUT",
+  "CANCELLED",
+];
+export const isCancellable = (state: RunState) =>
+  !TERMINAL.includes(state) && state !== "VERIFYING";
 
 /**
  * The states `reapExpiredLeases` sweeps (lib/worker.mjs) — exactly the states
@@ -54,7 +80,8 @@ export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && s
 export const IN_FLIGHT: RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
 
 /** `off`: no deadline running yet. `spent`: the deadline passed; the runtime has not caught up. */
-export type Clock = { kind: "off" } | { kind: "live"; leftMs: number } | { kind: "spent" };
+export type Clock =
+  { kind: "off" } | { kind: "live"; leftMs: number } | { kind: "spent" };
 
 /** A deadline we cannot read is no deadline: better silent than counting down to NaN. */
 export const clockTo = (iso: string, offsetMs: number, now: number): Clock => {
@@ -78,10 +105,18 @@ export const clockTo = (iso: string, offsetMs: number, now: number): Clock => {
  *   never renewed, so when it passes `reapExpiredLeases` re-queues the run
  *   whatever the worker believes it is doing.
  */
-export function deadlinesOf(a: Attempt, timeoutSeconds: number, now: number): { timeout: Clock; lease: Clock } {
+export function deadlinesOf(
+  a: Attempt,
+  timeoutSeconds: number,
+  now: number,
+): { timeout: Clock; lease: Clock } {
   return {
-    timeout: a.started_at ? clockTo(a.started_at, timeoutSeconds * 1000, now) : { kind: "off" },
-    lease: a.lease_expires_at ? clockTo(a.lease_expires_at, 0, now) : { kind: "off" },
+    timeout: a.started_at
+      ? clockTo(a.started_at, timeoutSeconds * 1000, now)
+      : { kind: "off" },
+    lease: a.lease_expires_at
+      ? clockTo(a.lease_expires_at, 0, now)
+      : { kind: "off" },
   };
 }
 
@@ -89,7 +124,8 @@ export function deadlinesOf(a: Attempt, timeoutSeconds: number, now: number): { 
 const budgetHue = (c: Clock, timeoutSeconds: number): string | undefined => {
   if (c.kind === "spent") return "var(--hue-err)";
   // The last tenth of the declared budget — long enough to notice on a long run.
-  if (c.kind === "live" && c.leftMs <= timeoutSeconds * 100) return "var(--hue-warn)";
+  if (c.kind === "live" && c.leftMs <= timeoutSeconds * 100)
+    return "var(--hue-warn)";
   return undefined;
 };
 
@@ -98,7 +134,13 @@ const budgetHue = (c: Clock, timeoutSeconds: number): string | undefined => {
  * local and the verdict stays the runtime's: a spent budget says so rather than
  * claiming the run is TIMED_OUT, which is the state badge's call on the next poll.
  */
-export function BudgetClock({ c, timeoutSeconds }: { c: Clock; timeoutSeconds: number }) {
+export function BudgetClock({
+  c,
+  timeoutSeconds,
+}: {
+  c: Clock;
+  timeoutSeconds: number;
+}) {
   const budget = `${formatDuration(timeoutSeconds)} budget`;
   if (c.kind === "off")
     return (
@@ -114,7 +156,10 @@ export function BudgetClock({ c, timeoutSeconds }: { c: Clock; timeoutSeconds: n
       </span>
     );
   return (
-    <span style={{ color: hue }} title={`timeout in ${formatDuration(c.leftMs / 1000)}`}>
+    <span
+      style={{ color: hue }}
+      title={`timeout in ${formatDuration(c.leftMs / 1000)}`}
+    >
       timeout in {formatDuration(c.leftMs / 1000)}
     </span>
   );
@@ -129,14 +174,23 @@ export function LeaseClock({ c, urgent }: { c: Clock; urgent: boolean }) {
       </span>
     );
   return (
-    <span style={urgent ? { color: "var(--hue-warn)" } : undefined} title={`reaped in ${formatDuration(c.leftMs / 1000)}`}>
+    <span
+      style={urgent ? { color: "var(--hue-warn)" } : undefined}
+      title={`reaped in ${formatDuration(c.leftMs / 1000)}`}
+    >
       reaped in {formatDuration(c.leftMs / 1000)}
     </span>
   );
 }
 
 /** How much of the budget is spent — the glance; `BudgetClock` is the number. */
-function BudgetMeter({ c, timeoutSeconds }: { c: Clock; timeoutSeconds: number }) {
+function BudgetMeter({
+  c,
+  timeoutSeconds,
+}: {
+  c: Clock;
+  timeoutSeconds: number;
+}) {
   if (c.kind === "off" || timeoutSeconds <= 0) return null;
   const spent = c.kind === "spent" ? 1 : 1 - c.leftMs / (timeoutSeconds * 1000);
   return (
@@ -183,7 +237,10 @@ export function RunFailureBanner({
     <div
       role="alert"
       className={`rounded-md border p-3 ${className}`}
-      style={{ borderColor: hue, background: `color-mix(in oklch, ${hue} 8%, var(--surface-1))` }}
+      style={{
+        borderColor: hue,
+        background: `color-mix(in oklch, ${hue} 8%, var(--surface-1))`,
+      }}
     >
       <div className="flex items-baseline justify-between gap-3">
         <div
@@ -234,7 +291,8 @@ export function ActorRef({
 }
 
 const isTextArtifact = (k: string) =>
-  /^(transcript|diff|report|evidence)$/i.test(k) || /\.(txt|json|jsonl|md|log)$/i.test(k);
+  /^(transcript|diff|report|evidence)$/i.test(k) ||
+  /\.(txt|json|jsonl|md|log)$/i.test(k);
 
 export function ArtifactRow({ a }: { a: ArtifactRef }) {
   const [open, setOpen] = useState(false);
@@ -270,12 +328,17 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
       <div className="flex items-baseline justify-between gap-3">
         <span className="truncate">
           {a.kind}
-          <span className="mono ml-2 text-[11px] text-(--text-faint)" title={a.sha256}>
+          <span
+            className="mono ml-2 text-[11px] text-(--text-faint)"
+            title={a.sha256}
+          >
             {a.sha256.slice(0, 12)}
           </span>
         </span>
         <span className="flex shrink-0 items-baseline gap-3">
-          <span className="tabular-nums text-(--text-faint)">{formatBytes(a.sizeBytes)}</span>
+          <span className="tabular-nums text-(--text-faint)">
+            {formatBytes(a.sizeBytes)}
+          </span>
           {textFriendly && (
             <button
               type="button"
@@ -297,7 +360,11 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
       </div>
       {open && (
         <div className="mt-2">
-          {loading && <div className="text-[11px] text-(--text-faint)">Loading artifact preview…</div>}
+          {loading && (
+            <div className="text-[11px] text-(--text-faint)">
+              Loading artifact preview…
+            </div>
+          )}
           {error && (
             <div className="text-[11px] text-(--hue-err)">
               Failed to load preview: {error}
@@ -339,7 +406,10 @@ const DEFAULT_MODEL_TEXT = "default (CLI)";
  * - the `default` sentinel, and a spec that declares nothing at all, both mean
  *   the CLI chose → `default (CLI)`; `model (observed)` is what it chose
  */
-export const pinnedModelText = (adapter: string, model: string | null | undefined): string => {
+export const pinnedModelText = (
+  adapter: string,
+  model: string | null | undefined,
+): string => {
   if (!MODEL_ADAPTERS.has(adapter)) return NOT_APPLICABLE;
   return model == null || model === DEFAULT_MODEL ? DEFAULT_MODEL_TEXT : model;
 };
@@ -348,7 +418,9 @@ export const pinnedModelText = (adapter: string, model: string | null | undefine
  * Declared intent — same split as `tierText` in the Agents view (WM-211): an
  * exact-id override answers for a definition that names no tier.
  */
-export const modelTierText = (spec: Pick<RunSpec, "adapter" | "modelTier" | "model">): string => {
+export const modelTierText = (
+  spec: Pick<RunSpec, "adapter" | "modelTier" | "model">,
+): string => {
   if (spec.modelTier) return spec.modelTier;
   if (!MODEL_ADAPTERS.has(spec.adapter)) return NOT_APPLICABLE;
   return spec.model ? "override" : "not declared";
@@ -359,8 +431,14 @@ function ModelDetailRow({ label, value }: { label: string; value: ReactNode }) {
   const icon = attrIcon(label);
   return (
     <div className="grid grid-cols-[minmax(0,9.25rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
-      <div className="flex min-w-0 items-center gap-1.5 whitespace-nowrap text-(--text-faint)" title={label}>
-        <i className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5" aria-hidden="true">
+      <div
+        className="flex min-w-0 items-center gap-1.5 whitespace-nowrap text-(--text-faint)"
+        title={label}
+      >
+        <i
+          className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5"
+          aria-hidden="true"
+        >
           {icon}
         </i>
         <span>{label}</span>
@@ -376,7 +454,13 @@ function ModelDetailRow({ label, value }: { label: string; value: ReactNode }) {
  * collapses to one honest `n/a` row rather than three — a declared tier that
  * the adapter cannot use is named in its tooltip rather than dropped.
  */
-function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null }) {
+function ModelRows({
+  spec,
+  observed,
+}: {
+  spec: RunSpec;
+  observed: string | null;
+}) {
   if (!MODEL_ADAPTERS.has(spec.adapter)) {
     return (
       <KV
@@ -437,7 +521,10 @@ function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null 
           observed ? (
             <ModelCell model={observed} className="text-(--text-dim)" />
           ) : (
-            <span className="text-(--text-faint)" title="observed model not recorded">
+            <span
+              className="text-(--text-faint)"
+              title="observed model not recorded"
+            >
               {NOT_APPLICABLE}
             </span>
           )
@@ -489,9 +576,18 @@ export function ticketIdOf(value: unknown): string | null {
 }
 
 /** The ticket an admitted event is about: its subject, or `payload.ticket`. */
-export function eventTicket(e: Pick<AdmittedEvent, "subject" | "envelope">): string | null {
-  const payload = (e.envelope as { payload?: Record<string, unknown> } | undefined)?.payload;
-  return ticketIdOf(e.subject) ?? ticketIdOf(payload?.ticket) ?? ticketIdOf(payload?.ticketId) ?? null;
+export function eventTicket(
+  e: Pick<AdmittedEvent, "subject" | "envelope">,
+): string | null {
+  const payload = (
+    e.envelope as { payload?: Record<string, unknown> } | undefined
+  )?.payload;
+  return (
+    ticketIdOf(e.subject) ??
+    ticketIdOf(payload?.ticket) ??
+    ticketIdOf(payload?.ticketId) ??
+    null
+  );
 }
 
 export const hashHref = (view: string, ...ids: string[]) =>
@@ -519,7 +615,12 @@ export function ReasonText({
   if (!h.text) return null;
   const refs = h.refs ?? {};
   // Split the sentence around each reference so the reference itself is a link.
-  const targets: Array<{ id: string; href: string; onClick?: () => void; title: string }> = [];
+  const targets: Array<{
+    id: string;
+    href: string;
+    onClick?: () => void;
+    title: string;
+  }> = [];
   if (refs.runId)
     targets.push({
       id: refs.runId,
@@ -531,7 +632,9 @@ export function ReasonText({
     targets.push({
       id: refs.proposalId,
       href: hashHref("proposals", refs.proposalId),
-      onClick: onJumpProposal ? () => onJumpProposal(refs.proposalId!) : undefined,
+      onClick: onJumpProposal
+        ? () => onJumpProposal(refs.proposalId!)
+        : undefined,
       title: `Open proposal ${refs.proposalId}`,
     });
   if (refs.ticket)
@@ -575,7 +678,9 @@ export function ReasonText({
         title={target.title}
         className="text-[inherit]"
       >
-        {target.id.startsWith("run_") || target.id.startsWith("prop_") ? shortId(target.id) : target.id}
+        {target.id.startsWith("run_") || target.id.startsWith("prop_")
+          ? shortId(target.id)
+          : target.id}
       </JumpLink>,
     );
     rest = rest.slice(firstAt + hit.id.length);
@@ -625,19 +730,26 @@ export function RunDetailBlocks({
   /** Panel slot for the inline RunTrace; the full page renders its trace in the main column. */
   afterLifecycle?: ReactNode;
 }) {
-
   // The reaper keys off the run's current attempt (`a.attempt = r.attempts`),
   // so that is the only attempt whose deadlines are still running.
   const current = IN_FLIGHT.includes(d.run.state)
     ? (d.attempts.find((a) => a.attempt === d.run.attempts) ?? null)
     : null;
-  const clocks = current ? deadlinesOf(current, d.run.spec.timeoutSeconds, now) : null;
-  const inputTicket = ticketIdOf((d.run.spec.input as Record<string, unknown> | null | undefined)?.ticket);
+  const clocks = current
+    ? deadlinesOf(current, d.run.spec.timeoutSeconds, now)
+    : null;
+  const inputTicket = ticketIdOf(
+    (d.run.spec.input as Record<string, unknown> | null | undefined)?.ticket,
+  );
 
   // The artifact's view sidecar rides the `/agents` item for this run's agent
   // (WM-454); the same query AgentHoverCard already keeps warm, so no new
   // request per run. No agent, no view → the JSON block, unchanged.
-  const agentsQ = useQuery({ queryKey: ["agents"], queryFn: () => api.agents(), staleTime: 30_000 });
+  const agentsQ = useQuery({
+    queryKey: ["agents"],
+    queryFn: () => api.agents(),
+    staleTime: 30_000,
+  });
   const agentDef = (agentsQ.data?.agents ?? []).find(
     (a) => a.ref === d.run.spec.agent || a.id === d.run.spec.agent,
   );
@@ -660,7 +772,11 @@ export function RunDetailBlocks({
         <ModelRows spec={d.run.spec} observed={d.observedModel ?? null} />
         {/* A count, not an identifier — mono bought it nothing but a mismatched
             font next to "any worker" and "26m ago" on the rows around it. */}
-        <KV k="attempts" v={`${d.run.attempts}/${d.run.spec.maxAttempts}`} mono={false} />
+        <KV
+          k="attempts"
+          v={`${d.run.attempts}/${d.run.spec.maxAttempts}`}
+          mono={false}
+        />
         <InputRows input={d.run.spec.input} />
         {origin?.eventId && (
           <KV
@@ -668,7 +784,9 @@ export function RunDetailBlocks({
             v={
               origin.eventSource ? (
                 <JumpLink
-                  onClick={() => onJumpEvent(origin.eventSource!, origin.eventId!)}
+                  onClick={() =>
+                    onJumpEvent(origin.eventSource!, origin.eventId!)
+                  }
                   title={origin.eventId}
                 >
                   {`${origin.eventSource} · ${shortId(origin.eventId)}`}
@@ -679,9 +797,30 @@ export function RunDetailBlocks({
             }
           />
         )}
-        <KV k="created" v={<span title={d.run.created_at}>{formatRelative(d.run.created_at, now)}</span>} />
-        <KV k="updated" v={<span title={d.run.updated_at}>{formatRelative(d.run.updated_at, now)}</span>} />
-        <KV k="placement" v={d.run.spec.placement ? JSON.stringify(d.run.spec.placement) : "any worker"} />
+        <KV
+          k="created"
+          v={
+            <span title={d.run.created_at}>
+              {formatRelative(d.run.created_at, now)}
+            </span>
+          }
+        />
+        <KV
+          k="updated"
+          v={
+            <span title={d.run.updated_at}>
+              {formatRelative(d.run.updated_at, now)}
+            </span>
+          }
+        />
+        <KV
+          k="placement"
+          v={
+            d.run.spec.placement
+              ? JSON.stringify(d.run.spec.placement)
+              : "any worker"
+          }
+        />
         <Disclosure label="internals — ids, hashes, paths">
           <KV k="run" v={d.run.runId} />
           <KV k="idempotencyKey" v={d.run.idempotencyKey} />
@@ -718,15 +857,27 @@ export function RunDetailBlocks({
                 attempt #{current.attempt}{" "}
                 {current.started_at ? (
                   <>
-                    started <span className="text-(--text-dim)" title={current.started_at}>{formatRelative(current.started_at, now)}</span>
+                    started{" "}
+                    <span
+                      className="text-(--text-dim)"
+                      title={current.started_at}
+                    >
+                      {formatRelative(current.started_at, now)}
+                    </span>
                   </>
                 ) : (
                   "not started"
                 )}
               </span>
-              <BudgetClock c={clocks.timeout} timeoutSeconds={d.run.spec.timeoutSeconds} />
+              <BudgetClock
+                c={clocks.timeout}
+                timeoutSeconds={d.run.spec.timeoutSeconds}
+              />
             </div>
-            <BudgetMeter c={clocks.timeout} timeoutSeconds={d.run.spec.timeoutSeconds} />
+            <BudgetMeter
+              c={clocks.timeout}
+              timeoutSeconds={d.run.spec.timeoutSeconds}
+            />
             <div className="mt-2 flex items-baseline justify-between gap-4 text-[11px] text-(--text-faint)">
               <span className="flex items-baseline gap-1.5 truncate">
                 lease owner
@@ -736,10 +887,14 @@ export function RunDetailBlocks({
                   <span className="mono">unclaimed</span>
                 )}
               </span>
-              <LeaseClock c={clocks.lease} urgent={clocks.timeout.kind === "spent"} />
+              <LeaseClock
+                c={clocks.lease}
+                urgent={clocks.timeout.kind === "spent"}
+              />
             </div>
             <div className="mt-2 text-[11px] text-(--text-faint)">
-              The lease outlasts the budget by a fixed grace and is never renewed.
+              The lease outlasts the budget by a fixed grace and is never
+              renewed.
             </div>
           </div>
         </Section>
@@ -758,28 +913,54 @@ export function RunDetailBlocks({
             // worth spelling out (WM-136).
             const jumped = prev != null && e.from_state !== prev.to_state;
             const hue = STATE_HUES[e.to_state] ?? "var(--hue-idle)";
-            const time = new Date(e.at).toLocaleTimeString([], { hour12: false });
-            const prevTime = prev ? new Date(prev.at).toLocaleTimeString([], { hour12: false }) : null;
+            const time = new Date(e.at).toLocaleTimeString([], {
+              hour12: false,
+            });
+            const prevTime = prev
+              ? new Date(prev.at).toLocaleTimeString([], { hour12: false })
+              : null;
             const isSameTime = prevTime !== null && time === prevTime;
             const deltaSeconds = prev
-              ? Math.max(0, Math.round((new Date(e.at).getTime() - new Date(prev.at).getTime()) / 1000))
+              ? Math.max(
+                  0,
+                  Math.round(
+                    (new Date(e.at).getTime() - new Date(prev.at).getTime()) /
+                      1000,
+                  ),
+                )
               : 0;
             return (
               <li key={e.seq} className="flex gap-2.5 py-1">
-                <span className="mono w-[52px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)" title={e.at}>
-                  {isSameTime ? <span className="opacity-60">+{deltaSeconds}s</span> : time}
+                <span
+                  className="mono w-[52px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)"
+                  title={e.at}
+                >
+                  {isSameTime ? (
+                    <span className="opacity-60">+{deltaSeconds}s</span>
+                  ) : (
+                    time
+                  )}
                 </span>
                 {/* Rail: a dot per transition, joined to the next one. */}
-                <span className="relative flex w-2 shrink-0 justify-center" aria-hidden="true">
+                <span
+                  className="relative flex w-2 shrink-0 justify-center"
+                  aria-hidden="true"
+                >
                   {i < d.lifecycle.length - 1 && (
                     <span className="absolute top-2.5 bottom-[-4px] w-px bg-(--border)" />
                   )}
-                  <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
+                  <span
+                    className="relative mt-[7px] size-1.5 shrink-0 rounded-full"
+                    style={{ background: hue }}
+                  />
                 </span>
                 <span className="flex min-w-0 flex-1 items-start gap-x-2">
                   <span className="flex w-[100px] shrink-0 items-center gap-1">
                     {jumped && (
-                      <span className="shrink-0 text-[10px] text-(--text-faint)" title={`from ${e.from_state ?? "·"}`}>
+                      <span
+                        className="shrink-0 text-[10px] text-(--text-faint)"
+                        title={`from ${e.from_state ?? "·"}`}
+                      >
                         {e.from_state ?? "·"}→
                       </span>
                     )}
@@ -809,17 +990,27 @@ export function RunDetailBlocks({
       {d.attempts.length > 0 && (
         <Section title="Attempts" card={false}>
           {d.attempts.map((a) => (
-            <div key={a.attempt} className="mb-1.5 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 last:mb-0">
+            <div
+              key={a.attempt}
+              className="mb-1.5 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 last:mb-0"
+            >
               <div className="flex items-center justify-between gap-2">
-                <span className="mono text-[12px] font-medium text-(--text)">#{a.attempt}</span>
+                <span className="mono text-[12px] font-medium text-(--text)">
+                  #{a.attempt}
+                </span>
                 {a.terminal_state ? (
                   <StateBadge state={a.terminal_state} />
                 ) : (
-                  <span className="text-[11px] text-(--text-faint)">in flight</span>
+                  <span className="text-[11px] text-(--text-faint)">
+                    in flight
+                  </span>
                 )}
               </div>
               {a.reason_code && (
-                <div className="mono mt-1 truncate text-[11px] text-(--hue-err)" title={a.reason_code}>
+                <div
+                  className="mono mt-1 truncate text-[11px] text-(--hue-err)"
+                  title={a.reason_code}
+                >
                   {a.reason_code}
                 </div>
               )}
@@ -828,13 +1019,23 @@ export function RunDetailBlocks({
                   owner off the edge (WM-136). */}
               <div className="mt-1.5 grid grid-cols-[minmax(0,4.5rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-0.5 text-[11px] text-(--text-faint)">
                 <span>owner</span>
-                <span className="min-w-0 truncate" title={a.lease_owner ?? "unclaimed"}>
-                  {a.lease_owner ? <ActorRef actor={a.lease_owner} /> : <span className="mono">unclaimed</span>}
+                <span
+                  className="min-w-0 truncate"
+                  title={a.lease_owner ?? "unclaimed"}
+                >
+                  {a.lease_owner ? (
+                    <ActorRef actor={a.lease_owner} />
+                  ) : (
+                    <span className="mono">unclaimed</span>
+                  )}
                 </span>
                 {a.workspace_path && (
                   <>
                     <span>workspace</span>
-                    <span className="mono min-w-0 truncate" title={a.workspace_path}>
+                    <span
+                      className="mono min-w-0 truncate"
+                      title={a.workspace_path}
+                    >
                       {a.workspace_path}
                     </span>
                   </>
@@ -843,7 +1044,9 @@ export function RunDetailBlocks({
                   <>
                     <span>started</span>
                     <span className="min-w-0 truncate">
-                      <span title={a.started_at}>{formatRelative(a.started_at, now)}</span>
+                      <span title={a.started_at}>
+                        {formatRelative(a.started_at, now)}
+                      </span>
                     </span>
                   </>
                 )}
@@ -851,7 +1054,9 @@ export function RunDetailBlocks({
                   <>
                     <span>finished</span>
                     <span className="min-w-0 truncate">
-                      <span title={a.finished_at}>{formatRelative(a.finished_at, now)}</span>
+                      <span title={a.finished_at}>
+                        {formatRelative(a.finished_at, now)}
+                      </span>
                     </span>
                   </>
                 )}

--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -12,7 +12,11 @@ afterEach(() => {
 
 const NOW = new Date().toISOString();
 
-function entry(seq: number, kind: string, payload: TraceEntry["payload"]): TraceEntry {
+function entry(
+  seq: number,
+  kind: string,
+  payload: TraceEntry["payload"],
+): TraceEntry {
   return { seq, attempt: 1, ts: NOW, kind, payload };
 }
 
@@ -35,7 +39,10 @@ function renderTrace(overrides?: { state?: RunState }) {
     />,
     {
       apiMocks: {
-        trace: async () => ({ head: TRACE[TRACE.length - 1].seq, entries: TRACE }),
+        trace: async () => ({
+          head: TRACE[TRACE.length - 1].seq,
+          entries: TRACE,
+        }),
       },
     },
   );
@@ -51,15 +58,20 @@ async function waitForChrome(r: ReturnType<typeof renderTrace>) {
 describe("RunTrace feed", () => {
   test("resets accumulated entries and cursor when runId changes (WM-245)", async () => {
     const requests: Array<{ runId: string; since: number }> = [];
-    const firstRunEntry = entry(41, "assistant_text", { text: "first run trace" });
-    const secondRunEntry = entry(1, "assistant_text", { text: "second run trace" });
+    const firstRunEntry = entry(41, "assistant_text", {
+      text: "first run trace",
+    });
+    const secondRunEntry = entry(1, "assistant_text", {
+      text: "second run trace",
+    });
     const r = renderWithClient(
       <RunTrace runId="run_first" state="COMPLETED" variant="full" />,
       {
         apiMocks: {
           trace: async (runId, since = 0) => {
             requests.push({ runId, since });
-            const entries = runId === "run_first" ? [firstRunEntry] : [secondRunEntry];
+            const entries =
+              runId === "run_first" ? [firstRunEntry] : [secondRunEntry];
             return { head: entries[0].seq, entries };
           },
         },
@@ -68,13 +80,15 @@ describe("RunTrace feed", () => {
 
     await waitFor(() => expect(r.getByText("first run trace")).toBeTruthy());
 
-    r.rerender(<RunTrace runId="run_second" state="COMPLETED" variant="full" />);
+    r.rerender(
+      <RunTrace runId="run_second" state="COMPLETED" variant="full" />,
+    );
 
     await waitFor(() => expect(r.getByText("second run trace")).toBeTruthy());
     expect(r.queryByText("first run trace")).toBeNull();
-    expect(requests.filter((request) => request.runId === "run_second")).toEqual([
-      { runId: "run_second", since: 0 },
-    ]);
+    expect(
+      requests.filter((request) => request.runId === "run_second"),
+    ).toEqual([{ runId: "run_second", since: 0 }]);
   });
 });
 
@@ -92,8 +106,22 @@ describe("RunTrace error context (WM-588)", () => {
   test("error rows retain their originating call input in the Errors tab", async () => {
     const ts = "2026-08-17T15:26:37Z";
     const contextualTrace: TraceEntry[] = [
-      { ...entry(1, "tool_use", { id: "call_bash", name: "bash", input: { command: "bun test missing.test.ts" } }), ts },
-      { ...entry(2, "tool_result", { toolUseId: "call_bash", content: "Command exited with code 2\nfull stderr", isError: true }), ts },
+      {
+        ...entry(1, "tool_use", {
+          id: "call_bash",
+          name: "bash",
+          input: { command: "bun test missing.test.ts" },
+        }),
+        ts,
+      },
+      {
+        ...entry(2, "tool_result", {
+          toolUseId: "call_bash",
+          content: "Command exited with code 2\nfull stderr",
+          isError: true,
+        }),
+        ts,
+      },
     ];
     const r = renderWithClient(
       <RunTrace runId="run_error_context" state="COMPLETED" variant="full" />,
@@ -107,7 +135,9 @@ describe("RunTrace error context (WM-588)", () => {
 
     fireEvent.click(r.getByRole("tab", { name: /^Errors/ }));
     const label = r.getByText("bash · Command exited with code 2");
-    expect(label.getAttribute("title")).toBe("bash · Command exited with code 2");
+    expect(label.getAttribute("title")).toBe(
+      "bash · Command exited with code 2",
+    );
     const timestamp = r.getByTitle(ts);
     expect(timestamp.textContent).toContain("15:26:37");
 
@@ -124,16 +154,31 @@ describe("RunTrace timing (WM-272)", () => {
   test("filtered views use the next unfiltered entry for duration", async () => {
     const start = Date.parse("2025-01-01T00:00:00.000Z");
     const timedTrace: TraceEntry[] = [
-      { ...entry(1, "tool_use", { name: "Read" }), ts: new Date(start).toISOString() },
-      { ...entry(2, "assistant_text", { text: "hidden by the tools filter" }), ts: new Date(start + 200).toISOString() },
-      { ...entry(3, "tool_use", { name: "Write" }), ts: new Date(start + 50_000).toISOString() },
-      { ...entry(4, "tool_result", { content: "done" }), ts: new Date(start + 50_300).toISOString() },
+      {
+        ...entry(1, "tool_use", { name: "Read" }),
+        ts: new Date(start).toISOString(),
+      },
+      {
+        ...entry(2, "assistant_text", { text: "hidden by the tools filter" }),
+        ts: new Date(start + 200).toISOString(),
+      },
+      {
+        ...entry(3, "tool_use", { name: "Write" }),
+        ts: new Date(start + 50_000).toISOString(),
+      },
+      {
+        ...entry(4, "tool_result", { content: "done" }),
+        ts: new Date(start + 50_300).toISOString(),
+      },
     ];
     const r = renderWithClient(
       <RunTrace runId="run_trace_timing" state="COMPLETED" variant="full" />,
       {
         apiMocks: {
-          trace: async () => ({ head: timedTrace[timedTrace.length - 1].seq, entries: timedTrace }),
+          trace: async () => ({
+            head: timedTrace[timedTrace.length - 1].seq,
+            entries: timedTrace,
+          }),
         },
       },
     );
@@ -183,16 +228,34 @@ describe("RunTrace a11y (WM-143)", () => {
     const clear = r.getByRole("button", { name: "Clear search" });
     expect(clear).toBeTruthy();
 
-    const scroller = r.container.querySelector("[data-trace-idx]")?.parentElement as HTMLElement;
-    Object.defineProperty(scroller, "scrollHeight", { value: 400, configurable: true });
-    Object.defineProperty(scroller, "clientHeight", { value: 100, configurable: true });
-    Object.defineProperty(scroller, "scrollTop", { value: 0, configurable: true });
+    const scroller = r.container.querySelector("[data-trace-idx]")
+      ?.parentElement as HTMLElement;
+    Object.defineProperty(scroller, "scrollHeight", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "clientHeight", {
+      value: 100,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      value: 0,
+      configurable: true,
+    });
     act(() => {
       fireEvent.scroll(scroller);
     });
-    const jump = await waitFor(() => r.getByRole("button", { name: /Jump to latest/ }));
+    const jump = await waitFor(() =>
+      r.getByRole("button", { name: /Jump to latest/ }),
+    );
 
-    const chrome = [tablist, errorJump, clear, jump, r.getByText(/12 in · 34 out/).parentElement!];
+    const chrome = [
+      tablist,
+      errorJump,
+      clear,
+      jump,
+      r.getByText(/12 in · 34 out/).parentElement!,
+    ];
     for (const el of chrome) {
       expect(el.textContent ?? "").not.toMatch(/🔧|🔥|⚠️|⬇|✕/);
       expect(el.textContent ?? "").not.toMatch(/\p{Extended_Pictographic}/u);
@@ -215,19 +278,29 @@ describe("RunTrace a11y (WM-143)", () => {
 
     tabs[0].focus();
     fireEvent.keyDown(tablist, { key: "ArrowRight" });
-    expect(r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.keyDown(tablist, { key: "ArrowRight" });
-    expect(r.getByRole("tab", { name: /^Reasoning/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Reasoning/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.keyDown(tablist, { key: "End" });
-    expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.keyDown(tablist, { key: "Home" });
-    expect(r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.keyDown(tablist, { key: "ArrowLeft" });
-    expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
   test.each(["LEASED", "RUNNING", "VERIFYING"] as const)(
@@ -245,7 +318,9 @@ describe("RunTrace a11y (WM-143)", () => {
         const r = renderTrace({ state });
         await waitForChrome(r);
 
-        const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+        const search = r.getByPlaceholderText(
+          "Search trace…",
+        ) as HTMLInputElement;
         search.focus();
         expect(document.activeElement).toBe(search);
 
@@ -282,40 +357,68 @@ describe("RunTrace a11y (WM-143)", () => {
     await waitForChrome(r);
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "2", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "2", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "3", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "3", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^Reasoning/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Reasoning/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "4", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "4", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^Errors/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Errors/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "5", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "5", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "1", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "1", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     // [ and ] relative cycling
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "]", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "]", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "[", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "[", bubbles: true }),
+      );
     });
-    expect(r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
   test("e toggles expand/collapse details and l toggles follow live (WM-217)", async () => {
@@ -326,12 +429,16 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(expandBtn).toBeTruthy();
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "e", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "e", bubbles: true }),
+      );
     });
     expect(r.getByRole("button", { name: /Collapse details/ })).toBeTruthy();
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "e", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "e", bubbles: true }),
+      );
     });
     expect(r.getByRole("button", { name: /Expand details/ })).toBeTruthy();
 
@@ -340,12 +447,18 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(followLiveBtn.textContent).toContain("Follow live");
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "l", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "l", bubbles: true }),
+      );
     });
-    expect(r.getByRole("button", { name: /Follow live \(paused\)/ })).toBeTruthy();
+    expect(
+      r.getByRole("button", { name: /Follow live \(paused\)/ }),
+    ).toBeTruthy();
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "l", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "l", bubbles: true }),
+      );
     });
     expect(r.getByRole("button", { name: /Follow live/ })).toBeTruthy();
   });
@@ -358,13 +471,17 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(errorBtn).toBeTruthy();
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: ".", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: ".", bubbles: true }),
+      );
     });
     expect(r.getByText("1/1")).toBeTruthy();
 
     // G triggers jump to latest
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "G", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "G", bubbles: true }),
+      );
     });
     expect(r.getByRole("button", { name: /Follow live/ })).toBeTruthy();
   });
@@ -409,12 +526,18 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(r.getByText("/")).toBeTruthy();
 
     // e hint on Expand details
-    expect(r.getByRole("button", { name: /Expand details/ }).textContent).toContain("e");
+    expect(
+      r.getByRole("button", { name: /Expand details/ }).textContent,
+    ).toContain("e");
 
     // l hint on Follow live
-    expect(r.getByRole("button", { name: /Follow live/ }).textContent).toContain("l");
+    expect(
+      r.getByRole("button", { name: /Follow live/ }).textContent,
+    ).toContain("l");
 
     // . hint on Error button
-    expect(r.getByRole("button", { name: /next error/ }).textContent).toContain(".");
+    expect(r.getByRole("button", { name: /next error/ }).textContent).toContain(
+      ".",
+    );
   });
 });

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -1,6 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowDownIcon, CodeIcon, CopyIcon, FileTextIcon } from "@radix-ui/react-icons";
-import { Fragment, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowDownIcon,
+  CodeIcon,
+  CopyIcon,
+  FileTextIcon,
+} from "@radix-ui/react-icons";
+import {
+  Fragment,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard } from "../hooks";
@@ -38,7 +52,11 @@ const TRACE_QUIET_BUTTON =
   "inline-flex h-7 items-center gap-1.5 rounded border border-(--border) bg-(--surface-0) px-2 text-[11px] font-medium text-(--text-faint) transition-colors hover:bg-(--surface-1) hover:text-(--text-dim)";
 
 /** States in which the trace is still being written — poll incrementally. */
-export const LIVE_STATES: readonly RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
+export const LIVE_STATES: readonly RunState[] = [
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+];
 
 /** Server page cap; the recorder's row cap (2000 + 1 marker) is ≤ 5 pages. */
 const PAGE = 500;
@@ -74,7 +92,10 @@ function useTraceFeed(runId: string, live: boolean) {
         const res = await api.trace(runId, cursor.current, PAGE);
         if (res.entries.length) {
           const seen = new Set(acc.current.map((e) => e.seq));
-          acc.current = [...acc.current, ...res.entries.filter((e) => !seen.has(e.seq))];
+          acc.current = [
+            ...acc.current,
+            ...res.entries.filter((e) => !seen.has(e.seq)),
+          ];
           cursor.current = res.entries[res.entries.length - 1].seq;
         }
         if (res.entries.length < PAGE) break;
@@ -104,7 +125,8 @@ function useTraceFeed(runId: string, live: boolean) {
 }
 
 function renderInlineMarkdown(text: string): React.ReactNode[] {
-  const tokenRegex = /(`[^`]+`)|(\*\*[^*]+\*\*|__[^_]+__)|(\*[^*]+\*|_[^_]+_)|(~~[^~]+~~)|(\[[^\]]+\]\([^)]+\))/g;
+  const tokenRegex =
+    /(`[^`]+`)|(\*\*[^*]+\*\*|__[^_]+__)|(\*[^*]+\*|_[^_]+_)|(~~[^~]+~~)|(\[[^\]]+\]\([^)]+\))/g;
   const nodes: React.ReactNode[] = [];
   let lastIdx = 0;
   let match: RegExpExecArray | null;
@@ -116,23 +138,44 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
     const full = match[0];
     if (match[1]) {
       nodes.push(
-        <code key={match.index} className="mono rounded bg-(--surface-2) px-1 py-0.5 text-[11px] text-(--text)">
+        <code
+          key={match.index}
+          className="mono rounded bg-(--surface-2) px-1 py-0.5 text-[11px] text-(--text)"
+        >
           {full.slice(1, -1)}
-        </code>
+        </code>,
       );
     } else if (match[2]) {
-      nodes.push(<strong key={match.index} className="font-semibold text-(--text)">{full.slice(2, -2)}</strong>);
+      nodes.push(
+        <strong key={match.index} className="font-semibold text-(--text)">
+          {full.slice(2, -2)}
+        </strong>,
+      );
     } else if (match[3]) {
-      nodes.push(<em key={match.index} className="italic text-(--text-dim)">{full.slice(1, -1)}</em>);
+      nodes.push(
+        <em key={match.index} className="italic text-(--text-dim)">
+          {full.slice(1, -1)}
+        </em>,
+      );
     } else if (match[4]) {
-      nodes.push(<del key={match.index} className="line-through text-(--text-faint)">{full.slice(2, -2)}</del>);
+      nodes.push(
+        <del key={match.index} className="line-through text-(--text-faint)">
+          {full.slice(2, -2)}
+        </del>,
+      );
     } else if (match[5]) {
       const linkMatch = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(full);
       if (linkMatch) {
         nodes.push(
-          <a key={match.index} href={linkMatch[2]} target="_blank" rel="noreferrer" className="text-(--accent) underline hover:opacity-80">
+          <a
+            key={match.index}
+            href={linkMatch[2]}
+            target="_blank"
+            rel="noreferrer"
+            className="text-(--accent) underline hover:opacity-80"
+          >
             {linkMatch[1]}
-          </a>
+          </a>,
         );
       } else {
         nodes.push(full);
@@ -161,11 +204,21 @@ export function MarkdownView({
     return (
       <div className={`relative ${className}`}>
         {allowToggle && (
-          <div className="mb-1 flex justify-end gap-1" role="group" aria-label="Markdown actions">
-            <TraceIconButton label="Copy raw markdown" onClick={() => copyText(text, "raw markdown")}>
+          <div
+            className="mb-1 flex justify-end gap-1"
+            role="group"
+            aria-label="Markdown actions"
+          >
+            <TraceIconButton
+              label="Copy raw markdown"
+              onClick={() => copyText(text, "raw markdown")}
+            >
               <CopyIcon className="size-3.5" />
             </TraceIconButton>
-            <TraceIconButton label="Show formatted view" onClick={() => setRaw(false)}>
+            <TraceIconButton
+              label="Show formatted view"
+              onClick={() => setRaw(false)}
+            >
               <FileTextIcon className="size-3.5" />
             </TraceIconButton>
           </div>
@@ -189,19 +242,25 @@ export function MarkdownView({
     if (!listType || !listItems.length) return;
     if (listType === "ul") {
       blocks.push(
-        <ul key={`ul-${key}`} className="my-1 ml-4 list-disc space-y-0.5 text-[12px] text-(--text-dim)">
+        <ul
+          key={`ul-${key}`}
+          className="my-1 ml-4 list-disc space-y-0.5 text-[12px] text-(--text-dim)"
+        >
           {listItems.map((item, idx) => (
             <li key={idx}>{renderInlineMarkdown(item)}</li>
           ))}
-        </ul>
+        </ul>,
       );
     } else {
       blocks.push(
-        <ol key={`ol-${key}`} className="my-1 ml-4 list-decimal space-y-0.5 text-[12px] text-(--text-dim)">
+        <ol
+          key={`ol-${key}`}
+          className="my-1 ml-4 list-decimal space-y-0.5 text-[12px] text-(--text-dim)"
+        >
           {listItems.map((item, idx) => (
             <li key={idx}>{renderInlineMarkdown(item)}</li>
           ))}
-        </ol>
+        </ol>,
       );
     }
     listType = null;
@@ -217,17 +276,23 @@ export function MarkdownView({
         inCodeBlock = false;
         const codeText = codeBuffer.join("\n");
         blocks.push(
-          <div key={`code-${i}`} className="my-1.5 overflow-hidden rounded-md border border-(--border) bg-(--surface-0)">
+          <div
+            key={`code-${i}`}
+            className="my-1.5 overflow-hidden rounded-md border border-(--border) bg-(--surface-0)"
+          >
             <div className="flex items-center justify-between border-b border-(--border) bg-(--surface-1) px-2.5 py-0.5 text-[11px] text-(--text-faint) mono">
               <span>{codeLang || "code"}</span>
-              <TraceIconButton label="Copy code block" onClick={() => copyText(codeText, "code block")}>
+              <TraceIconButton
+                label="Copy code block"
+                onClick={() => copyText(codeText, "code block")}
+              >
                 <CopyIcon className="size-3.5" />
               </TraceIconButton>
             </div>
             <pre className="mono overflow-auto p-2.5 text-[11px] leading-relaxed whitespace-pre-wrap text-(--text)">
               {codeText}
             </pre>
-          </div>
+          </div>,
         );
         codeBuffer = [];
         codeLang = "";
@@ -249,13 +314,41 @@ export function MarkdownView({
       const level = headingMatch[1].length;
       const content = headingMatch[2];
       if (level === 1) {
-        blocks.push(<h1 key={i} className="mb-1.5 mt-2 text-[14px] font-semibold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h1>);
+        blocks.push(
+          <h1
+            key={i}
+            className="mb-1.5 mt-2 text-[14px] font-semibold text-(--text) border-b border-(--border) pb-0.5"
+          >
+            {renderInlineMarkdown(content)}
+          </h1>,
+        );
       } else if (level === 2) {
-        blocks.push(<h2 key={i} className="mb-1 mt-2 text-[13px] font-semibold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h2>);
+        blocks.push(
+          <h2
+            key={i}
+            className="mb-1 mt-2 text-[13px] font-semibold text-(--text) border-b border-(--border) pb-0.5"
+          >
+            {renderInlineMarkdown(content)}
+          </h2>,
+        );
       } else if (level === 3) {
-        blocks.push(<h3 key={i} className="mb-0.5 mt-1.5 text-[12px] font-semibold text-(--text)">{renderInlineMarkdown(content)}</h3>);
+        blocks.push(
+          <h3
+            key={i}
+            className="mb-0.5 mt-1.5 text-[12px] font-semibold text-(--text)"
+          >
+            {renderInlineMarkdown(content)}
+          </h3>,
+        );
       } else {
-        blocks.push(<h4 key={i} className="mb-0.5 mt-1 text-[12px] font-semibold text-(--text)">{renderInlineMarkdown(content)}</h4>);
+        blocks.push(
+          <h4
+            key={i}
+            className="mb-0.5 mt-1 text-[12px] font-semibold text-(--text)"
+          >
+            {renderInlineMarkdown(content)}
+          </h4>,
+        );
       }
       continue;
     }
@@ -263,9 +356,12 @@ export function MarkdownView({
     if (line.startsWith("> ")) {
       flushList(i);
       blocks.push(
-        <blockquote key={i} className="my-1 border-l-2 border-(--accent) pl-2.5 italic text-(--text-dim) text-[12px]">
+        <blockquote
+          key={i}
+          className="my-1 border-l-2 border-(--accent) pl-2.5 italic text-(--text-dim) text-[12px]"
+        >
           {renderInlineMarkdown(line.slice(2))}
-        </blockquote>
+        </blockquote>,
       );
       continue;
     }
@@ -291,9 +387,12 @@ export function MarkdownView({
       blocks.push(<div key={i} className="h-1" />);
     } else {
       blocks.push(
-        <p key={i} className="my-0.5 text-[12px] leading-relaxed text-(--text-dim)">
+        <p
+          key={i}
+          className="my-0.5 text-[12px] leading-relaxed text-(--text-dim)"
+        >
           {renderInlineMarkdown(line)}
-        </p>
+        </p>,
       );
     }
   }
@@ -302,11 +401,21 @@ export function MarkdownView({
   return (
     <div className={`relative ${className}`}>
       {allowToggle && text.length > 50 && (
-        <div className="mb-1 flex justify-end gap-1" role="group" aria-label="Markdown actions">
-          <TraceIconButton label="Copy markdown text" onClick={() => copyText(text, "markdown text")}>
+        <div
+          className="mb-1 flex justify-end gap-1"
+          role="group"
+          aria-label="Markdown actions"
+        >
+          <TraceIconButton
+            label="Copy markdown text"
+            onClick={() => copyText(text, "markdown text")}
+          >
             <CopyIcon className="size-3.5" />
           </TraceIconButton>
-          <TraceIconButton label="Show raw markdown" onClick={() => setRaw(true)}>
+          <TraceIconButton
+            label="Show raw markdown"
+            onClick={() => setRaw(true)}
+          >
             <CodeIcon className="size-3.5" />
           </TraceIconButton>
         </div>
@@ -333,10 +442,12 @@ export function formatErrorRowLabel(
   content: unknown,
 ): { label: string; title: string } {
   const tool = toolName?.trim() || "unknown tool";
-  const firstLine = errorText(content).split(/\r?\n/, 1)[0].trim() || "No error message";
-  const preview = firstLine.length > ERROR_PREVIEW_LENGTH
-    ? `${firstLine.slice(0, ERROR_PREVIEW_LENGTH - 1)}…`
-    : firstLine;
+  const firstLine =
+    errorText(content).split(/\r?\n/, 1)[0].trim() || "No error message";
+  const preview =
+    firstLine.length > ERROR_PREVIEW_LENGTH
+      ? `${firstLine.slice(0, ERROR_PREVIEW_LENGTH - 1)}…`
+      : firstLine;
   return {
     label: `${tool} · ${preview}`,
     title: `${tool} · ${firstLine}`,
@@ -369,13 +480,28 @@ function getEntryDuration(e: TraceEntry, next?: TraceEntry): number | null {
   return Number.isNaN(delta) || delta < 0 ? null : delta;
 }
 
-function TimingWaterfall({ durationMs, maxMs }: { durationMs: number; maxMs: number }) {
+function TimingWaterfall({
+  durationMs,
+  maxMs,
+}: {
+  durationMs: number;
+  maxMs: number;
+}) {
   const pct = Math.min(100, Math.max(8, (durationMs / (maxMs || 1)) * 100));
-  const durLabel = durationMs >= 1000 ? `${(durationMs / 1000).toFixed(1)}s` : `${durationMs}ms`;
+  const durLabel =
+    durationMs >= 1000
+      ? `${(durationMs / 1000).toFixed(1)}s`
+      : `${durationMs}ms`;
   return (
-    <div className="flex items-center gap-1.5 mono text-[10px] text-(--text-faint)" title={`Execution time: ${durLabel}`}>
+    <div
+      className="flex items-center gap-1.5 mono text-[10px] text-(--text-faint)"
+      title={`Execution time: ${durLabel}`}
+    >
       <div className="h-1.5 w-12 overflow-hidden rounded-full bg-(--surface-2)">
-        <div className="h-full rounded-full bg-(--accent) opacity-80" style={{ width: `${pct}%` }} />
+        <div
+          className="h-full rounded-full bg-(--accent) opacity-80"
+          style={{ width: `${pct}%` }}
+        />
       </div>
       <span>{durLabel}</span>
     </div>
@@ -464,7 +590,9 @@ function TraceBody({
     return (
       <div className="min-w-0 flex-1" style={{ color: "var(--hue-err)" }}>
         <span className="font-medium">Denied: {p.tool ?? "tool"}</span>
-        {p.rule ? <span className="ml-1 text-(--text-dim)">— {p.rule}</span> : null}
+        {p.rule ? (
+          <span className="ml-1 text-(--text-dim)">— {p.rule}</span>
+        ) : null}
       </div>
     );
   }
@@ -475,7 +603,9 @@ function TraceBody({
           <div className="min-w-0 flex-1">
             <MarkdownView text={p.text ?? ""} />
           </div>
-          {durationMs != null && maxMs != null && <TimingWaterfall durationMs={durationMs} maxMs={maxMs} />}
+          {durationMs != null && maxMs != null && (
+            <TimingWaterfall durationMs={durationMs} maxMs={maxMs} />
+          )}
         </div>
       </div>
     );
@@ -485,7 +615,9 @@ function TraceBody({
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
           <span className="mono">tool · {p.name ?? "unknown tool"}</span>
-          {durationMs != null && maxMs != null && <TimingWaterfall durationMs={durationMs} maxMs={maxMs} />}
+          {durationMs != null && maxMs != null && (
+            <TimingWaterfall durationMs={durationMs} maxMs={maxMs} />
+          )}
         </div>
         {p.input !== undefined && (
           <Disclosure label="input" forceOpen={forceOpen}>
@@ -505,7 +637,11 @@ function TraceBody({
           forceOpen={forceOpen}
           label={
             errorLabel ? (
-              <span className="block max-w-full truncate" style={{ color: "var(--hue-err)" }} title={errorLabel.title}>
+              <span
+                className="block max-w-full truncate"
+                style={{ color: "var(--hue-err)" }}
+                title={errorLabel.title}
+              >
                 {errorLabel.label}
               </span>
             ) : (
@@ -529,7 +665,8 @@ function TraceBody({
   if (kind === "usage") {
     return (
       <div className="min-w-0 flex-1 text-(--text-faint)">
-        {p.numTurns ?? "?"} turns · {p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : "?"} ·{" "}
+        {p.numTurns ?? "?"} turns ·{" "}
+        {p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : "?"} ·{" "}
         {p.costUSD != null ? `$${p.costUSD.toFixed(4)}` : "?"}
         {p.usage && Object.keys(p.usage).length > 0 && (
           <Disclosure label="tokens" forceOpen={forceOpen}>
@@ -543,11 +680,16 @@ function TraceBody({
     if (p.note === "trace_truncated") {
       return (
         <div className="min-w-0 flex-1" style={{ color: "var(--hue-warn)" }}>
-          trace truncated — {p.dropped ?? "?"} event{p.dropped === 1 ? "" : "s"} dropped past the cap
+          trace truncated — {p.dropped ?? "?"} event{p.dropped === 1 ? "" : "s"}{" "}
+          dropped past the cap
         </div>
       );
     }
-    return <div className="min-w-0 flex-1 text-(--text-faint)">{p.note ?? "lifecycle"}</div>;
+    return (
+      <div className="min-w-0 flex-1 text-(--text-faint)">
+        {p.note ?? "lifecycle"}
+      </div>
+    );
   }
   // Unknown kind (future factory.trace versions): show, do not reinterpret.
   return (
@@ -567,10 +709,19 @@ const isErrorKind = (e: TraceEntry) =>
   (e.kind === "lifecycle" && e.payload?.note === "trace_truncated");
 const isUsageKind = (k: string) => k === "usage";
 
-const FILTER_ORDER: TraceFilterKind[] = ["all", "tools", "reasoning", "errors", "usage"];
+const FILTER_ORDER: TraceFilterKind[] = [
+  "all",
+  "tools",
+  "reasoning",
+  "errors",
+  "usage",
+];
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
 /**
@@ -638,7 +789,10 @@ export function RunTrace({
         if (payload.id != null) byId.set(String(payload.id), payload);
         latestByAttempt.set(entry.attempt, payload);
       } else if (entry.kind === "tool_result") {
-        const exact = payload.toolUseId != null ? byId.get(String(payload.toolUseId)) : undefined;
+        const exact =
+          payload.toolUseId != null
+            ? byId.get(String(payload.toolUseId))
+            : undefined;
         const call = exact ?? latestByAttempt.get(entry.attempt);
         if (call) byResultSeq.set(entry.seq, call);
       }
@@ -656,17 +810,25 @@ export function RunTrace({
         hasTokens = true;
         const u = e.payload.usage;
         promptTokens += u.input_tokens ?? u.prompt_tokens ?? u.inputTokens ?? 0;
-        completionTokens += u.output_tokens ?? u.completion_tokens ?? u.outputTokens ?? 0;
+        completionTokens +=
+          u.output_tokens ?? u.completion_tokens ?? u.outputTokens ?? 0;
       }
       if (e.payload?.costUSD) totalCost += e.payload.costUSD;
     }
-    return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens, totalCost, hasTokens };
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+      totalCost,
+      hasTokens,
+    };
   }, [entries]);
 
   const visibleEntries = useMemo(() => {
     if (filter === "all") return entries;
     if (filter === "tools") return entries.filter((e) => isToolKind(e.kind));
-    if (filter === "reasoning") return entries.filter((e) => isReasoningKind(e.kind));
+    if (filter === "reasoning")
+      return entries.filter((e) => isReasoningKind(e.kind));
     if (filter === "errors") return entries.filter(isErrorKind);
     if (filter === "usage") return entries.filter((e) => isUsageKind(e.kind));
     return entries;
@@ -677,7 +839,10 @@ export function RunTrace({
 
   const handleJumpToError = useCallback(() => {
     if (allErrorEntries.length === 0) return;
-    const nextIdx = activeErrorIdx === null ? 0 : (activeErrorIdx + 1) % allErrorEntries.length;
+    const nextIdx =
+      activeErrorIdx === null
+        ? 0
+        : (activeErrorIdx + 1) % allErrorEntries.length;
     const target = allErrorEntries[nextIdx];
     setActiveErrorIdx(nextIdx);
     setJumpCount((c) => c + 1);
@@ -703,7 +868,10 @@ export function RunTrace({
       const dur = getEntryDuration(entries[i], entries[i + 1]);
       if (dur != null) map.set(entries[i].seq, dur);
     }
-    const max = shown.reduce((largest, entry) => Math.max(largest, map.get(entry.seq) ?? 0), 0);
+    const max = shown.reduce(
+      (largest, entry) => Math.max(largest, map.get(entry.seq) ?? 0),
+      0,
+    );
     return { durations: map, maxDurationMs: max || 1000 };
   }, [entries, shown]);
 
@@ -719,9 +887,15 @@ export function RunTrace({
         e.payload?.text,
         e.payload?.name,
         e.payload?.note,
-        typeof e.payload?.input === "object" ? JSON.stringify(e.payload.input) : String(e.payload?.input ?? ""),
-        typeof e.payload?.content === "object" ? JSON.stringify(e.payload.content) : String(e.payload?.content ?? ""),
-      ].join(" ").toLowerCase();
+        typeof e.payload?.input === "object"
+          ? JSON.stringify(e.payload.input)
+          : String(e.payload?.input ?? ""),
+        typeof e.payload?.content === "object"
+          ? JSON.stringify(e.payload.content)
+          : String(e.payload?.content ?? ""),
+      ]
+        .join(" ")
+        .toLowerCase();
       if (text.includes(q)) matches.push(i);
     }
     return matches;
@@ -733,7 +907,8 @@ export function RunTrace({
   const jumpToLatest = useCallback(() => {
     setFollowLive(true);
     setUnreadCount(0);
-    lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+    lastSeenSeqRef.current =
+      entries.length > 0 ? entries[entries.length - 1].seq : 0;
     if (scroller.current) {
       scroller.current.scrollTo({
         top: scroller.current.scrollHeight,
@@ -748,8 +923,10 @@ export function RunTrace({
     const i = FILTER_ORDER.indexOf(filter);
     if (i < 0) return;
     let next: TraceFilterKind | null = null;
-    if (e.key === "ArrowRight") next = FILTER_ORDER[(i + 1) % FILTER_ORDER.length];
-    else if (e.key === "ArrowLeft") next = FILTER_ORDER[(i - 1 + FILTER_ORDER.length) % FILTER_ORDER.length];
+    if (e.key === "ArrowRight")
+      next = FILTER_ORDER[(i + 1) % FILTER_ORDER.length];
+    else if (e.key === "ArrowLeft")
+      next = FILTER_ORDER[(i - 1 + FILTER_ORDER.length) % FILTER_ORDER.length];
     else if (e.key === "Home") next = FILTER_ORDER[0];
     else if (e.key === "End") next = FILTER_ORDER[FILTER_ORDER.length - 1];
     if (!next || next === filter) {
@@ -761,7 +938,9 @@ export function RunTrace({
     if ((e.target as HTMLElement).closest('[role="tab"]')) {
       const key = next;
       queueMicrotask(() => {
-        regionRef.current?.querySelector<HTMLElement>(`[role="tab"][data-filter="${key}"]`)?.focus();
+        regionRef.current
+          ?.querySelector<HTMLElement>(`[role="tab"][data-filter="${key}"]`)
+          ?.focus();
       });
     }
   };
@@ -781,7 +960,9 @@ export function RunTrace({
       if (searchMatches.length > 0) {
         e.preventDefault();
         if (e.shiftKey || e.key === "ArrowUp") {
-          setActiveMatch((m) => (m - 1 + searchMatches.length) % searchMatches.length);
+          setActiveMatch(
+            (m) => (m - 1 + searchMatches.length) % searchMatches.length,
+          );
         } else {
           setActiveMatch((m) => (m + 1) % searchMatches.length);
         }
@@ -794,7 +975,15 @@ export function RunTrace({
   // e for expand/collapse details, l for follow-live, G for jump-to-latest, . for jump-to-error.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (keyGuard(e) || isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey || goPrefixActive()) return;
+      if (
+        keyGuard(e) ||
+        isTypingTarget(e.target) ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.altKey ||
+        goPrefixActive()
+      )
+        return;
 
       if (e.key === "1") {
         e.preventDefault();
@@ -814,7 +1003,10 @@ export function RunTrace({
       } else if (e.key === "[") {
         e.preventDefault();
         const i = FILTER_ORDER.indexOf(filter);
-        if (i >= 0) setFilter(FILTER_ORDER[(i - 1 + FILTER_ORDER.length) % FILTER_ORDER.length]);
+        if (i >= 0)
+          setFilter(
+            FILTER_ORDER[(i - 1 + FILTER_ORDER.length) % FILTER_ORDER.length],
+          );
       } else if (e.key === "]") {
         e.preventDefault();
         const i = FILTER_ORDER.indexOf(filter);
@@ -830,7 +1022,8 @@ export function RunTrace({
           e.preventDefault();
           if (followLive) {
             setFollowLive(false);
-            lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+            lastSeenSeqRef.current =
+              entries.length > 0 ? entries[entries.length - 1].seq : 0;
           } else {
             jumpToLatest();
           }
@@ -847,7 +1040,15 @@ export function RunTrace({
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [filter, live, followLive, entries, counts.errors, handleJumpToError, jumpToLatest]);
+  }, [
+    filter,
+    live,
+    followLive,
+    entries,
+    counts.errors,
+    handleJumpToError,
+    jumpToLatest,
+  ]);
 
   // Jump to active search match:
   useEffect(() => {
@@ -866,21 +1067,30 @@ export function RunTrace({
     }
     if (followLive) {
       setUnreadCount(0);
-      lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+      lastSeenSeqRef.current =
+        entries.length > 0 ? entries[entries.length - 1].seq : 0;
     } else {
-      const count = entries.filter((e) => e.seq > lastSeenSeqRef.current).length;
+      const count = entries.filter(
+        (e) => e.seq > lastSeenSeqRef.current,
+      ).length;
       setUnreadCount(count);
     }
   }, [entries, live, followLive]);
 
   // Jump to active error match:
   useEffect(() => {
-    if (activeErrorIdx !== null && allErrorEntries.length > 0 && scroller.current) {
+    if (
+      activeErrorIdx !== null &&
+      allErrorEntries.length > 0 &&
+      scroller.current
+    ) {
       const target = allErrorEntries[activeErrorIdx % allErrorEntries.length];
       if (!target) return;
       const targetIdx = shown.findIndex((e) => e.seq === target.seq);
       if (targetIdx !== -1) {
-        const el = scroller.current.querySelector(`[data-trace-idx="${targetIdx}"]`);
+        const el = scroller.current.querySelector(
+          `[data-trace-idx="${targetIdx}"]`,
+        );
         el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
       }
     }
@@ -902,11 +1112,13 @@ export function RunTrace({
         setFollowLive(true);
       }
       setUnreadCount(0);
-      lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+      lastSeenSeqRef.current =
+        entries.length > 0 ? entries[entries.length - 1].seq : 0;
     } else {
       if (followLive) {
         setFollowLive(false);
-        lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+        lastSeenSeqRef.current =
+          entries.length > 0 ? entries[entries.length - 1].seq : 0;
       }
     }
   };
@@ -933,22 +1145,38 @@ export function RunTrace({
               onClick={() => {
                 if (followLive) {
                   setFollowLive(false);
-                  lastSeenSeqRef.current = entries.length > 0 ? entries[entries.length - 1].seq : 0;
+                  lastSeenSeqRef.current =
+                    entries.length > 0 ? entries[entries.length - 1].seq : 0;
                 } else {
                   jumpToLatest();
                 }
               }}
               className={`${TRACE_QUIET_BUTTON} ${
-                followLive ? "border-(--border-strong) bg-(--surface-2) text-(--text)" : ""
+                followLive
+                  ? "border-(--border-strong) bg-(--surface-2) text-(--text)"
+                  : ""
               }`}
-              title={followLive ? "Auto-scrolling live (l). Click to pause." : "Auto-scroll paused (l). Click to follow live."}
+              title={
+                followLive
+                  ? "Auto-scrolling live (l). Click to pause."
+                  : "Auto-scroll paused (l). Click to follow live."
+              }
             >
               <span
                 className={`size-1.5 rounded-full ${followLive ? "motion-safe:animate-pulse" : ""}`}
-                style={{ background: followLive ? "var(--hue-warn)" : "var(--text-faint)" }}
+                style={{
+                  background: followLive
+                    ? "var(--hue-warn)"
+                    : "var(--text-faint)",
+                }}
               />
               <span>{followLive ? "Follow live" : "Follow live (paused)"}</span>
-              <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">l</span>
+              <span
+                aria-hidden="true"
+                className="mono ml-0.5 text-(--text-faint) text-[10px]"
+              >
+                l
+              </span>
             </button>
             {unreadCount > 0 && !followLive ? (
               <span className="text-[11px] font-medium text-(--hue-warn)">
@@ -956,19 +1184,32 @@ export function RunTrace({
               </span>
             ) : null}
           </div>
-        ) : <div />}
+        ) : (
+          <div />
+        )}
 
         {tokenStats.hasTokens && (
           <div className="flex items-center gap-1.5 rounded bg-(--surface-1) border border-(--border) px-2 py-0.5 text-[11px] mono text-(--text-dim)">
-            <span title="Cumulative token burn across trace">{tokenStats.promptTokens.toLocaleString()} in · {tokenStats.completionTokens.toLocaleString()} out</span>
-            {tokenStats.totalCost > 0 && <span className="text-(--text-faint)">(${tokenStats.totalCost.toFixed(4)})</span>}
+            <span title="Cumulative token burn across trace">
+              {tokenStats.promptTokens.toLocaleString()} in ·{" "}
+              {tokenStats.completionTokens.toLocaleString()} out
+            </span>
+            {tokenStats.totalCost > 0 && (
+              <span className="text-(--text-faint)">
+                (${tokenStats.totalCost.toFixed(4)})
+              </span>
+            )}
           </div>
         )}
       </div>
 
       {entries.length > 0 && (
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-          <div className="flex flex-wrap gap-1" role="tablist" aria-label="Trace kind">
+          <div
+            className="flex flex-wrap gap-1"
+            role="tablist"
+            aria-label="Trace kind"
+          >
             {filterTabs.map((t, idx) => (
               <button
                 key={t.key}
@@ -983,12 +1224,23 @@ export function RunTrace({
                     ? "bg-(--surface-3) text-(--text)"
                     : "text-(--text-faint) hover:bg-(--surface-2)"
                 }`}
-                style={t.key === "errors" && t.count > 0 ? { color: "var(--hue-err)" } : undefined}
+                style={
+                  t.key === "errors" && t.count > 0
+                    ? { color: "var(--hue-err)" }
+                    : undefined
+                }
                 title={`Filter to ${t.label} (${idx + 1})`}
               >
                 <span>{t.label}</span>
-                {t.count > 0 && <span className="ml-1 tabular-nums opacity-75">{t.count}</span>}
-                <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
+                {t.count > 0 && (
+                  <span className="ml-1 tabular-nums opacity-75">
+                    {t.count}
+                  </span>
+                )}
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                >
                   {idx + 1}
                 </span>
               </button>
@@ -1007,9 +1259,17 @@ export function RunTrace({
                 <ArrowDownIcon aria-hidden="true" className="size-3" />
                 <span>next error</span>
                 <span className="mono text-[10px] opacity-75">
-                  {activeErrorIdx === null ? 0 : (activeErrorIdx % counts.errors) + 1}/{counts.errors}
+                  {activeErrorIdx === null
+                    ? 0
+                    : (activeErrorIdx % counts.errors) + 1}
+                  /{counts.errors}
                 </span>
-                <span aria-hidden="true" className="mono ml-0.5 opacity-75 text-[10px]">.</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-0.5 opacity-75 text-[10px]"
+                >
+                  .
+                </span>
               </button>
             )}
 
@@ -1028,20 +1288,31 @@ export function RunTrace({
                 className="w-24 bg-transparent outline-none text-(--text) placeholder:text-(--text-faint) sm:w-32"
               />
               {!search && (
-                <kbd aria-hidden="true" className="mono text-[9px] text-(--text-faint) border border-(--border) rounded px-1 bg-(--surface-1)">
+                <kbd
+                  aria-hidden="true"
+                  className="mono text-[9px] text-(--text-faint) border border-(--border) rounded px-1 bg-(--surface-1)"
+                >
                   /
                 </kbd>
               )}
               {search && (
                 <>
                   <span className="mono text-[10px] text-(--text-faint)">
-                    {searchMatches.length ? `${(activeMatch % searchMatches.length) + 1}/${searchMatches.length}` : "0"}
+                    {searchMatches.length
+                      ? `${(activeMatch % searchMatches.length) + 1}/${searchMatches.length}`
+                      : "0"}
                   </span>
                   {searchMatches.length > 0 && (
                     <>
                       <button
                         type="button"
-                        onClick={() => setActiveMatch((m) => (m - 1 + searchMatches.length) % searchMatches.length)}
+                        onClick={() =>
+                          setActiveMatch(
+                            (m) =>
+                              (m - 1 + searchMatches.length) %
+                              searchMatches.length,
+                          )
+                        }
                         className="text-(--text-faint) hover:text-(--text)"
                         title="Previous match"
                         aria-label="Previous match"
@@ -1050,7 +1321,9 @@ export function RunTrace({
                       </button>
                       <button
                         type="button"
-                        onClick={() => setActiveMatch((m) => (m + 1) % searchMatches.length)}
+                        onClick={() =>
+                          setActiveMatch((m) => (m + 1) % searchMatches.length)
+                        }
                         className="text-(--text-faint) hover:text-(--text)"
                         title="Next match"
                         aria-label="Next match"
@@ -1081,7 +1354,12 @@ export function RunTrace({
               title="Toggle expand/collapse details (e)"
             >
               <span>{expandAll ? "Collapse details" : "Expand details"}</span>
-              <span aria-hidden="true" className="mono text-[10px] text-(--text-faint)">e</span>
+              <span
+                aria-hidden="true"
+                className="mono text-[10px] text-(--text-faint)"
+              >
+                e
+              </span>
             </button>
           </div>
         </div>
@@ -1110,18 +1388,22 @@ export function RunTrace({
           >
             {shown.map((e, i) => {
               const isMatch = searchMatches.includes(i);
-              const isActiveMatch = searchMatches.length > 0 && searchMatches[activeMatch % searchMatches.length] === i;
+              const isActiveMatch =
+                searchMatches.length > 0 &&
+                searchMatches[activeMatch % searchMatches.length] === i;
               const isActiveError =
                 activeErrorIdx !== null &&
                 allErrorEntries.length > 0 &&
-                allErrorEntries[activeErrorIdx % allErrorEntries.length]?.seq === e.seq;
+                allErrorEntries[activeErrorIdx % allErrorEntries.length]
+                  ?.seq === e.seq;
               return (
                 <Fragment key={e.seq}>
-                  {multiAttempt && (i === 0 || shown[i - 1].attempt !== e.attempt) && (
-                    <div className="border-b border-(--border) py-1 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-                      Attempt #{e.attempt}
-                    </div>
-                  )}
+                  {multiAttempt &&
+                    (i === 0 || shown[i - 1].attempt !== e.attempt) && (
+                      <div className="border-b border-(--border) py-1 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                        Attempt #{e.attempt}
+                      </div>
+                    )}
                   <div
                     data-trace-idx={i}
                     className={`flex items-baseline gap-2 border-b border-(--border) py-1.5 last:border-0 transition-colors ${
@@ -1134,8 +1416,12 @@ export function RunTrace({
                             : ""
                     }`}
                   >
-                    <span className="mono w-[72px] shrink-0 text-(--text-faint)" title={e.ts}>
-                      {new Date(e.ts).toLocaleTimeString([], { hour12: false })} ·
+                    <span
+                      className="mono w-[72px] shrink-0 text-(--text-faint)"
+                      title={e.ts}
+                    >
+                      {new Date(e.ts).toLocaleTimeString([], { hour12: false })}{" "}
+                      ·
                     </span>
                     <TraceBody
                       kind={e.kind}
@@ -1164,7 +1450,12 @@ export function RunTrace({
                     ? `New activity (${unreadCount}) — Jump to latest`
                     : "Jump to latest"}
                 </span>
-                <span aria-hidden="true" className="mono ml-0.5 text-white/75 text-[10px]">G</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-0.5 text-white/75 text-[10px]"
+                >
+                  G
+                </span>
               </button>
             </div>
           )}
@@ -1177,7 +1468,11 @@ export function RunTrace({
           {onExpand && (
             <>
               {" — "}
-              <button type="button" onClick={onExpand} className="text-(--accent) hover:underline">
+              <button
+                type="button"
+                onClick={onExpand}
+                className="text-(--accent) hover:underline"
+              >
                 open full view
               </button>
             </>
@@ -1191,11 +1486,18 @@ export function RunTrace({
     return (
       <div>
         <div className="display mb-2 text-[15px] font-semibold">
-          Trace{entries.length ? <span className="ml-2 text-(--text-faint)">· {entries.length}</span> : null}
+          Trace
+          {entries.length ? (
+            <span className="ml-2 text-(--text-faint)">· {entries.length}</span>
+          ) : null}
         </div>
         {body}
       </div>
     );
   }
-  return <Section title={`Trace${entries.length ? ` · ${entries.length}` : ""}`}>{body}</Section>;
+  return (
+    <Section title={`Trace${entries.length ? ` · ${entries.length}` : ""}`}>
+      {body}
+    </Section>
+  );
 }

--- a/event-runtime/web/src/components/ShortcutsDialog.test.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.test.tsx
@@ -29,7 +29,9 @@ describe("ShortcutsDialog", () => {
     const runTrace = r.getByRole("region", { name: "Run & Trace" });
     expect(runTrace.textContent).toContain("1–5");
     expect(runTrace.textContent).toContain("switch trace kind");
-    expect(runTrace.textContent).toContain("toggle expand / collapse trace details");
+    expect(runTrace.textContent).toContain(
+      "toggle expand / collapse trace details",
+    );
     expect(runTrace.textContent).toContain("toggle follow live trace");
     expect(runTrace.textContent).toContain("c i");
     expect(runTrace.textContent).toContain("copy CLI inspect command");
@@ -37,7 +39,13 @@ describe("ShortcutsDialog", () => {
 
   test("focuses the Close button and closes from it", () => {
     let closed = false;
-    const r = render(<ShortcutsDialog onClose={() => { closed = true; }} />);
+    const r = render(
+      <ShortcutsDialog
+        onClose={() => {
+          closed = true;
+        }}
+      />,
+    );
     const close = r.getByRole("button", { name: "Close" });
 
     expect(document.activeElement).toBe(close);
@@ -48,12 +56,18 @@ describe("ShortcutsDialog", () => {
   test("lists the command palette chord exactly once and corrects copy-link", () => {
     const r = render(<ShortcutsDialog onClose={() => {}} />);
     const actions = r.getByRole("region", { name: "Actions" });
-    const keys = [...actions.querySelectorAll(".mono")].map((node) => node.textContent);
+    const keys = [...actions.querySelectorAll(".mono")].map(
+      (node) => node.textContent,
+    );
 
     expect(keys.filter((key) => key === "⌘K")).toHaveLength(1);
     expect(keys.filter((key) => key === "c l")).toHaveLength(1);
-    expect(r.getByTestId("shortcuts-scroll").className).toContain("overflow-y-auto");
-    expect(r.getByTestId("shortcuts-scroll-fade").className).toContain("bg-linear-to-t");
+    expect(r.getByTestId("shortcuts-scroll").className).toContain(
+      "overflow-y-auto",
+    );
+    expect(r.getByTestId("shortcuts-scroll-fade").className).toContain(
+      "bg-linear-to-t",
+    );
   });
 
   test("documents Overview pipeline and anomaly shortcuts (WM-292)", () => {
@@ -92,7 +106,9 @@ describe("ShortcutsDialog", () => {
     expect(actions.textContent).toContain("c p");
     expect(actions.textContent).toContain("copy repo path (Projects)");
     expect(actions.textContent).toContain("pin / unpin selected run (Runs)");
-    expect(actions.textContent).toContain("reveal selected node on canvas (Graph)");
+    expect(actions.textContent).toContain(
+      "reveal selected node on canvas (Graph)",
+    );
   });
 
   test("documents 'v' for display options and '1–N' for status tabs (WM-234)", () => {
@@ -165,4 +181,3 @@ describe("ShortcutsDialog", () => {
     expect(content).toMatch(/confirm inject/i);
   });
 });
-

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -11,9 +11,15 @@ const CONTEXT_CHORDS: { chord: string; label: string }[] = [
 const ACTIONS: { keys: string; does: string }[] = [
   { keys: "⌘K", does: "command palette" },
   { keys: "c l", does: "copy link to this page" },
-  { keys: "footer theme button", does: "cycle theme (dark → light → contrast)" },
+  {
+    keys: "footer theme button",
+    does: "cycle theme (dark → light → contrast)",
+  },
   { keys: "i", does: "inject event" },
-  { keys: "/", does: "focus this view's filter (Artifacts, Events, Runs, and other lists)" },
+  {
+    keys: "/",
+    does: "focus this view's filter (Artifacts, Events, Runs, and other lists)",
+  },
   { keys: "v", does: "display options" },
   { keys: "j k  ↑↓", does: "move list (or graph) selection" },
   { keys: "[ ]", does: "previous / next status tab" },
@@ -22,11 +28,26 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "o", does: "open current run (Workers) · full run view (Runs)" },
   { keys: "r", does: "run schedule now (Schedules)" },
   { keys: "a", does: "approve proposal (Proposals) · ack item (Inbox)" },
-  { keys: "x", does: "reject proposal (Proposals) · cancel run (Runs) · resolve item (Inbox)" },
-  { keys: "Space / Shift+Space", does: "toggle highlighted proposal selection · toggle highlighted inbox item selection" },
-  { keys: "* a / ⌘A", does: "select all actionable proposals · select all actionable inbox items" },
-  { keys: "* n / Esc", does: "clear proposal selection · clear inbox selection" },
-  { keys: "A / X", does: "approve / reject selected proposals · ack / resolve selected inbox items" },
+  {
+    keys: "x",
+    does: "reject proposal (Proposals) · cancel run (Runs) · resolve item (Inbox)",
+  },
+  {
+    keys: "Space / Shift+Space",
+    does: "toggle highlighted proposal selection · toggle highlighted inbox item selection",
+  },
+  {
+    keys: "* a / ⌘A",
+    does: "select all actionable proposals · select all actionable inbox items",
+  },
+  {
+    keys: "* n / Esc",
+    does: "clear proposal selection · clear inbox selection",
+  },
+  {
+    keys: "A / X",
+    does: "approve / reject selected proposals · ack / resolve selected inbox items",
+  },
   { keys: "q", does: "requeue event (Events)" },
   { keys: "p", does: "pin / unpin selected run (Runs)" },
   { keys: "z / Enter", does: "reveal selected node on canvas (Graph)" },
@@ -38,13 +59,19 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "d j", does: "dispatch janitor scan (Projects)" },
   { keys: "g h", does: "open repository on GitHub (Projects)" },
   { keys: "⌘+Shift+F", does: "format JSON (Inject dialog)" },
-  { keys: "⌘↵", does: "confirm inject (Inject dialog) · confirm reject (Proposals)" },
+  {
+    keys: "⌘↵",
+    does: "confirm inject (Inject dialog) · confirm reject (Proposals)",
+  },
   { keys: "Esc", does: "close panel, clear filter, or close dialog" },
   { keys: "?", does: "this list" },
 ];
 
 const OVERVIEW_KEYS: { keys: string; does: string }[] = [
-  { keys: "1–5", does: "open pipeline stage views (Events, Proposals, queued, running, outcomes)" },
+  {
+    keys: "1–5",
+    does: "open pipeline stage views (Events, Proposals, queued, running, outcomes)",
+  },
   { keys: ".", does: "focus next anomaly" },
   { keys: "r", does: "requeue focused dead-letter event" },
 ];
@@ -54,11 +81,17 @@ const CONTEXT_STRIP: { keys: string; does: string }[] = [
   { keys: "← →", does: "move focus among All / repos / In flight tabs" },
   { keys: "Home / End", does: "first / last context tab" },
   { keys: "Enter / Space", does: "activate focused filter" },
-  { keys: "Delete / ⌫", does: "close focused repo tab (focus returns to active tab)" },
+  {
+    keys: "Delete / ⌫",
+    does: "close focused repo tab (focus returns to active tab)",
+  },
 ];
 
 const TRACE_KEYS: { keys: string; does: string }[] = [
-  { keys: "1–5", does: "switch trace kind (All, Tools, Reasoning, Errors, Usage)" },
+  {
+    keys: "1–5",
+    does: "switch trace kind (All, Tools, Reasoning, Errors, Usage)",
+  },
   { keys: "[ ]", does: "previous / next trace filter tab (on run view)" },
   { keys: "/", does: "focus trace search" },
   { keys: "e", does: "toggle expand / collapse trace details" },
@@ -113,99 +146,111 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
           data-testid="shortcuts-scroll"
           className="max-h-[calc(85vh-5rem)] space-y-5 overflow-y-auto pr-2 pb-8 text-[12px] text-(--text-dim)"
         >
-        <section aria-label="Navigation chords">
-          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-            Navigation chords
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4">
-            {NAV.map((n) => (
-              <div
-                key={n.key}
-                className="flex items-baseline justify-between gap-2 border-b border-(--border) py-1.5"
-              >
-                <span className="mono text-(--text)">g {n.go}</span>
-                <span className="text-right text-(--text-faint)">{n.label}</span>
-              </div>
-            ))}
-            {CONTEXT_CHORDS.map((c) => (
-              <div
-                key={c.chord}
-                className="flex items-baseline justify-between gap-2 border-b border-(--border) py-1.5"
-              >
-                <span className="mono text-(--text)">{c.chord}</span>
-                <span className="text-right text-(--text-faint)">{c.label}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <section aria-label="Navigation chords">
+            <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              Navigation chords
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4">
+              {NAV.map((n) => (
+                <div
+                  key={n.key}
+                  className="flex items-baseline justify-between gap-2 border-b border-(--border) py-1.5"
+                >
+                  <span className="mono text-(--text)">g {n.go}</span>
+                  <span className="text-right text-(--text-faint)">
+                    {n.label}
+                  </span>
+                </div>
+              ))}
+              {CONTEXT_CHORDS.map((c) => (
+                <div
+                  key={c.chord}
+                  className="flex items-baseline justify-between gap-2 border-b border-(--border) py-1.5"
+                >
+                  <span className="mono text-(--text)">{c.chord}</span>
+                  <span className="text-right text-(--text-faint)">
+                    {c.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section aria-label="Actions">
-          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-            Actions
-          </div>
-          <div>
-            {ACTIONS.map((r) => (
-              <div
-                key={`${r.keys}::${r.does}`}
-                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
-              >
-                <span className="mono text-(--text)">{r.keys}</span>
-                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <section aria-label="Actions">
+            <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              Actions
+            </div>
+            <div>
+              {ACTIONS.map((r) => (
+                <div
+                  key={`${r.keys}::${r.does}`}
+                  className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+                >
+                  <span className="mono text-(--text)">{r.keys}</span>
+                  <span className="text-left sm:text-right text-(--text-faint)">
+                    {r.does}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section aria-label="Overview">
-          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-            Overview
-          </div>
-          <div>
-            {OVERVIEW_KEYS.map((r) => (
-              <div
-                key={`${r.keys}::${r.does}`}
-                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
-              >
-                <span className="mono text-(--text)">{r.keys}</span>
-                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <section aria-label="Overview">
+            <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              Overview
+            </div>
+            <div>
+              {OVERVIEW_KEYS.map((r) => (
+                <div
+                  key={`${r.keys}::${r.does}`}
+                  className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+                >
+                  <span className="mono text-(--text)">{r.keys}</span>
+                  <span className="text-left sm:text-right text-(--text-faint)">
+                    {r.does}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section aria-label="Context strip">
-          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-            Context strip
-          </div>
-          <div>
-            {CONTEXT_STRIP.map((r) => (
-              <div
-                key={`${r.keys}::${r.does}`}
-                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
-              >
-                <span className="mono text-(--text)">{r.keys}</span>
-                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <section aria-label="Context strip">
+            <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              Context strip
+            </div>
+            <div>
+              {CONTEXT_STRIP.map((r) => (
+                <div
+                  key={`${r.keys}::${r.does}`}
+                  className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+                >
+                  <span className="mono text-(--text)">{r.keys}</span>
+                  <span className="text-left sm:text-right text-(--text-faint)">
+                    {r.does}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        <section aria-label="Run & Trace">
-          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-            Run & Trace
-          </div>
-          <div>
-            {TRACE_KEYS.map((r) => (
-              <div
-                key={`${r.keys}::${r.does}`}
-                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
-              >
-                <span className="mono text-(--text)">{r.keys}</span>
-                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <section aria-label="Run & Trace">
+            <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              Run & Trace
+            </div>
+            <div>
+              {TRACE_KEYS.map((r) => (
+                <div
+                  key={`${r.keys}::${r.does}`}
+                  className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+                >
+                  <span className="mono text-(--text)">{r.keys}</span>
+                  <span className="text-left sm:text-right text-(--text-faint)">
+                    {r.does}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
         </div>
         <div
           data-testid="shortcuts-scroll-fade"
@@ -216,4 +261,3 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
     </Dialog>
   );
 }
-

--- a/event-runtime/web/src/components/SpecDiff.test.tsx
+++ b/event-runtime/web/src/components/SpecDiff.test.tsx
@@ -66,8 +66,8 @@ describe("SpecDiff component", () => {
 
     const scroller = r.getByTestId("spec-diff-scroll");
     expect(scroller).not.toBeNull();
-    expect(scroller.textContent).toContain("-   \"maxAttempts\": 3");
-    expect(scroller.textContent).toContain("+   \"maxAttempts\": 5");
+    expect(scroller.textContent).toContain('-   "maxAttempts": 3');
+    expect(scroller.textContent).toContain('+   "maxAttempts": 5');
   });
 
   test("singular changed line count when exactly 1 line changes", () => {
@@ -79,11 +79,25 @@ describe("SpecDiff component", () => {
 
   function mockScrollerDimensions(
     scroller: HTMLElement,
-    { clientHeight, scrollHeight, scrollTop = 0 }: { clientHeight: number; scrollHeight: number; scrollTop?: number },
+    {
+      clientHeight,
+      scrollHeight,
+      scrollTop = 0,
+    }: { clientHeight: number; scrollHeight: number; scrollTop?: number },
   ) {
-    Object.defineProperty(scroller, "clientHeight", { configurable: true, value: clientHeight });
-    Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: scrollHeight });
-    Object.defineProperty(scroller, "scrollTop", { configurable: true, value: scrollTop, writable: true });
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: clientHeight,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: scrollHeight,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      value: scrollTop,
+      writable: true,
+    });
   }
 
   test("does not re-subscribe the overflow observer when props are unchanged", () => {
@@ -153,7 +167,9 @@ describe("SpecDiff component", () => {
     const hint = r.getByText(/\d+ more lines below/);
     expect(hint).toBeDefined();
 
-    const stickyBottomNodes = [...scroller.querySelectorAll(".sticky.bottom-0")];
+    const stickyBottomNodes = [
+      ...scroller.querySelectorAll(".sticky.bottom-0"),
+    ];
     expect(stickyBottomNodes).toHaveLength(1);
     expect(stickyBottomNodes[0]?.contains(hint)).toBe(true);
     expect(stickyBottomNodes[0]?.className).toContain("-mt-10");
@@ -167,8 +183,16 @@ describe("SpecDiff component", () => {
 
     const body = r.getByTestId("spec-diff-body");
     expect(body.className).toContain("whitespace-pre-wrap");
-    const indented = [...body.querySelectorAll("[data-diff-line]")].map((el) => el.textContent ?? "");
-    expect(indented.some((t) => t.startsWith("-   \"maxAttempts\"") || t.startsWith("+   \"maxAttempts\""))).toBe(true);
+    const indented = [...body.querySelectorAll("[data-diff-line]")].map(
+      (el) => el.textContent ?? "",
+    );
+    expect(
+      indented.some(
+        (t) =>
+          t.startsWith('-   "maxAttempts"') ||
+          t.startsWith('+   "maxAttempts"'),
+      ),
+    ).toBe(true);
   });
 
   test("keeps changed-line header sticky while scrolling diff body", () => {
@@ -206,8 +230,8 @@ describe("SpecDiff component", () => {
     const button = r.getByRole("button", { name: "Copy diff" });
     fireEvent.click(button);
 
-    expect(written).toContain("-   \"timeout\": 30");
-    expect(written).toContain("+   \"timeout\": 60");
+    expect(written).toContain('-   "timeout": 30');
+    expect(written).toContain('+   "timeout": 60');
     expect(r.getByRole("status").textContent).toContain("Copied diff");
   });
 });

--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -10,10 +10,15 @@ export type DiffLine = { type: "same" | "del" | "add"; text: string };
 export function diffLines(a: string[], b: string[]): DiffLine[] {
   const n = a.length;
   const m = b.length;
-  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  const lcs: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(m + 1).fill(0),
+  );
   for (let i = n - 1; i >= 0; i--) {
     for (let j = m - 1; j >= 0; j--) {
-      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
     }
   }
   const out: DiffLine[] = [];
@@ -37,7 +42,10 @@ export function diffLines(a: string[], b: string[]): DiffLine[] {
 
 export function formatDiff(lines: DiffLine[]): string {
   return lines
-    .map((l) => `${l.type === "del" ? "- " : l.type === "add" ? "+ " : "  "}${l.text}`)
+    .map(
+      (l) =>
+        `${l.type === "del" ? "- " : l.type === "add" ? "+ " : "  "}${l.text}`,
+    )
     .join("\n");
 }
 
@@ -52,7 +60,13 @@ function countLinesBelowViewport(scroller: HTMLElement): number {
   return below;
 }
 
-export function SpecDiff({ before, after }: { before: unknown; after: unknown }) {
+export function SpecDiff({
+  before,
+  after,
+}: {
+  before: unknown;
+  after: unknown;
+}) {
   const beforeJson = JSON.stringify(before, null, 2);
   const afterJson = JSON.stringify(after, null, 2);
   const lines = useMemo(
@@ -122,7 +136,10 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
           Copy diff
         </Button>
       </div>
-      <div data-testid="spec-diff-body" className="whitespace-pre-wrap p-3 leading-relaxed">
+      <div
+        data-testid="spec-diff-body"
+        className="whitespace-pre-wrap p-3 leading-relaxed"
+      >
         {lines.map((l, idx) => (
           <div
             key={idx}
@@ -130,9 +147,17 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
             className="whitespace-pre"
             style={
               l.type === "del"
-                ? { color: "var(--hue-err)", background: "color-mix(in oklch, var(--hue-err) 8%, transparent)" }
+                ? {
+                    color: "var(--hue-err)",
+                    background:
+                      "color-mix(in oklch, var(--hue-err) 8%, transparent)",
+                  }
                 : l.type === "add"
-                  ? { color: "var(--hue-ok)", background: "color-mix(in oklch, var(--hue-ok) 8%, transparent)" }
+                  ? {
+                      color: "var(--hue-ok)",
+                      background:
+                        "color-mix(in oklch, var(--hue-ok) 8%, transparent)",
+                    }
                   : undefined
             }
           >

--- a/event-runtime/web/src/components/TicketDecisions.tsx
+++ b/event-runtime/web/src/components/TicketDecisions.tsx
@@ -3,8 +3,22 @@ import { useMemo, useState } from "react";
 import { api } from "../api";
 import { humanizeReason } from "../reasons";
 import type { AdmittedEvent, Proposal, RunListItem } from "../types";
-import { DECISION_HUES, DisclosureChevron, EVENT_STATUS_HUES, JumpLink, Section, StateBadge, ago, shortId } from "./ui";
-import { ReasonText, eventTicket, hashHref, ticketIdOf } from "./RunDetailBlocks";
+import {
+  DECISION_HUES,
+  DisclosureChevron,
+  EVENT_STATUS_HUES,
+  JumpLink,
+  Section,
+  StateBadge,
+  ago,
+  shortId,
+} from "./ui";
+import {
+  ReasonText,
+  eventTicket,
+  hashHref,
+  ticketIdOf,
+} from "./RunDetailBlocks";
 
 /**
  * The per-ticket "why isn't this running?" answer (WM-594). Split out of
@@ -41,12 +55,20 @@ const OUTCOME_HUES: Record<string, string> = {
  */
 export function buildTicketDecisions(
   ticket: string,
-  data: { events: readonly AdmittedEvent[]; proposals: readonly Proposal[]; runs: readonly RunListItem[] },
+  data: {
+    events: readonly AdmittedEvent[];
+    proposals: readonly Proposal[];
+    runs: readonly RunListItem[];
+  },
 ): TicketDecision[] {
   const T = ticket.toUpperCase();
-  const eventKey = (source: string | null | undefined, id: string | null | undefined) => `${source}:${id}`;
+  const eventKey = (
+    source: string | null | undefined,
+    id: string | null | undefined,
+  ) => `${source}:${id}`;
   const events = new Map<string, AdmittedEvent>();
-  for (const e of data.events) if (eventTicket(e) === T) events.set(eventKey(e.source, e.eventId), e);
+  for (const e of data.events)
+    if (eventTicket(e) === T) events.set(eventKey(e.source, e.eventId), e);
 
   const proposals = data.proposals.filter((p) => {
     if (events.has(eventKey(p.eventSource, p.eventId))) return true;
@@ -55,7 +77,9 @@ export function buildTicketDecisions(
   });
   // A proposal whose spec names the ticket links its event even when the event
   // itself does not (a chain event carrying only the proposal's payload).
-  const eventById = new Map(data.events.map((e) => [eventKey(e.source, e.eventId), e]));
+  const eventById = new Map(
+    data.events.map((e) => [eventKey(e.source, e.eventId), e]),
+  );
   for (const p of proposals) {
     const k = eventKey(p.eventSource, p.eventId);
     const e = eventById.get(k);
@@ -65,14 +89,20 @@ export function buildTicketDecisions(
   // Only runs this ticket's planner opened: a noop proposal's runId can be
   // the *blocking* run of another ticket (`ticket_dispatch_already_live`).
   const runIds = new Set(
-    proposals.filter((p) => p.decision === "run").map((p) => p.runId).filter((id): id is string => !!id),
+    proposals
+      .filter((p) => p.decision === "run")
+      .map((p) => p.runId)
+      .filter((id): id is string => !!id),
   );
   const runs = data.runs.filter(
-    (r) => runIds.has(r.runId) || events.has(eventKey(r.eventSource, r.eventId)),
+    (r) =>
+      runIds.has(r.runId) || events.has(eventKey(r.eventSource, r.eventId)),
   );
 
   const decisions: TicketDecision[] = [];
-  const decidedEvents = new Set(proposals.map((p) => eventKey(p.eventSource, p.eventId)));
+  const decidedEvents = new Set(
+    proposals.map((p) => eventKey(p.eventSource, p.eventId)),
+  );
   for (const p of proposals) {
     const e = eventById.get(eventKey(p.eventSource, p.eventId));
     decisions.push({
@@ -106,7 +136,10 @@ export function buildTicketDecisions(
       outcome: "refused",
       status: null,
       reason: r.reasonCode,
-      event: r.eventSource && r.eventId ? { source: r.eventSource, eventId: r.eventId, type: "" } : null,
+      event:
+        r.eventSource && r.eventId
+          ? { source: r.eventSource, eventId: r.eventId, type: "" }
+          : null,
       proposalId: null,
       runId: r.runId,
     });
@@ -117,7 +150,10 @@ export function buildTicketDecisions(
 /** `noop · Owned paths overlap · 3m ago` — the one line an operator reads first. */
 export function decisionHeadline(d: TicketDecision, now: number): string {
   const reason = humanizeReason(d.reason).text;
-  const status = d.outcome === "planned" && d.status && d.status !== "approved" ? ` (${d.status})` : "";
+  const status =
+    d.outcome === "planned" && d.status && d.status !== "approved"
+      ? ` (${d.status})`
+      : "";
   return `${d.outcome}${status}${reason ? ` · ${reason}` : ""} · ${ago(d.at, now)}`;
 }
 
@@ -145,13 +181,21 @@ export function TicketDecisions({
   onJumpTicket?: (ticketId: string) => void;
 }) {
   const [open, setOpen] = useState(defaultOpen);
-  const eventsQ = useQuery({ queryKey: ["events", "all"], queryFn: () => api.events(), staleTime: 5_000 });
+  const eventsQ = useQuery({
+    queryKey: ["events", "all"],
+    queryFn: () => api.events(),
+    staleTime: 5_000,
+  });
   const proposalsQ = useQuery({
     queryKey: ["proposals", "history"],
     queryFn: () => api.proposalHistory("all"),
     staleTime: 5_000,
   });
-  const runsQ = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), staleTime: 5_000 });
+  const runsQ = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    staleTime: 5_000,
+  });
   const decisions = useMemo(
     () =>
       buildTicketDecisions(ticket, {
@@ -164,14 +208,20 @@ export function TicketDecisions({
   const loading = eventsQ.isPending || proposalsQ.isPending || runsQ.isPending;
   const latest = decisions.at(-1) ?? null;
   const jumpEvent = (source: string, eventId: string) =>
-    onJumpEvent ? onJumpEvent(source, eventId) : (window.location.hash = hashHref("events", source, eventId));
+    onJumpEvent
+      ? onJumpEvent(source, eventId)
+      : (window.location.hash = hashHref("events", source, eventId));
 
   return (
     <Section title="Decisions" id="decisions">
       {loading && !latest ? (
-        <div className="py-1 text-[11px] text-(--text-faint)">Loading planner decisions…</div>
+        <div className="py-1 text-[11px] text-(--text-faint)">
+          Loading planner decisions…
+        </div>
       ) : !latest ? (
-        <div className="py-1 text-[11px] text-(--text-faint)">No planner decisions recorded for this ticket.</div>
+        <div className="py-1 text-[11px] text-(--text-faint)">
+          No planner decisions recorded for this ticket.
+        </div>
       ) : (
         <>
           {/* The headline is the whole answer for most tickets; the list under
@@ -195,16 +245,38 @@ export function TicketDecisions({
               <DisclosureChevron open={open} />
               <span className="text-[11px] text-(--text-faint)">last:</span>
             </button>
-            <StateBadge state={latest.outcome} hues={OUTCOME_HUES} dot={false} />
+            <StateBadge
+              state={latest.outcome}
+              hues={OUTCOME_HUES}
+              dot={false}
+            />
             <span className="min-w-0 flex-1 truncate text-[12px] text-(--text-dim)">
-              {latest.outcome === "planned" && latest.status && latest.status !== "approved" && (
-                <span className="text-(--text-faint)">({latest.status}) </span>
+              {latest.outcome === "planned" &&
+                latest.status &&
+                latest.status !== "approved" && (
+                  <span className="text-(--text-faint)">
+                    ({latest.status}){" "}
+                  </span>
+                )}
+              <ReasonText
+                code={latest.reason}
+                onJumpRun={onJumpRun}
+                onJumpProposal={onJumpProposal}
+                onJumpTicket={onJumpTicket}
+              />
+              {!latest.reason && latest.outcome === "planned" && (
+                <span className="text-(--text-faint)">run proposed</span>
               )}
-              <ReasonText code={latest.reason} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpTicket={onJumpTicket} />
-              {!latest.reason && latest.outcome === "planned" && <span className="text-(--text-faint)">run proposed</span>}
-              {!latest.reason && latest.outcome === "admitted" && <span className="text-(--text-faint)">awaiting the planner</span>}
+              {!latest.reason && latest.outcome === "admitted" && (
+                <span className="text-(--text-faint)">
+                  awaiting the planner
+                </span>
+              )}
             </span>
-            <span className="shrink-0 text-[11px] tabular-nums text-(--text-faint)" title={latest.at}>
+            <span
+              className="shrink-0 text-[11px] tabular-nums text-(--text-faint)"
+              title={latest.at}
+            >
               {ago(latest.at, now)}
             </span>
             <span className="shrink-0 text-[11px] tabular-nums text-(--text-faint)">
@@ -212,24 +284,51 @@ export function TicketDecisions({
             </span>
           </div>
           {open && (
-            <ol className="m-0 mt-1 list-none border-t border-(--border) p-0 pt-1" aria-label={`Planner decisions for ${ticket}`}>
+            <ol
+              className="m-0 mt-1 list-none border-t border-(--border) p-0 pt-1"
+              aria-label={`Planner decisions for ${ticket}`}
+            >
               {decisions.map((d, i) => (
                 <li
                   key={`${d.proposalId ?? ""}:${d.runId ?? ""}:${d.event?.eventId ?? ""}:${i}`}
                   className="py-1 text-[11.5px]"
                 >
                   <div className="flex items-baseline gap-2">
-                    <span className="mono w-[52px] shrink-0 text-[11px] tabular-nums text-(--text-faint)" title={d.at}>
+                    <span
+                      className="mono w-[52px] shrink-0 text-[11px] tabular-nums text-(--text-faint)"
+                      title={d.at}
+                    >
                       {ago(d.at, now)}
                     </span>
-                    <StateBadge state={d.outcome} hues={OUTCOME_HUES} dot={false} />
+                    <StateBadge
+                      state={d.outcome}
+                      hues={OUTCOME_HUES}
+                      dot={false}
+                    />
                     <span className="min-w-0 flex-1 break-words text-(--text-dim)">
-                      {d.outcome === "planned" && d.status && d.status !== "approved" && (
-                        <span className="text-(--text-faint)">({d.status}) </span>
+                      {d.outcome === "planned" &&
+                        d.status &&
+                        d.status !== "approved" && (
+                          <span className="text-(--text-faint)">
+                            ({d.status}){" "}
+                          </span>
+                        )}
+                      <ReasonText
+                        code={d.reason}
+                        onJumpRun={onJumpRun}
+                        onJumpProposal={onJumpProposal}
+                        onJumpTicket={onJumpTicket}
+                      />
+                      {!d.reason && d.outcome === "planned" && (
+                        <span className="text-(--text-faint)">
+                          run proposed
+                        </span>
                       )}
-                      <ReasonText code={d.reason} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpTicket={onJumpTicket} />
-                      {!d.reason && d.outcome === "planned" && <span className="text-(--text-faint)">run proposed</span>}
-                      {!d.reason && d.outcome === "admitted" && <span className="text-(--text-faint)">awaiting the planner</span>}
+                      {!d.reason && d.outcome === "admitted" && (
+                        <span className="text-(--text-faint)">
+                          awaiting the planner
+                        </span>
+                      )}
                     </span>
                   </div>
                   {/* The joins on their own line: event ids can be long
@@ -240,7 +339,9 @@ export function TicketDecisions({
                       <span className="flex shrink-0 items-baseline gap-1">
                         <span>event</span>
                         <JumpLink
-                          onClick={() => jumpEvent(d.event!.source, d.event!.eventId)}
+                          onClick={() =>
+                            jumpEvent(d.event!.source, d.event!.eventId)
+                          }
                           title={`${d.event.source} · ${d.event.eventId}${d.event.type ? ` · ${d.event.type}` : ""}`}
                           className="inline-block max-w-[11rem] truncate align-bottom"
                         >
@@ -296,4 +397,3 @@ export function TicketDecisions({
     </Section>
   );
 }
-

--- a/event-runtime/web/src/components/attrIcons.test.tsx
+++ b/event-runtime/web/src/components/attrIcons.test.tsx
@@ -23,7 +23,18 @@ describe("attribute icon registry (§5.2 tier 4, WM-483)", () => {
   });
 
   test("identity and state labels are unmapped so they render an empty, reserved slot", () => {
-    for (const k of ["id", "run", "runId", "version", "specHash", "idempotencyKey", "state", "status", "decision", "pid"]) {
+    for (const k of [
+      "id",
+      "run",
+      "runId",
+      "version",
+      "specHash",
+      "idempotencyKey",
+      "state",
+      "status",
+      "decision",
+      "pid",
+    ]) {
       expect(attrIcon(k)).toBeNull();
     }
   });

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,7 +2,25 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, ChipInput, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, KVGroup, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
+import {
+  Button,
+  ChipInput,
+  clearToasts,
+  CopyActions,
+  Countdown,
+  DetailPane,
+  Dialog,
+  FilterInput,
+  getValueHue,
+  KV,
+  KVGroup,
+  notify,
+  Section,
+  shortId,
+  StateBadge,
+  SuggestInput,
+  ToastContainer,
+} from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { modal } from "../hooks";
 import { changeInput, typeText } from "../test-render";
@@ -32,8 +50,12 @@ afterEach(() => {
 
 describe("shortId (WM-96)", () => {
   test("shortens a prefixed UUID id to the prefix plus the first 8 body characters", () => {
-    expect(shortId("run_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d")).toBe("run_ec9c87f9");
-    expect(shortId("worker_0f3b2a1c-9e8d-4b7a-8c6d-5e4f3a2b1c0d")).toBe("worker_0f3b2a1c");
+    expect(shortId("run_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d")).toBe(
+      "run_ec9c87f9",
+    );
+    expect(shortId("worker_0f3b2a1c-9e8d-4b7a-8c6d-5e4f3a2b1c0d")).toBe(
+      "worker_0f3b2a1c",
+    );
   });
 
   test("returns ids whose body is already 8 characters or fewer unchanged", () => {
@@ -42,7 +64,9 @@ describe("shortId (WM-96)", () => {
   });
 
   test("returns ids without a prefix unchanged", () => {
-    expect(shortId("plainid-with-no-underscore")).toBe("plainid-with-no-underscore");
+    expect(shortId("plainid-with-no-underscore")).toBe(
+      "plainid-with-no-underscore",
+    );
     expect(shortId("")).toBe("");
   });
 });
@@ -59,7 +83,9 @@ describe("CopyActions (WM-302)", () => {
     );
 
     const id = r.getByRole("button", { name: "Copy run id (c)" });
-    const cli = r.getByRole("button", { name: "Copy CLI inspect command (c i)" });
+    const cli = r.getByRole("button", {
+      name: "Copy CLI inspect command (c i)",
+    });
     const link = r.getByRole("button", { name: "Copy link (c l)" });
     expect(id.getAttribute("title")).toBe("Copy run id · c");
     expect(cli.getAttribute("title")).toBe("Copy CLI inspect command · c i");
@@ -92,7 +118,9 @@ describe("CopyActions (WM-302)", () => {
     );
 
     fireEvent.click(r.getByRole("button", { name: "Copy run id (c)" }));
-    fireEvent.click(r.getByRole("button", { name: "Copy CLI inspect command (c i)" }));
+    fireEvent.click(
+      r.getByRole("button", { name: "Copy CLI inspect command (c i)" }),
+    );
     fireEvent.click(r.getByRole("button", { name: "Copy link (c l)" }));
 
     expect(writes).toEqual([
@@ -153,7 +181,9 @@ describe("ToastContainer", () => {
     act(() => {
       button.click();
     });
-    expect(r.queryByRole("button", { name: /Operation succeeded/i })).toBeNull();
+    expect(
+      r.queryByRole("button", { name: /Operation succeeded/i }),
+    ).toBeNull();
   });
 });
 
@@ -168,18 +198,24 @@ describe("Countdown", () => {
     jest.setSystemTime(now);
     const createdAt = now.toISOString();
     const ttlSeconds = 15 * 60 + 14;
-    const r = render(<Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />);
+    const r = render(
+      <Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />,
+    );
 
     const el = r.container.querySelector("span");
     if (!el) throw new Error("Countdown span is missing");
     expect(el.textContent).toBe("15:14 left");
-    expect(el.getAttribute("title")).toBe(new Date(now.getTime() + ttlSeconds * 1000).toISOString());
+    expect(el.getAttribute("title")).toBe(
+      new Date(now.getTime() + ttlSeconds * 1000).toISOString(),
+    );
   });
 
   test("counts down as time passes, without losing the 'left' qualifier", () => {
     const created = new Date("2024-01-01T00:00:00Z");
     jest.setSystemTime(new Date(created.getTime() + 60_000));
-    const r = render(<Countdown createdAt={created.toISOString()} ttlSeconds={15 * 60 + 14} />);
+    const r = render(
+      <Countdown createdAt={created.toISOString()} ttlSeconds={15 * 60 + 14} />,
+    );
 
     const el = r.container.querySelector("span");
     if (!el) throw new Error("Countdown span is missing");
@@ -190,13 +226,19 @@ describe("Countdown", () => {
     const now = new Date("2024-01-01T00:00:00Z");
     jest.setSystemTime(now);
     const ttlSeconds = 60;
-    const createdAt = new Date(now.getTime() - (ttlSeconds * 1000 + 2 * 3600 * 1000)).toISOString();
-    const r = render(<Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />);
+    const createdAt = new Date(
+      now.getTime() - (ttlSeconds * 1000 + 2 * 3600 * 1000),
+    ).toISOString();
+    const r = render(
+      <Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />,
+    );
 
     const el = r.container.querySelector("span");
     if (!el) throw new Error("Countdown span is missing");
     expect(el.textContent).toBe("expired 2h ago");
-    expect(el.getAttribute("title")).toBe(new Date(new Date(createdAt).getTime() + ttlSeconds * 1000).toISOString());
+    expect(el.getAttribute("title")).toBe(
+      new Date(new Date(createdAt).getTime() + ttlSeconds * 1000).toISOString(),
+    );
   });
 });
 
@@ -255,7 +297,11 @@ describe("DetailPane", () => {
 
   test("omits the close slot when no close action is given", () => {
     const r = render(
-      <DetailPane widthClass="w-[440px]" title="t" actions={<Button onClick={() => {}}>Copy id</Button>}>
+      <DetailPane
+        widthClass="w-[440px]"
+        title="t"
+        actions={<Button onClick={() => {}}>Copy id</Button>}
+      >
         <div>body</div>
       </DetailPane>,
     );
@@ -274,13 +320,20 @@ describe("getValueHue", () => {
 });
 
 describe("FilterInput autocomplete (OPS-506)", () => {
-  function renderFilter(props: {
-    value?: string;
-    onChange?: (v: string) => void;
-    query?: ReturnType<typeof parseFilterQuery>;
-    facets?: typeof RUN_FACETS;
-  } = {}) {
-    const { value = "", onChange = () => {}, query, facets = RUN_FACETS } = props;
+  function renderFilter(
+    props: {
+      value?: string;
+      onChange?: (v: string) => void;
+      query?: ReturnType<typeof parseFilterQuery>;
+      facets?: typeof RUN_FACETS;
+    } = {},
+  ) {
+    const {
+      value = "",
+      onChange = () => {},
+      query,
+      facets = RUN_FACETS,
+    } = props;
     const parsed = query ?? parseFilterQuery(value, facets);
     return render(
       <FilterInput
@@ -377,7 +430,6 @@ describe("FilterInput autocomplete (OPS-506)", () => {
   });
 });
 
-
 describe("KV mono discipline (WM-136)", () => {
   test("renders identifier-ish values in mono and prose values in the UI font", () => {
     const r = render(
@@ -388,7 +440,9 @@ describe("KV mono discipline (WM-136)", () => {
       </>,
     );
     expect(classes(r.getByTitle("dispatch@1"))).toContain("mono");
-    expect(classes(r.getByTitle("/Users/x/.factory/event-runtime"))).toContain("mono");
+    expect(classes(r.getByTitle("/Users/x/.factory/event-runtime"))).toContain(
+      "mono",
+    );
     // "any worker" is language, not an identifier — character alignment buys nothing.
     expect(classes(r.getByTitle("any worker"))).not.toContain("mono");
   });
@@ -416,7 +470,11 @@ describe("KV attribute icons and unset values (WM-482)", () => {
   test("renders a leading aria-hidden icon slot only when an icon is passed", () => {
     const r = render(
       <>
-        <KV k="timeout" v="120s" icon={<svg data-testid="icon" viewBox="0 0 15 15" />} />
+        <KV
+          k="timeout"
+          v="120s"
+          icon={<svg data-testid="icon" viewBox="0 0 15 15" />}
+        />
         <KV k="version" v="1" />
       </>,
     );
@@ -437,19 +495,29 @@ describe("KV attribute icons and unset values (WM-482)", () => {
         <KV k="runId" v="run_1" />
       </Section>,
     );
-    expect(r.getByTitle("adapter").querySelector("i[aria-hidden] svg")).toBeTruthy();
+    expect(
+      r.getByTitle("adapter").querySelector("i[aria-hidden] svg"),
+    ).toBeTruthy();
     const slot = r.getByTitle("runId").querySelector("i[aria-hidden]");
     expect(slot).toBeTruthy();
     expect(slot!.querySelector("svg")).toBeNull();
     cleanup();
     // Without the opt-in nothing changes for the ~100 existing KV call sites.
-    const bare = render(<Section title="Run"><KV k="adapter" v="pi" /></Section>);
-    expect(bare.getByTitle("adapter").querySelector("i[aria-hidden]")).toBeNull();
+    const bare = render(
+      <Section title="Run">
+        <KV k="adapter" v="pi" />
+      </Section>,
+    );
+    expect(
+      bare.getByTitle("adapter").querySelector("i[aria-hidden]"),
+    ).toBeNull();
   });
 
   test("a null icon reserves the slot so labels in the same group align", () => {
     const r = render(<KV k="model override" v="-" icon={null} />);
-    expect(r.getByTitle("model override").querySelector("[aria-hidden]")).toBeTruthy();
+    expect(
+      r.getByTitle("model override").querySelector("[aria-hidden]"),
+    ).toBeTruthy();
   });
 
   test("renders the unset marker fainter than a set value", () => {
@@ -487,31 +555,56 @@ describe("Section cards and collapse persistence (WM-136)", () => {
   beforeEach(() => localStorage.clear());
 
   test("wraps rows in a card by default and skips it when card is false", () => {
-    const carded = render(<Section title="Run"><KV k="agent" v="a@1" /></Section>);
+    const carded = render(
+      <Section title="Run">
+        <KV k="agent" v="a@1" />
+      </Section>,
+    );
     expect(carded.container.querySelector(".rounded-md")).toBeTruthy();
     cleanup();
-    const bare = render(<Section title="Heartbeat" card={false}><KV k="agent" v="a@1" /></Section>);
+    const bare = render(
+      <Section title="Heartbeat" card={false}>
+        <KV k="agent" v="a@1" />
+      </Section>,
+    );
     expect(bare.container.querySelector(".rounded-md")).toBeNull();
   });
 
   test("collapses on click, hides its rows, and persists the choice", () => {
-    const r = render(<Section title="Lifecycle"><KV k="agent" v="a@1" /></Section>);
+    const r = render(
+      <Section title="Lifecycle">
+        <KV k="agent" v="a@1" />
+      </Section>,
+    );
     expect(r.queryByText("agent")).toBeTruthy();
     fireEvent.click(r.getByRole("button", { expanded: true }));
     expect(r.queryByText("agent")).toBeNull();
-    expect(JSON.parse(localStorage.getItem("evrt-sections-collapsed")!)).toContain("Lifecycle");
+    expect(
+      JSON.parse(localStorage.getItem("evrt-sections-collapsed")!),
+    ).toContain("Lifecycle");
     // A remount reads the persisted choice back.
     cleanup();
-    const again = render(<Section title="Lifecycle"><KV k="agent" v="a@1" /></Section>);
+    const again = render(
+      <Section title="Lifecycle">
+        <KV k="agent" v="a@1" />
+      </Section>,
+    );
     expect(again.queryByText("agent")).toBeNull();
   });
 
   test("a toggle does not stomp a sibling section's persisted collapse", () => {
-    localStorage.setItem("evrt-sections-collapsed", JSON.stringify(["Receipt"]));
+    localStorage.setItem(
+      "evrt-sections-collapsed",
+      JSON.stringify(["Receipt"]),
+    );
     const r = render(
       <>
-        <Section title="Run"><KV k="agent" v="a@1" /></Section>
-        <Section title="Receipt"><KV k="hash" v="abc" /></Section>
+        <Section title="Run">
+          <KV k="agent" v="a@1" />
+        </Section>
+        <Section title="Receipt">
+          <KV k="hash" v="abc" />
+        </Section>
       </>,
     );
     fireEvent.click(r.getByRole("button", { expanded: true, name: /Run/ }));
@@ -521,12 +614,22 @@ describe("Section cards and collapse persistence (WM-136)", () => {
   });
 
   test("keys persistence on id so a title carrying live data stays stable", () => {
-    const r = render(<Section id="run-result" title="Result · COMPLETED · ok"><KV k="a" v="b" /></Section>);
+    const r = render(
+      <Section id="run-result" title="Result · COMPLETED · ok">
+        <KV k="a" v="b" />
+      </Section>,
+    );
     fireEvent.click(r.getByRole("button", { expanded: true }));
-    expect(JSON.parse(localStorage.getItem("evrt-sections-collapsed")!)).toEqual(["run-result"]);
+    expect(
+      JSON.parse(localStorage.getItem("evrt-sections-collapsed")!),
+    ).toEqual(["run-result"]);
     cleanup();
     // Same section, different terminal state in the title — still collapsed.
-    const again = render(<Section id="run-result" title="Result · FAILED · agent_exit_1"><KV k="a" v="b" /></Section>);
+    const again = render(
+      <Section id="run-result" title="Result · FAILED · agent_exit_1">
+        <KV k="a" v="b" />
+      </Section>,
+    );
     expect(again.queryByText("a")).toBeNull();
   });
 });
@@ -812,7 +915,9 @@ describe("ChipInput popover (WM-160)", () => {
 
   test("filters available suggestions and supports ArrowDown / ArrowUp / Enter / Escape", () => {
     const r = render(<Harness />);
-    const input = r.getByRole("combobox", { name: "Repos" }) as HTMLInputElement;
+    const input = r.getByRole("combobox", {
+      name: "Repos",
+    }) as HTMLInputElement;
     fireEvent.focus(input);
 
     const options = r.getAllByRole("option");
@@ -824,7 +929,9 @@ describe("ChipInput popover (WM-160)", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     expect(options[1].getAttribute("aria-selected")).toBe("true");
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(r.getByRole("button", { name: "Remove watt-mind/bj29" })).toBeTruthy();
+    expect(
+      r.getByRole("button", { name: "Remove watt-mind/bj29" }),
+    ).toBeTruthy();
     expect(r.queryByRole("listbox")).toBeNull();
 
     fireEvent.focus(input);
@@ -839,7 +946,9 @@ describe("ChipInput popover (WM-160)", () => {
 
   test("preserves free-text chip entry when no suggestion matches", () => {
     const r = render(<Harness />);
-    const input = r.getByRole("combobox", { name: "Repos" }) as HTMLInputElement;
+    const input = r.getByRole("combobox", {
+      name: "Repos",
+    }) as HTMLInputElement;
     fireEvent.focus(input);
     act(() => {
       changeInput(input, "custom-repo");
@@ -864,7 +973,10 @@ describe("Dialog (WM-270)", () => {
             </Dialog>
           )}
           {confirmationOpen && (
-            <Dialog title="Confirmation dialog" onClose={() => setConfirmationOpen(false)}>
+            <Dialog
+              title="Confirmation dialog"
+              onClose={() => setConfirmationOpen(false)}
+            >
               Confirmation content
             </Dialog>
           )}
@@ -882,4 +994,3 @@ describe("Dialog (WM-270)", () => {
     expect(modal.depth).toBe(1);
   });
 });
-

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,4 +1,13 @@
-import { createContext, type ReactNode, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { attrIcon } from "./attrIcons";
 import { createPortal } from "react-dom";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
@@ -69,7 +78,10 @@ export const WORKER_HUES: Record<string, string> = {
 /**
  * Returns the matching theme hue for a facet value (states, statuses, decisions).
  */
-export const getValueHue = (_field: string, value: string): string | undefined => {
+export const getValueHue = (
+  _field: string,
+  value: string,
+): string | undefined => {
   const norm = value.trim();
   return (
     STATE_HUES[norm.toUpperCase()] ??
@@ -111,7 +123,10 @@ export function ModelCell({
   const slash = model.indexOf("/");
   if (slash <= 0 || slash === model.length - 1) {
     return (
-      <span className={`mono block max-w-full truncate ${className}`} title={title}>
+      <span
+        className={`mono block max-w-full truncate ${className}`}
+        title={title}
+      >
         {model}
       </span>
     );
@@ -120,9 +135,15 @@ export function ModelCell({
   const provider = model.slice(0, slash + 1);
   const name = model.slice(slash + 1);
   return (
-    <span className={`mono block min-w-0 max-w-full ${className}`} title={title}>
+    <span
+      className={`mono block min-w-0 max-w-full ${className}`}
+      title={title}
+    >
       <span className="sr-only">{model}</span>
-      <span aria-hidden="true" className="flex min-w-0 max-w-full items-baseline">
+      <span
+        aria-hidden="true"
+        className="flex min-w-0 max-w-full items-baseline"
+      >
         <span className="min-w-0 truncate text-(--text-faint)">{provider}</span>
         <span className="max-w-full shrink-0 truncate">{name}</span>
       </span>
@@ -149,7 +170,13 @@ type CopyActionButtonProps = {
   children: ReactNode;
 };
 
-function CopyActionButton({ label, chord, onClick, quiet = false, children }: CopyActionButtonProps) {
+function CopyActionButton({
+  label,
+  chord,
+  onClick,
+  quiet = false,
+  children,
+}: CopyActionButtonProps) {
   return (
     <button
       type="button"
@@ -187,21 +214,40 @@ export function CopyActions({
 }) {
   if (variant === "quiet") {
     return (
-      <div className="inline-flex items-center gap-1.5" role="group" aria-label="Copy actions">
+      <div
+        className="inline-flex items-center gap-1.5"
+        role="group"
+        aria-label="Copy actions"
+      >
         <span>copy:</span>
-        <CopyActionButton label={`Copy ${idLabel}`} chord={idChord} onClick={() => copyText(id, idLabel)} quiet>
+        <CopyActionButton
+          label={`Copy ${idLabel}`}
+          chord={idChord}
+          onClick={() => copyText(id, idLabel)}
+          quiet
+        >
           id
         </CopyActionButton>
         <span aria-hidden="true">·</span>
         {cli !== undefined && (
           <>
-            <CopyActionButton label={`Copy ${cliLabel}`} chord="c i" onClick={() => copyText(cli, cliLabel)} quiet>
+            <CopyActionButton
+              label={`Copy ${cliLabel}`}
+              chord="c i"
+              onClick={() => copyText(cli, cliLabel)}
+              quiet
+            >
               CLI
             </CopyActionButton>
             <span aria-hidden="true">·</span>
           </>
         )}
-        <CopyActionButton label="Copy link" chord="c l" onClick={copyLink} quiet>
+        <CopyActionButton
+          label="Copy link"
+          chord="c l"
+          onClick={copyLink}
+          quiet
+        >
           link
         </CopyActionButton>
       </div>
@@ -209,8 +255,16 @@ export function CopyActions({
   }
 
   return (
-    <div className="inline-flex items-center gap-1" role="group" aria-label="Copy actions">
-      <CopyActionButton label={`Copy ${idLabel}`} chord={idChord} onClick={() => copyText(id, idLabel)}>
+    <div
+      className="inline-flex items-center gap-1"
+      role="group"
+      aria-label="Copy actions"
+    >
+      <CopyActionButton
+        label={`Copy ${idLabel}`}
+        chord={idChord}
+        onClick={() => copyText(id, idLabel)}
+      >
         <svg
           viewBox="0 0 14 14"
           fill="none"
@@ -224,7 +278,11 @@ export function CopyActions({
         </svg>
       </CopyActionButton>
       {cli !== undefined && (
-        <CopyActionButton label={`Copy ${cliLabel}`} chord="c i" onClick={() => copyText(cli, cliLabel)}>
+        <CopyActionButton
+          label={`Copy ${cliLabel}`}
+          chord="c i"
+          onClick={() => copyText(cli, cliLabel)}
+        >
           <svg
             viewBox="0 0 14 14"
             fill="none"
@@ -289,8 +347,13 @@ function FilterToken({
           : "border-dashed text-(--hue-warn)"
       }`}
     >
-      <span className={`mono ${token.supported ? "" : "line-through"}`}>{label}</span>
-      <span aria-hidden className="text-(--text-faint) group-hover:text-(--text)">
+      <span className={`mono ${token.supported ? "" : "line-through"}`}>
+        {label}
+      </span>
+      <span
+        aria-hidden
+        className="text-(--text-faint) group-hover:text-(--text)"
+      >
         ×
       </span>
     </button>
@@ -339,7 +402,11 @@ export function FilterInput<T = unknown, C = unknown>({
     return getFilterSuggestions(activeToken.raw, facets, query, getValueHue);
   }, [activeToken.raw, facets, query]);
 
-  const showPopover = isFocused && !isDismissed && (facets != null || query != null) && suggestions.length > 0;
+  const showPopover =
+    isFocused &&
+    !isDismissed &&
+    (facets != null || query != null) &&
+    suggestions.length > 0;
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -347,7 +414,9 @@ export function FilterInput<T = unknown, C = unknown>({
 
   useEffect(() => {
     if (showPopover && listRef.current) {
-      const activeEl = listRef.current.querySelector<HTMLElement>(`[aria-selected="true"]`);
+      const activeEl = listRef.current.querySelector<HTMLElement>(
+        `[aria-selected="true"]`,
+      );
       activeEl?.scrollIntoView({ block: "nearest" });
     }
   }, [selectedIndex, showPopover]);
@@ -393,7 +462,11 @@ export function FilterInput<T = unknown, C = unknown>({
           aria-expanded={showPopover}
           aria-autocomplete="list"
           aria-controls={showPopover ? listboxId : undefined}
-          aria-activedescendant={showPopover && suggestions[selectedIndex] ? `${listboxId}-opt-${selectedIndex}` : undefined}
+          aria-activedescendant={
+            showPopover && suggestions[selectedIndex]
+              ? `${listboxId}-opt-${selectedIndex}`
+              : undefined
+          }
           aria-describedby={query ? hintId : undefined}
           value={value}
           onChange={(e) => {
@@ -423,7 +496,10 @@ export function FilterInput<T = unknown, C = unknown>({
               }
               if (e.key === "ArrowUp") {
                 e.preventDefault();
-                setSelectedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length);
+                setSelectedIndex(
+                  (prev) =>
+                    (prev - 1 + suggestions.length) % suggestions.length,
+                );
                 return;
               }
               if (e.key === "Enter" || e.key === "Tab") {
@@ -440,7 +516,11 @@ export function FilterInput<T = unknown, C = unknown>({
                 setIsDismissed(true);
                 return;
               }
-            } else if (e.key === "ArrowDown" && suggestions.length > 0 && isDismissed) {
+            } else if (
+              e.key === "ArrowDown" &&
+              suggestions.length > 0 &&
+              isDismissed
+            ) {
               e.preventDefault();
               setIsDismissed(false);
               return;
@@ -569,7 +649,13 @@ export function FilterInput<T = unknown, C = unknown>({
 }
 
 /** Pinned title/tabs/filter; only the table (and anything below it) scrolls. */
-export function ListPane({ chrome, children }: { chrome: ReactNode; children: ReactNode }) {
+export function ListPane({
+  chrome,
+  children,
+}: {
+  chrome: ReactNode;
+  children: ReactNode;
+}) {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="shrink-0 px-5 pt-5 pb-3">{chrome}</div>
@@ -598,16 +684,22 @@ export function DetailPane({
   children: ReactNode;
 }) {
   return (
-    <aside className={`${widthClass} flex min-h-0 shrink-0 flex-col border-l border-(--border) bg-(--surface-1)`}>
+    <aside
+      className={`${widthClass} flex min-h-0 shrink-0 flex-col border-l border-(--border) bg-(--surface-1)`}
+    >
       <div className="shrink-0 border-b border-(--border) px-4 py-3">
         {/* Row 1: Title & Close */}
         <div className="flex items-center justify-between gap-2">
-          <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">{title}</div>
+          <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">
+            {title}
+          </div>
           {close != null && <div className="shrink-0">{close}</div>}
         </div>
         {/* Row 2: Verb Row (≤ 3 bordered buttons) */}
         {actions != null && (
-          <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">{actions}</div>
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">
+            {actions}
+          </div>
         )}
         {/* Row 3: Utility Row (copy/share quiet text line) */}
         {utility != null && (
@@ -624,7 +716,11 @@ export function DetailPane({
 export const ESC_CLEARS_FILTER = "Esc clears the filter";
 
 /** Previous/next controls for a 100-row table window. */
-export function TableWindowFooter({ colSpan, range, move }: {
+export function TableWindowFooter({
+  colSpan,
+  range,
+  move,
+}: {
   colSpan: number;
   range: readonly [number, number, number];
   move: (direction: number) => void;
@@ -635,12 +731,18 @@ export function TableWindowFooter({ colSpan, range, move }: {
     <tr>
       <td
         colSpan={colSpan}
-        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+        onKeyDown={(e) =>
+          (e.key === "Enter" || e.key === " ") && e.stopPropagation()
+        }
         align="right"
       >
         {start + 1}–{end}/{total}{" "}
-        <Button disabled={!start} onClick={() => move(-1)}>Prev</Button>{" "}
-        <Button disabled={end === total} onClick={() => move(1)}>Next</Button>
+        <Button disabled={!start} onClick={() => move(-1)}>
+          Prev
+        </Button>{" "}
+        <Button disabled={end === total} onClick={() => move(1)}>
+          Next
+        </Button>
       </td>
     </tr>
   );
@@ -671,10 +773,14 @@ export function ListEmpty({
   else if (query.isError && !query.data) {
     msg = `Cannot reach the control API — ${noun} will appear when it is up.`;
   } else if (filtered) msg = `No ${noun} match this filter.`;
-  const showEscHint = (filtered || escHint) && !query.isPending && !query.isError;
+  const showEscHint =
+    (filtered || escHint) && !query.isPending && !query.isError;
   return (
     <tr>
-      <td colSpan={colSpan} className="px-3 py-8 text-center text-(--text-faint)">
+      <td
+        colSpan={colSpan}
+        className="px-3 py-8 text-center text-(--text-faint)"
+      >
         <div>{msg}</div>
         {showEscHint && (
           <div className="mt-2 text-[11px]">{ESC_CLEARS_FILTER}</div>
@@ -684,7 +790,9 @@ export function ListEmpty({
             <Button onClick={onClear}>Clear filter</Button>
           </div>
         )}
-        {action && !query.isPending && !query.isError && !filtered && <div className="mt-3">{action}</div>}
+        {action && !query.isPending && !query.isError && !filtered && (
+          <div className="mt-3">{action}</div>
+        )}
       </td>
     </tr>
   );
@@ -716,15 +824,29 @@ export function Th({
 }) {
   const alignCls = align === "right" ? "text-right" : "text-left";
   const base = `sticky top-0 z-10 h-7 bg-(--surface-0) px-3 font-medium whitespace-nowrap shadow-[inset_0_-1px_0_var(--border)] ${alignCls}`;
-  if (!onSort && !onRemove) return <th className={base} title={title}>{label}</th>;
+  if (!onSort && !onRemove)
+    return (
+      <th className={base} title={title}>
+        {label}
+      </th>
+    );
   return (
-    <th aria-sort={dir === "asc" ? "ascending" : dir === "desc" ? "descending" : "none"} className={`${base} p-0`}>
-      <div className={`group/th flex h-7 w-full items-center justify-between gap-1 px-3 ${align === "right" ? "justify-end" : ""}`}>
+    <th
+      aria-sort={
+        dir === "asc" ? "ascending" : dir === "desc" ? "descending" : "none"
+      }
+      className={`${base} p-0`}
+    >
+      <div
+        className={`group/th flex h-7 w-full items-center justify-between gap-1 px-3 ${align === "right" ? "justify-end" : ""}`}
+      >
         {onSort ? (
           <button
             type="button"
             onClick={onSort}
-            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+            onKeyDown={(e) =>
+              (e.key === "Enter" || e.key === " ") && e.stopPropagation()
+            }
             title={title ?? `Sort by ${label.toLowerCase()}`}
             className={`inline-flex h-7 items-center gap-1 cursor-pointer font-medium transition-colors hover:text-(--text) ${dir ? "text-(--text)" : ""}`}
           >
@@ -796,12 +918,17 @@ export function GroupHeaderRow({
   const hue = section.hue ?? "var(--text-faint)";
   return (
     <tr>
-      <td colSpan={colSpan} className={`p-0 ${sub ? "" : "sticky top-7 z-[5]"}`}>
+      <td
+        colSpan={colSpan}
+        className={`p-0 ${sub ? "" : "sticky top-7 z-[5]"}`}
+      >
         <button
           type="button"
           aria-expanded={!collapsed}
           onClick={onToggle}
-          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+          onKeyDown={(e) =>
+            (e.key === "Enter" || e.key === " ") && e.stopPropagation()
+          }
           className={`flex w-full cursor-pointer items-center gap-2 border-b border-(--border) bg-(--surface-1) px-3 text-left transition-colors hover:bg-(--surface-2) ${
             sub ? "h-7 pl-8" : "h-8"
           }`}
@@ -811,15 +938,24 @@ export function GroupHeaderRow({
             <span
               aria-hidden
               className="size-2 rounded-full"
-              style={{ background: hue, boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)` }}
+              style={{
+                background: hue,
+                boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)`,
+              }}
             />
           )}
-          <span className={`font-medium ${sub ? "text-[11.5px] text-(--text-dim)" : "text-[12px] text-(--text)"}`}>
+          <span
+            className={`font-medium ${sub ? "text-[11.5px] text-(--text-dim)" : "text-[12px] text-(--text)"}`}
+          >
             {section.label}
           </span>
-          <span className="tabular-nums text-[11px] text-(--text-faint)">{section.count}</span>
+          <span className="tabular-nums text-[11px] text-(--text-faint)">
+            {section.count}
+          </span>
           {collapsed && section.count > 0 && (
-            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">collapsed</span>
+            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">
+              collapsed
+            </span>
           )}
         </button>
       </td>
@@ -842,110 +978,258 @@ export function StateIcon({
   switch (norm) {
     case "admitted":
       return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="currentColor"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="3" />
         </svg>
       );
     case "planned":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <polygon points="5,3.5 10.5,7 5,10.5" fill="currentColor" fillOpacity="0.2" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
+          <polygon
+            points="5,3.5 10.5,7 5,10.5"
+            fill="currentColor"
+            fillOpacity="0.2"
+          />
         </svg>
       );
     case "noop":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
           <line x1="4" y1="7" x2="10" y2="7" />
         </svg>
       );
     case "human_needed":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
-          <path d="M7 2.5 L12 11.5 L2 11.5 Z" fill="currentColor" fillOpacity="0.18" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={className}
+          aria-hidden="true"
+        >
+          <path
+            d="M7 2.5 L12 11.5 L2 11.5 Z"
+            fill="currentColor"
+            fillOpacity="0.18"
+          />
           <line x1="7" y1="5.5" x2="7" y2="8" />
           <circle cx="7" cy="9.8" r="0.5" fill="currentColor" />
         </svg>
       );
     case "dead_lettered":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <line x1="3.8" y1="10.2" x2="10.2" y2="3.8" />
         </svg>
       );
     case "queued":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2 2" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeDasharray="2 2"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
         </svg>
       );
     case "leased":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <circle cx="7" cy="7" r="1.8" fill="currentColor" />
         </svg>
       );
     case "running":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
         </svg>
       );
     case "verifying":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="6" cy="6" r="3.5" />
           <line x1="8.5" y1="8.5" x2="11.5" y2="11.5" />
         </svg>
       );
     case "completed":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={className}
+          aria-hidden="true"
+        >
+          <circle
+            cx="7"
+            cy="7"
+            r="4.5"
+            fill="currentColor"
+            fillOpacity="0.18"
+          />
           <polyline points="4.8,7.2 6.3,8.7 9.3,5.3" />
         </svg>
       );
     case "failed":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
+          <circle
+            cx="7"
+            cy="7"
+            r="4.5"
+            fill="currentColor"
+            fillOpacity="0.18"
+          />
           <line x1="5" y1="5" x2="9" y2="9" />
           <line x1="9" y1="5" x2="5" y2="9" />
         </svg>
       );
     case "timed_out":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <polyline points="7,4.5 7,7 9,7" />
         </svg>
       );
     case "cancelled":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <line x1="4" y1="7" x2="10" y2="7" />
         </svg>
       );
     case "refused":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <line x1="10" y1="4" x2="4" y2="10" />
         </svg>
       );
     case "open":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" strokeDasharray="3 2" />
         </svg>
       );
     case "expired":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
+          <circle
+            cx="7"
+            cy="7"
+            r="4.5"
+            fill="currentColor"
+            fillOpacity="0.18"
+          />
           <line x1="7" y1="4" x2="7" y2="7.5" />
           <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
         </svg>
@@ -953,28 +1237,59 @@ export function StateIcon({
     case "live":
     case "idle":
       return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="currentColor"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="3.5" />
         </svg>
       );
     case "busy":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="4.5" />
           <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
         </svg>
       );
     case "stale":
       return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={className}
+          aria-hidden="true"
+        >
+          <circle
+            cx="7"
+            cy="7"
+            r="4.5"
+            fill="currentColor"
+            fillOpacity="0.18"
+          />
           <line x1="7" y1="4" x2="7" y2="7.5" />
           <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
         </svg>
       );
     default:
       return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+        <svg
+          viewBox="0 0 14 14"
+          fill="currentColor"
+          className={className}
+          aria-hidden="true"
+        >
           <circle cx="7" cy="7" r="2.5" />
         </svg>
       );
@@ -997,7 +1312,10 @@ export function StateBadge({
   return (
     <span
       className="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px] font-medium"
-      style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
+      style={{
+        color: hue,
+        background: `color-mix(in oklch, ${hue} 12%, transparent)`,
+      }}
     >
       {dot && <StateIcon state={state} className="size-3 shrink-0" />}
       {state}
@@ -1025,13 +1343,23 @@ export function StatCard({
       data-stat-card
       className={`${compact ? "min-w-0 rounded-md px-3 py-2" : "min-w-36 rounded-lg px-3.5 py-3"} border border-(--border) bg-(--surface-1)`}
     >
-      <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
-      <div className={`display font-semibold tabular-nums ${compact ? "mt-0.5 text-lg" : "mt-1 text-xl"}`}>
-        <span data-stat-value style={hue ? { color: hue } : undefined}>{value}</span>
+      <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+        {label}
+      </div>
+      <div
+        className={`display font-semibold tabular-nums ${compact ? "mt-0.5 text-lg" : "mt-1 text-xl"}`}
+      >
+        <span data-stat-value style={hue ? { color: hue } : undefined}>
+          {value}
+        </span>
         {suffix}
       </div>
       {caption != null && (
-        <div className={`${compact ? "text-[10px]" : "text-[11px]"} mt-0.5 text-(--text-faint)`}>{caption}</div>
+        <div
+          className={`${compact ? "text-[10px]" : "text-[11px]"} mt-0.5 text-(--text-faint)`}
+        >
+          {caption}
+        </div>
       )}
     </div>
   );
@@ -1051,12 +1379,16 @@ export function StatTile({
   const inner = (
     <>
       <div className="text-[11px] text-(--text-faint)">{label}</div>
-      <div className="display text-xl tabular-nums" style={hue ? { color: hue } : undefined}>
+      <div
+        className="display text-xl tabular-nums"
+        style={hue ? { color: hue } : undefined}
+      >
         {value}
       </div>
     </>
   );
-  const cls = "rounded-md border border-(--border) bg-(--surface-1) px-3 py-2 text-left";
+  const cls =
+    "rounded-md border border-(--border) bg-(--surface-1) px-3 py-2 text-left";
   if (!onClick) return <div className={cls}>{inner}</div>;
   return (
     <button
@@ -1123,14 +1455,24 @@ export function JumpLink({
  * an expired badge elsewhere (e.g. the Proposals Decision column) should not
  * also repeat the word "expired" next to this.
  */
-export function Countdown({ createdAt, ttlSeconds }: { createdAt: string; ttlSeconds: number }) {
+export function Countdown({
+  createdAt,
+  ttlSeconds,
+}: {
+  createdAt: string;
+  ttlSeconds: number;
+}) {
   const now = useNow();
   const expiryMs = new Date(createdAt).getTime() + ttlSeconds * 1000;
   const expiryIso = new Date(expiryMs).toISOString();
   const left = Math.floor((expiryMs - now) / 1000);
   if (left <= 0) {
     return (
-      <span className="tabular-nums" style={{ color: "var(--hue-err)" }} title={expiryIso}>
+      <span
+        className="tabular-nums"
+        style={{ color: "var(--hue-err)" }}
+        title={expiryIso}
+      >
         expired {ago(expiryIso, now)}
       </span>
     );
@@ -1139,7 +1481,11 @@ export function Countdown({ createdAt, ttlSeconds }: { createdAt: string; ttlSec
   const s = left % 60;
   const low = left < 300;
   return (
-    <span className="tabular-nums" style={low ? { color: "var(--hue-warn)" } : undefined} title={expiryIso}>
+    <span
+      className="tabular-nums"
+      style={low ? { color: "var(--hue-warn)" } : undefined}
+      title={expiryIso}
+    >
       {m}:{String(s).padStart(2, "0")} left
     </span>
   );
@@ -1228,7 +1574,9 @@ export function ToastContainer() {
   const gap = polite.length > 0 && assertive.length > 0 ? "gap-2" : "";
 
   return (
-    <div className={`fixed bottom-4 right-4 z-50 flex flex-col pointer-events-none ${gap}`}>
+    <div
+      className={`fixed bottom-4 right-4 z-50 flex flex-col pointer-events-none ${gap}`}
+    >
       <ToastRegion role="status" live="polite" toasts={polite} />
       <ToastRegion role="alert" live="assertive" toasts={assertive} />
     </div>
@@ -1247,7 +1595,12 @@ function ToastRegion({
   return (
     // aria-atomic="false" — both roles default to atomic, which re-reads every
     // surviving toast whenever one is added or dismissed.
-    <div role={role} aria-live={live} aria-atomic="false" className="flex flex-col gap-2">
+    <div
+      role={role}
+      aria-live={live}
+      aria-atomic="false"
+      className="flex flex-col gap-2"
+    >
       {toasts.map((t) => (
         <button
           key={t.id}
@@ -1256,13 +1609,23 @@ function ToastRegion({
           onClick={() => dismissToast(t.id)}
           className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-md border bg-(--surface-1) px-3 py-2 text-left text-[12px] shadow-xl transition-all hover:bg-(--surface-2) focus:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
           style={{
-            borderColor: t.type === "err" ? "var(--hue-err)" : t.type === "ok" ? "var(--hue-ok)" : "var(--accent)",
+            borderColor:
+              t.type === "err"
+                ? "var(--hue-err)"
+                : t.type === "ok"
+                  ? "var(--hue-ok)"
+                  : "var(--accent)",
           }}
         >
           <span
             className="size-2 shrink-0 rounded-full"
             style={{
-              background: t.type === "err" ? "var(--hue-err)" : t.type === "ok" ? "var(--hue-ok)" : "var(--accent)",
+              background:
+                t.type === "err"
+                  ? "var(--hue-err)"
+                  : t.type === "ok"
+                    ? "var(--hue-ok)"
+                    : "var(--accent)",
             }}
           />
           <span className="text-(--text) font-medium">{t.message}</span>
@@ -1352,8 +1715,12 @@ const SECTIONS_KEY = "evrt-sections-collapsed";
 /** Collapsed section ids, shared by every Section on the page (WM-136). */
 function loadCollapsedSections(): string[] {
   try {
-    const parsed: unknown = JSON.parse(localStorage.getItem(SECTIONS_KEY) ?? "[]");
-    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === "string") : [];
+    const parsed: unknown = JSON.parse(
+      localStorage.getItem(SECTIONS_KEY) ?? "[]",
+    );
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === "string")
+      : [];
   } catch {
     // Private mode / stale value: sections simply start expanded.
     return [];
@@ -1411,7 +1778,9 @@ export function Section({
   icons?: boolean;
 }) {
   const key = id ?? title;
-  const [collapsed, setCollapsed] = useState(() => collapsible && loadCollapsedSections().includes(key));
+  const [collapsed, setCollapsed] = useState(
+    () => collapsible && loadCollapsedSections().includes(key),
+  );
   const toggle = () =>
     setCollapsed((prev) => {
       const next = !prev;
@@ -1420,32 +1789,36 @@ export function Section({
     });
 
   const heading = (
-    <span className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{title}</span>
+    <span className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+      {title}
+    </span>
   );
 
   return (
     <KVIconsContext.Provider value={icons}>
-    <div className="mb-5">
-      {collapsible ? (
-        <button
-          type="button"
-          onClick={toggle}
-          aria-expanded={!collapsed}
-          className="mb-1.5 flex w-full cursor-pointer items-center gap-1.5 text-left hover:text-(--text-dim)"
-        >
-          <DisclosureChevron open={!collapsed} />
-          {heading}
-        </button>
-      ) : (
-        <div className="mb-1.5">{heading}</div>
-      )}
-      {!collapsed &&
-        (card ? (
-          <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-1.5">{children}</div>
+      <div className="mb-5">
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={!collapsed}
+            className="mb-1.5 flex w-full cursor-pointer items-center gap-1.5 text-left hover:text-(--text-dim)"
+          >
+            <DisclosureChevron open={!collapsed} />
+            {heading}
+          </button>
         ) : (
-          children
-        ))}
-    </div>
+          <div className="mb-1.5">{heading}</div>
+        )}
+        {!collapsed &&
+          (card ? (
+            <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-1.5">
+              {children}
+            </div>
+          ) : (
+            children
+          ))}
+      </div>
     </KVIconsContext.Provider>
   );
 }
@@ -1484,7 +1857,8 @@ export function KV({
   icon?: ReactNode;
 }) {
   const autoIcons = useContext(KVIconsContext);
-  const resolvedIcon = icon !== undefined ? icon : autoIcons ? attrIcon(k) : undefined;
+  const resolvedIcon =
+    icon !== undefined ? icon : autoIcons ? attrIcon(k) : undefined;
   const text = typeof v === "string" ? v : null;
   const copyable = !!text && text !== "-";
   const isMono = mono ?? (text !== null && looksLikeIdentifier(text));
@@ -1494,9 +1868,15 @@ export function KV({
   // eye had to re-find on every row (WM-136).
   return (
     <div className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
-      <div className="flex min-w-0 items-center gap-1.5 text-(--text-faint)" title={k}>
+      <div
+        className="flex min-w-0 items-center gap-1.5 text-(--text-faint)"
+        title={k}
+      >
         {resolvedIcon !== undefined && (
-          <i className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5" aria-hidden="true">
+          <i
+            className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5"
+            aria-hidden="true"
+          >
             {resolvedIcon}
           </i>
         )}
@@ -1530,10 +1910,18 @@ export function KV({
  * fifteen rows has no landmarks; a faint title plus a hairline every four or
  * five rows gives the eye somewhere to land without adding a second card.
  */
-export function KVGroup({ title, children }: { title: string; children: ReactNode }) {
+export function KVGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
   return (
     <div className="not-first:mt-2 not-first:border-t not-first:border-(--border) not-first:pt-2">
-      <div className="pb-0.5 text-[11px] font-medium text-(--text-faint)">{title}</div>
+      <div className="pb-0.5 text-[11px] font-medium text-(--text-faint)">
+        {title}
+      </div>
       {children}
     </div>
   );
@@ -1553,8 +1941,10 @@ export function Button({
   autoFocus?: boolean;
 }) {
   const styles = {
-    default: "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
-    primary: "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
+    default:
+      "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
+    primary:
+      "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
     danger:
       "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-(--hue-err)",
   }[variant];
@@ -1591,14 +1981,15 @@ function isTabCycleNodeVisible(el: HTMLElement, root: HTMLElement): boolean {
     current = current.parentElement;
   }
 
-  const visibility = el.ownerDocument.defaultView?.getComputedStyle(el).visibility;
+  const visibility =
+    el.ownerDocument.defaultView?.getComputedStyle(el).visibility;
   return visibility !== "hidden" && visibility !== "collapse";
 }
 
 /** Keep Tab focus inside a modal while ignoring controls hidden by layout. */
 export function tabCycle(root: HTMLElement, e: KeyboardEvent) {
-  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((el) =>
-    isTabCycleNodeVisible(el, root),
+  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
+    (el) => isTabCycleNodeVisible(el, root),
   );
   if (nodes.length === 0) {
     e.preventDefault();
@@ -1642,7 +2033,8 @@ export function Dialog({
     const depth = modal.depth;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape" && depth === modal.depth) onCloseRef.current();
-      else if (e.key === "Tab" && panelRef.current) tabCycle(panelRef.current, e);
+      else if (e.key === "Tab" && panelRef.current)
+        tabCycle(panelRef.current, e);
     };
     window.addEventListener("keydown", onKey);
     const root = panelRef.current;
@@ -1689,7 +2081,11 @@ export function Tabs({
   label: string;
 }) {
   return (
-    <div role="tablist" aria-label={label} className="inline-flex gap-0.5 rounded-md border border-(--border) bg-(--surface-0) p-0.5">
+    <div
+      role="tablist"
+      aria-label={label}
+      className="inline-flex gap-0.5 rounded-md border border-(--border) bg-(--surface-0) p-0.5"
+    >
       {tabs.map((t) => (
         <button
           key={t.id}
@@ -1715,7 +2111,13 @@ export function Tabs({
 }
 
 /** Read-only value badge (schema `const` fields). */
-export function Pill({ children, title }: { children: ReactNode; title?: string }) {
+export function Pill({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title?: string;
+}) {
   return (
     <span
       title={title}
@@ -1763,7 +2165,9 @@ export function SuggestInput({
 
   useEffect(() => {
     if (!show || !listRef.current) return;
-    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+    listRef.current
+      .querySelector<HTMLElement>('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
   }, [highlight, show]);
 
   const pick = (s: string) => {
@@ -1780,7 +2184,9 @@ export function SuggestInput({
         aria-expanded={show}
         aria-autocomplete="list"
         aria-controls={show ? listId : undefined}
-        aria-activedescendant={show && items[highlight] ? `${listId}-opt-${highlight}` : undefined}
+        aria-activedescendant={
+          show && items[highlight] ? `${listId}-opt-${highlight}` : undefined
+        }
         value={value}
         onChange={(e) => {
           onChange(e.target.value);
@@ -1869,7 +2275,11 @@ export function ChipInput({
   const [draft, setDraft] = useState("");
   const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(0);
-  const [popoverRect, setPopoverRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [popoverRect, setPopoverRect] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
   const listId = useId();
   const anchorRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -1877,7 +2287,9 @@ export function ChipInput({
   const items = useMemo(() => {
     if (!suggestions || suggestions.length === 0) return [];
     const q = draft.trim().toLowerCase();
-    return suggestions.filter((s) => !values.includes(s) && (!q || s.toLowerCase().includes(q)));
+    return suggestions.filter(
+      (s) => !values.includes(s) && (!q || s.toLowerCase().includes(q)),
+    );
   }, [draft, suggestions, values]);
   const show = open && items.length > 0;
 
@@ -1888,7 +2300,12 @@ export function ChipInput({
     }
     const position = () => {
       const rect = anchorRef.current?.getBoundingClientRect();
-      if (rect) setPopoverRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+      if (rect)
+        setPopoverRect({
+          top: rect.bottom + 4,
+          left: rect.left,
+          width: rect.width,
+        });
     };
     position();
     window.addEventListener("resize", position);
@@ -1901,7 +2318,9 @@ export function ChipInput({
 
   useEffect(() => {
     if (!show || !listRef.current) return;
-    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+    listRef.current
+      .querySelector<HTMLElement>('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
   }, [highlight, show]);
 
   const add = (raw: string) => {
@@ -1925,7 +2344,10 @@ export function ChipInput({
               className="group inline-flex cursor-pointer items-center gap-1 rounded-md border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[11px] hover:border-(--border-strong) hover:bg-(--surface-3)"
             >
               <span className="mono">{v}</span>
-              <span aria-hidden className="text-(--text-faint) group-hover:text-(--text)">
+              <span
+                aria-hidden
+                className="text-(--text-faint) group-hover:text-(--text)"
+              >
                 ×
               </span>
             </button>
@@ -1940,7 +2362,9 @@ export function ChipInput({
           aria-expanded={show}
           aria-autocomplete="list"
           aria-controls={show ? listId : undefined}
-          aria-activedescendant={show && items[highlight] ? `${listId}-opt-${highlight}` : undefined}
+          aria-activedescendant={
+            show && items[highlight] ? `${listId}-opt-${highlight}` : undefined
+          }
           value={draft}
           onChange={(e) => {
             setDraft(e.target.value);
@@ -2077,4 +2501,3 @@ export function BulkActionBar({
     </div>
   );
 }
-

--- a/event-runtime/web/src/context.test.ts
+++ b/event-runtime/web/src/context.test.ts
@@ -28,7 +28,9 @@ describe("matchesRepo / matchesInFlight", () => {
     expect(matchesRepo([], { kind: "all" })).toBe(true);
     expect(matchesRepo([], { kind: "inflight" })).toBe(true);
     expect(matchesRepo([], { kind: "repo", name: "bj29" })).toBe(false);
-    expect(matchesRepo(["ok", "bj29"], { kind: "repo", name: "bj29" })).toBe(true);
+    expect(matchesRepo(["ok", "bj29"], { kind: "repo", name: "bj29" })).toBe(
+      true,
+    );
     expect(matchesRepo(undefined, { kind: "repo", name: "bj29" })).toBe(false);
   });
 
@@ -37,7 +39,9 @@ describe("matchesRepo / matchesInFlight", () => {
     expect(matchesInFlight("LEASED", { kind: "inflight" })).toBe(true);
     expect(matchesInFlight("RUNNING", { kind: "inflight" })).toBe(true);
     expect(matchesInFlight("QUEUED", { kind: "inflight" })).toBe(false);
-    expect(matchesInFlight("LEASED", { kind: "repo", name: "bj29" })).toBe(true);
+    expect(matchesInFlight("LEASED", { kind: "repo", name: "bj29" })).toBe(
+      true,
+    );
   });
 });
 
@@ -45,11 +49,20 @@ describe("readContextTabs", () => {
   test("empty, invalid, and reserved names", () => {
     expect(readContextTabs(null)).toEqual({ openRepos: [], active: "all" });
     expect(readContextTabs("{")).toEqual({ openRepos: [], active: "all" });
-    expect(readContextTabs(JSON.stringify({ openRepos: ["bj29", "all", INFLIGHT, ""], active: "bj29" }))).toEqual({
+    expect(
+      readContextTabs(
+        JSON.stringify({
+          openRepos: ["bj29", "all", INFLIGHT, ""],
+          active: "bj29",
+        }),
+      ),
+    ).toEqual({
       openRepos: ["bj29"],
       active: "bj29",
     });
-    expect(readContextTabs(JSON.stringify({ openRepos: ["ok"], active: "gone" }))).toEqual({
+    expect(
+      readContextTabs(JSON.stringify({ openRepos: ["ok"], active: "gone" })),
+    ).toEqual({
       openRepos: ["ok"],
       active: "all",
     });
@@ -60,7 +73,9 @@ describe("readContextTabs", () => {
 describe("toggleInflight", () => {
   test("In flight from any other context; All when already in flight", () => {
     expect(toggleInflight({ kind: "all" })).toEqual({ kind: "inflight" });
-    expect(toggleInflight({ kind: "repo", name: "bj29" })).toEqual({ kind: "inflight" });
+    expect(toggleInflight({ kind: "repo", name: "bj29" })).toEqual({
+      kind: "inflight",
+    });
     expect(toggleInflight({ kind: "inflight" })).toEqual({ kind: "all" });
   });
 });

--- a/event-runtime/web/src/context.ts
+++ b/event-runtime/web/src/context.ts
@@ -7,16 +7,16 @@ export const CONTEXT_STORAGE_KEY = "factory.contextTabs";
 export const INFLIGHT = "inflight";
 
 export type OperatorContext =
-  | { kind: "all" }
-  | { kind: "inflight" }
-  | { kind: "repo"; name: string };
+  { kind: "all" } | { kind: "inflight" } | { kind: "repo"; name: string };
 
 export type ContextTabsPersisted = {
   openRepos: string[];
   active: string;
 };
 
-export function contextFromProject(project: string | null | undefined): OperatorContext {
+export function contextFromProject(
+  project: string | null | undefined,
+): OperatorContext {
   if (!project || project === "all") return { kind: "all" };
   if (project === INFLIGHT) return { kind: "inflight" };
   return { kind: "repo", name: project };
@@ -29,7 +29,10 @@ export function projectFromContext(ctx: OperatorContext): string | null {
 }
 
 /** A repo tab filters to rows that name that repo. All and In flight do not. */
-export function matchesRepo(repos: string[] | undefined, ctx: OperatorContext): boolean {
+export function matchesRepo(
+  repos: string[] | undefined,
+  ctx: OperatorContext,
+): boolean {
   if (ctx.kind !== "repo") return true;
   return (repos ?? []).includes(ctx.name);
 }
@@ -93,14 +96,20 @@ export function readContextTabs(raw: string | null): ContextTabsPersisted {
     const openRepos = Array.isArray(value.openRepos)
       ? value.openRepos.filter(
           (name): name is string =>
-            typeof name === "string" && name !== "" && name !== "all" && name !== INFLIGHT,
+            typeof name === "string" &&
+            name !== "" &&
+            name !== "all" &&
+            name !== INFLIGHT,
         )
       : [];
     // Dedup while preserving order — sessionStorage can be written twice in Strict Mode.
     const seen = new Set<string>();
-    const unique = openRepos.filter((name) => (seen.has(name) ? false : (seen.add(name), true)));
+    const unique = openRepos.filter((name) =>
+      seen.has(name) ? false : (seen.add(name), true),
+    );
     let active = typeof value.active === "string" ? value.active : "all";
-    if (active !== "all" && active !== INFLIGHT && !unique.includes(active)) active = "all";
+    if (active !== "all" && active !== INFLIGHT && !unique.includes(active))
+      active = "all";
     return { openRepos: unique, active };
   } catch {
     return { openRepos: [], active: "all" };
@@ -108,6 +117,7 @@ export function readContextTabs(raw: string | null): ContextTabsPersisted {
 }
 
 export function rememberOpenRepo(openRepos: string[], name: string): string[] {
-  if (!name || name === "all" || name === INFLIGHT || openRepos.includes(name)) return openRepos;
+  if (!name || name === "all" || name === INFLIGHT || openRepos.includes(name))
+    return openRepos;
   return [...openRepos, name];
 }

--- a/event-runtime/web/src/displayOptions.test.ts
+++ b/event-runtime/web/src/displayOptions.test.ts
@@ -49,7 +49,13 @@ const CONFIG: DisplayConfig<Row> = {
   ],
   subGroups: ["agent"],
   sorts: [
-    { key: "created", label: "Created", get: (r) => r.created_at, defaultDir: "desc", column: "created" },
+    {
+      key: "created",
+      label: "Created",
+      get: (r) => r.created_at,
+      defaultDir: "desc",
+      column: "created",
+    },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
   ],
   columns: [
@@ -59,7 +65,13 @@ const CONFIG: DisplayConfig<Row> = {
   ],
 };
 
-const row = (id: string, state: string, agent: string, created: string, extra?: Partial<Row>): Row => ({
+const row = (
+  id: string,
+  state: string,
+  agent: string,
+  created: string,
+  extra?: Partial<Row>,
+): Row => ({
   id,
   state,
   agent,
@@ -68,10 +80,18 @@ const row = (id: string, state: string, agent: string, created: string, extra?: 
 });
 
 const ROWS: Row[] = [
-  row("r1", "COMPLETED", "doctor", "2026-01-03", { envelope: { payload: { repo: "watt-mind/factory", priority: 1 } } }),
-  row("r2", "RUNNING", "scout", "2026-01-01", { envelope: { payload: { repo: "watt-mind/core", priority: 3 } } }),
-  row("r3", "FAILED", "doctor", "2026-01-04", { envelope: { payload: { repo: "watt-mind/factory", priority: 2 } } }),
-  row("r4", "RUNNING", "doctor", "2026-01-02", { spec: { input: { repo: "watt-mind/agent" } } }),
+  row("r1", "COMPLETED", "doctor", "2026-01-03", {
+    envelope: { payload: { repo: "watt-mind/factory", priority: 1 } },
+  }),
+  row("r2", "RUNNING", "scout", "2026-01-01", {
+    envelope: { payload: { repo: "watt-mind/core", priority: 3 } },
+  }),
+  row("r3", "FAILED", "doctor", "2026-01-04", {
+    envelope: { payload: { repo: "watt-mind/factory", priority: 2 } },
+  }),
+  row("r4", "RUNNING", "doctor", "2026-01-02", {
+    spec: { input: { repo: "watt-mind/agent" } },
+  }),
   row("r5", "COMPLETED", "scout", "2026-01-05"),
 ];
 
@@ -87,9 +107,16 @@ afterEach(() => {
 describe("pathExtractor", () => {
   test("parsePath tokenizes dot and bracket paths safely", () => {
     expect(parsePath("payload.repo")).toEqual(["payload", "repo"]);
-    expect(parsePath("spec.input['model-name']")).toEqual(["spec", "input", "model-name"]);
+    expect(parsePath("spec.input['model-name']")).toEqual([
+      "spec",
+      "input",
+      "model-name",
+    ]);
     expect(parsePath("repos[0].name")).toEqual(["repos", "0", "name"]);
-    expect(parsePath("payload.__proto__.polluted")).toEqual(["payload", "polluted"]);
+    expect(parsePath("payload.__proto__.polluted")).toEqual([
+      "payload",
+      "polluted",
+    ]);
   });
 
   test("getPathValue extracts nested property safely", () => {
@@ -101,7 +128,10 @@ describe("pathExtractor", () => {
   });
 
   test("extractRowValue checks root and fallback payload/spec scopes", () => {
-    const eventRow = { id: "e1", envelope: { payload: { repo: "my-repo", count: 42 } } };
+    const eventRow = {
+      id: "e1",
+      envelope: { payload: { repo: "my-repo", count: 42 } },
+    };
     expect(extractRowValue(eventRow, "envelope.payload.repo")).toBe("my-repo");
     expect(extractRowValue(eventRow, "payload.repo")).toBe("my-repo");
     expect(extractRowValue(eventRow, "repo")).toBe("my-repo");
@@ -117,7 +147,9 @@ describe("schemaDiscovery", () => {
   test("discoverPayloadFields proposes candidate paths with sample values", () => {
     const fields = discoverPayloadFields(ROWS, []);
     expect(fields.length).toBeGreaterThan(0);
-    const repoField = fields.find((f) => f.path === "payload.repo" || f.path === "spec.input.repo");
+    const repoField = fields.find(
+      (f) => f.path === "payload.repo" || f.path === "spec.input.repo",
+    );
     expect(repoField).toBeDefined();
     expect(repoField?.occurrenceCount).toBeGreaterThanOrEqual(1);
   });
@@ -128,12 +160,22 @@ describe("buildSections", () => {
     const sections = buildSections(ROWS, CONFIG, state());
     expect(sections).toHaveLength(1);
     expect(sections[0].key).toBe(NONE);
-    expect(sections[0].rows.map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
+    expect(sections[0].rows.map((r) => r.id)).toEqual([
+      "r1",
+      "r2",
+      "r3",
+      "r4",
+      "r5",
+    ]);
   });
 
   test("enum grouping orders buckets canonically with counts and hues", () => {
     const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state" }));
-    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED"]);
+    expect(sections.map((s) => s.value)).toEqual([
+      "RUNNING",
+      "COMPLETED",
+      "FAILED",
+    ]);
     expect(sections.map((s) => s.count)).toEqual([2, 2, 1]);
     expect(sections[0].hue).toBe("var(--hue-warn)");
   });
@@ -147,27 +189,51 @@ describe("buildSections", () => {
   test("a value outside the canonical order still gets a bucket, after the enums", () => {
     const rows = [...ROWS, row("r6", "MYSTERY", "scout", "2026-01-06")];
     const sections = buildSections(rows, CONFIG, state({ groupBy: "state" }));
-    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED", "MYSTERY"]);
+    expect(sections.map((s) => s.value)).toEqual([
+      "RUNNING",
+      "COMPLETED",
+      "FAILED",
+      "MYSTERY",
+    ]);
     expect(sections[3].count).toBe(1);
   });
 
   test("show empty groups emits zero-count buckets from the canonical order", () => {
     const rows = [row("r1", "RUNNING", "doctor", "2026-01-01")];
-    const sections = buildSections(rows, CONFIG, state({ groupBy: "state", showEmpty: true }));
-    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED"]);
+    const sections = buildSections(
+      rows,
+      CONFIG,
+      state({ groupBy: "state", showEmpty: true }),
+    );
+    expect(sections.map((s) => s.value)).toEqual([
+      "RUNNING",
+      "COMPLETED",
+      "FAILED",
+    ]);
     expect(sections.map((s) => s.count)).toEqual([1, 0, 0]);
     expect(sections[1].rows).toEqual([]);
   });
 
   test("sub-grouping nests second-level sections with scoped collapse keys", () => {
-    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
+    const sections = buildSections(
+      ROWS,
+      CONFIG,
+      state({ groupBy: "state", subGroupBy: "agent" }),
+    );
     const running = sections.find((s) => s.value === "RUNNING");
     expect(running?.subsections).toBeDefined();
-    expect(running?.subsections?.map((sub) => sub.key)).toEqual(["RUNNING∕doctor", "RUNNING∕scout"]);
+    expect(running?.subsections?.map((sub) => sub.key)).toEqual([
+      "RUNNING∕doctor",
+      "RUNNING∕scout",
+    ]);
   });
 
   test("sub-group equal to the group collapses to a single level", () => {
-    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "state" }));
+    const sections = buildSections(
+      ROWS,
+      CONFIG,
+      state({ groupBy: "state", subGroupBy: "state" }),
+    );
     expect(sections.every((s) => !s.subsections)).toBe(true);
   });
 
@@ -180,18 +246,24 @@ describe("buildSections", () => {
 
 describe("sortRows", () => {
   test("default order preserves API order and desc reverses it", () => {
-    expect(sortRows(ROWS, CONFIG, state()).map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
-    expect(sortRows(ROWS, CONFIG, state({ sortDir: "desc" })).map((r) => r.id)).toEqual([
-      "r5",
-      "r4",
-      "r3",
-      "r2",
+    expect(sortRows(ROWS, CONFIG, state()).map((r) => r.id)).toEqual([
       "r1",
+      "r2",
+      "r3",
+      "r4",
+      "r5",
     ]);
+    expect(
+      sortRows(ROWS, CONFIG, state({ sortDir: "desc" })).map((r) => r.id),
+    ).toEqual(["r5", "r4", "r3", "r2", "r1"]);
   });
 
   test("field sort is applied inside groups and is stable on ties", () => {
-    const sorted = sortRows(ROWS, CONFIG, state({ sortBy: "created", sortDir: "asc" }));
+    const sorted = sortRows(
+      ROWS,
+      CONFIG,
+      state({ sortBy: "created", sortDir: "asc" }),
+    );
     expect(sorted.map((r) => r.created_at)).toEqual([
       "2026-01-01",
       "2026-01-02",
@@ -202,7 +274,11 @@ describe("sortRows", () => {
   });
 
   test("custom column sort evaluates nested payload path", () => {
-    const sorted = sortRows(ROWS, CONFIG, state({ sortBy: "custom:payload.priority", sortDir: "asc" }));
+    const sorted = sortRows(
+      ROWS,
+      CONFIG,
+      state({ sortBy: "custom:payload.priority", sortDir: "asc" }),
+    );
     expect(sorted[0].id).toBe("r1"); // priority 1
     expect(sorted[1].id).toBe("r3"); // priority 2
     expect(sorted[2].id).toBe("r2"); // priority 3
@@ -215,11 +291,29 @@ describe("sortRows", () => {
       row("r3", "RUNNING", "c", "2d ago"),
       row("r4", "RUNNING", "d", "2m ago"),
     ];
-    const asc = sortRows(timeRows, CONFIG, state({ sortBy: "created", sortDir: "asc" }));
-    expect(asc.map((r) => r.created_at)).toEqual(["1s ago", "2m ago", "1d ago", "2d ago"]);
+    const asc = sortRows(
+      timeRows,
+      CONFIG,
+      state({ sortBy: "created", sortDir: "asc" }),
+    );
+    expect(asc.map((r) => r.created_at)).toEqual([
+      "1s ago",
+      "2m ago",
+      "1d ago",
+      "2d ago",
+    ]);
 
-    const desc = sortRows(timeRows, CONFIG, state({ sortBy: "created", sortDir: "desc" }));
-    expect(desc.map((r) => r.created_at)).toEqual(["2d ago", "1d ago", "2m ago", "1s ago"]);
+    const desc = sortRows(
+      timeRows,
+      CONFIG,
+      state({ sortBy: "created", sortDir: "desc" }),
+    );
+    expect(desc.map((r) => r.created_at)).toEqual([
+      "2d ago",
+      "1d ago",
+      "2m ago",
+      "1s ago",
+    ]);
   });
 
   test("does not mutate its input", () => {
@@ -231,7 +325,11 @@ describe("sortRows", () => {
 
 describe("flattenSections", () => {
   test("skips collapsed sections and collapsed sub-sections", () => {
-    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
+    const sections = buildSections(
+      ROWS,
+      CONFIG,
+      state({ groupBy: "state", subGroupBy: "agent" }),
+    );
     const flatAll = flattenSections(sections, []);
     expect(flatAll).toHaveLength(ROWS.length);
 
@@ -255,11 +353,15 @@ describe("state transitions & custom columns (WM-214)", () => {
   test("addCustomColumn and removeCustomColumn work cleanly", () => {
     const s1 = addCustomColumn(state(), "payload.repo");
     expect(s1.customColumns).toEqual(["payload.repo"]);
-    expect(visibleColumns(CONFIG, s1).map((c) => c.key)).toContain("custom:payload.repo");
+    expect(visibleColumns(CONFIG, s1).map((c) => c.key)).toContain(
+      "custom:payload.repo",
+    );
 
     const s2 = removeCustomColumn(s1, "payload.repo");
     expect(s2.customColumns).toEqual([]);
-    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).not.toContain("custom:payload.repo");
+    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).not.toContain(
+      "custom:payload.repo",
+    );
   });
 
   test("cycleColumnSort walks custom column sort cycle", () => {
@@ -282,7 +384,10 @@ describe("state transitions & custom columns (WM-214)", () => {
     expect(visibleColumns(CONFIG, s1).map((c) => c.key)).toEqual(["id"]);
 
     const s2 = toggleColumn(s1, "agent");
-    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).toEqual(["id", "agent"]);
+    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).toEqual([
+      "id",
+      "agent",
+    ]);
   });
 });
 
@@ -324,7 +429,11 @@ describe("persistence", () => {
 
   test("isDefaultDisplayState detects deviation including customColumns", () => {
     expect(isDefaultDisplayState(CONFIG, state())).toBe(true);
-    expect(isDefaultDisplayState(CONFIG, state({ customColumns: ["payload.repo"] }))).toBe(false);
-    expect(isDefaultDisplayState(CONFIG, state({ groupBy: "state" }))).toBe(false);
+    expect(
+      isDefaultDisplayState(CONFIG, state({ customColumns: ["payload.repo"] })),
+    ).toBe(false);
+    expect(isDefaultDisplayState(CONFIG, state({ groupBy: "state" }))).toBe(
+      false,
+    );
   });
 });

--- a/event-runtime/web/src/displayOptions.ts
+++ b/event-runtime/web/src/displayOptions.ts
@@ -82,7 +82,9 @@ export function defaultDisplayState<T>(config: DisplayConfig<T>): DisplayState {
     sortBy: DEFAULT_ORDER,
     sortDir: "asc",
     showEmpty: false,
-    hiddenColumns: config.columns.filter((c) => c.defaultHidden).map((c) => c.key),
+    hiddenColumns: config.columns
+      .filter((c) => c.defaultHidden)
+      .map((c) => c.key),
     collapsed: [],
     customColumns: [],
     ...config.defaults,
@@ -115,10 +117,14 @@ export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
   const p = parsed as Record<string, unknown>;
 
   const customColumns: string[] = Array.isArray(p.customColumns)
-    ? p.customColumns.filter((k): k is string => typeof k === "string" && k.trim().length > 0)
+    ? p.customColumns.filter(
+        (k): k is string => typeof k === "string" && k.trim().length > 0,
+      )
     : fallback.customColumns;
 
-  const customColKeys = new Set(customColumns.map((c) => (c.startsWith("custom:") ? c : `custom:${c}`)));
+  const customColKeys = new Set(
+    customColumns.map((c) => (c.startsWith("custom:") ? c : `custom:${c}`)),
+  );
   const groupKeys = new Set([NONE, ...config.groups.map((g) => g.key)]);
   const sortKeys = new Set([
     DEFAULT_ORDER,
@@ -140,10 +146,18 @@ export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
     // be two; normalize it away at the edge so nothing downstream checks.
     subGroupBy: subGroupBy === groupBy ? NONE : subGroupBy,
     sortBy: str(p.sortBy, sortKeys, fallback.sortBy),
-    sortDir: p.sortDir === "desc" ? "desc" : p.sortDir === "asc" ? "asc" : fallback.sortDir,
-    showEmpty: typeof p.showEmpty === "boolean" ? p.showEmpty : fallback.showEmpty,
+    sortDir:
+      p.sortDir === "desc"
+        ? "desc"
+        : p.sortDir === "asc"
+          ? "asc"
+          : fallback.sortDir,
+    showEmpty:
+      typeof p.showEmpty === "boolean" ? p.showEmpty : fallback.showEmpty,
     hiddenColumns: Array.isArray(p.hiddenColumns)
-      ? p.hiddenColumns.filter((k): k is string => typeof k === "string" && columnKeys.has(k))
+      ? p.hiddenColumns.filter(
+          (k): k is string => typeof k === "string" && columnKeys.has(k),
+        )
       : fallback.hiddenColumns,
     collapsed: Array.isArray(p.collapsed)
       ? p.collapsed.filter((k): k is string => typeof k === "string")
@@ -152,7 +166,10 @@ export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
   };
 }
 
-export function saveDisplayState<T>(config: DisplayConfig<T>, state: DisplayState): void {
+export function saveDisplayState<T>(
+  config: DisplayConfig<T>,
+  state: DisplayState,
+): void {
   try {
     localStorage.setItem(storageKey(config.view), JSON.stringify(state));
   } catch {
@@ -160,7 +177,10 @@ export function saveDisplayState<T>(config: DisplayConfig<T>, state: DisplayStat
   }
 }
 
-export function isDefaultDisplayState<T>(config: DisplayConfig<T>, state: DisplayState): boolean {
+export function isDefaultDisplayState<T>(
+  config: DisplayConfig<T>,
+  state: DisplayState,
+): boolean {
   const d = defaultDisplayState(config);
   return (
     state.groupBy === d.groupBy &&
@@ -187,7 +207,11 @@ export interface Section<T> {
 }
 
 function parseDateString(s: string): number | null {
-  if (/^\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/.test(s.trim())) {
+  if (
+    /^\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/.test(
+      s.trim(),
+    )
+  ) {
     const t = Date.parse(s.trim());
     if (!Number.isNaN(t)) return t;
   }
@@ -205,13 +229,22 @@ function parseDurationString(s: string): number | null {
         parseInt(colonMatch[3], 10) * 1000
       );
     }
-    return parseInt(colonMatch[1], 10) * 60000 + parseInt(colonMatch[2], 10) * 1000;
+    return (
+      parseInt(colonMatch[1], 10) * 60000 + parseInt(colonMatch[2], 10) * 1000
+    );
   }
 
   if (/[0-9]+(?:\.[0-9]+)?\s*(?:d|h|m|s)/i.test(str)) {
-    const durRegex = /(?:(\d+(?:\.\d+)?)\s*d(?:ays?)?)?\s*(?:(\d+(?:\.\d+)?)\s*h(?:ours?|rs?)?)?\s*(?:(\d+(?:\.\d+)?)\s*m(?:in(?:ute)?s?)?)?\s*(?:(\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?)?(?:\s*ago)?$/;
+    const durRegex =
+      /(?:(\d+(?:\.\d+)?)\s*d(?:ays?)?)?\s*(?:(\d+(?:\.\d+)?)\s*h(?:ours?|rs?)?)?\s*(?:(\d+(?:\.\d+)?)\s*m(?:in(?:ute)?s?)?)?\s*(?:(\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?)?(?:\s*ago)?$/;
     const m = str.match(durRegex);
-    if (m && (m[1] !== undefined || m[2] !== undefined || m[3] !== undefined || m[4] !== undefined)) {
+    if (
+      m &&
+      (m[1] !== undefined ||
+        m[2] !== undefined ||
+        m[3] !== undefined ||
+        m[4] !== undefined)
+    ) {
       const days = parseFloat(m[1] || "0") * 86400000;
       const hours = parseFloat(m[2] || "0") * 3600000;
       const mins = parseFloat(m[3] || "0") * 60000;
@@ -238,13 +271,23 @@ export const cmp = (a: unknown, b: unknown): number => {
     const durB = parseDurationString(b);
     if (durA !== null && durB !== null) return durA - durB;
 
-    return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+    return a.localeCompare(b, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
   }
-  return String(a ?? "").localeCompare(String(b ?? ""), undefined, { numeric: true, sensitivity: "base" });
+  return String(a ?? "").localeCompare(String(b ?? ""), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
 };
 
 /** Stable sort by the configured field; DEFAULT_ORDER keeps (or reverses) API order. */
-export function sortRows<T>(rows: T[], config: DisplayConfig<T>, state: DisplayState): T[] {
+export function sortRows<T>(
+  rows: T[],
+  config: DisplayConfig<T>,
+  state: DisplayState,
+): T[] {
   const dirSign = state.sortDir === "desc" ? -1 : 1;
   if (state.sortBy === DEFAULT_ORDER) {
     return dirSign === 1 ? rows.slice() : rows.slice().reverse();
@@ -269,7 +312,11 @@ export function sortRows<T>(rows: T[], config: DisplayConfig<T>, state: DisplayS
     .map((e) => e.row);
 }
 
-function buckets<T>(rows: T[], field: GroupField<T>, showEmpty: boolean): Map<string, T[]> {
+function buckets<T>(
+  rows: T[],
+  field: GroupField<T>,
+  showEmpty: boolean,
+): Map<string, T[]> {
   const byValue = new Map<string, T[]>();
   if (showEmpty && field.order) for (const v of field.order) byValue.set(v, []);
   for (const row of rows) {
@@ -281,18 +328,27 @@ function buckets<T>(rows: T[], field: GroupField<T>, showEmpty: boolean): Map<st
   if (!field.order) {
     // Open-ended fields: busiest bucket first, name breaking ties.
     return new Map(
-      [...byValue.entries()].sort((a, b) => b[1].length - a[1].length || cmp(a[0], b[0])),
+      [...byValue.entries()].sort(
+        (a, b) => b[1].length - a[1].length || cmp(a[0], b[0]),
+      ),
     );
   }
   const rank = new Map(field.order.map((v, i) => [v, i]));
   return new Map(
     [...byValue.entries()].sort(
-      (a, b) => (rank.get(a[0]) ?? field.order!.length) - (rank.get(b[0]) ?? field.order!.length) || cmp(a[0], b[0]),
+      (a, b) =>
+        (rank.get(a[0]) ?? field.order!.length) -
+          (rank.get(b[0]) ?? field.order!.length) || cmp(a[0], b[0]),
     ),
   );
 }
 
-const section = <T,>(key: string, value: string, field: GroupField<T>, rows: T[]): Section<T> => ({
+const section = <T>(
+  key: string,
+  value: string,
+  field: GroupField<T>,
+  rows: T[],
+): Section<T> => ({
   key,
   value,
   label: value,
@@ -314,7 +370,15 @@ export function buildSections<T>(
   const sorted = sortRows(rows, config, state);
   const group = config.groups.find((g) => g.key === state.groupBy);
   if (!group) {
-    return [{ key: NONE, value: NONE, label: "All", count: sorted.length, rows: sorted }];
+    return [
+      {
+        key: NONE,
+        value: NONE,
+        label: "All",
+        count: sorted.length,
+        rows: sorted,
+      },
+    ];
   }
   const sub =
     state.subGroupBy !== state.groupBy
@@ -340,7 +404,10 @@ export const grouped = (state: DisplayState): boolean => state.groupBy !== NONE;
  * renders them: open sections contribute their rows (through open
  * sub-sections), collapsed ones contribute nothing.
  */
-export function flattenSections<T>(sections: Section<T>[], collapsed: readonly string[]): T[] {
+export function flattenSections<T>(
+  sections: Section<T>[],
+  collapsed: readonly string[],
+): T[] {
   const closed = new Set(collapsed);
   const out: T[] = [];
   for (const s of sections) {
@@ -356,7 +423,10 @@ export function flattenSections<T>(sections: Section<T>[], collapsed: readonly s
   return out;
 }
 
-export function toggleCollapsed(state: DisplayState, key: string): DisplayState {
+export function toggleCollapsed(
+  state: DisplayState,
+  key: string,
+): DisplayState {
   const collapsed = state.collapsed.includes(key)
     ? state.collapsed.filter((k) => k !== key)
     : [...state.collapsed, key];
@@ -364,14 +434,19 @@ export function toggleCollapsed(state: DisplayState, key: string): DisplayState 
 }
 
 /** Columns the table actually renders, in declared order followed by custom columns. */
-export function visibleColumns<T>(config: DisplayConfig<T>, state: DisplayState): ColumnDef[] {
+export function visibleColumns<T>(
+  config: DisplayConfig<T>,
+  state: DisplayState,
+): ColumnDef[] {
   const dynamicCols: ColumnDef[] = (state.customColumns ?? []).map((path) => ({
     key: path.startsWith("custom:") ? path : `custom:${path}`,
     label: path.startsWith("custom:") ? path.slice(7) : path,
     isCustom: true,
   }));
   const allCols = [...config.columns, ...dynamicCols];
-  return allCols.filter((c) => c.always || !state.hiddenColumns.includes(c.key));
+  return allCols.filter(
+    (c) => c.always || !state.hiddenColumns.includes(c.key),
+  );
 }
 
 export function toggleColumn(state: DisplayState, key: string): DisplayState {
@@ -381,25 +456,38 @@ export function toggleColumn(state: DisplayState, key: string): DisplayState {
   return { ...state, hiddenColumns };
 }
 
-export function addCustomColumn(state: DisplayState, path: string): DisplayState {
+export function addCustomColumn(
+  state: DisplayState,
+  path: string,
+): DisplayState {
   const clean = path.trim().replace(/^custom:/, "");
   if (!clean || state.customColumns.includes(clean)) return state;
   const colKey = `custom:${clean}`;
   return {
     ...state,
     customColumns: [...state.customColumns, clean],
-    hiddenColumns: state.hiddenColumns.filter((k) => k !== colKey && k !== clean),
+    hiddenColumns: state.hiddenColumns.filter(
+      (k) => k !== colKey && k !== clean,
+    ),
   };
 }
 
-export function removeCustomColumn(state: DisplayState, path: string): DisplayState {
+export function removeCustomColumn(
+  state: DisplayState,
+  path: string,
+): DisplayState {
   const clean = path.trim().replace(/^custom:/, "");
   const colKey = `custom:${clean}`;
   return {
     ...state,
     customColumns: state.customColumns.filter((c) => c !== clean),
-    hiddenColumns: state.hiddenColumns.filter((k) => k !== colKey && k !== clean),
-    sortBy: state.sortBy === colKey || state.sortBy === clean ? DEFAULT_ORDER : state.sortBy,
+    hiddenColumns: state.hiddenColumns.filter(
+      (k) => k !== colKey && k !== clean,
+    ),
+    sortBy:
+      state.sortBy === colKey || state.sortBy === clean
+        ? DEFAULT_ORDER
+        : state.sortBy,
   };
 }
 

--- a/event-runtime/web/src/filterQuery.test.ts
+++ b/event-runtime/web/src/filterQuery.test.ts
@@ -90,11 +90,30 @@ const noStale = { staleRuns: new Set<string>() };
 const matchRun = (input: string, row = run(), ctx = noStale) =>
   matchesFilterQuery(row, parseFilterQuery(input, RUN_FACETS), RUN_FACETS, ctx);
 const matchEvent = (input: string, row = event()) =>
-  matchesFilterQuery(row, parseFilterQuery(input, EVENT_FACETS), EVENT_FACETS, undefined);
-const matchProposal = (input: string, row = proposal(), runStates = new Map<string, string>()) =>
-  matchesFilterQuery(row, parseFilterQuery(input, PROPOSAL_FACETS), PROPOSAL_FACETS, { runStates });
+  matchesFilterQuery(
+    row,
+    parseFilterQuery(input, EVENT_FACETS),
+    EVENT_FACETS,
+    undefined,
+  );
+const matchProposal = (
+  input: string,
+  row = proposal(),
+  runStates = new Map<string, string>(),
+) =>
+  matchesFilterQuery(
+    row,
+    parseFilterQuery(input, PROPOSAL_FACETS),
+    PROPOSAL_FACETS,
+    { runStates },
+  );
 const matchInbox = (input: string, row = inboxItem()) =>
-  matchesFilterQuery(row, parseFilterQuery(input, INBOX_FACETS), INBOX_FACETS, undefined);
+  matchesFilterQuery(
+    row,
+    parseFilterQuery(input, INBOX_FACETS),
+    INBOX_FACETS,
+    undefined,
+  );
 
 describe("parseFilterQuery", () => {
   test("keyed tokens, flags and leftover words, each keeping its offsets", () => {
@@ -133,7 +152,12 @@ describe("parseFilterQuery", () => {
 
   test("aliases resolve to the canonical key; the chip still reads as typed", () => {
     const q = parseFilterQuery("STATUS:Failed", RUN_FACETS);
-    expect(q.tokens[0]).toMatchObject({ kind: "field", key: "state", typedKey: "status", value: "failed" });
+    expect(q.tokens[0]).toMatchObject({
+      kind: "field",
+      key: "state",
+      typedKey: "status",
+      value: "failed",
+    });
     expect(chipLabel(q.chips[0])).toBe("status:failed");
   });
 
@@ -145,25 +169,40 @@ describe("parseFilterQuery", () => {
 
   test("quotes hold a value together and are not part of it", () => {
     const q = parseFilterQuery('subject:"var full" plain', EVENT_FACETS);
-    expect(q.tokens[0]).toMatchObject({ kind: "field", key: "subject", value: "var full" });
+    expect(q.tokens[0]).toMatchObject({
+      kind: "field",
+      key: "subject",
+      value: "var full",
+    });
     expect(q.tokens[1]).toMatchObject({ kind: "text", value: "plain" });
   });
 
   test("a colon that was never a filter key stays free text", () => {
     const q = parseFilterQuery("https://linear.app/watt-mind", RUN_FACETS);
     expect(q.tokens).toHaveLength(1);
-    expect(q.tokens[0]).toMatchObject({ kind: "text", value: "https://linear.app/watt-mind" });
+    expect(q.tokens[0]).toMatchObject({
+      kind: "text",
+      value: "https://linear.app/watt-mind",
+    });
   });
 
   test("a known key this list has no field for is flagged, not silently dropped", () => {
     const q = parseFilterQuery("agent:ci-doctor", EVENT_FACETS);
-    expect(q.chips[0]).toMatchObject({ kind: "field", key: "agent", supported: false });
+    expect(q.chips[0]).toMatchObject({
+      kind: "field",
+      key: "agent",
+      supported: false,
+    });
     expect(matchEvent("agent:ci-doctor")).toBe(false);
   });
 
   test("an is: flag this list cannot answer is flagged the same way", () => {
     const q = parseFilterQuery("is:expired", RUN_FACETS);
-    expect(q.chips[0]).toMatchObject({ kind: "flag", flag: "expired", supported: false });
+    expect(q.chips[0]).toMatchObject({
+      kind: "flag",
+      flag: "expired",
+      supported: false,
+    });
     expect(matchRun("is:expired")).toBe(false);
   });
 });
@@ -187,8 +226,12 @@ describe("matchesFilterQuery", () => {
     expect(matchRun("agent:octor")).toBe(false);
     expect(matchRun("state:fail")).toBe(true);
     expect(matchRun("state:ail")).toBe(false);
-    expect(matchEvent("status:human", event({ status: "human_needed" }))).toBe(true);
-    expect(matchEvent("status:needed", event({ status: "human_needed" }))).toBe(true);
+    expect(matchEvent("status:human", event({ status: "human_needed" }))).toBe(
+      true,
+    );
+    expect(matchEvent("status:needed", event({ status: "human_needed" }))).toBe(
+      true,
+    );
   });
 
   test("case never matters", () => {
@@ -224,48 +267,113 @@ describe("matchesFilterQuery", () => {
 
   test("Runs is:stale is the stalled-worker projection, not a guess", () => {
     expect(matchRun("is:stale")).toBe(false);
-    expect(matchRun("is:stale", run(), { staleRuns: new Set(["run_48ac91"]) })).toBe(true);
-    expect(matchRun("is:stale state:completed", run({ state: "COMPLETED" }), {
-      staleRuns: new Set(["run_48ac91"]),
-    })).toBe(true);
+    expect(
+      matchRun("is:stale", run(), { staleRuns: new Set(["run_48ac91"]) }),
+    ).toBe(true);
+    expect(
+      matchRun("is:stale state:completed", run({ state: "COMPLETED" }), {
+        staleRuns: new Set(["run_48ac91"]),
+      }),
+    ).toBe(true);
   });
 
   test("Events is:stale is an admitted event with nothing behind it", () => {
     expect(matchEvent("is:stale")).toBe(false);
     expect(
-      matchEvent("is:stale", event({ status: "admitted", proposalId: null, runId: null })),
+      matchEvent(
+        "is:stale",
+        event({ status: "admitted", proposalId: null, runId: null }),
+      ),
     ).toBe(true);
     expect(matchEvent("is:stale", event({ status: "admitted" }))).toBe(false);
   });
 
   test("Proposals is:stale and is:expired answer the two ways an open row is dead", () => {
     expect(matchProposal("is:stale")).toBe(false);
-    expect(matchProposal("is:stale", proposal(), new Map([["run_48ac91", "CANCELLED"]]))).toBe(true);
-    expect(matchProposal("is:stale", proposal(), new Map([["run_48ac91", "PROPOSED"]]))).toBe(false);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal(),
+        new Map([["run_48ac91", "CANCELLED"]]),
+      ),
+    ).toBe(true);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal(),
+        new Map([["run_48ac91", "PROPOSED"]]),
+      ),
+    ).toBe(false);
     expect(matchProposal("is:expired")).toBe(false);
     expect(matchProposal("is:expired", proposal({ expired: true }))).toBe(true);
   });
 
   test("Proposals is:stale only flags open proposals whose run left PROPOSED, not decided history rows", () => {
-    expect(matchProposal("is:stale", proposal({ status: "open" }), new Map([["run_48ac91", "CANCELLED"]]))).toBe(true);
-    expect(matchProposal("is:stale", proposal({ status: "open" }), new Map([["run_48ac91", "PROPOSED"]]))).toBe(false);
-    expect(matchProposal("is:stale", proposal({ status: "approved" }), new Map([["run_48ac91", "COMPLETED"]]))).toBe(false);
-    expect(matchProposal("is:stale", proposal({ status: "rejected" }), new Map([["run_48ac91", "FAILED"]]))).toBe(false);
-    expect(matchProposal("is:stale", proposal({ status: "expired" }), new Map([["run_48ac91", "CANCELLED"]]))).toBe(false);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal({ status: "open" }),
+        new Map([["run_48ac91", "CANCELLED"]]),
+      ),
+    ).toBe(true);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal({ status: "open" }),
+        new Map([["run_48ac91", "PROPOSED"]]),
+      ),
+    ).toBe(false);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal({ status: "approved" }),
+        new Map([["run_48ac91", "COMPLETED"]]),
+      ),
+    ).toBe(false);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal({ status: "rejected" }),
+        new Map([["run_48ac91", "FAILED"]]),
+      ),
+    ).toBe(false);
+    expect(
+      matchProposal(
+        "is:stale",
+        proposal({ status: "expired" }),
+        new Map([["run_48ac91", "CANCELLED"]]),
+      ),
+    ).toBe(false);
   });
 
   test("Inbox facets cover kind, status, references, and title/body text", () => {
-    expect(matchInbox("kind:blocked repo:factory issue:WM-616 is:open")).toBe(true);
+    expect(matchInbox("kind:blocked repo:factory issue:WM-616 is:open")).toBe(
+      true,
+    );
     expect(matchInbox("chrome parity")).toBe(true);
     expect(matchInbox("repo:bj29")).toBe(false);
     expect(matchInbox("is:acked")).toBe(false);
-    expect(matchInbox("is:acked", inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" }))).toBe(true);
-    expect(matchInbox("is:resolved", inboxItem({ resolvedAt: "2026-08-14T11:00:00.000Z" }))).toBe(true);
-    expect(matchInbox("is:open", inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" }))).toBe(false);
+    expect(
+      matchInbox(
+        "is:acked",
+        inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" }),
+      ),
+    ).toBe(true);
+    expect(
+      matchInbox(
+        "is:resolved",
+        inboxItem({ resolvedAt: "2026-08-14T11:00:00.000Z" }),
+      ),
+    ).toBe(true);
+    expect(
+      matchInbox("is:open", inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" })),
+    ).toBe(false);
   });
 
   test("Proposals keyed fields cover the columns the list shows", () => {
-    expect(matchProposal("agent:ci-doctor decision:run status:open")).toBe(true);
+    expect(matchProposal("agent:ci-doctor decision:run status:open")).toBe(
+      true,
+    );
     expect(matchProposal("decision:human_needed")).toBe(false);
     expect(matchProposal("source:keephq event:evt_7719")).toBe(true);
     expect(matchProposal("proposal:prop_8f12")).toBe(true);
@@ -287,7 +395,9 @@ describe("removeFilterToken", () => {
     const q = parseFilterQuery(input, RUN_FACETS);
     expect(removeFilterToken(input, q.tokens[0])).toBe("is:stale 48ac");
     expect(removeFilterToken(input, q.tokens[1])).toBe("agent:ci-doctor 48ac");
-    expect(removeFilterToken(input, q.tokens[2])).toBe("agent:ci-doctor is:stale");
+    expect(removeFilterToken(input, q.tokens[2])).toBe(
+      "agent:ci-doctor is:stale",
+    );
   });
 
   test("a quoted value is one word, and removal leaves no double space", () => {
@@ -328,40 +438,102 @@ describe("chip and input copy", () => {
 
 describe("proposalRunState", () => {
   test("only a run that left PROPOSED is stale; an unknown run is not", () => {
-    expect(proposalRunState({ runId: "r1" }, new Map([["r1", "PROPOSED"]]))).toBeNull();
-    expect(proposalRunState({ runId: "r1" }, new Map([["r1", "RUNNING"]]))).toBe("RUNNING");
+    expect(
+      proposalRunState({ runId: "r1" }, new Map([["r1", "PROPOSED"]])),
+    ).toBeNull();
+    expect(
+      proposalRunState({ runId: "r1" }, new Map([["r1", "RUNNING"]])),
+    ).toBe("RUNNING");
     expect(proposalRunState({ runId: "r1" }, new Map())).toBeNull();
-    expect(proposalRunState({ runId: null }, new Map([["r1", "RUNNING"]]))).toBeNull();
+    expect(
+      proposalRunState({ runId: null }, new Map([["r1", "RUNNING"]])),
+    ).toBeNull();
   });
 
   test("decided proposals (status !== 'open') are never stale even if run is terminal", () => {
-    expect(proposalRunState({ runId: "r1", status: "open" }, new Map([["r1", "COMPLETED"]]))).toBe("COMPLETED");
-    expect(proposalRunState({ runId: "r1", status: "approved" }, new Map([["r1", "COMPLETED"]]))).toBeNull();
-    expect(proposalRunState({ runId: "r1", status: "rejected" }, new Map([["r1", "FAILED"]]))).toBeNull();
-    expect(proposalRunState({ runId: "r1", status: "expired" }, new Map([["r1", "CANCELLED"]]))).toBeNull();
+    expect(
+      proposalRunState(
+        { runId: "r1", status: "open" },
+        new Map([["r1", "COMPLETED"]]),
+      ),
+    ).toBe("COMPLETED");
+    expect(
+      proposalRunState(
+        { runId: "r1", status: "approved" },
+        new Map([["r1", "COMPLETED"]]),
+      ),
+    ).toBeNull();
+    expect(
+      proposalRunState(
+        { runId: "r1", status: "rejected" },
+        new Map([["r1", "FAILED"]]),
+      ),
+    ).toBeNull();
+    expect(
+      proposalRunState(
+        { runId: "r1", status: "expired" },
+        new Map([["r1", "CANCELLED"]]),
+      ),
+    ).toBeNull();
   });
 });
 
 describe("getActiveFilterToken", () => {
   test("finds active token under cursor when typing inside a word", () => {
     const input = "state:failed agent:ci";
-    expect(getActiveFilterToken(input, 5)).toMatchObject({ raw: "state:failed", start: 0, end: 12 });
-    expect(getActiveFilterToken(input, 12)).toMatchObject({ raw: "state:failed", start: 0, end: 12 });
-    expect(getActiveFilterToken(input, 13)).toMatchObject({ raw: "agent:ci", start: 13, end: 21 });
-    expect(getActiveFilterToken(input, 21)).toMatchObject({ raw: "agent:ci", start: 13, end: 21 });
+    expect(getActiveFilterToken(input, 5)).toMatchObject({
+      raw: "state:failed",
+      start: 0,
+      end: 12,
+    });
+    expect(getActiveFilterToken(input, 12)).toMatchObject({
+      raw: "state:failed",
+      start: 0,
+      end: 12,
+    });
+    expect(getActiveFilterToken(input, 13)).toMatchObject({
+      raw: "agent:ci",
+      start: 13,
+      end: 21,
+    });
+    expect(getActiveFilterToken(input, 21)).toMatchObject({
+      raw: "agent:ci",
+      start: 13,
+      end: 21,
+    });
   });
 
   test("returns empty token when cursor is in whitespace", () => {
     const input = "state:failed  agent:ci";
-    expect(getActiveFilterToken(input, 13)).toMatchObject({ raw: "", start: 13, end: 13 });
-    expect(getActiveFilterToken("   ", 1)).toMatchObject({ raw: "", start: 1, end: 1 });
-    expect(getActiveFilterToken("", 0)).toMatchObject({ raw: "", start: 0, end: 0 });
+    expect(getActiveFilterToken(input, 13)).toMatchObject({
+      raw: "",
+      start: 13,
+      end: 13,
+    });
+    expect(getActiveFilterToken("   ", 1)).toMatchObject({
+      raw: "",
+      start: 1,
+      end: 1,
+    });
+    expect(getActiveFilterToken("", 0)).toMatchObject({
+      raw: "",
+      start: 0,
+      end: 0,
+    });
   });
 
   test("handles quotes properly", () => {
     const input = 'subject:"disk pressure" state:fail';
-    expect(getActiveFilterToken(input, 10)).toMatchObject({ raw: 'subject:"disk pressure"', start: 0, end: 23 });
-    expect(getActiveFilterToken(input, 30)).toMatchObject({ raw: "state:fail", start: 24, end: 34 });
+    expect(getActiveFilterToken(input, 10)).toMatchObject({
+      raw: 'subject:"disk pressure"',
+      start: 0,
+      end: 23,
+    });
+    expect(getActiveFilterToken(input, 30)).toMatchObject({
+      raw: "state:fail",
+      start: 24,
+      end: 34,
+    });
   });
 });
 
@@ -382,8 +554,16 @@ describe("getFilterSuggestions", () => {
   });
 
   test("suggests enum values with state hues when typing a facet value", () => {
-    const stateSugs = getFilterSuggestions("state:", RUN_FACETS, undefined, (_field, val) =>
-      val === "failed" ? "var(--hue-err)" : val === "completed" ? "var(--hue-ok)" : undefined,
+    const stateSugs = getFilterSuggestions(
+      "state:",
+      RUN_FACETS,
+      undefined,
+      (_field, val) =>
+        val === "failed"
+          ? "var(--hue-err)"
+          : val === "completed"
+            ? "var(--hue-ok)"
+            : undefined,
     );
     expect(stateSugs.length).toBeGreaterThan(0);
     const failedSug = stateSugs.find((s) => s.label === "failed");
@@ -410,7 +590,11 @@ describe("getFilterSuggestions", () => {
 
   test("suggests enum values for Proposals and Events", () => {
     const decisionSugs = getFilterSuggestions("decision:", PROPOSAL_FACETS);
-    expect(decisionSugs.map((s) => s.label)).toEqual(["run", "human_needed", "noop"]);
+    expect(decisionSugs.map((s) => s.label)).toEqual([
+      "run",
+      "human_needed",
+      "noop",
+    ]);
 
     const eventStatusSugs = getFilterSuggestions("status:", EVENT_FACETS);
     expect(eventStatusSugs.map((s) => s.label)).toEqual([
@@ -423,22 +607,49 @@ describe("getFilterSuggestions", () => {
   });
 });
 
-
 describe("events reason: facet (WM-594)", () => {
   const rows = [
-    { ...event({ eventId: "evt_a", status: "noop" }), decisionReason: "owned_paths_overlap" },
-    { ...event({ eventId: "evt_b", status: "noop" }), decisionReason: "ticket_dispatch_already_live:run_x:same_ticket_worktree_held" },
-    { ...event({ eventId: "evt_c", status: "planned" }), decisionReason: "auto_approval_ineligible:proposal_expired" },
+    {
+      ...event({ eventId: "evt_a", status: "noop" }),
+      decisionReason: "owned_paths_overlap",
+    },
+    {
+      ...event({ eventId: "evt_b", status: "noop" }),
+      decisionReason:
+        "ticket_dispatch_already_live:run_x:same_ticket_worktree_held",
+    },
+    {
+      ...event({ eventId: "evt_c", status: "planned" }),
+      decisionReason: "auto_approval_ineligible:proposal_expired",
+    },
     event({ eventId: "evt_d", status: "admitted" }),
   ];
 
   test("reason:<code> matches the head code and word starts inside a chained reason", () => {
-    const overlap = parseFilterQuery("reason:owned_paths_overlap", EVENT_FACETS);
-    expect(rows.filter((r) => matchesFilterQuery(r, overlap, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_a"]);
-    const live = parseFilterQuery("reason:ticket_dispatch_already_live", EVENT_FACETS);
-    expect(rows.filter((r) => matchesFilterQuery(r, live, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_b"]);
+    const overlap = parseFilterQuery(
+      "reason:owned_paths_overlap",
+      EVENT_FACETS,
+    );
+    expect(
+      rows
+        .filter((r) => matchesFilterQuery(r, overlap, EVENT_FACETS, undefined))
+        .map((r) => r.eventId),
+    ).toEqual(["evt_a"]);
+    const live = parseFilterQuery(
+      "reason:ticket_dispatch_already_live",
+      EVENT_FACETS,
+    );
+    expect(
+      rows
+        .filter((r) => matchesFilterQuery(r, live, EVENT_FACETS, undefined))
+        .map((r) => r.eventId),
+    ).toEqual(["evt_b"]);
     const expired = parseFilterQuery("reason:proposal_expired", EVENT_FACETS);
-    expect(rows.filter((r) => matchesFilterQuery(r, expired, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_c"]);
+    expect(
+      rows
+        .filter((r) => matchesFilterQuery(r, expired, EVENT_FACETS, undefined))
+        .map((r) => r.eventId),
+    ).toEqual(["evt_c"]);
   });
 
   test("a row without a decision reason never matches reason:", () => {
@@ -447,8 +658,18 @@ describe("events reason: facet (WM-594)", () => {
   });
 
   test("reason: is offered as a facet and takes caller-supplied value suggestions", () => {
-    expect(getFilterSuggestions("rea", EVENT_FACETS).map((s) => s.insertText)).toContain("reason:");
-    const facets = { ...EVENT_FACETS, values: { ...EVENT_FACETS.values, reason: ["owned_paths_overlap", "ticket_assigned"] } };
-    expect(getFilterSuggestions("reason:own", facets).map((s) => s.insertText)).toEqual(["reason:owned_paths_overlap "]);
+    expect(
+      getFilterSuggestions("rea", EVENT_FACETS).map((s) => s.insertText),
+    ).toContain("reason:");
+    const facets = {
+      ...EVENT_FACETS,
+      values: {
+        ...EVENT_FACETS.values,
+        reason: ["owned_paths_overlap", "ticket_assigned"],
+      },
+    };
+    expect(
+      getFilterSuggestions("reason:own", facets).map((s) => s.insertText),
+    ).toEqual(["reason:owned_paths_overlap "]);
   });
 });

--- a/event-runtime/web/src/filterQuery.ts
+++ b/event-runtime/web/src/filterQuery.ts
@@ -14,7 +14,8 @@
 import type { AdmittedEvent, InboxItem, Proposal, RunListItem } from "./types";
 
 /** What a field accessor may return: one value, several, or nothing. */
-export type FieldValue = string | null | undefined | readonly (string | null | undefined)[];
+export type FieldValue =
+  string | null | undefined | readonly (string | null | undefined)[];
 
 export interface FilterFacets<T, C = undefined> {
   /**
@@ -42,10 +43,34 @@ export interface FilterSuggestion {
   hue?: string;
 }
 
-const RUN_STATES = ["proposed", "approved", "queued", "leased", "running", "verifying", "completed", "refused", "failed", "timed_out", "cancelled"] as const;
+const RUN_STATES = [
+  "proposed",
+  "approved",
+  "queued",
+  "leased",
+  "running",
+  "verifying",
+  "completed",
+  "refused",
+  "failed",
+  "timed_out",
+  "cancelled",
+] as const;
 const ADAPTERS = ["claude", "codex", "fake", "actions", "command"] as const;
-const EVENT_STATUSES = ["admitted", "planned", "noop", "human_needed", "dead_lettered"] as const;
-const PROPOSAL_STATUSES = ["open", "approved", "rejected", "superseded", "resolved"] as const;
+const EVENT_STATUSES = [
+  "admitted",
+  "planned",
+  "noop",
+  "human_needed",
+  "dead_lettered",
+] as const;
+const PROPOSAL_STATUSES = [
+  "open",
+  "approved",
+  "rejected",
+  "superseded",
+  "resolved",
+] as const;
 const DECISIONS = ["run", "human_needed", "noop"] as const;
 
 export const DEFAULT_FIELD_VALUES: Record<string, readonly string[]> = {
@@ -89,11 +114,20 @@ interface Span {
 
 export type FilterToken =
   | ({ kind: "text"; value: string } & Span)
-  | ({ kind: "field"; key: string; typedKey: string; value: string; supported: boolean } & Span)
+  | ({
+      kind: "field";
+      key: string;
+      typedKey: string;
+      value: string;
+      supported: boolean;
+    } & Span)
   | ({ kind: "flag"; flag: string; help: string; supported: boolean } & Span);
 
 /** The tokens that get a chip: everything the operator spelled as a filter. */
-export type FilterChipToken = Extract<FilterToken, { kind: "field" } | { kind: "flag" }>;
+export type FilterChipToken = Extract<
+  FilterToken,
+  { kind: "field" } | { kind: "flag" }
+>;
 
 export interface FilterQuery {
   tokens: FilterToken[];
@@ -151,7 +185,10 @@ export function getActiveFilterToken(input: string, cursorPos: number): Span {
   return { raw: "", start: safeCursor, end: safeCursor };
 }
 
-export function parseFilterQuery<T, C>(input: string, facets: FilterFacets<T, C>): FilterQuery {
+export function parseFilterQuery<T, C>(
+  input: string,
+  facets: FilterFacets<T, C>,
+): FilterQuery {
   const tokens: FilterToken[] = [];
   for (const span of splitWords(input)) {
     const keyed = KEYED.exec(span.raw);
@@ -159,7 +196,10 @@ export function parseFilterQuery<T, C>(input: string, facets: FilterFacets<T, C>
     const key = facets.aliases?.[typedKey] ?? typedKey;
     const value = keyed ? unquote(keyed[2]).trim() : "";
 
-    if (keyed && (key === "is" || FILTER_KEYS.has(key) || key in facets.fields)) {
+    if (
+      keyed &&
+      (key === "is" || FILTER_KEYS.has(key) || key in facets.fields)
+    ) {
       // `agent:` with nothing after it is half-typed, not a filter that matches
       // nothing: the list must not blank out between `agent:` and `agent:c`.
       if (!value) continue;
@@ -199,11 +239,16 @@ export function parseFilterQuery<T, C>(input: string, facets: FilterFacets<T, C>
   };
 }
 
-const read = <T,>(field: Extract<keyof T, string> | ((row: T) => FieldValue), row: T): FieldValue =>
+const read = <T>(
+  field: Extract<keyof T, string> | ((row: T) => FieldValue),
+  row: T,
+): FieldValue =>
   typeof field === "function" ? field(row) : (row[field] as FieldValue);
 
 const asList = (value: FieldValue): string[] =>
-  (Array.isArray(value) ? value : [value]).filter((v): v is string => typeof v === "string" && v !== "");
+  (Array.isArray(value) ? value : [value]).filter(
+    (v): v is string => typeof v === "string" && v !== "",
+  );
 
 /**
  * A keyed value matches its field whole or at a word start inside it:
@@ -262,12 +307,16 @@ export function matchesFilterQuery<T, C = undefined>(
 
 /** Dismiss one chip by cutting its word back out of the raw query. */
 export function removeFilterToken(input: string, token: FilterToken): string {
-  return `${input.slice(0, token.start)} ${input.slice(token.end)}`.replace(/\s+/g, " ").trim();
+  return `${input.slice(0, token.start)} ${input.slice(token.end)}`
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /** What the chip says — the key as typed, so chip and input never disagree. */
 export const chipLabel = (token: FilterChipToken): string =>
-  token.kind === "flag" ? `is:${token.flag}` : `${token.typedKey}:${token.value}`;
+  token.kind === "flag"
+    ? `is:${token.flag}`
+    : `${token.typedKey}:${token.value}`;
 
 /** Why this chip does (or cannot) narrow anything, on hover and for screen readers. */
 export function chipHelp(token: FilterChipToken, query: FilterQuery): string {
@@ -356,8 +405,15 @@ export const INBOX_FACETS: FilterFacets<InboxItem, undefined> = {
   text: (item) => [item.title, item.body],
   values: {
     kind: [
-      "decision_needed", "proposal_expired", "BLOCKED", "ESCALATED", "human_needed",
-      "CI RED", "SMOKE RED", "CIRCUIT BREAKER", "RC READY",
+      "decision_needed",
+      "proposal_expired",
+      "BLOCKED",
+      "ESCALATED",
+      "human_needed",
+      "CI RED",
+      "SMOKE RED",
+      "CIRCUIT BREAKER",
+      "RC READY",
     ],
   },
 };
@@ -462,7 +518,10 @@ export function getFilterSuggestions<T, C>(
     }
     // Facet aliases
     for (const [alias, canonical] of Object.entries(aliases)) {
-      if (!fields.includes(alias) && (!prefix || alias.toLowerCase().startsWith(prefix))) {
+      if (
+        !fields.includes(alias) &&
+        (!prefix || alias.toLowerCase().startsWith(prefix))
+      ) {
         suggestions.push({
           id: `facet:${alias}`,
           kind: "facet",
@@ -475,7 +534,12 @@ export function getFilterSuggestions<T, C>(
     // 2. Flags (e.g. is:stale)
     for (const flag of flags) {
       const flagLabel = `is:${flag}`;
-      if (!prefix || flagLabel.startsWith(prefix) || flag.toLowerCase().startsWith(prefix) || "is:".startsWith(prefix)) {
+      if (
+        !prefix ||
+        flagLabel.startsWith(prefix) ||
+        flag.toLowerCase().startsWith(prefix) ||
+        "is:".startsWith(prefix)
+      ) {
         suggestions.push({
           id: `flag:${flag}`,
           kind: "flag",
@@ -503,7 +567,11 @@ export function getFilterSuggestions<T, C>(
         }
       }
     } else {
-      const enumVals = values[canonicalKey] ?? values[rawKey] ?? DEFAULT_FIELD_VALUES[canonicalKey] ?? [];
+      const enumVals =
+        values[canonicalKey] ??
+        values[rawKey] ??
+        DEFAULT_FIELD_VALUES[canonicalKey] ??
+        [];
       for (const val of enumVals) {
         if (!valPrefix || val.toLowerCase().startsWith(valPrefix)) {
           const hue = customHues?.(canonicalKey, val);
@@ -523,4 +591,3 @@ export function getFilterSuggestions<T, C>(
 
   return suggestions;
 }
-

--- a/event-runtime/web/src/format.ts
+++ b/event-runtime/web/src/format.ts
@@ -19,7 +19,8 @@ export function formatDuration(seconds: number | null | undefined): string {
 
   for (const [size, suffix] of units) {
     const value = Math.floor(remaining / size);
-    if (value > 0 || (size === 1 && parts.length === 0)) parts.push(`${value}${suffix}`);
+    if (value > 0 || (size === 1 && parts.length === 0))
+      parts.push(`${value}${suffix}`);
     remaining %= size;
   }
 
@@ -41,7 +42,10 @@ export function formatRelative(
   now = Date.now(),
 ): string {
   if (timestamp == null) return EMPTY;
-  const at = timestamp instanceof Date ? timestamp.getTime() : new Date(timestamp).getTime();
+  const at =
+    timestamp instanceof Date
+      ? timestamp.getTime()
+      : new Date(timestamp).getTime();
   if (Number.isNaN(at)) return EMPTY;
 
   const seconds = Math.max(0, Math.floor((now - at) / 1000));

--- a/event-runtime/web/src/graph/chainModel.test.ts
+++ b/event-runtime/web/src/graph/chainModel.test.ts
@@ -10,7 +10,9 @@ import type { ChainEvent, ChainRun } from "../types";
 
 const at = (n: number) => new Date(Date.UTC(2026, 7, 17, 12, n)).toISOString();
 
-function event(overrides: Partial<ChainEvent> & { eventId: string }): ChainEvent {
+function event(
+  overrides: Partial<ChainEvent> & { eventId: string },
+): ChainEvent {
   return {
     source: "chain",
     type: "factory.work.requested",
@@ -54,15 +56,41 @@ function run(overrides: Partial<ChainRun> & { runId: string }): ChainRun {
  */
 const tree = {
   events: [
-    event({ source: "test", eventId: "origin", type: "clock.tick.work-scan", runId: "run-1" }),
+    event({
+      source: "test",
+      eventId: "origin",
+      type: "clock.tick.work-scan",
+      runId: "run-1",
+    }),
     event({ eventId: "chain-1-A", causationId: "run-1", runId: "run-2" }),
-    event({ eventId: "chain-1-B", causationId: "run-1", status: "dead_lettered" }),
-    event({ eventId: "chain-2", causationId: "run-2", runId: "run-3", type: "factory.merge.scan.requested" }),
+    event({
+      eventId: "chain-1-B",
+      causationId: "run-1",
+      status: "dead_lettered",
+    }),
+    event({
+      eventId: "chain-2",
+      causationId: "run-2",
+      runId: "run-3",
+      type: "factory.merge.scan.requested",
+    }),
   ],
   runs: [
-    run({ runId: "run-1", agent: "work-scan@1", eventSource: "test", eventId: "origin" }),
+    run({
+      runId: "run-1",
+      agent: "work-scan@1",
+      eventSource: "test",
+      eventId: "origin",
+    }),
     run({ runId: "run-2", eventSource: "chain", eventId: "chain-1-A" }),
-    run({ runId: "run-3", agent: "merge-scan@1", state: "RUNNING", eventSource: "chain", eventId: "chain-2", finishedAt: null }),
+    run({
+      runId: "run-3",
+      agent: "merge-scan@1",
+      state: "RUNNING",
+      eventSource: "chain",
+      eventId: "chain-2",
+      finishedAt: null,
+    }),
   ],
 };
 
@@ -70,7 +98,9 @@ describe("buildChainGraph (WM-527)", () => {
   test("one node per event and run; edges follow event→run and run→emitted event", () => {
     const g = buildChainGraph(tree);
     expect(g.nodes).toHaveLength(7);
-    const edges = g.edges.map((e) => `${e.kind}:${e.source}>${e.target}`).sort();
+    const edges = g.edges
+      .map((e) => `${e.kind}:${e.source}>${e.target}`)
+      .sort();
     expect(edges).toEqual(
       [
         `produced:${eventNodeId("test", "origin")}>${runNodeId("run-1")}`,
@@ -95,7 +125,9 @@ describe("buildChainGraph (WM-527)", () => {
     expect(depth[eventNodeId("chain", "chain-2")]).toBe(4);
     expect(depth[runNodeId("run-3")]).toBe(5);
     expect(g.maxDepth).toBe(5);
-    expect(g.nodes.find((n) => n.id === eventNodeId("test", "origin"))?.root).toBe(true);
+    expect(
+      g.nodes.find((n) => n.id === eventNodeId("test", "origin"))?.root,
+    ).toBe(true);
     expect(g.nodes.filter((n) => n.root)).toHaveLength(1);
     expect(chainOriginLabel(g)).toBe("clock.tick.work-scan · test");
   });
@@ -106,14 +138,23 @@ describe("buildChainGraph (WM-527)", () => {
       runs: [run({ runId: "run-1", eventSource: "test", eventId: "origin" })],
     });
     expect(g.edges).toHaveLength(1);
-    expect(g.edges[0]).toMatchObject({ kind: "produced", source: eventNodeId("test", "origin"), target: runNodeId("run-1") });
+    expect(g.edges[0]).toMatchObject({
+      kind: "produced",
+      source: eventNodeId("test", "origin"),
+      target: runNodeId("run-1"),
+    });
     expect(g.rootIds).toEqual([eventNodeId("test", "origin")]);
   });
 
   test("a causation parent outside the correlation becomes a root run", () => {
     const g = buildChainGraph({
-      events: [event({ eventId: "chain-2", causationId: "run-2", runId: "run-3" })],
-      runs: [run({ runId: "run-2" }), run({ runId: "run-3", eventSource: "chain", eventId: "chain-2" })],
+      events: [
+        event({ eventId: "chain-2", causationId: "run-2", runId: "run-3" }),
+      ],
+      runs: [
+        run({ runId: "run-2" }),
+        run({ runId: "run-3", eventSource: "chain", eventId: "chain-2" }),
+      ],
     });
     expect(g.rootIds).toEqual([runNodeId("run-2")]);
     expect(chainOriginLabel(g)).toBe("dispatch@1 · run");
@@ -122,7 +163,9 @@ describe("buildChainGraph (WM-527)", () => {
 
   test("dangling ids never produce edges; a self-referencing cycle does not hang", () => {
     const g = buildChainGraph({
-      events: [event({ eventId: "e", causationId: "ghost", runId: "also-ghost" })],
+      events: [
+        event({ eventId: "e", causationId: "ghost", runId: "also-ghost" }),
+      ],
       runs: [],
     });
     expect(g.edges).toEqual([]);
@@ -139,7 +182,9 @@ describe("buildChainGraph (WM-527)", () => {
   });
 
   test("chainKeyOfEvent mirrors the emitter: correlation id, else the event's own id", () => {
-    expect(chainKeyOfEvent({ correlationId: "corr-1", eventId: "x" })).toBe("corr-1");
+    expect(chainKeyOfEvent({ correlationId: "corr-1", eventId: "x" })).toBe(
+      "corr-1",
+    );
     expect(chainKeyOfEvent({ correlationId: null, eventId: "x" })).toBe("x");
     expect(chainKeyOfEvent({ eventId: "x" })).toBe("x");
   });

--- a/event-runtime/web/src/graph/chainModel.ts
+++ b/event-runtime/web/src/graph/chainModel.ts
@@ -16,8 +16,20 @@ import type { ChainEvent, ChainRun, ChainView } from "../types";
  */
 
 export type ChainNode =
-  | { kind: "chainEvent"; id: string; event: ChainEvent; root: boolean; depth: number }
-  | { kind: "chainRun"; id: string; run: ChainRun; root: boolean; depth: number };
+  | {
+      kind: "chainEvent";
+      id: string;
+      event: ChainEvent;
+      root: boolean;
+      depth: number;
+    }
+  | {
+      kind: "chainRun";
+      id: string;
+      run: ChainRun;
+      root: boolean;
+      depth: number;
+    };
 
 export interface ChainEdge {
   id: string;
@@ -35,10 +47,13 @@ export interface ChainGraph {
   maxDepth: number;
 }
 
-export const eventNodeId = (source: string, eventId: string) => `event:${source}:${eventId}`;
+export const eventNodeId = (source: string, eventId: string) =>
+  `event:${source}:${eventId}`;
 export const runNodeId = (runId: string) => `run:${runId}`;
 
-export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): ChainGraph {
+export function buildChainGraph(
+  view: Pick<ChainView, "events" | "runs">,
+): ChainGraph {
   const nodes = new Map<string, ChainNode>();
   const edges: ChainEdge[] = [];
   const runsById = new Map(view.runs.map((r) => [r.runId, r]));
@@ -55,7 +70,12 @@ export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): Chain
   const incoming = new Set<string>();
   const seenEdge = new Set<string>();
   const addEdge = (edge: ChainEdge) => {
-    if (seenEdge.has(edge.id) || !nodes.has(edge.source) || !nodes.has(edge.target)) return;
+    if (
+      seenEdge.has(edge.id) ||
+      !nodes.has(edge.source) ||
+      !nodes.has(edge.target)
+    )
+      return;
     if (edge.source === edge.target) return;
     seenEdge.add(edge.id);
     edges.push(edge);
@@ -65,7 +85,12 @@ export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): Chain
   for (const event of view.events) {
     const eid = eventNodeId(event.source, event.eventId);
     if (event.runId && runsById.has(event.runId)) {
-      addEdge({ id: `produced:${eid}`, source: eid, target: runNodeId(event.runId), kind: "produced" });
+      addEdge({
+        id: `produced:${eid}`,
+        source: eid,
+        target: runNodeId(event.runId),
+        kind: "produced",
+      });
     }
     if (event.causationId && runsById.has(event.causationId)) {
       addEdge({
@@ -82,7 +107,12 @@ export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): Chain
     if (!run.eventSource || !run.eventId) continue;
     const eid = eventNodeId(run.eventSource, run.eventId);
     if (nodes.has(eid)) {
-      addEdge({ id: `produced:${eid}`, source: eid, target: runNodeId(run.runId), kind: "produced" });
+      addEdge({
+        id: `produced:${eid}`,
+        source: eid,
+        target: runNodeId(run.runId),
+        kind: "produced",
+      });
     }
   }
 
@@ -106,7 +136,8 @@ export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): Chain
     if (visiting.has(id)) return 0;
     visiting.add(id);
     let depth = 0;
-    for (const parent of parents.get(id) ?? []) depth = Math.max(depth, depthOf(parent) + 1);
+    for (const parent of parents.get(id) ?? [])
+      depth = Math.max(depth, depthOf(parent) + 1);
     visiting.delete(id);
     memo.set(id, depth);
     return depth;
@@ -121,15 +152,20 @@ export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): Chain
 }
 
 /** The chain key an event belongs to — mirrors lib/api-chain.mjs `chainKeyOf`. */
-export function chainKeyOfEvent(event: { correlationId?: string | null; eventId: string }): string {
+export function chainKeyOfEvent(event: {
+  correlationId?: string | null;
+  eventId: string;
+}): string {
   return event.correlationId ?? event.eventId;
 }
 
 /** Human summary of the origin, for headers: "clock.tick.merge-scan · schedule". */
 export function chainOriginLabel(graph: ChainGraph): string | null {
   const root = graph.nodes.find((n) => n.root && n.kind === "chainEvent");
-  if (root && root.kind === "chainEvent") return `${root.event.type} · ${root.event.source}`;
+  if (root && root.kind === "chainEvent")
+    return `${root.event.type} · ${root.event.source}`;
   const rootRun = graph.nodes.find((n) => n.root && n.kind === "chainRun");
-  if (rootRun && rootRun.kind === "chainRun") return `${rootRun.run.agent ?? rootRun.run.runId} · run`;
+  if (rootRun && rootRun.kind === "chainRun")
+    return `${rootRun.run.agent ?? rootRun.run.runId} · run`;
   return null;
 }

--- a/event-runtime/web/src/graph/chainNodes.tsx
+++ b/event-runtime/web/src/graph/chainNodes.tsx
@@ -1,7 +1,13 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { ChainNode } from "./chainModel";
 import { Line, Shell, handleStyle } from "./nodes";
-import { EVENT_STATUS_HUES, STATE_HUES, StateBadge, ago, shortId } from "../components/ui";
+import {
+  EVENT_STATUS_HUES,
+  STATE_HUES,
+  StateBadge,
+  ago,
+  shortId,
+} from "../components/ui";
 
 // Chain trace nodes (WM-527): the same shell as the capability map so the two
 // canvases read as one tool, but every node is an *instance* — an admitted
@@ -9,10 +15,15 @@ import { EVENT_STATUS_HUES, STATE_HUES, StateBadge, ago, shortId } from "../comp
 
 export const CHAIN_EDGE_STYLES = {
   produced: { label: "event → run", stroke: "var(--border-strong)" },
-  emitted: { label: "run emitted event", stroke: "var(--accent)", strokeDasharray: "4 3" },
+  emitted: {
+    label: "run emitted event",
+    stroke: "var(--accent)",
+    strokeDasharray: "4 3",
+  },
 } as const;
 
-const nowOf = (data: NodeProps["data"]) => Number((data as { now?: number }).now ?? Date.now());
+const nowOf = (data: NodeProps["data"]) =>
+  Number((data as { now?: number }).now ?? Date.now());
 
 export function chainNodeAccessibleName(node: ChainNode): string {
   if (node.kind === "chainEvent") {
@@ -27,10 +38,19 @@ export function ChainEventNode({ data, selected }: NodeProps) {
   const accent = EVENT_STATUS_HUES[e.status] ?? "var(--hue-idle)";
   const now = nowOf(data);
   return (
-    <Shell accent={accent} selected={selected} accessibleName={chainNodeAccessibleName(node)}>
-      {!node.root && <Handle type="target" position={Position.Left} style={handleStyle} />}
+    <Shell
+      accent={accent}
+      selected={selected}
+      accessibleName={chainNodeAccessibleName(node)}
+    >
+      {!node.root && (
+        <Handle type="target" position={Position.Left} style={handleStyle} />
+      )}
       <div className="flex items-center justify-between gap-1">
-        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
+        <span
+          className="text-[10px] tracking-wide uppercase"
+          style={{ color: accent }}
+        >
           {node.root ? "origin event" : "event"} · {e.source}
         </span>
         <StateBadge state={e.status} hues={EVENT_STATUS_HUES} dot={false} />
@@ -58,10 +78,19 @@ export function ChainRunNode({ data, selected }: NodeProps) {
   const now = nowOf(data);
   const when = r.finishedAt ?? r.startedAt ?? r.created_at;
   return (
-    <Shell accent={accent} selected={selected} accessibleName={chainNodeAccessibleName(node)}>
-      {!node.root && <Handle type="target" position={Position.Left} style={handleStyle} />}
+    <Shell
+      accent={accent}
+      selected={selected}
+      accessibleName={chainNodeAccessibleName(node)}
+    >
+      {!node.root && (
+        <Handle type="target" position={Position.Left} style={handleStyle} />
+      )}
       <div className="flex items-center justify-between gap-1">
-        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
+        <span
+          className="text-[10px] tracking-wide uppercase"
+          style={{ color: accent }}
+        >
           run{r.adapter ? ` · ${r.adapter}` : ""}
         </span>
         <StateBadge state={r.state} />

--- a/event-runtime/web/src/graph/layout.test.ts
+++ b/event-runtime/web/src/graph/layout.test.ts
@@ -13,7 +13,14 @@ import type { CapabilityGraph, GraphNode } from "./model";
 function sampleGraph(): CapabilityGraph {
   return {
     nodes: [
-      { id: "event:gh.failed", kind: "eventType", label: "gh.failed", adapter: "claude", scope: [], ttl: null },
+      {
+        id: "event:gh.failed",
+        kind: "eventType",
+        label: "gh.failed",
+        adapter: "claude",
+        scope: [],
+        ttl: null,
+      },
       {
         id: "agent:doctor@1",
         kind: "agent",
@@ -28,7 +35,12 @@ function sampleGraph(): CapabilityGraph {
       },
     ],
     edges: [
-      { id: "routes:gh.failed", source: "event:gh.failed", target: "agent:doctor@1", kind: "routes" },
+      {
+        id: "routes:gh.failed",
+        source: "event:gh.failed",
+        target: "agent:doctor@1",
+        kind: "routes",
+      },
     ],
   };
 }
@@ -43,7 +55,14 @@ describe("layoutGraph", () => {
   test("calculates positions for nodes and edges in a graph", async () => {
     const graph: CapabilityGraph = {
       nodes: [
-        { id: "event:gh.failed", kind: "eventType", label: "gh.failed", adapter: "claude", scope: [], ttl: null },
+        {
+          id: "event:gh.failed",
+          kind: "eventType",
+          label: "gh.failed",
+          adapter: "claude",
+          scope: [],
+          ttl: null,
+        },
         {
           id: "agent:doctor@1",
           kind: "agent",
@@ -58,7 +77,12 @@ describe("layoutGraph", () => {
         },
       ],
       edges: [
-        { id: "routes:gh.failed", source: "event:gh.failed", target: "agent:doctor@1", kind: "routes" },
+        {
+          id: "routes:gh.failed",
+          source: "event:gh.failed",
+          target: "agent:doctor@1",
+          kind: "routes",
+        },
       ],
     };
 
@@ -85,7 +109,11 @@ describe("layoutGraph", () => {
             ? { ...n, activeRuns: [{ state: "RUNNING", count: 2 }] }
             : n,
       ),
-      edges: base.edges.map((e) => ({ ...e, label: "routes (3)", invocations: 3 })),
+      edges: base.edges.map((e) => ({
+        ...e,
+        label: "routes (3)",
+        invocations: 3,
+      })),
     };
     expect(graphIdentity(overlay)).toBe(graphIdentity(base));
   });
@@ -104,7 +132,15 @@ describe("layoutGraph", () => {
     expect(
       graphIdentity({
         ...base,
-        edges: [...base.edges, { id: "rec:x", source: "agent:doctor@1", target: "event:gh.failed", kind: "recommends" }],
+        edges: [
+          ...base.edges,
+          {
+            id: "rec:x",
+            source: "agent:doctor@1",
+            target: "event:gh.failed",
+            kind: "recommends",
+          },
+        ],
       }),
     ).not.toBe(graphIdentity(base));
   });
@@ -125,7 +161,11 @@ describe("layoutGraph", () => {
     const first = await layoutGraphIfIdentityChanged(base, null, layout);
     expect(calls).toBe(1);
     expect(first.positions).not.toBeNull();
-    const second = await layoutGraphIfIdentityChanged(overlay, first.identity, layout);
+    const second = await layoutGraphIfIdentityChanged(
+      overlay,
+      first.identity,
+      layout,
+    );
     expect(calls).toBe(1);
     expect(second.positions).toBeNull();
     expect(second.identity).toBe(first.identity);
@@ -134,7 +174,14 @@ describe("layoutGraph", () => {
   test("rejects when layout calculation exceeds bounded timeout", async () => {
     const graph: CapabilityGraph = {
       nodes: [
-        { id: "event:e1", kind: "eventType", label: "e1", adapter: "a", scope: [], ttl: null },
+        {
+          id: "event:e1",
+          kind: "eventType",
+          label: "e1",
+          adapter: "a",
+          scope: [],
+          ttl: null,
+        },
       ],
       edges: [],
     };

--- a/event-runtime/web/src/graph/layout.ts
+++ b/event-runtime/web/src/graph/layout.ts
@@ -32,7 +32,9 @@ const OPTIONS = {
  */
 export function graphIdentity<G extends LayoutGraph>(graph: G): string {
   const nodes = graph.nodes.map((n) => n.id).sort();
-  const edges = graph.edges.map((e) => `${e.id}\t${e.source}\t${e.target}`).sort();
+  const edges = graph.edges
+    .map((e) => `${e.id}\t${e.source}\t${e.target}`)
+    .sort();
   return `${nodes.join("\n")}\n--\n${edges.join("\n")}`;
 }
 
@@ -56,7 +58,10 @@ export async function layoutGraphIfIdentityChanged<G extends LayoutGraph>(
   graph: G,
   prevIdentity: string | null,
   layout: LayoutFn = layoutGraph,
-): Promise<{ identity: string; positions: Map<string, { x: number; y: number }> | null }> {
+): Promise<{
+  identity: string;
+  positions: Map<string, { x: number; y: number }> | null;
+}> {
   const identity = graphIdentity(graph);
   if (prevIdentity !== null && identity === prevIdentity) {
     return { identity, positions: null };
@@ -72,7 +77,9 @@ export async function layoutGraph<G extends LayoutGraph>(
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`ELK layout calculation timed out after ${timeoutMs}ms`));
+      reject(
+        new Error(`ELK layout calculation timed out after ${timeoutMs}ms`),
+      );
     }, timeoutMs);
   });
 
@@ -80,8 +87,16 @@ export async function layoutGraph<G extends LayoutGraph>(
     const layoutPromise = elk.layout({
       id: "root",
       layoutOptions,
-      children: graph.nodes.map((n) => ({ id: n.id, width: NODE_WIDTH, height: NODE_HEIGHT })),
-      edges: graph.edges.map((e) => ({ id: e.id, sources: [e.source], targets: [e.target] })),
+      children: graph.nodes.map((n) => ({
+        id: n.id,
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+      })),
+      edges: graph.edges.map((e) => ({
+        id: e.id,
+        sources: [e.source],
+        targets: [e.target],
+      })),
     });
 
     const result = await Promise.race([layoutPromise, timeoutPromise]);

--- a/event-runtime/web/src/graph/model.test.ts
+++ b/event-runtime/web/src/graph/model.test.ts
@@ -42,23 +42,52 @@ describe("buildCapabilityGraph", () => {
       view({
         agents: [agent({ ref: "doctor@1" })],
         eventTypes: [
-          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: ["inputHash"], proposalTtlSeconds: 1800 },
+          {
+            type: "gh.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: ["inputHash"],
+            proposalTtlSeconds: 1800,
+          },
         ],
       }),
     );
-    expect(g.nodes.map((n) => n.id)).toEqual(["event:gh.failed", "agent:doctor@1"]);
+    expect(g.nodes.map((n) => n.id)).toEqual([
+      "event:gh.failed",
+      "agent:doctor@1",
+    ]);
     expect(g.edges).toEqual([
-      { id: "routes:gh.failed", source: "event:gh.failed", target: "agent:doctor@1", kind: "routes" },
+      {
+        id: "routes:gh.failed",
+        source: "event:gh.failed",
+        target: "agent:doctor@1",
+        kind: "routes",
+      },
     ]);
   });
 
   test("draws recommendation edges from an agent to follow-up event types", () => {
     const g = buildCapabilityGraph(
       view({
-        agents: [agent({ ref: "doctor@1" }), agent({ ref: "rerun@1", mutating: true, command: ["gh", "run"] })],
+        agents: [
+          agent({ ref: "doctor@1" }),
+          agent({ ref: "rerun@1", mutating: true, command: ["gh", "run"] }),
+        ],
         eventTypes: [
-          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "gh.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.rerun",
+            agent: "rerun@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
         edges: {
           "doctor@1": {
@@ -69,9 +98,17 @@ describe("buildCapabilityGraph", () => {
       }),
     );
     const rec = g.edges.find((e) => e.kind === "recommends");
-    expect(rec).toMatchObject({ source: "agent:doctor@1", target: "event:ci.rerun", label: "verdict = FLAKE" });
+    expect(rec).toMatchObject({
+      source: "agent:doctor@1",
+      target: "event:ci.rerun",
+      label: "verdict = FLAKE",
+    });
     const rerun = g.nodes.find((n) => n.id === "agent:rerun@1");
-    expect(rerun).toMatchObject({ kind: "agent", mutating: true, execution: "command" });
+    expect(rerun).toMatchObject({
+      kind: "agent",
+      mutating: true,
+      execution: "command",
+    });
   });
 
   test("unmapped enum values become one terminal — 'the chain ends here' is topology", () => {
@@ -80,21 +117,41 @@ describe("buildCapabilityGraph", () => {
         agents: [
           agent({
             ref: "doctor@1",
-            outputSchema: { properties: { verdict: { enum: ["TICKET", "ENV", "FLAKE"] } } },
+            outputSchema: {
+              properties: { verdict: { enum: ["TICKET", "ENV", "FLAKE"] } },
+            },
           }),
           agent({ ref: "rerun@1" }),
         ],
         eventTypes: [
-          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "gh.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.rerun",
+            agent: "rerun@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
         edges: {
-          "doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "ci.rerun", input: {} } } },
+          "doctor@1": {
+            recommendationField: "verdict",
+            edges: { FLAKE: { eventType: "ci.rerun", input: {} } },
+          },
         },
       }),
     );
     const terminal = g.nodes.find((n) => n.kind === "terminal");
-    expect(terminal).toMatchObject({ id: "terminal:doctor@1", reason: "TICKET, ENV" });
+    expect(terminal).toMatchObject({
+      id: "terminal:doctor@1",
+      reason: "TICKET, ENV",
+    });
     expect(g.edges.some((e) => e.target === "terminal:doctor@1")).toBe(true);
   });
 
@@ -102,13 +159,27 @@ describe("buildCapabilityGraph", () => {
     const g = buildCapabilityGraph(
       view({
         agents: [
-          agent({ ref: "d@1", outputSchema: { properties: { r: { enum: ["GO"] } } } }),
+          agent({
+            ref: "d@1",
+            outputSchema: { properties: { r: { enum: ["GO"] } } },
+          }),
           agent({ ref: "next@1" }),
         ],
         eventTypes: [
-          { type: "t.next", agent: "next@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "t.next",
+            agent: "next@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
-        edges: { "d@1": { recommendationField: "r", edges: { GO: { eventType: "t.next", input: {} } } } },
+        edges: {
+          "d@1": {
+            recommendationField: "r",
+            edges: { GO: { eventType: "t.next", input: {} } },
+          },
+        },
       }),
     );
     expect(g.nodes.some((n) => n.kind === "terminal")).toBe(false);
@@ -118,7 +189,12 @@ describe("buildCapabilityGraph", () => {
     const g = buildCapabilityGraph(
       view({
         agents: [agent({ ref: "d@1" })],
-        edges: { "d@1": { recommendationField: "r", edges: { GO: { eventType: "nope.missing", input: {} } } } },
+        edges: {
+          "d@1": {
+            recommendationField: "r",
+            edges: { GO: { eventType: "nope.missing", input: {} } },
+          },
+        },
       }),
     );
     expect(g.edges).toEqual([]);
@@ -131,7 +207,11 @@ describe("buildCapabilityGraph", () => {
           agent({
             ref: "remediate@1",
             mutating: true,
-            actionRegistry: { "docker-builder-prune": { remote: "sudo docker builder prune -af" } },
+            actionRegistry: {
+              "docker-builder-prune": {
+                remote: "sudo docker builder prune -af",
+              },
+            },
             hosts: ["lab", "web"],
           }),
         ],
@@ -149,14 +229,74 @@ describe("buildCapabilityGraph", () => {
     const g = buildCapabilityGraph(
       view({
         agents: [agent({ ref: "doctor@1" }), agent({ ref: "idle@1" })],
-        eventTypes: [{ type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null }],
+        eventTypes: [
+          {
+            type: "gh.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+        ],
       }),
       {
         runs: [
-          { runId: "r1", state: "RUNNING", agent: "doctor@1", attempts: 1, maxAttempts: 3, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
-          { runId: "r2", state: "QUEUED", agent: "doctor@1", attempts: 1, maxAttempts: 3, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
-          { runId: "r3", state: "QUEUED", agent: "doctor@1", attempts: 1, maxAttempts: 3, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
-          { runId: "r4", state: "COMPLETED", agent: "doctor@1", attempts: 1, maxAttempts: 3, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
+          {
+            runId: "r1",
+            state: "RUNNING",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 3,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
+          {
+            runId: "r2",
+            state: "QUEUED",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 3,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
+          {
+            runId: "r3",
+            state: "QUEUED",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 3,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
+          {
+            runId: "r4",
+            state: "COMPLETED",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 3,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
         ],
       },
     );
@@ -176,15 +316,75 @@ describe("buildCapabilityGraph", () => {
       view({
         agents: [agent({ ref: "doctor@1" })],
         eventTypes: [
-          { type: "ci.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "ci.passed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "ci.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.passed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
       }),
       {
         events: [
-          { source: "gh", eventId: "e1", type: "ci.failed", subject: null, status: "admitted", occurredAt: "", receivedAt: "", correlationId: null, planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: null, runId: null, envelope: {}, repos: [] },
-          { source: "gh", eventId: "e2", type: "ci.failed", subject: null, status: "admitted", occurredAt: "", receivedAt: "", correlationId: null, planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: null, runId: null, envelope: {}, repos: [] },
-          { source: "gh", eventId: "e3", type: "ci.failed", subject: null, status: "planned", occurredAt: "", receivedAt: "", correlationId: null, planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: null, runId: null, envelope: {}, repos: [] },
+          {
+            source: "gh",
+            eventId: "e1",
+            type: "ci.failed",
+            subject: null,
+            status: "admitted",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: null,
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: null,
+            runId: null,
+            envelope: {},
+            repos: [],
+          },
+          {
+            source: "gh",
+            eventId: "e2",
+            type: "ci.failed",
+            subject: null,
+            status: "admitted",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: null,
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: null,
+            runId: null,
+            envelope: {},
+            repos: [],
+          },
+          {
+            source: "gh",
+            eventId: "e3",
+            type: "ci.failed",
+            subject: null,
+            status: "planned",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: null,
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: null,
+            runId: null,
+            envelope: {},
+            repos: [],
+          },
         ],
       },
     );
@@ -203,8 +403,20 @@ describe("buildCapabilityGraph", () => {
       view({
         agents: [agent({ ref: "doctor@1" }), agent({ ref: "rerun@1" })],
         eventTypes: [
-          { type: "ci.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "ci.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.rerun",
+            agent: "rerun@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
         edges: {
           "doctor@1": {
@@ -215,12 +427,72 @@ describe("buildCapabilityGraph", () => {
       }),
       {
         runs: [
-          { runId: "run-doc-101", state: "COMPLETED", agent: "doctor@1", attempts: 1, maxAttempts: 1, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
-          { runId: "run-doc-102", state: "COMPLETED", agent: "doctor@1", attempts: 1, maxAttempts: 1, adapter: "claude", reasonCode: null, eventId: null, eventSource: null, created_at: "", updated_at: "", repos: [] },
+          {
+            runId: "run-doc-101",
+            state: "COMPLETED",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 1,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
+          {
+            runId: "run-doc-102",
+            state: "COMPLETED",
+            agent: "doctor@1",
+            attempts: 1,
+            maxAttempts: 1,
+            adapter: "claude",
+            reasonCode: null,
+            eventId: null,
+            eventSource: null,
+            created_at: "",
+            updated_at: "",
+            repos: [],
+          },
         ],
         events: [
-          { source: "factory.chain", eventId: "chain-1", type: "ci.rerun", subject: "doctor@1", status: "admitted", occurredAt: "", receivedAt: "", correlationId: "c1", causationId: "run-doc-101", planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: null, runId: null, envelope: {}, repos: [] } as any,
-          { source: "factory.chain", eventId: "chain-2", type: "ci.rerun", subject: "doctor@1", status: "planned", occurredAt: "", receivedAt: "", correlationId: "c2", causationId: "run-doc-102", planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: null, runId: null, envelope: {}, repos: [] } as any,
+          {
+            source: "factory.chain",
+            eventId: "chain-1",
+            type: "ci.rerun",
+            subject: "doctor@1",
+            status: "admitted",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: "c1",
+            causationId: "run-doc-101",
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: null,
+            runId: null,
+            envelope: {},
+            repos: [],
+          } as any,
+          {
+            source: "factory.chain",
+            eventId: "chain-2",
+            type: "ci.rerun",
+            subject: "doctor@1",
+            status: "planned",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: "c2",
+            causationId: "run-doc-102",
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: null,
+            runId: null,
+            envelope: {},
+            repos: [],
+          } as any,
         ],
       },
     );
@@ -236,12 +508,34 @@ describe("buildCapabilityGraph", () => {
       view({
         agents: [agent({ ref: "rerun@1" })],
         eventTypes: [
-          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "ci.rerun",
+            agent: "rerun@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
       }),
       {
         events: [
-          { source: "factory.chain", eventId: "ev-100", type: "ci.rerun", subject: null, status: "planned", occurredAt: "", receivedAt: "", correlationId: null, planFailures: 0, lastPlanError: null, admittedAt: "", proposalId: "prop-99", runId: null, envelope: {}, repos: [] },
+          {
+            source: "factory.chain",
+            eventId: "ev-100",
+            type: "ci.rerun",
+            subject: null,
+            status: "planned",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: null,
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: "prop-99",
+            runId: null,
+            envelope: {},
+            repos: [],
+          },
         ],
         proposals: [
           {
@@ -270,11 +564,15 @@ describe("buildCapabilityGraph", () => {
     expect(propNode?.kind).toBe("proposal");
     expect(propNode?.label).toBe("pending: rerun@1");
 
-    const eventToPropEdge = g.edges.find((e) => e.source === "event:ci.rerun" && e.target === "proposal:prop-99");
+    const eventToPropEdge = g.edges.find(
+      (e) => e.source === "event:ci.rerun" && e.target === "proposal:prop-99",
+    );
     expect(eventToPropEdge).toBeDefined();
     expect(eventToPropEdge?.kind).toBe("proposal");
 
-    const propToAgentEdge = g.edges.find((e) => e.source === "proposal:prop-99" && e.target === "agent:rerun@1");
+    const propToAgentEdge = g.edges.find(
+      (e) => e.source === "proposal:prop-99" && e.target === "agent:rerun@1",
+    );
     expect(propToAgentEdge).toBeDefined();
     expect(propToAgentEdge?.kind).toBe("proposal");
   });

--- a/event-runtime/web/src/graph/model.ts
+++ b/event-runtime/web/src/graph/model.ts
@@ -1,4 +1,10 @@
-import type { AdmittedEvent, AgentsView, Proposal, RunListItem, StatusView } from "../types";
+import type {
+  AdmittedEvent,
+  AgentsView,
+  Proposal,
+  RunListItem,
+  StatusView,
+} from "../types";
 
 // The capability map: what this runtime can do, derived from the registry,
 // overlaid with live runtime state (OPS-227 phase 2): active run state badges,
@@ -69,14 +75,23 @@ export const agentNodeId = (ref: string) => `agent:${ref}`;
 export const proposalNodeId = (id: string) => `proposal:${id}`;
 
 /** How an agent actually executes — the honest distinction for the map. */
-function executionOf(def: AgentsView["agents"][number]): "model" | "command" | "actions" {
+function executionOf(
+  def: AgentsView["agents"][number],
+): "model" | "command" | "actions" {
   if (def.actionRegistry) return "actions";
   if (def.command) return "command";
   return "model";
 }
 
 /** Active run states to highlight on agent nodes in priority order */
-const ACTIVE_RUN_STATES = ["RUNNING", "QUEUED", "LEASED", "VERIFYING", "APPROVED", "PROPOSED"];
+const ACTIVE_RUN_STATES = [
+  "RUNNING",
+  "QUEUED",
+  "LEASED",
+  "VERIFYING",
+  "APPROVED",
+  "PROPOSED",
+];
 
 /**
  * Build the capability map overlaid with optional live state.
@@ -85,7 +100,10 @@ const ACTIVE_RUN_STATES = ["RUNNING", "QUEUED", "LEASED", "VERIFYING", "APPROVED
  * proposal ghost nodes.
  * Edges: routing, recommendations (with causation invocation counts), and ghost proposal edges.
  */
-export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): CapabilityGraph {
+export function buildCapabilityGraph(
+  view: AgentsView,
+  live?: LiveGraphState,
+): CapabilityGraph {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
@@ -96,10 +114,14 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
   // 1. Registered event types
   for (const route of routes) {
     const admittedCount = live?.events
-      ? live.events.filter((e) => e.type === route.type && e.status === "admitted").length
+      ? live.events.filter(
+          (e) => e.type === route.type && e.status === "admitted",
+        ).length
       : undefined;
     const plannedCount = live?.events
-      ? live.events.filter((e) => e.type === route.type && e.status === "planned").length
+      ? live.events.filter(
+          (e) => e.type === route.type && e.status === "planned",
+        ).length
       : undefined;
 
     nodes.push({
@@ -173,7 +195,8 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
           if (ev.type === edge.eventType) {
             const causation =
               (ev as { causationId?: string | null }).causationId ??
-              (ev.envelope as { causationId?: string | null } | undefined)?.causationId;
+              (ev.envelope as { causationId?: string | null } | undefined)
+                ?.causationId;
             if (causation) {
               const run = runsByRunId.get(causation);
               if (run ? run.agent === agentRef : ev.subject === agentRef) {
@@ -185,7 +208,8 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
       }
 
       const baseLabel = `${rule.recommendationField} = ${value}`;
-      const label = invocations > 0 ? `${baseLabel} (${invocations})` : baseLabel;
+      const label =
+        invocations > 0 ? `${baseLabel} (${invocations})` : baseLabel;
 
       edges.push({
         id: `rec:${agentRef}:${value}`,
@@ -203,8 +227,7 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
     const rule = view.edges?.[def.ref];
     if (!rule) continue;
     const schema = def.outputSchema as
-      | { properties?: Record<string, { enum?: string[] }> }
-      | undefined;
+      { properties?: Record<string, { enum?: string[] }> } | undefined;
     const declared = schema?.properties?.[rule.recommendationField]?.enum ?? [];
     const unmapped = declared.filter((value) => !(value in (rule.edges ?? {})));
     if (unmapped.length === 0) continue;
@@ -234,7 +257,9 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
       let eventType: string | null = null;
       if (p.eventId && live.events) {
         const ev = live.events.find(
-          (e) => (p.eventSource ? e.source === p.eventSource : true) && e.eventId === p.eventId,
+          (e) =>
+            (p.eventSource ? e.source === p.eventSource : true) &&
+            e.eventId === p.eventId,
         );
         if (ev) eventType = ev.type;
       }

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { useRef } from "react";
-import { AgentNode, EventTypeNode, ProposalNode, TerminalNode, nodeAccessibleName } from "./nodes";
+import {
+  AgentNode,
+  EventTypeNode,
+  ProposalNode,
+  TerminalNode,
+  nodeAccessibleName,
+} from "./nodes";
 import type { GraphNode } from "./model";
 import { Graph, focusedNodeFit, useSelectedNodeReveal } from "../views/Graph";
 import {
@@ -237,10 +243,19 @@ describe("node accessible names and selection", () => {
 
   test("each kind exposes the accessible name and aria-selected on the node", () => {
     const cases: Array<{ ui: React.ReactElement; name: RegExp }> = [
-      { ui: <EventTypeNode {...nodeProps(eventNode)} selected />, name: /event type/i },
+      {
+        ui: <EventTypeNode {...nodeProps(eventNode)} selected />,
+        name: /event type/i,
+      },
       { ui: <AgentNode {...nodeProps(agentNode)} selected />, name: /agent/i },
-      { ui: <TerminalNode {...nodeProps(terminalNode)} selected />, name: /terminal/i },
-      { ui: <ProposalNode {...nodeProps(proposalNode)} selected />, name: /proposal/i },
+      {
+        ui: <TerminalNode {...nodeProps(terminalNode)} selected />,
+        name: /terminal/i,
+      },
+      {
+        ui: <ProposalNode {...nodeProps(proposalNode)} selected />,
+        name: /proposal/i,
+      },
     ];
     for (const { ui, name } of cases) {
       const { getByRole, unmount } = renderNode(ui);
@@ -252,13 +267,23 @@ describe("node accessible names and selection", () => {
   });
 
   test("unselected nodes set aria-selected false", () => {
-    const { getByRole } = renderNode(<EventTypeNode {...nodeProps(eventNode)} />);
-    expect(getByRole("button", { name: /event type/i }).getAttribute("aria-selected")).toBe("false");
-    expect(getByRole("button", { name: /event type/i }).getAttribute("aria-pressed")).toBe("false");
+    const { getByRole } = renderNode(
+      <EventTypeNode {...nodeProps(eventNode)} />,
+    );
+    expect(
+      getByRole("button", { name: /event type/i }).getAttribute(
+        "aria-selected",
+      ),
+    ).toBe("false");
+    expect(
+      getByRole("button", { name: /event type/i }).getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 
   test("the current search match is visually distinct from other hits", () => {
-    const hit = renderNode(<EventTypeNode {...nodeProps(eventNode, { searchHit: true })} />);
+    const hit = renderNode(
+      <EventTypeNode {...nodeProps(eventNode, { searchHit: true })} />,
+    );
     const hitEl = hit.getByRole("button", { name: /event type/i });
     expect(hitEl.getAttribute("data-search-hit")).toBe("true");
     expect(hitEl.getAttribute("data-search-current")).toBeNull();
@@ -266,7 +291,9 @@ describe("node accessible names and selection", () => {
     hit.unmount();
 
     const current = renderNode(
-      <EventTypeNode {...nodeProps(eventNode, { searchHit: true, searchCurrent: true })} />,
+      <EventTypeNode
+        {...nodeProps(eventNode, { searchHit: true, searchCurrent: true })}
+      />,
     );
     const currentEl = current.getByRole("button", { name: /event type/i });
     expect(currentEl.getAttribute("data-search-current")).toBe("true");
@@ -409,7 +436,9 @@ describe("Graph view inspect loop", () => {
       },
       async () => {
         const { getByLabelText, getByText } = renderGraph();
-        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+        const input = (await waitFor(() =>
+          getByLabelText("Search graph nodes"),
+        )) as HTMLInputElement;
 
         changeInput(input, "agent:");
         const counter = await waitFor(() => getByText("1 / 2"));
@@ -431,7 +460,9 @@ describe("Graph view inspect loop", () => {
       },
       async () => {
         const { getByLabelText } = renderGraph();
-        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+        const input = (await waitFor(() =>
+          getByLabelText("Search graph nodes"),
+        )) as HTMLInputElement;
         input.focus();
         changeInput(input, "agent:");
 
@@ -454,7 +485,9 @@ describe("Graph view inspect loop", () => {
       },
       async () => {
         const { getByLabelText } = renderGraph({ onSelectNode });
-        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+        const input = (await waitFor(() =>
+          getByLabelText("Search graph nodes"),
+        )) as HTMLInputElement;
         changeInput(input, "agent:");
         fireEvent.keyDown(input, { key: "Enter" });
         expect(onSelectNode).toHaveBeenCalledWith("agent:doctor@1");
@@ -509,7 +542,10 @@ describe("Graph view inspect loop", () => {
   });
 
   test("selected proposal node shows Open in Proposals jumping via hashPath", async () => {
-    const proposal = createProposalFixture({ id: "prop_abc", agent: "doctor@1" });
+    const proposal = createProposalFixture({
+      id: "prop_abc",
+      agent: "doctor@1",
+    });
     await withApi(
       {
         agents: async () => graphAgents(),
@@ -518,7 +554,9 @@ describe("Graph view inspect loop", () => {
       },
       async () => {
         const { getByRole } = renderGraph({ focusNodeId: "proposal:prop_abc" });
-        const btn = await waitFor(() => getByRole("button", { name: "Open in Proposals" }));
+        const btn = await waitFor(() =>
+          getByRole("button", { name: "Open in Proposals" }),
+        );
         window.location.hash = "#/graph/proposal:prop_abc";
         fireEvent.click(btn);
         expect(window.location.hash).toBe("#/proposals/prop_abc");

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -7,9 +7,15 @@ import { DECISION_HUES, STATE_HUES, StateBadge } from "../components/ui";
 // reads as part of the tool rather than an embedded diagram widget. Accents
 // and dash styles come from ./style so the legend stays truthful (WM-99).
 
-export const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
+export const handleStyle = {
+  background: "var(--border-strong)",
+  width: 6,
+  height: 6,
+  border: "none",
+};
 
-const searchHitOf = (data: NodeProps["data"]) => Boolean((data as { searchHit?: boolean }).searchHit);
+const searchHitOf = (data: NodeProps["data"]) =>
+  Boolean((data as { searchHit?: boolean }).searchHit);
 const searchCurrentOf = (data: NodeProps["data"]) =>
   Boolean((data as { searchCurrent?: boolean }).searchCurrent);
 
@@ -18,16 +24,21 @@ function materialState(node: GraphNode): string {
     case "eventType": {
       const admitted = node.admittedCount ?? 0;
       const planned = node.plannedCount ?? 0;
-      if (admitted > 0 || planned > 0) return `${admitted} admitted, ${planned} planned`;
+      if (admitted > 0 || planned > 0)
+        return `${admitted} admitted, ${planned} planned`;
       return "idle";
     }
     case "agent": {
       const runs = node.activeRuns ?? [];
       if (runs.length === 0) return "idle";
-      return runs.map(({ state, count }) => (count > 1 ? `${state} ${count}` : state)).join(", ");
+      return runs
+        .map(({ state, count }) => (count > 1 ? `${state} ${count}` : state))
+        .join(", ");
     }
     case "proposal":
-      return node.proposal.expired ? `${node.decision}, expired` : node.decision;
+      return node.proposal.expired
+        ? `${node.decision}, expired`
+        : node.decision;
     case "terminal":
       return node.reason;
   }
@@ -74,7 +85,11 @@ export function Shell({
         boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
         borderLeft: `3px solid ${accent}`,
         outlineWidth: searchHit || searchCurrent ? "2px" : undefined,
-        outlineStyle: searchCurrent ? "solid" : searchHit ? "dashed" : undefined,
+        outlineStyle: searchCurrent
+          ? "solid"
+          : searchHit
+            ? "dashed"
+            : undefined,
         outlineColor: searchHit || searchCurrent ? "var(--accent)" : undefined,
         outlineOffset: searchHit || searchCurrent ? 2 : undefined,
       }}
@@ -84,7 +99,13 @@ export function Shell({
   );
 }
 
-export function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
+export function Line({
+  children,
+  dim,
+}: {
+  children: React.ReactNode;
+  dim?: boolean;
+}) {
   return (
     <div
       className="mono truncate text-[11.5px]"
@@ -111,7 +132,10 @@ export function EventTypeNode({ data, selected }: NodeProps) {
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
-        <span className="text-[10px] tracking-wide uppercase" style={{ color: NODE_STYLES.eventType.accent }}>
+        <span
+          className="text-[10px] tracking-wide uppercase"
+          style={{ color: NODE_STYLES.eventType.accent }}
+        >
           event type
         </span>
         {hasCounts && (
@@ -121,7 +145,8 @@ export function EventTypeNode({ data, selected }: NodeProps) {
                 className="rounded px-1 text-[11px] font-medium"
                 style={{
                   color: "var(--hue-info)",
-                  background: "color-mix(in oklch, var(--hue-info) 12%, transparent)",
+                  background:
+                    "color-mix(in oklch, var(--hue-info) 12%, transparent)",
                 }}
               >
                 {admitted} admitted
@@ -132,7 +157,8 @@ export function EventTypeNode({ data, selected }: NodeProps) {
                 className="rounded px-1 text-[11px] font-medium"
                 style={{
                   color: "var(--hue-ok)",
-                  background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
+                  background:
+                    "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
                 }}
               >
                 {planned} planned
@@ -157,7 +183,9 @@ export function EventTypeNode({ data, selected }: NodeProps) {
 
 export function AgentNode({ data, selected }: NodeProps) {
   const node = data.node as Extract<GraphNode, { kind: "agent" }>;
-  const accent = node.mutating ? NODE_STYLES.agentMutating.accent : NODE_STYLES.agentReadOnly.accent;
+  const accent = node.mutating
+    ? NODE_STYLES.agentMutating.accent
+    : NODE_STYLES.agentReadOnly.accent;
   const activeRuns = node.activeRuns ?? [];
 
   return (
@@ -170,8 +198,13 @@ export function AgentNode({ data, selected }: NodeProps) {
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-2">
-        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
-          {node.execution === "model" ? "agent · model" : `agent · ${node.execution}`}
+        <span
+          className="text-[10px] tracking-wide uppercase"
+          style={{ color: accent }}
+        >
+          {node.execution === "model"
+            ? "agent · model"
+            : `agent · ${node.execution}`}
         </span>
         <div className="flex items-center gap-1">
           {node.mutating && (
@@ -209,7 +242,7 @@ export function AgentNode({ data, selected }: NodeProps) {
       <Line dim>
         {node.execution === "actions"
           ? `${node.actions.length} actions · ${node.hosts.join(", ")}`
-          : (node.capabilities.join(", ") || "no declared services")}
+          : node.capabilities.join(", ") || "no declared services"}
       </Line>
       <Handle type="source" position={Position.Right} style={handleStyle} />
     </Shell>
@@ -228,7 +261,10 @@ export function TerminalNode({ data, selected }: NodeProps) {
       accessibleName={nodeAccessibleName(node)}
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
-      <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--text-faint)" }}>
+      <div
+        className="text-[10px] tracking-wide uppercase"
+        style={{ color: "var(--text-faint)" }}
+      >
         terminal
       </div>
       <div className="text-[12px]" style={{ color: "var(--text-dim)" }}>
@@ -252,7 +288,10 @@ export function ProposalNode({ data, selected }: NodeProps) {
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
-        <span className="text-[10px] tracking-wide uppercase font-semibold" style={{ color: NODE_STYLES.proposal.accent }}>
+        <span
+          className="text-[10px] tracking-wide uppercase font-semibold"
+          style={{ color: NODE_STYLES.proposal.accent }}
+        >
           proposal
         </span>
         <StateBadge state={node.decision} hues={DECISION_HUES} />
@@ -261,10 +300,13 @@ export function ProposalNode({ data, selected }: NodeProps) {
         {node.label}
       </div>
       <Line dim>
-        {node.agentRef ? `agent: ${node.agentRef}` : (node.proposal.reason || "pending execution")}
+        {node.agentRef
+          ? `agent: ${node.agentRef}`
+          : node.proposal.reason || "pending execution"}
       </Line>
       <Line dim>
-        ttl: {node.proposal.ttl_seconds}s {node.proposal.expired ? "(expired)" : "remaining"}
+        ttl: {node.proposal.ttl_seconds}s{" "}
+        {node.proposal.expired ? "(expired)" : "remaining"}
       </Line>
       <Handle type="source" position={Position.Right} style={handleStyle} />
     </Shell>

--- a/event-runtime/web/src/graph/search.test.ts
+++ b/event-runtime/web/src/graph/search.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { largestComponentIds, matchNodes, missingFocusNode, searchEnter } from "./search";
+import {
+  largestComponentIds,
+  matchNodes,
+  missingFocusNode,
+  searchEnter,
+} from "./search";
 import type { CapabilityGraph, GraphNode } from "./model";
 
 const event = (type: string): GraphNode => ({
@@ -25,7 +30,11 @@ const agent = (ref: string): GraphNode => ({
 });
 
 describe("matchNodes", () => {
-  const nodes = [event("gh.run.failed"), agent("ci-doctor@1"), agent("rerun@2")];
+  const nodes = [
+    event("gh.run.failed"),
+    agent("ci-doctor@1"),
+    agent("rerun@2"),
+  ];
 
   test("case-insensitive substring on label", () => {
     expect(matchNodes(nodes, "DOCTOR")).toEqual(["agent:ci-doctor@1"]);
@@ -61,22 +70,32 @@ describe("searchEnter", () => {
   });
 
   test("first Enter selects match 1 of N, not match 2", () => {
-    expect(searchEnter(matches, 0, null)).toEqual({ selectId: "event:a", nextIdx: 0 });
+    expect(searchEnter(matches, 0, null)).toEqual({
+      selectId: "event:a",
+      nextIdx: 0,
+    });
   });
 
   test("Enter while the current match is already selected advances to the next", () => {
-    expect(searchEnter(matches, 0, "event:a")).toEqual({ selectId: "agent:b", nextIdx: 1 });
+    expect(searchEnter(matches, 0, "event:a")).toEqual({
+      selectId: "agent:b",
+      nextIdx: 1,
+    });
   });
 });
 
 describe("missingFocusNode", () => {
   test("does not report a missing node while the graph is still loading", () => {
     expect(missingFocusNode(undefined, "event:gone", false)).toBe(false);
-    expect(missingFocusNode([{ id: "event:a" }], "event:gone", false)).toBe(false);
+    expect(missingFocusNode([{ id: "event:a" }], "event:gone", false)).toBe(
+      false,
+    );
   });
 
   test("reports missing when a loaded graph has no node for the deep-link id", () => {
-    expect(missingFocusNode([{ id: "event:a" }], "event:gone", true)).toBe(true);
+    expect(missingFocusNode([{ id: "event:a" }], "event:gone", true)).toBe(
+      true,
+    );
   });
 
   test("does not report missing when the deep-link node exists", () => {
@@ -87,7 +106,12 @@ describe("missingFocusNode", () => {
 
 describe("largestComponentIds", () => {
   const edge = (id: string, source: string, target: string) =>
-    ({ id, source, target, kind: "routes" }) as CapabilityGraph["edges"][number];
+    ({
+      id,
+      source,
+      target,
+      kind: "routes",
+    }) as CapabilityGraph["edges"][number];
 
   test("picks the component with the most nodes", () => {
     const graph: CapabilityGraph = {
@@ -112,7 +136,9 @@ describe("largestComponentIds", () => {
       ],
     };
     // Both components have 2 nodes; b's has 2 edges vs a's 0... a's are isolated.
-    expect(largestComponentIds(graph).sort()).toEqual(["agent:b@1", "event:b"].sort());
+    expect(largestComponentIds(graph).sort()).toEqual(
+      ["agent:b@1", "event:b"].sort(),
+    );
   });
 
   test("empty graph yields empty", () => {

--- a/event-runtime/web/src/graph/search.ts
+++ b/event-runtime/web/src/graph/search.ts
@@ -12,7 +12,11 @@ export function matchNodes(nodes: GraphNode[], query: string): string[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return [];
   return nodes
-    .filter((n) => n.label.toLowerCase().includes(needle) || n.id.toLowerCase().includes(needle))
+    .filter(
+      (n) =>
+        n.label.toLowerCase().includes(needle) ||
+        n.id.toLowerCase().includes(needle),
+    )
     .map((n) => n.id);
 }
 
@@ -54,7 +58,9 @@ export function missingFocusNode(
  * on screen at once.
  */
 export function largestComponentIds(graph: CapabilityGraph): string[] {
-  const adjacency = new Map<string, string[]>(graph.nodes.map((n) => [n.id, []]));
+  const adjacency = new Map<string, string[]>(
+    graph.nodes.map((n) => [n.id, []]),
+  );
   for (const edge of graph.edges) {
     adjacency.get(edge.source)?.push(edge.target);
     adjacency.get(edge.target)?.push(edge.source);
@@ -80,7 +86,10 @@ export function largestComponentIds(graph: CapabilityGraph): string[] {
       }
     }
     const edges = edgeEndpoints / 2;
-    if (ids.length > best.ids.length || (ids.length === best.ids.length && edges > best.edges)) {
+    if (
+      ids.length > best.ids.length ||
+      (ids.length === best.ids.length && edges > best.edges)
+    ) {
       best = { ids, edges };
     }
   }

--- a/event-runtime/web/src/graph/style.test.ts
+++ b/event-runtime/web/src/graph/style.test.ts
@@ -20,7 +20,12 @@ describe("nodeStyleKey", () => {
     expect(nodeStyleKey(agent("a@1", false))).toBe("agentReadOnly");
     expect(nodeStyleKey(agent("a@1", true))).toBe("agentMutating");
     expect(
-      nodeStyleKey({ id: "terminal:a@1", kind: "terminal", label: "chain ends", reason: "done" }),
+      nodeStyleKey({
+        id: "terminal:a@1",
+        kind: "terminal",
+        label: "chain ends",
+        reason: "done",
+      }),
     ).toBe("terminal");
     expect(
       nodeStyleKey({
@@ -41,23 +46,52 @@ describe("legendEntries", () => {
   test("lists only styles the graph actually uses", () => {
     const graph: CapabilityGraph = {
       nodes: [
-        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null },
+        {
+          id: "event:a",
+          kind: "eventType",
+          label: "a",
+          adapter: "claude",
+          scope: [],
+          ttl: null,
+        },
         agent("a@1", false),
       ],
-      edges: [{ id: "routes:a", source: "event:a", target: "agent:a@1", kind: "routes" }],
+      edges: [
+        {
+          id: "routes:a",
+          source: "event:a",
+          target: "agent:a@1",
+          kind: "routes",
+        },
+      ],
     };
     const legend = legendEntries(graph);
-    expect(legend.nodes.map((n) => n.key)).toEqual(["eventType", "agentReadOnly"]);
+    expect(legend.nodes.map((n) => n.key)).toEqual([
+      "eventType",
+      "agentReadOnly",
+    ]);
     expect(legend.edges.map((e) => e.kind)).toEqual(["routes"]);
   });
 
   test("full graph advertises every style, carrying the shared constants", () => {
     const graph: CapabilityGraph = {
       nodes: [
-        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null },
+        {
+          id: "event:a",
+          kind: "eventType",
+          label: "a",
+          adapter: "claude",
+          scope: [],
+          ttl: null,
+        },
         agent("a@1", false),
         agent("b@1", true),
-        { id: "terminal:b@1", kind: "terminal", label: "chain ends", reason: "done" },
+        {
+          id: "terminal:b@1",
+          kind: "terminal",
+          label: "chain ends",
+          reason: "done",
+        },
         {
           id: "proposal:p1",
           kind: "proposal",
@@ -70,9 +104,24 @@ describe("legendEntries", () => {
         },
       ],
       edges: [
-        { id: "routes:a", source: "event:a", target: "agent:a@1", kind: "routes" },
-        { id: "rec:b@1:x", source: "agent:b@1", target: "event:a", kind: "recommends" },
-        { id: "prop:1", source: "event:a", target: "proposal:p1", kind: "proposal" },
+        {
+          id: "routes:a",
+          source: "event:a",
+          target: "agent:a@1",
+          kind: "routes",
+        },
+        {
+          id: "rec:b@1:x",
+          source: "agent:b@1",
+          target: "event:a",
+          kind: "recommends",
+        },
+        {
+          id: "prop:1",
+          source: "event:a",
+          target: "proposal:p1",
+          kind: "proposal",
+        },
       ],
     };
     const legend = legendEntries(graph);
@@ -91,6 +140,9 @@ describe("legendEntries", () => {
   });
 
   test("empty graph yields an empty legend", () => {
-    expect(legendEntries({ nodes: [], edges: [] })).toEqual({ nodes: [], edges: [] });
+    expect(legendEntries({ nodes: [], edges: [] })).toEqual({
+      nodes: [],
+      edges: [],
+    });
   });
 });

--- a/event-runtime/web/src/graph/style.ts
+++ b/event-runtime/web/src/graph/style.ts
@@ -4,31 +4,61 @@ import type { CapabilityGraph, GraphEdge, GraphNode } from "./model";
 // (WM-99). Node components, edge mapping, and the legend all read from here,
 // so the legend can never drift from what the canvas actually draws.
 
-export type NodeStyleKey = "eventType" | "agentReadOnly" | "agentMutating" | "terminal" | "proposal";
+export type NodeStyleKey =
+  "eventType" | "agentReadOnly" | "agentMutating" | "terminal" | "proposal";
 
-export const NODE_STYLES: Record<NodeStyleKey, { label: string; accent: string; dashed: boolean }> = {
+export const NODE_STYLES: Record<
+  NodeStyleKey,
+  { label: string; accent: string; dashed: boolean }
+> = {
   eventType: { label: "event type", accent: "var(--hue-info)", dashed: false },
-  agentReadOnly: { label: "agent · read-only", accent: "var(--hue-ok)", dashed: false },
-  agentMutating: { label: "agent · mutating", accent: "var(--hue-warn)", dashed: false },
+  agentReadOnly: {
+    label: "agent · read-only",
+    accent: "var(--hue-ok)",
+    dashed: false,
+  },
+  agentMutating: {
+    label: "agent · mutating",
+    accent: "var(--hue-warn)",
+    dashed: false,
+  },
   terminal: { label: "chain ends", accent: "var(--hue-idle)", dashed: true },
-  proposal: { label: "pending proposal", accent: "var(--hue-info)", dashed: true },
+  proposal: {
+    label: "pending proposal",
+    accent: "var(--hue-info)",
+    dashed: true,
+  },
 };
 
 export const nodeStyleKey = (node: GraphNode): NodeStyleKey =>
-  node.kind === "agent" ? (node.mutating ? "agentMutating" : "agentReadOnly") : node.kind;
+  node.kind === "agent"
+    ? node.mutating
+      ? "agentMutating"
+      : "agentReadOnly"
+    : node.kind;
 
 export const EDGE_STYLES: Record<
   GraphEdge["kind"],
   { label: string; stroke: string; strokeDasharray?: string }
 > = {
   routes: { label: "routes to agent", stroke: "var(--border-strong)" },
-  recommends: { label: "recommendation", stroke: "var(--accent)", strokeDasharray: "4 3" },
-  proposal: { label: "pending execution", stroke: "var(--hue-info)", strokeDasharray: "3 3" },
+  recommends: {
+    label: "recommendation",
+    stroke: "var(--accent)",
+    strokeDasharray: "4 3",
+  },
+  proposal: {
+    label: "pending execution",
+    stroke: "var(--hue-info)",
+    strokeDasharray: "3 3",
+  },
 };
 
 export interface LegendEntries {
   nodes: Array<{ key: NodeStyleKey } & (typeof NODE_STYLES)[NodeStyleKey]>;
-  edges: Array<{ kind: GraphEdge["kind"] } & (typeof EDGE_STYLES)[GraphEdge["kind"]]>;
+  edges: Array<
+    { kind: GraphEdge["kind"] } & (typeof EDGE_STYLES)[GraphEdge["kind"]]
+  >;
 }
 
 /**

--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -31,7 +31,11 @@ describe("parseHash", () => {
 
   test("strips a query so ?type= cannot become a path segment", () => {
     expect(parseHash("#/events?type=factory.ticket.ready")).toEqual(["events"]);
-    expect(parseHash("#/events/web/evt_1?type=x")).toEqual(["events", "web", "evt_1"]);
+    expect(parseHash("#/events/web/evt_1?type=x")).toEqual([
+      "events",
+      "web",
+      "evt_1",
+    ]);
   });
 
   test("decodes encoded segments so agent refs round-trip", () => {
@@ -67,16 +71,24 @@ describe("shouldReplaceHash", () => {
     expect(shouldReplaceHash("#/runs", "runs/run_01")).toBe(true);
     expect(shouldReplaceHash("#/runs/run_01", "runs/run_02")).toBe(true);
     expect(shouldReplaceHash("#/runs/run_02", "runs")).toBe(true);
-    expect(shouldReplaceHash("#/events/web/evt_1", "events/web/evt_2")).toBe(true);
-    expect(shouldReplaceHash("#/agents", "agents/factory-status-report%401")).toBe(true);
-    expect(shouldReplaceHash("#/graph", "graph/event%3Afactory.ticket.ready")).toBe(true);
+    expect(shouldReplaceHash("#/events/web/evt_1", "events/web/evt_2")).toBe(
+      true,
+    );
+    expect(
+      shouldReplaceHash("#/agents", "agents/factory-status-report%401"),
+    ).toBe(true);
+    expect(
+      shouldReplaceHash("#/graph", "graph/event%3Afactory.ticket.ready"),
+    ).toBe(true);
     expect(shouldReplaceHash("#/workers", "workers/wkr_01")).toBe(true);
     expect(shouldReplaceHash("#/workers/wkr_01", "workers/wkr_02")).toBe(true);
     expect(shouldReplaceHash("#/workers/wkr_01", "workers")).toBe(true);
   });
 
   test("query-only changes on the same view replace", () => {
-    expect(shouldReplaceHash("#/events", "events?type=factory.ticket.ready")).toBe(true);
+    expect(
+      shouldReplaceHash("#/events", "events?type=factory.ticket.ready"),
+    ).toBe(true);
     expect(shouldReplaceHash("#/events?type=a", "events?type=b")).toBe(true);
     expect(shouldReplaceHash("#/events?type=a", "events/web/evt_1")).toBe(true);
   });
@@ -128,7 +140,9 @@ describe("withProject / hashProject", () => {
     expect(withProject("events?type=factory.ticket.ready", "bj29")).toBe(
       "events?type=factory.ticket.ready&project=bj29",
     );
-    expect(withProject("events?type=x&project=bj29", null)).toBe("events?type=x");
+    expect(withProject("events?type=x&project=bj29", null)).toBe(
+      "events?type=x",
+    );
     expect(withProject("runs/run_01", undefined)).toBe("runs/run_01");
   });
 
@@ -141,7 +155,9 @@ describe("withProject / hashProject", () => {
   test("same-view project query still replaces", () => {
     expect(shouldReplaceHash("#/runs", "runs?project=bj29")).toBe(true);
     expect(shouldReplaceHash("#/runs?project=bj29", "runs")).toBe(true);
-    expect(shouldReplaceHash("#/events?project=bj29", "runs?project=bj29")).toBe(false);
+    expect(
+      shouldReplaceHash("#/events?project=bj29", "runs?project=bj29"),
+    ).toBe(false);
   });
 });
 
@@ -310,7 +326,10 @@ describe("hashPath", () => {
 
   test("round-trips through parseHash", () => {
     const path = hashPath("agents", "factory-status-report@1");
-    expect(parseHash(`#/${path}`)).toEqual(["agents", "factory-status-report@1"]);
+    expect(parseHash(`#/${path}`)).toEqual([
+      "agents",
+      "factory-status-report@1",
+    ]);
     const worker = hashPath("workers", "wkr_lab_4821");
     expect(parseHash(`#/${worker}`)).toEqual(["workers", "wkr_lab_4821"]);
   });

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -49,7 +49,10 @@ export function hashView(hash: string): string {
  * replace the current history entry. Crossing views (nav rail, `g e`) must
  * push so Back returns to the previous view.
  */
-export function shouldReplaceHash(currentHash: string, nextPath: string): boolean {
+export function shouldReplaceHash(
+  currentHash: string,
+  nextPath: string,
+): boolean {
   return hashView(currentHash) === hashView(`#/${nextPath}`);
 }
 
@@ -59,7 +62,10 @@ export function hashSearch(hash: string): URLSearchParams {
 }
 
 /** Build a hash path; each id segment is encoded. */
-export function hashPath(view: string, ...ids: Array<string | null | undefined>): string {
+export function hashPath(
+  view: string,
+  ...ids: Array<string | null | undefined>
+): string {
   const parts = [view];
   for (const id of ids) {
     if (id == null || id === "") continue;
@@ -187,11 +193,13 @@ export function eventsHash(
 }
 
 /** Shareable Artifacts view filters. Project context is added by `withProject`. */
-export function artifactsHash(filters: {
-  kind?: string | null;
-  orphan?: boolean | null;
-  search?: string | null;
-} = {}): string {
+export function artifactsHash(
+  filters: {
+    kind?: string | null;
+    orphan?: boolean | null;
+    search?: string | null;
+  } = {},
+): string {
   const query = new URLSearchParams();
   if (filters.kind) query.set("kind", filters.kind);
   if (filters.orphan != null) query.set("orphan", String(filters.orphan));
@@ -209,7 +217,10 @@ export function hashProject(hash: string): string | null {
  * Set or clear `project` on a hash path, preserving other query keys (`type=`).
  * `project` null/empty strips it so All has no query of its own.
  */
-export function withProject(path: string, project: string | null | undefined): string {
+export function withProject(
+  path: string,
+  project: string | null | undefined,
+): string {
   const i = path.indexOf("?");
   const pathname = i >= 0 ? path.slice(0, i) : path;
   const query = new URLSearchParams(i >= 0 ? path.slice(i + 1) : "");

--- a/event-runtime/web/src/heartbeat.test.ts
+++ b/event-runtime/web/src/heartbeat.test.ts
@@ -35,7 +35,10 @@ describe("heartbeatOf", () => {
 
   test("stale outranks stopped: a stale row still shows overdue time", () => {
     const w = baseWorker({ state: "stopped", stale: true, lastSeen });
-    expect(heartbeatOf(w, deadline + 5000)).toEqual({ kind: "stale", overdueMs: 5000 });
+    expect(heartbeatOf(w, deadline + 5000)).toEqual({
+      kind: "stale",
+      overdueMs: 5000,
+    });
   });
 
   test("live worker halfway through the window", () => {
@@ -46,20 +49,35 @@ describe("heartbeatOf", () => {
 
   test("ceil rounds sub-second remainder up to the next whole second", () => {
     const w = baseWorker({ lastSeen });
-    expect(heartbeatOf(w, deadline - 1)).toEqual({ kind: "live", remainingMs: 1000 });
-    expect(heartbeatOf(w, deadline - 999)).toEqual({ kind: "live", remainingMs: 1000 });
+    expect(heartbeatOf(w, deadline - 1)).toEqual({
+      kind: "live",
+      remainingMs: 1000,
+    });
+    expect(heartbeatOf(w, deadline - 999)).toEqual({
+      kind: "live",
+      remainingMs: 1000,
+    });
   });
 
   test("at the 90s boundary remainingMs is zero (overdue, not stale yet)", () => {
     const w = baseWorker({ lastSeen });
     expect(heartbeatOf(w, deadline)).toEqual({ kind: "live", remainingMs: 0 });
-    expect(heartbeatOf(w, deadline + 10_000)).toEqual({ kind: "live", remainingMs: 0 });
+    expect(heartbeatOf(w, deadline + 10_000)).toEqual({
+      kind: "live",
+      remainingMs: 0,
+    });
   });
 
   test("stale overdueMs floors to at least one second", () => {
     const w = baseWorker({ stale: true, lastSeen });
-    expect(heartbeatOf(w, deadline + 1)).toEqual({ kind: "stale", overdueMs: 1000 });
-    expect(heartbeatOf(w, deadline + 2500)).toEqual({ kind: "stale", overdueMs: 2500 });
+    expect(heartbeatOf(w, deadline + 1)).toEqual({
+      kind: "stale",
+      overdueMs: 1000,
+    });
+    expect(heartbeatOf(w, deadline + 2500)).toEqual({
+      kind: "stale",
+      overdueMs: 2500,
+    });
   });
 });
 
@@ -74,17 +92,27 @@ describe("isOverdue", () => {
 
 describe("heartbeatHue", () => {
   test("stale is always error", () => {
-    expect(heartbeatHue({ kind: "stale", overdueMs: 1000 })).toBe("var(--hue-err)");
+    expect(heartbeatHue({ kind: "stale", overdueMs: 1000 })).toBe(
+      "var(--hue-err)",
+    );
   });
 
   test("live inside the warn band is warn", () => {
-    expect(heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS })).toBe("var(--hue-warn)");
-    expect(heartbeatHue({ kind: "live", remainingMs: 1000 })).toBe("var(--hue-warn)");
-    expect(heartbeatHue({ kind: "live", remainingMs: 0 })).toBe("var(--hue-warn)");
+    expect(heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS })).toBe(
+      "var(--hue-warn)",
+    );
+    expect(heartbeatHue({ kind: "live", remainingMs: 1000 })).toBe(
+      "var(--hue-warn)",
+    );
+    expect(heartbeatHue({ kind: "live", remainingMs: 0 })).toBe(
+      "var(--hue-warn)",
+    );
   });
 
   test("live outside the warn band has no accent", () => {
-    expect(heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS + 1000 })).toBeUndefined();
+    expect(
+      heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS + 1000 }),
+    ).toBeUndefined();
     expect(heartbeatHue({ kind: "none" })).toBeUndefined();
   });
 });

--- a/event-runtime/web/src/heartbeat.ts
+++ b/event-runtime/web/src/heartbeat.ts
@@ -27,27 +27,35 @@ export const heartbeatOf = (w: Worker, now: number): Heartbeat => {
   // Floored to a second, because `dur` renders the first sub-second of overdue as
   // `0:00` and "stale for no time at all" reads as a broken badge rather than a
   // fresh one. Same floor the countdown below uses, so the flip reads 0:01 next.
-  if (w.stale) return { kind: "stale", overdueMs: Math.max(1000, now - deadline) };
+  if (w.stale)
+    return { kind: "stale", overdueMs: Math.max(1000, now - deadline) };
   if (w.state === "stopped") return { kind: "none" };
   // Whole seconds, rounded up: the last fraction of a second reads 0:01, and only
   // a genuinely spent window reads 0 — which is what `overdue` keys off.
-  return { kind: "live", remainingMs: Math.max(0, Math.ceil((deadline - now) / 1000) * 1000) };
+  return {
+    kind: "live",
+    remainingMs: Math.max(0, Math.ceil((deadline - now) / 1000) * 1000),
+  };
 };
 
 /** One hue per clock, so the age, the countdown and the meter never disagree. */
 export const heartbeatHue = (hb: Heartbeat): string | undefined => {
   if (hb.kind === "stale") return "var(--hue-err)";
-  if (hb.kind === "live" && hb.remainingMs <= HEARTBEAT_WARN_MS) return "var(--hue-warn)";
+  if (hb.kind === "live" && hb.remainingMs <= HEARTBEAT_WARN_MS)
+    return "var(--hue-warn)";
   return undefined;
 };
 
 /** `m:ss` while seconds decide, coarser once they stop mattering. */
 export const dur = (ms: number) => {
   const s = Math.max(0, Math.floor(ms / 1000));
-  if (s < 3600) return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}m`;
+  if (s < 3600)
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+  if (s < 86400)
+    return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}m`;
   return `${Math.floor(s / 86400)}d${Math.floor((s % 86400) / 3600)}h`;
 };
 
 /** Whether the live countdown has spent the window but the server has not marked stale yet. */
-export const isOverdue = (hb: Heartbeat): boolean => hb.kind === "live" && hb.remainingMs === 0;
+export const isOverdue = (hb: Heartbeat): boolean =>
+  hb.kind === "live" && hb.remainingMs === 0;

--- a/event-runtime/web/src/highlight.test.ts
+++ b/event-runtime/web/src/highlight.test.ts
@@ -42,13 +42,22 @@ describe("tokenizeJson", () => {
   });
 
   it("classifies primitive types correctly", () => {
-    const input = '{\n  "n": 100,\n  "b": true,\n  "f": false,\n  "nil": null\n}';
+    const input =
+      '{\n  "n": 100,\n  "b": true,\n  "f": false,\n  "nil": null\n}';
     const tokens = tokenizeJson(input);
 
-    expect(tokens.some((t) => t.kind === "number" && t.text === "100")).toBeTrue();
-    expect(tokens.some((t) => t.kind === "boolean" && t.text === "true")).toBeTrue();
-    expect(tokens.some((t) => t.kind === "boolean" && t.text === "false")).toBeTrue();
-    expect(tokens.some((t) => t.kind === "null" && t.text === "null")).toBeTrue();
+    expect(
+      tokens.some((t) => t.kind === "number" && t.text === "100"),
+    ).toBeTrue();
+    expect(
+      tokens.some((t) => t.kind === "boolean" && t.text === "true"),
+    ).toBeTrue();
+    expect(
+      tokens.some((t) => t.kind === "boolean" && t.text === "false"),
+    ).toBeTrue();
+    expect(
+      tokens.some((t) => t.kind === "null" && t.text === "null"),
+    ).toBeTrue();
   });
 
   it("handles empty arrays and objects", () => {
@@ -56,16 +65,8 @@ describe("tokenizeJson", () => {
     const tokens = tokenizeJson(input);
 
     expect(tokens.map((t) => t.text).join("")).toBe(input);
-    expect(tokens.filter((t) => t.kind === "punct").map((t) => t.text)).toEqual([
-      "{",
-      ":",
-      "[",
-      "]",
-      ",",
-      ":",
-      "{",
-      "}",
-      "}",
-    ]);
+    expect(tokens.filter((t) => t.kind === "punct").map((t) => t.text)).toEqual(
+      ["{", ":", "[", "]", ",", ":", "{", "}", "}"],
+    );
   });
 });

--- a/event-runtime/web/src/highlight.ts
+++ b/event-runtime/web/src/highlight.ts
@@ -1,11 +1,5 @@
 export type JsonTokenKind =
-  | "key"
-  | "string"
-  | "number"
-  | "boolean"
-  | "null"
-  | "punct"
-  | "plain";
+  "key" | "string" | "number" | "boolean" | "null" | "punct" | "plain";
 
 export interface JsonToken {
   kind: JsonTokenKind;

--- a/event-runtime/web/src/hooks.test.ts
+++ b/event-runtime/web/src/hooks.test.ts
@@ -1,10 +1,20 @@
 import "./test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { createElement as h, useState } from "react";
 import { api } from "./api";
-import { modal, refetchIntervals, useHashRoute, useListKeys, useTheme } from "./hooks";
+import {
+  modal,
+  refetchIntervals,
+  useHashRoute,
+  useListKeys,
+  useTheme,
+} from "./hooks";
 
 const originalFetch = globalThis.fetch;
 
@@ -21,15 +31,24 @@ describe("API ETag cache", () => {
   test("sends If-None-Match and returns the same cached body on 304", async () => {
     const body = { events: [{ eventId: "evt-etag" }] };
     const requests: Array<{ url: string; init?: RequestInit }> = [];
-    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
       requests.push({ url: String(url), init });
       if (requests.length === 1) {
         return new Response(JSON.stringify(body), {
           status: 200,
-          headers: { "content-type": "application/json", etag: '"etag-events"' },
+          headers: {
+            "content-type": "application/json",
+            etag: '"etag-events"',
+          },
         });
       }
-      return new Response(null, { status: 304, headers: { etag: '"etag-events"' } });
+      return new Response(null, {
+        status: 304,
+        headers: { etag: '"etag-events"' },
+      });
     }) as typeof fetch;
 
     const first = await api.events("etag-cache-test");
@@ -53,25 +72,35 @@ describe("collection refetch intervals", () => {
   test("use a 15 second hidden-tab cadence and keep background polling active", () => {
     const originalHidden = Object.getOwnPropertyDescriptor(document, "hidden");
     try {
-      Object.defineProperty(document, "hidden", { configurable: true, value: false });
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
       expect(refetchIntervals.primary.refetchInterval()).toBe(2_000);
       expect(refetchIntervals.fast.refetchInterval()).toBe(5_000);
       expect(refetchIntervals.secondary.refetchInterval()).toBe(10_000);
 
-      Object.defineProperty(document, "hidden", { configurable: true, value: true });
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      });
       expect(refetchIntervals.primary.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.fast.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.secondary.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.primary.refetchIntervalInBackground).toBe(true);
     } finally {
-      if (originalHidden) Object.defineProperty(document, "hidden", originalHidden);
+      if (originalHidden)
+        Object.defineProperty(document, "hidden", originalHidden);
       else Reflect.deleteProperty(document, "hidden");
     }
   });
 
   test("refetches an active fresh query immediately when the tab becomes visible", async () => {
     const originalHidden = Object.getOwnPropertyDescriptor(document, "hidden");
-    const originalVisibility = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    const originalVisibility = Object.getOwnPropertyDescriptor(
+      document,
+      "visibilityState",
+    );
     let calls = 0;
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
@@ -86,25 +115,45 @@ describe("collection refetch intervals", () => {
     }
 
     try {
-      Object.defineProperty(document, "hidden", { configurable: true, value: false });
-      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
       render(h(QueryClientProvider, { client }, h(Probe)));
       await waitFor(() => expect(calls).toBe(1));
 
-      Object.defineProperty(document, "hidden", { configurable: true, value: true });
-      Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "hidden",
+      });
       act(() => window.dispatchEvent(new Event("visibilitychange")));
       expect(calls).toBe(1);
 
-      Object.defineProperty(document, "hidden", { configurable: true, value: false });
-      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
       act(() => window.dispatchEvent(new Event("visibilitychange")));
       await waitFor(() => expect(calls).toBe(2));
     } finally {
       client.clear();
-      if (originalHidden) Object.defineProperty(document, "hidden", originalHidden);
+      if (originalHidden)
+        Object.defineProperty(document, "hidden", originalHidden);
       else Reflect.deleteProperty(document, "hidden");
-      if (originalVisibility) Object.defineProperty(document, "visibilityState", originalVisibility);
+      if (originalVisibility)
+        Object.defineProperty(document, "visibilityState", originalVisibility);
       else Reflect.deleteProperty(document, "visibilityState");
     }
   });
@@ -317,10 +366,18 @@ describe("useListKeys unit tests — rapid j/k keydown movement", () => {
 
     act(() => {
       document.body.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "j", metaKey: true, bubbles: true }),
+        new KeyboardEvent("keydown", {
+          key: "j",
+          metaKey: true,
+          bubbles: true,
+        }),
       );
       document.body.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "j", ctrlKey: true, bubbles: true }),
+        new KeyboardEvent("keydown", {
+          key: "j",
+          ctrlKey: true,
+          bubbles: true,
+        }),
       );
       document.body.dispatchEvent(
         new KeyboardEvent("keydown", { key: "j", altKey: true, bubbles: true }),
@@ -347,7 +404,9 @@ describe("useListKeys unit tests — rapid j/k keydown movement", () => {
 
     // Dispatch event from input
     act(() => {
-      input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "j", bubbles: true }),
+      );
     });
     expect(selectedIndices.length).toBe(0);
 

--- a/event-runtime/web/src/hooks.test.tsx
+++ b/event-runtime/web/src/hooks.test.tsx
@@ -44,11 +44,15 @@ describe("useTabKeys", () => {
       scrolled.length = 0;
 
       act(() => {
-        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "]", bubbles: true }));
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "]", bubbles: true }),
+        );
       });
 
       expect(scrolled.length).toBeGreaterThan(0);
-      expect(scrolled.every((el) => !el.closest(`[${CONTEXT_TABS_ATTR}]`))).toBe(true);
+      expect(
+        scrolled.every((el) => !el.closest(`[${CONTEXT_TABS_ATTR}]`)),
+      ).toBe(true);
       const viewTab = r.getByRole("tab", { name: "running" });
       expect(viewTab.getAttribute("aria-selected")).toBe("true");
       expect(scrolled).toContain(viewTab);

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -49,7 +49,8 @@ export const refetchIntervals = {
 /** True when a global shortcut should be ignored (typing, or a modal is open). */
 export function keyGuard(e: KeyboardEvent): boolean {
   const t = e.target as HTMLElement | null;
-  if (t && t.closest("input, textarea, select, [contenteditable=true]")) return true;
+  if (t && t.closest("input, textarea, select, [contenteditable=true]"))
+    return true;
   return modal.depth > 0;
 }
 
@@ -120,7 +121,8 @@ export function useHashRoute(): [string[], (path: string) => void] {
     const replace = shouldReplaceHash(intended.current, path);
     // App reads `?type=` off window.location.hash as it renders, so a query
     // change cannot sit buffered; only same-view path moves (j/k) coalesce.
-    const queryChanged = hashSearch(intended.current).toString() !== hashSearch(next).toString();
+    const queryChanged =
+      hashSearch(intended.current).toString() !== hashSearch(next).toString();
     intended.current = next;
     setRoute(parseHash(next));
     setHash(next);
@@ -176,27 +178,40 @@ export function useListKeys(opts: {
   }, [count, selected, onSelect, onOpen, onClose, keys]);
 }
 
-export type TableToken<T> = [row: T] | [section: DisplaySection<T>, sub: boolean];
+export type TableToken<T> =
+  [row: T] | [section: DisplaySection<T>, sub: boolean];
 
 /** Flatten table rows and group headers into their exact DOM order. */
-export function tableTokens<T>(sections: DisplaySection<T>[], collapsed: readonly string[], grouped: boolean) {
-  if (!grouped) return (sections[0]?.rows ?? []).map((row): TableToken<T> => [row]);
+export function tableTokens<T>(
+  sections: DisplaySection<T>[],
+  collapsed: readonly string[],
+  grouped: boolean,
+) {
+  if (!grouped)
+    return (sections[0]?.rows ?? []).map((row): TableToken<T> => [row]);
   const closed = new Set(collapsed);
   const out: TableToken<T>[] = [];
   for (const section of sections) {
     out.push([section, false]);
     if (closed.has(section.key)) continue;
-    if (!section.subsections) out.push(...section.rows.map((row): TableToken<T> => [row]));
-    else for (const child of section.subsections) {
-      out.push([child, true]);
-      if (!closed.has(child.key)) out.push(...child.rows.map((row): TableToken<T> => [row]));
-    }
+    if (!section.subsections)
+      out.push(...section.rows.map((row): TableToken<T> => [row]));
+    else
+      for (const child of section.subsections) {
+        out.push([child, true]);
+        if (!closed.has(child.key))
+          out.push(...child.rows.map((row): TableToken<T> => [row]));
+      }
   }
   return out;
 }
 
 /** Repeat a page's group ancestry so a window never starts with contextless rows. */
-function sliceTableWindow<T>(tokens: TableToken<T>[], start: number, end: number) {
+function sliceTableWindow<T>(
+  tokens: TableToken<T>[],
+  start: number,
+  end: number,
+) {
   const page = tokens.slice(start, end);
   if (start && (page[0].length === 1 || page[0][1])) {
     // Only the page's own ancestry belongs here: at most one sub header (the
@@ -226,7 +241,9 @@ export function useTableWindow<T>(
   rowKey: (row: T) => string,
   resetKey: unknown,
 ) {
-  const selected = tokens.findIndex((token) => token.length === 1 && rowKey(token[0]) === selectedKey);
+  const selected = tokens.findIndex(
+    (token) => token.length === 1 && rowKey(token[0]) === selectedKey,
+  );
   const [start, setStart] = useState(0);
   const count = tokens.length;
   const max = count ? Math.floor((count - 1) / 100) * 100 : 0;
@@ -240,7 +257,8 @@ export function useTableWindow<T>(
     sliceTableWindow(tokens, safe, end),
     safe,
     end,
-    (direction: number) => setStart(Math.max(0, Math.min(max, safe + direction * 100))),
+    (direction: number) =>
+      setStart(Math.max(0, Math.min(max, safe + direction * 100))),
   ] as const;
 }
 
@@ -254,7 +272,9 @@ export const CONTEXT_TABS_ATTR = "data-context-tabs";
 /** The selected status tab of the current view — never a context-strip tab. */
 function selectedStatusTab(): HTMLElement | null {
   const strip = document.querySelector(`[${CONTEXT_TABS_ATTR}]`);
-  const selected = document.querySelectorAll<HTMLElement>('[role="tab"][aria-selected="true"]');
+  const selected = document.querySelectorAll<HTMLElement>(
+    '[role="tab"][aria-selected="true"]',
+  );
   for (const tab of selected) if (!strip?.contains(tab)) return tab;
   return null;
 }
@@ -279,7 +299,10 @@ export function useTabKeys<T extends string>(
     return () => window.removeEventListener("keydown", onKey);
   }, [tabs, current, onSelect]);
   useEffect(() => {
-    selectedStatusTab()?.scrollIntoView({ inline: "nearest", block: "nearest" });
+    selectedStatusTab()?.scrollIntoView({
+      inline: "nearest",
+      block: "nearest",
+    });
   }, [current]);
 }
 
@@ -292,8 +315,13 @@ export function useTabKeys<T extends string>(
  */
 export function useDisplayOptions<T>(
   config: DisplayConfig<T>,
-): [DisplayState, (next: DisplayState | ((state: DisplayState) => DisplayState)) => void] {
-  const [state, setState] = useState<DisplayState>(() => loadDisplayState(config));
+): [
+  DisplayState,
+  (next: DisplayState | ((state: DisplayState) => DisplayState)) => void,
+] {
+  const [state, setState] = useState<DisplayState>(() =>
+    loadDisplayState(config),
+  );
   const [prevView, setPrevView] = useState(config.view);
   if (prevView !== config.view) {
     setPrevView(config.view);
@@ -451,7 +479,10 @@ export function useRequeuePoll(onJumpProposal: (proposalId: string) => void) {
         // The requeue itself landed; only the confirmation poll broke, so say
         // that rather than claiming no proposal appeared.
         if (alive.current) {
-          notify(`Requeued ${eventId} — could not confirm a proposal appeared`, "err");
+          notify(
+            `Requeued ${eventId} — could not confirm a proposal appeared`,
+            "err",
+          );
         }
         return;
       }

--- a/event-runtime/web/src/isWorkerId.test.ts
+++ b/event-runtime/web/src/isWorkerId.test.ts
@@ -30,7 +30,9 @@ describe("isWorkerId", () => {
   test("short and test worker ids match", () => {
     expect(isWorkerId("worker_1")).toBe(true);
     expect(isWorkerId("worker_test")).toBe(true);
-    expect(isWorkerId("worker_0f3b2a1c-9e8d-4b7a-8c6d-5e4f3a2b1c0d")).toBe(true);
+    expect(isWorkerId("worker_0f3b2a1c-9e8d-4b7a-8c6d-5e4f3a2b1c0d")).toBe(
+      true,
+    );
   });
 });
 
@@ -47,10 +49,14 @@ describe("ActorRef component", () => {
   test.each(["operator", "planner", "reaper", "worker"])(
     "static actor '%s' renders inert text without jump link",
     (actor) => {
-      const { container, queryByRole } = render(createElement(ActorRef, { actor }));
+      const { container, queryByRole } = render(
+        createElement(ActorRef, { actor }),
+      );
       expect(queryByRole("button")).toBeNull();
       expect(container.textContent).toBe(actor);
-      expect(container.querySelector("span")?.getAttribute("title")).toBe(actor);
+      expect(container.querySelector("span")?.getAttribute("title")).toBe(
+        actor,
+      );
     },
   );
 
@@ -70,7 +76,9 @@ describe("ActorRef component", () => {
     (actor) => {
       const title = `${actor} · attempt timed out`;
       const { container } = render(createElement(ActorRef, { actor, title }));
-      expect(container.querySelector("[title]")?.getAttribute("title")).toBe(title);
+      expect(container.querySelector("[title]")?.getAttribute("title")).toBe(
+        title,
+      );
     },
   );
 

--- a/event-runtime/web/src/lib/artifactView.test.ts
+++ b/event-runtime/web/src/lib/artifactView.test.ts
@@ -29,8 +29,18 @@ const triageArtifact = {
   summary: "Three issues moved; one needs a human.",
   plan: [
     { issueId: "WM-1", action: "label-agent-ready", reason: "Complete spec." },
-    { issueId: "WM-2", action: "needs-human", reason: "Scope unclear.", detail: "## Acceptance Criteria\n- x" },
-    { issueId: "WM-3", action: "label-agent-ready", reason: "Ready.", ownedPaths: ["a.ts", "b.ts"] },
+    {
+      issueId: "WM-2",
+      action: "needs-human",
+      reason: "Scope unclear.",
+      detail: "## Acceptance Criteria\n- x",
+    },
+    {
+      issueId: "WM-3",
+      action: "label-agent-ready",
+      reason: "Ready.",
+      ownedPaths: ["a.ts", "b.ts"],
+    },
   ],
 };
 
@@ -56,7 +66,14 @@ const mergeArtifact = {
       ownedPaths: ["src/a.ts"],
     },
   ],
-  escalate: [{ pr: 471, ticket: "WM-210", headSha: "c".repeat(40), reason: "Draft hold." }],
+  escalate: [
+    {
+      pr: 471,
+      ticket: "WM-210",
+      headSha: "c".repeat(40),
+      reason: "Draft hold.",
+    },
+  ],
   summary: "One escalation.",
 };
 
@@ -104,8 +121,14 @@ describe("formatValue", () => {
       text: "#471",
       href: "https://github.com/watt-mind/factory/pull/471",
     });
-    expect(formatValue("#9", "pr")).toMatchObject({ kind: "chip", text: "#9", href: null });
-    expect(formatValue("run_44fa5716-0304-49b1-8b65-a45500d0d784", "run")).toMatchObject({
+    expect(formatValue("#9", "pr")).toMatchObject({
+      kind: "chip",
+      text: "#9",
+      href: null,
+    });
+    expect(
+      formatValue("run_44fa5716-0304-49b1-8b65-a45500d0d784", "run"),
+    ).toMatchObject({
       kind: "chip",
       chip: "run",
       id: "run_44fa5716-0304-49b1-8b65-a45500d0d784",
@@ -114,22 +137,61 @@ describe("formatValue", () => {
   });
 
   test("state / sha / url / duration / datetime / bytes / count use the app's formatters", () => {
-    expect(formatValue("COMPLETED", "state")).toEqual({ kind: "state", state: "COMPLETED" });
-    expect(formatValue("c".repeat(40), "sha")).toEqual({ kind: "text", text: "c".repeat(12), mono: true, title: "c".repeat(40) });
-    expect(formatValue("https://x.test/a", "url")).toEqual({ kind: "link", href: "https://x.test/a", text: "https://x.test/a" });
-    expect(formatValue(90, "duration")).toMatchObject({ kind: "text", text: "1:30", title: "90s" });
-    expect(formatValue(1536, "bytes")).toMatchObject({ kind: "text", text: "1.5 KB" });
-    expect(formatValue(1234567, "count")).toMatchObject({ kind: "text", text: (1234567).toLocaleString(), mono: true });
+    expect(formatValue("COMPLETED", "state")).toEqual({
+      kind: "state",
+      state: "COMPLETED",
+    });
+    expect(formatValue("c".repeat(40), "sha")).toEqual({
+      kind: "text",
+      text: "c".repeat(12),
+      mono: true,
+      title: "c".repeat(40),
+    });
+    expect(formatValue("https://x.test/a", "url")).toEqual({
+      kind: "link",
+      href: "https://x.test/a",
+      text: "https://x.test/a",
+    });
+    expect(formatValue(90, "duration")).toMatchObject({
+      kind: "text",
+      text: "1:30",
+      title: "90s",
+    });
+    expect(formatValue(1536, "bytes")).toMatchObject({
+      kind: "text",
+      text: "1.5 KB",
+    });
+    expect(formatValue(1234567, "count")).toMatchObject({
+      kind: "text",
+      text: (1234567).toLocaleString(),
+      mono: true,
+    });
     const dt = formatValue("2026-08-17T10:00:00.000Z", "datetime");
     expect(dt.kind).toBe("text");
     if (dt.kind === "text") expect(dt.title).toBe("2026-08-17T10:00:00.000Z");
-    expect(formatValue("not a date", "datetime")).toEqual({ kind: "text", text: "not a date", mono: false });
+    expect(formatValue("not a date", "datetime")).toEqual({
+      kind: "text",
+      text: "not a date",
+      mono: false,
+    });
   });
 
   test("no format: prose is proportional, identifiers and numbers are mono, nested values are json, absent is empty", () => {
-    expect(formatValue("Scope unclear.")).toEqual({ kind: "text", text: "Scope unclear.", mono: false });
-    expect(formatValue("feat/x")).toEqual({ kind: "text", text: "feat/x", mono: true });
-    expect(formatValue(true)).toEqual({ kind: "text", text: "true", mono: true });
+    expect(formatValue("Scope unclear.")).toEqual({
+      kind: "text",
+      text: "Scope unclear.",
+      mono: false,
+    });
+    expect(formatValue("feat/x")).toEqual({
+      kind: "text",
+      text: "feat/x",
+      mono: true,
+    });
+    expect(formatValue(true)).toEqual({
+      kind: "text",
+      text: "true",
+      mono: true,
+    });
     expect(formatValue({ a: 1 })).toEqual({ kind: "json", value: { a: 1 } });
     expect(formatValue(undefined)).toEqual({ kind: "empty" });
     expect(formatValue(null, "issue")).toEqual({ kind: "empty" });
@@ -146,7 +208,7 @@ describe("formatValue", () => {
 
 describe("toneFor / githubOf", () => {
   test("matches by string form, ignores unknown tones and non-maps", () => {
-    const map = { "true": "ok", "false": "warn", weird: "purple" };
+    const map = { true: "ok", false: "warn", weird: "purple" };
     expect(toneFor(true, map)).toBe("ok");
     expect(toneFor("false", map)).toBe("warn");
     expect(toneFor("weird", map)).toBeUndefined();
@@ -167,9 +229,21 @@ describe("headerFor", () => {
     const h = headerFor(triageView, triageArtifact, { title: "schema title" });
     expect(h.title).toBe("Triage plan");
     expect(h.summary).toBe("Three issues moved; one needs a human.");
-    expect(h.status).toEqual({ label: "recommendation", value: "TRIAGE", tone: "ok" });
-    const bare = headerFor({ schemaVersion: "factory.artifact-view/v1", sections: [] }, {}, { title: "schema title" });
-    expect(bare).toEqual({ title: "schema title", summary: null, status: null });
+    expect(h.status).toEqual({
+      label: "recommendation",
+      value: "TRIAGE",
+      tone: "ok",
+    });
+    const bare = headerFor(
+      { schemaVersion: "factory.artifact-view/v1", sections: [] },
+      {},
+      { title: "schema title" },
+    );
+    expect(bare).toEqual({
+      title: "schema title",
+      summary: null,
+      status: null,
+    });
     const noStatus = headerFor(mergeView, { summary: "s" });
     expect(noStatus.status).toBeNull();
     expect(noStatus.summary).toBe("s");
@@ -185,12 +259,19 @@ describe("sectionsFor with the shipped triage-scan view", () => {
     expect(table.label).toBe("Plan");
     expect(table.columns).toEqual(["issueId", "action", "reason"]);
     expect(table.rows).toHaveLength(3);
-    expect(table.rows[0].cells[0].value).toMatchObject({ kind: "chip", chip: "issue", id: "WM-1" });
+    expect(table.rows[0].cells[0].value).toMatchObject({
+      kind: "chip",
+      chip: "issue",
+      id: "WM-1",
+    });
     expect(table.rows[0].cells[1].tone).toBe("ok");
     expect(table.rows[1].cells[1].tone).toBe("warn");
     expect(table.rows[0].expand).toEqual([]);
     expect(table.rows[1].expand.map((c) => c.key)).toEqual(["detail"]);
-    expect(table.rows[2].expand[0]).toMatchObject({ key: "ownedPaths", value: { kind: "json", value: ["a.ts", "b.ts"] } });
+    expect(table.rows[2].expand[0]).toMatchObject({
+      key: "ownedPaths",
+      value: { kind: "json", value: ["a.ts", "b.ts"] },
+    });
     expect(table.hasExpand).toBe(true);
     // Grouped in first-seen order, group tone from the column's tone map.
     expect(table.groups?.map((g) => [g.label, g.rows.length, g.tone])).toEqual([
@@ -202,11 +283,21 @@ describe("sectionsFor with the shipped triage-scan view", () => {
 
     const repo = sections[1];
     if (repo.as !== "keyvalue") throw new Error("expected keyvalue");
-    expect(repo.entries).toEqual([{ key: "Repo", value: { kind: "text", text: "factory", mono: true }, tone: undefined }]);
+    expect(repo.entries).toEqual([
+      {
+        key: "Repo",
+        value: { kind: "text", text: "factory", mono: true },
+        tone: undefined,
+      },
+    ]);
   });
 
   test("a section whose pointer is absent in this artifact is dropped, not invented", () => {
-    const sections = sectionsFor(triageView, { recommendation: "NOOP", summary: "Nothing to do.", repo: "factory" });
+    const sections = sectionsFor(triageView, {
+      recommendation: "NOOP",
+      summary: "Nothing to do.",
+      repo: "factory",
+    });
     expect(sections.map((s) => s.as)).toEqual(["keyvalue"]);
     expect(sectionsFor(triageView, { plan: "not-an-array" })).toEqual([]);
     expect(sectionsFor(triageView, null)).toEqual([]);
@@ -214,35 +305,79 @@ describe("sectionsFor with the shipped triage-scan view", () => {
 
   test("groupRows parks rows without the property under — at the end", () => {
     const sections = sectionsFor(triageView, {
-      plan: [{ issueId: "WM-9", reason: "r" }, { issueId: "WM-8", action: "move-to-todo", reason: "r" }],
+      plan: [
+        { issueId: "WM-9", reason: "r" },
+        { issueId: "WM-8", action: "move-to-todo", reason: "r" },
+      ],
     });
     const table = sections[0];
     if (table.as !== "table") throw new Error("expected table");
     expect(table.groups?.map((g) => g.label)).toEqual(["move-to-todo", "—"]);
-    expect(groupRows(table.rows, "action").map((g) => g.rows.length)).toEqual([1, 1]);
+    expect(groupRows(table.rows, "action").map((g) => g.rows.length)).toEqual([
+      1, 1,
+    ]);
   });
 });
 
 describe("sectionsFor with the shipped merge-scan view", () => {
   test("empty tables stay (as empty), pr chips link to the artifact's github, keyvalue over the whole artifact keeps only present keys", () => {
     const sections = sectionsFor(mergeView, mergeArtifact);
-    expect(sections.map((s) => s.label)).toEqual(["Merge", "Fix", "Escalate", "Repo"]);
+    expect(sections.map((s) => s.label)).toEqual([
+      "Merge",
+      "Fix",
+      "Escalate",
+      "Repo",
+    ]);
     const [plan, fix, escalate, repo] = sections;
-    if (plan.as !== "table" || fix.as !== "table" || escalate.as !== "table" || repo.as !== "keyvalue") throw new Error("shape");
+    if (
+      plan.as !== "table" ||
+      fix.as !== "table" ||
+      escalate.as !== "table" ||
+      repo.as !== "keyvalue"
+    )
+      throw new Error("shape");
     expect(plan.rows).toEqual([]);
     expect(plan.groups).toBeNull();
-    expect(fix.rows[0].cells.map((c) => c.key)).toEqual(["pr", "ticket", "round", "mechanical", "finding"]);
-    expect(fix.rows[0].cells[0].value).toMatchObject({ kind: "chip", chip: "pr", href: "https://github.com/watt-mind/factory/pull/12" });
-    expect(fix.rows[0].cells[3]).toMatchObject({ tone: "ok", value: { kind: "text", text: "true" } });
-    expect(fix.rows[0].expand.find((c) => c.key === "withinOwnedPaths")?.tone).toBe("error");
-    expect(fix.rows[0].expand.find((c) => c.key === "headSha")?.value).toMatchObject({ kind: "text", text: "a".repeat(12) });
-    expect(escalate.rows[0].cells[1].value).toMatchObject({ kind: "chip", chip: "issue", id: "WM-210" });
-    expect(repo.entries.map((e) => e.key)).toEqual(["repo", "github", "base", "deployBranch"]);
+    expect(fix.rows[0].cells.map((c) => c.key)).toEqual([
+      "pr",
+      "ticket",
+      "round",
+      "mechanical",
+      "finding",
+    ]);
+    expect(fix.rows[0].cells[0].value).toMatchObject({
+      kind: "chip",
+      chip: "pr",
+      href: "https://github.com/watt-mind/factory/pull/12",
+    });
+    expect(fix.rows[0].cells[3]).toMatchObject({
+      tone: "ok",
+      value: { kind: "text", text: "true" },
+    });
+    expect(
+      fix.rows[0].expand.find((c) => c.key === "withinOwnedPaths")?.tone,
+    ).toBe("error");
+    expect(
+      fix.rows[0].expand.find((c) => c.key === "headSha")?.value,
+    ).toMatchObject({ kind: "text", text: "a".repeat(12) });
+    expect(escalate.rows[0].cells[1].value).toMatchObject({
+      kind: "chip",
+      chip: "issue",
+      id: "WM-210",
+    });
+    expect(repo.entries.map((e) => e.key)).toEqual([
+      "repo",
+      "github",
+      "base",
+      "deployBranch",
+    ]);
   });
 
   test("viewApplies gates the Artifacts inspector: a merge plan yes, a transcript-shaped object no", () => {
     expect(viewApplies(mergeView, mergeArtifact)).toBe(true);
-    expect(viewApplies(mergeView, { type: "assistant", message: "hi" })).toBe(false);
+    expect(viewApplies(mergeView, { type: "assistant", message: "hi" })).toBe(
+      false,
+    );
     expect(viewApplies(mergeView, "string")).toBe(false);
     expect(viewApplies(null, mergeArtifact)).toBe(false);
     expect(viewApplies(undefined, mergeArtifact)).toBe(false);
@@ -253,12 +388,28 @@ describe("the other section kinds", () => {
   const view: ArtifactView = {
     schemaVersion: "factory.artifact-view/v1",
     sections: [
-      { path: "/verdict", as: "badge", label: "Verdict", tone: { PASS: "ok", FAIL: "error" } },
+      {
+        path: "/verdict",
+        as: "badge",
+        label: "Verdict",
+        tone: { PASS: "ok", FAIL: "error" },
+      },
       { path: "/log", as: "code", label: "Log", language: "text" },
       { path: "/notes", as: "prose" },
       { path: "/files", as: "list", label: "Files" },
-      { path: "/checks", as: "list", label: "Checks", itemLabel: "name", tone: { name: { lint: "ok" } } },
-      { path: "/count", as: "keyvalue", label: "Count", formats: { "": "count" } },
+      {
+        path: "/checks",
+        as: "list",
+        label: "Checks",
+        itemLabel: "name",
+        tone: { name: { lint: "ok" } },
+      },
+      {
+        path: "/count",
+        as: "keyvalue",
+        label: "Count",
+        formats: { "": "count" },
+      },
       { path: "/blob", as: "code" },
     ],
   };
@@ -280,20 +431,51 @@ describe("the other section kinds", () => {
         as: "list",
         label: "Files",
         items: [
-          { key: "0", value: { kind: "text", text: "a.ts", mono: true }, tone: undefined },
-          { key: "1", value: { kind: "text", text: "b.ts", mono: true }, tone: undefined },
+          {
+            key: "0",
+            value: { kind: "text", text: "a.ts", mono: true },
+            tone: undefined,
+          },
+          {
+            key: "1",
+            value: { kind: "text", text: "b.ts", mono: true },
+            tone: undefined,
+          },
         ],
       },
       {
         as: "list",
         label: "Checks",
         items: [
-          { key: "0", value: { kind: "text", text: "lint", mono: true }, tone: "ok" },
-          { key: "1", value: { kind: "text", text: "typecheck", mono: true }, tone: undefined },
+          {
+            key: "0",
+            value: { kind: "text", text: "lint", mono: true },
+            tone: "ok",
+          },
+          {
+            key: "1",
+            value: { kind: "text", text: "typecheck", mono: true },
+            tone: undefined,
+          },
         ],
       },
-      { as: "keyvalue", label: undefined, entries: [{ key: "Count", value: { kind: "text", text: (4200).toLocaleString(), mono: true }, tone: undefined }] },
-      { as: "code", label: undefined, text: JSON.stringify({ k: 1 }, null, 2), language: "json" },
+      {
+        as: "keyvalue",
+        label: undefined,
+        entries: [
+          {
+            key: "Count",
+            value: { kind: "text", text: (4200).toLocaleString(), mono: true },
+            tone: undefined,
+          },
+        ],
+      },
+      {
+        as: "code",
+        label: undefined,
+        text: JSON.stringify({ k: 1 }, null, 2),
+        language: "json",
+      },
     ]);
   });
 });

--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -10,7 +10,12 @@
  * simply drops its section (optional fields are optional, §2.2).
  */
 import { dur } from "../heartbeat";
-import type { ArtifactFormat, ArtifactTone, ArtifactView, ArtifactViewSection } from "../types";
+import type {
+  ArtifactFormat,
+  ArtifactTone,
+  ArtifactView,
+  ArtifactViewSection,
+} from "../types";
 
 const isObject = (v: unknown): v is Record<string, unknown> =>
   v !== null && typeof v === "object" && !Array.isArray(v);
@@ -96,11 +101,17 @@ export const TONE_HUES: Record<ArtifactTone, string> = {
  * map names no such value. Values are matched by their string form so a
  * boolean `true` finds the `"true"` key merge-scan's view uses.
  */
-export function toneFor(value: unknown, toneMap: unknown): ArtifactTone | undefined {
-  if (!isObject(toneMap) || value === undefined || value === null) return undefined;
+export function toneFor(
+  value: unknown,
+  toneMap: unknown,
+): ArtifactTone | undefined {
+  if (!isObject(toneMap) || value === undefined || value === null)
+    return undefined;
   const key = typeof value === "string" ? value : String(value);
   const tone = toneMap[key];
-  return typeof tone === "string" && tone in TONE_HUES ? (tone as ArtifactTone) : undefined;
+  return typeof tone === "string" && tone in TONE_HUES
+    ? (tone as ArtifactTone)
+    : undefined;
 }
 
 /** A section's tone map for one column/key — table/keyvalue/list nest one map per key. */
@@ -119,9 +130,12 @@ function columnToneMap(section: ArtifactViewSection, key: string): unknown {
  * when the agent reports one (merge-scan does) — no repo, no link, chip only.
  */
 export const LINEAR_ISSUE_URL = "https://linear.app/watt-mind/issue/";
-export const issueHref = (id: string): string => `${LINEAR_ISSUE_URL}${encodeURIComponent(id)}`;
-export const prHref = (n: string | number, github: string | null | undefined): string | null =>
-  github ? `https://github.com/${github}/pull/${n}` : null;
+export const issueHref = (id: string): string =>
+  `${LINEAR_ISSUE_URL}${encodeURIComponent(id)}`;
+export const prHref = (
+  n: string | number,
+  github: string | null | undefined,
+): string | null => (github ? `https://github.com/${github}/pull/${n}` : null);
 
 export interface FormatContext {
   /** `owner/repo`, from the artifact's own `/github` when present. */
@@ -136,7 +150,13 @@ export interface FormatContext {
 export type Formatted =
   | { kind: "empty" }
   | { kind: "text"; text: string; mono: boolean; title?: string }
-  | { kind: "chip"; chip: "issue" | "pr" | "run"; id: string; text: string; href: string | null }
+  | {
+      kind: "chip";
+      chip: "issue" | "pr" | "run";
+      id: string;
+      text: string;
+      href: string | null;
+    }
   | { kind: "state"; state: string }
   | { kind: "link"; href: string; text: string }
   | { kind: "json"; value: unknown };
@@ -154,19 +174,42 @@ const isScalar = (v: unknown): boolean =>
  * absent format falls through to the plain rendering, so a view can only
  * *add* meaning to a value, never hide one.
  */
-export function formatValue(value: unknown, format?: ArtifactFormat, ctx: FormatContext = {}): Formatted {
-  if (value === undefined || value === null || value === "") return { kind: "empty" };
+export function formatValue(
+  value: unknown,
+  format?: ArtifactFormat,
+  ctx: FormatContext = {},
+): Formatted {
+  if (value === undefined || value === null || value === "")
+    return { kind: "empty" };
   if (!isScalar(value)) return { kind: "json", value };
   const text = asText(value);
   switch (format) {
     case "issue":
-      return { kind: "chip", chip: "issue", id: text, text, href: issueHref(text) };
+      return {
+        kind: "chip",
+        chip: "issue",
+        id: text,
+        text,
+        href: issueHref(text),
+      };
     case "pr": {
       const n = text.replace(/^#/, "");
-      return { kind: "chip", chip: "pr", id: n, text: `#${n}`, href: prHref(n, ctx.github) };
+      return {
+        kind: "chip",
+        chip: "pr",
+        id: n,
+        text: `#${n}`,
+        href: prHref(n, ctx.github),
+      };
     }
     case "run":
-      return { kind: "chip", chip: "run", id: text, text: shortRunId(text), href: null };
+      return {
+        kind: "chip",
+        chip: "run",
+        id: text,
+        text: shortRunId(text),
+        href: null,
+      };
     case "state":
       return { kind: "state", state: text };
     case "url":
@@ -178,17 +221,32 @@ export function formatValue(value: unknown, format?: ArtifactFormat, ctx: Format
     case "duration":
       // Seconds — the runtime's own duration fields are `*Seconds`; `dur` takes ms.
       return typeof value === "number"
-        ? { kind: "text", text: dur(value * 1000), mono: true, title: `${value}s` }
+        ? {
+            kind: "text",
+            text: dur(value * 1000),
+            mono: true,
+            title: `${value}s`,
+          }
         : { kind: "text", text, mono: looksLikeIdentifier(text) };
     case "datetime": {
       const ms = typeof value === "number" ? value : Date.parse(text);
       return Number.isNaN(ms)
         ? { kind: "text", text, mono: false }
-        : { kind: "text", text: new Date(ms).toLocaleString(), mono: false, title: new Date(ms).toISOString() };
+        : {
+            kind: "text",
+            text: new Date(ms).toLocaleString(),
+            mono: false,
+            title: new Date(ms).toISOString(),
+          };
     }
     case "bytes":
       return typeof value === "number"
-        ? { kind: "text", text: formatBytes(value), mono: true, title: `${value} B` }
+        ? {
+            kind: "text",
+            text: formatBytes(value),
+            mono: true,
+            title: `${value} B`,
+          }
         : { kind: "text", text, mono: true };
     case "count":
       return typeof value === "number"
@@ -255,18 +313,28 @@ export type SectionModel =
     }
   | { as: "keyvalue"; label: string | undefined; entries: Cell[] }
   | { as: "list"; label: string | undefined; items: Cell[] }
-  | { as: "badge"; label: string | undefined; value: string; tone?: ArtifactTone }
+  | {
+      as: "badge";
+      label: string | undefined;
+      value: string;
+      tone?: ArtifactTone;
+    }
   | { as: "code"; label: string | undefined; text: string; language?: string }
   | { as: "prose"; label: string | undefined; text: string };
 
-const groupLabel = (v: unknown): string => (v === undefined || v === null || v === "" ? "—" : asText(v));
+const groupLabel = (v: unknown): string =>
+  v === undefined || v === null || v === "" ? "—" : asText(v);
 
 /**
  * Group table rows by one item property, first-seen order, so the artifact's
  * own ordering (which the agent chose) survives. Rows without the property
  * gather under `—` at the end.
  */
-export function groupRows(rows: TableRow[], groupBy: string, toneMap?: unknown): RowGroup[] {
+export function groupRows(
+  rows: TableRow[],
+  groupBy: string,
+  toneMap?: unknown,
+): RowGroup[] {
   const groups = new Map<string, RowGroup>();
   let missing: RowGroup | null = null;
   for (const row of rows) {
@@ -279,7 +347,12 @@ export function groupRows(rows: TableRow[], groupBy: string, toneMap?: unknown):
     const key = asText(value);
     let group = groups.get(key);
     if (!group) {
-      group = { key, label: groupLabel(value), tone: toneFor(value, toneMap), rows: [] };
+      group = {
+        key,
+        label: groupLabel(value),
+        tone: toneFor(value, toneMap),
+        rows: [],
+      };
       groups.set(key, group);
     }
     group.rows.push(row);
@@ -289,7 +362,12 @@ export function groupRows(rows: TableRow[], groupBy: string, toneMap?: unknown):
   return out;
 }
 
-function cellFor(section: ArtifactViewSection, item: unknown, key: string, ctx: FormatContext): Cell {
+function cellFor(
+  section: ArtifactViewSection,
+  item: unknown,
+  key: string,
+  ctx: FormatContext,
+): Cell {
   const raw = resolveRelative(item, key);
   return {
     key,
@@ -298,7 +376,11 @@ function cellFor(section: ArtifactViewSection, item: unknown, key: string, ctx: 
   };
 }
 
-function tableSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+function tableSection(
+  section: ArtifactViewSection,
+  node: unknown,
+  ctx: FormatContext,
+): SectionModel | null {
   if (!Array.isArray(node)) return null;
   const columns = section.columns ?? [];
   const expandKeys = section.expand ?? [];
@@ -310,7 +392,9 @@ function tableSection(section: ArtifactViewSection, node: unknown, ctx: FormatCo
       .filter((cell) => cell.value.kind !== "empty"),
     raw: item,
   }));
-  const groups = section.groupBy ? groupRows(rows, section.groupBy, columnToneMap(section, section.groupBy)) : null;
+  const groups = section.groupBy
+    ? groupRows(rows, section.groupBy, columnToneMap(section, section.groupBy))
+    : null;
   return {
     as: "table",
     label: section.label,
@@ -321,7 +405,11 @@ function tableSection(section: ArtifactViewSection, node: unknown, ctx: FormatCo
   };
 }
 
-function keyvalueSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+function keyvalueSection(
+  section: ArtifactViewSection,
+  node: unknown,
+  ctx: FormatContext,
+): SectionModel | null {
   if (!isObject(node)) {
     // A scalar keyvalue: one row whose label is the section's — a heading
     // over a single row would just say the same word twice.
@@ -331,7 +419,13 @@ function keyvalueSection(section: ArtifactViewSection, node: unknown, ctx: Forma
     return {
       as: "keyvalue",
       label: undefined,
-      entries: [{ key: section.label ?? lastToken(section.path), value, tone: toneFor(node, section.tone?.[""]) }],
+      entries: [
+        {
+          key: section.label ?? lastToken(section.path),
+          value,
+          tone: toneFor(node, section.tone?.[""]),
+        },
+      ],
     };
   }
   const keys = section.keys ?? Object.keys(node);
@@ -342,10 +436,16 @@ function keyvalueSection(section: ArtifactViewSection, node: unknown, ctx: Forma
   return { as: "keyvalue", label: section.label, entries };
 }
 
-function listSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+function listSection(
+  section: ArtifactViewSection,
+  node: unknown,
+  ctx: FormatContext,
+): SectionModel | null {
   if (!Array.isArray(node)) return null;
   const items: Cell[] = node.map((item, index) => {
-    const raw = section.itemLabel ? resolveRelative(item, section.itemLabel) : item;
+    const raw = section.itemLabel
+      ? resolveRelative(item, section.itemLabel)
+      : item;
     return {
       key: String(index),
       value: formatValue(raw, section.formats?.[section.itemLabel ?? ""], ctx),
@@ -367,7 +467,10 @@ const lastToken = (pointer: string): string => {
  * non-array) — the JSON stays one Raw toggle away, so dropping is honest,
  * inventing a rendering is not.
  */
-export function sectionsFor(view: ArtifactView, artifact: unknown): SectionModel[] {
+export function sectionsFor(
+  view: ArtifactView,
+  artifact: unknown,
+): SectionModel[] {
   const ctx: FormatContext = { github: githubOf(artifact) };
   const out: SectionModel[] = [];
   for (const section of view.sections ?? []) {
@@ -386,15 +489,33 @@ export function sectionsFor(view: ArtifactView, artifact: unknown): SectionModel
         break;
       case "badge":
         if (isScalar(node)) {
-          model = { as: "badge", label: section.label, value: asText(node), tone: toneFor(node, section.tone) };
+          model = {
+            as: "badge",
+            label: section.label,
+            value: asText(node),
+            tone: toneFor(node, section.tone),
+          };
         }
         break;
       case "code":
-        if (typeof node === "string") model = { as: "code", label: section.label, text: node, language: section.language };
-        else if (!isScalar(node)) model = { as: "code", label: section.label, text: JSON.stringify(node, null, 2), language: "json" };
+        if (typeof node === "string")
+          model = {
+            as: "code",
+            label: section.label,
+            text: node,
+            language: section.language,
+          };
+        else if (!isScalar(node))
+          model = {
+            as: "code",
+            label: section.label,
+            text: JSON.stringify(node, null, 2),
+            language: "json",
+          };
         break;
       case "prose":
-        if (isScalar(node)) model = { as: "prose", label: section.label, text: asText(node) };
+        if (isScalar(node))
+          model = { as: "prose", label: section.label, text: asText(node) };
         break;
     }
     if (model) out.push(model);
@@ -415,16 +536,33 @@ export interface ViewHeader {
   status: { label: string; value: string; tone?: ArtifactTone } | null;
 }
 
-export function headerFor(view: ArtifactView, artifact: unknown, schema?: unknown): ViewHeader {
-  const schemaTitle = isObject(schema) && typeof schema.title === "string" ? schema.title : null;
-  const summary = view.summary !== undefined ? resolvePointer(artifact, view.summary) : undefined;
-  const statusValue = view.status ? resolvePointer(artifact, view.status.path) : undefined;
+export function headerFor(
+  view: ArtifactView,
+  artifact: unknown,
+  schema?: unknown,
+): ViewHeader {
+  const schemaTitle =
+    isObject(schema) && typeof schema.title === "string" ? schema.title : null;
+  const summary =
+    view.summary !== undefined
+      ? resolvePointer(artifact, view.summary)
+      : undefined;
+  const statusValue = view.status
+    ? resolvePointer(artifact, view.status.path)
+    : undefined;
   return {
     title: view.title ?? schemaTitle,
     summary: typeof summary === "string" && summary.trim() ? summary : null,
     status:
-      view.status && isScalar(statusValue) && statusValue !== null && statusValue !== ""
-        ? { label: lastToken(view.status.path), value: asText(statusValue), tone: toneFor(statusValue, view.status.tone) }
+      view.status &&
+      isScalar(statusValue) &&
+      statusValue !== null &&
+      statusValue !== ""
+        ? {
+            label: lastToken(view.status.path),
+            value: asText(statusValue),
+            tone: toneFor(statusValue, view.status.tone),
+          }
         : null,
   };
 }
@@ -434,8 +572,15 @@ export function headerFor(view: ArtifactView, artifact: unknown, schema?: unknow
  * Artifacts inspector uses before swapping its text preview for the view
  * (a transcript that happens to parse as JSON must not wear a merge-plan).
  */
-export function viewApplies(view: ArtifactView | null | undefined, artifact: unknown): view is ArtifactView {
+export function viewApplies(
+  view: ArtifactView | null | undefined,
+  artifact: unknown,
+): view is ArtifactView {
   if (!view || !isObject(artifact)) return false;
   const h = headerFor(view, artifact);
-  return h.summary !== null || h.status !== null || sectionsFor(view, artifact).length > 0;
+  return (
+    h.summary !== null ||
+    h.status !== null ||
+    sectionsFor(view, artifact).length > 0
+  );
 }

--- a/event-runtime/web/src/lib/injectForm.test.ts
+++ b/event-runtime/web/src/lib/injectForm.test.ts
@@ -37,7 +37,9 @@ describe("errorsByField pattern humanization (WM-86)", () => {
   });
 
   test("does not leak regex when no placeholder is available", () => {
-    const mapped = errorsByField(["$.logArtifact: does not match pattern ^[0-9a-f]{64}$"]);
+    const mapped = errorsByField([
+      "$.logArtifact: does not match pattern ^[0-9a-f]{64}$",
+    ]);
     const msg = (mapped.get("logArtifact") ?? []).join(" ");
     expect(msg).not.toContain("^");
     expect(msg).toMatch(/expected format/i);

--- a/event-runtime/web/src/lib/injectForm.ts
+++ b/event-runtime/web/src/lib/injectForm.ts
@@ -47,7 +47,12 @@ export function kindOf(schema: unknown): FieldKind {
     if (t === "string") return "string";
     if (t === "array") {
       const items = schema.items;
-      if (isPlainObject(items) && typesOf(items).length === 1 && typesOf(items)[0] === "string" && !Array.isArray(items.enum)) {
+      if (
+        isPlainObject(items) &&
+        typesOf(items).length === 1 &&
+        typesOf(items)[0] === "string" &&
+        !Array.isArray(items.enum)
+      ) {
         return "string-array";
       }
       return "json";
@@ -55,7 +60,10 @@ export function kindOf(schema: unknown): FieldKind {
     return "json"; // object, null, …
   }
   // Union types: string|integer (e.g. ci-doctor runId) edits fine as text.
-  if (types.length > 1 && types.every((t) => t === "string" || t === "integer" || t === "number")) {
+  if (
+    types.length > 1 &&
+    types.every((t) => t === "string" || t === "integer" || t === "number")
+  ) {
     return "string";
   }
   return "json";
@@ -70,7 +78,9 @@ export function schemaFields(schema: unknown): FieldSpec[] | null {
   const types = typesOf(schema);
   if (types.length > 0 && !types.includes("object")) return null;
   const props = isPlainObject(schema.properties) ? schema.properties : {};
-  const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
+  const required = Array.isArray(schema.required)
+    ? (schema.required as string[])
+    : [];
   const specs: FieldSpec[] = Object.entries(props)
     .filter(([name]) => !PLANNER_FIELDS.has(name))
     .map(([name, propSchema]) => ({
@@ -83,7 +93,10 @@ export function schemaFields(schema: unknown): FieldSpec[] | null {
           ? propSchema.description
           : null,
     }));
-  return [...specs.filter((s) => s.required), ...specs.filter((s) => !s.required)];
+  return [
+    ...specs.filter((s) => s.required),
+    ...specs.filter((s) => !s.required),
+  ];
 }
 
 /** Name conventions from templates.ts seedFor — never keyed off `format`. */
@@ -106,11 +119,14 @@ export function repoSuggestions(
 ): string[] | null {
   if (name === "repo" && kind === "string") {
     if (typeof schema.pattern === "string" && schema.pattern.includes("/")) {
-      return repos.map((r) => r.github).filter((g): g is string => typeof g === "string" && g.length > 0);
+      return repos
+        .map((r) => r.github)
+        .filter((g): g is string => typeof g === "string" && g.length > 0);
     }
     return repos.map((r) => r.name);
   }
-  if (name === "repos" && kind === "string-array") return repos.map((r) => r.name);
+  if (name === "repos" && kind === "string-array")
+    return repos.map((r) => r.name);
   return null;
 }
 
@@ -120,11 +136,15 @@ export function repoSuggestions(
  * examples belong in the placeholder, never pre-filled — and never show the
  * raw regex source.
  */
-export function placeholderFor(name: string, schema: Record<string, unknown>): string | null {
+export function placeholderFor(
+  name: string,
+  schema: Record<string, unknown>,
+): string | null {
   if (typeof schema.pattern !== "string") return null;
   // Order matters: a path pattern ("^/…") also contains a slash.
   if (schema.pattern.startsWith("^/")) return "/absolute/path";
-  if (schema.pattern.includes("/")) return name === "repo" ? "watt-mind/factory" : "owner/name";
+  if (schema.pattern.includes("/"))
+    return name === "repo" ? "watt-mind/factory" : "owner/name";
   return null;
 }
 
@@ -134,7 +154,10 @@ export function placeholderFor(name: string, schema: Record<string, unknown>): s
  * Pattern mismatches never include the raw regex — they reuse placeholderFor
  * when the field schema is known (WM-86).
  */
-export function errorsByField(errors: string[], fields?: FieldSpec[]): Map<string, string[]> {
+export function errorsByField(
+  errors: string[],
+  fields?: FieldSpec[],
+): Map<string, string[]> {
   const byName = new Map((fields ?? []).map((f) => [f.name, f]));
   const out = new Map<string, string[]>();
   const push = (key: string, msg: string) => {
@@ -147,7 +170,10 @@ export function errorsByField(errors: string[], fields?: FieldSpec[]): Map<strin
     const spec = byName.get(name);
     const example = spec ? placeholderFor(name, spec.schema) : null;
     const hint = example ? ` (e.g. ${example})` : "";
-    return msg.replace(/does not match pattern[\s\S]*$/, `does not match expected format${hint}`);
+    return msg.replace(
+      /does not match pattern[\s\S]*$/,
+      `does not match expected format${hint}`,
+    );
   };
   for (const err of errors) {
     const missing = err.match(/^\$: missing required property "([^"]+)"$/);
@@ -158,7 +184,8 @@ export function errorsByField(errors: string[], fields?: FieldSpec[]): Map<strin
     const fielded = err.match(/^\$\.([A-Za-z0-9_$-]+)((?:[.[])[^:]*)?: (.*)$/);
     if (fielded) {
       const name = fielded[1];
-      const rest = `${fielded[2] ?? ""}${fielded[2] ? ": " : ""}${fielded[3]}`.trim();
+      const rest =
+        `${fielded[2] ?? ""}${fielded[2] ? ": " : ""}${fielded[3]}`.trim();
       push(name, humanize(name, rest));
       continue;
     }
@@ -177,7 +204,10 @@ export function fieldErrorVisible(
 }
 
 /** Payload keys the schema does not declare — kept, surfaced, never dropped. */
-export function unknownKeys(schema: unknown, payload: Record<string, unknown>): string[] {
+export function unknownKeys(
+  schema: unknown,
+  payload: Record<string, unknown>,
+): string[] {
   if (!isPlainObject(schema)) return [];
   const props = isPlainObject(schema.properties) ? schema.properties : {};
   return Object.keys(payload).filter((k) => !(k in props));

--- a/event-runtime/web/src/lib/schema.test.ts
+++ b/event-runtime/web/src/lib/schema.test.ts
@@ -15,7 +15,9 @@ describe("validate (web port of lib/schema.mjs)", () => {
         tags: { type: "array", items: { type: "string" } },
       },
     };
-    expect(validate(schema, { name: "bj29", count: 2, tags: ["a"] }).valid).toBe(true);
+    expect(
+      validate(schema, { name: "bj29", count: 2, tags: ["a"] }).valid,
+    ).toBe(true);
   });
 
   test("rejects unknown properties when additionalProperties is false", () => {
@@ -40,11 +42,17 @@ describe("validate (web port of lib/schema.mjs)", () => {
   });
 
   test("const, enum, pattern, bounds", () => {
-    expect(validate({ const: "factory.event/v1" }, "factory.event/v1").valid).toBe(true);
+    expect(
+      validate({ const: "factory.event/v1" }, "factory.event/v1").valid,
+    ).toBe(true);
     expect(validate({ enum: ["a", "b"] }, "c").valid).toBe(false);
-    expect(validate({ type: "string", pattern: "^run_" }, "prop_1").valid).toBe(false);
+    expect(validate({ type: "string", pattern: "^run_" }, "prop_1").valid).toBe(
+      false,
+    );
     expect(validate({ type: "array", minItems: 1 }, []).valid).toBe(false);
-    expect(validate({ type: "number", minimum: 0, maximum: 100 }, 150).valid).toBe(false);
+    expect(
+      validate({ type: "number", minimum: 0, maximum: 100 }, 150).valid,
+    ).toBe(false);
   });
 
   test("empty schema accepts anything", () => {
@@ -63,7 +71,11 @@ describe("validate (web port of lib/schema.mjs)", () => {
       properties: {
         repos: {
           type: "array",
-          items: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+          items: {
+            type: "object",
+            required: ["name"],
+            properties: { name: { type: "string" } },
+          },
         },
       },
     };
@@ -81,7 +93,10 @@ describe("validate (web port of lib/schema.mjs)", () => {
   });
 
   test("pattern validation error does not expose raw regex", () => {
-    const { valid, errors } = validate({ type: "string", pattern: "^[0-9a-f]{40}$" }, "invalid");
+    const { valid, errors } = validate(
+      { type: "string", pattern: "^[0-9a-f]{40}$" },
+      "invalid",
+    );
     expect(valid).toBe(false);
     expect(errors[0]).toBe("$: does not match pattern");
     expect(errors[0]).not.toContain("^[0-9a-f]{40}$");

--- a/event-runtime/web/src/lib/schema.ts
+++ b/event-runtime/web/src/lib/schema.ts
@@ -7,20 +7,40 @@
  */
 
 const SUPPORTED = new Set([
-  "type", "enum", "const", "required", "properties", "additionalProperties",
-  "items", "minItems", "maxItems", "minLength", "maxLength", "pattern",
-  "minimum", "maximum", "description", "title", "$schema",
+  "type",
+  "enum",
+  "const",
+  "required",
+  "properties",
+  "additionalProperties",
+  "items",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "minimum",
+  "maximum",
+  "description",
+  "title",
+  "$schema",
 ]);
 
 const hasOwn = (obj: unknown, key: string): boolean =>
-  obj !== null && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+  obj !== null &&
+  typeof obj === "object" &&
+  Object.prototype.hasOwnProperty.call(obj, key);
 
 export interface ValidationResult {
   valid: boolean;
   errors: string[];
 }
 
-export function validate(schema: unknown, value: unknown, path = "$"): ValidationResult {
+export function validate(
+  schema: unknown,
+  value: unknown,
+  path = "$",
+): ValidationResult {
   const errors: string[] = [];
   check(schema, value, path, errors);
   return { valid: errors.length === 0, errors };
@@ -29,7 +49,8 @@ export function validate(schema: unknown, value: unknown, path = "$"): Validatio
 function typeOf(value: unknown): string {
   if (value === null) return "null";
   if (Array.isArray(value)) return "array";
-  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  if (typeof value === "number")
+    return Number.isInteger(value) ? "integer" : "number";
   return typeof value;
 }
 
@@ -37,7 +58,12 @@ function matchesType(declared: string, actual: string): boolean {
   return declared === actual || (declared === "number" && actual === "integer");
 }
 
-function check(schema: unknown, value: unknown, path: string, errors: string[]): void {
+function check(
+  schema: unknown,
+  value: unknown,
+  path: string,
+  errors: string[],
+): void {
   if (schema === undefined || schema === null) {
     errors.push(`${path}: schema is missing`);
     return;
@@ -49,7 +75,9 @@ function check(schema: unknown, value: unknown, path: string, errors: string[]):
   const s = schema as Record<string, unknown>;
   for (const key of Object.keys(s)) {
     if (!SUPPORTED.has(key)) {
-      errors.push(`${path}: unsupported schema keyword "${key}" — contracts fail closed`);
+      errors.push(
+        `${path}: unsupported schema keyword "${key}" — contracts fail closed`,
+      );
       return;
     }
   }
@@ -57,9 +85,13 @@ function check(schema: unknown, value: unknown, path: string, errors: string[]):
   const actual = typeOf(value);
 
   if (hasOwn(s, "type") && s.type !== undefined) {
-    const declared = Array.isArray(s.type) ? (s.type as string[]) : [s.type as string];
+    const declared = Array.isArray(s.type)
+      ? (s.type as string[])
+      : [s.type as string];
     if (!declared.some((t) => matchesType(t, actual))) {
-      errors.push(`${path}: expected type ${declared.join("|")}, got ${actual}`);
+      errors.push(
+        `${path}: expected type ${declared.join("|")}, got ${actual}`,
+      );
       return;
     }
   }
@@ -67,39 +99,71 @@ function check(schema: unknown, value: unknown, path: string, errors: string[]):
   if (hasOwn(s, "const") && JSON.stringify(value) !== JSON.stringify(s.const)) {
     errors.push(`${path}: expected const ${JSON.stringify(s.const)}`);
   }
-  if (hasOwn(s, "enum") && Array.isArray(s.enum) && !s.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))) {
+  if (
+    hasOwn(s, "enum") &&
+    Array.isArray(s.enum) &&
+    !s.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))
+  ) {
     errors.push(`${path}: value not in enum ${JSON.stringify(s.enum)}`);
   }
 
   if (actual === "string") {
     const str = value as string;
-    if (hasOwn(s, "minLength") && typeof s.minLength === "number" && str.length < s.minLength) {
+    if (
+      hasOwn(s, "minLength") &&
+      typeof s.minLength === "number" &&
+      str.length < s.minLength
+    ) {
       errors.push(`${path}: shorter than minLength ${s.minLength}`);
     }
-    if (hasOwn(s, "maxLength") && typeof s.maxLength === "number" && str.length > s.maxLength) {
+    if (
+      hasOwn(s, "maxLength") &&
+      typeof s.maxLength === "number" &&
+      str.length > s.maxLength
+    ) {
       errors.push(`${path}: longer than maxLength ${s.maxLength}`);
     }
-    if (hasOwn(s, "pattern") && typeof s.pattern === "string" && !new RegExp(s.pattern).test(str)) {
+    if (
+      hasOwn(s, "pattern") &&
+      typeof s.pattern === "string" &&
+      !new RegExp(s.pattern).test(str)
+    ) {
       errors.push(`${path}: does not match pattern`);
     }
   }
 
   if (actual === "integer" || actual === "number") {
     const num = value as number;
-    if (hasOwn(s, "minimum") && typeof s.minimum === "number" && num < s.minimum) {
+    if (
+      hasOwn(s, "minimum") &&
+      typeof s.minimum === "number" &&
+      num < s.minimum
+    ) {
       errors.push(`${path}: below minimum ${s.minimum}`);
     }
-    if (hasOwn(s, "maximum") && typeof s.maximum === "number" && num > s.maximum) {
+    if (
+      hasOwn(s, "maximum") &&
+      typeof s.maximum === "number" &&
+      num > s.maximum
+    ) {
       errors.push(`${path}: above maximum ${s.maximum}`);
     }
   }
 
   if (actual === "array") {
     const arr = value as unknown[];
-    if (hasOwn(s, "minItems") && typeof s.minItems === "number" && arr.length < s.minItems) {
+    if (
+      hasOwn(s, "minItems") &&
+      typeof s.minItems === "number" &&
+      arr.length < s.minItems
+    ) {
       errors.push(`${path}: fewer than minItems ${s.minItems}`);
     }
-    if (hasOwn(s, "maxItems") && typeof s.maxItems === "number" && arr.length > s.maxItems) {
+    if (
+      hasOwn(s, "maxItems") &&
+      typeof s.maxItems === "number" &&
+      arr.length > s.maxItems
+    ) {
       errors.push(`${path}: more than maxItems ${s.maxItems}`);
     }
     if (hasOwn(s, "items")) {
@@ -111,24 +175,33 @@ function check(schema: unknown, value: unknown, path: string, errors: string[]):
     const obj = value as Record<string, unknown>;
     if (hasOwn(s, "required") && Array.isArray(s.required)) {
       for (const key of s.required as string[]) {
-        if (!hasOwn(obj, key)) errors.push(`${path}: missing required property "${key}"`);
+        if (!hasOwn(obj, key))
+          errors.push(`${path}: missing required property "${key}"`);
       }
     }
     const properties: Record<string, unknown> =
-      hasOwn(s, "properties") && s.properties && typeof s.properties === "object"
+      hasOwn(s, "properties") &&
+      s.properties &&
+      typeof s.properties === "object"
         ? (s.properties as Record<string, unknown>)
         : {};
     for (const [key, propSchema] of Object.entries(properties)) {
-      if (hasOwn(obj, key)) check(propSchema, obj[key], `${path}.${key}`, errors);
+      if (hasOwn(obj, key))
+        check(propSchema, obj[key], `${path}.${key}`, errors);
     }
     if (hasOwn(s, "additionalProperties")) {
       if (s.additionalProperties === false) {
         for (const key of Object.keys(obj)) {
-          if (!hasOwn(properties, key)) errors.push(`${path}: unknown property "${key}"`);
+          if (!hasOwn(properties, key))
+            errors.push(`${path}: unknown property "${key}"`);
         }
-      } else if (typeof s.additionalProperties === "object" && s.additionalProperties !== null) {
+      } else if (
+        typeof s.additionalProperties === "object" &&
+        s.additionalProperties !== null
+      ) {
         for (const key of Object.keys(obj)) {
-          if (!hasOwn(properties, key)) check(s.additionalProperties, obj[key], `${path}.${key}`, errors);
+          if (!hasOwn(properties, key))
+            check(s.additionalProperties, obj[key], `${path}.${key}`, errors);
         }
       }
     }

--- a/event-runtime/web/src/pathExtractor.ts
+++ b/event-runtime/web/src/pathExtractor.ts
@@ -42,7 +42,10 @@ export function parsePath(path: string): readonly string[] {
 /**
  * Safely traverses an object along a tokenized path without throwing.
  */
-export function getPathValue(target: unknown, path: string | readonly string[]): unknown {
+export function getPathValue(
+  target: unknown,
+  path: string | readonly string[],
+): unknown {
   if (target == null) return undefined;
   const tokens = typeof path === "string" ? parsePath(path) : path;
   let curr: any = target;

--- a/event-runtime/web/src/reasons.test.ts
+++ b/event-runtime/web/src/reasons.test.ts
@@ -8,11 +8,19 @@ describe("humanizeReason (WM-594)", () => {
       raw: "owned_paths_overlap",
     });
     expect(humanizeReason("needs_human").text).toBe("Needs human");
-    expect(humanizeReason("ticket_security").text).toBe("Ticket is security-labelled");
-    expect(humanizeReason("merge_fix_pr_moved").text).toBe("PR head moved since the plan");
-    expect(humanizeReason("sandbox_unavailable").text).toBe("Sandbox unavailable");
+    expect(humanizeReason("ticket_security").text).toBe(
+      "Ticket is security-labelled",
+    );
+    expect(humanizeReason("merge_fix_pr_moved").text).toBe(
+      "PR head moved since the plan",
+    );
+    expect(humanizeReason("sandbox_unavailable").text).toBe(
+      "Sandbox unavailable",
+    );
     expect(humanizeReason("timeout").text).toBe("Timed out");
-    expect(humanizeReason("contract_violation").text).toBe("Output contract violated");
+    expect(humanizeReason("contract_violation").text).toBe(
+      "Output contract violated",
+    );
     expect(humanizeReason("cli_not_found").text).toBe("Agent CLI not found");
   });
 
@@ -71,8 +79,13 @@ describe("humanizeReason (WM-594)", () => {
   });
 
   test("unknown codes fall back to the code with underscores dropped, suffix kept as detail", () => {
-    expect(humanizeReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
-    expect(humanizeReason("some_new_code:extra_detail").text).toBe("some new code — extra detail");
+    expect(humanizeReason("some_new_code")).toEqual({
+      text: "some new code",
+      raw: "some_new_code",
+    });
+    expect(humanizeReason("some_new_code:extra_detail").text).toBe(
+      "some new code — extra detail",
+    );
     // The message after the colon is one free-text fragment, colons and all.
     expect(humanizeReason("repo_unknown: no repo named x: y").text).toBe(
       "Repo is not configured — no repo named x: y",
@@ -80,25 +93,34 @@ describe("humanizeReason (WM-594)", () => {
   });
 
   test("agent_exit_N is one family", () => {
-    expect(humanizeReason("agent_exit_1").text).toBe("Agent exited with code 1");
-    expect(humanizeReason("agent_exit_143").text).toBe("Agent exited with code 143");
+    expect(humanizeReason("agent_exit_1").text).toBe(
+      "Agent exited with code 1",
+    );
+    expect(humanizeReason("agent_exit_143").text).toBe(
+      "Agent exited with code 143",
+    );
   });
 
   test("chained codes humanize every known fragment", () => {
-    expect(humanizeReason("auto_approval_ineligible:proposal_expired").text).toBe(
-      "Not eligible for auto-approval — Proposal expired",
-    );
     expect(
-      humanizeReason("ticket_dispatch_already_live:run_6fe0cdb4-bb4b-4bcb-ae3a-638dd704a42d:same_ticket_worktree_held")
-        .text,
+      humanizeReason("auto_approval_ineligible:proposal_expired").text,
+    ).toBe("Not eligible for auto-approval — Proposal expired");
+    expect(
+      humanizeReason(
+        "ticket_dispatch_already_live:run_6fe0cdb4-bb4b-4bcb-ae3a-638dd704a42d:same_ticket_worktree_held",
+      ).text,
     ).toBe(
       "A dispatch for this ticket is already live — run_6fe0cdb4-bb4b-4bcb-ae3a-638dd704a42d · its worktree is still held",
     );
-    expect(humanizeReason("policy_denied:Bash").text).toBe("Policy denied tool — Bash");
+    expect(humanizeReason("policy_denied:Bash").text).toBe(
+      "Policy denied tool — Bash",
+    );
   });
 
   test("extracts run, proposal and ticket references from the suffix", () => {
-    const live = humanizeReason("ticket_dispatch_already_live:run_abc-123:same_ticket_worktree_held");
+    const live = humanizeReason(
+      "ticket_dispatch_already_live:run_abc-123:same_ticket_worktree_held",
+    );
     expect(live.refs).toEqual({ runId: "run_abc-123" });
     // The identifier survives verbatim inside the sentence, so callers can link it.
     expect(live.text).toContain("run_abc-123");
@@ -107,7 +129,9 @@ describe("humanizeReason (WM-594)", () => {
     expect(held.refs).toEqual({ runId: "run_x9", ticket: "WM-544" });
     expect(held.text).toBe("Owned paths overlap — held by WM-544 (run_x9)");
 
-    const prop = humanizeReason("auto_approval_ineligible:merge_barrier_uncertain:prop_0192abc");
+    const prop = humanizeReason(
+      "auto_approval_ineligible:merge_barrier_uncertain:prop_0192abc",
+    );
     expect(prop.refs).toEqual({ proposalId: "prop_0192abc" });
 
     expect(humanizeReason("owned_paths_overlap").refs).toBeUndefined();
@@ -115,7 +139,9 @@ describe("humanizeReason (WM-594)", () => {
   });
 
   test("free-text reasons come back verbatim, still with refs", () => {
-    const r = humanizeReason("WM-328 is already in flight (duplicate proposal)");
+    const r = humanizeReason(
+      "WM-328 is already in flight (duplicate proposal)",
+    );
     expect(r.text).toBe("WM-328 is already in flight (duplicate proposal)");
     expect(r.raw).toBe("WM-328 is already in flight (duplicate proposal)");
     expect(r.refs).toEqual({ ticket: "WM-328" });

--- a/event-runtime/web/src/reasons.ts
+++ b/event-runtime/web/src/reasons.ts
@@ -73,7 +73,8 @@ export const REASONS: Record<string, string> = {
   merge_barrier_uncertain: "Merge barrier uncertain",
   merge_fix_round_not_durable: "Merge-fix round not durable",
   merge_fix_round_exhausted: "Merge-fix rounds exhausted",
-  merge_fix_not_mechanical_or_in_scope: "Merge-fix not mechanical or out of scope",
+  merge_fix_not_mechanical_or_in_scope:
+    "Merge-fix not mechanical or out of scope",
   merge_fix_pr_moved: "PR head moved since the plan",
   merge_fix_pr_not_open: "PR is no longer open",
   merge_fix_pr_not_found: "PR not found",
@@ -169,7 +170,12 @@ function fragmentText(fragment: string): string {
   if (phrase) return phrase;
   // Free text (a Linear title, an error message) and identifiers are kept verbatim.
   if (/\s/.test(fragment) || !/^[a-z0-9_]+$/i.test(fragment)) return fragment;
-  if (RUN_REF.test(fragment) || PROPOSAL_REF.test(fragment) || TICKET_REF.test(fragment)) return fragment;
+  if (
+    RUN_REF.test(fragment) ||
+    PROPOSAL_REF.test(fragment) ||
+    TICKET_REF.test(fragment)
+  )
+    return fragment;
   return fragment.replace(/_/g, " ");
 }
 

--- a/event-runtime/web/src/reveal.test.ts
+++ b/event-runtime/web/src/reveal.test.ts
@@ -96,7 +96,9 @@ describe("formatRevealNotification", () => {
         tabChanged: true,
         filterCleared: true,
       }),
-    ).toBe("Showing all states and cleared filter — event evt_04 is human_needed");
+    ).toBe(
+      "Showing all states and cleared filter — event evt_04 is human_needed",
+    );
   });
 });
 
@@ -108,9 +110,21 @@ describe("decideRevealFilters", () => {
   };
 
   test("when target row is already visible, keeps all filters and clears nothing", () => {
-    const snapshot: EventFilters = { filter: "error", typeFilter: "deploy", sourceFilter: null };
-    const current: EventFilters = { filter: "error", typeFilter: "deploy", sourceFilter: null };
-    const empty: EventFilters = { filter: "", typeFilter: null, sourceFilter: null };
+    const snapshot: EventFilters = {
+      filter: "error",
+      typeFilter: "deploy",
+      sourceFilter: null,
+    };
+    const current: EventFilters = {
+      filter: "error",
+      typeFilter: "deploy",
+      sourceFilter: null,
+    };
+    const empty: EventFilters = {
+      filter: "",
+      typeFilter: null,
+      sourceFilter: null,
+    };
 
     const result = decideRevealFilters(snapshot, current, empty, true);
     expect(result.cleared).toBe(false);
@@ -119,38 +133,86 @@ describe("decideRevealFilters", () => {
   });
 
   test("when target row is hidden and filters are unchanged from snapshot, clears all non-empty fields", () => {
-    const snapshot: EventFilters = { filter: "error", typeFilter: "deploy", sourceFilter: null };
-    const current: EventFilters = { filter: "error", typeFilter: "deploy", sourceFilter: null };
-    const empty: EventFilters = { filter: "", typeFilter: null, sourceFilter: null };
+    const snapshot: EventFilters = {
+      filter: "error",
+      typeFilter: "deploy",
+      sourceFilter: null,
+    };
+    const current: EventFilters = {
+      filter: "error",
+      typeFilter: "deploy",
+      sourceFilter: null,
+    };
+    const empty: EventFilters = {
+      filter: "",
+      typeFilter: null,
+      sourceFilter: null,
+    };
 
     const result = decideRevealFilters(snapshot, current, empty, false);
     expect(result.cleared).toBe(true);
     expect(result.clearedFields).toEqual(["filter", "typeFilter"]);
-    expect(result.next).toEqual({ filter: "", typeFilter: null, sourceFilter: null });
+    expect(result.next).toEqual({
+      filter: "",
+      typeFilter: null,
+      sourceFilter: null,
+    });
   });
 
   test("Events: preserving a newly typed text filter while clearing stale type/source filters", () => {
-    const snapshot: EventFilters = { filter: "", typeFilter: "deploy", sourceFilter: "github" };
+    const snapshot: EventFilters = {
+      filter: "",
+      typeFilter: "deploy",
+      sourceFilter: "github",
+    };
     // Operator typed "new search" after latch armed, but left typeFilter/sourceFilter untouched
-    const current: EventFilters = { filter: "new search", typeFilter: "deploy", sourceFilter: "github" };
-    const empty: EventFilters = { filter: "", typeFilter: null, sourceFilter: null };
+    const current: EventFilters = {
+      filter: "new search",
+      typeFilter: "deploy",
+      sourceFilter: "github",
+    };
+    const empty: EventFilters = {
+      filter: "",
+      typeFilter: null,
+      sourceFilter: null,
+    };
 
     const result = decideRevealFilters(snapshot, current, empty, false);
     expect(result.cleared).toBe(true);
     expect(result.clearedFields).toEqual(["typeFilter", "sourceFilter"]);
-    expect(result.next).toEqual({ filter: "new search", typeFilter: null, sourceFilter: null });
+    expect(result.next).toEqual({
+      filter: "new search",
+      typeFilter: null,
+      sourceFilter: null,
+    });
   });
 
   test("Events: preserving modified type chip while clearing stale text filter", () => {
-    const snapshot: EventFilters = { filter: "old filter", typeFilter: null, sourceFilter: null };
+    const snapshot: EventFilters = {
+      filter: "old filter",
+      typeFilter: null,
+      sourceFilter: null,
+    };
     // Operator selected "webhook" type chip after latch armed
-    const current: EventFilters = { filter: "old filter", typeFilter: "webhook", sourceFilter: null };
-    const empty: EventFilters = { filter: "", typeFilter: null, sourceFilter: null };
+    const current: EventFilters = {
+      filter: "old filter",
+      typeFilter: "webhook",
+      sourceFilter: null,
+    };
+    const empty: EventFilters = {
+      filter: "",
+      typeFilter: null,
+      sourceFilter: null,
+    };
 
     const result = decideRevealFilters(snapshot, current, empty, false);
     expect(result.cleared).toBe(true);
     expect(result.clearedFields).toEqual(["filter"]);
-    expect(result.next).toEqual({ filter: "", typeFilter: "webhook", sourceFilter: null });
+    expect(result.next).toEqual({
+      filter: "",
+      typeFilter: "webhook",
+      sourceFilter: null,
+    });
   });
 
   test("Proposals: preserving newly typed filter while clearing stale expiredOnly", () => {

--- a/event-runtime/web/src/reveal.ts
+++ b/event-runtime/web/src/reveal.ts
@@ -18,11 +18,15 @@ export interface RevealFeedbackInput {
  * Returns a human-readable feedback message describing what the reveal changed,
  * or null if nothing was changed (silent reveal).
  */
-export function formatRevealNotification(input: RevealFeedbackInput): string | null {
+export function formatRevealNotification(
+  input: RevealFeedbackInput,
+): string | null {
   const { kind, id, state, tabChanged, filterCleared } = input;
   if (!tabChanged && !filterCleared) return null;
 
-  const stateReason = state ? ` — ${kind} ${id} is ${state}` : ` to show ${kind} ${id}`;
+  const stateReason = state
+    ? ` — ${kind} ${id} is ${state}`
+    : ` to show ${kind} ${id}`;
 
   if (tabChanged && filterCleared) {
     return `Showing all states and cleared filter${stateReason}`;

--- a/event-runtime/web/src/schemaDiscovery.test.ts
+++ b/event-runtime/web/src/schemaDiscovery.test.ts
@@ -17,8 +17,16 @@ describe("groupDiscoveredFields", () => {
       field("labels.priority"),
     ]);
 
-    expect(groups.map((group) => group.root)).toEqual(["payload", "spec", "top-level", "labels"]);
-    expect(groups[0].fields.map((item) => item.path)).toEqual(["payload.repo", "payload.owner"]);
+    expect(groups.map((group) => group.root)).toEqual([
+      "payload",
+      "spec",
+      "top-level",
+      "labels",
+    ]);
+    expect(groups[0].fields.map((item) => item.path)).toEqual([
+      "payload.repo",
+      "payload.owner",
+    ]);
     expect(groups[2].fields.map((item) => item.path)).toEqual(["id"]);
   });
 });

--- a/event-runtime/web/src/schemaDiscovery.ts
+++ b/event-runtime/web/src/schemaDiscovery.ts
@@ -15,18 +15,24 @@ export interface DiscoveredFieldGroup {
 }
 
 /** Preserve discovery relevance order while collecting fields under their root object. */
-export function groupDiscoveredFields(fields: DiscoveredField[]): DiscoveredFieldGroup[] {
+export function groupDiscoveredFields(
+  fields: DiscoveredField[],
+): DiscoveredFieldGroup[] {
   const groups = new Map<string, DiscoveredField[]>();
 
   for (const field of fields) {
     const separator = field.path.indexOf(".");
-    const root = separator === -1 ? "top-level" : field.path.slice(0, separator);
+    const root =
+      separator === -1 ? "top-level" : field.path.slice(0, separator);
     const group = groups.get(root);
     if (group) group.push(field);
     else groups.set(root, [field]);
   }
 
-  return Array.from(groups, ([root, groupedFields]) => ({ root, fields: groupedFields }));
+  return Array.from(groups, ([root, groupedFields]) => ({
+    root,
+    fields: groupedFields,
+  }));
 }
 
 const MAX_SCAN_ROWS = 60;
@@ -35,23 +41,37 @@ const MAX_SCAN_DEPTH = 3;
 /**
  * Scan rows to auto-discover nested keys from payload, spec.input, labels, limits, etc.
  */
-export function discoverPayloadFields<T>(rows: T[], activeCustomColumns: string[]): DiscoveredField[] {
+export function discoverPayloadFields<T>(
+  rows: T[],
+  activeCustomColumns: string[],
+): DiscoveredField[] {
   if (!rows?.length) return [];
   const sample = rows.slice(0, MAX_SCAN_ROWS);
   const counts = new Map<string, { count: number; sampleValue: string }>();
-  const activeSet = new Set(activeCustomColumns.map((c) => c.replace(/^custom:/, "")));
+  const activeSet = new Set(
+    activeCustomColumns.map((c) => c.replace(/^custom:/, "")),
+  );
 
   function walk(obj: unknown, prefix: string, depth: number) {
     if (depth > MAX_SCAN_DEPTH || obj == null) return;
     if (typeof obj !== "object" || Array.isArray(obj)) return;
 
     for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      if (key.startsWith("_") || key === "__proto__" || key === "constructor" || key === "prototype") {
+      if (
+        key.startsWith("_") ||
+        key === "__proto__" ||
+        key === "constructor" ||
+        key === "prototype"
+      ) {
         continue;
       }
       const fullPath = prefix ? `${prefix}.${key}` : key;
 
-      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      if (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value)
+      ) {
         walk(value, fullPath, depth + 1);
       } else {
         if (!activeSet.has(fullPath) && !activeSet.has(key)) {
@@ -59,7 +79,8 @@ export function discoverPayloadFields<T>(rows: T[], activeCustomColumns: string[
           let valStr = "";
           if (value === undefined || value === null) valStr = "—";
           else if (typeof value === "string") valStr = value;
-          else if (typeof value === "number" || typeof value === "boolean") valStr = String(value);
+          else if (typeof value === "number" || typeof value === "boolean")
+            valStr = String(value);
           else if (Array.isArray(value)) valStr = `[${value.length}]`;
           else valStr = "{…}";
 
@@ -90,5 +111,8 @@ export function discoverPayloadFields<T>(rows: T[], activeCustomColumns: string[
       sampleValue: data.sampleValue,
       occurrenceCount: data.count,
     }))
-    .sort((a, b) => b.occurrenceCount - a.occurrenceCount || a.path.localeCompare(b.path));
+    .sort(
+      (a, b) =>
+        b.occurrenceCount - a.occurrenceCount || a.path.localeCompare(b.path),
+    );
 }

--- a/event-runtime/web/src/subjectJourney.test.ts
+++ b/event-runtime/web/src/subjectJourney.test.ts
@@ -59,7 +59,10 @@ function run(
     usage:
       cost == null
         ? { totals: { attempts: 0, totalTokens: 0, costUSD: 0 }, attempts: [] }
-        : { totals: { attempts: 1, totalTokens: 1200, costUSD: cost }, attempts: [{}] },
+        : {
+            totals: { attempts: 1, totalTokens: 1200, costUSD: cost },
+            attempts: [{}],
+          },
   };
 }
 
@@ -108,7 +111,10 @@ function fixture(): TicketJourneySource {
         "2026-01-01T09:11:00.000Z",
         "2026-01-01T09:23:00.000Z",
         0.77,
-        { outcome: "PR_OPEN", prUrl: "https://github.com/watt-mind/factory/pull/499" },
+        {
+          outcome: "PR_OPEN",
+          prUrl: "https://github.com/watt-mind/factory/pull/499",
+        },
       ),
       run(
         "run_2",
@@ -125,19 +131,30 @@ describe("buildTicketJourney", () => {
   test("orders milestones, groups lifecycle rows under runs, and computes header aggregates", () => {
     const journey = buildTicketJourney(fixture());
     expect(journey.timeline[0].label).toBe("filed");
-    expect(journey.timeline.map((item) => item.label)).toContain("dispatch requested");
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "dispatch requested",
+    );
     const firstRun = journey.timeline.find((item) => item.id === "run:run_1");
-    expect(firstRun?.children?.map((item) => item.label)).toEqual(["QUEUED", "COMPLETED"]);
+    expect(firstRun?.children?.map((item) => item.label)).toEqual([
+      "QUEUED",
+      "COMPLETED",
+    ]);
     expect(firstRun?.children?.[1].durationMs).toBe(12 * 60 * 1000);
-    expect(journey.timeline.map((item) => item.label)).toContain("PR #499 opened");
-    expect(journey.timeline.map((item) => item.label)).toContain("CI checks green");
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "PR #499 opened",
+    );
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "CI checks green",
+    );
     expect(journey.timeline.map((item) => item.label)).toContain("merged");
     expect(journey.timeline.at(-1)?.label).toBe("Done");
     expect(journey.totalCost).toBeCloseTo(1);
     expect(journey.totalTokens).toBe(2400);
     expect(journey.leadTimeMs).toBe(67 * 60 * 1000);
     expect(journey.runCount).toBe(2);
-    expect(journey.prUrls).toEqual(["https://github.com/watt-mind/factory/pull/499"]);
+    expect(journey.prUrls).toEqual([
+      "https://github.com/watt-mind/factory/pull/499",
+    ]);
   });
 
   test("derives PR, CI, merge, and approval-next-action milestones from an open merge plan", () => {
@@ -145,10 +162,18 @@ describe("buildTicketJourney", () => {
     source.runs = [
       {
         ...source.runs[0],
-        run: { ...source.runs[0].run, runId: "run_merge", state: "PROPOSED", spec: { agent: "merge-apply@2", adapter: "fake" } },
+        run: {
+          ...source.runs[0].run,
+          runId: "run_merge",
+          state: "PROPOSED",
+          spec: { agent: "merge-apply@2", adapter: "fake" },
+        },
         lifecycle: [],
         result: null,
-        usage: { totals: { attempts: 0, totalTokens: 0, costUSD: 0 }, attempts: [] },
+        usage: {
+          totals: { attempts: 0, totalTokens: 0, costUSD: 0 },
+          attempts: [],
+        },
       },
     ];
     source.events[0] = {
@@ -158,17 +183,40 @@ describe("buildTicketJourney", () => {
         payload: {
           github: "watt-mind/factory",
           ticket: "WM-542",
-          plan: [{ action: "merge_pr", pr: 42, checksGreen: true, reason: "reviewed" }],
+          plan: [
+            {
+              action: "merge_pr",
+              pr: 42,
+              checksGreen: true,
+              reason: "reviewed",
+            },
+          ],
         },
       },
     };
-    source.proposals[0] = { ...source.proposals[0], id: "prop_merge", status: "open", runId: "run_merge" };
+    source.proposals[0] = {
+      ...source.proposals[0],
+      id: "prop_merge",
+      status: "open",
+      runId: "run_merge",
+    };
     const journey = buildTicketJourney(source);
-    expect(journey.prUrls).toEqual(["https://github.com/watt-mind/factory/pull/42"]);
-    expect(journey.timeline.map((item) => item.label)).toContain("PR #42 referenced");
-    expect(journey.timeline.map((item) => item.label)).toContain("CI checks green");
-    expect(journey.timeline.map((item) => item.label)).toContain("merge requested");
-    expect(journey.currentRun).toMatchObject({ runId: "run_merge", state: "PROPOSED" });
+    expect(journey.prUrls).toEqual([
+      "https://github.com/watt-mind/factory/pull/42",
+    ]);
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "PR #42 referenced",
+    );
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "CI checks green",
+    );
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "merge requested",
+    );
+    expect(journey.currentRun).toMatchObject({
+      runId: "run_merge",
+      state: "PROPOSED",
+    });
     expect(journey.nextAction).toBe("Awaiting approval for prop_merge");
   });
 
@@ -188,7 +236,9 @@ describe("buildTicketJourney", () => {
     const journey = buildTicketJourney(source);
     expect(journey.totalCost).toBeNull();
     expect(journey.leadTimeMs).toBeNull();
-    expect(journey.blockingReason).toBe("Owned paths overlap — WM-544 · run_held");
+    expect(journey.blockingReason).toBe(
+      "Owned paths overlap — WM-544 · run_held",
+    );
     expect(journey.nextAction).toContain("Owned paths overlap");
   });
 });
@@ -198,22 +248,51 @@ describe("buildTicketJourney concurrent rows", () => {
     const { scan, fix, dispatch } = prFixture();
     const neighbour: JourneyRun = {
       ...dispatch,
-      run: { ...dispatch.run, runId: "run_neighbour", spec: { agent: "dispatch@1", adapter: "pi", input: { repo: "factory", ticket: "WM-547" } } },
-      result: { terminalState: "completed", artifact: { outcome: "PR_OPEN", ticket: "WM-547", prUrl: "https://github.com/watt-mind/factory/pull/504" } },
+      run: {
+        ...dispatch.run,
+        runId: "run_neighbour",
+        spec: {
+          agent: "dispatch@1",
+          adapter: "pi",
+          input: { repo: "factory", ticket: "WM-547" },
+        },
+      },
+      result: {
+        terminalState: "completed",
+        artifact: {
+          outcome: "PR_OPEN",
+          ticket: "WM-547",
+          prUrl: "https://github.com/watt-mind/factory/pull/504",
+        },
+      },
     };
     const source: TicketJourneySource = {
-      ticket: { id: "WM-627", title: null, state: "In Review", createdAt: null, url: "https://linear.app/watt-mind/issue/WM-627" },
+      ticket: {
+        id: "WM-627",
+        title: null,
+        state: "In Review",
+        createdAt: null,
+        url: "https://linear.app/watt-mind/issue/WM-627",
+      },
       activity: true,
       events: [],
       proposals: [],
       runs: [neighbour, dispatch, scan, fix],
     };
     const journey = buildTicketJourney(source);
-    const concurrent = journey.timeline.filter((item) => item.kind === "concurrent").map((item) => item.label);
-    expect(concurrent).toEqual(["↔ WM-627 dispatch pushed 7b2b695 (run_dispatch)"]);
-    expect(journey.timeline.map((item) => item.label)).toContain("merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)");
+    const concurrent = journey.timeline
+      .filter((item) => item.kind === "concurrent")
+      .map((item) => item.label);
+    expect(concurrent).toEqual([
+      "↔ WM-627 dispatch pushed 7b2b695 (run_dispatch)",
+    ]);
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)",
+    );
     // Ticket-journey PR rows route to the PR journey.
-    expect(journey.timeline.find((item) => item.label === "PR #541 opened")?.href).toBe("#/prs/541");
+    expect(
+      journey.timeline.find((item) => item.label === "PR #541 opened")?.href,
+    ).toBe("#/prs/541");
   });
 });
 
@@ -221,16 +300,19 @@ describe("ticket journey helpers", () => {
   test("formats durations and ticket ids without guessing from prose", () => {
     expect(formatDuration(3_720_000)).toBe("1h 2m");
     expect(formatDuration(null)).toBe("—");
-    expect(ticketIdsIn({ subject: "wm-542", payload: { ticket: "WM-544" } })).toEqual([
-      "WM-542",
-      "WM-544",
-    ]);
+    expect(
+      ticketIdsIn({ subject: "wm-542", payload: { ticket: "WM-544" } }),
+    ).toEqual(["WM-542", "WM-544"]);
     expect(ticketIdsIn({ note: "mentions WM-999 in prose" })).toEqual([]);
   });
 
   test("humanizes known and unknown reason codes", () => {
-    expect(humanizeReason("ticket_assigned").text).toBe("Ticket is already assigned");
-    expect(humanizeReason("foreign_reason:WM-1").text).toBe("foreign reason — WM-1");
+    expect(humanizeReason("ticket_assigned").text).toBe(
+      "Ticket is already assigned",
+    );
+    expect(humanizeReason("foreign_reason:WM-1").text).toBe(
+      "foreign reason — WM-1",
+    );
   });
 });
 
@@ -239,7 +321,12 @@ describe("ticket journey helpers", () => {
  * at head 6dbaab4 while the WM-627 dispatch pushed 7b2b695; the fix planned
  * from the stale finding was refused `merge_fix_pr_moved`.
  */
-function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: JourneyRun; dispatch: JourneyRun } {
+function prFixture(): {
+  source: SubjectJourneySource;
+  scan: JourneyRun;
+  fix: JourneyRun;
+  dispatch: JourneyRun;
+} {
   const scan: JourneyRun = {
     run: {
       runId: "run_scan",
@@ -247,11 +334,35 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
       attempts: 1,
       created_at: "2026-08-17T18:45:00.445Z",
       updated_at: "2026-08-17T19:06:02.939Z",
-      spec: { agent: "merge-scan@2", adapter: "cursor", input: { repo: "factory", loop: "merge-factory", repoPin: { github: "watt-mind/factory" } } },
+      spec: {
+        agent: "merge-scan@2",
+        adapter: "cursor",
+        input: {
+          repo: "factory",
+          loop: "merge-factory",
+          repoPin: { github: "watt-mind/factory" },
+        },
+      },
     },
     lifecycle: [
-      { seq: 1, from_state: null, to_state: "QUEUED", actor: "schedule", reason: null, attempt: null, at: "2026-08-17T18:45:00.445Z" },
-      { seq: 2, from_state: "QUEUED", to_state: "COMPLETED", actor: "worker_a", reason: "ok", attempt: 1, at: "2026-08-17T19:06:02.939Z" },
+      {
+        seq: 1,
+        from_state: null,
+        to_state: "QUEUED",
+        actor: "schedule",
+        reason: null,
+        attempt: null,
+        at: "2026-08-17T18:45:00.445Z",
+      },
+      {
+        seq: 2,
+        from_state: "QUEUED",
+        to_state: "COMPLETED",
+        actor: "worker_a",
+        reason: "ok",
+        attempt: 1,
+        at: "2026-08-17T19:06:02.939Z",
+      },
     ],
     result: {
       terminalState: "completed",
@@ -261,7 +372,16 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
         repo: "factory",
         github: "watt-mind/factory",
         base: "develop",
-        plan: [{ pr: 529, headSha: "69b0d96d58a5ab7fc0294e069ff78246ccd5e559", ticket: "WM-613", action: "merge_pr", checksGreen: true, mergeable: true }],
+        plan: [
+          {
+            pr: 529,
+            headSha: "69b0d96d58a5ab7fc0294e069ff78246ccd5e559",
+            ticket: "WM-613",
+            action: "merge_pr",
+            checksGreen: true,
+            mergeable: true,
+          },
+        ],
         fix: [
           {
             pr: 541,
@@ -273,10 +393,20 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
             mechanical: true,
           },
         ],
-        escalate: [{ pr: 479, headSha: "1062773ce3dd37dab9e9fc83e84b1e00c2a90574", ticket: "WM-470", reason: "CONFLICTING against develop." }],
+        escalate: [
+          {
+            pr: 479,
+            headSha: "1062773ce3dd37dab9e9fc83e84b1e00c2a90574",
+            ticket: "WM-470",
+            reason: "CONFLICTING against develop.",
+          },
+        ],
       },
     },
-    usage: { totals: { attempts: 1, totalTokens: 5000, costUSD: 1.5 }, attempts: [{}] },
+    usage: {
+      totals: { attempts: 1, totalTokens: 5000, costUSD: 1.5 },
+      attempts: [{}],
+    },
   };
   const fix: JourneyRun = {
     run: {
@@ -288,16 +418,55 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
       spec: {
         agent: "merge-fix@1",
         adapter: "cursor",
-        input: { repo: "factory", github: "watt-mind/factory", pr: 541, headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", headRef: "feat/WM-627", ticket: "WM-627", round: 1 },
+        input: {
+          repo: "factory",
+          github: "watt-mind/factory",
+          pr: 541,
+          headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+          headRef: "feat/WM-627",
+          ticket: "WM-627",
+          round: 1,
+        },
       },
     },
     lifecycle: [
-      { seq: 1, from_state: null, to_state: "QUEUED", actor: "chain-auto-approval", reason: "auto_approved:chain-policy@1", attempt: null, at: "2026-08-17T19:06:04.284Z" },
-      { seq: 2, from_state: "QUEUED", to_state: "RUNNING", actor: "worker_b", reason: "started", attempt: 1, at: "2026-08-17T19:06:05.105Z" },
-      { seq: 3, from_state: "RUNNING", to_state: "REFUSED", actor: "worker_b", reason: "merge_fix_pr_moved", attempt: 1, at: "2026-08-17T19:06:05.657Z" },
+      {
+        seq: 1,
+        from_state: null,
+        to_state: "QUEUED",
+        actor: "chain-auto-approval",
+        reason: "auto_approved:chain-policy@1",
+        attempt: null,
+        at: "2026-08-17T19:06:04.284Z",
+      },
+      {
+        seq: 2,
+        from_state: "QUEUED",
+        to_state: "RUNNING",
+        actor: "worker_b",
+        reason: "started",
+        attempt: 1,
+        at: "2026-08-17T19:06:05.105Z",
+      },
+      {
+        seq: 3,
+        from_state: "RUNNING",
+        to_state: "REFUSED",
+        actor: "worker_b",
+        reason: "merge_fix_pr_moved",
+        attempt: 1,
+        at: "2026-08-17T19:06:05.657Z",
+      },
     ],
-    result: { terminalState: "refused", reasonCode: "merge_fix_pr_moved", artifacts: [] },
-    usage: { totals: { attempts: 1, totalTokens: 0, costUSD: 0 }, attempts: [{}] },
+    result: {
+      terminalState: "refused",
+      reasonCode: "merge_fix_pr_moved",
+      artifacts: [],
+    },
+    usage: {
+      totals: { attempts: 1, totalTokens: 0, costUSD: 0 },
+      attempts: [{}],
+    },
   };
   const dispatch: JourneyRun = {
     run: {
@@ -306,17 +475,48 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
       attempts: 1,
       created_at: "2026-08-17T18:27:40.824Z",
       updated_at: "2026-08-17T19:05:41.000Z",
-      spec: { agent: "dispatch@1", adapter: "pi", input: { repo: "factory", ticket: "WM-627" } },
+      spec: {
+        agent: "dispatch@1",
+        adapter: "pi",
+        input: { repo: "factory", ticket: "WM-627" },
+      },
     },
     lifecycle: [
-      { seq: 1, from_state: null, to_state: "QUEUED", actor: "operator", reason: "approved", attempt: null, at: "2026-08-17T18:27:40.824Z" },
-      { seq: 2, from_state: "QUEUED", to_state: "COMPLETED", actor: "worker_c", reason: "ok", attempt: 1, at: "2026-08-17T19:05:41.000Z" },
+      {
+        seq: 1,
+        from_state: null,
+        to_state: "QUEUED",
+        actor: "operator",
+        reason: "approved",
+        attempt: null,
+        at: "2026-08-17T18:27:40.824Z",
+      },
+      {
+        seq: 2,
+        from_state: "QUEUED",
+        to_state: "COMPLETED",
+        actor: "worker_c",
+        reason: "ok",
+        attempt: 1,
+        at: "2026-08-17T19:05:41.000Z",
+      },
     ],
     result: {
       terminalState: "completed",
-      artifact: { outcome: "PR_OPEN", ticket: "WM-627", repo: "factory", prNumber: 541, prUrl: "https://github.com/watt-mind/factory/pull/541", headSha: "7b2b6957c0ffee0000000000000000000000dead", summary: "pushed" },
+      artifact: {
+        outcome: "PR_OPEN",
+        ticket: "WM-627",
+        repo: "factory",
+        prNumber: 541,
+        prUrl: "https://github.com/watt-mind/factory/pull/541",
+        headSha: "7b2b6957c0ffee0000000000000000000000dead",
+        summary: "pushed",
+      },
     },
-    usage: { totals: { attempts: 1, totalTokens: 100, costUSD: 0.5 }, attempts: [{}] },
+    usage: {
+      totals: { attempts: 1, totalTokens: 100, costUSD: 0.5 },
+      attempts: [{}],
+    },
   };
   const events: JourneyEvent[] = [
     {
@@ -331,21 +531,61 @@ function prFixture(): { source: SubjectJourneySource; scan: JourneyRun; fix: Jou
       runId: "run_fix",
       correlationId: "clock:merge-factory:2026-08-17T18:45:00.000Z",
       envelope: {
-        payload: { repo: "factory", github: "watt-mind/factory", pr: 541, headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", headRef: "feat/WM-627", ticket: "WM-627", round: 1, finding: "Fix the failing owned worktree test." },
+        payload: {
+          repo: "factory",
+          github: "watt-mind/factory",
+          pr: 541,
+          headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+          headRef: "feat/WM-627",
+          ticket: "WM-627",
+          round: 1,
+          finding: "Fix the failing owned worktree test.",
+        },
       },
     },
   ];
   const source: SubjectJourneySource = {
-    subject: { kind: "pr", id: "541", title: null, state: null, createdAt: null, url: "#/prs/541" },
+    subject: {
+      kind: "pr",
+      id: "541",
+      title: null,
+      state: null,
+      createdAt: null,
+      url: "#/prs/541",
+    },
     activity: true,
     events,
     proposals: [
-      { id: "prop_fix", decision: "run", status: "approved", reason: null, created_at: "2026-08-17T19:06:04.284Z", decided_at: "2026-08-17T19:06:04.284Z", runId: "run_fix", eventId: "chain-run_scan-fix-541", eventSource: "chain", agent: "merge-fix@1", spec: null },
+      {
+        id: "prop_fix",
+        decision: "run",
+        status: "approved",
+        reason: null,
+        created_at: "2026-08-17T19:06:04.284Z",
+        decided_at: "2026-08-17T19:06:04.284Z",
+        runId: "run_fix",
+        eventId: "chain-run_scan-fix-541",
+        eventSource: "chain",
+        agent: "merge-fix@1",
+        spec: null,
+      },
     ],
     runs: [dispatch, scan, fix],
     schedules: [
-      { loop: "merge-factory", repo: "factory", eventType: "factory.merge.requested", nextDue: "2026-08-17T19:30:00.000Z", enabled: true },
-      { loop: "merge-bj29", repo: "bj29", eventType: "factory.merge.requested", nextDue: "2026-08-17T19:15:00.000Z", enabled: true },
+      {
+        loop: "merge-factory",
+        repo: "factory",
+        eventType: "factory.merge.requested",
+        nextDue: "2026-08-17T19:30:00.000Z",
+        enabled: true,
+      },
+      {
+        loop: "merge-bj29",
+        repo: "bj29",
+        eventType: "factory.merge.requested",
+        nextDue: "2026-08-17T19:15:00.000Z",
+        enabled: true,
+      },
     ],
   };
   return { source, scan, fix, dispatch };
@@ -356,25 +596,53 @@ describe("subjectJourney(pr)", () => {
     const { source } = prFixture();
     const journey = subjectJourney("pr", "541", source);
     const labels = journey.timeline.map((item) => item.label);
-    const at = (needle: string) => labels.findIndex((label) => label.includes(needle));
-    expect(journey.pr).toMatchObject({ number: 541, github: "watt-mind/factory", ticket: "WM-627", headRef: "feat/WM-627", url: "https://github.com/watt-mind/factory/pull/541" });
+    const at = (needle: string) =>
+      labels.findIndex((label) => label.includes(needle));
+    expect(journey.pr).toMatchObject({
+      number: 541,
+      github: "watt-mind/factory",
+      ticket: "WM-627",
+      headRef: "feat/WM-627",
+      url: "https://github.com/watt-mind/factory/pull/541",
+    });
     expect(journey.subject.title).toBe("feat/WM-627");
     // scan run row → ↔ push (inside the scan window) → scan verdict at 6dbaab4 → fix requested → fix run → refusal
     expect(at("run_scan · COMPLETED")).toBeGreaterThanOrEqual(0);
-    expect(at("↔ WM-627 dispatch pushed 7b2b695 (run_dispatch)")).toBeGreaterThan(at("run_scan · COMPLETED"));
-    expect(at("merge-scan: FIX · reviewed at 6dbaab4 · round 1")).toBeGreaterThan(at("↔ WM-627 dispatch pushed 7b2b695"));
-    expect(at("merge-fix requested · at 6dbaab4")).toBeGreaterThan(at("merge-scan: FIX"));
-    expect(at("merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)")).toBeGreaterThan(at("run_fix · REFUSED"));
+    expect(
+      at("↔ WM-627 dispatch pushed 7b2b695 (run_dispatch)"),
+    ).toBeGreaterThan(at("run_scan · COMPLETED"));
+    expect(
+      at("merge-scan: FIX · reviewed at 6dbaab4 · round 1"),
+    ).toBeGreaterThan(at("↔ WM-627 dispatch pushed 7b2b695"));
+    expect(at("merge-fix requested · at 6dbaab4")).toBeGreaterThan(
+      at("merge-scan: FIX"),
+    );
+    expect(
+      at(
+        "merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)",
+      ),
+    ).toBeGreaterThan(at("run_fix · REFUSED"));
     // The push happened during the fix window too? No — it finished before the fix started; only the scan gets the ↔ row.
     expect(labels.filter((label) => label.startsWith("↔")).length).toBe(1);
-    const concurrent = journey.timeline.find((item) => item.kind === "concurrent");
+    const concurrent = journey.timeline.find(
+      (item) => item.kind === "concurrent",
+    );
     expect(concurrent?.href).toBe("#/run/run_dispatch");
     expect(concurrent?.detail).toContain("merge-scan run_scan");
     // The refusal is the last run activity → it is the blocking reason, and the schedule tells when the loop comes back.
-    expect(journey.blockingReason).toBe("PR head moved since the scan (merge_fix_pr_moved)");
-    expect(journey.nextVisit).toEqual({ loop: "merge-factory", at: "2026-08-17T19:30:00.000Z" });
-    expect(labels.at(-1)).toMatch(/^next: merge-factory · re-examines at \d\d:\d\d \(/);
-    expect(journey.nextAction).toContain("Waiting: PR head moved since the scan");
+    expect(journey.blockingReason).toBe(
+      "PR head moved since the scan (merge_fix_pr_moved)",
+    );
+    expect(journey.nextVisit).toEqual({
+      loop: "merge-factory",
+      at: "2026-08-17T19:30:00.000Z",
+    });
+    expect(labels.at(-1)).toMatch(
+      /^next: merge-factory · re-examines at \d\d:\d\d \(/,
+    );
+    expect(journey.nextAction).toContain(
+      "Waiting: PR head moved since the scan",
+    );
     expect(journey.nextAction).toContain("merge-factory revisits at");
     // PR opened row links out to GitHub on a PR journey.
     const opened = journey.timeline.find((item) => item.id.startsWith("pr:"));
@@ -389,12 +657,18 @@ describe("subjectJourney(pr)", () => {
     const { source, dispatch } = prFixture();
     dispatch.run.state = "FAILED";
     dispatch.run.updated_at = "2026-08-17T19:10:30.000Z";
-    dispatch.lifecycle[1] = { ...dispatch.lifecycle[1], to_state: "FAILED", at: "2026-08-17T19:10:30.000Z" };
+    dispatch.lifecycle[1] = {
+      ...dispatch.lifecycle[1],
+      to_state: "FAILED",
+      at: "2026-08-17T19:10:30.000Z",
+    };
     dispatch.result = null;
     source.runs = source.runs.filter((run) => run !== dispatch);
     source.contextRuns = [dispatch];
     const journey = subjectJourney("pr", "541", source);
-    const concurrent = journey.timeline.filter((item) => item.kind === "concurrent");
+    const concurrent = journey.timeline.filter(
+      (item) => item.kind === "concurrent",
+    );
     expect(concurrent.map((item) => item.label)).toEqual([
       "↔ WM-627 dispatch run_dispatch was active during merge-scan",
       "↔ WM-627 dispatch run_dispatch was active during merge-fix",
@@ -402,8 +676,12 @@ describe("subjectJourney(pr)", () => {
     expect(concurrent[1].detail).toContain("failed");
     const labels = journey.timeline.map((item) => item.label);
     // The fix-window row sits between the fix run row and its refusal.
-    expect(labels.indexOf(concurrent[1].label)).toBeGreaterThan(labels.indexOf("run_fix · REFUSED"));
-    expect(labels.indexOf(concurrent[1].label)).toBeLessThan(labels.findIndex((label) => label.startsWith("merge-fix refused")));
+    expect(labels.indexOf(concurrent[1].label)).toBeGreaterThan(
+      labels.indexOf("run_fix · REFUSED"),
+    );
+    expect(labels.indexOf(concurrent[1].label)).toBeLessThan(
+      labels.findIndex((label) => label.startsWith("merge-fix refused")),
+    );
     // Context runs are evidence, not the subject's own work.
     expect(journey.runCount).toBe(2);
     expect(journey.totalCost).toBeCloseTo(1.5);
@@ -413,8 +691,23 @@ describe("subjectJourney(pr)", () => {
     const { source, dispatch, scan, fix } = prFixture();
     const other: JourneyRun = {
       ...dispatch,
-      run: { ...dispatch.run, runId: "run_other", spec: { agent: "dispatch@1", adapter: "pi", input: { repo: "factory", ticket: "WM-999" } } },
-      result: { terminalState: "completed", artifact: { outcome: "PR_OPEN", prUrl: "https://github.com/watt-mind/factory/pull/5410", summary: "mentions #541 in prose only" } },
+      run: {
+        ...dispatch.run,
+        runId: "run_other",
+        spec: {
+          agent: "dispatch@1",
+          adapter: "pi",
+          input: { repo: "factory", ticket: "WM-999" },
+        },
+      },
+      result: {
+        terminalState: "completed",
+        artifact: {
+          outcome: "PR_OPEN",
+          prUrl: "https://github.com/watt-mind/factory/pull/5410",
+          summary: "mentions #541 in prose only",
+        },
+      },
     };
     const failedRetry: JourneyRun = {
       ...dispatch,
@@ -426,16 +719,36 @@ describe("subjectJourney(pr)", () => {
       proposals: source.proposals,
       runs: [other, dispatch, scan, fix, failedRetry],
       inbox: [
-        { id: "inbox_1", kind: "CI RED", title: "CI RED PR #541", createdAt: "2026-08-17T19:20:00.000Z", refs: { pr: "PR#541", issue: "WM-627" } },
-        { id: "inbox_2", kind: "CI RED", title: "other", createdAt: "2026-08-17T19:20:00.000Z", refs: { pr: "PR#5410" } },
+        {
+          id: "inbox_1",
+          kind: "CI RED",
+          title: "CI RED PR #541",
+          createdAt: "2026-08-17T19:20:00.000Z",
+          refs: { pr: "PR#541", issue: "WM-627" },
+        },
+        {
+          id: "inbox_2",
+          kind: "CI RED",
+          title: "other",
+          createdAt: "2026-08-17T19:20:00.000Z",
+          refs: { pr: "PR#5410" },
+        },
       ],
     });
-    expect(selected.runs.map((run) => run.run.runId)).toEqual(["run_dispatch", "run_scan", "run_fix"]);
-    expect(selected.contextRuns?.map((run) => run.run.runId)).toEqual(["run_retry"]);
+    expect(selected.runs.map((run) => run.run.runId)).toEqual([
+      "run_dispatch",
+      "run_scan",
+      "run_fix",
+    ]);
+    expect(selected.contextRuns?.map((run) => run.run.runId)).toEqual([
+      "run_retry",
+    ]);
     expect(selected.inbox?.map((item) => item.id)).toEqual(["inbox_1"]);
     expect(selected.subject).toMatchObject({ kind: "pr", id: "541" });
     const journey = subjectJourney("pr", "541", selected);
-    expect(journey.timeline.map((item) => item.label)).toContain("CI RED: CI RED PR #541");
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "CI RED: CI RED PR #541",
+    );
   });
 
   test("a merged PR reads as merged and asks for nothing", () => {
@@ -450,13 +763,25 @@ describe("subjectJourney(pr)", () => {
       admittedAt: "2026-08-17T19:40:00.000Z",
       proposalId: null,
       runId: null,
-      envelope: { payload: { github: "watt-mind/factory", pr: 541, ticket: "WM-627", headSha: "7b2b6957c0ffee0000000000000000000000dead", mergeCommitSha: "d657c9ed47d27cfe45e65ec768616608ae85579d" } },
+      envelope: {
+        payload: {
+          github: "watt-mind/factory",
+          pr: 541,
+          ticket: "WM-627",
+          headSha: "7b2b6957c0ffee0000000000000000000000dead",
+          mergeCommitSha: "d657c9ed47d27cfe45e65ec768616608ae85579d",
+        },
+      },
     });
     const journey = subjectJourney("pr", "541", source);
-    expect(journey.timeline.map((item) => item.label)).toContain("merged as d657c9e");
+    expect(journey.timeline.map((item) => item.label)).toContain(
+      "merged as d657c9e",
+    );
     expect(journey.pr?.mergeState).toBe("MERGED");
     expect(journey.nextAction).toBe("Merged — no further action");
-    expect(journey.timeline.some((item) => item.kind === "schedule")).toBe(false);
+    expect(journey.timeline.some((item) => item.kind === "schedule")).toBe(
+      false,
+    );
   });
 });
 
@@ -471,10 +796,32 @@ describe("PR reference helpers", () => {
   });
 
   test("prNumbersIn keys on fields and pull URLs, never prose", () => {
-    expect(prNumbersIn({ payload: { pr: 541, plan: [{ pr: 529 }], prUrl: "https://github.com/o/r/pull/544" } }).sort()).toEqual([529, 541, 544]);
+    expect(
+      prNumbersIn({
+        payload: {
+          pr: 541,
+          plan: [{ pr: 529 }],
+          prUrl: "https://github.com/o/r/pull/544",
+        },
+      }).sort(),
+    ).toEqual([529, 541, 544]);
     expect(prNumbersIn({ refs: { pr: "PR#475" } })).toEqual([475]);
     expect(prNumbersIn({ summary: "PR #541 mentioned in prose" })).toEqual([]);
-    expect(scanVerdictFor({ escalate: [{ pr: 7, headSha: "abc", ticket: "wm-1", reason: "MERGEABLE but UNSTABLE" }] }, 7)).toMatchObject({ bucket: "ESCALATE", ticket: "WM-1" });
+    expect(
+      scanVerdictFor(
+        {
+          escalate: [
+            {
+              pr: 7,
+              headSha: "abc",
+              ticket: "wm-1",
+              reason: "MERGEABLE but UNSTABLE",
+            },
+          ],
+        },
+        7,
+      ),
+    ).toMatchObject({ bucket: "ESCALATE", ticket: "WM-1" });
     expect(scanVerdictFor({ escalate: [] }, 7)).toBeNull();
   });
 });

--- a/event-runtime/web/src/subjectJourney.ts
+++ b/event-runtime/web/src/subjectJourney.ts
@@ -26,29 +26,48 @@ export function parsePrRef(input: string): number | null {
 }
 
 /** Decorate exact ticket string tokens produced by JSON/detail renderers. */
-export function installTicketJourneyLinks(root: HTMLElement, open: (ticket: string) => void): () => void {
+export function installTicketJourneyLinks(
+  root: HTMLElement,
+  open: (ticket: string) => void,
+): () => void {
   const decorate = () => {
     for (const span of root.querySelectorAll<HTMLSpanElement>("span")) {
       if (span.childElementCount > 0 || span.dataset.ticketJourneyId) continue;
-      const ticket = (span.textContent ?? "").trim().replace(/^([\"'])|([\"'])$/g, "").toUpperCase();
+      const ticket = (span.textContent ?? "")
+        .trim()
+        .replace(/^([\"'])|([\"'])$/g, "")
+        .toUpperCase();
       if (!TICKET_ID_PATTERN.test(ticket)) continue;
       span.dataset.ticketJourneyId = ticket;
       span.setAttribute("role", "link");
       span.tabIndex = 0;
       span.setAttribute("aria-label", `Open ticket ${ticket}`);
       span.title = `Open ticket journey for ${ticket}`;
-      span.classList.add("cursor-pointer", "hover:text-(--accent)", "hover:underline");
+      span.classList.add(
+        "cursor-pointer",
+        "hover:text-(--accent)",
+        "hover:underline",
+      );
     }
   };
-  const ticketTarget = (target: EventTarget | null): { element: HTMLElement; ticket: string } | null => {
-    const element = target instanceof Element
-      ? target.closest<HTMLElement>("[data-ticket-journey-id], button")
-      : null;
+  const ticketTarget = (
+    target: EventTarget | null,
+  ): { element: HTMLElement; ticket: string } | null => {
+    const element =
+      target instanceof Element
+        ? target.closest<HTMLElement>("[data-ticket-journey-id], button")
+        : null;
     if (!element) return null;
     const dataTicket = element.dataset.ticketJourneyId;
-    const ticket = (dataTicket ?? element.textContent ?? "").trim().toUpperCase();
-    const exactCopyButton = element.tagName === "BUTTON" && element.title.trim().toUpperCase() === ticket;
-    return (dataTicket || exactCopyButton) && TICKET_ID_PATTERN.test(ticket) ? { element, ticket } : null;
+    const ticket = (dataTicket ?? element.textContent ?? "")
+      .trim()
+      .toUpperCase();
+    const exactCopyButton =
+      element.tagName === "BUTTON" &&
+      element.title.trim().toUpperCase() === ticket;
+    return (dataTicket || exactCopyButton) && TICKET_ID_PATTERN.test(ticket)
+      ? { element, ticket }
+      : null;
   };
   const onClick = (event: MouseEvent) => {
     const target = ticketTarget(event.target);
@@ -227,7 +246,14 @@ export interface TimelineItem {
 export interface SubjectJourney {
   subject: SubjectRef;
   /** For PR journeys: the repo (`owner/name`), ticket, branch and merge state the artifacts recorded. */
-  pr: { number: number; github: string | null; ticket: string | null; headRef: string | null; mergeState: string | null; url: string | null } | null;
+  pr: {
+    number: number;
+    github: string | null;
+    ticket: string | null;
+    headRef: string | null;
+    mergeState: string | null;
+    url: string | null;
+  } | null;
   activity: boolean;
   timeline: TimelineItem[];
   totalCost: number | null;
@@ -268,7 +294,10 @@ function validDate(value: string | null | undefined): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
-function timeOf(value: string | null | undefined, fallback = "1970-01-01T00:00:00.000Z"): string {
+function timeOf(
+  value: string | null | undefined,
+  fallback = "1970-01-01T00:00:00.000Z",
+): string {
   return validDate(value) == null ? fallback : value!;
 }
 
@@ -285,7 +314,10 @@ export function prHref(number: number | string): string {
   return `#/prs/${encodeURIComponent(String(number))}`;
 }
 
-function walk(value: unknown, visit: (key: string, value: unknown) => void): void {
+function walk(
+  value: unknown,
+  visit: (key: string, value: unknown) => void,
+): void {
   if (!value || typeof value !== "object") return;
   if (Array.isArray(value)) {
     for (const entry of value) walk(entry, visit);
@@ -306,7 +338,8 @@ export function ticketIdsIn(value: unknown): string[] {
   };
   if (typeof value === "string") add(value);
   walk(value, (key, entry) => {
-    if (/^(ticket|ticketId|issue|issueId|linearId|subject)$/i.test(key)) add(entry);
+    if (/^(ticket|ticketId|issue|issueId|linearId|subject)$/i.test(key))
+      add(entry);
   });
   return [...ids];
 }
@@ -318,7 +351,10 @@ export function ticketIdsIn(value: unknown): string[] {
 export function prNumbersIn(value: unknown): number[] {
   const numbers = new Set<number>();
   const addNumber = (candidate: unknown) => {
-    const number = typeof candidate === "string" ? Number(candidate.replace(/^PR\s*#?/i, "").trim()) : Number(candidate);
+    const number =
+      typeof candidate === "string"
+        ? Number(candidate.replace(/^PR\s*#?/i, "").trim())
+        : Number(candidate);
     if (Number.isInteger(number) && number > 0) numbers.add(number);
   };
   const inspect = (key: string, entry: unknown) => {
@@ -327,7 +363,9 @@ export function prNumbersIn(value: unknown): number[] {
       else if (typeof entry !== "object" || entry === null) addNumber(entry);
     }
     if (typeof entry === "string") {
-      const url = entry.match(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/);
+      const url = entry.match(
+        /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/,
+      );
       if (url) addNumber(url[1]);
     }
   };
@@ -340,7 +378,10 @@ function prUrlsIn(value: unknown): string[] {
   const urls = new Set<string>();
   const inspect = (entry: unknown) => {
     if (typeof entry !== "string") return;
-    if (/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:$|[/?#])/.test(entry)) urls.add(entry);
+    if (
+      /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:$|[/?#])/.test(entry)
+    )
+      urls.add(entry);
   };
   inspect(value);
   walk(value, (_key, entry) => inspect(entry));
@@ -361,15 +402,21 @@ function nestedValue(value: unknown, keyPattern: RegExp): unknown {
 
 function githubOf(value: unknown): string | null {
   const github = nestedValue(value, /^github$/i);
-  return typeof github === "string" && /^[^/]+\/[^/]+$/.test(github) ? github : null;
+  return typeof github === "string" && /^[^/]+\/[^/]+$/.test(github)
+    ? github
+    : null;
 }
 
 function shortSha(sha: unknown): string | null {
-  return typeof sha === "string" && /^[0-9a-f]{7,40}$/i.test(sha) ? sha.slice(0, 7) : null;
+  return typeof sha === "string" && /^[0-9a-f]{7,40}$/i.test(sha)
+    ? sha.slice(0, 7)
+    : null;
 }
 
 function eventPr(event: JourneyEvent): { number: number; url: string } | null {
-  const number = Number(nestedValue(event.envelope, /^(pr|prNumber|pullRequestNumber)$/i));
+  const number = Number(
+    nestedValue(event.envelope, /^(pr|prNumber|pullRequestNumber)$/i),
+  );
   if (!Number.isInteger(number) || number <= 0) return null;
   const github = githubOf(event.envelope);
   if (!github) return null;
@@ -377,11 +424,15 @@ function eventPr(event: JourneyEvent): { number: number; url: string } | null {
 }
 
 function lifecycleSorted(run: JourneyRun): JourneyLifecycle[] {
-  return [...run.lifecycle].sort((a, b) => a.at.localeCompare(b.at) || a.seq - b.seq);
+  return [...run.lifecycle].sort(
+    (a, b) => a.at.localeCompare(b.at) || a.seq - b.seq,
+  );
 }
 
 function resultAt(run: JourneyRun): string {
-  return lifecycleSorted(run).at(-1)?.at ?? run.run.updated_at ?? run.run.created_at;
+  return (
+    lifecycleSorted(run).at(-1)?.at ?? run.run.updated_at ?? run.run.created_at
+  );
 }
 
 function runWindow(run: JourneyRun): { start: number; end: number } | null {
@@ -401,7 +452,8 @@ export function formatDuration(ms: number | null): string {
   const seconds = Math.round(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
+  if (minutes < 60)
+    return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
   const hours = Math.floor(minutes / 60);
   const rest = minutes % 60;
   return `${hours}h${rest ? ` ${rest}m` : ""}`;
@@ -410,7 +462,11 @@ export function formatDuration(ms: number | null): string {
 function clock(value: string | number): string {
   const ms = typeof value === "number" ? value : validDate(value);
   if (ms == null) return "—";
-  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  return new Date(ms).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
 }
 
 function lifecycleChildren(run: JourneyRun): TimelineItem[] {
@@ -424,16 +480,23 @@ function lifecycleChildren(run: JourneyRun): TimelineItem[] {
       label: entry.to_state,
       detail: `${entry.actor}${entry.reason ? ` · ${entry.reason}` : ""}`,
       href: runHref(run.run.runId),
-      durationMs: previous != null && current != null ? Math.max(0, current - previous) : null,
+      durationMs:
+        previous != null && current != null
+          ? Math.max(0, current - previous)
+          : null,
     };
   });
 }
 
-function proposalFor(event: JourneyEvent, proposals: JourneyProposal[]): JourneyProposal | undefined {
+function proposalFor(
+  event: JourneyEvent,
+  proposals: JourneyProposal[],
+): JourneyProposal | undefined {
   return proposals.find(
     (proposal) =>
       proposal.id === event.proposalId ||
-      (proposal.eventId === event.eventId && proposal.eventSource === event.source),
+      (proposal.eventId === event.eventId &&
+        proposal.eventSource === event.source),
   );
 }
 
@@ -448,16 +511,21 @@ function mergeLabel(run: JourneyRun): string | null {
   return null;
 }
 
-function checkLabel(run: JourneyRun): { label: string; detail: string | null } | null {
+function checkLabel(
+  run: JourneyRun,
+): { label: string; detail: string | null } | null {
   const artifact = run.result?.artifact ?? {};
   let checksGreen: boolean | null = null;
   walk(artifact, (key, value) => {
-    if (/^(checksGreen|ciGreen)$/i.test(key) && typeof value === "boolean") checksGreen = value;
+    if (/^(checksGreen|ciGreen)$/i.test(key) && typeof value === "boolean")
+      checksGreen = value;
   });
   if (checksGreen == null) return null;
   return {
     label: checksGreen ? "CI checks green" : "CI checks red",
-    detail: checksGreen ? "All recorded checks passed" : "One or more recorded checks failed",
+    detail: checksGreen
+      ? "All recorded checks passed"
+      : "One or more recorded checks failed",
   };
 }
 
@@ -483,24 +551,38 @@ export interface ScanVerdict {
   round: number | null;
 }
 
-export function scanVerdictFor(artifact: unknown, pr: number): ScanVerdict | null {
+export function scanVerdictFor(
+  artifact: unknown,
+  pr: number,
+): ScanVerdict | null {
   if (!artifact || typeof artifact !== "object") return null;
   const record = artifact as Record<string, unknown>;
-  const buckets: Array<[ScanVerdict["bucket"], string]> = [["MERGE", "plan"], ["FIX", "fix"], ["ESCALATE", "escalate"]];
+  const buckets: Array<[ScanVerdict["bucket"], string]> = [
+    ["MERGE", "plan"],
+    ["FIX", "fix"],
+    ["ESCALATE", "escalate"],
+  ];
   for (const [bucket, key] of buckets) {
     const list = record[key];
     if (!Array.isArray(list)) continue;
-    const entry = list.find((item) => item && typeof item === "object" && Number((item as any).pr) === pr) as
-      | Record<string, unknown>
-      | undefined;
+    const entry = list.find(
+      (item) =>
+        item && typeof item === "object" && Number((item as any).pr) === pr,
+    ) as Record<string, unknown> | undefined;
     if (!entry) continue;
     return {
       bucket,
       headSha: typeof entry.headSha === "string" ? entry.headSha : null,
       headRef: typeof entry.headRef === "string" ? entry.headRef : null,
-      ticket: typeof entry.ticket === "string" ? entry.ticket.toUpperCase() : null,
+      ticket:
+        typeof entry.ticket === "string" ? entry.ticket.toUpperCase() : null,
       mergeable: typeof entry.mergeable === "boolean" ? entry.mergeable : null,
-      reason: typeof entry.reason === "string" ? entry.reason : typeof entry.finding === "string" ? entry.finding : null,
+      reason:
+        typeof entry.reason === "string"
+          ? entry.reason
+          : typeof entry.finding === "string"
+            ? entry.finding
+            : null,
       round: typeof entry.round === "number" ? entry.round : null,
     };
   }
@@ -509,7 +591,9 @@ export function scanVerdictFor(artifact: unknown, pr: number): ScanVerdict | nul
 
 /** GitHub's own vocabulary when a scan artifact quotes it; `mergeable` when it only recorded the boolean. */
 function mergeStateOf(verdict: ScanVerdict): string | null {
-  const quoted = verdict.reason?.match(/\b(CONFLICTING|MERGEABLE|UNSTABLE|DIRTY|BLOCKED|BEHIND|CLEAN|DRAFT)\b/);
+  const quoted = verdict.reason?.match(
+    /\b(CONFLICTING|MERGEABLE|UNSTABLE|DIRTY|BLOCKED|BEHIND|CLEAN|DRAFT)\b/,
+  );
   if (quoted) return quoted[1];
   if (verdict.mergeable === true) return "MERGEABLE";
   if (verdict.mergeable === false) return "NOT MERGEABLE";
@@ -517,11 +601,19 @@ function mergeStateOf(verdict: ScanVerdict): string | null {
 }
 
 /** A refused or failed run, with the code the runtime recorded for it. */
-function refusalOf(run: JourneyRun): { verb: "refused" | "failed"; code: string; at: string } | null {
+function refusalOf(
+  run: JourneyRun,
+): { verb: "refused" | "failed"; code: string; at: string } | null {
   const terminal = String(run.result?.terminalState ?? "");
-  const verb = run.run.state === "REFUSED" || /refused/i.test(terminal) ? "refused" : run.run.state === "FAILED" || /failed/i.test(terminal) ? "failed" : null;
+  const verb =
+    run.run.state === "REFUSED" || /refused/i.test(terminal)
+      ? "refused"
+      : run.run.state === "FAILED" || /failed/i.test(terminal)
+        ? "failed"
+        : null;
   if (!verb) return null;
-  const code: string | null = run.result?.reasonCode ?? lifecycleSorted(run).at(-1)?.reason ?? null;
+  const code: string | null =
+    run.result?.reasonCode ?? lifecycleSorted(run).at(-1)?.reason ?? null;
   return { verb, code: code ?? verb, at: resultAt(run) };
 }
 
@@ -543,13 +635,20 @@ function prEntryIn(value: unknown, pr: number): Record<string, unknown> | null {
   };
   visit(value);
   if (found) return found;
-  return prNumbersIn(value).includes(pr) && value && typeof value === "object" && !Array.isArray(value)
+  return prNumbersIn(value).includes(pr) &&
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
 }
 
 function ticketOfRun(run: JourneyRun): string | null {
-  return ticketIdsIn(run.run.spec.input)[0] ?? ticketIdsIn(run.result?.artifact)[0] ?? null;
+  return (
+    ticketIdsIn(run.run.spec.input)[0] ??
+    ticketIdsIn(run.result?.artifact)[0] ??
+    null
+  );
 }
 
 function repoOfSource(source: SubjectJourneySource): string | null {
@@ -571,25 +670,43 @@ function repoOfSource(source: SubjectJourneySource): string | null {
  * `headSha`) — no new recording. Rendered muted with a `↔` prefix so the
  * refusal they explain reads directly under them.
  */
-function concurrentRows(source: SubjectJourneySource, prOfSubject: number | null, subjectTicket: string | null): TimelineItem[] {
+function concurrentRows(
+  source: SubjectJourneySource,
+  prOfSubject: number | null,
+  subjectTicket: string | null,
+): TimelineItem[] {
   const rows: TimelineItem[] = [];
   const windows = source.runs
-    .filter((run) => RUN_FAMILY.scan.test(run.run.spec.agent) || RUN_FAMILY.fix.test(run.run.spec.agent))
+    .filter(
+      (run) =>
+        RUN_FAMILY.scan.test(run.run.spec.agent) ||
+        RUN_FAMILY.fix.test(run.run.spec.agent),
+    )
     .map((run) => ({ run, window: runWindow(run) }))
-    .filter((entry): entry is { run: JourneyRun; window: { start: number; end: number } } => entry.window != null);
+    .filter(
+      (
+        entry,
+      ): entry is { run: JourneyRun; window: { start: number; end: number } } =>
+        entry.window != null,
+    );
   if (!windows.length) return rows;
   const seen = new Set<string>();
-  const others = [...source.runs, ...(source.contextRuns ?? [])].filter((run) => {
-    if (seen.has(run.run.runId) || RUN_FAMILY.merge.test(run.run.spec.agent)) return false;
-    seen.add(run.run.runId);
-    // Only chains that touched *this* subject: the subject's own ticket, or a
-    // run whose result names the PR. The server-side ticket join can carry
-    // neighbours (other tickets' dispatches sharing a scan) — they are not
-    // concurrent activity on this subject.
-    const ticket = ticketOfRun(run);
-    if (subjectTicket && ticket === subjectTicket) return true;
-    return prOfSubject != null && prNumbersIn(run.result).includes(prOfSubject);
-  });
+  const others = [...source.runs, ...(source.contextRuns ?? [])].filter(
+    (run) => {
+      if (seen.has(run.run.runId) || RUN_FAMILY.merge.test(run.run.spec.agent))
+        return false;
+      seen.add(run.run.runId);
+      // Only chains that touched *this* subject: the subject's own ticket, or a
+      // run whose result names the PR. The server-side ticket join can carry
+      // neighbours (other tickets' dispatches sharing a scan) — they are not
+      // concurrent activity on this subject.
+      const ticket = ticketOfRun(run);
+      if (subjectTicket && ticket === subjectTicket) return true;
+      return (
+        prOfSubject != null && prNumbersIn(run.result).includes(prOfSubject)
+      );
+    },
+  );
   for (const { run: windowRun, window } of windows) {
     for (const other of others) {
       const span = runWindow(other);
@@ -597,10 +714,17 @@ function concurrentRows(source: SubjectJourneySource, prOfSubject: number | null
       const artifact = other.result?.artifact ?? null;
       const ticket = ticketOfRun(other);
       const who = `${ticket ? `${ticket} ` : ""}${agentShort(other.run.spec.agent)}`;
-      const pushed = shortSha(nestedValue(artifact, /^(headSha|pushedSha|commitSha)$/i));
-      const openedUrl = prUrlsIn(artifact).find((url) => prOfSubject == null || Number(prNumber(url)) === prOfSubject);
+      const pushed = shortSha(
+        nestedValue(artifact, /^(headSha|pushedSha|commitSha)$/i),
+      );
+      const openedUrl = prUrlsIn(artifact).find(
+        (url) => prOfSubject == null || Number(prNumber(url)) === prOfSubject,
+      );
       const finishedAt = validDate(resultAt(other));
-      const insideWindow = finishedAt != null && finishedAt >= window.start && finishedAt <= window.end;
+      const insideWindow =
+        finishedAt != null &&
+        finishedAt >= window.start &&
+        finishedAt <= window.end;
       let at: number;
       let label: string;
       let detail: string;
@@ -635,16 +759,25 @@ function concurrentRows(source: SubjectJourneySource, prOfSubject: number | null
 }
 
 /** Pure chronological join used by the views and fixture tests. */
-export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJourneySource): SubjectJourney {
+export function subjectJourney(
+  kind: SubjectKind,
+  id: string,
+  source: SubjectJourneySource,
+): SubjectJourney {
   const subject: SubjectRef = { ...source.subject, kind, id };
   const prOfSubject = kind === "pr" ? Number(id) : null;
   const timeline: TimelineItem[] = [];
-  const resultPrUrls = new Set(source.runs.flatMap((run) => prUrlsIn(run.result)));
+  const resultPrUrls = new Set(
+    source.runs.flatMap((run) => prUrlsIn(run.result)),
+  );
   const prUrls = new Set(resultPrUrls);
   const renderedPrUrls = new Set<string>();
   const allActivityTimes = [
     ...source.events.flatMap((event) => [event.occurredAt, event.admittedAt]),
-    ...source.proposals.flatMap((proposal) => [proposal.created_at, proposal.decided_at ?? ""]),
+    ...source.proposals.flatMap((proposal) => [
+      proposal.created_at,
+      proposal.decided_at ?? "",
+    ]),
     ...source.runs.flatMap((run) => [run.run.created_at, run.run.updated_at]),
   ].filter((value) => validDate(value) != null);
   const earliest = [...allActivityTimes].sort()[0] ?? null;
@@ -670,24 +803,36 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
 
   for (const event of source.events) {
     const proposal = proposalFor(event, source.proposals);
-    const decision = proposal?.decision ?? (event.status === "planned" ? "planned" : event.status);
+    const decision =
+      proposal?.decision ??
+      (event.status === "planned" ? "planned" : event.status);
     const reason = reasonText(proposal?.reason);
     const dispatch = /dispatch/i.test(event.type);
-    const agentReady = /agent[-_. ]?ready/i.test(event.type) || /agent[-_. ]?ready/i.test(JSON.stringify(event.envelope));
+    const agentReady =
+      /agent[-_. ]?ready/i.test(event.type) ||
+      /agent[-_. ]?ready/i.test(JSON.stringify(event.envelope));
     const at = timeOf(event.occurredAt, event.admittedAt);
     const eventPrRef = eventPr(event);
-    const prEntry = kind === "pr" ? prEntryIn(event.envelope, prOfSubject!) : null;
-    const eventHead = shortSha(prEntry ? prEntry.headSha : nestedValue(event.envelope, /^headSha$/i));
+    const prEntry =
+      kind === "pr" ? prEntryIn(event.envelope, prOfSubject!) : null;
+    const eventHead = shortSha(
+      prEntry ? prEntry.headSha : nestedValue(event.envelope, /^headSha$/i),
+    );
     if (prEntry) {
       prGithub ??= githubOf(event.envelope);
-      prTicket ??= ticketIdsIn(prEntry)[0] ?? ticketIdsIn(nestedValue(event.envelope, /^payload$/i))[0] ?? null;
+      prTicket ??=
+        ticketIdsIn(prEntry)[0] ??
+        ticketIdsIn(nestedValue(event.envelope, /^payload$/i))[0] ??
+        null;
       if (typeof prEntry.headRef === "string") prHeadRef ??= prEntry.headRef;
     }
     const typeLabel = agentReady
       ? "agent-ready"
       : dispatch
         ? "dispatch requested"
-        : event.type.replace(/^factory\./, "").replace(/\.requested$/, " requested");
+        : event.type
+            .replace(/^factory\./, "")
+            .replace(/\.requested$/, " requested");
     const prSuffix =
       kind === "pr" && prEntry && eventHead
         ? ` · at ${eventHead}`
@@ -699,13 +844,17 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
       kind: proposal ? "decision" : "event",
       at,
       label: `${typeLabel}${prSuffix}`,
-      detail: proposal ? `${decision}${reason ? ` · ${reason}` : ""}` : event.status,
+      detail: proposal
+        ? `${decision}${reason ? ` · ${reason}` : ""}`
+        : event.status,
       href: eventHref(event),
       durationMs: null,
     });
 
     if (eventPrRef) {
-      const knownUrl = [...resultPrUrls].find((url) => prNumber(url) === String(eventPrRef.number));
+      const knownUrl = [...resultPrUrls].find(
+        (url) => prNumber(url) === String(eventPrRef.number),
+      );
       const url = knownUrl ?? eventPrRef.url;
       prUrls.add(url);
       if (kind === "ticket" && !knownUrl && !renderedPrUrls.has(url)) {
@@ -724,7 +873,10 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     // On a PR journey the scan artifact already carries the CI verdict and the
     // merge decision for this PR; repeating them from the request event that
     // copies the plan would double every row.
-    const checksGreen = kind === "pr" ? null : nestedValue(event.envelope, /^(checksGreen|ciGreen)$/i);
+    const checksGreen =
+      kind === "pr"
+        ? null
+        : nestedValue(event.envelope, /^(checksGreen|ciGreen)$/i);
     if (typeof checksGreen === "boolean") {
       timeline.push({
         id: `ci:event:${event.source}:${event.eventId}`,
@@ -740,14 +892,27 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     const landed = /merge-landed/i.test(event.type);
     // Only decisions to merge are merge rows; scan ticks, fix and escalate
     // requests already have their own event row.
-    if (landed || (kind === "ticket" && (/merge-apply/i.test(event.type) || (typeof action === "string" && /merge/i.test(action))))) {
-      const mergeSha = shortSha(nestedValue(event.envelope, /^mergeCommitSha$/i));
+    if (
+      landed ||
+      (kind === "ticket" &&
+        (/merge-apply/i.test(event.type) ||
+          (typeof action === "string" && /merge/i.test(action))))
+    ) {
+      const mergeSha = shortSha(
+        nestedValue(event.envelope, /^mergeCommitSha$/i),
+      );
       timeline.push({
         id: `merge:event:${event.source}:${event.eventId}`,
         kind: "merge",
         at,
-        label: landed ? `merged${mergeSha ? ` as ${mergeSha}` : ""}` : action === "merge_pr" ? "merge requested" : "merge decision",
-        detail: (nestedValue(event.envelope, /^reason$/i) as string | undefined) ?? null,
+        label: landed
+          ? `merged${mergeSha ? ` as ${mergeSha}` : ""}`
+          : action === "merge_pr"
+            ? "merge requested"
+            : "merge decision",
+        detail:
+          (nestedValue(event.envelope, /^reason$/i) as string | undefined) ??
+          null,
         href: eventHref(event),
         durationMs: null,
       });
@@ -763,7 +928,11 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
   for (const run of source.runs) {
     const totals = run.usage?.totals;
     const attempts = totals?.attempts ?? run.usage?.attempts?.length ?? 0;
-    if (attempts > 0 || (totals?.costUSD ?? 0) > 0 || (totals?.totalTokens ?? 0) > 0) {
+    if (
+      attempts > 0 ||
+      (totals?.costUSD ?? 0) > 0 ||
+      (totals?.totalTokens ?? 0) > 0
+    ) {
       usageKnown = true;
       totalCost += Number(totals?.costUSD ?? 0);
       totalTokens += Number(totals?.totalTokens ?? 0);
@@ -776,7 +945,9 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
       model,
       formatDuration(duration),
       attempts > 0 ? `$${Number(totals?.costUSD ?? 0).toFixed(2)}` : "—",
-    ].filter(Boolean).join(" · ");
+    ]
+      .filter(Boolean)
+      .join(" · ");
     timeline.push({
       id: `run:${run.run.runId}`,
       kind: "run",
@@ -811,13 +982,22 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
         kind: "pr",
         at: resultAt(run),
         label: `PR #${prNumber(url)} opened`,
-        detail: kind === "pr" ? `by ${ticketOfRun(run) ?? agentShort(run.run.spec.agent)} · ${run.run.runId}` : null,
+        detail:
+          kind === "pr"
+            ? `by ${ticketOfRun(run) ?? agentShort(run.run.spec.agent)} · ${run.run.runId}`
+            : null,
         href: kind === "pr" ? url : prHref(number),
         external: kind === "pr",
         durationMs: null,
       });
     }
-    const ci = kind === "pr" ? checkLabel({ ...run, result: { artifact: prEntryIn(artifact, prOfSubject!) ?? {} } }) : checkLabel(run);
+    const ci =
+      kind === "pr"
+        ? checkLabel({
+            ...run,
+            result: { artifact: prEntryIn(artifact, prOfSubject!) ?? {} },
+          })
+        : checkLabel(run);
     if (ci) {
       timeline.push({
         id: `ci:${run.run.runId}`,
@@ -829,7 +1009,10 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
         durationMs: null,
       });
     }
-    const verdict = kind === "pr" && RUN_FAMILY.scan.test(run.run.spec.agent) ? scanVerdictFor(artifact, prOfSubject!) : null;
+    const verdict =
+      kind === "pr" && RUN_FAMILY.scan.test(run.run.spec.agent)
+        ? scanVerdictFor(artifact, prOfSubject!)
+        : null;
     if (verdict) {
       const head = shortSha(verdict.headSha);
       prTicket ??= verdict.ticket;
@@ -862,7 +1045,11 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
           durationMs: null,
         });
       }
-    } else if (RUN_FAMILY.apply.test(run.run.spec.agent) && artifact && /merge_pr/.test(JSON.stringify(artifact))) {
+    } else if (
+      RUN_FAMILY.apply.test(run.run.spec.agent) &&
+      artifact &&
+      /merge_pr/.test(JSON.stringify(artifact))
+    ) {
       timeline.push({
         id: `merge:${run.run.runId}`,
         kind: "merge",
@@ -875,20 +1062,28 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     }
     const refusal = refusalOf(run);
     if (refusal) {
-      const reason = (humanizeWithCode(refusal.code) ?? refusal.code).replace(/\s+/g, " ");
+      const reason = (humanizeWithCode(refusal.code) ?? refusal.code).replace(
+        /\s+/g,
+        " ",
+      );
       timeline.push({
         id: `refusal:${run.run.runId}`,
         kind: "decision",
         at: refusal.at,
         label: `${agentShort(run.run.spec.agent)} ${refusal.verb} · ${reason.length > 160 ? `${reason.slice(0, 159)}…` : reason}`,
-        detail: reason.length > 160 ? `${run.run.runId} · ${reason}` : run.run.runId,
+        detail:
+          reason.length > 160 ? `${run.run.runId} · ${reason}` : run.run.runId,
         href: runHref(run.run.runId),
         durationMs: null,
       });
     }
     if (activeStates.has(run.run.state)) {
       const last = lifecycleSorted(run).at(-1);
-      currentRun = { runId: run.run.runId, state: run.run.state, actor: last?.actor ?? null };
+      currentRun = {
+        runId: run.run.runId,
+        state: run.run.state,
+        actor: last?.actor ?? null,
+      };
     }
   }
 
@@ -904,10 +1099,21 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     });
   }
 
-  timeline.push(...concurrentRows(source, prOfSubject, kind === "ticket" ? subject.id : prTicket));
+  timeline.push(
+    ...concurrentRows(
+      source,
+      prOfSubject,
+      kind === "ticket" ? subject.id : prTicket,
+    ),
+  );
 
   if (kind === "ticket" && /^done$/i.test(subject.state ?? "")) {
-    const at = timeline.map((item) => item.at).filter((value) => validDate(value) != null).sort().at(-1) ?? earliest;
+    const at =
+      timeline
+        .map((item) => item.at)
+        .filter((value) => validDate(value) != null)
+        .sort()
+        .at(-1) ?? earliest;
     if (at) {
       timeline.push({
         id: `${subject.id}:done`,
@@ -933,22 +1139,45 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     .at(-1);
 
   const repo = repoOfSource(source);
-  const loopType = kind === "pr" ? /^factory\.merge\.requested$/ : /^factory\.(work|dispatch)\.requested$/;
-  const retryOriginType = [...source.events]
-    .filter((event) => loopType.test(event.type))
-    .sort((a, b) => timeOf(a.occurredAt, a.admittedAt).localeCompare(timeOf(b.occurredAt, b.admittedAt)))[0]?.type ??
+  const loopType =
+    kind === "pr"
+      ? /^factory\.merge\.requested$/
+      : /^factory\.(work|dispatch)\.requested$/;
+  const retryOriginType =
+    [...source.events]
+      .filter((event) => loopType.test(event.type))
+      .sort((a, b) =>
+        timeOf(a.occurredAt, a.admittedAt).localeCompare(
+          timeOf(b.occurredAt, b.admittedAt),
+        ),
+      )[0]?.type ??
     (source.schedules ?? [])
       .filter((schedule) => loopType.test(schedule.eventType))
-      .sort((a, b) => (validDate(a.nextDue) ?? Infinity) - (validDate(b.nextDue) ?? Infinity))[0]?.eventType ??
+      .sort(
+        (a, b) =>
+          (validDate(a.nextDue) ?? Infinity) -
+          (validDate(b.nextDue) ?? Infinity),
+      )[0]?.eventType ??
     (kind === "pr" ? "factory.merge.requested" : "factory.work.requested");
   const nextSchedule = nextScheduledRetry(
     { type: retryOriginType, repos: repo ? [repo] : [] },
     source.schedules ?? [],
   );
-  const nextVisit = nextSchedule?.nextDue ? { loop: nextSchedule.loop, at: nextSchedule.nextDue } : null;
-  const merged = timeline.some((item) => item.kind === "merge" && /^merged/.test(item.label));
-  const ticketWaiting = kind === "ticket" && (latestNoop != null || /^(todo|backlog)$/i.test(subject.state ?? ""));
-  if (nextVisit && !merged && !/^done$/i.test(subject.state ?? "") && (kind === "pr" || ticketWaiting)) {
+  const nextVisit = nextSchedule?.nextDue
+    ? { loop: nextSchedule.loop, at: nextSchedule.nextDue }
+    : null;
+  const merged = timeline.some(
+    (item) => item.kind === "merge" && /^merged/.test(item.label),
+  );
+  const ticketWaiting =
+    kind === "ticket" &&
+    (latestNoop != null || /^(todo|backlog)$/i.test(subject.state ?? ""));
+  if (
+    nextVisit &&
+    !merged &&
+    !/^done$/i.test(subject.state ?? "") &&
+    (kind === "pr" || ticketWaiting)
+  ) {
     timeline.push({
       id: `schedule:${nextVisit.loop}`,
       kind: "schedule",
@@ -963,44 +1192,57 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
   for (let index = 0; index < timeline.length; index += 1) {
     const previous = index ? validDate(timeline[index - 1].at) : null;
     const current = validDate(timeline[index].at);
-    timeline[index].durationMs = previous != null && current != null ? Math.max(0, current - previous) : null;
+    timeline[index].durationMs =
+      previous != null && current != null
+        ? Math.max(0, current - previous)
+        : null;
   }
 
   const activityRows = timeline.filter((item) => item.kind !== "schedule");
   const first = validDate(subject.createdAt ?? activityRows[0]?.at);
   const last = validDate(activityRows.at(-1)?.at);
-  const leadTimeMs = first != null && last != null && last > first ? last - first : null;
-  const lastRun = [...source.runs].sort((a, b) => resultAt(a).localeCompare(resultAt(b))).at(-1);
+  const leadTimeMs =
+    first != null && last != null && last > first ? last - first : null;
+  const lastRun = [...source.runs]
+    .sort((a, b) => resultAt(a).localeCompare(resultAt(b)))
+    .at(-1);
   const lastRefusal = lastRun ? refusalOf(lastRun) : null;
   const blockingReason =
     reasonText(latestNoop?.reason) ??
     (kind === "pr" && lastRefusal ? humanizeWithCode(lastRefusal.code) : null);
   const awaitingApproval = [...source.proposals]
-    .filter((proposal) => proposal.status === "open" && proposal.decision === "run")
+    .filter(
+      (proposal) => proposal.status === "open" && proposal.decision === "run",
+    )
     .sort((a, b) => a.created_at.localeCompare(b.created_at))
     .at(-1);
   if (!currentRun && awaitingApproval?.runId) {
-    currentRun = { runId: awaitingApproval.runId, state: "PROPOSED", actor: null };
+    currentRun = {
+      runId: awaitingApproval.runId,
+      state: "PROPOSED",
+      actor: null,
+    };
   }
-  const nextAction = currentRun && currentRun.state !== "PROPOSED"
-    ? `${currentRun.runId} is ${currentRun.state.toLowerCase()}${currentRun.actor ? ` on ${currentRun.actor}` : ""}`
-    : awaitingApproval
-      ? `Awaiting approval for ${awaitingApproval.id}`
-      : merged && kind === "pr"
-        ? "Merged — no further action"
-        : blockingReason
-          ? `Waiting: ${blockingReason}${nextVisit ? ` · ${nextVisit.loop} revisits at ${clock(nextVisit.at)}` : ""}`
-          : /^done$/i.test(subject.state ?? "")
-            ? "No further action"
-            : kind === "pr"
-              ? nextVisit
-                ? `Waiting for ${nextVisit.loop} at ${clock(nextVisit.at)}`
-                : "Waiting for the next merge scan"
-              : prUrls.size
-                ? "Waiting for review or merge"
-                : source.activity
-                  ? "Waiting for the next dispatch decision"
-                  : `No runtime activity for ${subject.id}`;
+  const nextAction =
+    currentRun && currentRun.state !== "PROPOSED"
+      ? `${currentRun.runId} is ${currentRun.state.toLowerCase()}${currentRun.actor ? ` on ${currentRun.actor}` : ""}`
+      : awaitingApproval
+        ? `Awaiting approval for ${awaitingApproval.id}`
+        : merged && kind === "pr"
+          ? "Merged — no further action"
+          : blockingReason
+            ? `Waiting: ${blockingReason}${nextVisit ? ` · ${nextVisit.loop} revisits at ${clock(nextVisit.at)}` : ""}`
+            : /^done$/i.test(subject.state ?? "")
+              ? "No further action"
+              : kind === "pr"
+                ? nextVisit
+                  ? `Waiting for ${nextVisit.loop} at ${clock(nextVisit.at)}`
+                  : "Waiting for the next merge scan"
+                : prUrls.size
+                  ? "Waiting for review or merge"
+                  : source.activity
+                    ? "Waiting for the next dispatch decision"
+                    : `No runtime activity for ${subject.id}`;
 
   const pr =
     kind === "pr"
@@ -1010,11 +1252,14 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
           ticket: prTicket,
           headRef: prHeadRef,
           mergeState: merged ? "MERGED" : prMergeState,
-          url: prGithub ? `https://github.com/${prGithub}/pull/${prOfSubject}` : null,
+          url: prGithub
+            ? `https://github.com/${prGithub}/pull/${prOfSubject}`
+            : null,
         }
       : null;
   if (pr?.url) subject.url = pr.url;
-  if (kind === "pr" && !subject.title && pr?.headRef) subject.title = pr.headRef;
+  if (kind === "pr" && !subject.title && pr?.headRef)
+    subject.title = pr.headRef;
   if (kind === "pr" && !subject.state) subject.state = pr?.mergeState ?? null;
 
   return {
@@ -1035,7 +1280,10 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
 }
 
 /** The WM-595 entry point: a ticket journey from the `/api/runs?ticket=` join. */
-export function buildTicketJourney(source: TicketJourneySource & Partial<Pick<SubjectJourneySource, "inbox" | "schedules">>): SubjectJourney {
+export function buildTicketJourney(
+  source: TicketJourneySource &
+    Partial<Pick<SubjectJourneySource, "inbox" | "schedules">>,
+): SubjectJourney {
   return subjectJourney("ticket", source.ticket.id, {
     subject: { kind: "ticket", ...source.ticket },
     activity: source.activity,
@@ -1065,16 +1313,22 @@ export function selectPrSource(
   },
 ): SubjectJourneySource {
   const namesPr = (value: unknown) => prNumbersIn(value).includes(pr);
-  const events = input.events.filter((event) => namesPr(event.envelope) || namesPr(event.subject));
-  const eventKeys = new Set(events.map((event) => `${event.source}\0${event.eventId}`));
+  const events = input.events.filter(
+    (event) => namesPr(event.envelope) || namesPr(event.subject),
+  );
+  const eventKeys = new Set(
+    events.map((event) => `${event.source}\0${event.eventId}`),
+  );
   const proposals = input.proposals.filter(
     (proposal) =>
       namesPr(proposal.spec?.input) ||
-      (proposal.eventId && eventKeys.has(`${proposal.eventSource}\0${proposal.eventId}`)),
+      (proposal.eventId &&
+        eventKeys.has(`${proposal.eventSource}\0${proposal.eventId}`)),
   );
   const runIds = new Set<string>();
   for (const event of events) if (event.runId) runIds.add(event.runId);
-  for (const proposal of proposals) if (proposal.runId) runIds.add(proposal.runId);
+  for (const proposal of proposals)
+    if (proposal.runId) runIds.add(proposal.runId);
   const runs = input.runs.filter(
     (run) =>
       runIds.has(run.run.runId) ||
@@ -1083,7 +1337,8 @@ export function selectPrSource(
       (run.result && scanVerdictFor(run.result.artifact, pr) != null),
   );
   const tickets = new Set<string>();
-  for (const event of events) for (const ticket of ticketIdsIn(event.envelope)) tickets.add(ticket);
+  for (const event of events)
+    for (const ticket of ticketIdsIn(event.envelope)) tickets.add(ticket);
   for (const run of runs) {
     const ticket = ticketOfRun(run);
     if (ticket) tickets.add(ticket);
@@ -1091,20 +1346,30 @@ export function selectPrSource(
       const list = (run.result?.artifact as any)?.[bucket];
       if (!Array.isArray(list)) continue;
       const entry = list.find((item: any) => Number(item?.pr) === pr);
-      if (typeof entry?.ticket === "string") tickets.add(entry.ticket.toUpperCase());
+      if (typeof entry?.ticket === "string")
+        tickets.add(entry.ticket.toUpperCase());
     }
   }
   // Same-ticket runs are the other chain that moves the PR's head (the
   // dispatch agent pushing while a scan reads) — context for the ↔ rows only.
   const own = new Set(runs.map((run) => run.run.runId));
   const contextRuns = input.runs.filter((run) => {
-    if (own.has(run.run.runId) || RUN_FAMILY.merge.test(run.run.spec.agent)) return false;
+    if (own.has(run.run.runId) || RUN_FAMILY.merge.test(run.run.spec.agent))
+      return false;
     const ticket = ticketOfRun(run);
     return ticket != null && tickets.has(ticket);
   });
-  const allRuns = [...runs].sort((a, b) => a.run.created_at.localeCompare(b.run.created_at));
+  const allRuns = [...runs].sort((a, b) =>
+    a.run.created_at.localeCompare(b.run.created_at),
+  );
   const inbox = (input.inbox ?? []).filter((item) => namesPr(item.refs));
-  const first = [...events.map((e) => e.occurredAt), ...allRuns.map((r) => r.run.created_at)].filter((v) => validDate(v) != null).sort()[0] ?? null;
+  const first =
+    [
+      ...events.map((e) => e.occurredAt),
+      ...allRuns.map((r) => r.run.created_at),
+    ]
+      .filter((v) => validDate(v) != null)
+      .sort()[0] ?? null;
   return {
     subject: {
       kind: "pr",
@@ -1114,7 +1379,11 @@ export function selectPrSource(
       createdAt: first,
       url: `#/prs/${pr}`,
     },
-    activity: events.length > 0 || proposals.length > 0 || allRuns.length > 0 || inbox.length > 0,
+    activity:
+      events.length > 0 ||
+      proposals.length > 0 ||
+      allRuns.length > 0 ||
+      inbox.length > 0,
     events,
     proposals,
     runs: allRuns,

--- a/event-runtime/web/src/templates.test.ts
+++ b/event-runtime/web/src/templates.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { buildSkeleton, buildTemplates, groupTemplates, retriggerEnvelope, summarize, triggerId } from "./templates";
+import {
+  buildSkeleton,
+  buildTemplates,
+  groupTemplates,
+  retriggerEnvelope,
+  summarize,
+  triggerId,
+} from "./templates";
 import type { AgentsView } from "./types";
 
 const NOW = Date.parse("2026-08-13T09:15:00.000Z");
@@ -35,7 +42,11 @@ describe("buildSkeleton", () => {
     expect(
       buildSkeleton({
         required: ["host", "mount"],
-        properties: { host: { type: "string" }, mount: { type: "string" }, note: { type: "string" } },
+        properties: {
+          host: { type: "string" },
+          mount: { type: "string" },
+          note: { type: "string" },
+        },
       }),
     ).toEqual({ host: "", mount: "" });
   });
@@ -63,7 +74,11 @@ describe("buildSkeleton", () => {
           plan: {
             type: "array",
             minItems: 1,
-            items: { type: "object", required: ["action"], properties: { action: { type: "string" } } },
+            items: {
+              type: "object",
+              required: ["action"],
+              properties: { action: { type: "string" } },
+            },
           },
         },
       }),
@@ -87,7 +102,11 @@ describe("buildSkeleton", () => {
       buildSkeleton({
         required: ["outer"],
         properties: {
-          outer: { type: "object", required: ["inner"], properties: { inner: { type: "integer", minimum: 3 } } },
+          outer: {
+            type: "object",
+            required: ["inner"],
+            properties: { inner: { type: "integer", minimum: 3 } },
+          },
         },
       }),
     ).toEqual({ outer: { inner: 3 } });
@@ -97,7 +116,17 @@ describe("buildSkeleton", () => {
     expect(
       buildSkeleton(
         {
-          required: ["id", "ID", "eventId", "correlationId", "alertId", "user_id", "task-id", "customRef", "grid"],
+          required: [
+            "id",
+            "ID",
+            "eventId",
+            "correlationId",
+            "alertId",
+            "user_id",
+            "task-id",
+            "customRef",
+            "grid",
+          ],
           properties: {
             id: { type: "string" },
             ID: { type: "string" },
@@ -129,7 +158,16 @@ describe("buildSkeleton", () => {
     expect(
       buildSkeleton(
         {
-          required: ["occurredAt", "createdAt", "updated_at", "started-at", "at", "timeField", "dateOnly", "plain"],
+          required: [
+            "occurredAt",
+            "createdAt",
+            "updated_at",
+            "started-at",
+            "at",
+            "timeField",
+            "dateOnly",
+            "plain",
+          ],
           properties: {
             occurredAt: { type: "string" },
             createdAt: { type: "string" },
@@ -214,16 +252,26 @@ describe("buildTemplates", () => {
   test.each([
     ["an array", []],
     ["an object missing agents", { eventTypes: view.eventTypes }],
-  ])("returns no templates when the registry response is %s", (_label, response) => {
-    expect(buildTemplates(response as unknown as AgentsView, NOW)).toEqual([]);
-  });
+  ])(
+    "returns no templates when the registry response is %s",
+    (_label, response) => {
+      expect(buildTemplates(response as unknown as AgentsView, NOW)).toEqual(
+        [],
+      );
+    },
+  );
 
   test("handles unrouted event types without agent or adapter (WM-475)", () => {
     const unroutedView = {
       agents: [],
-      eventTypes: [{ type: "factory.ticket.dispatched", proposalTtlSeconds: null }],
+      eventTypes: [
+        { type: "factory.ticket.dispatched", proposalTtlSeconds: null },
+      ],
     };
-    const templates = buildTemplates(unroutedView as unknown as AgentsView, NOW);
+    const templates = buildTemplates(
+      unroutedView as unknown as AgentsView,
+      NOW,
+    );
     expect(templates).toHaveLength(1);
     expect(templates[0]?.eventType).toBe("factory.ticket.dispatched");
     expect(templates[0]?.agent).toBe("");
@@ -242,10 +290,21 @@ describe("buildTemplates", () => {
         { type: "factory.status-report.requested" },
       ],
     };
-    const groups = groupTemplates(buildTemplates(unorderedView as unknown as AgentsView, NOW));
+    const groups = groupTemplates(
+      buildTemplates(unorderedView as unknown as AgentsView, NOW),
+    );
 
-    expect(groups.map((group) => group.domain)).toEqual(["clock.", "factory.", "github.", "keephq."]);
-    expect(groups.find((group) => group.domain === "factory.")?.templates.map((t) => t.eventType)).toEqual([
+    expect(groups.map((group) => group.domain)).toEqual([
+      "clock.",
+      "factory.",
+      "github.",
+      "keephq.",
+    ]);
+    expect(
+      groups
+        .find((group) => group.domain === "factory.")
+        ?.templates.map((t) => t.eventType),
+    ).toEqual([
       "factory.ci-rerun.requested",
       "factory.status-report.requested",
       "factory.triage.requested",

--- a/event-runtime/web/src/templates.ts
+++ b/event-runtime/web/src/templates.ts
@@ -21,12 +21,17 @@ export interface TriggerTemplateGroup {
 }
 
 /** Group templates by event-type domain, with deterministic group and item order. */
-export function groupTemplates(templates: TriggerTemplate[]): TriggerTemplateGroup[] {
+export function groupTemplates(
+  templates: TriggerTemplate[],
+): TriggerTemplateGroup[] {
   const groups = new Map<string, TriggerTemplate[]>();
-  const sorted = [...templates].sort((a, b) => a.eventType.localeCompare(b.eventType));
+  const sorted = [...templates].sort((a, b) =>
+    a.eventType.localeCompare(b.eventType),
+  );
   for (const template of sorted) {
     const separator = template.eventType.indexOf(".");
-    const domain = separator > 0 ? template.eventType.slice(0, separator + 1) : "other";
+    const domain =
+      separator > 0 ? template.eventType.slice(0, separator + 1) : "other";
     const group = groups.get(domain) ?? [];
     group.push(template);
     groups.set(domain, group);
@@ -37,9 +42,14 @@ export function groupTemplates(templates: TriggerTemplate[]): TriggerTemplateGro
 }
 
 /** A plausible starting value for one schema property — never a lie, just a seed. */
-function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown {
+function seedFor(
+  name: string,
+  schema: any,
+  nowMs: number = Date.now(),
+): unknown {
   if (!schema || typeof schema !== "object") return "";
-  if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0];
+  if (Array.isArray(schema.enum) && schema.enum.length > 0)
+    return schema.enum[0];
   if (schema.const !== undefined) return schema.const;
 
   const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
@@ -54,7 +64,9 @@ function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown
       // required shape is visible. Arrays of strings seed empty even under
       // minItems (WM-76 critique r1): a seeded empty-string chip reads as a
       // rendering glitch, and the minItems validation warning covers the ask.
-      const itemType = Array.isArray(schema.items?.type) ? schema.items.type[0] : schema.items?.type;
+      const itemType = Array.isArray(schema.items?.type)
+        ? schema.items.type[0]
+        : schema.items?.type;
       if ((schema.minItems ?? 0) > 0 && itemType !== "string") {
         return [seedFor(name, schema.items, nowMs)];
       }
@@ -69,7 +81,8 @@ function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown
       // validation warns, never blocks — and let the form surface the
       // example via placeholderFor() (lib/injectForm.ts).
       if (typeof schema.pattern === "string") {
-        if (schema.pattern.startsWith("^/") || schema.pattern.includes("/")) return "";
+        if (schema.pattern.startsWith("^/") || schema.pattern.includes("/"))
+          return "";
       }
       if (
         schema.format === "date-time" ||
@@ -92,7 +105,10 @@ function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown
 }
 
 /** Required properties only: the smallest envelope that can pass validation. */
-export function buildSkeleton(schema: any, nowMs: number = Date.now()): Record<string, unknown> {
+export function buildSkeleton(
+  schema: any,
+  nowMs: number = Date.now(),
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   const required: string[] = schema?.required ?? [];
   const props = schema?.properties ?? {};
@@ -114,11 +130,17 @@ export function summarize(schema: any): string {
  * function (and tests get stable output).
  */
 export function triggerId(nowMs: number, suffix = ""): string {
-  const stamp = new Date(nowMs).toISOString().replace(/[-:]/g, "").replace(/\..+/, "");
+  const stamp = new Date(nowMs)
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..+/, "");
   return `web-${stamp}${suffix}`;
 }
 
-export function buildTemplates(view: unknown, nowMs: number): TriggerTemplate[] {
+export function buildTemplates(
+  view: unknown,
+  nowMs: number,
+): TriggerTemplate[] {
   if (!view || typeof view !== "object" || Array.isArray(view)) return [];
   const agents = Array.isArray((view as Partial<AgentsView>).agents)
     ? (view as Partial<AgentsView>).agents!
@@ -159,7 +181,10 @@ export function buildTemplates(view: unknown, nowMs: number): TriggerTemplate[] 
  * again", which is deliberately NOT replay: replay reuses the delivery id and
  * dedups to a no-op, this makes a genuinely new admission.
  */
-export function retriggerEnvelope(envelope: Record<string, unknown>, nowMs: number): Record<string, unknown> {
+export function retriggerEnvelope(
+  envelope: Record<string, unknown>,
+  nowMs: number,
+): Record<string, unknown> {
   const id = triggerId(nowMs, "-again");
   return {
     ...envelope,

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -42,7 +42,9 @@ import type {
 // Fixture Factories
 // ============================================================================
 
-export function createEnvFixture(overrides?: Partial<EnvIdentity>): EnvIdentity {
+export function createEnvFixture(
+  overrides?: Partial<EnvIdentity>,
+): EnvIdentity {
   return {
     name: "test",
     home: "/tmp/factory-test",
@@ -51,7 +53,9 @@ export function createEnvFixture(overrides?: Partial<EnvIdentity>): EnvIdentity 
   };
 }
 
-export function createStatusFixture(overrides?: Partial<StatusView>): StatusView {
+export function createStatusFixture(
+  overrides?: Partial<StatusView>,
+): StatusView {
   return {
     env: createEnvFixture(),
     events: {},
@@ -72,7 +76,9 @@ export function createStatusFixture(overrides?: Partial<StatusView>): StatusView
   };
 }
 
-export function createRunListItemFixture(overrides?: Partial<RunListItem>): RunListItem {
+export function createRunListItemFixture(
+  overrides?: Partial<RunListItem>,
+): RunListItem {
   const now = new Date().toISOString();
   return {
     runId: "run_test_1001",
@@ -113,7 +119,10 @@ export function createLifecycleEventFixture(
   };
 }
 
-export function createRunSpecFixture(runId = "run_test_1001", overrides?: Partial<RunSpec>): RunSpec {
+export function createRunSpecFixture(
+  runId = "run_test_1001",
+  overrides?: Partial<RunSpec>,
+): RunSpec {
   return {
     schemaVersion: "1",
     runId,
@@ -133,7 +142,9 @@ export function createRunSpecFixture(runId = "run_test_1001", overrides?: Partia
   };
 }
 
-export function createRunDetailFixture(overrides?: Partial<RunDetail>): RunDetail {
+export function createRunDetailFixture(
+  overrides?: Partial<RunDetail>,
+): RunDetail {
   const now = new Date().toISOString();
   const runId = overrides?.run?.runId ?? "run_test_1001";
   const state: RunState = overrides?.run?.state ?? "RUNNING";
@@ -174,7 +185,9 @@ export function createRunDetailFixture(overrides?: Partial<RunDetail>): RunDetai
   };
 }
 
-export function createEventFixture(overrides?: Partial<AdmittedEvent>): AdmittedEvent {
+export function createEventFixture(
+  overrides?: Partial<AdmittedEvent>,
+): AdmittedEvent {
   const now = new Date().toISOString();
   return {
     source: "github",
@@ -243,7 +256,9 @@ export function createWorkerFixture(overrides?: Partial<Worker>): Worker {
   };
 }
 
-export function createAgentsFixture(overrides?: Partial<AgentsView>): AgentsView {
+export function createAgentsFixture(
+  overrides?: Partial<AgentsView>,
+): AgentsView {
   return {
     agents: [],
     eventTypes: [],
@@ -277,35 +292,55 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       env: createEnvFixture(),
     })),
     status: mock(async () => createStatusFixture()),
-    events: mock(async (_status?: string) => ({ events: [] as AdmittedEvent[] })),
-    chain: mock(async (correlationId: string) => ({ correlationId, events: [], runs: [] })),
+    events: mock(async (_status?: string) => ({
+      events: [] as AdmittedEvent[],
+    })),
+    chain: mock(async (correlationId: string) => ({
+      correlationId,
+      events: [],
+      runs: [],
+    })),
     proposals: mock(async () => ({ proposals: [] as Proposal[] })),
-    proposalHistory: mock(async (_status = "all") => ({ proposals: [] as Proposal[] })),
+    proposalHistory: mock(async (_status = "all") => ({
+      proposals: [] as Proposal[],
+    })),
     approve: mock(async (id: string): Promise<ApproveOutcome> => ({
       approved: true,
       runId: `run_${id}`,
     })),
     reject: mock(async (_id: string, _reason?: string) => ({ rejected: true })),
     runs: mock(async (_state?: string) => ({ runs: [] as RunListItem[] })),
-    run: mock(async (id: string) => createRunDetailFixture({ run: { runId: id, state: "RUNNING" } as any })),
-    trace: mock(async (_id: string, _since = 0, _limit = 500): Promise<TraceView> => ({
-      head: 0,
-      entries: [],
-    })),
-    cancel: mock(async (_id: string, _reason?: string): Promise<CancelOutcome> => ({
-      cancelled: true,
-    })),
+    run: mock(async (id: string) =>
+      createRunDetailFixture({ run: { runId: id, state: "RUNNING" } as any }),
+    ),
+    trace: mock(
+      async (_id: string, _since = 0, _limit = 500): Promise<TraceView> => ({
+        head: 0,
+        entries: [],
+      }),
+    ),
+    cancel: mock(
+      async (_id: string, _reason?: string): Promise<CancelOutcome> => ({
+        cancelled: true,
+      }),
+    ),
     retry: mock(async (_id: string, _force = false) => ({ queued: true })),
     replay: mock(async (_envelope: unknown) => ({
       admitted: true,
       duplicate: false,
       eventId: "evt_replayed_1",
     })),
-    injectEvent: mock(async (_type: string, _payload: Record<string, unknown>, _source = "factory-web") => ({
-      admitted: true,
-      duplicate: false,
-      eventId: `evt_injected_${Date.now()}`,
-    })),
+    injectEvent: mock(
+      async (
+        _type: string,
+        _payload: Record<string, unknown>,
+        _source = "factory-web",
+      ) => ({
+        admitted: true,
+        duplicate: false,
+        eventId: `evt_injected_${Date.now()}`,
+      }),
+    ),
     journal: mock(async (_since = 0, _limit = 100): Promise<JournalView> => ({
       head: 0,
       entries: [],
@@ -313,28 +348,43 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
     outbox: mock(async (_limit = 20): Promise<{ outbox: OutboxRow[] }> => ({
       outbox: [],
     })),
-    requeue: mock(async (_source: string, _eventId: string) => ({ requeued: true })),
-    archive: mock(async (_source: string, _eventId: string) => ({ archived: true })),
-    releaseWorker: mock(async (_workerId: string, runId: string) => ({ released: true, runId })),
+    requeue: mock(async (_source: string, _eventId: string) => ({
+      requeued: true,
+    })),
+    archive: mock(async (_source: string, _eventId: string) => ({
+      archived: true,
+    })),
+    releaseWorker: mock(async (_workerId: string, runId: string) => ({
+      released: true,
+      runId,
+    })),
     agents: mock(async () => createAgentsFixture()),
     repos: mock(async (): Promise<{ repos: RepoItem[] }> => ({ repos: [] })),
-    janitor: mock(async (name: string, apply = false): Promise<JanitorResult> => ({
-      repo: name,
-      apply,
-      actor: "janitor",
-      reclaimable: [],
-      kept: [],
-      named: [],
-      unknown: [],
-      removed: [],
-      refused: [],
-      held: [],
+    janitor: mock(
+      async (name: string, apply = false): Promise<JanitorResult> => ({
+        repo: name,
+        apply,
+        actor: "janitor",
+        reclaimable: [],
+        kept: [],
+        named: [],
+        unknown: [],
+        removed: [],
+        refused: [],
+        held: [],
+      }),
+    ),
+    workers: mock(async (): Promise<{ workers: Worker[] }> => ({
+      workers: [],
     })),
-    workers: mock(async (): Promise<{ workers: Worker[] }> => ({ workers: [] })),
     inbox: mock(async (_status = "open") => ({ items: [] })),
     ackInbox: mock(async (id: string) => ({ item: { id } })),
-    resolveInbox: mock(async (id: string, _reason?: string) => ({ item: { id } })),
-    schedules: mock(async (): Promise<{ schedules: any[] }> => ({ schedules: [] })),
+    resolveInbox: mock(async (id: string, _reason?: string) => ({
+      item: { id },
+    })),
+    schedules: mock(async (): Promise<{ schedules: any[] }> => ({
+      schedules: [],
+    })),
     triggerSchedule: mock(async (_loop: string, _prNumbers?: number[]) => ({
       admitted: true,
       duplicate: false,
@@ -468,10 +518,13 @@ function setNativeValue(element: HTMLElement, value: string): void {
   const setter =
     descriptor?.set ??
     (element instanceof HTMLTextAreaElement
-      ? Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set
+      ? Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")
+          ?.set
       : element instanceof HTMLSelectElement
-        ? Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set
-        : Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set);
+        ? Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")
+            ?.set
+        : Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+            ?.set);
 
   if (setter) {
     setter.call(element, value);
@@ -493,13 +546,19 @@ export function changeInput(el: HTMLElement, value: string): void {
   }
   setNativeValue(el, value);
   try {
-    el.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true }));
+    el.dispatchEvent(
+      new InputEvent("input", { bubbles: true, cancelable: true }),
+    );
   } catch {
     el.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
   }
   el.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
-  el.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true }));
-  el.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true, cancelable: true }));
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, cancelable: true }),
+  );
+  el.dispatchEvent(
+    new KeyboardEvent("keyup", { bubbles: true, cancelable: true }),
+  );
 }
 
 /**
@@ -508,15 +567,25 @@ export function changeInput(el: HTMLElement, value: string): void {
  * emits input and keyUp, and finally emits change when typing is complete.
  */
 export function typeText(element: HTMLElement, text: string): void {
-  if (typeof element.focus === "function" && document.activeElement !== element) {
+  if (
+    typeof element.focus === "function" &&
+    document.activeElement !== element
+  ) {
     try {
       element.focus();
     } catch {}
   }
   for (const char of text) {
-    element.dispatchEvent(new KeyboardEvent("keydown", { key: char, bubbles: true, cancelable: true }));
+    element.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: char,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
 
-    const currentVal = (element as HTMLInputElement | HTMLTextAreaElement).value ?? "";
+    const currentVal =
+      (element as HTMLInputElement | HTMLTextAreaElement).value ?? "";
     const start = (element as any).selectionStart ?? currentVal.length;
     const end = (element as any).selectionEnd ?? currentVal.length;
     const nextVal = currentVal.slice(0, start) + char + currentVal.slice(end);
@@ -536,13 +605,29 @@ export function typeText(element: HTMLElement, text: string): void {
     }
 
     try {
-      element.dispatchEvent(new InputEvent("input", { data: char, inputType: "insertText", bubbles: true, cancelable: true }));
+      element.dispatchEvent(
+        new InputEvent("input", {
+          data: char,
+          inputType: "insertText",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
     } catch {
-      element.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+      element.dispatchEvent(
+        new Event("input", { bubbles: true, cancelable: true }),
+      );
     }
 
-    element.dispatchEvent(new KeyboardEvent("keyup", { key: char, bubbles: true, cancelable: true }));
+    element.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key: char,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
   }
-  element.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+  element.dispatchEvent(
+    new Event("change", { bubbles: true, cancelable: true }),
+  );
 }
-

--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -86,7 +86,10 @@ body {
 
   /* Table banding is intentionally a semantic surface rather than a separate
      colour, so row text keeps the same contrast contract in every theme. */
-  tbody > tr:nth-child(even):not(.row-selected):not(.row-wash-err):not(.row-wash-warn) {
+  tbody
+    > tr:nth-child(even):not(.row-selected):not(.row-wash-err):not(
+      .row-wash-warn
+    ) {
     background: color-mix(in oklch, var(--surface-2) 70%, var(--surface-1));
   }
 
@@ -147,9 +150,16 @@ main[tabindex="-1"]:focus-visible {
 
 /* React Flow minimap: SVG fills cannot use var()/color-mix, so the node
    colors live here as classes (Graph view, OPS-224). */
-.react-flow__minimap-node.minimap-node { fill: var(--hue-info); stroke: none; }
-.react-flow__minimap-node.minimap-agent { fill: var(--hue-ok); }
-.react-flow__minimap-node.minimap-terminal { fill: var(--text-faint); }
+.react-flow__minimap-node.minimap-node {
+  fill: var(--hue-info);
+  stroke: none;
+}
+.react-flow__minimap-node.minimap-agent {
+  fill: var(--hue-ok);
+}
+.react-flow__minimap-node.minimap-terminal {
+  fill: var(--text-faint);
+}
 
 /* Canvas controls inherit the app's surfaces rather than React Flow's default white. */
 .react-flow__controls-button {
@@ -158,5 +168,9 @@ main[tabindex="-1"]:focus-visible {
   color: var(--text-dim);
   fill: var(--text-dim);
 }
-.react-flow__controls-button:hover { background: var(--surface-3); }
-.react-flow__edge-text { fill: var(--text-faint); }
+.react-flow__controls-button:hover {
+  background: var(--surface-3);
+}
+.react-flow__edge-text {
+  fill: var(--text-faint);
+}

--- a/event-runtime/web/src/theme.test.ts
+++ b/event-runtime/web/src/theme.test.ts
@@ -21,15 +21,24 @@ export function oklchToLinearRgb(c: OklchColor): [number, number, number] {
 
   const l_ = c.l + 0.3963377774 * a + 0.2158037573 * b;
   const m_ = c.l - 0.1055613458 * a - 0.0638541728 * b;
-  const s_ = c.l - 0.0894841775 * a - 1.2914855480 * b;
+  const s_ = c.l - 0.0894841775 * a - 1.291485548 * b;
 
   const l = l_ * l_ * l_;
   const m = m_ * m_ * m_;
   const s = s_ * s_ * s_;
 
-  const rLin = Math.min(Math.max(0, +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s), 1);
-  const gLin = Math.min(Math.max(0, -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s), 1);
-  const bLin = Math.min(Math.max(0, -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s), 1);
+  const rLin = Math.min(
+    Math.max(0, +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    1,
+  );
+  const gLin = Math.min(
+    Math.max(0, -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    1,
+  );
+  const bLin = Math.min(
+    Math.max(0, -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+    1,
+  );
 
   return [rLin, gLin, bLin];
 }
@@ -47,7 +56,11 @@ export function contrastRatio(c1: OklchColor, c2: OklchColor): number {
   return (l1 + 0.05) / (l2 + 0.05);
 }
 
-export function mixOklch(c1: OklchColor, c2: OklchColor, p1: number): OklchColor {
+export function mixOklch(
+  c1: OklchColor,
+  c2: OklchColor,
+  p1: number,
+): OklchColor {
   const p2 = 1 - p1;
   const h1Rad = (c1.h * Math.PI) / 180;
   const a1 = c1.c * Math.cos(h1Rad);
@@ -85,13 +98,17 @@ interface ParsedTheme {
   borderStrong: OklchColor;
 }
 
-function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedTheme> {
+function resolveThemesFromCss(): Record<
+  "dark" | "light" | "contrast",
+  ParsedTheme
+> {
   const cssPath = path.resolve(__dirname, "theme.css");
   const css = fs.readFileSync(cssPath, "utf-8");
 
   function extractBlock(selector: string): string {
     const startIdx = css.indexOf(selector);
-    if (startIdx === -1) throw new Error(`Selector ${selector} not found in theme.css`);
+    if (startIdx === -1)
+      throw new Error(`Selector ${selector} not found in theme.css`);
     const openBrace = css.indexOf("{", startIdx);
     const closeBrace = css.indexOf("}", openBrace);
     return css.slice(openBrace + 1, closeBrace);
@@ -124,15 +141,27 @@ function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedThe
 
   function parseMixPct(val: string, primaryVar: string): number {
     const match = val.match(new RegExp(`var\\(--${primaryVar}\\)\\s*(\\d+)%`));
-    if (!match) throw new Error(`Cannot parse mix percentage for var(--${primaryVar}) in "${val}"`);
+    if (!match)
+      throw new Error(
+        `Cannot parse mix percentage for var(--${primaryVar}) in "${val}"`,
+      );
     return parseInt(match[1], 10) / 100;
   }
 
   const textPct = parseMixPct(extractVar(sharedBlock, "text")!, "contrast");
-  const textDimPct = parseMixPct(extractVar(sharedBlock, "text-dim")!, "contrast");
-  const textFaintPct = parseMixPct(extractVar(sharedBlock, "text-faint")!, "contrast");
+  const textDimPct = parseMixPct(
+    extractVar(sharedBlock, "text-dim")!,
+    "contrast",
+  );
+  const textFaintPct = parseMixPct(
+    extractVar(sharedBlock, "text-faint")!,
+    "contrast",
+  );
   const borderPct = parseMixPct(extractVar(sharedBlock, "border")!, "base");
-  const borderStrongPct = parseMixPct(extractVar(sharedBlock, "border-strong")!, "base");
+  const borderStrongPct = parseMixPct(
+    extractVar(sharedBlock, "border-strong")!,
+    "base",
+  );
   const surfacePcts = {
     surface1: parseMixPct(extractVar(sharedBlock, "surface-1")!, "base"),
     surface2: parseMixPct(extractVar(sharedBlock, "surface-2")!, "base"),
@@ -159,11 +188,17 @@ function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedThe
       onAccent = parseOklch(onAccentStr);
     }
 
-    const surface = (name: "surface-0" | "surface-1" | "surface-2" | "surface-3"): OklchColor => {
+    const surface = (
+      name: "surface-0" | "surface-1" | "surface-2" | "surface-3",
+    ): OklchColor => {
       const explicit = extractVar(block, name);
       if (explicit) return parseOklch(explicit);
       if (name === "surface-0") return base;
-      return mixOklch(base, contrast, surfacePcts[name.replace("-", "") as keyof typeof surfacePcts]);
+      return mixOklch(
+        base,
+        contrast,
+        surfacePcts[name.replace("-", "") as keyof typeof surfacePcts],
+      );
     };
 
     return {
@@ -226,9 +261,15 @@ describe("Theme contrast & accessibility (OPS-447, OPS-338)", () => {
   }
 
   test("contrast theme primary button has >= contrast than dark or light", () => {
-    const contrastBtnCr = contrastRatio(themes.contrast.onAccent, themes.contrast.accent);
+    const contrastBtnCr = contrastRatio(
+      themes.contrast.onAccent,
+      themes.contrast.accent,
+    );
     const darkBtnCr = contrastRatio(themes.dark.onAccent, themes.dark.accent);
-    const lightBtnCr = contrastRatio(themes.light.onAccent, themes.light.accent);
+    const lightBtnCr = contrastRatio(
+      themes.light.onAccent,
+      themes.light.accent,
+    );
 
     expect(contrastBtnCr).toBeGreaterThanOrEqual(darkBtnCr);
     expect(contrastBtnCr).toBeGreaterThanOrEqual(lightBtnCr);
@@ -255,14 +296,22 @@ describe("Theme contrast & accessibility (OPS-447, OPS-338)", () => {
 
     expect(contrastRatio(light.hueWarn, liveWash)).toBeGreaterThanOrEqual(3);
     expect(contrastRatio(light.text, inFlightWash)).toBeGreaterThanOrEqual(3);
-    expect(contrastRatio(light.hueAccent, sidebarAccentWash)).toBeGreaterThanOrEqual(3);
-    expect(contrastRatio(light.hueWarn, sidebarWarnWash)).toBeGreaterThanOrEqual(3);
+    expect(
+      contrastRatio(light.hueAccent, sidebarAccentWash),
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      contrastRatio(light.hueWarn, sidebarWarnWash),
+    ).toBeGreaterThanOrEqual(3);
     expect(contrastRatio(light.textDim, zebra)).toBeGreaterThanOrEqual(3);
   });
 
   test("row treatments use semantic zebra surfaces and accent-hued 2px selection (WM-558)", () => {
     const css = fs.readFileSync(path.resolve(__dirname, "theme.css"), "utf-8");
-    expect(css).toMatch(/tbody\s*>\s*tr:nth-child\(even\)[^{]*\{[^}]*var\(--surface-2\)/s);
-    expect(css).toMatch(/\.row-selected\s*\{[^}]*var\(--hue-accent\)\s+1[2-6]%,\s*transparent[^}]*inset\s+2px\s+0\s+0\s+var\(--hue-accent\)/s);
+    expect(css).toMatch(
+      /tbody\s*>\s*tr:nth-child\(even\)[^{]*\{[^}]*var\(--surface-2\)/s,
+    );
+    expect(css).toMatch(
+      /\.row-selected\s*\{[^}]*var\(--hue-accent\)\s+1[2-6]%,\s*transparent[^}]*inset\s+2px\s+0\s+0\s+var\(--hue-accent\)/s,
+    );
   });
 });

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -358,7 +358,8 @@ export type ArtifactFormat =
   | "state"
   | "bytes"
   | "count";
-export type ArtifactSectionKind = "table" | "keyvalue" | "list" | "badge" | "code" | "prose";
+export type ArtifactSectionKind =
+  "table" | "keyvalue" | "list" | "badge" | "code" | "prose";
 export interface ArtifactViewSection {
   /** RFC 6901 pointer into the artifact; `""` is the whole document. */
   path: string;
@@ -544,13 +545,23 @@ export interface StatusView {
   /** Human inbox counts (WM-285); absent on a pre-inbox control API. */
   inbox?: { open: number; acked: number; byKind?: Record<string, number> };
   /** Artifact store rollup; `orphans` counts files no result references. Cached ~10s server-side (`at` = when computed). */
-  artifacts: { files: number; bytes: number; orphans: number; orphanBytes: number; at?: string };
+  artifacts: {
+    files: number;
+    bytes: number;
+    orphans: number;
+    orphanBytes: number;
+    at?: string;
+  };
   anomalies: {
     configuration?: string[];
     expiredOpenProposals: string[];
     staleLeases: number;
     unpublishedOutbox: number;
-    deadLettered: { source: string; eventId: string; lastError: string | null }[];
+    deadLettered: {
+      source: string;
+      eventId: string;
+      lastError: string | null;
+    }[];
     stalledWorkers: StalledWorker[];
     stoppedSchedules?: StoppedSchedule[];
     /** Placement-constrained queued runs that no active, non-stale worker can claim. */
@@ -615,7 +626,6 @@ export interface JanitorResult {
   skippedApplyReason?: string;
 }
 
-
 /** The kinds the inbox ledger accepts (lib/inbox.mjs INBOX_KINDS). */
 export type InboxKind =
   | "BLOCKED"
@@ -643,7 +653,11 @@ export interface InboxRefs {
 
 /** Telegram projection record written by deliverInboxItem; absent = not attempted. */
 export interface InboxDelivery {
-  telegram?: { sent_at: string; exit_code: number | null; error: string | null };
+  telegram?: {
+    sent_at: string;
+    exit_code: number | null;
+    error: string | null;
+  };
 }
 
 /** One row of the human inbox ledger (GET /inbox). */

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -2,8 +2,18 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Agents, adapterText, agentTabCounts, modelText, routeModel, tierText } from "./Agents";
-import { EMPTY_VALUE, formatDurationSeconds } from "../components/AgentHoverCard";
+import {
+  Agents,
+  adapterText,
+  agentTabCounts,
+  modelText,
+  routeModel,
+  tierText,
+} from "./Agents";
+import {
+  EMPTY_VALUE,
+  formatDurationSeconds,
+} from "../components/AgentHoverCard";
 import { api } from "../api";
 import type { AgentDef, AgentEventRoute, AgentsView } from "../types";
 
@@ -55,15 +65,23 @@ function stubAgent(id: string, over: Partial<AgentDef> = {}): AgentDef {
 }
 
 function renderWithClient(ui: React.ReactElement) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 const noop = () => {};
 
 function renderAgents(focusAgentRef: string | null = null) {
   return renderWithClient(
-    <Agents context={{ kind: "all" }} focusAgentRef={focusAgentRef} onSelectAgent={noop} />,
+    <Agents
+      context={{ kind: "all" }}
+      focusAgentRef={focusAgentRef}
+      onSelectAgent={noop}
+    />,
   );
 }
 
@@ -78,20 +96,28 @@ function withAgents(agents: AgentDef[], fn: () => Promise<void>) {
 
 describe("route model semantics (WM-211/WM-135)", () => {
   test("a resolved model is shown verbatim — it is what the planner pins", () => {
-    expect(routeModel(stubRoute({ resolvedModel: "openai-codex/gpt-5.6-sol", adapter: "pi" }))).toBe(
-      "openai-codex/gpt-5.6-sol",
-    );
+    expect(
+      routeModel(
+        stubRoute({ resolvedModel: "openai-codex/gpt-5.6-sol", adapter: "pi" }),
+      ),
+    ).toBe("openai-codex/gpt-5.6-sol");
   });
 
   test("non-model adapters read n/a, never blank — a fixed argv has no model by construction", () => {
     for (const adapter of ["command", "actions", "fake"]) {
-      expect(routeModel(stubRoute({ adapter, resolvedModel: null }))).toBe("n/a");
+      expect(routeModel(stubRoute({ adapter, resolvedModel: null }))).toBe(
+        "n/a",
+      );
     }
   });
 
   test("a model adapter that pins nothing rides the CLI default — not n/a", () => {
-    expect(routeModel(stubRoute({ adapter: "claude", resolvedModel: null }))).toBe("default");
-    expect(routeModel(stubRoute({ adapter: "pi", resolvedModel: null }))).toBe("default");
+    expect(
+      routeModel(stubRoute({ adapter: "claude", resolvedModel: null })),
+    ).toBe("default");
+    expect(routeModel(stubRoute({ adapter: "pi", resolvedModel: null }))).toBe(
+      "default",
+    );
   });
 });
 
@@ -116,8 +142,12 @@ describe("row roll-ups across routes (WM-211)", () => {
   });
 
   test("tier falls back to override when a definition names an exact id instead of a tier", () => {
-    expect(tierText(stubAgent("x", { modelTier: null, model: "haiku" }))).toBe("override");
-    expect(tierText(stubAgent("x", { modelTier: null, model: null }))).toBe(EMPTY_VALUE);
+    expect(tierText(stubAgent("x", { modelTier: null, model: "haiku" }))).toBe(
+      "override",
+    );
+    expect(tierText(stubAgent("x", { modelTier: null, model: null }))).toBe(
+      EMPTY_VALUE,
+    );
   });
 });
 
@@ -143,12 +173,18 @@ describe("Agents table columns (WM-211)", () => {
     const agents = [
       stubAgent("dispatch", {
         modelTier: "strong",
-        eventTypes: [stubRoute({ type: "factory.dispatch/v1", resolvedModel: "default" })],
+        eventTypes: [
+          stubRoute({ type: "factory.dispatch/v1", resolvedModel: "default" }),
+        ],
       }),
       stubAgent("reaper", {
         modelTier: null,
         eventTypes: [
-          stubRoute({ type: "factory.reap/v1", adapter: "command", resolvedModel: null }),
+          stubRoute({
+            type: "factory.reap/v1",
+            adapter: "command",
+            resolvedModel: null,
+          }),
         ],
       }),
     ];
@@ -158,7 +194,9 @@ describe("Agents table columns (WM-211)", () => {
         expect(getByText("dispatch@1")).toBeTruthy();
       });
       for (const label of ["Adapter", "Tier", "Model"]) {
-        expect(getByRole("columnheader", { name: new RegExp(label) })).toBeTruthy();
+        expect(
+          getByRole("columnheader", { name: new RegExp(label) }),
+        ).toBeTruthy();
       }
       expect(getAllByText("claude").length).toBeGreaterThan(0);
       expect(getByText("strong")).toBeTruthy();
@@ -169,7 +207,10 @@ describe("Agents table columns (WM-211)", () => {
   });
 
   test("a hidden column is dropped from the header and every row, and persists", async () => {
-    localStorage.setItem("evrt-display-agents", JSON.stringify({ hiddenColumns: ["capabilities"] }));
+    localStorage.setItem(
+      "evrt-display-agents",
+      JSON.stringify({ hiddenColumns: ["capabilities"] }),
+    );
     await withAgents([stubAgent("dispatch")], async () => {
       const { queryByRole, getByRole } = renderAgents();
       await waitFor(() => {
@@ -180,7 +221,10 @@ describe("Agents table columns (WM-211)", () => {
   });
 
   test("grouping by adapter sections the fleet, and every row still renders", async () => {
-    localStorage.setItem("evrt-display-agents", JSON.stringify({ groupBy: "adapter" }));
+    localStorage.setItem(
+      "evrt-display-agents",
+      JSON.stringify({ groupBy: "adapter" }),
+    );
     const agents = [
       stubAgent("dispatch"),
       stubAgent("reaper", {
@@ -195,7 +239,9 @@ describe("Agents table columns (WM-211)", () => {
       expect(getByText("reaper@1")).toBeTruthy();
       // One collapsible section header per adapter bucket — the header text
       // repeats the cell text, so identity is the aria-expanded control.
-      const headers = getAllByRole("button", { expanded: true }).map((b) => b.textContent ?? "");
+      const headers = getAllByRole("button", { expanded: true }).map(
+        (b) => b.textContent ?? "",
+      );
       expect(headers.filter((t) => /claude1/.test(t))).toHaveLength(1);
       expect(headers.filter((t) => /command1/.test(t))).toHaveLength(1);
     });
@@ -225,7 +271,9 @@ describe("Agents detail pane (WM-211)", () => {
       // The tier reads the same in the row cell and the detail pane, by design.
       expect(getAllByText("light").length).toBeGreaterThan(0);
       expect(getByText("model override")).toBeTruthy();
-      expect(getAllByText("openai-codex/gpt-5.6-luna").length).toBeGreaterThan(0);
+      expect(getAllByText("openai-codex/gpt-5.6-luna").length).toBeGreaterThan(
+        0,
+      );
       expect(getByText(/adapter pi/)).toBeTruthy();
     });
   });
@@ -235,7 +283,11 @@ describe("Agents detail pane (WM-211)", () => {
       stubAgent("reaper", {
         modelTier: null,
         eventTypes: [
-          stubRoute({ type: "factory.reap/v1", adapter: "command", resolvedModel: null }),
+          stubRoute({
+            type: "factory.reap/v1",
+            adapter: "command",
+            resolvedModel: null,
+          }),
         ],
       }),
     ];
@@ -271,7 +323,9 @@ describe("Agents copy chords and hints (WM-233)", () => {
     const agent = stubAgent("test-agent");
     await withAgents([agent], async () => {
       const r = renderAgents(agent.ref);
-      const refBtn = await r.findByRole("button", { name: "Copy agent ref (c)" });
+      const refBtn = await r.findByRole("button", {
+        name: "Copy agent ref (c)",
+      });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
       expect(refBtn.getAttribute("title")).toBe("Copy agent ref · c");

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { refetchIntervals, useDisplayOptions, useListKeys, useTabKeys } from "../hooks";
+import {
+  refetchIntervals,
+  useDisplayOptions,
+  useListKeys,
+  useTabKeys,
+} from "../hooks";
 import {
   buildSections,
   cycleColumnSort,
@@ -41,7 +46,9 @@ import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
 
 const caps = (a: AgentDef) =>
-  [a.capabilities.filesystem, ...(a.capabilities.services ?? [])].filter(Boolean).join(", ") || "none";
+  [a.capabilities.filesystem, ...(a.capabilities.services ?? [])]
+    .filter(Boolean)
+    .join(", ") || "none";
 
 /**
  * The adapters that take a model at all — the web-side mirror of
@@ -75,7 +82,11 @@ const matchesAgentTab = (agent: AgentDef, tab: AgentTab): boolean =>
 
 export function agentTabCounts(rows: AgentDef[]): Record<AgentTab, number> {
   const mutating = rows.filter((agent) => agent.mutating).length;
-  return { ALL: rows.length, MUTATING: mutating, READ_ONLY: rows.length - mutating };
+  return {
+    ALL: rows.length,
+    MUTATING: mutating,
+    READ_ONLY: rows.length - mutating,
+  };
 }
 
 const uniq = (values: string[]) => [...new Set(values)];
@@ -86,7 +97,8 @@ const uniq = (values: string[]) => [...new Set(values)];
  * to an empty cell.
  */
 export const routeModel = (r: AgentEventRoute): string =>
-  r.resolvedModel ?? (MODEL_ADAPTERS.has(r.adapter) ? "default" : NOT_APPLICABLE);
+  r.resolvedModel ??
+  (MODEL_ADAPTERS.has(r.adapter) ? "default" : NOT_APPLICABLE);
 
 /**
  * Row-level roll-ups. An agent is one row but can be routed by several event
@@ -126,12 +138,27 @@ const AGENTS_DISPLAY: DisplayConfig<AgentDef> = {
   subGroups: ["adapter", "tier", "contract"],
   sorts: [
     { key: "ref", label: "Ref", get: (a) => a.ref, column: "ref" },
-    { key: "contract", label: "Contract", get: (a) => a.outputContract, column: "contract" },
+    {
+      key: "contract",
+      label: "Contract",
+      get: (a) => a.outputContract,
+      column: "contract",
+    },
     { key: "adapter", label: "Adapter", get: adapterText, column: "adapter" },
     { key: "tier", label: "Tier", get: tierRank, column: "tier" },
     { key: "model", label: "Model", get: modelText, column: "model" },
-    { key: "mutating", label: "Mutating", get: (a) => Number(a.mutating), column: "mutating" },
-    { key: "capabilities", label: "Capabilities", get: caps, column: "capabilities" },
+    {
+      key: "mutating",
+      label: "Mutating",
+      get: (a) => Number(a.mutating),
+      column: "mutating",
+    },
+    {
+      key: "capabilities",
+      label: "Capabilities",
+      get: caps,
+      column: "capabilities",
+    },
     {
       key: "timeout",
       label: "Timeout",
@@ -181,7 +208,11 @@ export function Agents({
   focusAgentRef: string | null;
   onSelectAgent: (ref: string | null) => void;
 }) {
-  const query = useQuery({ queryKey: ["agents"], queryFn: api.agents, ...refetchIntervals.primary });
+  const query = useQuery({
+    queryKey: ["agents"],
+    queryFn: api.agents,
+    ...refetchIntervals.primary,
+  });
   const rows = query.data?.agents ?? [];
   const contracts = query.data?.contracts ?? {};
 
@@ -195,7 +226,10 @@ export function Agents({
   useTabKeys(AGENT_TABS, tab, selectTab);
 
   const [filter, setFilter] = useState("");
-  const byTab = useMemo(() => rows.filter((agent) => matchesAgentTab(agent, tab)), [rows, tab]);
+  const byTab = useMemo(
+    () => rows.filter((agent) => matchesAgentTab(agent, tab)),
+    [rows, tab],
+  );
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (!q) return byTab;
@@ -218,7 +252,10 @@ export function Agents({
   // Display options (OPS-493): partition into sections, order inside them, and
   // feed keyboard navigation only the rows of open sections.
   const [display, setDisplay] = useDisplayOptions(AGENTS_DISPLAY);
-  const sections = useMemo(() => buildSections(visible, AGENTS_DISPLAY, display), [visible, display]);
+  const sections = useMemo(
+    () => buildSections(visible, AGENTS_DISPLAY, display),
+    [visible, display],
+  );
   const flat = useMemo(
     () => flattenSections(sections, display.collapsed),
     [sections, display.collapsed],
@@ -229,18 +266,25 @@ export function Agents({
   const selectedRef = focusAgentRef;
   // Keyboard index walks the open sections; the detail pane keys off the row
   // itself so collapsing the group under a selection never closes the pane.
-  const selectedIndex = useMemo(() => flat.findIndex((a) => a.ref === selectedRef), [flat, selectedRef]);
+  const selectedIndex = useMemo(
+    () => flat.findIndex((a) => a.ref === selectedRef),
+    [flat, selectedRef],
+  );
   const sel = useMemo(
-    () => (selectedRef ? (visible.find((a) => a.ref === selectedRef) ?? null) : null),
+    () =>
+      selectedRef ? (visible.find((a) => a.ref === selectedRef) ?? null) : null,
     [visible, selectedRef],
   );
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
   useEffect(() => {
-    if (!focusAgentRef || visible.some((agent) => agent.ref === focusAgentRef)) return;
+    if (!focusAgentRef || visible.some((agent) => agent.ref === focusAgentRef))
+      return;
     if (!byTab.some((agent) => agent.ref === focusAgentRef)) setTab("ALL");
     setFilter("");
     // A row click updates only focusAgentRef, so inspect visibility at that
@@ -265,7 +309,11 @@ export function Agents({
         pendingC.current = Date.now();
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -278,7 +326,11 @@ export function Agents({
       setContextActions([]);
     } else {
       setContextActions([
-        { label: `Copy ${sel.ref}`, hint: "c", run: () => copyText(sel.ref, "agent ref") },
+        {
+          label: `Copy ${sel.ref}`,
+          hint: "c",
+          run: () => copyText(sel.ref, "agent ref"),
+        },
         { label: "Copy link to this agent", hint: "c l", run: copyLink },
       ]);
     }
@@ -289,208 +341,269 @@ export function Agents({
 
   return (
     <div className="flex h-full min-w-0">
-      <div className={`${sel ? "hidden lg:flex" : "flex"} min-h-0 min-w-0 flex-1`}>
-      <ListPane
-        chrome={
-          <>
-        <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
-        <ScopeCaption
-          context={context}
-          surface="registry"
-          subject={{ label: "Agents", plural: true }}
-        />
-        <div className="mb-2 text-[11px] text-(--text-faint)" aria-live="polite">
-          {rows.length} agents · {mutatingCount} mutating · {rows.length - mutatingCount} read-only
-        </div>
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Agent mutation safety">
-            {AGENT_TABS.map((item, index) => (
-              <button
-                key={item}
-                type="button"
-                role="tab"
-                aria-selected={tab === item}
-                onClick={() => selectTab(item)}
-                className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                  tab === item
-                    ? "bg-(--surface-3) text-(--text)"
-                    : "text-(--text-faint) hover:bg-(--surface-1)"
-                }`}
-              >
-                {AGENT_TAB_LABELS[item]}
-                <span className="ml-1.5 tabular-nums text-(--text-faint)">{tabCounts[item]}</span>
-                <span aria-hidden="true" className="mono ml-1 text-[10px] text-(--text-faint) opacity-70">
-                  {index + 1}
-                </span>
-              </button>
-            ))}
-          </div>
-          <span className="ml-auto">
-            <DisplayOptions
-              config={AGENTS_DISPLAY}
-              state={display}
-              onChange={setDisplay}
-              onExport={visible.length > 0 ? handleExport : undefined}
-              rows={rows}
-            />
-          </span>
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="Filter ref, contract, adapter, model, event type…"
-            label="Filter agents"
-          />
-        </div>
-          </>
-        }
+      <div
+        className={`${sel ? "hidden lg:flex" : "flex"} min-h-0 min-w-0 flex-1`}
       >
-
-        <table className="w-full border-separate border-spacing-0">
-          <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
-              {cols.map((c) => {
-                const sort = AGENTS_DISPLAY.sorts.find((s) => s.column === c.key);
-                const isCustom = c.isCustom || c.key.startsWith("custom:");
-                const customPath = c.key.replace(/^custom:/, "");
-                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
-                return (
-                  <Th
-                    key={c.key}
-                    label={c.label}
-                    dir={isCurrentSort ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir ?? "asc"}
-                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(AGENTS_DISPLAY, s, c.key)) : undefined}
-                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
-                  />
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {(() => {
-              const renderRow = (a: AgentDef) => (
-                <tr
-                  key={a.ref}
-                  onClick={() => onSelectAgent(a.ref)}
-                  aria-selected={a.ref === selectedRef}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${a.ref === selectedRef ? "row-selected" : ""}`}
-                >
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap">{a.ref}</td>
-                  {show.has("contract") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">{a.outputContract}</td>
-                  )}
-                  {show.has("adapter") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      {adapterText(a)}
-                    </td>
-                  )}
-                  {show.has("tier") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      {tierText(a)}
-                      {a.model && a.modelTier && (
-                        <span
-                          className="ml-1.5 text-[11px] text-(--text-faint)"
-                          title={`Overridden outright by model ${a.model} — the tier is declared but never resolved.`}
-                        >
-                          overridden
-                        </span>
-                      )}
-                    </td>
-                  )}
-                  {show.has("model") && (
-                    <td className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <ModelCell
-                        model={modelText(a)}
-                        className={modelText(a) === NOT_APPLICABLE ? "text-(--text-faint)" : "text-(--text-dim)"}
-                      />
-                    </td>
-                  )}
-                  {show.has("mutating") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <AgentMutationBadge mutating={a.mutating} />
-                    </td>
-                  )}
-                  {show.has("capabilities") && (
-                    <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">
-                      {caps(a)}
-                    </td>
-                  )}
-                  {show.has("timeout") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
-                      <span title={a.limits.timeout_seconds != null ? `${a.limits.timeout_seconds}s` : undefined}>
-                        {formatDuration(a.limits.timeout_seconds)}
-                      </span>
-                    </td>
-                  )}
-                  {show.has("attempts") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
-                      {a.limits.attempts ?? EMPTY}
-                    </td>
-                  )}
-                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
-                    <CustomCell key={c.key} row={a} path={c.key.replace(/^custom:/, "")} />
-                  ))}
-                </tr>
-              );
-              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
-              return sections.map((s) => {
-                const closed = display.collapsed.includes(s.key);
-                return (
-                  <Fragment key={s.key}>
-                    <GroupHeaderRow
-                      colSpan={cols.length}
-                      section={s}
-                      collapsed={closed}
-                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
-                    />
-                    {!closed &&
-                      (s.subsections
-                        ? s.subsections.map((child) => {
-                            const childClosed = display.collapsed.includes(child.key);
-                            return (
-                              <Fragment key={child.key}>
-                                <GroupHeaderRow
-                                  colSpan={cols.length}
-                                  section={child}
-                                  collapsed={childClosed}
-                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
-                                  sub
-                                />
-                                {!childClosed && child.rows.map(renderRow)}
-                              </Fragment>
-                            );
-                          })
-                        : s.rows.map(renderRow))}
-                  </Fragment>
-                );
-              });
-            })()}
-            {visible.length === 0 && (
-              <ListEmpty
-                colSpan={cols.length}
-                query={query}
-                filtered={rows.length > 0}
-                noun="agents"
-                empty="No registered agents."
+        <ListPane
+          chrome={
+            <>
+              <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
+              <ScopeCaption
+                context={context}
+                surface="registry"
+                subject={{ label: "Agents", plural: true }}
               />
-            )}
-          </tbody>
-        </table>
+              <div
+                className="mb-2 text-[11px] text-(--text-faint)"
+                aria-live="polite"
+              >
+                {rows.length} agents · {mutatingCount} mutating ·{" "}
+                {rows.length - mutatingCount} read-only
+              </div>
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <div
+                  className="flex min-w-0 flex-1 flex-wrap gap-1"
+                  role="tablist"
+                  aria-label="Agent mutation safety"
+                >
+                  {AGENT_TABS.map((item, index) => (
+                    <button
+                      key={item}
+                      type="button"
+                      role="tab"
+                      aria-selected={tab === item}
+                      onClick={() => selectTab(item)}
+                      className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                        tab === item
+                          ? "bg-(--surface-3) text-(--text)"
+                          : "text-(--text-faint) hover:bg-(--surface-1)"
+                      }`}
+                    >
+                      {AGENT_TAB_LABELS[item]}
+                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                        {tabCounts[item]}
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        className="mono ml-1 text-[10px] text-(--text-faint) opacity-70"
+                      >
+                        {index + 1}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <span className="ml-auto">
+                  <DisplayOptions
+                    config={AGENTS_DISPLAY}
+                    state={display}
+                    onChange={setDisplay}
+                    onExport={visible.length > 0 ? handleExport : undefined}
+                    rows={rows}
+                  />
+                </span>
+                <FilterInput
+                  value={filter}
+                  onChange={setFilter}
+                  placeholder="Filter ref, contract, adapter, model, event type…"
+                  label="Filter agents"
+                />
+              </div>
+            </>
+          }
+        >
+          <table className="w-full border-separate border-spacing-0">
+            <thead>
+              <tr className="text-left text-[11px] text-(--text-faint)">
+                {cols.map((c) => {
+                  const sort = AGENTS_DISPLAY.sorts.find(
+                    (s) => s.column === c.key,
+                  );
+                  const isCustom = c.isCustom || c.key.startsWith("custom:");
+                  const customPath = c.key.replace(/^custom:/, "");
+                  const isCurrentSort = isCustom
+                    ? display.sortBy === c.key
+                    : sort && display.sortBy === sort.key;
+                  return (
+                    <Th
+                      key={c.key}
+                      label={c.label}
+                      dir={isCurrentSort ? display.sortDir : null}
+                      naturalDir={sort?.defaultDir ?? "asc"}
+                      onSort={
+                        sort || isCustom
+                          ? () =>
+                              setDisplay((s) =>
+                                cycleColumnSort(AGENTS_DISPLAY, s, c.key),
+                              )
+                          : undefined
+                      }
+                      onRemove={
+                        isCustom
+                          ? () =>
+                              setDisplay((s) =>
+                                removeCustomColumn(s, customPath),
+                              )
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {(() => {
+                const renderRow = (a: AgentDef) => (
+                  <tr
+                    key={a.ref}
+                    onClick={() => onSelectAgent(a.ref)}
+                    aria-selected={a.ref === selectedRef}
+                    className={`cursor-pointer hover:bg-(--surface-1) ${a.ref === selectedRef ? "row-selected" : ""}`}
+                  >
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      {a.ref}
+                    </td>
+                    {show.has("contract") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">
+                        {a.outputContract}
+                      </td>
+                    )}
+                    {show.has("adapter") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                        {adapterText(a)}
+                      </td>
+                    )}
+                    {show.has("tier") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                        {tierText(a)}
+                        {a.model && a.modelTier && (
+                          <span
+                            className="ml-1.5 text-[11px] text-(--text-faint)"
+                            title={`Overridden outright by model ${a.model} — the tier is declared but never resolved.`}
+                          >
+                            overridden
+                          </span>
+                        )}
+                      </td>
+                    )}
+                    {show.has("model") && (
+                      <td className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                        <ModelCell
+                          model={modelText(a)}
+                          className={
+                            modelText(a) === NOT_APPLICABLE
+                              ? "text-(--text-faint)"
+                              : "text-(--text-dim)"
+                          }
+                        />
+                      </td>
+                    )}
+                    {show.has("mutating") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                        <AgentMutationBadge mutating={a.mutating} />
+                      </td>
+                    )}
+                    {show.has("capabilities") && (
+                      <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">
+                        {caps(a)}
+                      </td>
+                    )}
+                    {show.has("timeout") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
+                        <span
+                          title={
+                            a.limits.timeout_seconds != null
+                              ? `${a.limits.timeout_seconds}s`
+                              : undefined
+                          }
+                        >
+                          {formatDuration(a.limits.timeout_seconds)}
+                        </span>
+                      </td>
+                    )}
+                    {show.has("attempts") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
+                        {a.limits.attempts ?? EMPTY}
+                      </td>
+                    )}
+                    {cols
+                      .filter((c) => c.isCustom || c.key.startsWith("custom:"))
+                      .map((c) => (
+                        <CustomCell
+                          key={c.key}
+                          row={a}
+                          path={c.key.replace(/^custom:/, "")}
+                        />
+                      ))}
+                  </tr>
+                );
+                if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+                return sections.map((s) => {
+                  const closed = display.collapsed.includes(s.key);
+                  return (
+                    <Fragment key={s.key}>
+                      <GroupHeaderRow
+                        colSpan={cols.length}
+                        section={s}
+                        collapsed={closed}
+                        onToggle={() =>
+                          setDisplay((st) => toggleCollapsed(st, s.key))
+                        }
+                      />
+                      {!closed &&
+                        (s.subsections
+                          ? s.subsections.map((child) => {
+                              const childClosed = display.collapsed.includes(
+                                child.key,
+                              );
+                              return (
+                                <Fragment key={child.key}>
+                                  <GroupHeaderRow
+                                    colSpan={cols.length}
+                                    section={child}
+                                    collapsed={childClosed}
+                                    onToggle={() =>
+                                      setDisplay((st) =>
+                                        toggleCollapsed(st, child.key),
+                                      )
+                                    }
+                                    sub
+                                  />
+                                  {!childClosed && child.rows.map(renderRow)}
+                                </Fragment>
+                              );
+                            })
+                          : s.rows.map(renderRow))}
+                    </Fragment>
+                  );
+                });
+              })()}
+              {visible.length === 0 && (
+                <ListEmpty
+                  colSpan={cols.length}
+                  query={query}
+                  filtered={rows.length > 0}
+                  noun="agents"
+                  empty="No registered agents."
+                />
+              )}
+            </tbody>
+          </table>
 
-        <div className="mt-6">
-          <Section title="Shared contracts">
-            <div className="mb-1.5 text-[11px] text-(--text-faint)">
-              Every agent&apos;s input arrives as a factory.event/v1 envelope and its output must
-              validate against factory.agent-result/v1 — these schemas are the runtime&apos;s edges.
-            </div>
-            {Object.entries(contracts).map(([name, schema]) => (
-              <Disclosure key={name} label={name}>
-                <JsonBlock value={schema} />
-              </Disclosure>
-            ))}
-          </Section>
-        </div>
-      </ListPane>
+          <div className="mt-6">
+            <Section title="Shared contracts">
+              <div className="mb-1.5 text-[11px] text-(--text-faint)">
+                Every agent&apos;s input arrives as a factory.event/v1 envelope
+                and its output must validate against factory.agent-result/v1 —
+                these schemas are the runtime&apos;s edges.
+              </div>
+              {Object.entries(contracts).map(([name, schema]) => (
+                <Disclosure key={name} label={name}>
+                  <JsonBlock value={schema} />
+                </Disclosure>
+              ))}
+            </Section>
+          </div>
+        </ListPane>
       </div>
 
       {sel && (
@@ -506,7 +619,6 @@ export function Agents({
           }
           close={<Button onClick={() => onSelectAgent(null)}>Close</Button>}
         >
-
           <Section title="Definition" icons>
             {/* Grouped + attribute icons per §5.2 tier 4 (WM-482). Glyphs
                 resolve from the registry by label (WM-483); identity rows are
@@ -528,12 +640,27 @@ export function Agents({
               />
               <KV k="capabilities" v={caps(sel)} />
               <KV k="adapter" v={adapterText(sel)} />
-              <KV k="hosts" v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : EMPTY} />
-              <KV k="command" v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : EMPTY} />
+              <KV
+                k="hosts"
+                v={
+                  sel.hosts && sel.hosts.length > 0
+                    ? sel.hosts.join(", ")
+                    : EMPTY
+                }
+              />
+              <KV
+                k="command"
+                v={
+                  sel.command && sel.command.length > 0
+                    ? sel.command.join(" ")
+                    : EMPTY
+                }
+              />
               <KV
                 k="action registry"
                 v={
-                  sel.actionRegistry && Object.keys(sel.actionRegistry).length > 0
+                  sel.actionRegistry &&
+                  Object.keys(sel.actionRegistry).length > 0
                     ? Object.keys(sel.actionRegistry).join(", ")
                     : EMPTY
                 }
@@ -548,7 +675,9 @@ export function Agents({
                 k="model override"
                 v={
                   sel.model ? (
-                    <span title="Exact model id — resolved verbatim, whatever the tier says.">{sel.model}</span>
+                    <span title="Exact model id — resolved verbatim, whatever the tier says.">
+                      {sel.model}
+                    </span>
                   ) : (
                     EMPTY
                   )
@@ -559,7 +688,13 @@ export function Agents({
               <KV
                 k="timeout"
                 v={
-                  <span title={sel.limits.timeout_seconds != null ? `${sel.limits.timeout_seconds}s` : undefined}>
+                  <span
+                    title={
+                      sel.limits.timeout_seconds != null
+                        ? `${sel.limits.timeout_seconds}s`
+                        : undefined
+                    }
+                  >
                     {formatDuration(sel.limits.timeout_seconds)}
                   </span>
                 }
@@ -571,7 +706,11 @@ export function Agents({
           {sel.command && (
             <Section title="Command argv" card={false}>
               <div className="mb-1.5 flex justify-end">
-                <Button onClick={() => copyText(sel.command!.join(" "), "command")}>Copy command</Button>
+                <Button
+                  onClick={() => copyText(sel.command!.join(" "), "command")}
+                >
+                  Copy command
+                </Button>
               </div>
               <JsonBlock value={sel.command} />
             </Section>
@@ -588,8 +727,12 @@ export function Agents({
 
           <Section title={`Prompt · ${sel.promptFile}`} card={false}>
             <div className="mb-1.5 flex items-center justify-between gap-2">
-              <span className="text-[11px] font-medium text-(--text-faint)">Markdown source</span>
-              <Button onClick={() => copyText(sel.prompt, "prompt")}>Copy prompt</Button>
+              <span className="text-[11px] font-medium text-(--text-faint)">
+                Markdown source
+              </span>
+              <Button onClick={() => copyText(sel.prompt, "prompt")}>
+                Copy prompt
+              </Button>
             </div>
             <pre className="mono max-h-96 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-3 leading-relaxed whitespace-pre-wrap">
               {sel.prompt}
@@ -607,9 +750,10 @@ export function Agents({
 
           <Section title="Pins">
             <div className="mb-1.5 text-[11px] text-(--text-faint)">
-              Content-hash pins over the prompt and schema files: if a pinned file&apos;s bytes
-              drift from its hash, the registry fails closed at load — versions are bumped and
-              re-pinned, never edited in place.
+              Content-hash pins over the prompt and schema files: if a pinned
+              file&apos;s bytes drift from its hash, the registry fails closed
+              at load — versions are bumped and re-pinned, never edited in
+              place.
             </div>
             {Object.entries(sel.pins).map(([file, hash]) => (
               <KV key={file} k={file} v={hash} />
@@ -618,7 +762,9 @@ export function Agents({
 
           <Section title="Event routing" card={false}>
             {sel.eventTypes.length === 0 ? (
-              <div className="text-(--text-faint)">No event types route to this agent.</div>
+              <div className="text-(--text-faint)">
+                No event types route to this agent.
+              </div>
             ) : (
               <div className="rounded-md border border-(--border) px-3 py-1">
                 {sel.eventTypes.map((r) => (
@@ -628,7 +774,9 @@ export function Agents({
                     title={`Show ${r.type} in Events`}
                     className="group -mx-3 block border-b border-(--border) px-3 py-1.5 last:border-0 hover:bg-(--surface-1)"
                   >
-                    <div className="mono text-(--accent) group-hover:underline">{r.type}</div>
+                    <div className="mono text-(--accent) group-hover:underline">
+                      {r.type}
+                    </div>
                     <div className="text-[11px] text-(--text-faint)">
                       adapter {r.adapter} · model{" "}
                       <span
@@ -647,9 +795,13 @@ export function Agents({
                       {r.proposalTtlSeconds != null ? (
                         <>
                           {" · proposal TTL "}
-                          <span title={`${r.proposalTtlSeconds}s`}>{formatDuration(r.proposalTtlSeconds)}</span>
+                          <span title={`${r.proposalTtlSeconds}s`}>
+                            {formatDuration(r.proposalTtlSeconds)}
+                          </span>
                         </>
-                      ) : ""}
+                      ) : (
+                        ""
+                      )}
                     </div>
                   </a>
                 ))}

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -1,7 +1,13 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { useState } from "react";
@@ -58,7 +64,10 @@ afterEach(() => {
   cleanup();
   window.location.hash = "#/artifacts";
   globalThis.fetch = originalFetch;
-  Object.defineProperty(navigator, "clipboard", { configurable: true, value: originalClipboard });
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: originalClipboard,
+  });
   localStorage.removeItem("evrt-display-artifacts");
   localStorage.removeItem(ARTIFACT_RAW_KEY);
 });
@@ -69,10 +78,18 @@ function renderArtifacts(
   seed: { items?: ArtifactInventoryItem[]; agents?: unknown[] } = {},
 ) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, refetchInterval: false, staleTime: Infinity } },
+    defaultOptions: {
+      queries: { retry: false, refetchInterval: false, staleTime: Infinity },
+    },
   });
   client.setQueryData(["artifacts"], { artifacts: seed.items ?? ITEMS });
-  if (seed.agents) client.setQueryData(["agents"], { agents: seed.agents, edges: {}, eventTypes: [], contracts: {} });
+  if (seed.agents)
+    client.setQueryData(["agents"], {
+      agents: seed.agents,
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+    });
   client.setQueryData(["events", "all-for-artifacts"], {
     events: [
       {
@@ -128,17 +145,29 @@ describe("Artifacts inventory (WM-207)", () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
-    const summary = view.getByRole("region", { name: "Artifact storage summary" });
+    const summary = view.getByRole("region", {
+      name: "Artifact storage summary",
+    });
     expect(summary.textContent).toContain("2.4 GB");
     expect(summary.textContent).toContain("28");
     expect(summary.textContent).toContain("5.1 KB");
 
-    for (const heading of ["SHA", "Kind", "File size", "Age", "Referenced by"]) {
+    for (const heading of [
+      "SHA",
+      "Kind",
+      "File size",
+      "Age",
+      "Referenced by",
+    ]) {
       expect(view.getByRole("columnheader", { name: heading })).toBeTruthy();
     }
     expect(view.queryByRole("columnheader", { name: "Orphan" })).toBeNull();
-    const download = view.getByRole("link", { name: `Download artifact ${"a".repeat(64)}` });
-    expect(download.getAttribute("href")).toContain(`/api/artifacts/${"a".repeat(64)}`);
+    const download = view.getByRole("link", {
+      name: `Download artifact ${"a".repeat(64)}`,
+    });
+    expect(download.getAttribute("href")).toContain(
+      `/api/artifacts/${"a".repeat(64)}`,
+    );
 
     const runLink = view.getByRole("button", { name: "run_12345678" });
     expect(runLink.getAttribute("title")).toBe(LONG_RUN_ID);
@@ -156,30 +185,38 @@ describe("Artifacts inventory (WM-207)", () => {
       "bbbbbbbbbbbb",
       "aaaaaaaaaaaa",
     ]);
-    expect(view.getByRole("columnheader", { name: "Age" }).getAttribute("aria-sort")).toBe("descending");
+    expect(
+      view.getByRole("columnheader", { name: "Age" }).getAttribute("aria-sort"),
+    ).toBe("descending");
   });
 
   test("filters by kind and orphan status facets", async () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
-    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), { target: { value: "report" } });
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
+      target: { value: "report" },
+    });
     expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy();
     expect(view.queryByText("bbbbbbbbbbbb")).toBeNull();
 
-    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), { target: { value: "" } });
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
+      target: { value: "" },
+    });
     fireEvent.click(view.getByRole("tab", { name: "Orphans 28" }));
     expect(view.getByText("cccccccccccc")).toBeTruthy();
     expect(view.queryByText("aaaaaaaaaaaa")).toBeNull();
-
   });
 
   test("applies a free-text filter across reference metadata", async () => {
-    const view = renderArtifacts(mock(() => {}), {
-      kind: null,
-      orphan: null,
-      search: "ticket-agent",
-    });
+    const view = renderArtifacts(
+      mock(() => {}),
+      {
+        kind: null,
+        orphan: null,
+        search: "ticket-agent",
+      },
+    );
     await waitFor(() => expect(view.getByText("bbbbbbbbbbbb")).toBeTruthy());
     const table = view.getByRole("table");
     expect(within(table).queryByText("aaaaaaaaaaaa")).toBeNull();
@@ -188,7 +225,9 @@ describe("Artifacts inventory (WM-207)", () => {
 
   test("opens a deep-linked inspector with formatted preview, actions, search, and bidirectional references", async () => {
     const raw = JSON.stringify({ message: "hello artifact", count: 2 });
-    globalThis.fetch = mock(async () => new Response(raw, { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      async () => new Response(raw, { status: 200 }),
+    ) as unknown as typeof fetch;
     const writeText = mock(async () => {});
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -198,21 +237,35 @@ describe("Artifacts inventory (WM-207)", () => {
     window.location.hash = `#/artifacts/${"a".repeat(64)}`;
     const view = renderArtifacts();
 
-    const preview = await view.findByRole("region", { name: "Artifact content" });
+    const preview = await view.findByRole("region", {
+      name: "Artifact content",
+    });
     expect(preview.textContent).toContain('\"message\": \"hello artifact\"');
     expect(preview.textContent).toContain("1");
     expect(preview.textContent).toContain("2");
 
-    const references = view.getByRole("region", { name: "Artifact run references" });
-    fireEvent.click(within(references).getByRole("button", { name: /run_12345678/ }));
+    const references = view.getByRole("region", {
+      name: "Artifact run references",
+    });
+    fireEvent.click(
+      within(references).getByRole("button", { name: /run_12345678/ }),
+    );
     expect(view.onJumpRun).toHaveBeenCalledWith(LONG_RUN_ID);
-    fireEvent.click(within(references).getByTitle("Open consuming run run_consumer"));
+    fireEvent.click(
+      within(references).getByTitle("Open consuming run run_consumer"),
+    );
     expect(view.onJumpRun).toHaveBeenCalledWith("run_consumer");
-    expect(within(references).getByText(/factory-chain:evt_consumer/)).toBeTruthy();
+    expect(
+      within(references).getByText(/factory-chain:evt_consumer/),
+    ).toBeTruthy();
 
     const download = view.getByRole("link", { name: "Download" });
-    expect(download.getAttribute("href")).toContain(`/api/artifacts/${"a".repeat(64)}`);
-    expect(view.getByRole("combobox", { name: "Search artifact content" })).toBeTruthy();
+    expect(download.getAttribute("href")).toContain(
+      `/api/artifacts/${"a".repeat(64)}`,
+    );
+    expect(
+      view.getByRole("combobox", { name: "Search artifact content" }),
+    ).toBeTruthy();
 
     fireEvent.click(view.getByRole("button", { name: "Copy Raw Content" }));
     fireEvent.click(view.getByRole("button", { name: "Copy SHA-256" }));
@@ -221,13 +274,17 @@ describe("Artifacts inventory (WM-207)", () => {
   });
 
   test("selects a row into the inspector and routes run artifact links to the same deep link", async () => {
-    globalThis.fetch = mock(async () => new Response("line one\nline two", { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      async () => new Response("line one\nline two", { status: 200 }),
+    ) as unknown as typeof fetch;
     const view = renderArtifacts();
     const reportRow = view.getByText("1.0 KB").closest("tr");
     expect(reportRow).toBeTruthy();
     fireEvent.click(reportRow!);
     expect(window.location.hash).toBe(`#/${`artifacts/${"a".repeat(64)}`}`);
-    expect(await view.findByRole("region", { name: "Artifact content" })).toBeTruthy();
+    expect(
+      await view.findByRole("region", { name: "Artifact content" }),
+    ).toBeTruthy();
 
     window.location.hash = `#/runs/${LONG_RUN_ID}`;
     const runLink = render(
@@ -241,15 +298,31 @@ describe("Artifacts inventory (WM-207)", () => {
 });
 
 describe("Artifacts inspector renders a view for the producing agent's artifact (WM-455)", () => {
-  const MERGE_VIEW = JSON.parse(readFileSync(path.resolve(import.meta.dir, "../../../agents/merge-scan.view.json"), "utf8"));
-  const MERGE_AGENT = { ref: "merge-scan@2", id: "merge-scan", outputSchema: { title: "merge plan" }, outputView: MERGE_VIEW };
+  const MERGE_VIEW = JSON.parse(
+    readFileSync(
+      path.resolve(import.meta.dir, "../../../agents/merge-scan.view.json"),
+      "utf8",
+    ),
+  );
+  const MERGE_AGENT = {
+    ref: "merge-scan@2",
+    id: "merge-scan",
+    outputSchema: { title: "merge plan" },
+    outputView: MERGE_VIEW,
+  };
   const MERGE_ITEM: ArtifactInventoryItem = {
     sha256: "d".repeat(64),
     sizeBytes: 900,
     mtime: "2026-01-05T03:04:05.000Z",
     referenced: true,
     references: [
-      { runId: "run_merge", kind: "report", agent: "merge-scan@2", state: "COMPLETED", createdAt: "2026-01-05T03:04:05.000Z" },
+      {
+        runId: "run_merge",
+        kind: "report",
+        agent: "merge-scan@2",
+        state: "COMPLETED",
+        createdAt: "2026-01-05T03:04:05.000Z",
+      },
     ],
   };
   const MERGE_PLAN = {
@@ -260,28 +333,46 @@ describe("Artifacts inspector renders a view for the producing agent's artifact 
     deployBranch: "main",
     plan: [],
     fix: [],
-    escalate: [{ pr: 471, ticket: "WM-210", headSha: "c".repeat(40), reason: "Draft hold." }],
+    escalate: [
+      {
+        pr: 471,
+        ticket: "WM-210",
+        headSha: "c".repeat(40),
+        reason: "Draft hold.",
+      },
+    ],
     summary: "One PR held.",
   };
 
   test("a stored merge-plan JSON draws through the merge-scan view, Raw swaps back to the line preview", async () => {
-    globalThis.fetch = mock(async () => new Response(JSON.stringify(MERGE_PLAN), { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify(MERGE_PLAN), { status: 200 }),
+    ) as unknown as typeof fetch;
     window.location.hash = `#/artifacts/${"d".repeat(64)}`;
-    const view = renderArtifacts(undefined, undefined, { items: [MERGE_ITEM, ...ITEMS], agents: [MERGE_AGENT] });
+    const view = renderArtifacts(undefined, undefined, {
+      items: [MERGE_ITEM, ...ITEMS],
+      agents: [MERGE_AGENT],
+    });
 
     expect(await view.findByText("One PR held.")).toBeTruthy();
     expect(view.getByText("ESCALATE")).toBeTruthy();
-    expect((view.getByRole("link", { name: "#471" }) as HTMLAnchorElement).getAttribute("href")).toBe(
-      "https://github.com/watt-mind/factory/pull/471",
-    );
+    expect(
+      (
+        view.getByRole("link", { name: "#471" }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe("https://github.com/watt-mind/factory/pull/471");
     expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
-    expect(view.queryByRole("combobox", { name: "Search artifact content" })).toBeNull();
+    expect(
+      view.queryByRole("combobox", { name: "Search artifact content" }),
+    ).toBeNull();
     expect(view.getByText(/Merge plan · merge-scan@2/)).toBeTruthy();
 
     fireEvent.click(view.getByRole("button", { name: "Raw" }));
     const preview = view.getByRole("region", { name: "Artifact content" });
     expect(preview.textContent).toContain('"recommendation": "ESCALATE"');
-    expect(view.getByRole("combobox", { name: "Search artifact content" })).toBeTruthy();
+    expect(
+      view.getByRole("combobox", { name: "Search artifact content" }),
+    ).toBeTruthy();
     expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
 
     fireEvent.click(view.getByRole("button", { name: "View" }));
@@ -290,11 +381,23 @@ describe("Artifacts inspector renders a view for the producing agent's artifact 
   });
 
   test("a transcript from an agent with a view keeps the plain preview — the view says nothing about it", async () => {
-    globalThis.fetch = mock(async () => new Response(JSON.stringify({ type: "assistant", text: "hi" }), { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ type: "assistant", text: "hi" }), {
+          status: 200,
+        }),
+    ) as unknown as typeof fetch;
     window.location.hash = `#/artifacts/${"d".repeat(64)}`;
-    const view = renderArtifacts(undefined, undefined, { items: [MERGE_ITEM, ...ITEMS], agents: [MERGE_AGENT] });
-    const preview = await view.findByRole("region", { name: "Artifact content" });
+    const view = renderArtifacts(undefined, undefined, {
+      items: [MERGE_ITEM, ...ITEMS],
+      agents: [MERGE_AGENT],
+    });
+    const preview = await view.findByRole("region", {
+      name: "Artifact content",
+    });
     expect(preview.textContent).toContain('"type": "assistant"');
-    expect(view.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
+    expect(
+      view.queryByRole("group", { name: "Artifact rendering" }),
+    ).toBeNull();
   });
 });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -26,7 +26,12 @@ import {
 import { EMPTY, formatBytes, formatRelative } from "../format";
 import { refetchIntervals, useDisplayOptions, useNow } from "../hooks";
 import { viewApplies } from "../lib/artifactView";
-import type { AdmittedEvent, AgentDef, ArtifactInventoryItem, StatusView } from "../types";
+import type {
+  AdmittedEvent,
+  AgentDef,
+  ArtifactInventoryItem,
+  StatusView,
+} from "../types";
 
 export { formatBytes };
 
@@ -39,21 +44,47 @@ export type ArtifactFilters = {
 const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
 
 function kindsOf(artifact: ArtifactInventoryItem): string[] {
-  return [...new Set(artifact.references.flatMap((reference) => reference.kind ?? []))];
+  return [
+    ...new Set(
+      artifact.references.flatMap((reference) => reference.kind ?? []),
+    ),
+  ];
 }
 
 const ARTIFACTS_DISPLAY: DisplayConfig<ArtifactInventoryItem> = {
   view: "artifacts",
   groups: [],
   sorts: [
-    { key: "sha", label: "SHA", get: (artifact) => artifact.sha256, column: "sha" },
-    { key: "kind", label: "Kind", get: (artifact) => kindsOf(artifact).join(", "), column: "kind" },
-    { key: "size", label: "File size", get: (artifact) => artifact.sizeBytes, column: "size" },
-    { key: "age", label: "Age", get: (artifact) => Date.parse(artifact.mtime), defaultDir: "desc", column: "age" },
+    {
+      key: "sha",
+      label: "SHA",
+      get: (artifact) => artifact.sha256,
+      column: "sha",
+    },
+    {
+      key: "kind",
+      label: "Kind",
+      get: (artifact) => kindsOf(artifact).join(", "),
+      column: "kind",
+    },
+    {
+      key: "size",
+      label: "File size",
+      get: (artifact) => artifact.sizeBytes,
+      column: "size",
+    },
+    {
+      key: "age",
+      label: "Age",
+      get: (artifact) => Date.parse(artifact.mtime),
+      defaultDir: "desc",
+      column: "age",
+    },
     {
       key: "references",
       label: "Referenced by",
-      get: (artifact) => artifact.references.map((reference) => reference.runId).join(", "),
+      get: (artifact) =>
+        artifact.references.map((reference) => reference.runId).join(", "),
       column: "references",
     },
   ],
@@ -67,7 +98,10 @@ const ARTIFACTS_DISPLAY: DisplayConfig<ArtifactInventoryItem> = {
   defaults: { sortBy: "age", sortDir: "desc" },
 };
 
-function matchesSearch(artifact: ArtifactInventoryItem, search: string): boolean {
+function matchesSearch(
+  artifact: ArtifactInventoryItem,
+  search: string,
+): boolean {
   const term = search.trim().toLowerCase();
   if (!term) return true;
   return [
@@ -78,7 +112,11 @@ function matchesSearch(artifact: ArtifactInventoryItem, search: string): boolean
       reference.agent,
       reference.state,
     ]),
-  ].some((value) => String(value ?? "").toLowerCase().includes(term));
+  ].some((value) =>
+    String(value ?? "")
+      .toLowerCase()
+      .includes(term),
+  );
 }
 
 const ARTIFACT_HASH = /^[0-9a-f]{64}$/;
@@ -102,13 +140,20 @@ function openArtifactInspector(sha256: string) {
   window.location.hash = `#/artifacts/${encodeURIComponent(sha256)}`;
 }
 
-function containsArtifactHash(value: unknown, sha256: string, seen = new Set<object>()): boolean {
-  if (typeof value === "string") return value === sha256 || value === `sha256:${sha256}`;
+function containsArtifactHash(
+  value: unknown,
+  sha256: string,
+  seen = new Set<object>(),
+): boolean {
+  if (typeof value === "string")
+    return value === sha256 || value === `sha256:${sha256}`;
   if (!value || typeof value !== "object" || seen.has(value)) return false;
   seen.add(value);
   return Array.isArray(value)
     ? value.some((entry) => containsArtifactHash(entry, sha256, seen))
-    : Object.values(value).some((entry) => containsArtifactHash(entry, sha256, seen));
+    : Object.values(value).some((entry) =>
+        containsArtifactHash(entry, sha256, seen),
+      );
 }
 
 /** The stored bytes as one JSON object, or null — the only shape a view can describe. */
@@ -116,7 +161,9 @@ function parsedObject(raw: string): Record<string, unknown> | null {
   if (!/^\s*\{/.test(raw)) return null;
   try {
     const value: unknown = JSON.parse(raw);
-    return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
   } catch {
     return null;
   }
@@ -143,7 +190,14 @@ function highlightedLine(line: string, search: string): ReactNode {
   let match = lower.indexOf(needle);
   while (match >= 0) {
     chunks.push(line.slice(at, match));
-    chunks.push(<mark key={`${match}:${chunks.length}`} className="bg-(--hue-warn) text-inherit">{line.slice(match, match + term.length)}</mark>);
+    chunks.push(
+      <mark
+        key={`${match}:${chunks.length}`}
+        className="bg-(--hue-warn) text-inherit"
+      >
+        {line.slice(match, match + term.length)}
+      </mark>,
+    );
     at = match + term.length;
     match = lower.indexOf(needle, at);
   }
@@ -224,16 +278,18 @@ export function Artifacts({
 
   const kinds = useMemo(
     () =>
-      [...new Set([...COMMON_KINDS, ...artifacts.flatMap(kindsOf)])].sort((a, b) =>
-        a.localeCompare(b),
+      [...new Set([...COMMON_KINDS, ...artifacts.flatMap(kindsOf)])].sort(
+        (a, b) => a.localeCompare(b),
       ),
     [artifacts],
   );
   const visible = useMemo(
     () =>
       artifacts.filter((artifact) => {
-        if (filters.kind && !kindsOf(artifact).includes(filters.kind)) return false;
-        if (filters.orphan != null && filters.orphan === artifact.referenced) return false;
+        if (filters.kind && !kindsOf(artifact).includes(filters.kind))
+          return false;
+        if (filters.orphan != null && filters.orphan === artifact.referenced)
+          return false;
         return matchesSearch(artifact, filters.search);
       }),
     [artifacts, filters],
@@ -244,11 +300,15 @@ export function Artifacts({
     [visible, display],
   );
   const columns = visibleColumns(ARTIFACTS_DISPLAY, display);
-  const shown = useMemo(() => new Set(columns.map((column) => column.key)), [columns]);
+  const shown = useMemo(
+    () => new Set(columns.map((column) => column.key)),
+    [columns],
+  );
 
   const linkedEvents = (eventsQ.data?.events ?? []) as LinkedEvent[];
   const producerRunIds = useMemo(
-    () => new Set(selected?.references.map((reference) => reference.runId) ?? []),
+    () =>
+      new Set(selected?.references.map((reference) => reference.runId) ?? []),
     [selected],
   );
   const consumers = useMemo(
@@ -264,17 +324,26 @@ export function Artifacts({
     [linkedEvents, producerRunIds, selectedSha],
   );
   const causation = useMemo(
-    () => linkedEvents.filter((event) => event.causationId && producerRunIds.has(event.causationId)),
+    () =>
+      linkedEvents.filter(
+        (event) => event.causationId && producerRunIds.has(event.causationId),
+      ),
     [linkedEvents, producerRunIds],
   );
   const selectedKinds = selected ? kindsOf(selected) : [];
-  const preview = contentQ.data === undefined ? null : formattedContent(contentQ.data, selectedKinds);
+  const preview =
+    contentQ.data === undefined
+      ? null
+      : formattedContent(contentQ.data, selectedKinds);
   const parsedArtifact = useMemo(
     () => (contentQ.data === undefined ? null : parsedObject(contentQ.data)),
     [contentQ.data],
   );
   const producerAgent: AgentDef | undefined = useMemo(() => {
-    const refs = selected?.references.map((reference) => reference.agent).filter(Boolean) ?? [];
+    const refs =
+      selected?.references
+        .map((reference) => reference.agent)
+        .filter(Boolean) ?? [];
     const defs = agentsQ.data?.agents ?? [];
     for (const ref of refs) {
       const def = defs.find((a) => a.ref === ref || a.id === ref);
@@ -283,10 +352,14 @@ export function Artifacts({
     return undefined;
   }, [selected, agentsQ.data]);
   const viewShown =
-    parsedArtifact !== null && viewApplies(producerAgent?.outputView, parsedArtifact) && !artifactRaw;
+    parsedArtifact !== null &&
+    viewApplies(producerAgent?.outputView, parsedArtifact) &&
+    !artifactRaw;
   const previewLines = preview?.split("\n") ?? [];
   const matchCount = contentSearch.trim()
-    ? previewLines.filter((line) => line.toLowerCase().includes(contentSearch.trim().toLowerCase())).length
+    ? previewLines.filter((line) =>
+        line.toLowerCase().includes(contentSearch.trim().toLowerCase()),
+      ).length
     : null;
 
   const selectArtifact = (sha256: string) => {
@@ -312,346 +385,555 @@ export function Artifacts({
     [artifacts],
   );
   const summary: StatusView["artifacts"] = metrics ?? fallbackMetrics;
-  const filtered = Boolean(filters.kind || filters.orphan != null || filters.search.trim());
-  const set = (patch: Partial<ArtifactFilters>) => onFiltersChange({ ...filters, ...patch });
+  const filtered = Boolean(
+    filters.kind || filters.orphan != null || filters.search.trim(),
+  );
+  const set = (patch: Partial<ArtifactFilters>) =>
+    onFiltersChange({ ...filters, ...patch });
 
   return (
     <div className="flex h-full min-w-0">
-    <ListPane
-      chrome={
-        <>
-          <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
-            <div>
-              <h1 className="display text-lg font-semibold">Artifacts</h1>
-              <p className="mt-1 text-[12px] text-(--text-faint)">
-                Physical files in the content-addressed store. Project context does not narrow this factory-wide inventory.
-              </p>
-            </div>
-            {summary.at && (
-              <span className="text-[11px] text-(--text-faint)" title={summary.at}>
-                measured {formatRelative(summary.at, now)}
-              </span>
-            )}
-          </div>
-
-          <section aria-label="Artifact storage summary" className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
-            <StatCard label="Stored files" value={summary.files.toLocaleString()} />
-            <StatCard label="Disk usage" value={formatBytes(summary.bytes)} />
-            <StatCard
-              label="Orphans"
-              value={summary.orphans.toLocaleString()}
-              caption={formatBytes(summary.orphanBytes)}
-              hue={summary.orphans > 0 ? "var(--hue-warn)" : undefined}
-            />
-          </section>
-
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <div className="flex flex-wrap gap-1" role="tablist" aria-label="Artifact reference state">
-              {([
-                { label: "All", value: null, count: summary.files },
-                { label: "Referenced", value: false, count: summary.files - summary.orphans },
-                { label: "Orphans", value: true, count: summary.orphans },
-              ] as const).map((facet) => (
-                <button
-                  key={facet.label}
-                  type="button"
-                  role="tab"
-                  aria-selected={filters.orphan === facet.value}
-                  onClick={() => set({ orphan: facet.value })}
-                  className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                    filters.orphan === facet.value
-                      ? "bg-(--surface-3) text-(--text)"
-                      : "text-(--text-faint) hover:bg-(--surface-1)"
-                  }`}
+      <ListPane
+        chrome={
+          <>
+            <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+              <div>
+                <h1 className="display text-lg font-semibold">Artifacts</h1>
+                <p className="mt-1 text-[12px] text-(--text-faint)">
+                  Physical files in the content-addressed store. Project context
+                  does not narrow this factory-wide inventory.
+                </p>
+              </div>
+              {summary.at && (
+                <span
+                  className="text-[11px] text-(--text-faint)"
+                  title={summary.at}
                 >
-                  {facet.label}
-                  <span className="ml-1.5 tabular-nums text-(--text-faint)">{facet.count.toLocaleString()}</span>
-                </button>
-              ))}
+                  measured {formatRelative(summary.at, now)}
+                </span>
+              )}
             </div>
-            <span className="ml-auto">
-              <DisplayOptions
-                config={ARTIFACTS_DISPLAY}
-                state={display}
-                onChange={setDisplay}
-                rows={artifacts}
+
+            <section
+              aria-label="Artifact storage summary"
+              className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3"
+            >
+              <StatCard
+                label="Stored files"
+                value={summary.files.toLocaleString()}
               />
-            </span>
-            <label className="flex items-center gap-1.5 text-[11px] font-medium text-(--text-dim)">
-              <span>Kind:</span>
-              <select
-                aria-label="Artifact kind"
-                value={filters.kind ?? ""}
-                onChange={(event) => set({ kind: event.target.value || null })}
-                className="cursor-pointer rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent)"
+              <StatCard label="Disk usage" value={formatBytes(summary.bytes)} />
+              <StatCard
+                label="Orphans"
+                value={summary.orphans.toLocaleString()}
+                caption={formatBytes(summary.orphanBytes)}
+                hue={summary.orphans > 0 ? "var(--hue-warn)" : undefined}
+              />
+            </section>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <div
+                className="flex flex-wrap gap-1"
+                role="tablist"
+                aria-label="Artifact reference state"
               >
-                <option value="">Any kind</option>
-                {kinds.map((kind) => <option key={kind} value={kind}>{kind}</option>)}
-              </select>
-            </label>
-            <FilterInput
-              value={filters.search}
-              onChange={(search) => set({ search })}
-              placeholder="SHA, kind, run, agent…"
-              label="Search artifacts"
-            />
-          </div>
-        </>
-      }
-    >
-      <table className="w-full border-separate border-spacing-0 text-[12px]">
-        <thead>
-          <tr className="text-left text-[11px] text-(--text-faint)">
-            {columns.map((column) => {
-              const sort = ARTIFACTS_DISPLAY.sorts.find((field) => field.column === column.key);
-              const isCustom = column.isCustom || column.key.startsWith("custom:");
-              const customPath = column.key.replace(/^custom:/, "");
-              const current = isCustom ? display.sortBy === column.key : sort && display.sortBy === sort.key;
-              return (
-                <Th
-                  key={column.key}
-                  label={column.label}
-                  dir={current ? display.sortDir : null}
-                  naturalDir={sort?.defaultDir ?? "asc"}
-                  onSort={sort || isCustom ? () => setDisplay((state) => cycleColumnSort(ARTIFACTS_DISPLAY, state, column.key)) : undefined}
-                  onRemove={isCustom ? () => setDisplay((state) => removeCustomColumn(state, customPath)) : undefined}
+                {(
+                  [
+                    { label: "All", value: null, count: summary.files },
+                    {
+                      label: "Referenced",
+                      value: false,
+                      count: summary.files - summary.orphans,
+                    },
+                    { label: "Orphans", value: true, count: summary.orphans },
+                  ] as const
+                ).map((facet) => (
+                  <button
+                    key={facet.label}
+                    type="button"
+                    role="tab"
+                    aria-selected={filters.orphan === facet.value}
+                    onClick={() => set({ orphan: facet.value })}
+                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                      filters.orphan === facet.value
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1)"
+                    }`}
+                  >
+                    {facet.label}
+                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                      {facet.count.toLocaleString()}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <span className="ml-auto">
+                <DisplayOptions
+                  config={ARTIFACTS_DISPLAY}
+                  state={display}
+                  onChange={setDisplay}
+                  rows={artifacts}
                 />
+              </span>
+              <label className="flex items-center gap-1.5 text-[11px] font-medium text-(--text-dim)">
+                <span>Kind:</span>
+                <select
+                  aria-label="Artifact kind"
+                  value={filters.kind ?? ""}
+                  onChange={(event) =>
+                    set({ kind: event.target.value || null })
+                  }
+                  className="cursor-pointer rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent)"
+                >
+                  <option value="">Any kind</option>
+                  {kinds.map((kind) => (
+                    <option key={kind} value={kind}>
+                      {kind}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <FilterInput
+                value={filters.search}
+                onChange={(search) => set({ search })}
+                placeholder="SHA, kind, run, agent…"
+                label="Search artifacts"
+              />
+            </div>
+          </>
+        }
+      >
+        <table className="w-full border-separate border-spacing-0 text-[12px]">
+          <thead>
+            <tr className="text-left text-[11px] text-(--text-faint)">
+              {columns.map((column) => {
+                const sort = ARTIFACTS_DISPLAY.sorts.find(
+                  (field) => field.column === column.key,
+                );
+                const isCustom =
+                  column.isCustom || column.key.startsWith("custom:");
+                const customPath = column.key.replace(/^custom:/, "");
+                const current = isCustom
+                  ? display.sortBy === column.key
+                  : sort && display.sortBy === sort.key;
+                return (
+                  <Th
+                    key={column.key}
+                    label={column.label}
+                    dir={current ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={
+                      sort || isCustom
+                        ? () =>
+                            setDisplay((state) =>
+                              cycleColumnSort(
+                                ARTIFACTS_DISPLAY,
+                                state,
+                                column.key,
+                              ),
+                            )
+                        : undefined
+                    }
+                    onRemove={
+                      isCustom
+                        ? () =>
+                            setDisplay((state) =>
+                              removeCustomColumn(state, customPath),
+                            )
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {ordered.map((artifact) => {
+              const artifactKinds = kindsOf(artifact);
+              const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
+              return (
+                <tr
+                  key={artifact.sha256}
+                  onClick={() => selectArtifact(artifact.sha256)}
+                  aria-selected={artifact.sha256 === selectedSha}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
+                >
+                  <td
+                    className="mono max-w-48 border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    title={artifact.sha256}
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <a
+                        href={artifactUrl(artifact.sha256, name)}
+                        download={name}
+                        onClick={(event) => event.stopPropagation()}
+                        className="text-(--accent) hover:underline"
+                        aria-label={`Download artifact ${artifact.sha256}`}
+                      >
+                        {artifact.sha256.slice(0, 12)}
+                      </a>
+                      {!artifact.referenced && (
+                        <span
+                          className="rounded px-1.5 py-0.5 font-sans text-[11px] font-medium"
+                          style={{
+                            color: "var(--hue-warn)",
+                            background:
+                              "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
+                          }}
+                        >
+                          orphan
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  {shown.has("kind") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      {artifactKinds.length > 0 ? (
+                        <div className="flex flex-nowrap gap-1">
+                          {artifactKinds.map((kind) => (
+                            <KindBadge key={kind} kind={kind} />
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-(--text-faint)">{EMPTY}</span>
+                      )}
+                    </td>
+                  )}
+                  {shown.has("size") && (
+                    <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                      {formatBytes(artifact.sizeBytes)}
+                    </td>
+                  )}
+                  {shown.has("age") && (
+                    <td
+                      className="whitespace-nowrap border-b border-(--border) px-3 py-1.5"
+                      title={new Date(artifact.mtime).toLocaleString()}
+                    >
+                      <span title={artifact.mtime}>
+                        {formatRelative(artifact.mtime, now)}
+                      </span>
+                    </td>
+                  )}
+                  {shown.has("references") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      {artifact.references.length > 0 ? (
+                        <div className="flex flex-nowrap gap-2">
+                          {artifact.references.map((reference) => (
+                            <JumpLink
+                              key={`${reference.runId}:${reference.kind ?? "unknown"}`}
+                              onClick={() => onJumpRun(reference.runId)}
+                              title={reference.runId}
+                            >
+                              {shortId(reference.runId)}
+                            </JumpLink>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-(--text-faint)">{EMPTY}</span>
+                      )}
+                    </td>
+                  )}
+                  {columns
+                    .filter(
+                      (column) =>
+                        column.isCustom || column.key.startsWith("custom:"),
+                    )
+                    .map((column) => (
+                      <CustomCell
+                        key={column.key}
+                        row={artifact}
+                        path={column.key}
+                      />
+                    ))}
+                </tr>
               );
             })}
-          </tr>
-        </thead>
-        <tbody>
-          {ordered.map((artifact) => {
-            const artifactKinds = kindsOf(artifact);
-            const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
-            return (
-              <tr
-                key={artifact.sha256}
-                onClick={() => selectArtifact(artifact.sha256)}
-                aria-selected={artifact.sha256 === selectedSha}
-                className={`cursor-pointer hover:bg-(--surface-1) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
+            {visible.length === 0 && (
+              <ListEmpty
+                colSpan={columns.length}
+                query={artifactsQ}
+                filtered={filtered}
+                noun="artifacts"
+                empty="No artifacts are stored."
+                onClear={() =>
+                  onFiltersChange({ kind: null, orphan: null, search: "" })
+                }
+              />
+            )}
+          </tbody>
+        </table>
+      </ListPane>
+
+      {selectedSha && (
+        <DetailPane
+          widthClass="w-full sm:w-[560px]"
+          title={
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
+              <button
+                type="button"
+                onClick={closeInspector}
+                className="text-(--text-dim) hover:text-(--accent)"
               >
-                <td className="mono max-w-48 border-b border-(--border) px-3 py-1.5 whitespace-nowrap" title={artifact.sha256}>
-                  <span className="inline-flex items-center gap-2">
-                    <a
-                      href={artifactUrl(artifact.sha256, name)}
-                      download={name}
-                      onClick={(event) => event.stopPropagation()}
-                      className="text-(--accent) hover:underline"
-                      aria-label={`Download artifact ${artifact.sha256}`}
-                    >
-                      {artifact.sha256.slice(0, 12)}
-                    </a>
-                    {!artifact.referenced && (
-                      <span
-                        className="rounded px-1.5 py-0.5 font-sans text-[11px] font-medium"
-                        style={{
-                          color: "var(--hue-warn)",
-                          background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
-                        }}
-                      >
-                        orphan
-                      </span>
-                    )}
-                  </span>
-                </td>
-                {shown.has("kind") && (
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    {artifactKinds.length > 0 ? (
-                      <div className="flex flex-nowrap gap-1">
-                        {artifactKinds.map((kind) => <KindBadge key={kind} kind={kind} />)}
-                      </div>
+                Artifacts
+              </button>
+              <span aria-hidden="true" className="text-(--text-faint)">
+                /
+              </span>
+              <span
+                className="mono truncate font-semibold text-(--text)"
+                title={selectedSha}
+                aria-current="page"
+              >
+                {selectedSha.slice(0, 12)}
+              </span>
+            </nav>
+          }
+          actions={
+            <>
+              <a
+                href={artifactUrl(
+                  selectedSha,
+                  `${selectedSha.slice(0, 12)}${selectedKinds[0] ? `.${selectedKinds[0]}` : ""}`,
+                )}
+                download
+                className="inline-flex rounded-md border border-(--border-strong) px-2.5 py-1.5 text-[12px] font-medium hover:bg-(--surface-2)"
+              >
+                Download
+              </a>
+              <Button
+                disabled={contentQ.data === undefined}
+                onClick={() =>
+                  copyText(contentQ.data ?? "", "raw artifact content")
+                }
+              >
+                Copy Raw Content
+              </Button>
+              <Button onClick={() => copyText(selectedSha, "SHA-256")}>
+                Copy SHA-256
+              </Button>
+            </>
+          }
+          close={<Button onClick={closeInspector}>Close</Button>}
+        >
+          {!selected && artifactsQ.isPending && (
+            <div className="text-(--text-faint)">
+              Loading artifact metadata…
+            </div>
+          )}
+          {!selected && !artifactsQ.isPending && (
+            <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
+              Artifact metadata is unavailable. The content may have been
+              pruned.
+            </div>
+          )}
+
+          {selected && (
+            <>
+              <section
+                aria-label="Artifact metadata"
+                className="grid grid-cols-2 gap-2 text-[12px]"
+              >
+                <div>
+                  <span className="text-(--text-faint)">Size</span>
+                  <div className="mono mt-0.5">
+                    {formatBytes(selected.sizeBytes)}
+                  </div>
+                </div>
+                <div>
+                  <span className="text-(--text-faint)">Modified</span>
+                  <div className="mono mt-0.5">
+                    {new Date(selected.mtime).toLocaleString()}
+                  </div>
+                </div>
+                <div className="col-span-2">
+                  <span className="text-(--text-faint)">Kinds</span>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {selectedKinds.length ? (
+                      selectedKinds.map((kind) => (
+                        <KindBadge key={kind} kind={kind} />
+                      ))
                     ) : (
-                      <span className="text-(--text-faint)">{EMPTY}</span>
+                      <span>unknown</span>
                     )}
-                  </td>
-                )}
-                {shown.has("size") && (
-                  <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
-                    {formatBytes(artifact.sizeBytes)}
-                  </td>
-                )}
-                {shown.has("age") && (
-                  <td className="whitespace-nowrap border-b border-(--border) px-3 py-1.5" title={new Date(artifact.mtime).toLocaleString()}>
-                    <span title={artifact.mtime}>{formatRelative(artifact.mtime, now)}</span>
-                  </td>
-                )}
-                {shown.has("references") && (
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    {artifact.references.length > 0 ? (
-                      <div className="flex flex-nowrap gap-2">
-                        {artifact.references.map((reference) => (
+                  </div>
+                </div>
+                <div className="col-span-2 min-w-0">
+                  <span className="text-(--text-faint)">SHA-256</span>
+                  <div className="mono mt-0.5 break-all">{selectedSha}</div>
+                </div>
+              </section>
+
+              <section
+                aria-label="Artifact run references"
+                className="mt-5 border-t border-(--border) pt-4 text-[12px]"
+              >
+                <h2 className="display font-semibold">Run references</h2>
+                <div className="mt-3 grid gap-3">
+                  <div>
+                    <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                      Producing runs
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap gap-2">
+                      {selected.references.length ? (
+                        selected.references.map((reference) => (
                           <JumpLink
                             key={`${reference.runId}:${reference.kind ?? "unknown"}`}
                             onClick={() => onJumpRun(reference.runId)}
-                            title={reference.runId}
+                            title={`Open producing run ${reference.runId}`}
                           >
                             {shortId(reference.runId)}
+                            {reference.kind ? ` · ${reference.kind}` : ""}
                           </JumpLink>
-                        ))}
-                      </div>
-                    ) : (
-                      <span className="text-(--text-faint)">{EMPTY}</span>
-                    )}
-                  </td>
-                )}
-                {columns.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
-                  <CustomCell key={column.key} row={artifact} path={column.key} />
-                ))}
-              </tr>
-            );
-          })}
-          {visible.length === 0 && (
-            <ListEmpty
-              colSpan={columns.length}
-              query={artifactsQ}
-              filtered={filtered}
-              noun="artifacts"
-              empty="No artifacts are stored."
-              onClear={() => onFiltersChange({ kind: null, orphan: null, search: "" })}
-            />
+                        ))
+                      ) : (
+                        <span className="text-(--text-faint)">
+                          No accepted result references this artifact.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                      Consuming runs
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap gap-2">
+                      {consumers.length ? (
+                        consumers.map((event) => (
+                          <JumpLink
+                            key={`${event.source}:${event.eventId}:${event.runId}`}
+                            onClick={() => onJumpRun(event.runId!)}
+                            title={`Open consuming run ${event.runId}`}
+                          >
+                            {shortId(event.runId!)}
+                          </JumpLink>
+                        ))
+                      ) : (
+                        <span className="text-(--text-faint)">
+                          {eventsQ.isPending
+                            ? "Resolving…"
+                            : "No consuming runs found."}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                      Causation links
+                    </div>
+                    <div className="mt-1.5 grid gap-1">
+                      {causation.length ? (
+                        causation.map((event) => (
+                          <div
+                            key={`${event.source}:${event.eventId}`}
+                            className="flex flex-wrap items-center gap-1.5"
+                          >
+                            <span className="mono text-(--text-faint)">
+                              {event.source}:{shortId(event.eventId)}
+                            </span>
+                            {event.runId && (
+                              <>
+                                <span aria-hidden="true">→</span>
+                                <JumpLink
+                                  onClick={() => onJumpRun(event.runId!)}
+                                  title={`Open caused run ${event.runId}`}
+                                >
+                                  {shortId(event.runId)}
+                                </JumpLink>
+                              </>
+                            )}
+                          </div>
+                        ))
+                      ) : (
+                        <span className="text-(--text-faint)">
+                          {eventsQ.isPending
+                            ? "Resolving…"
+                            : "No caused events found."}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </>
           )}
-        </tbody>
-      </table>
-    </ListPane>
 
-    {selectedSha && (
-      <DetailPane
-        widthClass="w-full sm:w-[560px]"
-        title={
-          <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
-            <button type="button" onClick={closeInspector} className="text-(--text-dim) hover:text-(--accent)">
-              Artifacts
-            </button>
-            <span aria-hidden="true" className="text-(--text-faint)">/</span>
-            <span className="mono truncate font-semibold text-(--text)" title={selectedSha} aria-current="page">
-              {selectedSha.slice(0, 12)}
-            </span>
-          </nav>
-        }
-        actions={
-          <>
-            <a
-              href={artifactUrl(selectedSha, `${selectedSha.slice(0, 12)}${selectedKinds[0] ? `.${selectedKinds[0]}` : ""}`)}
-              download
-              className="inline-flex rounded-md border border-(--border-strong) px-2.5 py-1.5 text-[12px] font-medium hover:bg-(--surface-2)"
-            >
-              Download
-            </a>
-            <Button disabled={contentQ.data === undefined} onClick={() => copyText(contentQ.data ?? "", "raw artifact content")}>
-              Copy Raw Content
-            </Button>
-            <Button onClick={() => copyText(selectedSha, "SHA-256")}>Copy SHA-256</Button>
-          </>
-        }
-        close={<Button onClick={closeInspector}>Close</Button>}
-      >
-        {!selected && artifactsQ.isPending && <div className="text-(--text-faint)">Loading artifact metadata…</div>}
-        {!selected && !artifactsQ.isPending && (
-          <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
-            Artifact metadata is unavailable. The content may have been pruned.
-          </div>
-        )}
-
-        {selected && (
-          <>
-            <section aria-label="Artifact metadata" className="grid grid-cols-2 gap-2 text-[12px]">
-              <div><span className="text-(--text-faint)">Size</span><div className="mono mt-0.5">{formatBytes(selected.sizeBytes)}</div></div>
-              <div><span className="text-(--text-faint)">Modified</span><div className="mono mt-0.5">{new Date(selected.mtime).toLocaleString()}</div></div>
-              <div className="col-span-2">
-                <span className="text-(--text-faint)">Kinds</span>
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {selectedKinds.length ? selectedKinds.map((kind) => <KindBadge key={kind} kind={kind} />) : <span>unknown</span>}
-                </div>
+          <section
+            aria-label="Artifact preview"
+            className="mt-5 border-t border-(--border) pt-4"
+          >
+            <div className="flex flex-wrap items-end justify-between gap-2">
+              <div>
+                <h2 className="display text-[12px] font-semibold">Preview</h2>
+                <p className="mt-0.5 text-[11px] text-(--text-faint)">
+                  {viewShown
+                    ? `${producerAgent?.outputView?.title ?? "view"} · ${producerAgent?.ref}`
+                    : matchCount === null
+                      ? `${previewLines.length.toLocaleString()} lines`
+                      : `${matchCount.toLocaleString()} matching lines`}
+                </p>
               </div>
-              <div className="col-span-2 min-w-0">
-                <span className="text-(--text-faint)">SHA-256</span>
-                <div className="mono mt-0.5 break-all">{selectedSha}</div>
-              </div>
-            </section>
-
-            <section aria-label="Artifact run references" className="mt-5 border-t border-(--border) pt-4 text-[12px]">
-              <h2 className="display font-semibold">Run references</h2>
-              <div className="mt-3 grid gap-3">
-                <div>
-                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Producing runs</div>
-                  <div className="mt-1.5 flex flex-wrap gap-2">
-                    {selected.references.length ? selected.references.map((reference) => (
-                      <JumpLink key={`${reference.runId}:${reference.kind ?? "unknown"}`} onClick={() => onJumpRun(reference.runId)} title={`Open producing run ${reference.runId}`}>
-                        {shortId(reference.runId)}{reference.kind ? ` · ${reference.kind}` : ""}
-                      </JumpLink>
-                    )) : <span className="text-(--text-faint)">No accepted result references this artifact.</span>}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Consuming runs</div>
-                  <div className="mt-1.5 flex flex-wrap gap-2">
-                    {consumers.length ? consumers.map((event) => (
-                      <JumpLink key={`${event.source}:${event.eventId}:${event.runId}`} onClick={() => onJumpRun(event.runId!)} title={`Open consuming run ${event.runId}`}>
-                        {shortId(event.runId!)}
-                      </JumpLink>
-                    )) : <span className="text-(--text-faint)">{eventsQ.isPending ? "Resolving…" : "No consuming runs found."}</span>}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Causation links</div>
-                  <div className="mt-1.5 grid gap-1">
-                    {causation.length ? causation.map((event) => (
-                      <div key={`${event.source}:${event.eventId}`} className="flex flex-wrap items-center gap-1.5">
-                        <span className="mono text-(--text-faint)">{event.source}:{shortId(event.eventId)}</span>
-                        {event.runId && <><span aria-hidden="true">→</span><JumpLink onClick={() => onJumpRun(event.runId!)} title={`Open caused run ${event.runId}`}>{shortId(event.runId)}</JumpLink></>}
-                      </div>
-                    )) : <span className="text-(--text-faint)">{eventsQ.isPending ? "Resolving…" : "No caused events found."}</span>}
-                  </div>
-                </div>
-              </div>
-            </section>
-          </>
-        )}
-
-        <section aria-label="Artifact preview" className="mt-5 border-t border-(--border) pt-4">
-          <div className="flex flex-wrap items-end justify-between gap-2">
-            <div>
-              <h2 className="display text-[12px] font-semibold">Preview</h2>
-              <p className="mt-0.5 text-[11px] text-(--text-faint)">
-                {viewShown
-                  ? `${producerAgent?.outputView?.title ?? "view"} · ${producerAgent?.ref}`
-                  : matchCount === null
-                    ? `${previewLines.length.toLocaleString()} lines`
-                    : `${matchCount.toLocaleString()} matching lines`}
-              </p>
+              {!viewShown && (
+                <FilterInput
+                  value={contentSearch}
+                  onChange={setContentSearch}
+                  placeholder="Find in content…"
+                  label="Search artifact content"
+                />
+              )}
             </div>
-            {!viewShown && (
-              <FilterInput value={contentSearch} onChange={setContentSearch} placeholder="Find in content…" label="Search artifact content" />
+            {contentQ.isPending && (
+              <div className="mt-3 text-[12px] text-(--text-faint)">
+                Loading artifact preview…
+              </div>
             )}
-          </div>
-          {contentQ.isPending && <div className="mt-3 text-[12px] text-(--text-faint)">Loading artifact preview…</div>}
-          {contentQ.isError && <div className="mt-3 text-[12px] text-(--hue-err)">Could not load artifact content: {(contentQ.error as Error).message}</div>}
-          {preview !== null && (
-            <div className="mt-3">
-              <ArtifactPanel
-                artifact={parsedArtifact ?? preview}
-                schema={producerAgent?.outputSchema}
-                view={parsedArtifact ? producerAgent?.outputView : null}
-                onJumpRun={onJumpRun}
-                raw={artifactRaw}
-                onRawChange={setArtifactRaw}
-                rawFallback={
-                  <div role="region" aria-label="Artifact content" className="mono max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed">
-                    {previewLines.map((line, index) => (
-                      <div key={index} className={`grid grid-cols-[4rem_minmax(0,1fr)] px-2 ${contentSearch.trim() && line.toLowerCase().includes(contentSearch.trim().toLowerCase()) ? "bg-(--surface-2)" : ""}`}>
-                        <span aria-hidden="true" className="select-none border-r border-(--border) pr-2 text-right text-(--text-faint)">{index + 1}</span>
-                        <span className="min-w-0 whitespace-pre-wrap break-words pl-3">{highlightedLine(line, contentSearch)}</span>
-                      </div>
-                    ))}
-                  </div>
-                }
-              />
-            </div>
-          )}
-        </section>
-      </DetailPane>
-    )}
+            {contentQ.isError && (
+              <div className="mt-3 text-[12px] text-(--hue-err)">
+                Could not load artifact content:{" "}
+                {(contentQ.error as Error).message}
+              </div>
+            )}
+            {preview !== null && (
+              <div className="mt-3">
+                <ArtifactPanel
+                  artifact={parsedArtifact ?? preview}
+                  schema={producerAgent?.outputSchema}
+                  view={parsedArtifact ? producerAgent?.outputView : null}
+                  onJumpRun={onJumpRun}
+                  raw={artifactRaw}
+                  onRawChange={setArtifactRaw}
+                  rawFallback={
+                    <div
+                      role="region"
+                      aria-label="Artifact content"
+                      className="mono max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed"
+                    >
+                      {previewLines.map((line, index) => (
+                        <div
+                          key={index}
+                          className={`grid grid-cols-[4rem_minmax(0,1fr)] px-2 ${contentSearch.trim() && line.toLowerCase().includes(contentSearch.trim().toLowerCase()) ? "bg-(--surface-2)" : ""}`}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="select-none border-r border-(--border) pr-2 text-right text-(--text-faint)"
+                          >
+                            {index + 1}
+                          </span>
+                          <span className="min-w-0 whitespace-pre-wrap break-words pl-3">
+                            {highlightedLine(line, contentSearch)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  }
+                />
+              </div>
+            )}
+          </section>
+        </DetailPane>
+      )}
     </div>
   );
 }

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { Chain } from "./Chain";
 import { CHAIN_VIEW_STORAGE_KEY } from "../chainTimeline";
-import { createRunDetailFixture, renderWithClient, restoreApi } from "../test-render";
+import {
+  createRunDetailFixture,
+  renderWithClient,
+  restoreApi,
+} from "../test-render";
 import type { ChainView, LifecycleEvent, Proposal } from "../types";
 
 const CORR = "clock:merge-factory:2026-08-17T18:45:00.000Z";
@@ -52,24 +56,90 @@ function chainView(): ChainView {
   };
 }
 
-function lc(seq: number, from: string | null, to: string, actor: string, reason: string | null, at: string): LifecycleEvent {
-  return { seq, run_id: FIX_RUN, from_state: from, to_state: to, actor, reason, attempt: null, at };
+function lc(
+  seq: number,
+  from: string | null,
+  to: string,
+  actor: string,
+  reason: string | null,
+  at: string,
+): LifecycleEvent {
+  return {
+    seq,
+    run_id: FIX_RUN,
+    from_state: from,
+    to_state: to,
+    actor,
+    reason,
+    attempt: null,
+    at,
+  };
 }
 
 const runDetail = createRunDetailFixture({
   run: {
     runId: FIX_RUN,
     state: "REFUSED",
-    spec: { agent: "merge-fix@1", input: { github: "watt-mind/factory", pr: 541, ticket: "WM-627", headSha: "6dbaab46a7f362ea66f907b630e57849e2631915" } },
+    spec: {
+      agent: "merge-fix@1",
+      input: {
+        github: "watt-mind/factory",
+        pr: 541,
+        ticket: "WM-627",
+        headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+      },
+    },
   } as any,
   lifecycle: [
     lc(1, null, "PROPOSED", "planner", "planned", "2026-08-17T19:06:04.284Z"),
-    lc(2, "PROPOSED", "APPROVED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
-    lc(3, "APPROVED", "QUEUED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
-    lc(4, "QUEUED", "LEASED", "worker_30596_69", "claimed", "2026-08-17T19:06:05.102Z"),
-    lc(5, "LEASED", "RUNNING", "worker_30596_69", "started", "2026-08-17T19:06:05.105Z"),
-    lc(6, "RUNNING", "VERIFYING", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z"),
-    lc(7, "VERIFYING", "REFUSED", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z"),
+    lc(
+      2,
+      "PROPOSED",
+      "APPROVED",
+      "chain-auto-approval",
+      "auto_approved:chain-policy@1",
+      "2026-08-17T19:06:04.284Z",
+    ),
+    lc(
+      3,
+      "APPROVED",
+      "QUEUED",
+      "chain-auto-approval",
+      "auto_approved:chain-policy@1",
+      "2026-08-17T19:06:04.284Z",
+    ),
+    lc(
+      4,
+      "QUEUED",
+      "LEASED",
+      "worker_30596_69",
+      "claimed",
+      "2026-08-17T19:06:05.102Z",
+    ),
+    lc(
+      5,
+      "LEASED",
+      "RUNNING",
+      "worker_30596_69",
+      "started",
+      "2026-08-17T19:06:05.105Z",
+    ),
+    lc(
+      6,
+      "RUNNING",
+      "VERIFYING",
+      "worker_30596_69",
+      "merge_fix_pr_moved",
+      "2026-08-17T19:06:07.657Z",
+    ),
+    lc(
+      7,
+      "VERIFYING",
+      "REFUSED",
+      "worker_30596_69",
+      "merge_fix_pr_moved",
+      "2026-08-17T19:06:07.657Z",
+    ),
   ],
 });
 
@@ -155,16 +225,22 @@ describe("Chain view — Timeline mode (WM-639)", () => {
   test("Graph | Timeline toggle persists and renders the narrative rows", async () => {
     const view = renderChain();
     const timelineTab = await view.findByRole("tab", { name: "Timeline" });
-    expect(view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.click(timelineTab);
     expect(localStorage.getItem(CHAIN_VIEW_STORAGE_KEY)).toBe("timeline");
 
     const list = await view.findByRole("list", { name: "Chain timeline" });
-    await waitFor(() => expect(list.textContent).toContain("PR head moved after the plan"));
+    await waitFor(() =>
+      expect(list.textContent).toContain("PR head moved after the plan"),
+    );
     const text = list.textContent ?? "";
     expect(text).toContain("factory.merge-fix.requested (PR #541, WM-627)");
-    expect(text).toContain("merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)");
+    expect(text).toContain(
+      "merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)",
+    );
     expect(text).toContain("worker_30596_69");
     expect(text).toContain("+6s");
     // origin is a merge-fix request (not the schedule's event type) → uncovered.
@@ -172,10 +248,16 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     // Raw reason code rides the title for the humanized text.
     expect(view.getByTitle("merge_fix_pr_moved")).toBeTruthy();
     // Jump links: PR opens GitHub, ticket opens the journey.
-    const prLinks = view.getAllByTitle("https://github.com/watt-mind/factory/pull/541") as HTMLAnchorElement[];
+    const prLinks = view.getAllByTitle(
+      "https://github.com/watt-mind/factory/pull/541",
+    ) as HTMLAnchorElement[];
     expect(prLinks.length).toBeGreaterThan(0);
-    expect(prLinks[0].href).toBe("https://github.com/watt-mind/factory/pull/541");
-    const ticketLinks = view.getAllByTitle("Open ticket journey WM-627") as HTMLAnchorElement[];
+    expect(prLinks[0].href).toBe(
+      "https://github.com/watt-mind/factory/pull/541",
+    );
+    const ticketLinks = view.getAllByTitle(
+      "Open ticket journey WM-627",
+    ) as HTMLAnchorElement[];
     expect(ticketLinks[0].getAttribute("href")).toBe("#/tickets/WM-627");
   });
 
@@ -183,10 +265,16 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     localStorage.setItem(CHAIN_VIEW_STORAGE_KEY, "timeline");
     const view = renderChain();
     await view.findByRole("list", { name: "Chain timeline" });
-    expect(view.getByRole("tab", { name: "Timeline" }).getAttribute("aria-selected")).toBe("true");
+    expect(
+      view.getByRole("tab", { name: "Timeline" }).getAttribute("aria-selected"),
+    ).toBe("true");
 
     fireEvent.keyDown(document.body, { key: "t" });
-    await waitFor(() => expect(view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected")).toBe("true"));
+    await waitFor(() =>
+      expect(
+        view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected"),
+      ).toBe("true"),
+    );
     expect(localStorage.getItem(CHAIN_VIEW_STORAGE_KEY)).toBe("graph");
     expect(view.queryByRole("list", { name: "Chain timeline" })).toBeNull();
   });
@@ -203,7 +291,11 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     cleanup();
     const focused = renderChain({ focusNodeId: nodeId });
     const list = await focused.findByRole("list", { name: "Chain timeline" });
-    await waitFor(() => expect(list.querySelectorAll('[aria-current="true"]').length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        list.querySelectorAll('[aria-current="true"]').length,
+      ).toBeGreaterThan(0),
+    );
     for (const li of list.querySelectorAll('[aria-current="true"]')) {
       expect(li.getAttribute("data-node-id")).toBe(nodeId);
     }
@@ -211,7 +303,9 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     fireEvent.keyDown(document.body, { key: "Enter" });
     expect(focused.selected).toContain(nodeId);
     // The detail pane shows the run, with the reveal action renamed for the mode.
-    expect(await focused.findByRole("button", { name: /Show in timeline/ })).toBeTruthy();
+    expect(
+      await focused.findByRole("button", { name: /Show in timeline/ }),
+    ).toBeTruthy();
     expect(focused.getByRole("button", { name: "Open run" })).toBeTruthy();
   });
 

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -54,7 +54,10 @@ import type { RunDetail } from "../types";
 
 const INITIAL_FIT_MIN_ZOOM = 0.4;
 
-const TIMELINE_DECISION_HUES: Record<string, string> = { ...DECISION_HUES, planned: DECISION_HUES.run };
+const TIMELINE_DECISION_HUES: Record<string, string> = {
+  ...DECISION_HUES,
+  planned: DECISION_HUES.run,
+};
 const TIMELINE_EVENT_HUES: Record<string, string> = EVENT_STATUS_HUES;
 const TIMELINE_MUTED_HUES: Record<string, string> = { next: "var(--hue-idle)" };
 
@@ -74,7 +77,9 @@ function huesFor(row: ChainTimelineRow): Record<string, string> {
 function rowTime(at: string | null): string {
   if (!at) return "";
   const t = new Date(at);
-  return Number.isNaN(t.getTime()) ? at : t.toLocaleTimeString([], { hour12: false });
+  return Number.isNaN(t.getTime())
+    ? at
+    : t.toLocaleTimeString([], { hour12: false });
 }
 
 function flowEdges(graph: ChainGraph): Edge[] {
@@ -86,7 +91,9 @@ function flowEdges(graph: ChainGraph): Edge[] {
     style: {
       stroke: CHAIN_EDGE_STYLES[edge.kind].stroke,
       strokeWidth: 1.5,
-      strokeDasharray: (CHAIN_EDGE_STYLES[edge.kind] as { strokeDasharray?: string }).strokeDasharray,
+      strokeDasharray: (
+        CHAIN_EDGE_STYLES[edge.kind] as { strokeDasharray?: string }
+      ).strokeDasharray,
     },
   }));
 }
@@ -121,17 +128,26 @@ export function Chain({
     queryKey: ["chain", correlationId],
     queryFn: () => api.chain(correlationId),
     ...refetchIntervals.primary,
-    retry: (count, err) => !(err instanceof ApiError && err.status === 404) && count < 2,
+    retry: (count, err) =>
+      !(err instanceof ApiError && err.status === 404) && count < 2,
   });
   const now = useNow();
-  const notFound = chainQ.isError && chainQ.error instanceof ApiError && chainQ.error.status === 404;
+  const notFound =
+    chainQ.isError &&
+    chainQ.error instanceof ApiError &&
+    chainQ.error.status === 404;
 
-  const graph = useMemo(() => (chainQ.data ? buildChainGraph(chainQ.data) : null), [chainQ.data]);
+  const graph = useMemo(
+    () => (chainQ.data ? buildChainGraph(chainQ.data) : null),
+    [chainQ.data],
+  );
 
   // Graph | Timeline (WM-639). `?view=` on a deep link wins for this visit;
   // the toggle itself persists like the other display options.
   const [mode, setModeState] = useState<ChainViewMode>(
-    () => chainViewModeFromQuery(hashSearch(window.location.hash)) ?? loadChainViewMode(),
+    () =>
+      chainViewModeFromQuery(hashSearch(window.location.hash)) ??
+      loadChainViewMode(),
   );
   const setMode = useCallback((next: ChainViewMode) => {
     saveChainViewMode(next);
@@ -139,7 +155,9 @@ export function Chain({
   }, []);
   // `?node=` is the timeline's deep-link spelling of the path segment; lift it
   // into the selection so the row highlights and Enter opens the pane.
-  const deepLinkNodeRef = useRef<string | null>(hashSearch(window.location.hash).get("node"));
+  const deepLinkNodeRef = useRef<string | null>(
+    hashSearch(window.location.hash).get("node"),
+  );
   useEffect(() => {
     const node = deepLinkNodeRef.current;
     if (!node || focusNodeId) return;
@@ -149,7 +167,10 @@ export function Chain({
   }, []);
 
   const timelineOn = mode === "timeline";
-  const runIds = useMemo(() => (chainQ.data?.runs ?? []).map((r) => r.runId), [chainQ.data]);
+  const runIds = useMemo(
+    () => (chainQ.data?.runs ?? []).map((r) => r.runId),
+    [chainQ.data],
+  );
   const runQs = useQueries({
     queries: runIds.map((id) => ({
       queryKey: ["run", id],
@@ -200,10 +221,21 @@ export function Chain({
             now,
           })
         : null,
-    [timelineOn, chainQ.data, runDetails, proposalsQ.data, schedulesQ.data, inboxQ.data, now],
+    [
+      timelineOn,
+      chainQ.data,
+      runDetails,
+      proposalsQ.data,
+      schedulesQ.data,
+      inboxQ.data,
+      now,
+    ],
   );
 
-  const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
+  const [positioned, setPositioned] = useState<{
+    nodes: Node[];
+    edges: Edge[];
+  } | null>(null);
   const [layoutError, setLayoutError] = useState<string | null>(null);
   const [layoutEpoch, setLayoutEpoch] = useState(0);
   const lastIdentityRef = useRef<string | null>(null);
@@ -243,45 +275,61 @@ export function Chain({
     // reused while node/edge identity is unchanged so the 3s poll only
     // refreshes states/badges (WM-154 pattern).
     import("../graph/layout")
-      .then(({ CHAIN_LAYOUT_OPTIONS, layoutGraph, layoutGraphIfIdentityChanged, NODE_HEIGHT, NODE_WIDTH }) => {
-        const prevIdentity = layoutEpoch !== epochLaidOutRef.current ? null : lastIdentityRef.current;
-        return layoutGraphIfIdentityChanged(graph, prevIdentity, (g) =>
-          layoutGraph(g, undefined, CHAIN_LAYOUT_OPTIONS),
-        ).then((result) => {
-          if (cancelled) return;
-          lastIdentityRef.current = result.identity;
-          epochLaidOutRef.current = layoutEpoch;
-          const byId = new Map(graph.nodes.map((n) => [n.id, n]));
-          if (!result.positions) {
-            setPositioned((prev) =>
-              prev
-                ? {
-                    nodes: prev.nodes.map((n) => ({ ...n, data: { ...n.data, node: byId.get(n.id) } })),
-                    edges: flowEdges(graph),
-                  }
-                : prev,
-            );
-            return;
-          }
-          const positions = result.positions;
-          setPositioned({
-            nodes: graph.nodes.map((node) => ({
-              id: node.id,
-              type: node.kind,
-              position: positions.get(node.id) ?? { x: 0, y: 0 },
-              data: { node },
-              draggable: true,
-              width: NODE_WIDTH,
-              height: NODE_HEIGHT,
-            })),
-            edges: flowEdges(graph),
+      .then(
+        ({
+          CHAIN_LAYOUT_OPTIONS,
+          layoutGraph,
+          layoutGraphIfIdentityChanged,
+          NODE_HEIGHT,
+          NODE_WIDTH,
+        }) => {
+          const prevIdentity =
+            layoutEpoch !== epochLaidOutRef.current
+              ? null
+              : lastIdentityRef.current;
+          return layoutGraphIfIdentityChanged(graph, prevIdentity, (g) =>
+            layoutGraph(g, undefined, CHAIN_LAYOUT_OPTIONS),
+          ).then((result) => {
+            if (cancelled) return;
+            lastIdentityRef.current = result.identity;
+            epochLaidOutRef.current = layoutEpoch;
+            const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+            if (!result.positions) {
+              setPositioned((prev) =>
+                prev
+                  ? {
+                      nodes: prev.nodes.map((n) => ({
+                        ...n,
+                        data: { ...n.data, node: byId.get(n.id) },
+                      })),
+                      edges: flowEdges(graph),
+                    }
+                  : prev,
+              );
+              return;
+            }
+            const positions = result.positions;
+            setPositioned({
+              nodes: graph.nodes.map((node) => ({
+                id: node.id,
+                type: node.kind,
+                position: positions.get(node.id) ?? { x: 0, y: 0 },
+                data: { node },
+                draggable: true,
+                width: NODE_WIDTH,
+                height: NODE_HEIGHT,
+              })),
+              edges: flowEdges(graph),
+            });
           });
-        });
-      })
+        },
+      )
       .catch((err: unknown) => {
         if (cancelled) return;
         console.error("chain layout failed", err);
-        setLayoutError("Could not lay out the chain — the layout engine failed or timed out.");
+        setLayoutError(
+          "Could not lay out the chain — the layout engine failed or timed out.",
+        );
       });
     return () => {
       cancelled = true;
@@ -300,13 +348,18 @@ export function Chain({
     [positioned, focusNodeId, now],
   );
 
-  const selected: ChainNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
+  const selected: ChainNode | undefined = graph?.nodes.find(
+    (n) => n.id === focusNodeId,
+  );
 
   const timelineListRef = useRef<HTMLOListElement | null>(null);
   const revealSelected = () => {
     if (!focusNodeId) return;
     if (timelineOn) {
-      const rows = timelineListRef.current?.querySelectorAll<HTMLElement>("[data-node-id]") ?? [];
+      const rows =
+        timelineListRef.current?.querySelectorAll<HTMLElement>(
+          "[data-node-id]",
+        ) ?? [];
       for (const row of rows) {
         if (row.dataset.nodeId === focusNodeId) {
           row.scrollIntoView?.({ block: "nearest" });
@@ -317,13 +370,30 @@ export function Chain({
     }
     if (!flowRef.current) return;
     const zoom = flowRef.current.getZoom();
-    flowRef.current.fitView({ nodes: [{ id: focusNodeId }], padding: 0.45, duration: 180, minZoom: zoom, maxZoom: zoom });
+    flowRef.current.fitView({
+      nodes: [{ id: focusNodeId }],
+      padding: 0.45,
+      duration: 180,
+      minZoom: zoom,
+      maxZoom: zoom,
+    });
   };
 
   useEffect(() => {
-    if (didInitialFit.current || !flowRef.current || !positioned || !graph || graph.nodes.length === 0) return;
+    if (
+      didInitialFit.current ||
+      !flowRef.current ||
+      !positioned ||
+      !graph ||
+      graph.nodes.length === 0
+    )
+      return;
     didInitialFit.current = true;
-    flowRef.current.fitView({ padding: 0.2, minZoom: INITIAL_FIT_MIN_ZOOM, maxZoom: 1 });
+    flowRef.current.fitView({
+      padding: 0.2,
+      minZoom: INITIAL_FIT_MIN_ZOOM,
+      maxZoom: 1,
+    });
   }, [graph, positioned, flowReady]);
 
   useEffect(() => {
@@ -359,7 +429,10 @@ export function Chain({
         ? (timeline?.nodeOrder ?? [])
         : positioned
           ? [...positioned.nodes]
-              .sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y)
+              .sort(
+                (a, b) =>
+                  a.position.x - b.position.x || a.position.y - b.position.y,
+              )
               .map((n) => n.id)
           : [];
       if (!order.length) return;
@@ -367,7 +440,11 @@ export function Chain({
         e.preventDefault();
         const idx = focusNodeId ? order.indexOf(focusNodeId) : -1;
         onSelectNode(order[Math.min(idx + 1, order.length - 1)]);
-      } else if (e.key === "k" || e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      } else if (
+        e.key === "k" ||
+        e.key === "ArrowUp" ||
+        e.key === "ArrowLeft"
+      ) {
         e.preventDefault();
         const idx = focusNodeId ? order.indexOf(focusNodeId) : order.length;
         onSelectNode(order[Math.max(idx - 1, 0)]);
@@ -379,12 +456,15 @@ export function Chain({
   }, [onSelectNode, focusNodeId, positioned, timelineOn, timeline]);
 
   const origin = graph ? chainOriginLabel(graph) : null;
-  const eventCount = graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
-  const runCount = graph?.nodes.filter((n) => n.kind === "chainRun").length ?? 0;
+  const eventCount =
+    graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
+  const runCount =
+    graph?.nodes.filter((n) => n.kind === "chainRun").length ?? 0;
   const runStates = useMemo(() => {
     const counts = new Map<string, number>();
     for (const n of graph?.nodes ?? []) {
-      if (n.kind === "chainRun") counts.set(n.run.state, (counts.get(n.run.state) ?? 0) + 1);
+      if (n.kind === "chainRun")
+        counts.set(n.run.state, (counts.get(n.run.state) ?? 0) + 1);
     }
     return [...counts.entries()];
   }, [graph]);
@@ -395,85 +475,152 @@ export function Chain({
       ? "Loading chain…"
       : chainQ.isError
         ? "Cannot reach the control API — the chain will appear when /chain is up."
-        : layoutError ?? "Laying out the chain…";
+        : (layoutError ?? "Laying out the chain…");
 
   return (
     <div className="flex h-full min-w-0">
-      <div className={timelineOn ? "flex min-w-0 flex-1 flex-col" : "relative min-w-0 flex-1"}>
+      <div
+        className={
+          timelineOn
+            ? "flex min-w-0 flex-1 flex-col"
+            : "relative min-w-0 flex-1"
+        }
+      >
         {/* Timeline mode keeps the header in flow so scrolled rows never slide under it. */}
-        <div className={timelineOn ? "flex shrink-0 items-start justify-between gap-4 px-5 pt-4 pb-3" : "contents"}>
-        <div className={timelineOn ? "min-w-0 max-w-[60%]" : "absolute top-4 left-5 z-10 max-w-[60%]"}>
-          <h1 className="display text-lg font-semibold">Chain</h1>
-          <div className="mono truncate text-[11px] text-(--text-faint)" title={correlationId}>
-            {correlationId}
-          </div>
-          {graph && (
-            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-(--text-dim)">
-              {origin && (
-                <span>
-                  origin <span className="mono">{origin}</span>
-                </span>
-              )}
-              <span>
-                {eventCount} event{eventCount === 1 ? "" : "s"} · {runCount} run{runCount === 1 ? "" : "s"} ·{" "}
-                {graph.maxDepth} hop{graph.maxDepth === 1 ? "" : "s"}
-              </span>
-              {runStates.length > 0 && (
-                <span className="flex items-center gap-1">
-                  {runStates.map(([state, count]) => (
-                    <StateBadge key={state} state={count > 1 ? `${state} ×${count}` : state} hues={badgeHues(state, count)} dot={false} />
-                  ))}
-                </span>
-              )}
+        <div
+          className={
+            timelineOn
+              ? "flex shrink-0 items-start justify-between gap-4 px-5 pt-4 pb-3"
+              : "contents"
+          }
+        >
+          <div
+            className={
+              timelineOn
+                ? "min-w-0 max-w-[60%]"
+                : "absolute top-4 left-5 z-10 max-w-[60%]"
+            }
+          >
+            <h1 className="display text-lg font-semibold">Chain</h1>
+            <div
+              className="mono truncate text-[11px] text-(--text-faint)"
+              title={correlationId}
+            >
+              {correlationId}
             </div>
-          )}
-        </div>
-        <div className={timelineOn ? "flex shrink-0 flex-col items-end gap-2" : "absolute top-4 right-4 z-10 flex flex-col items-end gap-2"}>
-          <div className="flex items-center gap-2">
-            <CopyActions id={correlationId} idLabel="correlation id" />
-            <Tabs
-              label="Chain view"
-              active={mode}
-              onSelect={(id) => setMode(id as ChainViewMode)}
-              tabs={[
-                { id: "graph", label: "Graph", title: "Instance graph — t toggles" },
-                { id: "timeline", label: "Timeline", title: "Chronological narrative — t toggles" },
-              ]}
-            />
-            {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
-              <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
+            {graph && (
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-(--text-dim)">
+                {origin && (
+                  <span>
+                    origin <span className="mono">{origin}</span>
+                  </span>
+                )}
+                <span>
+                  {eventCount} event{eventCount === 1 ? "" : "s"} · {runCount}{" "}
+                  run{runCount === 1 ? "" : "s"} · {graph.maxDepth} hop
+                  {graph.maxDepth === 1 ? "" : "s"}
+                </span>
+                {runStates.length > 0 && (
+                  <span className="flex items-center gap-1">
+                    {runStates.map(([state, count]) => (
+                      <StateBadge
+                        key={state}
+                        state={count > 1 ? `${state} ×${count}` : state}
+                        hues={badgeHues(state, count)}
+                        dot={false}
+                      />
+                    ))}
+                  </span>
+                )}
+              </div>
             )}
           </div>
-          {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
-            <div
-              className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
-              role="img"
-              aria-label="Chain legend"
-            >
-              {(Object.keys(CHAIN_EDGE_STYLES) as Array<keyof typeof CHAIN_EDGE_STYLES>).map((kind) => {
-                const entry = CHAIN_EDGE_STYLES[kind] as { label: string; stroke: string; strokeDasharray?: string };
-                return (
-                  <div key={kind} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
-                    <span
-                      aria-hidden
-                      className="inline-block shrink-0"
-                      style={{ width: 14, borderTop: `2px ${entry.strokeDasharray ? "dashed" : "solid"} ${entry.stroke}` }}
-                    />
-                    {entry.label}
-                  </div>
-                );
-              })}
-              <div className="text-[11px] text-(--text-faint)">left border = event status / run state</div>
+          <div
+            className={
+              timelineOn
+                ? "flex shrink-0 flex-col items-end gap-2"
+                : "absolute top-4 right-4 z-10 flex flex-col items-end gap-2"
+            }
+          >
+            <div className="flex items-center gap-2">
+              <CopyActions id={correlationId} idLabel="correlation id" />
+              <Tabs
+                label="Chain view"
+                active={mode}
+                onSelect={(id) => setMode(id as ChainViewMode)}
+                tabs={[
+                  {
+                    id: "graph",
+                    label: "Graph",
+                    title: "Instance graph — t toggles",
+                  },
+                  {
+                    id: "timeline",
+                    label: "Timeline",
+                    title: "Chronological narrative — t toggles",
+                  },
+                ]}
+              />
+              {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
+                <Button onClick={() => setLayoutEpoch((n) => n + 1)}>
+                  Reset layout
+                </Button>
+              )}
             </div>
-          )}
-        </div>
+            {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
+              <div
+                className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
+                role="img"
+                aria-label="Chain legend"
+              >
+                {(
+                  Object.keys(CHAIN_EDGE_STYLES) as Array<
+                    keyof typeof CHAIN_EDGE_STYLES
+                  >
+                ).map((kind) => {
+                  const entry = CHAIN_EDGE_STYLES[kind] as {
+                    label: string;
+                    stroke: string;
+                    strokeDasharray?: string;
+                  };
+                  return (
+                    <div
+                      key={kind}
+                      className="flex items-center gap-2 text-[11px] text-(--text-dim)"
+                    >
+                      <span
+                        aria-hidden
+                        className="inline-block shrink-0"
+                        style={{
+                          width: 14,
+                          borderTop: `2px ${entry.strokeDasharray ? "dashed" : "solid"} ${entry.stroke}`,
+                        }}
+                      />
+                      {entry.label}
+                    </div>
+                  );
+                })}
+                <div className="text-[11px] text-(--text-faint)">
+                  left border = event status / run state
+                </div>
+              </div>
+            )}
+          </div>
         </div>
         {timelineOn ? (
           <ChainTimelineList
             listRef={timelineListRef}
             timeline={timeline}
             focusNodeId={focusNodeId}
-            emptyCopy={notFound ? emptyCopy : chainQ.isPending ? "Loading chain…" : chainQ.isError ? emptyCopy : null}
+            emptyCopy={
+              notFound
+                ? emptyCopy
+                : chainQ.isPending
+                  ? "Loading chain…"
+                  : chainQ.isError
+                    ? emptyCopy
+                    : null
+            }
             onSelectNode={onSelectNode}
             onJumpEvent={onJumpEvent}
             onJumpProposal={onJumpProposal}
@@ -488,9 +635,15 @@ export function Chain({
             onNodeClick={(_, node) => onSelectNode(node.id)}
             onPaneClick={() => onSelectNode(null)}
             onNodesChange={(changes: NodeChange[]) => {
-              const kept = changes.filter((c) => c.type === "position" || c.type === "dimensions");
+              const kept = changes.filter(
+                (c) => c.type === "position" || c.type === "dimensions",
+              );
               if (kept.length === 0) return;
-              setPositioned((prev) => (prev ? { ...prev, nodes: applyNodeChanges(kept, prev.nodes) } : prev));
+              setPositioned((prev) =>
+                prev
+                  ? { ...prev, nodes: applyNodeChanges(kept, prev.nodes) }
+                  : prev,
+              );
             }}
             onInit={(inst) => {
               flowRef.current = inst;
@@ -502,33 +655,57 @@ export function Chain({
             minZoom={0.2}
           >
             <Background color="var(--border)" gap={20} size={1} />
-            <Controls showInteractive={false} style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }} />
+            <Controls
+              showInteractive={false}
+              style={{
+                background: "var(--surface-1)",
+                border: "1px solid var(--border)",
+              }}
+            />
             <MiniMap
               pannable
               zoomable
-              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+              style={{
+                background: "var(--surface-1)",
+                border: "1px solid var(--border)",
+              }}
               maskColor="rgba(0, 0, 0, 0.55)"
               nodeClassName={(n) => `minimap-node minimap-${n.type}`}
             />
           </ReactFlow>
         ) : (
-          <div className="flex h-full items-center justify-center px-8 text-center text-(--text-faint)">{emptyCopy}</div>
+          <div className="flex h-full items-center justify-center px-8 text-center text-(--text-faint)">
+            {emptyCopy}
+          </div>
         )}
       </div>
 
       {selected && (
         <DetailPane
           widthClass="w-[420px]"
-          title={selected.kind === "chainEvent" ? selected.event.type : (selected.run.agent ?? selected.run.runId)}
+          title={
+            selected.kind === "chainEvent"
+              ? selected.event.type
+              : (selected.run.agent ?? selected.run.runId)
+          }
           actions={
             <Button onClick={revealSelected}>
               {timelineOn ? "Show in timeline" : "Show on canvas"}{" "}
-              <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
+              <span
+                className="mono ml-1 text-(--text-faint)"
+                aria-hidden="true"
+              >
+                z
+              </span>
             </Button>
           }
           utility={
             <CopyActions
-              id={selected.kind === "chainEvent" ? selected.event.eventId : selected.run.runId}
+              id={
+                selected.kind === "chainEvent"
+                  ? selected.event.eventId
+                  : selected.run.runId
+              }
               idLabel={selected.kind === "chainEvent" ? "event id" : "run id"}
             />
           }
@@ -536,19 +713,39 @@ export function Chain({
         >
           {selected.kind === "chainEvent" && (
             <>
-              <Section id="chain-event" title={selected.root ? "Origin event" : "Event"} icons>
+              <Section
+                id="chain-event"
+                title={selected.root ? "Origin event" : "Event"}
+                icons
+              >
                 <KV k="source" v={selected.event.source} />
                 <KV k="type" v={selected.event.type} />
                 <KV k="subject" v={selected.event.subject} />
-                <KV k="status" v={<StateBadge state={selected.event.status} hues={EVENT_STATUS_HUES} />} />
-                <KV k="depth" v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`} />
-                <KV k="admittedAt" v={<Ago iso={selected.event.admittedAt} now={now} />} />
+                <KV
+                  k="status"
+                  v={
+                    <StateBadge
+                      state={selected.event.status}
+                      hues={EVENT_STATUS_HUES}
+                    />
+                  }
+                />
+                <KV
+                  k="depth"
+                  v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`}
+                />
+                <KV
+                  k="admittedAt"
+                  v={<Ago iso={selected.event.admittedAt} now={now} />}
+                />
                 <KV
                   k="emitted by run"
                   v={
                     selected.event.causationId ? (
                       <JumpLink
-                        onClick={() => onSelectNode(runNodeId(selected.event.causationId!))}
+                        onClick={() =>
+                          onSelectNode(runNodeId(selected.event.causationId!))
+                        }
                         title={selected.event.causationId}
                       >
                         {shortId(selected.event.causationId)}
@@ -562,9 +759,16 @@ export function Chain({
                   k="proposal"
                   v={
                     selected.event.proposalId ? (
-                      <JumpLink onClick={() => onJumpProposal(selected.event.proposalId!)} title={selected.event.proposalId}>
+                      <JumpLink
+                        onClick={() =>
+                          onJumpProposal(selected.event.proposalId!)
+                        }
+                        title={selected.event.proposalId}
+                      >
                         {shortId(selected.event.proposalId)}
-                        {selected.event.proposalDecision ? ` · ${selected.event.proposalDecision}` : ""}
+                        {selected.event.proposalDecision
+                          ? ` · ${selected.event.proposalDecision}`
+                          : ""}
                       </JumpLink>
                     ) : null
                   }
@@ -573,15 +777,28 @@ export function Chain({
                   k="run"
                   v={
                     selected.event.runId ? (
-                      <JumpLink onClick={() => onSelectNode(runNodeId(selected.event.runId!))} title={selected.event.runId}>
+                      <JumpLink
+                        onClick={() =>
+                          onSelectNode(runNodeId(selected.event.runId!))
+                        }
+                        title={selected.event.runId}
+                      >
                         {shortId(selected.event.runId)}
                       </JumpLink>
                     ) : null
                   }
                 />
-                {selected.event.repos.length > 0 && <KV k="repos" v={selected.event.repos.join(", ")} />}
+                {selected.event.repos.length > 0 && (
+                  <KV k="repos" v={selected.event.repos.join(", ")} />
+                )}
               </Section>
-              <Button onClick={() => onJumpEvent(selected.event.source, selected.event.eventId)}>Open in Events</Button>
+              <Button
+                onClick={() =>
+                  onJumpEvent(selected.event.source, selected.event.eventId)
+                }
+              >
+                Open in Events
+              </Button>
             </>
           )}
           {selected.kind === "chainRun" && (
@@ -592,7 +809,10 @@ export function Chain({
                   k="agent"
                   v={
                     selected.run.agent ? (
-                      <JumpLink onClick={() => onJumpAgent(selected.run.agent!)} title="Open in Agents">
+                      <JumpLink
+                        onClick={() => onJumpAgent(selected.run.agent!)}
+                        title="Open in Agents"
+                      >
                         {selected.run.agent}
                       </JumpLink>
                     ) : null
@@ -605,21 +825,41 @@ export function Chain({
                     k="reason"
                     v={
                       <span title={selected.run.reasonCode}>
-                        {humanizeRunReason(selected.run.reasonCode)?.text ?? selected.run.reasonCode}
+                        {humanizeRunReason(selected.run.reasonCode)?.text ??
+                          selected.run.reasonCode}
                       </span>
                     }
                   />
                 )}
-                <KV k="depth" v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`} />
-                <KV k="created" v={<Ago iso={selected.run.created_at} now={now} />} />
-                <KV k="started" v={<Ago iso={selected.run.startedAt} now={now} />} />
-                <KV k="finished" v={<Ago iso={selected.run.finishedAt} now={now} />} />
+                <KV
+                  k="depth"
+                  v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`}
+                />
+                <KV
+                  k="created"
+                  v={<Ago iso={selected.run.created_at} now={now} />}
+                />
+                <KV
+                  k="started"
+                  v={<Ago iso={selected.run.startedAt} now={now} />}
+                />
+                <KV
+                  k="finished"
+                  v={<Ago iso={selected.run.finishedAt} now={now} />}
+                />
                 <KV
                   k="origin event"
                   v={
                     selected.run.eventSource && selected.run.eventId ? (
                       <JumpLink
-                        onClick={() => onSelectNode(eventNodeId(selected.run.eventSource!, selected.run.eventId!))}
+                        onClick={() =>
+                          onSelectNode(
+                            eventNodeId(
+                              selected.run.eventSource!,
+                              selected.run.eventId!,
+                            ),
+                          )
+                        }
                         title={selected.run.eventId}
                       >
                         {shortId(selected.run.eventId)}
@@ -627,11 +867,17 @@ export function Chain({
                     ) : null
                   }
                 />
-                {selected.run.repos.length > 0 && <KV k="repos" v={selected.run.repos.join(", ")} />}
+                {selected.run.repos.length > 0 && (
+                  <KV k="repos" v={selected.run.repos.join(", ")} />
+                )}
               </Section>
               <div className="flex flex-wrap gap-2">
-                <Button onClick={() => onOpenRunFull(selected.run.runId)}>Open run</Button>
-                <Button onClick={() => onJumpRun(selected.run.runId)}>Show in Runs</Button>
+                <Button onClick={() => onOpenRunFull(selected.run.runId)}>
+                  Open run
+                </Button>
+                <Button onClick={() => onJumpRun(selected.run.runId)}>
+                  Show in Runs
+                </Button>
               </div>
             </>
           )}
@@ -684,25 +930,41 @@ function ChainTimelineList({
     switch (ref.kind) {
       case "event":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpEvent(ref.source ?? "", ref.id)} title={`Open in Events · ${ref.id}`}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            onClick={() => onJumpEvent(ref.source ?? "", ref.id)}
+            title={`Open in Events · ${ref.id}`}
+          >
             event ↗
           </JumpLink>
         );
       case "run":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onOpenRunFull(ref.id)} title={`Open run · ${ref.id}`}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            onClick={() => onOpenRunFull(ref.id)}
+            title={`Open run · ${ref.id}`}
+          >
             {ref.label} ↗
           </JumpLink>
         );
       case "proposal":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpProposal(ref.id)} title={`Open proposal · ${ref.id}`}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            onClick={() => onJumpProposal(ref.id)}
+            title={`Open proposal · ${ref.id}`}
+          >
             proposal ↗
           </JumpLink>
         );
       case "agent":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpAgent(ref.id)} title="Open in Agents">
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            onClick={() => onJumpAgent(ref.id)}
+            title="Open in Agents"
+          >
             {ref.label}
           </JumpLink>
         );
@@ -722,19 +984,31 @@ function ChainTimelineList({
         ) : null;
       case "ticket":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/tickets/${encodeURIComponent(ref.id)}`} title={`Open ticket journey ${ref.id}`}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            href={`#/tickets/${encodeURIComponent(ref.id)}`}
+            title={`Open ticket journey ${ref.id}`}
+          >
             {ref.label}
           </JumpLink>
         );
       case "schedule":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/schedules/${encodeURIComponent(ref.id)}`} title={`Open schedule ${ref.id}`}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            href={`#/schedules/${encodeURIComponent(ref.id)}`}
+            title={`Open schedule ${ref.id}`}
+          >
             schedule ↗
           </JumpLink>
         );
       case "inbox":
         return (
-          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/inbox/${encodeURIComponent(ref.id)}`} title={ref.label}>
+          <JumpLink
+            key={`${ref.kind}:${ref.id}`}
+            href={`#/inbox/${encodeURIComponent(ref.id)}`}
+            title={ref.label}
+          >
             inbox: {ref.label} ↗
           </JumpLink>
         );
@@ -745,9 +1019,15 @@ function ChainTimelineList({
   return (
     <div className="min-h-0 flex-1 overflow-auto px-5 pt-1 pb-10">
       {rows.length === 0 ? (
-        <div className="text-[12px] text-(--text-faint)">{emptyCopy ?? "No steps recorded for this chain yet."}</div>
+        <div className="text-[12px] text-(--text-faint)">
+          {emptyCopy ?? "No steps recorded for this chain yet."}
+        </div>
       ) : (
-        <ol ref={listRef} className="m-0 max-w-5xl list-none p-0" aria-label="Chain timeline">
+        <ol
+          ref={listRef}
+          className="m-0 max-w-5xl list-none p-0"
+          aria-label="Chain timeline"
+        >
           {rows.map((row, i) => {
             const hue = huesFor(row)[row.badge] ?? "var(--hue-idle)";
             const selected = row.nodeId != null && row.nodeId === focusNodeId;
@@ -775,27 +1055,55 @@ function ChainTimelineList({
                   selected ? "bg-(--surface-2) ring-1 ring-(--accent)" : ""
                 } ${row.muted ? "opacity-80" : ""}`}
               >
-                <span className="mono w-[62px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)" title={row.at ?? undefined}>
+                <span
+                  className="mono w-[62px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)"
+                  title={row.at ?? undefined}
+                >
                   {time}
                 </span>
                 <span className="mono w-[52px] shrink-0 pt-0.5 text-right text-[10px] tabular-nums text-(--text-faint)">
                   {row.kind === "next" ? "" : formatDelta(row.deltaMs)}
                 </span>
-                <span className="relative flex w-2 shrink-0 justify-center" aria-hidden="true">
-                  {i < rows.length - 1 && <span className="absolute top-2.5 bottom-[-6px] w-px bg-(--border)" />}
-                  <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
+                <span
+                  className="relative flex w-2 shrink-0 justify-center"
+                  aria-hidden="true"
+                >
+                  {i < rows.length - 1 && (
+                    <span className="absolute top-2.5 bottom-[-6px] w-px bg-(--border)" />
+                  )}
+                  <span
+                    className="relative mt-[7px] size-1.5 shrink-0 rounded-full"
+                    style={{ background: hue }}
+                  />
                 </span>
                 <span className="flex min-w-0 flex-1 items-start gap-x-2">
                   <span className="flex w-[100px] shrink-0 items-center">
-                    <StateBadge state={row.badge} hues={huesFor(row)} dot={false} />
+                    <StateBadge
+                      state={row.badge}
+                      hues={huesFor(row)}
+                      dot={false}
+                    />
                   </span>
                   <span className="min-w-0 flex-1 break-words text-[11.5px] leading-relaxed text-(--text-dim)">
-                    {row.actor && <span className="mono text-(--text)">{row.actor}</span>}
+                    {row.actor && (
+                      <span className="mono text-(--text)">{row.actor}</span>
+                    )}
                     {row.actor && (row.what || row.reason) ? " · " : ""}
-                    {row.what && <span className={row.kind === "next" ? "text-(--text-faint)" : ""}>{row.what}</span>}
+                    {row.what && (
+                      <span
+                        className={
+                          row.kind === "next" ? "text-(--text-faint)" : ""
+                        }
+                      >
+                        {row.what}
+                      </span>
+                    )}
                     {row.what && row.reason ? " · " : ""}
                     {row.reason && (
-                      <span className="text-(--text-faint)" title={row.reason.raw}>
+                      <span
+                        className="text-(--text-faint)"
+                        title={row.reason.raw}
+                      >
                         {row.reason.text}
                       </span>
                     )}
@@ -812,7 +1120,9 @@ function ChainTimelineList({
         </ol>
       )}
       {timeline.partial && (
-        <div className="mt-3 text-[11px] text-(--text-faint)">Loading run lifecycles…</div>
+        <div className="mt-3 text-[11px] text-(--text-faint)">
+          Loading run lifecycles…
+        </div>
       )}
     </div>
   );

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -24,7 +24,11 @@ afterEach(() => {
 const noop = () => {};
 const NOW = new Date().toISOString();
 
-function stubEvent(eventId: string, status: string, overrides?: Partial<AdmittedEvent>): AdmittedEvent {
+function stubEvent(
+  eventId: string,
+  status: string,
+  overrides?: Partial<AdmittedEvent>,
+): AdmittedEvent {
   return createEventFixture({
     source: "github",
     eventId,
@@ -96,7 +100,10 @@ describe("Events component harness: selection & detail view", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const focusEvent: EventFocus = { source: "github", eventId: "evt_selected_1" };
+        const focusEvent: EventFocus = {
+          source: "github",
+          eventId: "evt_selected_1",
+        };
         const { container, getAllByText } = renderEvents({ focusEvent });
 
         const selectedRow = await waitFor(() => {
@@ -124,8 +131,14 @@ describe("Events component harness: selection & detail view", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const focusEvent: EventFocus = { source: "github", eventId: "evt_tab_1" };
-        const { getByRole, container } = renderEvents({ focusEvent, onSelectEvent });
+        const focusEvent: EventFocus = {
+          source: "github",
+          eventId: "evt_tab_1",
+        };
+        const { getByRole, container } = renderEvents({
+          focusEvent,
+          onSelectEvent,
+        });
 
         await waitFor(() => container.querySelector("tr.row-selected"));
 
@@ -140,8 +153,12 @@ describe("Events component harness: selection & detail view", () => {
 
 describe("Events component harness: filter retention", () => {
   test("typing in filter input restricts visible events and retains matching selection", async () => {
-    const e1 = stubEvent("evt_pr_opened", "admitted", { type: "pull_request.opened" });
-    const e2 = stubEvent("evt_pr_closed", "admitted", { type: "pull_request.closed" });
+    const e1 = stubEvent("evt_pr_opened", "admitted", {
+      type: "pull_request.opened",
+    });
+    const e2 = stubEvent("evt_pr_closed", "admitted", {
+      type: "pull_request.closed",
+    });
 
     await withApi(
       {
@@ -149,11 +166,16 @@ describe("Events component harness: filter retention", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const focusEvent: EventFocus = { source: "github", eventId: "evt_pr_opened" };
+        const focusEvent: EventFocus = {
+          source: "github",
+          eventId: "evt_pr_opened",
+        };
         const { getByLabelText, container } = renderEvents({ focusEvent });
 
         await waitFor(() => container.querySelector("tr.row-selected"));
-        expect(container.querySelector('td[title="evt_pr_closed"]')).toBeTruthy();
+        expect(
+          container.querySelector('td[title="evt_pr_closed"]'),
+        ).toBeTruthy();
 
         const filterInput = getByLabelText("Filter events") as HTMLInputElement;
         act(() => {
@@ -161,14 +183,20 @@ describe("Events component harness: filter retention", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector('td[title="evt_pr_opened"]')).toBeTruthy();
-          expect(container.querySelector('td[title="evt_pr_closed"]')).toBeNull();
+          expect(
+            container.querySelector('td[title="evt_pr_opened"]'),
+          ).toBeTruthy();
+          expect(
+            container.querySelector('td[title="evt_pr_closed"]'),
+          ).toBeNull();
         });
 
         // Selected event remains highlighted
         const selectedRow = container.querySelector("tr.row-selected");
         expect(selectedRow).toBeTruthy();
-        expect(selectedRow?.querySelector('td[title="evt_pr_opened"]')).toBeTruthy();
+        expect(
+          selectedRow?.querySelector('td[title="evt_pr_opened"]'),
+        ).toBeTruthy();
       },
     );
   });
@@ -183,7 +211,10 @@ describe("Events component harness: cross-tab reveal", () => {
     await withApi(
       {
         events: async (status?: string) => ({
-          events: status && status !== "all" ? allEvents.filter((e) => e.status === status) : allEvents,
+          events:
+            status && status !== "all"
+              ? allEvents.filter((e) => e.status === status)
+              : allEvents,
         }),
         status: async () => createStatusFixture(),
       },
@@ -221,7 +252,9 @@ describe("Events component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const allTab = getByRole("tab", { name: /^All/i });
           expect(allTab.getAttribute("aria-selected")).toBe("true");
-          expect(container.querySelector('td[title="evt_dead_lettered_1"]')).toBeTruthy();
+          expect(
+            container.querySelector('td[title="evt_dead_lettered_1"]'),
+          ).toBeTruthy();
         });
       },
     );
@@ -229,7 +262,9 @@ describe("Events component harness: cross-tab reveal", () => {
 
   test("clears active text filter when focusEvent is hidden by the filter", async () => {
     const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created" });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "issue_comment.created",
+    });
 
     await withApi(
       {
@@ -240,7 +275,9 @@ describe("Events component harness: cross-tab reveal", () => {
         const { getByLabelText, container, rerender } = renderEvents({});
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_1");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_1",
+          );
         });
 
         // Filter for type pull_request, hiding evt_2
@@ -250,7 +287,9 @@ describe("Events component harness: cross-tab reveal", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).not.toContain("evt_2");
+          expect(container.querySelector("tbody")?.textContent).not.toContain(
+            "evt_2",
+          );
         });
 
         // Focus evt_2 (which was hidden by the filter)
@@ -273,7 +312,9 @@ describe("Events component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const input = getByLabelText("Filter events") as HTMLInputElement;
           expect(input.value).toBe("");
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_2");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_2",
+          );
         });
       },
     );
@@ -292,7 +333,9 @@ describe("Events component harness: cross-tab reveal", () => {
         const { getByLabelText, container, rerender } = renderEvents({});
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_1");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_1",
+          );
         });
 
         const filterInput = getByLabelText("Filter events") as HTMLInputElement;
@@ -301,7 +344,9 @@ describe("Events component harness: cross-tab reveal", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_1");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_1",
+          );
         });
 
         // Focus evt_1 (already visible under source:github)
@@ -324,7 +369,9 @@ describe("Events component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const input = getByLabelText("Filter events") as HTMLInputElement;
           expect(input.value).toBe("source:github");
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_1");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_1",
+          );
         });
       },
     );
@@ -355,9 +402,18 @@ describe("Events component harness: cross-tab reveal", () => {
 
 describe("Events component harness: facet chips grouping and visual distinction", () => {
   test("renders Type and Source category groups with labels and numerical counts", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "pull_request.opened", source: "github" });
-    const e3 = stubEvent("evt_3", "planned", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e3 = stubEvent("evt_3", "planned", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -384,26 +440,26 @@ describe("Events component harness: facet chips grouping and visual distinction"
 
         // Numerical counts match the scoped events under current tab (All: 3 events)
         const typeGroup = getByRole("group", { name: "Event types" });
-        const prButton = Array.from(typeGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("pull_request.opened"),
+        const prButton = Array.from(typeGroup.querySelectorAll("button")).find(
+          (b) => b.textContent?.includes("pull_request.opened"),
         );
         expect(prButton).toBeTruthy();
         expect(prButton?.textContent).toContain("2");
 
-        const commentButton = Array.from(typeGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("issue_comment.created"),
-        );
+        const commentButton = Array.from(
+          typeGroup.querySelectorAll("button"),
+        ).find((b) => b.textContent?.includes("issue_comment.created"));
         expect(commentButton?.textContent).toContain("1");
 
         const sourceGroup = getByRole("group", { name: "Event sources" });
-        const githubButton = Array.from(sourceGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("github"),
-        );
+        const githubButton = Array.from(
+          sourceGroup.querySelectorAll("button"),
+        ).find((b) => b.textContent?.includes("github"));
         expect(githubButton?.textContent).toContain("2");
 
-        const gitlabButton = Array.from(sourceGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("gitlab"),
-        );
+        const gitlabButton = Array.from(
+          sourceGroup.querySelectorAll("button"),
+        ).find((b) => b.textContent?.includes("gitlab"));
         expect(gitlabButton?.textContent).toContain("1");
       },
     );
@@ -411,11 +467,26 @@ describe("Events component harness: facet chips grouping and visual distinction"
 
   test("sorts Type and Source facet chips by frequency, then alphabetically", async () => {
     const events = [
-      stubEvent("evt_1", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
-      stubEvent("evt_2", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
-      stubEvent("evt_3", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
-      stubEvent("evt_4", "admitted", { type: "alpha.rare", source: "alpha-source" }),
-      stubEvent("evt_5", "admitted", { type: "beta.rare", source: "beta-source" }),
+      stubEvent("evt_1", "admitted", {
+        type: "zeta.frequent",
+        source: "zeta-source",
+      }),
+      stubEvent("evt_2", "admitted", {
+        type: "zeta.frequent",
+        source: "zeta-source",
+      }),
+      stubEvent("evt_3", "admitted", {
+        type: "zeta.frequent",
+        source: "zeta-source",
+      }),
+      stubEvent("evt_4", "admitted", {
+        type: "alpha.rare",
+        source: "alpha-source",
+      }),
+      stubEvent("evt_5", "admitted", {
+        type: "beta.rare",
+        source: "beta-source",
+      }),
     ];
 
     await withApi(
@@ -426,30 +497,52 @@ describe("Events component harness: facet chips grouping and visual distinction"
       async () => {
         const { getByRole } = renderEvents({});
 
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
-        const typeLabels = Array.from(typeGroup.querySelectorAll("button > span:first-child")).map(
-          (span) => span.textContent,
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
         );
-        expect(typeLabels).toEqual(["zeta.frequent", "alpha.rare", "beta.rare"]);
+        const typeLabels = Array.from(
+          typeGroup.querySelectorAll("button > span:first-child"),
+        ).map((span) => span.textContent);
+        expect(typeLabels).toEqual([
+          "zeta.frequent",
+          "alpha.rare",
+          "beta.rare",
+        ]);
 
         const sourceGroup = getByRole("group", { name: "Event sources" });
-        const sourceLabels = Array.from(sourceGroup.querySelectorAll("button > span:first-child")).map(
-          (span) => span.textContent,
-        );
-        expect(sourceLabels).toEqual(["zeta-source", "alpha-source", "beta-source"]);
+        const sourceLabels = Array.from(
+          sourceGroup.querySelectorAll("button > span:first-child"),
+        ).map((span) => span.textContent);
+        expect(sourceLabels).toEqual([
+          "zeta-source",
+          "alpha-source",
+          "beta-source",
+        ]);
       },
     );
   });
 
   test("facet chip counts reflect the active tab scope", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "pull_request.opened", source: "github" });
-    const e3 = stubEvent("evt_3", "planned", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e3 = stubEvent("evt_3", "planned", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
         events: async (status?: string) => ({
-          events: status && status !== "all" ? [e1, e2, e3].filter((e) => e.status === status) : [e1, e2, e3],
+          events:
+            status && status !== "all"
+              ? [e1, e2, e3].filter((e) => e.status === status)
+              : [e1, e2, e3],
         }),
         status: async () => createStatusFixture(),
       },
@@ -475,8 +568,14 @@ describe("Events component harness: facet chips grouping and visual distinction"
 describe("Events component harness: facet chips synchronization with FilterInput", () => {
   test("clicking a Type facet chip synchronizes filter query box and token chips", async () => {
     const onSelectType = mock(() => {});
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -484,11 +583,17 @@ describe("Events component harness: facet chips synchronization with FilterInput
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { getByRole, getByLabelText, container } = renderEvents({ onSelectType });
+        const { getByRole, getByLabelText, container } = renderEvents({
+          onSelectType,
+        });
 
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
+        );
         const buttons = typeGroup.querySelectorAll("button");
-        const prButton = Array.from(buttons).find((b) => b.textContent?.includes("pull_request.opened"));
+        const prButton = Array.from(buttons).find((b) =>
+          b.textContent?.includes("pull_request.opened"),
+        );
         expect(prButton).toBeTruthy();
         expect(prButton?.getAttribute("aria-pressed")).toBe("false");
 
@@ -505,8 +610,12 @@ describe("Events component harness: facet chips synchronization with FilterInput
 
         // List is filtered to only pull_request.opened
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_1");
-          expect(container.querySelector("tbody")?.textContent).not.toContain("evt_2");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_1",
+          );
+          expect(container.querySelector("tbody")?.textContent).not.toContain(
+            "evt_2",
+          );
         });
 
         // Click again to toggle off
@@ -517,16 +626,27 @@ describe("Events component harness: facet chips synchronization with FilterInput
 
         // List returns to full
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_2");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "evt_2",
+          );
         });
       },
     );
   });
 
   test("replacing multiple Type facet tokens preserves the rest of the query", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "release.published", source: "github" });
-    const e3 = stubEvent("evt_3", "admitted", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "release.published",
+      source: "github",
+    });
+    const e3 = stubEvent("evt_3", "admitted", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -535,7 +655,9 @@ describe("Events component harness: facet chips synchronization with FilterInput
       },
       async () => {
         const { getByRole, getByLabelText } = renderEvents({});
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
+        );
         const filterInput = getByLabelText("Filter events") as HTMLInputElement;
 
         act(() => {
@@ -545,20 +667,30 @@ describe("Events component harness: facet chips synchronization with FilterInput
           );
         });
 
-        const issueButton = Array.from(typeGroup.querySelectorAll("button")).find((button) =>
+        const issueButton = Array.from(
+          typeGroup.querySelectorAll("button"),
+        ).find((button) =>
           button.textContent?.includes("issue_comment.created"),
         );
         expect(issueButton).toBeTruthy();
         fireEvent.click(issueButton!);
 
-        expect(filterInput.value).toBe("source:github type:issue_comment.created");
+        expect(filterInput.value).toBe(
+          "source:github type:issue_comment.created",
+        );
       },
     );
   });
 
   test("removing duplicate active Type facet tokens preserves the rest of the query", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -567,7 +699,9 @@ describe("Events component harness: facet chips synchronization with FilterInput
       },
       async () => {
         const { getByRole, getByLabelText } = renderEvents({});
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
+        );
         const filterInput = getByLabelText("Filter events") as HTMLInputElement;
 
         act(() => {
@@ -577,9 +711,9 @@ describe("Events component harness: facet chips synchronization with FilterInput
           );
         });
 
-        const pullRequestButton = Array.from(typeGroup.querySelectorAll("button")).find((button) =>
-          button.textContent?.includes("pull_request.opened"),
-        );
+        const pullRequestButton = Array.from(
+          typeGroup.querySelectorAll("button"),
+        ).find((button) => button.textContent?.includes("pull_request.opened"));
         expect(pullRequestButton?.getAttribute("aria-pressed")).toBe("true");
         fireEvent.click(pullRequestButton!);
 
@@ -589,8 +723,14 @@ describe("Events component harness: facet chips synchronization with FilterInput
   });
 
   test("typing type:<val> or source:<val> in FilterInput updates facet chips active state", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -600,15 +740,17 @@ describe("Events component harness: facet chips synchronization with FilterInput
       async () => {
         const { getByRole, getByLabelText } = renderEvents({});
 
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
+        );
         const sourceGroup = getByRole("group", { name: "Event sources" });
 
-        const prButton = Array.from(typeGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("pull_request.opened"),
+        const prButton = Array.from(typeGroup.querySelectorAll("button")).find(
+          (b) => b.textContent?.includes("pull_request.opened"),
         );
-        const githubButton = Array.from(sourceGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("github"),
-        );
+        const githubButton = Array.from(
+          sourceGroup.querySelectorAll("button"),
+        ).find((b) => b.textContent?.includes("github"));
 
         expect(prButton?.getAttribute("aria-pressed")).toBe("false");
         expect(githubButton?.getAttribute("aria-pressed")).toBe("false");
@@ -648,8 +790,14 @@ describe("Events component harness: facet chips synchronization with FilterInput
   });
 
   test("Escape key or clearing filter resets active facet chip selections", async () => {
-    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
-    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });
+    const e1 = stubEvent("evt_1", "admitted", {
+      type: "pull_request.opened",
+      source: "github",
+    });
+    const e2 = stubEvent("evt_2", "admitted", {
+      type: "issue_comment.created",
+      source: "gitlab",
+    });
 
     await withApi(
       {
@@ -659,9 +807,11 @@ describe("Events component harness: facet chips synchronization with FilterInput
       async () => {
         const { getByRole, getByLabelText, getByTitle } = renderEvents({});
 
-        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
-        const prButton = Array.from(typeGroup.querySelectorAll("button")).find((b) =>
-          b.textContent?.includes("pull_request.opened"),
+        const typeGroup = await waitFor(() =>
+          getByRole("group", { name: "Event types" }),
+        );
+        const prButton = Array.from(typeGroup.querySelectorAll("button")).find(
+          (b) => b.textContent?.includes("pull_request.opened"),
         );
 
         // Click to activate
@@ -669,12 +819,16 @@ describe("Events component harness: facet chips synchronization with FilterInput
         expect(prButton?.getAttribute("aria-pressed")).toBe("true");
 
         // Click clear in token chip bar
-        const clearButton = await waitFor(() => getByTitle("Clear query (Esc)"));
+        const clearButton = await waitFor(() =>
+          getByTitle("Clear query (Esc)"),
+        );
         fireEvent.click(clearButton);
 
         await waitFor(() => {
           expect(prButton?.getAttribute("aria-pressed")).toBe("false");
-          const filterInput = getByLabelText("Filter events") as HTMLInputElement;
+          const filterInput = getByLabelText(
+            "Filter events",
+          ) as HTMLInputElement;
           expect(filterInput.value).toBe("");
         });
 
@@ -697,8 +851,12 @@ describe("Events component harness: facet chips synchronization with FilterInput
 
 describe("Events repo scope caption (WM-142)", () => {
   test("repo context renders scope caption while rows are filtered", async () => {
-    const matching = stubEvent("evt_repo_match", "admitted", { repos: ["factory"] });
-    const other = stubEvent("evt_other_repo", "admitted", { repos: ["other-repo"] });
+    const matching = stubEvent("evt_repo_match", "admitted", {
+      repos: ["factory"],
+    });
+    const other = stubEvent("evt_other_repo", "admitted", {
+      repos: ["other-repo"],
+    });
 
     await withApi(
       {
@@ -716,8 +874,12 @@ describe("Events repo scope caption (WM-142)", () => {
           expect(getByText(/only rows naming this repo/i)).toBeTruthy();
         });
 
-        expect(container.querySelector('td[title="evt_repo_match"]')).toBeTruthy();
-        expect(container.querySelector('td[title="evt_other_repo"]')).toBeNull();
+        expect(
+          container.querySelector('td[title="evt_repo_match"]'),
+        ).toBeTruthy();
+        expect(
+          container.querySelector('td[title="evt_other_repo"]'),
+        ).toBeNull();
       },
     );
   });
@@ -740,7 +902,8 @@ describe("Events table short event ids (WM-142)", () => {
 
         const cell = await waitFor(() => {
           const el = container.querySelector(`td[title="${eventId}"]`);
-          if (!el) throw new Error("event id cell with full-id title is missing");
+          if (!el)
+            throw new Error("event id cell with full-id title is missing");
           return el;
         });
         expect(cell.textContent).toBe(shortId(eventId));
@@ -777,7 +940,9 @@ describe("Events copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderEvents({ focusEvent: { source: "github", eventId } });
-        const idBtn = await r.findByRole("button", { name: "Copy event id (c)" });
+        const idBtn = await r.findByRole("button", {
+          name: "Copy event id (c)",
+        });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
         expect(idBtn.getAttribute("title")).toBe("Copy event id · c");
@@ -801,13 +966,25 @@ describe("Planner decisions explain themselves (WM-594)", () => {
     source: "linear",
     subject: "WM-542",
     proposalId: "prop_noop_1",
-    envelope: { schemaVersion: "factory.event/v1", eventId: "evt_noop_1", type: "dispatch.requested", source: "linear", payload: { ticket: "WM-542" } },
+    envelope: {
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_noop_1",
+      type: "dispatch.requested",
+      source: "linear",
+      payload: { ticket: "WM-542" },
+    },
   });
   const liveEvent = stubEvent("evt_noop_2", "noop", {
     source: "linear",
     subject: "WM-543",
     proposalId: "prop_noop_2",
-    envelope: { schemaVersion: "factory.event/v1", eventId: "evt_noop_2", type: "dispatch.requested", source: "linear", payload: { ticket: "WM-543" } },
+    envelope: {
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_noop_2",
+      type: "dispatch.requested",
+      source: "linear",
+      payload: { ticket: "WM-543" },
+    },
   });
   const refusedEvent = stubEvent("evt_planned_1", "planned", {
     source: "linear",
@@ -817,15 +994,47 @@ describe("Planner decisions explain themselves (WM-594)", () => {
   });
   const plainEvent = stubEvent("evt_admitted_1", "admitted");
   const proposals = [
-    createProposalFixture({ id: "prop_noop_1", decision: "noop", status: "resolved", reason: "owned_paths_overlap", eventId: "evt_noop_1", eventSource: "linear", runId: null }),
-    createProposalFixture({ id: "prop_noop_2", decision: "noop", status: "resolved", reason: "ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held", eventId: "evt_noop_2", eventSource: "linear", runId: null }),
-    createProposalFixture({ id: "prop_run_1", decision: "run", status: "approved", eventId: "evt_planned_1", eventSource: "linear", runId: "run_refused_1" }),
+    createProposalFixture({
+      id: "prop_noop_1",
+      decision: "noop",
+      status: "resolved",
+      reason: "owned_paths_overlap",
+      eventId: "evt_noop_1",
+      eventSource: "linear",
+      runId: null,
+    }),
+    createProposalFixture({
+      id: "prop_noop_2",
+      decision: "noop",
+      status: "resolved",
+      reason:
+        "ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held",
+      eventId: "evt_noop_2",
+      eventSource: "linear",
+      runId: null,
+    }),
+    createProposalFixture({
+      id: "prop_run_1",
+      decision: "run",
+      status: "approved",
+      eventId: "evt_planned_1",
+      eventSource: "linear",
+      runId: "run_refused_1",
+    }),
   ];
   const runs = [
-    createRunListItemFixture({ runId: "run_refused_1", state: "REFUSED", reasonCode: "needs_human", eventId: "evt_planned_1", eventSource: "linear" }),
+    createRunListItemFixture({
+      runId: "run_refused_1",
+      state: "REFUSED",
+      reasonCode: "needs_human",
+      eventId: "evt_planned_1",
+      eventSource: "linear",
+    }),
   ];
   const apiWith = () => ({
-    events: async () => ({ events: [noopEvent, liveEvent, refusedEvent, plainEvent] }),
+    events: async () => ({
+      events: [noopEvent, liveEvent, refusedEvent, plainEvent],
+    }),
     proposalHistory: async () => ({ proposals }),
     runs: async () => ({ runs }),
     status: async () => createStatusFixture(),
@@ -834,15 +1043,22 @@ describe("Planner decisions explain themselves (WM-594)", () => {
   test("the event pane shows a decision row under status, humanized with the raw code in title", async () => {
     await withApi(apiWith(), async () => {
       const onJumpRun = mock(() => {});
-      const r = renderEvents({ focusEvent: { source: "linear", eventId: "evt_noop_2" }, onJumpRun });
+      const r = renderEvents({
+        focusEvent: { source: "linear", eventId: "evt_noop_2" },
+        onJumpRun,
+      });
       const row = await waitFor(() => {
         const el = r.container.querySelector('[data-testid="event-decision"]');
         if (!el) throw new Error("decision row not rendered");
         return el as HTMLElement;
       });
       expect(row.textContent).toContain("noop");
-      expect(row.textContent).toContain("A dispatch for this ticket is already live");
-      expect(row.getAttribute("title")).toBe("ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held");
+      expect(row.textContent).toContain(
+        "A dispatch for this ticket is already live",
+      );
+      expect(row.getAttribute("title")).toBe(
+        "ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held",
+      );
       // The run reference in the reason is a jump link.
       // Once on the decision row, once in the Decisions block headline.
       fireEvent.click(r.getAllByTitle("Open run run_held-99")[0]);
@@ -854,7 +1070,9 @@ describe("Planner decisions explain themselves (WM-594)", () => {
 
   test("a planned event whose run was refused reads `refused · Needs human`", async () => {
     await withApi(apiWith(), async () => {
-      const r = renderEvents({ focusEvent: { source: "linear", eventId: "evt_planned_1" } });
+      const r = renderEvents({
+        focusEvent: { source: "linear", eventId: "evt_planned_1" },
+      });
       const row = await waitFor(() => {
         const el = r.container.querySelector('[data-testid="event-decision"]');
         if (!el) throw new Error("decision row not rendered");
@@ -863,8 +1081,12 @@ describe("Planner decisions explain themselves (WM-594)", () => {
       expect(row.textContent).toContain("refused");
       expect(row.textContent).toContain("Needs human");
       // The list badge for that row carries the same answer as its tooltip.
-      const cell = r.container.querySelector('td[title="evt_planned_1"]')!.closest("tr")!;
-      expect(cell.querySelector('[data-decision="refused"]')?.getAttribute("title")).toBe("refused · Needs human\nneeds_human");
+      const cell = r.container
+        .querySelector('td[title="evt_planned_1"]')!
+        .closest("tr")!;
+      expect(
+        cell.querySelector('[data-decision="refused"]')?.getAttribute("title"),
+      ).toBe("refused · Needs human\nneeds_human");
     });
   });
 
@@ -872,27 +1094,41 @@ describe("Planner decisions explain themselves (WM-594)", () => {
     await withApi(apiWith(), async () => {
       const r = renderEvents();
       await waitFor(() => {
-        const badge = r.container.querySelector('td[title="evt_noop_1"]')?.closest("tr")?.querySelector('[data-decision="noop"]');
-        if (!badge?.getAttribute("title")) throw new Error("tooltip not joined yet");
-        expect(badge.getAttribute("title")).toBe("noop · Owned paths overlap\nowned_paths_overlap");
+        const badge = r.container
+          .querySelector('td[title="evt_noop_1"]')
+          ?.closest("tr")
+          ?.querySelector('[data-decision="noop"]');
+        if (!badge?.getAttribute("title"))
+          throw new Error("tooltip not joined yet");
+        expect(badge.getAttribute("title")).toBe(
+          "noop · Owned paths overlap\nowned_paths_overlap",
+        );
       });
-      expect(r.container.querySelector('td[title="evt_admitted_1"]')).toBeTruthy();
+      expect(
+        r.container.querySelector('td[title="evt_admitted_1"]'),
+      ).toBeTruthy();
 
       const filterInput = r.getByLabelText("Filter events") as HTMLInputElement;
       act(() => {
         changeInput(filterInput, "reason:owned_paths_overlap");
       });
       await waitFor(() => {
-        expect(r.container.querySelector('td[title="evt_noop_1"]')).toBeTruthy();
+        expect(
+          r.container.querySelector('td[title="evt_noop_1"]'),
+        ).toBeTruthy();
         expect(r.container.querySelector('td[title="evt_noop_2"]')).toBeNull();
-        expect(r.container.querySelector('td[title="evt_admitted_1"]')).toBeNull();
+        expect(
+          r.container.querySelector('td[title="evt_admitted_1"]'),
+        ).toBeNull();
       });
       // The refused run's reason code is a reason too.
       act(() => {
         changeInput(filterInput, "reason:needs_human");
       });
       await waitFor(() => {
-        expect(r.container.querySelector('td[title="evt_planned_1"]')).toBeTruthy();
+        expect(
+          r.container.querySelector('td[title="evt_planned_1"]'),
+        ).toBeTruthy();
         expect(r.container.querySelector('td[title="evt_noop_1"]')).toBeNull();
       });
     });
@@ -901,19 +1137,31 @@ describe("Planner decisions explain themselves (WM-594)", () => {
 
 describe("Events long-list window (WM-563)", () => {
   test("a 2,000-row deep link mounts fewer than 200 table rows and reveals its selection", async () => {
-    const events = Array.from({ length: 2000 }, (_, i) => stubEvent(`evt_window_${i}`, "admitted"));
+    const events = Array.from({ length: 2000 }, (_, i) =>
+      stubEvent(`evt_window_${i}`, "admitted"),
+    );
     await withApi(
       {
         events: async () => ({ events }),
         status: async () => createStatusFixture(),
       },
       async () => {
-        const r = renderEvents({ focusEvent: { source: "github", eventId: "evt_window_1999" } });
-        await waitFor(() => {
-          expect(r.container.querySelector('td[title="evt_window_1999"]')).toBeTruthy();
+        const r = renderEvents({
+          focusEvent: { source: "github", eventId: "evt_window_1999" },
         });
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
-        expect(r.container.querySelector('td[title="evt_window_1999"]')?.closest("tr")?.className).toContain("row-selected");
+        await waitFor(() => {
+          expect(
+            r.container.querySelector('td[title="evt_window_1999"]'),
+          ).toBeTruthy();
+        });
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
+        expect(
+          r.container
+            .querySelector('td[title="evt_window_1999"]')
+            ?.closest("tr")?.className,
+        ).toContain("row-selected");
       },
     );
   });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -2,7 +2,17 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { retriggerEnvelope } from "../templates";
-import { keyGuard, refetchIntervals, tableTokens, useDisplayOptions, useListKeys, useNow, useRequeuePoll, useTabKeys, useTableWindow } from "../hooks";
+import {
+  keyGuard,
+  refetchIntervals,
+  tableTokens,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useRequeuePoll,
+  useTabKeys,
+  useTableWindow,
+} from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   buildSections,
@@ -19,7 +29,12 @@ import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
-import type { AdmittedEvent, EventFocus, Proposal, RunListItem } from "../types";
+import type {
+  AdmittedEvent,
+  EventFocus,
+  Proposal,
+  RunListItem,
+} from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
 import {
@@ -30,7 +45,11 @@ import {
   type FilterToken,
 } from "../filterQuery";
 import { humanizeReason } from "../reasons";
-import { ReasonText, TicketDecisionsPanel, eventTicket } from "../components/RunDetailBlocks";
+import {
+  ReasonText,
+  TicketDecisionsPanel,
+  eventTicket,
+} from "../components/RunDetailBlocks";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import {
   Ago,
@@ -58,7 +77,10 @@ import {
   shortId,
 } from "../components/ui";
 
-function removeTokensFromQuery(filter: string, tokens: readonly FilterToken[]): string {
+function removeTokensFromQuery(
+  filter: string,
+  tokens: readonly FilterToken[],
+): string {
   const ordered = [...tokens].sort((a, b) => a.start - b.start);
   let cursor = 0;
   let next = "";
@@ -103,7 +125,9 @@ function FacetChoice({
     >
       <span className="min-w-0 truncate">{value}</span>
       {count > 0 && (
-        <span className={`${mono ? "font-sans" : ""} ml-1.5 shrink-0 tabular-nums text-(--text-faint)`}>
+        <span
+          className={`${mono ? "font-sans" : ""} ml-1.5 shrink-0 tabular-nums text-(--text-faint)`}
+        >
           {count}
         </span>
       )}
@@ -111,7 +135,15 @@ function FacetChoice({
   );
 }
 
-function FacetOverflow({ children, count, label }: { children: React.ReactNode; count: number; label: string }) {
+function FacetOverflow({
+  children,
+  count,
+  label,
+}: {
+  children: React.ReactNode;
+  count: number;
+  label: string;
+}) {
   if (count === 0) return null;
   return (
     <details className="relative shrink-0">
@@ -128,7 +160,11 @@ function FacetOverflow({ children, count, label }: { children: React.ReactNode; 
   );
 }
 
-function toggleFacetInQuery(filter: string, key: "type" | "source", value: string): string {
+function toggleFacetInQuery(
+  filter: string,
+  key: "type" | "source",
+  value: string,
+): string {
   const parsed = parseFilterQuery(filter, EVENT_FACETS);
   const existingTokens = parsed.tokens.filter(
     (t): t is Extract<FilterToken, { kind: "field" }> =>
@@ -150,7 +186,11 @@ function toggleFacetInQuery(filter: string, key: "type" | "source", value: strin
   return next ? `${next} ${addition}` : addition;
 }
 
-function setFacetInQuery(filter: string, key: "type" | "source", value: string): string {
+function setFacetInQuery(
+  filter: string,
+  key: "type" | "source",
+  value: string,
+): string {
   const parsed = parseFilterQuery(filter, EVENT_FACETS);
   const existingTokens = parsed.tokens.filter(
     (t): t is Extract<FilterToken, { kind: "field" }> =>
@@ -161,11 +201,21 @@ function setFacetInQuery(filter: string, key: "type" | "source", value: string):
   return next ? `${next} ${addition}` : addition;
 }
 
-const STATUS_TABS = ["all", "admitted", "planned", "noop", "human_needed", "dead_lettered"] as const;
+const STATUS_TABS = [
+  "all",
+  "admitted",
+  "planned",
+  "noop",
+  "human_needed",
+  "dead_lettered",
+] as const;
 type StatusTab = (typeof STATUS_TABS)[number];
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
 /** Only these two statuses may be requeued (planner.mjs requeueEvent). */
@@ -204,9 +254,15 @@ export function decisionOf(
   // `ticket_dispatch_already_live`); only a run planned from this very event
   // makes the event's decision `refused`.
   const run = e.runId ? runsById.get(e.runId) : undefined;
-  if (run?.state === "REFUSED" && run.eventSource === e.source && run.eventId === e.eventId)
+  if (
+    run?.state === "REFUSED" &&
+    run.eventSource === e.source &&
+    run.eventId === e.eventId
+  )
     return { outcome: "refused", status: null, reason: run.reasonCode };
-  const proposal = (e.proposalId ? proposalsById.get(e.proposalId) : undefined) ?? proposalsByEvent.get(keyOf(e));
+  const proposal =
+    (e.proposalId ? proposalsById.get(e.proposalId) : undefined) ??
+    proposalsByEvent.get(keyOf(e));
   if (proposal) {
     return {
       outcome: proposal.decision === "run" ? "planned" : proposal.decision,
@@ -214,7 +270,8 @@ export function decisionOf(
       reason: proposal.reason,
     };
   }
-  if (e.lastPlanError) return { outcome: e.status, status: null, reason: e.lastPlanError };
+  if (e.lastPlanError)
+    return { outcome: e.status, status: null, reason: e.lastPlanError };
   return null;
 }
 
@@ -222,7 +279,10 @@ export function decisionOf(
 export function decisionText(d: EventDecision | null): string {
   if (!d) return "";
   const reason = humanizeReason(d.reason).text;
-  const status = d.outcome === "planned" && d.status && d.status !== "approved" ? ` (${d.status})` : "";
+  const status =
+    d.outcome === "planned" && d.status && d.status !== "approved"
+      ? ` (${d.status})`
+      : "";
   return `${d.outcome}${status}${reason ? ` · ${reason}` : ""}`;
 }
 
@@ -231,10 +291,17 @@ function isStatusTab(value: string | undefined): value is StatusTab {
 }
 
 /** The list badge can also read `refused` — an event whose planned run the gate turned away. */
-const LIST_STATUS_HUES: Record<string, string> = { ...EVENT_STATUS_HUES, refused: "var(--hue-warn)" };
+const LIST_STATUS_HUES: Record<string, string> = {
+  ...EVENT_STATUS_HUES,
+  refused: "var(--hue-warn)",
+};
 
 const rowWash = (s: string) =>
-  s === "dead_lettered" ? "row-wash-err" : s === "human_needed" ? "row-wash-warn" : "";
+  s === "dead_lettered"
+    ? "row-wash-err"
+    : s === "human_needed"
+      ? "row-wash-warn"
+      : "";
 
 /**
  * Grouping/ordering/columns (OPS-493) — one config across every status tab:
@@ -260,11 +327,32 @@ const EVENTS_DISPLAY: DisplayConfig<AdmittedEvent> = {
     { key: "event", label: "Event", get: (e) => e.eventId, column: "event" },
     { key: "source", label: "Source", get: (e) => e.source, column: "source" },
     { key: "type", label: "Type", get: (e) => e.type, column: "type" },
-    { key: "subject", label: "Subject", get: (e) => e.subject ?? "", column: "subject" },
+    {
+      key: "subject",
+      label: "Subject",
+      get: (e) => e.subject ?? "",
+      column: "subject",
+    },
     { key: "status", label: "Status", get: (e) => e.status, column: "status" },
-    { key: "admitted", label: "Admitted", get: (e) => e.admittedAt, defaultDir: "desc", column: "admitted" },
-    { key: "occurred", label: "Occurred", get: (e) => e.occurredAt, defaultDir: "desc" },
-    { key: "received", label: "Received", get: (e) => e.receivedAt, defaultDir: "desc" },
+    {
+      key: "admitted",
+      label: "Admitted",
+      get: (e) => e.admittedAt,
+      defaultDir: "desc",
+      column: "admitted",
+    },
+    {
+      key: "occurred",
+      label: "Occurred",
+      get: (e) => e.occurredAt,
+      defaultDir: "desc",
+    },
+    {
+      key: "received",
+      label: "Received",
+      get: (e) => e.receivedAt,
+      defaultDir: "desc",
+    },
   ],
   columns: [
     { key: "event", label: "Event", always: true },
@@ -313,8 +401,12 @@ export function Events({
   const now = useNow();
   const queryClient = useQueryClient();
   const pollRequeue = useRequeuePoll(onJumpProposal);
-  const [tab, setTab] = useState<StatusTab>(isStatusTab(focusEvent?.status) ? focusEvent.status : "all");
-  const [filter, setFilter] = useState(focusEvent?.type ? `type:${focusEvent.type}` : "");
+  const [tab, setTab] = useState<StatusTab>(
+    isStatusTab(focusEvent?.status) ? focusEvent.status : "all",
+  );
+  const [filter, setFilter] = useState(
+    focusEvent?.type ? `type:${focusEvent.type}` : "",
+  );
   const [confirmReplay, setConfirmReplay] = useState(false);
 
   const fetchAll = context.kind === "repo";
@@ -323,7 +415,11 @@ export function Events({
     queryFn: () => api.events(fetchAll || tab === "all" ? undefined : tab),
     ...refetchIntervals.primary,
   });
-  const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, ...refetchIntervals.fast });
+  const statusQ = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.fast,
+  });
   // The reason behind a noop / refused row lives on the proposal and the run,
   // not the event (WM-594); both lists are already cached by other views.
   const proposalsQ = useQuery({
@@ -331,7 +427,11 @@ export function Events({
     queryFn: () => api.proposalHistory("all"),
     ...refetchIntervals.secondary,
   });
-  const runsQ = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), ...refetchIntervals.secondary });
+  const runsQ = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.secondary,
+  });
   const decisions = useMemo(() => {
     const byId = new Map<string, Proposal>();
     const byEvent = new Map<string, Proposal>();
@@ -345,19 +445,29 @@ export function Events({
     for (const r of runsQ.data?.runs ?? []) runsById.set(r.runId, r);
     return { byId, byEvent, runsById };
   }, [proposalsQ.data, runsQ.data]);
-  const decisionFor = (e: AdmittedEvent) => decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
+  const decisionFor = (e: AdmittedEvent) =>
+    decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
   const rows: EventFilterRow[] = useMemo(
     () =>
       (list.data?.events ?? []).map((e) => {
-        const d = decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
+        const d = decisionOf(
+          e,
+          decisions.byId,
+          decisions.byEvent,
+          decisions.runsById,
+        );
         return d?.reason ? { ...e, decisionReason: d.reason } : e;
       }),
     [list.data, decisions],
   );
   const scoped = useMemo(() => {
     const focusKey =
-      focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
-    return rows.filter((e) => keyOf(e) === focusKey || matchesRepo(e.repos, context));
+      focusEvent?.source && focusEvent?.eventId
+        ? `${focusEvent.source}:${focusEvent.eventId}`
+        : null;
+    return rows.filter(
+      (e) => keyOf(e) === focusKey || matchesRepo(e.repos, context),
+    );
   }, [rows, context, focusEvent?.source, focusEvent?.eventId]);
 
   const tabScoped = useMemo(() => {
@@ -386,19 +496,24 @@ export function Events({
   const types = useMemo(
     () =>
       Object.keys(typeCounts).sort(
-        (a, b) => (typeCounts[b] ?? 0) - (typeCounts[a] ?? 0) || a.localeCompare(b),
+        (a, b) =>
+          (typeCounts[b] ?? 0) - (typeCounts[a] ?? 0) || a.localeCompare(b),
       ),
     [typeCounts],
   );
   const sources = useMemo(
     () =>
       Object.keys(sourceCounts).sort(
-        (a, b) => (sourceCounts[b] ?? 0) - (sourceCounts[a] ?? 0) || a.localeCompare(b),
+        (a, b) =>
+          (sourceCounts[b] ?? 0) - (sourceCounts[a] ?? 0) || a.localeCompare(b),
       ),
     [sourceCounts],
   );
 
-  const parsed = useMemo(() => parseFilterQuery(filter, EVENT_FACETS), [filter]);
+  const parsed = useMemo(
+    () => parseFilterQuery(filter, EVENT_FACETS),
+    [filter],
+  );
 
   // `reason:` value suggestions come from the reasons actually in the loaded
   // set (head code only, most frequent first) — the vocabulary is the planner's.
@@ -414,13 +529,19 @@ export function Events({
     const reasons = [...counts.entries()]
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
       .map(([r]) => r);
-    return { ...EVENT_FACETS, values: { ...EVENT_FACETS.values, reason: reasons } };
+    return {
+      ...EVENT_FACETS,
+      values: { ...EVENT_FACETS.values, reason: reasons },
+    };
   }, [tabScoped]);
 
   const activeTypes = useMemo(() => {
     return new Set(
       parsed.tokens
-        .filter((t): t is Extract<FilterToken, { kind: "field" }> => t.kind === "field" && t.key === "type")
+        .filter(
+          (t): t is Extract<FilterToken, { kind: "field" }> =>
+            t.kind === "field" && t.key === "type",
+        )
         .map((t) => t.value.toLowerCase()),
     );
   }, [parsed.tokens]);
@@ -428,7 +549,10 @@ export function Events({
   const activeSources = useMemo(() => {
     return new Set(
       parsed.tokens
-        .filter((t): t is Extract<FilterToken, { kind: "field" }> => t.kind === "field" && t.key === "source")
+        .filter(
+          (t): t is Extract<FilterToken, { kind: "field" }> =>
+            t.kind === "field" && t.key === "source",
+        )
         .map((t) => t.value.toLowerCase()),
     );
   }, [parsed.tokens]);
@@ -450,7 +574,9 @@ export function Events({
         ? EVENTS_DISPLAY
         : {
             ...EVENTS_DISPLAY,
-            groups: EVENTS_DISPLAY.groups.map((g) => (g.key === "status" ? { ...g, order: [tab] } : g)),
+            groups: EVENTS_DISPLAY.groups.map((g) =>
+              g.key === "status" ? { ...g, order: [tab] } : g,
+            ),
           },
     [tab],
   );
@@ -466,7 +592,9 @@ export function Events({
   const cols = visibleColumns(displayConfig, display);
 
   const selectedKey =
-    focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
+    focusEvent?.source && focusEvent?.eventId
+      ? `${focusEvent.source}:${focusEvent.eventId}`
+      : null;
   // Keyboard index walks the open sections; the detail pane keys off the row
   // itself so collapsing the group under a selection never closes the pane.
   const selectedIndex = useMemo(
@@ -481,26 +609,34 @@ export function Events({
     JSON.stringify([tab, filter, context, display]),
   );
   const sel = useMemo(
-    () => (selectedKey ? (visible.find((e) => keyOf(e) === selectedKey) ?? null) : null),
+    () =>
+      selectedKey
+        ? (visible.find((e) => keyOf(e) === selectedKey) ?? null)
+        : null,
     [visible, selectedKey],
   );
   // The detail pane leaves a compact triage list. Keep the columns needed to
   // identify and compare events; the complete row remains in Display when the
   // pane closes, and every field remains available in the pane itself.
   const listCols = sel
-    ? cols.filter((c) => ["event", "type", "subject", "status", "admitted"].includes(c.key))
+    ? cols.filter((c) =>
+        ["event", "type", "subject", "status", "admitted"].includes(c.key),
+      )
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, windowStart]);
 
   // Ephemeral Overview/Graph jumps: apply tab/type then drop them so the hash
   // (if any) is the only remaining selection source.
   useEffect(() => {
     if (!focusEvent) return;
-    if (isStatusTab(focusEvent.status) && tab !== focusEvent.status) setTab(focusEvent.status);
+    if (isStatusTab(focusEvent.status) && tab !== focusEvent.status)
+      setTab(focusEvent.status);
     if (focusEvent.type) {
       setFilter((cur) => setFacetInQuery(cur, "type", focusEvent.type!));
     }
@@ -544,7 +680,12 @@ export function Events({
     const emptyFilters = {
       filter: "",
     };
-    const decision = decideRevealFilters(latch.snapshot, currentFilters, emptyFilters, isVisible);
+    const decision = decideRevealFilters(
+      latch.snapshot,
+      currentFilters,
+      emptyFilters,
+      isVisible,
+    );
     if (decision.cleared) {
       if (decision.clearedFields.includes("filter")) {
         setFilter(decision.next.filter);
@@ -600,7 +741,16 @@ export function Events({
       setTab("all");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusEvent?.source, focusEvent?.eventId, focusEvent?.status, rows, tab, fetchAll, list.isPending, list.data]);
+  }, [
+    focusEvent?.source,
+    focusEvent?.eventId,
+    focusEvent?.status,
+    rows,
+    tab,
+    fetchAll,
+    list.isPending,
+    list.data,
+  ]);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["events"] });
@@ -623,7 +773,12 @@ export function Events({
     onSuccess: (data) => {
       queryClient.invalidateQueries();
       setConfirmReplay(false);
-      notify(data.duplicate ? `Duplicate event ${data.eventId}` : `Replayed event ${data.eventId}`, "info");
+      notify(
+        data.duplicate
+          ? `Duplicate event ${data.eventId}`
+          : `Replayed event ${data.eventId}`,
+        "info",
+      );
     },
   });
 
@@ -677,7 +832,11 @@ export function Events({
         pendingC.current = Date.now();
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -692,14 +851,28 @@ export function Events({
     } else {
       setContextActions([
         ...(canRequeue
-          ? [{ label: `Requeue ${sel.eventId} (re-plan admitted event)`, hint: "q", run: () => requeue.mutate(sel) }]
+          ? [
+              {
+                label: `Requeue ${sel.eventId} (re-plan admitted event)`,
+                hint: "q",
+                run: () => requeue.mutate(sel),
+              },
+            ]
           : []),
-        { label: `Replay ${sel.eventId} through intake…`, run: () => setConfirmReplay(true) },
+        {
+          label: `Replay ${sel.eventId} through intake…`,
+          run: () => setConfirmReplay(true),
+        },
         {
           label: `Trigger ${sel.type} again (new event id)…`,
-          run: () => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now())),
+          run: () =>
+            onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now())),
         },
-        { label: `Copy ${sel.eventId}`, hint: "c", run: () => copyText(sel.eventId, "event id") },
+        {
+          label: `Copy ${sel.eventId}`,
+          hint: "c",
+          run: () => copyText(sel.eventId, "event id"),
+        },
         { label: "Copy link to this event", hint: "c l", run: copyLink },
       ]);
     }
@@ -722,7 +895,10 @@ export function Events({
     const sorted = sortRows(visible, displayConfig, display);
     const dateStr = new Date().toISOString().slice(0, 10);
     exportJson(`events-export-${dateStr}.json`, sorted);
-    notify(`Exported ${sorted.length} event${sorted.length === 1 ? "" : "s"} to JSON`, "info");
+    notify(
+      `Exported ${sorted.length} event${sorted.length === 1 ? "" : "s"} to JSON`,
+      "info",
+    );
   };
 
   return (
@@ -730,150 +906,211 @@ export function Events({
       <ListPane
         chrome={
           <>
-        <h1 className="display mb-4 text-lg font-semibold">Events</h1>
-        {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
-        {context.kind === "repo" && (
-          <p className="mb-3 text-[11px] text-(--text-faint)">
-            Scoped to <span className="mono">{context.name}</span> — only rows naming this repo.
-          </p>
-        )}
+            <h1 className="display mb-4 text-lg font-semibold">Events</h1>
+            {context.kind === "inflight" && (
+              <ScopeCaption context={context} surface="fleet" />
+            )}
+            {context.kind === "repo" && (
+              <p className="mb-3 text-[11px] text-(--text-faint)">
+                Scoped to <span className="mono">{context.name}</span> — only
+                rows naming this repo.
+              </p>
+            )}
 
-        <div className="mb-3 flex flex-wrap gap-1" role="tablist" aria-label="Event status">
-          {STATUS_TABS.map((t, idx) => {
-            const count = tabCount(t);
-            return (
-              <button
-                key={t}
-                type="button"
-                role="tab"
-                aria-selected={tab === t}
-                onClick={() => selectTab(t)}
-                title={t}
-                className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                  tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
-                }`}
-              >
-                {TAB_LABEL[t]}
-                {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
-                <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
-                  {idx + 1}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+            <div
+              className="mb-3 flex flex-wrap gap-1"
+              role="tablist"
+              aria-label="Event status"
+            >
+              {STATUS_TABS.map((t, idx) => {
+                const count = tabCount(t);
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === t}
+                    onClick={() => selectTab(t)}
+                    title={t}
+                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                      tab === t
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1)"
+                    }`}
+                  >
+                    {TAB_LABEL[t]}
+                    {count > 0 && (
+                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                        {count}
+                      </span>
+                    )}
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                    >
+                      {idx + 1}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
 
-        {(types.length > 1 || sources.length > 1) && (
-          <div className="mb-2 flex min-w-0 items-center gap-x-4 whitespace-nowrap text-[11px]">
-            {types.length > 1 && (
-              <div className="flex min-w-0 flex-1 items-center gap-1.5" role="group" aria-label="Event types">
-                <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">Type:</span>
-                {types.slice(0, FACET_PREVIEW_LIMIT).map((t) => {
-                  const isPressed = activeTypes.has(t.toLowerCase());
-                  return (
-                    <FacetChoice
-                      key={t}
-                      value={t}
-                      count={typeCounts[t] ?? 0}
-                      active={isPressed}
-                      onClick={() => {
-                        setFilter((cur) => toggleFacetInQuery(cur, "type", t));
-                        onSelectType(isPressed ? null : t);
-                      }}
-                    />
-                  );
-                })}
-                <FacetOverflow count={Math.max(0, types.length - FACET_PREVIEW_LIMIT)} label="event types">
-                  {types.slice(FACET_PREVIEW_LIMIT).map((t) => {
-                    const isPressed = activeTypes.has(t.toLowerCase());
-                    return (
+            {(types.length > 1 || sources.length > 1) && (
+              <div className="mb-2 flex min-w-0 items-center gap-x-4 whitespace-nowrap text-[11px]">
+                {types.length > 1 && (
+                  <div
+                    className="flex min-w-0 flex-1 items-center gap-1.5"
+                    role="group"
+                    aria-label="Event types"
+                  >
+                    <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">
+                      Type:
+                    </span>
+                    {types.slice(0, FACET_PREVIEW_LIMIT).map((t) => {
+                      const isPressed = activeTypes.has(t.toLowerCase());
+                      return (
+                        <FacetChoice
+                          key={t}
+                          value={t}
+                          count={typeCounts[t] ?? 0}
+                          active={isPressed}
+                          onClick={() => {
+                            setFilter((cur) =>
+                              toggleFacetInQuery(cur, "type", t),
+                            );
+                            onSelectType(isPressed ? null : t);
+                          }}
+                        />
+                      );
+                    })}
+                    <FacetOverflow
+                      count={Math.max(0, types.length - FACET_PREVIEW_LIMIT)}
+                      label="event types"
+                    >
+                      {types.slice(FACET_PREVIEW_LIMIT).map((t) => {
+                        const isPressed = activeTypes.has(t.toLowerCase());
+                        return (
+                          <FacetChoice
+                            key={t}
+                            value={t}
+                            count={typeCounts[t] ?? 0}
+                            active={isPressed}
+                            onClick={() => {
+                              setFilter((cur) =>
+                                toggleFacetInQuery(cur, "type", t),
+                              );
+                              onSelectType(isPressed ? null : t);
+                            }}
+                          />
+                        );
+                      })}
+                    </FacetOverflow>
+                  </div>
+                )}
+                {sources.length > 1 && (
+                  <div
+                    className="flex min-w-0 flex-1 items-center gap-1.5"
+                    role="group"
+                    aria-label="Event sources"
+                  >
+                    <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">
+                      Source:
+                    </span>
+                    {sources.slice(0, FACET_PREVIEW_LIMIT).map((s) => (
                       <FacetChoice
-                        key={t}
-                        value={t}
-                        count={typeCounts[t] ?? 0}
-                        active={isPressed}
-                        onClick={() => {
-                          setFilter((cur) => toggleFacetInQuery(cur, "type", t));
-                          onSelectType(isPressed ? null : t);
-                        }}
+                        key={s}
+                        value={s}
+                        count={sourceCounts[s] ?? 0}
+                        active={activeSources.has(s.toLowerCase())}
+                        mono
+                        onClick={() =>
+                          setFilter((cur) =>
+                            toggleFacetInQuery(cur, "source", s),
+                          )
+                        }
                       />
-                    );
-                  })}
-                </FacetOverflow>
+                    ))}
+                    <FacetOverflow
+                      count={Math.max(0, sources.length - FACET_PREVIEW_LIMIT)}
+                      label="event sources"
+                    >
+                      {sources.slice(FACET_PREVIEW_LIMIT).map((s) => (
+                        <FacetChoice
+                          key={s}
+                          value={s}
+                          count={sourceCounts[s] ?? 0}
+                          active={activeSources.has(s.toLowerCase())}
+                          mono
+                          onClick={() =>
+                            setFilter((cur) =>
+                              toggleFacetInQuery(cur, "source", s),
+                            )
+                          }
+                        />
+                      ))}
+                    </FacetOverflow>
+                  </div>
+                )}
               </div>
             )}
-            {sources.length > 1 && (
-              <div className="flex min-w-0 flex-1 items-center gap-1.5" role="group" aria-label="Event sources">
-                <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">Source:</span>
-                {sources.slice(0, FACET_PREVIEW_LIMIT).map((s) => (
-                  <FacetChoice
-                    key={s}
-                    value={s}
-                    count={sourceCounts[s] ?? 0}
-                    active={activeSources.has(s.toLowerCase())}
-                    mono
-                    onClick={() => setFilter((cur) => toggleFacetInQuery(cur, "source", s))}
-                  />
-                ))}
-                <FacetOverflow count={Math.max(0, sources.length - FACET_PREVIEW_LIMIT)} label="event sources">
-                  {sources.slice(FACET_PREVIEW_LIMIT).map((s) => (
-                    <FacetChoice
-                      key={s}
-                      value={s}
-                      count={sourceCounts[s] ?? 0}
-                      active={activeSources.has(s.toLowerCase())}
-                      mono
-                      onClick={() => setFilter((cur) => toggleFacetInQuery(cur, "source", s))}
-                    />
-                  ))}
-                </FacetOverflow>
-              </div>
-            )}
-          </div>
-        )}
 
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <span className="ml-auto">
-            <DisplayOptions
-              config={displayConfig}
-              state={display}
-              onChange={setDisplay}
-              onExport={visible.length > 0 ? handleExport : undefined}
-              rows={scoped}
-            />
-          </span>
-          {/* Last in the row: the token chips are a full-width item, so anything
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <span className="ml-auto">
+                <DisplayOptions
+                  config={displayConfig}
+                  state={display}
+                  onChange={setDisplay}
+                  onExport={visible.length > 0 ? handleExport : undefined}
+                  rows={scoped}
+                />
+              </span>
+              {/* Last in the row: the token chips are a full-width item, so anything
               after the filter box would be pushed onto a third line the moment
               a chip appeared. */}
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="source:… type:… reason:… is:stale"
-            label="Filter events"
-            query={parsed}
-            facets={facets}
-          />
-        </div>
+              <FilterInput
+                value={filter}
+                onChange={setFilter}
+                placeholder="source:… type:… reason:… is:stale"
+                label="Filter events"
+                query={parsed}
+                facets={facets}
+              />
+            </div>
           </>
         }
       >
-
         <table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {listCols.map((c) => {
-                const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                const sort = displayConfig.sorts.find(
+                  (s) => s.column === c.key,
+                );
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
-                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
+                const isCurrentSort = isCustom
+                  ? display.sortBy === c.key
+                  : sort && display.sortBy === sort.key;
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
                     dir={isCurrentSort ? display.sortDir : null}
                     naturalDir={sort?.defaultDir ?? "asc"}
-                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
-                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
+                    onSort={
+                      sort || isCustom
+                        ? () =>
+                            setDisplay((s) =>
+                              cycleColumnSort(displayConfig, s, c.key),
+                            )
+                        : undefined
+                    }
+                    onRemove={
+                      isCustom
+                        ? () =>
+                            setDisplay((s) => removeCustomColumn(s, customPath))
+                        : undefined
+                    }
                   />
                 );
               })}
@@ -892,21 +1129,33 @@ export function Events({
                     aria-selected={isSelected}
                     className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${isSelected ? "row-selected" : ""}`}
                   >
-                    <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap" title={e.eventId}>
+                    <td
+                      className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                      title={e.eventId}
+                    >
                       {shortId(e.eventId)}
                     </td>
                     {show.has("source") && (
-                      <td className="mono max-w-24 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)" title={e.source}>
+                      <td
+                        className="mono max-w-24 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
+                        title={e.source}
+                      >
                         {e.source}
                       </td>
                     )}
                     {show.has("type") && (
-                      <td className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)" title={e.type}>
+                      <td
+                        className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
+                        title={e.type}
+                      >
                         {e.type}
                       </td>
                     )}
                     {show.has("subject") && (
-                      <td className="max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)" title={e.subject ?? undefined}>
+                      <td
+                        className="max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
+                        title={e.subject ?? undefined}
+                      >
                         {e.subject ?? "-"}
                       </td>
                     )}
@@ -922,23 +1171,32 @@ export function Events({
                             className="flex shrink-0 items-center"
                             title={
                               decisionTitle
-                                ? decision?.reason && decision.reason !== decisionTitle
+                                ? decision?.reason &&
+                                  decision.reason !== decisionTitle
                                   ? `${decisionTitle}\n${decision.reason}`
                                   : decisionTitle
                                 : undefined
                             }
                             data-decision={decision?.outcome ?? undefined}
                           >
-                            <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                            <StateBadge
+                              state={e.status}
+                              hues={EVENT_STATUS_HUES}
+                            />
                             {decision?.outcome === "refused" && (
                               <span className="ml-1.5">
-                                <StateBadge state="refused" hues={LIST_STATUS_HUES} dot={false} />
+                                <StateBadge
+                                  state="refused"
+                                  hues={LIST_STATUS_HUES}
+                                  dot={false}
+                                />
                               </span>
                             )}
                           </span>
                           {e.planFailures > 0 && (
                             <span className="shrink-0 text-[11px] text-(--hue-err)">
-                              {e.planFailures} failure{e.planFailures === 1 ? "" : "s"}
+                              {e.planFailures} failure
+                              {e.planFailures === 1 ? "" : "s"}
                             </span>
                           )}
                           {e.lastPlanError && (
@@ -954,9 +1212,15 @@ export function Events({
                         <Ago iso={e.admittedAt} now={now} />
                       </td>
                     )}
-                    {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
-                      <CustomCell key={c.key} row={e} path={c.key.replace(/^custom:/, "")} />
-                    ))}
+                    {listCols
+                      .filter((c) => c.isCustom || c.key.startsWith("custom:"))
+                      .map((c) => (
+                        <CustomCell
+                          key={c.key}
+                          row={e}
+                          path={c.key.replace(/^custom:/, "")}
+                        />
+                      ))}
                   </tr>
                 );
               };
@@ -969,7 +1233,9 @@ export function Events({
                     colSpan={listCols.length}
                     section={s}
                     collapsed={display.collapsed.includes(s.key)}
-                    onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    onToggle={() =>
+                      setDisplay((st) => toggleCollapsed(st, s.key))
+                    }
                     sub={sub}
                   />
                 );
@@ -998,8 +1264,8 @@ export function Events({
                   context.kind === "repo"
                     ? `No events for ${context.name}.`
                     : tab === "all"
-                    ? "No events."
-                    : `No ${TAB_LABEL[tab].toLowerCase()} events.`
+                      ? "No events."
+                      : `No ${TAB_LABEL[tab].toLowerCase()} events.`
                 }
                 escHint={Boolean(filter.trim())}
                 action={
@@ -1017,7 +1283,10 @@ export function Events({
         <DetailPane
           widthClass="w-[440px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectEvent(null)}
@@ -1029,7 +1298,10 @@ export function Events({
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
-              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
                 <StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />
                 <span className="truncate mono" title={sel.eventId}>
                   {shortId(sel.eventId)}
@@ -1045,23 +1317,39 @@ export function Events({
                   disabled={!connected || requeue.isPending}
                   onClick={() => requeue.mutate(sel)}
                 >
-                  Requeue <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">q</span>
+                  Requeue{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    q
+                  </span>
                 </Button>
               )}
               <div className="flex items-center gap-1.5">
                 {onJumpChain && (
                   <Button
-                    onClick={() => onJumpChain(sel.correlationId ?? sel.eventId, `event:${sel.source}:${sel.eventId}`)}
+                    onClick={() =>
+                      onJumpChain(
+                        sel.correlationId ?? sel.eventId,
+                        `event:${sel.source}:${sel.eventId}`,
+                      )
+                    }
                   >
                     View chain
                   </Button>
                 )}
-                <Button disabled={!connected || replay.isPending} onClick={() => setConfirmReplay(true)}>
+                <Button
+                  disabled={!connected || replay.isPending}
+                  onClick={() => setConfirmReplay(true)}
+                >
                   Replay…
                 </Button>
                 <Button
                   disabled={!connected}
-                  onClick={() => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now()))}
+                  onClick={() =>
+                    onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now()))
+                  }
                 >
                   Trigger again…
                 </Button>
@@ -1071,12 +1359,14 @@ export function Events({
           utility={<CopyActions id={sel.eventId} idLabel="event id" />}
           close={<Button onClick={() => onSelectEvent(null)}>Close</Button>}
         >
-
           <Section title="Event" icons>
             <KV k="source" v={sel.source} />
             <KV k="type" v={sel.type} />
             <KV k="subject" v={sel.subject} />
-            <KV k="status" v={<StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />} />
+            <KV
+              k="status"
+              v={<StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />}
+            />
             {(() => {
               // Why the planner did what it did (WM-594): directly under status,
               // humanized, raw code in the tooltip, references as jump links.
@@ -1086,14 +1376,31 @@ export function Events({
                 <KV
                   k="decision"
                   v={
-                    <span className="flex min-w-0 flex-wrap items-baseline gap-1.5 whitespace-normal" data-testid="event-decision" title={d.reason ?? undefined}>
-                      <StateBadge state={d.outcome} hues={LIST_STATUS_HUES} dot={false} />
-                      {d.outcome === "planned" && d.status && d.status !== "approved" && (
-                        <span className="text-(--text-faint)">({d.status})</span>
-                      )}
+                    <span
+                      className="flex min-w-0 flex-wrap items-baseline gap-1.5 whitespace-normal"
+                      data-testid="event-decision"
+                      title={d.reason ?? undefined}
+                    >
+                      <StateBadge
+                        state={d.outcome}
+                        hues={LIST_STATUS_HUES}
+                        dot={false}
+                      />
+                      {d.outcome === "planned" &&
+                        d.status &&
+                        d.status !== "approved" && (
+                          <span className="text-(--text-faint)">
+                            ({d.status})
+                          </span>
+                        )}
                       {d.reason && (
                         <>
-                          <span className="text-(--text-faint)" aria-hidden="true">·</span>
+                          <span
+                            className="text-(--text-faint)"
+                            aria-hidden="true"
+                          >
+                            ·
+                          </span>
                           <ReasonText
                             code={d.reason}
                             onJumpRun={onJumpRun}
@@ -1111,7 +1418,10 @@ export function Events({
               k="correlationId"
               v={
                 sel.correlationId && onJumpChain ? (
-                  <JumpLink onClick={() => onJumpChain(sel.correlationId!)} title="Open chain trace">
+                  <JumpLink
+                    onClick={() => onJumpChain(sel.correlationId!)}
+                    title="Open chain trace"
+                  >
                     {sel.correlationId}
                   </JumpLink>
                 ) : (
@@ -1123,7 +1433,10 @@ export function Events({
               k="causationId"
               v={
                 sel.causationId ? (
-                  <JumpLink onClick={() => onJumpRun(sel.causationId!)} title="The run that emitted this event">
+                  <JumpLink
+                    onClick={() => onJumpRun(sel.causationId!)}
+                    title="The run that emitted this event"
+                  >
                     {shortId(sel.causationId)}
                   </JumpLink>
                 ) : null
@@ -1136,7 +1449,10 @@ export function Events({
               k="proposal"
               v={
                 sel.proposalId ? (
-                  <JumpLink onClick={() => onJumpProposal(sel.proposalId!)} title={sel.proposalId}>
+                  <JumpLink
+                    onClick={() => onJumpProposal(sel.proposalId!)}
+                    title={sel.proposalId}
+                  >
                     {shortId(sel.proposalId)}
                   </JumpLink>
                 ) : null
@@ -1146,7 +1462,10 @@ export function Events({
               k="run"
               v={
                 sel.runId ? (
-                  <JumpLink onClick={() => onJumpRun(sel.runId!)} title={sel.runId}>
+                  <JumpLink
+                    onClick={() => onJumpRun(sel.runId!)}
+                    title={sel.runId}
+                  >
                     {shortId(sel.runId)}
                   </JumpLink>
                 ) : null
@@ -1173,7 +1492,9 @@ export function Events({
             const hue = "var(--hue-err)";
             return (
               <Section title="Planning" icons>
-                {sel.planFailures > 0 && <KV k="planFailures" v={String(sel.planFailures)} />}
+                {sel.planFailures > 0 && (
+                  <KV k="planFailures" v={String(sel.planFailures)} />
+                )}
                 {err && (
                   <div
                     className="mt-1.5 rounded-md px-2.5 py-1.5 text-[12px]"
@@ -1200,7 +1521,10 @@ export function Events({
       )}
 
       {confirmReplay && sel && (
-        <Dialog title={`Replay ${sel.eventId} through intake?`} onClose={() => setConfirmReplay(false)}>
+        <Dialog
+          title={`Replay ${sel.eventId} through intake?`}
+          onClose={() => setConfirmReplay(false)}
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             Replay re-injects this envelope through intake.
           </div>

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -88,7 +88,15 @@ export function useSelectedNodeReveal(
   return revealSelected;
 }
 
-function flowEdges(graph: { edges: Array<{ id: string; source: string; target: string; kind: keyof typeof EDGE_STYLES; label?: string }> }): Edge[] {
+function flowEdges(graph: {
+  edges: Array<{
+    id: string;
+    source: string;
+    target: string;
+    kind: keyof typeof EDGE_STYLES;
+    label?: string;
+  }>;
+}): Edge[] {
   return graph.edges.map((edge) => ({
     id: edge.id,
     source: edge.source,
@@ -107,11 +115,17 @@ function flowEdges(graph: { edges: Array<{ id: string; source: string; target: s
 
 function applyGraphOverlay(
   prev: { nodes: Node[]; edges: Edge[] } | null,
-  graph: { nodes: GraphNode[]; edges: Parameters<typeof flowEdges>[0]["edges"] },
+  graph: {
+    nodes: GraphNode[];
+    edges: Parameters<typeof flowEdges>[0]["edges"];
+  },
 ): { nodes: Node[]; edges: Edge[] } | null {
   if (!prev) return prev;
   const byId = new Map(graph.nodes.map((n) => [n.id, n]));
-  if (prev.nodes.length !== graph.nodes.length || prev.nodes.some((n) => !byId.has(n.id))) {
+  if (
+    prev.nodes.length !== graph.nodes.length ||
+    prev.nodes.some((n) => !byId.has(n.id))
+  ) {
     return prev;
   }
   return {
@@ -145,15 +159,40 @@ export function Graph({
   onJumpAgent: (ref: string) => void;
   onJumpEvents: (focus: EventFocus) => void;
 }) {
-  const registry = useQuery({ queryKey: ["agents"], queryFn: api.agents, ...refetchIntervals.secondary });
-  const runsQ = useQuery({ queryKey: ["runs"], queryFn: () => api.runs(), ...refetchIntervals.fast });
-  const eventsQ = useQuery({ queryKey: ["events"], queryFn: () => api.events(), ...refetchIntervals.fast });
-  const proposalsQ = useQuery({ queryKey: ["proposals"], queryFn: api.proposals, ...refetchIntervals.fast });
-  const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, ...refetchIntervals.secondary });
+  const registry = useQuery({
+    queryKey: ["agents"],
+    queryFn: api.agents,
+    ...refetchIntervals.secondary,
+  });
+  const runsQ = useQuery({
+    queryKey: ["runs"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.fast,
+  });
+  const eventsQ = useQuery({
+    queryKey: ["events"],
+    queryFn: () => api.events(),
+    ...refetchIntervals.fast,
+  });
+  const proposalsQ = useQuery({
+    queryKey: ["proposals"],
+    queryFn: api.proposals,
+    ...refetchIntervals.fast,
+  });
+  const statusQ = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.secondary,
+  });
   const now = useNow();
 
-  const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
-  const [layoutError, setLayoutError] = useState<"chunk" | "layout" | "mapping" | null>(null);
+  const [positioned, setPositioned] = useState<{
+    nodes: Node[];
+    edges: Edge[];
+  } | null>(null);
+  const [layoutError, setLayoutError] = useState<
+    "chunk" | "layout" | "mapping" | null
+  >(null);
   const [layoutEpoch, setLayoutEpoch] = useState(0);
   const lastIdentityRef = useRef<string | null>(null);
   const epochLaidOutRef = useRef(0);
@@ -187,53 +226,54 @@ export function Graph({
     // async chunk (OPS-255) — fetched the first time there is a graph to lay
     // out, never by the list views. Overlay polls reuse positions when
     // node/edge identity is unchanged (WM-154).
-    import("../graph/layout")
-      .then(
-        ({ layoutGraphIfIdentityChanged, NODE_HEIGHT, NODE_WIDTH }) => {
-          const prevIdentity =
-            layoutEpoch !== epochLaidOutRef.current ? null : lastIdentityRef.current;
-          return layoutGraphIfIdentityChanged(graph, prevIdentity)
-            .then((result) => {
+    import("../graph/layout").then(
+      ({ layoutGraphIfIdentityChanged, NODE_HEIGHT, NODE_WIDTH }) => {
+        const prevIdentity =
+          layoutEpoch !== epochLaidOutRef.current
+            ? null
+            : lastIdentityRef.current;
+        return layoutGraphIfIdentityChanged(graph, prevIdentity)
+          .then((result) => {
+            if (cancelled) return;
+            lastIdentityRef.current = result.identity;
+            epochLaidOutRef.current = layoutEpoch;
+            if (!result.positions) {
+              setPositioned((prev) => applyGraphOverlay(prev, graph));
+              return;
+            }
+            const positions = result.positions;
+            try {
+              setPositioned({
+                nodes: graph.nodes.map((node) => ({
+                  id: node.id,
+                  type: node.kind,
+                  position: positions.get(node.id) ?? { x: 0, y: 0 },
+                  data: { node },
+                  draggable: true,
+                  width: NODE_WIDTH,
+                  height: NODE_HEIGHT,
+                })),
+                edges: flowEdges(graph),
+              });
+              setCompletedLayoutEpoch(layoutEpoch);
+            } catch (err) {
               if (cancelled) return;
-              lastIdentityRef.current = result.identity;
-              epochLaidOutRef.current = layoutEpoch;
-              if (!result.positions) {
-                setPositioned((prev) => applyGraphOverlay(prev, graph));
-                return;
-              }
-              const positions = result.positions;
-              try {
-                setPositioned({
-                  nodes: graph.nodes.map((node) => ({
-                    id: node.id,
-                    type: node.kind,
-                    position: positions.get(node.id) ?? { x: 0, y: 0 },
-                    data: { node },
-                    draggable: true,
-                    width: NODE_WIDTH,
-                    height: NODE_HEIGHT,
-                  })),
-                  edges: flowEdges(graph),
-                });
-                setCompletedLayoutEpoch(layoutEpoch);
-              } catch (err) {
-                if (cancelled) return;
-                console.error("graph node/edge positioning failed", err);
-                setLayoutError("mapping");
-              }
-            })
-            .catch((err: unknown) => {
-              if (cancelled) return;
-              console.error("graph layout calculation failed", err);
-              setLayoutError("layout");
-            });
-        },
-        (err: unknown) => {
-          if (cancelled) return;
-          console.error("graph layout chunk import failed", err);
-          setLayoutError("chunk");
-        },
-      );
+              console.error("graph node/edge positioning failed", err);
+              setLayoutError("mapping");
+            }
+          })
+          .catch((err: unknown) => {
+            if (cancelled) return;
+            console.error("graph layout calculation failed", err);
+            setLayoutError("layout");
+          });
+      },
+      (err: unknown) => {
+        if (cancelled) return;
+        console.error("graph layout chunk import failed", err);
+        setLayoutError("chunk");
+      },
+    );
     return () => {
       cancelled = true;
     };
@@ -243,7 +283,10 @@ export function Graph({
   // highlighted on canvas, Enter cycles through them.
   const [query, setQuery] = useState("");
   const [matchIdx, setMatchIdx] = useState(0);
-  const matches = useMemo(() => (graph ? matchNodes(graph.nodes, query) : []), [graph, query]);
+  const matches = useMemo(
+    () => (graph ? matchNodes(graph.nodes, query) : []),
+    [graph, query],
+  );
   const matchSet = useMemo(() => new Set(matches), [matches]);
   const safeMatchIdx = matches.length ? matchIdx % matches.length : 0;
   const currentMatch = matches[safeMatchIdx] ?? null;
@@ -255,14 +298,21 @@ export function Graph({
         ? positioned.nodes.map((n) => ({
             ...n,
             selected: n.id === focusNodeId,
-            data: { ...n.data, searchHit: matchSet.has(n.id), searchCurrent: n.id === currentMatch },
+            data: {
+              ...n.data,
+              searchHit: matchSet.has(n.id),
+              searchCurrent: n.id === currentMatch,
+            },
           }))
         : [],
     [positioned, focusNodeId, matchSet, currentMatch],
   );
 
-  const selected: GraphNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
-  const graphLoaded = Boolean(graph) && !registry.isPending && !proposalsQ.isPending;
+  const selected: GraphNode | undefined = graph?.nodes.find(
+    (n) => n.id === focusNodeId,
+  );
+  const graphLoaded =
+    Boolean(graph) && !registry.isPending && !proposalsQ.isPending;
   const staleFocus = missingFocusNode(graph?.nodes, focusNodeId, graphLoaded);
   const agentDef =
     selected?.kind === "agent"
@@ -285,7 +335,10 @@ export function Graph({
         e.key === "Enter" &&
         Boolean(target?.closest("button, a, [role=button], [role=link]")) &&
         !target?.closest(".react-flow__node");
-      if ((e.key === "z" || (e.key === "Enter" && !enterActivatesControl)) && focusNodeId) {
+      if (
+        (e.key === "z" || (e.key === "Enter" && !enterActivatesControl)) &&
+        focusNodeId
+      ) {
         e.preventDefault();
         revealSelected();
         return;
@@ -309,7 +362,10 @@ export function Graph({
       }
       const order = positioned
         ? [...positioned.nodes]
-            .sort((a, b) => a.position.y - b.position.y || a.position.x - b.position.x)
+            .sort(
+              (a, b) =>
+                a.position.y - b.position.y || a.position.x - b.position.x,
+            )
             .map((n) => n.id)
         : (graph?.nodes.map((n) => n.id) ?? []);
       if (!order.length) return;
@@ -339,7 +395,8 @@ export function Graph({
       !positioned ||
       !graph ||
       graph.nodes.length === 0
-    ) return;
+    )
+      return;
     lastFittedLayoutEpoch.current = layoutEpoch;
     flowRef.current.fitView({ padding: GRAPH_FIT_PADDING, maxZoom: 1 });
   }, [completedLayoutEpoch, flowReady, graph, layoutEpoch, positioned]);
@@ -382,7 +439,8 @@ export function Graph({
         <div className="absolute top-4 left-5 z-10 rounded-md bg-(--surface-0)/85 px-2.5 py-2 backdrop-blur-sm">
           <h1 className="display text-lg font-semibold">Graph</h1>
           <div className="text-[11px] text-(--text-faint)">
-            what this runtime can do — registered routes and recommendation edges
+            what this runtime can do — registered routes and recommendation
+            edges
           </div>
           <ScopeCaption context={context} surface="graph" />
           {staleFocus && (
@@ -391,7 +449,8 @@ export function Graph({
               role="status"
               style={{
                 color: "var(--hue-warn)",
-                background: "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
+                background:
+                  "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
               }}
             >
               <span>Node not found</span>
@@ -408,7 +467,11 @@ export function Graph({
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
-                    const result = searchEnter(matches, safeMatchIdx, focusNodeId);
+                    const result = searchEnter(
+                      matches,
+                      safeMatchIdx,
+                      focusNodeId,
+                    );
                     if (result) {
                       e.preventDefault();
                       setMatchIdx(result.nextIdx);
@@ -431,22 +494,33 @@ export function Graph({
                   className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-[11px] tabular-nums text-(--text-faint)"
                   aria-live="polite"
                 >
-                  {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
+                  {matches.length
+                    ? `${safeMatchIdx + 1} / ${matches.length}`
+                    : "no matches"}
                 </span>
               )}
             </div>
             {positioned && graph && graph.nodes.length > 0 && (
-              <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
+              <Button onClick={() => setLayoutEpoch((n) => n + 1)}>
+                Reset layout
+              </Button>
             )}
           </div>
-          {positioned && graph && graph.nodes.length > 0 && legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
+          {positioned &&
+            graph &&
+            graph.nodes.length > 0 &&
+            legend &&
+            (legend.nodes.length > 0 || legend.edges.length > 0) && (
               <div
                 className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
                 role="img"
                 aria-label="Graph legend"
               >
                 {legend.nodes.map((entry) => (
-                  <div key={entry.key} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
+                  <div
+                    key={entry.key}
+                    className="flex items-center gap-2 text-[11px] text-(--text-dim)"
+                  >
                     <span
                       aria-hidden
                       className="inline-block shrink-0 rounded-xs"
@@ -462,7 +536,10 @@ export function Graph({
                   </div>
                 ))}
                 {legend.edges.map((entry) => (
-                  <div key={entry.kind} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
+                  <div
+                    key={entry.kind}
+                    className="flex items-center gap-2 text-[11px] text-(--text-dim)"
+                  >
                     <span
                       aria-hidden
                       className="inline-block shrink-0"
@@ -476,7 +553,7 @@ export function Graph({
                 ))}
               </div>
             )}
-          </div>
+        </div>
         {positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow
             nodes={nodes}
@@ -485,7 +562,9 @@ export function Graph({
             onNodeClick={(_, node) => onSelectNode(node.id)}
             onPaneClick={() => onSelectNode(null)}
             onNodesChange={(changes: NodeChange[]) => {
-              const kept = changes.filter((c) => c.type === "position" || c.type === "dimensions");
+              const kept = changes.filter(
+                (c) => c.type === "position" || c.type === "dimensions",
+              );
               if (kept.length === 0) return;
               setPositioned((prev) => {
                 if (!prev) return prev;
@@ -504,14 +583,20 @@ export function Graph({
             <Background color="var(--border)" gap={20} size={1} />
             <Controls
               showInteractive={false}
-              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+              style={{
+                background: "var(--surface-1)",
+                border: "1px solid var(--border)",
+              }}
             />
             {/* Minimap paints into SVG where var()/color-mix do not resolve —
                 style its nodes by class instead (see theme.css). */}
             <MiniMap
               pannable
               zoomable
-              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+              style={{
+                background: "var(--surface-1)",
+                border: "1px solid var(--border)",
+              }}
               maskColor="rgba(0, 0, 0, 0.55)"
               nodeClassName={(n) => `minimap-node minimap-${n.type}`}
             />
@@ -529,7 +614,13 @@ export function Graph({
           title={selected.label}
           actions={
             <Button onClick={revealSelected}>
-              Show on canvas <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
+              Show on canvas{" "}
+              <span
+                className="mono ml-1 text-(--text-faint)"
+                aria-hidden="true"
+              >
+                z
+              </span>
             </Button>
           }
           utility={
@@ -540,14 +631,19 @@ export function Graph({
           }
           close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
         >
-
           {selected.kind === "eventType" && (
             <>
               <Section title="Event type">
                 <KV k="type" v={selected.label} />
                 <KV k="adapter" v={selected.adapter} />
-                <KV k="idempotency scope" v={selected.scope.join(" + ") || "—"} />
-                <KV k="proposal ttl" v={selected.ttl ? `${selected.ttl}s` : "—"} />
+                <KV
+                  k="idempotency scope"
+                  v={selected.scope.join(" + ") || "—"}
+                />
+                <KV
+                  k="proposal ttl"
+                  v={selected.ttl ? `${selected.ttl}s` : "—"}
+                />
                 {selected.admittedCount !== undefined && (
                   <KV k="admitted events" v={String(selected.admittedCount)} />
                 )}
@@ -564,8 +660,9 @@ export function Graph({
           {selected.kind === "terminal" && (
             <Section title="Terminal">
               <div className="text-[12px] text-(--text-dim)">
-                Recommendation values with no registered edge: <span className="mono">{selected.reason}</span>. A
-                run that returns one of these completes and chains no further.
+                Recommendation values with no registered edge:{" "}
+                <span className="mono">{selected.reason}</span>. A run that
+                returns one of these completes and chains no further.
               </div>
             </Section>
           )}
@@ -574,12 +671,23 @@ export function Graph({
             <>
               <Section title="Pending proposal">
                 <KV k="id" v={selected.proposalId} />
-                <KV k="decision" v={<StateBadge state={selected.decision} hues={DECISION_HUES} />} />
+                <KV
+                  k="decision"
+                  v={
+                    <StateBadge
+                      state={selected.decision}
+                      hues={DECISION_HUES}
+                    />
+                  }
+                />
                 <KV
                   k="agent"
                   v={
                     selected.agentRef ? (
-                      <JumpLink onClick={() => onJumpAgent(selected.agentRef!)} title="Open in Agents">
+                      <JumpLink
+                        onClick={() => onJumpAgent(selected.agentRef!)}
+                        title="Open in Agents"
+                      >
                         {selected.agentRef}
                       </JumpLink>
                     ) : (
@@ -591,18 +699,25 @@ export function Graph({
                   k="origin"
                   v={`${selected.proposal.eventSource ?? "—"} · ${selected.proposal.eventId ?? "—"}`}
                 />
-                <KV k="created" v={<Ago iso={selected.proposal.created_at} now={now} />} />
+                <KV
+                  k="created"
+                  v={<Ago iso={selected.proposal.created_at} now={now} />}
+                />
                 <KV
                   k="ttl"
                   v={`${selected.proposal.ttl_seconds}s ${selected.proposal.expired ? "(expired)" : "remaining"}`}
                 />
-                {selected.proposal.reason && <KV k="reason" v={selected.proposal.reason} />}
+                {selected.proposal.reason && (
+                  <KV k="reason" v={selected.proposal.reason} />
+                )}
                 {selected.eventType && (
                   <KV
                     k="event type"
                     v={
                       <JumpLink
-                        onClick={() => onJumpEvents({ type: selected.eventType! })}
+                        onClick={() =>
+                          onJumpEvents({ type: selected.eventType! })
+                        }
                         title="Open in Events"
                       >
                         {selected.eventType}
@@ -617,9 +732,15 @@ export function Graph({
                 </Section>
               )}
               {selected.agentRef && (
-                <Button onClick={() => onJumpAgent(selected.agentRef!)}>Open in Agents</Button>
+                <Button onClick={() => onJumpAgent(selected.agentRef!)}>
+                  Open in Agents
+                </Button>
               )}
-              <Button onClick={() => jumpHash(hashPath("proposals", selected.proposalId))}>
+              <Button
+                onClick={() =>
+                  jumpHash(hashPath("proposals", selected.proposalId))
+                }
+              >
                 Open in Proposals
               </Button>
             </>
@@ -631,7 +752,10 @@ export function Graph({
                 <KV
                   k="ref"
                   v={
-                    <JumpLink onClick={() => onJumpAgent(agentDef.ref)} title="Open in Agents">
+                    <JumpLink
+                      onClick={() => onJumpAgent(agentDef.ref)}
+                      title="Open in Agents"
+                    >
                       {agentDef.ref}
                     </JumpLink>
                   }
@@ -639,8 +763,14 @@ export function Graph({
                 <KV k="execution" v={selected.execution} />
                 <KV k="output contract" v={agentDef.outputContract} />
                 <KV k="mutating" v={agentDef.mutating ? "yes" : "no"} />
-                <KV k="capabilities" v={agentDef.capabilities?.services?.join(", ") ?? "—"} />
-                <KV k="timeout" v={`${agentDef.limits?.timeout_seconds ?? "—"}s`} />
+                <KV
+                  k="capabilities"
+                  v={agentDef.capabilities?.services?.join(", ") ?? "—"}
+                />
+                <KV
+                  k="timeout"
+                  v={`${agentDef.limits?.timeout_seconds ?? "—"}s`}
+                />
                 <KV k="attempts" v={String(agentDef.limits?.attempts ?? "—")} />
                 {selected.activeRuns && selected.activeRuns.length > 0 && (
                   <KV
@@ -653,7 +783,8 @@ export function Graph({
                             state={count > 1 ? `${state} ${count}` : state}
                             hues={{
                               ...STATE_HUES,
-                              [`${state} ${count}`]: STATE_HUES[state] ?? "var(--hue-idle)",
+                              [`${state} ${count}`]:
+                                STATE_HUES[state] ?? "var(--hue-idle)",
                             }}
                           />
                         ))}
@@ -668,7 +799,10 @@ export function Graph({
                 </Section>
               )}
               {agentDef.actionRegistry && (
-                <Section title={`Closed action registry · hosts ${agentDef.hosts?.join(", ")}`} card={false}>
+                <Section
+                  title={`Closed action registry · hosts ${agentDef.hosts?.join(", ")}`}
+                  card={false}
+                >
                   <JsonBlock value={agentDef.actionRegistry} />
                 </Section>
               )}
@@ -677,7 +811,9 @@ export function Graph({
                   {agentDef.prompt}
                 </pre>
               </Section>
-              <Button onClick={() => onJumpAgent(agentDef.ref)}>Open in Agents</Button>
+              <Button onClick={() => onJumpAgent(agentDef.ref)}>
+                Open in Agents
+              </Button>
             </>
           )}
         </DetailPane>

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -1,6 +1,13 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Inbox,
@@ -25,7 +32,9 @@ afterEach(() => {
   localStorage.clear();
 });
 
-function item(overrides: Partial<InboxItem> & Pick<InboxItem, "id" | "kind">): InboxItem {
+function item(
+  overrides: Partial<InboxItem> & Pick<InboxItem, "id" | "kind">,
+): InboxItem {
   return {
     severity: "normal",
     title: `${overrides.kind} ${overrides.id}`,
@@ -55,7 +64,11 @@ describe("inbox pure helpers", () => {
     ];
     const groups = groupItems(rows);
     expect(groups.map((g) => g.group.id)).toEqual(["decide", "red"]);
-    expect(groups[0].items.map((i) => i.id)).toEqual(["i-blocked-old", "i-decision", "i-blocked-new"]);
+    expect(groups[0].items.map((i) => i.id)).toEqual([
+      "i-blocked-old",
+      "i-decision",
+      "i-blocked-new",
+    ]);
     expect(groups[1].items.map((i) => i.id)).toEqual(["i-ci"]);
   });
 
@@ -68,21 +81,47 @@ describe("inbox pure helpers", () => {
 
   test("status is derived from the timestamps, resolved wins over acked", () => {
     expect(itemStatus(item({ id: "a", kind: "BLOCKED" }))).toBe("open");
-    expect(itemStatus(item({ id: "b", kind: "BLOCKED", ackedAt: T1 }))).toBe("acked");
-    expect(itemStatus(item({ id: "c", kind: "BLOCKED", ackedAt: T1, resolvedAt: T2 }))).toBe("resolved");
-    expect(matchesTab(item({ id: "d", kind: "BLOCKED", ackedAt: T1 }), "all")).toBe(true);
-    expect(matchesTab(item({ id: "e", kind: "BLOCKED", ackedAt: T1 }), "open")).toBe(false);
+    expect(itemStatus(item({ id: "b", kind: "BLOCKED", ackedAt: T1 }))).toBe(
+      "acked",
+    );
+    expect(
+      itemStatus(
+        item({ id: "c", kind: "BLOCKED", ackedAt: T1, resolvedAt: T2 }),
+      ),
+    ).toBe("resolved");
+    expect(
+      matchesTab(item({ id: "d", kind: "BLOCKED", ackedAt: T1 }), "all"),
+    ).toBe(true);
+    expect(
+      matchesTab(item({ id: "e", kind: "BLOCKED", ackedAt: T1 }), "open"),
+    ).toBe(false);
   });
 
   test("delivery: not attempted is neither sent nor failed", () => {
     expect(deliveryState(item({ id: "a", kind: "BLOCKED" }))).toBe("none");
-    expect(deliveryText(item({ id: "a", kind: "BLOCKED" }))).toBe("Telegram: not attempted");
-    const sent = item({ id: "b", kind: "BLOCKED", delivery: { telegram: { sent_at: T1, exit_code: 0, error: null } } });
+    expect(deliveryText(item({ id: "a", kind: "BLOCKED" }))).toBe(
+      "Telegram: not attempted",
+    );
+    const sent = item({
+      id: "b",
+      kind: "BLOCKED",
+      delivery: { telegram: { sent_at: T1, exit_code: 0, error: null } },
+    });
     expect(deliveryState(sent)).toBe("sent");
     expect(deliveryText(sent)).toMatch(/^Telegram: sent .* · exit 0$/);
-    const failed = item({ id: "c", kind: "BLOCKED", delivery: { telegram: { sent_at: T1, exit_code: 1, error: null } } });
+    const failed = item({
+      id: "c",
+      kind: "BLOCKED",
+      delivery: { telegram: { sent_at: T1, exit_code: 1, error: null } },
+    });
     expect(deliveryState(failed)).toBe("failed");
-    const errored = item({ id: "d", kind: "BLOCKED", delivery: { telegram: { sent_at: T1, exit_code: null, error: "spawn ENOENT" } } });
+    const errored = item({
+      id: "d",
+      kind: "BLOCKED",
+      delivery: {
+        telegram: { sent_at: T1, exit_code: null, error: "spawn ENOENT" },
+      },
+    });
     expect(deliveryState(errored)).toBe("failed");
     expect(deliveryText(errored)).toContain("spawn ENOENT");
   });
@@ -94,49 +133,98 @@ describe("inbox pure helpers", () => {
   });
 
   test("displayTitle removes redundant kind and visible issue/PR prefixes", () => {
-    expect(displayTitle(item({
-      id: "blocked",
-      kind: "BLOCKED",
-      title: "BLOCKED WM-303: expand Owned Paths to include the fixture",
-      refs: { issue: "WM-303" },
-    }))).toBe("expand Owned Paths to include the fixture");
-    expect(displayTitle(item({
-      id: "human",
-      kind: "human_needed",
-      title: "BLOCKED factory.ticket.reaped reap:CLNT-1393:1786698035",
-    }))).toBe("factory.ticket.reaped reap:CLNT-1393:1786698035");
-    expect(displayTitle(item({
-      id: "ci",
-      kind: "CI RED",
-      title: "CI RED PR#398/WM-398: Verify run failed",
-      refs: { issue: "WM-398", pr: "PR#398" },
-    }))).toBe("Verify run failed");
-    expect(displayTitle(item({
-      id: "escalated",
-      kind: "ESCALATED",
-      title: "escalated CLNT-12/PR#7: choose a release",
-      refs: { issue: "CLNT-12", pr: "#7", repo: "bj29" },
-    }))).toBe("choose a release");
+    expect(
+      displayTitle(
+        item({
+          id: "blocked",
+          kind: "BLOCKED",
+          title: "BLOCKED WM-303: expand Owned Paths to include the fixture",
+          refs: { issue: "WM-303" },
+        }),
+      ),
+    ).toBe("expand Owned Paths to include the fixture");
+    expect(
+      displayTitle(
+        item({
+          id: "human",
+          kind: "human_needed",
+          title: "BLOCKED factory.ticket.reaped reap:CLNT-1393:1786698035",
+        }),
+      ),
+    ).toBe("factory.ticket.reaped reap:CLNT-1393:1786698035");
+    expect(
+      displayTitle(
+        item({
+          id: "ci",
+          kind: "CI RED",
+          title: "CI RED PR#398/WM-398: Verify run failed",
+          refs: { issue: "WM-398", pr: "PR#398" },
+        }),
+      ),
+    ).toBe("Verify run failed");
+    expect(
+      displayTitle(
+        item({
+          id: "escalated",
+          kind: "ESCALATED",
+          title: "escalated CLNT-12/PR#7: choose a release",
+          refs: { issue: "CLNT-12", pr: "#7", repo: "bj29" },
+        }),
+      ),
+    ).toBe("choose a release");
   });
 
   test("displayTitle keeps a ref prefix that has no matching chip", () => {
-    const row = item({ id: "a", kind: "BLOCKED", title: "BLOCKED WM-303: expand paths", refs: {} });
+    const row = item({
+      id: "a",
+      kind: "BLOCKED",
+      title: "BLOCKED WM-303: expand paths",
+      refs: {},
+    });
     expect(displayTitle(row)).toBe("WM-303: expand paths");
     expect(row.title).toBe("BLOCKED WM-303: expand paths");
   });
 
   test("PR refs resolve only with an absolute URL or a known repository", () => {
-    expect(prHref(item({ id: "url", kind: "CI RED", refs: { pr: "https://github.com/watt-mind/factory/pull/9" } })))
-      .toBe("https://github.com/watt-mind/factory/pull/9");
-    expect(prHref(item({ id: "repo", kind: "CI RED", refs: { pr: "PR#123", repo: "factory" } })))
-      .toBe("https://github.com/watt-mind/factory/pull/123");
-    expect(prHref(item({ id: "issue", kind: "CI RED", refs: { pr: "#124", issue: "WM-617" } })))
-      .toBe("https://github.com/watt-mind/factory/pull/124");
-    expect(prHref(item({ id: "bare", kind: "CI RED", refs: { pr: "PR#125" } }))).toBeNull();
+    expect(
+      prHref(
+        item({
+          id: "url",
+          kind: "CI RED",
+          refs: { pr: "https://github.com/watt-mind/factory/pull/9" },
+        }),
+      ),
+    ).toBe("https://github.com/watt-mind/factory/pull/9");
+    expect(
+      prHref(
+        item({
+          id: "repo",
+          kind: "CI RED",
+          refs: { pr: "PR#123", repo: "factory" },
+        }),
+      ),
+    ).toBe("https://github.com/watt-mind/factory/pull/123");
+    expect(
+      prHref(
+        item({
+          id: "issue",
+          kind: "CI RED",
+          refs: { pr: "#124", issue: "WM-617" },
+        }),
+      ),
+    ).toBe("https://github.com/watt-mind/factory/pull/124");
+    expect(
+      prHref(item({ id: "bare", kind: "CI RED", refs: { pr: "PR#125" } })),
+    ).toBeNull();
   });
 
   test("Inbox age preserves hour precision after 24 hours", () => {
-    expect(inboxAge("2026-08-16T05:30:00.000Z", Date.parse("2026-08-17T10:00:00.000Z"))).toBe("1d 4h ago");
+    expect(
+      inboxAge(
+        "2026-08-16T05:30:00.000Z",
+        Date.parse("2026-08-17T10:00:00.000Z"),
+      ),
+    ).toBe("1d 4h ago");
   });
 });
 
@@ -150,10 +238,37 @@ beforeEach(() => {
   clearToasts();
   localStorage.clear();
   ledger = [
-    item({ id: "inbox_open_1", kind: "BLOCKED", title: "BLOCKED WM-1: decide X", body: "Choose a safe recovery", createdAt: T0, refs: { runId: "run_a", issue: "WM-1", repo: "factory" } }),
-    item({ id: "inbox_open_2", kind: "CI RED", title: "CI RED WM-2/PR #9", createdAt: T1, refs: { pr: "https://github.com/watt-mind/factory/pull/9" } }),
-    item({ id: "inbox_acked_1", kind: "ESCALATED", title: "ESCALATED merge", createdAt: T0, ackedAt: T1 }),
-    item({ id: "inbox_resolved_1", kind: "RC READY", title: "RC READY factory", createdAt: T0, ackedAt: T1, resolvedAt: T2, resolvedBy: "operator" }),
+    item({
+      id: "inbox_open_1",
+      kind: "BLOCKED",
+      title: "BLOCKED WM-1: decide X",
+      body: "Choose a safe recovery",
+      createdAt: T0,
+      refs: { runId: "run_a", issue: "WM-1", repo: "factory" },
+    }),
+    item({
+      id: "inbox_open_2",
+      kind: "CI RED",
+      title: "CI RED WM-2/PR #9",
+      createdAt: T1,
+      refs: { pr: "https://github.com/watt-mind/factory/pull/9" },
+    }),
+    item({
+      id: "inbox_acked_1",
+      kind: "ESCALATED",
+      title: "ESCALATED merge",
+      createdAt: T0,
+      ackedAt: T1,
+    }),
+    item({
+      id: "inbox_resolved_1",
+      kind: "RC READY",
+      title: "RC READY factory",
+      createdAt: T0,
+      ackedAt: T1,
+      resolvedAt: T2,
+      resolvedBy: "operator",
+    }),
   ];
   api.inbox = mock(async () => ({ items: ledger }));
   api.ackInbox = mock(async (id: string) => {
@@ -161,7 +276,9 @@ beforeEach(() => {
     return { item: ledger.find((it) => it.id === id)! };
   });
   api.resolveInbox = mock(async (id: string) => {
-    ledger = ledger.map((it) => (it.id === id ? { ...it, resolvedAt: T2, resolvedBy: "operator" } : it));
+    ledger = ledger.map((it) =>
+      it.id === id ? { ...it, resolvedAt: T2, resolvedBy: "operator" } : it,
+    );
     return { item: ledger.find((it) => it.id === id)! };
   });
 });
@@ -173,7 +290,9 @@ afterEach(() => {
 });
 
 function renderInbox(props: Partial<React.ComponentProps<typeof Inbox>> = {}) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   const jumps = {
     onJumpRun: mock(() => {}),
     onJumpProposal: mock(() => {}),
@@ -215,9 +334,13 @@ describe("Inbox view", () => {
 
   test("filters with inbox facets and free text, with an Esc-hinted empty state", async () => {
     const { view } = renderInbox();
-    const input = await waitFor(() => view.getByLabelText("Filter inbox")) as HTMLInputElement;
+    const input = (await waitFor(() =>
+      view.getByLabelText("Filter inbox"),
+    )) as HTMLInputElement;
 
-    act(() => changeInput(input, "kind:blocked repo:factory issue:WM-1 is:open"));
+    act(() =>
+      changeInput(input, "kind:blocked repo:factory issue:WM-1 is:open"),
+    );
     expect(view.getByText("decide X")).toBeTruthy();
     expect(view.queryByText("WM-2/PR #9")).toBeNull();
 
@@ -242,7 +365,11 @@ describe("Inbox view", () => {
     fireEvent.click(view.getByRole("button", { name: /Display/ }));
     const chooseGroup = (name: string) => {
       fireEvent.click(view.getByRole("combobox", { name: "Group by" }));
-      fireEvent.mouseDown(within(view.getByRole("listbox", { name: "Group by options" })).getByRole("option", { name }));
+      fireEvent.mouseDown(
+        within(
+          view.getByRole("listbox", { name: "Group by options" }),
+        ).getByRole("option", { name }),
+      );
     };
     chooseGroup("Kind");
     expect(view.getByRole("button", { name: /BLOCKED 1/ })).toBeTruthy();
@@ -260,8 +387,15 @@ describe("Inbox view", () => {
     const age = view.getByRole("button", { name: "Age" }).closest("th")!;
     expect(age.getAttribute("aria-sort")).toBe("ascending");
     fireEvent.click(view.getByRole("button", { name: "Kind" }));
-    expect(view.getByRole("button", { name: "Kind" }).closest("th")?.getAttribute("aria-sort")).toBe("ascending");
-    const persisted = JSON.parse(localStorage.getItem("evrt-display-inbox") ?? "{}");
+    expect(
+      view
+        .getByRole("button", { name: "Kind" })
+        .closest("th")
+        ?.getAttribute("aria-sort"),
+    ).toBe("ascending");
+    const persisted = JSON.parse(
+      localStorage.getItem("evrt-display-inbox") ?? "{}",
+    );
     expect(persisted.sortBy).toBe("kind");
   });
 
@@ -275,7 +409,9 @@ describe("Inbox view", () => {
     }
     expect(view.getByRole("columnheader", { name: "Title" })).toBeTruthy();
     expect(view.getByText("decide X")).toBeTruthy();
-    const persisted = JSON.parse(localStorage.getItem("evrt-display-inbox") ?? "{}");
+    const persisted = JSON.parse(
+      localStorage.getItem("evrt-display-inbox") ?? "{}",
+    );
     expect(persisted.hiddenColumns).not.toContain("title");
   });
 
@@ -294,28 +430,36 @@ describe("Inbox view", () => {
     expect(jumps.onJumpRun).toHaveBeenCalledWith("run_a");
     expect(onSelectItem).not.toHaveBeenCalled();
     const issue = view.getByText("WM-1") as HTMLAnchorElement;
-    expect(issue.getAttribute("href")).toBe("https://linear.app/watt-mind/issue/WM-1");
+    expect(issue.getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-1",
+    );
     const pr = view.getByTitle("Open pull request") as HTMLAnchorElement;
-    expect(pr.getAttribute("href")).toBe("https://github.com/watt-mind/factory/pull/9");
+    expect(pr.getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/pull/9",
+    );
   });
 
   test("ref chips shorten events and cap the row at three with a remainder tooltip", async () => {
-    ledger = [item({
-      id: "many_refs",
-      kind: "BLOCKED",
-      title: "BLOCKED inspect refs",
-      refs: {
-        runId: "run_1234567890",
-        eventSource: "github",
-        eventId: "event_abcdefghijk",
-        issue: "WM-617",
-        pr: "PR#42",
-        repo: "factory",
-      },
-    })];
+    ledger = [
+      item({
+        id: "many_refs",
+        kind: "BLOCKED",
+        title: "BLOCKED inspect refs",
+        refs: {
+          runId: "run_1234567890",
+          eventSource: "github",
+          eventId: "event_abcdefghijk",
+          issue: "WM-617",
+          pr: "PR#42",
+          repo: "factory",
+        },
+      }),
+    ];
     const { view } = renderInbox();
     await waitFor(() => view.getByText("inspect refs"));
-    expect(view.getByText("event_abcdefgh").getAttribute("title")).toBe("event_abcdefghijk");
+    expect(view.getByText("event_abcdefgh").getAttribute("title")).toBe(
+      "event_abcdefghijk",
+    );
     expect(view.getByText("WM-617")).toBeTruthy();
     expect(view.queryByText("PR#42")).toBeNull();
     const more = view.getByText("+1");
@@ -323,7 +467,14 @@ describe("Inbox view", () => {
   });
 
   test("an unresolved PR shorthand renders as text, never a relative link", async () => {
-    ledger = [item({ id: "bare_pr", kind: "CI RED", title: "CI RED inspect PR", refs: { pr: "PR#88" } })];
+    ledger = [
+      item({
+        id: "bare_pr",
+        kind: "CI RED",
+        title: "CI RED inspect PR",
+        refs: { pr: "PR#88" },
+      }),
+    ];
     const { view } = renderInbox();
     await waitFor(() => view.getByText("inspect PR"));
     const ref = view.getByText("PR#88");
@@ -334,8 +485,14 @@ describe("Inbox view", () => {
   test("deep link selects the item and follows it onto the tab that has it", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_acked_1" });
     await waitFor(() => view.getByRole("tab", { selected: true }));
-    await waitFor(() => expect(view.getByRole("tab", { selected: true }).textContent).toContain("Acked"));
-    expect(view.getByText("Telegram: not attempted".replace(/^Telegram: /, ""))).toBeTruthy();
+    await waitFor(() =>
+      expect(view.getByRole("tab", { selected: true }).textContent).toContain(
+        "Acked",
+      ),
+    );
+    expect(
+      view.getByText("Telegram: not attempted".replace(/^Telegram: /, "")),
+    ).toBeTruthy();
     expect(view.getByRole("button", { name: /Resolve…/ })).toBeTruthy();
     expect(view.queryByRole("button", { name: /^Ack/ })).toBeNull();
   });
@@ -343,7 +500,9 @@ describe("Inbox view", () => {
   test("unknown deep link shows an inline notice, not a blank list", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_nope" });
     await waitFor(() => view.getByText(/^No inbox item/));
-    expect(view.getByText(/^No inbox item/).textContent).toContain("No inbox item");
+    expect(view.getByText(/^No inbox item/).textContent).toContain(
+      "No inbox item",
+    );
     expect(view.getByText("decide X")).toBeTruthy();
   });
 
@@ -351,10 +510,18 @@ describe("Inbox view", () => {
     const { view } = renderInbox({ focusItemId: "inbox_open_1" });
     await waitFor(() => view.getByRole("button", { name: /^Ack/ }));
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "a", bubbles: true }),
+      );
     });
-    await waitFor(() => expect(api.ackInbox).toHaveBeenCalledWith("inbox_open_1"));
-    await waitFor(() => expect(view.getByRole("tab", { selected: true }).textContent).toContain("Acked"));
+    await waitFor(() =>
+      expect(api.ackInbox).toHaveBeenCalledWith("inbox_open_1"),
+    );
+    await waitFor(() =>
+      expect(view.getByRole("tab", { selected: true }).textContent).toContain(
+        "Acked",
+      ),
+    );
     expect(view.queryByRole("button", { name: /^Ack(?:\s|$)/ })).toBeNull();
   });
 
@@ -362,15 +529,25 @@ describe("Inbox view", () => {
     const { view } = renderInbox({ focusItemId: "inbox_open_1" });
     await waitFor(() => view.getByRole("button", { name: /Resolve…/ }));
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "x", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "x", bubbles: true }),
+      );
     });
     await waitFor(() => view.getByRole("dialog"));
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
     });
-    await waitFor(() => expect(api.resolveInbox).toHaveBeenCalledWith("inbox_open_1"));
+    await waitFor(() =>
+      expect(api.resolveInbox).toHaveBeenCalledWith("inbox_open_1"),
+    );
     await waitFor(() => expect(view.queryByRole("dialog")).toBeNull());
-    await waitFor(() => expect(view.getByRole("tab", { selected: true }).textContent).toContain("Resolved"));
+    await waitFor(() =>
+      expect(view.getByRole("tab", { selected: true }).textContent).toContain(
+        "Resolved",
+      ),
+    );
   });
 
   test("select-all selects every visible actionable inbox item", async () => {
@@ -379,9 +556,23 @@ describe("Inbox view", () => {
 
     fireEvent.click(view.getByLabelText("Select all inbox items"));
 
-    expect(view.getByRole("toolbar", { name: "Bulk actions" }).textContent).toContain("2 selected");
-    expect((view.getByLabelText("Select inbox item inbox_open_1") as HTMLInputElement).checked).toBe(true);
-    expect((view.getByLabelText("Select inbox item inbox_open_2") as HTMLInputElement).checked).toBe(true);
+    expect(
+      view.getByRole("toolbar", { name: "Bulk actions" }).textContent,
+    ).toContain("2 selected");
+    expect(
+      (
+        view.getByLabelText(
+          "Select inbox item inbox_open_1",
+        ) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(
+      (
+        view.getByLabelText(
+          "Select inbox item inbox_open_2",
+        ) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
   });
 
   test("* a selects all without acking the focused item", async () => {
@@ -389,11 +580,19 @@ describe("Inbox view", () => {
     await waitFor(() => view.getByLabelText("Select all inbox items"));
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "*", bubbles: true }));
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "*", bubbles: true }),
+      );
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "a", bubbles: true }),
+      );
     });
 
-    await waitFor(() => expect(view.getByRole("toolbar", { name: "Bulk actions" }).textContent).toContain("2 selected"));
+    await waitFor(() =>
+      expect(
+        view.getByRole("toolbar", { name: "Bulk actions" }).textContent,
+      ).toContain("2 selected"),
+    );
     expect(api.ackInbox).not.toHaveBeenCalled();
   });
 
@@ -409,11 +608,21 @@ describe("Inbox view", () => {
     fireEvent.click(view.getByLabelText("Select all inbox items"));
 
     act(() => {
-      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "A", shiftKey: true, bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "A",
+          shiftKey: true,
+          bubbles: true,
+        }),
+      );
     });
 
-    await waitFor(() => expect(calls).toEqual(["inbox_open_1", "inbox_open_2"]));
-    expect(view.getByRole("button", { name: "Ack: 2 done / 0 failed" })).toBeTruthy();
+    await waitFor(() =>
+      expect(calls).toEqual(["inbox_open_1", "inbox_open_2"]),
+    );
+    expect(
+      view.getByRole("button", { name: "Ack: 2 done / 0 failed" }),
+    ).toBeTruthy();
   });
 
   test("bulk ack reports one done / failed summary toast", async () => {
@@ -428,26 +637,49 @@ describe("Inbox view", () => {
     fireEvent.click(view.getByRole("button", { name: /^Ack$/ }));
 
     await waitFor(() => expect(api.ackInbox).toHaveBeenCalledTimes(2));
-    expect(view.getByRole("button", { name: "Ack: 1 done / 1 failed" })).toBeTruthy();
+    expect(
+      view.getByRole("button", { name: "Ack: 1 done / 1 failed" }),
+    ).toBeTruthy();
   });
 
   test("background refetch preserves selected ids and prunes ids that leave the tab", async () => {
     const { view, client } = renderInbox();
     await waitFor(() => view.getByLabelText("Select all inbox items"));
     fireEvent.click(view.getByLabelText("Select all inbox items"));
-    expect(view.getByRole("toolbar", { name: "Bulk actions" }).textContent).toContain("2 selected");
+    expect(
+      view.getByRole("toolbar", { name: "Bulk actions" }).textContent,
+    ).toContain("2 selected");
 
     ledger = ledger.filter((it) => it.id !== "inbox_open_2");
     await client.invalidateQueries({ queryKey: ["inbox"] });
 
-    await waitFor(() => expect(view.getByRole("toolbar", { name: "Bulk actions" }).textContent).toContain("1 selected"));
-    expect((view.getByLabelText("Select inbox item inbox_open_1") as HTMLInputElement).checked).toBe(true);
+    await waitFor(() =>
+      expect(
+        view.getByRole("toolbar", { name: "Bulk actions" }).textContent,
+      ).toContain("1 selected"),
+    );
+    expect(
+      (
+        view.getByLabelText(
+          "Select inbox item inbox_open_1",
+        ) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
   });
 
   test("verbs are disabled while disconnected", async () => {
-    const { view } = renderInbox({ focusItemId: "inbox_open_1", connected: false });
+    const { view } = renderInbox({
+      focusItemId: "inbox_open_1",
+      connected: false,
+    });
     await waitFor(() => view.getByRole("button", { name: /^Ack/ }));
-    expect((view.getByRole("button", { name: /^Ack/ }) as HTMLButtonElement).disabled).toBe(true);
-    expect((view.getByRole("button", { name: /Resolve…/ }) as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      (view.getByRole("button", { name: /^Ack/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (view.getByRole("button", { name: /Resolve…/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 });

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -1,7 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { keyGuard, refetchIntervals, useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
+import {
+  keyGuard,
+  refetchIntervals,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useTabKeys,
+} from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   buildSections,
@@ -17,7 +24,11 @@ import {
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
-import { INBOX_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
+import {
+  INBOX_FACETS,
+  matchesFilterQuery,
+  parseFilterQuery,
+} from "../filterQuery";
 import type { InboxItem } from "../types";
 import {
   Ago,
@@ -68,13 +79,29 @@ export const INBOX_GROUPS: readonly InboxGroup[] = [
     id: "decide",
     label: "Decide",
     hue: "var(--hue-warn)",
-    kinds: ["decision_needed", "proposal_expired", "BLOCKED", "ESCALATED", "human_needed"],
+    kinds: [
+      "decision_needed",
+      "proposal_expired",
+      "BLOCKED",
+      "ESCALATED",
+      "human_needed",
+    ],
   },
-  { id: "red", label: "Red", hue: "var(--hue-err)", kinds: ["CI RED", "SMOKE RED", "CIRCUIT BREAKER"] },
+  {
+    id: "red",
+    label: "Red",
+    hue: "var(--hue-err)",
+    kinds: ["CI RED", "SMOKE RED", "CIRCUIT BREAKER"],
+  },
   { id: "ready", label: "Ready", hue: "var(--hue-ok)", kinds: ["RC READY"] },
 ];
 
-const OTHER_GROUP: InboxGroup = { id: "other", label: "Other", hue: "var(--hue-idle)", kinds: [] };
+const OTHER_GROUP: InboxGroup = {
+  id: "other",
+  label: "Other",
+  hue: "var(--hue-idle)",
+  kinds: [],
+};
 
 export function groupOf(kind: string): InboxGroup {
   return INBOX_GROUPS.find((g) => g.kinds.includes(kind)) ?? OTHER_GROUP;
@@ -100,7 +127,12 @@ export const INBOX_DISPLAY: DisplayConfig<InboxItem> = {
       order: [...INBOX_GROUPS.map((group) => group.label), OTHER_GROUP.label],
       hue: INBOX_GROUP_HUES,
     },
-    { key: "kind", label: "Kind", get: (item) => item.kind, hue: INBOX_KIND_HUES },
+    {
+      key: "kind",
+      label: "Kind",
+      get: (item) => item.kind,
+      hue: INBOX_KIND_HUES,
+    },
     { key: "repo", label: "Repo", get: (item) => item.refs.repo ?? "—" },
   ],
   sorts: [
@@ -119,12 +151,17 @@ export const INBOX_DISPLAY: DisplayConfig<InboxItem> = {
 
 /** Keep one identity column visible while allowing every Inbox property to be toggled. */
 export function ensureInboxColumn(state: DisplayState): DisplayState {
-  const visibleBuiltIn = INBOX_DISPLAY.columns.some((column) => !state.hiddenColumns.includes(column.key));
+  const visibleBuiltIn = INBOX_DISPLAY.columns.some(
+    (column) => !state.hiddenColumns.includes(column.key),
+  );
   const visibleCustom = state.customColumns.some(
     (path) => !state.hiddenColumns.includes(`custom:${path}`),
   );
   if (visibleBuiltIn || visibleCustom) return state;
-  return { ...state, hiddenColumns: state.hiddenColumns.filter((key) => key !== "title") };
+  return {
+    ...state,
+    hiddenColumns: state.hiddenColumns.filter((key) => key !== "title"),
+  };
 }
 
 export type InboxItemStatus = Exclude<InboxTab, "all">;
@@ -145,7 +182,9 @@ export type DeliveryState = "sent" | "failed" | "none";
 export function deliveryState(item: InboxItem): DeliveryState {
   const t = item.delivery?.telegram;
   if (!t) return "none";
-  return t.error || (t.exit_code !== null && t.exit_code !== 0) ? "failed" : "sent";
+  return t.error || (t.exit_code !== null && t.exit_code !== 0)
+    ? "failed"
+    : "sent";
 }
 
 export function deliveryText(item: InboxItem): string {
@@ -153,7 +192,8 @@ export function deliveryText(item: InboxItem): string {
   if (!t) return "Telegram: not attempted";
   const when = new Date(t.sent_at).toLocaleTimeString([], { hour12: false });
   if (t.error) return `Telegram: failed ${when} · ${t.error}`;
-  if (t.exit_code !== null && t.exit_code !== 0) return `Telegram: failed ${when} · exit ${t.exit_code}`;
+  if (t.exit_code !== null && t.exit_code !== 0)
+    return `Telegram: failed ${when} · exit ${t.exit_code}`;
   return `Telegram: sent ${when} · exit ${t.exit_code ?? 0}`;
 }
 
@@ -164,7 +204,9 @@ const DELIVERY_HUES: Record<DeliveryState, string> = {
 };
 
 /** Group in triage order, oldest first inside a group; empty groups are dropped. */
-export function groupItems(items: InboxItem[]): { group: InboxGroup; items: InboxItem[] }[] {
+export function groupItems(
+  items: InboxItem[],
+): { group: InboxGroup; items: InboxItem[] }[] {
   const byGroup = new Map<InboxGroupId, InboxItem[]>();
   for (const item of items) {
     const g = groupOf(item.kind);
@@ -177,7 +219,9 @@ export function groupItems(items: InboxItem[]): { group: InboxGroup; items: Inbo
     .filter((g) => byGroup.has(g.id))
     .map((g) => ({
       group: g,
-      items: [...byGroup.get(g.id)!].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+      items: [...byGroup.get(g.id)!].sort((a, b) =>
+        a.createdAt.localeCompare(b.createdAt),
+      ),
     }));
 }
 
@@ -211,7 +255,11 @@ const ISSUE_PREFIX_GITHUB: Record<string, string> = {
 
 function prNumber(ref: string | undefined): string | null {
   if (!ref) return null;
-  return /^(?:PR\s*)?#(\d+)$/i.exec(ref.trim())?.[1] ?? /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref)?.[1] ?? null;
+  return (
+    /^(?:PR\s*)?#(\d+)$/i.exec(ref.trim())?.[1] ??
+    /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref)?.[1] ??
+    null
+  );
 }
 
 function githubRepo(item: InboxItem): string | null {
@@ -220,7 +268,9 @@ function githubRepo(item: InboxItem): string | null {
     if (/^[^/\s]+\/[^/\s]+$/.test(repo)) return repo;
     if (REPO_GITHUB[repo]) return REPO_GITHUB[repo];
   }
-  const team = /^([A-Z][A-Z0-9]+)-\d+$/i.exec(item.refs.issue ?? "")?.[1]?.toUpperCase();
+  const team = /^([A-Z][A-Z0-9]+)-\d+$/i
+    .exec(item.refs.issue ?? "")?.[1]
+    ?.toUpperCase();
   return team ? (ISSUE_PREFIX_GITHUB[team] ?? null) : null;
 }
 
@@ -248,8 +298,9 @@ function refPrefixIsVisible(prefix: string, item: InboxItem): boolean {
 /** Keep the row focused on the action by removing labels already shown beside it. */
 export function displayTitle(item: InboxItem): string {
   let title = item.title.trimStart();
-  const knownKinds = [...new Set([item.kind, ...INBOX_GROUPS.flatMap((group) => group.kinds)])]
-    .sort((a, b) => b.length - a.length);
+  const knownKinds = [
+    ...new Set([item.kind, ...INBOX_GROUPS.flatMap((group) => group.kinds)]),
+  ].sort((a, b) => b.length - a.length);
   for (const kind of knownKinds) {
     const plain = kind.toLowerCase();
     const bracketed = `[${plain}]`;
@@ -265,14 +316,21 @@ export function displayTitle(item: InboxItem): string {
     }
   }
 
-  const refPrefix = /^((?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+))(?:\s*\/\s*(?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+)))?)\s*:\s*/i.exec(title);
-  if (refPrefix && refPrefixIsVisible(refPrefix[1], item)) title = title.slice(refPrefix[0].length);
+  const refPrefix =
+    /^((?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+))(?:\s*\/\s*(?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+)))?)\s*:\s*/i.exec(
+      title,
+    );
+  if (refPrefix && refPrefixIsVisible(refPrefix[1], item))
+    title = title.slice(refPrefix[0].length);
   return title || item.title;
 }
 
 /** WM-559 will move this precision into shared `Ago`; keep the Inbox local until then. */
 export function inboxAge(iso: string, now: number): string {
-  const seconds = Math.max(0, Math.floor((now - new Date(iso).getTime()) / 1000));
+  const seconds = Math.max(
+    0,
+    Math.floor((now - new Date(iso).getTime()) / 1000),
+  );
   if (seconds < 60) return `${seconds}s ago`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
@@ -282,7 +340,8 @@ export function inboxAge(iso: string, now: number): string {
 }
 
 const isTypingTarget = (target: EventTarget | null): boolean =>
-  target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  target instanceof HTMLElement &&
+  Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
 
 export function Inbox({
   connected,
@@ -303,26 +362,48 @@ export function Inbox({
   const queryClient = useQueryClient();
   // One fetch of the whole ledger: it is small, every tab is a client-side
   // filter, and a deep link to a resolved item still resolves from the Open tab.
-  const query = useQuery({ queryKey: ["inbox", "all"], queryFn: () => api.inbox("all"), ...refetchIntervals.primary });
+  const query = useQuery({
+    queryKey: ["inbox", "all"],
+    queryFn: () => api.inbox("all"),
+    ...refetchIntervals.primary,
+  });
   const items = query.data?.items ?? [];
 
   const [tab, setTab] = useState<InboxTab>("open");
   const [filter, setFilter] = useState("");
   const counts = useMemo(() => {
-    const c: Record<InboxTab, number> = { open: 0, acked: 0, resolved: 0, all: items.length };
+    const c: Record<InboxTab, number> = {
+      open: 0,
+      acked: 0,
+      resolved: 0,
+      all: items.length,
+    };
     for (const it of items) c[itemStatus(it)] += 1;
     return c;
   }, [items]);
 
-  const byTab = useMemo(() => items.filter((item) => matchesTab(item, tab)), [items, tab]);
-  const parsed = useMemo(() => parseFilterQuery(filter, INBOX_FACETS), [filter]);
+  const byTab = useMemo(
+    () => items.filter((item) => matchesTab(item, tab)),
+    [items, tab],
+  );
+  const parsed = useMemo(
+    () => parseFilterQuery(filter, INBOX_FACETS),
+    [filter],
+  );
   const filtered = useMemo(
-    () => byTab.filter((item) => matchesFilterQuery(item, parsed, INBOX_FACETS, undefined)),
+    () =>
+      byTab.filter((item) =>
+        matchesFilterQuery(item, parsed, INBOX_FACETS, undefined),
+      ),
     [byTab, parsed],
   );
   const [display, updateDisplay] = useDisplayOptions(INBOX_DISPLAY);
-  const setDisplay = (next: DisplayState | ((state: DisplayState) => DisplayState)) => {
-    updateDisplay((state) => ensureInboxColumn(typeof next === "function" ? next(state) : next));
+  const setDisplay = (
+    next: DisplayState | ((state: DisplayState) => DisplayState),
+  ) => {
+    updateDisplay((state) =>
+      ensureInboxColumn(typeof next === "function" ? next(state) : next),
+    );
   };
   const sections = useMemo(
     () => buildSections(filtered, INBOX_DISPLAY, display),
@@ -345,18 +426,25 @@ export function Inbox({
   const pendingStar = useRef(0);
 
   const allActionableSelected =
-    actionableVisible.length > 0 && actionableVisible.every((it) => selectedIds.has(it.id));
+    actionableVisible.length > 0 &&
+    actionableVisible.every((it) => selectedIds.has(it.id));
   const someActionableSelected =
-    actionableVisible.some((it) => selectedIds.has(it.id)) && !allActionableSelected;
+    actionableVisible.some((it) => selectedIds.has(it.id)) &&
+    !allActionableSelected;
   const selectedRows = useMemo(
     () => visible.filter((it) => selectedIds.has(it.id)),
     [visible, selectedIds],
   );
-  const ackableSelected = selectedRows.filter((it) => itemStatus(it) === "open");
-  const resolvableSelected = selectedRows.filter((it) => itemStatus(it) !== "resolved");
+  const ackableSelected = selectedRows.filter(
+    (it) => itemStatus(it) === "open",
+  );
+  const resolvableSelected = selectedRows.filter(
+    (it) => itemStatus(it) !== "resolved",
+  );
 
   useEffect(() => {
-    if (headerCheckboxRef.current) headerCheckboxRef.current.indeterminate = someActionableSelected;
+    if (headerCheckboxRef.current)
+      headerCheckboxRef.current.indeterminate = someActionableSelected;
   }, [someActionableSelected]);
 
   // IDs survive ordinary polling, while items that leave the active tab are
@@ -380,13 +468,16 @@ export function Inbox({
       return next;
     });
   };
-  const selectAllActionable = () => setSelectedIds(new Set(actionableVisible.map((it) => it.id)));
+  const selectAllActionable = () =>
+    setSelectedIds(new Set(actionableVisible.map((it) => it.id)));
   const toggleSelectAll = () => {
     if (allActionableSelected) setSelectedIds(new Set());
     else selectAllActionable();
   };
 
-  const sel = focusItemId ? (items.find((it) => it.id === focusItemId) ?? null) : null;
+  const sel = focusItemId
+    ? (items.find((it) => it.id === focusItemId) ?? null)
+    : null;
   const selectedIndex = sel ? visible.findIndex((it) => it.id === sel.id) : -1;
   // A deep link is only "unknown" once the ledger has actually answered.
   const unknownFocus = !!focusItemId && !sel && query.isSuccess;
@@ -421,11 +512,14 @@ export function Inbox({
       setConfirmResolve(false);
       notify(`Resolved ${shortId(id)}`, "ok");
     },
-    onError: (err) => notify(`Resolve failed: ${(err as Error).message}`, "err"),
+    onError: (err) =>
+      notify(`Resolve failed: ${(err as Error).message}`, "err"),
   });
 
-  const canAck = !!sel && connected && itemStatus(sel) === "open" && !ack.isPending;
-  const canResolve = !!sel && connected && itemStatus(sel) !== "resolved" && !resolve.isPending;
+  const canAck =
+    !!sel && connected && itemStatus(sel) === "open" && !ack.isPending;
+  const canResolve =
+    !!sel && connected && itemStatus(sel) !== "resolved" && !resolve.isPending;
 
   const handleBulkAck = async () => {
     if (!connected || bulkAcking || ackableSelected.length === 0) return;
@@ -472,7 +566,12 @@ export function Inbox({
     if (!confirmResolve && !bulkResolveOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
-      if (bulkResolveOpen && connected && !bulkResolving && resolvableSelected.length > 0) {
+      if (
+        bulkResolveOpen &&
+        connected &&
+        !bulkResolving &&
+        resolvableSelected.length > 0
+      ) {
         e.preventDefault();
         void handleBulkResolve();
       } else if (confirmResolve && sel && canResolve) {
@@ -482,7 +581,16 @@ export function Inbox({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [confirmResolve, bulkResolveOpen, sel, canResolve, resolve, connected, bulkResolving, resolvableSelected]);
+  }, [
+    confirmResolve,
+    bulkResolveOpen,
+    sel,
+    canResolve,
+    resolve,
+    connected,
+    bulkResolving,
+    resolvableSelected,
+  ]);
 
   const selectTab = (t: InboxTab) => {
     setTab(t);
@@ -517,7 +625,8 @@ export function Inbox({
     },
     keys: {
       a: () => {
-        const starActive = pendingStar.current > 0 && Date.now() - pendingStar.current < 800;
+        const starActive =
+          pendingStar.current > 0 && Date.now() - pendingStar.current < 800;
         if (!starActive && canAck && sel) ack.mutate(sel.id);
       },
       x: () => {
@@ -530,14 +639,20 @@ export function Inbox({
     function onSelectionKey(e: KeyboardEvent) {
       if (keyGuard(e) || e.altKey || goPrefixActive() || e.repeat) return;
       const now = Date.now();
-      const starActive = pendingStar.current > 0 && now - pendingStar.current < 800;
+      const starActive =
+        pendingStar.current > 0 && now - pendingStar.current < 800;
 
       if (!e.metaKey && !e.ctrlKey && e.key === "*") {
         e.preventDefault();
         pendingStar.current = now;
         return;
       }
-      if (!e.metaKey && !e.ctrlKey && starActive && (e.key === "a" || e.key === "n")) {
+      if (
+        !e.metaKey &&
+        !e.ctrlKey &&
+        starActive &&
+        (e.key === "a" || e.key === "n")
+      ) {
         e.preventDefault();
         pendingStar.current = 0;
         if (e.key === "a") selectAllActionable();
@@ -546,7 +661,11 @@ export function Inbox({
       }
       pendingStar.current = 0;
 
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "a") {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        e.key.toLowerCase() === "a"
+      ) {
         if (actionableVisible.length === 0) return;
         e.preventDefault();
         selectAllActionable();
@@ -566,7 +685,8 @@ export function Inbox({
         return;
       }
       if (e.key === "X" && selectedIds.size > 0) {
-        if (!connected || bulkResolving || resolvableSelected.length === 0) return;
+        if (!connected || bulkResolving || resolvableSelected.length === 0)
+          return;
         e.preventDefault();
         setBulkResolveOpen(true);
       }
@@ -587,23 +707,33 @@ export function Inbox({
   ]);
 
   const tdCls = "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
-  const openEmpty = tab === "open" && byTab.length === 0 && !filter.trim() && query.isSuccess;
+  const openEmpty =
+    tab === "open" && byTab.length === 0 && !filter.trim() && query.isSuccess;
   const handleExport = () => {
     const sorted = sortRows(filtered, INBOX_DISPLAY, display);
     const dateStr = new Date().toISOString().slice(0, 10);
     exportJson(`inbox-export-${dateStr}.json`, sorted);
-    notify(`Exported ${sorted.length} inbox item${sorted.length === 1 ? "" : "s"} to JSON`, "info");
+    notify(
+      `Exported ${sorted.length} inbox item${sorted.length === 1 ? "" : "s"} to JSON`,
+      "info",
+    );
   };
 
   return (
     <div className="flex h-full min-w-0">
-      <div className={`${sel ? "hidden sm:flex" : "flex"} min-h-0 min-w-0 flex-1`}>
+      <div
+        className={`${sel ? "hidden sm:flex" : "flex"} min-h-0 min-w-0 flex-1`}
+      >
         <ListPane
           chrome={
             <>
               <h1 className="display mb-4 text-lg font-semibold">Inbox</h1>
               <div className="mb-3 flex flex-wrap items-center gap-2">
-                <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Inbox status">
+                <div
+                  className="flex min-w-0 flex-1 flex-wrap gap-1"
+                  role="tablist"
+                  aria-label="Inbox status"
+                >
                   {INBOX_TABS.map((t, idx) => (
                     <button
                       key={t}
@@ -613,14 +743,21 @@ export function Inbox({
                       onClick={() => selectTab(t)}
                       title={t}
                       className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                        tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                        tab === t
+                          ? "bg-(--surface-3) text-(--text)"
+                          : "text-(--text-faint) hover:bg-(--surface-1)"
                       }`}
                     >
                       {t[0].toUpperCase() + t.slice(1)}
                       {counts[t] > 0 && (
-                        <span className="ml-1.5 tabular-nums text-(--text-faint)">{counts[t]}</span>
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {counts[t]}
+                        </span>
                       )}
-                      <span aria-hidden="true" className="mono ml-1 text-[10px] text-(--text-faint) opacity-70">
+                      <span
+                        aria-hidden="true"
+                        className="mono ml-1 text-[10px] text-(--text-faint) opacity-70"
+                      >
                         {idx + 1}
                       </span>
                     </button>
@@ -653,10 +790,12 @@ export function Inbox({
               className="mb-3 rounded-md px-3 py-2 text-[12px]"
               style={{
                 color: "var(--hue-warn)",
-                background: "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
+                background:
+                  "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
               }}
             >
-              No inbox item <span className="mono">{focusItemId}</span> — it may predate the ledger or the link is stale.
+              No inbox item <span className="mono">{focusItemId}</span> — it may
+              predate the ledger or the link is stale.
             </div>
           )}
           {openEmpty ? (
@@ -686,8 +825,11 @@ export function Inbox({
                     </th>
                   )}
                   {cols.map((column) => {
-                    const sort = INBOX_DISPLAY.sorts.find((field) => field.column === column.key);
-                    const isCustom = column.isCustom || column.key.startsWith("custom:");
+                    const sort = INBOX_DISPLAY.sorts.find(
+                      (field) => field.column === column.key,
+                    );
+                    const isCustom =
+                      column.isCustom || column.key.startsWith("custom:");
                     const customPath = column.key.replace(/^custom:/, "");
                     const isCurrentSort = isCustom
                       ? display.sortBy === column.key
@@ -696,15 +838,33 @@ export function Inbox({
                       <Th
                         key={column.key}
                         label={column.label}
-                        title={column.key === "sent" ? "Telegram delivery: sent, failed, or not attempted" : undefined}
+                        title={
+                          column.key === "sent"
+                            ? "Telegram delivery: sent, failed, or not attempted"
+                            : undefined
+                        }
                         dir={isCurrentSort ? display.sortDir : null}
                         naturalDir={sort?.defaultDir ?? "asc"}
-                        onSort={sort || isCustom
-                          ? () => setDisplay((state) => cycleColumnSort(INBOX_DISPLAY, state, column.key))
-                          : undefined}
-                        onRemove={isCustom
-                          ? () => setDisplay((state) => removeCustomColumn(state, customPath))
-                          : undefined}
+                        onSort={
+                          sort || isCustom
+                            ? () =>
+                                setDisplay((state) =>
+                                  cycleColumnSort(
+                                    INBOX_DISPLAY,
+                                    state,
+                                    column.key,
+                                  ),
+                                )
+                            : undefined
+                        }
+                        onRemove={
+                          isCustom
+                            ? () =>
+                                setDisplay((state) =>
+                                  removeCustomColumn(state, customPath),
+                                )
+                            : undefined
+                        }
                       />
                     );
                   })}
@@ -722,7 +882,10 @@ export function Inbox({
                         className={`cursor-pointer hover:bg-(--surface-1) ${item.id === sel?.id ? "row-selected" : ""}`}
                       >
                         {selectionEnabled && (
-                          <td className={`${tdCls} w-8`} onClick={(e) => e.stopPropagation()}>
+                          <td
+                            className={`${tdCls} w-8`}
+                            onClick={(e) => e.stopPropagation()}
+                          >
                             <input
                               type="checkbox"
                               aria-label={`Select inbox item ${item.id}`}
@@ -734,12 +897,21 @@ export function Inbox({
                         )}
                         {show.has("kind") && (
                           <td className={`${tdCls} w-32`}>
-                            <StateBadge state={item.kind} hues={INBOX_KIND_HUES} dot={false} />
+                            <StateBadge
+                              state={item.kind}
+                              hues={INBOX_KIND_HUES}
+                              dot={false}
+                            />
                           </td>
                         )}
                         {show.has("title") && (
                           <td className={`${tdCls} min-w-40 max-w-0`}>
-                            <div className="truncate text-(--text)" title={item.title}>{displayTitle(item)}</div>
+                            <div
+                              className="truncate text-(--text)"
+                              title={item.title}
+                            >
+                              {displayTitle(item)}
+                            </div>
                           </td>
                         )}
                         {show.has("age") && (
@@ -768,22 +940,40 @@ export function Inbox({
                             />
                           </td>
                         )}
-                        {cols.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
-                          <CustomCell key={column.key} row={item} path={column.key.replace(/^custom:/, "")} />
-                        ))}
+                        {cols
+                          .filter(
+                            (column) =>
+                              column.isCustom ||
+                              column.key.startsWith("custom:"),
+                          )
+                          .map((column) => (
+                            <CustomCell
+                              key={column.key}
+                              row={item}
+                              path={column.key.replace(/^custom:/, "")}
+                            />
+                          ))}
                       </tr>
                     );
                   };
-                  if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+                  if (!grouped(display))
+                    return sections[0]?.rows.map(renderRow);
                   return sections.map((section) => {
                     const collapsed = display.collapsed.includes(section.key);
                     return (
                       <Fragment key={section.key}>
                         <GroupHeaderRow
-                          colSpan={Math.max(cols.length + (selectionEnabled ? 1 : 0), 1)}
+                          colSpan={Math.max(
+                            cols.length + (selectionEnabled ? 1 : 0),
+                            1,
+                          )}
                           section={section}
                           collapsed={collapsed}
-                          onToggle={() => setDisplay((state) => toggleCollapsed(state, section.key))}
+                          onToggle={() =>
+                            setDisplay((state) =>
+                              toggleCollapsed(state, section.key),
+                            )
+                          }
                         />
                         {!collapsed && section.rows.map(renderRow)}
                       </Fragment>
@@ -792,7 +982,10 @@ export function Inbox({
                 })()}
                 {filtered.length === 0 && (
                   <ListEmpty
-                    colSpan={Math.max(cols.length + (selectionEnabled ? 1 : 0), 1)}
+                    colSpan={Math.max(
+                      cols.length + (selectionEnabled ? 1 : 0),
+                      1,
+                    )}
                     query={query}
                     filtered={byTab.length > 0}
                     onClear={filter.trim() ? () => setFilter("") : undefined}
@@ -819,7 +1012,10 @@ export function Inbox({
         <DetailPane
           widthClass="w-full sm:w-[460px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectItem(null)}
@@ -828,22 +1024,49 @@ export function Inbox({
               >
                 Inbox
               </button>
-              <span className="text-(--text-faint)" aria-hidden="true">/</span>
-              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
-                <StateBadge state={sel.kind} hues={INBOX_KIND_HUES} dot={false} />
-                <span className="mono truncate" title={sel.id}>{shortId(sel.id)}</span>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
+              </span>
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
+                <StateBadge
+                  state={sel.kind}
+                  hues={INBOX_KIND_HUES}
+                  dot={false}
+                />
+                <span className="mono truncate" title={sel.id}>
+                  {shortId(sel.id)}
+                </span>
               </span>
             </nav>
           }
           actions={
             itemStatus(sel) !== "resolved" ? (
               <div className="flex items-center gap-1.5">
-                <Button disabled={!canResolve} onClick={() => setConfirmResolve(true)}>
-                  Resolve… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                <Button
+                  disabled={!canResolve}
+                  onClick={() => setConfirmResolve(true)}
+                >
+                  Resolve…{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    x
+                  </span>
                 </Button>
                 {itemStatus(sel) === "open" && (
-                  <Button variant="primary" disabled={!canAck} onClick={() => ack.mutate(sel.id)}>
-                    Ack <span className="mono ml-1 opacity-80" aria-hidden="true">a</span>
+                  <Button
+                    variant="primary"
+                    disabled={!canAck}
+                    onClick={() => ack.mutate(sel.id)}
+                  >
+                    Ack{" "}
+                    <span className="mono ml-1 opacity-80" aria-hidden="true">
+                      a
+                    </span>
                   </Button>
                 )}
               </div>
@@ -853,18 +1076,34 @@ export function Inbox({
           close={<Button onClick={() => onSelectItem(null)}>Close</Button>}
         >
           <Section title="Item" icons>
-            <KV k="kind" v={<StateBadge state={sel.kind} hues={INBOX_KIND_HUES} dot={false} />} />
+            <KV
+              k="kind"
+              v={
+                <StateBadge
+                  state={sel.kind}
+                  hues={INBOX_KIND_HUES}
+                  dot={false}
+                />
+              }
+            />
             <KV k="status" v={itemStatus(sel)} />
             {sel.severity !== "normal" && <KV k="severity" v={sel.severity} />}
             <KV k="created" v={<Ago iso={sel.createdAt} now={now} />} />
-            {sel.ackedAt && <KV k="acked" v={<Ago iso={sel.ackedAt} now={now} />} />}
-            {sel.resolvedAt && <KV k="resolved" v={<Ago iso={sel.resolvedAt} now={now} />} />}
+            {sel.ackedAt && (
+              <KV k="acked" v={<Ago iso={sel.ackedAt} now={now} />} />
+            )}
+            {sel.resolvedAt && (
+              <KV k="resolved" v={<Ago iso={sel.resolvedAt} now={now} />} />
+            )}
             {sel.resolvedBy && <KV k="resolved by" v={sel.resolvedBy} />}
             <KV
               k="source"
               v={
                 sourceRunId(sel.source) ? (
-                  <JumpLink onClick={() => onJumpRun(sourceRunId(sel.source)!)} title={`Open run ${sourceRunId(sel.source)}`}>
+                  <JumpLink
+                    onClick={() => onJumpRun(sourceRunId(sel.source)!)}
+                    title={`Open run ${sourceRunId(sel.source)}`}
+                  >
                     {sel.source}
                   </JumpLink>
                 ) : (
@@ -878,7 +1117,9 @@ export function Inbox({
             <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] leading-relaxed">
               <div className="font-medium text-(--text)">{sel.title}</div>
               {sel.body && (
-                <div className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)">{sel.body}</div>
+                <div className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)">
+                  {sel.body}
+                </div>
               )}
             </div>
           </Section>
@@ -886,17 +1127,42 @@ export function Inbox({
           {Object.keys(sel.refs).length > 0 && (
             <Section title="References" icons>
               {sel.refs.runId && (
-                <KV k="run" v={<JumpLink onClick={() => onJumpRun(sel.refs.runId!)} title={`Open run ${sel.refs.runId}`}>{shortId(sel.refs.runId)}</JumpLink>} />
+                <KV
+                  k="run"
+                  v={
+                    <JumpLink
+                      onClick={() => onJumpRun(sel.refs.runId!)}
+                      title={`Open run ${sel.refs.runId}`}
+                    >
+                      {shortId(sel.refs.runId)}
+                    </JumpLink>
+                  }
+                />
               )}
               {sel.refs.proposalId && (
-                <KV k="proposal" v={<JumpLink onClick={() => onJumpProposal(sel.refs.proposalId!)} title={`Open proposal ${sel.refs.proposalId}`}>{shortId(sel.refs.proposalId)}</JumpLink>} />
+                <KV
+                  k="proposal"
+                  v={
+                    <JumpLink
+                      onClick={() => onJumpProposal(sel.refs.proposalId!)}
+                      title={`Open proposal ${sel.refs.proposalId}`}
+                    >
+                      {shortId(sel.refs.proposalId)}
+                    </JumpLink>
+                  }
+                />
               )}
               {sel.refs.eventId && (
                 <KV
                   k="event"
                   v={
                     sel.refs.eventSource ? (
-                      <JumpLink onClick={() => onJumpEvent(sel.refs.eventSource!, sel.refs.eventId!)} title={`Open event ${sel.refs.eventId}`}>
+                      <JumpLink
+                        onClick={() =>
+                          onJumpEvent(sel.refs.eventSource!, sel.refs.eventId!)
+                        }
+                        title={`Open event ${sel.refs.eventId}`}
+                      >
                         {shortId(sel.refs.eventId)}
                       </JumpLink>
                     ) : (
@@ -906,7 +1172,17 @@ export function Inbox({
                 />
               )}
               {sel.refs.issue && (
-                <KV k="issue" v={<JumpLink href={`${LINEAR_ISSUE_URL}${encodeURIComponent(sel.refs.issue)}`} title="Open in Linear">{sel.refs.issue}</JumpLink>} />
+                <KV
+                  k="issue"
+                  v={
+                    <JumpLink
+                      href={`${LINEAR_ISSUE_URL}${encodeURIComponent(sel.refs.issue)}`}
+                      title="Open in Linear"
+                    >
+                      {sel.refs.issue}
+                    </JumpLink>
+                  }
+                />
               )}
               {sel.refs.pr && <KV k="pr" v={<PrRef item={sel} />} />}
               {sel.refs.repo && <KV k="repo" v={sel.refs.repo} />}
@@ -917,33 +1193,53 @@ export function Inbox({
             <KV
               k="telegram"
               v={
-                <span style={{ color: DELIVERY_HUES[deliveryState(sel)] }} title={deliveryText(sel)}>
+                <span
+                  style={{ color: DELIVERY_HUES[deliveryState(sel)] }}
+                  title={deliveryText(sel)}
+                >
                   {deliveryText(sel).replace(/^Telegram: /, "")}
                 </span>
               }
             />
           </Section>
 
-          {(ack.isError || resolve.isError) && <VerbError error={ack.error ?? resolve.error} />}
+          {(ack.isError || resolve.isError) && (
+            <VerbError error={ack.error ?? resolve.error} />
+          )}
         </DetailPane>
       )}
 
       {selectedIds.size > 0 && selectionEnabled && (
-        <BulkActionBar count={selectedIds.size} onClear={() => setSelectedIds(new Set())}>
+        <BulkActionBar
+          count={selectedIds.size}
+          onClear={() => setSelectedIds(new Set())}
+        >
           <Button
             variant="primary"
             disabled={!connected || bulkAcking || ackableSelected.length === 0}
             onClick={() => void handleBulkAck()}
           >
             {bulkAcking ? "Acking…" : "Ack"}
-            <span className="mono ml-1 text-[10px] text-(--text-faint)" aria-hidden="true">A</span>
+            <span
+              className="mono ml-1 text-[10px] text-(--text-faint)"
+              aria-hidden="true"
+            >
+              A
+            </span>
           </Button>
           <Button
-            disabled={!connected || bulkResolving || resolvableSelected.length === 0}
+            disabled={
+              !connected || bulkResolving || resolvableSelected.length === 0
+            }
             onClick={() => setBulkResolveOpen(true)}
           >
             Resolve…
-            <span className="mono ml-1 text-[10px] text-(--text-faint)" aria-hidden="true">X</span>
+            <span
+              className="mono ml-1 text-[10px] text-(--text-faint)"
+              aria-hidden="true"
+            >
+              X
+            </span>
           </Button>
         </BulkActionBar>
       )}
@@ -954,8 +1250,9 @@ export function Inbox({
           onClose={() => setBulkResolveOpen(false)}
         >
           <p className="mb-3 text-[12px] text-(--text-dim)">
-            Marks all {resolvableSelected.length} selected items as dealt with. They leave Open or Acked and stay in the
-            ledger under Resolved. This does not act on their underlying runs, proposals, or PRs.
+            Marks all {resolvableSelected.length} selected items as dealt with.
+            They leave Open or Acked and stay in the ledger under Resolved. This
+            does not act on their underlying runs, proposals, or PRs.
           </p>
           <div className="flex justify-end gap-2">
             <Button onClick={() => setBulkResolveOpen(false)}>Cancel</Button>
@@ -965,21 +1262,32 @@ export function Inbox({
               onClick={() => void handleBulkResolve()}
               autoFocus
             >
-              {bulkResolving ? "Resolving…" : `Resolve ${resolvableSelected.length} items`}
+              {bulkResolving
+                ? "Resolving…"
+                : `Resolve ${resolvableSelected.length} items`}
             </Button>
           </div>
         </Dialog>
       )}
 
       {confirmResolve && sel && (
-        <Dialog title="Resolve inbox item?" onClose={() => setConfirmResolve(false)}>
+        <Dialog
+          title="Resolve inbox item?"
+          onClose={() => setConfirmResolve(false)}
+        >
           <p className="mb-3 text-[12px] text-(--text-dim)">
-            Marks <span className="mono">{shortId(sel.id)}</span> as dealt with. It leaves Open and Acked and stays in the
-            ledger under Resolved. This does not act on the underlying run, proposal or PR.
+            Marks <span className="mono">{shortId(sel.id)}</span> as dealt with.
+            It leaves Open and Acked and stays in the ledger under Resolved.
+            This does not act on the underlying run, proposal or PR.
           </p>
           <div className="flex justify-end gap-2">
             <Button onClick={() => setConfirmResolve(false)}>Cancel</Button>
-            <Button variant="primary" disabled={!canResolve} onClick={() => resolve.mutate(sel.id)} autoFocus>
+            <Button
+              variant="primary"
+              disabled={!canResolve}
+              onClick={() => resolve.mutate(sel.id)}
+              autoFocus
+            >
               Resolve
             </Button>
           </div>
@@ -994,9 +1302,13 @@ function PrRef({ item, className }: { item: InboxItem; className?: string }) {
   const href = prHref(item);
   const label = ref.replace(/^https?:\/\/(www\.)?github\.com\//, "");
   return href ? (
-    <JumpLink className={className} href={href} title="Open pull request">{label}</JumpLink>
+    <JumpLink className={className} href={href} title="Open pull request">
+      {label}
+    </JumpLink>
   ) : (
-    <span className={`mono ${className ?? ""}`} title={ref}>{ref}</span>
+    <span className={`mono ${className ?? ""}`} title={ref}>
+      {ref}
+    </span>
   );
 }
 /** Every ref is one click from the thing it is about; nothing here selects the row. */
@@ -1012,26 +1324,93 @@ function RefChips({
   onJumpEvent: (source: string, eventId: string) => void;
 }) {
   const r = item.refs;
-  const chip = "inline-block max-w-20 truncate rounded border border-(--border) bg-(--surface-1) px-1 align-bottom text-[10px]";
-  const chips: { key: string; description: string; node: React.ReactNode }[] = [];
-  if (r.runId) chips.push({ key: "run", description: `run ${r.runId}`, node: <JumpLink className={chip} onClick={() => onJumpRun(r.runId!)} title={r.runId}>{shortId(r.runId)}</JumpLink> });
-  if (r.proposalId) chips.push({ key: "prop", description: `proposal ${r.proposalId}`, node: <JumpLink className={chip} onClick={() => onJumpProposal(r.proposalId!)} title={r.proposalId}>{shortId(r.proposalId)}</JumpLink> });
+  const chip =
+    "inline-block max-w-20 truncate rounded border border-(--border) bg-(--surface-1) px-1 align-bottom text-[10px]";
+  const chips: { key: string; description: string; node: React.ReactNode }[] =
+    [];
+  if (r.runId)
+    chips.push({
+      key: "run",
+      description: `run ${r.runId}`,
+      node: (
+        <JumpLink
+          className={chip}
+          onClick={() => onJumpRun(r.runId!)}
+          title={r.runId}
+        >
+          {shortId(r.runId)}
+        </JumpLink>
+      ),
+    });
+  if (r.proposalId)
+    chips.push({
+      key: "prop",
+      description: `proposal ${r.proposalId}`,
+      node: (
+        <JumpLink
+          className={chip}
+          onClick={() => onJumpProposal(r.proposalId!)}
+          title={r.proposalId}
+        >
+          {shortId(r.proposalId)}
+        </JumpLink>
+      ),
+    });
   if (r.eventId) {
-    const event = r.eventSource
-      ? <JumpLink className={chip} onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title={r.eventId}>{shortId(r.eventId)}</JumpLink>
-      : <span className={`mono ${chip}`} title={r.eventId}>{shortId(r.eventId)}</span>;
-    chips.push({ key: "event", description: `event ${r.eventId}`, node: event });
+    const event = r.eventSource ? (
+      <JumpLink
+        className={chip}
+        onClick={() => onJumpEvent(r.eventSource!, r.eventId!)}
+        title={r.eventId}
+      >
+        {shortId(r.eventId)}
+      </JumpLink>
+    ) : (
+      <span className={`mono ${chip}`} title={r.eventId}>
+        {shortId(r.eventId)}
+      </span>
+    );
+    chips.push({
+      key: "event",
+      description: `event ${r.eventId}`,
+      node: event,
+    });
   }
-  if (r.issue) chips.push({ key: "issue", description: `issue ${r.issue}`, node: <JumpLink className={chip} href={`${LINEAR_ISSUE_URL}${encodeURIComponent(r.issue)}`} title="Open in Linear">{r.issue}</JumpLink> });
-  if (r.pr) chips.push({ key: "pr", description: `pull request ${r.pr}`, node: <PrRef item={item} className={chip} /> });
+  if (r.issue)
+    chips.push({
+      key: "issue",
+      description: `issue ${r.issue}`,
+      node: (
+        <JumpLink
+          className={chip}
+          href={`${LINEAR_ISSUE_URL}${encodeURIComponent(r.issue)}`}
+          title="Open in Linear"
+        >
+          {r.issue}
+        </JumpLink>
+      ),
+    });
+  if (r.pr)
+    chips.push({
+      key: "pr",
+      description: `pull request ${r.pr}`,
+      node: <PrRef item={item} className={chip} />,
+    });
   if (chips.length === 0) return <span className="text-(--text-faint)">-</span>;
   const visible = chips.slice(0, 3);
   const hidden = chips.slice(3);
   return (
     <div className="flex gap-1 overflow-hidden whitespace-nowrap [&>*]:shrink-0">
-      {visible.map(({ key, node }) => <span key={key} className="contents">{node}</span>)}
+      {visible.map(({ key, node }) => (
+        <span key={key} className="contents">
+          {node}
+        </span>
+      ))}
       {hidden.length > 0 && (
-        <span className={`mono ${chip} text-(--text-faint)`} title={hidden.map((ref) => ref.description).join(", ")}>
+        <span
+          className={`mono ${chip} text-(--text-faint)`}
+          title={hidden.map((ref) => ref.description).join(", ")}
+        >
           +{hidden.length}
         </span>
       )}

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Overview,
@@ -15,7 +21,14 @@ import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import { changeInput } from "../test-render";
-import type { AdmittedEvent, EventFocus, JournalEntry, Proposal, RunListItem, StatusView } from "../types";
+import type {
+  AdmittedEvent,
+  EventFocus,
+  JournalEntry,
+  Proposal,
+  RunListItem,
+  StatusView,
+} from "../types";
 
 afterEach(() => {
   cleanup();
@@ -25,12 +38,16 @@ function renderWithClient(ui: React.ReactElement) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 const noop = () => {};
 
-function baseStatus(overrides: Partial<StatusView["anomalies"]> = {}): StatusView {
+function baseStatus(
+  overrides: Partial<StatusView["anomalies"]> = {},
+): StatusView {
   return {
     env: { name: "test", home: "/tmp/test", adapter: null },
     events: {},
@@ -66,7 +83,10 @@ function baseStatus(overrides: Partial<StatusView["anomalies"]> = {}): StatusVie
   };
 }
 
-function stubEvent(overrides: Partial<AdmittedEvent> & Pick<AdmittedEvent, "eventId" | "status" | "repos">): AdmittedEvent {
+function stubEvent(
+  overrides: Partial<AdmittedEvent> &
+    Pick<AdmittedEvent, "eventId" | "status" | "repos">,
+): AdmittedEvent {
   const now = new Date().toISOString();
   return {
     source: "github",
@@ -85,7 +105,10 @@ function stubEvent(overrides: Partial<AdmittedEvent> & Pick<AdmittedEvent, "even
   };
 }
 
-function stubRun(overrides: Partial<RunListItem> & Pick<RunListItem, "runId" | "state" | "repos">): RunListItem {
+function stubRun(
+  overrides: Partial<RunListItem> &
+    Pick<RunListItem, "runId" | "state" | "repos">,
+): RunListItem {
   const now = new Date().toISOString();
   return {
     attempts: 1,
@@ -122,7 +145,11 @@ const stubProposal: Proposal = {
 type OverviewCallbacks = Partial<
   Pick<
     React.ComponentProps<typeof Overview>,
-    "onJumpRun" | "onJumpProposal" | "onJumpEvents" | "onJumpRuns" | "onNavigate"
+    | "onJumpRun"
+    | "onJumpProposal"
+    | "onJumpEvents"
+    | "onJumpRuns"
+    | "onNavigate"
   >
 >;
 
@@ -147,7 +174,9 @@ function renderOverview(
 }
 
 /** Build a journal entry; the feed keeps entries newest-first, so tests pass them that way. */
-function entry(overrides: Partial<JournalEntry> & Pick<JournalEntry, "seq" | "runId" | "to">): JournalEntry {
+function entry(
+  overrides: Partial<JournalEntry> & Pick<JournalEntry, "seq" | "runId" | "to">,
+): JournalEntry {
   return {
     from: null,
     actor: "worker",
@@ -173,7 +202,13 @@ describe("groupJournalEntries (WM-100)", () => {
     expect(groups[0]!.from).toBe("PROPOSED");
     expect(groups[0]!.to).toBe("FAILED");
     expect(groups[0]!.count).toBe(4);
-    expect(groups[0]!.path).toEqual(["PROPOSED", "QUEUED", "LEASED", "RUNNING", "FAILED"]);
+    expect(groups[0]!.path).toEqual([
+      "PROPOSED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "FAILED",
+    ]);
     // Key, timestamp, and actor come from the most recent transition.
     expect(groups[0]!.seq).toBe(5);
     expect(groups[0]!.at).toBe(entries[0]!.at);
@@ -200,7 +235,13 @@ describe("groupJournalEntries (WM-100)", () => {
     const entries: JournalEntry[] = [
       entry({ seq: 3, runId: "run_c", from: "RUNNING", to: "COMPLETED" }),
       entry({ seq: 2, runId: "run_b", from: null, to: "QUEUED" }),
-      entry({ seq: 1, runId: "run_a", from: "QUEUED", to: "CANCELLED", reason: "operator" }),
+      entry({
+        seq: 1,
+        runId: "run_a",
+        from: "QUEUED",
+        to: "CANCELLED",
+        reason: "operator",
+      }),
     ];
     const groups = groupJournalEntries(entries);
     expect(groups.length).toBe(3);
@@ -211,7 +252,13 @@ describe("groupJournalEntries (WM-100)", () => {
 
   test("formats collapsed steps without ellipsis and suppresses state-duplicate reasons", () => {
     const [group] = groupJournalEntries([
-      entry({ seq: 3, runId: "run_a", from: "RUNNING", to: "COMPLETED", reason: "exit_0" }),
+      entry({
+        seq: 3,
+        runId: "run_a",
+        from: "RUNNING",
+        to: "COMPLETED",
+        reason: "exit_0",
+      }),
       entry({ seq: 2, runId: "run_a", from: "LEASED", to: "RUNNING" }),
       entry({ seq: 1, runId: "run_a", from: "QUEUED", to: "LEASED" }),
     ]);
@@ -237,27 +284,39 @@ describe("anomaly normalization (WM-548)", () => {
       { source: "github", eventId: "delivery_1", lastError: "duplicate key" },
     ]);
 
-    expect(groups.map((group) => [group.source, group.errorMessage, group.events.length])).toEqual([
+    expect(
+      groups.map((group) => [
+        group.source,
+        group.errorMessage,
+        group.events.length,
+      ]),
+    ).toEqual([
       ["chain", "duplicate key", 2],
       ["chain", "timeout", 1],
       ["github", "duplicate key", 1],
     ]);
-    expect(groups[0]!.events.map((event) => event.eventId)).toEqual(["chain-run_1", "chain-run_2"]);
+    expect(groups[0]!.events.map((event) => event.eventId)).toEqual([
+      "chain-run_1",
+      "chain-run_2",
+    ]);
   });
 
   test("strips a redundant kind prefix without altering unrelated text", () => {
-    expect(stripAnomalyKindPrefix("configuration", "configuration: FACTORY_EVENT_SECRET is unset")).toBe(
-      "FACTORY_EVENT_SECRET is unset",
-    );
+    expect(
+      stripAnomalyKindPrefix(
+        "configuration",
+        "configuration: FACTORY_EVENT_SECRET is unset",
+      ),
+    ).toBe("FACTORY_EVENT_SECRET is unset");
     expect(
       stripAnomalyKindPrefix(
         "dead_letter",
         "dead-lettered (chain, chain-run_123): UNIQUE constraint failed",
       ),
     ).toBe("chain, chain-run_123: UNIQUE constraint failed");
-    expect(stripAnomalyKindPrefix("proposal", "expired open proposal prop_123")).toBe(
-      "expired open proposal prop_123",
-    );
+    expect(
+      stripAnomalyKindPrefix("proposal", "expired open proposal prop_123"),
+    ).toBe("expired open proposal prop_123");
   });
 });
 
@@ -275,7 +334,12 @@ describe("Overview activity feed rendering (WM-100)", () => {
       entries: [
         entry({ seq: 4, runId: "run_cda2b3c0", from: "RUNNING", to: "FAILED" }),
         entry({ seq: 3, runId: "run_cda2b3c0", from: "LEASED", to: "RUNNING" }),
-        entry({ seq: 2, runId: "run_cda2b3c0", from: "PROPOSED", to: "LEASED" }),
+        entry({
+          seq: 2,
+          runId: "run_cda2b3c0",
+          from: "PROPOSED",
+          to: "LEASED",
+        }),
         entry({ seq: 1, runId: "run_other", from: null, to: "QUEUED" }),
       ],
     });
@@ -357,7 +421,10 @@ describe("Overview keyboard navigation (WM-292)", () => {
     const onNavigate = mock(() => {});
 
     try {
-      const view = renderOverview({ kind: "all" }, { onJumpEvents, onNavigate });
+      const view = renderOverview(
+        { kind: "all" },
+        { onJumpEvents, onNavigate },
+      );
       fireEvent.keyDown(document.body, { key: "1", metaKey: true });
       fireEvent.keyDown(document.body, { key: "2", ctrlKey: true });
       const input = document.createElement("input");
@@ -376,12 +443,17 @@ describe("Overview keyboard navigation (WM-292)", () => {
       baseStatus({
         expiredOpenProposals: ["prop_expired"],
         deadLettered: [
-          { source: "github", eventId: "evt_dead", lastError: "planner failed" },
+          {
+            source: "github",
+            eventId: "evt_dead",
+            lastError: "planner failed",
+          },
         ],
       }),
     );
     const requeue = mock(
-      (_source: string, _eventId: string) => new Promise<{ requeued: boolean }>(() => {}),
+      (_source: string, _eventId: string) =>
+        new Promise<{ requeued: boolean }>(() => {}),
     );
     api.requeue = requeue;
 
@@ -389,8 +461,12 @@ describe("Overview keyboard navigation (WM-292)", () => {
       const view = renderOverview();
       await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
 
-      const first = view.getByRole("button", { name: "expired open" }).closest('[tabindex="-1"]');
-      const second = view.getByRole("button", { name: /github.*planner failed/ }).closest('[tabindex="-1"]');
+      const first = view
+        .getByRole("button", { name: "expired open" })
+        .closest('[tabindex="-1"]');
+      const second = view
+        .getByRole("button", { name: /github.*planner failed/ })
+        .closest('[tabindex="-1"]');
       expect(first).toBeTruthy();
       expect(second).toBeTruthy();
 
@@ -402,7 +478,9 @@ describe("Overview keyboard navigation (WM-292)", () => {
       fireEvent.keyDown(document.body, { key: "." });
       expect(document.activeElement).toBe(second);
       fireEvent.keyDown(document.body, { key: "r" });
-      await waitFor(() => expect(requeue).toHaveBeenCalledWith("github", "evt_dead"));
+      await waitFor(() =>
+        expect(requeue).toHaveBeenCalledWith("github", "evt_dead"),
+      );
 
       fireEvent.keyDown(document.body, { key: "." });
       expect(document.activeElement).toBe(first);
@@ -434,7 +512,9 @@ describe("Overview anomaly deck (WM-95)", () => {
       expect(getByText(/ambiguous repo pin/)).toBeTruthy();
       const originId = queryByTitle("evt-789");
       expect(originId).toBeTruthy();
-      expect(originId?.parentElement?.textContent).toBe("origin github/evt-789");
+      expect(originId?.parentElement?.textContent).toBe(
+        "origin github/evt-789",
+      );
 
       // Raw id is demoted to secondary, copyable text rather than the primary label.
       const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
@@ -468,13 +548,19 @@ describe("Overview anomaly deck (WM-95)", () => {
 
     try {
       const view = renderOverview();
-      const reject = await waitFor(() => view.getByRole("button", { name: "Reject…" }));
+      const reject = await waitFor(() =>
+        view.getByRole("button", { name: "Reject…" }),
+      );
 
       expect(view.queryByRole("button", { name: "Dismiss" })).toBeNull();
       fireEvent.click(reject);
 
-      const confirm = view.getByRole("button", { name: "Reject proposal" }) as HTMLButtonElement;
-      const reasonInput = view.getByLabelText("Rejection reason") as HTMLInputElement;
+      const confirm = view.getByRole("button", {
+        name: "Reject proposal",
+      }) as HTMLButtonElement;
+      const reasonInput = view.getByLabelText(
+        "Rejection reason",
+      ) as HTMLInputElement;
       expect(reasonInput.placeholder).toMatch(/Reason \(required/i);
       expect(confirm.disabled).toBe(true);
 
@@ -504,7 +590,8 @@ describe("Overview anomaly deck (WM-95)", () => {
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
     const origJournal = api.journal;
-    api.status = async () => baseStatus({ expiredOpenProposals: ["prop_missing"] });
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: ["prop_missing"] });
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
@@ -539,8 +626,16 @@ describe("Overview anomaly deck (WM-95)", () => {
     api.status = async () =>
       baseStatus({
         deadLettered: [
-          ...eventIds.map((eventId) => ({ source: "chain", eventId, lastError: "duplicate key" })),
-          { source: "chain", eventId: "chain-run_timeout123456", lastError: "timeout" },
+          ...eventIds.map((eventId) => ({
+            source: "chain",
+            eventId,
+            lastError: "duplicate key",
+          })),
+          {
+            source: "chain",
+            eventId: "chain-run_timeout123456",
+            lastError: "timeout",
+          },
         ],
       });
     api.proposals = async () => ({ proposals: [] });
@@ -551,10 +646,14 @@ describe("Overview anomaly deck (WM-95)", () => {
     try {
       const view = renderOverview({ kind: "all" }, { onJumpEvents });
       const group = await waitFor(() =>
-        view.getByRole("button", { name: /3 dead-lettered.*chain.*duplicate key/ }),
+        view.getByRole("button", {
+          name: /3 dead-lettered.*chain.*duplicate key/,
+        }),
       );
 
-      expect(view.getByText(/Anomalies · 2 active issues · \(4 events\)/)).toBeTruthy();
+      expect(
+        view.getByText(/Anomalies · 2 active issues · \(4 events\)/),
+      ).toBeTruthy();
       expect(group.getAttribute("aria-expanded")).toBe("false");
       fireEvent.click(group);
       expect(group.getAttribute("aria-expanded")).toBe("true");
@@ -562,11 +661,16 @@ describe("Overview anomaly deck (WM-95)", () => {
       const firstEvent = view.getByTitle(eventIds[0]!);
       expect(firstEvent.textContent).toBe(shortId(eventIds[0]!));
       fireEvent.click(firstEvent);
-      expect(onJumpEvents).toHaveBeenCalledWith({ source: "chain", eventId: eventIds[0] });
+      expect(onJumpEvents).toHaveBeenCalledWith({
+        source: "chain",
+        eventId: eventIds[0],
+      });
 
       fireEvent.click(view.getByRole("button", { name: "Archive all" }));
       expect(view.getByText("Archive 3 dead-lettered events?")).toBeTruthy();
-      expect(view.getByRole("button", { name: "Archive 3 events" })).toBeTruthy();
+      expect(
+        view.getByRole("button", { name: "Archive 3 events" }),
+      ).toBeTruthy();
     } finally {
       api.status = originals.status;
       api.proposals = originals.proposals;
@@ -577,8 +681,14 @@ describe("Overview anomaly deck (WM-95)", () => {
 
   test("archives dead letters and releases stalled worker leases, removing both rows (WM-326)", async () => {
     const mutableApi = api as typeof api & {
-      archive: (source: string, eventId: string) => Promise<{ archived: boolean }>;
-      releaseWorker: (workerId: string, runId: string) => Promise<{ released: boolean; runId: string }>;
+      archive: (
+        source: string,
+        eventId: string,
+      ) => Promise<{ archived: boolean }>;
+      releaseWorker: (
+        workerId: string,
+        runId: string,
+      ) => Promise<{ released: boolean; runId: string }>;
     };
     const originals = {
       status: api.status,
@@ -593,22 +703,41 @@ describe("Overview anomaly deck (WM-95)", () => {
     api.status = async () =>
       baseStatus({
         deadLettered: deadLettered
-          ? [{ source: "github", eventId: "dead-1", lastError: "historical failure" }]
+          ? [
+              {
+                source: "github",
+                eventId: "dead-1",
+                lastError: "historical failure",
+              },
+            ]
           : [],
         stalledWorkers: stalled
-          ? [{ workerId: "worker-1", runId: "run-1", host: "lab", lastSeen: new Date(0).toISOString() }]
+          ? [
+              {
+                workerId: "worker-1",
+                runId: "run-1",
+                host: "lab",
+                lastSeen: new Date(0).toISOString(),
+              },
+            ]
           : [],
       });
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
     mutableApi.archive = async (source, eventId) => {
-      expect({ source, eventId }).toEqual({ source: "github", eventId: "dead-1" });
+      expect({ source, eventId }).toEqual({
+        source: "github",
+        eventId: "dead-1",
+      });
       deadLettered = false;
       return { archived: true };
     };
     mutableApi.releaseWorker = async (workerId, runId) => {
-      expect({ workerId, runId }).toEqual({ workerId: "worker-1", runId: "run-1" });
+      expect({ workerId, runId }).toEqual({
+        workerId: "worker-1",
+        runId: "run-1",
+      });
       stalled = false;
       return { released: true, runId };
     };
@@ -617,13 +746,19 @@ describe("Overview anomaly deck (WM-95)", () => {
       const view = renderOverview();
       await waitFor(() => view.getByRole("button", { name: "Archive" }));
 
-      expect(view.getByRole("button", { name: /github.*historical failure/ })).toBeTruthy();
+      expect(
+        view.getByRole("button", { name: /github.*historical failure/ }),
+      ).toBeTruthy();
       view.getByRole("button", { name: "Archive" }).click();
       await waitFor(() =>
-        expect(view.queryByRole("button", { name: /github.*historical failure/ })).toBeNull(),
+        expect(
+          view.queryByRole("button", { name: /github.*historical failure/ }),
+        ).toBeNull(),
       );
 
-      const releaseLease = await waitFor(() => view.getByRole("button", { name: "Release lease" }));
+      const releaseLease = await waitFor(() =>
+        view.getByRole("button", { name: "Release lease" }),
+      );
       releaseLease.click();
       await waitFor(() => view.getByText(/Doctor: All systems nominal/));
       expect(view.queryByText(/stalled worker worker-1/)).toBeNull();
@@ -675,8 +810,12 @@ describe("scopedCount / scopedTally (WM-147)", () => {
 
   test("repo tab counts named-repo rows only; unscoped rows stay out", () => {
     expect(scopedCount(rows, repo, { repos: (r) => r.repos })).toBe(2);
-    expect(scopedCount(rows, { kind: "all" }, { repos: (r) => r.repos })).toBe(4);
-    expect(scopedTally(rows, repo, { repos: (r) => r.repos, key: (r) => r.state })).toEqual({
+    expect(scopedCount(rows, { kind: "all" }, { repos: (r) => r.repos })).toBe(
+      4,
+    );
+    expect(
+      scopedTally(rows, repo, { repos: (r) => r.repos, key: (r) => r.state }),
+    ).toEqual({
       LEASED: 1,
       QUEUED: 1,
     });
@@ -684,14 +823,22 @@ describe("scopedCount / scopedTally (WM-147)", () => {
 
   test("in flight keeps LEASED/RUNNING and drops QUEUED even when repos match", () => {
     expect(
-      scopedTally(rows, { kind: "inflight" }, {
-        repos: (r) => r.repos,
-        state: (r) => r.state,
-        key: (r) => r.state,
-      }),
+      scopedTally(
+        rows,
+        { kind: "inflight" },
+        {
+          repos: (r) => r.repos,
+          state: (r) => r.state,
+          key: (r) => r.state,
+        },
+      ),
     ).toEqual({ LEASED: 2, RUNNING: 1 });
     expect(
-      scopedCount(rows, { kind: "inflight" }, { repos: (r) => r.repos, state: (r) => r.state }),
+      scopedCount(
+        rows,
+        { kind: "inflight" },
+        { repos: (r) => r.repos, state: (r) => r.state },
+      ),
     ).toBe(3);
   });
 });
@@ -749,17 +896,30 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     });
 
     try {
-      const { getByRole, queryByRole } = renderOverview({ kind: "repo", name: "bj29" });
+      const { getByRole, queryByRole } = renderOverview({
+        kind: "repo",
+        name: "bj29",
+      });
 
-      await waitFor(() => getByRole("button", { name: "events · human_needed: 1" }));
+      await waitFor(() =>
+        getByRole("button", { name: "events · human_needed: 1" }),
+      );
 
       // Negative: factory-wide totals must not appear as the clickable count.
-      expect(queryByRole("button", { name: "events · human_needed: 4" })).toBeNull();
-      expect(queryByRole("button", { name: "events · dead_lettered: 2" })).toBeNull();
-      expect(getByRole("button", { name: "events · dead_lettered: 0" })).toBeTruthy();
+      expect(
+        queryByRole("button", { name: "events · human_needed: 4" }),
+      ).toBeNull();
+      expect(
+        queryByRole("button", { name: "events · dead_lettered: 2" }),
+      ).toBeNull();
+      expect(
+        getByRole("button", { name: "events · dead_lettered: 0" }),
+      ).toBeTruthy();
       expect(getByRole("button", { name: "proposals · open: 2" })).toBeTruthy();
       expect(queryByRole("button", { name: "proposals · open: 5" })).toBeNull();
-      expect(getByRole("button", { name: "proposals · expired: 1" })).toBeTruthy();
+      expect(
+        getByRole("button", { name: "proposals · expired: 1" }),
+      ).toBeTruthy();
     } finally {
       restore();
     }
@@ -772,17 +932,28 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
         events: { admitted: 1 },
         workers: { live: 3, busy: 1, stale: 2 },
       },
-      events: [stubEvent({ eventId: "e1", status: "admitted", repos: ["bj29"] })],
+      events: [
+        stubEvent({ eventId: "e1", status: "admitted", repos: ["bj29"] }),
+      ],
     });
 
     try {
-      const { getByRole, queryByRole } = renderOverview({ kind: "repo", name: "bj29" });
+      const { getByRole, queryByRole } = renderOverview({
+        kind: "repo",
+        name: "bj29",
+      });
 
       await waitFor(() => getByRole("button", { name: /workers · live/ }));
 
-      expect(getByRole("button", { name: "workers · live · factory-wide: 3" })).toBeTruthy();
-      expect(getByRole("button", { name: "workers · busy · factory-wide: 1" })).toBeTruthy();
-      expect(getByRole("button", { name: "workers · stale · factory-wide: 2" })).toBeTruthy();
+      expect(
+        getByRole("button", { name: "workers · live · factory-wide: 3" }),
+      ).toBeTruthy();
+      expect(
+        getByRole("button", { name: "workers · busy · factory-wide: 1" }),
+      ).toBeTruthy();
+      expect(
+        getByRole("button", { name: "workers · stale · factory-wide: 2" }),
+      ).toBeTruthy();
       expect(queryByRole("button", { name: "workers · live: 3" })).toBeNull();
     } finally {
       restore();
@@ -796,17 +967,29 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
 
     try {
       const repo = renderOverview({ kind: "repo", name: "bj29" });
-      const repoActivity = await waitFor(() => repo.getByText("Activity").closest("button"));
+      const repoActivity = await waitFor(() =>
+        repo.getByText("Activity").closest("button"),
+      );
       const repoOutbox = repo.getByText("Outbox").closest("button");
-      expect(repoActivity?.textContent?.toLowerCase()).toMatch(/latest 0.*factory-wide/);
-      expect(repoOutbox?.textContent?.toLowerCase()).toMatch(/published results.*factory-wide/);
-      expect(repo.container.textContent).not.toMatch(/\/journal|\/outbox|GET \//);
+      expect(repoActivity?.textContent?.toLowerCase()).toMatch(
+        /latest 0.*factory-wide/,
+      );
+      expect(repoOutbox?.textContent?.toLowerCase()).toMatch(
+        /published results.*factory-wide/,
+      );
+      expect(repo.container.textContent).not.toMatch(
+        /\/journal|\/outbox|GET \//,
+      );
       repo.unmount();
 
       const all = renderOverview({ kind: "all" });
-      const allActivity = await waitFor(() => all.getByText("Activity").closest("button"));
+      const allActivity = await waitFor(() =>
+        all.getByText("Activity").closest("button"),
+      );
       const allOutbox = all.getByText("Outbox").closest("button");
-      expect(allActivity?.textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+      expect(allActivity?.textContent?.toLowerCase()).not.toMatch(
+        /factory-wide/,
+      );
       expect(allOutbox?.textContent?.toLowerCase()).not.toMatch(/factory-wide/);
       expect(all.queryByRole("status")).toBeNull();
     } finally {
@@ -837,7 +1020,9 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     });
 
     try {
-      const { getByRole, queryByRole, getAllByText } = renderOverview({ kind: "inflight" });
+      const { getByRole, queryByRole, getAllByText } = renderOverview({
+        kind: "inflight",
+      });
 
       await waitFor(() => getByRole("button", { name: "active · leased: 2" }));
 
@@ -861,12 +1046,16 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     try {
       const repo = renderOverview({ kind: "repo", name: "bj29" });
       await waitFor(() => repo.getByText(/Anomalies ·/));
-      expect(repo.getByText(/Anomalies ·/).textContent?.toLowerCase()).toMatch(/factory-wide/);
+      expect(repo.getByText(/Anomalies ·/).textContent?.toLowerCase()).toMatch(
+        /factory-wide/,
+      );
       repo.unmount();
 
       const all = renderOverview({ kind: "all" });
       await waitFor(() => all.getByText(/Anomalies ·/));
-      expect(all.getByText(/Anomalies ·/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+      expect(
+        all.getByText(/Anomalies ·/).textContent?.toLowerCase(),
+      ).not.toMatch(/factory-wide/);
     } finally {
       restore();
     }
@@ -932,8 +1121,17 @@ describe("buildAnomalyRows (WM-205)", () => {
       expiredOpenProposals: ["prop_1"],
       staleLeases: 2,
       unpublishedOutbox: 1,
-      deadLettered: [{ source: "github", eventId: "e99", lastError: "timeout" }],
-      stalledWorkers: [{ workerId: "w1", runId: "r1", host: "srv1", lastSeen: new Date().toISOString() }],
+      deadLettered: [
+        { source: "github", eventId: "e99", lastError: "timeout" },
+      ],
+      stalledWorkers: [
+        {
+          workerId: "w1",
+          runId: "r1",
+          host: "srv1",
+          lastSeen: new Date().toISOString(),
+        },
+      ],
       ambiguousOpenProposals: [{ runId: "r2", count: 3 }],
       noWorkers: true,
     };
@@ -989,7 +1187,10 @@ describe("buildAnomalyRows (WM-205)", () => {
       configuration: ["policyVersion is unknown"],
     };
 
-    const rows = buildAnomalyRows(anomalies, new Map(), { ...callbacks, onNavigate });
+    const rows = buildAnomalyRows(anomalies, new Map(), {
+      ...callbacks,
+      onNavigate,
+    });
 
     expect(rows.map((row) => [row.kind, row.text])).toEqual([
       ["schedule", "stopped schedule nightly: 3 intervals late"],
@@ -1005,7 +1206,10 @@ describe("buildAnomalyRows (WM-205)", () => {
     rows[2]!.links[0]!.go();
     expect(rows[0]!.links[0]!.label).toBe("View schedules");
     expect(rows[2]!.links[0]!.label).toBe("View proposals");
-    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual(["schedules", "proposals"]);
+    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual([
+      "schedules",
+      "proposals",
+    ]);
   });
 
   test("returns empty array for undefined anomalies", () => {
@@ -1081,7 +1285,12 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     api.journal = async () => ({
       head: 3,
       entries: [
-        entry({ seq: 3, runId: "run_term_1", from: "RUNNING", to: "COMPLETED" }),
+        entry({
+          seq: 3,
+          runId: "run_term_1",
+          from: "RUNNING",
+          to: "COMPLETED",
+        }),
         entry({ seq: 2, runId: "run_term_2", from: "RUNNING", to: "FAILED" }),
         entry({ seq: 1, runId: "run_term_3", from: "LEASED", to: "RUNNING" }),
       ],
@@ -1096,7 +1305,11 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
 
       await waitFor(() => getByText(/Worker Fleet Capacity/));
       expect(getByText(/3 live · 1 busy · 2 idle/)).toBeTruthy();
-      expect(getByRole("button", { name: "worker capacity: 1 running of 4, 2 queued" })).toBeTruthy();
+      expect(
+        getByRole("button", {
+          name: "worker capacity: 1 running of 4, 2 queued",
+        }),
+      ).toBeTruthy();
       expect(getByText("per-repo max_in_flight reached")).toBeTruthy();
       expect(getByText("light 1/3")).toBeTruthy();
 
@@ -1104,9 +1317,13 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
       expect(getByText("Recent outcomes")).toBeTruthy();
       expect(getByText("last 2")).toBeTruthy();
       const completedTick = getByTitle(/^run_term_1 · COMPLETED · /);
-      expect(completedTick.getAttribute("title")).toMatch(/^run_term_1 · COMPLETED · .+ ago$/);
+      expect(completedTick.getAttribute("title")).toMatch(
+        /^run_term_1 · COMPLETED · .+ ago$/,
+      );
       expect(getByTitle(/^run_term_2 · FAILED · /)).toBeTruthy();
-      expect(getByRole("generic", { name: "1 completed, 1 failed" })).toBeTruthy();
+      expect(
+        getByRole("generic", { name: "1 completed, 1 failed" }),
+      ).toBeTruthy();
       fireEvent.click(completedTick);
       expect(onJumpRun).toHaveBeenCalledWith("run_term_1");
 
@@ -1121,10 +1338,14 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
   });
 });
 
-
 describe("Overview waiting-on-you tile (WM-286)", () => {
   function withStatus(status: StatusView) {
-    const orig = { status: api.status, proposals: api.proposals, outbox: api.outbox, journal: api.journal };
+    const orig = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+    };
     api.status = async () => status;
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({ outbox: [] });
@@ -1145,7 +1366,11 @@ describe("Overview waiting-on-you tile (WM-286)", () => {
     const onNavigate = mock(() => {});
     try {
       const view = renderOverview({ kind: "all" }, { onNavigate });
-      const tile = await waitFor(() => view.getByRole("button", { name: /Waiting on you: 3 open inbox items/ }));
+      const tile = await waitFor(() =>
+        view.getByRole("button", {
+          name: /Waiting on you: 3 open inbox items/,
+        }),
+      );
       expect(tile.textContent).toContain("2 BLOCKED · 1 CI RED");
       expect(view.getByText("3 open")).toBeTruthy();
       fireEvent.click(tile);
@@ -1162,17 +1387,24 @@ describe("Overview waiting-on-you tile (WM-286)", () => {
     });
     try {
       const view = renderOverview();
-      const tile = await waitFor(() => view.getByRole("button", { name: /Waiting on you: 1 open inbox item/ }));
+      const tile = await waitFor(() =>
+        view.getByRole("button", { name: /Waiting on you: 1 open inbox item/ }),
+      );
       expect(tile.textContent).toContain("open + acked · 2 BLOCKED");
       expect(view.getByText("1 open · 1 acked")).toBeTruthy();
     } finally {
       restore();
     }
     cleanup();
-    const restoreZero = withStatus({ ...baseStatus(), inbox: { open: 0, acked: 0, byKind: {} } });
+    const restoreZero = withStatus({
+      ...baseStatus(),
+      inbox: { open: 0, acked: 0, byKind: {} },
+    });
     try {
       const view = renderOverview();
-      await waitFor(() => view.getByText("Nothing needs a decision right now."));
+      await waitFor(() =>
+        view.getByText("Nothing needs a decision right now."),
+      );
       expect(view.getByText("nothing waiting")).toBeTruthy();
     } finally {
       restoreZero();

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -3,7 +3,13 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard, refetchIntervals, useNow, useRequeuePoll } from "../hooks";
-import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
+import type {
+  JournalEntry,
+  EventFocus,
+  Proposal,
+  RunState,
+  StatusView,
+} from "../types";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import { EMPTY, formatBytes, formatRelative } from "../format";
@@ -47,7 +53,9 @@ export function SectionTitle({
     </span>
   );
   const metaNode = meta != null && (
-    <span className="ml-auto text-right text-[11px] text-(--text-faint)">{meta}</span>
+    <span className="ml-auto text-right text-[11px] text-(--text-faint)">
+      {meta}
+    </span>
   );
 
   if (collapsible) {
@@ -95,7 +103,10 @@ export function SegmentMeter({
   segments: Segment[];
   onSegment?: (key: string) => void;
 }) {
-  const total = segments.reduce((acc, s) => acc + (s.value > 0 ? s.value : 0), 0);
+  const total = segments.reduce(
+    (acc, s) => acc + (s.value > 0 ? s.value : 0),
+    0,
+  );
 
   if (total === 0) {
     return (
@@ -175,7 +186,9 @@ export function StatLegendItem({
       }`}
     >
       <StateIcon state={token} />
-      <span className={lit ? "" : "group-hover:text-(--text) group-hover:underline"}>
+      <span
+        className={lit ? "" : "group-hover:text-(--text) group-hover:underline"}
+      >
         {label.split(" · ").pop()}
       </span>
       <span
@@ -184,7 +197,9 @@ export function StatLegendItem({
       >
         {value}
       </span>
-      {factoryWide && <span className="text-[10px] text-(--text-faint)">(all)</span>}
+      {factoryWide && (
+        <span className="text-[10px] text-(--text-faint)">(all)</span>
+      )}
     </button>
   );
 }
@@ -210,7 +225,9 @@ export function StageCard({
   className?: string;
 }) {
   return (
-    <section className={`rounded-lg border border-(--border) bg-(--surface-1) p-3.5 ${className}`}>
+    <section
+      className={`rounded-lg border border-(--border) bg-(--surface-1) p-3.5 ${className}`}
+    >
       <SectionTitle
         title={index != null ? `${index}. ${title}` : title}
         meta={
@@ -316,7 +333,15 @@ export function groupJournalEntries(entries: JournalEntry[]): ActivityGroup[] {
 
 const DUPLICATE_STATE_REASONS: Partial<Record<string, Set<string>>> = {
   RUNNING: new Set(["run", "running", "start", "started"]),
-  COMPLETED: new Set(["complete", "completed", "ok", "success", "succeeded", "exit_0", "exit 0"]),
+  COMPLETED: new Set([
+    "complete",
+    "completed",
+    "ok",
+    "success",
+    "succeeded",
+    "exit_0",
+    "exit 0",
+  ]),
   FAILED: new Set(["fail", "failed"]),
   QUEUED: new Set(["queue", "queued"]),
   LEASED: new Set(["lease", "leased"]),
@@ -333,8 +358,9 @@ export function formatActivityGroup(group: ActivityGroup): {
 } {
   const normalizedReason = group.reason?.trim().toLowerCase() ?? null;
   const reason =
-    normalizedReason && !DUPLICATE_STATE_REASONS[group.to]?.has(normalizedReason)
-      ? group.reason?.trim() ?? null
+    normalizedReason &&
+    !DUPLICATE_STATE_REASONS[group.to]?.has(normalizedReason)
+      ? (group.reason?.trim() ?? null)
       : null;
   return {
     steps: group.count > 1 ? `+${group.count} steps` : null,
@@ -383,19 +409,26 @@ export function groupDeadLetters(deadLetters: DeadLetter[]): DeadLetterGroup[] {
     const key = JSON.stringify([event.source, errorMessage]);
     const group = groups.get(key);
     if (group) group.events.push(event);
-    else groups.set(key, { source: event.source, errorMessage, events: [event] });
+    else
+      groups.set(key, { source: event.source, errorMessage, events: [event] });
   }
   return [...groups.values()];
 }
 
 /** Remove a kind prefix when the adjacent badge already communicates it. */
-export function stripAnomalyKindPrefix(kind: AnomalyKind, text: string): string {
+export function stripAnomalyKindPrefix(
+  kind: AnomalyKind,
+  text: string,
+): string {
   const label = kind.replaceAll("_", "-");
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const colonPrefix = new RegExp(`^${escaped}\\s*:\\s*`, "i");
   if (colonPrefix.test(text)) return text.replace(colonPrefix, "");
 
-  const inflectedPrefix = new RegExp(`^${escaped}ed\\s*\\(([^)]*)\\)\\s*:?\\s*`, "i");
+  const inflectedPrefix = new RegExp(
+    `^${escaped}ed\\s*\\(([^)]*)\\)\\s*:?\\s*`,
+    "i",
+  );
   const match = text.match(inflectedPrefix);
   if (!match) return text;
   const remainder = text.slice(match[0].length);
@@ -425,20 +458,33 @@ export function buildAnomalyRows(
     rows.push({
       kind: "schedule",
       text: `stopped schedule ${schedule.loop}: ${schedule.error ? `error: ${schedule.error}` : `${schedule.intervalsLate} intervals late`}`,
-      links: [{ label: "View schedules", go: () => callbacks.onNavigate("schedules") }],
+      links: [
+        {
+          label: "View schedules",
+          go: () => callbacks.onNavigate("schedules"),
+        },
+      ],
     });
   }
   for (const proposal of anomalies.proposalsPilingUp ?? []) {
     rows.push({
       kind: "proposal",
       text: `proposals piling up for schedule ${proposal.loop}: ${proposal.count} open proposals (threshold ${proposal.threshold})`,
-      links: [{ label: "View proposals", go: () => callbacks.onNavigate("proposals") }],
+      links: [
+        {
+          label: "View proposals",
+          go: () => callbacks.onNavigate("proposals"),
+        },
+      ],
     });
   }
   for (const warning of anomalies.configuration ?? []) {
     rows.push({
       kind: "configuration",
-      text: stripAnomalyKindPrefix("configuration", `configuration: ${warning}`),
+      text: stripAnomalyKindPrefix(
+        "configuration",
+        `configuration: ${warning}`,
+      ),
       links: [],
     });
   }
@@ -449,7 +495,9 @@ export function buildAnomalyRows(
       text: `expired open proposal ${id}`,
       proposalId: id,
       proposal: proposalsById.get(id),
-      links: [{ label: "View proposal", go: () => callbacks.onJumpProposal(id) }],
+      links: [
+        { label: "View proposal", go: () => callbacks.onJumpProposal(id) },
+      ],
       dismissProposalId: id,
     });
   }
@@ -457,7 +505,9 @@ export function buildAnomalyRows(
     rows.push({
       kind: "lease",
       text: `stale leases: ${anomalies.staleLeases}`,
-      links: [{ label: "View leased runs", go: () => callbacks.onJumpRuns("LEASED") }],
+      links: [
+        { label: "View leased runs", go: () => callbacks.onJumpRuns("LEASED") },
+      ],
     });
   }
   if (anomalies.unpublishedOutbox > 0) {
@@ -467,7 +517,10 @@ export function buildAnomalyRows(
       links: [
         {
           label: "View outbox",
-          go: () => document.getElementById("outbox")?.scrollIntoView({ block: "start" }),
+          go: () =>
+            document
+              .getElementById("outbox")
+              ?.scrollIntoView({ block: "start" }),
         },
       ],
     });
@@ -480,9 +533,24 @@ export function buildAnomalyRows(
         group.events.length > 1
           ? `${group.events.length} dead-lettered · ${group.source} · ${group.errorMessage}`
           : `${group.source} · ${group.errorMessage}`,
-      links: [{ label: "View event", go: () => callbacks.onJumpEvents({ source: first.source, eventId: first.eventId }) }],
-      requeue: group.events.length === 1 ? { source: first.source, eventId: first.eventId } : undefined,
-      archive: group.events.length === 1 ? { source: first.source, eventId: first.eventId } : undefined,
+      links: [
+        {
+          label: "View event",
+          go: () =>
+            callbacks.onJumpEvents({
+              source: first.source,
+              eventId: first.eventId,
+            }),
+        },
+      ],
+      requeue:
+        group.events.length === 1
+          ? { source: first.source, eventId: first.eventId }
+          : undefined,
+      archive:
+        group.events.length === 1
+          ? { source: first.source, eventId: first.eventId }
+          : undefined,
       deadLetterGroup: group,
     });
   }
@@ -502,7 +570,10 @@ export function buildAnomalyRows(
       kind: "ambiguous",
       text: `ambiguous open proposals: ${a.count} proposals target run ${a.runId}`,
       links: [
-        { label: "View proposals", go: () => callbacks.onNavigate("proposals") },
+        {
+          label: "View proposals",
+          go: () => callbacks.onNavigate("proposals"),
+        },
         { label: "View run", go: () => callbacks.onJumpRun(a.runId) },
       ],
     });
@@ -521,7 +592,9 @@ export function buildAnomalyRows(
     rows.push({
       kind: "capacity",
       text: `${s?.runs.byState?.QUEUED ?? 0} queued runs and no live worker available to claim them`,
-      links: [{ label: "View workers", go: () => callbacks.onNavigate("workers") }],
+      links: [
+        { label: "View workers", go: () => callbacks.onNavigate("workers") },
+      ],
     });
   }
 
@@ -573,14 +646,22 @@ function RecentOutcomesStrip({
   now: number;
   onJumpRun: (runId: string) => void;
 }) {
-  const terminalStates = new Set(["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
+  const terminalStates = new Set([
+    "COMPLETED",
+    "FAILED",
+    "REFUSED",
+    "TIMED_OUT",
+    "CANCELLED",
+  ]);
   const outcomes = entries.filter((e) => terminalStates.has(e.to)).slice(0, 48);
 
   if (outcomes.length === 0) return null;
 
   // Chronological left-to-right (oldest -> newest at right)
   const chrono = outcomes.slice().reverse();
-  const completed = outcomes.filter((outcome) => outcome.to === "COMPLETED").length;
+  const completed = outcomes.filter(
+    (outcome) => outcome.to === "COMPLETED",
+  ).length;
   const failed = outcomes.filter((outcome) => outcome.to === "FAILED").length;
 
   return (
@@ -619,7 +700,10 @@ function RecentOutcomesStrip({
             );
           })}
         </div>
-        <div className="flex shrink-0 items-center gap-1.5 text-[11px] text-(--text-faint)" aria-label={`${completed} completed, ${failed} failed`}>
+        <div
+          className="flex shrink-0 items-center gap-1.5 text-[11px] text-(--text-faint)"
+          aria-label={`${completed} completed, ${failed} failed`}
+        >
           <span className="text-(--hue-ok)">●</span>
           <span>{completed} completed</span>
           <span>·</span>
@@ -636,7 +720,11 @@ function RecentOutcomesStrip({
  * then each 2 s poll asks only for `since=<last head>` and prepends what is
  * new — an append-only log consumed incrementally, capped at FEED_CAP shown.
  */
-function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isError: boolean } {
+function useJournalFeed(): {
+  entries: JournalEntry[];
+  isPending: boolean;
+  isError: boolean;
+} {
   const headRef = useRef(0);
   const [entries, setEntries] = useState<JournalEntry[]>([]);
   const query = useQuery({
@@ -662,7 +750,14 @@ function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isErro
   };
 }
 
-const ATTENTION_KEYS = new Set(["human_needed", "dead_lettered", "FAILED", "TIMED_OUT", "expired", "stale"]);
+const ATTENTION_KEYS = new Set([
+  "human_needed",
+  "dead_lettered",
+  "FAILED",
+  "TIMED_OUT",
+  "expired",
+  "stale",
+]);
 
 /**
  * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360, WM-205) — the unified StageCard dashboard:
@@ -699,14 +794,22 @@ export function Overview({
   const now = useNow();
   const queryClient = useQueryClient();
   const pollRequeue = useRequeuePoll(onJumpProposal);
-  const [rejectingProposalId, setRejectingProposalId] = useState<string | null>(null);
+  const [rejectingProposalId, setRejectingProposalId] = useState<string | null>(
+    null,
+  );
   const [rejectReason, setRejectReason] = useState("");
-  const [expandedDeadLetterGroups, setExpandedDeadLetterGroups] = useState<Set<string>>(new Set());
+  const [expandedDeadLetterGroups, setExpandedDeadLetterGroups] = useState<
+    Set<string>
+  >(new Set());
   const [bulkDeadLetterAction, setBulkDeadLetterAction] = useState<{
     action: "archive" | "requeue";
     group: DeadLetterGroup;
   } | null>(null);
-  const status = useQuery({ queryKey: ["status"], queryFn: api.status, ...refetchIntervals.primary });
+  const status = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.primary,
+  });
   const outbox = useQuery({
     queryKey: ["outbox"],
     queryFn: () => api.outbox(15),
@@ -732,7 +835,8 @@ export function Overview({
   const feed = useJournalFeed();
 
   const requeue = useMutation({
-    mutationFn: ({ source, eventId }: { source: string; eventId: string }) => api.requeue(source, eventId),
+    mutationFn: ({ source, eventId }: { source: string; eventId: string }) =>
+      api.requeue(source, eventId),
     onSuccess: async (_, { source, eventId }) => {
       await queryClient.invalidateQueries({ queryKey: ["status"] });
       notify(`Requeued event ${eventId}`, "ok");
@@ -747,8 +851,11 @@ export function Overview({
         | { kind: "archive"; source: string; eventId: string }
         | { kind: "release"; workerId: string; runId: string },
     ) => {
-      if (target.kind === "archive") return api.archive(target.source, target.eventId).then(() => undefined);
-      return api.releaseWorker(target.workerId, target.runId).then(() => undefined);
+      if (target.kind === "archive")
+        return api.archive(target.source, target.eventId).then(() => undefined);
+      return api
+        .releaseWorker(target.workerId, target.runId)
+        .then(() => undefined);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["status"] });
@@ -773,7 +880,9 @@ export function Overview({
         ),
       );
       return {
-        succeeded: group.events.filter((_, index) => results[index]?.status === "fulfilled"),
+        succeeded: group.events.filter(
+          (_, index) => results[index]?.status === "fulfilled",
+        ),
         failed: results.filter((result) => result.status === "rejected").length,
       };
     },
@@ -786,10 +895,15 @@ export function Overview({
           "err",
         );
       } else {
-        notify(`${action === "archive" ? "Archived" : "Requeued"} ${group.events.length} events`, "ok");
+        notify(
+          `${action === "archive" ? "Archived" : "Requeued"} ${group.events.length} events`,
+          "ok",
+        );
       }
       if (action === "requeue") {
-        await Promise.all(succeeded.map((event) => pollRequeue(event.source, event.eventId)));
+        await Promise.all(
+          succeeded.map((event) => pollRequeue(event.source, event.eventId)),
+        );
       }
     },
     onError: () => queryClient.invalidateQueries({ queryKey: ["status"] }),
@@ -798,7 +912,8 @@ export function Overview({
   const reject = useMutation({
     mutationFn: ({ proposalId, why }: { proposalId: string; why: string }) => {
       const trimmed = why.trim();
-      if (!trimmed) return Promise.reject(new Error("Rejection reason required"));
+      if (!trimmed)
+        return Promise.reject(new Error("Rejection reason required"));
       return api.reject(proposalId, trimmed);
     },
     onSuccess: async (_, { proposalId }) => {
@@ -825,7 +940,13 @@ export function Overview({
   };
 
   const submitReject = () => {
-    if (!rejectingProposalId || !rejectReason.trim() || reject.isPending || !connected) return;
+    if (
+      !rejectingProposalId ||
+      !rejectReason.trim() ||
+      reject.isPending ||
+      !connected
+    )
+      return;
     reject.mutate({ proposalId: rejectingProposalId, why: rejectReason });
   };
 
@@ -851,7 +972,17 @@ export function Overview({
       s,
       now,
     );
-  }, [anomalies, proposalsById, onJumpProposal, onJumpRuns, onJumpEvents, onJumpRun, onNavigate, s, now]);
+  }, [
+    anomalies,
+    proposalsById,
+    onJumpProposal,
+    onJumpRuns,
+    onJumpEvents,
+    onJumpRun,
+    onNavigate,
+    s,
+    now,
+  ]);
 
   const hasAnomalies = anomalyRows.length > 0;
   const deadLetterEventCount = anomalies?.deadLettered.length ?? 0;
@@ -872,7 +1003,8 @@ export function Overview({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey || goPrefixActive()) return;
+      if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey || goPrefixActive())
+        return;
 
       if ("12345".includes(e.key)) {
         e.preventDefault();
@@ -887,16 +1019,27 @@ export function Overview({
       );
       if (e.key === "." && anomalyRows.length > 0) {
         e.preventDefault();
-        anomalyRowRefs.current[(focusedIndex + 1) % anomalyRows.length]?.focus();
+        anomalyRowRefs.current[
+          (focusedIndex + 1) % anomalyRows.length
+        ]?.focus();
         return;
       }
 
       if (e.key === "r") {
         const focused = anomalyRows[focusedIndex];
-        if (!focused?.deadLetterGroup || !connected || requeue.isPending || bulkDeadLetter.isPending) return;
+        if (
+          !focused?.deadLetterGroup ||
+          !connected ||
+          requeue.isPending ||
+          bulkDeadLetter.isPending
+        )
+          return;
         e.preventDefault();
         if (focused.deadLetterGroup.events.length > 1) {
-          setBulkDeadLetterAction({ action: "requeue", group: focused.deadLetterGroup });
+          setBulkDeadLetterAction({
+            action: "requeue",
+            group: focused.deadLetterGroup,
+          });
         } else if (focused.requeue) {
           requeue.mutate(focused.requeue);
         }
@@ -905,10 +1048,29 @@ export function Overview({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [anomalyRows, bulkDeadLetter.isPending, connected, onJumpEvents, onJumpRuns, onNavigate, requeue]);
+  }, [
+    anomalyRows,
+    bulkDeadLetter.isPending,
+    connected,
+    onJumpEvents,
+    onJumpRuns,
+    onNavigate,
+    requeue,
+  ]);
 
-  const activeRunStates: RunState[] = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
-  const terminalRunStates: RunState[] = ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"];
+  const activeRunStates: RunState[] = [
+    "QUEUED",
+    "LEASED",
+    "RUNNING",
+    "VERIFYING",
+  ];
+  const terminalRunStates: RunState[] = [
+    "COMPLETED",
+    "FAILED",
+    "REFUSED",
+    "TIMED_OUT",
+    "CANCELLED",
+  ];
   const factoryWide = context.kind !== "all";
   const feedsUnscoped = context.kind === "repo";
   const eventTally =
@@ -938,16 +1100,27 @@ export function Overview({
           { repos: (p) => p.repos },
         )
       : (s?.proposals.expired ?? 0);
-  const eventValue = (k: string, factory: number) => (eventTally ? (eventTally[k] ?? 0) : factory);
-  const runValue = (k: RunState) => (runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0));
+  const eventValue = (k: string, factory: number) =>
+    eventTally ? (eventTally[k] ?? 0) : factory;
+  const runValue = (k: RunState) =>
+    runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0);
 
-  const groupedFeed = useMemo(() => groupJournalEntries(feed.entries), [feed.entries]);
+  const groupedFeed = useMemo(
+    () => groupJournalEntries(feed.entries),
+    [feed.entries],
+  );
 
   // Stage 1 metrics
   const activeEventKeys = (
     Object.keys(s?.events ?? {}) as (keyof typeof EVENT_STATUS_HUES)[]
   ).sort((a, b) => {
-    const order = ["admitted", "planned", "noop", "human_needed", "dead_lettered"];
+    const order = [
+      "admitted",
+      "planned",
+      "noop",
+      "human_needed",
+      "dead_lettered",
+    ];
     return order.indexOf(a) - order.indexOf(b);
   });
   const eventSegs: Segment[] = activeEventKeys.map((k) => ({
@@ -961,7 +1134,12 @@ export function Overview({
   // Stage 2 metrics
   const proposalSegs: Segment[] = [
     { key: "open", label: "open", value: proposalOpen, hue: "var(--hue-info)" },
-    { key: "expired", label: "expired", value: proposalExpired, hue: "var(--hue-warn)" },
+    {
+      key: "expired",
+      label: "expired",
+      value: proposalExpired,
+      hue: "var(--hue-warn)",
+    },
   ];
   const proposalTotal = proposalOpen + proposalExpired;
 
@@ -981,7 +1159,10 @@ export function Overview({
   const inflightTotal = inflightSegs.reduce((a, x) => a + x.value, 0);
   const finishedTotal = terminalSegs.reduce((a, x) => a + x.value, 0);
   const okTotal = terminalSegs.find((x) => x.key === "COMPLETED")?.value ?? 0;
-  const idleWorkers = Math.max(0, (s?.workers.live ?? 0) - (s?.workers.busy ?? 0));
+  const idleWorkers = Math.max(
+    0,
+    (s?.workers.live ?? 0) - (s?.workers.busy ?? 0),
+  );
   const capacity = s
     ? (s.capacity ?? {
         running: s.workers.busy,
@@ -1017,13 +1198,15 @@ export function Overview({
           className="mb-5 rounded-lg border p-3"
           style={{
             borderColor: "var(--hue-warn)",
-            backgroundColor: "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
+            backgroundColor:
+              "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
           }}
         >
           <div className="mb-2 flex items-center justify-between">
             <div className="flex items-center gap-2 text-[12px] font-semibold text-(--hue-warn)">
               <span className="size-2 rounded-full bg-(--hue-warn) motion-safe:animate-pulse" />
-              Anomalies · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
+              Anomalies · {anomalyRows.length} active issue
+              {anomalyRows.length === 1 ? "" : "s"}
               {deadLetterEventCount > 0
                 ? ` · (${deadLetterEventCount} event${deadLetterEventCount === 1 ? "" : "s"})`
                 : ""}
@@ -1033,8 +1216,12 @@ export function Overview({
           <div className="rounded-md border border-(--border) bg-(--surface-1)">
             {anomalyRows.map((a, i) => {
               const deadLetters = a.deadLetterGroup;
-              const deadLetterKey = deadLetters ? deadLetterGroupKey(deadLetters) : null;
-              const expanded = deadLetterKey ? expandedDeadLetterGroups.has(deadLetterKey) : false;
+              const deadLetterKey = deadLetters
+                ? deadLetterGroupKey(deadLetters)
+                : null;
+              const expanded = deadLetterKey
+                ? expandedDeadLetterGroups.has(deadLetterKey)
+                : false;
               const primaryLink = a.links[0];
               const quietActionClass =
                 "cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent) disabled:cursor-not-allowed disabled:opacity-40";
@@ -1061,24 +1248,35 @@ export function Overview({
                                   ? toggleDeadLetterGroup(deadLetters)
                                   : primaryLink?.go()
                               }
-                              aria-expanded={deadLetters.events.length > 1 ? expanded : undefined}
+                              aria-expanded={
+                                deadLetters.events.length > 1
+                                  ? expanded
+                                  : undefined
+                              }
                               className="flex min-w-0 cursor-pointer items-center gap-1.5 break-words text-left text-[12px] text-(--hue-warn) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent) sm:truncate"
                               title={a.text}
                             >
                               {deadLetters.events.length > 1 && (
-                                <span aria-hidden="true" className="w-3 shrink-0 text-(--text-faint)">
+                                <span
+                                  aria-hidden="true"
+                                  className="w-3 shrink-0 text-(--text-faint)"
+                                >
                                   {expanded ? "▾" : "▸"}
                                 </span>
                               )}
                               {deadLetters.events.length > 1 && (
                                 <>
-                                  <span>{deadLetters.events.length} dead-lettered</span>
+                                  <span>
+                                    {deadLetters.events.length} dead-lettered
+                                  </span>
                                   <span className="text-(--text-faint)">·</span>
                                 </>
                               )}
                               <span>{deadLetters.source}</span>
                               <span className="text-(--text-faint)">·</span>
-                              <span className="sm:truncate">{deadLetters.errorMessage}</span>
+                              <span className="sm:truncate">
+                                {deadLetters.errorMessage}
+                              </span>
                             </button>
                             {expanded && (
                               <ul className="mt-2 space-y-1 border-l border-(--border) pl-3">
@@ -1086,7 +1284,12 @@ export function Overview({
                                   <li key={`${event.source}:${event.eventId}`}>
                                     <button
                                       type="button"
-                                      onClick={() => onJumpEvents({ source: event.source, eventId: event.eventId })}
+                                      onClick={() =>
+                                        onJumpEvents({
+                                          source: event.source,
+                                          eventId: event.eventId,
+                                        })
+                                      }
                                       className="mono cursor-pointer text-[11px] text-(--text-dim) hover:text-(--text) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                                       title={event.eventId}
                                     >
@@ -1111,7 +1314,9 @@ export function Overview({
                               type="button"
                               className="mono cursor-pointer text-[11px] text-(--text-dim) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                               title={`${a.proposalId} — click to copy`}
-                              onClick={() => copyText(a.proposalId!, "proposal id")}
+                              onClick={() =>
+                                copyText(a.proposalId!, "proposal id")
+                              }
                             >
                               {shortId(a.proposalId)}
                             </button>
@@ -1120,13 +1325,18 @@ export function Overview({
                             <span className="text-(--text-faint)">·</span>
                             <span>
                               {a.proposal?.decision ?? EMPTY}
-                              {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
+                              {a.proposal?.reason
+                                ? ` — ${a.proposal.reason}`
+                                : ""}
                             </span>
                             <span className="text-(--text-faint)">·</span>
                             <span className="text-(--text-faint)">
                               origin {a.proposal?.eventSource ?? EMPTY}/
                               {a.proposal?.eventId ? (
-                                <span className="mono" title={a.proposal.eventId}>
+                                <span
+                                  className="mono"
+                                  title={a.proposal.eventId}
+                                >
                                   {shortId(a.proposal.eventId)}
                                 </span>
                               ) : (
@@ -1135,11 +1345,16 @@ export function Overview({
                             </span>
                             <span className="text-(--text-faint)">·</span>
                             {a.proposal?.created_at ? (
-                              <span className="mono text-(--text-faint)" title={a.proposal.created_at}>
+                              <span
+                                className="mono text-(--text-faint)"
+                                title={a.proposal.created_at}
+                              >
                                 {formatRelative(a.proposal.created_at, now)}
                               </span>
                             ) : (
-                              <span className="text-(--text-faint)">age {EMPTY}</span>
+                              <span className="text-(--text-faint)">
+                                age {EMPTY}
+                              </span>
                             )}
                           </div>
                         ) : primaryLink ? (
@@ -1190,7 +1405,12 @@ export function Overview({
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
-                              onClick={() => setBulkDeadLetterAction({ action: "archive", group: deadLetters })}
+                              onClick={() =>
+                                setBulkDeadLetterAction({
+                                  action: "archive",
+                                  group: deadLetters,
+                                })
+                              }
                             >
                               Archive all
                             </button>
@@ -1198,7 +1418,12 @@ export function Overview({
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
-                              onClick={() => setBulkDeadLetterAction({ action: "requeue", group: deadLetters })}
+                              onClick={() =>
+                                setBulkDeadLetterAction({
+                                  action: "requeue",
+                                  group: deadLetters,
+                                })
+                              }
                             >
                               Requeue all
                             </button>
@@ -1209,8 +1434,15 @@ export function Overview({
                               <button
                                 type="button"
                                 className={quietActionClass}
-                                disabled={!connected || resolveAnomaly.isPending}
-                                onClick={() => resolveAnomaly.mutate({ kind: "archive", ...a.archive! })}
+                                disabled={
+                                  !connected || resolveAnomaly.isPending
+                                }
+                                onClick={() =>
+                                  resolveAnomaly.mutate({
+                                    kind: "archive",
+                                    ...a.archive!,
+                                  })
+                                }
                               >
                                 Archive
                               </button>
@@ -1232,7 +1464,12 @@ export function Overview({
                             type="button"
                             className={quietActionClass}
                             disabled={!connected || resolveAnomaly.isPending}
-                            onClick={() => resolveAnomaly.mutate({ kind: "release", ...a.releaseWorker! })}
+                            onClick={() =>
+                              resolveAnomaly.mutate({
+                                kind: "release",
+                                ...a.releaseWorker!,
+                              })
+                            }
                           >
                             Release lease
                           </button>
@@ -1254,20 +1491,31 @@ export function Overview({
               );
             })}
           </div>
-          <VerbError error={resolveAnomaly.error ?? bulkDeadLetter.error ?? reject.error ?? requeue.error} />
+          <VerbError
+            error={
+              resolveAnomaly.error ??
+              bulkDeadLetter.error ??
+              reject.error ??
+              requeue.error
+            }
+          />
         </div>
       ) : (
         <div className="mb-5 flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-(--hue-ok)" />
-            <span className="font-medium text-(--text)">Doctor: All systems nominal</span>
+            <span className="font-medium text-(--text)">
+              Doctor: All systems nominal
+            </span>
           </div>
           <div className="flex items-center gap-2 text-[11px] text-(--text-faint)">
             <span>
               as of {formatRelative(new Date(status.dataUpdatedAt || now), now)}
             </span>
             <span>·</span>
-            <span>{feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}</span>
+            <span>
+              {feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}
+            </span>
           </div>
         </div>
       )}
@@ -1275,7 +1523,9 @@ export function Overview({
       {/* Band B: Unified Stage Cards (WM-205) */}
       {!s ? (
         <div className="mb-6 text-(--text-faint)">
-          {status.isError ? "Cannot reach the control API." : "Loading overview…"}
+          {status.isError
+            ? "Cannot reach the control API."
+            : "Loading overview…"}
         </div>
       ) : (
         <div className="mb-6 flex flex-col gap-4">
@@ -1311,13 +1561,17 @@ export function Overview({
                 </div>
               </>
             ) : (
-              <div className="text-[12px] text-(--text-faint)">no events yet</div>
+              <div className="text-[12px] text-(--text-faint)">
+                no events yet
+              </div>
             )}
 
             {/* Sub-row 2: Approval Gate */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                <span className="font-semibold text-(--text)">Approval Gate</span>
+                <span className="font-semibold text-(--text)">
+                  Approval Gate
+                </span>
                 <span className="mono text-(--text-dim)">
                   {proposalTotal > 0
                     ? `${proposalExpired > 0 ? `${proposalExpired} expired · ` : ""}${proposalOpen} open`
@@ -1351,7 +1605,9 @@ export function Overview({
                   </div>
                 </>
               ) : (
-                <div className="text-[12px] text-(--text-faint)">no proposals in gate</div>
+                <div className="text-[12px] text-(--text-faint)">
+                  no proposals in gate
+                </div>
               )}
             </div>
 
@@ -1360,7 +1616,9 @@ export function Overview({
             {s.inbox && (
               <div className="mt-3.5 border-t border-(--border) pt-2.5">
                 <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                  <span className="font-semibold text-(--text)">Waiting on you</span>
+                  <span className="font-semibold text-(--text)">
+                    Waiting on you
+                  </span>
                   <span className="mono text-(--text-dim)">
                     {s.inbox.open > 0
                       ? `${s.inbox.open} open${s.inbox.acked > 0 ? ` · ${s.inbox.acked} acked` : ""}`
@@ -1377,7 +1635,11 @@ export function Overview({
                 >
                   <span
                     className="display text-xl tabular-nums"
-                    style={s.inbox.open > 0 ? { color: "var(--hue-warn)" } : undefined}
+                    style={
+                      s.inbox.open > 0
+                        ? { color: "var(--hue-warn)" }
+                        : undefined
+                    }
                   >
                     {s.inbox.open}
                   </span>
@@ -1387,15 +1649,24 @@ export function Overview({
                           const kinds = Object.entries(s.inbox.byKind!)
                             .filter(([, n]) => n > 0)
                             .sort((a, b) => b[1] - a[1]);
-                          const total = kinds.reduce((sum, [, n]) => sum + n, 0);
+                          const total = kinds.reduce(
+                            (sum, [, n]) => sum + n,
+                            0,
+                          );
                           // byKind spans open + acked on the API; say so when the
                           // breakdown would not add up to the open headline.
-                          const prefix = total !== s.inbox!.open ? "open + acked · " : "";
-                          return prefix + kinds.map(([kind, n]) => `${n} ${kind}`).join(" · ");
+                          const prefix =
+                            total !== s.inbox!.open ? "open + acked · " : "";
+                          return (
+                            prefix +
+                            kinds.map(([kind, n]) => `${n} ${kind}`).join(" · ")
+                          );
                         })()
                       : "Nothing needs a decision right now."}
                   </span>
-                  <span className="mono text-[11px] text-(--text-faint)">g n →</span>
+                  <span className="mono text-[11px] text-(--text-faint)">
+                    g n →
+                  </span>
                 </button>
               </div>
             )}
@@ -1409,9 +1680,13 @@ export function Overview({
           >
             {/* Sub-row 1: Active In-Flight Workloads */}
             <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-              <span className="font-semibold text-(--text)">Active In-Flight Pipeline</span>
+              <span className="font-semibold text-(--text)">
+                Active In-Flight Pipeline
+              </span>
               {inflightTotal > 0 && (
-                <span className="mono text-(--text-dim)">{inflightTotal} active</span>
+                <span className="mono text-(--text-dim)">
+                  {inflightTotal} active
+                </span>
               )}
             </div>
             {inflightTotal > 0 ? (
@@ -1435,13 +1710,17 @@ export function Overview({
                 </div>
               </>
             ) : (
-              <div className="text-[12px] text-(--text-faint)">nothing in flight</div>
+              <div className="text-[12px] text-(--text-faint)">
+                nothing in flight
+              </div>
             )}
 
             {/* Sub-row 2: Outcomes */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                <span className="font-semibold text-(--text)">Terminal Outcomes</span>
+                <span className="font-semibold text-(--text)">
+                  Terminal Outcomes
+                </span>
                 <span className="mono text-(--text-dim)">
                   {finishedTotal > 0
                     ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} runs)`
@@ -1470,7 +1749,9 @@ export function Overview({
                   </div>
                 </>
               ) : (
-                <div className="text-[12px] text-(--text-faint)">no terminal runs</div>
+                <div className="text-[12px] text-(--text-faint)">
+                  no terminal runs
+                </div>
               )}
             </div>
 
@@ -1486,8 +1767,13 @@ export function Overview({
                   aria-label={`worker capacity${factoryWide ? " · factory-wide" : ""}: ${capacity!.running} running of ${capacity!.capacity}, ${capacity!.queued} queued`}
                   className="mono cursor-pointer rounded-full border border-(--border) bg-(--surface-2) px-2.5 py-1 text-(--text-dim) hover:text-(--text)"
                 >
-                  <strong className="text-(--text)">{capacity!.running}/{capacity!.capacity}</strong> capacity · {capacity!.queued} queued
-                  {capacity!.draining > 0 ? ` · ${capacity!.draining} draining` : ""}
+                  <strong className="text-(--text)">
+                    {capacity!.running}/{capacity!.capacity}
+                  </strong>{" "}
+                  capacity · {capacity!.queued} queued
+                  {capacity!.draining > 0
+                    ? ` · ${capacity!.draining} draining`
+                    : ""}
                 </button>
               </div>
               {capacity!.queued > 0 && capacity!.limitingFactor && (
@@ -1498,23 +1784,45 @@ export function Overview({
               {capacity!.classes.length > 0 && (
                 <div className="mb-2 flex flex-wrap gap-1.5 text-[11px] text-(--text-dim)">
                   {capacity!.classes.map((workerClass) => (
-                    <span key={workerClass.name} className="mono rounded-full bg-(--surface-2) px-2 py-0.5">
-                      {workerClass.name} {workerClass.running}/{workerClass.capacity}
+                    <span
+                      key={workerClass.name}
+                      className="mono rounded-full bg-(--surface-2) px-2 py-0.5"
+                    >
+                      {workerClass.name} {workerClass.running}/
+                      {workerClass.capacity}
                     </span>
                   ))}
                 </div>
               )}
               <div className="mb-1.5 mono text-[11px] text-(--text-dim)">
-                {s.workers.live} live · {s.workers.busy} busy · {idleWorkers} idle{s.workers.stale > 0 ? ` · ${s.workers.stale} stale` : ""}
+                {s.workers.live} live · {s.workers.busy} busy · {idleWorkers}{" "}
+                idle{s.workers.stale > 0 ? ` · ${s.workers.stale} stale` : ""}
               </div>
               <SegmentMeter
                 segments={[
-                  { key: "busy", label: "busy", value: s.workers.busy, hue: "var(--hue-info)" },
-                  { key: "idle", label: "idle", value: idleWorkers, hue: "var(--hue-ok)" },
-                  { key: "stale", label: "stale", value: s.workers.stale, hue: "var(--hue-warn)" },
+                  {
+                    key: "busy",
+                    label: "busy",
+                    value: s.workers.busy,
+                    hue: "var(--hue-info)",
+                  },
+                  {
+                    key: "idle",
+                    label: "idle",
+                    value: idleWorkers,
+                    hue: "var(--hue-ok)",
+                  },
+                  {
+                    key: "stale",
+                    label: "stale",
+                    value: s.workers.stale,
+                    hue: "var(--hue-warn)",
+                  },
                 ]}
                 onSegment={(status) =>
-                  jumpToWorkerHealth(status === "busy" || status === "stale" ? status : "live")
+                  jumpToWorkerHealth(
+                    status === "busy" || status === "stale" ? status : "live",
+                  )
                 }
               />
               <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
@@ -1565,7 +1873,9 @@ export function Overview({
               meta={
                 <span className="mono">
                   {s.artifacts.files} files · {formatBytes(s.artifacts.bytes)}
-                  {s.artifacts.orphans > 0 ? ` · ${s.artifacts.orphans} orphans` : ""}
+                  {s.artifacts.orphans > 0
+                    ? ` · ${s.artifacts.orphans} orphans`
+                    : ""}
                   {factoryWide ? " · factory-wide" : ""}
                 </span>
               }
@@ -1596,27 +1906,44 @@ export function Overview({
               {groupedFeed.map((group) => {
                 const row = formatActivityGroup(group);
                 return (
-                  <div key={group.seq} className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-(--border) py-1.5 last:border-0">
-                    <span className="mono shrink-0 text-(--text-faint)" title={group.at}>
+                  <div
+                    key={group.seq}
+                    className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-(--border) py-1.5 last:border-0"
+                  >
+                    <span
+                      className="mono shrink-0 text-(--text-faint)"
+                      title={group.at}
+                    >
                       {formatRelative(group.at, now)}
                     </span>
                     <span className="text-(--text-faint)">·</span>
-                    <JumpLink onClick={() => onJumpRun(group.runId)} title={group.runId} className="shrink-0">
+                    <JumpLink
+                      onClick={() => onJumpRun(group.runId)}
+                      title={group.runId}
+                      className="shrink-0"
+                    >
                       {shortId(group.runId)}
                     </JumpLink>
                     <span className="text-(--text-faint)">·</span>
                     <StateBadge state={group.to} />
                     {row.steps && (
-                      <span className="shrink-0 text-[11px] text-(--text-faint)" title={row.path}>
+                      <span
+                        className="shrink-0 text-[11px] text-(--text-faint)"
+                        title={row.path}
+                      >
                         {row.steps}
                       </span>
                     )}
                     <span className="text-(--text-faint)">·</span>
-                    <span className="shrink-0 text-(--text-faint)">by {shortId(group.actor)}</span>
+                    <span className="shrink-0 text-(--text-faint)">
+                      by {shortId(group.actor)}
+                    </span>
                     {row.reason && (
                       <>
                         <span className="text-(--text-faint)">·</span>
-                        <span className="min-w-0 break-words text-(--text-dim)">{row.reason}</span>
+                        <span className="min-w-0 break-words text-(--text-dim)">
+                          {row.reason}
+                        </span>
                       </>
                     )}
                   </div>
@@ -1640,12 +1967,22 @@ export function Overview({
                     : "Nothing published yet."}
               </div>
             ) : (
-              <div className="rounded-md border border-(--border) px-3 py-1" aria-live="off">
+              <div
+                className="rounded-md border border-(--border) px-3 py-1"
+                aria-live="off"
+              >
                 {(outbox.data?.outbox ?? []).map((o) => {
                   const type = String(o.event.type ?? "unknown event");
-                  const source = typeof o.event.source === "string" ? o.event.source : null;
-                  const eventId = typeof o.event.eventId === "string" ? o.event.eventId : null;
-                  const payload = (o.event.payload ?? {}) as Record<string, unknown>;
+                  const source =
+                    typeof o.event.source === "string" ? o.event.source : null;
+                  const eventId =
+                    typeof o.event.eventId === "string"
+                      ? o.event.eventId
+                      : null;
+                  const payload = (o.event.payload ?? {}) as Record<
+                    string,
+                    unknown
+                  >;
                   const summary =
                     typeof payload.outcome === "string"
                       ? payload.outcome
@@ -1656,7 +1993,10 @@ export function Overview({
                           : null;
 
                   return (
-                    <div key={o.seq} className="border-b border-(--border) py-1.5 last:border-0">
+                    <div
+                      key={o.seq}
+                      className="border-b border-(--border) py-1.5 last:border-0"
+                    >
                       <div className="flex items-baseline justify-between gap-3">
                         <div className="flex items-baseline gap-2 min-w-0 max-w-[75%]">
                           {source && eventId ? (
@@ -1668,7 +2008,10 @@ export function Overview({
                               {type}
                             </JumpLink>
                           ) : (
-                            <span className="truncate text-(--text-dim) font-medium" title={type}>
+                            <span
+                              className="truncate text-(--text-dim) font-medium"
+                              title={type}
+                            >
                               {type}
                             </span>
                           )}
@@ -1679,7 +2022,10 @@ export function Overview({
                           )}
                         </div>
                         {o.published_at ? (
-                          <span className="mono shrink-0 text-(--text-faint)" title={o.published_at}>
+                          <span
+                            className="mono shrink-0 text-(--text-faint)"
+                            title={o.published_at}
+                          >
                             {formatRelative(o.published_at, now)}
                           </span>
                         ) : (
@@ -1708,7 +2054,9 @@ export function Overview({
           }}
         >
           <p className="mb-4 text-[12px] text-(--text-dim)">
-            This will {bulkDeadLetterAction.action} all {bulkDeadLetterAction.group.events.length} events from {bulkDeadLetterAction.group.source} with this error.
+            This will {bulkDeadLetterAction.action} all{" "}
+            {bulkDeadLetterAction.group.events.length} events from{" "}
+            {bulkDeadLetterAction.group.source} with this error.
           </p>
           <VerbError error={bulkDeadLetter.error} />
           <div className="flex justify-end gap-2">
@@ -1719,7 +2067,9 @@ export function Overview({
               Cancel
             </Button>
             <Button
-              variant={bulkDeadLetterAction.action === "archive" ? "danger" : "primary"}
+              variant={
+                bulkDeadLetterAction.action === "archive" ? "danger" : "primary"
+              }
               disabled={!connected || bulkDeadLetter.isPending}
               onClick={() => bulkDeadLetter.mutate(bulkDeadLetterAction)}
             >
@@ -1740,7 +2090,8 @@ export function Overview({
             }}
           >
             <p className="mb-3 text-[12px] text-(--text-dim)">
-              Rejections are audit records. Explain why this proposal should not run.
+              Rejections are audit records. Explain why this proposal should not
+              run.
             </p>
             <label
               htmlFor="overview-rejection-reason"
@@ -1763,7 +2114,9 @@ export function Overview({
               </Button>
               <Button
                 variant="danger"
-                disabled={!rejectReason.trim() || reject.isPending || !connected}
+                disabled={
+                  !rejectReason.trim() || reject.isPending || !connected
+                }
                 onClick={submitReject}
               >
                 {reject.isPending ? "Rejecting…" : "Reject proposal"}

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -2,11 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { Projects } from "./Projects";
-import {
-  renderWithClient,
-  restoreApi,
-  withApi,
-} from "../test-render";
+import { renderWithClient, restoreApi, withApi } from "../test-render";
 import type { JanitorResult, RepoItem } from "../types";
 import { CONTEXT_STORAGE_KEY } from "../context";
 import { goPrefix } from "../goSequence";
@@ -59,7 +55,11 @@ function janitor(overrides: Partial<JanitorResult> = {}): JanitorResult {
 
 function renderProjects(focusRepoName: string | null = null) {
   return renderWithClient(
-    <Projects connected={true} focusRepoName={focusRepoName} onSelectRepo={noop} />,
+    <Projects
+      connected={true}
+      focusRepoName={focusRepoName}
+      onSelectRepo={noop}
+    />,
   );
 }
 
@@ -75,7 +75,10 @@ describe("Projects unscoped caption (WM-157)", () => {
   test("All context shows no factory-wide caption", async () => {
     window.location.hash = "#/projects";
     // Stale sessionStorage must not invent a caption — hash is the live source (same as App).
-    sessionStorage.setItem(CONTEXT_STORAGE_KEY, JSON.stringify({ openRepos: ["factory"], active: "factory" }));
+    sessionStorage.setItem(
+      CONTEXT_STORAGE_KEY,
+      JSON.stringify({ openRepos: ["factory"], active: "factory" }),
+    );
     await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
       const r = renderProjects();
       await waitFor(() => {
@@ -123,7 +126,13 @@ describe("Projects unscoped caption (WM-157)", () => {
       window.addEventListener("hashchange", swallow, true);
       try {
         window.location.hash = "#/projects?project=factory";
-        r.rerender(<Projects connected={true} focusRepoName={null} onSelectRepo={noop} />);
+        r.rerender(
+          <Projects
+            connected={true}
+            focusRepoName={null}
+            onSelectRepo={noop}
+          />,
+        );
       } finally {
         window.removeEventListener("hashchange", swallow, true);
       }
@@ -138,7 +147,8 @@ describe("Projects Clean Reclaimable Apply (WM-157)", () => {
     await withApi(
       {
         repos: async () => ({ repos: [repo()] }),
-        janitor: async (name: string) => janitor({ repo: name, reclaimable: [] }),
+        janitor: async (name: string) =>
+          janitor({ repo: name, reclaimable: [] }),
       },
       async () => {
         const r = await openJanitor();
@@ -146,7 +156,9 @@ describe("Projects Clean Reclaimable Apply (WM-157)", () => {
         await waitFor(() => {
           expect(r.getByText("0 reclaimable")).toBeTruthy();
         });
-        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        const apply = r.getByRole("button", {
+          name: "Clean Reclaimable Worktrees…",
+        });
         expect((apply as HTMLButtonElement).disabled).toBe(true);
         expect(r.getByText("Nothing to reclaim")).toBeTruthy();
         fireEvent.click(apply);
@@ -172,7 +184,9 @@ describe("Projects Clean Reclaimable Apply (WM-157)", () => {
         await waitFor(() => {
           expect(r.getByText("1 reclaimable")).toBeTruthy();
         });
-        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        const apply = r.getByRole("button", {
+          name: "Clean Reclaimable Worktrees…",
+        });
         expect((apply as HTMLButtonElement).disabled).toBe(false);
         expect(r.queryByText("Nothing to reclaim")).toBeNull();
         fireEvent.click(apply);
@@ -200,7 +214,9 @@ describe("Projects Clean Reclaimable Apply (WM-157)", () => {
         await waitFor(() => {
           expect(r.getByText("1 reclaimable")).toBeTruthy();
         });
-        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        const apply = r.getByRole("button", {
+          name: "Clean Reclaimable Worktrees…",
+        });
         expect((apply as HTMLButtonElement).disabled).toBe(true);
         expect(r.getByText(/Apply is disabled: report-only repo/)).toBeTruthy();
         fireEvent.click(apply);
@@ -236,7 +252,9 @@ describe("Projects copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderProjects("factory");
-        const pathBtn = await r.findByRole("button", { name: "Copy repo path (c p)" });
+        const pathBtn = await r.findByRole("button", {
+          name: "Copy repo path (c p)",
+        });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
         expect(pathBtn.getAttribute("title")).toBe("Copy repo path · c p");
@@ -315,14 +333,24 @@ describe("Projects quick dispatch and GitHub chords (WM-294)", () => {
         const r = renderProjects("factory");
         await r.findByText("Quick Dispatch (Agent Tasks)");
 
-        expect(r.getByRole("button", { name: "Triage Scan" }).textContent).toContain("d t");
-        expect(r.getByRole("button", { name: "Status Report" }).textContent).toContain("d s");
-        expect(r.getByRole("button", { name: "Janitor Scan" }).textContent).toContain("d j");
-        expect(r.getByRole("link", { name: "GitHub" }).textContent).toContain("g h");
+        expect(
+          r.getByRole("button", { name: "Triage Scan" }).textContent,
+        ).toContain("d t");
+        expect(
+          r.getByRole("button", { name: "Status Report" }).textContent,
+        ).toContain("d s");
+        expect(
+          r.getByRole("button", { name: "Janitor Scan" }).textContent,
+        ).toContain("d j");
+        expect(r.getByRole("link", { name: "GitHub" }).textContent).toContain(
+          "g h",
+        );
 
         fireEvent.keyDown(document.body, { key: "g" });
         fireEvent.keyDown(document.body, { key: "h" });
-        expect(opened).toEqual([["https://github.com/watt-mind/factory", "_blank"]]);
+        expect(opened).toEqual([
+          ["https://github.com/watt-mind/factory", "_blank"],
+        ]);
       });
     } finally {
       window.open = originalOpen;
@@ -337,14 +365,17 @@ describe("Projects quick dispatch and GitHub chords (WM-294)", () => {
       return null;
     }) as typeof window.open;
     try {
-      await withApi({ repos: async () => ({ repos: [repo({ github: null })] }) }, async () => {
-        const r = renderProjects("factory");
-        await r.findByText("Quick Dispatch (Agent Tasks)");
-        fireEvent.keyDown(document.body, { key: "g" });
-        fireEvent.keyDown(document.body, { key: "h" });
-        expect(opens).toBe(0);
-        expect(r.queryByRole("link", { name: "GitHub" })).toBeNull();
-      });
+      await withApi(
+        { repos: async () => ({ repos: [repo({ github: null })] }) },
+        async () => {
+          const r = renderProjects("factory");
+          await r.findByText("Quick Dispatch (Agent Tasks)");
+          fireEvent.keyDown(document.body, { key: "g" });
+          fireEvent.keyDown(document.body, { key: "h" });
+          expect(opens).toBe(0);
+          expect(r.queryByRole("link", { name: "GitHub" })).toBeNull();
+        },
+      );
     } finally {
       window.open = originalOpen;
     }
@@ -369,20 +400,44 @@ describe("Projects toolbar counts and ordering (WM-560)", () => {
         await r.findByText("a-dispatch");
 
         const tabs = r.getAllByRole("tab");
-        const counts = tabs.map((tab) => Number(tab.querySelector(".tabular-nums")?.textContent));
+        const counts = tabs.map((tab) =>
+          Number(tab.querySelector(".tabular-nums")?.textContent),
+        );
         expect(counts).toEqual([4, 2, 2]);
         expect(counts[1] + counts[2]).toBe(counts[0]);
 
         const rowNames = () =>
-          Array.from(r.container.querySelectorAll("tbody tr td:first-child")).map((cell) => cell.textContent);
-        expect(rowNames()).toEqual(["a-dispatch", "z-dispatch", "a-report", "z-report"]);
+          Array.from(
+            r.container.querySelectorAll("tbody tr td:first-child"),
+          ).map((cell) => cell.textContent);
+        expect(rowNames()).toEqual([
+          "a-dispatch",
+          "z-dispatch",
+          "a-report",
+          "z-report",
+        ]);
 
         fireEvent.click(r.getByRole("button", { name: "Name" }));
-        expect(rowNames()).toEqual(["a-dispatch", "a-report", "z-dispatch", "z-report"]);
+        expect(rowNames()).toEqual([
+          "a-dispatch",
+          "a-report",
+          "z-dispatch",
+          "z-report",
+        ]);
         fireEvent.click(r.getByRole("button", { name: "Name" }));
-        expect(rowNames()).toEqual(["z-report", "z-dispatch", "a-report", "a-dispatch"]);
+        expect(rowNames()).toEqual([
+          "z-report",
+          "z-dispatch",
+          "a-report",
+          "a-dispatch",
+        ]);
         fireEvent.click(r.getByRole("button", { name: "Name" }));
-        expect(rowNames()).toEqual(["a-dispatch", "z-dispatch", "a-report", "z-report"]);
+        expect(rowNames()).toEqual([
+          "a-dispatch",
+          "z-dispatch",
+          "a-report",
+          "z-report",
+        ]);
       },
     );
   });
@@ -404,7 +459,9 @@ describe("Projects toolbar counts and ordering (WM-560)", () => {
         const r = renderProjects();
         await r.findByText("factory");
         const scriptsCell = r.container.querySelector("tbody tr td:last-child");
-        const placeholder = scriptsCell?.querySelector("span.text-\\(--text-faint\\)");
+        const placeholder = scriptsCell?.querySelector(
+          "span.text-\\(--text-faint\\)",
+        );
         expect(placeholder?.textContent).toBe("—");
       },
     );
@@ -449,17 +506,23 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
       expect(tabs[0].getAttribute("aria-selected")).toBe("true");
 
       act(() => {
-        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "]", bubbles: true }));
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "]", bubbles: true }),
+        );
       });
       expect(tabs[1].getAttribute("aria-selected")).toBe("true");
 
       act(() => {
-        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "]", bubbles: true }));
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "]", bubbles: true }),
+        );
       });
       expect(tabs[2].getAttribute("aria-selected")).toBe("true");
 
       act(() => {
-        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "[", bubbles: true }));
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "[", bubbles: true }),
+        );
       });
       expect(tabs[1].getAttribute("aria-selected")).toBe("true");
     });
@@ -486,7 +549,9 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
 
         // Key 2 -> Dispatchable
         act(() => {
-          document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "2", bubbles: true }));
+          document.body.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "2", bubbles: true }),
+          );
         });
         expect(tabs[1].getAttribute("aria-selected")).toBe("true");
         expect(r.getByText("r-dispatch")).toBeTruthy();
@@ -494,7 +559,9 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
 
         // Key 3 -> Report-Only
         act(() => {
-          document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "3", bubbles: true }));
+          document.body.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "3", bubbles: true }),
+          );
         });
         expect(tabs[2].getAttribute("aria-selected")).toBe("true");
         expect(r.queryByText("r-dispatch")).toBeNull();
@@ -502,7 +569,9 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
 
         // Key 1 -> All
         act(() => {
-          document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "1", bubbles: true }));
+          document.body.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "1", bubbles: true }),
+          );
         });
         expect(tabs[0].getAttribute("aria-selected")).toBe("true");
         expect(r.getByText("r-dispatch")).toBeTruthy();
@@ -541,11 +610,12 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
       goPrefix.armedAt = Date.now();
 
       act(() => {
-        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "2", bubbles: true }));
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "2", bubbles: true }),
+        );
       });
       expect(tabs[0].getAttribute("aria-selected")).toBe("true");
       expect(tabs[1].getAttribute("aria-selected")).toBe("false");
     });
   });
 });
-

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -19,7 +19,10 @@ const PROJECT_MODES = ["ALL", "DISPATCHABLE", "REPORT_ONLY"] as const;
 type ProjectMode = (typeof PROJECT_MODES)[number];
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 import {
   Button,
@@ -38,31 +41,59 @@ import {
   notify,
 } from "../components/ui";
 
-const projectTarget = (repo: RepoItem) => repo.project || repo.github || repo.path;
+const projectTarget = (repo: RepoItem) =>
+  repo.project || repo.github || repo.path;
 const worktreeScripts = (repo: RepoItem) =>
-  [repo.hasWorktreeUp && "up", repo.hasWorktreeDown && "down", repo.hasWorktreeWarm && "warm"]
+  [
+    repo.hasWorktreeUp && "up",
+    repo.hasWorktreeDown && "down",
+    repo.hasWorktreeWarm && "warm",
+  ]
     .filter(Boolean)
     .join(" · ");
 
 const defaultProjectOrder = (a: RepoItem, b: RepoItem) =>
   Number(a.reportOnly) - Number(b.reportOnly) ||
-  a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" });
+  a.name.localeCompare(b.name, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
 
 const PROJECTS_SORT: DisplayConfig<RepoItem> = {
   view: "projects-table-sort",
   groups: [],
   sorts: [
     { key: "name", label: "Name", get: (repo) => repo.name, column: "name" },
-    { key: "team", label: "Team", get: (repo) => repo.team ?? "", column: "team" },
-    { key: "target", label: "Project / GitHub", get: projectTarget, column: "target" },
-    { key: "mode", label: "Mode", get: (repo) => Number(repo.reportOnly), column: "mode" },
+    {
+      key: "team",
+      label: "Team",
+      get: (repo) => repo.team ?? "",
+      column: "team",
+    },
+    {
+      key: "target",
+      label: "Project / GitHub",
+      get: projectTarget,
+      column: "target",
+    },
+    {
+      key: "mode",
+      label: "Mode",
+      get: (repo) => Number(repo.reportOnly),
+      column: "mode",
+    },
     {
       key: "base",
       label: "Base",
       get: (repo) => `${repo.base}:${repo.deployBranch ?? ""}`,
       column: "base",
     },
-    { key: "scripts", label: "Worktree Scripts", get: worktreeScripts, column: "scripts" },
+    {
+      key: "scripts",
+      label: "Worktree Scripts",
+      get: worktreeScripts,
+      column: "scripts",
+    },
   ],
   columns: [
     { key: "name", label: "Name" },
@@ -76,7 +107,9 @@ const PROJECTS_SORT: DisplayConfig<RepoItem> = {
 
 /** Live operator context from the hash — same source App uses. Read on every render: context-tab switches replaceState and do not fire hashchange. Do not read sessionStorage: stale `active` must not caption All. */
 function operatorContext(): OperatorContext {
-  return contextFromProject(hashProject(typeof window === "undefined" ? "" : window.location.hash));
+  return contextFromProject(
+    hashProject(typeof window === "undefined" ? "" : window.location.hash),
+  );
 }
 
 /** Projects view (OPS-300 + OPS-362): configured factory repositories and janitor maintenance. */
@@ -143,7 +176,10 @@ export function Projects({
     }),
     [repos],
   );
-  const defaultOrdered = useMemo(() => repos.slice().sort(defaultProjectOrder), [repos]);
+  const defaultOrdered = useMemo(
+    () => repos.slice().sort(defaultProjectOrder),
+    [repos],
+  );
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -160,10 +196,16 @@ export function Projects({
     });
   }, [defaultOrdered, filter, filterMode]);
   const [sort, setSort] = useState(() => defaultDisplayState(PROJECTS_SORT));
-  const visible = useMemo(() => sortRows(filtered, PROJECTS_SORT, sort), [filtered, sort]);
+  const visible = useMemo(
+    () => sortRows(filtered, PROJECTS_SORT, sort),
+    [filtered, sort],
+  );
 
   const selectedName = focusRepoName;
-  const selectedIndex = useMemo(() => visible.findIndex((r) => r.name === selectedName), [visible, selectedName]);
+  const selectedIndex = useMemo(
+    () => visible.findIndex((r) => r.name === selectedName),
+    [visible, selectedName],
+  );
   const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
 
   // Reset janitor results when selected repo changes
@@ -176,7 +218,9 @@ export function Projects({
   }, [selectedName]);
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
   useEffect(() => {
@@ -202,13 +246,21 @@ export function Projects({
         pendingC.current = Date.now();
       },
       p: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyText(sel.path, "repo path");
           pendingC.current = 0;
         }
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -222,7 +274,9 @@ export function Projects({
     onSuccess: (res) => {
       setDryResult(res);
       setApplyResult(null);
-      notify(`Dry run complete: ${res.reclaimable.length} reclaimable worktrees found`);
+      notify(
+        `Dry run complete: ${res.reclaimable.length} reclaimable worktrees found`,
+      );
     },
     onError: (err: ApiError) => {
       notify(`Dry run failed: ${err.message}`, "err");
@@ -246,7 +300,15 @@ export function Projects({
 
   // Quick Dispatch mutation for factory agent events
   const quickDispatchMutation = useMutation({
-    mutationFn: async ({ type, payload, label }: { type: string; payload: Record<string, unknown>; label: string }) => {
+    mutationFn: async ({
+      type,
+      payload,
+      label,
+    }: {
+      type: string;
+      payload: Record<string, unknown>;
+      label: string;
+    }) => {
       return { label, res: await api.injectEvent(type, payload) };
     },
     onSuccess: (data) => {
@@ -266,7 +328,11 @@ export function Projects({
       if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey || e.repeat) return;
       const now = Date.now();
 
-      if (pendingGitHub.current > 0 && now - pendingGitHub.current < 800 && e.key === "h") {
+      if (
+        pendingGitHub.current > 0 &&
+        now - pendingGitHub.current < 800 &&
+        e.key === "h"
+      ) {
         pendingGitHub.current = 0;
         if (!sel?.github) return;
         e.preventDefault();
@@ -310,7 +376,8 @@ export function Projects({
     }
 
     window.addEventListener("keydown", onChord, { capture: true });
-    return () => window.removeEventListener("keydown", onChord, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onChord, { capture: true });
   }, [connected, quickDispatchMutation.isPending, sel]);
 
   // Context actions for ⌘K palette
@@ -378,7 +445,8 @@ export function Projects({
         ? [
             {
               label: `Open ${r.name} on GitHub`,
-              run: () => window.open(`https://github.com/${r.github}`, "_blank"),
+              run: () =>
+                window.open(`https://github.com/${r.github}`, "_blank"),
             },
           ]
         : []),
@@ -398,7 +466,11 @@ export function Projects({
               subject={{ label: "Projects", plural: true }}
             />
             <div className="mb-3 flex flex-wrap items-center gap-2">
-              <div className="flex min-w-0 flex-1 flex-wrap gap-1 text-[12px]" role="tablist" aria-label="Project mode">
+              <div
+                className="flex min-w-0 flex-1 flex-wrap gap-1 text-[12px]"
+                role="tablist"
+                aria-label="Project mode"
+              >
                 {PROJECT_MODES.map((mode, idx) => (
                   <button
                     key={mode}
@@ -412,9 +484,18 @@ export function Projects({
                         : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
                     }`}
                   >
-                    {mode === "ALL" ? "All" : mode === "DISPATCHABLE" ? "Dispatchable" : "Report-Only"}
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">{modeCounts[mode]}</span>
-                    <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
+                    {mode === "ALL"
+                      ? "All"
+                      : mode === "DISPATCHABLE"
+                        ? "Dispatchable"
+                        : "Report-Only"}
+                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                      {modeCounts[mode]}
+                    </span>
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                    >
                       {idx + 1}
                     </span>
                   </button>
@@ -434,13 +515,19 @@ export function Projects({
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {PROJECTS_SORT.columns.map((column) => {
-                const field = PROJECTS_SORT.sorts.find((candidate) => candidate.column === column.key)!;
+                const field = PROJECTS_SORT.sorts.find(
+                  (candidate) => candidate.column === column.key,
+                )!;
                 return (
                   <Th
                     key={column.key}
                     label={column.label}
                     dir={sort.sortBy === field.key ? sort.sortDir : null}
-                    onSort={() => setSort((state) => cycleColumnSort(PROJECTS_SORT, state, column.key))}
+                    onSort={() =>
+                      setSort((state) =>
+                        cycleColumnSort(PROJECTS_SORT, state, column.key),
+                      )
+                    }
                   />
                 );
               })}
@@ -455,7 +542,9 @@ export function Projects({
                   aria-selected={i === selectedIndex}
                   className={`cursor-pointer hover:bg-(--surface-1) ${i === selectedIndex ? "row-selected" : ""}`}
                 >
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-semibold text-(--text)">{r.name}</td>
+                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-semibold text-(--text)">
+                    {r.name}
+                  </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                     {r.team ? (
                       <span className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11px] font-medium text-(--text-dim)">
@@ -475,11 +564,13 @@ export function Projects({
                         r.reportOnly
                           ? {
                               color: "var(--text-faint)",
-                              background: "color-mix(in oklch, var(--text-faint) 12%, transparent)",
+                              background:
+                                "color-mix(in oklch, var(--text-faint) 12%, transparent)",
                             }
                           : {
                               color: "var(--hue-ok)",
-                              background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
+                              background:
+                                "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
                             }
                       }
                     >
@@ -491,7 +582,9 @@ export function Projects({
                     {r.deployBranch ? ` → ${r.deployBranch}` : ""}
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-faint)">
-                    {worktreeScripts(r) || <span className="text-(--text-faint)">—</span>}
+                    {worktreeScripts(r) || (
+                      <span className="text-(--text-faint)">—</span>
+                    )}
                   </td>
                 </tr>
               );
@@ -533,13 +626,18 @@ export function Projects({
                 className="rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 py-1 text-[12px] font-medium text-(--text) transition-colors hover:bg-(--surface-3)"
               >
                 GitHub
-                <span aria-hidden="true" className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70">
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                >
                   g h
                 </span>
               </a>
             ) : null
           }
-          utility={<CopyActions id={sel.path} idLabel="repo path" idChord="c p" />}
+          utility={
+            <CopyActions id={sel.path} idLabel="repo path" idChord="c p" />
+          }
           close={<Button onClick={() => onSelectRepo(null)}>Close</Button>}
         >
           <div className="space-y-4">
@@ -549,7 +647,8 @@ export function Projects({
                   className="mb-2 inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
                   style={{
                     color: "var(--hue-warn)",
-                    background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
+                    background:
+                      "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
                   }}
                 >
                   <span className="size-1.5 rounded-full bg-(--hue-warn)" />
@@ -569,7 +668,10 @@ export function Projects({
                   }
                 >
                   Triage Scan
-                  <span aria-hidden="true" className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70">
+                  <span
+                    aria-hidden="true"
+                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                  >
                     d t
                   </span>
                 </Button>
@@ -585,7 +687,10 @@ export function Projects({
                   }
                 >
                   Status Report
-                  <span aria-hidden="true" className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70">
+                  <span
+                    aria-hidden="true"
+                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                  >
                     d s
                   </span>
                 </Button>
@@ -601,13 +706,17 @@ export function Projects({
                   }
                 >
                   Janitor Scan
-                  <span aria-hidden="true" className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70">
+                  <span
+                    aria-hidden="true"
+                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                  >
                     d j
                   </span>
                 </Button>
               </div>
               <div className="mt-1.5 text-[11px] text-(--text-faint)">
-                Injects an event into the queue for worker lease with live trace streaming.
+                Injects an event into the queue for worker lease with live trace
+                streaming.
               </div>
             </Section>
 
@@ -643,23 +752,37 @@ export function Projects({
                 />
               )}
               <KV k="Base branch" v={sel.base} />
-              {sel.deployBranch && <KV k="Deploy branch" v={sel.deployBranch} />}
+              {sel.deployBranch && (
+                <KV k="Deploy branch" v={sel.deployBranch} />
+              )}
               <KV
                 k="Execution mode"
                 v={
                   <span
                     className="font-medium"
-                    style={{ color: sel.reportOnly ? "var(--text-faint)" : "var(--hue-ok)" }}
+                    style={{
+                      color: sel.reportOnly
+                        ? "var(--text-faint)"
+                        : "var(--hue-ok)",
+                    }}
                   >
-                    {sel.reportOnly ? "Report Only (Watched)" : "Autonomous Dispatchable"}
+                    {sel.reportOnly
+                      ? "Report Only (Watched)"
+                      : "Autonomous Dispatchable"}
                   </span>
                 }
               />
-              {sel.maxInFlight !== null && <KV k="Max in flight" v={sel.maxInFlight} />}
-              {sel.worktreeRoot && <KV k="Worktrees root" v={sel.worktreeRoot} />}
+              {sel.maxInFlight !== null && (
+                <KV k="Max in flight" v={sel.maxInFlight} />
+              )}
+              {sel.worktreeRoot && (
+                <KV k="Worktrees root" v={sel.worktreeRoot} />
+              )}
               {sel.verify && (
                 <div className="mt-2">
-                  <div className="text-[11px] text-(--text-faint)">Verification Command</div>
+                  <div className="text-[11px] text-(--text-faint)">
+                    Verification Command
+                  </div>
                   <pre className="mono mt-1 overflow-auto rounded bg-(--surface-0) p-2 text-[11px] text-(--text-dim)">
                     {sel.verify}
                   </pre>
@@ -673,36 +796,59 @@ export function Projects({
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeUp ? 1 : 0.4 }}
                 >
-                  <div className="text-[11px] text-(--text-faint) uppercase">Up Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeUp ? "Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">
+                    Up Script
+                  </div>
+                  <div className="font-semibold">
+                    {sel.hasWorktreeUp ? "Present" : "None"}
+                  </div>
                 </div>
                 <div
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeDown ? 1 : 0.4 }}
                 >
-                  <div className="text-[11px] text-(--text-faint) uppercase">Down Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeDown ? "Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">
+                    Down Script
+                  </div>
+                  <div className="font-semibold">
+                    {sel.hasWorktreeDown ? "Present" : "None"}
+                  </div>
                 </div>
                 <div
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeWarm ? 1 : 0.4 }}
                 >
-                  <div className="text-[11px] text-(--text-faint) uppercase">Warm Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeWarm ? "Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">
+                    Warm Script
+                  </div>
+                  <div className="font-semibold">
+                    {sel.hasWorktreeWarm ? "Present" : "None"}
+                  </div>
                 </div>
               </div>
             </Section>
 
-            <Section title="Worktree Janitor & Maintenance (OPS-362)" card={false}>
+            <Section
+              title="Worktree Janitor & Maintenance (OPS-362)"
+              card={false}
+            >
               <div className="rounded-md border border-(--border) bg-(--surface-0) p-3">
                 <div className="text-[12px] text-(--text-dim)">
-                  Janitor inspects worktrees in <code className="mono">{sel.worktreeRoot ?? "repo worktrees"}</code>,
-                  checks their Linear ticket states, and reclaims finished ticket checkouts.
+                  Janitor inspects worktrees in{" "}
+                  <code className="mono">
+                    {sel.worktreeRoot ?? "repo worktrees"}
+                  </code>
+                  , checks their Linear ticket states, and reclaims finished
+                  ticket checkouts.
                 </div>
 
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   <Button
-                    disabled={!connected || dryMutation.isPending || applyMutation.isPending}
+                    disabled={
+                      !connected ||
+                      dryMutation.isPending ||
+                      applyMutation.isPending
+                    }
                     onClick={() => dryMutation.mutate(sel.name)}
                   >
                     {dryMutation.isPending ? "Scanning…" : "Run Dry Janitor"}
@@ -727,7 +873,9 @@ export function Projects({
                     Clean Reclaimable Worktrees…
                   </Button>
                   {dryResult && dryResult.reclaimable.length === 0 && (
-                    <span className="text-[11px] text-(--text-faint)">Nothing to reclaim</span>
+                    <span className="text-[11px] text-(--text-faint)">
+                      Nothing to reclaim
+                    </span>
                   )}
 
                   <Button
@@ -741,17 +889,25 @@ export function Projects({
                       })
                     }
                   >
-                    {quickDispatchMutation.isPending ? "Dispatching…" : "Dispatch Scan Event"}
+                    {quickDispatchMutation.isPending
+                      ? "Dispatching…"
+                      : "Dispatch Scan Event"}
                   </Button>
                 </div>
 
                 <div className="mt-2 text-[11px] text-(--text-faint)">
-                  Supports direct execution or asynchronous placement dispatch via <code>janitor-scan@1</code> & <code>janitor-apply@1</code> events.
+                  Supports direct execution or asynchronous placement dispatch
+                  via <code>janitor-scan@1</code> & <code>janitor-apply@1</code>{" "}
+                  events.
                 </div>
 
                 {sel.reportOnly && !sel.hasWorktreeDown && (
-                  <div className="mt-2 text-[11px]" style={{ color: "var(--hue-warn)" }}>
-                    Apply is disabled: report-only repo "{sel.name}" has no worktree_down script.
+                  <div
+                    className="mt-2 text-[11px]"
+                    style={{ color: "var(--hue-warn)" }}
+                  >
+                    Apply is disabled: report-only repo "{sel.name}" has no
+                    worktree_down script.
                   </div>
                 )}
 
@@ -767,7 +923,8 @@ export function Projects({
                             className="rounded px-1.5 py-0.2 text-[11px]"
                             style={{
                               color: "var(--hue-warn)",
-                              background: "color-mix(in oklch, var(--hue-warn) 14%, transparent)",
+                              background:
+                                "color-mix(in oklch, var(--hue-warn) 14%, transparent)",
                             }}
                           >
                             {dryResult.held.length} held
@@ -776,9 +933,14 @@ export function Projects({
                         <span
                           className="rounded px-1.5 py-0.2 text-[11px]"
                           style={{
-                            color: dryResult.reclaimable.length > 0 ? "var(--hue-ok)" : "var(--text-faint)",
+                            color:
+                              dryResult.reclaimable.length > 0
+                                ? "var(--hue-ok)"
+                                : "var(--text-faint)",
                             background: `color-mix(in oklch, ${
-                              dryResult.reclaimable.length > 0 ? "var(--hue-ok)" : "var(--text-faint)"
+                              dryResult.reclaimable.length > 0
+                                ? "var(--hue-ok)"
+                                : "var(--text-faint)"
                             } 14%, transparent)`,
                           }}
                         >
@@ -789,20 +951,25 @@ export function Projects({
 
                     {dryResult.reclaimable.length > 0 ? (
                       <div>
-                        <div className="text-[11px] text-(--text-faint)">Reclaimable (Completed/Canceled):</div>
+                        <div className="text-[11px] text-(--text-faint)">
+                          Reclaimable (Completed/Canceled):
+                        </div>
                         <div className="mono mt-1 flex flex-wrap gap-1.5">
                           {dryResult.reclaimable.map((t) => (
                             <span
                               key={t.id}
                               className="rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px]"
                             >
-                              {t.id} <span className="opacity-60">({t.state})</span>
+                              {t.id}{" "}
+                              <span className="opacity-60">({t.state})</span>
                             </span>
                           ))}
                         </div>
                       </div>
                     ) : (
-                      <div className="text-[11px] text-(--text-faint)">No finished worktrees to reclaim.</div>
+                      <div className="text-[11px] text-(--text-faint)">
+                        No finished worktrees to reclaim.
+                      </div>
                     )}
 
                     {dryResult.held && dryResult.held.length > 0 && (
@@ -817,15 +984,23 @@ export function Projects({
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
                               <div className="flex items-center gap-1.5">
-                                <span className="font-semibold text-(--text)">{h.id}</span>
-                                {h.state && <span className="text-(--text-dim)">({h.state})</span>}
+                                <span className="font-semibold text-(--text)">
+                                  {h.id}
+                                </span>
+                                {h.state && (
+                                  <span className="text-(--text-dim)">
+                                    ({h.state})
+                                  </span>
+                                )}
                                 {h.branch && (
                                   <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
                                     {h.branch}
                                   </span>
                                 )}
                               </div>
-                              <div className="mt-0.5 text-[11px] text-(--text-dim)">{h.reason}</div>
+                              <div className="mt-0.5 text-[11px] text-(--text-dim)">
+                                {h.reason}
+                              </div>
                             </div>
                           ))}
                         </div>
@@ -834,14 +1009,17 @@ export function Projects({
 
                     {dryResult.kept.length > 0 && (
                       <div>
-                        <div className="text-[11px] text-(--text-faint)">Kept (In Progress/Active):</div>
+                        <div className="text-[11px] text-(--text-faint)">
+                          Kept (In Progress/Active):
+                        </div>
                         <div className="mono mt-1 flex flex-wrap gap-1.5">
                           {dryResult.kept.map((t) => (
                             <span
                               key={t.id}
                               className="rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px] text-(--text-dim)"
                             >
-                              {t.id} <span className="opacity-60">({t.state})</span>
+                              {t.id}{" "}
+                              <span className="opacity-60">({t.state})</span>
                             </span>
                           ))}
                         </div>
@@ -850,13 +1028,15 @@ export function Projects({
 
                     {dryResult.named.length > 0 && (
                       <div className="text-[11px] text-(--text-faint)">
-                        Named/custom worktrees (kept safe): {dryResult.named.join(", ")}
+                        Named/custom worktrees (kept safe):{" "}
+                        {dryResult.named.join(", ")}
                       </div>
                     )}
 
                     {dryResult.unknown.length > 0 && (
                       <div className="text-[11px] text-(--text-faint)">
-                        Unknown tickets (kept safe): {dryResult.unknown.join(", ")}
+                        Unknown tickets (kept safe):{" "}
+                        {dryResult.unknown.join(", ")}
                       </div>
                     )}
                   </div>
@@ -864,10 +1044,14 @@ export function Projects({
 
                 {applyResult && (
                   <div className="mt-3 space-y-2 border-t border-(--border) pt-3 text-[12px]">
-                    <div className="font-semibold text-(--hue-ok)">Janitor Apply Execution Finished</div>
+                    <div className="font-semibold text-(--hue-ok)">
+                      Janitor Apply Execution Finished
+                    </div>
                     {applyResult.removed.length > 0 && (
                       <div>
-                        <div className="text-[11px] text-(--text-faint)">Removed Worktrees:</div>
+                        <div className="text-[11px] text-(--text-faint)">
+                          Removed Worktrees:
+                        </div>
                         <div className="mono mt-1 flex flex-wrap gap-1.5">
                           {applyResult.removed.map((id) => (
                             <span
@@ -893,15 +1077,23 @@ export function Projects({
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
                               <div className="flex items-center gap-1.5">
-                                <span className="font-semibold text-(--text)">{h.id}</span>
-                                {h.state && <span className="text-(--text-dim)">({h.state})</span>}
+                                <span className="font-semibold text-(--text)">
+                                  {h.id}
+                                </span>
+                                {h.state && (
+                                  <span className="text-(--text-dim)">
+                                    ({h.state})
+                                  </span>
+                                )}
                                 {h.branch && (
                                   <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
                                     {h.branch}
                                   </span>
                                 )}
                               </div>
-                              <div className="mt-0.5 text-[11px] text-(--text-dim)">{h.reason}</div>
+                              <div className="mt-0.5 text-[11px] text-(--text-dim)">
+                                {h.reason}
+                              </div>
                             </div>
                           ))}
                         </div>
@@ -919,7 +1111,8 @@ export function Projects({
                               key={r.id}
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
-                              <span className="font-semibold">{r.id}:</span> {r.reason}
+                              <span className="font-semibold">{r.id}:</span>{" "}
+                              {r.reason}
                             </div>
                           ))}
                         </div>
@@ -949,14 +1142,24 @@ export function Projects({
         >
           <div className="space-y-3">
             <div className="text-[13px] text-(--text-dim)">
-              This will run <code className="mono">{sel.hasWorktreeDown ? "worktree_down" : "janitor"}</code> on{" "}
-              <strong>{dryResult?.reclaimable.length ?? 0} reclaimable worktrees</strong>. Worktrees with uncommitted
-              changes will be safely refused.
+              This will run{" "}
+              <code className="mono">
+                {sel.hasWorktreeDown ? "worktree_down" : "janitor"}
+              </code>{" "}
+              on{" "}
+              <strong>
+                {dryResult?.reclaimable.length ?? 0} reclaimable worktrees
+              </strong>
+              . Worktrees with uncommitted changes will be safely refused.
             </div>
 
             <div>
               <label className="text-[11px] font-medium text-(--text-faint)">
-                Type <span className="mono font-semibold text-(--text)">{sel.name}</span> to confirm:
+                Type{" "}
+                <span className="mono font-semibold text-(--text)">
+                  {sel.name}
+                </span>{" "}
+                to confirm:
               </label>
               <input
                 type="text"
@@ -981,7 +1184,9 @@ export function Projects({
               </Button>
               <Button
                 variant="danger"
-                disabled={confirmInput.trim() !== sel.name || applyMutation.isPending}
+                disabled={
+                  confirmInput.trim() !== sel.name || applyMutation.isPending
+                }
                 onClick={() => applyMutation.mutate(sel.name)}
               >
                 {applyMutation.isPending ? "Tearing down…" : "Confirm & Clean"}
@@ -1001,7 +1206,8 @@ export function Projects({
         >
           <div className="space-y-3">
             <div className="text-[13px] text-(--text-dim)">
-              Injects an event into the queue for worker lease with live trace streaming.
+              Injects an event into the queue for worker lease with live trace
+              streaming.
             </div>
 
             {env?.name === "live" && (
@@ -1010,26 +1216,48 @@ export function Projects({
                 style={{
                   borderColor: "var(--hue-warn)",
                   color: "var(--hue-warn)",
-                  background: "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
+                  background:
+                    "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
                 }}
               >
                 <span className="font-semibold">LIVE ENVIRONMENT</span>
-                <span className="text-(--text-dim)">— dispatches trigger real agent runs in production.</span>
+                <span className="text-(--text-dim)">
+                  — dispatches trigger real agent runs in production.
+                </span>
               </div>
             )}
 
             <div className="rounded border border-(--border) bg-(--surface-0) p-2 text-[12px]">
-              <KV k="Event Type" v={<span className="mono text-(--text)">{dispatchConfirm.type}</span>} />
-              <KV k="Repository" v={<span className="mono text-(--text)">{dispatchConfirm.repo}</span>} />
+              <KV
+                k="Event Type"
+                v={
+                  <span className="mono text-(--text)">
+                    {dispatchConfirm.type}
+                  </span>
+                }
+              />
+              <KV
+                k="Repository"
+                v={
+                  <span className="mono text-(--text)">
+                    {dispatchConfirm.repo}
+                  </span>
+                }
+              />
               <KV
                 k="Environment"
                 v={
                   <span
                     className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                     style={{
-                      color: env?.name === "live" ? "var(--hue-warn)" : "var(--hue-info)",
+                      color:
+                        env?.name === "live"
+                          ? "var(--hue-warn)"
+                          : "var(--hue-info)",
                       background: `color-mix(in oklch, ${
-                        env?.name === "live" ? "var(--hue-warn)" : "var(--hue-info)"
+                        env?.name === "live"
+                          ? "var(--hue-warn)"
+                          : "var(--hue-info)"
                       } 16%, transparent)`,
                     }}
                   >
@@ -1056,7 +1284,9 @@ export function Projects({
                 disabled={!connected || quickDispatchMutation.isPending}
                 onClick={() => quickDispatchMutation.mutate(dispatchConfirm)}
               >
-                {quickDispatchMutation.isPending ? "Dispatching…" : "Confirm & Dispatch"}
+                {quickDispatchMutation.isPending
+                  ? "Dispatching…"
+                  : "Confirm & Dispatch"}
               </Button>
             </div>
           </div>

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1,5 +1,13 @@
 import "../test-dom";
-import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { filterOpenProposals, Proposals } from "./Proposals";
 import { api } from "../api";
@@ -32,7 +40,11 @@ function stubStatus(): StatusView {
   });
 }
 
-function stubProposal(id: string, status = "open", overrides?: Partial<Proposal>): Proposal {
+function stubProposal(
+  id: string,
+  status = "open",
+  overrides?: Partial<Proposal>,
+): Proposal {
   return createProposalFixture({
     id,
     decision: "run",
@@ -88,7 +100,12 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     api.proposalHistory = async () => ({ proposals: [] });
     api.runs = async () => ({ runs: [] });
     api.events = async () => ({ events: [] });
-    api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
+    api.agents = async () => ({
+      agents: [],
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+    });
   });
 
   afterEach(() => {
@@ -109,7 +126,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     api.proposalHistory = async () => ({ proposals: [] });
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
     // Initially no bulk action bar
     expect(r.queryByRole("toolbar", { name: /bulk actions/i })).toBeNull();
@@ -148,9 +167,13 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     api.proposalHistory = async () => ({ proposals: [] });
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
-    const selectAll = r.getByLabelText("Select all proposals") as HTMLInputElement;
+    const selectAll = r.getByLabelText(
+      "Select all proposals",
+    ) as HTMLInputElement;
     expect(selectAll.checked).toBe(false);
 
     // Click select all
@@ -164,7 +187,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     expect(r.queryByRole("toolbar", { name: /bulk actions/i })).toBeNull();
 
     // Now filter by security using changeInput
-    const filterInput = r.getByLabelText("Filter proposals") as HTMLInputElement;
+    const filterInput = r.getByLabelText(
+      "Filter proposals",
+    ) as HTMLInputElement;
     await act(async () => {
       changeInput(filterInput, "security");
     });
@@ -173,7 +198,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     expect(r.getByLabelText("Select proposal prop_2")).toBeTruthy();
 
     // Click select all under filter — only 1 matching row should be selected
-    const selectAllAfter = r.getByLabelText("Select all proposals") as HTMLInputElement;
+    const selectAllAfter = r.getByLabelText(
+      "Select all proposals",
+    ) as HTMLInputElement;
     fireEvent.click(selectAllAfter);
     expect(r.getByText("Approve selected (1)")).toBeTruthy();
   });
@@ -188,11 +215,18 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     const approvedIds: string[] = [];
     api.approve = async (id: string) => {
       approvedIds.push(id);
-      return { approved: true, runId: `run_${id}`, proposal: undefined, replanned: false };
+      return {
+        approved: true,
+        runId: `run_${id}`,
+        proposal: undefined,
+        replanned: false,
+      };
     };
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
     // Select all 3
     const selectAll = r.getByLabelText("Select all proposals");
@@ -225,7 +259,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     };
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
     // Select all 2
     const selectAll = r.getByLabelText("Select all proposals");
@@ -260,12 +296,15 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
   });
 
   test("Space and Shift+Space toggle the highlighted proposal checkbox", async () => {
-    const p1 = stubProposal("prop_keyboard", "open", { agent: "keyboard-agent" });
+    const p1 = stubProposal("prop_keyboard", "open", {
+      agent: "keyboard-agent",
+    });
     api.proposals = async () => ({ proposals: [p1] });
 
     const r = renderProposals({ focusProposalId: "prop_keyboard" });
     const checkbox = await waitFor(
-      () => r.getByLabelText("Select proposal prop_keyboard") as HTMLInputElement,
+      () =>
+        r.getByLabelText("Select proposal prop_keyboard") as HTMLInputElement,
     );
 
     fireEvent.keyDown(document.body, { key: " " });
@@ -281,7 +320,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     api.proposals = async () => ({ proposals: [p1, p2] });
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
     fireEvent.keyDown(document.body, { key: "*" });
     fireEvent.keyDown(document.body, { key: "a" });
@@ -304,31 +345,45 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     api.proposals = async () => ({ proposals: [p1, p2] });
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
     fireEvent.click(r.getByLabelText("Select all proposals"));
 
-    const approveButton = r.getByRole("button", { name: /Approve selected \(2\)/ });
-    const rejectButton = r.getByRole("button", { name: /Reject selected \(2\)/ });
+    const approveButton = r.getByRole("button", {
+      name: /Approve selected \(2\)/,
+    });
+    const rejectButton = r.getByRole("button", {
+      name: /Reject selected \(2\)/,
+    });
     expect(approveButton.textContent).toContain("A");
     expect(rejectButton.textContent).toContain("X");
 
     fireEvent.keyDown(document.body, { key: "A", shiftKey: true });
-    expect(r.getByRole("dialog", { name: /Approve and queue 2 runs/i })).toBeTruthy();
+    expect(
+      r.getByRole("dialog", { name: /Approve and queue 2 runs/i }),
+    ).toBeTruthy();
     fireEvent.click(r.getByRole("button", { name: "Not yet" }));
 
     await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
     fireEvent.keyDown(document.body, { key: "X", shiftKey: true });
-    expect(r.getByRole("dialog", { name: /Reject 2 selected proposals/i })).toBeTruthy();
+    expect(
+      r.getByRole("dialog", { name: /Reject 2 selected proposals/i }),
+    ).toBeTruthy();
   });
 
   test("selection clears on tab switch and history rows are not selectable", async () => {
     const pOpen = stubProposal("prop_open", "open", { agent: "open-agent" });
-    const pHist = stubProposal("prop_hist", "approved", { agent: "hist-agent" });
+    const pHist = stubProposal("prop_hist", "approved", {
+      agent: "hist-agent",
+    });
     api.proposals = async () => ({ proposals: [pOpen] });
     api.proposalHistory = async () => ({ proposals: [pHist] });
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_open")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_open")).toBeTruthy(),
+    );
 
     // Select open proposal
     const cb = r.getByLabelText("Select proposal prop_open");
@@ -358,7 +413,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
       expect(r.getByText("open-agent")).toBeTruthy();
     });
     expect(r.queryByRole("toolbar", { name: /bulk actions/i })).toBeNull();
-    const cbAfter = r.getByLabelText("Select proposal prop_open") as HTMLInputElement;
+    const cbAfter = r.getByLabelText(
+      "Select proposal prop_open",
+    ) as HTMLInputElement;
     expect(cbAfter.checked).toBe(false);
   });
 });
@@ -366,7 +423,9 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
 describe("Proposals component harness: selection & detail view", () => {
   test("clicking a row selects the proposal via onSelectProposal", async () => {
     const onSelectProposal = mock(() => {});
-    const p1 = stubProposal("prop_click_test", "open", { agent: "agent-click-test" });
+    const p1 = stubProposal("prop_click_test", "open", {
+      agent: "agent-click-test",
+    });
 
     await withApi(
       {
@@ -402,7 +461,9 @@ describe("Proposals component harness: selection & detail view", () => {
         events: async () => ({ events: [] }),
       },
       async () => {
-        const { container, getAllByText } = renderProposals({ focusProposalId: "prop_selected_1" });
+        const { container, getAllByText } = renderProposals({
+          focusProposalId: "prop_selected_1",
+        });
 
         const selectedRow = await waitFor(() => {
           const el = container.querySelector("tr.row-selected");
@@ -434,19 +495,29 @@ describe("Proposals component harness: filter retention", () => {
         events: async () => ({ events: [] }),
       },
       async () => {
-        const { getByLabelText, container } = renderProposals({ focusProposalId: "prop_alpha" });
+        const { getByLabelText, container } = renderProposals({
+          focusProposalId: "prop_alpha",
+        });
 
         await waitFor(() => container.querySelector("tr.row-selected"));
-        expect(container.querySelector("tbody")?.textContent).toContain("review-scan");
+        expect(container.querySelector("tbody")?.textContent).toContain(
+          "review-scan",
+        );
 
-        const filterInput = getByLabelText("Filter proposals") as HTMLInputElement;
+        const filterInput = getByLabelText(
+          "Filter proposals",
+        ) as HTMLInputElement;
         act(() => {
           changeInput(filterInput, "agent:triage-scan");
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("triage-scan");
-          expect(container.querySelector("tbody")?.textContent).not.toContain("review-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "triage-scan",
+          );
+          expect(container.querySelector("tbody")?.textContent).not.toContain(
+            "review-scan",
+          );
         });
 
         // Selected proposal remains highlighted
@@ -469,12 +540,12 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
       ttl_seconds: 300,
     });
 
-    expect(filterOpenProposals([expired, active], now, false).map((p) => p.id)).toEqual([
-      "prop_active",
-    ]);
-    expect(filterOpenProposals([expired, active], now, true).map((p) => p.id)).toEqual([
-      "prop_expired",
-    ]);
+    expect(
+      filterOpenProposals([expired, active], now, false).map((p) => p.id),
+    ).toEqual(["prop_active"]);
+    expect(
+      filterOpenProposals([expired, active], now, true).map((p) => p.id),
+    ).toEqual(["prop_expired"]);
   });
 
   test("expired detail disables approval with a reason and the Expired filter can be cleared", async () => {
@@ -503,7 +574,8 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
       async () => {
         const r = renderProposals({ focusProposalId: expired.id });
         const approve = await waitFor(
-          () => r.getByRole("button", { name: /^Approve/ }) as HTMLButtonElement,
+          () =>
+            r.getByRole("button", { name: /^Approve/ }) as HTMLButtonElement,
         );
 
         expect(approve.disabled).toBe(true);
@@ -511,11 +583,17 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
           "This proposal has expired and can no longer be approved.",
         );
         // Rendered through the shared reason table (WM-594), not a local map.
-        expect(r.getAllByText("Not eligible for auto-approval — Proposal expired").length).toBeGreaterThan(0);
+        expect(
+          r.getAllByText("Not eligible for auto-approval — Proposal expired")
+            .length,
+        ).toBeGreaterThan(0);
         expect(r.getAllByTitle(rawReason).length).toBeGreaterThan(0);
         expect(r.getByText("Safety & blast radius")).toBeTruthy();
 
-        const expiredRow = r.getAllByText("expired-agent").find((node) => node.closest("tr"))?.closest("tr");
+        const expiredRow = r
+          .getAllByText("expired-agent")
+          .find((node) => node.closest("tr"))
+          ?.closest("tr");
         expect(
           Array.from(expiredRow?.querySelectorAll("td") ?? []).some(
             (cell) =>
@@ -541,7 +619,10 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
 
 describe("Proposals selection safety under focus and expiry (WM-547)", () => {
   /** Re-render with a different focused row, the way the hash/parent does. */
-  function refocus(r: ReturnType<typeof renderProposals>, focusProposalId: string | null) {
+  function refocus(
+    r: ReturnType<typeof renderProposals>,
+    focusProposalId: string | null,
+  ) {
     r.rerender(
       <Proposals
         connected={true}
@@ -571,7 +652,9 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
       },
       async () => {
         const r = renderProposals({ focusProposalId: null });
-        await waitFor(() => expect(r.getByLabelText("Select proposal prop_bulk_1")).toBeTruthy());
+        await waitFor(() =>
+          expect(r.getByLabelText("Select proposal prop_bulk_1")).toBeTruthy(),
+        );
 
         act(() => {
           fireEvent.click(r.getByLabelText("Select proposal prop_bulk_1"));
@@ -581,15 +664,22 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
 
         // Open one of the ticked rows to read its spec before bulk-approving.
         act(() => refocus(r, "prop_bulk_1"));
-        await waitFor(() => expect(r.container.querySelector("tr.row-selected")).toBeTruthy());
+        await waitFor(() =>
+          expect(r.container.querySelector("tr.row-selected")).toBeTruthy(),
+        );
 
         expect(r.getByRole("toolbar", { name: /bulk actions/i })).toBeTruthy();
         expect(r.getByText("Approve selected (2)")).toBeTruthy();
-        expect((r.getByLabelText("Select proposal prop_bulk_2") as HTMLInputElement).checked).toBe(true);
+        expect(
+          (r.getByLabelText("Select proposal prop_bulk_2") as HTMLInputElement)
+            .checked,
+        ).toBe(true);
 
         // And moving on to the next row keeps it too.
         act(() => refocus(r, "prop_bulk_2"));
-        await waitFor(() => expect(r.getByText("Approve selected (2)")).toBeTruthy());
+        await waitFor(() =>
+          expect(r.getByText("Approve selected (2)")).toBeTruthy(),
+        );
       },
     );
   });
@@ -615,7 +705,8 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
       async () => {
         const r = renderProposals({ focusProposalId: "prop_armed_1" });
         const openApprove = await waitFor(
-          () => r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
+          () =>
+            r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
         );
         act(() => {
           fireEvent.click(openApprove);
@@ -628,12 +719,16 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
         await act(async () => {
           await r.queryClient.invalidateQueries({ queryKey: ["proposals"] });
         });
-        await waitFor(() => expect(r.queryByText("Approve and queue this run?")).toBeNull());
+        await waitFor(() =>
+          expect(r.queryByText("Approve and queue this run?")).toBeNull(),
+        );
 
         // Selecting another proposal must not re-open an approve dialog the
         // operator never armed — Enter is bound to its confirm button.
         act(() => refocus(r, "prop_armed_2"));
-        await waitFor(() => expect(r.getAllByText("prop_armed_2").length).toBeGreaterThan(0));
+        await waitFor(() =>
+          expect(r.getAllByText("prop_armed_2").length).toBeGreaterThan(0),
+        );
         expect(r.queryByText("Approve and queue this run?")).toBeNull();
       },
     );
@@ -661,7 +756,8 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
         async () => {
           const r = renderProposals({ focusProposalId: "prop_ticking" });
           const approve = await waitFor(
-            () => r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
+            () =>
+              r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
           );
           expect(approve.disabled).toBe(false);
 
@@ -669,7 +765,9 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
           setSystemTime(new Date(t0 + 120_000));
           await waitFor(
             () => {
-              const b = r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement;
+              const b = r.getByRole("button", {
+                name: /^Approve…/,
+              }) as HTMLButtonElement;
               expect(b.disabled).toBe(true);
               expect(b.parentElement?.getAttribute("title")).toBe(
                 "This proposal has expired and can no longer be approved.",
@@ -730,7 +828,9 @@ describe("Proposals component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const historyTab = getByRole("tab", { name: /^History/i });
           expect(historyTab.getAttribute("aria-selected")).toBe("true");
-          expect(container.querySelector("tbody")?.textContent).toContain("agent-decided");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "agent-decided",
+          );
         });
       },
     );
@@ -751,17 +851,23 @@ describe("Proposals component harness: cross-tab reveal", () => {
         const { getByLabelText, container, rerender } = renderProposals({});
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("triage-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "triage-scan",
+          );
         });
 
         // Filter for agent triage, hiding prop_2
-        const filterInput = getByLabelText("Filter proposals") as HTMLInputElement;
+        const filterInput = getByLabelText(
+          "Filter proposals",
+        ) as HTMLInputElement;
         act(() => {
           changeInput(filterInput, "agent:triage-scan");
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).not.toContain("review-scan");
+          expect(container.querySelector("tbody")?.textContent).not.toContain(
+            "review-scan",
+          );
         });
 
         // Focus prop_2 (which was hidden by the filter)
@@ -783,7 +889,9 @@ describe("Proposals component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const input = getByLabelText("Filter proposals") as HTMLInputElement;
           expect(input.value).toBe("");
-          expect(container.querySelector("tbody")?.textContent).toContain("review-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "review-scan",
+          );
         });
       },
     );
@@ -804,16 +912,22 @@ describe("Proposals component harness: cross-tab reveal", () => {
         const { getByLabelText, container, rerender } = renderProposals({});
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("triage-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "triage-scan",
+          );
         });
 
-        const filterInput = getByLabelText("Filter proposals") as HTMLInputElement;
+        const filterInput = getByLabelText(
+          "Filter proposals",
+        ) as HTMLInputElement;
         act(() => {
           changeInput(filterInput, "agent:triage-scan");
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("triage-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "triage-scan",
+          );
         });
 
         // Focus prop_1 (already visible under agent:triage-scan)
@@ -835,7 +949,9 @@ describe("Proposals component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const input = getByLabelText("Filter proposals") as HTMLInputElement;
           expect(input.value).toBe("agent:triage-scan");
-          expect(container.querySelector("tbody")?.textContent).toContain("triage-scan");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "triage-scan",
+          );
         });
       },
     );
@@ -859,7 +975,8 @@ describe("Proposals component harness: cross-tab reveal", () => {
     await withApi(
       {
         proposals: async () => ({ proposals: [pExpired, pActive] }),
-        status: async () => createStatusFixture({ proposals: { open: 2, expired: 1 } }),
+        status: async () =>
+          createStatusFixture({ proposals: { open: 2, expired: 1 } }),
         runs: async () => ({ runs: [] }),
         events: async () => ({ events: [] }),
       },
@@ -873,8 +990,12 @@ describe("Proposals component harness: cross-tab reveal", () => {
           const openTab = getByRole("tab", { name: /^Open/i });
           expect(openTab.getAttribute("aria-selected")).toBe("true");
           expect(onFocusExpiredConsumed).toHaveBeenCalled();
-          expect(container.querySelector("tbody")?.textContent).toContain("agent-expired");
-          expect(container.querySelector("tbody")?.textContent).not.toContain("agent-active");
+          expect(container.querySelector("tbody")?.textContent).toContain(
+            "agent-expired",
+          );
+          expect(container.querySelector("tbody")?.textContent).not.toContain(
+            "agent-active",
+          );
         });
       },
     );
@@ -905,7 +1026,12 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     api.proposals = async () => ({ proposals: [] });
     api.runs = async () => ({ runs: [] });
     api.events = async () => ({ events: [] });
-    api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
+    api.agents = async () => ({
+      agents: [],
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+    });
     api.proposalHistory = async () => ({ proposals: [] });
   });
 
@@ -948,17 +1074,30 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     });
     api.proposals = async () => ({ proposals: [p1, p2, stale] });
     api.runs = async () => ({
-      runs: [createRunListItemFixture({ runId: "run_stale", state: "CANCELLED", agent: "stale-agent" })],
+      runs: [
+        createRunListItemFixture({
+          runId: "run_stale",
+          state: "CANCELLED",
+          agent: "stale-agent",
+        }),
+      ],
     });
 
     const approvedIds: string[] = [];
     api.approve = async (id: string) => {
       approvedIds.push(id);
-      return { approved: true, runId: `run_${id}`, proposal: undefined, replanned: false };
+      return {
+        approved: true,
+        runId: `run_${id}`,
+        proposal: undefined,
+        replanned: false,
+      };
     };
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
 
     fireEvent.click(r.getByLabelText("Select all proposals"));
     fireEvent.click(r.getByText("Approve selected (2)"));
@@ -996,20 +1135,29 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     };
 
     const r = renderProposals({ focusProposalId: "prop_1" });
-    await waitFor(() => expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy(),
+    );
 
     expect(r.queryByRole("button", { name: /^Dismiss$/ })).toBeNull();
     expect(rejectedCalls).toEqual([]);
 
     fireEvent.click(r.getByRole("button", { name: /^Reject/ }));
-    const confirm = await waitFor(() => r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement);
+    const confirm = await waitFor(
+      () => r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement,
+    );
     expect(confirm.disabled).toBe(true);
 
-    const reasonInput = r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement;
+    const reasonInput = r.getByPlaceholderText(
+      /Reason \(required/i,
+    ) as HTMLInputElement;
     await act(async () => {
       changeInput(reasonInput, "   ");
     });
-    expect((r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      (r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
     fireEvent.keyDown(reasonInput, { key: "Enter" });
     expect(rejectedCalls).toEqual([]);
 
@@ -1032,7 +1180,10 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
       agent: "triage-scan",
       created_at: new Date(Date.now() - 10_000).toISOString(),
       ttl_seconds: 1,
-      spec: createRunSpecFixture("run_prop_1b", { timeoutSeconds: 900, agent: "triage-scan" }),
+      spec: createRunSpecFixture("run_prop_1b", {
+        timeoutSeconds: 900,
+        agent: "triage-scan",
+      }),
     });
     api.proposals = async () => ({ proposals: [p1, p2] });
 
@@ -1040,13 +1191,25 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     api.approve = async (id: string) => {
       approveCalls.push(id);
       if (id === "prop_1") {
-        return { approved: false, runId: undefined, replanned: true, proposal: replacement };
+        return {
+          approved: false,
+          runId: undefined,
+          replanned: true,
+          proposal: replacement,
+        };
       }
-      return { approved: true, runId: `run_${id}`, proposal: undefined, replanned: false };
+      return {
+        approved: true,
+        runId: `run_${id}`,
+        proposal: undefined,
+        replanned: false,
+      };
     };
 
     const r = renderProposals();
-    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    await waitFor(() =>
+      expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy(),
+    );
     fireEvent.click(r.getByLabelText("Select all proposals"));
     fireEvent.click(r.getByText("Approve selected (2)"));
 
@@ -1062,8 +1225,14 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     await waitFor(() => expect(approveCalls.length).toBeGreaterThan(0));
     expect(approveCalls).toEqual(["prop_1"]);
     expect(r.getByText(/re-planned against current state/i)).toBeTruthy();
-    expect(r.getByText(/nothing runs until you approve the new proposal explicitly/i)).toBeTruthy();
-    const approveReplacement = r.getByRole("button", { name: /Approve new proposal/i }) as HTMLButtonElement;
+    expect(
+      r.getByText(
+        /nothing runs until you approve the new proposal explicitly/i,
+      ),
+    ).toBeTruthy();
+    const approveReplacement = r.getByRole("button", {
+      name: /Approve new proposal/i,
+    }) as HTMLButtonElement;
     expect(approveReplacement.disabled).toBe(true);
     expect(approveReplacement.parentElement?.getAttribute("title")).toBe(
       "This replacement proposal has expired and can no longer be approved.",
@@ -1071,7 +1240,10 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
   });
 
   test("repo context shows a persistent caption that the list is scoped to that repo", async () => {
-    const p1 = stubProposal("prop_1", "open", { repos: ["repo-test"], agent: "triage-scan" });
+    const p1 = stubProposal("prop_1", "open", {
+      repos: ["repo-test"],
+      agent: "triage-scan",
+    });
     api.proposals = async () => ({ proposals: [p1] });
 
     const r = renderProposals({ context: { kind: "repo", name: "repo-test" } });
@@ -1092,14 +1264,18 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
       repos: ["another-repo"],
       agent: "review-scan",
     });
-    api.proposals = async () => ({ proposals: [matching, unscoped, otherRepo] });
+    api.proposals = async () => ({
+      proposals: [matching, unscoped, otherRepo],
+    });
 
     const r = renderProposals({ context: { kind: "repo", name: "repo-test" } });
     await waitFor(() => expect(r.getByText("triage-scan")).toBeTruthy());
     expect(r.queryByText("human-needed")).toBeNull();
     expect(r.queryByText("review-scan")).toBeNull();
     expect(
-      r.getByText("Showing proposals that name repo-test. 2 open proposals do not name this repo and are hidden."),
+      r.getByText(
+        "Showing proposals that name repo-test. 2 open proposals do not name this repo and are hidden.",
+      ),
     ).toBeTruthy();
   });
 
@@ -1114,7 +1290,13 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     });
     api.proposals = async () => ({ proposals: [p1] });
     api.events = async () => ({
-      events: [createEventFixture({ eventId, source: "github", type: "pull_request.opened" })],
+      events: [
+        createEventFixture({
+          eventId,
+          source: "github",
+          type: "pull_request.opened",
+        }),
+      ],
     });
 
     const r = renderProposals();
@@ -1155,7 +1337,9 @@ describe("Proposals copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderProposals({ focusProposalId: proposalId });
-        const idBtn = await r.findByRole("button", { name: "Copy proposal id (c)" });
+        const idBtn = await r.findByRole("button", {
+          name: "Copy proposal id (c)",
+        });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
         expect(idBtn.getAttribute("title")).toBe("Copy proposal id · c");
@@ -1189,7 +1373,9 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
   });
 
   test("Cmd+Enter and Ctrl+Enter submit reject dialog when valid and connected", async () => {
-    const p1 = stubProposal("prop_reject_hotkey", "open", { agent: "triage-scan" });
+    const p1 = stubProposal("prop_reject_hotkey", "open", {
+      agent: "triage-scan",
+    });
     const rejectedCalls: { id: string; why?: string }[] = [];
     api.proposals = async () => ({ proposals: [p1] });
     api.reject = async (id: string, why?: string) => {
@@ -1197,11 +1383,18 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
       return { rejected: true };
     };
 
-    const r = renderProposals({ focusProposalId: "prop_reject_hotkey", connected: true });
-    await waitFor(() => expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy());
+    const r = renderProposals({
+      focusProposalId: "prop_reject_hotkey",
+      connected: true,
+    });
+    await waitFor(() =>
+      expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy(),
+    );
 
     fireEvent.click(r.getByRole("button", { name: /^Reject/ }));
-    const reasonInput = await waitFor(() => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement);
+    const reasonInput = await waitFor(
+      () => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement,
+    );
 
     // Enter with metaKey (Cmd+Enter)
     await act(async () => {
@@ -1209,11 +1402,17 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
     });
     fireEvent.keyDown(reasonInput, { key: "Enter", metaKey: true });
 
-    await waitFor(() => expect(rejectedCalls).toEqual([{ id: "prop_reject_hotkey", why: "Not needed right now" }]));
+    await waitFor(() =>
+      expect(rejectedCalls).toEqual([
+        { id: "prop_reject_hotkey", why: "Not needed right now" },
+      ]),
+    );
 
     // Ctrl+Enter also works on reopened dialog
     fireEvent.click(r.getByRole("button", { name: /^Reject/ }));
-    const reasonInput2 = await waitFor(() => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement);
+    const reasonInput2 = await waitFor(
+      () => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement,
+    );
 
     await act(async () => {
       changeInput(reasonInput2, "Second rejection reason");
@@ -1229,7 +1428,9 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
   });
 
   test("Cmd+Enter does not submit when reason is empty or when disconnected", async () => {
-    const p1 = stubProposal("prop_reject_disconn", "open", { agent: "triage-scan" });
+    const p1 = stubProposal("prop_reject_disconn", "open", {
+      agent: "triage-scan",
+    });
     const rejectedCalls: { id: string; why?: string }[] = [];
     api.proposals = async () => ({ proposals: [p1] });
     api.reject = async (id: string, why?: string) => {
@@ -1237,11 +1438,18 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
       return { rejected: true };
     };
 
-    const r = renderProposals({ focusProposalId: "prop_reject_disconn", connected: true });
-    await waitFor(() => expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy());
+    const r = renderProposals({
+      focusProposalId: "prop_reject_disconn",
+      connected: true,
+    });
+    await waitFor(() =>
+      expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy(),
+    );
 
     fireEvent.click(r.getByRole("button", { name: /^Reject/ }));
-    const reasonInput = await waitFor(() => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement);
+    const reasonInput = await waitFor(
+      () => r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement,
+    );
 
     // Empty / whitespace reason does not submit on Cmd+Enter
     await act(async () => {
@@ -1275,7 +1483,10 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
   });
 
   test("Enter key submits single-proposal approve dialog when connected", async () => {
-    const p1 = stubProposal("prop_approve_hotkey", "open", { agent: "triage-scan", decision: "run" });
+    const p1 = stubProposal("prop_approve_hotkey", "open", {
+      agent: "triage-scan",
+      decision: "run",
+    });
     const approvedCalls: string[] = [];
     api.proposals = async () => ({ proposals: [p1] });
     api.approve = async (id: string) => {
@@ -1283,8 +1494,13 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
       return { approved: true, runId: "run_approved_1" };
     };
 
-    const r = renderProposals({ focusProposalId: "prop_approve_hotkey", connected: true });
-    const approveBtn = await waitFor(() => r.getByRole("button", { name: /^Approve/ }));
+    const r = renderProposals({
+      focusProposalId: "prop_approve_hotkey",
+      connected: true,
+    });
+    const approveBtn = await waitFor(() =>
+      r.getByRole("button", { name: /^Approve/ }),
+    );
     expect(approveBtn.textContent).toContain("a");
 
     // Open confirmation dialog
@@ -1299,7 +1515,9 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
 
 describe("Proposals long-list window (WM-563)", () => {
   test("a 2,000-row fixture mounts fewer than 200 table rows and pages forward", async () => {
-    const proposals = Array.from({ length: 2000 }, (_, i) => stubProposal(`prop_window_${i}`));
+    const proposals = Array.from({ length: 2000 }, (_, i) =>
+      stubProposal(`prop_window_${i}`),
+    );
     await withApi(
       {
         proposals: async () => ({ proposals }),
@@ -1308,15 +1526,22 @@ describe("Proposals long-list window (WM-563)", () => {
       async () => {
         const r = renderProposals();
         const next = await r.findByRole("button", { name: "Next" });
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
-        expect(r.queryByLabelText("Select proposal prop_window_100")).toBeNull();
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
+        expect(
+          r.queryByLabelText("Select proposal prop_window_100"),
+        ).toBeNull();
         fireEvent.click(next);
         await waitFor(() => {
-          expect(r.getByLabelText("Select proposal prop_window_100")).toBeTruthy();
+          expect(
+            r.getByLabelText("Select proposal prop_window_100"),
+          ).toBeTruthy();
         });
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
       },
     );
   });
 });
-

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1,7 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { keyGuard, refetchIntervals, tableTokens, useDisplayOptions, useListKeys, useNow, useTabKeys, useTableWindow } from "../hooks";
+import {
+  keyGuard,
+  refetchIntervals,
+  tableTokens,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useTabKeys,
+  useTableWindow,
+} from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   buildSections,
@@ -19,11 +28,19 @@ import { setContextActions } from "../palette";
 import type { Proposal } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
-import { PROPOSAL_FACETS, matchesFilterQuery, parseFilterQuery, proposalRunState } from "../filterQuery";
+import {
+  PROPOSAL_FACETS,
+  matchesFilterQuery,
+  parseFilterQuery,
+  proposalRunState,
+} from "../filterQuery";
 import { ScopeCaption } from "../components/ContextTabs";
 import { SpecDiff } from "../components/SpecDiff";
 import { AgentHoverCard } from "../components/AgentHoverCard";
-import { ApprovalRiskDetails, ApprovalSafetyCard } from "../components/ApprovalRisk";
+import {
+  ApprovalRiskDetails,
+  ApprovalSafetyCard,
+} from "../components/ApprovalRisk";
 import { decideRevealFilters } from "../reveal";
 import { humanizeReason } from "../reasons";
 import {
@@ -59,10 +76,14 @@ const PROPOSAL_TABS = ["open", "history"] as const;
 type ProposalTab = (typeof PROPOSAL_TABS)[number];
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
-const ttlExpiry = (p: Proposal) => new Date(p.created_at).getTime() + p.ttl_seconds * 1000;
+const ttlExpiry = (p: Proposal) =>
+  new Date(p.created_at).getTime() + p.ttl_seconds * 1000;
 
 export function proposalIsExpired(p: Proposal, now = Date.now()): boolean {
   return ttlExpiry(p) < now;
@@ -93,8 +114,18 @@ const OPEN_DISPLAY: DisplayConfig<Proposal> = {
   ],
   subGroups: ["agent", "decision"],
   sorts: [
-    { key: "agent", label: "Agent", get: (p) => p.agent ?? "", column: "agent" },
-    { key: "decision", label: "Decision", get: (p) => p.decision, column: "decision" },
+    {
+      key: "agent",
+      label: "Agent",
+      get: (p) => p.agent ?? "",
+      column: "agent",
+    },
+    {
+      key: "decision",
+      label: "Decision",
+      get: (p) => p.decision,
+      column: "decision",
+    },
     { key: "ttl", label: "Time left", get: ttlExpiry, column: "ttl" },
     {
       key: "origin",
@@ -102,8 +133,19 @@ const OPEN_DISPLAY: DisplayConfig<Proposal> = {
       get: (p) => `${p.eventSource ?? ""}:${p.eventId ?? ""}`,
       column: "origin",
     },
-    { key: "created", label: "Created", get: (p) => p.created_at, defaultDir: "desc", column: "created" },
-    { key: "reason", label: "Reason", get: (p) => p.reason ?? "", column: "reason" },
+    {
+      key: "created",
+      label: "Created",
+      get: (p) => p.created_at,
+      defaultDir: "desc",
+      column: "created",
+    },
+    {
+      key: "reason",
+      label: "Reason",
+      get: (p) => p.reason ?? "",
+      column: "reason",
+    },
   ],
   columns: [
     { key: "agent", label: "Agent", always: true },
@@ -129,17 +171,39 @@ const HISTORY_DISPLAY: DisplayConfig<Proposal> = {
   ],
   subGroups: ["agent", "status"],
   sorts: [
-    { key: "agent", label: "Agent", get: (p) => p.agent ?? "", column: "agent" },
+    {
+      key: "agent",
+      label: "Agent",
+      get: (p) => p.agent ?? "",
+      column: "agent",
+    },
     { key: "status", label: "Status", get: (p) => p.status, column: "status" },
-    { key: "decided", label: "Decided", get: (p) => p.decided_at ?? "", defaultDir: "desc", column: "decided" },
+    {
+      key: "decided",
+      label: "Decided",
+      get: (p) => p.decided_at ?? "",
+      defaultDir: "desc",
+      column: "decided",
+    },
     {
       key: "origin",
       label: "Origin",
       get: (p) => `${p.eventSource ?? ""}:${p.eventId ?? ""}`,
       column: "origin",
     },
-    { key: "created", label: "Created", get: (p) => p.created_at, defaultDir: "desc", column: "created" },
-    { key: "reason", label: "Reason", get: (p) => p.reason ?? "", column: "reason" },
+    {
+      key: "created",
+      label: "Created",
+      get: (p) => p.created_at,
+      defaultDir: "desc",
+      column: "created",
+    },
+    {
+      key: "reason",
+      label: "Reason",
+      get: (p) => p.reason ?? "",
+      column: "reason",
+    },
   ],
   columns: [
     { key: "agent", label: "Agent", always: true },
@@ -196,17 +260,26 @@ export function Proposals({
   });
   const [expiredOnly, setExpiredOnly] = useState(false);
   const rows = useMemo(() => {
-    if (tab !== "open") return (history.data?.proposals ?? []).filter((p) => p.status !== "open");
+    if (tab !== "open")
+      return (history.data?.proposals ?? []).filter((p) => p.status !== "open");
     const open = query.data?.proposals ?? [];
-    const shown = new Set(filterOpenProposals(open, now, expiredOnly).map((p) => p.id));
+    const shown = new Set(
+      filterOpenProposals(open, now, expiredOnly).map((p) => p.id),
+    );
     // The focused proposal never drops out from under the operator: a TTL that
     // passes while it is selected would otherwise close the detail pane and take
     // the expired banner with it, mid-read (WM-547). `scoped` exempts the focused
     // id from repo scoping for the same reason.
-    return open.filter((p) => p.status === "open" && (shown.has(p.id) || p.id === focusProposalId));
+    return open.filter(
+      (p) =>
+        p.status === "open" && (shown.has(p.id) || p.id === focusProposalId),
+    );
   }, [tab, query.data, history.data, now, expiredOnly, focusProposalId]);
   const scoped = useMemo(
-    () => rows.filter((p) => p.id === focusProposalId || matchesRepo(p.repos, context)),
+    () =>
+      rows.filter(
+        (p) => p.id === focusProposalId || matchesRepo(p.repos, context),
+      ),
     [rows, context, focusProposalId],
   );
   const hiddenOpenRepoCount = useMemo(
@@ -227,7 +300,13 @@ export function Proposals({
     ...refetchIntervals.secondary,
   });
   const eventTypes = useMemo(
-    () => new Map((eventsQuery.data?.events ?? []).map((e) => [`${e.source}:${e.eventId}`, e.type])),
+    () =>
+      new Map(
+        (eventsQuery.data?.events ?? []).map((e) => [
+          `${e.source}:${e.eventId}`,
+          e.type,
+        ]),
+      ),
     [eventsQuery.data],
   );
   const originType = (p: Proposal) =>
@@ -235,7 +314,11 @@ export function Proposals({
 
   // An open proposal's run should still be PROPOSED; anything else means it
   // was raced (e.g. cancelled from the Runs view) and can never be approved.
-  const runsQuery = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), ...refetchIntervals.fast });
+  const runsQuery = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.fast,
+  });
   const runStates = useMemo(
     () => new Map((runsQuery.data?.runs ?? []).map((r) => [r.runId, r.state])),
     [runsQuery.data],
@@ -261,7 +344,10 @@ export function Proposals({
   const [rejecting, setRejecting] = useState(false);
   const [confirmApprove, setConfirmApprove] = useState(false);
   const [reason, setReason] = useState("");
-  const [replan, setReplan] = useState<{ before: Proposal; after: Proposal } | null>(null);
+  const [replan, setReplan] = useState<{
+    before: Proposal;
+    after: Proposal;
+  } | null>(null);
   const reasonRef = useRef<HTMLInputElement>(null);
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -276,12 +362,22 @@ export function Proposals({
   // The expired chip only exists on Open; History rows have no live TTL. Derive
   // the gate once so the row filter and the empty copy can never disagree.
   const expiredFilter = expiredOnly && tab === "open";
-  const expiredCount = filterOpenProposals(query.data?.proposals ?? [], now, true).filter(
+  const expiredCount = filterOpenProposals(
+    query.data?.proposals ?? [],
+    now,
+    true,
+  ).filter(
     (p) => context.kind !== "repo" || matchesRepo(p.repos, context),
   ).length;
-  const parsed = useMemo(() => parseFilterQuery(filter, PROPOSAL_FACETS), [filter]);
+  const parsed = useMemo(
+    () => parseFilterQuery(filter, PROPOSAL_FACETS),
+    [filter],
+  );
   const visible = useMemo(
-    () => scoped.filter((p) => matchesFilterQuery(p, parsed, PROPOSAL_FACETS, { runStates })),
+    () =>
+      scoped.filter((p) =>
+        matchesFilterQuery(p, parsed, PROPOSAL_FACETS, { runStates }),
+      ),
     [scoped, parsed, runStates],
   );
 
@@ -290,9 +386,11 @@ export function Proposals({
     [tab, visible],
   );
   const allActionableSelected =
-    actionableVisible.length > 0 && actionableVisible.every((p) => selectedIds.has(p.id));
+    actionableVisible.length > 0 &&
+    actionableVisible.every((p) => selectedIds.has(p.id));
   const someActionableSelected =
-    actionableVisible.some((p) => selectedIds.has(p.id)) && !allActionableSelected;
+    actionableVisible.some((p) => selectedIds.has(p.id)) &&
+    !allActionableSelected;
 
   useEffect(() => {
     if (headerCheckboxRef.current) {
@@ -391,7 +489,8 @@ export function Proposals({
       setSelectedIds(new Set());
     }
     if (ok) notify(`Approved ${ok} proposal${ok === 1 ? "" : "s"}`, "ok");
-    if (err) notify(`Failed to approve ${err} proposal${err === 1 ? "" : "s"}`, "err");
+    if (err)
+      notify(`Failed to approve ${err} proposal${err === 1 ? "" : "s"}`, "err");
   };
 
   const handleBulkReject = async () => {
@@ -414,7 +513,8 @@ export function Proposals({
     setBulkRejectOpen(false);
     setBulkReason("");
     if (ok) notify(`Rejected ${ok} proposal${ok === 1 ? "" : "s"}`, "info");
-    if (err) notify(`Failed to reject ${err} proposal${err === 1 ? "" : "s"}`, "err");
+    if (err)
+      notify(`Failed to reject ${err} proposal${err === 1 ? "" : "s"}`, "err");
   };
 
   // What the list would show without the text filter — the tab and the expired
@@ -447,7 +547,10 @@ export function Proposals({
   const selectedId = focusProposalId;
   // Keyboard index walks the open sections; the detail pane keys off the row
   // itself so collapsing the group under a selection never closes the pane.
-  const selectedIndex = useMemo(() => flat.findIndex((p) => p.id === selectedId), [flat, selectedId]);
+  const selectedIndex = useMemo(
+    () => flat.findIndex((p) => p.id === selectedId),
+    [flat, selectedId],
+  );
   const tokens = tableTokens(sections, display.collapsed, grouped(display));
   const [windowTokens, windowStart, windowEnd, moveWindow] = useTableWindow(
     tokens,
@@ -456,13 +559,18 @@ export function Proposals({
     JSON.stringify([tab, filter, expiredOnly, context, display]),
   );
   const sel = useMemo(
-    () => (selectedId ? (visible.find((p) => p.id === selectedId) ?? null) : null),
+    () =>
+      selectedId ? (visible.find((p) => p.id === selectedId) ?? null) : null,
     [visible, selectedId],
   );
   // Keep the selected-row list as a compact audit rail. Open and History expose
   // different columns, so this union leaves four useful columns in either tab.
   const listCols = sel
-    ? cols.filter((c) => ["agent", "decision", "ttl", "status", "decided", "origin"].includes(c.key))
+    ? cols.filter((c) =>
+        ["agent", "decision", "ttl", "status", "decided", "origin"].includes(
+          c.key,
+        ),
+      )
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
@@ -471,14 +579,20 @@ export function Proposals({
     () =>
       sel
         ? (agentsQuery.data?.agents ?? []).find(
-            (a) => a.id === sel.agent || a.ref === sel.agent || a.id === sel.spec?.agent,
+            (a) =>
+              a.id === sel.agent ||
+              a.ref === sel.agent ||
+              a.id === sel.spec?.agent,
           )
         : undefined,
     [agentsQuery.data, sel],
   );
 
   /** Planner reason for the selection, humanized off the shared table (WM-594). */
-  const selReason = useMemo(() => (sel?.reason ? humanizeReason(sel.reason) : null), [sel]);
+  const selReason = useMemo(
+    () => (sel?.reason ? humanizeReason(sel.reason) : null),
+    [sel],
+  );
 
   // Losing the selection must disarm its dialogs. Both render inside `sel`, so a
   // proposal that leaves `visible` (decided elsewhere, scoped away) unmounts them
@@ -492,7 +606,9 @@ export function Proposals({
   }, [noSelection]);
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, windowStart]);
 
   // Reveal a hash-selected proposal only when current filters hide it. Latch
@@ -524,10 +640,17 @@ export function Proposals({
     const isVisible = visible.some((p) => p.id === latch.key);
     const currentFilters = { filter, expiredOnly };
     const emptyFilters = { filter: "", expiredOnly: false };
-    const decision = decideRevealFilters(latch.snapshot, currentFilters, emptyFilters, isVisible);
+    const decision = decideRevealFilters(
+      latch.snapshot,
+      currentFilters,
+      emptyFilters,
+      isVisible,
+    );
     if (decision.cleared) {
-      if (decision.clearedFields.includes("filter")) setFilter(decision.next.filter);
-      if (decision.clearedFields.includes("expiredOnly")) setExpiredOnly(decision.next.expiredOnly);
+      if (decision.clearedFields.includes("filter"))
+        setFilter(decision.next.filter);
+      if (decision.clearedFields.includes("expiredOnly"))
+        setExpiredOnly(decision.next.expiredOnly);
     }
   }, [focusProposalId, rejumpEpoch, rows, visible, filter, expiredOnly]);
 
@@ -542,12 +665,15 @@ export function Proposals({
       return;
     }
     if (query.isPending || history.isPending) return;
-    const focusedOpen = (query.data?.proposals ?? []).find((p) => p.id === focusProposalId);
+    const focusedOpen = (query.data?.proposals ?? []).find(
+      (p) => p.id === focusProposalId,
+    );
     const inHistory = (history.data?.proposals ?? []).some(
       (p) => p.id === focusProposalId && p.status !== "open",
     );
     const isNewFocus = locatedFocusId.current !== focusProposalId;
-    if (isNewFocus && (focusedOpen || inHistory)) locatedFocusId.current = focusProposalId;
+    if (isNewFocus && (focusedOpen || inHistory))
+      locatedFocusId.current = focusProposalId;
 
     if (focusedOpen) {
       // Only a real tab switch drops the bulk selection (selectTab does the same).
@@ -564,7 +690,15 @@ export function Proposals({
       setExpiredOnly(false);
       setSelectedIds(new Set());
     }
-  }, [focusProposalId, query.isPending, history.isPending, query.data, history.data, tab, now]);
+  }, [
+    focusProposalId,
+    query.isPending,
+    history.isPending,
+    query.data,
+    history.data,
+    tab,
+    now,
+  ]);
 
   useEffect(() => {
     if (!focusExpired) return;
@@ -584,7 +718,9 @@ export function Proposals({
   const approve = useMutation({
     mutationFn: (p: Proposal) => {
       if (proposalIsExpired(p)) {
-        return Promise.reject(new Error("This proposal has expired and can no longer be approved."));
+        return Promise.reject(
+          new Error("This proposal has expired and can no longer be approved."),
+        );
       }
       return api.approve(p.id).then((outcome) => ({ p, outcome }));
     },
@@ -606,7 +742,8 @@ export function Proposals({
   const reject = useMutation({
     mutationFn: ({ id, why }: { id: string; why: string }) => {
       const trimmed = why.trim();
-      if (!trimmed) return Promise.reject(new Error("Rejection reason required"));
+      if (!trimmed)
+        return Promise.reject(new Error("Rejection reason required"));
       return api.reject(id, trimmed);
     },
     onSuccess: (_, { id }) => {
@@ -621,7 +758,8 @@ export function Proposals({
   // History rows are audit records — no verbs, ever (doc §10.2).
   const isOpen = sel !== null && sel.status === "open";
   const selectionExpired = sel !== null && proposalIsExpired(sel, now);
-  const canApprove = isOpen && sel.decision === "run" && !selectionExpired && !staleState(sel);
+  const canApprove =
+    isOpen && sel.decision === "run" && !selectionExpired && !staleState(sel);
   const approvalDisabledReason = selectionExpired
     ? "This proposal has expired and can no longer be approved."
     : sel && staleState(sel)
@@ -639,7 +777,13 @@ export function Proposals({
   };
   const replanExpired = replan !== null && proposalIsExpired(replan.after, now);
   const approveReplan = () => {
-    if (!replan || !connected || proposalIsExpired(replan.after) || approve.isPending) return;
+    if (
+      !replan ||
+      !connected ||
+      proposalIsExpired(replan.after) ||
+      approve.isPending
+    )
+      return;
     const fresh = replan.after;
     setReplan(null);
     approve.mutate(fresh);
@@ -675,7 +819,11 @@ export function Proposals({
         pendingC.current = Date.now();
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -697,7 +845,12 @@ export function Proposals({
         return;
       }
 
-      if (!e.metaKey && !e.ctrlKey && starActive && (e.key === "a" || e.key === "n")) {
+      if (
+        !e.metaKey &&
+        !e.ctrlKey &&
+        starActive &&
+        (e.key === "a" || e.key === "n")
+      ) {
         e.preventDefault();
         pendingStar.current = 0;
         if (e.key === "a") selectAllActionable();
@@ -706,7 +859,11 @@ export function Proposals({
       }
       pendingStar.current = 0;
 
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "a") {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        e.key.toLowerCase() === "a"
+      ) {
         if (actionableVisible.length === 0) return;
         e.preventDefault();
         selectAllActionable();
@@ -714,21 +871,27 @@ export function Proposals({
       }
       if (e.metaKey || e.ctrlKey) return;
 
-      if ((e.key === " " || e.key === "Spacebar") && tab === "open" && sel?.status === "open") {
+      if (
+        (e.key === " " || e.key === "Spacebar") &&
+        tab === "open" &&
+        sel?.status === "open"
+      ) {
         e.preventDefault();
         toggleSelect(sel.id);
         return;
       }
 
       if (e.shiftKey && e.key.toLowerCase() === "a" && selectedIds.size > 0) {
-        if (!connected || bulkApproving || approvableSelected.length === 0) return;
+        if (!connected || bulkApproving || approvableSelected.length === 0)
+          return;
         e.preventDefault();
         setBulkConfirmOpen(true);
         return;
       }
 
       if (e.shiftKey && e.key.toLowerCase() === "x" && selectedIds.size > 0) {
-        if (!connected || bulkRejecting || rejectableSelected.length === 0) return;
+        if (!connected || bulkRejecting || rejectableSelected.length === 0)
+          return;
         e.preventDefault();
         setBulkRejectOpen(true);
         setBulkReason("");
@@ -755,7 +918,11 @@ export function Proposals({
       setContextActions([]);
     } else {
       const copy = [
-        { label: `Copy ${sel.id}`, hint: "c", run: () => copyText(sel.id, "proposal id") },
+        {
+          label: `Copy ${sel.id}`,
+          hint: "c",
+          run: () => copyText(sel.id, "proposal id"),
+        },
         { label: "Copy link to this proposal", hint: "c l", run: copyLink },
       ];
       if (!connected || !isOpen) {
@@ -763,9 +930,19 @@ export function Proposals({
       } else {
         setContextActions([
           ...(canApprove
-            ? [{ label: `Approve ${sel.agent ?? sel.id}…`, hint: "a", run: openApprove }]
+            ? [
+                {
+                  label: `Approve ${sel.agent ?? sel.id}…`,
+                  hint: "a",
+                  run: openApprove,
+                },
+              ]
             : []),
-          { label: `Reject ${sel.agent ?? sel.id}…`, hint: "x", run: openReject },
+          {
+            label: `Reject ${sel.agent ?? sel.id}…`,
+            hint: "x",
+            run: openReject,
+          },
           ...copy,
         ]);
       }
@@ -812,9 +989,19 @@ export function Proposals({
         ) {
           setConfirmApprove(false);
           approve.mutate(sel);
-        } else if (replan && connected && !replanExpired && !approve.isPending) {
+        } else if (
+          replan &&
+          connected &&
+          !replanExpired &&
+          !approve.isPending
+        ) {
           approveReplan();
-        } else if (bulkConfirmOpen && connected && !bulkApproving && approvableSelected.length > 0) {
+        } else if (
+          bulkConfirmOpen &&
+          connected &&
+          !bulkApproving &&
+          approvableSelected.length > 0
+        ) {
           void handleBulkApprove();
         }
       }
@@ -837,282 +1024,364 @@ export function Proposals({
 
   return (
     <div className="flex h-full min-w-0 max-sm:fixed max-sm:inset-0 max-sm:z-50 max-sm:bg-(--surface-0) [&_[role=dialog]]:max-w-[calc(100vw-2rem)]">
-      <div className={`${sel ? "hidden sm:flex" : "flex"} min-h-0 min-w-0 flex-1`}>
+      <div
+        className={`${sel ? "hidden sm:flex" : "flex"} min-h-0 min-w-0 flex-1`}
+      >
         <ListPane
-        chrome={
-          <>
-        <h1 className="display mb-4 text-lg font-semibold">Proposals</h1>
-        {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
-        {context.kind === "repo" && (
-          <p className="mb-3 text-[11px] text-(--text-faint)">
-            {`Showing proposals that name ${context.name}.`}
-            {hiddenOpenRepoCount > 0 &&
-              ` ${hiddenOpenRepoCount} open proposal${hiddenOpenRepoCount === 1 ? "" : "s"} ${hiddenOpenRepoCount === 1 ? "does" : "do"} not name this repo and ${hiddenOpenRepoCount === 1 ? "is" : "are"} hidden.`}
-          </p>
-        )}
+          chrome={
+            <>
+              <h1 className="display mb-4 text-lg font-semibold">Proposals</h1>
+              {context.kind === "inflight" && (
+                <ScopeCaption context={context} surface="fleet" />
+              )}
+              {context.kind === "repo" && (
+                <p className="mb-3 text-[11px] text-(--text-faint)">
+                  {`Showing proposals that name ${context.name}.`}
+                  {hiddenOpenRepoCount > 0 &&
+                    ` ${hiddenOpenRepoCount} open proposal${hiddenOpenRepoCount === 1 ? "" : "s"} ${hiddenOpenRepoCount === 1 ? "does" : "do"} not name this repo and ${hiddenOpenRepoCount === 1 ? "is" : "are"} hidden.`}
+                </p>
+              )}
 
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <div className="flex gap-1" role="tablist" aria-label="Proposal status">
-            {PROPOSAL_TABS.map((t, idx) => {
-              const count = t === "open"
-                ? filterOpenProposals(query.data?.proposals ?? [], now).filter(
-                    (p) => context.kind !== "repo" || matchesRepo(p.repos, context),
-                  ).length
-                : (history.data?.proposals ?? []).filter((p) => p.status !== "open" && matchesRepo(p.repos, context)).length;
-              return (
-                <button
-                  key={t}
-                  type="button"
-                  role="tab"
-                  aria-selected={tab === t}
-                  onClick={() => selectTab(t)}
-                  title={t}
-                  className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"}`}
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <div
+                  className="flex gap-1"
+                  role="tablist"
+                  aria-label="Proposal status"
                 >
-                  {t === "open" ? "Open" : "History"}
-                  {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
-                  <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
-                    {idx + 1}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-          {tab === "open" && expiredCount > 0 && (
-            <button
-              type="button"
-              aria-pressed={expiredOnly}
-              onClick={() => setExpiredOnly((v) => !v)}
-              title="Filter to expired open proposals"
-              className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
-                expiredOnly
-                  ? "bg-(--surface-3) text-(--text)"
-                  : "text-(--text-faint) hover:bg-(--surface-1)"
-              }`}
-            >
-              Expired
-              <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                {expiredCount}
-              </span>
-            </button>
-          )}
-          <span className="ml-auto">
-            <DisplayOptions
-              config={displayConfig}
-              state={display}
-              onChange={setDisplay}
-              rows={scoped}
-            />
-          </span>
-          {/* Last in the row: the token chips are a full-width item, so anything
+                  {PROPOSAL_TABS.map((t, idx) => {
+                    const count =
+                      t === "open"
+                        ? filterOpenProposals(
+                            query.data?.proposals ?? [],
+                            now,
+                          ).filter(
+                            (p) =>
+                              context.kind !== "repo" ||
+                              matchesRepo(p.repos, context),
+                          ).length
+                        : (history.data?.proposals ?? []).filter(
+                            (p) =>
+                              p.status !== "open" &&
+                              matchesRepo(p.repos, context),
+                          ).length;
+                    return (
+                      <button
+                        key={t}
+                        type="button"
+                        role="tab"
+                        aria-selected={tab === t}
+                        onClick={() => selectTab(t)}
+                        title={t}
+                        className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"}`}
+                      >
+                        {t === "open" ? "Open" : "History"}
+                        {count > 0 && (
+                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                            {count}
+                          </span>
+                        )}
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                        >
+                          {idx + 1}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+                {tab === "open" && expiredCount > 0 && (
+                  <button
+                    type="button"
+                    aria-pressed={expiredOnly}
+                    onClick={() => setExpiredOnly((v) => !v)}
+                    title="Filter to expired open proposals"
+                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
+                      expiredOnly
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1)"
+                    }`}
+                  >
+                    Expired
+                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                      {expiredCount}
+                    </span>
+                  </button>
+                )}
+                <span className="ml-auto">
+                  <DisplayOptions
+                    config={displayConfig}
+                    state={display}
+                    onChange={setDisplay}
+                    rows={scoped}
+                  />
+                </span>
+                {/* Last in the row: the token chips are a full-width item, so anything
               after the filter box would be pushed onto a third line the moment
               a chip appears. */}
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="agent:… is:stale is:expired"
-            label="Filter proposals"
-            query={parsed}
-          />
-        </div>
-          </>
-        }
-      >
-
-        <table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
-          <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
-              {tab === "open" && (
-                <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
-                  <input
-                    type="checkbox"
-                    aria-label="Select all proposals"
-                    ref={headerCheckboxRef}
-                    checked={allActionableSelected}
-                    disabled={actionableVisible.length === 0}
-                    onChange={toggleSelectAll}
-                    className="cursor-pointer"
-                  />
-                </th>
-              )}
-              {listCols.map((c) => {
-                const sort = displayConfig.sorts.find((s) => s.column === c.key);
-                const isCustom = c.isCustom || c.key.startsWith("custom:");
-                const customPath = c.key.replace(/^custom:/, "");
-                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
-                return (
-                  <Th
-                    key={c.key}
-                    label={c.label}
-                    dir={isCurrentSort ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir ?? "asc"}
-                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
-                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
-                  />
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {(() => {
-              const totalColSpan = listCols.length + (tab === "open" ? 1 : 0);
-              const tdCls = "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
-              const renderRow = (p: Proposal) => (
-                <tr
-                  key={p.id}
-                  onClick={() => onSelectProposal(p.id)}
-                  aria-selected={p.id === selectedId}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : proposalIsExpired(p, now) ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
-                >
-                  {tab === "open" && (
-                    <td className={`${tdCls} w-8`} onClick={(e) => e.stopPropagation()}>
-                      <input
-                        type="checkbox"
-                        aria-label={`Select proposal ${p.id}`}
-                        checked={selectedIds.has(p.id)}
-                        onChange={(e) => {
-                          e.stopPropagation();
-                          toggleSelect(p.id);
-                        }}
-                        className="cursor-pointer"
-                      />
-                    </td>
-                  )}
-                  <td className={`${tdCls} max-w-32 truncate`}>
-                    {p.agent ? (
-                      <AgentHoverCard
-                        agentRef={p.agent}
-                        onJumpAgent={onJumpAgent}
-                      />
-                    ) : (
-                      <span className="text-(--text-faint)" title="no agent: proposal rejected at planning">
-                        —
-                      </span>
+                <FilterInput
+                  value={filter}
+                  onChange={setFilter}
+                  placeholder="agent:… is:stale is:expired"
+                  label="Filter proposals"
+                  query={parsed}
+                />
+              </div>
+            </>
+          }
+        >
+          <table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
+            <thead>
+              <tr className="text-left text-[11px] text-(--text-faint)">
+                {tab === "open" && (
+                  <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all proposals"
+                      ref={headerCheckboxRef}
+                      checked={allActionableSelected}
+                      disabled={actionableVisible.length === 0}
+                      onChange={toggleSelectAll}
+                      className="cursor-pointer"
+                    />
+                  </th>
+                )}
+                {listCols.map((c) => {
+                  const sort = displayConfig.sorts.find(
+                    (s) => s.column === c.key,
+                  );
+                  const isCustom = c.isCustom || c.key.startsWith("custom:");
+                  const customPath = c.key.replace(/^custom:/, "");
+                  const isCurrentSort = isCustom
+                    ? display.sortBy === c.key
+                    : sort && display.sortBy === sort.key;
+                  return (
+                    <Th
+                      key={c.key}
+                      label={c.label}
+                      dir={isCurrentSort ? display.sortDir : null}
+                      naturalDir={sort?.defaultDir ?? "asc"}
+                      onSort={
+                        sort || isCustom
+                          ? () =>
+                              setDisplay((s) =>
+                                cycleColumnSort(displayConfig, s, c.key),
+                              )
+                          : undefined
+                      }
+                      onRemove={
+                        isCustom
+                          ? () =>
+                              setDisplay((s) =>
+                                removeCustomColumn(s, customPath),
+                              )
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {(() => {
+                const totalColSpan = listCols.length + (tab === "open" ? 1 : 0);
+                const tdCls =
+                  "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
+                const renderRow = (p: Proposal) => (
+                  <tr
+                    key={p.id}
+                    onClick={() => onSelectProposal(p.id)}
+                    aria-selected={p.id === selectedId}
+                    className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : proposalIsExpired(p, now) ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
+                  >
+                    {tab === "open" && (
+                      <td
+                        className={`${tdCls} w-8`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <input
+                          type="checkbox"
+                          aria-label={`Select proposal ${p.id}`}
+                          checked={selectedIds.has(p.id)}
+                          onChange={(e) => {
+                            e.stopPropagation();
+                            toggleSelect(p.id);
+                          }}
+                          className="cursor-pointer"
+                        />
+                      </td>
                     )}
-                  </td>
-                  {show.has("decision") && (
-                    <td className={`${tdCls} max-w-28 truncate`}>
-                      <StateBadge state={p.decision} hues={DECISION_HUES} />
-                      {staleState(p) && (
-                        <span className="ml-2" style={{ color: "var(--hue-err)" }}>
-                          run {staleState(p)}
+                    <td className={`${tdCls} max-w-32 truncate`}>
+                      {p.agent ? (
+                        <AgentHoverCard
+                          agentRef={p.agent}
+                          onJumpAgent={onJumpAgent}
+                        />
+                      ) : (
+                        <span
+                          className="text-(--text-faint)"
+                          title="no agent: proposal rejected at planning"
+                        >
+                          —
                         </span>
                       )}
                     </td>
-                  )}
-                  {show.has("ttl") && (
-                    <td className={`${tdCls} min-w-24 max-w-28 truncate whitespace-nowrap`}>
-                      <Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />
-                    </td>
-                  )}
-                  {show.has("status") && (
-                    <td className={`${tdCls} max-w-28 truncate`}>
-                      <StateBadge state={p.status} hues={PROPOSAL_STATUS_HUES} />
-                    </td>
-                  )}
-                  {show.has("decided") && (
-                    <td
-                      className={`max-w-36 truncate ${tdCls} text-(--text-faint)`}
-                      title={
-                        p.decided_at
-                          ? `${new Date(p.decided_at).toLocaleString()}${p.decided_by ? ` · ${p.decided_by}` : ""}`
-                          : undefined
-                      }
-                    >
-                      {p.decided_at ? (
-                        <>
-                          <Ago iso={p.decided_at} now={now} />
-                          {p.decided_by && <span className="text-(--text-faint)"> · {p.decided_by}</span>}
-                        </>
-                      ) : (
-                        "-"
-                      )}
-                    </td>
-                  )}
-                  {show.has("origin") && (
-                    <td className={`mono max-w-32 truncate ${tdCls} text-(--text-faint)`} title={p.eventId ?? undefined}>
-                      {p.eventId && p.eventSource ? (
-                        <JumpLink
-                          onClick={() => onJumpEvent(p.eventSource!, p.eventId!)}
-                          title={`Open origin event ${p.eventId}`}
-                        >
-                          {shortId(p.eventId)}
-                        </JumpLink>
-                      ) : (
-                        (p.eventId ? shortId(p.eventId) : "-")
-                      )}
-                    </td>
-                  )}
-                  {show.has("created") && (
-                    <td className={`max-w-24 whitespace-nowrap ${tdCls} text-(--text-faint)`}>
-                      <Ago iso={p.created_at} now={now} />
-                    </td>
-                  )}
-                  {show.has("reason") &&
-                    (() => {
-                      const r = humanizeReason(p.reason);
-                      return (
-                        <td
-                          className={`max-w-48 truncate ${tdCls} text-(--text-dim)`}
-                          title={r.raw ?? undefined}
-                        >
-                          {r.text || "-"}
-                        </td>
-                      );
-                    })()}
-                  {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
-                    <CustomCell key={c.key} row={p} path={c.key.replace(/^custom:/, "")} />
-                  ))}
-                </tr>
-              );
-              return windowTokens.map((token) => {
-                if (token.length === 1) return renderRow(token[0]);
-                const [s, sub] = token;
-                return (
-                  <GroupHeaderRow
-                    key={`group:${s.key}`}
-                    colSpan={totalColSpan}
-                    section={s}
-                    collapsed={display.collapsed.includes(s.key)}
-                    onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
-                    sub={sub}
-                  />
+                    {show.has("decision") && (
+                      <td className={`${tdCls} max-w-28 truncate`}>
+                        <StateBadge state={p.decision} hues={DECISION_HUES} />
+                        {staleState(p) && (
+                          <span
+                            className="ml-2"
+                            style={{ color: "var(--hue-err)" }}
+                          >
+                            run {staleState(p)}
+                          </span>
+                        )}
+                      </td>
+                    )}
+                    {show.has("ttl") && (
+                      <td
+                        className={`${tdCls} min-w-24 max-w-28 truncate whitespace-nowrap`}
+                      >
+                        <Countdown
+                          createdAt={p.created_at}
+                          ttlSeconds={p.ttl_seconds}
+                        />
+                      </td>
+                    )}
+                    {show.has("status") && (
+                      <td className={`${tdCls} max-w-28 truncate`}>
+                        <StateBadge
+                          state={p.status}
+                          hues={PROPOSAL_STATUS_HUES}
+                        />
+                      </td>
+                    )}
+                    {show.has("decided") && (
+                      <td
+                        className={`max-w-36 truncate ${tdCls} text-(--text-faint)`}
+                        title={
+                          p.decided_at
+                            ? `${new Date(p.decided_at).toLocaleString()}${p.decided_by ? ` · ${p.decided_by}` : ""}`
+                            : undefined
+                        }
+                      >
+                        {p.decided_at ? (
+                          <>
+                            <Ago iso={p.decided_at} now={now} />
+                            {p.decided_by && (
+                              <span className="text-(--text-faint)">
+                                {" "}
+                                · {p.decided_by}
+                              </span>
+                            )}
+                          </>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    )}
+                    {show.has("origin") && (
+                      <td
+                        className={`mono max-w-32 truncate ${tdCls} text-(--text-faint)`}
+                        title={p.eventId ?? undefined}
+                      >
+                        {p.eventId && p.eventSource ? (
+                          <JumpLink
+                            onClick={() =>
+                              onJumpEvent(p.eventSource!, p.eventId!)
+                            }
+                            title={`Open origin event ${p.eventId}`}
+                          >
+                            {shortId(p.eventId)}
+                          </JumpLink>
+                        ) : p.eventId ? (
+                          shortId(p.eventId)
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    )}
+                    {show.has("created") && (
+                      <td
+                        className={`max-w-24 whitespace-nowrap ${tdCls} text-(--text-faint)`}
+                      >
+                        <Ago iso={p.created_at} now={now} />
+                      </td>
+                    )}
+                    {show.has("reason") &&
+                      (() => {
+                        const r = humanizeReason(p.reason);
+                        return (
+                          <td
+                            className={`max-w-48 truncate ${tdCls} text-(--text-dim)`}
+                            title={r.raw ?? undefined}
+                          >
+                            {r.text || "-"}
+                          </td>
+                        );
+                      })()}
+                    {listCols
+                      .filter((c) => c.isCustom || c.key.startsWith("custom:"))
+                      .map((c) => (
+                        <CustomCell
+                          key={c.key}
+                          row={p}
+                          path={c.key.replace(/^custom:/, "")}
+                        />
+                      ))}
+                  </tr>
                 );
-              });
-            })()}
-            <TableWindowFooter
-              colSpan={listCols.length + (tab === "open" ? 1 : 0)}
-              range={[windowStart, windowEnd, tokens.length]}
-              move={moveWindow}
-            />
-            {visible.length === 0 && (
-              <ListEmpty
-                colSpan={listCols.length + (tab === "open" ? 1 : 0)}
-                query={tab === "open" ? query : history}
-                filtered={unfilteredCount > 0}
-                onClear={
-                  escClearsFilter
-                    ? () => {
-                        setFilter("");
-                        setExpiredOnly(false);
+                return windowTokens.map((token) => {
+                  if (token.length === 1) return renderRow(token[0]);
+                  const [s, sub] = token;
+                  return (
+                    <GroupHeaderRow
+                      key={`group:${s.key}`}
+                      colSpan={totalColSpan}
+                      section={s}
+                      collapsed={display.collapsed.includes(s.key)}
+                      onToggle={() =>
+                        setDisplay((st) => toggleCollapsed(st, s.key))
                       }
-                    : undefined
-                }
-                noun="proposals"
-                empty={
-                  expiredFilter
-                    ? "No expired open proposals."
-                    : context.kind === "repo"
-                      ? `No proposals naming ${context.name}.`
-                      : tab === "open"
-                        ? "No open proposals — the operator's work is done, for now."
-                        : "No decided proposals yet."
-                }
-                escHint={escClearsFilter}
+                      sub={sub}
+                    />
+                  );
+                });
+              })()}
+              <TableWindowFooter
+                colSpan={listCols.length + (tab === "open" ? 1 : 0)}
+                range={[windowStart, windowEnd, tokens.length]}
+                move={moveWindow}
               />
-            )}
-          </tbody>
-        </table>
+              {visible.length === 0 && (
+                <ListEmpty
+                  colSpan={listCols.length + (tab === "open" ? 1 : 0)}
+                  query={tab === "open" ? query : history}
+                  filtered={unfilteredCount > 0}
+                  onClear={
+                    escClearsFilter
+                      ? () => {
+                          setFilter("");
+                          setExpiredOnly(false);
+                        }
+                      : undefined
+                  }
+                  noun="proposals"
+                  empty={
+                    expiredFilter
+                      ? "No expired open proposals."
+                      : context.kind === "repo"
+                        ? `No proposals naming ${context.name}.`
+                        : tab === "open"
+                          ? "No open proposals — the operator's work is done, for now."
+                          : "No decided proposals yet."
+                  }
+                  escHint={escClearsFilter}
+                />
+              )}
+            </tbody>
+          </table>
         </ListPane>
       </div>
 
@@ -1120,7 +1389,10 @@ export function Proposals({
         <DetailPane
           widthClass="w-full sm:w-[460px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectProposal(null)}
@@ -1132,10 +1404,15 @@ export function Proposals({
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
-              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
                 <StateBadge
                   state={sel.status === "open" ? sel.decision : sel.status}
-                  hues={sel.status === "open" ? DECISION_HUES : PROPOSAL_STATUS_HUES}
+                  hues={
+                    sel.status === "open" ? DECISION_HUES : PROPOSAL_STATUS_HUES
+                  }
                 />
                 <span className="truncate mono" title={sel.id}>
                   {shortId(sel.id)}
@@ -1151,7 +1428,13 @@ export function Proposals({
                   disabled={!connected || reject.isPending}
                   onClick={openReject}
                 >
-                  Reject… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                  Reject…{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    x
+                  </span>
                 </Button>
                 {sel.decision === "run" && (
                   <span title={approvalDisabledReason}>
@@ -1160,7 +1443,10 @@ export function Proposals({
                       disabled={!canApprove || !connected || approve.isPending}
                       onClick={openApprove}
                     >
-                      Approve… <span className="mono ml-1 opacity-80" aria-hidden="true">a</span>
+                      Approve…{" "}
+                      <span className="mono ml-1 opacity-80" aria-hidden="true">
+                        a
+                      </span>
                     </Button>
                   </span>
                 )}
@@ -1170,7 +1456,6 @@ export function Proposals({
           utility={<CopyActions id={sel.id} idLabel="proposal id" />}
           close={<Button onClick={() => onSelectProposal(null)}>Close</Button>}
         >
-
           <Section title="Proposal" icons>
             <KV k="id" v={sel.id} />
             {sel.agent && (
@@ -1184,13 +1469,22 @@ export function Proposals({
                 }
               />
             )}
-            <KV k="decision" v={<StateBadge state={sel.decision} hues={DECISION_HUES} />} />
-            <KV k="status" v={<StateBadge state={sel.status} hues={PROPOSAL_STATUS_HUES} />} />
+            <KV
+              k="decision"
+              v={<StateBadge state={sel.decision} hues={DECISION_HUES} />}
+            />
+            <KV
+              k="status"
+              v={<StateBadge state={sel.status} hues={PROPOSAL_STATUS_HUES} />}
+            />
             <KV
               k="run"
               v={
                 sel.runId ? (
-                  <JumpLink onClick={() => onRunQueued(sel.runId!)} title={`Open run ${sel.runId}`}>
+                  <JumpLink
+                    onClick={() => onRunQueued(sel.runId!)}
+                    title={`Open run ${sel.runId}`}
+                  >
                     {shortId(sel.runId)}
                   </JumpLink>
                 ) : null
@@ -1199,11 +1493,18 @@ export function Proposals({
             {isOpen && (
               <KV
                 k="ttl"
-                v={<Countdown createdAt={sel.created_at} ttlSeconds={sel.ttl_seconds} />}
+                v={
+                  <Countdown
+                    createdAt={sel.created_at}
+                    ttlSeconds={sel.ttl_seconds}
+                  />
+                }
               />
             )}
             <KV k="created" v={<Ago iso={sel.created_at} now={now} />} />
-            {sel.decided_at && <KV k="decided at" v={<Ago iso={sel.decided_at} now={now} />} />}
+            {sel.decided_at && (
+              <KV k="decided at" v={<Ago iso={sel.decided_at} now={now} />} />
+            )}
             {sel.decided_by && <KV k="decided by" v={sel.decided_by} />}
             {selReason && (
               <KV
@@ -1226,7 +1527,12 @@ export function Proposals({
                 k="eventId"
                 v={
                   sel.eventSource ? (
-                    <JumpLink onClick={() => onJumpEvent(sel.eventSource!, sel.eventId!)} title={`Open origin event ${sel.eventId}`}>
+                    <JumpLink
+                      onClick={() =>
+                        onJumpEvent(sel.eventSource!, sel.eventId!)
+                      }
+                      title={`Open origin event ${sel.eventId}`}
+                    >
                       {shortId(sel.eventId)}
                     </JumpLink>
                   ) : (
@@ -1239,45 +1545,63 @@ export function Proposals({
             </Section>
           )}
 
-          {sel.spec && (() => {
-            const prev = (runsQuery.data?.runs ?? []).find((r) => r.agent === sel.agent && r.state === "COMPLETED");
+          {sel.spec &&
+            (() => {
+              const prev = (runsQuery.data?.runs ?? []).find(
+                (r) => r.agent === sel.agent && r.state === "COMPLETED",
+              );
 
-            return (
-              <Section title="Safety & blast radius" card={false}>
-                {/*
+              return (
+                <Section title="Safety & blast radius" card={false}>
+                  {/*
                   Shared with the Runs view's approve dialog (WM-505) so both
                   approval paths present identical risk context.
                 */}
-                <ApprovalSafetyCard
-                  proposal={sel}
-                  agent={selAgent}
-                  footer={
-                    <>
-                      <div className="uppercase text-(--text-faint) mb-0.5">Historical Comparison</div>
-                      {prev ? (
-                        <div className="flex justify-between text-(--text-dim)">
-                          <span>Prior: <JumpLink onClick={() => onRunQueued(prev.runId)}>{prev.runId}</JumpLink> (<Ago iso={prev.updated_at} now={now} />)</span>
-                          <span className="mono text-(--text-faint)">{prev.attempts} att</span>
+                  <ApprovalSafetyCard
+                    proposal={sel}
+                    agent={selAgent}
+                    footer={
+                      <>
+                        <div className="uppercase text-(--text-faint) mb-0.5">
+                          Historical Comparison
                         </div>
-                      ) : <div className="text-(--text-faint)">No prior run for {sel.agent}.</div>}
-                    </>
-                  }
-                />
-                <Disclosure label="immutable RunSpec" defaultOpen={isOpen}>
-                  <div className="min-w-0 overflow-x-auto">
-                    <JsonBlock value={sel.spec} />
-                  </div>
-                </Disclosure>
-              </Section>
-            );
-          })()}
+                        {prev ? (
+                          <div className="flex justify-between text-(--text-dim)">
+                            <span>
+                              Prior:{" "}
+                              <JumpLink onClick={() => onRunQueued(prev.runId)}>
+                                {prev.runId}
+                              </JumpLink>{" "}
+                              (<Ago iso={prev.updated_at} now={now} />)
+                            </span>
+                            <span className="mono text-(--text-faint)">
+                              {prev.attempts} att
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="text-(--text-faint)">
+                            No prior run for {sel.agent}.
+                          </div>
+                        )}
+                      </>
+                    }
+                  />
+                  <Disclosure label="immutable RunSpec" defaultOpen={isOpen}>
+                    <div className="min-w-0 overflow-x-auto">
+                      <JsonBlock value={sel.spec} />
+                    </div>
+                  </Disclosure>
+                </Section>
+              );
+            })()}
 
           {isOpen && (selectionExpired || staleState(sel)) && (
             <div
               className="mb-3 rounded-md px-2.5 py-1.5 text-[12px]"
               style={{
                 color: "var(--hue-err)",
-                background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
+                background:
+                  "color-mix(in oklch, var(--hue-err) 10%, transparent)",
               }}
             >
               {selectionExpired
@@ -1288,7 +1612,9 @@ export function Proposals({
 
           {isOpen && rejecting && (
             <div className="mt-3 flex flex-col gap-2 rounded-md border border-(--border) bg-(--surface-0) p-2.5">
-              <div className="text-[11px] font-medium text-(--text-faint)">Canned Rejection Templates:</div>
+              <div className="text-[11px] font-medium text-(--text-faint)">
+                Canned Rejection Templates:
+              </div>
               <div className="flex flex-wrap gap-1.5">
                 {CANNED_REJECTION_REASONS.map((tmpl) => (
                   <button
@@ -1315,7 +1641,8 @@ export function Proposals({
                   onChange={(e) => setReason(e.target.value)}
                   onKeyDown={(e) => {
                     if (
-                      (e.key === "Enter" || ((e.metaKey || e.ctrlKey) && e.key === "Enter")) &&
+                      (e.key === "Enter" ||
+                        ((e.metaKey || e.ctrlKey) && e.key === "Enter")) &&
                       reason.trim() &&
                       !reject.isPending &&
                       connected
@@ -1331,7 +1658,9 @@ export function Proposals({
                 <Button
                   variant="danger"
                   disabled={!reason.trim() || reject.isPending || !connected}
-                  onClick={() => reject.mutate({ id: sel.id, why: reason.trim() })}
+                  onClick={() =>
+                    reject.mutate({ id: sel.id, why: reason.trim() })
+                  }
                 >
                   Confirm
                 </Button>
@@ -1345,10 +1674,14 @@ export function Proposals({
       )}
 
       {confirmApprove && sel && (
-        <Dialog title="Approve and queue this run?" onClose={() => setConfirmApprove(false)} wide>
+        <Dialog
+          title="Approve and queue this run?"
+          onClose={() => setConfirmApprove(false)}
+          wide
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            You are approving this exact immutable spec — the agent below runs with these
-            capabilities the moment you confirm.
+            You are approving this exact immutable spec — the agent below runs
+            with these capabilities the moment you confirm.
           </div>
           {/* Shared with the Runs view's approve dialog (WM-505). */}
           <ApprovalRiskDetails proposal={sel} agent={selAgent} />
@@ -1364,7 +1697,10 @@ export function Proposals({
                   approve.mutate(sel);
                 }}
               >
-                Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+                Approve and queue{" "}
+                <span className="mono ml-1 opacity-80" aria-hidden="true">
+                  ↵
+                </span>
               </Button>
             </span>
           </div>
@@ -1372,23 +1708,37 @@ export function Proposals({
       )}
 
       {replan && (
-        <Dialog title="Proposal expired — re-planned against current state" onClose={() => setReplan(null)} wide>
+        <Dialog
+          title="Proposal expired — re-planned against current state"
+          onClose={() => setReplan(null)}
+          wide
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            The TTL passed, so the planner re-read authoritative state and produced a new spec. Review
-            the difference; nothing runs until you approve the new proposal explicitly.
+            The TTL passed, so the planner re-read authoritative state and
+            produced a new spec. Review the difference; nothing runs until you
+            approve the new proposal explicitly.
           </div>
           <div className="mb-3 max-h-[38vh] overflow-auto">
             <SpecDiff before={replan.before.spec} after={replan.after.spec} />
           </div>
           <div className="mt-3 flex justify-end gap-2">
             <Button onClick={() => setReplan(null)}>Not yet</Button>
-            <span title={replanExpired ? "This replacement proposal has expired and can no longer be approved." : undefined}>
+            <span
+              title={
+                replanExpired
+                  ? "This replacement proposal has expired and can no longer be approved."
+                  : undefined
+              }
+            >
               <Button
                 variant="primary"
                 disabled={!connected || replanExpired || approve.isPending}
                 onClick={approveReplan}
               >
-                Approve new proposal <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+                Approve new proposal{" "}
+                <span className="mono ml-1 opacity-80" aria-hidden="true">
+                  ↵
+                </span>
               </Button>
             </span>
           </div>
@@ -1396,25 +1746,44 @@ export function Proposals({
       )}
 
       {selectedIds.size > 0 && tab === "open" && (
-        <BulkActionBar count={selectedIds.size} onClear={() => setSelectedIds(new Set())}>
+        <BulkActionBar
+          count={selectedIds.size}
+          onClear={() => setSelectedIds(new Set())}
+        >
           <Button
             variant="primary"
-            disabled={!connected || bulkApproving || approvableSelected.length === 0}
+            disabled={
+              !connected || bulkApproving || approvableSelected.length === 0
+            }
             onClick={() => setBulkConfirmOpen(true)}
           >
-            {bulkApproving ? "Approving…" : `Approve selected (${approvableSelected.length})`}
-            <span className="mono ml-1 text-[10px] text-(--text-faint)" aria-hidden="true">A</span>
+            {bulkApproving
+              ? "Approving…"
+              : `Approve selected (${approvableSelected.length})`}
+            <span
+              className="mono ml-1 text-[10px] text-(--text-faint)"
+              aria-hidden="true"
+            >
+              A
+            </span>
           </Button>
           <Button
             variant="danger"
-            disabled={!connected || bulkRejecting || rejectableSelected.length === 0}
+            disabled={
+              !connected || bulkRejecting || rejectableSelected.length === 0
+            }
             onClick={() => {
               setBulkRejectOpen(true);
               setBulkReason("");
             }}
           >
             Reject selected ({selectedIds.size})
-            <span className="mono ml-1 text-[10px] text-(--text-faint)" aria-hidden="true">X</span>
+            <span
+              className="mono ml-1 text-[10px] text-(--text-faint)"
+              aria-hidden="true"
+            >
+              X
+            </span>
           </Button>
         </BulkActionBar>
       )}
@@ -1426,20 +1795,39 @@ export function Proposals({
           wide
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            You are approving {approvableSelected.length === 1 ? "this exact immutable spec" : "these exact immutable specs"}{" "}
-            — each agent below runs with these capabilities the moment you confirm. Stale and non-run
-            rows are skipped.
+            You are approving{" "}
+            {approvableSelected.length === 1
+              ? "this exact immutable spec"
+              : "these exact immutable specs"}{" "}
+            — each agent below runs with these capabilities the moment you
+            confirm. Stale and non-run rows are skipped.
           </div>
           <div className="flex max-h-[50vh] flex-col gap-4 overflow-auto">
             {approvableSelected.map((p) => (
-              <div key={p.id} className="rounded-md border border-(--border) bg-(--surface-0) p-2.5">
-                <div className="mb-2 font-medium text-[12px]">{p.agent ?? p.id}</div>
+              <div
+                key={p.id}
+                className="rounded-md border border-(--border) bg-(--surface-0) p-2.5"
+              >
+                <div className="mb-2 font-medium text-[12px]">
+                  {p.agent ?? p.id}
+                </div>
                 <KV k="agent" v={p.spec?.agent} />
                 <KV k="adapter" v={p.spec?.adapter} />
-                <KV k="capabilities" v={p.spec?.capabilities.join(", ") || "none"} />
+                <KV
+                  k="capabilities"
+                  v={p.spec?.capabilities.join(", ") || "none"}
+                />
                 <KV k="timeout" v={`${p.spec?.timeoutSeconds}s`} />
                 <KV k="attempts" v={String(p.spec?.maxAttempts)} />
-                <KV k="ttl" v={<Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />} />
+                <KV
+                  k="ttl"
+                  v={
+                    <Countdown
+                      createdAt={p.created_at}
+                      ttlSeconds={p.ttl_seconds}
+                    />
+                  }
+                />
                 {p.spec && (
                   <div className="min-w-0 overflow-x-auto">
                     <JsonBlock value={p.spec} />
@@ -1458,7 +1846,10 @@ export function Proposals({
                 void handleBulkApprove();
               }}
             >
-              Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+              Approve and queue{" "}
+              <span className="mono ml-1 opacity-80" aria-hidden="true">
+                ↵
+              </span>
             </Button>
           </div>
         </Dialog>
@@ -1470,7 +1861,8 @@ export function Proposals({
           onClose={() => setBulkRejectOpen(false)}
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            Provide a rejection reason for all {rejectableSelected.length} selected proposals:
+            Provide a rejection reason for all {rejectableSelected.length}{" "}
+            selected proposals:
           </div>
           <div className="mb-3 flex flex-wrap gap-1.5">
             {CANNED_REJECTION_REASONS.map((tmpl) => (
@@ -1498,7 +1890,8 @@ export function Proposals({
             onChange={(e) => setBulkReason(e.target.value)}
             onKeyDown={(e) => {
               if (
-                (e.key === "Enter" || ((e.metaKey || e.ctrlKey) && e.key === "Enter")) &&
+                (e.key === "Enter" ||
+                  ((e.metaKey || e.ctrlKey) && e.key === "Enter")) &&
                 bulkReason.trim() &&
                 !bulkRejecting &&
                 connected
@@ -1517,7 +1910,9 @@ export function Proposals({
               disabled={!bulkReason.trim() || bulkRejecting || !connected}
               onClick={handleBulkReject}
             >
-              {bulkRejecting ? "Rejecting…" : `Reject ${rejectableSelected.length} proposals`}
+              {bulkRejecting
+                ? "Rejecting…"
+                : `Reject ${rejectableSelected.length} proposals`}
             </Button>
           </div>
         </Dialog>

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -129,44 +129,61 @@ describe("RunFull deadline extension (WM-566)", () => {
     globalThis.fetch = (async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}"));
       calls.push(body.seconds);
-      return new Response(JSON.stringify({
-        extended: true,
-        runId,
-        seconds: body.seconds,
-        deadlineAt: new Date(Date.parse(deadlineAt) + body.seconds * 1000).toISOString(),
-        leaseExpiresAt: new Date(Date.parse(deadlineAt) + (body.seconds + 120) * 1000).toISOString(),
-        override: false,
-      }), { status: 200, headers: { "content-type": "application/json" } });
+      return new Response(
+        JSON.stringify({
+          extended: true,
+          runId,
+          seconds: body.seconds,
+          deadlineAt: new Date(
+            Date.parse(deadlineAt) + body.seconds * 1000,
+          ).toISOString(),
+          leaseExpiresAt: new Date(
+            Date.parse(deadlineAt) + (body.seconds + 120) * 1000,
+          ).toISOString(),
+          override: false,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }) as typeof fetch;
     try {
       await withApi(
-      {
-        run: async () => detail,
-        runs: async () => ({
-          runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt })],
-        }),
-      },
-      async () => {
-        const { getByRole, getByText, getByLabelText } = renderRunFull(runId);
-        await waitFor(() => getByText(/Remaining/));
-        expect(getByText(/Remaining/).textContent).toContain("30m");
+        {
+          run: async () => detail,
+          runs: async () => ({
+            runs: [
+              createRunListItemFixture({ runId, state: "RUNNING", deadlineAt }),
+            ],
+          }),
+        },
+        async () => {
+          const { getByRole, getByText, getByLabelText } = renderRunFull(runId);
+          await waitFor(() => getByText(/Remaining/));
+          expect(getByText(/Remaining/).textContent).toContain("30m");
 
-        fireEvent.click(getByRole("button", { name: "+15m" }));
-        await waitFor(() => expect(calls).toEqual([900]));
-        expect(getByText(/Run extended by 15 minutes/)).toBeTruthy();
+          fireEvent.click(getByRole("button", { name: "+15m" }));
+          await waitFor(() => expect(calls).toEqual([900]));
+          expect(getByText(/Run extended by 15 minutes/)).toBeTruthy();
 
-        fireEvent.click(getByRole("button", { name: "Custom…" }));
-        const input = getByLabelText("Extension minutes");
-        changeInput(input as HTMLInputElement, "0");
-        expect(input.getAttribute("aria-invalid")).toBe("true");
-        expect(getByText("Enter a whole number from 1 to 60.")).toBeTruthy();
-        expect(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }).hasAttribute("disabled")).toBe(true);
-        changeInput(input as HTMLInputElement, "20");
-        expect(input.getAttribute("aria-invalid")).toBe("false");
-        fireEvent.click(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }));
-        await waitFor(() => expect(calls).toEqual([900, 1200]));
-      },
-    );
+          fireEvent.click(getByRole("button", { name: "Custom…" }));
+          const input = getByLabelText("Extension minutes");
+          changeInput(input as HTMLInputElement, "0");
+          expect(input.getAttribute("aria-invalid")).toBe("true");
+          expect(getByText("Enter a whole number from 1 to 60.")).toBeTruthy();
+          expect(
+            within(getByRole("dialog"))
+              .getByRole("button", { name: "Extend run" })
+              .hasAttribute("disabled"),
+          ).toBe(true);
+          changeInput(input as HTMLInputElement, "20");
+          expect(input.getAttribute("aria-invalid")).toBe("false");
+          fireEvent.click(
+            within(getByRole("dialog")).getByRole("button", {
+              name: "Extend run",
+            }),
+          );
+          await waitFor(() => expect(calls).toEqual([900, 1200]));
+        },
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -179,17 +196,27 @@ describe("RunFull deadline extension (WM-566)", () => {
     });
     detail.deadlineAt = new Date(Date.now() + 60_000).toISOString();
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response(JSON.stringify({
-      error: "deadline_already_expired",
-      extended: false,
-      refusal: { code: "deadline_already_expired", retryable: false },
-    }), { status: 409, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: "deadline_already_expired",
+          extended: false,
+          refusal: { code: "deadline_already_expired", retryable: false },
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
     try {
       await withApi(
         {
           run: async () => detail,
           runs: async () => ({
-            runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt: detail.deadlineAt })],
+            runs: [
+              createRunListItemFixture({
+                runId,
+                state: "RUNNING",
+                deadlineAt: detail.deadlineAt,
+              }),
+            ],
           }),
         },
         async () => {
@@ -215,15 +242,27 @@ describe("RunFull deadline extension (WM-566)", () => {
       {
         run: async () => detail,
         runs: async () => ({
-          runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt: detail.deadlineAt })],
+          runs: [
+            createRunListItemFixture({
+              runId,
+              state: "RUNNING",
+              deadlineAt: detail.deadlineAt,
+            }),
+          ],
         }),
       },
       async () => {
         const { getByRole } = renderRunFull(runId, false);
-        const custom = await waitFor(() => getByRole("button", { name: "Custom…" }));
+        const custom = await waitFor(() =>
+          getByRole("button", { name: "Custom…" }),
+        );
         expect(custom.hasAttribute("disabled")).toBe(false);
         fireEvent.click(custom);
-        expect(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }).hasAttribute("disabled")).toBe(true);
+        expect(
+          within(getByRole("dialog"))
+            .getByRole("button", { name: "Extend run" })
+            .hasAttribute("disabled"),
+        ).toBe(true);
       },
     );
   });
@@ -285,14 +324,22 @@ describe("RunFull header copy verbs and hints (WM-218)", () => {
       },
       async () => {
         const { getByRole } = renderRunFull(runId);
-        const openInTab = await waitFor(() => getByRole("button", { name: /Open in tab/ }));
-        expect(openInTab.querySelector('[aria-hidden="true"]')?.textContent).toBe("p");
+        const openInTab = await waitFor(() =>
+          getByRole("button", { name: /Open in tab/ }),
+        );
+        expect(
+          openInTab.querySelector('[aria-hidden="true"]')?.textContent,
+        ).toBe("p");
 
         fireEvent.keyDown(document.body, { key: "p" });
-        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([runId]);
+        expect(
+          JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]"),
+        ).toEqual([runId]);
 
         fireEvent.keyDown(document.body, { key: "p" });
-        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([]);
+        expect(
+          JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]"),
+        ).toEqual([]);
       },
     );
   });
@@ -316,15 +363,21 @@ describe("RunFull header copy verbs and hints (WM-218)", () => {
         expect(getByRole("button", { name: /← Runs/ }).textContent).toContain(
           "Esc",
         );
-        expect(getByRole("button", { name: "Copy run id (c)" }).getAttribute("title")).toBe(
-          "Copy run id · c",
-        );
-        expect(getByRole("button", { name: "Copy CLI inspect command (c i)" }).getAttribute("title")).toBe(
-          "Copy CLI inspect command · c i",
-        );
-        expect(getByRole("button", { name: "Copy link (c l)" }).getAttribute("title")).toBe(
-          "Copy link · c l",
-        );
+        expect(
+          getByRole("button", { name: "Copy run id (c)" }).getAttribute(
+            "title",
+          ),
+        ).toBe("Copy run id · c");
+        expect(
+          getByRole("button", {
+            name: "Copy CLI inspect command (c i)",
+          }).getAttribute("title"),
+        ).toBe("Copy CLI inspect command · c i");
+        expect(
+          getByRole("button", { name: "Copy link (c l)" }).getAttribute(
+            "title",
+          ),
+        ).toBe("Copy link · c l");
       },
     );
   });
@@ -493,7 +546,10 @@ describe("RunFull causal follow-up events and chained runs (WM-420)", () => {
         run: async () => detail,
         runs: async () => ({
           runs: [
-            createRunListItemFixture({ runId: parentRunId, state: "COMPLETED" }),
+            createRunListItemFixture({
+              runId: parentRunId,
+              state: "COMPLETED",
+            }),
             childRun,
           ],
         }),

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -91,7 +91,8 @@ export function RunFull({
   const followUpEvents = useMemo(() => {
     const events = eventsQ.data?.events ?? [];
     return events.filter(
-      (e) => e.causationId === runId || (e.envelope as any)?.causationId === runId,
+      (e) =>
+        e.causationId === runId || (e.envelope as any)?.causationId === runId,
     );
   }, [eventsQ.data, runId]);
   // The chain this run belongs to: its origin event's correlation id (falling
@@ -100,7 +101,10 @@ export function RunFull({
   const chainKey = useMemo(() => {
     const events = eventsQ.data?.events ?? [];
     const origin = listRow
-      ? events.find((e) => e.source === listRow.eventSource && e.eventId === listRow.eventId)
+      ? events.find(
+          (e) =>
+            e.source === listRow.eventSource && e.eventId === listRow.eventId,
+        )
       : null;
     if (origin) return origin.correlationId ?? origin.eventId;
     const emitted = events.find((e) => e.causationId === runId);
@@ -201,9 +205,9 @@ export function RunFull({
 
   const canApprove = Boolean(
     selProposal &&
-      selProposal.status === "open" &&
-      selProposal.decision === "run" &&
-      d?.run.state === "PROPOSED",
+    selProposal.status === "open" &&
+    selProposal.decision === "run" &&
+    d?.run.state === "PROPOSED",
   );
 
   // Verbs: Esc back to list, x cancel, c copy id, c i / c c copy CLI inspect command, c l copy link.
@@ -329,7 +333,14 @@ export function RunFull({
     }
     return () => setContextActions([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [d?.run.runId, d?.run.state, attemptsExhausted, connected, canApprove, selProposal]);
+  }, [
+    d?.run.runId,
+    d?.run.state,
+    attemptsExhausted,
+    connected,
+    canApprove,
+    selProposal,
+  ]);
 
   return (
     <div className="fixed inset-0 z-20 flex h-full min-w-0 flex-col overflow-hidden bg-(--surface-0) sm:static sm:z-auto">
@@ -411,7 +422,10 @@ export function RunFull({
                   Remaining{" "}
                   {d.deadlineAt
                     ? (() => {
-                        const left = Math.max(0, Date.parse(d.deadlineAt) - now);
+                        const left = Math.max(
+                          0,
+                          Date.parse(d.deadlineAt) - now,
+                        );
                         const minutes = Math.ceil(left / 60_000);
                         return minutes >= 60
                           ? `${Math.floor(minutes / 60)}h ${minutes % 60}m`
@@ -421,13 +435,17 @@ export function RunFull({
                 </span>
                 <Button
                   disabled={!connected || extend.isPending}
-                  onClick={() => extend.mutate({ id: d.run.runId, seconds: 15 * 60 })}
+                  onClick={() =>
+                    extend.mutate({ id: d.run.runId, seconds: 15 * 60 })
+                  }
                 >
                   +15m
                 </Button>
                 <Button
                   disabled={!connected || extend.isPending}
-                  onClick={() => extend.mutate({ id: d.run.runId, seconds: 30 * 60 })}
+                  onClick={() =>
+                    extend.mutate({ id: d.run.runId, seconds: 30 * 60 })
+                  }
                 >
                   +30m
                 </Button>
@@ -439,7 +457,8 @@ export function RunFull({
                 </Button>
               </div>
             )}
-            {d && d.run.state === "FAILED" &&
+            {d &&
+              d.run.state === "FAILED" &&
               (attemptsExhausted ? (
                 <Button
                   disabled={!connected}
@@ -465,9 +484,7 @@ export function RunFull({
               </Button>
             )}
             {onJumpChain && chainKey && (
-              <Button
-                onClick={() => onJumpChain(chainKey, `run:${runId}`)}
-              >
+              <Button onClick={() => onJumpChain(chainKey, `run:${runId}`)}>
                 View chain
               </Button>
             )}
@@ -485,7 +502,9 @@ export function RunFull({
         {extend.error && !customExtend && <VerbError error={extend.error} />}
         {extendNotice && (
           <div className="mt-1 text-[12px] text-(--hue-ok)" role="status">
-            {extendNotice}. The Remaining clock is the current execution deadline; the sidebar budget preserves the original approved RunSpec.
+            {extendNotice}. The Remaining clock is the current execution
+            deadline; the sidebar budget preserves the original approved
+            RunSpec.
           </div>
         )}
         <div className="flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
@@ -524,7 +543,9 @@ export function RunFull({
                 <div className="mb-6 rounded-md border border-(--border) bg-(--surface-1) p-4 text-[13px]">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <div className="font-semibold text-(--text)">Awaiting Proposal Approval</div>
+                      <div className="font-semibold text-(--text)">
+                        Awaiting Proposal Approval
+                      </div>
                       <div className="text-[12px] text-(--text-dim) mt-0.5">
                         {selProposal
                           ? `Proposal ${shortId(selProposal.id)} is open and ready to approve.`
@@ -578,7 +599,11 @@ export function RunFull({
                 onForceRetry={() => setConfirm("force-retry")}
                 retryPending={retry.isPending}
                 afterLifecycle={
-                  <Section title="Follow-up Events" id="run-follow-up-events" card={followUpEvents.length === 0}>
+                  <Section
+                    title="Follow-up Events"
+                    id="run-follow-up-events"
+                    card={followUpEvents.length === 0}
+                  >
                     {followUpEvents.length === 0 ? (
                       <div className="text-[12px] text-(--text-faint)">
                         No follow-up event was emitted.
@@ -586,21 +611,33 @@ export function RunFull({
                     ) : (
                       <div className="space-y-2">
                         {followUpEvents.map((e) => {
-                          const linkedRun = e.runId ? runsById.get(e.runId) : null;
+                          const linkedRun = e.runId
+                            ? runsById.get(e.runId)
+                            : null;
                           return (
                             <div
                               key={`${e.source}:${e.eventId}`}
                               className="rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px]"
                             >
                               <div className="flex items-baseline justify-between gap-2">
-                                <span className="mono font-medium text-(--text) truncate" title={e.type}>
+                                <span
+                                  className="mono font-medium text-(--text) truncate"
+                                  title={e.type}
+                                >
                                   {e.type}
                                 </span>
                                 <span
                                   className="mono shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase"
                                   style={{
-                                    background: e.status === "planned" || e.status === "admitted" ? "var(--surface-2)" : "var(--surface-1)",
-                                    color: e.status === "dead_lettered" ? "var(--hue-err)" : "var(--text-dim)",
+                                    background:
+                                      e.status === "planned" ||
+                                      e.status === "admitted"
+                                        ? "var(--surface-2)"
+                                        : "var(--surface-1)",
+                                    color:
+                                      e.status === "dead_lettered"
+                                        ? "var(--hue-err)"
+                                        : "var(--text-dim)",
                                   }}
                                 >
                                   {e.status}
@@ -610,7 +647,9 @@ export function RunFull({
                               <div className="mt-1.5 flex items-baseline justify-between gap-2 text-[11px] text-(--text-faint)">
                                 <span className="shrink-0">event</span>
                                 <JumpLink
-                                  onClick={() => onJumpEvent(e.source, e.eventId)}
+                                  onClick={() =>
+                                    onJumpEvent(e.source, e.eventId)
+                                  }
                                   title={e.eventId}
                                   className="truncate"
                                 >
@@ -642,7 +681,9 @@ export function RunFull({
                                     )}
                                   </div>
                                   <div className="mt-1 flex items-baseline justify-between gap-2 text-[11px]">
-                                    <span className="text-(--text-faint)">agent</span>
+                                    <span className="text-(--text-faint)">
+                                      agent
+                                    </span>
                                     <span className="text-(--text-dim) truncate">
                                       {linkedRun?.agent ? (
                                         <AgentHoverCard
@@ -655,7 +696,9 @@ export function RunFull({
                                     </span>
                                   </div>
                                   <div className="mt-1 flex items-baseline justify-between gap-2 text-[11px]">
-                                    <span className="text-(--text-faint)">run</span>
+                                    <span className="text-(--text-faint)">
+                                      run
+                                    </span>
                                     <JumpLink
                                       href={`#/${withProject(hashPath("run", e.runId), hashProject(window.location.hash))}`}
                                       title={`Open run ${e.runId}`}
@@ -690,7 +733,9 @@ export function RunFull({
           wide
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            Approving proposal <span className="mono font-semibold">{selProposal.id}</span> queues this run for execution.
+            Approving proposal{" "}
+            <span className="mono font-semibold">{selProposal.id}</span> queues
+            this run for execution.
           </div>
           <VerbError error={approve.error} />
           <div className="flex justify-end gap-2">
@@ -701,16 +746,23 @@ export function RunFull({
                 approve.mutate(selProposal.id);
               }}
             >
-              Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+              Approve and queue{" "}
+              <span className="mono ml-1 opacity-80" aria-hidden="true">
+                ↵
+              </span>
             </Button>
           </div>
         </Dialog>
       )}
 
       {customExtend && d && (
-        <Dialog title={`Extend ${d.run.runId}`} onClose={() => setCustomExtend(false)}>
+        <Dialog
+          title={`Extend ${d.run.runId}`}
+          onClose={() => setCustomExtend(false)}
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            Add up to 60 minutes per request. The policy run limit still applies.
+            Add up to 60 minutes per request. The policy run limit still
+            applies.
           </div>
           <VerbError error={extend.error} />
           <label className="mb-3 block text-[12px] text-(--text-dim)">
@@ -729,7 +781,11 @@ export function RunFull({
             />
             <span
               id="extension-minutes-help"
-              className={customMinutesValid ? "mt-1 block text-(--text-faint)" : "mt-1 block text-(--hue-err)"}
+              className={
+                customMinutesValid
+                  ? "mt-1 block text-(--text-faint)"
+                  : "mt-1 block text-(--hue-err)"
+              }
             >
               Enter a whole number from 1 to 60.
             </span>
@@ -738,11 +794,7 @@ export function RunFull({
             <Button onClick={() => setCustomExtend(false)}>Cancel</Button>
             <Button
               variant="primary"
-              disabled={
-                !connected ||
-                extend.isPending ||
-                !customMinutesValid
-              }
+              disabled={!connected || extend.isPending || !customMinutesValid}
               onClick={() =>
                 extend.mutate({
                   id: d.run.runId,

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -16,7 +16,12 @@ import {
   restoreApi,
   withApi,
 } from "../test-render";
-import type { LifecycleEvent, RunDetail, RunListItem, RunState } from "../types";
+import type {
+  LifecycleEvent,
+  RunDetail,
+  RunListItem,
+  RunState,
+} from "../types";
 
 afterEach(() => {
   cleanup();
@@ -28,7 +33,11 @@ const noop = () => {};
 const FAILURE_REASON = 'contract_violation: $: unknown property "captured"';
 const NOW = new Date().toISOString();
 
-function stubListItem(runId: string, state: RunState, overrides?: Partial<RunListItem>): RunListItem {
+function stubListItem(
+  runId: string,
+  state: RunState,
+  overrides?: Partial<RunListItem>,
+): RunListItem {
   return createRunListItemFixture({
     runId,
     state,
@@ -46,7 +55,12 @@ function stubListItem(runId: string, state: RunState, overrides?: Partial<RunLis
   });
 }
 
-function stubDetail(runId: string, state: RunState, lifecycle: LifecycleEvent[], overrides?: Partial<RunDetail>): RunDetail {
+function stubDetail(
+  runId: string,
+  state: RunState,
+  lifecycle: LifecycleEvent[],
+  overrides?: Partial<RunDetail>,
+): RunDetail {
   return createRunDetailFixture({
     run: {
       runId,
@@ -78,7 +92,13 @@ function stubDetail(runId: string, state: RunState, lifecycle: LifecycleEvent[],
   });
 }
 
-function transition(seq: number, runId: string, from: string | null, to: string, reason: string | null): LifecycleEvent {
+function transition(
+  seq: number,
+  runId: string,
+  from: string | null,
+  to: string,
+  reason: string | null,
+): LifecycleEvent {
   return createLifecycleEventFixture(seq, runId, from, to, reason, NOW);
 }
 
@@ -130,8 +150,20 @@ describe("Runs sortable columns (OPS-492)", () => {
         const r = renderRuns({ onSelectRun });
         await waitFor(() => r.getByRole("columnheader", { name: /Run/ }));
 
-        for (const label of ["Run", "State", "Agent", "Adapter", "Model", "Attempts", "Reason", "Origin", "Updated"]) {
-          const header = r.getByRole("columnheader", { name: new RegExp(label) });
+        for (const label of [
+          "Run",
+          "State",
+          "Agent",
+          "Adapter",
+          "Model",
+          "Attempts",
+          "Reason",
+          "Origin",
+          "Updated",
+        ]) {
+          const header = r.getByRole("columnheader", {
+            name: new RegExp(label),
+          });
           expect(header.getAttribute("aria-sort")).toBe("none");
           expect(header.querySelector("button")).toBeTruthy();
         }
@@ -139,13 +171,16 @@ describe("Runs sortable columns (OPS-492)", () => {
         const runHeader = r.getByRole("columnheader", { name: /Run/ });
         fireEvent.click(r.getByRole("button", { name: /Run/ }));
         expect(runHeader.getAttribute("aria-sort")).toBe("ascending");
-        expect(Array.from(r.container.querySelectorAll("tbody tr td:first-child")).map((cell) => cell.textContent)).toEqual([
-          "run_alpha",
-          "run_zulu",
-        ]);
+        expect(
+          Array.from(
+            r.container.querySelectorAll("tbody tr td:first-child"),
+          ).map((cell) => cell.textContent),
+        ).toEqual(["run_alpha", "run_zulu"]);
 
         act(() => {
-          document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+          document.body.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+          );
         });
         expect(onSelectRun).toHaveBeenLastCalledWith("run_alpha");
 
@@ -161,7 +196,9 @@ describe("Runs sortable columns (OPS-492)", () => {
 describe("Runs table short run ids (WM-96)", () => {
   test("run id cell displays the short form and carries the full id as title", async () => {
     const runId = "run_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d";
-    const detail = stubDetail(runId, "COMPLETED", [transition(1, runId, null, "QUEUED", null)]);
+    const detail = stubDetail(runId, "COMPLETED", [
+      transition(1, runId, null, "QUEUED", null),
+    ]);
     await withApi(
       {
         runs: async () => ({ runs: [stubListItem(runId, "COMPLETED")] }),
@@ -212,7 +249,10 @@ describe("Runs detail failure banner (WM-93)", () => {
 
         // Before the metadata rows: the banner precedes the "Run" section in the document.
         const runSection = getByText("idempotencyKey");
-        expect(banner.compareDocumentPosition(runSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(
+          banner.compareDocumentPosition(runSection) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
       },
     );
   });
@@ -256,14 +296,22 @@ describe("Runs component harness: selection & filter retention", () => {
       },
       async () => {
         const { getByRole } = renderRuns({ focusRunId: runId });
-        const openInTab = await waitFor(() => getByRole("button", { name: /Open in tab/ }));
-        expect(openInTab.querySelector('[aria-hidden="true"]')?.textContent).toBe("p");
+        const openInTab = await waitFor(() =>
+          getByRole("button", { name: /Open in tab/ }),
+        );
+        expect(
+          openInTab.querySelector('[aria-hidden="true"]')?.textContent,
+        ).toBe("p");
 
         fireEvent.keyDown(document.body, { key: "p" });
-        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([runId]);
+        expect(
+          JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]"),
+        ).toEqual([runId]);
 
         fireEvent.keyDown(document.body, { key: "p" });
-        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([]);
+        expect(
+          JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]"),
+        ).toEqual([]);
       },
     );
   });
@@ -296,7 +344,9 @@ describe("Runs component harness: selection & filter retention", () => {
 
   test("focusRunId highlights the selected row and renders the detail pane", async () => {
     const r1 = stubListItem("run_selected_1", "RUNNING");
-    const detail = stubDetail("run_selected_1", "RUNNING", [transition(1, "run_selected_1", null, "RUNNING", null)]);
+    const detail = stubDetail("run_selected_1", "RUNNING", [
+      transition(1, "run_selected_1", null, "RUNNING", null),
+    ]);
     await withApi(
       {
         runs: async () => ({ runs: [r1] }),
@@ -304,7 +354,9 @@ describe("Runs component harness: selection & filter retention", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { container, getByText } = renderRuns({ focusRunId: "run_selected_1" });
+        const { container, getByText } = renderRuns({
+          focusRunId: "run_selected_1",
+        });
 
         const selectedRow = await waitFor(() => {
           const el = container.querySelector("tr.row-selected");
@@ -329,7 +381,9 @@ describe("Runs component harness: selection & filter retention", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { container, getByLabelText } = renderRuns({ focusRunId: "run_alpha" });
+        const { container, getByLabelText } = renderRuns({
+          focusRunId: "run_alpha",
+        });
 
         await waitFor(() => container.querySelector(`td[title="${r1.runId}"]`));
         expect(container.querySelector(`td[title="${r2.runId}"]`)).toBeTruthy();
@@ -340,14 +394,18 @@ describe("Runs component harness: selection & filter retention", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector(`td[title="${r1.runId}"]`)).toBeTruthy();
+          expect(
+            container.querySelector(`td[title="${r1.runId}"]`),
+          ).toBeTruthy();
           expect(container.querySelector(`td[title="${r2.runId}"]`)).toBeNull();
         });
 
         // The selected row remains selected
         const selectedRow = container.querySelector("tr.row-selected");
         expect(selectedRow).toBeTruthy();
-        expect(selectedRow?.querySelector(`td[title="${r1.runId}"]`)).toBeTruthy();
+        expect(
+          selectedRow?.querySelector(`td[title="${r1.runId}"]`),
+        ).toBeTruthy();
       },
     );
   });
@@ -362,7 +420,10 @@ describe("Runs component harness: selection & filter retention", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { getByRole, container } = renderRuns({ focusRunId: "run_tab_1", onSelectRun });
+        const { getByRole, container } = renderRuns({
+          focusRunId: "run_tab_1",
+          onSelectRun,
+        });
 
         await waitFor(() => container.querySelector("tr.row-selected"));
 
@@ -387,7 +448,10 @@ describe("Runs component harness: cross-tab reveal", () => {
     await withApi(
       {
         runs: async (state?: string) => ({
-          runs: state && state !== "ALL" ? allRuns.filter((r) => r.state === state) : allRuns,
+          runs:
+            state && state !== "ALL"
+              ? allRuns.filter((r) => r.state === state)
+              : allRuns,
         }),
         run: async () => detailFailed,
         status: async () => createStatusFixture(),
@@ -424,7 +488,9 @@ describe("Runs component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const allTab = getByRole("tab", { name: /^All/i });
           expect(allTab.getAttribute("aria-selected")).toBe("true");
-          const targetCell = container.querySelector(`td[title="run_failed_target"]`);
+          const targetCell = container.querySelector(
+            `td[title="run_failed_target"]`,
+          );
           expect(targetCell).toBeTruthy();
         });
       },
@@ -502,7 +568,9 @@ describe("Runs component harness: cross-tab reveal", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector(`td[title="${r1.runId}"]`)).toBeTruthy();
+          expect(
+            container.querySelector(`td[title="${r1.runId}"]`),
+          ).toBeTruthy();
         });
 
         // Now focus run_alpha (which is already visible)
@@ -556,9 +624,21 @@ describe("Runs component harness: cross-tab reveal", () => {
 describe("Runs Model column (WM-221)", () => {
   test("renders the pinned model per row, with the sentinel and n/a spelled out", async () => {
     const modelRows = [
-      stubListItem("run_pinned", "COMPLETED", { adapter: "claude", modelTier: "standard", model: "sonnet" }),
-      stubListItem("run_sentinel", "COMPLETED", { adapter: "claude", modelTier: "strong", model: "default" }),
-      stubListItem("run_command", "COMPLETED", { adapter: "command", modelTier: null, model: null }),
+      stubListItem("run_pinned", "COMPLETED", {
+        adapter: "claude",
+        modelTier: "standard",
+        model: "sonnet",
+      }),
+      stubListItem("run_sentinel", "COMPLETED", {
+        adapter: "claude",
+        modelTier: "strong",
+        model: "default",
+      }),
+      stubListItem("run_command", "COMPLETED", {
+        adapter: "command",
+        modelTier: null,
+        model: null,
+      }),
     ];
     await withApi(
       {
@@ -579,8 +659,16 @@ describe("Runs Model column (WM-221)", () => {
   });
 
   test("the column can be hidden through Display Options like any other", async () => {
-    localStorage.setItem("evrt-display-runs", JSON.stringify({ hiddenColumns: ["model"] }));
-    const modelRows = [stubListItem("run_pinned", "COMPLETED", { adapter: "claude", model: "sonnet" })];
+    localStorage.setItem(
+      "evrt-display-runs",
+      JSON.stringify({ hiddenColumns: ["model"] }),
+    );
+    const modelRows = [
+      stubListItem("run_pinned", "COMPLETED", {
+        adapter: "claude",
+        model: "sonnet",
+      }),
+    ];
     await withApi(
       {
         runs: async () => ({ runs: modelRows }),
@@ -631,8 +719,12 @@ describe("Runs copy chords and hints (WM-233)", () => {
 
         // Verify icon-action tooltips preserve shortcut discoverability.
         expect(idBtn.getAttribute("title")).toBe("Copy run id · c");
-        const cliBtn = r.getByRole("button", { name: "Copy CLI inspect command (c i)" });
-        expect(cliBtn.getAttribute("title")).toBe("Copy CLI inspect command · c i");
+        const cliBtn = r.getByRole("button", {
+          name: "Copy CLI inspect command (c i)",
+        });
+        expect(cliBtn.getAttribute("title")).toBe(
+          "Copy CLI inspect command · c i",
+        );
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
         expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
@@ -735,7 +827,9 @@ describe("Runs copy chords and hints (WM-233)", () => {
         // Verify detail pane shows "Awaiting Proposal Approval" section and "Approve…" button
         await waitFor(() => {
           expect(r.getByText("Awaiting Proposal Approval")).toBeTruthy();
-          expect(r.getAllByRole("button", { name: /Approve…/i }).length).toBeGreaterThan(0);
+          expect(
+            r.getAllByRole("button", { name: /Approve…/i }).length,
+          ).toBeGreaterThan(0);
         });
 
         // Click "Approve…" button in the detail pane
@@ -749,7 +843,9 @@ describe("Runs copy chords and hints (WM-233)", () => {
         });
 
         // Click "Approve and queue" in the dialog
-        const confirmBtn = r.getByRole("button", { name: /Approve and queue/i });
+        const confirmBtn = r.getByRole("button", {
+          name: /Approve and queue/i,
+        });
         fireEvent.click(confirmBtn);
 
         await waitFor(() => {
@@ -784,7 +880,9 @@ describe("Runs copy chords and hints (WM-233)", () => {
 
     await withApi(
       {
-        runs: mock(async () => ({ runs: [stubListItem(runId, "PROPOSED", { agent: "shipper" })] })),
+        runs: mock(async () => ({
+          runs: [stubListItem(runId, "PROPOSED", { agent: "shipper" })],
+        })),
         run: mock(async () => stubDetail(runId, "PROPOSED", [])),
         proposals: mock(async () => ({ proposals: [proposal] })),
         agents: mock(async () =>
@@ -796,7 +894,10 @@ describe("Runs copy chords and hints (WM-233)", () => {
                 version: 1,
                 outputContract: "factory.agent-result/v1",
                 workspace: { type: "ephemeral" },
-                capabilities: { filesystem: "workspace-only", services: ["github"] },
+                capabilities: {
+                  filesystem: "workspace-only",
+                  services: ["github"],
+                },
                 limits: { timeout_seconds: 900, attempts: 2 },
                 mutating: true,
                 promptFile: "agents/shipper.md",
@@ -817,13 +918,17 @@ describe("Runs copy chords and hints (WM-233)", () => {
           } as unknown as Parameters<typeof createAgentsFixture>[0]),
         ),
         approve: mock(async () => ({ approved: true as const, runId })),
-        status: mock(async () => createStatusFixture({ runs: { byState: { PROPOSED: 1 } } })),
+        status: mock(async () =>
+          createStatusFixture({ runs: { byState: { PROPOSED: 1 } } }),
+        ),
       },
       async () => {
         const r = renderRuns({ focusRunId: runId, onJumpProposal: noop });
 
         await waitFor(() => {
-          expect(r.getAllByRole("button", { name: /Approve…/i }).length).toBeGreaterThan(0);
+          expect(
+            r.getAllByRole("button", { name: /Approve…/i }).length,
+          ).toBeGreaterThan(0);
         });
         fireEvent.click(r.getAllByRole("button", { name: /Approve…/i })[0]);
 
@@ -854,19 +959,28 @@ describe("Runs copy chords and hints (WM-233)", () => {
   test("State cell does not clip the proposal jump link", async () => {
     const runId = "run-proposed-clip";
     const propId = "prop-clip-1";
-    const proposal = createProposalFixture({ id: propId, runId, status: "open", decision: "run" });
+    const proposal = createProposalFixture({
+      id: propId,
+      runId,
+      status: "open",
+      decision: "run",
+    });
 
     await withApi(
       {
         runs: mock(async () => ({ runs: [stubListItem(runId, "PROPOSED")] })),
         run: mock(async () => stubDetail(runId, "PROPOSED", [])),
         proposals: mock(async () => ({ proposals: [proposal] })),
-        status: mock(async () => createStatusFixture({ runs: { byState: { PROPOSED: 1 } } })),
+        status: mock(async () =>
+          createStatusFixture({ runs: { byState: { PROPOSED: 1 } } }),
+        ),
       },
       async () => {
         const r = renderRuns({ focusRunId: runId, onJumpProposal: noop });
 
-        const link = await waitFor(() => r.getByTitle(`Open proposal ${propId}`));
+        const link = await waitFor(() =>
+          r.getByTitle(`Open proposal ${propId}`),
+        );
         const cell = link.closest("td");
         expect(cell).toBeTruthy();
 
@@ -886,7 +1000,9 @@ describe("Runs copy chords and hints (WM-233)", () => {
 
 describe("Runs long-list window (WM-563)", () => {
   test("a 2,000-row fixture mounts fewer than 200 table rows and pages forward", async () => {
-    const runs = Array.from({ length: 2000 }, (_, i) => stubListItem(`run_window_${i}`, "COMPLETED"));
+    const runs = Array.from({ length: 2000 }, (_, i) =>
+      stubListItem(`run_window_${i}`, "COMPLETED"),
+    );
     await withApi(
       {
         runs: async () => ({ runs }),
@@ -895,14 +1011,24 @@ describe("Runs long-list window (WM-563)", () => {
       async () => {
         const r = renderRuns();
         const next = await r.findByRole("button", { name: "Next" });
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
-        expect(r.container.querySelector('td[title="run_window_100"]')).toBeNull();
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
+        expect(
+          r.container.querySelector('td[title="run_window_100"]'),
+        ).toBeNull();
         fireEvent.click(next);
         await waitFor(() => {
-          expect(r.container.querySelector('td[title="run_window_100"]')).toBeTruthy();
+          expect(
+            r.container.querySelector('td[title="run_window_100"]'),
+          ).toBeTruthy();
         });
-        expect(r.container.querySelector("tbody tr:last-child")?.textContent).toContain("101–200/2000");
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
+        expect(
+          r.container.querySelector("tbody tr:last-child")?.textContent,
+        ).toContain("101–200/2000");
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
       },
     );
   });
@@ -911,25 +1037,37 @@ describe("Runs long-list window (WM-563)", () => {
     const runs = Array.from({ length: 2000 }, (_, i) =>
       stubListItem(`run_group_${i}`, "COMPLETED", { agent: `agent-${i}` }),
     );
-    localStorage.setItem("evrt-display-runs", JSON.stringify({
-      groupBy: "agent",
-      subGroupBy: "none",
-      sortBy: "default",
-      sortDir: "asc",
-      showEmpty: false,
-      hiddenColumns: [],
-      collapsed: runs.map((run) => run.agent),
-      customColumns: [],
-    }));
+    localStorage.setItem(
+      "evrt-display-runs",
+      JSON.stringify({
+        groupBy: "agent",
+        subGroupBy: "none",
+        sortBy: "default",
+        sortDir: "asc",
+        showEmpty: false,
+        hiddenColumns: [],
+        collapsed: runs.map((run) => run.agent),
+        customColumns: [],
+      }),
+    );
     await withApi(
-      { runs: async () => ({ runs }), status: async () => createStatusFixture() },
+      {
+        runs: async () => ({ runs }),
+        status: async () => createStatusFixture(),
+      },
       async () => {
         const r = renderRuns();
         await r.findByRole("button", { name: /agent-0/ });
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
         fireEvent.click(r.getByRole("button", { name: "Next" }));
-        await waitFor(() => expect(r.getByRole("button", { name: /agent-100/ })).toBeTruthy());
-        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(200);
+        await waitFor(() =>
+          expect(r.getByRole("button", { name: /agent-100/ })).toBeTruthy(),
+        );
+        expect(r.container.querySelectorAll("tbody tr").length).toBeLessThan(
+          200,
+        );
       },
     );
   });
@@ -940,25 +1078,35 @@ describe("Runs long-list window (WM-563)", () => {
     // has to replay exactly two headers — COMPLETED and that agent — and no
     // sub header whose rows all live on the previous page.
     const runs = Array.from({ length: 250 }, (_, i) =>
-      stubListItem(`run_sub_${i}`, "COMPLETED", { agent: `agent-${Math.floor(i / 50)}` }),
+      stubListItem(`run_sub_${i}`, "COMPLETED", {
+        agent: `agent-${Math.floor(i / 50)}`,
+      }),
     );
-    localStorage.setItem("evrt-display-runs", JSON.stringify({
-      groupBy: "state",
-      subGroupBy: "agent",
-      sortBy: "default",
-      sortDir: "asc",
-      showEmpty: false,
-      hiddenColumns: [],
-      collapsed: [],
-      customColumns: [],
-    }));
+    localStorage.setItem(
+      "evrt-display-runs",
+      JSON.stringify({
+        groupBy: "state",
+        subGroupBy: "agent",
+        sortBy: "default",
+        sortDir: "asc",
+        showEmpty: false,
+        hiddenColumns: [],
+        collapsed: [],
+        customColumns: [],
+      }),
+    );
     await withApi(
-      { runs: async () => ({ runs }), status: async () => createStatusFixture() },
+      {
+        runs: async () => ({ runs }),
+        status: async () => createStatusFixture(),
+      },
       async () => {
         const r = renderRuns();
         fireEvent.click(await r.findByRole("button", { name: "Next" }));
         await waitFor(() => {
-          expect(r.container.querySelector('td[title="run_sub_100"]')).toBeTruthy();
+          expect(
+            r.container.querySelector('td[title="run_sub_100"]'),
+          ).toBeTruthy();
         });
 
         // Walk the rendered body: every expanded sub header must own at least
@@ -968,10 +1116,12 @@ describe("Runs long-list window (WM-563)", () => {
         const phantoms: string[] = [];
         rows.forEach((row, i) => {
           const header = row.querySelector("button[aria-expanded]");
-          if (!header || header.getAttribute("aria-expanded") !== "true") return;
+          if (!header || header.getAttribute("aria-expanded") !== "true")
+            return;
           const next = rows[i + 1];
           if (!next || !next.querySelector('td[title^="run_sub_"]')) {
-            if (header.className.includes("pl-8")) phantoms.push(header.textContent ?? "");
+            if (header.className.includes("pl-8"))
+              phantoms.push(header.textContent ?? "");
           }
         });
         expect(phantoms).toEqual([]);
@@ -979,20 +1129,27 @@ describe("Runs long-list window (WM-563)", () => {
         // Positively: the page's own ancestry is replayed — its state header
         // and its own agent — and the subsection that ended on the previous
         // page is gone entirely.
-        const headers = [...r.container.querySelectorAll("tbody tr button[aria-expanded]")]
-          .map((el) => el.textContent ?? "");
+        const headers = [
+          ...r.container.querySelectorAll("tbody tr button[aria-expanded]"),
+        ].map((el) => el.textContent ?? "");
         expect(headers[0]).toStartWith("COMPLETED");
         expect(headers[1]).toStartWith("agent-1");
-        expect(headers.filter((label) => label.startsWith("agent-0"))).toEqual([]);
+        expect(headers.filter((label) => label.startsWith("agent-0"))).toEqual(
+          [],
+        );
       },
     );
   });
 
   test("j crosses a page boundary, Enter opens that row, and footer Enter does not", async () => {
-    const runs = Array.from({ length: 250 }, (_, i) => stubListItem(`run_keys_${i}`, "COMPLETED"));
+    const runs = Array.from({ length: 250 }, (_, i) =>
+      stubListItem(`run_keys_${i}`, "COMPLETED"),
+    );
     const onOpenFull = mock(() => {});
     function Harness() {
-      const [focusRunId, setFocusRunId] = useState<string | null>("run_keys_99");
+      const [focusRunId, setFocusRunId] = useState<string | null>(
+        "run_keys_99",
+      );
       return (
         <Runs
           connected
@@ -1008,21 +1165,32 @@ describe("Runs long-list window (WM-563)", () => {
       );
     }
     await withApi(
-      { runs: async () => ({ runs }), status: async () => createStatusFixture() },
+      {
+        runs: async () => ({ runs }),
+        status: async () => createStatusFixture(),
+      },
       async () => {
         const r = renderWithClient(<Harness />);
-        await waitFor(() => expect(r.container.querySelector('td[title="run_keys_99"]')).toBeTruthy());
+        await waitFor(() =>
+          expect(
+            r.container.querySelector('td[title="run_keys_99"]'),
+          ).toBeTruthy(),
+        );
         fireEvent.keyDown(document.body, { key: "j" });
         await waitFor(() => {
-          expect(r.container.querySelector('td[title="run_keys_100"]')?.closest("tr")?.className).toContain("row-selected");
+          expect(
+            r.container.querySelector('td[title="run_keys_100"]')?.closest("tr")
+              ?.className,
+          ).toContain("row-selected");
         });
         fireEvent.keyDown(document.body, { key: "Enter" });
         expect(onOpenFull).toHaveBeenCalledWith("run_keys_100");
         onOpenFull.mockClear();
-        fireEvent.keyDown(r.getByRole("button", { name: "Next" }), { key: "Enter" });
+        fireEvent.keyDown(r.getByRole("button", { name: "Next" }), {
+          key: "Enter",
+        });
         expect(onOpenFull).not.toHaveBeenCalled();
       },
     );
   });
 });
-

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,7 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { api, ApiError } from "../api";
-import { keyGuard, refetchIntervals, tableTokens, useDisplayOptions, useListKeys, useNow, useTabKeys, useTableWindow } from "../hooks";
+import {
+  keyGuard,
+  refetchIntervals,
+  tableTokens,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useTabKeys,
+  useTableWindow,
+} from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   buildSections,
@@ -19,7 +34,10 @@ import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import { AgentHoverCard } from "../components/AgentHoverCard";
-import { ApprovalRiskDetails, useProposalAgent } from "../components/ApprovalRisk";
+import {
+  ApprovalRiskDetails,
+  useProposalAgent,
+} from "../components/ApprovalRisk";
 import {
   BudgetClock,
   IN_FLIGHT,
@@ -33,7 +51,11 @@ import {
 import { readPinnedRuns, savePinnedRuns } from "../components/ContextTabs";
 import type { OperatorContext } from "../context";
 import { matchesInFlight, matchesRepo } from "../context";
-import { RUN_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
+import {
+  RUN_FACETS,
+  matchesFilterQuery,
+  parseFilterQuery,
+} from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import type { Proposal, RunListItem, RunState } from "../types";
 import { EMPTY, formatRelative } from "../format";
@@ -81,7 +103,10 @@ export function toggleRunPin(id: string) {
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
 export const RUN_TAB_LABELS: Record<RunTab, string> = {
@@ -102,8 +127,10 @@ export const RUN_TAB_TITLES: Record<RunTab, string> = {
 
 export function matchesRunTab(state: RunState, tab: RunTab): boolean {
   if (tab === "ALL") return true;
-  if (tab === "ACTIVE") return ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state);
-  if (tab === "FAILED") return ["FAILED", "TIMED_OUT", "REFUSED"].includes(state);
+  if (tab === "ACTIVE")
+    return ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state);
+  if (tab === "FAILED")
+    return ["FAILED", "TIMED_OUT", "REFUSED"].includes(state);
   if (tab === "COMPLETED") return state === "COMPLETED";
   if (tab === "CANCELLED") return state === "CANCELLED";
   return true;
@@ -112,8 +139,17 @@ export function matchesRunTab(state: RunState, tab: RunTab): boolean {
 export function statesForRunTab(tab: RunTab): readonly string[] {
   if (tab === "ALL") {
     return [
-      "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING",
-      "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
+      "PROPOSED",
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+      "REFUSED",
+      "FAILED",
+      "TIMED_OUT",
+      "CANCELLED",
     ];
   }
   if (tab === "ACTIVE") return ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
@@ -124,7 +160,8 @@ export function statesForRunTab(tab: RunTab): readonly string[] {
 }
 
 export function tabForRunState(state: string): RunTab {
-  if (["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state)) return "ACTIVE";
+  if (["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state))
+    return "ACTIVE";
   if (["FAILED", "TIMED_OUT", "REFUSED"].includes(state)) return "FAILED";
   if (state === "COMPLETED") return "COMPLETED";
   if (state === "CANCELLED") return "CANCELLED";
@@ -151,8 +188,17 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
       label: "State",
       get: (r) => r.state,
       order: [
-        "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING",
-        "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
+        "PROPOSED",
+        "APPROVED",
+        "QUEUED",
+        "LEASED",
+        "RUNNING",
+        "VERIFYING",
+        "COMPLETED",
+        "REFUSED",
+        "FAILED",
+        "TIMED_OUT",
+        "CANCELLED",
       ],
       hue: STATE_HUES,
     },
@@ -164,20 +210,52 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   sorts: [
     { key: "run", label: "Run", get: (r) => r.runId, column: "run" },
     { key: "state", label: "State", get: (r) => r.state, column: "state" },
-    { key: "remaining", label: "Remaining", get: (r) => r.deadlineAt ?? "", column: "remaining" },
+    {
+      key: "remaining",
+      label: "Remaining",
+      get: (r) => r.deadlineAt ?? "",
+      column: "remaining",
+    },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
-    { key: "adapter", label: "Adapter", get: (r) => r.adapter, column: "adapter" },
+    {
+      key: "adapter",
+      label: "Adapter",
+      get: (r) => r.adapter,
+      column: "adapter",
+    },
     { key: "model", label: "Model", get: rowModel, column: "model" },
-    { key: "attempts", label: "Attempts", get: (r) => r.attempts, defaultDir: "desc", column: "attempts" },
-    { key: "reason", label: "Reason", get: (r) => r.reasonCode ?? "", column: "reason" },
+    {
+      key: "attempts",
+      label: "Attempts",
+      get: (r) => r.attempts,
+      defaultDir: "desc",
+      column: "attempts",
+    },
+    {
+      key: "reason",
+      label: "Reason",
+      get: (r) => r.reasonCode ?? "",
+      column: "reason",
+    },
     {
       key: "origin",
       label: "Origin",
       get: (r) => `${r.eventSource ?? ""}:${r.eventId ?? ""}`,
       column: "origin",
     },
-    { key: "updated", label: "Updated", get: (r) => r.updated_at, defaultDir: "desc", column: "updated" },
-    { key: "created", label: "Created", get: (r) => r.created_at, defaultDir: "desc" },
+    {
+      key: "updated",
+      label: "Updated",
+      get: (r) => r.updated_at,
+      defaultDir: "desc",
+      column: "updated",
+    },
+    {
+      key: "created",
+      label: "Created",
+      get: (r) => r.created_at,
+      defaultDir: "desc",
+    },
   ],
   columns: [
     { key: "run", label: "Run", always: true },
@@ -193,12 +271,24 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   ],
 };
 
-function RemainingCell({ deadlineAt, now }: { deadlineAt?: string | null; now: number }) {
+function RemainingCell({
+  deadlineAt,
+  now,
+}: {
+  deadlineAt?: string | null;
+  now: number;
+}) {
   if (!deadlineAt) return <span>—</span>;
   const left = Math.max(0, Date.parse(deadlineAt) - now);
   if (!Number.isFinite(left)) return <span>—</span>;
   const minutes = Math.ceil(left / 60_000);
-  return <span title={deadlineAt}>{minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`}</span>;
+  return (
+    <span title={deadlineAt}>
+      {minutes >= 60
+        ? `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+        : `${minutes}m`}
+    </span>
+  );
 }
 
 function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
@@ -222,13 +312,22 @@ function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
 }
 
 const rowWash = (s: string) =>
-  s === "FAILED" || s === "TIMED_OUT" ? "row-wash-err" : s === "REFUSED" ? "row-wash-warn" : "";
+  s === "FAILED" || s === "TIMED_OUT"
+    ? "row-wash-err"
+    : s === "REFUSED"
+      ? "row-wash-warn"
+      : "";
 
 /** Route raw links rendered by RunDetailBlocks to the deep-linkable artifact inspector. */
 export function handleRunArtifactClick(event: ReactMouseEvent<HTMLElement>) {
-  const target = event.target instanceof Element ? event.target.closest<HTMLAnchorElement>("a[href]") : null;
+  const target =
+    event.target instanceof Element
+      ? event.target.closest<HTMLAnchorElement>("a[href]")
+      : null;
   if (!target) return;
-  const match = (target.getAttribute("href") ?? "").match(/\/api\/artifacts\/([0-9a-f]{64})(?=[?#]|$)/);
+  const match = (target.getAttribute("href") ?? "").match(
+    /\/api\/artifacts\/([0-9a-f]{64})(?=[?#]|$)/,
+  );
   if (!match) return;
   event.preventDefault();
   event.stopPropagation();
@@ -291,7 +390,11 @@ export function Runs({
     queryFn: () => api.runs(),
     ...refetchIntervals.primary,
   });
-  const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, ...refetchIntervals.fast });
+  const statusQ = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.fast,
+  });
   const rows = list.data?.runs ?? [];
   const scoped = useMemo(
     () =>
@@ -303,18 +406,27 @@ export function Runs({
     [rows, context, focusRunId],
   );
   const byTab = useMemo(
-    () => (tab === "ALL" ? scoped : scoped.filter((r) => matchesRunTab(r.state, tab))),
+    () =>
+      tab === "ALL"
+        ? scoped
+        : scoped.filter((r) => matchesRunTab(r.state, tab)),
     [scoped, tab],
   );
   // `is:stale` is the doctor's projection, not a guess this view makes: a run
   // held by a worker whose heartbeat has gone (lib/workers.mjs stalledWorkers).
   const staleRuns = useMemo(
-    () => new Set((statusQ.data?.anomalies.stalledWorkers ?? []).map((w) => w.runId)),
+    () =>
+      new Set(
+        (statusQ.data?.anomalies.stalledWorkers ?? []).map((w) => w.runId),
+      ),
     [statusQ.data],
   );
   const parsed = useMemo(() => parseFilterQuery(filter, RUN_FACETS), [filter]);
   const visible = useMemo(
-    () => byTab.filter((r) => matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns })),
+    () =>
+      byTab.filter((r) =>
+        matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns }),
+      ),
     [byTab, parsed, staleRuns],
   );
 
@@ -346,7 +458,10 @@ export function Runs({
   const selectedId = focusRunId;
   // Keyboard index walks the open sections; the detail pane keys off the row
   // itself so collapsing the group under a selection never closes the pane.
-  const selectedIndex = useMemo(() => flat.findIndex((r) => r.runId === selectedId), [flat, selectedId]);
+  const selectedIndex = useMemo(
+    () => flat.findIndex((r) => r.runId === selectedId),
+    [flat, selectedId],
+  );
   const tokens = tableTokens(sections, display.collapsed, grouped(display));
   const [windowTokens, windowStart, windowEnd, moveWindow] = useTableWindow(
     tokens,
@@ -390,7 +505,9 @@ export function Runs({
     }
 
     const onTab = rows.some(
-      (r) => r.runId === focusRunId && (tab === "ALL" || matchesRunTab(r.state, tab)),
+      (r) =>
+        r.runId === focusRunId &&
+        (tab === "ALL" || matchesRunTab(r.state, tab)),
     );
     if (onTab) {
       const latch = pendingReveal.current;
@@ -399,7 +516,12 @@ export function Runs({
         const isVisible = visible.some((r) => r.runId === focusRunId);
         const currentFilters = { filter };
         const emptyFilters = { filter: "" };
-        const decision = decideRevealFilters(latch.snapshot, currentFilters, emptyFilters, isVisible);
+        const decision = decideRevealFilters(
+          latch.snapshot,
+          currentFilters,
+          emptyFilters,
+          isVisible,
+        );
         if (decision.cleared) {
           setFilter(decision.next.filter);
         }
@@ -439,19 +561,26 @@ export function Runs({
   }, [context.kind]);
 
   const sel = useMemo(
-    () => (selectedId ? (visible.find((r) => r.runId === selectedId) ?? null) : null),
+    () =>
+      selectedId ? (visible.find((r) => r.runId === selectedId) ?? null) : null,
     [visible, selectedId],
   );
   // A side pane turns the list into a compact comparison rail. Keep the five
   // decision-bearing columns instead of forcing a horizontal scrollbar; the
   // pane and the unselected list retain every configured column.
   const listCols = sel
-    ? cols.filter((c) => ["run", "state", "remaining", "reason", "origin", "updated"].includes(c.key))
+    ? cols.filter((c) =>
+        ["run", "state", "remaining", "reason", "origin", "updated"].includes(
+          c.key,
+        ),
+      )
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, windowStart]);
 
   const detail = useQuery({
@@ -464,7 +593,8 @@ export function Runs({
   const invalidate = () => queryClient.invalidateQueries();
 
   const cancel = useMutation({
-    mutationFn: ({ id, reason }: { id: string; reason?: string }) => api.cancel(id, reason),
+    mutationFn: ({ id, reason }: { id: string; reason?: string }) =>
+      api.cancel(id, reason),
     onSuccess: (_, { id }) => {
       invalidate();
       notify(`Cancelled run ${id}`, "info");
@@ -475,7 +605,8 @@ export function Runs({
   });
 
   const retry = useMutation({
-    mutationFn: ({ id, force }: { id: string; force: boolean }) => api.retry(id, force),
+    mutationFn: ({ id, force }: { id: string; force: boolean }) =>
+      api.retry(id, force),
     onSuccess: (_, { id, force }) => {
       invalidate();
       notify(`${force ? "Force retried" : "Retried"} run ${id}`, "ok");
@@ -484,7 +615,8 @@ export function Runs({
     onError: (err) => {
       invalidate();
       // attempts_exhausted → offer the explicit, recorded override (spec §4.3)
-      if (err instanceof ApiError && err.message === "attempts_exhausted") setConfirm("force-retry");
+      if (err instanceof ApiError && err.message === "attempts_exhausted")
+        setConfirm("force-retry");
     },
   });
 
@@ -512,12 +644,25 @@ export function Runs({
   const byState = statusQ.data?.runs.byState ?? {};
   const tabCount = (t: RunTab) => {
     if (fetchAll) {
-      return t === "ALL" ? scoped.length : scoped.filter((r) => matchesRunTab(r.state, t)).length;
+      return t === "ALL"
+        ? scoped.length
+        : scoped.filter((r) => matchesRunTab(r.state, t)).length;
     }
-    if (t === "ALL") return Object.values(byState).reduce((n, v) => n + (v ?? 0), 0);
+    if (t === "ALL")
+      return Object.values(byState).reduce((n, v) => n + (v ?? 0), 0);
     if (t === "ACTIVE")
-      return (byState.QUEUED ?? 0) + (byState.LEASED ?? 0) + (byState.RUNNING ?? 0) + (byState.VERIFYING ?? 0);
-    if (t === "FAILED") return (byState.FAILED ?? 0) + (byState.TIMED_OUT ?? 0) + (byState.REFUSED ?? 0);
+      return (
+        (byState.QUEUED ?? 0) +
+        (byState.LEASED ?? 0) +
+        (byState.RUNNING ?? 0) +
+        (byState.VERIFYING ?? 0)
+      );
+    if (t === "FAILED")
+      return (
+        (byState.FAILED ?? 0) +
+        (byState.TIMED_OUT ?? 0) +
+        (byState.REFUSED ?? 0)
+      );
     if (t === "COMPLETED") return byState.COMPLETED ?? 0;
     if (t === "CANCELLED") return byState.CANCELLED ?? 0;
     return 0;
@@ -530,11 +675,15 @@ export function Runs({
   useTabKeys(RUN_TABS, tab, selectTab);
 
   const d = detail.data;
-  const attemptsExhausted = d ? d.run.attempts >= d.run.spec.maxAttempts : false;
+  const attemptsExhausted = d
+    ? d.run.attempts >= d.run.spec.maxAttempts
+    : false;
 
   const selProposal = useMemo(() => {
-    if (sel?.runId && proposalByRunId.has(sel.runId)) return proposalByRunId.get(sel.runId)!;
-    if (d?.run.runId && proposalByRunId.has(d.run.runId)) return proposalByRunId.get(d.run.runId)!;
+    if (sel?.runId && proposalByRunId.has(sel.runId))
+      return proposalByRunId.get(sel.runId)!;
+    if (d?.run.runId && proposalByRunId.has(d.run.runId))
+      return proposalByRunId.get(d.run.runId)!;
     return null;
   }, [sel?.runId, d?.run.runId, proposalByRunId]);
 
@@ -543,9 +692,9 @@ export function Runs({
 
   const canApprove = Boolean(
     selProposal &&
-      selProposal.status === "open" &&
-      selProposal.decision === "run" &&
-      (sel?.state === "PROPOSED" || d?.run.state === "PROPOSED"),
+    selProposal.status === "open" &&
+    selProposal.decision === "run" &&
+    (sel?.state === "PROPOSED" || d?.run.state === "PROPOSED"),
   );
 
   const pendingC = useRef<number>(0);
@@ -577,14 +726,22 @@ export function Runs({
       else if (filter) setFilter("");
     },
     keys: {
-      a: () => canApprove && connected && !approve.isPending && setConfirmApprove(true),
+      a: () =>
+        canApprove &&
+        connected &&
+        !approve.isPending &&
+        setConfirmApprove(true),
       // §5 convention: `x` is the destructive verb on the selection — here, cancel.
-      x: () => sel && connected && isCancellable(sel.state) && setConfirm("cancel"),
+      x: () =>
+        sel && connected && isCancellable(sel.state) && setConfirm("cancel"),
       c: () => {
         if (!sel) return;
         const now = Date.now();
         if (pendingC.current > 0 && now - pendingC.current < 800) {
-          copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command");
+          copyText(
+            `bun event-runtime/cli.mjs inspect ${sel.runId}`,
+            "CLI inspect command",
+          );
           pendingC.current = 0;
         } else {
           copyText(sel.runId, "run id");
@@ -592,7 +749,11 @@ export function Runs({
         }
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -611,13 +772,17 @@ export function Runs({
         if (e.key === "i" || e.key === "I") {
           e.preventDefault();
           e.stopImmediatePropagation();
-          copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command");
+          copyText(
+            `bun event-runtime/cli.mjs inspect ${sel.runId}`,
+            "CLI inspect command",
+          );
           pendingC.current = 0;
         }
       }
     }
     window.addEventListener("keydown", onKey, { capture: true });
-    return () => window.removeEventListener("keydown", onKey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKey, { capture: true });
   }, [sel]);
 
   // Offer the selection's verbs in the ⌘K palette (§5).
@@ -627,12 +792,24 @@ export function Runs({
     } else {
       const copy = [
         { label: "Open in tab", hint: "p", run: () => toggleRunPin(sel.runId) },
-        { label: "Open full view", hint: "o", run: () => onOpenFull(sel.runId) },
-        { label: "Copy run id", hint: "c", run: () => copyText(sel.runId, "run id") },
+        {
+          label: "Open full view",
+          hint: "o",
+          run: () => onOpenFull(sel.runId),
+        },
+        {
+          label: "Copy run id",
+          hint: "c",
+          run: () => copyText(sel.runId, "run id"),
+        },
         {
           label: "Copy CLI inspect command",
           hint: "c i",
-          run: () => copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command"),
+          run: () =>
+            copyText(
+              `bun event-runtime/cli.mjs inspect ${sel.runId}`,
+              "CLI inspect command",
+            ),
         },
         { label: "Copy link", hint: "c l", run: copyLink },
       ];
@@ -641,19 +818,43 @@ export function Runs({
       } else {
         setContextActions([
           ...(canApprove && selProposal
-            ? [{ label: `Approve proposal ${selProposal.id}…`, hint: "a", run: () => setConfirmApprove(true) }]
+            ? [
+                {
+                  label: `Approve proposal ${selProposal.id}…`,
+                  hint: "a",
+                  run: () => setConfirmApprove(true),
+                },
+              ]
             : []),
           ...(selProposal && onJumpProposal
-            ? [{ label: `Open proposal ${selProposal.id}`, run: () => onJumpProposal(selProposal.id) }]
+            ? [
+                {
+                  label: `Open proposal ${selProposal.id}`,
+                  run: () => onJumpProposal(selProposal.id),
+                },
+              ]
             : []),
           ...(isCancellable(d.run.state)
-            ? [{ label: "Cancel run…", hint: "x", run: () => setConfirm("cancel") }]
+            ? [
+                {
+                  label: "Cancel run…",
+                  hint: "x",
+                  run: () => setConfirm("cancel"),
+                },
+              ]
             : []),
           ...(d.run.state === "FAILED"
             ? [
                 attemptsExhausted
-                  ? { label: "Force retry run…", run: () => setConfirm("force-retry") }
-                  : { label: "Retry run", run: () => retry.mutate({ id: d.run.runId, force: false }) },
+                  ? {
+                      label: "Force retry run…",
+                      run: () => setConfirm("force-retry"),
+                    }
+                  : {
+                      label: "Retry run",
+                      run: () =>
+                        retry.mutate({ id: d.run.runId, force: false }),
+                    },
               ]
             : []),
           ...copy,
@@ -662,13 +863,24 @@ export function Runs({
     }
     return () => setContextActions([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sel?.runId, d?.run.runId, d?.run.state, attemptsExhausted, connected, canApprove, selProposal]);
+  }, [
+    sel?.runId,
+    d?.run.runId,
+    d?.run.state,
+    attemptsExhausted,
+    connected,
+    canApprove,
+    selProposal,
+  ]);
 
   const handleExport = () => {
     const sorted = sortRows(visible, displayConfig, display);
     const dateStr = new Date().toISOString().slice(0, 10);
     exportJson(`runs-export-${dateStr}.json`, sorted);
-    notify(`Exported ${sorted.length} run${sorted.length === 1 ? "" : "s"} to JSON`, "info");
+    notify(
+      `Exported ${sorted.length} run${sorted.length === 1 ? "" : "s"} to JSON`,
+      "info",
+    );
   };
 
   return (
@@ -676,74 +888,102 @@ export function Runs({
       <ListPane
         chrome={
           <>
-        <h1 className="display mb-4 text-lg font-semibold">Runs</h1>
+            <h1 className="display mb-4 text-lg font-semibold">Runs</h1>
 
-        {/* `flex-wrap`: the token chips are a full-width item, so they take
+            {/* `flex-wrap`: the token chips are a full-width item, so they take
             their own line under the tabs and the box instead of squeezing them. */}
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          {/* Wrap, never scroll or clip: at 1280px the strip used to run out of
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              {/* Wrap, never scroll or clip: at 1280px the strip used to run out of
               width at CANCELLED with no scrollbar affordance (WM-96). */}
-          <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Run state">
-            {RUN_TABS.map((t, idx) => {
-              const count = tabCount(t);
-              return (
-                <button
-                  key={t}
-                  type="button"
-                  role="tab"
-                  aria-selected={tab === t}
-                  onClick={() => selectTab(t)}
-                  title={RUN_TAB_TITLES[t]}
-                  className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                    tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
-                  }`}
-                >
-                  {RUN_TAB_LABELS[t]}
-                  {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
-                  <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
-                    {idx + 1}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-          <span className="ml-auto">
-            <DisplayOptions
-              config={displayConfig}
-              state={display}
-              onChange={setDisplay}
-              onExport={visible.length > 0 ? handleExport : undefined}
-              rows={scoped}
-            />
-          </span>
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="agent:… state:… is:stale"
-            label="Filter runs"
-            query={parsed}
-          />
-        </div>
+              <div
+                className="flex min-w-0 flex-1 flex-wrap gap-1"
+                role="tablist"
+                aria-label="Run state"
+              >
+                {RUN_TABS.map((t, idx) => {
+                  const count = tabCount(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      role="tab"
+                      aria-selected={tab === t}
+                      onClick={() => selectTab(t)}
+                      title={RUN_TAB_TITLES[t]}
+                      className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                        tab === t
+                          ? "bg-(--surface-3) text-(--text)"
+                          : "text-(--text-faint) hover:bg-(--surface-1)"
+                      }`}
+                    >
+                      {RUN_TAB_LABELS[t]}
+                      {count > 0 && (
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {count}
+                        </span>
+                      )}
+                      <span
+                        aria-hidden="true"
+                        className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                      >
+                        {idx + 1}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <span className="ml-auto">
+                <DisplayOptions
+                  config={displayConfig}
+                  state={display}
+                  onChange={setDisplay}
+                  onExport={visible.length > 0 ? handleExport : undefined}
+                  rows={scoped}
+                />
+              </span>
+              <FilterInput
+                value={filter}
+                onChange={setFilter}
+                placeholder="agent:… state:… is:stale"
+                label="Filter runs"
+                query={parsed}
+              />
+            </div>
           </>
         }
       >
-
         <table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {listCols.map((c) => {
-                const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                const sort = displayConfig.sorts.find(
+                  (s) => s.column === c.key,
+                );
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
-                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
+                const isCurrentSort = isCustom
+                  ? display.sortBy === c.key
+                  : sort && display.sortBy === sort.key;
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
                     dir={isCurrentSort ? display.sortDir : null}
                     naturalDir={sort?.defaultDir ?? "asc"}
-                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
-                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
+                    onSort={
+                      sort || isCustom
+                        ? () =>
+                            setDisplay((s) =>
+                              cycleColumnSort(displayConfig, s, c.key),
+                            )
+                        : undefined
+                    }
+                    onRemove={
+                      isCustom
+                        ? () =>
+                            setDisplay((s) => removeCustomColumn(s, customPath))
+                        : undefined
+                    }
                   />
                 );
               })}
@@ -758,7 +998,10 @@ export function Runs({
                   aria-selected={r.runId === selectedId}
                   className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
                 >
-                  <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap" title={r.runId}>
+                  <td
+                    className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    title={r.runId}
+                  >
                     {shortId(r.runId)}
                   </td>
                   {/*
@@ -772,31 +1015,38 @@ export function Runs({
                     <td className="overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                       <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
                         <StateBadge state={r.state} />
-                        {r.state === "PROPOSED" && (() => {
-                          const prop = proposalByRunId.get(r.runId);
-                          if (prop && onJumpProposal) {
-                            return (
-                              <JumpLink
-                                onClick={(e) => {
-                                  e?.stopPropagation();
-                                  onJumpProposal(prop.id);
-                                }}
-                                title={`Open proposal ${prop.id}`}
-                                className="text-[11px]"
-                              >
-                                proposal
-                              </JumpLink>
-                            );
-                          }
-                          return null;
-                        })()}
+                        {r.state === "PROPOSED" &&
+                          (() => {
+                            const prop = proposalByRunId.get(r.runId);
+                            if (prop && onJumpProposal) {
+                              return (
+                                <JumpLink
+                                  onClick={(e) => {
+                                    e?.stopPropagation();
+                                    onJumpProposal(prop.id);
+                                  }}
+                                  title={`Open proposal ${prop.id}`}
+                                  className="text-[11px]"
+                                >
+                                  proposal
+                                </JumpLink>
+                              );
+                            }
+                            return null;
+                          })()}
                       </div>
-                      {IN_FLIGHT.includes(r.state) && <RowDeadlines r={r} now={now} />}
+                      {IN_FLIGHT.includes(r.state) && (
+                        <RowDeadlines r={r} now={now} />
+                      )}
                     </td>
                   )}
                   {show.has("remaining") && (
                     <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
-                      {IN_FLIGHT.includes(r.state) ? <RemainingCell deadlineAt={r.deadlineAt} now={now} /> : ""}
+                      {IN_FLIGHT.includes(r.state) ? (
+                        <RemainingCell deadlineAt={r.deadlineAt} now={now} />
+                      ) : (
+                        ""
+                      )}
                     </td>
                   )}
                   {show.has("agent") && (
@@ -808,13 +1058,19 @@ export function Runs({
                     </td>
                   )}
                   {show.has("adapter") && (
-                    <td className="max-w-24 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)" title={r.adapter}>
+                    <td
+                      className="max-w-24 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
+                      title={r.adapter}
+                    >
                       {r.adapter}
                     </td>
                   )}
                   {show.has("model") && (
                     <td className="max-w-40 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <ModelCell model={rowModel(r)} className="text-(--text-faint)" />
+                      <ModelCell
+                        model={rowModel(r)}
+                        className="text-(--text-faint)"
+                      />
                     </td>
                   )}
                   {show.has("attempts") && (
@@ -825,9 +1081,15 @@ export function Runs({
                   {show.has("reason") && (
                     <td
                       className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
-                      title={r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : undefined}
+                      title={
+                        r.reasonCode && r.reasonCode.toLowerCase() !== "ok"
+                          ? r.reasonCode
+                          : undefined
+                      }
                     >
-                      {r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : EMPTY}
+                      {r.reasonCode && r.reasonCode.toLowerCase() !== "ok"
+                        ? r.reasonCode
+                        : EMPTY}
                     </td>
                   )}
                   {show.has("origin") && (
@@ -837,24 +1099,36 @@ export function Runs({
                     >
                       {r.eventId && r.eventSource ? (
                         <JumpLink
-                          onClick={() => onJumpEvent(r.eventSource!, r.eventId!)}
+                          onClick={() =>
+                            onJumpEvent(r.eventSource!, r.eventId!)
+                          }
                           title={`Open origin event ${r.eventId}`}
                         >
                           {shortId(r.eventId)}
                         </JumpLink>
+                      ) : r.eventId ? (
+                        shortId(r.eventId)
                       ) : (
-                        (r.eventId ? shortId(r.eventId) : EMPTY)
+                        EMPTY
                       )}
                     </td>
                   )}
                   {show.has("updated") && (
                     <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                      <span title={r.updated_at}>{formatRelative(r.updated_at, now)}</span>
+                      <span title={r.updated_at}>
+                        {formatRelative(r.updated_at, now)}
+                      </span>
                     </td>
                   )}
-                  {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
-                    <CustomCell key={c.key} row={r} path={c.key.replace(/^custom:/, "")} />
-                  ))}
+                  {listCols
+                    .filter((c) => c.isCustom || c.key.startsWith("custom:"))
+                    .map((c) => (
+                      <CustomCell
+                        key={c.key}
+                        row={r}
+                        path={c.key.replace(/^custom:/, "")}
+                      />
+                    ))}
                 </tr>
               );
               return windowTokens.map((token) => {
@@ -866,7 +1140,9 @@ export function Runs({
                     colSpan={listCols.length}
                     section={s}
                     collapsed={display.collapsed.includes(s.key)}
-                    onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    onToggle={() =>
+                      setDisplay((st) => toggleCollapsed(st, s.key))
+                    }
                     sub={sub}
                   />
                 );
@@ -900,7 +1176,8 @@ export function Runs({
                   context.kind === "inflight" ? (
                     <Button
                       onClick={() => {
-                        if (typeof window !== "undefined") window.location.hash = "#/runs";
+                        if (typeof window !== "undefined")
+                          window.location.hash = "#/runs";
                       }}
                     >
                       Show all runs
@@ -917,7 +1194,10 @@ export function Runs({
         <DetailPane
           widthClass="fixed inset-0 z-20 w-full sm:static sm:z-auto sm:w-[460px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectRun(null)}
@@ -929,7 +1209,10 @@ export function Runs({
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
-              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
                 <StateBadge state={sel.state} />
                 <JumpLink
                   onClick={() => onOpenFull(sel.runId)}
@@ -949,7 +1232,13 @@ export function Runs({
                     disabled={!connected || approve.isPending}
                     onClick={() => setConfirmApprove(true)}
                   >
-                    Approve… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">a</span>
+                    Approve…{" "}
+                    <span
+                      className="mono ml-1 text-(--text-faint)"
+                      aria-hidden="true"
+                    >
+                      a
+                    </span>
                   </Button>
                 )}
                 {selProposal && onJumpProposal && (
@@ -963,30 +1252,53 @@ export function Runs({
                     disabled={!connected || cancel.isPending}
                     onClick={() => setConfirm("cancel")}
                   >
-                    Cancel <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                    Cancel{" "}
+                    <span
+                      className="mono ml-1 text-(--text-faint)"
+                      aria-hidden="true"
+                    >
+                      x
+                    </span>
                   </Button>
                 )}
-                {d && d.run.state === "FAILED" && (
-                  attemptsExhausted ? (
-                    <Button disabled={!connected} onClick={() => setConfirm("force-retry")}>
+                {d &&
+                  d.run.state === "FAILED" &&
+                  (attemptsExhausted ? (
+                    <Button
+                      disabled={!connected}
+                      onClick={() => setConfirm("force-retry")}
+                    >
                       Force retry…
                     </Button>
                   ) : (
                     <Button
                       disabled={!connected || retry.isPending}
-                      onClick={() => retry.mutate({ id: d.run.runId, force: false })}
+                      onClick={() =>
+                        retry.mutate({ id: d.run.runId, force: false })
+                      }
                     >
                       Retry
                     </Button>
-                  )
-                )}
+                  ))}
               </div>
               <div className="flex items-center gap-1.5">
                 <Button onClick={() => onOpenFull(sel.runId)}>
-                  Expand <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">o</span>
+                  Expand{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    o
+                  </span>
                 </Button>
                 <Button onClick={() => toggleRunPin(sel.runId)}>
-                  Open in tab <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">p</span>
+                  Open in tab{" "}
+                  <span
+                    className="mono ml-1 text-(--text-faint)"
+                    aria-hidden="true"
+                  >
+                    p
+                  </span>
                 </Button>
               </div>
             </>
@@ -1002,67 +1314,76 @@ export function Runs({
           }
           close={<Button onClick={() => onSelectRun(null)}>Close</Button>}
         >
-
           {!d && (
-            <div className="text-(--text-faint)">{detail.isError ? "Could not load run detail." : "Loading run…"}</div>
+            <div className="text-(--text-faint)">
+              {detail.isError ? "Could not load run detail." : "Loading run…"}
+            </div>
           )}
 
           {d && (
             <>
-          <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} />
-          {d.run.state === "PROPOSED" && (
-            <div className="mb-4 rounded-md border border-(--border) bg-(--surface-1) p-3 text-[12px]">
-              <div className="flex items-center justify-between gap-2">
-                <div>
-                  <div className="font-semibold text-(--text)">Awaiting Proposal Approval</div>
-                  <div className="text-[11px] text-(--text-dim) mt-0.5">
-                    {selProposal
-                      ? `Proposal ${shortId(selProposal.id)} is open and ready to approve.`
-                      : "This run was proposed and is waiting for proposal approval."}
+              <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} />
+              {d.run.state === "PROPOSED" && (
+                <div className="mb-4 rounded-md border border-(--border) bg-(--surface-1) p-3 text-[12px]">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <div className="font-semibold text-(--text)">
+                        Awaiting Proposal Approval
+                      </div>
+                      <div className="text-[11px] text-(--text-dim) mt-0.5">
+                        {selProposal
+                          ? `Proposal ${shortId(selProposal.id)} is open and ready to approve.`
+                          : "This run was proposed and is waiting for proposal approval."}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      {selProposal && onJumpProposal && (
+                        <Button onClick={() => onJumpProposal(selProposal.id)}>
+                          Open proposal
+                        </Button>
+                      )}
+                      {canApprove && selProposal && (
+                        <Button
+                          disabled={!connected || approve.isPending}
+                          onClick={() => setConfirmApprove(true)}
+                        >
+                          Approve…
+                        </Button>
+                      )}
+                    </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  {selProposal && onJumpProposal && (
-                    <Button onClick={() => onJumpProposal(selProposal.id)}>
-                      Open proposal
-                    </Button>
-                  )}
-                  {canApprove && selProposal && (
-                    <Button
-                      disabled={!connected || approve.isPending}
-                      onClick={() => setConfirmApprove(true)}
-                    >
-                      Approve…
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-          <div onClickCapture={handleRunArtifactClick}>
-            <RunDetailBlocks
-              d={d}
-              now={now}
-              connected={connected}
-              origin={sel}
-              onJumpAgent={onJumpAgent}
-              onJumpEvent={onJumpEvent}
-              onCancel={() => setConfirm("cancel")}
-              onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
-              onForceRetry={() => setConfirm("force-retry")}
-              retryPending={retry.isPending}
-              verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error) ?? approve.error}
-              afterLifecycle={
-                /* key: a run switch must reset the feed's cursor and scroll state. */
-                <RunTrace
-                  key={d.run.runId}
-                  runId={d.run.runId}
-                  state={d.run.state}
-                  onExpand={() => onOpenFull(d.run.runId)}
+              )}
+              <div onClickCapture={handleRunArtifactClick}>
+                <RunDetailBlocks
+                  d={d}
+                  now={now}
+                  connected={connected}
+                  origin={sel}
+                  onJumpAgent={onJumpAgent}
+                  onJumpEvent={onJumpEvent}
+                  onCancel={() => setConfirm("cancel")}
+                  onRetry={() =>
+                    retry.mutate({ id: d.run.runId, force: false })
+                  }
+                  onForceRetry={() => setConfirm("force-retry")}
+                  retryPending={retry.isPending}
+                  verbError={
+                    cancel.error ??
+                    (confirm === "force-retry" ? null : retry.error) ??
+                    approve.error
+                  }
+                  afterLifecycle={
+                    /* key: a run switch must reset the feed's cursor and scroll state. */
+                    <RunTrace
+                      key={d.run.runId}
+                      runId={d.run.runId}
+                      state={d.run.state}
+                      onExpand={() => onOpenFull(d.run.runId)}
+                    />
+                  }
                 />
-              }
-            />
-          </div>
+              </div>
             </>
           )}
         </DetailPane>
@@ -1075,9 +1396,10 @@ export function Runs({
           wide
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            You are approving this exact immutable spec — the agent below runs with these
-            capabilities the moment you confirm. Approving proposal{" "}
-            <span className="mono font-semibold">{selProposal.id}</span> queues this run for execution.
+            You are approving this exact immutable spec — the agent below runs
+            with these capabilities the moment you confirm. Approving proposal{" "}
+            <span className="mono font-semibold">{selProposal.id}</span> queues
+            this run for execution.
           </div>
           <ApprovalRiskDetails proposal={selProposal} agent={approveAgent} />
           <VerbError error={approve.error} />
@@ -1090,14 +1412,20 @@ export function Runs({
                 approve.mutate(selProposal.id);
               }}
             >
-              Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+              Approve and queue{" "}
+              <span className="mono ml-1 opacity-80" aria-hidden="true">
+                ↵
+              </span>
             </Button>
           </div>
         </Dialog>
       )}
 
       {confirm === "cancel" && d && (
-        <Dialog title={`Cancel ${d.run.runId}?`} onClose={() => setConfirm(null)}>
+        <Dialog
+          title={`Cancel ${d.run.runId}?`}
+          onClose={() => setConfirm(null)}
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             {d.run.state === "RUNNING"
               ? "Running attempt is stopped with TERM/KILL and cancelled."
@@ -1115,7 +1443,12 @@ export function Runs({
             <Button
               variant="danger"
               disabled={cancel.isPending}
-              onClick={() => cancel.mutate({ id: d.run.runId, reason: cancelReason.trim() || undefined })}
+              onClick={() =>
+                cancel.mutate({
+                  id: d.run.runId,
+                  reason: cancelReason.trim() || undefined,
+                })
+              }
             >
               Cancel run
             </Button>
@@ -1124,9 +1457,13 @@ export function Runs({
       )}
 
       {confirm === "force-retry" && d && (
-        <Dialog title="Retry past attempt budget?" onClose={() => setConfirm(null)}>
+        <Dialog
+          title="Retry past attempt budget?"
+          onClose={() => setConfirm(null)}
+        >
           <div className="mb-3 text-[12px] text-(--text-dim)">
-            Used {d.run.attempts}/{d.run.spec.maxAttempts} attempts. Forcing retry is recorded as an operator override.
+            Used {d.run.attempts}/{d.run.spec.maxAttempts} attempts. Forcing
+            retry is recorded as an operator override.
           </div>
           <VerbError error={retry.error} />
           <div className="mt-3 flex justify-end gap-2">

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -1,9 +1,19 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Schedules, scheduleFilterTokens, type ScheduleItem } from "./Schedules";
+import {
+  Schedules,
+  scheduleFilterTokens,
+  type ScheduleItem,
+} from "./Schedules";
 import { api } from "../api";
 import { useContextActions } from "../palette";
 import { changeInput } from "../test-render";
@@ -16,12 +26,16 @@ function renderWithClient(ui: React.ReactElement) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 const noop = () => {};
 
-function schedule(overrides: Partial<ScheduleItem> & Pick<ScheduleItem, "loop">): ScheduleItem {
+function schedule(
+  overrides: Partial<ScheduleItem> & Pick<ScheduleItem, "loop">,
+): ScheduleItem {
   return {
     repo: null,
     every: "5m",
@@ -45,9 +59,19 @@ function schedule(overrides: Partial<ScheduleItem> & Pick<ScheduleItem, "loop">)
 /** The four enabled × stopped combinations (WM-101). */
 const rows: ScheduleItem[] = [
   schedule({ loop: "loop-enabled-running", enabled: true, stopped: false }),
-  schedule({ loop: "loop-enabled-stopped", enabled: true, stopped: true, intervalsLate: 3 }),
+  schedule({
+    loop: "loop-enabled-stopped",
+    enabled: true,
+    stopped: true,
+    intervalsLate: 3,
+  }),
   schedule({ loop: "loop-disabled-idle", enabled: false, stopped: false }),
-  schedule({ loop: "loop-disabled-stopped", enabled: false, stopped: true, intervalsLate: 7 }),
+  schedule({
+    loop: "loop-disabled-stopped",
+    enabled: false,
+    stopped: true,
+    intervalsLate: 7,
+  }),
 ];
 
 const origFetch = globalThis.fetch;
@@ -57,7 +81,12 @@ const origTriggerSchedule = api.triggerSchedule;
 
 beforeEach(() => {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
     if (url.startsWith("/api/schedules")) {
       return new Response(JSON.stringify({ schedules: rows }), {
         status: 200,
@@ -66,7 +95,12 @@ beforeEach(() => {
     }
     return origFetch(input, init);
   }) as typeof fetch;
-  api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
+  api.agents = async () => ({
+    agents: [],
+    edges: {},
+    eventTypes: [],
+    contracts: {},
+  });
   api.events = async () => ({ events: [] });
 });
 
@@ -114,17 +148,31 @@ function StatefulSchedules({
   initialLoop?: string | null;
 }) {
   const [loop, setLoop] = useState<string | null>(initialLoop);
-  return <Schedules {...scheduleViewProps({ connected, focusScheduleLoop: loop, onSelectSchedule: setLoop })} />;
+  return (
+    <Schedules
+      {...scheduleViewProps({
+        connected,
+        focusScheduleLoop: loop,
+        onSelectSchedule: setLoop,
+      })}
+    />
+  );
 }
 
 function PaletteProbe() {
   const actions = useContextActions();
-  return <div data-testid="palette-probe">{actions.map((a) => a.label).join(" | ")}</div>;
+  return (
+    <div data-testid="palette-probe">
+      {actions.map((a) => a.label).join(" | ")}
+    </div>
+  );
 }
 
 function pressKey(key: string) {
   act(() => {
-    document.body.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true }),
+    );
   });
 }
 
@@ -136,7 +184,9 @@ describe("Schedules enabled/state wording (WM-101)", () => {
 
     const enabledCells = getAllByText("enabled");
     expect(enabledCells.length).toBe(2); // the two enabled rows
-    expect(enabledCells[0]!.title).toContain("enabled: true in event-runtime/schedules.json");
+    expect(enabledCells[0]!.title).toContain(
+      "enabled: true in event-runtime/schedules.json",
+    );
 
     const running = getByText("running");
     expect(running.title).toContain("scheduler loop is ticking");
@@ -152,7 +202,9 @@ describe("Schedules enabled/state wording (WM-101)", () => {
     await waitFor(() => getByText("loop-enabled-stopped"));
 
     const stopped = getByText("stopped (3 late)");
-    expect(stopped.title).toContain("enabled: true but the scheduler loop is not ticking");
+    expect(stopped.title).toContain(
+      "enabled: true but the scheduler loop is not ticking",
+    );
     expect(stopped.title).toContain("3 intervals");
   });
 
@@ -165,14 +217,19 @@ describe("Schedules enabled/state wording (WM-101)", () => {
 
     const disabledCells = getAllByText("disabled");
     expect(disabledCells.length).toBe(2); // the two disabled rows
-    expect(disabledCells[0]!.title).toContain("enabled: false in event-runtime/schedules.json");
+    expect(disabledCells[0]!.title).toContain(
+      "enabled: false in event-runtime/schedules.json",
+    );
 
     const notScheduled = getAllByText("not scheduled");
-    expect(notScheduled[0]!.title).toContain("enabled: false in event-runtime/schedules.json");
+    expect(notScheduled[0]!.title).toContain(
+      "enabled: false in event-runtime/schedules.json",
+    );
   });
 
   test("disabled + stopped still renders 'not scheduled' (a disabled loop cannot be a stalled clock)", async () => {
-    const { getByText, getAllByText, queryByText, getByRole } = renderSchedules();
+    const { getByText, getAllByText, queryByText, getByRole } =
+      renderSchedules();
 
     await waitFor(() => getByRole("tab", { name: /Disabled/ }));
     fireEvent.click(getByRole("tab", { name: /Disabled/ }));
@@ -189,7 +246,9 @@ describe("Schedules enabled/state wording (WM-101)", () => {
 
     await waitFor(() => getByText("loop-enabled-running"));
 
-    expect(getByTitle(/Config flag from event-runtime\/schedules.json/).title).toContain("event-runtime/schedules.json");
+    expect(
+      getByTitle(/Config flag from event-runtime\/schedules.json/).title,
+    ).toContain("event-runtime/schedules.json");
     expect(getByText("State").title).toContain("Runtime health");
     expect(getByText(/there is no.*toggle here/s)).toBeTruthy();
   });
@@ -210,7 +269,9 @@ describe("Schedules enabled/state wording (WM-101)", () => {
       expect(tokens).not.toContain("ok");
     }
     // error wins the state token
-    expect(scheduleFilterTokens(schedule({ loop: "l", error: "bad cadence" }))).toContain("error");
+    expect(
+      scheduleFilterTokens(schedule({ loop: "l", error: "bad cadence" })),
+    ).toContain("error");
   });
 });
 
@@ -237,14 +298,30 @@ describe("Schedules tabs and default ordering (WM-549)", () => {
 
   test("orders enabled first, then next due ascending, then loop name", async () => {
     const orderedRows = [
-      schedule({ loop: "disabled-z", enabled: false, nextDue: "2030-01-01T00:00:00.000Z" }),
+      schedule({
+        loop: "disabled-z",
+        enabled: false,
+        nextDue: "2030-01-01T00:00:00.000Z",
+      }),
       schedule({ loop: "enabled-later", nextDue: "2030-01-02T00:00:00.000Z" }),
       schedule({ loop: "enabled-undated", nextDue: null }),
-      schedule({ loop: "disabled-a", enabled: false, nextDue: "2030-01-03T00:00:00.000Z" }),
+      schedule({
+        loop: "disabled-a",
+        enabled: false,
+        nextDue: "2030-01-03T00:00:00.000Z",
+      }),
       schedule({ loop: "enabled-sooner", nextDue: "2030-01-01T00:00:00.000Z" }),
     ];
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
       if (url.startsWith("/api/schedules")) {
         return new Response(JSON.stringify({ schedules: orderedRows }), {
           status: 200,
@@ -258,9 +335,9 @@ describe("Schedules tabs and default ordering (WM-549)", () => {
     const allTab = await view.findByRole("tab", { name: /All\s*5/ });
     fireEvent.click(allTab);
 
-    const renderedLoops = [...view.container.querySelectorAll("tbody tr td:first-child")].map(
-      (cell) => cell.textContent,
-    );
+    const renderedLoops = [
+      ...view.container.querySelectorAll("tbody tr td:first-child"),
+    ].map((cell) => cell.textContent);
     expect(renderedLoops).toEqual([
       "enabled-sooner",
       "enabled-later",
@@ -278,7 +355,11 @@ describe("Schedules connected gating (WM-156)", () => {
       focusScheduleLoop: "loop-enabled-running",
     });
 
-    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(
+        getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(1),
+    );
 
     for (const btn of getAllByRole("button", { name: "Run now…" })) {
       expect((btn as HTMLButtonElement).disabled).toBe(true);
@@ -287,10 +368,17 @@ describe("Schedules connected gating (WM-156)", () => {
 
   test("keyboard r does not open confirm when disconnected", async () => {
     const { getAllByRole, queryByRole, queryByText } = renderWithClient(
-      <StatefulSchedules connected={false} initialLoop="loop-enabled-running" />,
+      <StatefulSchedules
+        connected={false}
+        initialLoop="loop-enabled-running"
+      />,
     );
 
-    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
     pressKey("r");
 
     expect(queryByRole("button", { name: "Trigger Run" }) === null).toBe(true);
@@ -300,13 +388,24 @@ describe("Schedules connected gating (WM-156)", () => {
   test("palette omits Run now when disconnected", async () => {
     const { getAllByRole, getByTestId } = renderWithClient(
       <>
-        <StatefulSchedules connected={false} initialLoop="loop-enabled-running" />
+        <StatefulSchedules
+          connected={false}
+          initialLoop="loop-enabled-running"
+        />
         <PaletteProbe />
       </>,
     );
 
-    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
-    await waitFor(() => expect(getByTestId("palette-probe").textContent).toContain("Copy loop-enabled-running"));
+    await waitFor(() =>
+      expect(
+        getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
+    await waitFor(() =>
+      expect(getByTestId("palette-probe").textContent).toContain(
+        "Copy loop-enabled-running",
+      ),
+    );
 
     const labels = getByTestId("palette-probe").textContent ?? "";
     expect(labels).not.toMatch(/Run .* now/);
@@ -320,22 +419,37 @@ describe("Schedules connected gating (WM-156)", () => {
           <button type="button" onClick={() => setConnected(false)}>
             simulate-disconnect
           </button>
-          <StatefulSchedules connected={connected} initialLoop="loop-enabled-running" />
+          <StatefulSchedules
+            connected={connected}
+            initialLoop="loop-enabled-running"
+          />
         </>
       );
     }
 
-    const { getByText, getByRole, getAllByRole } = renderWithClient(<ConfirmThenDisconnect />);
+    const { getByText, getByRole, getAllByRole } = renderWithClient(
+      <ConfirmThenDisconnect />,
+    );
 
-    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
     fireEvent.click(getAllByRole("button", { name: "Run now…" })[0]!);
     await waitFor(() => getByRole("button", { name: "Trigger Run" }));
 
-    expect((getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      (getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
 
     fireEvent.click(getByText("simulate-disconnect"));
 
-    expect((getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      (getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 
   test("Run now buttons are enabled when connected={true}", async () => {
@@ -344,7 +458,11 @@ describe("Schedules connected gating (WM-156)", () => {
       focusScheduleLoop: "loop-enabled-running",
     });
 
-    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(
+        getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(1),
+    );
 
     for (const btn of getAllByRole("button", { name: "Run now…" })) {
       expect((btn as HTMLButtonElement).disabled).toBe(false);
@@ -354,16 +472,24 @@ describe("Schedules connected gating (WM-156)", () => {
 
 describe("Schedules aria-selected (WM-156)", () => {
   test("selected row has aria-selected=true; others false; updates on click and j/k", async () => {
-    const { getByText, container } = renderWithClient(<StatefulSchedules connected={true} />);
+    const { getByText, container } = renderWithClient(
+      <StatefulSchedules connected={true} />,
+    );
 
     await waitFor(() => getByText("loop-enabled-running"));
 
     const dataRows = () => [...container.querySelectorAll("tbody tr")];
-    expect(dataRows().every((row) => row.getAttribute("aria-selected") === "false")).toBe(true);
+    expect(
+      dataRows().every((row) => row.getAttribute("aria-selected") === "false"),
+    ).toBe(true);
 
     fireEvent.click(getByText("loop-enabled-running"));
     expect(dataRows()[0]!.getAttribute("aria-selected")).toBe("true");
-    expect(dataRows().slice(1).every((row) => row.getAttribute("aria-selected") === "false")).toBe(true);
+    expect(
+      dataRows()
+        .slice(1)
+        .every((row) => row.getAttribute("aria-selected") === "false"),
+    ).toBe(true);
 
     pressKey("j");
     expect(dataRows()[0]!.getAttribute("aria-selected")).toBe("false");
@@ -398,7 +524,9 @@ describe("Schedules copy chords and hints (WM-233)", () => {
       focusScheduleLoop: "loop-enabled-running",
     });
 
-    const loopBtn = await r.findByRole("button", { name: "Copy schedule loop (c)" });
+    const loopBtn = await r.findByRole("button", {
+      name: "Copy schedule loop (c)",
+    });
 
     // Verify icon-action tooltips preserve shortcut discoverability.
     expect(loopBtn.getAttribute("title")).toBe("Copy schedule loop · c");
@@ -447,8 +575,16 @@ describe("Schedules manual merge targeting (WM-426)", () => {
   });
 
   function serveMergeSchedule() {
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
       if (url.startsWith("/api/schedules")) {
         return new Response(JSON.stringify({ schedules: [mergeSchedule] }), {
           status: 200,
@@ -480,18 +616,34 @@ describe("Schedules manual merge targeting (WM-426)", () => {
     const view = renderWithClient(
       <StatefulSchedules connected={true} initialLoop="merge-factory" />,
     );
-    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        view.getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
     fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
 
-    const input = await view.findByRole("textbox", { name: "PR numbers (optional)" });
-    expect(view.getByText(/Leave blank to review all open PRs in factory/)).toBeTruthy();
+    const input = await view.findByRole("textbox", {
+      name: "PR numbers (optional)",
+    });
+    expect(
+      view.getByText(/Leave blank to review all open PRs in factory/),
+    ).toBeTruthy();
     expect(view.getByText("Autonomous merge automation")).toBeTruthy();
-    expect(view.getByText(/mutating downstream automation without another confirmation/)).toBeTruthy();
-    expect(input.getAttribute("aria-describedby")).toBe("schedule-pr-numbers-help");
+    expect(
+      view.getByText(
+        /mutating downstream automation without another confirmation/,
+      ),
+    ).toBeTruthy();
+    expect(input.getAttribute("aria-describedby")).toBe(
+      "schedule-pr-numbers-help",
+    );
     act(() => changeInput(input, "411, 426"));
     fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
 
-    await waitFor(() => expect(calls).toEqual([{ loop: "merge-factory", prNumbers: [411, 426] }]));
+    await waitFor(() =>
+      expect(calls).toEqual([{ loop: "merge-factory", prNumbers: [411, 426] }]),
+    );
   });
 
   test("invalid merge selection exposes an input-associated error", async () => {
@@ -499,9 +651,15 @@ describe("Schedules manual merge targeting (WM-426)", () => {
     const view = renderWithClient(
       <StatefulSchedules connected={true} initialLoop="merge-factory" />,
     );
-    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        view.getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
     fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
-    const input = await view.findByRole("textbox", { name: "PR numbers (optional)" });
+    const input = await view.findByRole("textbox", {
+      name: "PR numbers (optional)",
+    });
     act(() => changeInput(input, "426, 426"));
     fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
 
@@ -532,12 +690,17 @@ describe("Schedules manual merge targeting (WM-426)", () => {
     const view = renderWithClient(
       <StatefulSchedules connected={true} initialLoop="merge-factory" />,
     );
-    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(
+        view.getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
     fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
     await view.findByRole("textbox", { name: "PR numbers (optional)" });
     fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
 
-    await waitFor(() => expect(calls).toEqual([{ loop: "merge-factory", prNumbers: undefined }]));
+    await waitFor(() =>
+      expect(calls).toEqual([{ loop: "merge-factory", prNumbers: undefined }]),
+    );
   });
 });
-

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -49,12 +49,24 @@ export function scheduleFilterTokens(s: ScheduleItem): string[] {
     s.approval,
     s.catchUp,
     s.enabled ? "enabled" : "disabled",
-    s.error ? "error" : !s.enabled ? "not scheduled" : s.stopped ? "stopped" : "running",
+    s.error
+      ? "error"
+      : !s.enabled
+        ? "not scheduled"
+        : s.stopped
+          ? "stopped"
+          : "running",
   ];
 }
 
 const scheduleState = (schedule: ScheduleItem): string =>
-  schedule.error ? "error" : !schedule.enabled ? "not scheduled" : schedule.stopped ? "stopped" : "running";
+  schedule.error
+    ? "error"
+    : !schedule.enabled
+      ? "not scheduled"
+      : schedule.stopped
+        ? "stopped"
+        : "running";
 
 type ScheduleTab = "all" | "enabled" | "disabled";
 const SCHEDULE_TABS: readonly ScheduleTab[] = ["all", "enabled", "disabled"];
@@ -64,8 +76,10 @@ export function compareSchedules(a: ScheduleItem, b: ScheduleItem): number {
   if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
   // Disabled schedules are not due, even if the API retains a historical
   // nextDue value; the table renders the shared empty value for them, so name is their tie-break.
-  const parsedADue = a.enabled && a.nextDue ? Date.parse(a.nextDue) : Number.POSITIVE_INFINITY;
-  const parsedBDue = b.enabled && b.nextDue ? Date.parse(b.nextDue) : Number.POSITIVE_INFINITY;
+  const parsedADue =
+    a.enabled && a.nextDue ? Date.parse(a.nextDue) : Number.POSITIVE_INFINITY;
+  const parsedBDue =
+    b.enabled && b.nextDue ? Date.parse(b.nextDue) : Number.POSITIVE_INFINITY;
   const aDue = Number.isNaN(parsedADue) ? Number.POSITIVE_INFINITY : parsedADue;
   const bDue = Number.isNaN(parsedBDue) ? Number.POSITIVE_INFINITY : parsedBDue;
   if (aDue !== bDue) return aDue - bDue;
@@ -84,10 +98,16 @@ function ScheduleStateBadge({
   return (
     <span
       className="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px] font-medium"
-      style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
+      style={{
+        color: hue,
+        background: `color-mix(in oklch, ${hue} 12%, transparent)`,
+      }}
       title={title}
     >
-      <span className="size-1.5 shrink-0 rounded-full bg-current" aria-hidden="true" />
+      <span
+        className="size-1.5 shrink-0 rounded-full bg-current"
+        aria-hidden="true"
+      />
       {state}
     </span>
   );
@@ -97,16 +117,36 @@ const SCHEDULES_SORT: DisplayConfig<ScheduleItem> = {
   view: "schedules-table-sort",
   groups: [],
   sorts: [
-    { key: "loop", label: "Loop", get: (schedule) => schedule.loop, column: "loop" },
+    {
+      key: "loop",
+      label: "Loop",
+      get: (schedule) => schedule.loop,
+      column: "loop",
+    },
     {
       key: "cadence",
       label: "Cadence",
       get: (schedule) => schedule.cadenceSeconds ?? Number.POSITIVE_INFINITY,
       column: "cadence",
     },
-    { key: "enabled", label: "Enabled", get: (schedule) => Number(schedule.enabled), column: "enabled" },
-    { key: "approval", label: "Approval", get: (schedule) => schedule.approval, column: "approval" },
-    { key: "catchUp", label: "Catch-up", get: (schedule) => schedule.catchUp, column: "catchUp" },
+    {
+      key: "enabled",
+      label: "Enabled",
+      get: (schedule) => Number(schedule.enabled),
+      column: "enabled",
+    },
+    {
+      key: "approval",
+      label: "Approval",
+      get: (schedule) => schedule.approval,
+      column: "approval",
+    },
+    {
+      key: "catchUp",
+      label: "Catch-up",
+      get: (schedule) => schedule.catchUp,
+      column: "catchUp",
+    },
     {
       key: "lastFire",
       label: "Last fire",
@@ -194,30 +234,43 @@ export function Schedules({
     return rows.filter((schedule) => {
       if (tab === "enabled" && !schedule.enabled) return false;
       if (tab === "disabled" && schedule.enabled) return false;
-      return !q || scheduleFilterTokens(schedule).some((value) => value.toLowerCase().includes(q));
+      return (
+        !q ||
+        scheduleFilterTokens(schedule).some((value) =>
+          value.toLowerCase().includes(q),
+        )
+      );
     });
   }, [rows, tab, filter]);
   const [sort, setSort] = useState(() => defaultDisplayState(SCHEDULES_SORT));
   const visible = useMemo(
-    () => sort.sortBy === DEFAULT_ORDER
-      ? [...filtered].sort(compareSchedules)
-      : sortRows(filtered, SCHEDULES_SORT, sort),
+    () =>
+      sort.sortBy === DEFAULT_ORDER
+        ? [...filtered].sort(compareSchedules)
+        : sortRows(filtered, SCHEDULES_SORT, sort),
     [filtered, sort],
   );
   const nextSchedule = useMemo(
-    () => [...rows]
-      .filter((schedule) => schedule.enabled && schedule.nextDue && !Number.isNaN(Date.parse(schedule.nextDue)))
-      .sort(compareSchedules)[0] ?? null,
+    () =>
+      [...rows]
+        .filter(
+          (schedule) =>
+            schedule.enabled &&
+            schedule.nextDue &&
+            !Number.isNaN(Date.parse(schedule.nextDue)),
+        )
+        .sort(compareSchedules)[0] ?? null,
     [rows],
   );
   const nextFireSeconds = nextSchedule?.nextDue
     ? Math.max(0, Math.floor((Date.parse(nextSchedule.nextDue) - now) / 1000))
     : null;
-  const nextFireLabel = nextFireSeconds === null
-    ? "not scheduled"
-    : nextFireSeconds === 0
-      ? "due now"
-      : `in ${Math.floor(nextFireSeconds / 60)}:${String(nextFireSeconds % 60).padStart(2, "0")}`;
+  const nextFireLabel =
+    nextFireSeconds === null
+      ? "not scheduled"
+      : nextFireSeconds === 0
+        ? "due now"
+        : `in ${Math.floor(nextFireSeconds / 60)}:${String(nextFireSeconds % 60).padStart(2, "0")}`;
 
   const selectedLoop = focusScheduleLoop;
   const selectedIndex = useMemo(
@@ -229,20 +282,29 @@ export function Schedules({
   // Find agent corresponding to the selected schedule's eventType
   const selAgent: AgentDef | undefined = useMemo(() => {
     if (!sel) return undefined;
-    return agents.find((a) => a.eventTypes.some((t) => t.type === sel.eventType));
+    return agents.find((a) =>
+      a.eventTypes.some((t) => t.type === sel.eventType),
+    );
   }, [sel, agents]);
 
   // Recent ticks for the selected loop
   const recentTicks: AdmittedEvent[] = useMemo(() => {
     if (!sel) return [];
     return allEvents
-      .filter((e) => e.type === sel.eventType || (e.envelope?.payload as Record<string, unknown> | undefined)?.loop === sel.loop)
+      .filter(
+        (e) =>
+          e.type === sel.eventType ||
+          (e.envelope?.payload as Record<string, unknown> | undefined)?.loop ===
+            sel.loop,
+      )
       .slice(0, 10);
   }, [sel, allEvents]);
 
   const [confirmLoop, setConfirmLoop] = useState<ScheduleItem | null>(null);
   const [prNumbersInput, setPrNumbersInput] = useState("");
-  const [triggerInputError, setTriggerInputError] = useState<string | null>(null);
+  const [triggerInputError, setTriggerInputError] = useState<string | null>(
+    null,
+  );
 
   const triggerMut = useMutation({
     mutationFn: ({ loop, prNumbers }: { loop: string; prNumbers?: number[] }) =>
@@ -255,7 +317,10 @@ export function Schedules({
       queryClient.invalidateQueries({ queryKey: ["status"] });
       setConfirmLoop(null);
       if (outcome.decision === "noop") {
-        notify(`Schedule "${loop}" was not started: ${outcome.reason ?? "previous run in flight"}`, "info");
+        notify(
+          `Schedule "${loop}" was not started: ${outcome.reason ?? "previous run in flight"}`,
+          "info",
+        );
       } else if (outcome.proposalId) {
         notify(`Triggered "${loop}" · proposal ${outcome.proposalId}`, "ok");
         onJumpProposal(outcome.proposalId);
@@ -271,13 +336,17 @@ export function Schedules({
   }, [confirmLoop]);
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, rejumpEpoch]);
 
   useEffect(() => {
     if (!focusScheduleLoop) return;
     setFilter("");
-    const focused = rows.find((schedule) => schedule.loop === focusScheduleLoop);
+    const focused = rows.find(
+      (schedule) => schedule.loop === focusScheduleLoop,
+    );
     // Keep deep-linked selections visible, but preserve an explicit All choice.
     if (focused && tab !== "all" && focused.enabled !== (tab === "enabled")) {
       setTab(focused.enabled ? "enabled" : "disabled");
@@ -298,12 +367,18 @@ export function Schedules({
     }
     const tokens = raw.split(/[\s,]+/);
     if (tokens.some((token) => !/^\d+$/.test(token))) {
-      setTriggerInputError("Enter positive PR numbers separated by commas or spaces.");
+      setTriggerInputError(
+        "Enter positive PR numbers separated by commas or spaces.",
+      );
       return;
     }
     const prNumbers = tokens.map(Number);
-    if (prNumbers.some((number) => !Number.isSafeInteger(number) || number <= 0)) {
-      setTriggerInputError("Enter positive PR numbers separated by commas or spaces.");
+    if (
+      prNumbers.some((number) => !Number.isSafeInteger(number) || number <= 0)
+    ) {
+      setTriggerInputError(
+        "Enter positive PR numbers separated by commas or spaces.",
+      );
       return;
     }
     if (new Set(prNumbers).size !== prNumbers.length) {
@@ -331,7 +406,11 @@ export function Schedules({
         pendingC.current = Date.now();
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -345,13 +424,24 @@ export function Schedules({
       setContextActions([]);
     } else {
       const copy = [
-        { label: `Copy ${sel.loop}`, hint: "c", run: () => copyText(sel.loop, "schedule loop") },
+        {
+          label: `Copy ${sel.loop}`,
+          hint: "c",
+          run: () => copyText(sel.loop, "schedule loop"),
+        },
         { label: "Copy link to this schedule", hint: "c l", run: copyLink },
       ];
       setContextActions(
         connected === false
           ? copy
-          : [{ label: `Run ${sel.loop} now…`, hint: "r", run: () => setConfirmLoop(sel) }, ...copy],
+          : [
+              {
+                label: `Run ${sel.loop} now…`,
+                hint: "r",
+                run: () => setConfirmLoop(sel),
+              },
+              ...copy,
+            ],
       );
     }
     return () => setContextActions([]);
@@ -368,13 +458,18 @@ export function Schedules({
               surface="registry"
               subject={{ label: "Schedules", plural: true }}
             />
-            <div className="mb-2 flex gap-1" role="tablist" aria-label="Schedule state">
+            <div
+              className="mb-2 flex gap-1"
+              role="tablist"
+              aria-label="Schedule state"
+            >
               {SCHEDULE_TABS.map((scheduleTab) => {
-                const count = scheduleTab === "all"
-                  ? rows.length
-                  : scheduleTab === "enabled"
-                    ? enabledCount
-                    : disabledCount;
+                const count =
+                  scheduleTab === "all"
+                    ? rows.length
+                    : scheduleTab === "enabled"
+                      ? enabledCount
+                      : disabledCount;
                 return (
                   <button
                     key={scheduleTab}
@@ -392,13 +487,19 @@ export function Schedules({
                     }`}
                   >
                     {scheduleTab[0]!.toUpperCase() + scheduleTab.slice(1)}
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>
+                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                      {count}
+                    </span>
                   </button>
                 );
               })}
             </div>
-            <p className="mb-3 text-[11px] text-(--text-faint)" aria-label="Schedule summary">
-              {enabledCount} enabled · {disabledCount} disabled · next fire {nextFireLabel}
+            <p
+              className="mb-3 text-[11px] text-(--text-faint)"
+              aria-label="Schedule summary"
+            >
+              {enabledCount} enabled · {disabledCount} disabled · next fire{" "}
+              {nextFireLabel}
               {nextSchedule && <> ({nextSchedule.loop})</>}
             </p>
             <div className="mb-3">
@@ -417,154 +518,182 @@ export function Schedules({
           role="tabpanel"
           aria-labelledby={`schedule-tab-${tab}`}
         >
-        <table className="w-full border-separate border-spacing-0">
-          <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
-              {SCHEDULES_SORT.columns.map((column) => {
-                const field = SCHEDULES_SORT.sorts.find((candidate) => candidate.column === column.key)!;
-                const title =
-                  column.key === "enabled"
-                    ? "Config flag from event-runtime/schedules.json — edit that file (or use the CLI) to enable/disable; there is no toggle in this UI"
-                    : column.key === "state"
-                      ? "Runtime health of the scheduler loop: running, stopped (no ticks), not scheduled (disabled), or error"
-                      : undefined;
+          <table className="w-full border-separate border-spacing-0">
+            <thead>
+              <tr className="text-left text-[11px] text-(--text-faint)">
+                {SCHEDULES_SORT.columns.map((column) => {
+                  const field = SCHEDULES_SORT.sorts.find(
+                    (candidate) => candidate.column === column.key,
+                  )!;
+                  const title =
+                    column.key === "enabled"
+                      ? "Config flag from event-runtime/schedules.json — edit that file (or use the CLI) to enable/disable; there is no toggle in this UI"
+                      : column.key === "state"
+                        ? "Runtime health of the scheduler loop: running, stopped (no ticks), not scheduled (disabled), or error"
+                        : undefined;
+                  return (
+                    <Th
+                      key={column.key}
+                      label={column.label}
+                      title={title}
+                      dir={sort.sortBy === field.key ? sort.sortDir : null}
+                      naturalDir={field.defaultDir ?? "asc"}
+                      onSort={() =>
+                        setSort((state) =>
+                          cycleColumnSort(SCHEDULES_SORT, state, column.key),
+                        )
+                      }
+                    />
+                  );
+                })}
+                <Th label="Action" align="right" />
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((s, idx) => {
+                const isSel = idx === selectedIndex;
+                const isAuto = s.approval === "auto";
                 return (
-                  <Th
-                    key={column.key}
-                    label={column.label}
-                    title={title}
-                    dir={sort.sortBy === field.key ? sort.sortDir : null}
-                    naturalDir={field.defaultDir ?? "asc"}
-                    onSort={() => setSort((state) => cycleColumnSort(SCHEDULES_SORT, state, column.key))}
-                  />
+                  <tr
+                    key={s.loop}
+                    onClick={() => onSelectSchedule(s.loop)}
+                    aria-selected={isSel}
+                    className={`group cursor-pointer border-b border-(--border) text-[13px] hover:bg-(--surface-2) ${
+                      isSel ? "row-selected bg-(--surface-3)" : ""
+                    }`}
+                  >
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-medium text-(--text)">
+                      {s.loop}
+                    </td>
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      {s.every}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <ScheduleStateBadge
+                        state={s.enabled ? "enabled" : "disabled"}
+                        hue={s.enabled ? "var(--hue-ok)" : "var(--text-faint)"}
+                        title={
+                          s.enabled
+                            ? "enabled: true in event-runtime/schedules.json — the scheduler will fire this loop on cadence"
+                            : "enabled: false in event-runtime/schedules.json — edit that file (or use the CLI) to re-enable"
+                        }
+                      />
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <ScheduleStateBadge
+                        state={isAuto ? "auto" : "watched"}
+                        hue={isAuto ? "var(--hue-warn)" : "var(--hue-info)"}
+                        title={
+                          isAuto
+                            ? "approval: auto — executes unattended without operator prompt"
+                            : "approval: watched — requires human approval"
+                        }
+                      />
+                    </td>
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
+                      {s.catchUp}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
+                      {s.lastSlot ? (
+                        <span title={s.lastSlot}>
+                          {formatRelative(s.lastSlot, now)}
+                        </span>
+                      ) : (
+                        <span className="text-(--text-faint)">never</span>
+                      )}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
+                      {!s.enabled ? (
+                        <span className="text-(--text-faint)">{EMPTY}</span>
+                      ) : s.error ? (
+                        <span className="text-(--hue-err)">{EMPTY}</span>
+                      ) : s.nextDue && s.cadenceSeconds ? (
+                        <Countdown
+                          createdAt={
+                            s.lastSlot ??
+                            new Date(
+                              Date.parse(s.nextDue) - s.cadenceSeconds * 1000,
+                            ).toISOString()
+                          }
+                          ttlSeconds={s.cadenceSeconds}
+                        />
+                      ) : (
+                        EMPTY
+                      )}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      {s.error ? (
+                        <span
+                          className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
+                          style={{
+                            background:
+                              "color-mix(in oklch, var(--hue-err) 12%, transparent)",
+                          }}
+                          title={s.error}
+                        >
+                          error
+                        </span>
+                      ) : !s.enabled ? (
+                        <span
+                          className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--text-faint)"
+                          style={{ background: "var(--surface-2)" }}
+                          title="Not scheduled: enabled: false in event-runtime/schedules.json, so the scheduler loop is not running for this schedule"
+                        >
+                          not scheduled
+                        </span>
+                      ) : s.stopped ? (
+                        <span
+                          className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
+                          style={{
+                            background:
+                              "color-mix(in oklch, var(--hue-err) 12%, transparent)",
+                          }}
+                          title={`Stopped: enabled: true but the scheduler loop is not ticking — no ticks for ${s.intervalsLate} intervals. Check the event runtime serve process.`}
+                        >
+                          stopped ({s.intervalsLate} late)
+                        </span>
+                      ) : (
+                        <span
+                          className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-ok)"
+                          style={{
+                            background:
+                              "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
+                          }}
+                          title="Running: enabled: true and the scheduler loop is ticking on cadence"
+                        >
+                          running
+                        </span>
+                      )}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-right">
+                      <span className="pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                        <Button
+                          disabled={connected === false}
+                          onClick={() => setConfirmLoop(s)}
+                        >
+                          Run now…
+                        </Button>
+                      </span>
+                    </td>
+                  </tr>
                 );
               })}
-              <Th label="Action" align="right" />
-            </tr>
-          </thead>
-          <tbody>
-            {visible.map((s, idx) => {
-              const isSel = idx === selectedIndex;
-              const isAuto = s.approval === "auto";
-              return (
-                <tr
-                  key={s.loop}
-                  onClick={() => onSelectSchedule(s.loop)}
-                  aria-selected={isSel}
-                  className={`group cursor-pointer border-b border-(--border) text-[13px] hover:bg-(--surface-2) ${
-                    isSel ? "row-selected bg-(--surface-3)" : ""
-                  }`}
-                >
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-medium text-(--text)">
-                    {s.loop}
-                  </td>
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                    {s.every}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    <ScheduleStateBadge
-                      state={s.enabled ? "enabled" : "disabled"}
-                      hue={s.enabled ? "var(--hue-ok)" : "var(--text-faint)"}
-                      title={s.enabled
-                        ? "enabled: true in event-runtime/schedules.json — the scheduler will fire this loop on cadence"
-                        : "enabled: false in event-runtime/schedules.json — edit that file (or use the CLI) to re-enable"}
-                    />
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    <ScheduleStateBadge
-                      state={isAuto ? "auto" : "watched"}
-                      hue={isAuto ? "var(--hue-warn)" : "var(--hue-info)"}
-                      title={isAuto
-                        ? "approval: auto — executes unattended without operator prompt"
-                        : "approval: watched — requires human approval"}
-                    />
-                  </td>
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
-                    {s.catchUp}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
-                    {s.lastSlot ? <span title={s.lastSlot}>{formatRelative(s.lastSlot, now)}</span> : <span className="text-(--text-faint)">never</span>}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
-                    {!s.enabled ? (
-                      <span className="text-(--text-faint)">{EMPTY}</span>
-                    ) : s.error ? (
-                      <span className="text-(--hue-err)">{EMPTY}</span>
-                    ) : s.nextDue && s.cadenceSeconds ? (
-                      <Countdown
-                        createdAt={
-                          s.lastSlot ?? new Date(Date.parse(s.nextDue) - s.cadenceSeconds * 1000).toISOString()
-                        }
-                        ttlSeconds={s.cadenceSeconds}
-                      />
-                    ) : (
-                      EMPTY
-                    )}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    {s.error ? (
-                      <span
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
-                        style={{ background: "color-mix(in oklch, var(--hue-err) 12%, transparent)" }}
-                        title={s.error}
-                      >
-                        error
-                      </span>
-                    ) : !s.enabled ? (
-                      <span
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--text-faint)"
-                        style={{ background: "var(--surface-2)" }}
-                        title="Not scheduled: enabled: false in event-runtime/schedules.json, so the scheduler loop is not running for this schedule"
-                      >
-                        not scheduled
-                      </span>
-                    ) : s.stopped ? (
-                      <span
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
-                        style={{ background: "color-mix(in oklch, var(--hue-err) 12%, transparent)" }}
-                        title={`Stopped: enabled: true but the scheduler loop is not ticking — no ticks for ${s.intervalsLate} intervals. Check the event runtime serve process.`}
-                      >
-                        stopped ({s.intervalsLate} late)
-                      </span>
-                    ) : (
-                      <span
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-ok)"
-                        style={{ background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)" }}
-                        title="Running: enabled: true and the scheduler loop is ticking on cadence"
-                      >
-                        running
-                      </span>
-                    )}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-right">
-                    <span className="pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
-                      <Button
-                        disabled={connected === false}
-                        onClick={() => setConfirmLoop(s)}
-                      >
-                        Run now…
-                      </Button>
-                    </span>
-                  </td>
-                </tr>
-              );
-            })}
-            {visible.length === 0 && (
-              <ListEmpty
-                colSpan={9}
-                query={schedulesQ}
-                filtered={rows.length > 0}
-                noun="schedules"
-                empty="No schedules registered (event-runtime/schedules.json)"
-              />
-            )}
-          </tbody>
-        </table>
-        <div className="px-3 py-2 text-[11px] text-(--text-faint)">
-          Enable or disable schedules in{" "}
-          <code className="mono">event-runtime/schedules.json</code> (or via the CLI) — there is no
-          toggle here.
-        </div>
+              {visible.length === 0 && (
+                <ListEmpty
+                  colSpan={9}
+                  query={schedulesQ}
+                  filtered={rows.length > 0}
+                  noun="schedules"
+                  empty="No schedules registered (event-runtime/schedules.json)"
+                />
+              )}
+            </tbody>
+          </table>
+          <div className="px-3 py-2 text-[11px] text-(--text-faint)">
+            Enable or disable schedules in{" "}
+            <code className="mono">event-runtime/schedules.json</code> (or via
+            the CLI) — there is no toggle here.
+          </div>
         </div>
       </ListPane>
 
@@ -581,8 +710,10 @@ export function Schedules({
                   className="rounded border px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                   style={{
                     color: "var(--hue-warn)",
-                    borderColor: "color-mix(in oklch, var(--hue-warn) 40%, var(--border))",
-                    background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
+                    borderColor:
+                      "color-mix(in oklch, var(--hue-warn) 40%, var(--border))",
+                    background:
+                      "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
                   }}
                 >
                   auto
@@ -596,7 +727,13 @@ export function Schedules({
               disabled={connected === false}
               onClick={() => setConfirmLoop(sel)}
             >
-              Run now… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">r</span>
+              Run now…{" "}
+              <span
+                className="mono ml-1 text-(--text-faint)"
+                aria-hidden="true"
+              >
+                r
+              </span>
             </Button>
           }
           utility={<CopyActions id={sel.loop} idLabel="schedule loop" />}
@@ -604,21 +741,18 @@ export function Schedules({
         >
           <div className="space-y-6">
             {sel.stopped && (
-              <div
-                className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)"
-              >
+              <div className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)">
                 <div className="font-semibold">Schedule clock stopped</div>
                 <div className="mt-1 text-(--text-dim)">
-                  This loop is enabled but has been silent for {sel.intervalsLate} intervals (cadence: {sel.every}).
-                  Check that the event runtime serve process is running.
+                  This loop is enabled but has been silent for{" "}
+                  {sel.intervalsLate} intervals (cadence: {sel.every}). Check
+                  that the event runtime serve process is running.
                 </div>
               </div>
             )}
 
             {sel.error && (
-              <div
-                className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)"
-              >
+              <div className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)">
                 <div className="font-semibold">Cadence configuration error</div>
                 <div className="mono mt-1 text-(--text-dim)">{sel.error}</div>
               </div>
@@ -632,7 +766,10 @@ export function Schedules({
                   <span>
                     <span className="mono">{sel.every}</span>
                     {sel.cadenceSeconds && (
-                      <span className="ml-2 text-(--text-faint)" title={`${sel.cadenceSeconds}s`}>
+                      <span
+                        className="ml-2 text-(--text-faint)"
+                        title={`${sel.cadenceSeconds}s`}
+                      >
                         ({formatDuration(sel.cadenceSeconds)})
                       </span>
                     )}
@@ -669,14 +806,23 @@ export function Schedules({
                       auto (unattended execution)
                     </span>
                   ) : (
-                    <span className="text-(--text-dim)">watched (requires human approval)</span>
+                    <span className="text-(--text-dim)">
+                      watched (requires human approval)
+                    </span>
                   )
                 }
               />
-              <KV k="catch-up" v={<span className="mono">{sel.catchUp}</span>} />
+              <KV
+                k="catch-up"
+                v={<span className="mono">{sel.catchUp}</span>}
+              />
               <KV
                 k="singleton"
-                v={sel.singleton ? "true (previous run must finish before next starts)" : "false"}
+                v={
+                  sel.singleton
+                    ? "true (previous run must finish before next starts)"
+                    : "false"
+                }
               />
               <KV
                 k="enabled"
@@ -685,7 +831,8 @@ export function Schedules({
                     <span className="text-(--hue-ok)">true</span>
                   ) : (
                     <span className="text-(--text-faint)">
-                      false (disabled — re-enable in event-runtime/schedules.json or via the CLI)
+                      false (disabled — re-enable in
+                      event-runtime/schedules.json or via the CLI)
                     </span>
                   )
                 }
@@ -698,8 +845,12 @@ export function Schedules({
                 v={
                   sel.lastSlot ? (
                     <span>
-                      <span title={sel.lastSlot}>{formatRelative(sel.lastSlot, now)}</span>{" "}
-                      <span className="mono text-[11px] text-(--text-faint)">({sel.lastSlot})</span>
+                      <span title={sel.lastSlot}>
+                        {formatRelative(sel.lastSlot, now)}
+                      </span>{" "}
+                      <span className="mono text-[11px] text-(--text-faint)">
+                        ({sel.lastSlot})
+                      </span>
                     </span>
                   ) : (
                     <span className="text-(--text-faint)">never fired</span>
@@ -711,7 +862,9 @@ export function Schedules({
                 v={
                   sel.lastCompletedSlot ? (
                     <span>
-                      <span title={sel.lastCompletedSlot}>{formatRelative(sel.lastCompletedSlot, now)}</span>{" "}
+                      <span title={sel.lastCompletedSlot}>
+                        {formatRelative(sel.lastCompletedSlot, now)}
+                      </span>{" "}
                       <span className="mono text-[11px] text-(--text-faint)">
                         ({sel.lastCompletedSlot})
                       </span>
@@ -731,11 +884,15 @@ export function Schedules({
                       <Countdown
                         createdAt={
                           sel.lastSlot ??
-                          new Date(Date.parse(sel.nextDue) - sel.cadenceSeconds * 1000).toISOString()
+                          new Date(
+                            Date.parse(sel.nextDue) - sel.cadenceSeconds * 1000,
+                          ).toISOString()
                         }
                         ttlSeconds={sel.cadenceSeconds}
                       />{" "}
-                      <span className="mono text-[11px] text-(--text-faint)">({sel.nextDue})</span>
+                      <span className="mono text-[11px] text-(--text-faint)">
+                        ({sel.nextDue})
+                      </span>
                     </span>
                   ) : (
                     EMPTY
@@ -752,8 +909,11 @@ export function Schedules({
               ) : (
                 <div className="space-y-2">
                   {recentTicks.map((e) => {
-                    const payload = (e.envelope?.payload as Record<string, unknown> | undefined) ?? {};
-                    const isAdhoc = e.source === "operator" || payload.adhoc === true;
+                    const payload =
+                      (e.envelope?.payload as
+                        Record<string, unknown> | undefined) ?? {};
+                    const isAdhoc =
+                      e.source === "operator" || payload.adhoc === true;
                     return (
                       <div
                         key={`${e.source}:${e.eventId}`}
@@ -775,28 +935,35 @@ export function Schedules({
                             )}
                           </div>
                           <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-(--text-dim)">
-                            <span title={e.occurredAt}>{formatRelative(e.occurredAt, now)}</span>
+                            <span title={e.occurredAt}>
+                              {formatRelative(e.occurredAt, now)}
+                            </span>
                             <span>·</span>
                             <span>source: {e.source}</span>
-                            {typeof payload.skippedSlots === "number" && payload.skippedSlots > 0 && (
-                              <>
-                                <span>·</span>
-                                <span className="text-(--hue-warn)">
-                                  skipped: {payload.skippedSlots}
-                                </span>
-                              </>
-                            )}
+                            {typeof payload.skippedSlots === "number" &&
+                              payload.skippedSlots > 0 && (
+                                <>
+                                  <span>·</span>
+                                  <span className="text-(--hue-warn)">
+                                    skipped: {payload.skippedSlots}
+                                  </span>
+                                </>
+                              )}
                           </div>
                         </div>
                         <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
                           <span
                             className="mono text-[11px]"
-                            style={{ color: EVENT_STATUS_HUES[e.status] ?? "inherit" }}
+                            style={{
+                              color: EVENT_STATUS_HUES[e.status] ?? "inherit",
+                            }}
                           >
                             {e.status}
                           </span>
                           {e.proposalId && (
-                            <JumpLink onClick={() => onJumpProposal(e.proposalId!)}>
+                            <JumpLink
+                              onClick={() => onJumpProposal(e.proposalId!)}
+                            >
                               proposal
                             </JumpLink>
                           )}
@@ -825,13 +992,16 @@ export function Schedules({
         >
           <div className="space-y-4 text-[13px]">
             <p className="text-(--text-dim)">
-              Triggering an ad-hoc run admits a new event immediately with source{" "}
+              Triggering an ad-hoc run admits a new event immediately with
+              source{" "}
               <code className="mono rounded bg-(--surface-2) px-1 py-0.5 text-(--text)">
                 operator
               </code>
-              . It {confirmLoop.approval === "watched"
+              . It{" "}
+              {confirmLoop.approval === "watched"
                 ? "creates an open proposal for review"
-                : "uses the schedule’s auto-approval policy"} and does not alter the schedule&apos;s normal slot timer.
+                : "uses the schedule’s auto-approval policy"}{" "}
+              and does not alter the schedule&apos;s normal slot timer.
             </p>
 
             {confirmLoop.eventType === "factory.merge.requested" && (
@@ -857,8 +1027,13 @@ export function Schedules({
                   placeholder="411, 426"
                   className="mono w-full rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[13px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
                 />
-                <p id="schedule-pr-numbers-help" className="text-[11px] text-(--text-faint)">
-                  Enter unique positive PR numbers separated by commas or spaces. Leave blank to review all open PRs in {confirmLoop.repo ?? "the configured repository"}.
+                <p
+                  id="schedule-pr-numbers-help"
+                  className="text-[11px] text-(--text-faint)"
+                >
+                  Enter unique positive PR numbers separated by commas or
+                  spaces. Leave blank to review all open PRs in{" "}
+                  {confirmLoop.repo ?? "the configured repository"}.
                 </p>
                 {triggerInputError && (
                   <div
@@ -874,18 +1049,33 @@ export function Schedules({
 
             {confirmLoop.eventType === "factory.merge.requested" && (
               <div className="rounded-md border border-(--hue-warn) bg-[color-mix(in_oklch,var(--hue-warn)_10%,var(--surface-1))] p-3 text-[12px]">
-                <div className="font-semibold text-(--hue-warn)">Autonomous merge automation</div>
+                <div className="font-semibold text-(--hue-warn)">
+                  Autonomous merge automation
+                </div>
                 <p className="mt-1 text-(--text-dim)">
-                  The scanner is read-only, but a MERGE or FIX recommendation can launch mutating downstream automation without another confirmation.
-                  {confirmLoop.approval === "auto" && " This schedule is auto-approved, so the scan starts unattended."}
+                  The scanner is read-only, but a MERGE or FIX recommendation
+                  can launch mutating downstream automation without another
+                  confirmation.
+                  {confirmLoop.approval === "auto" &&
+                    " This schedule is auto-approved, so the scan starts unattended."}
                 </p>
               </div>
             )}
 
             {confirmLoop && (
               <div className="rounded-md border border-(--border) bg-(--surface-2) p-3 space-y-2">
-                <KV k="loop" v={<span className="mono font-semibold">{confirmLoop.loop}</span>} />
-                <KV k="event type" v={<span className="mono">{confirmLoop.eventType}</span>} />
+                <KV
+                  k="loop"
+                  v={
+                    <span className="mono font-semibold">
+                      {confirmLoop.loop}
+                    </span>
+                  }
+                />
+                <KV
+                  k="event type"
+                  v={<span className="mono">{confirmLoop.eventType}</span>}
+                />
                 {(() => {
                   const agent = agents.find((a) =>
                     a.eventTypes.some((t) => t.type === confirmLoop.eventType),
@@ -903,7 +1093,9 @@ export function Schedules({
                                 (mutating)
                               </span>
                             ) : (
-                              <span className="ml-2 text-(--text-faint)">(read-only)</span>
+                              <span className="ml-2 text-(--text-faint)">
+                                (read-only)
+                              </span>
                             )}
                           </span>
                         }
@@ -923,9 +1115,11 @@ export function Schedules({
                 })()}
                 {!confirmLoop.enabled && (
                   <div className="mt-2 rounded bg-(--surface-3) p-2 text-[12px] text-(--hue-warn)">
-                    Note: This schedule is disabled (<code className="mono">enabled: false</code> in{" "}
-                    <code className="mono">event-runtime/schedules.json</code>), so it is not
-                    scheduled to run on its own. Triggering ad-hoc will evaluate the loop once.
+                    Note: This schedule is disabled (
+                    <code className="mono">enabled: false</code> in{" "}
+                    <code className="mono">event-runtime/schedules.json</code>),
+                    so it is not scheduled to run on its own. Triggering ad-hoc
+                    will evaluate the loop once.
                   </div>
                 )}
               </div>

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -7,7 +7,11 @@ import type { JourneyRun, TicketJourneySource } from "../subjectJourney";
 
 const realFetch = globalThis.fetch;
 
-function run(id: string, at: string, artifact: Record<string, unknown> = {}): JourneyRun {
+function run(
+  id: string,
+  at: string,
+  artifact: Record<string, unknown> = {},
+): JourneyRun {
   return {
     run: {
       runId: id,
@@ -15,38 +19,105 @@ function run(id: string, at: string, artifact: Record<string, unknown> = {}): Jo
       attempts: 1,
       created_at: at,
       updated_at: new Date(Date.parse(at) + 60_000).toISOString(),
-      spec: { agent: id === "run_merge" ? "merge-apply@1" : "dispatch@1", adapter: "pi" },
+      spec: {
+        agent: id === "run_merge" ? "merge-apply@1" : "dispatch@1",
+        adapter: "pi",
+      },
     },
     lifecycle: [
-      { seq: 1, from_state: null, to_state: "QUEUED", actor: "planner", reason: null, attempt: null, at },
-      { seq: 2, from_state: "QUEUED", to_state: "COMPLETED", actor: "worker_demo", reason: "ok", attempt: 1, at: new Date(Date.parse(at) + 60_000).toISOString() },
+      {
+        seq: 1,
+        from_state: null,
+        to_state: "QUEUED",
+        actor: "planner",
+        reason: null,
+        attempt: null,
+        at,
+      },
+      {
+        seq: 2,
+        from_state: "QUEUED",
+        to_state: "COMPLETED",
+        actor: "worker_demo",
+        reason: "ok",
+        attempt: 1,
+        at: new Date(Date.parse(at) + 60_000).toISOString(),
+      },
     ],
     result: { terminalState: "completed", artifact },
-    usage: { totals: { attempts: 1, totalTokens: 100, costUSD: 0.5 }, attempts: [{}] },
+    usage: {
+      totals: { attempts: 1, totalTokens: 100, costUSD: 0.5 },
+      attempts: [{}],
+    },
   };
 }
 
 function source(): TicketJourneySource {
   return {
-    ticket: { id: "WM-542", title: "Ticket journey fixture", state: "In Review", createdAt: "2026-01-01T09:00:00.000Z", url: "https://linear.app/watt-mind/issue/WM-542" },
+    ticket: {
+      id: "WM-542",
+      title: "Ticket journey fixture",
+      state: "In Review",
+      createdAt: "2026-01-01T09:00:00.000Z",
+      url: "https://linear.app/watt-mind/issue/WM-542",
+    },
     activity: true,
-    events: [{
-      source: "operator", eventId: "dispatch-542", type: "factory.ticket.dispatched", subject: "WM-542", status: "planned",
-      occurredAt: "2026-01-01T09:01:00.000Z", admittedAt: "2026-01-01T09:01:01.000Z", proposalId: "prop_1", runId: "run_dispatch",
-      envelope: { payload: { ticket: "WM-542" } },
-    }],
-    proposals: [{ id: "prop_1", decision: "run", status: "approved", reason: null, created_at: "2026-01-01T09:01:02.000Z", decided_at: null, runId: "run_dispatch", eventId: "dispatch-542", eventSource: "operator", agent: "dispatch@1", spec: null }],
+    events: [
+      {
+        source: "operator",
+        eventId: "dispatch-542",
+        type: "factory.ticket.dispatched",
+        subject: "WM-542",
+        status: "planned",
+        occurredAt: "2026-01-01T09:01:00.000Z",
+        admittedAt: "2026-01-01T09:01:01.000Z",
+        proposalId: "prop_1",
+        runId: "run_dispatch",
+        envelope: { payload: { ticket: "WM-542" } },
+      },
+    ],
+    proposals: [
+      {
+        id: "prop_1",
+        decision: "run",
+        status: "approved",
+        reason: null,
+        created_at: "2026-01-01T09:01:02.000Z",
+        decided_at: null,
+        runId: "run_dispatch",
+        eventId: "dispatch-542",
+        eventSource: "operator",
+        agent: "dispatch@1",
+        spec: null,
+      },
+    ],
     runs: [
-      run("run_dispatch", "2026-01-01T09:02:00.000Z", { outcome: "PR_OPEN", prUrl: "https://github.com/watt-mind/factory/pull/499" }),
-      run("run_merge", "2026-01-01T10:00:00.000Z", { pr: 499, checksGreen: true, outcome: "MERGED" }),
+      run("run_dispatch", "2026-01-01T09:02:00.000Z", {
+        outcome: "PR_OPEN",
+        prUrl: "https://github.com/watt-mind/factory/pull/499",
+      }),
+      run("run_merge", "2026-01-01T10:00:00.000Z", {
+        pr: 499,
+        checksGreen: true,
+        outcome: "MERGED",
+      }),
     ],
   };
 }
 
 function renderTicket(data: TicketJourneySource) {
-  globalThis.fetch = (async () => new Response(JSON.stringify(data), { status: 200 })) as unknown as typeof fetch;
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
-  return render(<QueryClientProvider client={queryClient}><Ticket ticketId="WM-542" onNavigate={() => {}} /></QueryClientProvider>);
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(data), {
+      status: 200,
+    })) as unknown as typeof fetch;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Ticket ticketId="WM-542" onNavigate={() => {}} />
+    </QueryClientProvider>,
+  );
 }
 
 afterEach(() => {
@@ -58,13 +129,19 @@ describe("Ticket journey view", () => {
   test("renders a two-run journey, PR, aggregates, timeline sources, and current-state block", async () => {
     const view = renderTicket(source());
     await view.findByRole("heading", { name: "WM-542" });
-    expect(view.getAllByText("Ticket journey fixture").length).toBeGreaterThan(0);
+    expect(view.getAllByText("Ticket journey fixture").length).toBeGreaterThan(
+      0,
+    );
     expect(view.getByText("$1.00")).toBeTruthy();
     expect(view.getByText("2", { selector: "div" })).toBeTruthy();
     expect(view.getByText("PR #499 opened")).toBeTruthy();
     expect(view.getByText("CI checks green")).toBeTruthy();
     expect(view.getByText("merged")).toBeTruthy();
-    expect(view.getByRole("link", { name: "run_dispatch · COMPLETED" }).getAttribute("href")).toBe("#/run/run_dispatch");
+    expect(
+      view
+        .getByRole("link", { name: "run_dispatch · COMPLETED" })
+        .getAttribute("href"),
+    ).toBe("#/run/run_dispatch");
     const timeline = view.getByRole("region", { name: /timeline/i });
     expect(within(timeline).getAllByText("QUEUED").length).toBeGreaterThan(0);
     expect(view.getByRole("heading", { name: "Where it is now" })).toBeTruthy();
@@ -76,7 +153,12 @@ describe("Ticket journey view", () => {
     data.ticket.state = "Todo";
     data.ticket.createdAt = null;
     data.events[0].status = "noop";
-    data.proposals[0] = { ...data.proposals[0], decision: "noop", reason: "owned_paths_overlap:WM-544", runId: null };
+    data.proposals[0] = {
+      ...data.proposals[0],
+      decision: "noop",
+      reason: "owned_paths_overlap:WM-544",
+      runId: null,
+    };
     const view = renderTicket(data);
     await view.findByRole("heading", { name: "WM-542" });
     expect(view.getAllByText("—").length).toBeGreaterThan(0);
@@ -96,10 +178,23 @@ describe("Ticket journey view", () => {
     data.events = [];
     data.proposals = [];
     data.runs = [];
-    globalThis.fetch = (async () => new Response(JSON.stringify(data), { status: 200 })) as unknown as typeof fetch;
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
-    const view = render(<QueryClientProvider client={client}><Ticket ticketId="WM-999" onNavigate={() => {}} /></QueryClientProvider>);
-    await waitFor(() => expect(view.getByRole("status").textContent).toContain("no runtime activity for WM-999"));
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(data), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId="WM-999" onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toContain(
+        "no runtime activity for WM-999",
+      ),
+    );
   });
 });
 
@@ -113,11 +208,17 @@ function prFetch(data: {
 }) {
   return (async (input: RequestInfo | URL) => {
     const url = String(input);
-    const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+    const json = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
     if (/\/api\/events/.test(url)) return json({ events: data.events });
-    if (/\/api\/proposals/.test(url)) return json({ proposals: data.proposals });
+    if (/\/api\/proposals/.test(url))
+      return json({ proposals: data.proposals });
     if (/\/api\/inbox/.test(url)) return json({ items: data.inbox ?? [] });
-    if (/\/api\/schedules/.test(url)) return json({ schedules: data.schedules ?? [] });
+    if (/\/api\/schedules/.test(url))
+      return json({ schedules: data.schedules ?? [] });
     const detail = url.match(/\/api\/runs\/([^/?]+)$/);
     if (detail) {
       const run = data.runs[decodeURIComponent(detail[1])];
@@ -149,83 +250,237 @@ function prData() {
   const scan = run("run_scan", "2026-08-17T18:45:00.000Z", {
     github: "watt-mind/factory",
     repo: "factory",
-    fix: [{ pr: 541, headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", headRef: "feat/WM-627", ticket: "WM-627", finding: "Fix the failing owned test.", round: 1 }],
+    fix: [
+      {
+        pr: 541,
+        headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+        headRef: "feat/WM-627",
+        ticket: "WM-627",
+        finding: "Fix the failing owned test.",
+        round: 1,
+      },
+    ],
   });
-  scan.run.spec = { agent: "merge-scan@2", adapter: "cursor", input: { repo: "factory", repoPin: { github: "watt-mind/factory" } } };
+  scan.run.spec = {
+    agent: "merge-scan@2",
+    adapter: "cursor",
+    input: { repo: "factory", repoPin: { github: "watt-mind/factory" } },
+  };
   scan.run.updated_at = "2026-08-17T19:06:02.000Z";
   scan.lifecycle[1].at = "2026-08-17T19:06:02.000Z";
   const dispatch = run("run_dispatch", "2026-08-17T18:27:40.000Z");
-  dispatch.run.spec = { agent: "dispatch@1", adapter: "pi", input: { repo: "factory", ticket: "WM-627" } };
+  dispatch.run.spec = {
+    agent: "dispatch@1",
+    adapter: "pi",
+    input: { repo: "factory", ticket: "WM-627" },
+  };
   dispatch.run.state = "FAILED";
   dispatch.run.updated_at = "2026-08-17T19:10:30.000Z";
-  dispatch.lifecycle[1] = { ...dispatch.lifecycle[1], to_state: "FAILED", at: "2026-08-17T19:10:30.000Z" };
+  dispatch.lifecycle[1] = {
+    ...dispatch.lifecycle[1],
+    to_state: "FAILED",
+    at: "2026-08-17T19:10:30.000Z",
+  };
   dispatch.result = null;
   const fix = run("run_fix", "2026-08-17T19:06:04.000Z");
-  fix.run.spec = { agent: "merge-fix@1", adapter: "cursor", input: { repo: "factory", github: "watt-mind/factory", pr: 541, headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", ticket: "WM-627" } };
+  fix.run.spec = {
+    agent: "merge-fix@1",
+    adapter: "cursor",
+    input: {
+      repo: "factory",
+      github: "watt-mind/factory",
+      pr: 541,
+      headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+      ticket: "WM-627",
+    },
+  };
   fix.run.state = "REFUSED";
   fix.run.updated_at = "2026-08-17T19:06:05.000Z";
-  fix.lifecycle[1] = { ...fix.lifecycle[1], to_state: "REFUSED", reason: "merge_fix_pr_moved", at: "2026-08-17T19:06:05.000Z" };
+  fix.lifecycle[1] = {
+    ...fix.lifecycle[1],
+    to_state: "REFUSED",
+    reason: "merge_fix_pr_moved",
+    at: "2026-08-17T19:06:05.000Z",
+  };
   fix.result = { terminalState: "refused", reasonCode: "merge_fix_pr_moved" };
   const events = [
     {
-      source: "schedule", eventId: "clock:merge-factory:2026-08-17T18:45:00.000Z", type: "factory.merge.requested", subject: "merge-factory", status: "planned",
-      occurredAt: "2026-08-17T18:45:00.000Z", admittedAt: "2026-08-17T18:45:00.000Z", correlationId: "clock:merge-factory:2026-08-17T18:45:00.000Z", proposalId: null, runId: "run_scan",
-      envelope: { payload: { repo: "factory", loop: "merge-factory" } }, repos: ["factory"],
+      source: "schedule",
+      eventId: "clock:merge-factory:2026-08-17T18:45:00.000Z",
+      type: "factory.merge.requested",
+      subject: "merge-factory",
+      status: "planned",
+      occurredAt: "2026-08-17T18:45:00.000Z",
+      admittedAt: "2026-08-17T18:45:00.000Z",
+      correlationId: "clock:merge-factory:2026-08-17T18:45:00.000Z",
+      proposalId: null,
+      runId: "run_scan",
+      envelope: { payload: { repo: "factory", loop: "merge-factory" } },
+      repos: ["factory"],
     },
     {
-      source: "chain", eventId: "chain-run_scan-fix-541", type: "factory.merge-fix.requested", subject: "merge-scan@2", status: "planned",
-      occurredAt: "2026-08-17T19:06:03.000Z", admittedAt: "2026-08-17T19:06:03.000Z", correlationId: "clock:merge-factory:2026-08-17T18:45:00.000Z", proposalId: "prop_fix", runId: "run_fix",
-      envelope: { payload: { repo: "factory", github: "watt-mind/factory", pr: 541, headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", headRef: "feat/WM-627", ticket: "WM-627", round: 1 } }, repos: ["factory"],
+      source: "chain",
+      eventId: "chain-run_scan-fix-541",
+      type: "factory.merge-fix.requested",
+      subject: "merge-scan@2",
+      status: "planned",
+      occurredAt: "2026-08-17T19:06:03.000Z",
+      admittedAt: "2026-08-17T19:06:03.000Z",
+      correlationId: "clock:merge-factory:2026-08-17T18:45:00.000Z",
+      proposalId: "prop_fix",
+      runId: "run_fix",
+      envelope: {
+        payload: {
+          repo: "factory",
+          github: "watt-mind/factory",
+          pr: 541,
+          headSha: "6dbaab46a7f362ea66f907b630e57849e2631915",
+          headRef: "feat/WM-627",
+          ticket: "WM-627",
+          round: 1,
+        },
+      },
+      repos: ["factory"],
     },
     {
-      source: "operator", eventId: "operator:dispatch:WM-627", type: "factory.dispatch.requested", subject: "WM-627", status: "planned",
-      occurredAt: "2026-08-17T18:27:40.000Z", admittedAt: "2026-08-17T18:27:40.000Z", correlationId: null, proposalId: null, runId: "run_dispatch",
-      envelope: { payload: { repo: "factory", ticket: "WM-627" } }, repos: ["factory"],
+      source: "operator",
+      eventId: "operator:dispatch:WM-627",
+      type: "factory.dispatch.requested",
+      subject: "WM-627",
+      status: "planned",
+      occurredAt: "2026-08-17T18:27:40.000Z",
+      admittedAt: "2026-08-17T18:27:40.000Z",
+      correlationId: null,
+      proposalId: null,
+      runId: "run_dispatch",
+      envelope: { payload: { repo: "factory", ticket: "WM-627" } },
+      repos: ["factory"],
     },
   ];
   const proposals = [
-    { id: "prop_fix", decision: "run", status: "approved", reason: null, created_at: "2026-08-17T19:06:04.000Z", decided_at: null, runId: "run_fix", eventId: "chain-run_scan-fix-541", eventSource: "chain", agent: "merge-fix@1", spec: null, expired: false, ttl_seconds: 0, decided_by: null, repos: [] },
+    {
+      id: "prop_fix",
+      decision: "run",
+      status: "approved",
+      reason: null,
+      created_at: "2026-08-17T19:06:04.000Z",
+      decided_at: null,
+      runId: "run_fix",
+      eventId: "chain-run_scan-fix-541",
+      eventSource: "chain",
+      agent: "merge-fix@1",
+      spec: null,
+      expired: false,
+      ttl_seconds: 0,
+      decided_by: null,
+      repos: [],
+    },
   ];
-  return { events, proposals, runs: { run_scan: scan, run_dispatch: dispatch, run_fix: fix }, schedules: [{ loop: "merge-factory", repo: "factory", eventType: "factory.merge.requested", nextDue: "2026-08-17T19:30:00.000Z", enabled: true }] };
+  return {
+    events,
+    proposals,
+    runs: { run_scan: scan, run_dispatch: dispatch, run_fix: fix },
+    schedules: [
+      {
+        loop: "merge-factory",
+        repo: "factory",
+        eventType: "factory.merge.requested",
+        nextDue: "2026-08-17T19:30:00.000Z",
+        enabled: true,
+      },
+    ],
+  };
 }
 
 describe("PR journey view", () => {
   test("renders #/prs/541 with the scan verdict, the concurrent dispatch, and the humanized refusal", async () => {
     const data = prData();
     globalThis.fetch = prFetch(data);
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
-    const view = render(<QueryClientProvider client={client}><PullRequest number="541" onNavigateTicket={() => {}} /></QueryClientProvider>);
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <PullRequest number="541" onNavigateTicket={() => {}} />
+      </QueryClientProvider>,
+    );
     await view.findByRole("heading", { name: "#541" });
     expect(view.getByText("feat/WM-627")).toBeTruthy();
-    expect(view.getByRole("link", { name: "WM-627" }).getAttribute("href")).toBe("#/tickets/WM-627");
-    expect(view.getByRole("link", { name: "Open on GitHub ↗" }).getAttribute("href")).toBe("https://github.com/watt-mind/factory/pull/541");
-    expect(view.getByText("merge-scan: FIX · reviewed at 6dbaab4 · round 1")).toBeTruthy();
-    expect(view.getByText("↔ WM-627 dispatch run_dispatch was active during merge-scan")).toBeTruthy();
-    expect(view.getByText("merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)")).toBeTruthy();
+    expect(
+      view.getByRole("link", { name: "WM-627" }).getAttribute("href"),
+    ).toBe("#/tickets/WM-627");
+    expect(
+      view.getByRole("link", { name: "Open on GitHub ↗" }).getAttribute("href"),
+    ).toBe("https://github.com/watt-mind/factory/pull/541");
+    expect(
+      view.getByText("merge-scan: FIX · reviewed at 6dbaab4 · round 1"),
+    ).toBeTruthy();
+    expect(
+      view.getByText(
+        "↔ WM-627 dispatch run_dispatch was active during merge-scan",
+      ),
+    ).toBeTruthy();
+    expect(
+      view.getByText(
+        "merge-fix refused · PR head moved since the scan (merge_fix_pr_moved)",
+      ),
+    ).toBeTruthy();
     expect(view.getByText(/^next: merge-factory at/)).toBeTruthy();
-    expect(view.getByText(/Waiting: PR head moved since the scan/)).toBeTruthy();
+    expect(
+      view.getByText(/Waiting: PR head moved since the scan/),
+    ).toBeTruthy();
     // The failed dispatch is context, not one of the PR's own runs.
     expect(view.getByText("2", { selector: "div" })).toBeTruthy();
   });
 
   test("an unknown PR reads as no runtime activity, and a bad reference as an inline error", async () => {
     globalThis.fetch = prFetch({ events: [], proposals: [], runs: {} });
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
-    const view = render(<QueryClientProvider client={client}><PullRequest number="9999" /></QueryClientProvider>);
-    await waitFor(() => expect(view.getByRole("status").textContent).toContain("no runtime activity for PR #9999"));
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <PullRequest number="9999" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toContain(
+        "no runtime activity for PR #9999",
+      ),
+    );
     cleanup();
-    const bad = render(<QueryClientProvider client={client}><PullRequest number="not-a-pr" /></QueryClientProvider>);
-    expect(bad.getByRole("alert").textContent).toContain("Invalid PR reference");
+    const bad = render(
+      <QueryClientProvider client={client}>
+        <PullRequest number="not-a-pr" />
+      </QueryClientProvider>,
+    );
+    expect(bad.getByRole("alert").textContent).toContain(
+      "Invalid PR reference",
+    );
   });
 
   test("prCandidateRunIds is bounded to the PR's chains and its ticket, never the whole registry", () => {
     const data = prData();
     const runs = Object.values(data.runs).map((run) => ({
-      runId: run.run.runId, state: run.run.state, attempts: 1, maxAttempts: 1, agent: run.run.spec.agent, adapter: run.run.spec.adapter,
-      reasonCode: null, eventId: null, eventSource: null, created_at: run.run.created_at, updated_at: run.run.updated_at, repos: ["factory"],
+      runId: run.run.runId,
+      state: run.run.state,
+      attempts: 1,
+      maxAttempts: 1,
+      agent: run.run.spec.agent,
+      adapter: run.run.spec.adapter,
+      reasonCode: null,
+      eventId: null,
+      eventSource: null,
+      created_at: run.run.created_at,
+      updated_at: run.run.updated_at,
+      repos: ["factory"],
     }));
     runs.push({ ...runs[0], runId: "run_unrelated", agent: "dispatch@1" });
-    const ids = prCandidateRunIds(541, { events: data.events as any, proposals: data.proposals as any, runs: runs as any });
+    const ids = prCandidateRunIds(541, {
+      events: data.events as any,
+      proposals: data.proposals as any,
+      runs: runs as any,
+    });
     expect(ids.sort()).toEqual(["run_dispatch", "run_fix", "run_scan"]);
   });
 });

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1,5 +1,12 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { api } from "../api";
 import { refetchIntervals } from "../hooks";
 import {
@@ -22,8 +29,12 @@ import {
 import { StateBadge, STATE_HUES } from "../components/ui";
 import type { AdmittedEvent, Proposal, RunDetail, RunListItem } from "../types";
 
-async function fetchTicketJourney(ticketId: string): Promise<TicketJourneySource> {
-  const response = await fetch(`/api/runs?ticket=${encodeURIComponent(ticketId)}`);
+async function fetchTicketJourney(
+  ticketId: string,
+): Promise<TicketJourneySource> {
+  const response = await fetch(
+    `/api/runs?ticket=${encodeURIComponent(ticketId)}`,
+  );
   if (!response.ok) {
     let message = `HTTP ${response.status}`;
     try {
@@ -39,13 +50,23 @@ async function fetchTicketJourney(ticketId: string): Promise<TicketJourneySource
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-24 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2">
-      <div className="text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
-      <div className="mt-0.5 tabular-nums text-[13px] font-medium text-(--text)">{value}</div>
+      <div className="text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+        {label}
+      </div>
+      <div className="mt-0.5 tabular-nums text-[13px] font-medium text-(--text)">
+        {value}
+      </div>
     </div>
   );
 }
 
-function SourceLink({ item, children }: { item: TimelineItem; children: ReactNode }) {
+function SourceLink({
+  item,
+  children,
+}: {
+  item: TimelineItem;
+  children: ReactNode;
+}) {
   return (
     <a
       href={item.href}
@@ -76,9 +97,16 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
             ? "var(--border-strong)"
             : "var(--accent)";
   const body = (
-    <div className={`flex min-w-0 flex-1 items-start gap-3 ${muted ? "pb-3" : "pb-5"}`}>
-      <span className="relative flex w-3 shrink-0 justify-center" aria-hidden="true">
-        {!last && <span className="absolute top-2 bottom-[-22px] w-px bg-(--border)" />}
+    <div
+      className={`flex min-w-0 flex-1 items-start gap-3 ${muted ? "pb-3" : "pb-5"}`}
+    >
+      <span
+        className="relative flex w-3 shrink-0 justify-center"
+        aria-hidden="true"
+      >
+        {!last && (
+          <span className="absolute top-2 bottom-[-22px] w-px bg-(--border)" />
+        )}
         <span
           className={`relative mt-1.5 size-2 rounded-full ring-4 ring-(--surface-1) ${item.kind === "schedule" ? "outline outline-1 outline-dashed outline-(--text-faint) bg-transparent!" : ""}`}
           style={{ background: hue }}
@@ -86,12 +114,28 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
       </span>
       <div className="min-w-0 flex-1">
         <SourceLink item={item}>
-          <div className={`mono break-words text-[12px] ${muted ? "font-normal text-(--text-dim) italic" : "font-medium text-(--text)"}`}>{item.label}</div>
+          <div
+            className={`mono break-words text-[12px] ${muted ? "font-normal text-(--text-dim) italic" : "font-medium text-(--text)"}`}
+          >
+            {item.label}
+          </div>
         </SourceLink>
-        {item.detail && <div className="mt-0.5 break-words text-[11.5px] text-(--text-faint)">{item.detail}</div>}
+        {item.detail && (
+          <div className="mt-0.5 break-words text-[11.5px] text-(--text-faint)">
+            {item.detail}
+          </div>
+        )}
       </div>
-      <time className="mono shrink-0 text-[10px] text-(--text-faint)" dateTime={item.at} title={item.at}>
-        {new Date(item.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })}
+      <time
+        className="mono shrink-0 text-[10px] text-(--text-faint)"
+        dateTime={item.at}
+        title={item.at}
+      >
+        {new Date(item.at).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        })}
       </time>
     </div>
   );
@@ -103,17 +147,28 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
       </div>
       {item.children?.length ? (
         <details className="min-w-0 flex-1" open>
-          <summary className="list-none cursor-pointer [&::-webkit-details-marker]:hidden">{body}</summary>
+          <summary className="list-none cursor-pointer [&::-webkit-details-marker]:hidden">
+            {body}
+          </summary>
           <ol className="mb-4 ml-[5.25rem] border-l border-(--border) pl-4">
             {item.children.map((child) => (
-              <li key={child.id} className="grid grid-cols-[4rem_minmax(0,1fr)] gap-3 py-1 text-[11px]">
+              <li
+                key={child.id}
+                className="grid grid-cols-[4rem_minmax(0,1fr)] gap-3 py-1 text-[11px]"
+              >
                 <span className="mono text-right tabular-nums text-(--text-faint)">
-                  {child.durationMs == null ? "" : `+${formatDuration(child.durationMs)}`}
+                  {child.durationMs == null
+                    ? ""
+                    : `+${formatDuration(child.durationMs)}`}
                 </span>
                 <SourceLink item={child}>
                   <span className="inline-flex flex-wrap items-baseline gap-x-2">
                     <StateBadge state={child.label} hues={STATE_HUES} />
-                    {child.detail && <span className="text-(--text-faint)">{child.detail}</span>}
+                    {child.detail && (
+                      <span className="text-(--text-faint)">
+                        {child.detail}
+                      </span>
+                    )}
                   </span>
                 </SourceLink>
               </li>
@@ -127,7 +182,13 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
   );
 }
 
-function TicketPicker({ onNavigate, onNavigatePr }: { onNavigate: (ticketId: string) => void; onNavigatePr?: (number: number) => void }) {
+function TicketPicker({
+  onNavigate,
+  onNavigatePr,
+}: {
+  onNavigate: (ticketId: string) => void;
+  onNavigatePr?: (number: number) => void;
+}) {
   const [value, setValue] = useState("");
   const [error, setError] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -155,7 +216,8 @@ function TicketPicker({ onNavigate, onNavigatePr }: { onNavigate: (ticketId: str
     <div className="mx-auto max-w-lg p-8">
       <h1 className="display text-xl font-semibold">Ticket journey</h1>
       <p className="mt-2 text-[13px] text-(--text-dim)">
-        Enter a Linear ticket id to see its decisions, attempts, PR, CI, and merge history on one timeline.
+        Enter a Linear ticket id to see its decisions, attempts, PR, CI, and
+        merge history on one timeline.
         {onNavigatePr ? " A PR reference (#541) opens that PR's journey." : ""}
       </p>
       <form onSubmit={submit} className="mt-5 flex gap-2">
@@ -169,27 +231,48 @@ function TicketPicker({ onNavigate, onNavigatePr }: { onNavigate: (ticketId: str
           aria-invalid={error}
           className="mono min-w-0 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-2 text-[13px] outline-none focus:border-(--accent)"
         />
-        <button type="submit" className="rounded-md bg-(--accent) px-4 py-2 text-[12px] font-medium text-(--on-accent)">
+        <button
+          type="submit"
+          className="rounded-md bg-(--accent) px-4 py-2 text-[12px] font-medium text-(--on-accent)"
+        >
           Open
         </button>
       </form>
-      {error && <div role="alert" className="mt-2 text-[11px] text-(--hue-err)">Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.</div>}
-      <div className="mt-3 text-[11px] text-(--text-faint)">Shortcut: <span className="mono">g k</span></div>
+      {error && (
+        <div role="alert" className="mt-2 text-[11px] text-(--hue-err)">
+          Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
+        </div>
+      )}
+      <div className="mt-3 text-[11px] text-(--text-faint)">
+        Shortcut: <span className="mono">g k</span>
+      </div>
     </div>
   );
 }
 
 /** Shared header + timeline + "Where it is now" for either subject kind. */
-function JourneyLayout({ journey, onNavigateTicket }: { journey: SubjectJourney; onNavigateTicket?: (ticketId: string) => void }) {
-  const cost = journey.totalCost == null ? "—" : `$${journey.totalCost.toFixed(2)}`;
-  const tokens = journey.totalTokens == null ? "—" : journey.totalTokens.toLocaleString();
+function JourneyLayout({
+  journey,
+  onNavigateTicket,
+}: {
+  journey: SubjectJourney;
+  onNavigateTicket?: (ticketId: string) => void;
+}) {
+  const cost =
+    journey.totalCost == null ? "—" : `$${journey.totalCost.toFixed(2)}`;
+  const tokens =
+    journey.totalTokens == null ? "—" : journey.totalTokens.toLocaleString();
   const isPr = journey.subject.kind === "pr";
-  const title = journey.subject.title ?? (isPr ? `PR #${journey.subject.id}` : "title not recorded");
+  const title =
+    journey.subject.title ??
+    (isPr ? `PR #${journey.subject.id}` : "title not recorded");
   const state = journey.subject.state ?? (isPr ? null : "unknown");
   const heading = isPr ? `#${journey.subject.id}` : journey.subject.id;
-  const noActivityLabel = isPr ? `no runtime activity for PR #${journey.subject.id}` : `no runtime activity for ${journey.subject.id}`;
+  const noActivityLabel = isPr
+    ? `no runtime activity for PR #${journey.subject.id}`
+    : `no runtime activity for ${journey.subject.id}`;
   const externalLabel = isPr ? "Open on GitHub ↗" : "Open in Linear ↗";
-  const externalUrl = isPr ? journey.pr?.url ?? null : journey.subject.url;
+  const externalUrl = isPr ? (journey.pr?.url ?? null) : journey.subject.url;
 
   return (
     <div className="h-full overflow-auto bg-(--surface-0) p-5 lg:p-7">
@@ -198,60 +281,179 @@ function JourneyLayout({ journey, onNavigateTicket }: { journey: SubjectJourney;
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
-                <h1 className="display mono text-lg font-semibold text-(--text)">{heading}</h1>
+                <h1 className="display mono text-lg font-semibold text-(--text)">
+                  {heading}
+                </h1>
                 {state && <StateBadge state={state} />}
                 {isPr && journey.pr?.ticket && (
                   <span className="text-[12px] text-(--text-dim)">
                     ticket{" "}
-                    <a href={`#/tickets/${encodeURIComponent(journey.pr.ticket)}`} onClick={onNavigateTicket ? (event) => { event.preventDefault(); onNavigateTicket(journey.pr!.ticket!); } : undefined} className="mono text-(--accent) hover:underline">
+                    <a
+                      href={`#/tickets/${encodeURIComponent(journey.pr.ticket)}`}
+                      onClick={
+                        onNavigateTicket
+                          ? (event) => {
+                              event.preventDefault();
+                              onNavigateTicket(journey.pr!.ticket!);
+                            }
+                          : undefined
+                      }
+                      className="mono text-(--accent) hover:underline"
+                    >
                       {journey.pr.ticket}
                     </a>
                   </span>
                 )}
-                {isPr && journey.pr?.github && <span className="mono text-[11px] text-(--text-faint)">{journey.pr.github}</span>}
+                {isPr && journey.pr?.github && (
+                  <span className="mono text-[11px] text-(--text-faint)">
+                    {journey.pr.github}
+                  </span>
+                )}
               </div>
-              <div className="mt-1 break-words text-[14px] text-(--text-dim)">{title}</div>
+              <div className="mt-1 break-words text-[14px] text-(--text-dim)">
+                {title}
+              </div>
             </div>
             <div className="flex flex-wrap gap-3 text-[12px]">
-              {externalUrl && <a href={externalUrl} target="_blank" rel="noreferrer" className="text-(--accent) hover:underline">{externalLabel}</a>}
-              {!isPr && journey.prUrls[0] && (
-                <a href={prHref(journey.prUrls[0].match(/\/pull\/(\d+)/)?.[1] ?? "")} className="text-(--accent) hover:underline">PR journey</a>
+              {externalUrl && (
+                <a
+                  href={externalUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-(--accent) hover:underline"
+                >
+                  {externalLabel}
+                </a>
               )}
-              {!isPr && journey.prUrls[0] && <a href={journey.prUrls[0]} target="_blank" rel="noreferrer" className="text-(--accent) hover:underline">Open PR ↗</a>}
+              {!isPr && journey.prUrls[0] && (
+                <a
+                  href={prHref(
+                    journey.prUrls[0].match(/\/pull\/(\d+)/)?.[1] ?? "",
+                  )}
+                  className="text-(--accent) hover:underline"
+                >
+                  PR journey
+                </a>
+              )}
+              {!isPr && journey.prUrls[0] && (
+                <a
+                  href={journey.prUrls[0]}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-(--accent) hover:underline"
+                >
+                  Open PR ↗
+                </a>
+              )}
             </div>
           </div>
           <div className="mt-5 flex flex-wrap gap-2">
             <Metric label="total cost" value={cost} />
-            <Metric label="lead time" value={formatDuration(journey.leadTimeMs)} />
+            <Metric
+              label="lead time"
+              value={formatDuration(journey.leadTimeMs)}
+            />
             <Metric label="runs" value={String(journey.runCount)} />
-            {!isPr && <Metric label="PRs" value={String(journey.prUrls.length)} />}
+            {!isPr && (
+              <Metric label="PRs" value={String(journey.prUrls.length)} />
+            )}
             <Metric label="tokens" value={tokens} />
           </div>
         </header>
 
         {!journey.activity ? (
-          <div role="status" className="mt-5 rounded-lg border border-dashed border-(--border-strong) bg-(--surface-1) p-8 text-center">
-            <div className="mono text-[13px] text-(--text-dim)">{noActivityLabel}</div>
-            {externalUrl && <a href={externalUrl} target="_blank" rel="noreferrer" className="mt-2 inline-block text-[12px] text-(--accent) hover:underline">{externalLabel}</a>}
+          <div
+            role="status"
+            className="mt-5 rounded-lg border border-dashed border-(--border-strong) bg-(--surface-1) p-8 text-center"
+          >
+            <div className="mono text-[13px] text-(--text-dim)">
+              {noActivityLabel}
+            </div>
+            {externalUrl && (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-2 inline-block text-[12px] text-(--accent) hover:underline"
+              >
+                {externalLabel}
+              </a>
+            )}
           </div>
         ) : (
           <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
-            <section aria-labelledby="ticket-timeline" className="rounded-lg border border-(--border) bg-(--surface-1) p-5">
-              <h2 id="ticket-timeline" className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Timeline · oldest to newest</h2>
+            <section
+              aria-labelledby="ticket-timeline"
+              className="rounded-lg border border-(--border) bg-(--surface-1) p-5"
+            >
+              <h2
+                id="ticket-timeline"
+                className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase"
+              >
+                Timeline · oldest to newest
+              </h2>
               <ol className="mt-5">
-                {journey.timeline.map((item, index) => <TimelineRow key={item.id} item={item} last={index === journey.timeline.length - 1} />)}
+                {journey.timeline.map((item, index) => (
+                  <TimelineRow
+                    key={item.id}
+                    item={item}
+                    last={index === journey.timeline.length - 1}
+                  />
+                ))}
               </ol>
             </section>
             <aside className="self-start rounded-lg border border-(--border) bg-(--surface-1) p-4 lg:sticky lg:top-5">
-              <h2 className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Where it is now</h2>
+              <h2 className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                Where it is now
+              </h2>
               <dl className="mt-3 space-y-3 text-[12px]">
-                <div><dt className="text-(--text-faint)">{isPr ? "Merge state" : "Linear state"}</dt><dd className="mt-1">{state ? <StateBadge state={state} /> : <span className="text-(--text-dim)">— (no scan recorded it yet)</span>}</dd></div>
-                <div><dt className="text-(--text-faint)">Current run / worker</dt><dd className="mono mt-1 break-words text-(--text-dim)">{journey.currentRun ? `${journey.currentRun.runId}${journey.currentRun.actor ? ` · ${journey.currentRun.actor}` : ""}` : "—"}</dd></div>
-                <div><dt className="text-(--text-faint)">Blocking reason</dt><dd className="mt-1 break-words text-(--text-dim)">{journey.blockingReason ?? "—"}</dd></div>
+                <div>
+                  <dt className="text-(--text-faint)">
+                    {isPr ? "Merge state" : "Linear state"}
+                  </dt>
+                  <dd className="mt-1">
+                    {state ? (
+                      <StateBadge state={state} />
+                    ) : (
+                      <span className="text-(--text-dim)">
+                        — (no scan recorded it yet)
+                      </span>
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-(--text-faint)">Current run / worker</dt>
+                  <dd className="mono mt-1 break-words text-(--text-dim)">
+                    {journey.currentRun
+                      ? `${journey.currentRun.runId}${journey.currentRun.actor ? ` · ${journey.currentRun.actor}` : ""}`
+                      : "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-(--text-faint)">Blocking reason</dt>
+                  <dd className="mt-1 break-words text-(--text-dim)">
+                    {journey.blockingReason ?? "—"}
+                  </dd>
+                </div>
                 {journey.nextVisit && (
-                  <div><dt className="text-(--text-faint)">Next visit</dt><dd className="mono mt-1 break-words text-(--text-dim)">{journey.nextVisit.loop} at {new Date(journey.nextVisit.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })}</dd></div>
+                  <div>
+                    <dt className="text-(--text-faint)">Next visit</dt>
+                    <dd className="mono mt-1 break-words text-(--text-dim)">
+                      {journey.nextVisit.loop} at{" "}
+                      {new Date(journey.nextVisit.at).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        hour12: false,
+                      })}
+                    </dd>
+                  </div>
                 )}
-                <div className="border-t border-(--border) pt-3"><dt className="text-(--text-faint)">Next action</dt><dd className="mt-1 break-words font-medium text-(--text)">{journey.nextAction}</dd></div>
+                <div className="border-t border-(--border) pt-3">
+                  <dt className="text-(--text-faint)">Next action</dt>
+                  <dd className="mt-1 break-words font-medium text-(--text)">
+                    {journey.nextAction}
+                  </dd>
+                </div>
               </dl>
             </aside>
           </div>
@@ -279,31 +481,59 @@ export function Ticket({
     // fetchTicketJourney uses raw fetch() and bypasses the ETag wrapper in api.ts, so it stays at 5s.
     refetchInterval: 5000,
   });
-  const schedules = useQuery({ queryKey: ["schedules"], queryFn: api.schedules, enabled: valid, ...refetchIntervals.secondary });
+  const schedules = useQuery({
+    queryKey: ["schedules"],
+    queryFn: api.schedules,
+    enabled: valid,
+    ...refetchIntervals.secondary,
+  });
 
-  if (!ticketId) return <TicketPicker onNavigate={onNavigate} onNavigatePr={onNavigatePr} />;
+  if (!ticketId)
+    return <TicketPicker onNavigate={onNavigate} onNavigatePr={onNavigatePr} />;
   if (!valid) {
     return (
       <div className="p-8">
-        <div role="alert" className="rounded-md border border-(--hue-warn) bg-(--surface-1) p-4 text-(--hue-warn)">
-          Invalid ticket id <span className="mono">{ticketId}</span>. Use an id like WM-542.
+        <div
+          role="alert"
+          className="rounded-md border border-(--hue-warn) bg-(--surface-1) p-4 text-(--hue-warn)"
+        >
+          Invalid ticket id <span className="mono">{ticketId}</span>. Use an id
+          like WM-542.
         </div>
-        <button type="button" onClick={() => onNavigate("")} className="mt-3 text-[12px] text-(--accent) hover:underline">Choose another ticket</button>
+        <button
+          type="button"
+          onClick={() => onNavigate("")}
+          className="mt-3 text-[12px] text-(--accent) hover:underline"
+        >
+          Choose another ticket
+        </button>
       </div>
     );
   }
-  if (query.isPending) return <div className="p-8 text-[13px] text-(--text-faint)">Loading {normalized} journey…</div>;
+  if (query.isPending)
+    return (
+      <div className="p-8 text-[13px] text-(--text-faint)">
+        Loading {normalized} journey…
+      </div>
+    );
   if (query.isError || !query.data) {
     return (
       <div className="p-8">
-        <div role="alert" className="rounded-md border border-(--hue-err) bg-(--surface-1) p-4 text-(--hue-err)">
-          Cannot load {normalized}: {(query.error as Error)?.message ?? "control API unavailable"}
+        <div
+          role="alert"
+          className="rounded-md border border-(--hue-err) bg-(--surface-1) p-4 text-(--hue-err)"
+        >
+          Cannot load {normalized}:{" "}
+          {(query.error as Error)?.message ?? "control API unavailable"}
         </div>
       </div>
     );
   }
 
-  const journey = buildTicketJourney({ ...query.data, schedules: schedules.data?.schedules });
+  const journey = buildTicketJourney({
+    ...query.data,
+    schedules: schedules.data?.schedules,
+  });
   return <JourneyLayout journey={journey} />;
 }
 
@@ -315,30 +545,49 @@ export function Ticket({
  */
 export function prCandidateRunIds(
   pr: number,
-  input: { events: AdmittedEvent[]; proposals: Proposal[]; runs: RunListItem[] },
+  input: {
+    events: AdmittedEvent[];
+    proposals: Proposal[];
+    runs: RunListItem[];
+  },
   cap = 80,
 ): string[] {
   const namesPr = (value: unknown) => prNumbersIn(value).includes(pr);
   const events = input.events.filter((event) => namesPr(event.envelope));
-  const eventKeys = new Set(events.map((event) => `${event.source}\0${event.eventId}`));
-  const roots = new Set(events.map((event) => event.correlationId).filter((id): id is string => !!id));
+  const eventKeys = new Set(
+    events.map((event) => `${event.source}\0${event.eventId}`),
+  );
+  const roots = new Set(
+    events
+      .map((event) => event.correlationId)
+      .filter((id): id is string => !!id),
+  );
   const tickets = new Set<string>();
-  for (const event of events) for (const ticket of ticketIdsIn(event.envelope)) tickets.add(ticket);
+  for (const event of events)
+    for (const ticket of ticketIdsIn(event.envelope)) tickets.add(ticket);
   const ids = new Set<string>();
   for (const event of events) if (event.runId) ids.add(event.runId);
   for (const proposal of input.proposals) {
-    const linked = proposal.eventId && eventKeys.has(`${proposal.eventSource}\0${proposal.eventId}`);
-    if ((linked || namesPr(proposal.spec?.input)) && proposal.runId) ids.add(proposal.runId);
+    const linked =
+      proposal.eventId &&
+      eventKeys.has(`${proposal.eventSource}\0${proposal.eventId}`);
+    if ((linked || namesPr(proposal.spec?.input)) && proposal.runId)
+      ids.add(proposal.runId);
   }
   // Root events of the chains that touched the PR (the merge scan itself) and
   // the dispatch events of the PR's ticket.
   const rootIds = new Set<string>();
   for (const event of input.events) {
-    const isRoot = event.correlationId && roots.has(event.correlationId) && event.eventId === event.correlationId;
+    const isRoot =
+      event.correlationId &&
+      roots.has(event.correlationId) &&
+      event.eventId === event.correlationId;
     const isTicketEvent =
       tickets.size > 0 &&
       (ticketIdsIn(event.subject).some((ticket) => tickets.has(ticket)) ||
-        ticketIdsIn((event.envelope as { payload?: unknown }).payload).some((ticket) => tickets.has(ticket)));
+        ticketIdsIn((event.envelope as { payload?: unknown }).payload).some(
+          (ticket) => tickets.has(ticket),
+        ));
     if (!isRoot && !isTicketEvent) continue;
     rootIds.add(`${event.source}\0${event.eventId}`);
     if (event.runId) ids.add(event.runId);
@@ -349,10 +598,19 @@ export function prCandidateRunIds(
   }
   const order = new Map(input.runs.map((run, index) => [run.runId, index]));
   // The list is newest-first; keep the newest `cap` when the PR has a long history.
-  return [...ids].sort((a, b) => (order.get(a) ?? Infinity) - (order.get(b) ?? Infinity)).slice(0, cap);
+  return [...ids]
+    .sort((a, b) => (order.get(a) ?? Infinity) - (order.get(b) ?? Infinity))
+    .slice(0, cap);
 }
 
-const TERMINAL_STATES = new Set(["COMPLETED", "FAILED", "REFUSED", "CANCELLED", "TIMED_OUT", "DEAD"]);
+const TERMINAL_STATES = new Set([
+  "COMPLETED",
+  "FAILED",
+  "REFUSED",
+  "CANCELLED",
+  "TIMED_OUT",
+  "DEAD",
+]);
 
 export function PullRequest({
   number,
@@ -361,27 +619,67 @@ export function PullRequest({
   number: string | null;
   onNavigateTicket?: (ticketId: string) => void;
 }) {
-  const pr = number != null && /^\d{1,7}$/.test(number.trim()) ? Number(number.trim()) : null;
+  const pr =
+    number != null && /^\d{1,7}$/.test(number.trim())
+      ? Number(number.trim())
+      : null;
   const enabled = pr != null;
-  const events = useQuery({ queryKey: ["events", "all"], queryFn: () => api.events(), enabled, ...refetchIntervals.fast });
-  const proposals = useQuery({ queryKey: ["proposals", "history"], queryFn: () => api.proposalHistory("all"), enabled, ...refetchIntervals.fast });
-  const runs = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), enabled, ...refetchIntervals.fast });
-  const inbox = useQuery({ queryKey: ["inbox", "all"], queryFn: () => api.inbox("all"), enabled, ...refetchIntervals.secondary });
-  const schedules = useQuery({ queryKey: ["schedules"], queryFn: api.schedules, enabled, ...refetchIntervals.secondary });
+  const events = useQuery({
+    queryKey: ["events", "all"],
+    queryFn: () => api.events(),
+    enabled,
+    ...refetchIntervals.fast,
+  });
+  const proposals = useQuery({
+    queryKey: ["proposals", "history"],
+    queryFn: () => api.proposalHistory("all"),
+    enabled,
+    ...refetchIntervals.fast,
+  });
+  const runs = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    enabled,
+    ...refetchIntervals.fast,
+  });
+  const inbox = useQuery({
+    queryKey: ["inbox", "all"],
+    queryFn: () => api.inbox("all"),
+    enabled,
+    ...refetchIntervals.secondary,
+  });
+  const schedules = useQuery({
+    queryKey: ["schedules"],
+    queryFn: api.schedules,
+    enabled,
+    ...refetchIntervals.secondary,
+  });
 
   const eventList = events.data?.events ?? [];
   const proposalList = proposals.data?.proposals ?? [];
   const runList = runs.data?.runs ?? [];
   const candidateIds = useMemo(
-    () => (pr != null && events.data && proposals.data && runs.data ? prCandidateRunIds(pr, { events: eventList, proposals: proposalList, runs: runList }) : []),
+    () =>
+      pr != null && events.data && proposals.data && runs.data
+        ? prCandidateRunIds(pr, {
+            events: eventList,
+            proposals: proposalList,
+            runs: runList,
+          })
+        : [],
     [pr, events.data, proposals.data, runs.data],
   );
-  const stateById = useMemo(() => new Map(runList.map((run) => [run.runId, run.state])), [runs.data]);
+  const stateById = useMemo(
+    () => new Map(runList.map((run) => [run.runId, run.state])),
+    [runs.data],
+  );
   const details = useQueries({
     queries: candidateIds.map((id) => ({
       queryKey: ["run", id],
       queryFn: () => api.run(id),
-      staleTime: TERMINAL_STATES.has(stateById.get(id) ?? "") ? Infinity : 5_000,
+      staleTime: TERMINAL_STATES.has(stateById.get(id) ?? "")
+        ? Infinity
+        : 5_000,
       ...refetchIntervals.primary,
       refetchInterval: TERMINAL_STATES.has(stateById.get(id) ?? "")
         ? false
@@ -390,15 +688,22 @@ export function PullRequest({
   });
   const detailsReady = details.every((query) => query.data || query.isError);
   const loadedRuns = useMemo(
-    () => details.map((query) => query.data).filter((run): run is RunDetail => !!run) as unknown as JourneyRun[],
+    () =>
+      details
+        .map((query) => query.data)
+        .filter((run): run is RunDetail => !!run) as unknown as JourneyRun[],
     [details],
   );
 
   if (pr == null) {
     return (
       <div className="p-8">
-        <div role="alert" className="rounded-md border border-(--hue-warn) bg-(--surface-1) p-4 text-(--hue-warn)">
-          Invalid PR reference <span className="mono">{number}</span>. Use a number like 541.
+        <div
+          role="alert"
+          className="rounded-md border border-(--hue-warn) bg-(--surface-1) p-4 text-(--hue-warn)"
+        >
+          Invalid PR reference <span className="mono">{number}</span>. Use a
+          number like 541.
         </div>
       </div>
     );
@@ -407,14 +712,22 @@ export function PullRequest({
   if (listError) {
     return (
       <div className="p-8">
-        <div role="alert" className="rounded-md border border-(--hue-err) bg-(--surface-1) p-4 text-(--hue-err)">
-          Cannot load PR #{pr}: {(listError as Error).message ?? "control API unavailable"}
+        <div
+          role="alert"
+          className="rounded-md border border-(--hue-err) bg-(--surface-1) p-4 text-(--hue-err)"
+        >
+          Cannot load PR #{pr}:{" "}
+          {(listError as Error).message ?? "control API unavailable"}
         </div>
       </div>
     );
   }
   if (!events.data || !proposals.data || !runs.data || !detailsReady) {
-    return <div className="p-8 text-[13px] text-(--text-faint)">Loading PR #{pr} journey…</div>;
+    return (
+      <div className="p-8 text-[13px] text-(--text-faint)">
+        Loading PR #{pr} journey…
+      </div>
+    );
   }
 
   const source = selectPrSource(pr, {
@@ -425,5 +738,7 @@ export function PullRequest({
     schedules: schedules.data?.schedules,
   });
   const journey = subjectJourney("pr", String(pr), source);
-  return <JourneyLayout journey={journey} onNavigateTicket={onNavigateTicket} />;
+  return (
+    <JourneyLayout journey={journey} onNavigateTicket={onNavigateTicket} />
+  );
 }

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   CapacityBand,
@@ -23,7 +29,11 @@ afterEach(() => {
 
 const NOW = new Date().toISOString();
 
-function stubWorker(workerId: string, state: WorkerState, stale = false): Worker {
+function stubWorker(
+  workerId: string,
+  state: WorkerState,
+  stale = false,
+): Worker {
   return {
     workerId,
     host: "lab-1",
@@ -43,20 +53,33 @@ function renderWithClient(ui: React.ReactElement) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
 }
 
 const noop = () => {};
 
 function renderWorkers() {
   return renderWithClient(
-    <Workers context={{ kind: "all" }} focusWorkerId={null} onSelectWorker={noop} />,
+    <Workers
+      context={{ kind: "all" }}
+      focusWorkerId={null}
+      onSelectWorker={noop}
+    />,
   );
 }
 
-function withWorkers(workers: Worker[], fn: () => Promise<void>, capacity?: WorkerCapacity) {
+function withWorkers(
+  workers: Worker[],
+  fn: () => Promise<void>,
+  capacity?: WorkerCapacity,
+) {
   const orig = api.workers;
-  api.workers = async () => ({ workers, capacity: capacity ?? capacityFromWorkers(workers) });
+  api.workers = async () => ({
+    workers,
+    capacity: capacity ?? capacityFromWorkers(workers),
+  });
   return fn().finally(() => {
     api.workers = orig;
   });
@@ -82,15 +105,21 @@ describe("worker live/stopped partition (WM-98)", () => {
     ];
     const { live, stopped } = partitionWorkers(rows);
     expect(live.map((w) => w.workerId)).toEqual(["w_idle", "w_stale"]);
-    expect(stopped.map((w) => w.workerId)).toEqual(["w_stopped_1", "w_stopped_2"]);
+    expect(stopped.map((w) => w.workerId)).toEqual([
+      "w_stopped_1",
+      "w_stopped_2",
+    ]);
   });
 });
 
 describe("default worker tab (WM-98)", () => {
   test("opens on Live when at least one worker is live", () => {
-    expect(defaultWorkerTab([stubWorker("w_stopped", "stopped"), stubWorker("w_idle", "idle")])).toBe(
-      "LIVE",
-    );
+    expect(
+      defaultWorkerTab([
+        stubWorker("w_stopped", "stopped"),
+        stubWorker("w_idle", "idle"),
+      ]),
+    ).toBe("LIVE");
   });
 
   test("opens on All when every worker is stopped, and when the registry is empty", () => {
@@ -101,8 +130,15 @@ describe("default worker tab (WM-98)", () => {
 
 describe("worker capacity and draining state (WM-228)", () => {
   test("draining is explicit unless stale overrides the supervisor request", () => {
-    expect(workerDisplayState({ ...stubWorker("w_drain", "idle"), draining: true })).toBe("draining");
-    expect(workerDisplayState({ ...stubWorker("w_stale", "busy", true), draining: true })).toBe("stale");
+    expect(
+      workerDisplayState({ ...stubWorker("w_drain", "idle"), draining: true }),
+    ).toBe("draining");
+    expect(
+      workerDisplayState({
+        ...stubWorker("w_stale", "busy", true),
+        draining: true,
+      }),
+    ).toBe("stale");
   });
 
   test("uses worker-health hues on the running number only", () => {
@@ -122,19 +158,26 @@ describe("worker capacity and draining state (WM-228)", () => {
       classes: [],
     };
     const view = render(<CapacityBand capacity={capacity} />);
-    const runningValue = () => view.container.querySelector("[data-stat-value]");
+    const runningValue = () =>
+      view.container.querySelector("[data-stat-value]");
 
     expect(runningValue()?.textContent).toBe("1");
     expect(runningValue()?.getAttribute("style")).toContain("var(--hue-ok)");
     expect(runningValue()?.nextElementSibling?.textContent).toBe(" / 2");
-    expect(runningValue()?.nextElementSibling?.getAttribute("style")).toBeNull();
+    expect(
+      runningValue()?.nextElementSibling?.getAttribute("style"),
+    ).toBeNull();
 
     view.rerender(
-      <CapacityBand capacity={{ ...capacity, queued: 1, limitingFactor: "at worker max" }} />,
+      <CapacityBand
+        capacity={{ ...capacity, queued: 1, limitingFactor: "at worker max" }}
+      />,
     );
     expect(runningValue()?.getAttribute("style")).toContain("var(--hue-warn)");
 
-    view.rerender(<CapacityBand capacity={{ ...capacity, supervisor: "stopped" }} />);
+    view.rerender(
+      <CapacityBand capacity={{ ...capacity, supervisor: "stopped" }} />,
+    );
     expect(runningValue()?.getAttribute("style")).toContain("var(--hue-err)");
   });
 
@@ -160,47 +203,63 @@ describe("worker capacity and draining state (WM-228)", () => {
       limitingFactor: "at worker max",
       classes: [{ name: "heavy", running: 1, capacity: 2 }],
     };
-    await withWorkers([worker], async () => {
-      const { getByText, getAllByText, getByTitle, getByRole } = renderWorkers();
-      const summary = await waitFor(() => getByRole("region", { name: "Worker pool capacity" }));
-      const statCells = summary.querySelectorAll("[data-stat-card]");
-      expect(statCells).toHaveLength(4);
-      expect(Array.from(statCells).map((cell) => cell.textContent)).toEqual([
-        "Running1 / 2",
-        "Queued4",
-        "Idle0",
-        "Target0supervisor active",
-      ]);
-      expect(statCells[0]?.querySelector("[data-stat-value]")?.textContent).toBe("1");
-      expect(statCells[0]?.querySelector("[data-stat-value]")?.getAttribute("style")).toContain(
-        "var(--hue-warn)",
-      );
-      expect(getByText("at worker max")).toBeTruthy();
-      expect(getByText("heavy 1/2")).toBeTruthy();
-      expect(getAllByText("draining").length).toBeGreaterThan(0);
-      expect(getByTitle("Open run_capacity_123456")).toBeTruthy();
-      expect(getByTitle(new RegExp(`Started ${NOW}`))).toBeTruthy();
-    }, capacity);
+    await withWorkers(
+      [worker],
+      async () => {
+        const { getByText, getAllByText, getByTitle, getByRole } =
+          renderWorkers();
+        const summary = await waitFor(() =>
+          getByRole("region", { name: "Worker pool capacity" }),
+        );
+        const statCells = summary.querySelectorAll("[data-stat-card]");
+        expect(statCells).toHaveLength(4);
+        expect(Array.from(statCells).map((cell) => cell.textContent)).toEqual([
+          "Running1 / 2",
+          "Queued4",
+          "Idle0",
+          "Target0supervisor active",
+        ]);
+        expect(
+          statCells[0]?.querySelector("[data-stat-value]")?.textContent,
+        ).toBe("1");
+        expect(
+          statCells[0]
+            ?.querySelector("[data-stat-value]")
+            ?.getAttribute("style"),
+        ).toContain("var(--hue-warn)");
+        expect(getByText("at worker max")).toBeTruthy();
+        expect(getByText("heavy 1/2")).toBeTruthy();
+        expect(getAllByText("draining").length).toBeGreaterThan(0);
+        expect(getByTitle("Open run_capacity_123456")).toBeTruthy();
+        expect(getByTitle(new RegExp(`Started ${NOW}`))).toBeTruthy();
+      },
+      capacity,
+    );
   });
 });
 
 describe("Workers responsive state control (WM-163)", () => {
   test("offers every state in a compact mobile control and keeps bracket cycling in sync", async () => {
-    const workers = [stubWorker("w_idle", "idle"), stubWorker("w_stopped", "stopped")];
+    const workers = [
+      stubWorker("w_idle", "idle"),
+      stubWorker("w_stopped", "stopped"),
+    ];
     await withWorkers(workers, async () => {
       const { getByRole, getByText } = renderWorkers();
-      const stateControl = await waitFor(() => getByRole("combobox", { name: "Worker state" })) as HTMLSelectElement;
+      const stateControl = (await waitFor(() =>
+        getByRole("combobox", { name: "Worker state" }),
+      )) as HTMLSelectElement;
 
-      expect(Array.from(stateControl.options).map((option) => option.textContent)).toEqual([
-        "All 2",
-        "Live 1",
-        "Stopped 1",
-      ]);
+      expect(
+        Array.from(stateControl.options).map((option) => option.textContent),
+      ).toEqual(["All 2", "Live 1", "Stopped 1"]);
       expect(stateControl.value).toBe("LIVE");
 
       fireEvent.change(stateControl, { target: { value: "STOPPED" } });
       await waitFor(() => expect(getByText("w_stopped")).toBeTruthy());
-      expect(getByRole("tab", { selected: true }).textContent).toContain("Stopped");
+      expect(getByRole("tab", { selected: true }).textContent).toContain(
+        "Stopped",
+      );
 
       fireEvent.keyDown(document.body, { key: "]" });
       await waitFor(() => expect(stateControl.value).toBe("ALL"));
@@ -231,7 +290,10 @@ describe("Workers empty tab copy (WM-162)", () => {
       expect(await findByText("No live workers")).toBeTruthy();
 
       act(() => {
-        changeInput(getByRole("combobox", { name: "Filter workers" }), "missing");
+        changeInput(
+          getByRole("combobox", { name: "Filter workers" }),
+          "missing",
+        );
       });
       expect(await findByText("No workers match this filter.")).toBeTruthy();
       expect(await findByText("Esc clears the filter")).toBeTruthy();
@@ -253,12 +315,17 @@ describe("Workers view default visibility (WM-98)", () => {
       });
       expect(queryByText("w_stopped_old")).toBeNull();
       expect(queryByText("w_stopped_new")).toBeNull();
-      expect(getByRole("tab", { selected: true }).textContent).toContain("Live");
+      expect(getByRole("tab", { selected: true }).textContent).toContain(
+        "Live",
+      );
     });
   });
 
   test("an all-stopped registry opens on All so the page is not blank", async () => {
-    const workers = [stubWorker("w_stopped_1", "stopped"), stubWorker("w_stopped_2", "stopped")];
+    const workers = [
+      stubWorker("w_stopped_1", "stopped"),
+      stubWorker("w_stopped_2", "stopped"),
+    ];
     await withWorkers(workers, async () => {
       const { getByText, getByRole } = renderWorkers();
       await waitFor(() => {
@@ -273,13 +340,28 @@ describe("Workers view default visibility (WM-98)", () => {
 describe("fleet banner vs Live tab (WM-155)", () => {
   test("classifier: empty, all-stopped, and stale-only are distinct; idle/busy suppress the banner", () => {
     expect(fleetBanner([])).toEqual({ kind: "empty" });
-    expect(fleetBanner([stubWorker("w_stopped", "stopped")])).toEqual({ kind: "all-stopped", count: 1 });
-    expect(fleetBanner([stubWorker("w_stale", "busy", true)])).toEqual({ kind: "stale", stale: 1, stopped: 0 });
+    expect(fleetBanner([stubWorker("w_stopped", "stopped")])).toEqual({
+      kind: "all-stopped",
+      count: 1,
+    });
+    expect(fleetBanner([stubWorker("w_stale", "busy", true)])).toEqual({
+      kind: "stale",
+      stale: 1,
+      stopped: 0,
+    });
     expect(
-      fleetBanner([stubWorker("w_stale", "idle", true), stubWorker("w_stopped", "stopped")]),
+      fleetBanner([
+        stubWorker("w_stale", "idle", true),
+        stubWorker("w_stopped", "stopped"),
+      ]),
     ).toEqual({ kind: "stale", stale: 1, stopped: 1 });
     expect(fleetBanner([stubWorker("w_idle", "idle")])).toBeNull();
-    expect(fleetBanner([stubWorker("w_idle", "idle"), stubWorker("w_stale", "busy", true)])).toBeNull();
+    expect(
+      fleetBanner([
+        stubWorker("w_idle", "idle"),
+        stubWorker("w_stale", "busy", true),
+      ]),
+    ).toBeNull();
   });
 
   test("stale-only fleet opens on Live with the stale row and does not say “No live workers detected”", async () => {
@@ -289,7 +371,9 @@ describe("fleet banner vs Live tab (WM-155)", () => {
       await waitFor(() => {
         expect(getByText("w_stale_only")).toBeTruthy();
       });
-      expect(getByRole("tab", { selected: true }).textContent).toContain("Live");
+      expect(getByRole("tab", { selected: true }).textContent).toContain(
+        "Live",
+      );
       expect(queryByText("No live workers detected")).toBeNull();
       expect(getByText("Workers are stale")).toBeTruthy();
       expect(getByText(/missed the heartbeat window/i)).toBeTruthy();
@@ -301,12 +385,17 @@ describe("fleet banner vs Live tab (WM-155)", () => {
       const { getByText, queryByText, findByText } = renderWorkers();
       expect(await findByText("No workers registered")).toBeTruthy();
       expect(queryByText("No live workers detected")).toBeNull();
-      expect(getByText(/No workers have registered with the runtime/i)).toBeTruthy();
+      expect(
+        getByText(/No workers have registered with the runtime/i),
+      ).toBeTruthy();
     });
   });
 
   test("all-stopped banner says workers are stopped, not stale-or-stopped", async () => {
-    const workers = [stubWorker("w_stopped_1", "stopped"), stubWorker("w_stopped_2", "stopped")];
+    const workers = [
+      stubWorker("w_stopped_1", "stopped"),
+      stubWorker("w_stopped_2", "stopped"),
+    ];
     await withWorkers(workers, async () => {
       const { getByText, queryByText } = renderWorkers();
       await waitFor(() => {
@@ -341,9 +430,15 @@ describe("Workers copy chords and hints (WM-233)", () => {
     const w = stubWorker("worker-copy-test", "idle");
     await withWorkers([w], async () => {
       const r = renderWithClient(
-        <Workers context={{ kind: "all" }} focusWorkerId="worker-copy-test" onSelectWorker={noop} />,
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId="worker-copy-test"
+          onSelectWorker={noop}
+        />,
       );
-      const idBtn = await r.findByRole("button", { name: "Copy worker id (c)" });
+      const idBtn = await r.findByRole("button", {
+        name: "Copy worker id (c)",
+      });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
       expect(idBtn.getAttribute("title")).toBe("Copy worker id · c");
@@ -369,7 +464,11 @@ describe("Workers Open run action shortcut badge (WM-236)", () => {
     };
     await withWorkers([workerWithRun], async () => {
       const { getByRole } = renderWithClient(
-        <Workers context={{ kind: "all" }} focusWorkerId="w_busy_1" onSelectWorker={noop} />,
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId="w_busy_1"
+          onSelectWorker={noop}
+        />,
       );
 
       await waitFor(() => {
@@ -394,7 +493,11 @@ describe("Workers Open run action shortcut badge (WM-236)", () => {
     const workerIdle: Worker = stubWorker("w_idle_1", "idle");
     await withWorkers([workerIdle], async () => {
       const { queryByRole, container } = renderWithClient(
-        <Workers context={{ kind: "all" }} focusWorkerId="w_idle_1" onSelectWorker={noop} />,
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId="w_idle_1"
+          onSelectWorker={noop}
+        />,
       );
 
       await waitFor(() => {
@@ -424,10 +527,17 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
     repos: ["factory"],
   };
 
-  function withRunsAndWorkers(workers: Worker[], runs: typeof stubRun[], fn: () => Promise<void>) {
+  function withRunsAndWorkers(
+    workers: Worker[],
+    runs: (typeof stubRun)[],
+    fn: () => Promise<void>,
+  ) {
     const origWorkers = api.workers;
     const origRuns = api.runs;
-    api.workers = async () => ({ workers, capacity: capacityFromWorkers(workers) });
+    api.workers = async () => ({
+      workers,
+      capacity: capacityFromWorkers(workers),
+    });
     api.runs = async () => ({ runs });
     return fn().finally(() => {
       api.workers = origWorkers;
@@ -473,9 +583,20 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
 
     await withRunsAndWorkers([workerBusy], [stubRun], async () => {
       const { getByRole, getByTitle, queryByRole } = renderWorkers();
-      await waitFor(() => expect(getByRole("columnheader", { name: "Worker" })).toBeTruthy());
+      await waitFor(() =>
+        expect(getByRole("columnheader", { name: "Worker" })).toBeTruthy(),
+      );
 
-      for (const name of ["Worker", "State", "Agent", "Target", "Model", "Current run", "Uptime", "Heartbeat"]) {
+      for (const name of [
+        "Worker",
+        "State",
+        "Agent",
+        "Target",
+        "Model",
+        "Current run",
+        "Uptime",
+        "Heartbeat",
+      ]) {
         expect(getByRole("columnheader", { name })).toBeTruthy();
       }
       for (const name of ["Host", "PID", "Adapters", "Labels"]) {
@@ -486,7 +607,9 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
       fireEvent.click(getByRole("button", { name: "Adapters" }));
 
       expect(getByRole("columnheader", { name: "Adapters" })).toBeTruthy();
-      const adapters = getByTitle("actions, agy, claude, command, cursor, fake, pi");
+      const adapters = getByTitle(
+        "actions, agy, claude, command, cursor, fake, pi",
+      );
       expect(adapters.textContent).toBe("7 adapters");
     });
   });
@@ -506,7 +629,10 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
       });
 
       act(() => {
-        changeInput(getByRole("combobox", { name: "Filter workers" }), "dispatch");
+        changeInput(
+          getByRole("combobox", { name: "Filter workers" }),
+          "dispatch",
+        );
       });
 
       await waitFor(() => {
@@ -515,7 +641,10 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
       });
 
       act(() => {
-        changeInput(getByRole("combobox", { name: "Filter workers" }), "WM-253");
+        changeInput(
+          getByRole("combobox", { name: "Filter workers" }),
+          "WM-253",
+        );
       });
 
       await waitFor(() => {
@@ -533,15 +662,19 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
 
     await withRunsAndWorkers([workerBusy], [stubRun], async () => {
       const { findByText, getAllByText } = renderWithClient(
-        <Workers context={{ kind: "all" }} focusWorkerId="w_busy_active" onSelectWorker={noop} />,
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId="w_busy_active"
+          onSelectWorker={noop}
+        />,
       );
 
       await findByText("Active Run");
       expect(getAllByText("dispatch@1").length).toBeGreaterThanOrEqual(2);
       expect(getAllByText("factory · WM-253").length).toBeGreaterThanOrEqual(1);
-      expect(getAllByText("openai-codex/gpt-5.6-sol").length).toBeGreaterThanOrEqual(1);
+      expect(
+        getAllByText("openai-codex/gpt-5.6-sol").length,
+      ).toBeGreaterThanOrEqual(1);
     });
   });
 });
-
-

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -1,7 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { keyGuard, refetchIntervals, useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
+import {
+  keyGuard,
+  refetchIntervals,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useTabKeys,
+} from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   buildSections,
@@ -56,13 +63,20 @@ export type WorkerDisplayState = ReturnType<typeof health> | "draining";
 export const WORKER_HEALTH_FILTERS = ["live", "busy", "stale"] as const;
 export type WorkerHealthFilter = (typeof WORKER_HEALTH_FILTERS)[number];
 
-export const isWorkerHealthFilter = (value: string | null): value is WorkerHealthFilter =>
+export const isWorkerHealthFilter = (
+  value: string | null,
+): value is WorkerHealthFilter =>
   WORKER_HEALTH_FILTERS.some((filter) => filter === value);
 
 /** Overview health counts are disjoint: live excludes stale and stopped workers. */
-export const workerMatchesHealth = (worker: Worker, filter: WorkerHealthFilter): boolean => {
+export const workerMatchesHealth = (
+  worker: Worker,
+  filter: WorkerHealthFilter,
+): boolean => {
   const state = health(worker);
-  return filter === "live" ? state === "idle" || state === "busy" : state === filter;
+  return filter === "live"
+    ? state === "idle" || state === "busy"
+    : state === filter;
 };
 
 const WORKER_STATE_HUES: Record<WorkerDisplayState, string> = {
@@ -72,11 +86,17 @@ const WORKER_STATE_HUES: Record<WorkerDisplayState, string> = {
 
 /** Stale remains the strongest signal; otherwise a drain request is explicit. */
 export const workerDisplayState = (worker: Worker): WorkerDisplayState =>
-  worker.stale ? "stale" : worker.draining && worker.state !== "stopped" ? "draining" : health(worker);
+  worker.stale
+    ? "stale"
+    : worker.draining && worker.state !== "stopped"
+      ? "draining"
+      : health(worker);
 
 /** Compatibility projection for an older API that has not added capacity yet. */
 export function capacityFromWorkers(rows: Worker[]): WorkerCapacity {
-  const live = rows.filter((worker) => worker.state !== "stopped" && !worker.stale);
+  const live = rows.filter(
+    (worker) => worker.state !== "stopped" && !worker.stale,
+  );
   const running = live.filter((worker) => worker.state === "busy").length;
   const draining = live.filter((worker) => worker.draining).length;
   return {
@@ -84,7 +104,8 @@ export function capacityFromWorkers(rows: Worker[]): WorkerCapacity {
     capacity: live.length,
     queued: 0,
     live: live.length,
-    idle: live.filter((worker) => worker.state !== "busy" && !worker.draining).length,
+    idle: live.filter((worker) => worker.state !== "busy" && !worker.draining)
+      .length,
     draining,
     target: Math.max(0, live.length - draining),
     min: null,
@@ -97,7 +118,10 @@ export function capacityFromWorkers(rows: Worker[]): WorkerCapacity {
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest("input, textarea, select, [contenteditable=true]"))
+  );
 }
 
 /**
@@ -134,7 +158,9 @@ export function fleetBanner(rows: Worker[]): FleetBanner | null {
 }
 
 /** Split the registry into live and stopped, preserving order within each group. */
-export function partitionWorkers<T extends Worker>(rows: T[]): { live: T[]; stopped: T[] } {
+export function partitionWorkers<T extends Worker>(
+  rows: T[],
+): { live: T[]; stopped: T[] } {
   const live: T[] = [];
   const stopped: T[] = [];
   for (const w of rows) (isLive(w) ? live : stopped).push(w);
@@ -156,11 +182,15 @@ export interface EnrichedWorker extends Worker {
   runItem: RunListItem | null;
 }
 
-export function enrichWorker(w: Worker, runMap: Map<string, RunListItem>): EnrichedWorker {
+export function enrichWorker(
+  w: Worker,
+  runMap: Map<string, RunListItem>,
+): EnrichedWorker {
   const r = w.currentRun ? (runMap.get(w.currentRun) ?? null) : null;
   const activeAgent = r?.agent ?? EMPTY;
   const repos = r?.repos?.length ? r.repos.join(", ") : "";
-  const ticketMatch = r?.eventId?.match(/\b([A-Z]{2,10}-\d+|PR-\d+)\b/)?.[0] ?? "";
+  const ticketMatch =
+    r?.eventId?.match(/\b([A-Z]{2,10}-\d+|PR-\d+)\b/)?.[0] ?? "";
   const activeTarget =
     repos && ticketMatch && !repos.includes(ticketMatch)
       ? `${repos} · ${ticketMatch}`
@@ -191,18 +221,65 @@ const WORKERS_DISPLAY: DisplayConfig<EnrichedWorker> = {
   ],
   subGroups: ["agent", "host", "state"],
   sorts: [
-    { key: "worker", label: "Worker", get: (w) => w.workerId, column: "worker" },
+    {
+      key: "worker",
+      label: "Worker",
+      get: (w) => w.workerId,
+      column: "worker",
+    },
     { key: "host", label: "Host", get: (w) => w.host, column: "host" },
     { key: "pid", label: "PID", get: (w) => w.pid, column: "pid" },
     { key: "state", label: "State", get: workerDisplayState, column: "state" },
-    { key: "agent", label: "Agent", get: (w) => w.activeAgent, column: "agent" },
-    { key: "target", label: "Target", get: (w) => w.activeTarget, column: "target" },
-    { key: "activeModel", label: "Model", get: (w) => w.activeModel, column: "activeModel" },
-    { key: "labels", label: "Labels", get: (w) => labelText(w.labels), column: "labels" },
-    { key: "adapters", label: "Adapters", get: (w) => w.adapters.join(", "), column: "adapters" },
-    { key: "run", label: "Current run", get: (w) => w.currentRun ?? "", column: "run" },
-    { key: "started", label: "Started", get: (w) => w.startedAt ?? "", defaultDir: "desc", column: "uptime" },
-    { key: "lastSeen", label: "Last seen", get: (w) => w.lastSeen ?? "", defaultDir: "desc", column: "heartbeat" },
+    {
+      key: "agent",
+      label: "Agent",
+      get: (w) => w.activeAgent,
+      column: "agent",
+    },
+    {
+      key: "target",
+      label: "Target",
+      get: (w) => w.activeTarget,
+      column: "target",
+    },
+    {
+      key: "activeModel",
+      label: "Model",
+      get: (w) => w.activeModel,
+      column: "activeModel",
+    },
+    {
+      key: "labels",
+      label: "Labels",
+      get: (w) => labelText(w.labels),
+      column: "labels",
+    },
+    {
+      key: "adapters",
+      label: "Adapters",
+      get: (w) => w.adapters.join(", "),
+      column: "adapters",
+    },
+    {
+      key: "run",
+      label: "Current run",
+      get: (w) => w.currentRun ?? "",
+      column: "run",
+    },
+    {
+      key: "started",
+      label: "Started",
+      get: (w) => w.startedAt ?? "",
+      defaultDir: "desc",
+      column: "uptime",
+    },
+    {
+      key: "lastSeen",
+      label: "Last seen",
+      get: (w) => w.lastSeen ?? "",
+      defaultDir: "desc",
+      column: "heartbeat",
+    },
   ],
   columns: [
     { key: "worker", label: "Worker", always: true },
@@ -288,12 +365,19 @@ function HeartbeatCell({ w, now }: { w: Worker; now: number }) {
 /** How much of the window is spent — the glance; `StaleClock` is the number. */
 function HeartbeatMeter({ hb }: { hb: Heartbeat }) {
   if (hb.kind === "none") return null;
-  const spent = hb.kind === "stale" ? 1 : 1 - hb.remainingMs / HEARTBEAT_STALE_MS;
+  const spent =
+    hb.kind === "stale" ? 1 : 1 - hb.remainingMs / HEARTBEAT_STALE_MS;
   return (
-    <div className="mt-2 h-1 overflow-hidden rounded-full bg-(--surface-2)" aria-hidden="true">
+    <div
+      className="mt-2 h-1 overflow-hidden rounded-full bg-(--surface-2)"
+      aria-hidden="true"
+    >
       <div
         className="h-full rounded-full transition-[width,background-color] duration-1000 ease-linear"
-        style={{ width: `${Math.min(100, Math.max(2, spent * 100))}%`, background: heartbeatHue(hb) ?? "var(--hue-ok)" }}
+        style={{
+          width: `${Math.min(100, Math.max(2, spent * 100))}%`,
+          background: heartbeatHue(hb) ?? "var(--hue-ok)",
+        }}
       />
     </div>
   );
@@ -328,25 +412,44 @@ export function CapacityBand({ capacity }: { capacity: WorkerCapacity }) {
           compact
           label="Running"
           value={capacity.running}
-          suffix={<span className="text-(--text-dim)"> / {capacity.capacity}</span>}
+          suffix={
+            <span className="text-(--text-dim)"> / {capacity.capacity}</span>
+          }
           hue={runningHue}
         />
         <StatCard compact label="Queued" value={capacity.queued} />
         <StatCard compact label="Idle" value={capacity.idle} />
-        <StatCard compact label="Target" value={capacity.target} caption={targetCaption} />
+        <StatCard
+          compact
+          label="Target"
+          value={capacity.target}
+          caption={targetCaption}
+        />
       </div>
       {constrained && (
-        <div className="mt-2 flex items-center gap-2 text-[12px]" style={{ color: WORKER_HUES.busy }}>
-          <span className="size-1.5 rounded-full" style={{ background: WORKER_HUES.busy }} />
+        <div
+          className="mt-2 flex items-center gap-2 text-[12px]"
+          style={{ color: WORKER_HUES.busy }}
+        >
+          <span
+            className="size-1.5 rounded-full"
+            style={{ background: WORKER_HUES.busy }}
+          />
           <span>
             Queue is waiting: <strong>{capacity.limitingFactor}</strong>
           </span>
         </div>
       )}
       {capacity.classes.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker class capacity">
+        <div
+          className="mt-2 flex flex-wrap gap-1.5"
+          aria-label="Worker class capacity"
+        >
           {capacity.classes.map((workerClass) => (
-            <span key={workerClass.name} className="mono rounded-full bg-(--surface-2) px-2 py-0.5 text-[11px] text-(--text-dim)">
+            <span
+              key={workerClass.name}
+              className="mono rounded-full bg-(--surface-2) px-2 py-0.5 text-[11px] text-(--text-dim)"
+            >
               {workerClass.name} {workerClass.running}/{workerClass.capacity}
             </span>
           ))}
@@ -389,8 +492,7 @@ function FleetStatusBanner({ banner }: { banner: FleetBanner }) {
         <span>{title}</span>
       </div>
       <div className="mt-1 text-(--text-dim)">
-        {lead}{" "}
-        Queued runs will remain waiting until a worker is started with{" "}
+        {lead} Queued runs will remain waiting until a worker is started with{" "}
         <code className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[11px] text-(--text)">
           bun event-runtime/cli.mjs work
         </code>
@@ -420,16 +522,31 @@ export function Workers({
   onFocusHealthChange?: (health: WorkerHealthFilter | null) => void;
 }) {
   const now = useNow();
-  const query = useQuery({ queryKey: ["workers"], queryFn: api.workers, ...refetchIntervals.primary });
-  const runsQuery = useQuery({ queryKey: ["runs"], queryFn: () => api.runs(), ...refetchIntervals.secondary });
+  const query = useQuery({
+    queryKey: ["workers"],
+    queryFn: api.workers,
+    ...refetchIntervals.primary,
+  });
+  const runsQuery = useQuery({
+    queryKey: ["runs"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.secondary,
+  });
   const runs = runsQuery.data?.runs ?? [];
-  const runMap = useMemo(() => new Map<string, RunListItem>(runs.map((r) => [r.runId, r])), [runs]);
+  const runMap = useMemo(
+    () => new Map<string, RunListItem>(runs.map((r) => [r.runId, r])),
+    [runs],
+  );
 
   // GET /workers gained capacity without changing the legacy client method's
   // minimum response contract; older servers simply exercise the fallback.
-  const response = query.data as ({ workers: Worker[]; capacity?: WorkerCapacity } | undefined);
+  const response = query.data as
+    { workers: Worker[]; capacity?: WorkerCapacity } | undefined;
   const rawRows = response?.workers ?? [];
-  const rows = useMemo(() => rawRows.map((w) => enrichWorker(w, runMap)), [rawRows, runMap]);
+  const rows = useMemo(
+    () => rawRows.map((w) => enrichWorker(w, runMap)),
+    [rawRows, runMap],
+  );
   const capacity = response?.capacity ?? capacityFromWorkers(rawRows);
 
   const parts = useMemo(() => partitionWorkers(rows), [rows]);
@@ -466,7 +583,11 @@ export function Workers({
   // top of whatever the active tab lets through.
   const byTab = useMemo(
     () =>
-      tab === "ALL" ? [...parts.live, ...parts.stopped] : tab === "LIVE" ? parts.live : parts.stopped,
+      tab === "ALL"
+        ? [...parts.live, ...parts.stopped]
+        : tab === "LIVE"
+          ? parts.live
+          : parts.stopped,
     [tab, parts],
   );
 
@@ -481,7 +602,10 @@ export function Workers({
   }, [focusHealth]);
 
   const byHealth = useMemo(
-    () => (focusHealth ? byTab.filter((worker) => workerMatchesHealth(worker, focusHealth)) : byTab),
+    () =>
+      focusHealth
+        ? byTab.filter((worker) => workerMatchesHealth(worker, focusHealth))
+        : byTab,
     [byTab, focusHealth],
   );
   const visible = useMemo(() => {
@@ -499,9 +623,7 @@ export function Workers({
         w.activeAgent,
         w.activeTarget,
         w.activeModel,
-      ].some(
-        (v) => (v ?? "").toLowerCase().includes(q),
-      ),
+      ].some((v) => (v ?? "").toLowerCase().includes(q)),
     );
   }, [byHealth, filter]);
 
@@ -527,13 +649,20 @@ export function Workers({
     [flat, selectedId],
   );
   const sel = useMemo(
-    () => (selectedId ? (visible.find((w) => w.workerId === selectedId) ?? null) : null),
+    () =>
+      selectedId
+        ? (visible.find((w) => w.workerId === selectedId) ?? null)
+        : null,
     [visible, selectedId],
   );
-  const selHeartbeat: Heartbeat = sel ? heartbeatOf(sel, now) : { kind: "none" };
+  const selHeartbeat: Heartbeat = sel
+    ? heartbeatOf(sel, now)
+    : { kind: "none" };
 
   useEffect(() => {
-    document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
+    document
+      .querySelector("tr.row-selected")
+      ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
   useEffect(() => {
@@ -569,7 +698,11 @@ export function Workers({
         pendingC.current = Date.now();
       },
       l: () => {
-        if (sel && pendingC.current > 0 && Date.now() - pendingC.current < 800) {
+        if (
+          sel &&
+          pendingC.current > 0 &&
+          Date.now() - pendingC.current < 800
+        ) {
           copyLink();
           pendingC.current = 0;
         }
@@ -583,9 +716,19 @@ export function Workers({
       setContextActions([]);
     } else {
       setContextActions([
-        { label: `Copy ${sel.workerId}`, hint: "c", run: () => copyText(sel.workerId, "worker id") },
+        {
+          label: `Copy ${sel.workerId}`,
+          hint: "c",
+          run: () => copyText(sel.workerId, "worker id"),
+        },
         ...(sel.currentRun
-          ? [{ label: `Open run ${sel.currentRun}`, hint: "o", run: () => openRun(sel.currentRun!) }]
+          ? [
+              {
+                label: `Open run ${sel.currentRun}`,
+                hint: "o",
+                run: () => openRun(sel.currentRun!),
+              },
+            ]
           : []),
         { label: "Copy link to this worker", hint: "c l", run: copyLink },
       ]);
@@ -614,11 +757,16 @@ export function Workers({
               >
                 {WORKER_TABS.map((t) => (
                   <option key={t} value={t}>
-                    {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"} {tabCounts[t]}
+                    {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"}{" "}
+                    {tabCounts[t]}
                   </option>
                 ))}
               </select>
-              <div className="hidden min-w-0 flex-1 gap-1 sm:flex" role="tablist" aria-label="Worker state">
+              <div
+                className="hidden min-w-0 flex-1 gap-1 sm:flex"
+                role="tablist"
+                aria-label="Worker state"
+              >
                 {WORKER_TABS.map((t, idx) => (
                   <button
                     key={t}
@@ -629,14 +777,29 @@ export function Workers({
                       setTabChoice(t);
                       if (focusHealth) onFocusHealthChange(null);
                     }}
-                    title={t === "LIVE" ? "idle, busy, or stale" : t === "STOPPED" ? "cleanly stopped — history" : undefined}
+                    title={
+                      t === "LIVE"
+                        ? "idle, busy, or stale"
+                        : t === "STOPPED"
+                          ? "cleanly stopped — history"
+                          : undefined
+                    }
                     className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                      tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                      tab === t
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1)"
                     }`}
                   >
                     {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"}
-                    {tabCounts[t] > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{tabCounts[t]}</span>}
-                    <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
+                    {tabCounts[t] > 0 && (
+                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                        {tabCounts[t]}
+                      </span>
+                    )}
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                    >
                       {idx + 1}
                     </span>
                   </button>
@@ -657,7 +820,9 @@ export function Workers({
                   value={focusHealth ?? ""}
                   onChange={(event) => {
                     const value = event.target.value;
-                    onFocusHealthChange(isWorkerHealthFilter(value) ? value : null);
+                    onFocusHealthChange(
+                      isWorkerHealthFilter(value) ? value : null,
+                    );
                   }}
                   className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text)"
                 >
@@ -682,18 +847,34 @@ export function Workers({
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
-                const sort = WORKERS_DISPLAY.sorts.find((s) => s.column === c.key);
+                const sort = WORKERS_DISPLAY.sorts.find(
+                  (s) => s.column === c.key,
+                );
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
-                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
+                const isCurrentSort = isCustom
+                  ? display.sortBy === c.key
+                  : sort && display.sortBy === sort.key;
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
                     dir={isCurrentSort ? display.sortDir : null}
                     naturalDir={sort?.defaultDir ?? "asc"}
-                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(WORKERS_DISPLAY, s, c.key)) : undefined}
-                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
+                    onSort={
+                      sort || isCustom
+                        ? () =>
+                            setDisplay((s) =>
+                              cycleColumnSort(WORKERS_DISPLAY, s, c.key),
+                            )
+                        : undefined
+                    }
+                    onRemove={
+                      isCustom
+                        ? () =>
+                            setDisplay((s) => removeCustomColumn(s, customPath))
+                        : undefined
+                    }
                   />
                 );
               })}
@@ -712,24 +893,36 @@ export function Workers({
                 >
                   <td
                     className={`mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap ${
-                      w.state === "stopped" && !w.stale ? "text-(--text-faint)" : ""
+                      w.state === "stopped" && !w.stale
+                        ? "text-(--text-faint)"
+                        : ""
                     }`}
                     title={w.workerId}
                   >
                     {w.workerId}
                   </td>
                   {show.has("host") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">{w.host}</td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      {w.host}
+                    </td>
                   )}
                   {show.has("pid") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)">{w.pid}</td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)">
+                      {w.pid}
+                    </td>
                   )}
                   {show.has("state") && (
                     <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                       <span className="flex items-baseline gap-1.5 whitespace-nowrap">
-                        <StateBadge state={workerDisplayState(w)} hues={WORKER_STATE_HUES} />
+                        <StateBadge
+                          state={workerDisplayState(w)}
+                          hues={WORKER_STATE_HUES}
+                        />
                         {w.stale && (
-                          <span className="text-[11px] text-(--text-faint) whitespace-nowrap" title="What the worker last reported before its heartbeat stopped">
+                          <span
+                            className="text-[11px] text-(--text-faint) whitespace-nowrap"
+                            title="What the worker last reported before its heartbeat stopped"
+                          >
                             reported {w.state}
                           </span>
                         )}
@@ -739,10 +932,14 @@ export function Workers({
                   {show.has("agent") && (
                     <td
                       className="max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
-                      title={w.activeAgent !== EMPTY ? w.activeAgent : undefined}
+                      title={
+                        w.activeAgent !== EMPTY ? w.activeAgent : undefined
+                      }
                     >
                       {w.activeAgent !== EMPTY ? (
-                        <span className="mono font-medium text-(--text)">{w.activeAgent}</span>
+                        <span className="mono font-medium text-(--text)">
+                          {w.activeAgent}
+                        </span>
                       ) : (
                         <span className="text-(--text-faint)">{EMPTY}</span>
                       )}
@@ -751,7 +948,9 @@ export function Workers({
                   {show.has("target") && (
                     <td
                       className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
-                      title={w.activeTarget !== EMPTY ? w.activeTarget : undefined}
+                      title={
+                        w.activeTarget !== EMPTY ? w.activeTarget : undefined
+                      }
                     >
                       {w.activeTarget !== EMPTY ? (
                         <span>{w.activeTarget}</span>
@@ -762,13 +961,19 @@ export function Workers({
                   )}
                   {show.has("activeModel") && (
                     <td className="max-w-40 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <ModelCell model={w.activeModel} className="text-(--text-faint)" />
+                      <ModelCell
+                        model={w.activeModel}
+                        className="text-(--text-faint)"
+                      />
                     </td>
                   )}
                   {show.has("run") && (
                     <td className="mono max-w-56 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)">
                       {w.currentRun ? (
-                        <JumpLink onClick={() => openRun(w.currentRun!)} title={`Open ${w.currentRun}`}>
+                        <JumpLink
+                          onClick={() => openRun(w.currentRun!)}
+                          title={`Open ${w.currentRun}`}
+                        >
                           {shortId(w.currentRun)}
                         </JumpLink>
                       ) : (
@@ -779,7 +984,11 @@ export function Workers({
                   {show.has("adapters") && (
                     <td
                       className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
-                      title={w.adapters.length > 0 ? w.adapters.join(", ") : undefined}
+                      title={
+                        w.adapters.length > 0
+                          ? w.adapters.join(", ")
+                          : undefined
+                      }
                     >
                       {w.adapters.length > 0
                         ? `${w.adapters.length} adapter${w.adapters.length === 1 ? "" : "s"}`
@@ -787,7 +996,10 @@ export function Workers({
                     </td>
                   )}
                   {show.has("labels") && (
-                    <td className="max-w-48 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)" title={labelText(w.labels)}>
+                    <td
+                      className="max-w-48 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
+                      title={labelText(w.labels)}
+                    >
                       {labelText(w.labels)}
                     </td>
                   )}
@@ -796,7 +1008,9 @@ export function Workers({
                       className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)"
                       title={`Started ${w.startedAt}`}
                     >
-                      <span title={w.startedAt}>{formatRelative(w.startedAt, now)}</span>
+                      <span title={w.startedAt}>
+                        {formatRelative(w.startedAt, now)}
+                      </span>
                     </td>
                   )}
                   {show.has("heartbeat") && (
@@ -804,9 +1018,15 @@ export function Workers({
                       <HeartbeatCell w={w} now={now} />
                     </td>
                   )}
-                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
-                    <CustomCell key={c.key} row={w} path={c.key.replace(/^custom:/, "")} />
-                  ))}
+                  {cols
+                    .filter((c) => c.isCustom || c.key.startsWith("custom:"))
+                    .map((c) => (
+                      <CustomCell
+                        key={c.key}
+                        row={w}
+                        path={c.key.replace(/^custom:/, "")}
+                      />
+                    ))}
                 </tr>
               );
               if (!grouped(display)) return sections[0]?.rows.map(renderRow);
@@ -818,19 +1038,27 @@ export function Workers({
                       colSpan={cols.length}
                       section={s}
                       collapsed={closed}
-                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                      onToggle={() =>
+                        setDisplay((st) => toggleCollapsed(st, s.key))
+                      }
                     />
                     {!closed &&
                       (s.subsections
                         ? s.subsections.map((child) => {
-                            const childClosed = display.collapsed.includes(child.key);
+                            const childClosed = display.collapsed.includes(
+                              child.key,
+                            );
                             return (
                               <Fragment key={child.key}>
                                 <GroupHeaderRow
                                   colSpan={cols.length}
                                   section={child}
                                   collapsed={childClosed}
-                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
+                                  onToggle={() =>
+                                    setDisplay((st) =>
+                                      toggleCollapsed(st, child.key),
+                                    )
+                                  }
                                   sub
                                 />
                                 {!childClosed && child.rows.map(renderRow)}
@@ -874,7 +1102,10 @@ export function Workers({
           widthClass="w-[460px]"
           title={
             <span className="flex min-w-0 items-center gap-2">
-              <StateBadge state={workerDisplayState(sel)} hues={WORKER_STATE_HUES} />
+              <StateBadge
+                state={workerDisplayState(sel)}
+                hues={WORKER_STATE_HUES}
+              />
               <span className="mono truncate" title={sel.workerId}>
                 {sel.workerId}
               </span>
@@ -883,7 +1114,13 @@ export function Workers({
           actions={
             sel.currentRun ? (
               <Button onClick={() => openRun(sel.currentRun!)}>
-                Open run <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">o</span>
+                Open run{" "}
+                <span
+                  className="mono ml-1 text-(--text-faint)"
+                  aria-hidden="true"
+                >
+                  o
+                </span>
               </Button>
             ) : undefined
           }
@@ -895,11 +1132,17 @@ export function Workers({
               className="mb-4 rounded-md px-2.5 py-1.5 text-[12px]"
               style={{
                 color: "var(--hue-err)",
-                background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
+                background:
+                  "color-mix(in oklch, var(--hue-err) 10%, transparent)",
               }}
             >
-              Heartbeat went stale {formatDuration(selHeartbeat.overdueMs / 1000)} ago — this process is gone, whatever it last reported
-              {sel.currentRun ? ` (it still holds ${sel.currentRun}; the run is reclaimed when its lease expires)` : ""}.
+              Heartbeat went stale{" "}
+              {formatDuration(selHeartbeat.overdueMs / 1000)} ago — this process
+              is gone, whatever it last reported
+              {sel.currentRun
+                ? ` (it still holds ${sel.currentRun}; the run is reclaimed when its lease expires)`
+                : ""}
+              .
             </div>
           )}
 
@@ -908,23 +1151,49 @@ export function Workers({
               <KV
                 k="runId"
                 v={
-                  <JumpLink onClick={() => openRun(sel.currentRun!)} title={`Open ${sel.currentRun}`}>
+                  <JumpLink
+                    onClick={() => openRun(sel.currentRun!)}
+                    title={`Open ${sel.currentRun}`}
+                  >
                     {shortId(sel.currentRun)}
                   </JumpLink>
                 }
               />
               {sel.runItem?.agent && (
-                <KV k="agent" v={<span className="mono font-medium">{sel.runItem.agent}</span>} />
+                <KV
+                  k="agent"
+                  v={
+                    <span className="mono font-medium">
+                      {sel.runItem.agent}
+                    </span>
+                  }
+                />
               )}
-              {sel.activeTarget !== EMPTY && <KV k="target" v={sel.activeTarget} />}
+              {sel.activeTarget !== EMPTY && (
+                <KV k="target" v={sel.activeTarget} />
+              )}
               {sel.runItem && (
                 <KV
                   k="model"
-                  v={<ModelCell model={pinnedModelText(sel.runItem.adapter, sel.runItem.model)} />}
+                  v={
+                    <ModelCell
+                      model={pinnedModelText(
+                        sel.runItem.adapter,
+                        sel.runItem.model,
+                      )}
+                    />
+                  }
                 />
               )}
-              {sel.runItem && <KV k="adapter" v={<span className="mono">{sel.runItem.adapter}</span>} />}
-              {sel.runItem?.state && <KV k="state" v={<StateBadge state={sel.runItem.state} />} />}
+              {sel.runItem && (
+                <KV
+                  k="adapter"
+                  v={<span className="mono">{sel.runItem.adapter}</span>}
+                />
+              )}
+              {sel.runItem?.state && (
+                <KV k="state" v={<StateBadge state={sel.runItem.state} />} />
+              )}
             </Section>
           )}
 
@@ -932,15 +1201,19 @@ export function Workers({
             <div className="rounded-md border border-(--border) px-3 py-2 tabular-nums">
               <div className="flex items-baseline justify-between gap-4">
                 <span className="text-(--text-faint)">
-                  last check-in <span className="text-(--text-dim)" title={sel.lastSeen}>{formatRelative(sel.lastSeen, now)}</span>
+                  last check-in{" "}
+                  <span className="text-(--text-dim)" title={sel.lastSeen}>
+                    {formatRelative(sel.lastSeen, now)}
+                  </span>
                 </span>
                 <StaleClock hb={selHeartbeat} />
               </div>
               <HeartbeatMeter hb={selHeartbeat} />
               {selHeartbeat.kind !== "none" && (
                 <div className="mt-2 text-[11px] text-(--text-faint)">
-                  A worker that has not checked in for {formatDuration(HEARTBEAT_STALE_MS / 1000)} is treated as gone, whatever its
-                  last reported state was.
+                  A worker that has not checked in for{" "}
+                  {formatDuration(HEARTBEAT_STALE_MS / 1000)} is treated as
+                  gone, whatever its last reported state was.
                 </div>
               )}
             </div>
@@ -953,7 +1226,13 @@ export function Workers({
             <KV
               k="state"
               v={
-                <span style={{ color: WORKER_STATE_HUES[workerDisplayState(sel)] ?? "var(--hue-idle)" }}>
+                <span
+                  style={{
+                    color:
+                      WORKER_STATE_HUES[workerDisplayState(sel)] ??
+                      "var(--hue-idle)",
+                  }}
+                >
                   {workerDisplayState(sel)}
                   {sel.stale ? ` (last reported ${sel.state})` : ""}
                 </span>
@@ -963,7 +1242,10 @@ export function Workers({
               k="currentRun"
               v={
                 sel.currentRun ? (
-                  <JumpLink onClick={() => openRun(sel.currentRun!)} title={`Open ${sel.currentRun}`}>
+                  <JumpLink
+                    onClick={() => openRun(sel.currentRun!)}
+                    title={`Open ${sel.currentRun}`}
+                  >
                     {shortId(sel.currentRun)}
                   </JumpLink>
                 ) : (
@@ -971,17 +1253,38 @@ export function Workers({
                 )
               }
             />
-            <KV k="startedAt" v={<span title={sel.startedAt}>{formatRelative(sel.startedAt, now)}</span>} />
-            {sel.stoppedAt && <KV k="stoppedAt" v={<span title={sel.stoppedAt}>{formatRelative(sel.stoppedAt, now)}</span>} />}
+            <KV
+              k="startedAt"
+              v={
+                <span title={sel.startedAt}>
+                  {formatRelative(sel.startedAt, now)}
+                </span>
+              }
+            />
+            {sel.stoppedAt && (
+              <KV
+                k="stoppedAt"
+                v={
+                  <span title={sel.stoppedAt}>
+                    {formatRelative(sel.stoppedAt, now)}
+                  </span>
+                }
+              />
+            )}
           </Section>
 
           <Section title="Adapters" card={false}>
             {sel.adapters.length === 0 ? (
-              <div className="text-(--text-faint)">No adapters declared — this worker claims nothing.</div>
+              <div className="text-(--text-faint)">
+                No adapters declared — this worker claims nothing.
+              </div>
             ) : (
               <div className="rounded-md border border-(--border) px-3 py-1">
                 {sel.adapters.map((a) => (
-                  <div key={a} className="mono border-b border-(--border) py-1.5 last:border-0">
+                  <div
+                    key={a}
+                    className="mono border-b border-(--border) py-1.5 last:border-0"
+                  >
                     {a}
                   </div>
                 ))}
@@ -991,8 +1294,8 @@ export function Workers({
 
           <Section title="Labels" card={false}>
             <div className="mb-1.5 text-[11px] text-(--text-faint)">
-              Placement labels the worker declared at registration — what a run&apos;s placement
-              constraints are matched against.
+              Placement labels the worker declared at registration — what a
+              run&apos;s placement constraints are matched against.
             </div>
             <JsonBlock value={sel.labels} />
           </Section>

--- a/event-runtime/web/src/workerHealth.ts
+++ b/event-runtime/web/src/workerHealth.ts
@@ -4,11 +4,13 @@ import { WORKER_HUES as UI_WORKER_HUES } from "./components/ui";
 export type WorkerHealth = WorkerState | "stale";
 
 /** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector (re-exported from centralized ui.tsx). */
-export const WORKER_HUES: Record<WorkerHealth, string> = UI_WORKER_HUES as Record<WorkerHealth, string>;
+export const WORKER_HUES: Record<WorkerHealth, string> =
+  UI_WORKER_HUES as Record<WorkerHealth, string>;
 
 /**
  * A stale heartbeat outranks whatever the row claims: a stale busy worker is
  * gone, not busy. `listWorkers` never marks a cleanly stopped worker stale, so
  * these four are disjoint.
  */
-export const health = (w: Worker): WorkerHealth => (w.stale ? "stale" : w.state);
+export const health = (w: Worker): WorkerHealth =>
+  w.stale ? "stale" : w.state;

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -25,8 +25,16 @@ const registry = loadRegistry();
 const PV = "git:test-pv";
 // See repository.test.mjs: neutralise the operator's global git config so a
 // signing key or a global hooks path cannot hang the fixture (OPS-441).
-const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
-const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+const HERMETIC = [
+  "-c",
+  "commit.gpgsign=false",
+  "-c",
+  "core.hooksPath=/dev/null",
+  "-c",
+  "commit.template=",
+];
+const git = (args, cwd) =>
+  execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
 
 // Hermetic repo fixtures: a real git repo (the scan's repository workspace
 // pins a SHA) whose config also carries the worktree scripts and team/project
@@ -110,7 +118,9 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-work-home-"));
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(
+    path.join(os.tmpdir(), "evrt-work-home-"),
+  );
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -162,7 +172,10 @@ function workScanEvidence(repo) {
     ];
     inFlightSeen = 3;
   } else {
-    candidates = [seenCandidate(FIRST, "selected"), seenCandidate(SECOND, "selected")];
+    candidates = [
+      seenCandidate(FIRST, "selected"),
+      seenCandidate(SECOND, "selected"),
+    ];
   }
   return {
     commands: ["fake"],
@@ -255,8 +268,16 @@ function workScanArtifact(repo) {
     repo,
     ticket: FIRST,
     plan: [
-      { ticket: FIRST, ownedPaths: ["src/feature-a/**"], reason: "fake: priority 1, disjoint" },
-      { ticket: SECOND, ownedPaths: ["src/feature-b/**"], reason: "fake: priority 2, disjoint" },
+      {
+        ticket: FIRST,
+        ownedPaths: ["src/feature-a/**"],
+        reason: "fake: priority 1, disjoint",
+      },
+      {
+        ticket: SECOND,
+        ownedPaths: ["src/feature-b/**"],
+        reason: "fake: priority 2, disjoint",
+      },
     ],
     deferred: [],
     readyCandidates: 2,
@@ -271,13 +292,17 @@ const workFake = {
     if (spec.outputContract === "factory.work-plan/v1") {
       writeFileSync(
         path.join(workspaceDir, "result.json"),
-        `${JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          reasonCode: "ok",
-          artifact: workScanArtifact(spec.input.repo),
-          evidence: workScanEvidence(spec.input.repo),
-        }, null, 2)}\n`,
+        `${JSON.stringify(
+          {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: workScanArtifact(spec.input.repo),
+            evidence: workScanEvidence(spec.input.repo),
+          },
+          null,
+          2,
+        )}\n`,
         "utf8",
       );
       return { exitCode: 0, timedOut: false };
@@ -285,20 +310,28 @@ const workFake = {
     if (spec.outputContract === "factory.dispatch-result/v1") {
       writeFileSync(
         path.join(workspaceDir, "result.json"),
-        `${JSON.stringify({
-          schemaVersion: "factory.agent-result/v1",
-          terminalState: "completed",
-          reasonCode: "ok",
-          artifact: {
-            outcome: "PR_OPEN",
-            repo: spec.input.repo,
-            ticket: spec.input.ticket,
-            prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/1`,
-            verification: { command: "echo verified", passed: true, output: "verified" },
-            summary: `fake dispatch of ${spec.input.ticket}`,
+        `${JSON.stringify(
+          {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "PR_OPEN",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/1`,
+              verification: {
+                command: "echo verified",
+                passed: true,
+                output: "verified",
+              },
+              summary: `fake dispatch of ${spec.input.ticket}`,
+            },
+            evidence: { commands: ["echo verified"] },
           },
-          evidence: { commands: ["echo verified"] },
-        }, null, 2)}\n`,
+          null,
+          2,
+        )}\n`,
         "utf8",
       );
       return { exitCode: 0, timedOut: false };
@@ -321,7 +354,10 @@ const openWorld = {
     state: { name: "Todo" },
     assignee: null,
     labels: { nodes: [{ name: "ai:agent-ready" }] },
-    description: ticketId === SECOND ? "## Owned Paths\n- src/feature-b/**\n" : "## Owned Paths\n- src/feature-a/**\n",
+    description:
+      ticketId === SECOND
+        ? "## Owned Paths\n- src/feature-b/**\n"
+        : "## Owned Paths\n- src/feature-a/**\n",
   }),
   fetchInFlight: () => [],
   countLeases: () => 0,
@@ -332,15 +368,29 @@ function harness() {
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-work-ws-"));
   const adapters = { pi: workFake };
-  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV, dispatch: openWorld };
+  const workerOpts = {
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+    dispatch: openWorld,
+  };
 
-  const planAll = () => planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld });
+  const planAll = () =>
+    planAdmittedEvents(db, registry, {
+      policyVersion: PV,
+      dispatch: openWorld,
+    });
 
   async function approveNext(agentRef) {
     planAll();
-    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === agentRef,
+    );
     expect(proposal).toBeTruthy();
-    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const approved = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
     const summary = await runOnce(db, registry, adapters, workerOpts);
     return { proposal, runId: approved.runId, summary };
   }
@@ -364,7 +414,11 @@ describe("work-scan registration (WM-110)", () => {
     expect(def.mutating).toBe(false);
     // It verifies Owned Paths globs against real paths, so it reads the
     // pinned tree — repository checkout, never a mutable worktree.
-    expect(def.workspace).toEqual({ type: "repository", checkoutDir: "repo", retainOnFailure: true });
+    expect(def.workspace).toEqual({
+      type: "repository",
+      checkoutDir: "repo",
+      retainOnFailure: true,
+    });
     expect(def.output_contract).toBe("factory.work-plan/v1");
     expect(def.capabilities.services).toEqual(["linear:read", "repo:read"]);
   });
@@ -399,7 +453,9 @@ describe("work-scan registration (WM-110)", () => {
     // route, so a pi+worktree+mutating definition is admitted and its strong
     // tier resolves against models.pi.
     expect(def.model_tier).toBe("strong");
-    expect(resolveModel(def, "pi", registry.modelTiers)).toBe(registry.modelTiers.pi.strong);
+    expect(resolveModel(def, "pi", registry.modelTiers)).toBe(
+      registry.modelTiers.pi.strong,
+    );
   });
 
   test("every LLM route is the pi adapter; command/actions routes are untouched (WM-215)", () => {
@@ -416,18 +472,38 @@ describe("work-scan registration (WM-110)", () => {
     // Every pi route resolves a model: loadRegistry fails closed otherwise,
     // but assert the values so a silently-null resolution can't pass.
     for (const ref of byAdapter.pi) {
-      const resolved = resolveModel(registry.agents.get(ref), "pi", registry.modelTiers);
+      const resolved = resolveModel(
+        registry.agents.get(ref),
+        "pi",
+        registry.modelTiers,
+      );
       expect(Object.values(registry.modelTiers.pi)).toContain(resolved);
     }
   });
 
   test("the plan item shape pins {ticket, ownedPaths, reason}; NOOP reasons are the closed set", () => {
     const schema = registry.agents.get("work-scan@1").outputSchema;
-    expect(schema.properties.plan.items.required).toEqual(["ticket", "ownedPaths", "reason"]);
-    expect(schema.properties.plan.items.properties.ticket.pattern).toBe("^[A-Z]+-[0-9]+$");
-    expect(schema.properties.deferred.items.required).toEqual(["ticket", "reason"]);
-    expect(schema.properties.deferred.items.properties.reason.enum).toEqual(["cap_full", "owned_paths_overlap"]);
-    expect(schema.properties.noopReason.enum).toEqual(["queue_empty", "cap_full", "all_overlapping"]);
+    expect(schema.properties.plan.items.required).toEqual([
+      "ticket",
+      "ownedPaths",
+      "reason",
+    ]);
+    expect(schema.properties.plan.items.properties.ticket.pattern).toBe(
+      "^[A-Z]+-[0-9]+$",
+    );
+    expect(schema.properties.deferred.items.required).toEqual([
+      "ticket",
+      "reason",
+    ]);
+    expect(schema.properties.deferred.items.properties.reason.enum).toEqual([
+      "cap_full",
+      "owned_paths_overlap",
+    ]);
+    expect(schema.properties.noopReason.enum).toEqual([
+      "queue_empty",
+      "cap_full",
+      "all_overlapping",
+    ]);
   });
 
   test("DISPATCH remains multi-emit and LOW_SUPPLY chains to triage", () => {
@@ -460,21 +536,35 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     expect(scan.summary.terminalState).toBe("COMPLETED");
     // The scan run's spec pins an immutable SHA (OPS-228): reproducible, and
     // dedup distinguishes "same repo, new commit".
-    expect(scan.proposal.spec.input.repoPin).toMatchObject({ repo: "wm29", ref: "develop" });
+    expect(scan.proposal.spec.input.repoPin).toMatchObject({
+      repo: "wm29",
+      ref: "develop",
+    });
     expect(scan.proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
 
     // Multi-emit fan-out: every item in plan becomes an admitted internal event.
-    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(scan.runId).result_json,
+    );
     expect(result.artifact.plan).toHaveLength(2);
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 2, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 2,
+      skipped: 0,
+      errors: [],
+    });
     const chainEvent1 = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
       .get(`chain-${scan.runId}-${FIRST}`);
     expect(chainEvent1.type).toBe("factory.dispatch.requested");
     expect(chainEvent1.correlation_id).toBe("work-1"); // inherited from the scan's event
     expect(chainEvent1.causation_id).toBe(scan.runId);
-    expect(JSON.parse(chainEvent1.envelope_json).payload).toEqual({ repo: "wm29", ticket: FIRST });
+    expect(JSON.parse(chainEvent1.envelope_json).payload).toEqual({
+      repo: "wm29",
+      ticket: FIRST,
+    });
 
     const chainEvent2 = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
@@ -482,22 +572,33 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     expect(chainEvent2.type).toBe("factory.dispatch.requested");
     expect(chainEvent2.correlation_id).toBe("work-1");
     expect(chainEvent2.causation_id).toBe(scan.runId);
-    expect(JSON.parse(chainEvent2.envelope_json).payload).toEqual({ repo: "wm29", ticket: SECOND });
+    expect(JSON.parse(chainEvent2.envelope_json).payload).toEqual({
+      repo: "wm29",
+      ticket: SECOND,
+    });
 
     // Both chained events are planned through WM-108's gate (injected world) and
     // land as watched proposals with their respective dispatch input shape.
     planAll();
-    const dispatches = openProposals(db, {}).filter((p) => p.spec?.agent === "dispatch@1");
+    const dispatches = openProposals(db, {}).filter(
+      (p) => p.spec?.agent === "dispatch@1",
+    );
     expect(dispatches).toHaveLength(2);
     for (const dispatch of dispatches) {
       expect(dispatch.status).toBe("open"); // watched: nothing mutates without approval
       expect(dispatch.spec.workspace.type).toBe("worktree");
       expect(dispatch.spec.input.repo).toBe("wm29");
     }
-    expect(dispatches.map((p) => p.spec.input.ticket).sort()).toEqual([FIRST, SECOND].sort());
+    expect(dispatches.map((p) => p.spec.input.ticket).sort()).toEqual(
+      [FIRST, SECOND].sort(),
+    );
 
     // One chain pass per run: re-resolving emits nothing new.
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("a LOW_SUPPLY scan chains to one triage scan", async () => {
@@ -505,19 +606,29 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     admitEvent(db, registry, workEnvelope("low", "work-low-1"));
     const scan = await approveNext("work-scan@1");
     expect(scan.summary.terminalState).toBe("COMPLETED");
-    const scanResult = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    const scanResult = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(scan.runId).result_json,
+    );
     expect(scanResult.artifact.readyCandidates).toBe(0);
     expect(scanResult.artifact.triageBacklog).toBe(3);
 
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
 
-    const chainEvent = db.query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`).get(scan.runId);
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`)
+      .get(scan.runId);
     expect(chainEvent.type).toBe("factory.triage.requested");
-    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({ repo: "low" });
+    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({
+      repo: "low",
+    });
 
     planAll();
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1")).toBeTruthy();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1"),
+    ).toBeTruthy();
   });
 
   test("cap-overlap NOOP outcomes still do not fallback to triage", async () => {
@@ -529,7 +640,11 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
       admitEvent(db, registry, workEnvelope(repo, `work-${repo}-1`));
       const scan = await approveNext("work-scan@1");
       expect(scan.summary.terminalState).toBe("COMPLETED");
-      const scanResult = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+      const scanResult = JSON.parse(
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(scan.runId).result_json,
+      );
       expect(scanResult.artifact.noopReason).toBe(reason);
       expect(scanResult.artifact.readyCandidates).toBe(2);
       expect(scanResult.artifact.triageBacklog).toBe(0);
@@ -538,8 +653,12 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
       expect(chain).toEqual({ emitted: 0, skipped: 1, errors: [] });
 
       planAll();
-      expect(openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1")).toBeUndefined();
-      expect(openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1")).toBeUndefined();
+      expect(
+        openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1"),
+      ).toBeUndefined();
+      expect(
+        openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1"),
+      ).toBeUndefined();
     }
   });
 
@@ -552,17 +671,25 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
 
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 0, skipped: 0, errors: [] });
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1"),
+    ).toBeUndefined();
 
     const journal = db
-      .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
+      .query(
+        `SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`,
+      )
       .get(scan.runId);
     expect(journal.reason).toContain("low_supply_readyCandidates_must_be_0");
   });
 
   test("three ready tickets plus two in progress cannot complete as queue_empty", async () => {
     const { db, approveNext } = harness();
-    admitEvent(db, registry, workEnvelope("contradiction", "work-contradiction-1"));
+    admitEvent(
+      db,
+      registry,
+      workEnvelope("contradiction", "work-contradiction-1"),
+    );
     const scan = await approveNext("work-scan@1");
     expect(scan.summary.terminalState).toBe("FAILED");
     expect(scan.summary.reasonCode).toBe("contract_violation");
@@ -570,7 +697,9 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     const chain = resolveChains(db, registry);
     expect(chain).toEqual({ emitted: 0, skipped: 0, errors: [] });
     const journal = db
-      .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
+      .query(
+        `SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`,
+      )
       .get(scan.runId);
     expect(journal.reason).toContain("queue_empty_candidatesSeen_must_be_0");
   });
@@ -581,18 +710,30 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     const scan = await approveNext("work-scan@1");
     expect(scan.summary.terminalState).toBe("COMPLETED");
 
-    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
     planAll();
-    expect(openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1")).toBeUndefined();
+    expect(
+      openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1"),
+    ).toBeUndefined();
   });
 
   test("re-injecting the same envelope converges: one event, one scan proposal", async () => {
     const { db, planAll } = harness();
-    expect(admitEvent(db, registry, workEnvelope("wm29", "work-3")).admitted).toBe(true);
-    expect(admitEvent(db, registry, workEnvelope("wm29", "work-3")).duplicate).toBe(true);
+    expect(
+      admitEvent(db, registry, workEnvelope("wm29", "work-3")).admitted,
+    ).toBe(true);
+    expect(
+      admitEvent(db, registry, workEnvelope("wm29", "work-3")).duplicate,
+    ).toBe(true);
     planAll();
     expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
-    expect(openProposals(db, {}).filter((p) => p.spec?.agent === "work-scan@1")).toHaveLength(1);
+    expect(
+      openProposals(db, {}).filter((p) => p.spec?.agent === "work-scan@1"),
+    ).toHaveLength(1);
   });
 
   test("a re-fired scan (new eventId, same repo) plans a NEW run — rolling re-fires are not deduped away", async () => {
@@ -605,7 +746,9 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     // re-fire re-reads the queue instead of resolving as duplicate_run.
     admitEvent(db, registry, workEnvelope("wm29", "work-5"));
     planAll();
-    const again = openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1" && p.decision === "run");
+    const again = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "work-scan@1" && p.decision === "run",
+    );
     expect(again).toBeTruthy();
     expect(again.reason).toBeNull();
   });
@@ -620,7 +763,9 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     const dispatch = await approveNext("dispatch@1");
     expect(dispatch.summary.terminalState).toBe("COMPLETED");
     expect(dispatch.summary.reasonCode).toBe("ok");
-    const resultRow = db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(dispatch.runId);
+    const resultRow = db
+      .query(`SELECT result_json FROM results WHERE run_id = ?`)
+      .get(dispatch.runId);
     const result = JSON.parse(resultRow.result_json);
     expect(result.artifact.outcome).toBe("PR_OPEN");
     expect(result.verification.checks).toContain("repo_verify_passed");

--- a/lib/actions-cache.mjs
+++ b/lib/actions-cache.mjs
@@ -5,11 +5,18 @@ export function formatGigabytes(bytes) {
 }
 
 /** Turn GitHub's org cache-usage payload into a stable, display-ready snapshot. */
-export function summarizeActionsCacheUsage(payload, { includedGb, warningPercent }) {
+export function summarizeActionsCacheUsage(
+  payload,
+  { includedGb, warningPercent },
+) {
   if (!Number.isFinite(includedGb) || includedGb <= 0) {
     throw new Error("includedGb must be a positive number");
   }
-  if (!Number.isFinite(warningPercent) || warningPercent <= 0 || warningPercent > 100) {
+  if (
+    !Number.isFinite(warningPercent) ||
+    warningPercent <= 0 ||
+    warningPercent > 100
+  ) {
     throw new Error("warningPercent must be between 0 and 100");
   }
 
@@ -20,10 +27,12 @@ export function summarizeActionsCacheUsage(payload, { includedGb, warningPercent
       bytes: repo.active_caches_size_in_bytes ?? 0,
     }))
     .sort((a, b) => b.bytes - a.bytes || a.name.localeCompare(b.name));
-  const bytes = payload.total_active_caches_size_in_bytes
-    ?? repositories.reduce((total, repo) => total + repo.bytes, 0);
-  const count = payload.total_active_caches_count
-    ?? repositories.reduce((total, repo) => total + repo.count, 0);
+  const bytes =
+    payload.total_active_caches_size_in_bytes ??
+    repositories.reduce((total, repo) => total + repo.bytes, 0);
+  const count =
+    payload.total_active_caches_count ??
+    repositories.reduce((total, repo) => total + repo.count, 0);
   const percent = (bytes / (includedGb * BYTES_PER_GB)) * 100;
 
   return {
@@ -46,11 +55,16 @@ export function renderActionsCacheUsage(summary) {
   ];
 
   for (const repo of summary.repositories) {
-    lines.push(`${repo.name.padEnd(34)} ${String(repo.count).padStart(7)}  ${formatGigabytes(repo.bytes).padStart(12)}`);
+    lines.push(
+      `${repo.name.padEnd(34)} ${String(repo.count).padStart(7)}  ${formatGigabytes(repo.bytes).padStart(12)}`,
+    );
   }
 
   if (summary.warning) {
-    lines.push("", `WARNING: Actions cache storage is at or above the ${summary.warningPercent}% threshold.`);
+    lines.push(
+      "",
+      `WARNING: Actions cache storage is at or above the ${summary.warningPercent}% threshold.`,
+    );
   }
   return lines.join("\n");
 }

--- a/lib/actions-cache.test.mjs
+++ b/lib/actions-cache.test.mjs
@@ -1,25 +1,47 @@
 import { test, expect } from "bun:test";
-import { renderActionsCacheUsage, summarizeActionsCacheUsage } from "./actions-cache.mjs";
+import {
+  renderActionsCacheUsage,
+  summarizeActionsCacheUsage,
+} from "./actions-cache.mjs";
 
 const usage = {
   total_active_caches_size_in_bytes: 45_000_000_000,
   total_active_caches_count: 9,
   repository_cache_usages: [
-    { full_name: "watt-mind/small", active_caches_size_in_bytes: 5_000_000_000, active_caches_count: 2 },
-    { full_name: "watt-mind/large", active_caches_size_in_bytes: 40_000_000_000, active_caches_count: 7 },
+    {
+      full_name: "watt-mind/small",
+      active_caches_size_in_bytes: 5_000_000_000,
+      active_caches_count: 2,
+    },
+    {
+      full_name: "watt-mind/large",
+      active_caches_size_in_bytes: 40_000_000_000,
+      active_caches_count: 7,
+    },
   ],
 };
 
 test("summarizeActionsCacheUsage sorts repositories and warns at the threshold", () => {
-  const summary = summarizeActionsCacheUsage(usage, { includedGb: 70, warningPercent: 60 });
+  const summary = summarizeActionsCacheUsage(usage, {
+    includedGb: 70,
+    warningPercent: 60,
+  });
   expect(summary.percent).toBeCloseTo(64.2857, 3);
   expect(summary.warning).toBe(true);
-  expect(summary.repositories.map((repo) => repo.name)).toEqual(["watt-mind/large", "watt-mind/small"]);
-  expect(renderActionsCacheUsage(summary)).toContain("WARNING: Actions cache storage is at or above the 60% threshold.");
+  expect(summary.repositories.map((repo) => repo.name)).toEqual([
+    "watt-mind/large",
+    "watt-mind/small",
+  ]);
+  expect(renderActionsCacheUsage(summary)).toContain(
+    "WARNING: Actions cache storage is at or above the 60% threshold.",
+  );
 });
 
 test("summarizeActionsCacheUsage falls back to repository totals", () => {
-  const summary = summarizeActionsCacheUsage({ repository_cache_usages: usage.repository_cache_usages }, { includedGb: 100, warningPercent: 60 });
+  const summary = summarizeActionsCacheUsage(
+    { repository_cache_usages: usage.repository_cache_usages },
+    { includedGb: 100, warningPercent: 60 },
+  );
   expect(summary.bytes).toBe(45_000_000_000);
   expect(summary.count).toBe(9);
   expect(summary.warning).toBe(false);

--- a/lib/emit-event.mjs
+++ b/lib/emit-event.mjs
@@ -21,8 +21,13 @@
 
 const DEFAULT_PORT = 7381;
 
-export function buildEnvelope(type, payload, { eventId, subject = null, occurredAt } = {}) {
-  if (!eventId) throw new Error("emit-event: a deterministic eventId is required");
+export function buildEnvelope(
+  type,
+  payload,
+  { eventId, subject = null, occurredAt } = {},
+) {
+  if (!eventId)
+    throw new Error("emit-event: a deterministic eventId is required");
   if (!type) throw new Error("emit-event: type is required");
   return {
     schemaVersion: "factory.event/v1",
@@ -42,7 +47,9 @@ export function buildEnvelope(type, payload, { eventId, subject = null, occurred
  *   runtime is unreachable / refused — callers must not branch on this.
  */
 export async function emitFactoryEvent(type, payload, opts = {}) {
-  const port = Number(opts.port ?? process.env.FACTORY_EVENT_PORT ?? DEFAULT_PORT);
+  const port = Number(
+    opts.port ?? process.env.FACTORY_EVENT_PORT ?? DEFAULT_PORT,
+  );
   const timeoutMs = opts.timeoutMs ?? 1000;
   let envelope;
   try {

--- a/lib/emit-event.test.mjs
+++ b/lib/emit-event.test.mjs
@@ -6,7 +6,11 @@ describe("buildEnvelope", () => {
     const env = buildEnvelope(
       "factory.ticket.dispatched",
       { repo: "bj29", ticket: "CLNT-1" },
-      { eventId: "dispatch:CLNT-1:x", subject: "CLNT-1", occurredAt: "2026-08-14T00:00:00Z" },
+      {
+        eventId: "dispatch:CLNT-1:x",
+        subject: "CLNT-1",
+        occurredAt: "2026-08-14T00:00:00Z",
+      },
     );
     expect(env).toEqual({
       schemaVersion: "factory.event/v1",

--- a/lib/factory-gitignore.mjs
+++ b/lib/factory-gitignore.mjs
@@ -37,7 +37,8 @@ export function spliceHarnessGitignore(existing) {
     const before = body.slice(0, i);
     const after = body.slice(j + HARNES_END.length);
     const prefix = before.endsWith("\n") || !before ? before : `${before}\n`;
-    const suffix = after.startsWith("\n") || !after.trim() ? after : `\n${after}`;
+    const suffix =
+      after.startsWith("\n") || !after.trim() ? after : `\n${after}`;
     return `${prefix}${HARNES_BLOCK}${suffix}`;
   }
   const sep = body.trim() ? body.replace(/\s*$/, "") + "\n\n" : "";
@@ -46,7 +47,7 @@ export function spliceHarnessGitignore(existing) {
 
 /**
  * Ensure repo/.gitignore excludes factory harness symlinks.
- * @returns {"ok"|"added"|"updated"|"skip"} 
+ * @returns {"ok"|"added"|"updated"|"skip"}
  */
 export function ensureHarnessGitignore(repoPath) {
   const file = path.join(repoPath, ".gitignore");

--- a/lib/factory-gitignore.test.mjs
+++ b/lib/factory-gitignore.test.mjs
@@ -48,9 +48,13 @@ test("splice replaces stale marked block", () => {
 // (WM-652, same failure shape as OPS-69). Nothing else notices the drift.
 test("this repo tracks no factory command symlinks", () => {
   const root = path.resolve(import.meta.dir, "..");
-  const tracked = execFileSync("git", ["ls-files", "--", ".claude/commands", ".cursor/commands"], {
-    cwd: root,
-    encoding: "utf8",
-  }).trim();
+  const tracked = execFileSync(
+    "git",
+    ["ls-files", "--", ".claude/commands", ".cursor/commands"],
+    {
+      cwd: root,
+      encoding: "utf8",
+    },
+  ).trim();
   expect(tracked).toBe("");
 });

--- a/lib/factory-root.mjs
+++ b/lib/factory-root.mjs
@@ -16,7 +16,10 @@ export function factoryRoot() {
   const defaultPath = path.join(homedir(), "Develop/factory");
   if (existsSync(path.join(defaultPath, MARKER))) return defaultPath;
 
-  const fromLib = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const fromLib = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
   if (existsSync(path.join(fromLib, MARKER))) return fromLib;
 
   return env ? path.resolve(env) : defaultPath;

--- a/lib/factory-state.mjs
+++ b/lib/factory-state.mjs
@@ -35,7 +35,11 @@ function readLines(file = EVENTS_FILE) {
     .split("\n")
     .filter(Boolean)
     .map((line) => {
-      try { return JSON.parse(line); } catch { return null; }
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
     })
     .filter(Boolean);
 }
@@ -43,7 +47,14 @@ function readLines(file = EVENTS_FILE) {
 /**
  * @param {{ repo?: string, harness?: string, session?: string, since?: number, limit?: number, file?: string }} opts
  */
-export function readEvents({ repo, harness, session, since = 0, limit, file = EVENTS_FILE } = {}) {
+export function readEvents({
+  repo,
+  harness,
+  session,
+  since = 0,
+  limit,
+  file = EVENTS_FILE,
+} = {}) {
   let events = readLines(file);
   if (repo) events = events.filter((e) => e.repo === repo);
   if (harness) events = events.filter((e) => e.harness === harness);
@@ -75,7 +86,13 @@ export function resolveSessionId(ctx) {
 /**
  * @param {{ repo: string, harness?: string, now?: number, file?: string, idleMs?: number }} opts
  */
-export function activeSession({ repo, harness, now = Date.now(), file = EVENTS_FILE, idleMs = SESSION_IDLE_MS }) {
+export function activeSession({
+  repo,
+  harness,
+  now = Date.now(),
+  file = EVENTS_FILE,
+  idleMs = SESSION_IDLE_MS,
+}) {
   const events = readEvents({ repo, harness, file });
   const sessions = sessionsFromEvents(events);
   if (!sessions.length) return null;
@@ -98,14 +115,20 @@ export function activeSession({ repo, harness, now = Date.now(), file = EVENTS_F
  * @param {object} event
  * @param {{ file?: string, now?: number }} opts
  */
-export function appendEvent(event, { file = EVENTS_FILE, now = Date.now() } = {}) {
+export function appendEvent(
+  event,
+  { file = EVENTS_FILE, now = Date.now() } = {},
+) {
   mkdirSync(path.dirname(file), { recursive: true });
 
-  const session = event.session
-    ?? process.env.FACTORY_SESSION_ID
-    ?? resolveSessionId({ repo: event.repo, harness: event.harness, now, file });
+  const session =
+    event.session ??
+    process.env.FACTORY_SESSION_ID ??
+    resolveSessionId({ repo: event.repo, harness: event.harness, now, file });
 
-  const prior = event.repo ? readEvents({ repo: event.repo, session, file }) : [];
+  const prior = event.repo
+    ? readEvents({ repo: event.repo, session, file })
+    : [];
   const needsSessionStart =
     event.repo &&
     event.type !== "session-start" &&
@@ -113,13 +136,17 @@ export function appendEvent(event, { file = EVENTS_FILE, now = Date.now() } = {}
     !prior.length;
 
   if (needsSessionStart) {
-    appendFileSync(file, `${JSON.stringify({
-      ts: new Date(now).toISOString(),
-      type: "session-start",
-      repo: event.repo,
-      harness: event.harness ?? "unknown",
-      session,
-    })}\n`, "utf8");
+    appendFileSync(
+      file,
+      `${JSON.stringify({
+        ts: new Date(now).toISOString(),
+        type: "session-start",
+        repo: event.repo,
+        harness: event.harness ?? "unknown",
+        session,
+      })}\n`,
+      "utf8",
+    );
   }
 
   const row = { ts: new Date(now).toISOString(), ...event, session };
@@ -162,11 +189,17 @@ export function formatDuration(ms) {
 export function eventLabel(e) {
   switch (e.type) {
     case "recommend": {
-      const slash = e.slash ?? (e.command ? `/factory-${String(e.command).replace(/^factory-/, "")}${e.args ? ` ${e.args}` : ""}` : "(wait)");
+      const slash =
+        e.slash ??
+        (e.command
+          ? `/factory-${String(e.command).replace(/^factory-/, "")}${e.args ? ` ${e.args}` : ""}`
+          : "(wait)");
       return `recommend   ${slash}`;
     }
     case "start": {
-      const cmd = e.command ? `/factory-${String(e.command).replace(/^factory-/, "")}${e.args ? ` ${e.args}` : ""}` : e.exec ?? "?";
+      const cmd = e.command
+        ? `/factory-${String(e.command).replace(/^factory-/, "")}${e.args ? ` ${e.args}` : ""}`
+        : (e.exec ?? "?");
       return `start       ${cmd}`;
     }
     case "complete":

--- a/lib/factory-state.test.mjs
+++ b/lib/factory-state.test.mjs
@@ -16,14 +16,48 @@ test("appendEvent groups events into one session per repo/harness window", () =>
   const file = path.join(dir, "events.jsonl");
   const t0 = Date.UTC(2026, 7, 10, 17, 0, 0);
 
-  appendEvent({ type: "session-start", repo: "bj29", harness: "cursor", session: "cursor-bj29-test" }, { file, now: t0 });
-  const start = appendEvent({ type: "recommend", repo: "bj29", harness: "cursor", command: "factory-triage", args: "5", session: "cursor-bj29-test" }, { file, now: t0 + 1000 });
-  appendEvent({ type: "start", repo: "bj29", harness: "cursor", command: "factory-triage", args: "5", session: "cursor-bj29-test" }, { file, now: t0 + 2000 });
+  appendEvent(
+    {
+      type: "session-start",
+      repo: "bj29",
+      harness: "cursor",
+      session: "cursor-bj29-test",
+    },
+    { file, now: t0 },
+  );
+  const start = appendEvent(
+    {
+      type: "recommend",
+      repo: "bj29",
+      harness: "cursor",
+      command: "factory-triage",
+      args: "5",
+      session: "cursor-bj29-test",
+    },
+    { file, now: t0 + 1000 },
+  );
+  appendEvent(
+    {
+      type: "start",
+      repo: "bj29",
+      harness: "cursor",
+      command: "factory-triage",
+      args: "5",
+      session: "cursor-bj29-test",
+    },
+    { file, now: t0 + 2000 },
+  );
 
   expect(start.session).toBe("cursor-bj29-test");
   expect(readEvents({ repo: "bj29", file })).toHaveLength(3);
 
-  const active = activeSession({ repo: "bj29", harness: "cursor", now: t0 + 60_000, file, idleMs: SESSION_IDLE_MS });
+  const active = activeSession({
+    repo: "bj29",
+    harness: "cursor",
+    now: t0 + 60_000,
+    file,
+    idleMs: SESSION_IDLE_MS,
+  });
   expect(active?.id).toBe(start.session);
 
   rmSync(dir, { recursive: true, force: true });
@@ -34,8 +68,13 @@ test("activeSession expires after idle gap", () => {
   const file = path.join(dir, "events.jsonl");
   const t0 = Date.UTC(2026, 7, 10, 17, 0, 0);
 
-  appendEvent({ type: "start", repo: "bj29", harness: "pi", command: "factory-work" }, { file, now: t0 });
-  expect(activeSession({ repo: "bj29", now: t0 + SESSION_IDLE_MS + 1, file })).toBeNull();
+  appendEvent(
+    { type: "start", repo: "bj29", harness: "pi", command: "factory-work" },
+    { file, now: t0 },
+  );
+  expect(
+    activeSession({ repo: "bj29", now: t0 + SESSION_IDLE_MS + 1, file }),
+  ).toBeNull();
 
   rmSync(dir, { recursive: true, force: true });
 });
@@ -43,11 +82,17 @@ test("activeSession expires after idle gap", () => {
 test("resolveSessionId respects FACTORY_SESSION_ID", () => {
   const prev = process.env.FACTORY_SESSION_ID;
   process.env.FACTORY_SESSION_ID = "custom-session";
-  expect(resolveSessionId({ repo: "bj29", harness: "cursor" })).toBe("custom-session");
+  expect(resolveSessionId({ repo: "bj29", harness: "cursor" })).toBe(
+    "custom-session",
+  );
   process.env.FACTORY_SESSION_ID = prev;
 });
 
 test("eventLabel formats recommend and complete rows", () => {
-  expect(eventLabel({ type: "recommend", command: "factory-merge", args: "" })).toBe("recommend   /factory-merge");
-  expect(eventLabel({ type: "complete", summary: "merged 2 PRs" })).toBe("complete    merged 2 PRs");
+  expect(
+    eventLabel({ type: "recommend", command: "factory-merge", args: "" }),
+  ).toBe("recommend   /factory-merge");
+  expect(eventLabel({ type: "complete", summary: "merged 2 PRs" })).toBe(
+    "complete    merged 2 PRs",
+  );
 });

--- a/lib/floor.mjs
+++ b/lib/floor.mjs
@@ -27,7 +27,9 @@ export function spliceFloor(existing, floorBlock) {
   const i = body.indexOf(FLOOR_BEGIN);
   const j = body.indexOf(FLOOR_END);
   if (i !== -1 && j !== -1 && j > i) {
-    return body.slice(0, i) + floorBlock.trim() + body.slice(j + FLOOR_END.length);
+    return (
+      body.slice(0, i) + floorBlock.trim() + body.slice(j + FLOOR_END.length)
+    );
   }
   // Append rather than prepend: a human opening AGENTS.md should see the repo's
   // own orientation first, not 100 lines of boilerplate.
@@ -37,4 +39,6 @@ export function spliceFloor(existing, floorBlock) {
 
 /** True when the repo's AGENTS.md already carries exactly this floor. */
 export const floorIsCurrent = (existing, floorBlock) =>
-  Boolean(existing) && existing.includes(FLOOR_BEGIN) && spliceFloor(existing, floorBlock) === existing;
+  Boolean(existing) &&
+  existing.includes(FLOOR_BEGIN) &&
+  spliceFloor(existing, floorBlock) === existing;

--- a/lib/floor.test.mjs
+++ b/lib/floor.test.mjs
@@ -10,15 +10,19 @@
 import { test, expect } from "bun:test";
 import { spliceFloor } from "./floor.mjs";
 
-const FLOOR = "<!-- FACTORY:FLOOR:BEGIN -->\n## Agent operating floor\n\nrule one.\n<!-- FACTORY:FLOOR:END -->";
-const FLOOR_V2 = "<!-- FACTORY:FLOOR:BEGIN -->\n## Agent operating floor\n\nrule one.\nrule two.\n<!-- FACTORY:FLOOR:END -->";
+const FLOOR =
+  "<!-- FACTORY:FLOOR:BEGIN -->\n## Agent operating floor\n\nrule one.\n<!-- FACTORY:FLOOR:END -->";
+const FLOOR_V2 =
+  "<!-- FACTORY:FLOOR:BEGIN -->\n## Agent operating floor\n\nrule one.\nrule two.\n<!-- FACTORY:FLOOR:END -->";
 
 test("appends the floor to a repo that has none, keeping the repo's own content", () => {
   const out = spliceFloor("# bj29\n\nRun `npm test` before pushing.\n", FLOOR);
   expect(out).toContain("Run `npm test` before pushing.");
   expect(out).toContain("## Agent operating floor");
   // The repo's own orientation must stay at the top; the floor is boilerplate.
-  expect(out.indexOf("bj29")).toBeLessThan(out.indexOf("Agent operating floor"));
+  expect(out.indexOf("bj29")).toBeLessThan(
+    out.indexOf("Agent operating floor"),
+  );
 });
 
 test("creates a usable file when AGENTS.md is empty or absent", () => {
@@ -49,7 +53,8 @@ test("preserves repo content written AFTER the floor block", () => {
 
 test("a truncated marker pair is treated as absent rather than corrupting the file", () => {
   // A half-written file (BEGIN but no END) must not swallow the rest of the doc.
-  const body = "# repo\n\n<!-- FACTORY:FLOOR:BEGIN -->\n\n## Repo-specific\n\nkeep me.\n";
+  const body =
+    "# repo\n\n<!-- FACTORY:FLOOR:BEGIN -->\n\n## Repo-specific\n\nkeep me.\n";
   const out = spliceFloor(body, FLOOR);
   expect(out).toContain("keep me.");
 });

--- a/lib/next-recommend.mjs
+++ b/lib/next-recommend.mjs
@@ -12,9 +12,19 @@ import { STAGE_GATES } from "./queue-summary.mjs";
  * @param {QueueSummary} s
  * @param {{ orchestrated?: boolean, includeSweep?: boolean }} opts
  */
-export function recommendNext(s, { orchestrated = false, includeSweep = false } = {}) {
+export function recommendNext(
+  s,
+  { orchestrated = false, includeSweep = false } = {},
+) {
   const alternates = [];
-  const note = (cmd, args, reason, extra = {}) => ({ repo: s.repo, command: cmd, args, reason, alternates, ...extra });
+  const note = (cmd, args, reason, extra = {}) => ({
+    repo: s.repo,
+    command: cmd,
+    args,
+    reason,
+    alternates,
+    ...extra,
+  });
 
   const loopIdle =
     !STAGE_GATES.merge(s) &&
@@ -23,71 +33,107 @@ export function recommendNext(s, { orchestrated = false, includeSweep = false } 
     s.todoNotReady === 0;
 
   if (s.answered > 0) {
-    return note("factory-triage", "5",
+    return note(
+      "factory-triage",
+      "5",
       `${s.answered} held ticket(s) have replies — triage releases holds and re-runs promote-or-hold`,
-      { constraint: "holds with answers", stage: "triage" });
+      { constraint: "holds with answers", stage: "triage" },
+    );
   }
 
   if (s.openPRs > 0) {
     if (STAGE_GATES.triage(s)) {
-      alternates.push(note("factory-triage", "5",
-        `${s.triageState} Triage ticket(s) — specification backlog`, { stage: "triage" }));
+      alternates.push(
+        note(
+          "factory-triage",
+          "5",
+          `${s.triageState} Triage ticket(s) — specification backlog`,
+          { stage: "triage" },
+        ),
+      );
     }
-    return note("factory-merge", "",
+    return note(
+      "factory-merge",
+      "",
       `${s.openPRs} open PR(s) waiting on GitHub (merge gate open)`,
-      { constraint: "merge backlog", stage: "merge" });
+      { constraint: "merge backlog", stage: "merge" },
+    );
   }
 
   if (s.slotsFree > 0 && s.startable.length > 0) {
     if (s.reportOnly) {
-      return note(null, "",
+      return note(
+        null,
+        "",
         `report_only — ${s.startable.length} startable ticket(s) but dispatch is disabled here (PC-15)`,
-        { constraint: "report_only", stage: "none" });
+        { constraint: "report_only", stage: "none" },
+      );
     }
     const ids = s.startable.slice(0, 3).join(", ");
     if (orchestrated) {
-      return note("tick", "",
+      return note(
+        "tick",
+        "",
         `${s.startable.length} startable, ${s.slotsFree} slot(s) free — would start ${ids}`,
         {
           constraint: "execution",
           stage: "dispatch",
           exec: `bun orchestrator/tick.mjs --repo ${s.repo} --apply`,
           slash: null,
-        });
+        },
+      );
     }
-    return note("factory-work", "3 at a time",
+    return note(
+      "factory-work",
+      "3 at a time",
       `${s.startable.length} startable, ${s.slotsFree} slot(s) free — would start ${ids}`,
-      { constraint: "execution", stage: "dispatch" });
+      { constraint: "execution", stage: "dispatch" },
+    );
   }
 
   if (s.ready > 0 && s.slotsFree === 0) {
-    return note(null, "",
+    return note(
+      null,
+      "",
       `${s.ready} ready ticket(s) but no free slot (${s.inProgress} In Progress, cap full) — wait for a slot`,
-      { constraint: "capacity", stage: "none" });
+      { constraint: "capacity", stage: "none" },
+    );
   }
 
   if (s.ready > 0 && s.slotsFree > 0) {
-    return note(null, "",
+    return note(
+      null,
+      "",
       `${s.ready} ready but none startable — Owned Paths collide with in-flight work`,
-      { constraint: "path collision", stage: "none" });
+      { constraint: "path collision", stage: "none" },
+    );
   }
 
   if (s.readyHeld > 0) {
-    return note(null, "",
+    return note(
+      null,
+      "",
       `${s.readyHeld} ready ticket(s) held by blockers — dispatch waits for their dependencies`,
-      { constraint: "blocked", stage: "none" });
+      { constraint: "blocked", stage: "none" },
+    );
   }
 
   if (s.triageState > 0) {
-    return note("factory-triage", "5",
+    return note(
+      "factory-triage",
+      "5",
       `${s.triageState} ticket(s) in Triage — specification is the bottleneck`,
-      { constraint: "specification", stage: "triage" });
+      { constraint: "specification", stage: "triage" },
+    );
   }
 
   if (s.todoNotReady > 0) {
-    return note("factory-triage", "5",
+    return note(
+      "factory-triage",
+      "5",
       `${s.todoNotReady} Todo ticket(s) missing ai:agent-ready — triage or label-guard`,
-      { constraint: "specification", stage: "triage" });
+      { constraint: "specification", stage: "triage" },
+    );
   }
 
   if (s.orphanedClaims > 0) {
@@ -111,14 +157,23 @@ export function recommendNext(s, { orchestrated = false, includeSweep = false } 
       exec: `bun orchestrator/digest.mjs --repo ${s.repo}`,
       stage: "digest",
     });
-    alternates.push(note("factory-unblock", "10",
-      `${n} hold(s) — re-examine for evidence that resolved without a reply`, { stage: "unblock" }));
+    alternates.push(
+      note(
+        "factory-unblock",
+        "10",
+        `${n} hold(s) — re-examine for evidence that resolved without a reply`,
+        { stage: "unblock" },
+      ),
+    );
   }
 
   if (includeSweep && loopIdle) {
-    return note("factory-sweep", "20",
+    return note(
+      "factory-sweep",
+      "20",
       "main loop idle — optional hygiene sweep for obsolete tickets",
-      { constraint: "idle", stage: "sweep" });
+      { constraint: "idle", stage: "sweep" },
+    );
   }
 
   if (alternates.length) {
@@ -127,6 +182,8 @@ export function recommendNext(s, { orchestrated = false, includeSweep = false } 
     return primary;
   }
 
-  return note(null, "", "idle — nothing the factory loop would run right now",
-    { constraint: "idle", stage: "none" });
+  return note(null, "", "idle — nothing the factory loop would run right now", {
+    constraint: "idle",
+    stage: "none",
+  });
 }

--- a/lib/ps.mjs
+++ b/lib/ps.mjs
@@ -34,7 +34,8 @@ export const noColors = {
 
 export const pad = (val, width) => String(val ?? "-").padEnd(width);
 export const cell = (val, width) => `${pad(val, width)}  `;
-const expand = (p, home = osHomedir()) => (p ? String(p).replace(/^~/, home) : p);
+const expand = (p, home = osHomedir()) =>
+  p ? String(p).replace(/^~/, home) : p;
 
 /**
  * Parse lines from `ps -axo pid,ppid,%cpu,%mem,etime,command`
@@ -45,9 +46,12 @@ export function parsePs(raw) {
   const procs = [];
   for (const line of lines) {
     const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("PID") || trimmed.startsWith("pid")) continue;
+    if (!trimmed || trimmed.startsWith("PID") || trimmed.startsWith("pid"))
+      continue;
     // Format: PID PPID %CPU %MEM ETIME COMMAND...
-    const match = trimmed.match(/^(\d+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+(\S+)\s+(.+)$/);
+    const match = trimmed.match(
+      /^(\d+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+(\S+)\s+(.+)$/,
+    );
     if (!match) continue;
     const [, pidStr, ppidStr, cpuStr, memStr, etime, command] = match;
     procs.push({
@@ -71,7 +75,12 @@ export function parseLsof(raw) {
   const entries = [];
   for (const line of lines) {
     const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("COMMAND") || trimmed.startsWith("command")) continue;
+    if (
+      !trimmed ||
+      trimmed.startsWith("COMMAND") ||
+      trimmed.startsWith("command")
+    )
+      continue;
     // Example: bun 80301 hdkiller 12u IPv4 0x... 0t0 TCP 127.0.0.1:7404 (LISTEN)
     // or: Google Chrome 671 hdkiller 11u IPv6 0x... 0t0 TCP *:60840 (LISTEN)
     const parts = trimmed.split(/\s+/);
@@ -133,7 +142,9 @@ export function extractAdapterOverride(command) {
 export function extractWorktreePath(command, home = osHomedir()) {
   if (!command) return null;
   const expanded = expand(command, home);
-  const wtMatch = expanded.match(/(\/[^\s]+(?:\.worktrees\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))/);
+  const wtMatch = expanded.match(
+    /(\/[^\s]+(?:\.worktrees\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))/,
+  );
   if (wtMatch) return wtMatch[1];
   const devMatch = expanded.match(/(\/[^\s]+(?:Develop\/[a-zA-Z0-9_.-]+))/);
   if (devMatch) return devMatch[1];
@@ -143,7 +154,10 @@ export function extractWorktreePath(command, home = osHomedir()) {
 /**
  * Categorize a single process from `ps`
  */
-export function categorizeProcess(proc, { worktrees = [], repos = [], home = osHomedir() } = {}) {
+export function categorizeProcess(
+  proc,
+  { worktrees = [], repos = [], home = osHomedir() } = {},
+) {
   const cmd = proc.command;
 
   // Ignore Electron desktop helper processes for Claude / ChatGPT chrome extension
@@ -158,16 +172,22 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
   }
 
   // Find if process PID matches any known worktree pidfile
-  const matchingWt = worktrees.find((wt) =>
-    Object.values(wt.pids || {}).includes(proc.pid) || (wt.path && cmd.includes(wt.path)),
+  const matchingWt = worktrees.find(
+    (wt) =>
+      Object.values(wt.pids || {}).includes(proc.pid) ||
+      (wt.path && cmd.includes(wt.path)),
   );
 
   // 1. Control Plane Services
-  if (cmd.includes("event-runtime/cli.mjs serve") || cmd.includes("event-runtime/cli.js serve")) {
+  if (
+    cmd.includes("event-runtime/cli.mjs serve") ||
+    cmd.includes("event-runtime/cli.js serve")
+  ) {
     const port = extractPortFlag(cmd);
     const adapter = extractAdapterOverride(cmd);
     const worktree = matchingWt?.path ?? extractWorktreePath(cmd, home);
-    const ticket = matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
+    const ticket =
+      matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
     return {
       kind: "control-plane",
       service: "serve",
@@ -180,10 +200,14 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
     };
   }
 
-  if (cmd.includes("event-runtime/web/serve.mjs") || cmd.includes("event-runtime/web/serve.js")) {
+  if (
+    cmd.includes("event-runtime/web/serve.mjs") ||
+    cmd.includes("event-runtime/web/serve.js")
+  ) {
     const port = extractPortFlag(cmd);
     const worktree = matchingWt?.path ?? extractWorktreePath(cmd, home);
-    const ticket = matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
+    const ticket =
+      matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
     return {
       kind: "control-plane",
       service: "web",
@@ -195,10 +219,14 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
     };
   }
 
-  if (cmd.includes("event-runtime/cli.mjs work") || cmd.includes("event-runtime/cli.js work")) {
+  if (
+    cmd.includes("event-runtime/cli.mjs work") ||
+    cmd.includes("event-runtime/cli.js work")
+  ) {
     const adapter = extractAdapterOverride(cmd);
     const worktree = matchingWt?.path ?? extractWorktreePath(cmd, home);
-    const ticket = matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
+    const ticket =
+      matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
     return {
       kind: "control-plane",
       service: "worker",
@@ -211,10 +239,14 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
   }
 
   // 2. Vite / Dev servers running inside event-runtime/web
-  if (cmd.includes("vite") && (cmd.includes("event-runtime/web") || cmd.includes("factory"))) {
+  if (
+    cmd.includes("vite") &&
+    (cmd.includes("event-runtime/web") || cmd.includes("factory"))
+  ) {
     const port = extractPortFlag(cmd);
     const worktree = matchingWt?.path ?? extractWorktreePath(cmd, home);
-    const ticket = matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
+    const ticket =
+      matchingWt?.ticket ?? (extractTicket(cmd) || extractTicket(worktree));
     return {
       kind: "control-plane",
       service: "web",
@@ -241,7 +273,11 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
   }
 
   // CLI Claude runs (e.g. `claude -p` or bare `claude` in an interactive shell)
-  if (/(?:^|\/|\s)claude(?:\s|$)/.test(cmd) && !cmd.includes("/Applications/") && !cmd.includes("Helper")) {
+  if (
+    /(?:^|\/|\s)claude(?:\s|$)/.test(cmd) &&
+    !cmd.includes("/Applications/") &&
+    !cmd.includes("Helper")
+  ) {
     const ticket = extractTicket(cmd) || matchingWt?.ticket;
     const worktree = matchingWt?.path ?? extractWorktreePath(cmd, home);
     return {
@@ -262,7 +298,9 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
     cmd.includes("orchestrator/doctor.mjs") ||
     cmd.includes("tools/dispatch.mjs")
   ) {
-    const script = cmd.match(/(?:orchestrator|tools)\/([a-zA-Z0-9_-]+)\.mjs/)?.[1] ?? "orchestrator";
+    const script =
+      cmd.match(/(?:orchestrator|tools)\/([a-zA-Z0-9_-]+)\.mjs/)?.[1] ??
+      "orchestrator";
     const ticket = extractTicket(cmd) || matchingWt?.ticket;
     return {
       kind: "agent",
@@ -313,9 +351,13 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
 
 /** Read the POSIX process state and full command for a PID. */
 function inspectPidWithPs(pid) {
-  const result = spawnSync("ps", ["-o", "stat=", "-o", "command=", "-p", String(pid)], {
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    "ps",
+    ["-o", "stat=", "-o", "command=", "-p", String(pid)],
+    {
+      encoding: "utf8",
+    },
+  );
   if (result.status !== 0) return null;
   return String(result.stdout ?? "").trim() || null;
 }
@@ -324,7 +366,11 @@ function inspectPidWithPs(pid) {
 export function isPidAlive(
   pid,
   expectedCommand = null,
-  { inspectPid = inspectPidWithPs, kill = process.kill, platform = process.platform } = {},
+  {
+    inspectPid = inspectPidWithPs,
+    kill = process.kill,
+    platform = process.platform,
+  } = {},
 ) {
   const numericPid = Number(pid);
   if (!Number.isInteger(numericPid) || numericPid <= 0) return false;
@@ -340,11 +386,17 @@ export function isPidAlive(
 
   try {
     const processInfo = inspectPid(numericPid);
-    const match = String(processInfo ?? "").trim().match(/^(\S+)\s+(.+)$/s);
+    const match = String(processInfo ?? "")
+      .trim()
+      .match(/^(\S+)\s+(.+)$/s);
     if (!match) return false;
 
     const [, state, command] = match;
-    if (state.toUpperCase().includes("Z") || command.toLowerCase().includes("<defunct>")) return false;
+    if (
+      state.toUpperCase().includes("Z") ||
+      command.toLowerCase().includes("<defunct>")
+    )
+      return false;
     return expectedCommand ? command.includes(expectedCommand) : true;
   } catch {
     return false;
@@ -391,7 +443,8 @@ export function scanWorktrees({
   if (existsSync(fallback)) {
     try {
       for (const entry of readdirSync(fallback, { withFileTypes: true })) {
-        if (entry.isDirectory()) rootsToScan.add(path.join(fallback, entry.name));
+        if (entry.isDirectory())
+          rootsToScan.add(path.join(fallback, entry.name));
       }
     } catch {
       // ignore
@@ -417,7 +470,9 @@ export function scanWorktrees({
             const gitContent = readFileSync(gitPath, "utf8").trim();
             if (gitContent.startsWith("gitdir:")) {
               const gitDir = gitContent.slice("gitdir:".length).trim();
-              const headPath = path.isAbsolute(gitDir) ? path.join(gitDir, "HEAD") : path.join(wtPath, gitDir, "HEAD");
+              const headPath = path.isAbsolute(gitDir)
+                ? path.join(gitDir, "HEAD")
+                : path.join(wtPath, gitDir, "HEAD");
               if (existsSync(headPath)) {
                 const headRef = readFileSync(headPath, "utf8").trim();
                 branch = headRef.replace(/^ref:\s*refs\/heads\//, "");
@@ -466,7 +521,11 @@ export function scanWorktrees({
 /**
  * Probe a Control API on host:port
  */
-export async function probeControlApi({ host = API_HOST, port = DEFAULT_PORT, timeoutMs = 800 } = {}) {
+export async function probeControlApi({
+  host = API_HOST,
+  port = DEFAULT_PORT,
+  timeoutMs = 800,
+} = {}) {
   const base = `http://${host}:${port}`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -478,7 +537,9 @@ export async function probeControlApi({ host = API_HOST, port = DEFAULT_PORT, ti
 
     let workers = [];
     try {
-      const wRes = await fetch(`${base}/workers`, { signal: controller.signal });
+      const wRes = await fetch(`${base}/workers`, {
+        signal: controller.signal,
+      });
       if (wRes.ok) {
         const wJson = await wRes.json();
         workers = wJson.workers ?? [];
@@ -539,7 +600,11 @@ export async function collectFactoryPsSnapshot({
     psOutput ??
     (() => {
       try {
-        const r = spawnSync("ps", ["-axo", "pid,ppid,%cpu,%mem,etime,command"], { encoding: "utf8" });
+        const r = spawnSync(
+          "ps",
+          ["-axo", "pid,ppid,%cpu,%mem,etime,command"],
+          { encoding: "utf8" },
+        );
         return r.stdout ?? "";
       } catch {
         return "";
@@ -550,7 +615,9 @@ export async function collectFactoryPsSnapshot({
     lsofOutput ??
     (() => {
       try {
-        const r = spawnSync("lsof", ["-iTCP", "-sTCP:LISTEN", "-n", "-P"], { encoding: "utf8" });
+        const r = spawnSync("lsof", ["-iTCP", "-sTCP:LISTEN", "-n", "-P"], {
+          encoding: "utf8",
+        });
         return r.stdout ?? "";
       } catch {
         return "";
@@ -575,7 +642,17 @@ export async function collectFactoryPsSnapshot({
   const devServers = [];
 
   for (const item of categorized) {
-    const { proc, kind, service, port, adapter, worktree, ticket, harness, subservice } = item;
+    const {
+      proc,
+      kind,
+      service,
+      port,
+      adapter,
+      worktree,
+      ticket,
+      harness,
+      subservice,
+    } = item;
 
     if (kind === "control-plane") {
       let resolvedPort = port;
@@ -646,14 +723,20 @@ export async function collectFactoryPsSnapshot({
 
   // Also check ports in 7381..7800 from listeningPorts that match bun/node
   for (const lp of listeningPorts) {
-    if (lp.port >= 7381 && lp.port <= 7800 && (lp.command.includes("bun") || lp.command.includes("node"))) {
+    if (
+      lp.port >= 7381 &&
+      lp.port <= 7800 &&
+      (lp.command.includes("bun") || lp.command.includes("node"))
+    ) {
       candidatePorts.add(lp.port);
     }
   }
 
   const apiProbes = [];
   if (fetchApi) {
-    const probePromises = Array.from(candidatePorts).map((p) => probeControlApi({ port: p }));
+    const probePromises = Array.from(candidatePorts).map((p) =>
+      probeControlApi({ port: p }),
+    );
     const results = await Promise.allSettled(probePromises);
     for (const res of results) {
       if (res.status === "fulfilled" && res.value) {
@@ -675,7 +758,11 @@ export async function collectFactoryPsSnapshot({
     }
     if (Array.isArray(probe.runs)) {
       for (const r of probe.runs) {
-        if (r.state === "RUNNING" || r.state === "LEASED" || r.state === "PROPOSED") {
+        if (
+          r.state === "RUNNING" ||
+          r.state === "LEASED" ||
+          r.state === "PROPOSED"
+        ) {
           inFlightRuns.push({ ...r, apiPort: probe.port });
         }
       }
@@ -686,7 +773,9 @@ export async function collectFactoryPsSnapshot({
   const summary = {
     controlServices: controlPlane.length,
     activeWorkers: allWorkers.filter((w) => !w.stale).length,
-    activeRuns: inFlightRuns.filter((r) => r.state === "RUNNING" || r.state === "LEASED").length,
+    activeRuns: inFlightRuns.filter(
+      (r) => r.state === "RUNNING" || r.state === "LEASED",
+    ).length,
     activeAgents: agentSessions.length,
     activeWorktrees: worktrees.filter((w) => w.active).length,
     totalWorktrees: worktrees.length,
@@ -710,7 +799,10 @@ export async function collectFactoryPsSnapshot({
 /**
  * Format the PS snapshot into high-signal human terminal output
  */
-export function formatFactoryPsReport(snapshot, { colors = true, all = false, repo = null } = {}) {
+export function formatFactoryPsReport(
+  snapshot,
+  { colors = true, all = false, repo = null } = {},
+) {
   const col = colors ? c : noColors;
   const out = [];
 
@@ -719,7 +811,11 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
   // 1. Control Plane & Daemons
   out.push(col.bold("\nCONTROL PLANE & DAEMONS"));
   if (snapshot.controlPlane.length === 0) {
-    out.push(col.dim("  no active control plane daemons (start API with: factory serve)"));
+    out.push(
+      col.dim(
+        "  no active control plane daemons (start API with: factory serve)",
+      ),
+    );
   } else {
     out.push(
       `  ${cell("SERVICE", 16)}${cell("PID", 8)}${cell("PORT", 8)}${cell("UPTIME", 12)}${cell("CPU/MEM", 12)}${cell("SCOPE/TICKET", 22)}STATUS`,
@@ -735,7 +831,8 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
           status = col.green("running");
         }
       }
-      const scope = cp.ticket ?? (cp.worktree ? path.basename(cp.worktree) : "main");
+      const scope =
+        cp.ticket ?? (cp.worktree ? path.basename(cp.worktree) : "main");
       out.push(
         `  ${col.cyan(cell(cp.subservice, 16))}${cell(cp.pid, 8)}${cell(cp.port ?? "-", 8)}${cell(cp.uptime, 12)}${cell(`${cp.cpu}/${cp.mem}`, 12)}${cell(scope, 22)}${status}`,
       );
@@ -745,14 +842,22 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
   // Control APIs summary
   for (const probe of snapshot.apiProbes) {
     if (probe.online) {
-      const envStr = probe.env ? `${probe.env.name} (adapter: ${probe.env.adapter ?? "live"})` : "live";
-      const wCount = probe.workersCount ? `${probe.workersCount.live ?? 0} live (${probe.workersCount.busy ?? 0} busy)` : "none";
+      const envStr = probe.env
+        ? `${probe.env.name} (adapter: ${probe.env.adapter ?? "live"})`
+        : "live";
+      const wCount = probe.workersCount
+        ? `${probe.workersCount.live ?? 0} live (${probe.workersCount.busy ?? 0} busy)`
+        : "none";
       const rCount = probe.runsCount?.byState
         ? Object.entries(probe.runsCount.byState)
             .map(([k, v]) => `${k}:${v}`)
             .join(" ")
         : "none";
-      out.push(col.dim(`  └─ API :${probe.port} [${envStr}]  workers: ${wCount}  runs: ${rCount}`));
+      out.push(
+        col.dim(
+          `  └─ API :${probe.port} [${envStr}]  workers: ${wCount}  runs: ${rCount}`,
+        ),
+      );
     }
   }
 
@@ -765,7 +870,11 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
         `    ${cell("WORKER ID", 28)}${cell("PORT", 8)}${cell("PID", 8)}${cell("STATE", 10)}${cell("CURRENT RUN", 42)}LAST SEEN`,
       );
       for (const w of snapshot.workers) {
-        const stateColor = w.stale ? col.red("stale") : w.state === "busy" ? col.yellow("busy") : col.green("idle");
+        const stateColor = w.stale
+          ? col.red("stale")
+          : w.state === "busy"
+            ? col.yellow("busy")
+            : col.green("idle");
         out.push(
           `    ${cell(w.workerId, 28)}${cell(w.apiPort ?? "-", 8)}${cell(w.pid ?? "-", 8)}${cell(stateColor, 18)}${cell(w.currentRun ?? "-", 42)}${col.dim(w.lastSeen ?? "-")}`,
         );
@@ -777,7 +886,8 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
         `    ${cell("RUN ID", 42)}${cell("STATE", 12)}${cell("AGENT", 24)}${cell("ADAPTER", 10)}${cell("ATTEMPTS", 10)}ORIGIN`,
       );
       for (const r of snapshot.runs) {
-        const stateColor = r.state === "RUNNING" ? col.green(r.state) : col.yellow(r.state);
+        const stateColor =
+          r.state === "RUNNING" ? col.green(r.state) : col.yellow(r.state);
         out.push(
           `    ${cell(r.runId, 42)}${cell(stateColor, 20)}${cell(r.spec?.agent ?? r.agent ?? "-", 24)}${cell(r.spec?.adapter ?? r.adapter ?? "-", 10)}${cell(`${r.attempts ?? 1}/${r.maxAttempts ?? r.spec?.maxAttempts ?? 1}`, 10)}${r.eventId ?? "-"}`,
         );
@@ -795,7 +905,8 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
     );
     for (const a of snapshot.agents) {
       if (repo && a.worktree && !a.worktree.includes(repo)) continue;
-      const cmdClip = a.command.length > 60 ? `${a.command.slice(0, 58)}…` : a.command;
+      const cmdClip =
+        a.command.length > 60 ? `${a.command.slice(0, 58)}…` : a.command;
       out.push(
         `  ${col.magenta(cell(a.harness, 16))}${cell(a.pid, 8)}${cell(a.ticket ?? "-", 12)}${cell(a.uptime, 12)}${cell(`${a.cpu}/${a.mem}`, 12)}${col.dim(cmdClip)}`,
       );
@@ -809,13 +920,19 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
         (w) =>
           w.active ||
           snapshot.devServers.some(
-            (d) => (d.worktree && d.worktree === w.path) || (d.ticket && w.ticket && d.ticket === w.ticket),
+            (d) =>
+              (d.worktree && d.worktree === w.path) ||
+              (d.ticket && w.ticket && d.ticket === w.ticket),
           ),
       );
 
   out.push(col.bold("\nWORKTREE DEV SERVERS & DAEMONS"));
   if (filteredWorktrees.length === 0 && snapshot.devServers.length === 0) {
-    out.push(col.dim(`  no active worktree dev servers${all ? "" : " (use --all to list idle worktrees)"}`));
+    out.push(
+      col.dim(
+        `  no active worktree dev servers${all ? "" : " (use --all to list idle worktrees)"}`,
+      ),
+    );
   } else {
     out.push(
       `  ${cell("REPO / TICKET", 24)}${cell("BRANCH", 28)}${cell("ACTIVE PIDS", 42)}${cell("PORTS", 16)}PATH`,
@@ -833,7 +950,9 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
         renderedDevPids.add(d.pid);
       }
 
-      const daemonPids = Object.entries(wt.pids || {}).map(([k, v]) => `${k}:${v}`);
+      const daemonPids = Object.entries(wt.pids || {}).map(
+        ([k, v]) => `${k}:${v}`,
+      );
       const devPids = wtDevs.map((d) => `${d.service}:${d.pid}`);
       const pidsStr = [...daemonPids, ...devPids].join(", ") || "-";
 
@@ -846,20 +965,28 @@ export function formatFactoryPsReport(snapshot, { colors = true, all = false, re
       const devPortsFromLsof = snapshot.ports
         .filter((lp) => devPidValues.includes(lp.pid))
         .map((lp) => lp.port);
-      const allPorts = Array.from(new Set([...daemonPorts, ...devServerPorts, ...devPortsFromLsof])).sort(
-        (a, b) => a - b,
-      );
+      const allPorts = Array.from(
+        new Set([...daemonPorts, ...devServerPorts, ...devPortsFromLsof]),
+      ).sort((a, b) => a - b);
       const boundPorts = allPorts.join(", ") || "-";
-      const branchDisplay = wt.branch.length > 26 ? `${wt.branch.slice(0, 24)}…` : wt.branch;
+      const branchDisplay =
+        wt.branch.length > 26 ? `${wt.branch.slice(0, 24)}…` : wt.branch;
       out.push(
         `  ${col.cyan(cell(`${wt.repo}/${wt.name}`, 24))}${cell(branchDisplay, 28)}${cell(pidsStr, 42)}${cell(boundPorts, 16)}${col.dim(wt.path)}`,
       );
     }
 
-    const unrenderedDevs = snapshot.devServers.filter((d) => !renderedDevPids.has(d.pid));
+    const unrenderedDevs = snapshot.devServers.filter(
+      (d) => !renderedDevPids.has(d.pid),
+    );
     for (const d of unrenderedDevs) {
       if (repo && d.repo && d.repo !== repo) continue;
-      const repoTicket = d.repo && d.ticket ? `${d.repo}/${d.ticket}` : d.ticket ? d.ticket : d.service;
+      const repoTicket =
+        d.repo && d.ticket
+          ? `${d.repo}/${d.ticket}`
+          : d.ticket
+            ? d.ticket
+            : d.service;
       const branch = "-";
       const pidStr = `${d.service}:${d.pid}`;
       const lsofPort = snapshot.ports.find((lp) => lp.pid === d.pid)?.port;

--- a/lib/queue-summary.mjs
+++ b/lib/queue-summary.mjs
@@ -8,10 +8,19 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { gql } from "../orchestrator/reaper.mjs";
 import { ROOT } from "./schedule.mjs";
-import { effectiveOwnedPaths, pathsCollide } from "../orchestrator/owned-paths.mjs";
-import { AI_BLOCKED, answeredHeldTickets } from "../orchestrator/reply-detection.mjs";
+import {
+  effectiveOwnedPaths,
+  pathsCollide,
+} from "../orchestrator/owned-paths.mjs";
+import {
+  AI_BLOCKED,
+  answeredHeldTickets,
+} from "../orchestrator/reply-detection.mjs";
 import { liveWorkerLeases } from "./worker-leases.mjs";
-import { openBlockers, BLOCKING_RELATIONS_GQL } from "../orchestrator/blockers.mjs";
+import {
+  openBlockers,
+  BLOCKING_RELATIONS_GQL,
+} from "../orchestrator/blockers.mjs";
 
 const QUERY = `
   query($team: String!, $project: String!) {
@@ -46,37 +55,73 @@ export const STAGE_GATES = {
 };
 
 export function loadQueueConfig(repoFilter = []) {
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-  const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const policy = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"),
+  );
   const defaultCap = policy?.concurrency?.max_in_flight_per_repo ?? 3;
-  const repos = (cfg.repos ?? []).filter((r) => !repoFilter.length || repoFilter.includes(r.name));
+  const repos = (cfg.repos ?? []).filter(
+    (r) => !repoFilter.length || repoFilter.includes(r.name),
+  );
   return { repos, policy, defaultCap };
 }
 
 async function openPRSummary(nameWithOwner) {
-  const p = Bun.spawnSync(["gh", "pr", "list", "--repo", nameWithOwner, "--state", "all", "--limit", "250",
-    "--json", "number,url,body,isDraft,labels,title,state"]);
-  if (p.exitCode !== 0) return { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] };
+  const p = Bun.spawnSync([
+    "gh",
+    "pr",
+    "list",
+    "--repo",
+    nameWithOwner,
+    "--state",
+    "all",
+    "--limit",
+    "250",
+    "--json",
+    "number,url,body,isDraft,labels,title,state",
+  ]);
+  if (p.exitCode !== 0)
+    return { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] };
   try {
     const prs = JSON.parse(p.stdout.toString());
     const open = prs.filter((pr) => pr.state === "OPEN");
     return {
       all: open.length,
       drafts: open.filter((pr) => pr.isDraft).length,
-      escalated: open.filter((pr) => (pr.labels ?? []).some((l) => l.name === "escalated")).length,
+      escalated: open.filter((pr) =>
+        (pr.labels ?? []).some((l) => l.name === "escalated"),
+      ).length,
       allPRs: prs,
-      mergeCandidates: open.filter((pr) => !pr.isDraft && !(pr.labels ?? []).some((l) => l.name === "escalated")),
+      mergeCandidates: open.filter(
+        (pr) =>
+          !pr.isDraft && !(pr.labels ?? []).some((l) => l.name === "escalated"),
+      ),
     };
-  } catch { return { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] }; }
+  } catch {
+    return { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] };
+  }
 }
 
 function issuePR(issue, repo, prs) {
-  const attachmentNumbers = new Set((issue.attachments?.nodes ?? []).flatMap((a) => {
-    const m = new RegExp(`github\\.com/${repo.github.replace("/", "\\/")}/pull/(\\d+)`, "i").exec(a.url ?? "");
-    return m ? [Number(m[1])] : [];
-  }));
+  const attachmentNumbers = new Set(
+    (issue.attachments?.nodes ?? []).flatMap((a) => {
+      const m = new RegExp(
+        `github\\.com/${repo.github.replace("/", "\\/")}/pull/(\\d+)`,
+        "i",
+      ).exec(a.url ?? "");
+      return m ? [Number(m[1])] : [];
+    }),
+  );
   const id = String(issue.identifier).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return prs.find((pr) => attachmentNumbers.has(pr.number) || new RegExp(`\\b${id}\\b`, "i").test(`${pr.title ?? ""}\n${pr.body ?? ""}`));
+  return prs.find(
+    (pr) =>
+      attachmentNumbers.has(pr.number) ||
+      new RegExp(`\\b${id}\\b`, "i").test(
+        `${pr.title ?? ""}\n${pr.body ?? ""}`,
+      ),
+  );
 }
 
 /** @param {object[]} repos from config/repos.yaml @param {number} defaultCap */
@@ -93,33 +138,57 @@ export async function fetchQueueSummaries(repos, defaultCap) {
     const labels = (i) => (i.labels?.nodes ?? []).map((l) => l.name);
     const state = (i) => i.state?.name ?? "?";
 
-    const triage = nodes.filter((i) => state(i) === "Triage" && !labels(i).includes(AI_BLOCKED));
-    const triageHeld = nodes.filter((i) => state(i) === "Triage" && labels(i).includes(AI_BLOCKED));
-    const readyAll = nodes.filter((i) => state(i) === "Todo" && labels(i).includes("ai:agent-ready"));
+    const triage = nodes.filter(
+      (i) => state(i) === "Triage" && !labels(i).includes(AI_BLOCKED),
+    );
+    const triageHeld = nodes.filter(
+      (i) => state(i) === "Triage" && labels(i).includes(AI_BLOCKED),
+    );
+    const readyAll = nodes.filter(
+      (i) => state(i) === "Todo" && labels(i).includes("ai:agent-ready"),
+    );
     // "Ready" and "ready but waiting on another ticket" are different facts, and
     // folding them into one count hides the second entirely: a held ticket sits
     // in Todo consuming no slot and raising no error, so a wrong or forgotten
     // `blocked by` relation would starve it invisibly. Split the line instead.
     const readyHeld = readyAll.filter((i) => openBlockers(i).length);
     const ready = readyAll.filter((i) => !openBlockers(i).length);
-    const notReady = nodes.filter((i) => state(i) === "Todo" && !labels(i).includes("ai:agent-ready"));
+    const notReady = nodes.filter(
+      (i) => state(i) === "Todo" && !labels(i).includes("ai:agent-ready"),
+    );
     const inProgress = nodes.filter((i) => state(i) === "In Progress");
     const inReview = nodes.filter((i) => state(i) === "In Review");
     const blocked = nodes.filter((i) => state(i) === "Blocked");
 
-    const heldAny = nodes.filter((i) => ["Triage", "Blocked"].includes(state(i)) && labels(i).includes(AI_BLOCKED));
-    const answeredIds = heldAny.length ? await answeredHeldTickets(repo) : new Set();
+    const heldAny = nodes.filter(
+      (i) =>
+        ["Triage", "Blocked"].includes(state(i)) &&
+        labels(i).includes(AI_BLOCKED),
+    );
+    const answeredIds = heldAny.length
+      ? await answeredHeldTickets(repo)
+      : new Set();
     const answered = heldAny.filter((i) => answeredIds.has(i.identifier));
 
-    const prs = repo.github ? await openPRSummary(repo.github) : { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] };
+    const prs = repo.github
+      ? await openPRSummary(repo.github)
+      : { all: 0, drafts: 0, escalated: 0, allPRs: [], mergeCandidates: [] };
     const openPRs = prs.mergeCandidates;
 
     const workers = liveWorkerLeases(repo.name);
     const workerIds = new Set(workers.map((w) => w.ticket));
-    const orphanedClaims = inProgress.filter((i) => !workerIds.has(i.identifier));
-    const inFlightPaths = inProgress.flatMap((i) => effectiveOwnedPaths(i.description ?? ""));
-    const sorted = [...ready].sort((a, b) => (a.priority || 99) - (b.priority || 99));
-    const slotsFree = repo.report_only ? 0 : Math.max(0, (repo.max_in_flight ?? defaultCap) - workers.length);
+    const orphanedClaims = inProgress.filter(
+      (i) => !workerIds.has(i.identifier),
+    );
+    const inFlightPaths = inProgress.flatMap((i) =>
+      effectiveOwnedPaths(i.description ?? ""),
+    );
+    const sorted = [...ready].sort(
+      (a, b) => (a.priority || 99) - (b.priority || 99),
+    );
+    const slotsFree = repo.report_only
+      ? 0
+      : Math.max(0, (repo.max_in_flight ?? defaultCap) - workers.length);
     const free = [];
     const busyPaths = [...inFlightPaths];
     for (const t of sorted) {
@@ -148,7 +217,12 @@ export async function fetchQueueSummaries(repos, defaultCap) {
       // finish. Surfaced separately so starvation from a stale relation is a
       // visible line in watch, not an empty queue.
       readyHeld: readyHeld.length,
-      readyHeldTickets: readyHeld.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url, blockedBy: openBlockers(t) })),
+      readyHeldTickets: readyHeld.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+        blockedBy: openBlockers(t),
+      })),
       inProgress: inProgress.length,
       workers: workers.length,
       liveWorkerIds: workers.map((w) => w.ticket),
@@ -161,17 +235,41 @@ export async function fetchQueueSummaries(repos, defaultCap) {
       blocked: blocked.length,
       slotsFree,
       startable: free.map((t) => t.identifier),
-      startableTickets: free.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
+      startableTickets: free.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+      })),
       inProgressTickets: inProgress.map((t) => {
         const pr = issuePR(t, repo, prs.allPRs);
-        return { identifier: t.identifier, title: t.title, url: t.url, prNumber: pr?.number, prUrl: pr?.url };
+        return {
+          identifier: t.identifier,
+          title: t.title,
+          url: t.url,
+          prNumber: pr?.number,
+          prUrl: pr?.url,
+        };
       }),
       inReviewTickets: inReview.map((t) => {
         const pr = issuePR(t, repo, prs.allPRs);
-        return { identifier: t.identifier, title: t.title, url: t.url, prNumber: pr?.number, prUrl: pr?.url };
+        return {
+          identifier: t.identifier,
+          title: t.title,
+          url: t.url,
+          prNumber: pr?.number,
+          prUrl: pr?.url,
+        };
       }),
-      blockedTickets: blocked.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
-      answeredTickets: answered.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
+      blockedTickets: blocked.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+      })),
+      answeredTickets: answered.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+      })),
     });
   }
 

--- a/lib/repo-status.mjs
+++ b/lib/repo-status.mjs
@@ -1,13 +1,22 @@
 /** Helpers for the read-only `factory status` command. */
 
-export const DEFAULT_REVISION_FIELDS = ["revision", "commit", "git_sha", "gitSha", "sha"];
+export const DEFAULT_REVISION_FIELDS = [
+  "revision",
+  "commit",
+  "git_sha",
+  "gitSha",
+  "sha",
+];
 
 export function deployedRevision(payload, configuredField) {
   if (!payload || typeof payload !== "object") return null;
-  const fields = configuredField ? [configuredField, ...DEFAULT_REVISION_FIELDS] : DEFAULT_REVISION_FIELDS;
+  const fields = configuredField
+    ? [configuredField, ...DEFAULT_REVISION_FIELDS]
+    : DEFAULT_REVISION_FIELDS;
   for (const field of fields) {
     const value = payload[field];
-    if (typeof value === "string" && value.trim()) return { field, value: value.trim() };
+    if (typeof value === "string" && value.trim())
+      return { field, value: value.trim() };
   }
   return null;
 }
@@ -16,16 +25,25 @@ export function deployedRevision(payload, configuredField) {
 export function metadataUrl(url) {
   if (!url) return null;
   const parsed = new URL(url);
-  if (parsed.pathname === "/" || parsed.pathname === "") parsed.pathname = "/version.json";
+  if (parsed.pathname === "/" || parsed.pathname === "")
+    parsed.pathname = "/version.json";
   return parsed.toString();
 }
 
 export function deploymentState({ deployed, remoteSha, localContains = null }) {
-  if (!deployed) return { state: "unknown", message: "endpoint did not expose a revision" };
-  if (!remoteSha) return { state: "unknown", message: "could not read the remote branch" };
-  if (deployed === remoteSha) return { state: "current", message: "matches the remote branch tip" };
-  if (localContains === true) return { state: "stale", message: "is behind the remote branch tip" };
-  if (localContains === false) return { state: "diverged", message: "does not occur in the local remote-branch history" };
+  if (!deployed)
+    return { state: "unknown", message: "endpoint did not expose a revision" };
+  if (!remoteSha)
+    return { state: "unknown", message: "could not read the remote branch" };
+  if (deployed === remoteSha)
+    return { state: "current", message: "matches the remote branch tip" };
+  if (localContains === true)
+    return { state: "stale", message: "is behind the remote branch tip" };
+  if (localContains === false)
+    return {
+      state: "diverged",
+      message: "does not occur in the local remote-branch history",
+    };
   return { state: "different", message: "differs from the remote branch tip" };
 }
 

--- a/lib/repo-status.test.mjs
+++ b/lib/repo-status.test.mjs
@@ -1,21 +1,45 @@
 import { expect, test } from "bun:test";
-import { deployedRevision, deploymentState, formatAge, metadataUrl } from "./repo-status.mjs";
+import {
+  deployedRevision,
+  deploymentState,
+  formatAge,
+  metadataUrl,
+} from "./repo-status.mjs";
 
 test("uses a configured revision field and accepts common revision payloads", () => {
-  expect(deployedRevision({ revision: "abc", commit: "def" }, "revision")).toEqual({ field: "revision", value: "abc" });
-  expect(deployedRevision({ commit: "def" })).toEqual({ field: "commit", value: "def" });
+  expect(
+    deployedRevision({ revision: "abc", commit: "def" }, "revision"),
+  ).toEqual({ field: "revision", value: "abc" });
+  expect(deployedRevision({ commit: "def" })).toEqual({
+    field: "commit",
+    value: "def",
+  });
   expect(deployedRevision({ status: "ok" })).toBeNull();
 });
 
 test("preserves exact metadata endpoint and supplies version.json for an origin", () => {
-  expect(metadataUrl("https://app.example.test")).toBe("https://app.example.test/version.json");
-  expect(metadataUrl("https://app.example.test/healthz")).toBe("https://app.example.test/healthz");
+  expect(metadataUrl("https://app.example.test")).toBe(
+    "https://app.example.test/version.json",
+  );
+  expect(metadataUrl("https://app.example.test/healthz")).toBe(
+    "https://app.example.test/healthz",
+  );
 });
 
 test("reports deployed revision freshness without claiming a failed lookup is stale", () => {
-  expect(deploymentState({ deployed: "abc", remoteSha: "abc" }).state).toBe("current");
-  expect(deploymentState({ deployed: "abc", remoteSha: "def", localContains: true }).state).toBe("stale");
-  expect(deploymentState({ deployed: "abc", remoteSha: "def", localContains: false }).state).toBe("diverged");
-  expect(deploymentState({ deployed: null, remoteSha: "def" }).state).toBe("unknown");
+  expect(deploymentState({ deployed: "abc", remoteSha: "abc" }).state).toBe(
+    "current",
+  );
+  expect(
+    deploymentState({ deployed: "abc", remoteSha: "def", localContains: true })
+      .state,
+  ).toBe("stale");
+  expect(
+    deploymentState({ deployed: "abc", remoteSha: "def", localContains: false })
+      .state,
+  ).toBe("diverged");
+  expect(deploymentState({ deployed: null, remoteSha: "def" }).state).toBe(
+    "unknown",
+  );
   expect(formatAge(null)).toBe("never recorded");
 });

--- a/lib/schedule.mjs
+++ b/lib/schedule.mjs
@@ -14,12 +14,15 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 
 if (typeof Bun === "undefined") {
   throw new Error(
     "factory runs on bun (Bun.YAML). Use `bun <script>` instead of `node <script>`.\n" +
-    "Install: brew install oven-sh/bun/bun"
+      "Install: brew install oven-sh/bun/bun",
   );
 }
 
@@ -34,7 +37,8 @@ if (typeof Bun === "undefined") {
 function withVars(cmd, vars) {
   if (typeof cmd !== "string") return cmd;
   let out = cmd;
-  for (const [k, v] of Object.entries(vars)) out = out.replaceAll(`{{${k}}}`, v);
+  for (const [k, v] of Object.entries(vars))
+    out = out.replaceAll(`{{${k}}}`, v);
   return out;
 }
 
@@ -61,5 +65,9 @@ export function toSeconds(every) {
 }
 
 export function loadSchedule(repo = null, harness = null) {
-  return parseSchedule(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"), repo, harness);
+  return parseSchedule(
+    readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"),
+    repo,
+    harness,
+  );
 }

--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -31,17 +31,25 @@ export const LOG_DIR = path.join(homedir(), ".factory/logs");
 /** {usd, reported, estimated, runs} — `estimated` is the non-Claude share. */
 export function todaysSpendBreakdown(logDir = LOG_DIR) {
   const today = new Date().toISOString().slice(0, 10);
-  let reported = 0, estimated = 0, runs = 0;
+  let reported = 0,
+    estimated = 0,
+    runs = 0;
   try {
     for (const f of new Bun.Glob("*.jsonl").scanSync(logDir)) {
       const full = path.join(logDir, f);
-      if (new Date(Bun.file(full).lastModified).toISOString().slice(0, 10) !== today) continue;
+      if (
+        new Date(Bun.file(full).lastModified).toISOString().slice(0, 10) !==
+        today
+      )
+        continue;
       const run = parseRun(f, readFileSync(full, "utf8"));
       runs++;
       if (run.cost > 0) reported += run.cost;
       else estimated += estimateUSD(run);
     }
-  } catch { /* no log dir yet — nothing spent */ }
+  } catch {
+    /* no log dir yet — nothing spent */
+  }
   return { usd: reported + estimated, reported, estimated, runs };
 }
 
@@ -55,8 +63,9 @@ export function budgetExhausted(policy, logDir = LOG_DIR) {
   if (!perDay) return null;
   const { usd, reported, estimated } = todaysSpendBreakdown(logDir);
   if (usd < perDay) return null;
-  const split = estimated > 0.005
-    ? ` — $${reported.toFixed(2)} reported + $${estimated.toFixed(2)} estimated for harnesses that report no cost`
-    : "";
+  const split =
+    estimated > 0.005
+      ? ` — $${reported.toFixed(2)} reported + $${estimated.toFixed(2)} estimated for harnesses that report no cost`
+      : "";
   return `day budget spent (~$${usd.toFixed(2)} of $${perDay} notional${split})`;
 }

--- a/lib/transcript.mjs
+++ b/lib/transcript.mjs
@@ -36,16 +36,24 @@ const DURATION_UNIT_MS = {
 /** Parse a CLI duration into milliseconds. Unitless values preserve the
  * historical `--since` behavior and are interpreted as days. */
 export function parseDuration(value) {
-  const match = String(value ?? "").trim().toLowerCase().match(/^(\d+)([smhdw])?$/);
+  const match = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .match(/^(\d+)([smhdw])?$/);
   if (!match) throw new TypeError(`invalid duration: ${value}`);
 
   const amount = Number(match[1]);
   const durationMs = amount * DURATION_UNIT_MS[match[2] ?? "d"];
-  if (!Number.isSafeInteger(durationMs)) throw new RangeError(`duration is too large: ${value}`);
+  if (!Number.isSafeInteger(durationMs))
+    throw new RangeError(`duration is too large: ${value}`);
   return durationMs;
 }
 
-const oneLine = (s, n = 120) => String(s ?? "").replace(/\s+/g, " ").trim().slice(0, n);
+const oneLine = (s, n = 120) =>
+  String(s ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, n);
 
 // Sonnet-ish per-token rates, used ONLY for harnesses that report no cost of
 // their own. Wrong by a constant factor is fine; blind to a whole harness is
@@ -53,8 +61,10 @@ const oneLine = (s, n = 120) => String(s ?? "").replace(/\s+/g, " ").trim().slic
 const RATE = { in: 3e-6, out: 15e-6, cacheRead: 0.3e-6, cacheWrite: 3.75e-6 };
 
 export const estimateUSD = (r) =>
-  (r.in ?? 0) * RATE.in + (r.out ?? 0) * RATE.out +
-  (r.cacheRead ?? 0) * RATE.cacheRead + (r.cacheWrite ?? 0) * RATE.cacheWrite;
+  (r.in ?? 0) * RATE.in +
+  (r.out ?? 0) * RATE.out +
+  (r.cacheRead ?? 0) * RATE.cacheRead +
+  (r.cacheWrite ?? 0) * RATE.cacheWrite;
 
 /** Group an error by the SHAPE of the failure — paths and ids differ per run
  *  and would otherwise fragment one recurring bug into a list of singletons. */
@@ -73,8 +83,7 @@ export const errorSignature = (body) =>
  * hiding which command is missing. Only the varying numbers are erased, which
  * is what actually fragments these ("resets in 44h1m15s" vs "44h21m16s").
  */
-export const messageSignature = (msg) =>
-  oneLine(msg, 90).replace(/\d+/g, "N");
+export const messageSignature = (msg) => oneLine(msg, 90).replace(/\d+/g, "N");
 
 /** `bj29-CLNT-616-20260804-101500.jsonl` -> repo bj29, stage ticket. */
 export function identify(file) {
@@ -99,16 +108,35 @@ export function identify(file) {
 export function parseRun(file, text, mtimeMs = 0) {
   const { repo, stage, ticket } = identify(file);
   const run = {
-    file, repo, stage, ticket, harness: "unknown", mtime: mtimeMs,
-    in: 0, out: 0, cacheRead: 0, cacheWrite: 0, cost: 0,
-    turns: 0, tools: 0, errors: 0, durMs: 0,
-    ok: null, error: null, truncated: false, wasted: false,
-    resultBytes: 0, weightedBytes: 0,
-    toolCalls: new Map(), toolResultBytes: new Map(), errorSigs: new Map(), commands: new Map(),
+    file,
+    repo,
+    stage,
+    ticket,
+    harness: "unknown",
+    mtime: mtimeMs,
+    in: 0,
+    out: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    turns: 0,
+    tools: 0,
+    errors: 0,
+    durMs: 0,
+    ok: null,
+    error: null,
+    truncated: false,
+    wasted: false,
+    resultBytes: 0,
+    weightedBytes: 0,
+    toolCalls: new Map(),
+    toolResultBytes: new Map(),
+    errorSigs: new Map(),
+    commands: new Map(),
   };
 
-  const pending = new Map();       // tool_use_id -> {name, brief}
-  const payloads = [];             // {name, bytes, atTurn}
+  const pending = new Map(); // tool_use_id -> {name, brief}
+  const payloads = []; // {name, bytes, atTurn}
   let sawEnvelope = false;
   let sawAnyEvent = false;
 
@@ -123,7 +151,12 @@ export function parseRun(file, text, mtimeMs = 0) {
 
   for (const line of text.split("\n")) {
     if (!line.startsWith("{")) continue;
-    let e; try { e = JSON.parse(line); } catch { continue; }
+    let e;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
     sawAnyEvent = true;
 
     // ---------------------------------------------------------- claude ----
@@ -137,9 +170,16 @@ export function parseRun(file, text, mtimeMs = 0) {
       for (const part of e.message.content ?? []) {
         if (part.type !== "tool_use") continue;
         bumpTool(part.name);
-        const brief = oneLine(part.input?.command ?? part.input?.file_path ?? part.input?.pattern ?? "", 120);
+        const brief = oneLine(
+          part.input?.command ??
+            part.input?.file_path ??
+            part.input?.pattern ??
+            "",
+          120,
+        );
         pending.set(part.id, { name: part.name, brief });
-        if (part.name === "Bash" && brief) run.commands.set(brief, (run.commands.get(brief) ?? 0) + 1);
+        if (part.name === "Bash" && brief)
+          run.commands.set(brief, (run.commands.get(brief) ?? 0) + 1);
       }
       continue;
     }
@@ -147,12 +187,19 @@ export function parseRun(file, text, mtimeMs = 0) {
       for (const part of e.message.content ?? []) {
         if (part.type !== "tool_result") continue;
         const src = pending.get(part.tool_use_id) ?? { name: "?", brief: "" };
-        const body = typeof part.content === "string" ? part.content : JSON.stringify(part.content ?? "");
+        const body =
+          typeof part.content === "string"
+            ? part.content
+            : JSON.stringify(part.content ?? "");
         bumpResult(src.name, body.length);
         if (!part.is_error) continue;
         run.errors++;
         const sig = `${src.name}|${errorSignature(body)}`;
-        const hit = run.errorSigs.get(sig) ?? { count: 0, tool: src.name, sample: oneLine(body, 110) };
+        const hit = run.errorSigs.get(sig) ?? {
+          count: 0,
+          tool: src.name,
+          sample: oneLine(body, 110),
+        };
         hit.count++;
         run.errorSigs.set(sig, hit);
       }
@@ -167,7 +214,8 @@ export function parseRun(file, text, mtimeMs = 0) {
         if (item.type === "command_execution") {
           bumpTool("Bash");
           const brief = oneLine(item.command, 120);
-          if (brief) run.commands.set(brief, (run.commands.get(brief) ?? 0) + 1);
+          if (brief)
+            run.commands.set(brief, (run.commands.get(brief) ?? 0) + 1);
         } else if (item.type === "mcp_tool_call") {
           bumpTool(item.tool ?? "mcp");
         } else if (item.type === "file_change" || item.type === "patch") {
@@ -175,13 +223,25 @@ export function parseRun(file, text, mtimeMs = 0) {
         }
       }
       if (e.type === "item.completed") {
-        const body = String(item.aggregated_output ?? item.text ?? item.output ?? "");
-        if (body) bumpResult(item.type === "command_execution" ? "Bash" : (item.tool ?? item.type), body.length);
+        const body = String(
+          item.aggregated_output ?? item.text ?? item.output ?? "",
+        );
+        if (body)
+          bumpResult(
+            item.type === "command_execution"
+              ? "Bash"
+              : (item.tool ?? item.type),
+            body.length,
+          );
         // Codex reports a shell failure as a non-zero exit_code, not an error flag.
         if (item.exit_code != null && item.exit_code !== 0) {
           run.errors++;
           const sig = `Bash|${errorSignature(body || `exit ${item.exit_code}`)}`;
-          const hit = run.errorSigs.get(sig) ?? { count: 0, tool: "Bash", sample: oneLine(body, 110) };
+          const hit = run.errorSigs.get(sig) ?? {
+            count: 0,
+            tool: "Bash",
+            sample: oneLine(body, 110),
+          };
           hit.count++;
           run.errorSigs.set(sig, hit);
         }
@@ -197,7 +257,10 @@ export function parseRun(file, text, mtimeMs = 0) {
       // the same tokens get counted twice and the cache ratio reads as perfect.
       run.cacheRead = u.cached_input_tokens ?? 0;
       run.cacheWrite = u.cache_write_input_tokens ?? 0;
-      run.in = Math.max(0, (u.input_tokens ?? 0) - (u.cached_input_tokens ?? 0));
+      run.in = Math.max(
+        0,
+        (u.input_tokens ?? 0) - (u.cached_input_tokens ?? 0),
+      );
       run.out = (u.output_tokens ?? 0) + (u.reasoning_output_tokens ?? 0);
       run.turns++;
       run.ok = true;
@@ -205,11 +268,15 @@ export function parseRun(file, text, mtimeMs = 0) {
     }
 
     // -------------------------------------------------------------- agy ----
-    if (e.event === "init") { run.harness = "agy"; continue; }
+    if (e.event === "init") {
+      run.harness = "agy";
+      continue;
+    }
     if (e.event === "step_update") {
       run.harness = "agy";
       const s = e.step_update ?? {};
-      if (s.step_type === "tool" && s.state === "ACTIVE") bumpTool(s.tool_name ?? "tool");
+      if (s.step_type === "tool" && s.state === "ACTIVE")
+        bumpTool(s.tool_name ?? "tool");
       continue;
     }
     if (e.event === "result" && e.result) {
@@ -255,7 +322,11 @@ export function parseRun(file, text, mtimeMs = 0) {
       const result = String(e.result ?? "");
       const unknownCommand = /^Unknown command:/.test(result);
       if (unknownCommand) run.error = oneLine(result, 90);
-      run.ok = e.subtype === "success" && !e.is_error && !unknownCommand && (e.num_turns ?? 0) > 0;
+      run.ok =
+        e.subtype === "success" &&
+        !e.is_error &&
+        !unknownCommand &&
+        (e.num_turns ?? 0) > 0;
     }
   }
 
@@ -276,8 +347,14 @@ export function parseRun(file, text, mtimeMs = 0) {
     const remaining = Math.max(1, run.tools - p.atTurn);
     const w = p.bytes * remaining;
     run.weightedBytes += w;
-    const t = run.toolResultBytes.get(p.name) ?? { bytes: 0, calls: 0, weighted: 0 };
-    t.bytes += p.bytes; t.calls++; t.weighted += w;
+    const t = run.toolResultBytes.get(p.name) ?? {
+      bytes: 0,
+      calls: 0,
+      weighted: 0,
+    };
+    t.bytes += p.bytes;
+    t.calls++;
+    t.weighted += w;
     run.toolResultBytes.set(p.name, t);
   }
 

--- a/lib/transcript.test.mjs
+++ b/lib/transcript.test.mjs
@@ -8,9 +8,17 @@
  * assertion that matters is that a non-Claude run produces non-zero numbers.
  */
 import { test, expect } from "bun:test";
-import { parseRun, identify, messageSignature, errorSignature, estimateUSD, parseDuration } from "./transcript.mjs";
+import {
+  parseRun,
+  identify,
+  messageSignature,
+  errorSignature,
+  estimateUSD,
+  parseDuration,
+} from "./transcript.mjs";
 
-const jsonl = (...events) => events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+const jsonl = (...events) =>
+  events.map((e) => JSON.stringify(e)).join("\n") + "\n";
 
 // ------------------------------------------------------------- duration ---
 test("parseDuration supports seconds, minutes, hours, days, and weeks", () => {
@@ -34,23 +42,75 @@ test("parseDuration rejects invalid or unsafe values", () => {
 
 // ------------------------------------------------------------- identify ---
 test("identify pulls repo, stage and ticket out of the log filename", () => {
-  expect(identify("bj29-CLNT-616-20260804-101500.jsonl")).toEqual({ repo: "bj29", stage: "ticket", ticket: "CLNT-616" });
-  expect(identify("legalease-factory-merge-20260804-211936.jsonl")).toEqual({ repo: "legalease", stage: "factory-merge", ticket: null });
+  expect(identify("bj29-CLNT-616-20260804-101500.jsonl")).toEqual({
+    repo: "bj29",
+    stage: "ticket",
+    ticket: "CLNT-616",
+  });
+  expect(identify("legalease-factory-merge-20260804-211936.jsonl")).toEqual({
+    repo: "legalease",
+    stage: "factory-merge",
+    ticket: null,
+  });
   // Dispatch writes a trailing dot before the extension; it must not leak into the stage.
-  expect(identify("cashsaas-CLNT-902-20260804191509..jsonl").ticket).toBe("CLNT-902");
+  expect(identify("cashsaas-CLNT-902-20260804191509..jsonl").ticket).toBe(
+    "CLNT-902",
+  );
   // Absolute path handling (WM-254)
-  expect(identify("/Users/hdkiller/.factory/logs/bj29-CLNT-616-20260804-101500.jsonl")).toEqual({ repo: "bj29", stage: "ticket", ticket: "CLNT-616" });
+  expect(
+    identify(
+      "/Users/hdkiller/.factory/logs/bj29-CLNT-616-20260804-101500.jsonl",
+    ),
+  ).toEqual({ repo: "bj29", stage: "ticket", ticket: "CLNT-616" });
   expect(identify("/path/to/repo-TICKET-date.jsonl").repo).toBe("repo");
 });
 
 // --------------------------------------------------------------- claude ---
 test("claude: usage, tools, cost and verdict", () => {
-  const run = parseRun("bj29-CLNT-1-x.jsonl", jsonl(
-    { type: "assistant", message: { usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 9000, cache_creation_input_tokens: 300 },
-      content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "git status" } }] } },
-    { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "on branch main" }] } },
-    { type: "result", subtype: "success", is_error: false, num_turns: 7, total_cost_usd: 1.25, duration_ms: 60000 },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-1-x.jsonl",
+    jsonl(
+      {
+        type: "assistant",
+        message: {
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 9000,
+            cache_creation_input_tokens: 300,
+          },
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Bash",
+              input: { command: "git status" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: "on branch main",
+            },
+          ],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 7,
+        total_cost_usd: 1.25,
+        duration_ms: 60000,
+      },
+    ),
+  );
   expect(run.harness).toBe("claude");
   expect(run.in).toBe(100);
   expect(run.cacheRead).toBe(9000);
@@ -63,19 +123,59 @@ test("claude: usage, tools, cost and verdict", () => {
 });
 
 test("claude: an errored tool result is counted and grouped by shape", () => {
-  const run = parseRun("bj29-CLNT-2-x.jsonl", jsonl(
-    { type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "Read", input: { file_path: "/a/b.md" } }] } },
-    { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: true, content: "File does not exist: /a/b.md" }] } },
-    { type: "result", subtype: "success", is_error: false, num_turns: 1, total_cost_usd: 0.1 },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-2-x.jsonl",
+    jsonl(
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Read",
+              input: { file_path: "/a/b.md" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              is_error: true,
+              content: "File does not exist: /a/b.md",
+            },
+          ],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 1,
+        total_cost_usd: 0.1,
+      },
+    ),
+  );
   expect(run.errors).toBe(1);
   expect([...run.errorSigs.keys()][0]).toStartWith("Read|");
 });
 
 test("claude: an Unknown command reply is a failure, not a success", () => {
-  const run = parseRun("bj29-factory-ticket-x.jsonl", jsonl(
-    { type: "result", subtype: "success", is_error: false, num_turns: 1, result: "Unknown command: /factory-ticket" },
-  ));
+  const run = parseRun(
+    "bj29-factory-ticket-x.jsonl",
+    jsonl({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      num_turns: 1,
+      result: "Unknown command: /factory-ticket",
+    }),
+  );
   expect(run.ok).toBe(false);
   expect(run.error).toBe("Unknown command: /factory-ticket");
 });
@@ -84,11 +184,33 @@ test("claude: an Unknown command reply is a failure, not a success", () => {
 test("codex: token usage is recorded and input excludes the cached part", () => {
   // Codex's input_tokens INCLUDES cached_input_tokens, unlike Claude's disjoint
   // fields. Double-counting here makes the cache ratio read as perfect.
-  const run = parseRun("bj29-CLNT-603-x.jsonl", jsonl(
-    { type: "item.started", item: { type: "command_execution", command: "npm test" } },
-    { type: "item.completed", item: { type: "command_execution", aggregated_output: "ok", exit_code: 0 } },
-    { type: "turn.completed", usage: { input_tokens: 1_291_572, cached_input_tokens: 1_223_424, cache_write_input_tokens: 0, output_tokens: 6591, reasoning_output_tokens: 2044 } },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-603-x.jsonl",
+    jsonl(
+      {
+        type: "item.started",
+        item: { type: "command_execution", command: "npm test" },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          aggregated_output: "ok",
+          exit_code: 0,
+        },
+      },
+      {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 1_291_572,
+          cached_input_tokens: 1_223_424,
+          cache_write_input_tokens: 0,
+          output_tokens: 6591,
+          reasoning_output_tokens: 2044,
+        },
+      },
+    ),
+  );
   expect(run.harness).toBe("codex");
   expect(run.in).toBe(1_291_572 - 1_223_424);
   expect(run.cacheRead).toBe(1_223_424);
@@ -98,10 +220,31 @@ test("codex: token usage is recorded and input excludes the cached part", () => 
 });
 
 test("codex: cumulative usage snapshots replace prior turns", () => {
-  const run = parseRun("bj29-CLNT-276-x.jsonl", jsonl(
-    { type: "turn.completed", usage: { input_tokens: 100, cached_input_tokens: 60, cache_write_input_tokens: 10, output_tokens: 20, reasoning_output_tokens: 5 } },
-    { type: "turn.completed", usage: { input_tokens: 250, cached_input_tokens: 150, cache_write_input_tokens: 25, output_tokens: 50, reasoning_output_tokens: 15 } },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-276-x.jsonl",
+    jsonl(
+      {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 60,
+          cache_write_input_tokens: 10,
+          output_tokens: 20,
+          reasoning_output_tokens: 5,
+        },
+      },
+      {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 250,
+          cached_input_tokens: 150,
+          cache_write_input_tokens: 25,
+          output_tokens: 50,
+          reasoning_output_tokens: 15,
+        },
+      },
+    ),
+  );
   expect(run.turns).toBe(2);
   expect(run.in).toBe(100);
   expect(run.cacheRead).toBe(150);
@@ -110,18 +253,38 @@ test("codex: cumulative usage snapshots replace prior turns", () => {
 });
 
 test("codex: a non-zero exit code counts as an error", () => {
-  const run = parseRun("bj29-CLNT-4-x.jsonl", jsonl(
-    { type: "item.started", item: { type: "command_execution", command: "npm test" } },
-    { type: "item.completed", item: { type: "command_execution", aggregated_output: "1 failing", exit_code: 1 } },
-    { type: "turn.completed", usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 1 } },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-4-x.jsonl",
+    jsonl(
+      {
+        type: "item.started",
+        item: { type: "command_execution", command: "npm test" },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          aggregated_output: "1 failing",
+          exit_code: 1,
+        },
+      },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ),
+  );
   expect(run.errors).toBe(1);
 });
 
 test("codex: a run killed before turn.completed is truncated, not merely quiet", () => {
-  const run = parseRun("legalease-factory-merge-x.jsonl", jsonl(
-    { type: "item.started", item: { type: "command_execution", command: "gh pr checks 186 --watch" } },
-  ));
+  const run = parseRun(
+    "legalease-factory-merge-x.jsonl",
+    jsonl({
+      type: "item.started",
+      item: { type: "command_execution", command: "gh pr checks 186 --watch" },
+    }),
+  );
   expect(run.truncated).toBe(true);
   expect(run.wasted).toBe(true);
   expect(run.harness).toBe("codex");
@@ -129,10 +292,27 @@ test("codex: a run killed before turn.completed is truncated, not merely quiet",
 
 // ------------------------------------------------------------------ agy ---
 test("agy: a quota error is captured with the wall clock it burned", () => {
-  const run = parseRun("bj29-factory-merge-x.jsonl", jsonl(
-    { event: "init", conversation_id: "abc", init: { tools: ["run_command"] } },
-    { event: "result", result: { status: "ERROR", response: "", error: "Individual quota reached. Resets in 44h1m15s.", duration_seconds: 600.66, num_turns: 1, usage: { input_tokens: 0, output_tokens: 0 } } },
-  ));
+  const run = parseRun(
+    "bj29-factory-merge-x.jsonl",
+    jsonl(
+      {
+        event: "init",
+        conversation_id: "abc",
+        init: { tools: ["run_command"] },
+      },
+      {
+        event: "result",
+        result: {
+          status: "ERROR",
+          response: "",
+          error: "Individual quota reached. Resets in 44h1m15s.",
+          duration_seconds: 600.66,
+          num_turns: 1,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      },
+    ),
+  );
   expect(run.harness).toBe("agy");
   expect(run.ok).toBe(false);
   expect(run.durMs).toBeCloseTo(600660, 0);
@@ -140,7 +320,10 @@ test("agy: a quota error is captured with the wall clock it burned", () => {
 });
 
 test("agy: an init-only transcript is truncated", () => {
-  const run = parseRun("bj29-factory-triage-x.jsonl", jsonl({ event: "init", conversation_id: "abc", init: { tools: [] } }));
+  const run = parseRun(
+    "bj29-factory-triage-x.jsonl",
+    jsonl({ event: "init", conversation_id: "abc", init: { tools: [] } }),
+  );
   expect(run.harness).toBe("agy");
   expect(run.truncated).toBe(true);
 });
@@ -150,14 +333,82 @@ test("a payload is weighted by the turns it stayed in the context window", () =>
   // 1000 bytes read at tool call 1, with 3 more calls after it, is re-sent
   // roughly 3 times. Raw payload alone would rank this the same as a 1000-byte
   // result on the very last call, which costs nothing further.
-  const run = parseRun("bj29-CLNT-5-x.jsonl", jsonl(
-    { type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "Read", input: { file_path: "/big.png" } }] } },
-    { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "x".repeat(1000) }] } },
-    { type: "assistant", message: { content: [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "ls" } }] } },
-    { type: "assistant", message: { content: [{ type: "tool_use", id: "t3", name: "Bash", input: { command: "pwd" } }] } },
-    { type: "assistant", message: { content: [{ type: "tool_use", id: "t4", name: "Bash", input: { command: "id" } }] } },
-    { type: "result", subtype: "success", is_error: false, num_turns: 4, total_cost_usd: 0.1 },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-5-x.jsonl",
+    jsonl(
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Read",
+              input: { file_path: "/big.png" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: "x".repeat(1000),
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t2",
+              name: "Bash",
+              input: { command: "ls" },
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t3",
+              name: "Bash",
+              input: { command: "pwd" },
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t4",
+              name: "Bash",
+              input: { command: "id" },
+            },
+          ],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 4,
+        total_cost_usd: 0.1,
+      },
+    ),
+  );
   expect(run.resultBytes).toBe(1000);
   expect(run.weightedBytes).toBe(3000);
   expect(run.toolResultBytes.get("Read").weighted).toBe(3000);
@@ -165,31 +416,61 @@ test("a payload is weighted by the turns it stayed in the context window", () =>
 
 // ------------------------------------------------------------ signatures ---
 test("errorSignature collapses paths, shas and numbers so one bug counts once", () => {
-  const a = errorSignature("File does not exist: /Users/x/repo/a.md at line 42");
-  const b = errorSignature("File does not exist: /Users/y/other/b.md at line 7");
+  const a = errorSignature(
+    "File does not exist: /Users/x/repo/a.md at line 42",
+  );
+  const b = errorSignature(
+    "File does not exist: /Users/y/other/b.md at line 7",
+  );
   expect(a).toBe(b);
 });
 
 test("messageSignature keeps the command name that errorSignature would erase", () => {
-  expect(messageSignature("Unknown command: /factory-ticket")).toContain("/factory-ticket");
-  expect(messageSignature("quota reached. Resets in 44h1m15s."))
-    .toBe(messageSignature("quota reached. Resets in 44h21m16s."));
+  expect(messageSignature("Unknown command: /factory-ticket")).toContain(
+    "/factory-ticket",
+  );
+  expect(messageSignature("quota reached. Resets in 44h1m15s.")).toBe(
+    messageSignature("quota reached. Resets in 44h21m16s."),
+  );
 });
 
 // -------------------------------------------------------------- pricing ---
 test("a harness reporting no cost is still priced, so the budget gate sees it", () => {
-  const run = parseRun("bj29-CLNT-6-x.jsonl", jsonl(
-    { type: "turn.completed", usage: { input_tokens: 1_000_000, cached_input_tokens: 900_000, output_tokens: 10_000 } },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-6-x.jsonl",
+    jsonl({
+      type: "turn.completed",
+      usage: {
+        input_tokens: 1_000_000,
+        cached_input_tokens: 900_000,
+        output_tokens: 10_000,
+      },
+    }),
+  );
   expect(run.cost).toBe(0);
   expect(run.estCost).toBeGreaterThan(0);
   expect(run.estCost).toBeCloseTo(estimateUSD(run), 10);
 });
 
 test("a claude run keeps its reported cost rather than the estimate", () => {
-  const run = parseRun("bj29-CLNT-7-x.jsonl", jsonl(
-    { type: "assistant", message: { usage: { input_tokens: 1000, output_tokens: 10 }, content: [] } },
-    { type: "result", subtype: "success", is_error: false, num_turns: 1, total_cost_usd: 3.5 },
-  ));
+  const run = parseRun(
+    "bj29-CLNT-7-x.jsonl",
+    jsonl(
+      {
+        type: "assistant",
+        message: {
+          usage: { input_tokens: 1000, output_tokens: 10 },
+          content: [],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 1,
+        total_cost_usd: 3.5,
+      },
+    ),
+  );
   expect(run.estCost).toBe(3.5);
 });

--- a/lib/worker-leases.mjs
+++ b/lib/worker-leases.mjs
@@ -7,7 +7,14 @@
  * answer. Leases expire when their owner stops renewing them, which prevents a
  * dead dispatcher from filling the capacity counter forever.
  */
-import { mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -23,21 +30,40 @@ function leaseFile(repo, ticket, dir) {
 }
 
 function readLease(file) {
-  try { return JSON.parse(readFileSync(file, "utf8")); } catch { return null; }
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function isAlive(pid) {
   if (!Number.isInteger(pid) || pid < 1) return false;
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Write or refresh a ticket's lease. `owner` prevents another run deleting it. */
-export function writeWorkerLease({ repo, ticket, owner, pid = process.pid, dir = leaseDir(), now = Date.now() }) {
+export function writeWorkerLease({
+  repo,
+  ticket,
+  owner,
+  pid = process.pid,
+  dir = leaseDir(),
+  now = Date.now(),
+}) {
   mkdirSync(dir, { recursive: true });
   const file = leaseFile(repo, ticket, dir);
   const prior = readLease(file);
   const lease = {
-    repo, ticket, owner, pid,
+    repo,
+    ticket,
+    owner,
+    pid,
     startedAt: prior?.owner === owner ? prior.startedAt : now,
     heartbeatAt: now,
   };
@@ -48,7 +74,13 @@ export function writeWorkerLease({ repo, ticket, owner, pid = process.pid, dir =
 }
 
 /** Refresh without changing the worker pid recorded when the child started. */
-export function renewWorkerLease({ repo, ticket, owner, dir = leaseDir(), now = Date.now() }) {
+export function renewWorkerLease({
+  repo,
+  ticket,
+  owner,
+  dir = leaseDir(),
+  now = Date.now(),
+}) {
   const prior = readLease(leaseFile(repo, ticket, dir));
   if (!prior || prior.owner !== owner) return false;
   writeWorkerLease({ repo, ticket, owner, pid: prior.pid, dir, now });
@@ -59,7 +91,12 @@ export function releaseWorkerLease({ repo, ticket, owner, dir = leaseDir() }) {
   const file = leaseFile(repo, ticket, dir);
   const prior = readLease(file);
   if (!prior || prior.owner !== owner) return false;
-  try { unlinkSync(file); return true; } catch { return false; }
+  try {
+    unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -67,13 +104,28 @@ export function releaseWorkerLease({ repo, ticket, owner, dir = leaseDir() }) {
  * process check makes a killed agent release capacity immediately; the TTL
  * handles a supervisor that vanished while its child was still around.
  */
-export function liveWorkerLeases(repo, { dir = leaseDir(), now = Date.now(), ttlMs = LEASE_TTL_MS, pidAlive = isAlive } = {}) {
+export function liveWorkerLeases(
+  repo,
+  {
+    dir = leaseDir(),
+    now = Date.now(),
+    ttlMs = LEASE_TTL_MS,
+    pidAlive = isAlive,
+  } = {},
+) {
   let names;
-  try { names = readdirSync(dir); } catch { return []; }
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
   return names
     .filter((name) => name.startsWith(`${repo}-`) && name.endsWith(".json"))
     .map((name) => readLease(path.join(dir, name)))
     .filter((lease) => lease?.repo === repo && typeof lease.ticket === "string")
-    .filter((lease) => Number.isFinite(lease.heartbeatAt) && now - lease.heartbeatAt < ttlMs)
+    .filter(
+      (lease) =>
+        Number.isFinite(lease.heartbeatAt) && now - lease.heartbeatAt < ttlMs,
+    )
     .filter((lease) => pidAlive(lease.pid));
 }

--- a/lib/worker-leases.test.mjs
+++ b/lib/worker-leases.test.mjs
@@ -2,23 +2,74 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { writeWorkerLease, renewWorkerLease, releaseWorkerLease, liveWorkerLeases } from "./worker-leases.mjs";
+import {
+  writeWorkerLease,
+  renewWorkerLease,
+  releaseWorkerLease,
+  liveWorkerLeases,
+} from "./worker-leases.mjs";
 
 test("a lease occupies capacity only while its worker is alive and heartbeating", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-lease-"));
-  writeWorkerLease({ repo: "legalease", ticket: "CLNT-1", owner: "run-a", pid: 42, dir, now: 1_000 });
-  expect(liveWorkerLeases("legalease", { dir, now: 2_000, pidAlive: (pid) => pid === 42 })).toHaveLength(1);
-  expect(liveWorkerLeases("legalease", { dir, now: 2_000, pidAlive: () => false })).toEqual([]);
-  expect(liveWorkerLeases("legalease", { dir, now: 100_001, pidAlive: () => true })).toEqual([]);
+  writeWorkerLease({
+    repo: "legalease",
+    ticket: "CLNT-1",
+    owner: "run-a",
+    pid: 42,
+    dir,
+    now: 1_000,
+  });
+  expect(
+    liveWorkerLeases("legalease", {
+      dir,
+      now: 2_000,
+      pidAlive: (pid) => pid === 42,
+    }),
+  ).toHaveLength(1);
+  expect(
+    liveWorkerLeases("legalease", { dir, now: 2_000, pidAlive: () => false }),
+  ).toEqual([]);
+  expect(
+    liveWorkerLeases("legalease", { dir, now: 100_001, pidAlive: () => true }),
+  ).toEqual([]);
   rmSync(dir, { recursive: true, force: true });
 });
 
 test("only the owner can refresh or release a lease", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-lease-"));
-  writeWorkerLease({ repo: "legalease", ticket: "CLNT-2", owner: "run-a", pid: process.pid, dir, now: 1_000 });
-  expect(renewWorkerLease({ repo: "legalease", ticket: "CLNT-2", owner: "run-b", dir, now: 2_000 })).toBe(false);
-  expect(releaseWorkerLease({ repo: "legalease", ticket: "CLNT-2", owner: "run-b", dir })).toBe(false);
-  expect(releaseWorkerLease({ repo: "legalease", ticket: "CLNT-2", owner: "run-a", dir })).toBe(true);
+  writeWorkerLease({
+    repo: "legalease",
+    ticket: "CLNT-2",
+    owner: "run-a",
+    pid: process.pid,
+    dir,
+    now: 1_000,
+  });
+  expect(
+    renewWorkerLease({
+      repo: "legalease",
+      ticket: "CLNT-2",
+      owner: "run-b",
+      dir,
+      now: 2_000,
+    }),
+  ).toBe(false);
+  expect(
+    releaseWorkerLease({
+      repo: "legalease",
+      ticket: "CLNT-2",
+      owner: "run-b",
+      dir,
+    }),
+  ).toBe(false);
+  expect(
+    releaseWorkerLease({
+      repo: "legalease",
+      ticket: "CLNT-2",
+      owner: "run-a",
+      dir,
+    }),
+  ).toBe(true);
   expect(liveWorkerLeases("legalease", { dir })).toEqual([]);
   rmSync(dir, { recursive: true, force: true });
 });

--- a/orchestrator/actions-cache.mjs
+++ b/orchestrator/actions-cache.mjs
@@ -13,7 +13,10 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
-import { renderActionsCacheUsage, summarizeActionsCacheUsage } from "../lib/actions-cache.mjs";
+import {
+  renderActionsCacheUsage,
+  summarizeActionsCacheUsage,
+} from "../lib/actions-cache.mjs";
 
 const argv = process.argv.slice(2);
 const value = (flag) => {
@@ -31,7 +34,9 @@ const number = (flag, fallback) => {
   return parsed;
 };
 
-const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
+const policy = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"),
+);
 const configured = policy.actions_cache ?? {};
 const organization = value("--org") ?? configured.organization;
 const includedGb = number("--included-gb", configured.included_gb);
@@ -39,7 +44,9 @@ const warningPercent = number("--warning-percent", configured.warning_percent);
 const json = argv.includes("--json");
 
 if (!organization || !includedGb || !warningPercent) {
-  console.error("Actions-cache policy is incomplete; set organization, included_gb, and warning_percent in config/policy.yaml.");
+  console.error(
+    "Actions-cache policy is incomplete; set organization, included_gb, and warning_percent in config/policy.yaml.",
+  );
   process.exit(2);
 }
 
@@ -49,7 +56,9 @@ if (process.env.FACTORY_ACTIONS_CACHE_USAGE_JSON) {
   raw = process.env.FACTORY_ACTIONS_CACHE_USAGE_JSON;
 } else {
   const api = Bun.spawnSync([
-    "gh", "api", `orgs/${organization}/actions/cache/usage-by-repository?per_page=100`,
+    "gh",
+    "api",
+    `orgs/${organization}/actions/cache/usage-by-repository?per_page=100`,
   ]);
   if (api.exitCode !== 0) {
     process.stderr.write(api.stderr);
@@ -66,7 +75,10 @@ try {
   process.exit(1);
 }
 
-const summary = summarizeActionsCacheUsage(payload, { includedGb, warningPercent });
+const summary = summarizeActionsCacheUsage(payload, {
+  includedGb,
+  warningPercent,
+});
 if (json) console.log(JSON.stringify(summary, null, 2));
 else console.log(renderActionsCacheUsage(summary));
 process.exit(summary.warning ? 1 : 0);

--- a/orchestrator/actions-cache.test.mjs
+++ b/orchestrator/actions-cache.test.mjs
@@ -6,7 +6,11 @@ const usage = JSON.stringify({
   total_active_caches_size_in_bytes: 45_000_000_000,
   total_active_caches_count: 9,
   repository_cache_usages: [
-    { full_name: "watt-mind/example", active_caches_size_in_bytes: 45_000_000_000, active_caches_count: 9 },
+    {
+      full_name: "watt-mind/example",
+      active_caches_size_in_bytes: 45_000_000_000,
+      active_caches_count: 9,
+    },
   ],
 });
 
@@ -29,5 +33,8 @@ test("actions-cache exits non-zero and renders a warning at the configured thres
 test("actions-cache can output its report as JSON", () => {
   const result = run(["--included-gb", "100", "--json"]);
   expect(result.exitCode).toBe(0);
-  expect(JSON.parse(result.stdout.toString())).toMatchObject({ bytes: 45_000_000_000, warning: false });
+  expect(JSON.parse(result.stdout.toString())).toMatchObject({
+    bytes: 45_000_000_000,
+    warning: false,
+  });
 });

--- a/orchestrator/blockers.test.mjs
+++ b/orchestrator/blockers.test.mjs
@@ -5,22 +5,42 @@ const issueWith = (nodes) => ({ inverseRelations: { nodes } });
 
 describe("openBlockers", () => {
   test("open blocker holds the ticket", () => {
-    const i = issueWith([{ type: "blocks", issue: { identifier: "OPS-1", state: { type: "started" } } }]);
+    const i = issueWith([
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-1", state: { type: "started" } },
+      },
+    ]);
     expect(openBlockers(i)).toEqual(["OPS-1"]);
   });
 
   test("unstarted blocker holds too — Todo is not Done", () => {
-    const i = issueWith([{ type: "blocks", issue: { identifier: "OPS-2", state: { type: "unstarted" } } }]);
+    const i = issueWith([
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-2", state: { type: "unstarted" } },
+      },
+    ]);
     expect(openBlockers(i)).toEqual(["OPS-2"]);
   });
 
   test("completed blocker releases", () => {
-    const i = issueWith([{ type: "blocks", issue: { identifier: "OPS-3", state: { type: "completed" } } }]);
+    const i = issueWith([
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-3", state: { type: "completed" } },
+      },
+    ]);
     expect(openBlockers(i)).toEqual([]);
   });
 
   test("canceled blocker releases — dead work must not gate live work", () => {
-    const i = issueWith([{ type: "blocks", issue: { identifier: "OPS-4", state: { type: "canceled" } } }]);
+    const i = issueWith([
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-4", state: { type: "canceled" } },
+      },
+    ]);
     expect(openBlockers(i)).toEqual([]);
   });
 
@@ -35,18 +55,36 @@ describe("openBlockers", () => {
 
   test("duplicate/related relation types do not gate", () => {
     const i = issueWith([
-      { type: "duplicate", issue: { identifier: "OPS-5", state: { type: "started" } } },
-      { type: "related", issue: { identifier: "OPS-6", state: { type: "unstarted" } } },
+      {
+        type: "duplicate",
+        issue: { identifier: "OPS-5", state: { type: "started" } },
+      },
+      {
+        type: "related",
+        issue: { identifier: "OPS-6", state: { type: "unstarted" } },
+      },
     ]);
     expect(openBlockers(i)).toEqual([]);
   });
 
   test("mixed relations report only the open blockers", () => {
     const i = issueWith([
-      { type: "blocks", issue: { identifier: "OPS-7", state: { type: "completed" } } },
-      { type: "blocks", issue: { identifier: "OPS-8", state: { type: "started" } } },
-      { type: "related", issue: { identifier: "OPS-9", state: { type: "started" } } },
-      { type: "blocks", issue: { identifier: "OPS-10", state: { type: "backlog" } } },
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-7", state: { type: "completed" } },
+      },
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-8", state: { type: "started" } },
+      },
+      {
+        type: "related",
+        issue: { identifier: "OPS-9", state: { type: "started" } },
+      },
+      {
+        type: "blocks",
+        issue: { identifier: "OPS-10", state: { type: "backlog" } },
+      },
     ]);
     expect(openBlockers(i)).toEqual(["OPS-8", "OPS-10"]);
   });

--- a/orchestrator/branch-guard.mjs
+++ b/orchestrator/branch-guard.mjs
@@ -37,14 +37,18 @@ export function protectedBranchesFor(repo) {
 
 /** Normalize branch refs for protected-branch comparisons. */
 function normalizeBranchName(branch) {
-  return String(branch).toLowerCase().replace(/^(?:refs\/heads\/|origin\/|heads\/)/, "");
+  return String(branch)
+    .toLowerCase()
+    .replace(/^(?:refs\/heads\/|origin\/|heads\/)/, "");
 }
 
 /** Check if a branch name matches any protected branch for this repo. */
 export function isProtectedBranch(branch, repo) {
   if (!branch) return false;
   const candidate = normalizeBranchName(branch);
-  return protectedBranchesFor(repo).some((protectedBranch) => normalizeBranchName(protectedBranch) === candidate);
+  return protectedBranchesFor(repo).some(
+    (protectedBranch) => normalizeBranchName(protectedBranch) === candidate,
+  );
 }
 
 /**
@@ -53,8 +57,11 @@ export function isProtectedBranch(branch, repo) {
  */
 export function openPrHold(branch, targetPr, openPrs) {
   if (!branch) return null;
-  const targetStr = targetPr !== null && targetPr !== undefined ? String(targetPr) : null;
-  const holders = (openPrs ?? []).filter((pr) => String(pr?.number) !== targetStr && pr?.headRefName === branch);
+  const targetStr =
+    targetPr !== null && targetPr !== undefined ? String(targetPr) : null;
+  const holders = (openPrs ?? []).filter(
+    (pr) => String(pr?.number) !== targetStr && pr?.headRefName === branch,
+  );
   if (!holders.length) return null;
   const list = holders.map((pr) => `#${pr.number}`).join(", ");
   return `branch "${branch}" is still the head of other open PR(s): ${list} (WM-17)`;
@@ -65,10 +72,18 @@ export function openPrHold(branch, targetPr, openPrs) {
  */
 export function evaluateBranchGuard({ branch, repo, targetPr, openPrs }) {
   if (!branch) {
-    return { ok: false, exitCode: EXIT.CANNOT_EVALUATE, reason: "head branch is empty or missing" };
+    return {
+      ok: false,
+      exitCode: EXIT.CANNOT_EVALUATE,
+      reason: "head branch is empty or missing",
+    };
   }
   if (!repo) {
-    return { ok: false, exitCode: EXIT.CANNOT_EVALUATE, reason: "repo configuration is missing" };
+    return {
+      ok: false,
+      exitCode: EXIT.CANNOT_EVALUATE,
+      reason: "repo configuration is missing",
+    };
   }
   if (isProtectedBranch(branch, repo)) {
     return {
@@ -97,10 +112,14 @@ export function evaluateBranchGuard({ branch, repo, targetPr, openPrs }) {
  * Returns null when gh fails.
  */
 export function resolveHeadBranch(repoPath, pr, run = spawnSync) {
-  const r = run("gh", ["pr", "view", String(pr), "--json", "headRefName", "-q", ".headRefName"], {
-    cwd: repoPath,
-    encoding: "utf8",
-  });
+  const r = run(
+    "gh",
+    ["pr", "view", String(pr), "--json", "headRefName", "-q", ".headRefName"],
+    {
+      cwd: repoPath,
+      encoding: "utf8",
+    },
+  );
   if (r.status !== 0) return null;
   const out = (r.stdout || "").trim();
   return out || null;
@@ -111,10 +130,23 @@ export function resolveHeadBranch(repoPath, pr, run = spawnSync) {
  * Returns null when gh fails.
  */
 export function listOpenPrs(repoPath, run = spawnSync) {
-  const r = run("gh", ["pr", "list", "--state", "open", "--limit", "200", "--json", "number,headRefName"], {
-    cwd: repoPath,
-    encoding: "utf8",
-  });
+  const r = run(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      "200",
+      "--json",
+      "number,headRefName",
+    ],
+    {
+      cwd: repoPath,
+      encoding: "utf8",
+    },
+  );
   if (r.status !== 0) return null;
   try {
     const parsed = JSON.parse(r.stdout || "[]");
@@ -126,29 +158,40 @@ export function listOpenPrs(repoPath, run = spawnSync) {
 
 if (import.meta.main) {
   const argv = process.argv.slice(2);
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
 
   const repoName = val("--repo");
   const pr = val("--pr");
   const explicitHead = val("--head");
 
   if (!repoName || !pr) {
-    console.error("usage: bun orchestrator/branch-guard.mjs --repo <name> --pr <number> [--head <branch>]");
+    console.error(
+      "usage: bun orchestrator/branch-guard.mjs --repo <name> --pr <number> [--head <branch>]",
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
 
-  const configPath = process.env.FACTORY_BRANCH_GUARD_REPOS_YAML || path.join(ROOT, "config/repos.yaml");
+  const configPath =
+    process.env.FACTORY_BRANCH_GUARD_REPOS_YAML ||
+    path.join(ROOT, "config/repos.yaml");
   let cfg;
   try {
     cfg = Bun.YAML.parse(readFileSync(configPath, "utf8"));
   } catch (err) {
-    console.error(`CANNOT EVALUATE — could not read ${configPath}: ${err.message}`);
+    console.error(
+      `CANNOT EVALUATE — could not read ${configPath}: ${err.message}`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
 
   const repo = (cfg?.repos ?? []).find((r) => r.name === repoName);
   if (!repo) {
-    console.error(`CANNOT EVALUATE — no repo named "${repoName}" in ${configPath}`);
+    console.error(
+      `CANNOT EVALUATE — no repo named "${repoName}" in ${configPath}`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
 
@@ -158,7 +201,9 @@ if (import.meta.main) {
   if (!branch) {
     branch = resolveHeadBranch(repoPath, pr);
     if (!branch) {
-      console.error(`CANNOT EVALUATE — could not resolve head branch for PR #${pr} in ${repoName}`);
+      console.error(
+        `CANNOT EVALUATE — could not resolve head branch for PR #${pr} in ${repoName}`,
+      );
       process.exit(EXIT.CANNOT_EVALUATE);
     }
   }
@@ -180,7 +225,9 @@ if (import.meta.main) {
 
   const result = evaluateBranchGuard({ branch, repo, targetPr: pr, openPrs });
   if (result.exitCode === EXIT.SAFE) {
-    console.log(`SAFE — PR #${pr} branch "${branch}" in ${repoName} is safe to delete`);
+    console.log(
+      `SAFE — PR #${pr} branch "${branch}" in ${repoName} is safe to delete`,
+    );
     process.exit(EXIT.SAFE);
   } else if (result.exitCode === EXIT.REFUSED) {
     console.error(`REFUSED — ${result.reason}`);

--- a/orchestrator/branch-guard.test.mjs
+++ b/orchestrator/branch-guard.test.mjs
@@ -67,7 +67,9 @@ describe("protectedBranchesFor & isProtectedBranch", () => {
     expect(isProtectedBranch("MASTER", repo)).toBe(true);
     expect(isProtectedBranch("REFS/HEADS/PRODUCTION", repo)).toBe(true);
     expect(isProtectedBranch("origin/Staging", repo)).toBe(true);
-    expect(isProtectedBranch("staging", { ...repo, base: "StAgInG" })).toBe(true);
+    expect(isProtectedBranch("staging", { ...repo, base: "StAgInG" })).toBe(
+      true,
+    );
     expect(isProtectedBranch("upstream/develop", repo)).toBe(false);
     expect(isProtectedBranch("feature/origin/develop", repo)).toBe(false);
   });
@@ -159,7 +161,14 @@ describe("evaluateBranchGuard", () => {
   });
 
   test("returns REFUSED (2) for prefixed and case-variant protected branches", () => {
-    for (const branch of ["refs/heads/develop", "origin/develop", "heads/develop", "Develop", "Master", "MAIN"]) {
+    for (const branch of [
+      "refs/heads/develop",
+      "origin/develop",
+      "heads/develop",
+      "Develop",
+      "Master",
+      "MAIN",
+    ]) {
       const res = evaluateBranchGuard({
         branch,
         repo,
@@ -185,27 +194,52 @@ describe("evaluateBranchGuard", () => {
   });
 
   test("returns CANNOT_EVALUATE (3) on missing branch or repo", () => {
-    expect(evaluateBranchGuard({ branch: "", repo, targetPr: 1, openPrs }).exitCode).toBe(EXIT.CANNOT_EVALUATE);
-    expect(evaluateBranchGuard({ branch: "feat/foo", repo: null, targetPr: 1, openPrs }).exitCode).toBe(EXIT.CANNOT_EVALUATE);
+    expect(
+      evaluateBranchGuard({ branch: "", repo, targetPr: 1, openPrs }).exitCode,
+    ).toBe(EXIT.CANNOT_EVALUATE);
+    expect(
+      evaluateBranchGuard({
+        branch: "feat/foo",
+        repo: null,
+        targetPr: 1,
+        openPrs,
+      }).exitCode,
+    ).toBe(EXIT.CANNOT_EVALUATE);
   });
 });
 
 describe("gh helper failure modes", () => {
   test("resolveHeadBranch returns null on gh error", () => {
-    const run = recorder(() => ({ status: 1, stdout: "", stderr: "not found" }));
+    const run = recorder(() => ({
+      status: 1,
+      stdout: "",
+      stderr: "not found",
+    }));
     expect(resolveHeadBranch("/fake", 123, run)).toBeNull();
   });
 
   test("resolveHeadBranch returns branch name on success", () => {
-    const run = recorder(() => ({ status: 0, stdout: "feat/my-branch\n", stderr: "" }));
+    const run = recorder(() => ({
+      status: 0,
+      stdout: "feat/my-branch\n",
+      stderr: "",
+    }));
     expect(resolveHeadBranch("/fake", 123, run)).toBe("feat/my-branch");
   });
 
   test("listOpenPrs returns null on gh failure or JSON parse error", () => {
-    const runFail = recorder(() => ({ status: 1, stdout: "", stderr: "gh error" }));
+    const runFail = recorder(() => ({
+      status: 1,
+      stdout: "",
+      stderr: "gh error",
+    }));
     expect(listOpenPrs("/fake", runFail)).toBeNull();
 
-    const runBadJson = recorder(() => ({ status: 0, stdout: "invalid json", stderr: "" }));
+    const runBadJson = recorder(() => ({
+      status: 0,
+      stdout: "invalid json",
+      stderr: "",
+    }));
     expect(listOpenPrs("/fake", runBadJson)).toBeNull();
   });
 
@@ -215,7 +249,9 @@ describe("gh helper failure modes", () => {
       stdout: JSON.stringify([{ number: 10, headRefName: "feat/x" }]),
       stderr: "",
     }));
-    expect(listOpenPrs("/fake", run)).toEqual([{ number: 10, headRefName: "feat/x" }]);
+    expect(listOpenPrs("/fake", run)).toEqual([
+      { number: 10, headRefName: "feat/x" },
+    ]);
   });
 });
 
@@ -253,7 +289,11 @@ repos:
       },
     );
 
-    try { unlinkSync(tmpConfig); } catch { /* intentionally ignored */ }
+    try {
+      unlinkSync(tmpConfig);
+    } catch {
+      /* intentionally ignored */
+    }
     expect(r.status).toBe(EXIT.SAFE);
     expect(r.stdout).toContain("safe to delete");
   });
@@ -289,7 +329,11 @@ repos:
       },
     );
 
-    try { unlinkSync(tmpConfig); } catch { /* intentionally ignored */ }
+    try {
+      unlinkSync(tmpConfig);
+    } catch {
+      /* intentionally ignored */
+    }
     expect(r.status).toBe(EXIT.REFUSED);
     expect(r.stderr).toContain("protected branch");
   });
@@ -304,7 +348,13 @@ repos:
 
     const rBadRepo = spawnSync(
       "bun",
-      [path.join(import.meta.dirname, "branch-guard.mjs"), "--repo", "nonexistent", "--pr", "123"],
+      [
+        path.join(import.meta.dirname, "branch-guard.mjs"),
+        "--repo",
+        "nonexistent",
+        "--pr",
+        "123",
+      ],
       { encoding: "utf8" },
     );
     expect(rBadRepo.status).toBe(EXIT.CANNOT_EVALUATE);

--- a/orchestrator/chrome-sweep.mjs
+++ b/orchestrator/chrome-sweep.mjs
@@ -27,21 +27,26 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 const APPLY = process.argv.includes("--apply");
-const SHARED_PROFILE = path.join(homedir(), ".cache/chrome-devtools-mcp/chrome-profile");
+const SHARED_PROFILE = path.join(
+  homedir(),
+  ".cache/chrome-devtools-mcp/chrome-profile",
+);
 
 /** Does this ps line look like an agent-launched Chrome profile? */
-const AGENT_PROFILE = /--user-data-dir=[^ ]*(chrome-devtools-mcp|puppeteer_dev_(chrome|firefox)_profile)/;
+const AGENT_PROFILE =
+  /--user-data-dir=[^ ]*(chrome-devtools-mcp|puppeteer_dev_(chrome|firefox)_profile)/;
 
 /**
  * Pure classifier over `ps -axo pid=,ppid=,command=` rows so the kill logic is
  * testable without killing anything. Returns { orphans, live }.
  */
 export function classify(rows) {
-  const orphans = [], live = [];
+  const orphans = [],
+    live = [];
   for (const r of rows) {
-    if (!AGENT_PROFILE.test(r.command)) continue;     // fence 1: agent profile only
-    if (/--type=/.test(r.command)) continue;          // fence 2: main process only
-    (r.ppid === 1 ? orphans : live).push(r);          // fence 3: dead parent = orphan
+    if (!AGENT_PROFILE.test(r.command)) continue; // fence 1: agent profile only
+    if (/--type=/.test(r.command)) continue; // fence 2: main process only
+    (r.ppid === 1 ? orphans : live).push(r); // fence 3: dead parent = orphan
   }
   return { orphans, live };
 }
@@ -54,26 +59,46 @@ export function parsePs(text) {
 }
 
 if (import.meta.main) {
-  const rows = parsePs(execSync("ps -axo pid=,ppid=,command=", { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
+  const rows = parsePs(
+    execSync("ps -axo pid=,ppid=,command=", {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    }),
+  );
   const { orphans, live } = classify(rows);
 
-  if (live.length) console.log(`${live.length} agent Chrome(s) with a living MCP server — left alone`);
+  if (live.length)
+    console.log(
+      `${live.length} agent Chrome(s) with a living MCP server — left alone`,
+    );
 
   if (!orphans.length) {
     console.log("no orphaned agent Chromes");
   } else {
     for (const o of orphans) {
-      const profile = (o.command.match(/--user-data-dir=([^ ]+)/) ?? [])[1] ?? "?";
-      console.log(`  ${APPLY ? "killing" : "would kill"} pid ${o.pid}  ${profile}`);
+      const profile =
+        (o.command.match(/--user-data-dir=([^ ]+)/) ?? [])[1] ?? "?";
+      console.log(
+        `  ${APPLY ? "killing" : "would kill"} pid ${o.pid}  ${profile}`,
+      );
       if (!APPLY) continue;
-      try { process.kill(o.pid, "SIGTERM"); } catch { /* intentionally ignored */ }
+      try {
+        process.kill(o.pid, "SIGTERM");
+      } catch {
+        /* intentionally ignored */
+      }
     }
     if (APPLY) {
       // TERM first so Chrome flushes its profile; KILL whatever ignores it.
       await Bun.sleep(5000);
       for (const o of orphans) {
-        try { process.kill(o.pid, 0); process.kill(o.pid, "SIGKILL"); console.log(`  SIGKILL pid ${o.pid} (survived TERM)`); }
-        catch { /* already gone — the normal case */ }
+        try {
+          process.kill(o.pid, 0);
+          process.kill(o.pid, "SIGKILL");
+          console.log(`  SIGKILL pid ${o.pid} (survived TERM)`);
+        } catch {
+          /* already gone — the normal case */
+        }
       }
     }
   }
@@ -89,9 +114,12 @@ if (import.meta.main) {
         lstatSync(p); // throws when absent — symlinks to dead sockets need lstat
         console.log(`  ${APPLY ? "removing" : "would remove"} stale ${f}`);
         if (APPLY) unlinkSync(p);
-      } catch { /* not present */ }
+      } catch {
+        /* not present */
+      }
     }
   }
 
-  if (!APPLY && orphans.length) console.log("\ndry run — re-run with --apply to kill them");
+  if (!APPLY && orphans.length)
+    console.log("\ndry run — re-run with --apply to kill them");
 }

--- a/orchestrator/chrome-sweep.test.mjs
+++ b/orchestrator/chrome-sweep.test.mjs
@@ -11,7 +11,11 @@ const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 
 test("an orphaned agent Chrome (reparented to launchd) is flagged", () => {
   const { orphans } = classify([
-    { pid: 500, ppid: 1, command: `${CHROME} --user-data-dir=/Users/x/.cache/chrome-devtools-mcp/chrome-profile --headless` },
+    {
+      pid: 500,
+      ppid: 1,
+      command: `${CHROME} --user-data-dir=/Users/x/.cache/chrome-devtools-mcp/chrome-profile --headless`,
+    },
   ]);
   expect(orphans).toHaveLength(1);
   expect(orphans[0].pid).toBe(500);
@@ -19,7 +23,11 @@ test("an orphaned agent Chrome (reparented to launchd) is flagged", () => {
 
 test("an isolated temp profile from a killed run is flagged too", () => {
   const { orphans } = classify([
-    { pid: 501, ppid: 1, command: `${CHROME} --user-data-dir=/var/folders/pd/T/puppeteer_dev_chrome_profile-Xa1B2c` },
+    {
+      pid: 501,
+      ppid: 1,
+      command: `${CHROME} --user-data-dir=/var/folders/pd/T/puppeteer_dev_chrome_profile-Xa1B2c`,
+    },
   ]);
   expect(orphans).toHaveLength(1);
 });
@@ -29,7 +37,11 @@ test("the human's normal Chrome is NEVER touched, even at ppid 1", () => {
   // the profile fence is what protects it, not the parent check.
   const { orphans, live } = classify([
     { pid: 600, ppid: 1, command: `${CHROME}` },
-    { pid: 601, ppid: 1, command: `${CHROME} --user-data-dir=/Users/x/Library/Application Support/Google/Chrome` },
+    {
+      pid: 601,
+      ppid: 1,
+      command: `${CHROME} --user-data-dir=/Users/x/Library/Application Support/Google/Chrome`,
+    },
   ]);
   expect(orphans).toHaveLength(0);
   expect(live).toHaveLength(0);
@@ -37,7 +49,11 @@ test("the human's normal Chrome is NEVER touched, even at ppid 1", () => {
 
 test("an agent Chrome whose MCP server is alive is left alone", () => {
   const { orphans, live } = classify([
-    { pid: 700, ppid: 42371, command: `${CHROME} --user-data-dir=/var/folders/T/chrome-devtools-mcp-tmp-abc --headless` },
+    {
+      pid: 700,
+      ppid: 42371,
+      command: `${CHROME} --user-data-dir=/var/folders/T/chrome-devtools-mcp-tmp-abc --headless`,
+    },
   ]);
   expect(orphans).toHaveLength(0);
   expect(live).toHaveLength(1);
@@ -45,14 +61,28 @@ test("an agent Chrome whose MCP server is alive is left alone", () => {
 
 test("helper processes are skipped — killing the main brings them down", () => {
   const { orphans } = classify([
-    { pid: 800, ppid: 1, command: `${CHROME} --type=renderer --user-data-dir=/x/chrome-devtools-mcp/chrome-profile` },
-    { pid: 801, ppid: 1, command: `${CHROME} --type=gpu-process --user-data-dir=/x/chrome-devtools-mcp/chrome-profile` },
+    {
+      pid: 800,
+      ppid: 1,
+      command: `${CHROME} --type=renderer --user-data-dir=/x/chrome-devtools-mcp/chrome-profile`,
+    },
+    {
+      pid: 801,
+      ppid: 1,
+      command: `${CHROME} --type=gpu-process --user-data-dir=/x/chrome-devtools-mcp/chrome-profile`,
+    },
   ]);
   expect(orphans).toHaveLength(0);
 });
 
 test("parsePs handles ps output with leading whitespace and spaces in commands", () => {
-  const rows = parsePs(`  123     1 ${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p\n 45  6789 /usr/bin/tail -f log\n\n`);
+  const rows = parsePs(
+    `  123     1 ${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p\n 45  6789 /usr/bin/tail -f log\n\n`,
+  );
   expect(rows).toHaveLength(2);
-  expect(rows[0]).toEqual({ pid: 123, ppid: 1, command: `${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p` });
+  expect(rows[0]).toEqual({
+    pid: 123,
+    ppid: 1,
+    command: `${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p`,
+  });
 });

--- a/orchestrator/ci.mjs
+++ b/orchestrator/ci.mjs
@@ -28,35 +28,68 @@ import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 const JSON_OUT = argv.includes("--json");
 
 const sinceArg = val("--since") || "14d";
 const sinceDays = Number(sinceArg.replace(/[^\d]/g, "")) || 14;
-const sinceDate = new Date(Date.now() - sinceDays * 86400e3).toISOString().slice(0, 10);
+const sinceDate = new Date(Date.now() - sinceDays * 86400e3)
+  .toISOString()
+  .slice(0, 10);
 
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const repos = (cfg.repos ?? []).filter((r) => r.github && (!only.length || only.includes(r.name)));
+const cfg = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+);
+const repos = (cfg.repos ?? []).filter(
+  (r) => r.github && (!only.length || only.includes(r.name)),
+);
 
 if (!repos.length) {
-  console.error(only.length ? `no repo named "${only}" in config/repos.yaml with a github remote` : "no repos with a github remote configured");
+  console.error(
+    only.length
+      ? `no repo named "${only}" in config/repos.yaml with a github remote`
+      : "no repos with a github remote configured",
+  );
   process.exit(2);
 }
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, green: (s) => `\x1b[32m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
 };
 
 function runList(nameWithOwner, branch) {
   const p = Bun.spawnSync([
-    "gh", "run", "list", "--repo", nameWithOwner, "--branch", branch,
-    "--created", `>=${sinceDate}`, "--limit", "200",
-    "--json", "databaseId,name,workflowName,status,conclusion,createdAt,startedAt,updatedAt",
+    "gh",
+    "run",
+    "list",
+    "--repo",
+    nameWithOwner,
+    "--branch",
+    branch,
+    "--created",
+    `>=${sinceDate}`,
+    "--limit",
+    "200",
+    "--json",
+    "databaseId,name,workflowName,status,conclusion,createdAt,startedAt,updatedAt",
   ]);
   if (p.exitCode !== 0) return null;
-  try { return JSON.parse(p.stdout.toString()); } catch { return null; }
+  try {
+    return JSON.parse(p.stdout.toString());
+  } catch {
+    return null;
+  }
 }
 
 function median(nums) {
@@ -71,7 +104,10 @@ for (const repo of repos) {
   const branch = repo.base || "main";
   const runs = runList(repo.github, branch);
   if (runs === null) {
-    repoReports.push({ repo: repo.name, error: "gh run list failed (no access, or repo has no Actions history)" });
+    repoReports.push({
+      repo: repo.name,
+      error: "gh run list failed (no access, or repo has no Actions history)",
+    });
     continue;
   }
   if (!runs.length) {
@@ -85,7 +121,11 @@ for (const repo of repos) {
     const key = r.workflowName || r.name || "?";
     const hit = byWorkflow.get(key) ?? [];
     const durMs = new Date(r.updatedAt) - new Date(r.startedAt || r.createdAt);
-    hit.push({ conclusion: r.conclusion, durMs: Math.max(durMs, 0), createdAt: r.createdAt });
+    hit.push({
+      conclusion: r.conclusion,
+      durMs: Math.max(durMs, 0),
+      createdAt: r.createdAt,
+    });
     byWorkflow.set(key, hit);
   }
 
@@ -103,8 +143,14 @@ for (const repo of repos) {
     let trendPct = null;
     if (entries.length >= 6 && med >= 30_000) {
       const third = Math.max(2, Math.floor(entries.length / 3));
-      const oldest = entries.slice(0, third).map((e) => e.durMs).filter((d) => d > 0);
-      const newest = entries.slice(-third).map((e) => e.durMs).filter((d) => d > 0);
+      const oldest = entries
+        .slice(0, third)
+        .map((e) => e.durMs)
+        .filter((d) => d > 0);
+      const newest = entries
+        .slice(-third)
+        .map((e) => e.durMs)
+        .filter((d) => d > 0);
       if (oldest.length && newest.length) {
         const oldAvg = oldest.reduce((a, b) => a + b, 0) / oldest.length;
         const newAvg = newest.reduce((a, b) => a + b, 0) / newest.length;
@@ -112,7 +158,13 @@ for (const repo of repos) {
       }
     }
 
-    workflows.push({ name, runs: entries.length, failures, medianMs: med, trendPct });
+    workflows.push({
+      name,
+      runs: entries.length,
+      failures,
+      medianMs: med,
+      trendPct,
+    });
   }
   workflows.sort((a, b) => b.medianMs - a.medianMs);
   repoReports.push({ repo: repo.name, error: null, workflows });
@@ -123,30 +175,55 @@ if (JSON_OUT) {
   process.exit(0);
 }
 
-console.log(c.bold(`\nCI health across ${repos.length} repo(s), last ${sinceDays}d\n`));
+console.log(
+  c.bold(`\nCI health across ${repos.length} repo(s), last ${sinceDays}d\n`),
+);
 
 const flaky = [];
 const slowing = [];
 
 for (const r of repoReports) {
   console.log(c.bold(r.repo));
-  if (r.error) { console.log(c.yellow(`  ${r.error}`)); continue; }
-  if (!r.workflows.length) { console.log(c.dim(`  no completed runs on base branch in window`)); continue; }
+  if (r.error) {
+    console.log(c.yellow(`  ${r.error}`));
+    continue;
+  }
+  if (!r.workflows.length) {
+    console.log(c.dim(`  no completed runs on base branch in window`));
+    continue;
+  }
   for (const w of r.workflows) {
     const mins = (w.medianMs / 60000).toFixed(1);
-    const failFlag = w.failures > 1 ? c.red(`${w.failures} failures`) : w.failures === 1 ? c.dim("1 failure") : c.green("0 failures");
+    const failFlag =
+      w.failures > 1
+        ? c.red(`${w.failures} failures`)
+        : w.failures === 1
+          ? c.dim("1 failure")
+          : c.green("0 failures");
     let trendFlag = "";
-    if (w.trendPct !== null && w.trendPct > 20) trendFlag = c.red(`  ↑${w.trendPct.toFixed(0)}% slower (recent vs earlier)`);
-    else if (w.trendPct !== null && w.trendPct < -20) trendFlag = c.green(`  ↓${Math.abs(w.trendPct).toFixed(0)}% faster`);
-    console.log(`  ${w.name.padEnd(28)} median ${mins}min  ${failFlag}  (${w.runs} runs)${trendFlag}`);
+    if (w.trendPct !== null && w.trendPct > 20)
+      trendFlag = c.red(
+        `  ↑${w.trendPct.toFixed(0)}% slower (recent vs earlier)`,
+      );
+    else if (w.trendPct !== null && w.trendPct < -20)
+      trendFlag = c.green(`  ↓${Math.abs(w.trendPct).toFixed(0)}% faster`);
+    console.log(
+      `  ${w.name.padEnd(28)} median ${mins}min  ${failFlag}  (${w.runs} runs)${trendFlag}`,
+    );
     if (w.failures > 1) flaky.push({ repo: r.repo, ...w });
-    if (w.trendPct !== null && w.trendPct > 20) slowing.push({ repo: r.repo, ...w });
+    if (w.trendPct !== null && w.trendPct > 20)
+      slowing.push({ repo: r.repo, ...w });
   }
   console.log("");
 }
 
 if (flaky.length) {
-  console.log(c.bold(`repeat failures`) + c.dim("  (failed more than once in the window — worth fixing, not rerunning)\n"));
+  console.log(
+    c.bold(`repeat failures`) +
+      c.dim(
+        "  (failed more than once in the window — worth fixing, not rerunning)\n",
+      ),
+  );
   for (const w of flaky.sort((a, b) => b.failures - a.failures)) {
     console.log(`  ${c.red(`×${w.failures}`)}  ${w.repo} / ${w.name}`);
   }
@@ -154,11 +231,22 @@ if (flaky.length) {
 }
 
 if (slowing.length) {
-  console.log(c.bold(`trending slower`) + c.dim("  (recent runs meaningfully slower than earlier ones in the window)\n"));
+  console.log(
+    c.bold(`trending slower`) +
+      c.dim(
+        "  (recent runs meaningfully slower than earlier ones in the window)\n",
+      ),
+  );
   for (const w of slowing.sort((a, b) => b.trendPct - a.trendPct)) {
-    console.log(`  ${c.red(`↑${w.trendPct.toFixed(0)}%`)}  ${w.repo} / ${w.name}  (now ~${(w.medianMs / 60000).toFixed(1)}min)`);
+    console.log(
+      `  ${c.red(`↑${w.trendPct.toFixed(0)}%`)}  ${w.repo} / ${w.name}  (now ~${(w.medianMs / 60000).toFixed(1)}min)`,
+    );
   }
   console.log("");
 }
 
-console.log(c.dim(`Next: /factory-retro folds this in alongside friction.mjs — a repeat failure or a real trend is a harness defect, a one-off isn't.\n`));
+console.log(
+  c.dim(
+    `Next: /factory-retro folds this in alongside friction.mjs — a repeat failure or a real trend is a harness defect, a one-off isn't.\n`,
+  ),
+);

--- a/orchestrator/digest.mjs
+++ b/orchestrator/digest.mjs
@@ -21,13 +21,27 @@ import { ROOT } from "../lib/schedule.mjs";
 import { AI_BLOCKED, blockedLabelIds, holdInfo } from "./reply-detection.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
+const cfg = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+);
+const repos = (cfg.repos ?? []).filter(
+  (r) => !only.length || only.includes(r.name),
+);
 if (!repos.length) {
-  console.error(only.length ? `no repo named "${only}" in config/repos.yaml` : "no repos configured");
+  console.error(
+    only.length
+      ? `no repo named "${only}" in config/repos.yaml`
+      : "no repos configured",
+  );
   process.exit(2);
 }
 
@@ -70,7 +84,9 @@ const age = (ms) => {
   return `${Math.max(1, Math.floor(d / 60_000))}m`;
 };
 const excerpt = (body, n = 110) => {
-  const s = String(body ?? "").replace(/\s+/g, " ").trim();
+  const s = String(body ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
   return s.length > n ? s.slice(0, n - 1) + "…" : s;
 };
 
@@ -79,32 +95,64 @@ let totalHeld = 0;
 let totalAnswered = 0;
 
 for (const repo of repos) {
-  const nodes = (await gql(DIGEST_QUERY, { team: repo.team, project: repo.project, label: AI_BLOCKED }))?.issues?.nodes ?? [];
+  const nodes =
+    (
+      await gql(DIGEST_QUERY, {
+        team: repo.team,
+        project: repo.project,
+        label: AI_BLOCKED,
+      })
+    )?.issues?.nodes ?? [];
   const held = nodes
     .map((n) => ({ node: n, info: holdInfo(n, ids) }))
     .filter((h) => h.info)
     // Oldest hold first; unknown hold times sink to the bottom rather than
     // masquerading as the most urgent.
-    .sort((a, b) => (a.info.heldAtMs ?? Infinity) - (b.info.heldAtMs ?? Infinity));
+    .sort(
+      (a, b) => (a.info.heldAtMs ?? Infinity) - (b.info.heldAtMs ?? Infinity),
+    );
 
-  console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project} — ${held.length} held`));
-  if (!held.length) { console.log(c.dim("  nothing held — no ai:blocked tickets")); continue; }
+  console.log(
+    c.bold(`\n${repo.name}`) +
+      c.dim(`  ${repo.team} / ${repo.project} — ${held.length} held`),
+  );
+  if (!held.length) {
+    console.log(c.dim("  nothing held — no ai:blocked tickets"));
+    continue;
+  }
 
   for (const { node, info } of held) {
     totalHeld++;
     const answered = Boolean(info.reply);
     if (answered) totalAnswered++;
     const marker = answered
-      ? c.green(`  ANSWERED ${age(info.reply.atMs)} ago — triage will re-examine`)
+      ? c.green(
+          `  ANSWERED ${age(info.reply.atMs)} ago — triage will re-examine`,
+        )
       : "";
-    console.log(`  ${c.red(node.identifier.padEnd(10))} held ${age(info.heldAtMs)}${marker}`);
+    console.log(
+      `  ${c.red(node.identifier.padEnd(10))} held ${age(info.heldAtMs)}${marker}`,
+    );
     console.log(c.dim(`    ${excerpt(node.title, 100)}`));
-    if (info.question?.body) console.log(`    Q: ${excerpt(info.question.body)}`);
-    else console.log(c.dim(`    (no blocking comment found — the hold never said what it needs)`));
+    if (info.question?.body)
+      console.log(`    Q: ${excerpt(info.question.body)}`);
+    else
+      console.log(
+        c.dim(
+          `    (no blocking comment found — the hold never said what it needs)`,
+        ),
+      );
   }
 }
 
-console.log(c.bold(`\n${totalHeld} held ticket(s)`) + (totalAnswered
-  ? c.green(`, ${totalAnswered} answered and waiting for the next triage tick`)
-  : c.dim(", none answered — every hold above is waiting on a human reply")));
+console.log(
+  c.bold(`\n${totalHeld} held ticket(s)`) +
+    (totalAnswered
+      ? c.green(
+          `, ${totalAnswered} answered and waiting for the next triage tick`,
+        )
+      : c.dim(
+          ", none answered — every hold above is waiting on a human reply",
+        )),
+);
 console.log();

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -13,7 +13,13 @@
  *
  * Read-only. Every failure names the fix.
  */
-import { readFileSync, readdirSync, existsSync, statSync, lstatSync } from "node:fs";
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  statSync,
+  lstatSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { homedir } from "node:os";
@@ -23,42 +29,63 @@ import { harnessGitignoreIsCurrent } from "../lib/factory-gitignore.mjs";
 
 const ROOT = factoryRoot();
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 const expand = (p) => String(p ?? "").replace(/^~/, homedir());
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
+const cfg = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+);
+const repos = (cfg.repos ?? []).filter(
+  (r) => !only.length || only.includes(r.name),
+);
 
 // Commits behind origin/<base> before the main checkout is worth flagging.
 const BEHIND_WARN = 10;
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
 };
 
 let failures = 0;
 const check = (ok, label, detail, fix) => {
   if (ok === "warn") {
-    console.log(`  ${c.yellow("!")} ${label}${detail ? c.dim("  " + detail) : ""}`);
+    console.log(
+      `  ${c.yellow("!")} ${label}${detail ? c.dim("  " + detail) : ""}`,
+    );
     if (fix) console.log(`      ${c.dim(fix)}`);
     return;
   }
-  console.log(`  ${ok ? c.green("✓") : c.red("✗")} ${label}${detail ? c.dim("  " + detail) : ""}`);
+  console.log(
+    `  ${ok ? c.green("✓") : c.red("✗")} ${label}${detail ? c.dim("  " + detail) : ""}`,
+  );
   if (!ok) {
     failures++;
     if (fix) console.log(`      ${c.bold("fix:")} ${fix}`);
   }
 };
 
-const sh = (cmd, cwd) => spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
+const sh = (cmd, cwd) =>
+  spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
 
 // ------------------------------------------------------------------ machine ---
 console.log(c.bold("\nmachine"));
 for (const [bin, fix] of [
   ["bun", "brew install oven-sh/bun/bun"],
-  ["claude", "install Claude Code, then `claude setup-token` for unattended runs"],
+  [
+    "claude",
+    "install Claude Code, then `claude setup-token` for unattended runs",
+  ],
   ["git", "xcode-select --install"],
   ["gh", "brew install gh && gh auth login"],
 ]) {
@@ -68,21 +95,44 @@ for (const [bin, fix] of [
 
 const factoryBin = sh("command -v factory");
 const factoryScript = path.join(ROOT, "bin/factory");
-check(factoryBin.status === 0, "factory CLI on PATH", factoryBin.stdout.trim(),
-  "bun build/emit.mjs --link-bin && ensure ~/.local/bin is on PATH");
-check(existsSync(factoryScript), "bin/factory in checkout", factoryScript,
-  "git pull the factory repo — bin/factory is part of the control plane");
+check(
+  factoryBin.status === 0,
+  "factory CLI on PATH",
+  factoryBin.stdout.trim(),
+  "bun build/emit.mjs --link-bin && ensure ~/.local/bin is on PATH",
+);
+check(
+  existsSync(factoryScript),
+  "bin/factory in checkout",
+  factoryScript,
+  "git pull the factory repo — bin/factory is part of the control plane",
+);
 
-const key = process.env.LINEAR_API_KEY || (existsSync(expand("~/Develop/hdkiller/.env")) &&
-  /LINEAR_API_KEY/.test(readFileSync(expand("~/Develop/hdkiller/.env"), "utf8")));
-check(Boolean(key), "LINEAR_API_KEY", key ? "found" : "", "add it to ~/Develop/hdkiller/.env or the environment");
+const key =
+  process.env.LINEAR_API_KEY ||
+  (existsSync(expand("~/Develop/hdkiller/.env")) &&
+    /LINEAR_API_KEY/.test(
+      readFileSync(expand("~/Develop/hdkiller/.env"), "utf8"),
+    ));
+check(
+  Boolean(key),
+  "LINEAR_API_KEY",
+  key ? "found" : "",
+  "add it to ~/Develop/hdkiller/.env or the environment",
+);
 
 // Disk: worktrees are the bulk of what this machine holds, and a bootstrap that
 // fails halfway leaves a half-provisioned database behind.
-const df = sh("df -h ~ | tail -1 | awk '{print $5\" used, \"$4\" free\"}'");
+const df = sh('df -h ~ | tail -1 | awk \'{print $5" used, "$4" free"}\'');
 const pct = Number((df.stdout.match(/(\d+)%/) || [])[1] || 0);
-check(pct < 90 ? true : "warn", "disk", df.stdout.trim(),
-  pct >= 90 ? "run `factory janitor --repo <name> --apply` to reclaim finished worktrees" : null);
+check(
+  pct < 90 ? true : "warn",
+  "disk",
+  df.stdout.trim(),
+  pct >= 90
+    ? "run `factory janitor --repo <name> --apply` to reclaim finished worktrees"
+    : null,
+);
 
 if (!repos.length) {
   console.error(c.red(`\nno matching repo in config/repos.yaml`));
@@ -101,17 +151,27 @@ const expectedCommands = readdirSync(path.join(ROOT, "shared/commands"))
 
 // -------------------------------------------------------------------- repos ---
 for (const repo of repos) {
-  console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}`));
+  console.log(
+    c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}`),
+  );
   const p = expand(repo.path);
 
   const cloned = existsSync(p) && existsSync(path.join(p, ".git"));
-  check(cloned, "checkout exists", p,
-    `git clone git@github.com:${repo.github}.git ${repo.path}   ${c.dim("(you clone it, not the factory)")}`);
+  check(
+    cloned,
+    "checkout exists",
+    p,
+    `git clone git@github.com:${repo.github}.git ${repo.path}   ${c.dim("(you clone it, not the factory)")}`,
+  );
   if (!cloned) continue;
 
   const remote = sh("git remote get-url origin", p).stdout.trim();
-  check(remote.includes(repo.github), "remote matches repos.yaml", remote,
-    `expected ${repo.github} — fix repos.yaml or the remote`);
+  check(
+    remote.includes(repo.github),
+    "remote matches repos.yaml",
+    remote,
+    `expected ${repo.github} — fix repos.yaml or the remote`,
+  );
 
   // `git fetch` updates remote-tracking refs only — it never touches the
   // working tree or your branches, so it stays within this script's read-only
@@ -121,9 +181,16 @@ for (const repo of repos) {
   // exact staleness this exists to catch — failing open on the question it
   // exists to answer.
   const fetched = sh("git fetch --quiet", p).status === 0;
-  check(fetched, "fetch origin", fetched ? "" : "offline or auth expired",
-    fetched ? null : "check network/`gh auth status` — freshness below is unverified until this succeeds");
-  const hasBase = fetched && sh(`git rev-parse --verify origin/${repo.base}`, p).status === 0;
+  check(
+    fetched,
+    "fetch origin",
+    fetched ? "" : "offline or auth expired",
+    fetched
+      ? null
+      : "check network/`gh auth status` — freshness below is unverified until this succeeds",
+  );
+  const hasBase =
+    fetched && sh(`git rev-parse --verify origin/${repo.base}`, p).status === 0;
   check(hasBase, `base branch origin/${repo.base}`, "", "git fetch origin");
 
   // The read-only stages (sweep, triage, audit) read THIS checkout and judge
@@ -137,21 +204,34 @@ for (const repo of repos) {
   // rev-list, and `"" || 0` reads that as "0 commits behind" — the same
   // failing-open bug as ignoring fetch's exit status, just one line later.
   if (hasBase) {
-    const behindResult = sh(`git rev-list --count HEAD..origin/${repo.base}`, p);
+    const behindResult = sh(
+      `git rev-list --count HEAD..origin/${repo.base}`,
+      p,
+    );
     const behindOk = behindResult.status === 0;
     const behind = behindOk ? Number(behindResult.stdout.trim() || 0) : null;
-    const dirty = sh("git status --porcelain", p).stdout.trim().split("\n").filter(Boolean).length;
+    const dirty = sh("git status --porcelain", p)
+      .stdout.trim()
+      .split("\n")
+      .filter(Boolean).length;
     if (!behindOk) {
-      check("warn", "checkout current", "rev-list failed — behind-count unknown",
-        `git -C ${repo.path} rev-list --count HEAD..origin/${repo.base}   (run by hand to see the error)`);
+      check(
+        "warn",
+        "checkout current",
+        "rev-list failed — behind-count unknown",
+        `git -C ${repo.path} rev-list --count HEAD..origin/${repo.base}   (run by hand to see the error)`,
+      );
     } else {
-      check(behind < BEHIND_WARN ? true : "warn", "checkout current",
+      check(
+        behind < BEHIND_WARN ? true : "warn",
+        "checkout current",
         `${behind} commit(s) behind origin/${repo.base}${dirty ? `, ${dirty} uncommitted` : ""}`,
         behind >= BEHIND_WARN
           ? dirty
             ? `commit or stash first, then \`git -C ${repo.path} merge --ff-only origin/${repo.base}\` — stages must read origin/${repo.base}, not this tree`
             : `git -C ${repo.path} merge --ff-only origin/${repo.base}`
-          : null);
+          : null,
+      );
     }
   }
 
@@ -161,76 +241,151 @@ for (const repo of repos) {
   for (const name of expectedCommands) {
     const target = path.join(commandsDir, `${name}.md`);
     let st = null;
-    try { st = lstatSync(target); } catch { /* intentionally ignored */ }
-    if (!st) { missing.push(name); continue; }
+    try {
+      st = lstatSync(target);
+    } catch {
+      /* intentionally ignored */
+    }
+    if (!st) {
+      missing.push(name);
+      continue;
+    }
     if (st.isSymbolicLink() && !existsSync(target)) broken.push(name); // dangling symlink
   }
   const problems = [...missing, ...broken];
-  check(problems.length === 0, "/factory-* commands linked",
-    problems.length ? `${problems.length}/${expectedCommands.length} missing or broken: ${problems.join(", ")}` : `${expectedCommands.length} commands`,
-    problems.length ? "factory emit" : null);
+  check(
+    problems.length === 0,
+    "/factory-* commands linked",
+    problems.length
+      ? `${problems.length}/${expectedCommands.length} missing or broken: ${problems.join(", ")}`
+      : `${expectedCommands.length} commands`,
+    problems.length ? "factory emit" : null,
+  );
 
   const gitignorePath = path.join(p, ".gitignore");
-  const gitignoreBody = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf8") : "";
-  check(harnessGitignoreIsCurrent(gitignoreBody), "factory harness gitignored",
+  const gitignoreBody = existsSync(gitignorePath)
+    ? readFileSync(gitignorePath, "utf8")
+    : "";
+  check(
+    harnessGitignoreIsCurrent(gitignoreBody),
+    "factory harness gitignored",
     existsSync(gitignorePath) ? ".gitignore" : "no .gitignore",
-    "factory emit  (adds FACTORY:HARNES block — symlinks must not be committed)");
+    "factory emit  (adds FACTORY:HARNES block — symlinks must not be committed)",
+  );
 
-  const tracked = sh("git ls-files -- '.claude/commands/factory-*.md' '.cursor/commands/factory-*.md' 2>/dev/null", p)
-    .stdout.trim().split("\n").filter(Boolean);
-  check(tracked.length === 0, "no tracked factory command files",
+  const tracked = sh(
+    "git ls-files -- '.claude/commands/factory-*.md' '.cursor/commands/factory-*.md' 2>/dev/null",
+    p,
+  )
+    .stdout.trim()
+    .split("\n")
+    .filter(Boolean);
+  check(
+    tracked.length === 0,
+    "no tracked factory command files",
     tracked.length ? tracked.join(", ") : "",
-    tracked.length ? "git rm --cached the listed paths; they are local symlinks from factory emit" : null);
+    tracked.length
+      ? "git rm --cached the listed paths; they are local symlinks from factory emit"
+      : null,
+  );
 
   // Worktree tooling is PC-15 — the precondition for dispatching concurrent
   // agents. Without it a repo's safe concurrency is one agent, whatever the
   // dispatcher thinks. `report_only: true` repos have already acknowledged
   // this in repos.yaml (dispatch itself refuses to run for them — see
   // tick.mjs), so a missing script here is expected, not a doctor failure.
-  for (const [k, label] of [["worktree_up", "worktree-up script"], ["worktree_down", "worktree-down script"]]) {
+  for (const [k, label] of [
+    ["worktree_up", "worktree-up script"],
+    ["worktree_down", "worktree-down script"],
+  ]) {
     const s = repo[k];
     const full = s ? path.join(p, s) : null;
     const ok = Boolean(full && existsSync(full));
     const exec = ok && (statSync(full).mode & 0o111) !== 0;
     if (repo.report_only && !ok) {
-      check("warn", `${label}`, "not configured", "report_only repo — dispatch is disabled here by design (PC-15)");
+      check(
+        "warn",
+        `${label}`,
+        "not configured",
+        "report_only repo — dispatch is disabled here by design (PC-15)",
+      );
       continue;
     }
-    check(ok && exec, `${label}`, s ?? "not configured",
-      !ok ? `this repo has no ${k} — dispatch is unsafe here (PC-15); see CW-363 / CLNT-609 for the pattern`
-          : `chmod +x ${s}`);
+    check(
+      ok && exec,
+      `${label}`,
+      s ?? "not configured",
+      !ok
+        ? `this repo has no ${k} — dispatch is unsafe here (PC-15); see CW-363 / CLNT-609 for the pattern`
+        : `chmod +x ${s}`,
+    );
   }
 
   const wtRoot = expand(repo.worktree_root ?? "");
-  check(Boolean(wtRoot) && existsSync(wtRoot) ? true : "warn", "worktree root", repo.worktree_root ?? "not set",
-    "created on first worktree-up; nothing to do if the repo is new");
+  check(
+    Boolean(wtRoot) && existsSync(wtRoot) ? true : "warn",
+    "worktree root",
+    repo.worktree_root ?? "not set",
+    "created on first worktree-up; nothing to do if the repo is new",
+  );
 
   const dirty = sh("git status --porcelain | wc -l", p).stdout.trim();
-  check(dirty === "0" ? true : "warn", "main checkout clean", `${dirty} uncommitted file(s)`,
-    dirty === "0" ? null : "fine for triage (read-only), but specs are written against what's on disk");
+  check(
+    dirty === "0" ? true : "warn",
+    "main checkout clean",
+    `${dirty} uncommitted file(s)`,
+    dirty === "0"
+      ? null
+      : "fine for triage (read-only), but specs are written against what's on disk",
+  );
 
   // Does the Linear project actually resolve? A typo here fails at dispatch
   // time, after a worktree and a database already exist.
   try {
     const q = `query($t:String!,$p:String!){ issues(first:1, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}} }){ nodes{ identifier } } }`;
-    const nodes = (await gql(q, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
-    check(true, "Linear team/project resolves", `${repo.team} / ${repo.project}${nodes[0] ? ` (e.g. ${nodes[0].identifier})` : " (no open issues)"}`);
+    const nodes =
+      (await gql(q, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
+    check(
+      true,
+      "Linear team/project resolves",
+      `${repo.team} / ${repo.project}${nodes[0] ? ` (e.g. ${nodes[0].identifier})` : " (no open issues)"}`,
+    );
   } catch (e) {
-    check(false, "Linear team/project resolves", String(e.message).slice(0, 60),
-      "check team key and project name against linear.md §1–2 (CW projects carry a 'Coach Watts - ' prefix)");
+    check(
+      false,
+      "Linear team/project resolves",
+      String(e.message).slice(0, 60),
+      "check team key and project name against linear.md §1–2 (CW projects carry a 'Coach Watts - ' prefix)",
+    );
   }
 
-  check(repo.verify ? true : (repo.report_only ? "warn" : false), "verification command", repo.verify ?? "",
-    repo.verify ? null : repo.report_only
-      ? "report_only repo — set `verify:` before flipping dispatch on"
-      : "set `verify:` in repos.yaml — agents must never open a PR without clean output");
-  check(repo.smoke_workflow ? true : "warn", "post-deploy smoke check", repo.smoke_workflow ?? "none",
-    repo.smoke_workflow ? null : "without one, Done means merged rather than running");
+  check(
+    repo.verify ? true : repo.report_only ? "warn" : false,
+    "verification command",
+    repo.verify ?? "",
+    repo.verify
+      ? null
+      : repo.report_only
+        ? "report_only repo — set `verify:` before flipping dispatch on"
+        : "set `verify:` in repos.yaml — agents must never open a PR without clean output",
+  );
+  check(
+    repo.smoke_workflow ? true : "warn",
+    "post-deploy smoke check",
+    repo.smoke_workflow ?? "none",
+    repo.smoke_workflow
+      ? null
+      : "without one, Done means merged rather than running",
+  );
 }
 
 console.log();
 if (failures) {
-  console.log(c.red(`${failures} problem(s) — the loop will fail on these before it does anything useful.\n`));
+  console.log(
+    c.red(
+      `${failures} problem(s) — the loop will fail on these before it does anything useful.\n`,
+    ),
+  );
   process.exit(1);
 }
 console.log(c.green("ready.\n"));

--- a/orchestrator/economics.mjs
+++ b/orchestrator/economics.mjs
@@ -31,18 +31,38 @@
  * normalised into one Run record here, and `lib/spend.mjs` shares the parser so
  * the budget gate cannot see a different world than this report does.
  */
-import { readdirSync, readFileSync, statSync, existsSync, mkdirSync, appendFileSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { LOG_DIR, METRICS_DIR, ROLLUP, parseRun, messageSignature, parseDuration } from "../lib/transcript.mjs";
+import {
+  LOG_DIR,
+  METRICS_DIR,
+  ROLLUP,
+  parseRun,
+  messageSignature,
+  parseDuration,
+} from "../lib/transcript.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
 const JSON_OUT = argv.includes("--json");
 const ROLL = argv.includes("--roll");
 const TOP = Number(val("--top") ?? 15);
 
-if (!existsSync(LOG_DIR)) { console.error(`no transcripts at ${LOG_DIR}`); process.exit(1); }
+if (!existsSync(LOG_DIR)) {
+  console.error(`no transcripts at ${LOG_DIR}`);
+  process.exit(1);
+}
 
 // --gate: is there enough un-rolled material to justify a retro run? Filename
 // comparison only — the rollup keys on the transcript basename, so this never
@@ -56,12 +76,18 @@ if (argv.includes("--gate")) {
   if (existsSync(ROLLUP)) {
     for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
       if (!line.startsWith("{")) continue;
-      try { seen.add(JSON.parse(line).file); } catch { /* intentionally ignored */ }
+      try {
+        seen.add(JSON.parse(line).file);
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   const unrolled = readdirSync(LOG_DIR)
     .filter((f) => f.endsWith(".jsonl") && !seen.has(f))
-    .filter((f) => Date.now() - statSync(path.join(LOG_DIR, f)).mtimeMs > 5 * 60_000);
+    .filter(
+      (f) => Date.now() - statSync(path.join(LOG_DIR, f)).mtimeMs > 5 * 60_000,
+    );
   console.error(`gate: ${unrolled.length} un-rolled run(s), threshold ${min}`);
   process.exit(unrolled.length >= min ? 0 : 1);
 }
@@ -71,13 +97,22 @@ const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
 
 const files = readdirSync(LOG_DIR)
   .filter((f) => f.endsWith(".jsonl"))
-  .map((f) => ({ f, p: path.join(LOG_DIR, f), t: statSync(path.join(LOG_DIR, f)).mtimeMs }))
+  .map((f) => ({
+    f,
+    p: path.join(LOG_DIR, f),
+    t: statSync(path.join(LOG_DIR, f)).mtimeMs,
+  }))
   .filter((x) => x.t >= sinceMs)
   .sort((a, b) => a.t - b.t);
 
-if (!files.length) { console.error("no transcripts match"); process.exit(1); }
+if (!files.length) {
+  console.error("no transcripts match");
+  process.exit(1);
+}
 
-const runs = files.map(({ f, p, t }) => parseRun(f, readFileSync(p, "utf8"), t));
+const runs = files.map(({ f, p, t }) =>
+  parseRun(f, readFileSync(p, "utf8"), t),
+);
 
 // ---------------------------------------------------------------- rollup ---
 // Transcripts are big (350MB for two days) and will eventually be pruned. The
@@ -89,52 +124,79 @@ if (ROLL) {
   if (existsSync(ROLLUP)) {
     for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
       if (!line.startsWith("{")) continue;
-      try { seen.add(JSON.parse(line).file); } catch { /* intentionally ignored */ }
+      try {
+        seen.add(JSON.parse(line).file);
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
-  let added = 0, inFlight = 0;
+  let added = 0,
+    inFlight = 0;
   for (const r of runs) {
     if (seen.has(r.file)) continue;
     // A run still streaming has no verdict yet, and the append-only key would
     // then refuse to replace the half-finished row. Judge that by RECENCY, not
     // by the missing verdict: a truncated transcript is a permanent record of a
     // killed run, and that is precisely the waste worth keeping.
-    if (r.truncated && Date.now() - r.mtime < 5 * 60_000) { inFlight++; continue; }
+    if (r.truncated && Date.now() - r.mtime < 5 * 60_000) {
+      inFlight++;
+      continue;
+    }
     const { commands, toolResultBytes, toolCalls, errorSigs, ...rest } = r;
     // Maps stringify to {}. Flatten the two worth keeping — per-run tool mix and
     // failure shapes are what makes the rollup answer questions on its own,
     // after the 350MB of transcripts behind it have been pruned.
-    appendFileSync(ROLLUP, JSON.stringify({
-      ...rest,
-      toolCalls: Object.fromEntries(toolCalls),
-      errorSigs: Object.fromEntries([...errorSigs].map(([k, v]) => [k, v.count])),
-    }) + "\n");
+    appendFileSync(
+      ROLLUP,
+      JSON.stringify({
+        ...rest,
+        toolCalls: Object.fromEntries(toolCalls),
+        errorSigs: Object.fromEntries(
+          [...errorSigs].map(([k, v]) => [k, v.count]),
+        ),
+      }) + "\n",
+    );
     added++;
   }
-  console.error(`rollup: +${added} run(s)${inFlight ? `, ${inFlight} still in flight` : ""} -> ${ROLLUP}`);
+  console.error(
+    `rollup: +${added} run(s)${inFlight ? `, ${inFlight} still in flight` : ""} -> ${ROLLUP}`,
+  );
 }
 
 // ----------------------------------------------------------- aggregation ---
 const sum = (xs, k) => xs.reduce((a, b) => a + (b[k] ?? 0), 0);
 const groupBy = (xs, key) => {
   const m = new Map();
-  for (const x of xs) { const k = key(x); (m.get(k) ?? m.set(k, []).get(k)).push(x); }
+  for (const x of xs) {
+    const k = key(x);
+    (m.get(k) ?? m.set(k, []).get(k)).push(x);
+  }
   return m;
 };
 
-const toolBytes = new Map();   // tool -> {bytes, calls, weighted}
+const toolBytes = new Map(); // tool -> {bytes, calls, weighted}
 const toolCalls = new Map();
 const errorsBySig = new Map();
 for (const r of runs) {
   for (const [name, v] of r.toolResultBytes) {
     const t = toolBytes.get(name) ?? { bytes: 0, calls: 0, weighted: 0 };
-    t.bytes += v.bytes; t.calls += v.calls; t.weighted += v.weighted;
+    t.bytes += v.bytes;
+    t.calls += v.calls;
+    t.weighted += v.weighted;
     toolBytes.set(name, t);
   }
-  for (const [name, n] of r.toolCalls) toolCalls.set(name, (toolCalls.get(name) ?? 0) + n);
+  for (const [name, n] of r.toolCalls)
+    toolCalls.set(name, (toolCalls.get(name) ?? 0) + n);
   for (const [sig, v] of r.errorSigs) {
-    const e = errorsBySig.get(sig) ?? { count: 0, runs: 0, sample: v.sample, tool: v.tool };
-    e.count += v.count; e.runs++;
+    const e = errorsBySig.get(sig) ?? {
+      count: 0,
+      runs: 0,
+      sample: v.sample,
+      tool: v.tool,
+    };
+    e.count += v.count;
+    e.runs++;
     errorsBySig.set(sig, e);
   }
 }
@@ -153,55 +215,108 @@ const totals = {
   resultBytes: sum(runs, "resultBytes"),
   weightedBytes: sum(runs, "weightedBytes"),
   wasted: runs.filter((r) => r.wasted).length,
-  wastedMin: runs.filter((r) => r.wasted).reduce((a, b) => a + b.durMs, 0) / 60000,
+  wastedMin:
+    runs.filter((r) => r.wasted).reduce((a, b) => a + b.durMs, 0) / 60000,
 };
 
 if (JSON_OUT) {
-  console.log(JSON.stringify({
-    totals,
-    runs: runs.map(({ commands, toolResultBytes, errorSigs, toolCalls, ...r }) => r),
-    tools: [...toolBytes.entries()].map(([name, v]) => ({ name, ...v, calls: toolCalls.get(name) ?? v.calls })),
-    errors: [...errorsBySig.entries()].map(([sig, v]) => ({ sig, ...v })),
-  }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        totals,
+        runs: runs.map(
+          ({ commands, toolResultBytes, errorSigs, toolCalls, ...r }) => r,
+        ),
+        tools: [...toolBytes.entries()].map(([name, v]) => ({
+          name,
+          ...v,
+          calls: toolCalls.get(name) ?? v.calls,
+        })),
+        errors: [...errorsBySig.entries()].map(([sig, v]) => ({ sig, ...v })),
+      },
+      null,
+      2,
+    ),
+  );
   process.exit(0);
 }
 
 // --------------------------------------------------------------- render ---
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
 };
-const M = (n) => n >= 1e6 ? (n / 1e6).toFixed(1) + "M" : n >= 1e3 ? (n / 1e3).toFixed(0) + "k" : String(Math.round(n));
+const M = (n) =>
+  n >= 1e6
+    ? (n / 1e6).toFixed(1) + "M"
+    : n >= 1e3
+      ? (n / 1e3).toFixed(0) + "k"
+      : String(Math.round(n));
 const MB = (n) => (n / 1e6).toFixed(1) + "MB";
 const pad = (s, n) => String(s).padStart(n);
 const padR = (s, n) => String(s).padEnd(n);
 
-console.log(c.bold(`\neconomics across ${totals.runs} run(s)${sinceArg ? ` (last ${sinceArg})` : ""}\n`));
+console.log(
+  c.bold(
+    `\neconomics across ${totals.runs} run(s)${sinceArg ? ` (last ${sinceArg})` : ""}\n`,
+  ),
+);
 
 const allIn = totals.freshIn + totals.cacheRead + totals.cacheWrite;
-console.log(`  input   fresh ${pad(M(totals.freshIn), 7)}   cache-write ${pad(M(totals.cacheWrite), 7)}   cache-read ${pad(M(totals.cacheRead), 7)}`);
-console.log(`  output  ${pad(M(totals.out), 7)}        wall ${pad(totals.wallMin.toFixed(0) + "min", 8)}    turns ${pad(totals.turns, 6)}   tools ${pad(totals.tools, 6)}`);
+console.log(
+  `  input   fresh ${pad(M(totals.freshIn), 7)}   cache-write ${pad(M(totals.cacheWrite), 7)}   cache-read ${pad(M(totals.cacheRead), 7)}`,
+);
+console.log(
+  `  output  ${pad(M(totals.out), 7)}        wall ${pad(totals.wallMin.toFixed(0) + "min", 8)}    turns ${pad(totals.turns, 6)}   tools ${pad(totals.tools, 6)}`,
+);
 if (allIn) {
-  const hit = 100 * totals.cacheRead / allIn;
+  const hit = (100 * totals.cacheRead) / allIn;
   const ratio = totals.cacheWrite ? totals.cacheRead / totals.cacheWrite : 0;
-  const verdict = ratio >= 20 ? c.green("healthy") : ratio >= 8 ? c.yellow("mediocre") : c.red("POOR — prefix keeps invalidating");
-  console.log(`  cache   ${hit.toFixed(1)}% of input served from cache · read:write 1:${ratio.toFixed(1)}  ${verdict}`);
+  const verdict =
+    ratio >= 20
+      ? c.green("healthy")
+      : ratio >= 8
+        ? c.yellow("mediocre")
+        : c.red("POOR — prefix keeps invalidating");
+  console.log(
+    `  cache   ${hit.toFixed(1)}% of input served from cache · read:write 1:${ratio.toFixed(1)}  ${verdict}`,
+  );
 }
-console.log(`  cost    $${totals.cost.toFixed(2)} notional  ${c.dim(`(subscription auth — a runaway gauge, not a bill)`)}`);
+console.log(
+  `  cost    $${totals.cost.toFixed(2)} notional  ${c.dim(`(subscription auth — a runaway gauge, not a bill)`)}`,
+);
 
 // Context burn is the number that actually explains the bill: bytes of tool
 // output multiplied by the turns that output was still in the window for.
-console.log(`  context ${MB(totals.resultBytes)} of tool output, re-sent ${MB(totals.weightedBytes)} across turns ` +
-  c.dim(`(~${M(totals.weightedBytes / 4)} tok of cache traffic)`));
+console.log(
+  `  context ${MB(totals.resultBytes)} of tool output, re-sent ${MB(totals.weightedBytes)} across turns ` +
+    c.dim(`(~${M(totals.weightedBytes / 4)} tok of cache traffic)`),
+);
 if (totals.wasted) {
-  console.log(c.red(`  wasted  ${totals.wasted} run(s) produced nothing — ${totals.wastedMin.toFixed(0)}min of wall clock`));
+  console.log(
+    c.red(
+      `  wasted  ${totals.wasted} run(s) produced nothing — ${totals.wastedMin.toFixed(0)}min of wall clock`,
+    ),
+  );
 }
 
 // ---- by harness: the blind spot that motivated this file -------------------
-console.log(c.bold(`\nby harness`) + c.dim(`   a harness that only ever errors still consumes dispatch slots\n`));
-console.log(c.dim("  harness   runs    ok   fail  none   cost$   wall   avg turns   note"));
-for (const [h, rs] of [...groupBy(runs, (r) => r.harness)].sort((a, b) => b[1].length - a[1].length)) {
+console.log(
+  c.bold(`\nby harness`) +
+    c.dim(`   a harness that only ever errors still consumes dispatch slots\n`),
+);
+console.log(
+  c.dim(
+    "  harness   runs    ok   fail  none   cost$   wall   avg turns   note",
+  ),
+);
+for (const [h, rs] of [...groupBy(runs, (r) => r.harness)].sort(
+  (a, b) => b[1].length - a[1].length,
+)) {
   const ok = rs.filter((r) => r.ok === true).length;
   const fail = rs.filter((r) => r.ok === false).length;
   const none = rs.filter((r) => r.ok === null).length;
@@ -209,64 +324,105 @@ for (const [h, rs] of [...groupBy(runs, (r) => r.harness)].sort((a, b) => b[1].l
   const wall = sum(rs, "durMs") / 60000;
   // Only Claude and agy report a duration. Printing "0m" for the others reads
   // as "instant" when it means "not measured" — say which it is.
-  const wallCell = wall > 0 ? pad(wall.toFixed(0) + "m", 7) : c.dim(pad("n/a", 7));
-  const note = cost === 0 && rs.length > 3
-    ? c.yellow(`priced from tokens (~$${sum(rs, "estCost").toFixed(0)}) — this harness reports no cost`) : "";
-  console.log(`  ${padR(h, 9)}${pad(rs.length, 5)}${pad(ok, 6)}${pad(fail, 7)}${pad(none, 6)}${pad("$" + cost.toFixed(0), 8)}${wallCell}${pad((sum(rs, "turns") / rs.length).toFixed(0), 12)}   ${note}`);
+  const wallCell =
+    wall > 0 ? pad(wall.toFixed(0) + "m", 7) : c.dim(pad("n/a", 7));
+  const note =
+    cost === 0 && rs.length > 3
+      ? c.yellow(
+          `priced from tokens (~$${sum(rs, "estCost").toFixed(0)}) — this harness reports no cost`,
+        )
+      : "";
+  console.log(
+    `  ${padR(h, 9)}${pad(rs.length, 5)}${pad(ok, 6)}${pad(fail, 7)}${pad(none, 6)}${pad("$" + cost.toFixed(0), 8)}${wallCell}${pad((sum(rs, "turns") / rs.length).toFixed(0), 12)}   ${note}`,
+  );
 }
 
 // ---- by stage --------------------------------------------------------------
 console.log(c.bold(`\nby stage\n`));
-console.log(c.dim("  stage            runs   cost$  $/run  turns/run  tools/run  err  wasted  ctx re-sent"));
-for (const [s, rs] of [...groupBy(runs, (r) => r.stage)].sort((a, b) => sum(b[1], "cost") - sum(a[1], "cost"))) {
+console.log(
+  c.dim(
+    "  stage            runs   cost$  $/run  turns/run  tools/run  err  wasted  ctx re-sent",
+  ),
+);
+for (const [s, rs] of [...groupBy(runs, (r) => r.stage)].sort(
+  (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
+)) {
   const cost = sum(rs, "cost");
   console.log(
     `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}` +
-    `${pad((sum(rs, "turns") / rs.length).toFixed(0), 11)}${pad((sum(rs, "tools") / rs.length).toFixed(0), 11)}` +
-    `${pad(sum(rs, "errors"), 5)}${pad(rs.filter((r) => r.wasted).length, 8)}${pad(MB(sum(rs, "weightedBytes")), 13)}`
+      `${pad((sum(rs, "turns") / rs.length).toFixed(0), 11)}${pad((sum(rs, "tools") / rs.length).toFixed(0), 11)}` +
+      `${pad(sum(rs, "errors"), 5)}${pad(rs.filter((r) => r.wasted).length, 8)}${pad(MB(sum(rs, "weightedBytes")), 13)}`,
   );
 }
 
 // ---- by repo ---------------------------------------------------------------
 console.log(c.bold(`\nby repo\n`));
 console.log(c.dim("  repo             runs   cost$  $/run   err  wasted"));
-for (const [s, rs] of [...groupBy(runs, (r) => r.repo)].sort((a, b) => sum(b[1], "cost") - sum(a[1], "cost"))) {
+for (const [s, rs] of [...groupBy(runs, (r) => r.repo)].sort(
+  (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
+)) {
   const cost = sum(rs, "cost");
-  console.log(`  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}${pad(sum(rs, "errors"), 6)}${pad(rs.filter((r) => r.wasted).length, 8)}`);
+  console.log(
+    `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}${pad(sum(rs, "errors"), 6)}${pad(rs.filter((r) => r.wasted).length, 8)}`,
+  );
 }
 
 // ---- context burn ----------------------------------------------------------
-console.log(c.bold(`\ncontext burn by tool`) + c.dim(`   "re-sent" = payload x turns it stayed in the window\n`));
+console.log(
+  c.bold(`\ncontext burn by tool`) +
+    c.dim(`   "re-sent" = payload x turns it stayed in the window\n`),
+);
 console.log(c.dim("     calls    payload    re-sent   avg/call   tool"));
-for (const [name, v] of [...toolBytes.entries()].sort((a, b) => b[1].weighted - a[1].weighted).slice(0, TOP)) {
+for (const [name, v] of [...toolBytes.entries()]
+  .sort((a, b) => b[1].weighted - a[1].weighted)
+  .slice(0, TOP)) {
   const avg = v.bytes / Math.max(1, v.calls);
   const flag = avg > 50000 ? c.red("  <- huge payload per call") : "";
-  console.log(`  ${pad(toolCalls.get(name) ?? v.calls, 6)}${pad(MB(v.bytes), 11)}${pad(MB(v.weighted), 11)}${pad(M(avg) + "B", 11)}   ${name}${flag}`);
+  console.log(
+    `  ${pad(toolCalls.get(name) ?? v.calls, 6)}${pad(MB(v.bytes), 11)}${pad(MB(v.weighted), 11)}${pad(M(avg) + "B", 11)}   ${name}${flag}`,
+  );
 }
 
 // ---- worst individual runs -------------------------------------------------
 console.log(c.bold(`\nmost expensive runs\n`));
 for (const r of [...runs].sort((a, b) => b.cost - a.cost).slice(0, TOP)) {
   const ratio = r.cacheWrite ? (r.cacheRead / r.cacheWrite).toFixed(0) : "-";
-  console.log(`  ${pad("$" + r.cost.toFixed(2), 8)}  ${pad(r.turns + "t", 6)} ${pad(r.tools + "tc", 7)}  cache 1:${pad(ratio, 3)}  ${pad((r.durMs / 60000).toFixed(0) + "m", 5)}  ${c.dim(r.file.replace(/\.+jsonl$/, ""))}`);
+  console.log(
+    `  ${pad("$" + r.cost.toFixed(2), 8)}  ${pad(r.turns + "t", 6)} ${pad(r.tools + "tc", 7)}  cache 1:${pad(ratio, 3)}  ${pad((r.durMs / 60000).toFixed(0) + "m", 5)}  ${c.dim(r.file.replace(/\.+jsonl$/, ""))}`,
+  );
 }
 
 // ---- waste -----------------------------------------------------------------
 const wasted = runs.filter((r) => r.wasted);
 if (wasted.length) {
-  console.log(c.bold(`\nruns that produced nothing`) + c.dim(`   these still held a dispatch slot\n`));
+  console.log(
+    c.bold(`\nruns that produced nothing`) +
+      c.dim(`   these still held a dispatch slot\n`),
+  );
   // Group by failure SHAPE, not exact text: "quota reached, resets in 44h1m15s"
   // and "...44h21m16s" are one problem, and listing them separately buries it.
   const byReason = groupBy(wasted, (r) =>
-    r.error ? messageSignature(r.error)
-      : r.truncated ? "killed mid-run — no final envelope (wall-clock cap, crash, or kill)"
-        : r.ok === false ? "harness reported failure"
-          : "no verdict recorded");
-  for (const [reason, rs] of [...byReason].sort((a, b) => b[1].length - a[1].length).slice(0, TOP)) {
+    r.error
+      ? messageSignature(r.error)
+      : r.truncated
+        ? "killed mid-run — no final envelope (wall-clock cap, crash, or kill)"
+        : r.ok === false
+          ? "harness reported failure"
+          : "no verdict recorded",
+  );
+  for (const [reason, rs] of [...byReason]
+    .sort((a, b) => b[1].length - a[1].length)
+    .slice(0, TOP)) {
     const mins = sum(rs, "durMs") / 60000;
     const where = [...new Set(rs.map((r) => r.harness))].join("/");
-    console.log(`  ${c.red("x" + pad(rs.length, 3))}  ${padR(reason.slice(0, 66), 66)} ${c.dim(padR(where, 8))} ${c.dim(mins ? mins.toFixed(0) + "min" : "")}`);
+    console.log(
+      `  ${c.red("x" + pad(rs.length, 3))}  ${padR(reason.slice(0, 66), 66)} ${c.dim(padR(where, 8))} ${c.dim(mins ? mins.toFixed(0) + "min" : "")}`,
+    );
   }
 }
 
-console.log(c.dim(`\nNext: friction.mjs for what wasted time; --roll to persist these rows for a dashboard.\n`));
+console.log(
+  c.dim(
+    `\nNext: friction.mjs for what wasted time; --roll to persist these rows for a dashboard.\n`,
+  ),
+);

--- a/orchestrator/escalate.mjs
+++ b/orchestrator/escalate.mjs
@@ -63,9 +63,18 @@ export function resolveEscalateGlobs(repo) {
   const name = repo?.name ?? "?";
   const raw = repo?.escalate_paths;
   if (raw === undefined || raw === null)
-    return { ok: false, reason: `"${name}" has no escalate_paths key in config/repos.yaml` };
-  if (!Array.isArray(raw) || raw.some((g) => typeof g !== "string" || !g.trim()))
-    return { ok: false, reason: `escalate_paths for "${name}" is not a list of path globs` };
+    return {
+      ok: false,
+      reason: `"${name}" has no escalate_paths key in config/repos.yaml`,
+    };
+  if (
+    !Array.isArray(raw) ||
+    raw.some((g) => typeof g !== "string" || !g.trim())
+  )
+    return {
+      ok: false,
+      reason: `escalate_paths for "${name}" is not a list of path globs`,
+    };
   return { ok: true, globs: raw };
 }
 
@@ -81,7 +90,10 @@ export function resolveChangedFiles(raw) {
     .map((s) => s.trim())
     .filter(Boolean);
   if (!files.length)
-    return { ok: false, reason: "the changed-file list is empty — the diff was never read" };
+    return {
+      ok: false,
+      reason: "the changed-file list is empty — the diff was never read",
+    };
   return { ok: true, files };
 }
 
@@ -92,8 +104,16 @@ export function checkoutFreshness(configPath) {
     const r = spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
     return r.status === 0 ? (r.stdout ?? "").trim() : null;
   };
-  const upstream = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
-  const behindRaw = upstream === null ? null : git(["rev-list", "--count", `HEAD..${upstream}`]);
+  const upstream = git([
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "@{u}",
+  ]);
+  const behindRaw =
+    upstream === null
+      ? null
+      : git(["rev-list", "--count", `HEAD..${upstream}`]);
   const behind = behindRaw === null ? null : Number(behindRaw);
   // Absolute pathspec: the config need not sit at the root of its checkout.
   const status = git(["status", "--porcelain", "--", path.resolve(configPath)]);
@@ -110,7 +130,10 @@ export function checkoutFreshness(configPath) {
  * command reports "unknown", never "clean" — that is the same fail-open shape
  * this gate exists to avoid.
  */
-export function freshnessWarnings(freshness, dir = freshness.root ?? "the factory checkout") {
+export function freshnessWarnings(
+  freshness,
+  dir = freshness.root ?? "the factory checkout",
+) {
   const out = [];
   const ref = freshness.upstream ?? "origin";
   if (freshness.behind === null)
@@ -126,7 +149,9 @@ export function freshnessWarnings(freshness, dir = freshness.root ?? "the factor
         `Run \`git -C ${dir} pull --ff-only\` and re-check before trusting this result.`,
     );
   if (freshness.dirtyConfig === null)
-    out.push(`WARNING: cannot tell whether config/repos.yaml is locally modified in ${dir}`);
+    out.push(
+      `WARNING: cannot tell whether config/repos.yaml is locally modified in ${dir}`,
+    );
   else if (freshness.dirtyConfig)
     out.push(
       `WARNING: config/repos.yaml has uncommitted local changes — ` +
@@ -137,35 +162,58 @@ export function freshnessWarnings(freshness, dir = freshness.root ?? "the factor
 
 if (import.meta.main) {
   const argv = process.argv.slice(2);
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
 
   const pr = val("--pr");
-  if (!val("--repo") || !pr) { console.error(`usage: bun orchestrator/escalate.mjs --repo <name> --pr <number>`); process.exit(EXIT.CANNOT_EVALUATE); }
+  if (!val("--repo") || !pr) {
+    console.error(
+      `usage: bun orchestrator/escalate.mjs --repo <name> --pr <number>`,
+    );
+    process.exit(EXIT.CANNOT_EVALUATE);
+  }
 
-  const configPath = process.env.FACTORY_ESCALATE_REPOS_YAML || path.join(ROOT, "config/repos.yaml");
+  const configPath =
+    process.env.FACTORY_ESCALATE_REPOS_YAML ||
+    path.join(ROOT, "config/repos.yaml");
   let cfg;
   try {
     cfg = Bun.YAML.parse(readFileSync(configPath, "utf8"));
   } catch (err) {
-    console.error(`CANNOT EVALUATE — could not read ${configPath}: ${err.message}`);
-    console.error(`the escalation gate did not run => treat the PR as ESCALATED until it can`);
+    console.error(
+      `CANNOT EVALUATE — could not read ${configPath}: ${err.message}`,
+    );
+    console.error(
+      `the escalation gate did not run => treat the PR as ESCALATED until it can`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
   const repo = (cfg?.repos ?? []).find((r) => r.name === val("--repo"));
 
-  for (const line of freshnessWarnings(checkoutFreshness(configPath))) console.error(line);
+  for (const line of freshnessWarnings(checkoutFreshness(configPath)))
+    console.error(line);
 
   if (!repo) {
-    console.error(`CANNOT EVALUATE — no repo named "${val("--repo")}" in ${configPath}`);
-    console.error(`the escalation gate did not run => treat PR #${pr} as ESCALATED until it can`);
+    console.error(
+      `CANNOT EVALUATE — no repo named "${val("--repo")}" in ${configPath}`,
+    );
+    console.error(
+      `the escalation gate did not run => treat PR #${pr} as ESCALATED until it can`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
 
   const resolved = resolveEscalateGlobs(repo);
   if (!resolved.ok) {
     console.error(`CANNOT EVALUATE — ${resolved.reason}`);
-    console.error(`the escalation gate did not run => treat PR #${pr} as ESCALATED until it can.`);
-    console.error(`Fix: give ${repo.name} an escalate_paths list, or an explicit \`escalate_paths: []\` if there is deliberately nothing to check mechanically.`);
+    console.error(
+      `the escalation gate did not run => treat PR #${pr} as ESCALATED until it can.`,
+    );
+    console.error(
+      `Fix: give ${repo.name} an escalate_paths list, or an explicit \`escalate_paths: []\` if there is deliberately nothing to check mechanically.`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
   const globs = resolved.globs;
@@ -178,7 +226,10 @@ if (import.meta.main) {
     raw = injected;
   } else {
     const repoPath = String(repo.path).replace(/^~/, homedir());
-    const diff = spawnSync("gh", ["pr", "diff", pr, "--name-only"], { cwd: repoPath, encoding: "utf8" });
+    const diff = spawnSync("gh", ["pr", "diff", pr, "--name-only"], {
+      cwd: repoPath,
+      encoding: "utf8",
+    });
     if (diff.status !== 0) {
       console.error(`gh pr diff failed: ${(diff.stderr || "").trim()}`);
       console.error(`cannot see the diff => treat as ESCALATE, not as clean`);
@@ -190,19 +241,29 @@ if (import.meta.main) {
   const changed = resolveChangedFiles(raw);
   if (!changed.ok) {
     console.error(`CANNOT EVALUATE — PR #${pr}: ${changed.reason}`);
-    console.error(`zero files match every glob list => treat PR #${pr} as ESCALATED, not as clean`);
-    console.error(`Check: \`gh pr diff ${pr} --name-only\` in ${repo.name} — an empty result usually means the wrong PR number, a closed or cross-fork PR, or a \`gh\` auth failure.`);
+    console.error(
+      `zero files match every glob list => treat PR #${pr} as ESCALATED, not as clean`,
+    );
+    console.error(
+      `Check: \`gh pr diff ${pr} --name-only\` in ${repo.name} — an empty result usually means the wrong PR number, a closed or cross-fork PR, or a \`gh\` auth failure.`,
+    );
     process.exit(EXIT.CANNOT_EVALUATE);
   }
   const files = changed.files;
 
   const hits = matchEscalations(files, globs);
   if (hits.length) {
-    console.log(`ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`);
+    console.log(
+      `ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`,
+    );
     for (const h of hits) console.log(`  ${h.file}  (${h.globs.join(", ")})`);
     process.exit(EXIT.ESCALATE);
   }
-  const list = globs.length ? `${globs.length} escalate_paths glob(s)` : `an explicitly empty escalate_paths list`;
-  console.log(`PR #${pr}: none of ${files.length} changed file(s) hit ${list} — mechanical check clean (judgment list still applies)`);
+  const list = globs.length
+    ? `${globs.length} escalate_paths glob(s)`
+    : `an explicitly empty escalate_paths list`;
+  console.log(
+    `PR #${pr}: none of ${files.length} changed file(s) hit ${list} — mechanical check clean (judgment list still applies)`,
+  );
   process.exit(EXIT.CLEAN);
 }

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -1,5 +1,12 @@
 import { test, expect, afterAll } from "bun:test";
-import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -15,11 +22,21 @@ const globs = ["app/src/payment/**", "app/src/auth/**", "app/migrations/**"];
 const repos = Bun.YAML.parse(
   readFileSync(new URL("../config/repos.yaml", import.meta.url), "utf8"),
 ).repos;
-const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_paths;
-const wmHomeGlobs = repos.find((repo) => repo.name === "wm-home")?.escalate_paths;
-const wattsMobileGlobs = repos.find((repo) => repo.name === "watts-mobile")?.escalate_paths;
-const coachWattzGlobs = repos.find((repo) => repo.name === "coach-wattz")?.escalate_paths;
-const legaleaseGlobs = repos.find((repo) => repo.name === "legalease")?.escalate_paths;
+const cashsaasGlobs = repos.find(
+  (repo) => repo.name === "cashsaas",
+)?.escalate_paths;
+const wmHomeGlobs = repos.find(
+  (repo) => repo.name === "wm-home",
+)?.escalate_paths;
+const wattsMobileGlobs = repos.find(
+  (repo) => repo.name === "watts-mobile",
+)?.escalate_paths;
+const coachWattzGlobs = repos.find(
+  (repo) => repo.name === "coach-wattz",
+)?.escalate_paths;
+const legaleaseGlobs = repos.find(
+  (repo) => repo.name === "legalease",
+)?.escalate_paths;
 
 test("wm-home config protects its schema, auth, admin, and deployment boundaries", () => {
   expect(wmHomeGlobs).toBeDefined();
@@ -251,15 +268,23 @@ test("flags a file under an escalate glob", () => {
 });
 
 test("clean diff passes", () => {
-  expect(matchEscalations(["app/src/pages/Home.tsx", "README.md"], globs)).toEqual([]);
+  expect(
+    matchEscalations(["app/src/pages/Home.tsx", "README.md"], globs),
+  ).toEqual([]);
 });
 
 test("a single protected file among many still escalates", () => {
   const hits = matchEscalations(
-    ["docs/notes.md", "app/migrations/0042_add_index.sql", "app/src/ui/Button.tsx"],
+    [
+      "docs/notes.md",
+      "app/migrations/0042_add_index.sql",
+      "app/src/ui/Button.tsx",
+    ],
     globs,
   );
-  expect(hits.map((h) => h.file)).toEqual(["app/migrations/0042_add_index.sql"]);
+  expect(hits.map((h) => h.file)).toEqual([
+    "app/migrations/0042_add_index.sql",
+  ]);
 });
 
 test("settings glob with wildcard filename matches", () => {
@@ -276,9 +301,15 @@ test("empty glob list never escalates", () => {
 
 test("a missing escalate_paths key is not an empty list", () => {
   expect(resolveEscalateGlobs({ name: "unguarded" }).ok).toBe(false);
-  expect(resolveEscalateGlobs({ name: "nulled", escalate_paths: null }).ok).toBe(false);
-  expect(resolveEscalateGlobs({ name: "bad", escalate_paths: "src/auth/**" }).ok).toBe(false);
-  expect(resolveEscalateGlobs({ name: "declared", escalate_paths: [] })).toEqual({ ok: true, globs: [] });
+  expect(
+    resolveEscalateGlobs({ name: "nulled", escalate_paths: null }).ok,
+  ).toBe(false);
+  expect(
+    resolveEscalateGlobs({ name: "bad", escalate_paths: "src/auth/**" }).ok,
+  ).toBe(false);
+  expect(
+    resolveEscalateGlobs({ name: "declared", escalate_paths: [] }),
+  ).toEqual({ ok: true, globs: [] });
 });
 
 test("a changed-file list only answers the question when it names a file", () => {
@@ -293,18 +324,36 @@ test("a changed-file list only answers the question when it names a file", () =>
 });
 
 test("freshness warns when behind, when dirty, and when it cannot tell", () => {
-  expect(freshnessWarnings({ upstream: "origin/main", behind: 0, dirtyConfig: false })).toEqual([]);
+  expect(
+    freshnessWarnings({
+      upstream: "origin/main",
+      behind: 0,
+      dirtyConfig: false,
+    }),
+  ).toEqual([]);
 
-  const behind = freshnessWarnings({ upstream: "origin/main", behind: 2, dirtyConfig: false });
+  const behind = freshnessWarnings({
+    upstream: "origin/main",
+    behind: 2,
+    dirtyConfig: false,
+  });
   expect(behind.length).toBe(1);
   expect(behind[0]).toContain("2 commit(s) behind origin/main");
 
-  const dirty = freshnessWarnings({ upstream: "origin/main", behind: 0, dirtyConfig: true });
+  const dirty = freshnessWarnings({
+    upstream: "origin/main",
+    behind: 0,
+    dirtyConfig: true,
+  });
   expect(dirty.length).toBe(1);
   expect(dirty[0]).toContain("config/repos.yaml has uncommitted local changes");
 
   // A failed git command must read as "unknown", never as "clean".
-  const unknown = freshnessWarnings({ upstream: null, behind: null, dirtyConfig: null });
+  const unknown = freshnessWarnings({
+    upstream: null,
+    behind: null,
+    dirtyConfig: null,
+  });
   expect(unknown.length).toBe(2);
   expect(unknown[0]).toContain("cannot tell whether");
 });
@@ -338,13 +387,22 @@ writeFileSync(
 // most here: exit 0 with no files named.
 const stubBin = path.join(tmp, "stub-bin");
 mkdirSync(stubBin, { recursive: true });
-writeFileSync(path.join(stubBin, "gh"), `#!/bin/sh\nprintf '%s' "$FACTORY_TEST_GH_FILES"\n`, {
-  mode: 0o755,
-});
+writeFileSync(
+  path.join(stubBin, "gh"),
+  `#!/bin/sh\nprintf '%s' "$FACTORY_TEST_GH_FILES"\n`,
+  {
+    mode: 0o755,
+  },
+);
 
 test("checkoutFreshness sees a locally modified config wherever it sits in the checkout", () => {
   const repo = mkdtempSync(path.join(tmp, "checkout-"));
-  const git = (...args) => Bun.spawnSync({ cmd: ["git", "-C", repo, ...args], stdout: "pipe", stderr: "pipe" });
+  const git = (...args) =>
+    Bun.spawnSync({
+      cmd: ["git", "-C", repo, ...args],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
   git("init", "-q");
   git("config", "user.email", "test@example.com");
   git("config", "user.name", "test");
@@ -357,7 +415,9 @@ test("checkoutFreshness sees a locally modified config wherever it sits in the c
   expect(checkoutFreshness(cfg).dirtyConfig).toBe(false);
   appendFileSync(cfg, "# local edit\n");
   expect(checkoutFreshness(cfg).dirtyConfig).toBe(true);
-  expect(freshnessWarnings(checkoutFreshness(cfg)).join("\n")).toContain("uncommitted local changes");
+  expect(freshnessWarnings(checkoutFreshness(cfg)).join("\n")).toContain(
+    "uncommitted local changes",
+  );
 });
 
 const CLI = path.join(import.meta.dir, "escalate.mjs");

--- a/orchestrator/friction.mjs
+++ b/orchestrator/friction.mjs
@@ -30,10 +30,16 @@ import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { parseRun, LOG_DIR, parseDuration } from "../lib/transcript.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
 const JSON_OUT = argv.includes("--json");
 
-if (!existsSync(LOG_DIR)) { console.error(`no transcripts at ${LOG_DIR}`); process.exit(1); }
+if (!existsSync(LOG_DIR)) {
+  console.error(`no transcripts at ${LOG_DIR}`);
+  process.exit(1);
+}
 
 const sinceArg = val("--since");
 const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
@@ -42,29 +48,45 @@ const onlyRun = val("--run");
 const files = readdirSync(LOG_DIR)
   .filter((f) => f.endsWith(".jsonl"))
   .filter((f) => !onlyRun || f.startsWith(onlyRun))
-  .map((f) => ({ f, p: `${LOG_DIR}/${f}`, t: statSync(`${LOG_DIR}/${f}`).mtimeMs }))
+  .map((f) => ({
+    f,
+    p: `${LOG_DIR}/${f}`,
+    t: statSync(`${LOG_DIR}/${f}`).mtimeMs,
+  }))
   .filter((x) => x.t >= sinceMs)
   .sort((a, b) => a.t - b.t);
 
-if (!files.length) { console.error("no transcripts match"); process.exit(1); }
+if (!files.length) {
+  console.error("no transcripts match");
+  process.exit(1);
+}
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, green: (s) => `\x1b[32m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
 };
 
-const errors = new Map();     // signature -> {count, tool, sample, runs:Set}
-const repeats = new Map();    // command -> {count, runs:Set}
-const toolUse = new Map();    // tool -> count
+const errors = new Map(); // signature -> {count, tool, sample, runs:Set}
+const repeats = new Map(); // command -> {count, runs:Set}
+const toolUse = new Map(); // tool -> count
 const runs = [];
 
 for (const { f, p, t } of files) {
   const parsed = parseRun(f, readFileSync(p, "utf8"), t);
 
-  for (const [name, n] of parsed.toolCalls) toolUse.set(name, (toolUse.get(name) ?? 0) + n);
+  for (const [name, n] of parsed.toolCalls)
+    toolUse.set(name, (toolUse.get(name) ?? 0) + n);
 
   for (const [sig, hit] of parsed.errorSigs) {
-    const agg = errors.get(sig) ?? { count: 0, tool: hit.tool, sample: hit.sample, runs: new Set() };
+    const agg = errors.get(sig) ?? {
+      count: 0,
+      tool: hit.tool,
+      sample: hit.sample,
+      runs: new Set(),
+    };
     agg.count += hit.count;
     agg.runs.add(f);
     errors.set(sig, agg);
@@ -91,37 +113,90 @@ for (const { f, p, t } of files) {
 }
 
 if (JSON_OUT) {
-  console.log(JSON.stringify({
-    runs: runs.map((r) => ({ file: r.file, harness: r.harness, ok: r.ok, turns: r.turns, cost: r.cost, tools: r.tools, errors: r.errors })),
-    errors: [...errors.values()].map((e) => ({ tool: e.tool, count: e.count, sample: e.sample, runs: e.runs.size })),
-    repeats: [...repeats.entries()].map(([cmd, v]) => ({ cmd, count: v.count, runs: v.runs.size })),
-  }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        runs: runs.map((r) => ({
+          file: r.file,
+          harness: r.harness,
+          ok: r.ok,
+          turns: r.turns,
+          cost: r.cost,
+          tools: r.tools,
+          errors: r.errors,
+        })),
+        errors: [...errors.values()].map((e) => ({
+          tool: e.tool,
+          count: e.count,
+          sample: e.sample,
+          runs: e.runs.size,
+        })),
+        repeats: [...repeats.entries()].map(([cmd, v]) => ({
+          cmd,
+          count: v.count,
+          runs: v.runs.size,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
   process.exit(0);
 }
 
 console.log(c.bold(`\nfriction across ${files.length} run(s)\n`));
 for (const r of runs) {
-  const status = r.ok === null ? c.yellow("no result") : r.ok ? c.green("ok") : c.red("FAILED");
+  const status =
+    r.ok === null
+      ? c.yellow("no result")
+      : r.ok
+        ? c.green("ok")
+        : c.red("FAILED");
   const harness = r.harness !== "unknown" ? c.dim(`[${r.harness}] `) : "";
-  console.log(`  ${status.padEnd(18)} ${harness}${r.file.replace(/\.jsonl$/, "")}`);
-  console.log(c.dim(`     ${r.turns} turns · ${r.tools} tool calls · ${r.errors} errors · ~$${r.cost.toFixed(2)} · ${(r.durationMs / 60000).toFixed(1)}min`));
+  console.log(
+    `  ${status.padEnd(18)} ${harness}${r.file.replace(/\.jsonl$/, "")}`,
+  );
+  console.log(
+    c.dim(
+      `     ${r.turns} turns · ${r.tools} tool calls · ${r.errors} errors · ~$${r.cost.toFixed(2)} · ${(r.durationMs / 60000).toFixed(1)}min`,
+    ),
+  );
 }
 
 const sortedErrors = [...errors.values()].sort((a, b) => b.count - a.count);
 if (sortedErrors.length) {
-  console.log(c.bold(`\nrecurring failures`) + c.dim("  (grouped by failure shape, paths and ids normalised)\n"));
+  console.log(
+    c.bold(`\nrecurring failures`) +
+      c.dim("  (grouped by failure shape, paths and ids normalised)\n"),
+  );
   for (const e of sortedErrors.slice(0, 12)) {
-    const flag = e.runs.size > 1 ? c.red(`×${e.count} in ${e.runs.size} runs`) : c.yellow(`×${e.count}`);
+    const flag =
+      e.runs.size > 1
+        ? c.red(`×${e.count} in ${e.runs.size} runs`)
+        : c.yellow(`×${e.count}`);
     console.log(`  ${flag}  ${c.bold(e.tool)}`);
     console.log(c.dim(`     err: ${e.sample}`));
   }
-  console.log(c.dim(`\n  Failures spanning MORE THAN ONE run are the ones worth fixing —`));
-  console.log(c.dim(`  a one-off is a ticket's problem, a repeat is the harness's.`));
+  console.log(
+    c.dim(
+      `\n  Failures spanning MORE THAN ONE run are the ones worth fixing —`,
+    ),
+  );
+  console.log(
+    c.dim(`  a one-off is a ticket's problem, a repeat is the harness's.`),
+  );
 }
 
-const sortedRepeats = [...repeats.entries()].filter(([, v]) => v.count > 2).sort((a, b) => b[1].count - a[1].count);
+const sortedRepeats = [...repeats.entries()]
+  .filter(([, v]) => v.count > 2)
+  .sort((a, b) => b[1].count - a[1].count);
 if (sortedRepeats.length) {
-  console.log(c.bold(`\nrepeated commands`) + c.dim("  (same command re-run inside a session — a retry loop or a missing shortcut)\n"));
+  console.log(
+    c.bold(`\nrepeated commands`) +
+      c.dim(
+        "  (same command re-run inside a session — a retry loop or a missing shortcut)\n",
+      ),
+  );
   for (const [cmd, v] of sortedRepeats.slice(0, 10)) {
     console.log(`  ${c.yellow(`×${v.count}`)}  ${cmd.slice(0, 100)}`);
   }
@@ -131,5 +206,13 @@ const topTools = [...toolUse.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8);
 console.log(c.bold(`\ntool usage\n`));
 console.log("  " + topTools.map(([n, k]) => `${n}×${k}`).join("  "));
 
-console.log(c.dim(`\nNext: /factory-retro turns the repeats above into changes, or records why not.`));
-console.log(c.dim(`Interactive sessions without transcripts: search Linear for FIP: and ## Session friction.\n`));
+console.log(
+  c.dim(
+    `\nNext: /factory-retro turns the repeats above into changes, or records why not.`,
+  ),
+);
+console.log(
+  c.dim(
+    `Interactive sessions without transcripts: search Linear for FIP: and ## Session friction.\n`,
+  ),
+);

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -40,7 +40,13 @@
  * reimplement Linear + worktree discovery. Stdout is JSON only; the colour
  * log is skipped. `--force` is still not a flag and must never become one.
  */
-import { readFileSync, existsSync, readdirSync, mkdirSync, appendFileSync } from "node:fs";
+import {
+  readFileSync,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+  appendFileSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { homedir } from "node:os";
@@ -49,20 +55,29 @@ import { ROOT } from "../lib/schedule.mjs";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export function parseArgs(argv) {
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
   return {
     apply: argv.includes("--apply"),
     gate: argv.includes("--gate"),
     json: argv.includes("--json"),
-    only: (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean),
+    only: (val("--repo") || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
   };
 }
 
 const expand = (p) => p.replace(/^~/, homedir());
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
 
 /**
@@ -74,8 +89,13 @@ export function parseWorktreeBranches(porcelain) {
   const branches = {};
   let current = null;
   for (const line of String(porcelain ?? "").split("\n")) {
-    if (line.startsWith("worktree ")) current = line.slice("worktree ".length).trim();
-    else if (line.startsWith("branch ") && current) branches[current] = line.slice("branch ".length).trim().replace(/^refs\/heads\//, "");
+    if (line.startsWith("worktree "))
+      current = line.slice("worktree ".length).trim();
+    else if (line.startsWith("branch ") && current)
+      branches[current] = line
+        .slice("branch ".length)
+        .trim()
+        .replace(/^refs\/heads\//, "");
     else if (!line.trim()) current = null;
   }
   return branches;
@@ -103,7 +123,20 @@ export function openPrHold(branch, openPrs) {
  * an open PR holder due to pagination limits (WM-56).
  */
 export function listOpenPrs(repoPath, run = spawnSync, limit = 200) {
-  const r = run("gh", ["pr", "list", "--state", "open", "--limit", String(limit), "--json", "number,headRefName"], { cwd: repoPath, encoding: "utf8" });
+  const r = run(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      String(limit),
+      "--json",
+      "number,headRefName",
+    ],
+    { cwd: repoPath, encoding: "utf8" },
+  );
   if (r.status !== 0) return null;
   try {
     const parsed = JSON.parse(r.stdout || "[]");
@@ -121,7 +154,10 @@ export function listOpenPrs(repoPath, run = spawnSync, limit = 200) {
  * shape as `listOpenPrs`: "don't know" is not "no branch, so nothing is held".
  */
 export function ticketBranches(repoPath, root, tickets, run = spawnSync) {
-  const r = run("git", ["worktree", "list", "--porcelain"], { cwd: repoPath, encoding: "utf8" });
+  const r = run("git", ["worktree", "list", "--porcelain"], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
   if (r.status !== 0) return null;
   const byPath = parseWorktreeBranches(r.stdout);
   const byTicket = {};
@@ -139,9 +175,14 @@ export function ticketBranches(repoPath, root, tickets, run = spawnSync) {
  * a real checkout: `run` is the only way this reaches the filesystem, so a test
  * that injects a recorder proves a held ticket never reaches worktree-down.sh.
  */
-export function reclaim(finished, { repoPath, down, branches = {}, openPrs, run = spawnSync } = {}) {
+export function reclaim(
+  finished,
+  { repoPath, down, branches = {}, openPrs, run = spawnSync } = {},
+) {
   if (!Array.isArray(openPrs)) {
-    throw new Error("reclaim requires openPrs array — refusing unguarded teardown (WM-56)");
+    throw new Error(
+      "reclaim requires openPrs array — refusing unguarded teardown (WM-56)",
+    );
   }
   const removed = [];
   const refused = [];
@@ -157,7 +198,9 @@ export function reclaim(finished, { repoPath, down, branches = {}, openPrs, run 
     const r = run("/bin/bash", [down, t], { cwd: repoPath, encoding: "utf8" });
     if (r.status === 0) removed.push(t);
     else {
-      const reason = (r.stderr || r.stdout || "").trim().split("\n").pop() || `exit ${r.status}`;
+      const reason =
+        (r.stderr || r.stdout || "").trim().split("\n").pop() ||
+        `exit ${r.status}`;
       refused.push({ id: t, reason });
     }
   }
@@ -180,14 +223,18 @@ function emptySurvey(repo, apply) {
   };
 }
 
-export async function survey(repo, { apply }, {
-  readdir = readdirSync,
-  exists = existsSync,
-  queryIssues,
-  getBranches = ticketBranches,
-  getOpenPrs = listOpenPrs,
-  doReclaim = reclaim,
-} = {}) {
+export async function survey(
+  repo,
+  { apply },
+  {
+    readdir = readdirSync,
+    exists = existsSync,
+    queryIssues,
+    getBranches = ticketBranches,
+    getOpenPrs = listOpenPrs,
+    doReclaim = reclaim,
+  } = {},
+) {
   const result = emptySurvey(repo, apply);
   const root = expand(repo.worktree_root ?? "");
   const repoPath = expand(repo.path);
@@ -207,30 +254,41 @@ export async function survey(repo, { apply }, {
   let states = {};
   if (tickets.length) {
     const nums = tickets.map((t) => Number(t.split("-")[1]));
-    const queryBatch = queryIssues ?? (async (team, batch) => {
-      const q = `query($n:[Float!]){ issues(first:250, filter:{ number:{in:$n}, team:{key:{eq:"${team}"}} }){ nodes{ identifier state{name type} } } }`;
-      return (await gql(q, { n: batch }))?.issues?.nodes ?? [];
-    });
+    const queryBatch =
+      queryIssues ??
+      (async (team, batch) => {
+        const q = `query($n:[Float!]){ issues(first:250, filter:{ number:{in:$n}, team:{key:{eq:"${team}"}} }){ nodes{ identifier state{name type} } } }`;
+        return (await gql(q, { n: batch }))?.issues?.nodes ?? [];
+      });
 
     // Linear caps this connection at 250 nodes. Keep each filter at or below
     // that cap and run the independent requests together so every worktree is
     // resolved without turning a large checkout into a serial API crawl.
     const batches = [];
-    for (let i = 0; i < nums.length; i += 250) batches.push(nums.slice(i, i + 250));
-    const nodes = (await Promise.all(batches.map((batch) => queryBatch(repo.team, batch)))).flat();
+    for (let i = 0; i < nums.length; i += 250)
+      batches.push(nums.slice(i, i + 250));
+    const nodes = (
+      await Promise.all(batches.map((batch) => queryBatch(repo.team, batch)))
+    ).flat();
     states = Object.fromEntries(nodes.map((n) => [n.identifier, n.state]));
   }
 
-  const allFinished = tickets.filter((t) => ["completed", "canceled"].includes(states[t]?.type));
+  const allFinished = tickets.filter((t) =>
+    ["completed", "canceled"].includes(states[t]?.type),
+  );
   result.kept = tickets
-    .filter((t) => states[t] && !["completed", "canceled"].includes(states[t].type))
+    .filter(
+      (t) => states[t] && !["completed", "canceled"].includes(states[t].type),
+    )
     .map((t) => ({ id: t, state: states[t].name }));
   result.unknown = tickets.filter((t) => !states[t]);
 
   // WM-17: the open-PR hold is evaluated in the survey, not just under --apply,
   // so a held worktree is neither reported as reclaimable nor allowed to keep
   // the --gate firing on work that every apply run will correctly decline.
-  const branches = allFinished.length ? getBranches(repoPath, root, allFinished) : {};
+  const branches = allFinished.length
+    ? getBranches(repoPath, root, allFinished)
+    : {};
   const openPrs = allFinished.length ? getOpenPrs(repoPath) : [];
   const cannotTell = openPrs === null || branches === null;
   if (cannotTell) {
@@ -247,7 +305,12 @@ export async function survey(repo, { apply }, {
   const finished = allFinished.filter((t) => !openPrHold(branches[t], openPrs));
   result.held = allFinished
     .filter((t) => !finished.includes(t))
-    .map((t) => ({ id: t, state: states[t].name, branch: branches[t], reason: openPrHold(branches[t], openPrs) }));
+    .map((t) => ({
+      id: t,
+      state: states[t].name,
+      branch: branches[t],
+      reason: openPrHold(branches[t], openPrs),
+    }));
   result.reclaimable = finished.map((t) => ({ id: t, state: states[t].name }));
 
   if (!apply || !allFinished.length) return result;
@@ -278,14 +341,31 @@ export async function survey(repo, { apply }, {
 
 function printHuman(repo, result) {
   if (result.missingRoot) return;
-  const n = result.reclaimable.length + result.kept.length + result.unknown.length;
-  console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${n} ticket worktree(s) in ${repo.worktree_root}`));
+  const n =
+    result.reclaimable.length + result.kept.length + result.unknown.length;
+  console.log(
+    c.bold(`\n${repo.name}`) +
+      c.dim(`  ${n} ticket worktree(s) in ${repo.worktree_root}`),
+  );
   if (result.kept.length) {
-    console.log(c.dim(`  keeping ${result.kept.length} live: ${result.kept.map((t) => `${t.id} (${t.state})`).join(", ")}`));
+    console.log(
+      c.dim(
+        `  keeping ${result.kept.length} live: ${result.kept.map((t) => `${t.id} (${t.state})`).join(", ")}`,
+      ),
+    );
   }
-  if (result.named.length) console.log(c.dim(`  ignoring ${result.named.length} named worktree(s): ${result.named.join(", ")}`));
+  if (result.named.length)
+    console.log(
+      c.dim(
+        `  ignoring ${result.named.length} named worktree(s): ${result.named.join(", ")}`,
+      ),
+    );
   if (result.unknown.length) {
-    console.log(c.yellow(`  ${result.unknown.length} worktree(s) with no matching ticket — left alone: ${result.unknown.join(", ")}`));
+    console.log(
+      c.yellow(
+        `  ${result.unknown.length} worktree(s) with no matching ticket — left alone: ${result.unknown.join(", ")}`,
+      ),
+    );
   }
   for (const t of result.held) {
     console.log(c.yellow(`  holding ${t.id} — ${t.reason}`));
@@ -294,8 +374,11 @@ function printHuman(repo, result) {
     console.log(c.green("  nothing to reclaim"));
     return;
   }
-  console.log(`  ${c.bold(String(result.reclaimable.length))} reclaimable (ticket finished):`);
-  for (const t of result.reclaimable) console.log(`    ${t.id}  ${c.dim(t.state)}`);
+  console.log(
+    `  ${c.bold(String(result.reclaimable.length))} reclaimable (ticket finished):`,
+  );
+  for (const t of result.reclaimable)
+    console.log(`    ${t.id}  ${c.dim(t.state)}`);
   if (!result.apply) {
     console.log(c.dim(`\n  dry run — re-run with --apply to remove them`));
     return;
@@ -303,21 +386,40 @@ function printHuman(repo, result) {
   if (result.skippedApplyReason) {
     console.log(c.yellow(`\n  ${result.skippedApplyReason}`));
     if (result.skippedApplyReason.startsWith("report-only:")) {
-      console.log(c.dim(`  Not removing anything. These need the repo's own worktree-down.sh so the`));
+      console.log(
+        c.dim(
+          `  Not removing anything. These need the repo's own worktree-down.sh so the`,
+        ),
+      );
       console.log(c.dim(`  per-ticket database goes with the checkout.`));
     }
     return;
   }
   for (const t of result.removed) console.log(`    ${c.green("removed")} ${t}`);
-  for (const t of result.refused) console.log(`    ${c.yellow("kept")}    ${t.id} — ${t.reason}`);
-  console.log(`\n  ${result.removed.length} removed, ${result.refused.length} kept (unpushed or uncommitted work).`);
+  for (const t of result.refused)
+    console.log(`    ${c.yellow("kept")}    ${t.id} — ${t.reason}`);
+  console.log(
+    `\n  ${result.removed.length} removed, ${result.refused.length} kept (unpushed or uncommitted work).`,
+  );
 }
 
 async function main() {
-  const { apply: APPLY, gate: GATE, json: JSON_OUT, only } = parseArgs(process.argv.slice(2));
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-  const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
-  if (!repos.length) { console.error("no matching repo in config/repos.yaml"); process.exit(2); }
+  const {
+    apply: APPLY,
+    gate: GATE,
+    json: JSON_OUT,
+    only,
+  } = parseArgs(process.argv.slice(2));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const repos = (cfg.repos ?? []).filter(
+    (r) => !only.length || only.includes(r.name),
+  );
+  if (!repos.length) {
+    console.error("no matching repo in config/repos.yaml");
+    process.exit(2);
+  }
 
   const quiet = JSON_OUT || GATE;
 
@@ -328,9 +430,19 @@ async function main() {
     try {
       const logDir = path.join(homedir(), ".factory/logs");
       mkdirSync(logDir, { recursive: true });
-      const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
-      for (const repo of repos) appendFileSync(path.join(logDir, `janitor-${repo.name}-${stamp}.log`), `${new Date().toISOString()} ${APPLY ? "apply" : "dry"}\n`);
-    } catch { /* observability must never block safe cleanup */ }
+      const stamp = new Date()
+        .toISOString()
+        .replace(/[-:]/g, "")
+        .replace(/\.\d+Z$/, "")
+        .replace("T", "-");
+      for (const repo of repos)
+        appendFileSync(
+          path.join(logDir, `janitor-${repo.name}-${stamp}.log`),
+          `${new Date().toISOString()} ${APPLY ? "apply" : "dry"}\n`,
+        );
+    } catch {
+      /* observability must never block safe cleanup */
+    }
   }
 
   const surveys = [];
@@ -342,17 +454,28 @@ async function main() {
     // re-run reports the same removal once but a later worktree for the same
     // ticket is a new event.
     for (const t of result.removed) {
-      await emitFactoryEvent("factory.worktree.reclaimed",
+      await emitFactoryEvent(
+        "factory.worktree.reclaimed",
         { repo: repo.name, ticket: t },
-        { eventId: `janitor:${repo.name}:${t}:${new Date().toISOString().slice(0, 10)}`, subject: t });
+        {
+          eventId: `janitor:${repo.name}:${t}:${new Date().toISOString().slice(0, 10)}`,
+          subject: t,
+        },
+      );
     }
     if (GATE) continue;
     if (!quiet) printHuman(repo, result);
   }
 
   if (GATE) {
-    const totalReclaimable = surveys.reduce((n, s) => n + s.reclaimable.length, 0);
-    if (totalReclaimable > 0) { console.log(`${totalReclaimable} reclaimable worktree(s)`); process.exit(0); }
+    const totalReclaimable = surveys.reduce(
+      (n, s) => n + s.reclaimable.length,
+      0,
+    );
+    if (totalReclaimable > 0) {
+      console.log(`${totalReclaimable} reclaimable worktree(s)`);
+      process.exit(0);
+    }
     console.log("no worktrees to reclaim");
     process.exit(1);
   }
@@ -360,7 +483,8 @@ async function main() {
   if (JSON_OUT) {
     // One `--repo` is the API's contract (a single selected project). Several
     // names wrap in `{ results }` so a human ` --repo a,b --json` still parses.
-    const payload = surveys.length === 1 ? surveys[0] : { apply: APPLY, results: surveys };
+    const payload =
+      surveys.length === 1 ? surveys[0] : { apply: APPLY, results: surveys };
     console.log(JSON.stringify(payload));
   } else {
     console.log();

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -15,7 +15,14 @@
  * misses: they release themselves as soon as the holding PR closes.
  */
 import { test, expect, describe } from "bun:test";
-import { parseWorktreeBranches, openPrHold, listOpenPrs, ticketBranches, reclaim, survey } from "./janitor.mjs";
+import {
+  parseWorktreeBranches,
+  openPrHold,
+  listOpenPrs,
+  ticketBranches,
+  reclaim,
+  survey,
+} from "./janitor.mjs";
 
 /** A spawnSync stand-in that records every call and never touches the disk. */
 function recorder(handler = () => ({ status: 0, stdout: "", stderr: "" })) {
@@ -47,7 +54,12 @@ describe("parseWorktreeBranches", () => {
   });
 
   test("a detached worktree has no branch and simply does not appear", () => {
-    const porcelain = ["worktree /Users/x/wt/CLNT-1", "HEAD cccc", "detached", ""].join("\n");
+    const porcelain = [
+      "worktree /Users/x/wt/CLNT-1",
+      "HEAD cccc",
+      "detached",
+      "",
+    ].join("\n");
     expect(parseWorktreeBranches(porcelain)).toEqual({});
   });
 
@@ -80,7 +92,10 @@ describe("openPrHold", () => {
   });
 
   test("several open PRs on one branch are all named", () => {
-    const hold = openPrHold("feat/CLNT-520", [...openPrs, { number: 264, headRefName: "feat/CLNT-520" }]);
+    const hold = openPrHold("feat/CLNT-520", [
+      ...openPrs,
+      { number: 264, headRefName: "feat/CLNT-520" },
+    ]);
     expect(hold).toContain("#261");
     expect(hold).toContain("#264");
   });
@@ -92,8 +107,13 @@ describe("openPrHold", () => {
 
 describe("listOpenPrs", () => {
   test("returns the parsed PR list", () => {
-    const run = recorder(() => ({ status: 0, stdout: JSON.stringify([{ number: 261, headRefName: "feat/CLNT-520" }]) }));
-    expect(listOpenPrs("/repo", run)).toEqual([{ number: 261, headRefName: "feat/CLNT-520" }]);
+    const run = recorder(() => ({
+      status: 0,
+      stdout: JSON.stringify([{ number: 261, headRefName: "feat/CLNT-520" }]),
+    }));
+    expect(listOpenPrs("/repo", run)).toEqual([
+      { number: 261, headRefName: "feat/CLNT-520" },
+    ]);
     expect(run.calls[0].args).toContain("--state");
     expect(run.calls[0].args).toContain("open");
   });
@@ -101,19 +121,41 @@ describe("listOpenPrs", () => {
   test("a failed or unparseable `gh` is null, not an empty list", () => {
     // The distinction is the whole point: empty means "no open PR", null means
     // "could not tell", and only the first one licenses a teardown.
-    expect(listOpenPrs("/repo", recorder(() => ({ status: 1, stderr: "gh: not authenticated" })))).toBeNull();
-    expect(listOpenPrs("/repo", recorder(() => ({ status: 0, stdout: "not json" })))).toBeNull();
+    expect(
+      listOpenPrs(
+        "/repo",
+        recorder(() => ({ status: 1, stderr: "gh: not authenticated" })),
+      ),
+    ).toBeNull();
+    expect(
+      listOpenPrs(
+        "/repo",
+        recorder(() => ({ status: 0, stdout: "not json" })),
+      ),
+    ).toBeNull();
   });
 
   test("fails closed (returns null) when hitting the fetch limit (WM-56)", () => {
-    const atLimit = Array.from({ length: 200 }, (_, i) => ({ number: i + 1, headRefName: `branch-${i + 1}` }));
-    const run = recorder(() => ({ status: 0, stdout: JSON.stringify(atLimit) }));
+    const atLimit = Array.from({ length: 200 }, (_, i) => ({
+      number: i + 1,
+      headRefName: `branch-${i + 1}`,
+    }));
+    const run = recorder(() => ({
+      status: 0,
+      stdout: JSON.stringify(atLimit),
+    }));
     expect(listOpenPrs("/repo", run, 200)).toBeNull();
   });
 
   test("returns PRs when below the fetch limit (WM-56)", () => {
-    const belowLimit = Array.from({ length: 199 }, (_, i) => ({ number: i + 1, headRefName: `branch-${i + 1}` }));
-    const run = recorder(() => ({ status: 0, stdout: JSON.stringify(belowLimit) }));
+    const belowLimit = Array.from({ length: 199 }, (_, i) => ({
+      number: i + 1,
+      headRefName: `branch-${i + 1}`,
+    }));
+    const run = recorder(() => ({
+      status: 0,
+      stdout: JSON.stringify(belowLimit),
+    }));
     expect(listOpenPrs("/repo", run, 200)).toHaveLength(199);
   });
 });
@@ -129,15 +171,28 @@ describe("ticketBranches", () => {
       "",
     ].join("\n");
     const run = recorder(() => ({ status: 0, stdout: porcelain }));
-    expect(ticketBranches("/repo", "/wt/legalease", ["CLNT-520", "CLNT-600", "CLNT-700"], run)).toEqual({
+    expect(
+      ticketBranches(
+        "/repo",
+        "/wt/legalease",
+        ["CLNT-520", "CLNT-600", "CLNT-700"],
+        run,
+      ),
+    ).toEqual({
       "CLNT-520": "feat/CLNT-520",
       "CLNT-600": "fix/CLNT-600-thing",
     });
   });
 
   test("a failed git worktree list is cannot-tell, not an empty map", () => {
-    const run = recorder(() => ({ status: 128, stdout: "", stderr: "fatal: not a git repository\n" }));
-    expect(ticketBranches("/repo", "/wt/legalease", ["CLNT-520"], run)).toBeNull();
+    const run = recorder(() => ({
+      status: 128,
+      stdout: "",
+      stderr: "fatal: not a git repository\n",
+    }));
+    expect(
+      ticketBranches("/repo", "/wt/legalease", ["CLNT-520"], run),
+    ).toBeNull();
   });
 });
 
@@ -176,10 +231,18 @@ describe("reclaim (WM-17 regression: branch A merged while a second PR still hea
   });
 
   test("worktree-down.sh's own refusal (unpushed work) is still reported, not overridden", () => {
-    const run = recorder(() => ({ status: 1, stderr: "CLNT-600 has uncommitted changes — commit/stash them\n" }));
+    const run = recorder(() => ({
+      status: 1,
+      stderr: "CLNT-600 has uncommitted changes — commit/stash them\n",
+    }));
     const out = reclaim(["CLNT-600"], { ...scenario, run });
     expect(out.removed).toEqual([]);
-    expect(out.refused).toEqual([{ id: "CLNT-600", reason: "CLNT-600 has uncommitted changes — commit/stash them" }]);
+    expect(out.refused).toEqual([
+      {
+        id: "CLNT-600",
+        reason: "CLNT-600 has uncommitted changes — commit/stash them",
+      },
+    ]);
   });
 
   test("teardown is never invoked with --force", () => {
@@ -190,10 +253,18 @@ describe("reclaim (WM-17 regression: branch A merged while a second PR still hea
 
   test("reclaim throws if openPrs is missing, null, or not an array (WM-56)", () => {
     const run = recorder();
-    expect(() => reclaim(["CLNT-520"], { ...scenario, openPrs: undefined, run })).toThrow("reclaim requires openPrs array");
-    expect(() => reclaim(["CLNT-520"], { ...scenario, openPrs: null, run })).toThrow("reclaim requires openPrs array");
-    expect(() => reclaim(["CLNT-520"], { ...scenario, openPrs: "invalid", run })).toThrow("reclaim requires openPrs array");
-    expect(() => reclaim(["CLNT-520"], { repoPath: "/repo", down: "down.sh" })).toThrow("reclaim requires openPrs array");
+    expect(() =>
+      reclaim(["CLNT-520"], { ...scenario, openPrs: undefined, run }),
+    ).toThrow("reclaim requires openPrs array");
+    expect(() =>
+      reclaim(["CLNT-520"], { ...scenario, openPrs: null, run }),
+    ).toThrow("reclaim requires openPrs array");
+    expect(() =>
+      reclaim(["CLNT-520"], { ...scenario, openPrs: "invalid", run }),
+    ).toThrow("reclaim requires openPrs array");
+    expect(() =>
+      reclaim(["CLNT-520"], { repoPath: "/repo", down: "down.sh" }),
+    ).toThrow("reclaim requires openPrs array");
   });
 });
 
@@ -213,7 +284,10 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
       { identifier: "CLNT-520", state: { name: "Done", type: "completed" } },
       { identifier: "CLNT-600", state: { name: "Done", type: "completed" } },
     ],
-    getBranches: () => ({ "CLNT-520": "feat/CLNT-520", "CLNT-600": "fix/CLNT-600" }),
+    getBranches: () => ({
+      "CLNT-520": "feat/CLNT-520",
+      "CLNT-600": "fix/CLNT-600",
+    }),
     getOpenPrs: () => [{ number: 261, headRefName: "feat/CLNT-520" }],
   };
 
@@ -232,19 +306,24 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
       // in one request silently omits every worktree after the first 250.
       return nums.slice(0, 250).map((number) => ({
         identifier: `CLNT-${number}`,
-        state: number % 2 === 0
-          ? { name: "Done", type: "completed" }
-          : { name: "In Progress", type: "started" },
+        state:
+          number % 2 === 0
+            ? { name: "Done", type: "completed" }
+            : { name: "In Progress", type: "started" },
       }));
     };
 
-    const res = await survey(repo, { apply: false }, {
-      readdir: () => worktrees,
-      exists: () => true,
-      queryIssues,
-      getBranches: () => ({}),
-      getOpenPrs: () => [],
-    });
+    const res = await survey(
+      repo,
+      { apply: false },
+      {
+        readdir: () => worktrees,
+        exists: () => true,
+        queryIssues,
+        getBranches: () => ({}),
+        getOpenPrs: () => [],
+      },
+    );
 
     expect(calls.map((nums) => nums.length)).toEqual([250, 250, 1]);
     expect(maxActive).toBe(3);
@@ -260,20 +339,26 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
       expect(surveyRes.held).toHaveLength(1);
       expect(surveyRes.held[0].id).toBe("CLNT-520");
       expect(surveyRes.held[0].reason).toContain("#261");
-      expect(surveyRes.reclaimable).toEqual([{ id: "CLNT-600", state: "Done" }]);
+      expect(surveyRes.reclaimable).toEqual([
+        { id: "CLNT-600", state: "Done" },
+      ]);
       expect(surveyRes.skippedApplyReason).toBeNull();
     });
   });
 
   test("an open-PR hold populates the held array and is excluded from reclaimable (apply run)", async () => {
     let reclaimed = null;
-    const res = await survey(repo, { apply: true }, {
-      ...defaultDeps,
-      doReclaim: (finished, opts) => {
-        reclaimed = finished;
-        return { removed: finished, refused: [], held: [] };
+    const res = await survey(
+      repo,
+      { apply: true },
+      {
+        ...defaultDeps,
+        doReclaim: (finished, opts) => {
+          reclaimed = finished;
+          return { removed: finished, refused: [], held: [] };
+        },
       },
-    });
+    );
     expect(res.held).toHaveLength(1);
     expect(res.held[0].id).toBe("CLNT-520");
     expect(res.reclaimable).toEqual([{ id: "CLNT-600", state: "Done" }]);
@@ -282,40 +367,60 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
   });
 
   test("cannot-tell from gh (getOpenPrs returns null) yields empty reclaimable and populates skippedApplyReason (dry and apply)", async () => {
-    const dry = await survey(repo, { apply: false }, {
-      ...defaultDeps,
-      getOpenPrs: () => null,
-    });
+    const dry = await survey(
+      repo,
+      { apply: false },
+      {
+        ...defaultDeps,
+        getOpenPrs: () => null,
+      },
+    );
     expect(dry.reclaimable).toEqual([]);
     expect(dry.held).toEqual([]);
     expect(dry.skippedApplyReason).toContain("could not list open PRs");
 
-    const apply = await survey(repo, { apply: true }, {
-      ...defaultDeps,
-      getOpenPrs: () => null,
-    });
+    const apply = await survey(
+      repo,
+      { apply: true },
+      {
+        ...defaultDeps,
+        getOpenPrs: () => null,
+      },
+    );
     expect(apply.reclaimable).toEqual([]);
     expect(apply.held).toEqual([]);
     expect(apply.skippedApplyReason).toContain("could not list open PRs");
   });
 
   test("cannot-tell from git worktree list (getBranches returns null) yields empty reclaimable and populates skippedApplyReason (dry and apply)", async () => {
-    const dry = await survey(repo, { apply: false }, {
-      ...defaultDeps,
-      getBranches: () => null,
-      getOpenPrs: () => [],
-    });
+    const dry = await survey(
+      repo,
+      { apply: false },
+      {
+        ...defaultDeps,
+        getBranches: () => null,
+        getOpenPrs: () => [],
+      },
+    );
     expect(dry.reclaimable).toEqual([]);
     expect(dry.held).toEqual([]);
-    expect(dry.skippedApplyReason).toContain("could not list worktree branches");
+    expect(dry.skippedApplyReason).toContain(
+      "could not list worktree branches",
+    );
 
-    const apply = await survey(repo, { apply: true }, {
-      ...defaultDeps,
-      getBranches: () => null,
-      getOpenPrs: () => [],
-    });
+    const apply = await survey(
+      repo,
+      { apply: true },
+      {
+        ...defaultDeps,
+        getBranches: () => null,
+        getOpenPrs: () => [],
+      },
+    );
     expect(apply.reclaimable).toEqual([]);
     expect(apply.held).toEqual([]);
-    expect(apply.skippedApplyReason).toContain("could not list worktree branches");
+    expect(apply.skippedApplyReason).toContain(
+      "could not list worktree branches",
+    );
   });
 });

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -59,7 +59,8 @@ function sections(description = "") {
  */
 // "None", "N/A", or "no ... path(s)" within a short span -- covers "None in
 // this repo", "No repository paths", "None — infra/deploy verification only".
-const NOT_APPLICABLE = /\b(none|n\/a|not applicable)\b|\bno\b[^.]{0,30}\bpaths?\b/i;
+const NOT_APPLICABLE =
+  /\b(none|n\/a|not applicable)\b|\bno\b[^.]{0,30}\bpaths?\b/i;
 
 /**
  * Which of the two *mechanically load-bearing* §5 sections a description is
@@ -88,7 +89,8 @@ export function templateGaps(description = "") {
   // explicit "not applicable" declaration in the section body.
   const owned = secs.find((s) => /\bowned\s+paths\b/i.test(s.heading));
   const ownedNA = owned && NOT_APPLICABLE.test(owned.body);
-  if (!parseOwnedPaths(description).length && !ownedNA) gaps.push("Owned Paths");
+  if (!parseOwnedPaths(description).length && !ownedNA)
+    gaps.push("Owned Paths");
 
   // "Evidence Required" / "Evidence line" is the accepted non-code substitute
   // for a Verification Command (linear.md §5's non-code-work exception).
@@ -97,7 +99,8 @@ export function templateGaps(description = "") {
   // method and must not satisfy this.
   const verified = secs.some((s) => {
     return (
-      (/\bverification\s+command\b/i.test(s.heading) || /\bevidence\b.*\b(required|line)\b/i.test(s.heading)) &&
+      (/\bverification\s+command\b/i.test(s.heading) ||
+        /\bevidence\b.*\b(required|line)\b/i.test(s.heading)) &&
       s.body.length > 0
     );
   });
@@ -121,7 +124,8 @@ function ownedPathsClosureCheck(description = "", repo, manifestCache) {
   }
 
   const key = JSON.stringify(owned.sort());
-  if (cached.messagesByOwned.has(key)) return { messages: cached.messagesByOwned.get(key), gaps: [] };
+  if (cached.messagesByOwned.has(key))
+    return { messages: cached.messagesByOwned.get(key), gaps: [] };
 
   const gaps = ownedPathsClosureGaps({
     ownedPaths: owned,
@@ -164,7 +168,7 @@ export async function demote(issue, triageStateId, gaps, apply) {
 
   await gql(
     `mutation($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success } }`,
-    { id: issue.id, input: { stateId: triageStateId, labelIds: keepLabelIds } }
+    { id: issue.id, input: { stateId: triageStateId, labelIds: keepLabelIds } },
   );
 
   const body =
@@ -177,20 +181,28 @@ export async function demote(issue, triageStateId, gaps, apply) {
 
   await gql(
     `mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success } }`,
-    { input: { issueId: issue.id, body } }
+    { input: { issueId: issue.id, body } },
   );
 }
 
 export function parseArgs(argv = process.argv.slice(2)) {
   const apply = argv.includes("--apply");
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-  const repos = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const repos = (val("--repo") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
   return { apply, repos };
 }
 
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-  const allRepos = [...loadRepos().values()].filter((r) => !args.repos.length || args.repos.includes(r.name));
+  const allRepos = [...loadRepos().values()].filter(
+    (r) => !args.repos.length || args.repos.includes(r.name),
+  );
   const repos = allRepos.map((r) => ({
     name: r.name,
     team: r.team,
@@ -200,11 +212,17 @@ export async function main(argv = process.argv.slice(2)) {
   }));
 
   if (!repos.length) {
-    console.error(args.repos.length ? `no repo named "${args.repos.join(",")}" in config/repos.yaml` : "no repos configured");
+    console.error(
+      args.repos.length
+        ? `no repo named "${args.repos.join(",")}" in config/repos.yaml`
+        : "no repos configured",
+    );
     process.exit(2);
   }
 
-  console.log(`=== ai:agent-ready template guard [${args.apply ? "APPLY" : "DRY RUN"}] ===\n`);
+  console.log(
+    `=== ai:agent-ready template guard [${args.apply ? "APPLY" : "DRY RUN"}] ===\n`,
+  );
 
   let teams = null;
   let violations = 0;
@@ -216,7 +234,11 @@ export async function main(argv = process.argv.slice(2)) {
       .map((issue) => {
         const gapNames = [...templateGaps(issue.description ?? "")];
         try {
-          const closure = ownedPathsClosureCheck(issue.description ?? "", repo, closureRequirements);
+          const closure = ownedPathsClosureCheck(
+            issue.description ?? "",
+            repo,
+            closureRequirements,
+          );
           gapNames.push(...closure.messages);
           return { issue, gaps: gapNames };
         } catch (err) {
@@ -226,19 +248,27 @@ export async function main(argv = process.argv.slice(2)) {
       })
       .filter((r) => r.gaps.length);
 
-    console.log(`${repo.name}  ${repo.team} / ${repo.project}  --  ${issues.length} ai:agent-ready ticket(s), ${bad.length} failing §5`);
+    console.log(
+      `${repo.name}  ${repo.team} / ${repo.project}  --  ${issues.length} ai:agent-ready ticket(s), ${bad.length} failing §5`,
+    );
 
     if (!bad.length) continue;
     violations += bad.length;
 
     if (args.apply && !teams) teams = await fetchTeams();
-    const triageStateId = args.apply ? teams?.[repo.team]?.states?.["triage"] : null;
+    const triageStateId = args.apply
+      ? teams?.[repo.team]?.states?.["triage"]
+      : null;
     if (args.apply && !triageStateId) {
-      console.log(`  ! no 'Triage' state on team ${repo.team}, skipping demotion for this repo`);
+      console.log(
+        `  ! no 'Triage' state on team ${repo.team}, skipping demotion for this repo`,
+      );
     }
 
     for (const { issue, gaps } of bad) {
-      console.log(`  ${issue.identifier.padEnd(10)} ${issue.title.slice(0, 60)}`);
+      console.log(
+        `  ${issue.identifier.padEnd(10)} ${issue.title.slice(0, 60)}`,
+      );
       for (const g of gaps) console.log(`      missing: ${g}`);
 
       if (args.apply && triageStateId) {
@@ -252,8 +282,11 @@ export async function main(argv = process.argv.slice(2)) {
     }
   }
 
-  console.log(`\n=== ${args.apply ? "Demoted" : "Would demote"}: ${violations} ===`);
-  if (!args.apply && violations) console.log("Run again with --apply to demote these.");
+  console.log(
+    `\n=== ${args.apply ? "Demoted" : "Would demote"}: ${violations} ===`,
+  );
+  if (!args.apply && violations)
+    console.log("Run again with --apply to demote these.");
 }
 
 if (import.meta.main || process.argv[1]?.endsWith("label-guard.mjs")) {

--- a/orchestrator/next.mjs
+++ b/orchestrator/next.mjs
@@ -18,8 +18,14 @@ import { appendEvent } from "../lib/factory-state.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 const JSON_OUT = argv.includes("--json");
 const APPLY = argv.includes("--apply");
 const ORCHESTRATED = argv.includes("--orchestrated");
@@ -28,19 +34,32 @@ const HARNESS = val("--harness") || "claude";
 
 const { repos, policy, defaultCap } = loadQueueConfig(only);
 if (!repos.length) {
-  console.error(only.length ? `no repo named "${only.join(",")}" in config/repos.yaml` : "no repos configured");
+  console.error(
+    only.length
+      ? `no repo named "${only.join(",")}" in config/repos.yaml`
+      : "no repos configured",
+  );
   process.exit(2);
 }
 
 const spent = budgetExhausted(policy);
 const summaries = await fetchQueueSummaries(repos, defaultCap);
 const plans = summaries.map((s) => ({
-  ...recommendNext(s, { orchestrated: ORCHESTRATED, includeSweep: INCLUDE_SWEEP }),
+  ...recommendNext(s, {
+    orchestrated: ORCHESTRATED,
+    includeSweep: INCLUDE_SWEEP,
+  }),
   queue: s,
 }));
 
 function slashCommand(plan) {
-  if (!plan.command || plan.command === "tick" || plan.command === "reconcile" || plan.command === "digest") return null;
+  if (
+    !plan.command ||
+    plan.command === "tick" ||
+    plan.command === "reconcile" ||
+    plan.command === "digest"
+  )
+    return null;
   const args = plan.args ? ` ${plan.args}` : "";
   return `/factory-${plan.command.replace(/^factory-/, "")}${args}`;
 }
@@ -85,7 +104,9 @@ for (const plan of output.plans) {
       reason: plan.reason,
       constraint: plan.constraint ?? undefined,
     });
-  } catch { /* journal must not block routing */ }
+  } catch {
+    /* journal must not block routing */
+  }
 }
 
 if (JSON_OUT) {
@@ -109,7 +130,8 @@ for (const plan of output.plans) {
   console.log(c.bold(`\n${plan.repo}`));
   if (plan.constraint) console.log(`  constraint   ${plan.constraint}`);
   if (plan.command) {
-    const label = plan.slash ?? plan.exec ?? `${plan.command} ${plan.args}`.trim();
+    const label =
+      plan.slash ?? plan.exec ?? `${plan.command} ${plan.args}`.trim();
     console.log(`  recommend    ${c.green(label)}`);
     console.log(c.dim(`  because      ${plan.reason}`));
   } else {
@@ -122,7 +144,11 @@ for (const plan of output.plans) {
   }
 }
 
-console.log(c.dim("\nRun one stage: add --apply (interactive: run the slash command; headless: --orchestrated --apply)\n"));
+console.log(
+  c.dim(
+    "\nRun one stage: add --apply (interactive: run the slash command; headless: --orchestrated --apply)\n",
+  ),
+);
 
 if (APPLY) await runApply(output);
 
@@ -147,18 +173,31 @@ async function runApply(out) {
       slash: target.slash ?? undefined,
       runId: process.env.FACTORY_RUN_ID,
     });
-  } catch { /* journal must not block execution */ }
+  } catch {
+    /* journal must not block execution */
+  }
   if (target.exec) {
     console.log(`\n> ${target.exec}\n`);
-    const p = Bun.spawn(["bash", "-lc", target.exec], { cwd: ROOT, stdout: "inherit", stderr: "inherit" });
+    const p = Bun.spawn(["bash", "-lc", target.exec], {
+      cwd: ROOT,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
     process.exit(await p.exited);
   }
-  const readOnly = target.command === "factory-triage" || target.command === "factory-unblock" || target.command === "factory-sweep";
+  const readOnly =
+    target.command === "factory-triage" ||
+    target.command === "factory-unblock" ||
+    target.command === "factory-sweep";
   const cmd = [
-    "bash", path.join(ROOT, "runners/run-agent.sh"),
-    "--repo", target.repo,
-    "--command", target.command,
-    "--harness", HARNESS,
+    "bash",
+    path.join(ROOT, "runners/run-agent.sh"),
+    "--repo",
+    target.repo,
+    "--command",
+    target.command,
+    "--harness",
+    HARNESS,
   ];
   if (readOnly) cmd.push("--read-only");
   if (target.args) cmd.push("--args", target.args);

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -42,28 +42,43 @@ export function parseOwnedPaths(description = "") {
   let inFence = false;
 
   for (const raw of section.split("\n").slice(1)) {
-    if (/^\s*```/.test(raw)) { inFence = !inFence; continue; }
+    if (/^\s*```/.test(raw)) {
+      inFence = !inFence;
+      continue;
+    }
     const line = raw.trim();
     if (!line) continue;
 
-    if (inFence) { out.push(line); continue; }
-    if (/^[-*]\s+/.test(line)) { out.push(line.replace(/^[-*]\s*/, "")); continue; }
-    if (/^ {4,}\S/.test(raw)) out.push(line);           // indented code block
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    if (/^[-*]\s+/.test(line)) {
+      out.push(line.replace(/^[-*]\s*/, ""));
+      continue;
+    }
+    if (/^ {4,}\S/.test(raw)) out.push(line); // indented code block
   }
 
-  return out
-    .map((s) => s.replace(/`/g, "").replace(/[,;]$/, "").trim())
-    // Tickets routinely annotate a path with its change kind — "(new)",
-    // "(modified)", "(deleted)" — right after the backtick. Left in place that
-    // annotation is prose, not part of the path, and used to sink the whole
-    // line: `foo.ts (new)` has a space, so it read as prose and got dropped,
-    // silently downgrading a perfectly good path to "no Owned Paths".
-    .map((s) => s.replace(/\s*\([^()]*\)\s*$/, "").trim())
-    .filter(Boolean)
-    .filter((s) => !s.startsWith("#"))
-    // A path has no spaces and looks like a path: a separator, a wildcard, or an
-    // extension. This drops the prose that legitimately appears in the section.
-    .filter((s) => !/\s/.test(s) && (s.includes("/") || s.includes("*") || /\.[a-z0-9]+$/i.test(s)));
+  return (
+    out
+      .map((s) => s.replace(/`/g, "").replace(/[,;]$/, "").trim())
+      // Tickets routinely annotate a path with its change kind — "(new)",
+      // "(modified)", "(deleted)" — right after the backtick. Left in place that
+      // annotation is prose, not part of the path, and used to sink the whole
+      // line: `foo.ts (new)` has a space, so it read as prose and got dropped,
+      // silently downgrading a perfectly good path to "no Owned Paths".
+      .map((s) => s.replace(/\s*\([^()]*\)\s*$/, "").trim())
+      .filter(Boolean)
+      .filter((s) => !s.startsWith("#"))
+      // A path has no spaces and looks like a path: a separator, a wildcard, or an
+      // extension. This drops the prose that legitimately appears in the section.
+      .filter(
+        (s) =>
+          !/\s/.test(s) &&
+          (s.includes("/") || s.includes("*") || /\.[a-z0-9]+$/i.test(s)),
+      )
+  );
 }
 
 /**
@@ -107,7 +122,8 @@ export function globToRegExp(glob) {
   // common at repo root), so it must match itself too, not just descendants.
   // A path with an explicit trailing slash (`app/services/`) means "contents
   // only" and does not get this treatment.
-  const matchSelf = !g.endsWith("/") && !/[*?{}]/.test(g) && !/\.[a-z0-9]+$/i.test(g);
+  const matchSelf =
+    !g.endsWith("/") && !/[*?{}]/.test(g) && !/\.[a-z0-9]+$/i.test(g);
   if (g.endsWith("/")) g += "**";
   else if (matchSelf) g += "/**";
 
@@ -117,16 +133,27 @@ export function globToRegExp(glob) {
     if (c === "*") {
       if (g[i + 1] === "*") {
         // `**/` should also match zero segments, so `a/**/b.ts` matches `a/b.ts`.
-        if (g[i + 2] === "/") { re += "(?:.*/)?"; i += 2; }
-        else { re += ".*"; i += 1; }
+        if (g[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 2;
+        } else {
+          re += ".*";
+          i += 1;
+        }
       } else {
         re += "[^/]*";
       }
     } else if (c === "?") re += "[^/]";
     else if (c === "{") {
       const close = g.indexOf("}", i);
-      if (close === -1) { re += "\\{"; continue; }
-      const alts = g.slice(i + 1, close).split(",").map((a) => escapeLiteral(a.trim()));
+      if (close === -1) {
+        re += "\\{";
+        continue;
+      }
+      const alts = g
+        .slice(i + 1, close)
+        .split(",")
+        .map((a) => escapeLiteral(a.trim()));
       re += `(?:${alts.join("|")})`;
       i = close;
     } else re += escapeLiteral(c);
@@ -185,7 +212,8 @@ export function pathsCollide(setA = [], setB = []) {
  */
 export function pathOverlaps(setA = [], setB = []) {
   const out = [];
-  for (const a of setA) for (const b of setB) if (globsOverlap(a, b)) out.push({ a, b });
+  for (const a of setA)
+    for (const b of setB) if (globsOverlap(a, b)) out.push({ a, b });
   return out;
 }
 
@@ -203,8 +231,14 @@ export function pathOverlaps(setA = [], setB = []) {
  * exists to end.
  */
 export function hardPathConflicts(setA = [], setB = []) {
-  const norm = (g) => String(g ?? "").trim().replace(/^\.\//, "").replace(/\/$/, "");
-  return pathOverlaps(setA, setB).filter(({ a, b }) => norm(a) === "**" || norm(b) === "**");
+  const norm = (g) =>
+    String(g ?? "")
+      .trim()
+      .replace(/^\.\//, "")
+      .replace(/\/$/, "");
+  return pathOverlaps(setA, setB).filter(
+    ({ a, b }) => norm(a) === "**" || norm(b) === "**",
+  );
 }
 
 function walkFiles(rootDir, baseDir = rootDir, out = []) {
@@ -225,7 +259,9 @@ function walkFiles(rootDir, baseDir = rootDir, out = []) {
 function matchingManifestPaths(repoPath, manifestGlobs = []) {
   if (!Array.isArray(manifestGlobs) || manifestGlobs.length === 0) return [];
   if (!existsSync(repoPath)) {
-    throw new Error(`owned-path closure check failed: repo path does not exist: ${repoPath}`);
+    throw new Error(
+      `owned-path closure check failed: repo path does not exist: ${repoPath}`,
+    );
   }
   const files = walkFiles(repoPath);
   const matched = new Set();
@@ -243,12 +279,17 @@ function parsePinnedPaths(manifestPath) {
   try {
     payload = JSON.parse(readFileSync(manifestPath, "utf8"));
   } catch (err) {
-    throw new Error(`owned-path closure check failed: cannot parse pin manifest ${manifestPath}: ${err.message}`, { cause: err });
+    throw new Error(
+      `owned-path closure check failed: cannot parse pin manifest ${manifestPath}: ${err.message}`,
+      { cause: err },
+    );
   }
   const raw = payload?.pins;
   if (raw == null) return [];
   if (typeof raw !== "object" || Array.isArray(raw) || raw === null) {
-    throw new Error(`owned-path closure check failed: pin manifest ${manifestPath} has invalid "pins" value`);
+    throw new Error(
+      `owned-path closure check failed: pin manifest ${manifestPath} has invalid "pins" value`,
+    );
   }
   return Object.keys(raw)
     .filter((value) => typeof value === "string")
@@ -289,8 +330,12 @@ export function ownedPathsClosureGaps({
 } = {}) {
   const own = Array.isArray(ownedPaths) ? ownedPaths : [];
   const policy = {
-    direct: Array.isArray(ownedPathsPolicy?.direct) ? ownedPathsPolicy.direct : [],
-    pinManifests: Array.isArray(ownedPathsPolicy?.pinManifests) ? ownedPathsPolicy.pinManifests : [],
+    direct: Array.isArray(ownedPathsPolicy?.direct)
+      ? ownedPathsPolicy.direct
+      : [],
+    pinManifests: Array.isArray(ownedPathsPolicy?.pinManifests)
+      ? ownedPathsPolicy.pinManifests
+      : [],
   };
 
   const gaps = [];
@@ -318,12 +363,21 @@ export function ownedPathsClosureGaps({
   }
 
   for (const manifestRequirement of pinManifestRequirements) {
-    const pinnedPaths = Array.isArray(manifestRequirement?.pinnedPaths) ? manifestRequirement.pinnedPaths : [];
+    const pinnedPaths = Array.isArray(manifestRequirement?.pinnedPaths)
+      ? manifestRequirement.pinnedPaths
+      : [];
     const manifestPath = manifestRequirement?.manifestPath;
     if (!manifestPath || !Array.isArray(pinnedPaths)) continue;
-    if (!pinnedPaths.some((pinnedPath) => own.some((owned) => globsOverlap(owned, pinnedPath)))) continue;
+    if (
+      !pinnedPaths.some((pinnedPath) =>
+        own.some((owned) => globsOverlap(owned, pinnedPath)),
+      )
+    )
+      continue;
     if (!own.some((owned) => globsOverlap(owned, manifestPath))) {
-      const requiredBy = pinnedPaths.find((pinnedPath) => own.some((owned) => globsOverlap(owned, pinnedPath)));
+      const requiredBy = pinnedPaths.find((pinnedPath) =>
+        own.some((owned) => globsOverlap(owned, pinnedPath)),
+      );
       addGap({
         rule: "pin-manifest",
         requiredPath: manifestPath,

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -36,7 +36,10 @@ Something is broken.
 ## Verification Command
 
     npm test`;
-  expectEqual(parseOwnedPaths(desc), ["app/services/api.ts", "app/services/__tests__/*"]);
+  expectEqual(parseOwnedPaths(desc), [
+    "app/services/api.ts",
+    "app/services/__tests__/*",
+  ]);
 });
 
 test("missing section yields no paths (caller decides what that means)", () => {
@@ -45,7 +48,9 @@ test("missing section yields no paths (caller decides what that means)", () => {
 
 test("effectiveOwnedPaths turns unparseable into the maximal glob, not a skip", () => {
   expectEqual(effectiveOwnedPaths("## Problem\n\nno paths here"), ["**"]);
-  expectEqual(effectiveOwnedPaths("## Owned Paths\n\n- `app/api.ts`"), ["app/api.ts"]);
+  expectEqual(effectiveOwnedPaths("## Owned Paths\n\n- `app/api.ts`"), [
+    "app/api.ts",
+  ]);
 });
 
 test("identical and nested globs overlap", () => {
@@ -74,9 +79,16 @@ test("extensionless concrete files (Dockerfile, Makefile) match themselves", () 
 
 test("the case keyword matching gets wrong", () => {
   // Same vocabulary, unrelated files: must NOT collide.
-  expectTrue(!pathsCollide(["app/ui/LoginButton.tsx"], ["server/auth/middleware.ts"]));
+  expectTrue(
+    !pathsCollide(["app/ui/LoginButton.tsx"], ["server/auth/middleware.ts"]),
+  );
   // Different vocabulary, same files: MUST collide.
-  expectTrue(pathsCollide(["app/pages/onboarding/**"], ["app/pages/onboarding/step2.tsx"]));
+  expectTrue(
+    pathsCollide(
+      ["app/pages/onboarding/**"],
+      ["app/pages/onboarding/step2.tsx"],
+    ),
+  );
 });
 
 test("CW-363 and CLNT-609 are concurrent-safe (different repos, same globs)", () => {
@@ -91,8 +103,8 @@ test("nextDispatchable skips collisions but still picks up unparseable Owned Pat
   const inFlight = [{ id: "A", ownedPaths: ["app/services/**"] }];
   const candidates = [
     { id: "B", ownedPaths: ["app/services/api.ts"] }, // collides
-    { id: "C", ownedPaths: [] },                       // unparseable, but nothing else queued ahead of it collides
-    { id: "D", ownedPaths: ["docs/**"] },              // free
+    { id: "C", ownedPaths: [] }, // unparseable, but nothing else queued ahead of it collides
+    { id: "D", ownedPaths: ["docs/**"] }, // free
   ];
   // C is treated as owning everything, so it collides with A (in flight) too — D is next in queue order and free.
   expectEqual(nextDispatchable(candidates, inFlight)?.id, "D");
@@ -151,12 +163,14 @@ Everything else is off limits.`;
 });
 
 test("indented code blocks work too", () => {
-  const desc = "## Owned Paths\n\n    src/main.ts\n    src/**/*.test.ts\n\n## Next";
+  const desc =
+    "## Owned Paths\n\n    src/main.ts\n    src/**/*.test.ts\n\n## Next";
   expectEqual(parseOwnedPaths(desc), ["src/main.ts", "src/**/*.test.ts"]);
 });
 
 test("a trailing change-kind annotation doesn't sink the path (CLNT-765/768/764 shape)", () => {
-  const desc = "## Owned Paths\n\n* `src/analytics/kpis/avgBasePriceByProduct.ts` (new)\n* `src/analytics/kpis/existing.ts` (modified)\n";
+  const desc =
+    "## Owned Paths\n\n* `src/analytics/kpis/avgBasePriceByProduct.ts` (new)\n* `src/analytics/kpis/existing.ts` (modified)\n";
   expectEqual(parseOwnedPaths(desc), [
     "src/analytics/kpis/avgBasePriceByProduct.ts",
     "src/analytics/kpis/existing.ts",
@@ -167,31 +181,37 @@ test("owned path closure flags missing required direct outputs", () => {
   const policy = {
     direct: [{ source: "shared/**", requires: ["dist/**", "plugins/core/**"] }],
   };
-  expectEqual(ownedPathsClosureGaps({
-    ownedPaths: ["shared/**"],
-    ownedPathsPolicy: policy,
-  }), [
-    {
-      rule: "direct",
-      requiredPath: "dist/**",
-      requiredBy: "shared/**",
-    },
-    {
-      rule: "direct",
-      requiredPath: "plugins/core/**",
-      requiredBy: "shared/**",
-    },
-  ]);
+  expectEqual(
+    ownedPathsClosureGaps({
+      ownedPaths: ["shared/**"],
+      ownedPathsPolicy: policy,
+    }),
+    [
+      {
+        rule: "direct",
+        requiredPath: "dist/**",
+        requiredBy: "shared/**",
+      },
+      {
+        rule: "direct",
+        requiredPath: "plugins/core/**",
+        requiredBy: "shared/**",
+      },
+    ],
+  );
 });
 
 test("owned path closure passes when required paths are also owned", () => {
   const policy = {
     direct: [{ source: "shared/**", requires: ["dist/**", "plugins/core/**"] }],
   };
-  expectEqual(ownedPathsClosureGaps({
-    ownedPaths: ["shared/**", "dist/**", "plugins/core/**"],
-    ownedPathsPolicy: policy,
-  }), []);
+  expectEqual(
+    ownedPathsClosureGaps({
+      ownedPaths: ["shared/**", "dist/**", "plugins/core/**"],
+      ownedPathsPolicy: policy,
+    }),
+    [],
+  );
 });
 
 test("pin manifests require owning generated output manifests", () => {
@@ -202,7 +222,9 @@ test("pin manifests require owning generated output manifests", () => {
       path.join(repo, "event-runtime/agents/triage-scan.json"),
       `${JSON.stringify({ pins: { "event-runtime/schemas/triage-scan.output.json": "factory" } })}\n`,
     );
-    const requirements = readPinManifestRequirements(repo, ["event-runtime/agents/*.json"]);
+    const requirements = readPinManifestRequirements(repo, [
+      "event-runtime/agents/*.json",
+    ]);
     expectEqual(requirements, [
       {
         manifestPath: "event-runtime/agents/triage-scan.json",
@@ -213,7 +235,10 @@ test("pin manifests require owning generated output manifests", () => {
     expectEqual(
       ownedPathsClosureGaps({
         ownedPaths: ["event-runtime/schemas/triage-scan.output.json"],
-        ownedPathsPolicy: { direct: [], pinManifests: ["event-runtime/agents/*.json"] },
+        ownedPathsPolicy: {
+          direct: [],
+          pinManifests: ["event-runtime/agents/*.json"],
+        },
         pinManifestRequirements: requirements,
       }),
       [
@@ -279,7 +304,10 @@ test("supports level 4 numbered headers (#### 4. Owned Paths)", () => {
 // "textual overlap a rebase resolves" and "the same file, or everything".
 test("pathOverlaps returns every overlapping pair, in order", () => {
   expectEqual(
-    pathOverlaps(["src/api/**", "docs/a.md"], ["src/api/routes.ts", "docs/a.md", "lib/x.mjs"]),
+    pathOverlaps(
+      ["src/api/**", "docs/a.md"],
+      ["src/api/routes.ts", "docs/a.md", "lib/x.mjs"],
+    ),
     [
       { a: "src/api/**", b: "src/api/routes.ts" },
       { a: "docs/a.md", b: "docs/a.md" },
@@ -292,7 +320,10 @@ test("hardPathConflicts: ** on either side — nothing else", () => {
   // Containment, shared-prefix, same-glob, and even the SAME concrete file are
   // NOT hard: same file is not same lines, and a rebase resolves it.
   expectEqual(hardPathConflicts(["src/api/**"], ["src/api/routes.ts"]), []);
-  expectEqual(hardPathConflicts(["src/**/*.test.mjs"], ["src/lib/registry.test.mjs"]), []);
+  expectEqual(
+    hardPathConflicts(["src/**/*.test.mjs"], ["src/lib/registry.test.mjs"]),
+    [],
+  );
   expectEqual(hardPathConflicts(["views/*.tsx"], ["views/*.tsx"]), []);
   expectEqual(hardPathConflicts(["docs/a.md"], ["docs/a.md"]), []);
   // `**` on either side is hard against anything it reaches.

--- a/orchestrator/ps.mjs
+++ b/orchestrator/ps.mjs
@@ -9,7 +9,11 @@
  *   factory ps --port 7404
  */
 import { factoryRoot } from "../lib/factory-root.mjs";
-import { collectFactoryPsSnapshot, formatFactoryPsReport, c } from "../lib/ps.mjs";
+import {
+  collectFactoryPsSnapshot,
+  formatFactoryPsReport,
+  c,
+} from "../lib/ps.mjs";
 
 const argv = process.argv.slice(2);
 const val = (flag) => {

--- a/orchestrator/ps.test.mjs
+++ b/orchestrator/ps.test.mjs
@@ -45,7 +45,8 @@ describe("ps parser", () => {
       cpu: 0.1,
       mem: 0.2,
       etime: "01:23",
-      command: "bun event-runtime/cli.mjs serve --port 7404 --adapter-override fake",
+      command:
+        "bun event-runtime/cli.mjs serve --port 7404 --adapter-override fake",
     });
   });
 
@@ -121,8 +122,12 @@ Google 2024 Chrome 1234 hdkiller   42u  IPv4 0x3ef0e58c7a3caa5c      0t0  TCP 12
 describe("string extraction helpers", () => {
   test("extractTicket finds ticket IDs in branches and commands", () => {
     expect(extractTicket("feat/OPS-402-factory-ps")).toBe("OPS-402");
-    expect(extractTicket("/Users/dev/.worktrees/bj29/CLNT-1393")).toBe("CLNT-1393");
-    expect(extractTicket("runners/run-agent.sh --ticket LAB-176")).toBe("LAB-176");
+    expect(extractTicket("/Users/dev/.worktrees/bj29/CLNT-1393")).toBe(
+      "CLNT-1393",
+    );
+    expect(extractTicket("runners/run-agent.sh --ticket LAB-176")).toBe(
+      "LAB-176",
+    );
     expect(extractTicket("no ticket here")).toBe(null);
   });
 
@@ -133,40 +138,81 @@ describe("string extraction helpers", () => {
   });
 
   test("extractAdapterOverride extracts adapter name", () => {
-    expect(extractAdapterOverride("serve --adapter-override fake")).toBe("fake");
-    expect(extractAdapterOverride("work --adapter-override claude")).toBe("claude");
+    expect(extractAdapterOverride("serve --adapter-override fake")).toBe(
+      "fake",
+    );
+    expect(extractAdapterOverride("work --adapter-override claude")).toBe(
+      "claude",
+    );
     expect(extractAdapterOverride("work")).toBe(null);
   });
 
   test("extractWorktreePath resolves worktree root paths", () => {
-    expect(extractWorktreePath("/Users/hdkiller/Develop/.worktrees/factory/OPS-402/app")).toBe(
-      "/Users/hdkiller/Develop/.worktrees/factory/OPS-402",
-    );
+    expect(
+      extractWorktreePath(
+        "/Users/hdkiller/Develop/.worktrees/factory/OPS-402/app",
+      ),
+    ).toBe("/Users/hdkiller/Develop/.worktrees/factory/OPS-402");
   });
 });
 
 describe("process categorization", () => {
   test("categorizes control plane serve, work, and web", () => {
-    const serveProc = { pid: 101, ppid: 1, cpu: 0.1, mem: 0.2, etime: "01:00", command: "bun event-runtime/cli.mjs serve --port 7404" };
+    const serveProc = {
+      pid: 101,
+      ppid: 1,
+      cpu: 0.1,
+      mem: 0.2,
+      etime: "01:00",
+      command: "bun event-runtime/cli.mjs serve --port 7404",
+    };
     const cat = categorizeProcess(serveProc);
     expect(cat.kind).toBe("control-plane");
     expect(cat.service).toBe("serve");
     expect(cat.port).toBe(7404);
 
-    const workProc = { pid: 102, ppid: 1, cpu: 0.1, mem: 0.2, etime: "01:00", command: "bun event-runtime/cli.mjs work" };
+    const workProc = {
+      pid: 102,
+      ppid: 1,
+      cpu: 0.1,
+      mem: 0.2,
+      etime: "01:00",
+      command: "bun event-runtime/cli.mjs work",
+    };
     expect(categorizeProcess(workProc).service).toBe("worker");
 
-    const webProc = { pid: 103, ppid: 1, cpu: 0.1, mem: 0.2, etime: "01:00", command: "bun event-runtime/web/serve.mjs" };
+    const webProc = {
+      pid: 103,
+      ppid: 1,
+      cpu: 0.1,
+      mem: 0.2,
+      etime: "01:00",
+      command: "bun event-runtime/web/serve.mjs",
+    };
     expect(categorizeProcess(webProc).service).toBe("web");
   });
 
   test("categorizes agent runners and ignores desktop electron apps", () => {
-    const runner = { pid: 201, ppid: 1, cpu: 0, mem: 0, etime: "10:00", command: "bash runners/run-agent.sh --ticket OPS-123" };
+    const runner = {
+      pid: 201,
+      ppid: 1,
+      cpu: 0,
+      mem: 0,
+      etime: "10:00",
+      command: "bash runners/run-agent.sh --ticket OPS-123",
+    };
     const catRunner = categorizeProcess(runner);
     expect(catRunner.kind).toBe("agent");
     expect(catRunner.ticket).toBe("OPS-123");
 
-    const helper = { pid: 401, ppid: 1, cpu: 0, mem: 0, etime: "10:00", command: "/Applications/Claude.app/Contents/Frameworks/Claude Helper" };
+    const helper = {
+      pid: 401,
+      ppid: 1,
+      cpu: 0,
+      mem: 0,
+      etime: "10:00",
+      command: "/Applications/Claude.app/Contents/Frameworks/Claude Helper",
+    };
     expect(categorizeProcess(helper).kind).toBe("ignored");
   });
 });
@@ -175,19 +221,26 @@ describe("worktree daemon liveness", () => {
   test("isPidAlive rejects zombie and defunct daemon processes", () => {
     const inspectPid = () => "Z+   [bun] <defunct>";
 
-    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(false);
+    expect(
+      isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid }),
+    ).toBe(false);
   });
 
   test("isPidAlive rejects a recycled PID whose command does not match the daemon", () => {
     const inspectPid = () => "S+   unrelated-system-process --background";
 
-    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(false);
+    expect(
+      isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid }),
+    ).toBe(false);
   });
 
   test("isPidAlive accepts a non-zombie process with the expected daemon signature", () => {
-    const inspectPid = () => "S+   bun event-runtime/cli.mjs work --adapter-override fake";
+    const inspectPid = () =>
+      "S+   bun event-runtime/cli.mjs work --adapter-override fake";
 
-    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(true);
+    expect(
+      isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid }),
+    ).toBe(true);
   });
 
   test("scanWorktrees does not mark a worktree active when its PID was recycled", () => {

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -26,8 +26,17 @@ const c = {
 
 function sh(args, cwd = ROOT) {
   try {
-    const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
-    return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+    const result = Bun.spawnSync({
+      cmd: args,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      ok: result.exitCode === 0,
+      out: result.stdout.toString().trim(),
+      err: result.stderr.toString().trim(),
+    };
   } catch (err) {
     return { ok: false, out: "", err: String(err) };
   }
@@ -44,7 +53,9 @@ function hasLinearKey() {
       try {
         const content = readFileSync(envPath, "utf8");
         if (content.includes("LINEAR_API_KEY=")) return true;
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   return false;
@@ -60,19 +71,41 @@ export async function gatherPulse({
 } = {}) {
   const pulse = {
     timestamp: new Date().toISOString(),
-    stack: { api: { ok: false }, web: { ok: false, port: webPort }, workers: { total: 0, busy: 0, idle: 0, list: [] } },
+    stack: {
+      api: { ok: false },
+      web: { ok: false, port: webPort },
+      workers: { total: 0, busy: 0, idle: 0, list: [] },
+    },
     runs: { active: [], proposed: 0, byState: {} },
-    supply: { repo: repoName, team: "WM", dispatchable: 0, triage: 0, tickets: [] },
+    supply: {
+      repo: repoName,
+      team: "WM",
+      dispatchable: 0,
+      triage: 0,
+      tickets: [],
+    },
     prs: { total: 0, candidates: [] },
-    workspace: { branch: "unknown", head: "unknown", behind: 0, ahead: 0, clean: true },
+    workspace: {
+      branch: "unknown",
+      head: "unknown",
+      behind: 0,
+      ahead: 0,
+      clean: true,
+    },
   };
 
   // 1. API Health & Status
   try {
-    const healthRes = await fetch(`http://${host}:${port}/health`, { signal: AbortSignal.timeout(3000) });
+    const healthRes = await fetch(`http://${host}:${port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
     if (healthRes.ok) {
       const healthJson = await healthRes.json();
-      pulse.stack.api = { ok: true, policyVersion: healthJson.policyVersion, env: healthJson.env?.name };
+      pulse.stack.api = {
+        ok: true,
+        policyVersion: healthJson.policyVersion,
+        env: healthJson.env?.name,
+      };
     }
   } catch (err) {
     pulse.stack.api = { ok: false, error: err.message };
@@ -80,11 +113,17 @@ export async function gatherPulse({
 
   // 2. Web UI Health
   try {
-    const webRes = await fetch(`http://${host}:${webPort}/`, { signal: AbortSignal.timeout(2000) });
+    const webRes = await fetch(`http://${host}:${webPort}/`, {
+      signal: AbortSignal.timeout(2000),
+    });
     const ok = webRes.ok || webRes.status === 404; // serving HTTP
     pulse.stack.web = ok
       ? { ok: true, port: webPort }
-      : { ok: false, port: webPort, error: `WEB_DOWN: Web UI returned HTTP ${webRes.status}` };
+      : {
+          ok: false,
+          port: webPort,
+          error: `WEB_DOWN: Web UI returned HTTP ${webRes.status}`,
+        };
   } catch (err) {
     pulse.stack.web = {
       ok: false,
@@ -97,9 +136,15 @@ export async function gatherPulse({
   if (pulse.stack.api.ok) {
     try {
       const [statusRes, workersRes, runsRes] = await Promise.all([
-        fetch(`http://${host}:${port}/status`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/workers`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/runs?state=RUNNING`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/status`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/workers`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/runs?state=RUNNING`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
       ]);
 
       if (workersRes?.workers) {
@@ -108,7 +153,12 @@ export async function gatherPulse({
           total: workers.length,
           busy: workers.filter((w) => w.state === "busy").length,
           idle: workers.filter((w) => w.state === "idle").length,
-          list: workers.map((w) => ({ id: w.workerId, state: w.state, host: w.host, runId: w.runId })),
+          list: workers.map((w) => ({
+            id: w.workerId,
+            state: w.state,
+            host: w.host,
+            runId: w.runId,
+          })),
         };
       }
 
@@ -141,10 +191,14 @@ export async function gatherPulse({
       // Find repo team from repos.yaml
       let team = "WM";
       try {
-        const reposCfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+        const reposCfg = Bun.YAML.parse(
+          readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+        );
         const match = (reposCfg.repos ?? []).find((r) => r.name === repoName);
         if (match?.team) team = match.team;
-      } catch { /* intentionally ignored */ }
+      } catch {
+        /* intentionally ignored */
+      }
       pulse.supply.team = team;
 
       if (!hasLinearKey()) {
@@ -170,7 +224,9 @@ export async function gatherPulse({
 
         pulse.supply.dispatchable = ready.length;
         pulse.supply.triage = triage.length;
-        pulse.supply.tickets = ready.slice(0, 5).map((i) => ({ identifier: i.identifier, title: i.title }));
+        pulse.supply.tickets = ready
+          .slice(0, 5)
+          .map((i) => ({ identifier: i.identifier, title: i.title }));
       }
     } catch (err) {
       pulse.supply.error = err.message;
@@ -180,7 +236,17 @@ export async function gatherPulse({
   // 5. Open GitHub PRs
   if (fetchGitHub) {
     try {
-      const p = sh(["gh", "pr", "list", "--state", "open", "--limit", "15", "--json", "number,title,headRefName,isDraft,statusCheckRollup"]);
+      const p = sh([
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "15",
+        "--json",
+        "number,title,headRefName,isDraft,statusCheckRollup",
+      ]);
       if (p.ok && p.out) {
         const prs = JSON.parse(p.out);
         pulse.prs.total = prs.length;
@@ -189,7 +255,9 @@ export async function gatherPulse({
           let ciStatus = "NONE";
           if (checks.length > 0) {
             const hasFailure = checks.some((c) => c.conclusion === "FAILURE");
-            const hasPending = checks.some((c) => c.status === "IN_PROGRESS" || c.status === "QUEUED");
+            const hasPending = checks.some(
+              (c) => c.status === "IN_PROGRESS" || c.status === "QUEUED",
+            );
             const allSuccess = checks.every((c) => c.conclusion === "SUCCESS");
             if (hasFailure) ciStatus = "FAILING";
             else if (hasPending) ciStatus = "PENDING";
@@ -214,7 +282,12 @@ export async function gatherPulse({
     const branchRes = sh(["git", "branch", "--show-current"]);
     const headRes = sh(["git", "rev-parse", "--short", "HEAD"]);
     const statusRes = sh(["git", "status", "--porcelain"]);
-    const behindRes = sh(["git", "rev-list", "--count", "HEAD..origin/develop"]);
+    const behindRes = sh([
+      "git",
+      "rev-list",
+      "--count",
+      "HEAD..origin/develop",
+    ]);
     const aheadRes = sh(["git", "rev-list", "--count", "origin/develop..HEAD"]);
 
     pulse.workspace = {
@@ -224,14 +297,18 @@ export async function gatherPulse({
       ahead: aheadRes.ok ? parseInt(aheadRes.out, 10) || 0 : 0,
       clean: statusRes.ok && statusRes.out.length === 0,
     };
-  } catch { /* intentionally ignored */ }
+  } catch {
+    /* intentionally ignored */
+  }
 
   return pulse;
 }
 
 export function formatPulse(pulse) {
   const lines = [];
-  lines.push(c.bold(`FACTORY PULSE — ${new Date(pulse.timestamp).toUTCString()}`));
+  lines.push(
+    c.bold(`FACTORY PULSE — ${new Date(pulse.timestamp).toUTCString()}`),
+  );
   lines.push("");
 
   // Stack & Workers
@@ -248,22 +325,29 @@ export function formatPulse(pulse) {
   lines.push(`  Web (:${webPort}):     ${webStatus}`);
 
   const workers = pulse.stack.workers;
-  const workerDetail = workers.total > 0
-    ? `${workers.total} registered (${c.green(`${workers.busy} busy`)}, ${workers.idle} idle)`
-    : c.yellow("0 registered");
+  const workerDetail =
+    workers.total > 0
+      ? `${workers.total} registered (${c.green(`${workers.busy} busy`)}, ${workers.idle} idle)`
+      : c.yellow("0 registered");
   lines.push(`  Workers:         ${workerDetail}`);
   lines.push("");
 
   // In-Flight Runs
   const activeRuns = pulse.runs.active;
-  lines.push(c.bold(`IN-FLIGHT RUNS (${activeRuns.length} active, ${pulse.runs.proposed} proposed)`));
+  lines.push(
+    c.bold(
+      `IN-FLIGHT RUNS (${activeRuns.length} active, ${pulse.runs.proposed} proposed)`,
+    ),
+  );
   if (activeRuns.length === 0) {
     lines.push(c.dim("  No runs currently executing"));
   } else {
     for (const r of activeRuns) {
       const ageMs = Date.now() - new Date(r.created_at || Date.now()).getTime();
       const ageMin = Math.round(ageMs / 60000);
-      lines.push(`  ${c.cyan(r.runId.slice(0, 12))} ${c.bold(r.agent)} [${r.state}] (${ageMin}m) ${c.dim(r.eventId || "")}`);
+      lines.push(
+        `  ${c.cyan(r.runId.slice(0, 12))} ${c.bold(r.agent)} [${r.state}] (${ageMin}m) ${c.dim(r.eventId || "")}`,
+      );
     }
   }
   lines.push("");
@@ -273,8 +357,15 @@ export function formatPulse(pulse) {
   if (pulse.supply.error) {
     lines.push(`  ${c.red("Linear read error:")} ${pulse.supply.error}`);
   } else {
-    const supplyColor = pulse.supply.dispatchable >= 5 ? c.green : (pulse.supply.dispatchable > 0 ? c.yellow : c.red);
-    lines.push(`  Dispatchable:    ${supplyColor(`${pulse.supply.dispatchable} tickets`)} in Todo (ai:agent-ready, unassigned)`);
+    const supplyColor =
+      pulse.supply.dispatchable >= 5
+        ? c.green
+        : pulse.supply.dispatchable > 0
+          ? c.yellow
+          : c.red;
+    lines.push(
+      `  Dispatchable:    ${supplyColor(`${pulse.supply.dispatchable} tickets`)} in Todo (ai:agent-ready, unassigned)`,
+    );
     lines.push(`  Triage Backlog:  ${pulse.supply.triage} tickets in Triage`);
     if (pulse.supply.tickets.length > 0) {
       lines.push(c.dim("  Next up:"));
@@ -297,18 +388,27 @@ export function formatPulse(pulse) {
       else if (pr.ciStatus === "PENDING") ciBadge = c.yellow("[CI PENDING]");
 
       const draftBadge = pr.isDraft ? c.dim("(draft) ") : "";
-      lines.push(`  ${c.bold(`#${pr.number}`)} ${ciBadge} ${draftBadge}${pr.title.slice(0, 60)}`);
+      lines.push(
+        `  ${c.bold(`#${pr.number}`)} ${ciBadge} ${draftBadge}${pr.title.slice(0, 60)}`,
+      );
     }
   }
   lines.push("");
 
   // Workspace
   lines.push(c.bold("WORKSPACE"));
-  const cleanStatus = pulse.workspace.clean ? c.green("clean") : c.yellow("dirty (uncommitted changes)");
-  const syncStatus = pulse.workspace.behind > 0
-    ? c.yellow(`behind origin/develop by ${pulse.workspace.behind}`)
-    : (pulse.workspace.ahead > 0 ? c.cyan(`ahead of origin/develop by ${pulse.workspace.ahead}`) : c.green("up to date"));
-  lines.push(`  Branch:          ${c.bold(pulse.workspace.branch)} @ ${pulse.workspace.head} (${syncStatus})`);
+  const cleanStatus = pulse.workspace.clean
+    ? c.green("clean")
+    : c.yellow("dirty (uncommitted changes)");
+  const syncStatus =
+    pulse.workspace.behind > 0
+      ? c.yellow(`behind origin/develop by ${pulse.workspace.behind}`)
+      : pulse.workspace.ahead > 0
+        ? c.cyan(`ahead of origin/develop by ${pulse.workspace.ahead}`)
+        : c.green("up to date");
+  lines.push(
+    `  Branch:          ${c.bold(pulse.workspace.branch)} @ ${pulse.workspace.head} (${syncStatus})`,
+  );
   lines.push(`  Working tree:    ${cleanStatus}`);
 
   return lines.join("\n");

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -13,25 +13,42 @@
  * about to idle? A deep Triage pile with an empty agent-ready queue means the
  * constraint is specification, not execution, and dispatching harder won't help.
  */
-import { fetchQueueSummaries, loadQueueConfig, STAGE_GATES } from "../lib/queue-summary.mjs";
+import {
+  fetchQueueSummaries,
+  loadQueueConfig,
+  STAGE_GATES,
+} from "../lib/queue-summary.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 const GATE = val("--gate");
 const JSON_OUT = argv.includes("--json");
 
 const { repos, policy, defaultCap } = loadQueueConfig(only);
 if (!repos.length) {
-  console.error(only ? `no repo named "${only}" in config/repos.yaml` : "no repos configured");
+  console.error(
+    only
+      ? `no repo named "${only}" in config/repos.yaml`
+      : "no repos configured",
+  );
   process.exit(2);
 }
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`, cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
 };
 
 const summary = await fetchQueueSummaries(repos, defaultCap);
@@ -40,14 +57,23 @@ for (const repo of repos) {
   const s = summary.find((x) => x.repo === repo.name);
   if (!s) continue;
 
-  if (!GATE && !JSON_OUT) console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}  ->  ${repo.base}`));
+  if (!GATE && !JSON_OUT)
+    console.log(
+      c.bold(`\n${repo.name}`) +
+        c.dim(`  ${repo.team} / ${repo.project}  ->  ${repo.base}`),
+    );
 
   const quiet = GATE || JSON_OUT;
   const line = (label, n, color = (x) => x) => {
-    if (!quiet) console.log(`  ${label.padEnd(22)} ${color(String(n).padStart(3))}`);
+    if (!quiet)
+      console.log(`  ${label.padEnd(22)} ${color(String(n).padStart(3))}`);
   };
 
-  line("Triage (unspecified)", s.triageState, s.triageState > 20 ? c.yellow : (x) => x);
+  line(
+    "Triage (unspecified)",
+    s.triageState,
+    s.triageState > 20 ? c.yellow : (x) => x,
+  );
   if (s.triageHeld) line("Triage, held for you", s.triageHeld, c.red);
   if (s.answered) line("Held, reply received", s.answered, c.green);
   line("Todo, not ready", s.todoNotReady);
@@ -56,50 +82,103 @@ for (const repo of repos) {
   line("In Progress", s.inProgress);
   line("In Review", s.inReview, s.inReview ? c.cyan : (x) => x);
   line("Blocked", s.blocked, s.blocked ? c.red : (x) => x);
-  line("Done / project total", `${s.done}/${s.total}${s.countCapped ? "+" : ""}`, c.dim);
+  line(
+    "Done / project total",
+    `${s.done}/${s.total}${s.countCapped ? "+" : ""}`,
+    c.dim,
+  );
 
   if (quiet) continue;
 
-  const answeredIds = new Set((s.answeredTickets ?? []).map((t) => t.identifier));
+  const answeredIds = new Set(
+    (s.answeredTickets ?? []).map((t) => t.identifier),
+  );
   const workerIds = new Set(s.liveWorkerIds ?? []);
 
   if (s.startable.length) {
-    console.log(c.dim(`\n  dispatch would start (cap ${repo.max_in_flight ?? defaultCap}, ${s.inProgress} running, ${s.slotsFree} slot(s) free):`));
-    for (const t of s.startableTickets) console.log(`    ${c.green(t.identifier.padEnd(10))} ${t.title.slice(0, 60)}`);
+    console.log(
+      c.dim(
+        `\n  dispatch would start (cap ${repo.max_in_flight ?? defaultCap}, ${s.inProgress} running, ${s.slotsFree} slot(s) free):`,
+      ),
+    );
+    for (const t of s.startableTickets)
+      console.log(
+        `    ${c.green(t.identifier.padEnd(10))} ${t.title.slice(0, 60)}`,
+      );
   } else if (repo.report_only && s.ready) {
-    console.log(c.dim(`\n  report_only — dispatch is disabled here by design (${s.ready} ready ticket(s) would otherwise start)`));
+    console.log(
+      c.dim(
+        `\n  report_only — dispatch is disabled here by design (${s.ready} ready ticket(s) would otherwise start)`,
+      ),
+    );
   } else if (s.ready && s.slotsFree === 0) {
-    console.log(c.dim(`\n  no free worker slot — ${s.workers}/${repo.max_in_flight ?? defaultCap} live, ${s.ready} ready and waiting`));
-    for (const t of s.inProgressTickets.filter((i) => workerIds.has(i.identifier))) {
-      console.log(c.dim(`    working: ${t.identifier.padEnd(10)} ${t.title.slice(0, 55)}`));
+    console.log(
+      c.dim(
+        `\n  no free worker slot — ${s.workers}/${repo.max_in_flight ?? defaultCap} live, ${s.ready} ready and waiting`,
+      ),
+    );
+    for (const t of s.inProgressTickets.filter((i) =>
+      workerIds.has(i.identifier),
+    )) {
+      console.log(
+        c.dim(
+          `    working: ${t.identifier.padEnd(10)} ${t.title.slice(0, 55)}`,
+        ),
+      );
     }
   } else if (s.ready) {
-    console.log(c.dim(`\n  nothing startable — all ready tickets collide with running or with each other's unparseable Owned Paths`));
+    console.log(
+      c.dim(
+        `\n  nothing startable — all ready tickets collide with running or with each other's unparseable Owned Paths`,
+      ),
+    );
   } else if (s.readyHeld) {
     // Not "queue empty": there IS specified work, it is waiting on its
     // blockers, and if those never finish this line is the only symptom.
-    console.log(c.dim(`\n  nothing startable — every ready ticket is waiting on a blocker (see below)`));
+    console.log(
+      c.dim(
+        `\n  nothing startable — every ready ticket is waiting on a blocker (see below)`,
+      ),
+    );
   } else {
-    console.log(c.dim(`\n  queue empty — the constraint is specification, not dispatch.`));
-    console.log(c.dim(`  ${s.triageState} ticket(s) in Triage. Run the triage stage.`));
+    console.log(
+      c.dim(`\n  queue empty — the constraint is specification, not dispatch.`),
+    );
+    console.log(
+      c.dim(`  ${s.triageState} ticket(s) in Triage. Run the triage stage.`),
+    );
   }
 
   if (s.readyHeld) {
-    console.log(c.dim(`\n  ready but held — waiting on another ticket, not on capacity:`));
-    for (const t of s.readyHeldTickets) console.log(`    ${c.yellow(t.identifier.padEnd(10))} blocked by ${t.blockedBy.join(", ")}  ${c.dim(t.title.slice(0, 45))}`);
+    console.log(
+      c.dim(`\n  ready but held — waiting on another ticket, not on capacity:`),
+    );
+    for (const t of s.readyHeldTickets)
+      console.log(
+        `    ${c.yellow(t.identifier.padEnd(10))} blocked by ${t.blockedBy.join(", ")}  ${c.dim(t.title.slice(0, 45))}`,
+      );
   }
   if (s.inReview) {
     console.log(c.dim(`\n  awaiting review/merge:`));
-    for (const t of s.inReviewTickets) console.log(`    ${c.cyan(t.identifier.padEnd(10))} ${t.title.slice(0, 60)}`);
+    for (const t of s.inReviewTickets)
+      console.log(
+        `    ${c.cyan(t.identifier.padEnd(10))} ${t.title.slice(0, 60)}`,
+      );
   }
   if (s.openPRs) {
-    console.log(c.dim(`\n  open PRs the merge stage would look at: ${s.openPRs}`));
+    console.log(
+      c.dim(`\n  open PRs the merge stage would look at: ${s.openPRs}`),
+    );
   }
   if (s.blocked) {
     console.log(c.red(`\n  BLOCKED — needs a human:`));
     for (const t of s.blockedTickets) {
-      const tag = answeredIds.has(t.identifier) ? c.green("  <- reply received, triage will re-examine") : "";
-      console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}${tag}`);
+      const tag = answeredIds.has(t.identifier)
+        ? c.green("  <- reply received, triage will re-examine")
+        : "";
+      console.log(
+        `    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}${tag}`,
+      );
     }
   }
 }
@@ -112,7 +191,9 @@ if (JSON_OUT) {
 if (GATE) {
   const spent = budgetExhausted(policy);
   if (spent) {
-    console.log(`${spent} — no ${GATE} this tick. Running work finishes; nothing new starts.`);
+    console.log(
+      `${spent} — no ${GATE} this tick. Running work finishes; nothing new starts.`,
+    );
     process.exit(1);
   }
 
@@ -124,7 +205,9 @@ if (GATE) {
 
   const hits = summary.filter(has);
   if (hits.length) {
-    console.log(hits.map((s) => `${s.repo}: ${GATE} work available`).join("; "));
+    console.log(
+      hits.map((s) => `${s.repo}: ${GATE} work available`).join("; "),
+    );
     process.exit(0);
   }
   console.log(`no ${GATE} work in ${summary.map((s) => s.repo).join(", ")}`);

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -25,7 +25,14 @@
  *     bun orchestrator/reaper.mjs --any-assignee      # audit unlabeled ones too
  */
 
-import { readFileSync, existsSync, mkdirSync, appendFileSync, readdirSync, statSync } from "node:fs";
+import {
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
@@ -45,7 +52,9 @@ export function latestReaperRunMs(logDir = REAPER_LOG_DIR) {
       const m = statSync(path.join(logDir, f)).mtimeMs;
       if (best === null || m > best) best = m;
     }
-  } catch { /* no log dir yet */ }
+  } catch {
+    /* no log dir yet */
+  }
   return best;
 }
 
@@ -60,11 +69,21 @@ function teeToLogFile() {
   const p2 = (n) => String(n).padStart(2, "0");
   const stamp = `${d.getFullYear()}${p2(d.getMonth() + 1)}${p2(d.getDate())}-${p2(d.getHours())}${p2(d.getMinutes())}${p2(d.getSeconds())}`;
   const file = path.join(REAPER_LOG_DIR, `reaper-${stamp}.log`);
-  try { mkdirSync(REAPER_LOG_DIR, { recursive: true }); } catch { return; }
-  const wrap = (orig) => (...args) => {
-    orig(...args);
-    try { appendFileSync(file, args.join(" ") + "\n"); } catch { /* keep running */ }
-  };
+  try {
+    mkdirSync(REAPER_LOG_DIR, { recursive: true });
+  } catch {
+    return;
+  }
+  const wrap =
+    (orig) =>
+    (...args) => {
+      orig(...args);
+      try {
+        appendFileSync(file, args.join(" ") + "\n");
+      } catch {
+        /* keep running */
+      }
+    };
   console.log = wrap(console.log.bind(console));
   console.error = wrap(console.error.bind(console));
 }
@@ -93,7 +112,10 @@ function loadEnv() {
           if (trimmed && !trimmed.startsWith("#") && trimmed.includes("=")) {
             const idx = trimmed.indexOf("=");
             const key = trimmed.slice(0, idx).trim();
-            const val = trimmed.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+            const val = trimmed
+              .slice(idx + 1)
+              .trim()
+              .replace(/^['"]|['"]$/g, "");
             if (!process.env[key]) {
               process.env[key] = val;
             }
@@ -111,7 +133,9 @@ function loadEnv() {
 export function getApiKey() {
   const key = loadEnv();
   if (!key) {
-    console.error("Linear API error: LINEAR_API_KEY not found in env or ~/Develop/hdkiller/.env");
+    console.error(
+      "Linear API error: LINEAR_API_KEY not found in env or ~/Develop/hdkiller/.env",
+    );
     process.exit(1);
   }
   return key;
@@ -135,7 +159,10 @@ export async function gql(query, variables = {}, retries = 5) {
       });
 
       if (!res.ok) {
-        if ([429, 500, 502, 503, 504].includes(res.status) && attempt < retries - 1) {
+        if (
+          [429, 500, 502, 503, 504].includes(res.status) &&
+          attempt < retries - 1
+        ) {
           await new Promise((r) => setTimeout(r, delay));
           delay *= 2;
           continue;
@@ -147,7 +174,10 @@ export async function gql(query, variables = {}, retries = 5) {
       const data = await res.json();
       if (data.errors && data.errors.length > 0) {
         const msg = JSON.stringify(data.errors);
-        if (msg.toUpperCase().includes("RATELIMITED") && attempt < retries - 1) {
+        if (
+          msg.toUpperCase().includes("RATELIMITED") &&
+          attempt < retries - 1
+        ) {
           await new Promise((r) => setTimeout(r, delay));
           delay *= 2;
           continue;
@@ -157,7 +187,10 @@ export async function gql(query, variables = {}, retries = 5) {
 
       return data.data || {};
     } catch (err) {
-      if (attempt < retries - 1 && !(err.message && err.message.startsWith("HTTP 4"))) {
+      if (
+        attempt < retries - 1 &&
+        !(err.message && err.message.startsWith("HTTP 4"))
+      ) {
         await new Promise((r) => setTimeout(r, delay));
         delay *= 2;
         continue;
@@ -253,7 +286,7 @@ export function isAgentClaim(issue) {
   const labels = issue.labels?.nodes || [];
   const names = labels.map((l) => (l.name || "").toLowerCase());
   return names.some(
-    (n) => n === HEARTBEAT_LABEL || n.startsWith(AGENT_LABEL_PREFIX)
+    (n) => n === HEARTBEAT_LABEL || n.startsWith(AGENT_LABEL_PREFIX),
   );
 }
 
@@ -278,11 +311,17 @@ export function lastActivity(issue) {
 export async function fetchAgentReadyLabelId() {
   const q = `query { issueLabels(first: 250) { nodes { id name } } }`;
   const data = await gql(q);
-  const node = (data.issueLabels?.nodes || []).find((l) => (l.name || "").toLowerCase() === AGENT_READY_LABEL);
+  const node = (data.issueLabels?.nodes || []).find(
+    (l) => (l.name || "").toLowerCase() === AGENT_READY_LABEL,
+  );
   return node?.id || null;
 }
 
-export function computeReclaimLabelIds(issue, isReturningToTodo, agentReadyLabelId = null) {
+export function computeReclaimLabelIds(
+  issue,
+  isReturningToTodo,
+  agentReadyLabelId = null,
+) {
   const labels = issue.labels?.nodes || [];
   const keep = labels
     .filter((l) => {
@@ -291,22 +330,44 @@ export function computeReclaimLabelIds(issue, isReturningToTodo, agentReadyLabel
     })
     .map((l) => l.id);
 
-  if (isReturningToTodo && agentReadyLabelId && !keep.includes(agentReadyLabelId)) {
+  if (
+    isReturningToTodo &&
+    agentReadyLabelId &&
+    !keep.includes(agentReadyLabelId)
+  ) {
     keep.push(agentReadyLabelId);
   }
   return keep;
 }
 
-export async function reclaim(issue, todoStateId, minutes, apply, quiet = false, agentReadyLabelId = null) {
+export async function reclaim(
+  issue,
+  todoStateId,
+  minutes,
+  apply,
+  quiet = false,
+  agentReadyLabelId = null,
+) {
   if (todoStateId && !agentReadyLabelId && apply) {
     try {
       agentReadyLabelId = await fetchAgentReadyLabelId();
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
   }
 
-  const keep = computeReclaimLabelIds(issue, Boolean(todoStateId), agentReadyLabelId);
+  const keep = computeReclaimLabelIds(
+    issue,
+    Boolean(todoStateId),
+    agentReadyLabelId,
+  );
 
-  if (!apply) return { labelIds: keep, stateId: todoStateId, assigneeId: todoStateId ? null : undefined };
+  if (!apply)
+    return {
+      labelIds: keep,
+      stateId: todoStateId,
+      assigneeId: todoStateId ? null : undefined,
+    };
 
   // Two different repairs, because the two claims mean different things.
   //
@@ -320,7 +381,10 @@ export async function reclaim(issue, todoStateId, minutes, apply, quiet = false,
   // (OPS-40) the two are indistinguishable. Removing the label is unambiguous
   // and sufficient; clearing the assignee would be guessing.
   const input = { labelIds: keep };
-  if (todoStateId) { input.stateId = todoStateId; input.assigneeId = null; }
+  if (todoStateId) {
+    input.stateId = todoStateId;
+    input.assigneeId = null;
+  }
 
   await gql(
     `
@@ -328,7 +392,7 @@ export async function reclaim(issue, todoStateId, minutes, apply, quiet = false,
       issueUpdate(id: $id, input: $input) { success }
     }
     `,
-    { id: issue.id, input }
+    { id: issue.id, input },
   );
 
   // Clearing a stale marker off a finished ticket needs no audit trail — 50
@@ -358,7 +422,7 @@ export async function reclaim(issue, todoStateId, minutes, apply, quiet = false,
         issueId: issue.id,
         body,
       },
-    }
+    },
   );
 }
 
@@ -417,14 +481,18 @@ Options:
   teeToLogFile();
 
   const mode = args.apply ? "APPLY" : "DRY RUN";
-  console.log(`=== Stale-claim reaper [${mode}] threshold=${args.minutes}min${args.team ? ` team=${args.team}` : ""} ===\n`);
+  console.log(
+    `=== Stale-claim reaper [${mode}] threshold=${args.minutes}min${args.team ? ` team=${args.team}` : ""} ===\n`,
+  );
 
   const teams = await fetchTeams();
   let agentReadyLabelId = null;
   if (args.apply) {
     try {
       agentReadyLabelId = await fetchAgentReadyLabelId();
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
   }
   let issues = await fetchInProgress(args.team, args.anyAssignee);
   const now = new Date();
@@ -434,7 +502,9 @@ Options:
     const claims = issues.filter(isAgentClaim);
     const skipped = issues.length - claims.length;
     if (skipped > 0) {
-      console.log(`  (skipping ${skipped} In Progress ticket(s) with no agent claim labels -- not agent work)\n`);
+      console.log(
+        `  (skipping ${skipped} In Progress ticket(s) with no agent claim labels -- not agent work)\n`,
+      );
     }
     issues = claims;
   }
@@ -452,7 +522,9 @@ Options:
   }
 
   for (const { issue, seen } of live) {
-    const age = seen ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString() : "?";
+    const age = seen
+      ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString()
+      : "?";
     const who = issue.assignee?.name || "unassigned";
     const id = (issue.identifier || "").padEnd(10);
     const ageStr = age.padStart(4);
@@ -462,20 +534,28 @@ Options:
   }
 
   if (stale.length === 0) {
-    console.log(`\n=== No stale claims among ${issues.length} in progress. ===`);
+    console.log(
+      `\n=== No stale claims among ${issues.length} in progress. ===`,
+    );
     return;
   }
 
   console.log();
   const considered = args.markersOnly
-    ? stale.filter(({ issue }) => (issue.state?.name || "").toLowerCase() !== IN_PROGRESS)
+    ? stale.filter(
+        ({ issue }) => (issue.state?.name || "").toLowerCase() !== IN_PROGRESS,
+      )
     : stale;
   if (args.markersOnly && considered.length !== stale.length) {
-    console.log(`  (markers-only: leaving ${stale.length - considered.length} In Progress claim(s) alone)\n`);
+    console.log(
+      `  (markers-only: leaving ${stale.length - considered.length} In Progress claim(s) alone)\n`,
+    );
   }
 
   for (const { issue, seen } of considered) {
-    const age = seen ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString() : "?";
+    const age = seen
+      ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString()
+      : "?";
     const who = issue.assignee?.name || "unassigned";
     const id = (issue.identifier || "").padEnd(10);
     const ageStr = age.padStart(4);
@@ -489,7 +569,9 @@ Options:
     // human's ticket because they didn't comment in 45 minutes would be far
     // worse than the crashed agent this reaper exists to clean up after.
     if (!isAgentClaim(issue)) {
-      console.log(`        (no agent claim label — a human's work, not touching it)`);
+      console.log(
+        `        (no agent claim label — a human's work, not touching it)`,
+      );
       continue;
     }
 
@@ -501,14 +583,24 @@ Options:
     // A triage claim (any other state) only loses its markers — moving a ticket
     // that was mid-specification into Todo would assert it is ready when it is
     // not.
-    const todoId = stateName === IN_PROGRESS ? team?.states?.[RECLAIM_TO] : null;
+    const todoId =
+      stateName === IN_PROGRESS ? team?.states?.[RECLAIM_TO] : null;
     if (stateName === IN_PROGRESS && !todoId) {
-      console.log(`        ! no '${RECLAIM_TO}' state on team ${teamKey}, skipping`);
+      console.log(
+        `        ! no '${RECLAIM_TO}' state on team ${teamKey}, skipping`,
+      );
       continue;
     }
 
     try {
-      await reclaim(issue, todoId, args.minutes, args.apply, !todoId, agentReadyLabelId);
+      await reclaim(
+        issue,
+        todoId,
+        args.minutes,
+        args.apply,
+        !todoId,
+        agentReadyLabelId,
+      );
     } catch (err) {
       console.log(`        ! failed: ${err.message || err}`);
       continue;
@@ -519,14 +611,22 @@ Options:
       // Lifecycle observation (WM-75): fire-and-forget; the last-activity
       // timestamp keys the id, so retrying the same stale claim re-admits
       // nothing while the next genuine reap is a new event.
-      await emitFactoryEvent("factory.ticket.reaped",
-        { ticket: issue.identifier, reason: todoId ? "returned_to_todo" : "marker_cleared" },
-        { eventId: `reap:${issue.identifier}:${seen?.getTime() ?? "unknown"}`, subject: issue.identifier });
+      await emitFactoryEvent(
+        "factory.ticket.reaped",
+        {
+          ticket: issue.identifier,
+          reason: todoId ? "returned_to_todo" : "marker_cleared",
+        },
+        {
+          eventId: `reap:${issue.identifier}:${seen?.getTime() ?? "unknown"}`,
+          subject: issue.identifier,
+        },
+      );
     }
   }
 
   console.log(
-    `\n=== ${args.apply ? "Reclaimed" : "Would reclaim"}: ${considered.length} | Healthy: ${live.length} ===`
+    `\n=== ${args.apply ? "Reclaimed" : "Would reclaim"}: ${considered.length} | Healthy: ${live.length} ===`,
   );
   if (!args.apply) {
     console.log("Run again with --apply to reclaim these.");

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -90,7 +90,10 @@ describe("reaper run log discovery", () => {
   test("latestReaperRunMs picks the newest reaper log and ignores other files", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "reaper-"));
     writeFileSync(path.join(dir, "reaper-20260804-120000.log"), "old");
-    writeFileSync(path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"), "not a reaper log");
+    writeFileSync(
+      path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"),
+      "not a reaper log",
+    );
     const t0 = latestReaperRunMs(dir);
     expect(t0).not.toBeNull();
     writeFileSync(path.join(dir, "reaper-20260804-130000.log"), "new");
@@ -121,9 +124,14 @@ describe("issue fetch filter (OPS-63)", () => {
   test("default filter no longer excludes agent-labelled tickets lacking the heartbeat label", () => {
     // The regression itself: the old filter was the label clause ALONE, so a
     // ticket isAgentClaim() accepts via `agent:*` was never returned.
-    const agentOnly = { labels: { nodes: [{ name: "agent:claude-code" }] }, state: { name: "In Progress" } };
+    const agentOnly = {
+      labels: { nodes: [{ name: "agent:claude-code" }] },
+      state: { name: "In Progress" },
+    };
     expect(isAgentClaim(agentOnly)).toBe(true);
-    expect(buildIssueFilter()).not.toBe(`labels: { name: { eq: "${HEARTBEAT_LABEL}" } }`);
+    expect(buildIssueFilter()).not.toBe(
+      `labels: { name: { eq: "${HEARTBEAT_LABEL}" } }`,
+    );
   });
 
   test("--any-assignee still queries by state alone, so it can surface human work", () => {
@@ -134,7 +142,9 @@ describe("issue fetch filter (OPS-63)", () => {
 
   test("team scoping is ANDed onto both variants", () => {
     expect(buildIssueFilter("CLNT")).toContain(`team: { key: { eq: "CLNT" } }`);
-    expect(buildIssueFilter("CW", true)).toContain(`team: { key: { eq: "CW" } }`);
+    expect(buildIssueFilter("CW", true)).toContain(
+      `team: { key: { eq: "CW" } }`,
+    );
     expect(buildIssueFilter(null)).not.toContain("team:");
   });
 });
@@ -210,7 +220,14 @@ describe("reclaim label computation (WM-14)", () => {
         ],
       },
     };
-    const res = await reclaim(issue, "state-todo", 45, false, false, "lbl-ready");
+    const res = await reclaim(
+      issue,
+      "state-todo",
+      45,
+      false,
+      false,
+      "lbl-ready",
+    );
     expect(res).toBeDefined();
     expect(res.stateId).toBe("state-todo");
     expect(res.labelIds).toContain("lbl-ready");
@@ -223,8 +240,14 @@ describe("dispatch unclaim & repeated failure detection (WM-14 & WM-12)", () => 
   test("countPriorDispatchFailures counts consecutive dispatch failure comments", () => {
     const comments = [
       { body: "Claimed ticket", createdAt: "2026-08-01T10:00:00Z" },
-      { body: "Dispatch run failed, claim released back to Todo.\n\n**Why:** fail 1", createdAt: "2026-08-01T10:05:00Z" },
-      { body: "Dispatch run failed, claim released back to Todo.\n\n**Why:** fail 2", createdAt: "2026-08-01T10:10:00Z" },
+      {
+        body: "Dispatch run failed, claim released back to Todo.\n\n**Why:** fail 1",
+        createdAt: "2026-08-01T10:05:00Z",
+      },
+      {
+        body: "Dispatch run failed, claim released back to Todo.\n\n**Why:** fail 2",
+        createdAt: "2026-08-01T10:10:00Z",
+      },
     ];
     expect(countPriorDispatchFailures(comments)).toBe(2);
     expect(isRepeatedDispatchFailure(comments, 3)).toBe(true); // 2 prior + 1 current = 3 >= 3
@@ -232,10 +255,22 @@ describe("dispatch unclaim & repeated failure detection (WM-14 & WM-12)", () => 
 
   test("countPriorDispatchFailures resets streak on intervening non-failure comment", () => {
     const comments = [
-      { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T09:00:00Z" },
-      { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T09:10:00Z" },
-      { body: "Human checked and fixed repo config", createdAt: "2026-08-01T09:20:00Z" },
-      { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T09:30:00Z" },
+      {
+        body: "Dispatch run failed, claim released back to Todo.",
+        createdAt: "2026-08-01T09:00:00Z",
+      },
+      {
+        body: "Dispatch run failed, claim released back to Todo.",
+        createdAt: "2026-08-01T09:10:00Z",
+      },
+      {
+        body: "Human checked and fixed repo config",
+        createdAt: "2026-08-01T09:20:00Z",
+      },
+      {
+        body: "Dispatch run failed, claim released back to Todo.",
+        createdAt: "2026-08-01T09:30:00Z",
+      },
     ];
     expect(countPriorDispatchFailures(comments)).toBe(1);
     expect(isRepeatedDispatchFailure(comments, 3)).toBe(false); // 1 prior + 1 current = 2 < 3
@@ -258,7 +293,10 @@ describe("dispatch unclaim & repeated failure detection (WM-14 & WM-12)", () => 
       },
       comments: {
         nodes: [
-          { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T10:00:00Z" },
+          {
+            body: "Dispatch run failed, claim released back to Todo.",
+            createdAt: "2026-08-01T10:00:00Z",
+          },
         ],
       },
     };
@@ -299,8 +337,14 @@ describe("dispatch unclaim & repeated failure detection (WM-14 & WM-12)", () => 
       },
       comments: {
         nodes: [
-          { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T10:00:00Z" },
-          { body: "Dispatch run failed, claim released back to Todo.", createdAt: "2026-08-01T10:05:00Z" },
+          {
+            body: "Dispatch run failed, claim released back to Todo.",
+            createdAt: "2026-08-01T10:00:00Z",
+          },
+          {
+            body: "Dispatch run failed, claim released back to Todo.",
+            createdAt: "2026-08-01T10:05:00Z",
+          },
         ],
       },
     };
@@ -321,7 +365,9 @@ describe("dispatch unclaim & repeated failure detection (WM-14 & WM-12)", () => 
     expect(action.labelIds).not.toContain("lbl-ready");
     expect(action.labelIds).not.toContain("lbl-prog");
     expect(action.labelIds).not.toContain("lbl-agent");
-    expect(action.commentBody).toContain("Dispatch run failed repeatedly (3 consecutive dispatch failures), moved to Blocked");
+    expect(action.commentBody).toContain(
+      "Dispatch run failed repeatedly (3 consecutive dispatch failures), moved to Blocked",
+    );
     expect(action.commentBody).toContain("ai:blocked");
   });
 });
@@ -336,7 +382,9 @@ describe("WIP preservation (WM-12)", () => {
   test("preserveWip returns clean when worktree is clean", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "wip-clean-"));
     spawnSync("git", ["init"], { cwd: dir });
-    spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    spawnSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: dir,
+    });
     spawnSync("git", ["config", "user.name", "Test User"], { cwd: dir });
     writeFileSync(path.join(dir, "file.txt"), "committed content\n");
     spawnSync("git", ["add", "file.txt"], { cwd: dir });
@@ -351,7 +399,9 @@ describe("WIP preservation (WM-12)", () => {
   test("preserveWip commits uncommitted modifications and untracked files safely", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "wip-dirty-"));
     spawnSync("git", ["init"], { cwd: dir });
-    spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    spawnSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: dir,
+    });
     spawnSync("git", ["config", "user.name", "Test User"], { cwd: dir });
     writeFileSync(path.join(dir, "file.txt"), "initial\n");
     spawnSync("git", ["add", "file.txt"], { cwd: dir });
@@ -368,10 +418,16 @@ describe("WIP preservation (WM-12)", () => {
     expect(res.hash).toBeDefined();
 
     // Verify git log and clean status
-    const log = spawnSync("git", ["log", "-1", "--pretty=%B"], { cwd: dir, encoding: "utf8" });
+    const log = spawnSync("git", ["log", "-1", "--pretty=%B"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
     expect(log.stdout.trim()).toBe("wip: CLNT-518 uncommitted progress");
 
-    const status = spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8" });
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
     expect(status.stdout.trim()).toBe("");
 
     rmSync(dir, { recursive: true, force: true });

--- a/orchestrator/reconcile.mjs
+++ b/orchestrator/reconcile.mjs
@@ -36,19 +36,28 @@ import { ROOT } from "../lib/schedule.mjs";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export function parseArgs(argv) {
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
   return {
     apply: argv.includes("--apply"),
     gate: argv.includes("--gate"),
     quietMin: Number(val("--quiet-minutes") ?? 25),
-    only: (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean),
+    only: (val("--repo") || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
   };
 }
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`, cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
 };
 
 export const Q = `query($t:String!,$p:String!){ issues(first:250, filter:{
@@ -67,7 +76,10 @@ export const Q_DONE = `query($t:String!,$p:String!){ issues(first:100, filter:{
 
 /** PR numbers attached to a ticket, for this repo only. */
 export function prNumbers(issue, nameWithOwner) {
-  const re = new RegExp(`github\\.com/${nameWithOwner.replace("/", "\\/")}/pull/(\\d+)`, "i");
+  const re = new RegExp(
+    `github\\.com/${nameWithOwner.replace("/", "\\/")}/pull/(\\d+)`,
+    "i",
+  );
   const out = new Set();
   for (const a of issue.attachments?.nodes ?? []) {
     const m = re.exec(a.url ?? "");
@@ -77,8 +89,16 @@ export function prNumbers(issue, nameWithOwner) {
 }
 
 export function prState(nameWithOwner, number, run = Bun.spawnSync) {
-  const p = run(["gh", "pr", "view", String(number), "--repo", nameWithOwner,
-    "--json", "state,isDraft,labels"]);
+  const p = run([
+    "gh",
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    nameWithOwner,
+    "--json",
+    "state,isDraft,labels",
+  ]);
   if ((p.exitCode ?? p.status) !== 0) return null;
   try {
     const raw = p.stdout ? p.stdout.toString() : "";
@@ -99,7 +119,9 @@ export const LIFECYCLE_LABELS = [
 /** Remove all factory lifecycle markers; preserve all project labels (WM-16). */
 export function settledLabelIds(issue) {
   return (issue.labels?.nodes ?? [])
-    .filter((l) => !LIFECYCLE_LABELS.includes(l.name) && !l.name.startsWith("agent:"))
+    .filter(
+      (l) => !LIFECYCLE_LABELS.includes(l.name) && !l.name.startsWith("agent:"),
+    )
     .map((l) => l.id);
 }
 
@@ -107,14 +129,26 @@ export function settledLabelIds(issue) {
  * Evaluate drift between ticket state in Linear and PR state on GitHub.
  * Returns drift descriptor or null if ticket is consistent.
  */
-export function evaluateTicketDrift(issue, repoGithub, prStates, { quietMin = 25 } = {}) {
+export function evaluateTicketDrift(
+  issue,
+  repoGithub,
+  prStates,
+  { quietMin = 25 } = {},
+) {
   const openPrs = prStates.filter((pr) => pr.state === "OPEN");
   const open = openPrs.map((pr) => pr.number);
-  const isDone = issue.state?.type === "completed" || issue.state?.name?.toLowerCase() === "done";
+  const isDone =
+    issue.state?.type === "completed" ||
+    issue.state?.name?.toLowerCase() === "done";
 
   if (isDone) {
     if (!open.length) return null;
-    const isEscalated = openPrs.some((pr) => (pr.labels ?? []).some((l) => (typeof l === "string" ? l : l.name)?.toLowerCase() === "escalated"));
+    const isEscalated = openPrs.some((pr) =>
+      (pr.labels ?? []).some(
+        (l) =>
+          (typeof l === "string" ? l : l.name)?.toLowerCase() === "escalated",
+      ),
+    );
     return {
       type: "done-with-open-pr",
       issue,
@@ -128,7 +162,9 @@ export function evaluateTicketDrift(issue, repoGithub, prStates, { quietMin = 25
   // held tickets may link historical PRs as context without being complete.
   if (!open.length) {
     if (!["In Review", "In Progress"].includes(issue.state?.name)) return null;
-    const merged = prStates.filter((pr) => pr.state === "MERGED").map((pr) => pr.number);
+    const merged = prStates
+      .filter((pr) => pr.state === "MERGED")
+      .map((pr) => pr.number);
     if (!merged.length) return null;
     return {
       type: "merged-not-done",
@@ -141,7 +177,9 @@ export function evaluateTicketDrift(issue, repoGithub, prStates, { quietMin = 25
   // Active ticket with open PR
   if (issue.state?.name !== "In Progress") return null;
 
-  const quietFor = Math.round((Date.now() - (lastActivity(issue)?.getTime() ?? Date.now())) / 60000);
+  const quietFor = Math.round(
+    (Date.now() - (lastActivity(issue)?.getTime() ?? Date.now())) / 60000,
+  );
   if (quietFor < quietMin) {
     return {
       type: "still-active",
@@ -160,11 +198,18 @@ export function evaluateTicketDrift(issue, repoGithub, prStates, { quietMin = 25
   };
 }
 
-export async function reconcileRepo(repo, { apply = false, gate = false, quietMin = 25 } = {}, deps = {}) {
+export async function reconcileRepo(
+  repo,
+  { apply = false, gate = false, quietMin = 25 } = {},
+  deps = {},
+) {
   const queryGql = deps.gql ?? gql;
   const getPrState = deps.prState ?? prState;
 
-  if (!gate) console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}`));
+  if (!gate)
+    console.log(
+      c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}`),
+    );
   if (!repo.github) {
     if (!gate) console.log(c.dim("  no github: in repos.yaml — skipping"));
     return { drift: 0, actions: [] };
@@ -173,18 +218,44 @@ export async function reconcileRepo(repo, { apply = false, gate = false, quietMi
   let activeNodes;
   let doneNodes;
   if (deps.issues) {
-    activeNodes = deps.issues.filter((i) => i.state?.type !== "completed" && i.state?.name?.toLowerCase() !== "done");
-    doneNodes = deps.issues.filter((i) => i.state?.type === "completed" || i.state?.name?.toLowerCase() === "done");
+    activeNodes = deps.issues.filter(
+      (i) =>
+        i.state?.type !== "completed" &&
+        i.state?.name?.toLowerCase() !== "done",
+    );
+    doneNodes = deps.issues.filter(
+      (i) =>
+        i.state?.type === "completed" ||
+        i.state?.name?.toLowerCase() === "done",
+    );
   } else {
-    activeNodes = (await queryGql(Q, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
-    doneNodes = (await queryGql(Q_DONE, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
+    activeNodes =
+      (await queryGql(Q, { t: repo.team, p: repo.project }))?.issues?.nodes ??
+      [];
+    doneNodes =
+      (await queryGql(Q_DONE, { t: repo.team, p: repo.project }))?.issues
+        ?.nodes ?? [];
   }
   const nodes = [...activeNodes, ...doneNodes];
 
-  const states = deps.states ?? (await queryGql(`query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name type } } } }`, { t: repo.team }))?.team?.states?.nodes ?? [];
-  const inReviewId = states.find((s) => s.name.toLowerCase() === "in review")?.id;
+  const states =
+    deps.states ??
+    (
+      await queryGql(
+        `query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name type } } } }`,
+        { t: repo.team },
+      )
+    )?.team?.states?.nodes ??
+    [];
+  const inReviewId = states.find(
+    (s) => s.name.toLowerCase() === "in review",
+  )?.id;
   const doneId = states.find((s) => s.type === "completed")?.id;
-  const allLabels = deps.labels ?? (await queryGql(`query{ issueLabels(first:250){ nodes{ id name } } }`))?.issueLabels?.nodes ?? [];
+  const allLabels =
+    deps.labels ??
+    (await queryGql(`query{ issueLabels(first:250){ nodes{ id name } } }`))
+      ?.issueLabels?.nodes ??
+    [];
   const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
 
   let drift = 0;
@@ -194,18 +265,34 @@ export async function reconcileRepo(repo, { apply = false, gate = false, quietMi
     const prs = prNumbers(issue, repo.github);
     if (!prs.length) continue;
 
-    const prStates = prs.map((n) => ({ number: n, ...(getPrState(repo.github, n) ?? {}) }));
-    const evaluation = evaluateTicketDrift(issue, repo.github, prStates, { quietMin });
+    const prStates = prs.map((n) => ({
+      number: n,
+      ...(getPrState(repo.github, n) ?? {}),
+    }));
+    const evaluation = evaluateTicketDrift(issue, repo.github, prStates, {
+      quietMin,
+    });
     if (!evaluation) {
-      if (!gate && !prStates.some((pr) => pr.state === "OPEN" || pr.state === "MERGED")) {
-        console.log(c.dim(`  ${issue.identifier} — PR ${prs.map((n) => "#" + n).join(", ")} not open; leaving to the merge stage`));
+      if (
+        !gate &&
+        !prStates.some((pr) => pr.state === "OPEN" || pr.state === "MERGED")
+      ) {
+        console.log(
+          c.dim(
+            `  ${issue.identifier} — PR ${prs.map((n) => "#" + n).join(", ")} not open; leaving to the merge stage`,
+          ),
+        );
       }
       continue;
     }
 
     if (evaluation.type === "still-active") {
       if (!gate) {
-        console.log(c.dim(`  ${issue.identifier} — PR ${evaluation.open.map((n) => "#" + n).join(", ")} open but active ${evaluation.quietFor}m ago; its agent is still working`));
+        console.log(
+          c.dim(
+            `  ${issue.identifier} — PR ${evaluation.open.map((n) => "#" + n).join(", ")} open but active ${evaluation.quietFor}m ago; its agent is still working`,
+          ),
+        );
       }
       continue;
     }
@@ -215,53 +302,119 @@ export async function reconcileRepo(repo, { apply = false, gate = false, quietMi
     if (gate) continue;
 
     if (evaluation.type === "done-with-open-pr") {
-      console.log(`  ${c.yellow(issue.identifier)} is Done but PR ${evaluation.open.map((n) => "#" + n).join(", ")} is still OPEN — ${apply ? "moving to In Review" : "would move to In Review"}`);
+      console.log(
+        `  ${c.yellow(issue.identifier)} is Done but PR ${evaluation.open.map((n) => "#" + n).join(", ")} is still OPEN — ${apply ? "moving to In Review" : "would move to In Review"}`,
+      );
       console.log(c.dim(`    ${issue.title.slice(0, 70)}`));
       if (!apply) continue;
-      if (!inReviewId) { console.log(c.red(`    ! no 'In Review' state on team ${repo.team}, skipping`)); continue; }
+      if (!inReviewId) {
+        console.log(
+          c.red(`    ! no 'In Review' state on team ${repo.team}, skipping`),
+        );
+        continue;
+      }
 
-      const keep = (issue.labels?.nodes ?? []).filter((l) => !LIFECYCLE_LABELS.includes(l.name) && !l.name.startsWith("agent:")).map((l) => l.id);
+      const keep = (issue.labels?.nodes ?? [])
+        .filter(
+          (l) =>
+            !LIFECYCLE_LABELS.includes(l.name) && !l.name.startsWith("agent:"),
+        )
+        .map((l) => l.id);
       const wantNames = ["ai:needs-review"];
       if (evaluation.isEscalated) wantNames.push("ai:escalated");
-      const want = [...new Set([...keep, ...wantNames.map((n) => labelId(n))].filter(Boolean))];
+      const want = [
+        ...new Set(
+          [...keep, ...wantNames.map((n) => labelId(n))].filter(Boolean),
+        ),
+      ];
 
-      await queryGql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-        { id: issue.id, in: { stateId: inReviewId, labelIds: want } });
-      await queryGql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
-        { in: { issueId: issue.id, body:
-          `**State reconciled: \`Done\` → \`In Review\` (WM-11).**\n\n` +
-          `PR ${evaluation.open.map((n) => `#${n}`).join(", ")} is still open, but the ticket was marked Done. ` +
-          `Reopened to In Review${evaluation.isEscalated ? " with `ai:escalated`" : ""}.\n\n` +
-          `The merge stage reviews it from here.` } });
+      await queryGql(
+        `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+        { id: issue.id, in: { stateId: inReviewId, labelIds: want } },
+      );
+      await queryGql(
+        `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+        {
+          in: {
+            issueId: issue.id,
+            body:
+              `**State reconciled: \`Done\` → \`In Review\` (WM-11).**\n\n` +
+              `PR ${evaluation.open.map((n) => `#${n}`).join(", ")} is still open, but the ticket was marked Done. ` +
+              `Reopened to In Review${evaluation.isEscalated ? " with `ai:escalated`" : ""}.\n\n` +
+              `The merge stage reviews it from here.`,
+          },
+        },
+      );
     } else if (evaluation.type === "merged-not-done") {
-      console.log(`  ${c.yellow(issue.identifier)} has merged PR ${evaluation.merged.map((n) => "#" + n).join(", ")} but is still ${issue.state?.name ?? "active"} — ${apply ? "moving to Done" : "would move to Done"}`);
+      console.log(
+        `  ${c.yellow(issue.identifier)} has merged PR ${evaluation.merged.map((n) => "#" + n).join(", ")} but is still ${issue.state?.name ?? "active"} — ${apply ? "moving to Done" : "would move to Done"}`,
+      );
       console.log(c.dim(`    ${issue.title.slice(0, 70)}`));
       if (!apply) continue;
-      if (!doneId) { console.log(c.red(`    ! no completed state on team ${repo.team}, skipping`)); continue; }
+      if (!doneId) {
+        console.log(
+          c.red(`    ! no completed state on team ${repo.team}, skipping`),
+        );
+        continue;
+      }
 
-      await queryGql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-        { id: issue.id, in: { stateId: doneId, labelIds: settledLabelIds(issue) } });
-      await queryGql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
-        { in: { issueId: issue.id, body:
-          `**State reconciled: \`${issue.state?.name ?? "active"}\` → \`Done\`.**\n\n` +
-          `PR ${evaluation.merged.map((n) => `#${n}`).join(", ")} is merged, but the ticket's final Linear update was missed. ` +
-          `Removed the factory lifecycle labels; all project labels were preserved.` } });
+      await queryGql(
+        `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+        {
+          id: issue.id,
+          in: { stateId: doneId, labelIds: settledLabelIds(issue) },
+        },
+      );
+      await queryGql(
+        `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+        {
+          in: {
+            issueId: issue.id,
+            body:
+              `**State reconciled: \`${issue.state?.name ?? "active"}\` → \`Done\`.**\n\n` +
+              `PR ${evaluation.merged.map((n) => `#${n}`).join(", ")} is merged, but the ticket's final Linear update was missed. ` +
+              `Removed the factory lifecycle labels; all project labels were preserved.`,
+          },
+        },
+      );
     } else if (evaluation.type === "in-progress-with-open-pr") {
-      console.log(`  ${c.yellow(issue.identifier)} holds a slot but PR ${evaluation.open.map((n) => "#" + n).join(", ")} is open — ${apply ? "moving to In Review" : "would move to In Review"}`);
+      console.log(
+        `  ${c.yellow(issue.identifier)} holds a slot but PR ${evaluation.open.map((n) => "#" + n).join(", ")} is open — ${apply ? "moving to In Review" : "would move to In Review"}`,
+      );
       console.log(c.dim(`    ${issue.title.slice(0, 70)}`));
       if (!apply) continue;
-      if (!inReviewId) { console.log(c.red(`    ! no 'In Review' state on team ${repo.team}, skipping`)); continue; }
+      if (!inReviewId) {
+        console.log(
+          c.red(`    ! no 'In Review' state on team ${repo.team}, skipping`),
+        );
+        continue;
+      }
 
-      const keep = (issue.labels?.nodes ?? []).filter((l) => l.name !== "ai:in-progress" && !l.name.startsWith("agent:")).map((l) => l.id);
-      const want = [...new Set([...keep, labelId("ai:needs-review")].filter(Boolean))];
-      await queryGql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-        { id: issue.id, in: { stateId: inReviewId, labelIds: want } });
-      await queryGql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
-        { in: { issueId: issue.id, body:
-          `**State reconciled: \`In Progress\` → \`In Review\`.**\n\n` +
-          `PR ${evaluation.open.map((n) => `#${n}`).join(", ")} is open, so the implementation phase is over — but the ticket was still ` +
-          `holding a dispatch slot, which caps how many agents can run in this repo.\n\n` +
-          `Nothing about the PR was changed. The merge stage reviews it from here.` } });
+      const keep = (issue.labels?.nodes ?? [])
+        .filter(
+          (l) => l.name !== "ai:in-progress" && !l.name.startsWith("agent:"),
+        )
+        .map((l) => l.id);
+      const want = [
+        ...new Set([...keep, labelId("ai:needs-review")].filter(Boolean)),
+      ];
+      await queryGql(
+        `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+        { id: issue.id, in: { stateId: inReviewId, labelIds: want } },
+      );
+      await queryGql(
+        `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+        {
+          in: {
+            issueId: issue.id,
+            body:
+              `**State reconciled: \`In Progress\` → \`In Review\`.**\n\n` +
+              `PR ${evaluation.open.map((n) => `#${n}`).join(", ")} is open, so the implementation phase is over — but the ticket was still ` +
+              `holding a dispatch slot, which caps how many agents can run in this repo.\n\n` +
+              `Nothing about the PR was changed. The merge stage reviews it from here.`,
+          },
+        },
+      );
     }
   }
 
@@ -269,31 +422,76 @@ export async function reconcileRepo(repo, { apply = false, gate = false, quietMi
 }
 
 async function main() {
-  const { apply: APPLY, gate: GATE, quietMin: QUIET_MIN, only } = parseArgs(process.argv.slice(2));
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-  const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
-  if (!repos.length) { console.error(`--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`); process.exit(2); }
+  const {
+    apply: APPLY,
+    gate: GATE,
+    quietMin: QUIET_MIN,
+    only,
+  } = parseArgs(process.argv.slice(2));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const repos = (cfg.repos ?? []).filter(
+    (r) => !only.length || only.includes(r.name),
+  );
+  if (!repos.length) {
+    console.error(
+      `--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`,
+    );
+    process.exit(2);
+  }
 
   let totalDrift = 0;
   for (const repo of repos) {
-    const { drift, actions } = await reconcileRepo(repo, { apply: APPLY, gate: GATE, quietMin: QUIET_MIN });
+    const { drift, actions } = await reconcileRepo(repo, {
+      apply: APPLY,
+      gate: GATE,
+      quietMin: QUIET_MIN,
+    });
     totalDrift += drift;
     // Lifecycle observation (WM-75): fire-and-forget, one event per applied
     // move; the PR numbers make the id stable across re-runs of the same drift.
     if (APPLY && !GATE) {
       for (const a of actions) {
         const prs = (a.open ?? a.merged ?? []).join(",");
-        await emitFactoryEvent("factory.ticket.reconciled",
-          { repo: repo.name, ticket: a.issue.identifier, kind: a.type, targetState: a.targetState, prs: a.open ?? a.merged ?? [] },
-          { eventId: `reconcile:${a.issue.identifier}:${a.type}:${prs}`, subject: a.issue.identifier });
+        await emitFactoryEvent(
+          "factory.ticket.reconciled",
+          {
+            repo: repo.name,
+            ticket: a.issue.identifier,
+            kind: a.type,
+            targetState: a.targetState,
+            prs: a.open ?? a.merged ?? [],
+          },
+          {
+            eventId: `reconcile:${a.issue.identifier}:${a.type}:${prs}`,
+            subject: a.issue.identifier,
+          },
+        );
       }
     }
   }
 
   if (GATE) process.exit(totalDrift ? 0 : 1);
-  if (!totalDrift) console.log(c.dim("\nno drift — every In Progress ticket is genuinely in progress.\n"));
-  else if (APPLY) console.log(c.dim(`\n${totalDrift} ticket(s) reconciled; those slots are free now.\n`));
-  else console.log(c.dim(`\n${totalDrift} ticket(s) would be reconciled — re-run with --apply.\n`));
+  if (!totalDrift)
+    console.log(
+      c.dim(
+        "\nno drift — every In Progress ticket is genuinely in progress.\n",
+      ),
+    );
+  else if (APPLY)
+    console.log(
+      c.dim(
+        `\n${totalDrift} ticket(s) reconciled; those slots are free now.\n`,
+      ),
+    );
+  else
+    console.log(
+      c.dim(
+        `\n${totalDrift} ticket(s) would be reconciled — re-run with --apply.\n`,
+      ),
+    );
 }
 
-if (import.meta.main || process.argv[1]?.endsWith("reconcile.mjs")) await main();
+if (import.meta.main || process.argv[1]?.endsWith("reconcile.mjs"))
+  await main();

--- a/orchestrator/reconcile.test.mjs
+++ b/orchestrator/reconcile.test.mjs
@@ -22,7 +22,14 @@ describe("parseArgs", () => {
   });
 
   test("parses provided arguments", () => {
-    const opts = parseArgs(["--apply", "--gate", "--quiet-minutes", "40", "--repo", "bj29,legalease"]);
+    const opts = parseArgs([
+      "--apply",
+      "--gate",
+      "--quiet-minutes",
+      "40",
+      "--repo",
+      "bj29,legalease",
+    ]);
     expect(opts.apply).toBe(true);
     expect(opts.gate).toBe(true);
     expect(opts.quietMin).toBe(40);
@@ -47,7 +54,9 @@ describe("prNumbers", () => {
 
   test("returns empty array when no attachments match", () => {
     expect(prNumbers({}, "watt-mind/factory")).toEqual([]);
-    expect(prNumbers({ attachments: { nodes: [] } }, "watt-mind/factory")).toEqual([]);
+    expect(
+      prNumbers({ attachments: { nodes: [] } }, "watt-mind/factory"),
+    ).toEqual([]);
   });
 });
 
@@ -55,11 +64,13 @@ describe("prState", () => {
   test("returns parsed JSON state, isDraft, and labels on exit 0", () => {
     const mockRun = () => ({
       exitCode: 0,
-      stdout: Buffer.from(JSON.stringify({
-        state: "OPEN",
-        isDraft: false,
-        labels: [{ name: "escalated" }],
-      })),
+      stdout: Buffer.from(
+        JSON.stringify({
+          state: "OPEN",
+          isDraft: false,
+          labels: [{ name: "escalated" }],
+        }),
+      ),
     });
     const state = prState("watt-mind/factory", 110, mockRun);
     expect(state).toEqual({
@@ -70,8 +81,15 @@ describe("prState", () => {
   });
 
   test("returns null on non-zero exit or invalid json", () => {
-    expect(prState("watt-mind/factory", 110, () => ({ exitCode: 1, stdout: "" }))).toBeNull();
-    expect(prState("watt-mind/factory", 110, () => ({ exitCode: 0, stdout: "invalid" }))).toBeNull();
+    expect(
+      prState("watt-mind/factory", 110, () => ({ exitCode: 1, stdout: "" })),
+    ).toBeNull();
+    expect(
+      prState("watt-mind/factory", 110, () => ({
+        exitCode: 0,
+        stdout: "invalid",
+      })),
+    ).toBeNull();
   });
 });
 
@@ -119,10 +137,10 @@ describe("evaluateTicketDrift (WM-11, WM-16)", () => {
       identifier: "CLNT-522",
       state: { name: "Done", type: "completed" },
     };
-    const prStates = [
-      { number: 203, state: "MERGED", labels: [] },
-    ];
-    expect(evaluateTicketDrift(issue, "watt-mind/legalease", prStates)).toBeNull();
+    const prStates = [{ number: 203, state: "MERGED", labels: [] }];
+    expect(
+      evaluateTicketDrift(issue, "watt-mind/legalease", prStates),
+    ).toBeNull();
   });
 
   test.each(["In Review", "In Progress"])(
@@ -151,7 +169,9 @@ describe("evaluateTicketDrift (WM-11, WM-16)", () => {
       };
       const prStates = [{ number: 100, state: "MERGED" }];
 
-      expect(evaluateTicketDrift(issue, "watt-mind/legalease", prStates)).toBeNull();
+      expect(
+        evaluateTicketDrift(issue, "watt-mind/legalease", prStates),
+      ).toBeNull();
     },
   );
 
@@ -163,10 +183,10 @@ describe("evaluateTicketDrift (WM-11, WM-16)", () => {
       updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
       comments: { nodes: [] },
     };
-    const prStates = [
-      { number: 150, state: "OPEN", labels: [] },
-    ];
-    const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates, { quietMin: 25 });
+    const prStates = [{ number: 150, state: "OPEN", labels: [] }];
+    const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates, {
+      quietMin: 25,
+    });
     expect(res).not.toBeNull();
     expect(res.type).toBe("in-progress-with-open-pr");
     expect(res.open).toEqual([150]);
@@ -181,10 +201,10 @@ describe("evaluateTicketDrift (WM-11, WM-16)", () => {
       updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       comments: { nodes: [] },
     };
-    const prStates = [
-      { number: 150, state: "OPEN", labels: [] },
-    ];
-    const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates, { quietMin: 25 });
+    const prStates = [{ number: 150, state: "OPEN", labels: [] }];
+    const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates, {
+      quietMin: 25,
+    });
     expect(res).not.toBeNull();
     expect(res.type).toBe("still-active");
   });
@@ -216,7 +236,9 @@ describe("reconcileRepo (WM-11)", () => {
       title: "Something failed",
       state: { id: "s-done", name: "Done", type: "completed" },
       labels: { nodes: [{ id: "l-bug", name: "type:bug" }] },
-      attachments: { nodes: [{ url: "https://github.com/watt-mind/legalease/pull/203" }] },
+      attachments: {
+        nodes: [{ url: "https://github.com/watt-mind/legalease/pull/203" }],
+      },
     };
 
     const mutations = [];
@@ -231,13 +253,17 @@ describe("reconcileRepo (WM-11)", () => {
       labels: [{ name: "escalated" }],
     });
 
-    const res = await reconcileRepo(repo, { apply: true, gate: false }, {
-      gql: mockGql,
-      prState: mockPrState,
-      issues: [issue],
-      states,
-      labels,
-    });
+    const res = await reconcileRepo(
+      repo,
+      { apply: true, gate: false },
+      {
+        gql: mockGql,
+        prState: mockPrState,
+        issues: [issue],
+        states,
+        labels,
+      },
+    );
 
     expect(res.drift).toBe(1);
     expect(res.actions).toHaveLength(1);
@@ -266,7 +292,9 @@ describe("reconcileRepo (WM-11)", () => {
       title: "Something failed",
       state: { id: "s-done", name: "Done", type: "completed" },
       labels: { nodes: [] },
-      attachments: { nodes: [{ url: "https://github.com/watt-mind/legalease/pull/203" }] },
+      attachments: {
+        nodes: [{ url: "https://github.com/watt-mind/legalease/pull/203" }],
+      },
     };
 
     const mutations = [];
@@ -275,13 +303,17 @@ describe("reconcileRepo (WM-11)", () => {
       return { success: true };
     };
 
-    const res = await reconcileRepo(repo, { apply: false, gate: true }, {
-      gql: mockGql,
-      prState: () => ({ state: "OPEN", labels: [] }),
-      issues: [issue],
-      states,
-      labels,
-    });
+    const res = await reconcileRepo(
+      repo,
+      { apply: false, gate: true },
+      {
+        gql: mockGql,
+        prState: () => ({ state: "OPEN", labels: [] }),
+        issues: [issue],
+        states,
+        labels,
+      },
+    );
 
     expect(res.drift).toBe(1);
     expect(mutations).toHaveLength(0);

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -54,7 +54,11 @@ export const HELD_QUERY = `
  * comments is NOT answered. Wrongly resurfacing a hold re-derives it every
  * 5 minutes; wrongly leaving one held costs what it costs today.
  */
-export function answeredIdentifiers(heldNodes, labelIds, graceMs = REPLY_GRACE_MS) {
+export function answeredIdentifiers(
+  heldNodes,
+  labelIds,
+  graceMs = REPLY_GRACE_MS,
+) {
   const answered = new Set();
   for (const t of heldNodes ?? []) {
     // Only the two documented hold shapes. An In Progress ticket carrying a
@@ -63,9 +67,12 @@ export function answeredIdentifiers(heldNodes, labelIds, graceMs = REPLY_GRACE_M
     const adds = (t.history?.nodes ?? [])
       .filter((h) => (h.addedLabelIds ?? []).some((id) => labelIds.has(id)))
       .map((h) => Date.parse(h.createdAt));
-    const comments = (t.comments?.nodes ?? []).map((n) => Date.parse(n.createdAt));
+    const comments = (t.comments?.nodes ?? []).map((n) =>
+      Date.parse(n.createdAt),
+    );
     if (!adds.length || !comments.length) continue;
-    if (Math.max(...comments) > Math.max(...adds) + graceMs) answered.add(t.identifier);
+    if (Math.max(...comments) > Math.max(...adds) + graceMs)
+      answered.add(t.identifier);
   }
   return answered;
 }
@@ -124,6 +131,13 @@ export async function blockedLabelIds() {
 export async function answeredHeldTickets(repo) {
   const ids = await blockedLabelIds();
   if (!ids.size) return new Set();
-  const held = (await gql(HELD_QUERY, { team: repo.team, project: repo.project, label: AI_BLOCKED }))?.issues?.nodes ?? [];
+  const held =
+    (
+      await gql(HELD_QUERY, {
+        team: repo.team,
+        project: repo.project,
+        label: AI_BLOCKED,
+      })
+    )?.issues?.nodes ?? [];
   return answeredIdentifiers(held, ids);
 }

--- a/orchestrator/reply-detection.test.mjs
+++ b/orchestrator/reply-detection.test.mjs
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { answeredIdentifiers, HELD_QUERY, holdInfo, REPLY_GRACE_MS } from "./reply-detection.mjs";
+import {
+  answeredIdentifiers,
+  HELD_QUERY,
+  holdInfo,
+  REPLY_GRACE_MS,
+} from "./reply-detection.mjs";
 
 const LABEL_ID = "label-ai-blocked";
 const IDS = new Set([LABEL_ID]);
@@ -8,18 +13,32 @@ const T0 = Date.parse("2026-08-04T12:00:00.000Z");
 const iso = (ms) => new Date(ms).toISOString();
 
 /** A held issue: label-add events and comments given as offsets from T0. */
-function issue({ id = "CLNT-1", state = "Blocked", adds = [], comments = [], addedIds = [LABEL_ID] } = {}) {
+function issue({
+  id = "CLNT-1",
+  state = "Blocked",
+  adds = [],
+  comments = [],
+  addedIds = [LABEL_ID],
+} = {}) {
   return {
     identifier: id,
     state: { name: state },
     comments: { nodes: comments.map((ms) => ({ createdAt: iso(T0 + ms) })) },
-    history: { nodes: adds.map((ms) => ({ createdAt: iso(T0 + ms), addedLabelIds: addedIds })) },
+    history: {
+      nodes: adds.map((ms) => ({
+        createdAt: iso(T0 + ms),
+        addedLabelIds: addedIds,
+      })),
+    },
   };
 }
 
 describe("answeredIdentifiers", () => {
   test("held-ticket queries request newest history and comments instead of truncating long timelines", () => {
-    const digestSource = readFileSync(new URL("./digest.mjs", import.meta.url), "utf8");
+    const digestSource = readFileSync(
+      new URL("./digest.mjs", import.meta.url),
+      "utf8",
+    );
     for (const querySource of [HELD_QUERY, digestSource]) {
       expect(querySource).toContain("history(last: 50)");
       expect(querySource).not.toContain("history(first:");
@@ -31,7 +50,9 @@ describe("answeredIdentifiers", () => {
   test("a recent re-add in a long history keeps an older reply classified as unanswered", () => {
     const oldAdds = Array.from({ length: 100 }, (_, i) => i * 60_000);
     const recentAdd = 120 * 60_000;
-    const held = [issue({ adds: [...oldAdds, recentAdd], comments: [110 * 60_000] })];
+    const held = [
+      issue({ adds: [...oldAdds, recentAdd], comments: [110 * 60_000] }),
+    ];
     expect(answeredIdentifiers(held, IDS)).toEqual(new Set());
   });
 
@@ -50,29 +71,62 @@ describe("answeredIdentifiers", () => {
 
   test("grace boundary: answered strictly beyond REPLY_GRACE_MS", () => {
     const at = issue({ id: "AT", adds: [0], comments: [REPLY_GRACE_MS] });
-    const past = issue({ id: "PAST", adds: [0], comments: [REPLY_GRACE_MS + 1] });
+    const past = issue({
+      id: "PAST",
+      adds: [0],
+      comments: [REPLY_GRACE_MS + 1],
+    });
     expect(answeredIdentifiers([at, past], IDS)).toEqual(new Set(["PAST"]));
   });
 
   test("re-adding the label resets the clock", () => {
     // Held at 0, answered at +10m, triage re-held at +11m with a sharper
     // question: not answered again until a comment lands after the re-add.
-    const held = [issue({ adds: [0, 11 * 60_000], comments: [-1000, 10 * 60_000, 11 * 60_000 - 5000] })];
+    const held = [
+      issue({
+        adds: [0, 11 * 60_000],
+        comments: [-1000, 10 * 60_000, 11 * 60_000 - 5000],
+      }),
+    ];
     expect(answeredIdentifiers(held, IDS)).toEqual(new Set());
   });
 
   test("conservative on missing evidence: no label-add event or no comments", () => {
     const noEvent = issue({ id: "NOEV", adds: [], comments: [60 * 60_000] });
-    const otherLabel = issue({ id: "OTHER", adds: [0], comments: [60 * 60_000], addedIds: ["some-other-label"] });
+    const otherLabel = issue({
+      id: "OTHER",
+      adds: [0],
+      comments: [60 * 60_000],
+      addedIds: ["some-other-label"],
+    });
     const noComments = issue({ id: "NOC", adds: [0], comments: [] });
-    expect(answeredIdentifiers([noEvent, otherLabel, noComments], IDS)).toEqual(new Set());
+    expect(answeredIdentifiers([noEvent, otherLabel, noComments], IDS)).toEqual(
+      new Set(),
+    );
   });
 
   test("only Triage and Blocked states count", () => {
-    const inProgress = issue({ id: "IP", state: "In Progress", adds: [0], comments: [60 * 60_000] });
-    const backlog = issue({ id: "BL", state: "Backlog", adds: [0], comments: [60 * 60_000] });
-    const triage = issue({ id: "TR", state: "Triage", adds: [0], comments: [60 * 60_000] });
-    expect(answeredIdentifiers([inProgress, backlog, triage], IDS)).toEqual(new Set(["TR"]));
+    const inProgress = issue({
+      id: "IP",
+      state: "In Progress",
+      adds: [0],
+      comments: [60 * 60_000],
+    });
+    const backlog = issue({
+      id: "BL",
+      state: "Backlog",
+      adds: [0],
+      comments: [60 * 60_000],
+    });
+    const triage = issue({
+      id: "TR",
+      state: "Triage",
+      adds: [0],
+      comments: [60 * 60_000],
+    });
+    expect(answeredIdentifiers([inProgress, backlog, triage], IDS)).toEqual(
+      new Set(["TR"]),
+    );
   });
 
   test("tolerates missing nested fields", () => {
@@ -85,11 +139,19 @@ describe("answeredIdentifiers", () => {
 describe("holdInfo", () => {
   const withBodies = ({ comments, ...spec }) => ({
     ...issue(spec),
-    comments: { nodes: comments.map(([ms, body]) => ({ createdAt: iso(T0 + ms), body })) },
+    comments: {
+      nodes: comments.map(([ms, body]) => ({ createdAt: iso(T0 + ms), body })),
+    },
   });
 
   test("splits the blocking question from the reply", () => {
-    const node = withBodies({ adds: [0], comments: [[-1500, "need a decision on X"], [60 * 60_000, "go with option A"]] });
+    const node = withBodies({
+      adds: [0],
+      comments: [
+        [-1500, "need a decision on X"],
+        [60 * 60_000, "go with option A"],
+      ],
+    });
     const info = holdInfo(node, IDS);
     expect(info.heldAtMs).toBe(T0);
     expect(info.question.body).toBe("need a decision on X");
@@ -97,14 +159,23 @@ describe("holdInfo", () => {
   });
 
   test("a label-then-comment hold keeps its comment as the question, not a reply", () => {
-    const node = withBodies({ adds: [0], comments: [[10_000, "blocked: which env?"]] });
+    const node = withBodies({
+      adds: [0],
+      comments: [[10_000, "blocked: which env?"]],
+    });
     const info = holdInfo(node, IDS);
     expect(info.question.body).toBe("blocked: which env?");
     expect(info.reply).toBeNull();
   });
 
   test("no add event: newest comment is the question guess, heldAtMs null, no reply ever", () => {
-    const node = withBodies({ adds: [], comments: [[0, "old"], [60 * 60_000, "newest"]] });
+    const node = withBodies({
+      adds: [],
+      comments: [
+        [0, "old"],
+        [60 * 60_000, "newest"],
+      ],
+    });
     const info = holdInfo(node, IDS);
     expect(info.heldAtMs).toBeNull();
     expect(info.question.body).toBe("newest");
@@ -112,13 +183,19 @@ describe("holdInfo", () => {
   });
 
   test("non-hold states return null", () => {
-    expect(holdInfo(issue({ state: "In Progress", adds: [0], comments: [0] }), IDS)).toBeNull();
+    expect(
+      holdInfo(issue({ state: "In Progress", adds: [0], comments: [0] }), IDS),
+    ).toBeNull();
     expect(holdInfo(undefined, IDS)).toBeNull();
   });
 
   test("agrees with answeredIdentifiers on the grace boundary", () => {
     const at = issue({ id: "AT", adds: [0], comments: [REPLY_GRACE_MS] });
-    const past = issue({ id: "PAST", adds: [0], comments: [REPLY_GRACE_MS + 1] });
+    const past = issue({
+      id: "PAST",
+      adds: [0],
+      comments: [REPLY_GRACE_MS + 1],
+    });
     expect(holdInfo(at, IDS).reply).toBeNull();
     expect(holdInfo(past, IDS).reply).not.toBeNull();
   });

--- a/orchestrator/repos-config.test.mjs
+++ b/orchestrator/repos-config.test.mjs
@@ -24,7 +24,9 @@ test("factory is a dispatch target, not report_only (OPS-463)", () => {
 test("factory declares its worktree lifecycle and the scripts exist, executable", () => {
   expect(factory.worktreeUp).toBe("bin/worktree-up.sh");
   expect(factory.worktreeDown).toBe("bin/worktree-down.sh");
-  expect(factory.worktreeRoot).toBe(path.join(process.env.HOME ?? "", "Develop/.worktrees/factory"));
+  expect(factory.worktreeRoot).toBe(
+    path.join(process.env.HOME ?? "", "Develop/.worktrees/factory"),
+  );
   for (const script of [factory.worktreeUp, factory.worktreeDown]) {
     // Throws (failing the test) if the declared script is missing or not
     // executable — config must never point dispatch at tooling that isn't there.

--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -33,7 +33,10 @@ import { latestReaperRunMs } from "./reaper.mjs";
  * Keep spawned processes reachable until their stdio has closed. Shutdown can
  * then signal every active child and await settlement without polling.
  */
-export function createChildTracker({ setTimeoutFn = setTimeout, clearTimeoutFn = clearTimeout } = {}) {
+export function createChildTracker({
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+} = {}) {
   const active = new Set();
   const waiters = new Set();
 
@@ -44,7 +47,9 @@ export function createChildTracker({ setTimeoutFn = setTimeout, clearTimeoutFn =
 
   return {
     active,
-    get size() { return active.size; },
+    get size() {
+      return active.size;
+    },
 
     track(child) {
       active.add(child);
@@ -61,7 +66,11 @@ export function createChildTracker({ setTimeoutFn = setTimeout, clearTimeoutFn =
 
     terminateAll(signal = "SIGTERM") {
       for (const child of [...active]) {
-        try { child.kill(signal); } catch { /* intentionally ignored */ }
+        try {
+          child.kill(signal);
+        } catch {
+          /* intentionally ignored */
+        }
       }
     },
 
@@ -109,7 +118,9 @@ export function createShutdownController({
     const names = getRunningNames();
     if (childTracker.size) {
       const detail = names.length ? ` (${names.join(", ")})` : "";
-      log(`\n${signal} — stopping ${childTracker.size} active child process(es)${detail}. Signal again to exit immediately.`);
+      log(
+        `\n${signal} — stopping ${childTracker.size} active child process(es)${detail}. Signal again to exit immediately.`,
+      );
     }
 
     childTracker.terminateAll("SIGTERM");
@@ -118,7 +129,10 @@ export function createShutdownController({
 
     setTitle("");
     log(`\nstopped. ${completed} run(s) ok, ${failed} failed.`);
-    if (!drained) log(`  shutdown deadline reached; exiting with child process(es) still active.`);
+    if (!drained)
+      log(
+        `  shutdown deadline reached; exiting with child process(es) still active.`,
+      );
     log("nothing is scheduled; nothing runs until you start this again.\n");
     exit(failed ? 1 : 0);
     return { forced: false, drained };
@@ -127,12 +141,18 @@ export function createShutdownController({
 
 export async function main(argv = process.argv.slice(2)) {
   const has = (flag) => argv.includes(flag);
-  const val = (flag) => { const i = argv.indexOf(flag); return i === -1 ? null : argv[i + 1]; };
+  const val = (flag) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? null : argv[i + 1];
+  };
 
   const APPLY = has("--apply");
   const ONCE = has("--once");
   const ALL = has("--all");
-  const ONLY = (val("--only") || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const ONLY = (val("--only") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 
   // One supervisor per repo. Run two of these side by side to work two repos at
   // once — they share nothing but the machine, and either can be stopped alone.
@@ -153,15 +173,23 @@ export async function main(argv = process.argv.slice(2)) {
 
   // Terminal tab title (OSC 0) — so a wall of tabs reads "which repo, which
   // mode, what's running right now" without focusing any of them.
-  const setTitle = (s) => { if (process.stdout.isTTY) process.stdout.write(`\x1b]0;${s}\x07`); };
+  const setTitle = (s) => {
+    if (process.stdout.isTTY) process.stdout.write(`\x1b]0;${s}\x07`);
+  };
   const baseTitle = () => `factory ${TARGET} — ${APPLY ? "APPLY" : "dry"}`;
-  const refreshTitle = () => setTitle(running.size ? `${baseTitle()} ▸ ${[...running].join(",")}` : baseTitle());
+  const refreshTitle = () =>
+    setTitle(
+      running.size ? `${baseTitle()} ▸ ${[...running].join(",")}` : baseTitle(),
+    );
 
   if (has("--list") || (!ALL && ONLY.length === 0)) {
     console.log(c.bold("\njobs in config/schedule.yaml\n"));
     for (const job of jobs) {
-      const timer = job.enabled === false ? c.dim("no timer") : c.green("timer eligible");
-      console.log(`  ${c.bold(job.name.padEnd(18))} every ${String(job.every).padEnd(5)} ${timer}`);
+      const timer =
+        job.enabled === false ? c.dim("no timer") : c.green("timer eligible");
+      console.log(
+        `  ${c.bold(job.name.padEnd(18))} every ${String(job.every).padEnd(5)} ${timer}`,
+      );
       if (job.dry_command) console.log(c.dim(`    dry:   ${job.dry_command}`));
       console.log(c.dim(`    apply: ${job.command}`));
     }
@@ -189,17 +217,34 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
 
   for (const job of selected) {
     if (!APPLY && !job.dry_command) {
-      console.error(c.red(`\n${job.name} has no dry_command, so there is no safe way to preview it.`));
-      console.error("Add one to config/schedule.yaml, or run with --apply if you mean it.\n");
+      console.error(
+        c.red(
+          `\n${job.name} has no dry_command, so there is no safe way to preview it.`,
+        ),
+      );
+      console.error(
+        "Add one to config/schedule.yaml, or run with --apply if you mean it.\n",
+      );
       return 2;
     }
   }
 
   const commandFor = (job) => (APPLY ? job.command : job.dry_command);
 
-  console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} · ${c.cyan(AGENT)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
-  console.log(c.dim(`${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`));
-  for (const job of selected) console.log(`  ${c.cyan(job.name)}  every ${job.every}  ${c.dim(commandFor(job))}`);
+  console.log(
+    c.bold(
+      `\nfactory supervisor — ${c.cyan(TARGET)} · ${c.cyan(AGENT)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`,
+    ),
+  );
+  console.log(
+    c.dim(
+      `${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`,
+    ),
+  );
+  for (const job of selected)
+    console.log(
+      `  ${c.cyan(job.name)}  every ${job.every}  ${c.dim(commandFor(job))}`,
+    );
   console.log();
 
   const children = createChildTracker();
@@ -213,7 +258,12 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
    */
   function probe(cmd) {
     return new Promise((resolve) => {
-      const child = children.track(spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] }));
+      const child = children.track(
+        spawn("/bin/bash", ["-lc", cmd], {
+          cwd: ROOT,
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      );
       let out = "";
       child.stdout.on("data", (data) => (out += data));
       child.stderr.on("data", (data) => (out += data));
@@ -223,7 +273,9 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
 
   async function runJob(job) {
     if (running.has(job.name)) {
-      console.log(`${c.dim(clock())} ${c.yellow("skip")}  ${job.name} — previous run still going`);
+      console.log(
+        `${c.dim(clock())} ${c.yellow("skip")}  ${job.name} — previous run still going`,
+      );
       return;
     }
 
@@ -233,25 +285,38 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
     if (job.gate_command && APPLY) {
       const { code, out } = await probe(job.gate_command);
       if (code === 1) {
-        console.log(`${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`);
+        console.log(
+          `${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`,
+        );
         return;
       }
       if (code !== 0) {
         failed++;
-        console.log(`${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`);
+        console.log(
+          `${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`,
+        );
         return;
       }
-      console.log(`${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`);
+      console.log(
+        `${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`,
+      );
     }
 
     running.add(job.name);
     refreshTitle();
     const cmd = commandFor(job);
     const started = Date.now();
-    console.log(`${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`);
+    console.log(
+      `${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`,
+    );
 
     return new Promise((resolve) => {
-      const child = children.track(spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] }));
+      const child = children.track(
+        spawn("/bin/bash", ["-lc", cmd], {
+          cwd: ROOT,
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      );
       const prefix = c.dim("  │ ");
       const pipe = (stream, color) => {
         let buf = "";
@@ -259,9 +324,12 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
           buf += data.toString();
           const lines = buf.split("\n");
           buf = lines.pop();
-          for (const line of lines) console.log(prefix + (color ? color(line) : line));
+          for (const line of lines)
+            console.log(prefix + (color ? color(line) : line));
         });
-        stream.on("end", () => { if (buf.trim()) console.log(prefix + (color ? color(buf) : buf)); });
+        stream.on("end", () => {
+          if (buf.trim()) console.log(prefix + (color ? color(buf) : buf));
+        });
       };
       pipe(child.stdout);
       pipe(child.stderr, c.red);
@@ -272,10 +340,14 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
         const secs = ((Date.now() - started) / 1000).toFixed(1);
         if (code === 0) {
           completed++;
-          console.log(`${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`);
+          console.log(
+            `${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`,
+          );
         } else {
           failed++;
-          console.log(`${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`);
+          console.log(
+            `${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`,
+          );
         }
         resolve();
       });
@@ -285,13 +357,19 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
   const timers = [];
   const shutdown = createShutdownController({
     childTracker: children,
-    clearTimers: () => { for (const timer of timers) clearInterval(timer); },
+    clearTimers: () => {
+      for (const timer of timers) clearInterval(timer);
+    },
     setTitle,
     getCounts: () => ({ completed, failed }),
     getRunningNames: () => [...running],
   });
-  process.on("SIGINT", () => { void shutdown("SIGINT"); });
-  process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
+  });
 
   // Startup backstop: the reaper matters most at exactly the moment the factory
   // comes back up — agents crash while the supervisor is down, and their stale
@@ -306,10 +384,18 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
     const ageMin = last === null ? Infinity : (Date.now() - last) / 60_000;
     if (ageMin > REAPER_BACKSTOP_MIN) {
       const ageStr = last === null ? "never" : `${Math.round(ageMin)}m ago`;
-      console.log(`${c.dim(clock())} ${c.yellow("reaper")} last ran ${ageStr} — backstop ${APPLY ? "apply" : "dry"} pass first`);
-      const { code, out } = await probe(`bun orchestrator/reaper.mjs${APPLY ? " --apply" : ""}`);
-      for (const line of out.split("\n")) if (line.trim()) console.log(c.dim(`  │ ${line}`));
-      if (code !== 0) console.log(`${c.dim(clock())} ${c.red("reaper backstop failed")} ${c.dim(`exit ${code}`)}`);
+      console.log(
+        `${c.dim(clock())} ${c.yellow("reaper")} last ran ${ageStr} — backstop ${APPLY ? "apply" : "dry"} pass first`,
+      );
+      const { code, out } = await probe(
+        `bun orchestrator/reaper.mjs${APPLY ? " --apply" : ""}`,
+      );
+      for (const line of out.split("\n"))
+        if (line.trim()) console.log(c.dim(`  │ ${line}`));
+      if (code !== 0)
+        console.log(
+          `${c.dim(clock())} ${c.red("reaper backstop failed")} ${c.dim(`exit ${code}`)}`,
+        );
     }
   }
 
@@ -320,7 +406,9 @@ ${c.dim("not this supervisor — see deploy/gen.mjs.")}
 
   if (ONCE) {
     await firstPass;
-    console.log(`\n${c.bold("one pass complete.")} ${completed} ok, ${failed} failed.`);
+    console.log(
+      `\n${c.bold("one pass complete.")} ${completed} ok, ${failed} failed.`,
+    );
     return failed ? 1 : 0;
   }
 

--- a/orchestrator/run.test.mjs
+++ b/orchestrator/run.test.mjs
@@ -18,14 +18,23 @@ function shutdownHarness(childTracker, overrides = {}) {
   let timersCleared = 0;
   const shutdown = createShutdownController({
     childTracker,
-    clearTimers: () => { timersCleared++; },
+    clearTimers: () => {
+      timersCleared++;
+    },
     getCounts: () => ({ completed: 2, failed: 0 }),
     getRunningNames: () => ["dispatch"],
     log: (message) => logs.push(message),
     exit: (code) => exits.push(code),
     ...overrides,
   });
-  return { shutdown, exits, logs, get timersCleared() { return timersCleared; } };
+  return {
+    shutdown,
+    exits,
+    logs,
+    get timersCleared() {
+      return timersCleared;
+    },
+  };
 }
 
 test("active child processes are tracked and removed when they close", async () => {
@@ -80,14 +89,18 @@ test("shutdown stops waiting at its deadline", async () => {
 
   expect(result).toEqual({ forced: false, drained: false });
   expect(harness.exits).toEqual([0]);
-  expect(harness.logs.some((line) => line.includes("deadline reached"))).toBe(true);
+  expect(harness.logs.some((line) => line.includes("deadline reached"))).toBe(
+    true,
+  );
 });
 
 test("a second interrupt exits immediately with code 130", async () => {
   let terminateCalls = 0;
   const childTracker = {
     size: 1,
-    terminateAll: () => { terminateCalls++; },
+    terminateAll: () => {
+      terminateCalls++;
+    },
     waitForEmpty: () => new Promise(() => {}),
   };
   const harness = shutdownHarness(childTracker);

--- a/orchestrator/state.mjs
+++ b/orchestrator/state.mjs
@@ -26,13 +26,18 @@ import { recommendNext } from "../lib/next-recommend.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
 const has = (f) => argv.includes(f);
 
 if (has("record")) {
   const type = val("--type");
   if (!type) {
-    console.error("record requires --type (start|complete|recommend|friction|session-start|session-end)");
+    console.error(
+      "record requires --type (start|complete|recommend|friction|session-start|session-end)",
+    );
     process.exit(2);
   }
   const repo = val("--repo");
@@ -40,7 +45,10 @@ if (has("record")) {
     console.error("record requires --repo");
     process.exit(2);
   }
-  const issues = (val("--issues") || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const issues = (val("--issues") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
   const row = appendEvent({
     type,
     repo,
@@ -61,11 +69,15 @@ if (has("record")) {
   process.exit(0);
 }
 
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 const JSON_OUT = has("--json");
 const sinceArg = val("--since");
 const sinceMs = sinceArg
-  ? Date.now() - (/\d+d$/.test(sinceArg) ? Number(sinceArg) * 86_400_000 : Number(sinceArg))
+  ? Date.now() -
+    (/\d+d$/.test(sinceArg) ? Number(sinceArg) * 86_400_000 : Number(sinceArg))
   : Date.now() - 7 * 86_400_000;
 const NO_LIVE = has("--no-live");
 
@@ -90,7 +102,7 @@ if (!NO_LIVE) {
       const plan = recommendNext(s);
       const slash = plan.command
         ? `/factory-${String(plan.command).replace(/^factory-/, "")}${plan.args ? ` ${plan.args}` : ""}`
-        : plan.exec ?? "(wait)";
+        : (plan.exec ?? "(wait)");
       liveNext = {
         slash,
         reason: plan.reason,
@@ -103,12 +115,14 @@ if (!NO_LIVE) {
 
 const output = {
   repo: repoName,
-  session: session ? {
-    id: session.id,
-    harness: session.harness,
-    ageMs: Date.now() - session.startedAt,
-    events: session.events.length,
-  } : null,
+  session: session
+    ? {
+        id: session.id,
+        harness: session.harness,
+        ageMs: Date.now() - session.startedAt,
+        events: session.events.length,
+      }
+    : null,
   timeline: (session?.events ?? events.slice(-20)).map((e) => ({
     ts: e.ts,
     type: e.type,
@@ -119,7 +133,8 @@ const output = {
   recentSessions: recentSessions.map((s) => ({
     id: s.id,
     harness: s.harness,
-    stages: s.events.filter((e) => e.type === "start" || e.type === "complete").length,
+    stages: s.events.filter((e) => e.type === "start" || e.type === "complete")
+      .length,
     lastAt: s.lastAt,
   })),
   liveNext,
@@ -141,11 +156,15 @@ console.log(c.bold(`\nfactory state — ${repoName}\n`));
 
 if (session) {
   const age = formatDuration(Date.now() - session.startedAt);
-  console.log(`Session  ${session.id}  ${c.green("active")}, ${age}, harness: ${session.harness}`);
+  console.log(
+    `Session  ${session.id}  ${c.green("active")}, ${age}, harness: ${session.harness}`,
+  );
   for (const e of session.events.slice(-12)) {
     console.log(`  ${formatClock(e.ts)}  ${eventLabel(e)}`);
-    if (e.reason && e.type === "recommend") console.log(c.dim(`           ${e.reason}`));
-    if (e.summary && e.type === "complete") console.log(c.dim(`           ${e.summary}`));
+    if (e.reason && e.type === "recommend")
+      console.log(c.dim(`           ${e.reason}`));
+    if (e.summary && e.type === "complete")
+      console.log(c.dim(`           ${e.summary}`));
   }
 } else {
   console.log(c.dim("No active session (idle > 4h or none recorded)."));
@@ -162,11 +181,20 @@ if (liveNext) {
   console.log(c.bold("\nNext now:"));
   console.log(`  ${c.green(liveNext.slash)}`);
   console.log(c.dim(`  ${liveNext.reason}`));
-  if (liveNext.constraint) console.log(c.dim(`  constraint: ${liveNext.constraint}`));
+  if (liveNext.constraint)
+    console.log(c.dim(`  constraint: ${liveNext.constraint}`));
 } else if (!NO_LIVE) {
   console.log(c.dim("\nNext: (could not compute — check queue/network)"));
 }
 
 const stageCount = events.filter((e) => e.type === "complete").length;
-console.log(c.dim(`\nSince ${Math.round((Date.now() - sinceMs) / 86_400_000)}d: ${recentSessions.length} session(s), ${stageCount} completed stage(s)`));
-console.log(c.dim(`Record: bun orchestrator/state.mjs record --type complete --repo ${repoName} --command ... --summary "..."\n`));
+console.log(
+  c.dim(
+    `\nSince ${Math.round((Date.now() - sinceMs) / 86_400_000)}d: ${recentSessions.length} session(s), ${stageCount} completed stage(s)`,
+  ),
+);
+console.log(
+  c.dim(
+    `Record: bun orchestrator/state.mjs record --type complete --repo ${repoName} --command ... --summary "..."\n`,
+  ),
+);

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -15,11 +15,19 @@ import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
 import { loadQueueConfig, fetchQueueSummaries } from "../lib/queue-summary.mjs";
 import { recommendNext } from "../lib/next-recommend.mjs";
-import { formatAge, deployedRevision, deploymentState, metadataUrl } from "../lib/repo-status.mjs";
+import {
+  formatAge,
+  deployedRevision,
+  deploymentState,
+  metadataUrl,
+} from "../lib/repo-status.mjs";
 import { latestReaperRunMs } from "./reaper.mjs";
 
 const argv = process.argv.slice(2);
-const val = (flag) => { const i = argv.indexOf(flag); return i === -1 ? null : argv[i + 1]; };
+const val = (flag) => {
+  const i = argv.indexOf(flag);
+  return i === -1 ? null : argv[i + 1];
+};
 const JSON_OUT = argv.includes("--json");
 const explicitRepo = val("--repo");
 const c = {
@@ -30,10 +38,19 @@ const c = {
   red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
 const expand = (p) => p?.replace(/^~/, homedir());
-const quoteArg = (value) => `"${String(value).replace(/"/g, "\\\"")}"`;
+const quoteArg = (value) => `"${String(value).replace(/"/g, '\\"')}"`;
 const sh = (args, cwd) => {
-  const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
-  return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+  const result = Bun.spawnSync({
+    cmd: args,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    ok: result.exitCode === 0,
+    out: result.stdout.toString().trim(),
+    err: result.stderr.toString().trim(),
+  };
 };
 
 function normalizeGitRemote(raw) {
@@ -46,19 +63,29 @@ function normalizeGitRemote(raw) {
 }
 
 function gitRemote(cwd) {
-  return normalizeGitRemote(sh(["git", "config", "--get", "remote.origin.url"], cwd).out);
+  return normalizeGitRemote(
+    sh(["git", "config", "--get", "remote.origin.url"], cwd).out,
+  );
 }
 
-function checkoutMatchesRepo(repo, checkoutRoot, fallbackRemote = gitRemote(checkoutRoot)) {
+function checkoutMatchesRepo(
+  repo,
+  checkoutRoot,
+  fallbackRemote = gitRemote(checkoutRoot),
+) {
   const roots = [repo.path, repo.worktree_root].map(expand).filter(Boolean);
-  const byPath = roots.some((root) => checkoutRoot === root || checkoutRoot.startsWith(`${root}/`));
+  const byPath = roots.some(
+    (root) => checkoutRoot === root || checkoutRoot.startsWith(`${root}/`),
+  );
   if (byPath) return true;
   if (!fallbackRemote || !repo.github) return false;
   return normalizeGitRemote(repo.github) === fallbackRemote;
 }
 
 function configuredRepo() {
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
   const repos = cfg.repos ?? [];
 
   if (explicitRepo) {
@@ -97,12 +124,19 @@ function recommendedCommand(plan, repoName) {
   if (!plan || typeof plan !== "object") return null;
   if (plan.exec) return plan.exec;
 
-  if (plan.command === "tick") return `bun orchestrator/tick.mjs --repo ${quoteArg(repoName)} --apply`;
-  if (plan.command === "reconcile") return `bun orchestrator/reconcile.mjs --repo ${quoteArg(repoName)} --apply`;
-  if (plan.command === "digest") return `bun orchestrator/digest.mjs --repo ${quoteArg(repoName)}`;
+  if (plan.command === "tick")
+    return `bun orchestrator/tick.mjs --repo ${quoteArg(repoName)} --apply`;
+  if (plan.command === "reconcile")
+    return `bun orchestrator/reconcile.mjs --repo ${quoteArg(repoName)} --apply`;
+  if (plan.command === "digest")
+    return `bun orchestrator/digest.mjs --repo ${quoteArg(repoName)}`;
   if (plan.command?.startsWith("factory-")) {
     const args = plan.args ? ` --args ${quoteArg(plan.args)}` : "";
-    const readOnly = new Set(["factory-triage", "factory-unblock", "factory-sweep"]).has(plan.command);
+    const readOnly = new Set([
+      "factory-triage",
+      "factory-unblock",
+      "factory-sweep",
+    ]).has(plan.command);
     const readOnlyFlag = readOnly ? " --read-only" : "";
     return `factory run --repo ${quoteArg(repoName)} --command ${plan.command}${args}${readOnlyFlag}`.trim();
   }
@@ -111,68 +145,151 @@ function recommendedCommand(plan, repoName) {
 
 function factoryQueueAvailability(config) {
   if (config.report_only) return "report-only repository";
-  if (!config.team || !config.project) return "missing linear team/project configuration";
+  if (!config.team || !config.project)
+    return "missing linear team/project configuration";
   return null;
 }
 
 // Resolve before doing network work so an unmapped cwd fails with an actionable message.
 const repoConfig = configuredRepo();
 if (!repoConfig) {
-  const names = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8")).repos?.map((r) => r.name).join(", ") ?? "";
-  console.error(`no configured repository for cwd${explicitRepo ? ` --repo ${explicitRepo}` : ""} — pass --repo <name>`);
+  const names =
+    Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"))
+      .repos?.map((r) => r.name)
+      .join(", ") ?? "";
+  console.error(
+    `no configured repository for cwd${explicitRepo ? ` --repo ${explicitRepo}` : ""} — pass --repo <name>`,
+  );
   if (!explicitRepo && names) console.error(`known repositories: ${names}`);
   process.exit(2);
 }
 const configuredPath = expand(repoConfig.path);
 const cwdTop = sh(["git", "rev-parse", "--show-toplevel"], process.cwd()).out;
-const repoPath = cwdTop && checkoutMatchesRepo(repoConfig, cwdTop, gitRemote(cwdTop)) ? cwdTop : configuredPath;
+const repoPath =
+  cwdTop && checkoutMatchesRepo(repoConfig, cwdTop, gitRemote(cwdTop))
+    ? cwdTop
+    : configuredPath;
 if (!existsSync(repoPath)) {
   console.error(`configured path does not exist: ${repoPath}`);
   process.exit(2);
 }
 
-const deployBranch = repoConfig.deploy_branch ?? (repoConfig.base === "main" ? "main" : "master");
+const deployBranch =
+  repoConfig.deploy_branch ?? (repoConfig.base === "main" ? "main" : "master");
 const baseBranch = repoConfig.base;
 const metadataBranch = repoConfig.deployment?.branch ?? deployBranch;
-const fetchResult = sh(["git", "fetch", "--quiet", "origin", ...new Set([baseBranch, deployBranch, metadataBranch])], repoPath);
-const branch = sh(["git", "branch", "--show-current"], repoPath).out || "(detached)";
+const fetchResult = sh(
+  [
+    "git",
+    "fetch",
+    "--quiet",
+    "origin",
+    ...new Set([baseBranch, deployBranch, metadataBranch]),
+  ],
+  repoPath,
+);
+const branch =
+  sh(["git", "branch", "--show-current"], repoPath).out || "(detached)";
 const head = sh(["git", "rev-parse", "HEAD"], repoPath).out || null;
-const dirty = sh(["git", "status", "--porcelain"], repoPath).out.split("\n").filter(Boolean);
+const dirty = sh(["git", "status", "--porcelain"], repoPath)
+  .out.split("\n")
+  .filter(Boolean);
 
 function remoteRef(name) {
   // Cached origin refs are not trustworthy when refresh failed: reporting a
   // stale deployment as current is worse than reporting it unknown.
-  if (!fetchResult.ok) return { branch: name, sha: null, checkoutAhead: null, checkoutBehind: null };
+  if (!fetchResult.ok)
+    return {
+      branch: name,
+      sha: null,
+      checkoutAhead: null,
+      checkoutBehind: null,
+    };
   const sha = sh(["git", "rev-parse", `origin/${name}`], repoPath).out || null;
-  const aheadBehind = head && sha ? sh(["git", "rev-list", "--left-right", "--count", `HEAD...origin/${name}`], repoPath).out.split(/\s+/).map(Number) : [];
-  return { branch: name, sha, checkoutAhead: aheadBehind[0] ?? null, checkoutBehind: aheadBehind[1] ?? null };
+  const aheadBehind =
+    head && sha
+      ? sh(
+          [
+            "git",
+            "rev-list",
+            "--left-right",
+            "--count",
+            `HEAD...origin/${name}`,
+          ],
+          repoPath,
+        )
+          .out.split(/\s+/)
+          .map(Number)
+      : [];
+  return {
+    branch: name,
+    sha,
+    checkoutAhead: aheadBehind[0] ?? null,
+    checkoutBehind: aheadBehind[1] ?? null,
+  };
 }
 const base = remoteRef(baseBranch);
 const deploy = remoteRef(deployBranch);
-const metadataRef = metadataBranch === deployBranch ? deploy : metadataBranch === baseBranch ? base : remoteRef(metadataBranch);
+const metadataRef =
+  metadataBranch === deployBranch
+    ? deploy
+    : metadataBranch === baseBranch
+      ? base
+      : remoteRef(metadataBranch);
 
 let deployment = { configured: false, state: "not configured" };
 if (repoConfig.deployment?.url) {
   const url = metadataUrl(repoConfig.deployment.url);
-  deployment = { configured: true, url, branch: metadataBranch, state: "unknown" };
-  if (!fetchResult.ok) deployment.error = `remote refresh failed: ${fetchResult.err || "unknown error"}`;
+  deployment = {
+    configured: true,
+    url,
+    branch: metadataBranch,
+    state: "unknown",
+  };
+  if (!fetchResult.ok)
+    deployment.error = `remote refresh failed: ${fetchResult.err || "unknown error"}`;
   try {
     if (!fetchResult.ok) throw new Error(deployment.error);
-    const response = await fetch(url, { signal: AbortSignal.timeout(10_000), headers: { accept: "application/json" } });
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10_000),
+      headers: { accept: "application/json" },
+    });
     if (!response.ok) {
       deployment.error = `HTTP ${response.status}`;
     } else {
       const payload = await response.json();
-      const revision = deployedRevision(payload, repoConfig.deployment.revision_field);
+      const revision = deployedRevision(
+        payload,
+        repoConfig.deployment.revision_field,
+      );
       deployment.payload = payload;
       deployment.revision = revision?.value ?? null;
       deployment.revisionField = revision?.field ?? null;
-      const contains = revision?.value && metadataRef.sha
-        ? sh(["git", "merge-base", "--is-ancestor", revision.value, `origin/${metadataBranch}`], repoPath).ok
-        : null;
-      Object.assign(deployment, deploymentState({ deployed: revision?.value, remoteSha: metadataRef.sha, localContains: contains }));
+      const contains =
+        revision?.value && metadataRef.sha
+          ? sh(
+              [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                revision.value,
+                `origin/${metadataBranch}`,
+              ],
+              repoPath,
+            ).ok
+          : null;
+      Object.assign(
+        deployment,
+        deploymentState({
+          deployed: revision?.value,
+          remoteSha: metadataRef.sha,
+          localContains: contains,
+        }),
+      );
     }
-  } catch (error) { deployment.error = error.message; }
+  } catch (error) {
+    deployment.error = error.message;
+  }
 }
 
 function latestJanitorRunMs(repo) {
@@ -180,16 +297,25 @@ function latestJanitorRunMs(repo) {
   let latest = null;
   try {
     for (const name of readdirSync(dir)) {
-      if (!new RegExp(`^janitor-${repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d{8}-\\d{6}\\.log$`).test(name)) continue;
+      if (
+        !new RegExp(
+          `^janitor-${repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d{8}-\\d{6}\\.log$`,
+        ).test(name)
+      )
+        continue;
       const at = statSync(path.join(dir, name)).mtimeMs;
       if (latest === null || at > latest) latest = at;
     }
-  } catch { /* no logs yet */ }
+  } catch {
+    /* no logs yet */
+  }
   return latest;
 }
 
 const { repos, defaultCap } = loadQueueConfig([repoConfig.name]);
-let queue = null, next = null, queueError = null;
+let queue = null,
+  next = null,
+  queueError = null;
 const queueUnavailable = factoryQueueAvailability(repoConfig);
 if (!queueUnavailable) {
   try {
@@ -210,12 +336,27 @@ const output = {
   fetch: fetchResult.ok ? null : fetchResult.err,
   branches: { base, deploy },
   deployment,
-  maintenance: { reaperLastRun: latestReaperRunMs(), janitorLastRun: latestJanitorRunMs(repoConfig.name) },
+  maintenance: {
+    reaperLastRun: latestReaperRunMs(),
+    janitorLastRun: latestJanitorRunMs(repoConfig.name),
+  },
   factory: queueUnavailable
-    ? { available: false, reason: queueUnavailable, queue: null, next: null, error: null }
+    ? {
+        available: false,
+        reason: queueUnavailable,
+        queue: null,
+        next: null,
+        error: null,
+      }
     : queue
       ? { available: true, queue, next }
-      : { available: false, reason: queueError ?? "unknown error", queue: null, next: null, error: queueError },
+      : {
+          available: false,
+          reason: queueError ?? "unknown error",
+          queue: null,
+          next: null,
+          error: queueError,
+        },
 };
 
 if (JSON_OUT) {
@@ -224,29 +365,59 @@ if (JSON_OUT) {
 }
 
 console.log(c.bold(`\nfactory status — ${repoConfig.name}`));
-console.log(c.dim(`${repoPath}${repoConfig.report_only ? "  · report-only" : ""}`));
-console.log(`\nCheckout   ${branch}  ${(head ?? "unknown").slice(0, 12)}  ${dirty.length ? c.yellow(`${dirty.length} changed file(s)`) : c.green("clean")}`);
-for (const [label, ref] of [["Base", base], ["Deploy", deploy]]) {
-  const delta = ref.checkoutAhead == null ? "unavailable" : `checkout +${ref.checkoutAhead}/-${ref.checkoutBehind}`;
-  console.log(`${label.padEnd(10)} origin/${ref.branch}  ${(ref.sha ?? "unavailable").slice(0, 12)}  ${c.dim(delta)}`);
+console.log(
+  c.dim(`${repoPath}${repoConfig.report_only ? "  · report-only" : ""}`),
+);
+console.log(
+  `\nCheckout   ${branch}  ${(head ?? "unknown").slice(0, 12)}  ${dirty.length ? c.yellow(`${dirty.length} changed file(s)`) : c.green("clean")}`,
+);
+for (const [label, ref] of [
+  ["Base", base],
+  ["Deploy", deploy],
+]) {
+  const delta =
+    ref.checkoutAhead == null
+      ? "unavailable"
+      : `checkout +${ref.checkoutAhead}/-${ref.checkoutBehind}`;
+  console.log(
+    `${label.padEnd(10)} origin/${ref.branch}  ${(ref.sha ?? "unavailable").slice(0, 12)}  ${c.dim(delta)}`,
+  );
 }
-console.log(`\nDeployment ${deployment.configured ? deployment.url : c.dim("not configured")}`);
+console.log(
+  `\nDeployment ${deployment.configured ? deployment.url : c.dim("not configured")}`,
+);
 if (deployment.configured) {
   console.log(c.dim(`  comparing with origin/${deployment.branch}`));
-  if (deployment.revision) console.log(`  ${deployment.revisionField}  ${deployment.revision.slice(0, 12)}`);
-  const color = deployment.state === "current" ? c.green : ["stale", "diverged", "different"].includes(deployment.state) ? c.yellow : c.red;
-  console.log(`  ${color(deployment.state)} — ${deployment.message ?? deployment.error ?? "could not fetch endpoint"}`);
+  if (deployment.revision)
+    console.log(
+      `  ${deployment.revisionField}  ${deployment.revision.slice(0, 12)}`,
+    );
+  const color =
+    deployment.state === "current"
+      ? c.green
+      : ["stale", "diverged", "different"].includes(deployment.state)
+        ? c.yellow
+        : c.red;
+  console.log(
+    `  ${color(deployment.state)} — ${deployment.message ?? deployment.error ?? "could not fetch endpoint"}`,
+  );
 }
 
 const factoryStatus = output.factory;
-console.log(`\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`);
+console.log(
+  `\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`,
+);
 console.log(c.bold("\nFactory now:"));
 
 if (!factoryStatus.available) {
   console.log(c.red(`  queue unavailable — ${factoryStatus.reason}`));
 } else if (queue) {
-  console.log(`  Triage ${queue.triageState} · Todo ${queue.todoNotReady} · Ready ${queue.ready} · In progress ${queue.inProgress} · Review ${queue.inReview} · Blocked ${queue.blocked}`);
-  const command = next.command ? `${next.command}${next.args ? ` ${next.args}` : ""}` : "(wait)";
+  console.log(
+    `  Triage ${queue.triageState} · Todo ${queue.todoNotReady} · Ready ${queue.ready} · In progress ${queue.inProgress} · Review ${queue.inReview} · Blocked ${queue.blocked}`,
+  );
+  const command = next.command
+    ? `${next.command}${next.args ? ` ${next.args}` : ""}`
+    : "(wait)";
   console.log(`  Next ${c.green(command)} — ${next.reason}`);
 
   const suggested = recommendedCommand(next, repoConfig.name);
@@ -255,17 +426,26 @@ if (!factoryStatus.available) {
     console.log(`  ${c.green(suggested)} — ${next.reason}.`);
   } else {
     const waitExplanation = {
-      capacity: "Workers are already at capacity; let an active ticket finish before dispatching another.",
-      "path collision": "Ready tickets overlap paths with active work; wait rather than create a conflicting worktree.",
-      report_only: "This repository is intentionally report-only until its safe worktree lifecycle exists.",
+      capacity:
+        "Workers are already at capacity; let an active ticket finish before dispatching another.",
+      "path collision":
+        "Ready tickets overlap paths with active work; wait rather than create a conflicting worktree.",
+      report_only:
+        "This repository is intentionally report-only until its safe worktree lifecycle exists.",
       idle: "No ticket needs action right now; re-run after a branch, deploy, or ticket changes.",
     };
-    const alternate = waitExplanation[next?.constraint] ?? "No safe factory command is applicable yet; re-run after the state changes.";
+    const alternate =
+      waitExplanation[next?.constraint] ??
+      "No safe factory command is applicable yet; re-run after the state changes.";
     console.log(`  ${c.dim(alternate)}`);
   }
 } else {
   console.log(c.red(`  queue unavailable — ${queueError ?? "unknown error"}`));
 }
 
-console.log(c.dim("  `factory status --json` is available for scripts; this view is the human-facing hub."));
+console.log(
+  c.dim(
+    "  `factory status --json` is available for scripts; this view is the human-facing hub.",
+  ),
+);
 console.log();

--- a/orchestrator/stuck.mjs
+++ b/orchestrator/stuck.mjs
@@ -28,19 +28,38 @@ import { parseOwnedPaths } from "./owned-paths.mjs";
 import { AI_BLOCKED, answeredHeldTickets } from "./reply-detection.mjs";
 
 const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const val = (f) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? null : argv[i + 1];
+};
+const only = (val("--repo") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 const JSON_OUT = argv.includes("--json");
-const STALE_MIN = 45;   // matches reaper.mjs's default claim-silence threshold
-const QUIET_MIN = 25;   // matches reconcile.mjs's default
+const STALE_MIN = 45; // matches reaper.mjs's default claim-silence threshold
+const QUIET_MIN = 25; // matches reconcile.mjs's default
 
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
-if (!repos.length) { console.error(only.length ? `no repo named "${only}" in config/repos.yaml` : "no repos configured"); process.exit(2); }
+const cfg = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+);
+const repos = (cfg.repos ?? []).filter(
+  (r) => !only.length || only.includes(r.name),
+);
+if (!repos.length) {
+  console.error(
+    only.length
+      ? `no repo named "${only}" in config/repos.yaml`
+      : "no repos configured",
+  );
+  process.exit(2);
+}
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
   yellow: (s) => `\x1b[33m${s}\x1b[0m`,
 };
 
@@ -66,7 +85,10 @@ const QUERY = `
 function supervisorAlive(name) {
   const p = Bun.spawnSync(["ps", "-eo", "command"]);
   if (p.exitCode !== 0) return null; // unknown, not "no" — never assert a false negative from a broken `ps`
-  const lines = p.stdout.toString().split("\n").filter((l) => l.includes("run.mjs") && l.includes("--repo"));
+  const lines = p.stdout
+    .toString()
+    .split("\n")
+    .filter((l) => l.includes("run.mjs") && l.includes("--repo"));
   return lines.some((l) => {
     const m = /--repo\s+(\S+)/.exec(l);
     return m && m[1].split(",").includes(name);
@@ -75,13 +97,32 @@ function supervisorAlive(name) {
 
 /** Open, non-draft PR numbers for a repo, via `gh` — [] on any failure. */
 function openPRs(nameWithOwner) {
-  const p = Bun.spawnSync(["gh", "pr", "list", "--repo", nameWithOwner, "--state", "open", "--json", "number,isDraft"]);
+  const p = Bun.spawnSync([
+    "gh",
+    "pr",
+    "list",
+    "--repo",
+    nameWithOwner,
+    "--state",
+    "open",
+    "--json",
+    "number,isDraft",
+  ]);
   if (p.exitCode !== 0) return [];
-  try { return JSON.parse(p.stdout.toString()).filter((pr) => !pr.isDraft).map((pr) => pr.number); } catch { return []; }
+  try {
+    return JSON.parse(p.stdout.toString())
+      .filter((pr) => !pr.isDraft)
+      .map((pr) => pr.number);
+  } catch {
+    return [];
+  }
 }
 
 function prNumbersOnIssue(issue, nameWithOwner) {
-  const re = new RegExp(`github\\.com/${nameWithOwner.replace("/", "\\/")}/pull/(\\d+)`, "i");
+  const re = new RegExp(
+    `github\\.com/${nameWithOwner.replace("/", "\\/")}/pull/(\\d+)`,
+    "i",
+  );
   const out = new Set();
   for (const a of issue.attachments?.nodes ?? []) {
     const m = re.exec(a.url ?? "");
@@ -90,21 +131,38 @@ function prNumbersOnIssue(issue, nameWithOwner) {
   return [...out];
 }
 
-const rows = [];   // one per repo, for the summary table
+const rows = []; // one per repo, for the summary table
 const details = []; // { repo, category, severity, items: [{id, title, why}] }
 
 for (const repo of repos) {
   const labels = (i) => (i.labels?.nodes ?? []).map((l) => l.name);
   const state = (i) => i.state?.name ?? "?";
 
-  const nodes = (await gql(QUERY, { team: repo.team, project: repo.project }))?.issues?.nodes ?? [];
+  const nodes =
+    (await gql(QUERY, { team: repo.team, project: repo.project }))?.issues
+      ?.nodes ?? [];
 
-  const ready = nodes.filter((i) => state(i) === "Todo" && labels(i).includes("ai:agent-ready") && !i.assignee);
-  const readyUnparseable = ready.filter((i) => parseOwnedPaths(i.description ?? "").length === 0);
+  const ready = nodes.filter(
+    (i) =>
+      state(i) === "Todo" &&
+      labels(i).includes("ai:agent-ready") &&
+      !i.assignee,
+  );
+  const readyUnparseable = ready.filter(
+    (i) => parseOwnedPaths(i.description ?? "").length === 0,
+  );
 
-  const inProgress = nodes.filter((i) => state(i) === "In Progress" && isAgentClaim({ labels: { nodes: (i.labels?.nodes ?? []) } }));
+  const inProgress = nodes.filter(
+    (i) =>
+      state(i) === "In Progress" &&
+      isAgentClaim({ labels: { nodes: i.labels?.nodes ?? [] } }),
+  );
   const staleClaims = inProgress.filter((i) => {
-    const seen = lastActivity({ startedAt: i.startedAt, updatedAt: i.updatedAt, comments: i.comments });
+    const seen = lastActivity({
+      startedAt: i.startedAt,
+      updatedAt: i.updatedAt,
+      comments: i.comments,
+    });
     return seen && (Date.now() - seen.getTime()) / 60000 > STALE_MIN;
   });
 
@@ -114,13 +172,23 @@ for (const repo of repos) {
     orphanedPR = inProgress.filter((i) => {
       const prs = prNumbersOnIssue(i, repo.github).filter((n) => open.has(n));
       if (!prs.length) return false;
-      const seen = lastActivity({ startedAt: i.startedAt, updatedAt: i.updatedAt, comments: i.comments });
+      const seen = lastActivity({
+        startedAt: i.startedAt,
+        updatedAt: i.updatedAt,
+        comments: i.comments,
+      });
       return seen && (Date.now() - seen.getTime()) / 60000 > QUIET_MIN;
     });
   }
 
-  const heldAny = nodes.filter((i) => ["Triage", "Blocked"].includes(state(i)) && labels(i).includes(AI_BLOCKED));
-  const answeredIds = heldAny.length ? await answeredHeldTickets(repo) : new Set();
+  const heldAny = nodes.filter(
+    (i) =>
+      ["Triage", "Blocked"].includes(state(i)) &&
+      labels(i).includes(AI_BLOCKED),
+  );
+  const answeredIds = heldAny.length
+    ? await answeredHeldTickets(repo)
+    : new Set();
   const answeredHolds = nodes.filter((i) => answeredIds.has(i.identifier));
 
   const backlog = nodes.filter((i) => state(i) === "Backlog");
@@ -128,19 +196,88 @@ for (const repo of repos) {
   const alive = repo.report_only ? null : supervisorAlive(repo.name);
 
   const cats = [
-    { key: "no-supervisor", severity: 3, items: (!repo.report_only && alive === false) ? [{ id: "", title: "no `run.mjs --repo " + repo.name + "` process is running", why: "nothing will dispatch, triage, or merge here regardless of what's queued" }] : [] },
-    { key: "report-only-ready", severity: 3, items: repo.report_only ? ready.map((i) => ({ id: i.identifier, title: i.title, why: "repo is report_only — dispatch will never target it" })) : [] },
-    { key: "unparseable-owned-paths", severity: 1, items: readyUnparseable.map((i) => ({ id: i.identifier, title: i.title, why: "ai:agent-ready but Owned Paths parses to zero paths — dispatch treats it as owning everything, so it only starts alone, serialized behind whatever's already running" })) },
-    { key: "stale-claim", severity: 2, items: staleClaims.map((i) => ({ id: i.identifier, title: i.title, why: `In Progress, no heartbeat in over ${STALE_MIN}m — likely a crashed agent` })) },
-    { key: "orphaned-pr", severity: 2, items: orphanedPR.map((i) => ({ id: i.identifier, title: i.title, why: `open PR but ticket still In Progress and quiet ${QUIET_MIN}m+ — holding a dispatch slot for nothing` })) },
-    { key: "answered-hold", severity: 1, items: answeredHolds.map((i) => ({ id: i.identifier, title: i.title, why: "ai:blocked with a newer reply — ready for the triage sweep to re-examine" })) },
+    {
+      key: "no-supervisor",
+      severity: 3,
+      items:
+        !repo.report_only && alive === false
+          ? [
+              {
+                id: "",
+                title:
+                  "no `run.mjs --repo " + repo.name + "` process is running",
+                why: "nothing will dispatch, triage, or merge here regardless of what's queued",
+              },
+            ]
+          : [],
+    },
+    {
+      key: "report-only-ready",
+      severity: 3,
+      items: repo.report_only
+        ? ready.map((i) => ({
+            id: i.identifier,
+            title: i.title,
+            why: "repo is report_only — dispatch will never target it",
+          }))
+        : [],
+    },
+    {
+      key: "unparseable-owned-paths",
+      severity: 1,
+      items: readyUnparseable.map((i) => ({
+        id: i.identifier,
+        title: i.title,
+        why: "ai:agent-ready but Owned Paths parses to zero paths — dispatch treats it as owning everything, so it only starts alone, serialized behind whatever's already running",
+      })),
+    },
+    {
+      key: "stale-claim",
+      severity: 2,
+      items: staleClaims.map((i) => ({
+        id: i.identifier,
+        title: i.title,
+        why: `In Progress, no heartbeat in over ${STALE_MIN}m — likely a crashed agent`,
+      })),
+    },
+    {
+      key: "orphaned-pr",
+      severity: 2,
+      items: orphanedPR.map((i) => ({
+        id: i.identifier,
+        title: i.title,
+        why: `open PR but ticket still In Progress and quiet ${QUIET_MIN}m+ — holding a dispatch slot for nothing`,
+      })),
+    },
+    {
+      key: "answered-hold",
+      severity: 1,
+      items: answeredHolds.map((i) => ({
+        id: i.identifier,
+        title: i.title,
+        why: "ai:blocked with a newer reply — ready for the triage sweep to re-examine",
+      })),
+    },
   ];
 
-  for (const cat of cats) if (cat.items.length) details.push({ repo: repo.name, category: cat.key, severity: cat.severity, items: cat.items });
+  for (const cat of cats)
+    if (cat.items.length)
+      details.push({
+        repo: repo.name,
+        category: cat.key,
+        severity: cat.severity,
+        items: cat.items,
+      });
 
   rows.push({
     repo: repo.name,
-    supervisor: repo.report_only ? "n/a" : alive === null ? "?" : alive ? "up" : "DOWN",
+    supervisor: repo.report_only
+      ? "n/a"
+      : alive === null
+        ? "?"
+        : alive
+          ? "up"
+          : "DOWN",
     noSupervisor: cats[0].items.length,
     reportOnlyReady: cats[1].items.length,
     unparseable: cats[2].items.length,
@@ -157,18 +294,32 @@ if (JSON_OUT) {
 }
 
 console.log(c.bold("\nstuck, by repo") + c.dim("  (0 cells omitted)\n"));
-const COLS = [["repo", 12], ["loop", 7], ["parse", 7], ["stale", 7], ["orphan", 7], ["answrd", 7], ["backlog", 7]];
+const COLS = [
+  ["repo", 12],
+  ["loop", 7],
+  ["parse", 7],
+  ["stale", 7],
+  ["orphan", 7],
+  ["answrd", 7],
+  ["backlog", 7],
+];
 console.log("  " + COLS.map(([h, w]) => h.padEnd(w)).join(""));
 for (const r of rows) {
-  const pad = (s, w, colorFn = (x) => x) => colorFn(s) + " ".repeat(Math.max(0, w - s.length));
+  const pad = (s, w, colorFn = (x) => x) =>
+    colorFn(s) + " ".repeat(Math.max(0, w - s.length));
   const cellN = (n, w) => pad(n ? String(n) : "-", w, n ? c.yellow : c.dim);
   const loopText = r.supervisor === "DOWN" ? "DOWN" : r.supervisor;
-  const loopColor = r.supervisor === "DOWN" ? c.red : r.supervisor === "n/a" ? c.dim : c.green;
+  const loopColor =
+    r.supervisor === "DOWN" ? c.red : r.supervisor === "n/a" ? c.dim : c.green;
   console.log(
-    "  " + pad(r.repo, 12) +
-    pad(loopText, 7, loopColor) +
-    cellN(r.unparseable, 7) + cellN(r.staleClaims, 7) + cellN(r.orphanedPR, 7) + cellN(r.answeredHolds, 7) +
-    pad(r.backlogParked ? String(r.backlogParked) : "-", 7, c.dim)
+    "  " +
+      pad(r.repo, 12) +
+      pad(loopText, 7, loopColor) +
+      cellN(r.unparseable, 7) +
+      cellN(r.staleClaims, 7) +
+      cellN(r.orphanedPR, 7) +
+      cellN(r.answeredHolds, 7) +
+      pad(r.backlogParked ? String(r.backlogParked) : "-", 7, c.dim),
   );
 }
 
@@ -185,17 +336,23 @@ const LABELS = {
 const MAX_SHOWN = 6;
 
 if (!bySeverity.length) {
-  console.log(c.dim("\nnothing stuck — every ready/in-progress/held ticket is moving normally.\n"));
+  console.log(
+    c.dim(
+      "\nnothing stuck — every ready/in-progress/held ticket is moving normally.\n",
+    ),
+  );
 } else {
   for (const d of bySeverity) {
-    const tone = d.severity === 3 ? c.red : d.severity === 2 ? c.yellow : (s) => s;
+    const tone =
+      d.severity === 3 ? c.red : d.severity === 2 ? c.yellow : (s) => s;
     console.log(`\n${c.bold(d.repo)}  ${tone(LABELS[d.category])}`);
     console.log(c.dim(`  ${d.items[0].why}`));
     for (const it of d.items.slice(0, MAX_SHOWN)) {
       const id = it.id ? it.id.padEnd(10) : "";
       console.log(`    ${id} ${it.title.slice(0, 60)}`);
     }
-    if (d.items.length > MAX_SHOWN) console.log(c.dim(`    … +${d.items.length - MAX_SHOWN} more`));
+    if (d.items.length > MAX_SHOWN)
+      console.log(c.dim(`    … +${d.items.length - MAX_SHOWN} more`));
   }
   console.log();
 }

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -20,17 +20,34 @@
  * *during* the run (triage promoting one, or an agent filing follow-up work)
  * get picked up without waiting for the next supervisor tick.
  */
-import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, createWriteStream } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  existsSync,
+  createWriteStream,
+} from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { gql } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
-import { parseOwnedPaths, effectiveOwnedPaths, pathsCollide } from "./owned-paths.mjs";
+import {
+  parseOwnedPaths,
+  effectiveOwnedPaths,
+  pathsCollide,
+} from "./owned-paths.mjs";
 import { openBlockers, BLOCKING_RELATIONS_GQL } from "./blockers.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
 import { agentLabel } from "../tools/linear.mjs";
-import { LEASE_HEARTBEAT_MS, releaseWorkerLease, renewWorkerLease, writeWorkerLease, liveWorkerLeases } from "../lib/worker-leases.mjs";
+import {
+  LEASE_HEARTBEAT_MS,
+  releaseWorkerLease,
+  renewWorkerLease,
+  writeWorkerLease,
+  liveWorkerLeases,
+} from "../lib/worker-leases.mjs";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export const DISPATCH_FAILURE_THRESHOLD = 3;
@@ -79,8 +96,11 @@ export function countPriorDispatchFailures(comments = []) {
   return count;
 }
 
-export function isRepeatedDispatchFailure(comments = [], threshold = DISPATCH_FAILURE_THRESHOLD) {
-  return (countPriorDispatchFailures(comments) + 1) >= threshold;
+export function isRepeatedDispatchFailure(
+  comments = [],
+  threshold = DISPATCH_FAILURE_THRESHOLD,
+) {
+  return countPriorDispatchFailures(comments) + 1 >= threshold;
 }
 
 export function computeUnclaimAction({
@@ -95,7 +115,13 @@ export function computeUnclaimAction({
 }) {
   const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
   const keep = (issue.labels?.nodes ?? [])
-    .filter((l) => l.name !== "ai:in-progress" && !l.name.startsWith("agent:") && l.name !== "ai:agent-ready" && l.name !== "ai:blocked")
+    .filter(
+      (l) =>
+        l.name !== "ai:in-progress" &&
+        !l.name.startsWith("agent:") &&
+        l.name !== "ai:agent-ready" &&
+        l.name !== "ai:blocked",
+    )
     .map((l) => l.id);
 
   const priorFailures = countPriorDispatchFailures(issue.comments?.nodes ?? []);
@@ -131,16 +157,24 @@ export function computeUnclaimAction({
 }
 
 export function preserveWip(wt, ticketIdentifier) {
-  if (!wt || !existsSync(wt)) return { preserved: false, reason: "no_worktree" };
+  if (!wt || !existsSync(wt))
+    return { preserved: false, reason: "no_worktree" };
   try {
-    const status = spawnSync("git", ["status", "--porcelain"], { cwd: wt, encoding: "utf8" });
-    if (status.status !== 0) return { preserved: false, reason: "git_error", error: status.stderr };
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: wt,
+      encoding: "utf8",
+    });
+    if (status.status !== 0)
+      return { preserved: false, reason: "git_error", error: status.stderr };
     const dirty = (status.stdout || "").trim();
     if (!dirty) return { preserved: false, reason: "clean" };
 
     const add = spawnSync("git", ["add", "-A"], { cwd: wt, encoding: "utf8" });
     if (add.status !== 0) {
-      const diff = spawnSync("git", ["diff", "HEAD"], { cwd: wt, encoding: "utf8" });
+      const diff = spawnSync("git", ["diff", "HEAD"], {
+        cwd: wt,
+        encoding: "utf8",
+      });
       if (diff.stdout) {
         const patchPath = path.join(tmpdir(), `${ticketIdentifier}-wip.patch`);
         writeFileSync(patchPath, diff.stdout);
@@ -150,14 +184,23 @@ export function preserveWip(wt, ticketIdentifier) {
     }
 
     const commitMsg = `wip: ${ticketIdentifier} uncommitted progress`;
-    const commit = spawnSync("git", ["commit", "-m", commitMsg], { cwd: wt, encoding: "utf8" });
+    const commit = spawnSync("git", ["commit", "-m", commitMsg], {
+      cwd: wt,
+      encoding: "utf8",
+    });
     if (commit.status === 0) {
-      const rev = spawnSync("git", ["rev-parse", "HEAD"], { cwd: wt, encoding: "utf8" });
+      const rev = spawnSync("git", ["rev-parse", "HEAD"], {
+        cwd: wt,
+        encoding: "utf8",
+      });
       const hash = (rev.stdout || "").trim();
       return { preserved: true, method: "commit", hash, message: commitMsg };
     }
 
-    const diff = spawnSync("git", ["diff", "--cached"], { cwd: wt, encoding: "utf8" });
+    const diff = spawnSync("git", ["diff", "--cached"], {
+      cwd: wt,
+      encoding: "utf8",
+    });
     if (diff.stdout) {
       const patchPath = path.join(tmpdir(), `${ticketIdentifier}-wip.patch`);
       writeFileSync(patchPath, diff.stdout);
@@ -211,674 +254,1072 @@ export function acquireClaimLock(
       const fields = raw.trim().split(/\s+/);
       const pid = Number(fields[0]);
       const at = Number(fields[1]);
-      const valid = fields.length === 2
-        && Number.isInteger(pid)
-        && pid > 0
-        && Number.isFinite(at);
+      const valid =
+        fields.length === 2 &&
+        Number.isInteger(pid) &&
+        pid > 0 &&
+        Number.isFinite(at);
       const alive = valid && isProcessAlive(pid);
       if (alive && now() - at < 120_000) return false;
 
       onStale(valid ? pid : null);
-      try { unlinkSync(lock); } catch { /* intentionally ignored */ }
+      try {
+        unlinkSync(lock);
+      } catch {
+        /* intentionally ignored */
+      }
     }
   }
   return false;
 }
 
 export async function main(argv = process.argv.slice(2)) {
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const APPLY = argv.includes("--apply");
-const REFILL = !argv.includes("--no-refill");
-const MAX = Number(val("--max") ?? 0) || Infinity;
-const ONE = val("--ticket");
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const APPLY = argv.includes("--apply");
+  const REFILL = !argv.includes("--no-refill");
+  const MAX = Number(val("--max") ?? 0) || Infinity;
+  const ONE = val("--ticket");
 
-const expand = (p) => String(p ?? "").replace(/^~/, homedir());
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
-const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
-if (!repo) { console.error(`--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`); process.exit(2); }
-if (repo.report_only) { console.error(`${repo.name} is report_only — no worktree tooling, dispatch is unsafe here`); process.exit(2); }
+  const expand = (p) => String(p ?? "").replace(/^~/, homedir());
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const policy = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"),
+  );
+  const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
+  if (!repo) {
+    console.error(
+      `--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`,
+    );
+    process.exit(2);
+  }
+  if (repo.report_only) {
+    console.error(
+      `${repo.name} is report_only — no worktree tooling, dispatch is unsafe here`,
+    );
+    process.exit(2);
+  }
 
-const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`, cyan: (s) => `\x1b[36m${s}\x1b[0m`,
-};
-const clock = () => new Date().toTimeString().slice(0, 8);
-const repoPath = expand(repo.path);
-const cap = repo.max_in_flight ?? policy?.concurrency?.max_in_flight_per_repo ?? 3;
+  const c = {
+    dim: (s) => `\x1b[2m${s}\x1b[0m`,
+    bold: (s) => `\x1b[1m${s}\x1b[0m`,
+    green: (s) => `\x1b[32m${s}\x1b[0m`,
+    red: (s) => `\x1b[31m${s}\x1b[0m`,
+    yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+    cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  };
+  const clock = () => new Date().toTimeString().slice(0, 8);
+  const repoPath = expand(repo.path);
+  const cap =
+    repo.max_in_flight ?? policy?.concurrency?.max_in_flight_per_repo ?? 3;
 
-// Same probe as run-agent.sh: the wall-clock cap is a safety feature, and a
-// safety feature that crashes every spawn on a machine without coreutils is
-// worse than saying plainly that the cap is off.
-// Which agent CLI runs the tickets. Claude by default; `agy` (Antigravity)
-// draws on a different provider's quota entirely, which is the point — a
-// second supervisor on a second harness adds capacity without spending more
-// of the same weekly allowance.
-const HARNESS = val("--harness") ?? "claude";
-if (!Bun.which(HARNESS)) { console.error(`harness "${HARNESS}" is not on PATH`); process.exit(2); }
-// linear.md's agent:* taxonomy names the harness that actually holds the
-// claim (agent:claude-code, agent:gemini, ...) — it must track HARNESS, not
-// assume claude, or a ticket run on agy gets labelled as if Claude did it.
-const AGENT_LABEL = agentLabel(HARNESS);
+  // Same probe as run-agent.sh: the wall-clock cap is a safety feature, and a
+  // safety feature that crashes every spawn on a machine without coreutils is
+  // worse than saying plainly that the cap is off.
+  // Which agent CLI runs the tickets. Claude by default; `agy` (Antigravity)
+  // draws on a different provider's quota entirely, which is the point — a
+  // second supervisor on a second harness adds capacity without spending more
+  // of the same weekly allowance.
+  const HARNESS = val("--harness") ?? "claude";
+  if (!Bun.which(HARNESS)) {
+    console.error(`harness "${HARNESS}" is not on PATH`);
+    process.exit(2);
+  }
+  // linear.md's agent:* taxonomy names the harness that actually holds the
+  // claim (agent:claude-code, agent:gemini, ...) — it must track HARNESS, not
+  // assume claude, or a ticket run on agy gets labelled as if Claude did it.
+  const AGENT_LABEL = agentLabel(HARNESS);
 
-const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
-if (!TIMEOUT_BIN) console.log(c.yellow("  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped"));
+  const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
+  if (!TIMEOUT_BIN)
+    console.log(
+      c.yellow(
+        "  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped",
+      ),
+    );
 
-// The ticket prompt, inlined rather than invoked as `/factory-ticket <ID>`.
-//
-// A slash command only resolves from the directory the session runs in, and
-// that directory is a fresh WORKTREE. `.claude/commands/` holds symlinks into
-// this repo, but a worktree carries only what the branch has committed — so a
-// command added here after the last commit to the product repo does not exist
-// where it is needed, and `claude -p` answers "Unknown command", reports
-// subtype `success`, and exits having done nothing. Every ticket in the batch
-// then burns a claim in under a second.
-//
-// The body is plain harness-neutral markdown, which is why run-agent.sh
-// already passes it this way for the non-Claude harnesses. Doing the same here
-// deletes the failure class instead of documenting it.
-const COMMAND_MD = readFileSync(path.join(ROOT, "shared/commands/factory-ticket.md"), "utf8");
-const COMMAND_MODEL = /^model:\s*(\S+)/m.exec(/^---\n([\s\S]*?)\n---\n/.exec(COMMAND_MD)?.[1] ?? "")?.[1] ?? null;
-const COMMAND_BODY = COMMAND_MD.replace(/^---\n[\s\S]*?\n---\n/, "");
-const promptFor = (id) => COMMAND_BODY.replaceAll("$ARGUMENTS", id);
+  // The ticket prompt, inlined rather than invoked as `/factory-ticket <ID>`.
+  //
+  // A slash command only resolves from the directory the session runs in, and
+  // that directory is a fresh WORKTREE. `.claude/commands/` holds symlinks into
+  // this repo, but a worktree carries only what the branch has committed — so a
+  // command added here after the last commit to the product repo does not exist
+  // where it is needed, and `claude -p` answers "Unknown command", reports
+  // subtype `success`, and exits having done nothing. Every ticket in the batch
+  // then burns a claim in under a second.
+  //
+  // The body is plain harness-neutral markdown, which is why run-agent.sh
+  // already passes it this way for the non-Claude harnesses. Doing the same here
+  // deletes the failure class instead of documenting it.
+  const COMMAND_MD = readFileSync(
+    path.join(ROOT, "shared/commands/factory-ticket.md"),
+    "utf8",
+  );
+  const COMMAND_MODEL =
+    /^model:\s*(\S+)/m.exec(
+      /^---\n([\s\S]*?)\n---\n/.exec(COMMAND_MD)?.[1] ?? "",
+    )?.[1] ?? null;
+  const COMMAND_BODY = COMMAND_MD.replace(/^---\n[\s\S]*?\n---\n/, "");
+  const promptFor = (id) => COMMAND_BODY.replaceAll("$ARGUMENTS", id);
 
-const Q = `query($t:String!,$p:String!){ issues(first:250, filter:{
+  const Q = `query($t:String!,$p:String!){ issues(first:250, filter:{
     team:{key:{eq:$t}}, project:{name:{eq:$p}},
     state:{ type:{ nin:["completed","canceled"] } } }){
   nodes{ id identifier title description state{name} assignee{id} labels(first:20){nodes{name}} priority ${BLOCKING_RELATIONS_GQL} } } }`;
 
-/** Current queue straight from Linear — never cached, because it changes under us. */
-async function fetchState() {
-  const nodes = (await gql(Q, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
-  const has = (i, n) => (i.labels?.nodes ?? []).some((l) => l.name === n);
-  return {
-    inProgress: nodes.filter((i) => i.state?.name === "In Progress"),
-    // Assignee is NOT a gate: this workspace hasn't landed per-agent Linear
-    // identities (OPS-40) yet, so every claim -- human or agent -- writes the
-    // same shared account. That makes "has an assignee" indistinguishable
-    // from "was claimed and never cleared," which is exactly the reaper's
-    // job to fix, not dispatch's job to avoid by skipping the ticket forever.
-    // The actual collision guard is claim()'s read-back compare-and-swap
-    // below, which is assignee-based but per-ticket at claim time, not a
-    // blanket "already has anyone" skip.
-    ready: nodes
-      .filter((i) => i.state?.name === "Todo" && has(i, "ai:agent-ready"))
-      .sort((a, b) => (a.priority || 99) - (b.priority || 99)),
-  };
-}
-
-/**
- * What can start right now, given what is running right now.
- * Owned Paths overlap is checked at THIS moment, not from a plan computed
- * earlier — under rolling dispatch the in-flight set changes continuously.
- *
- * Two orthogonal gates: `blocked by` relations answer "can this run AT ALL
- * yet", Owned Paths answers "can it run alongside what's in flight". Both are
- * read fresh with the queue on every fill, so a blocker merged mid-run
- * releases its dependents on the next refill, no sweep needed.
- */
-function selectable(state, excludeIds, limit) {
-  const busy = state.inProgress.flatMap((i) => effectiveOwnedPaths(i.description ?? ""));
-  const out = [];
-  for (const t of state.ready) {
-    if (out.length >= limit) break;
-    if (excludeIds.has(t.identifier)) continue;
-    if (ONE && t.identifier !== ONE) continue;
-    if (openBlockers(t).length) continue;
-    const own = effectiveOwnedPaths(t.description ?? "");
-    if (pathsCollide(own, busy)) continue;
-    out.push({ ...t, own });
-    busy.push(...own);
+  /** Current queue straight from Linear — never cached, because it changes under us. */
+  async function fetchState() {
+    const nodes =
+      (await gql(Q, { t: repo.team, p: repo.project }))?.issues?.nodes ?? [];
+    const has = (i, n) => (i.labels?.nodes ?? []).some((l) => l.name === n);
+    return {
+      inProgress: nodes.filter((i) => i.state?.name === "In Progress"),
+      // Assignee is NOT a gate: this workspace hasn't landed per-agent Linear
+      // identities (OPS-40) yet, so every claim -- human or agent -- writes the
+      // same shared account. That makes "has an assignee" indistinguishable
+      // from "was claimed and never cleared," which is exactly the reaper's
+      // job to fix, not dispatch's job to avoid by skipping the ticket forever.
+      // The actual collision guard is claim()'s read-back compare-and-swap
+      // below, which is assignee-based but per-ticket at claim time, not a
+      // blanket "already has anyone" skip.
+      ready: nodes
+        .filter((i) => i.state?.name === "Todo" && has(i, "ai:agent-ready"))
+        .sort((a, b) => (a.priority || 99) - (b.priority || 99)),
+    };
   }
-  return out;
-}
 
-// ------------------------------------------------------------------- dry ----
-const first = await fetchState();
-const firstWorkers = liveWorkerLeases(repo.name);
-const freeNow = Math.max(0, cap - firstWorkers.length);
-console.log(c.bold(`\n${repo.name}`) + c.dim(`  cap ${cap} · ${firstWorkers.length} live worker(s) · ${first.inProgress.length} claim(s) · ${freeNow} slot(s) · ${first.ready.length} ready`));
-
-if (!APPLY) {
-  const picked = selectable(first, new Set(), Math.min(freeNow, MAX));
-  for (const t of first.ready) {
-    const blockers = openBlockers(t);
-    if (blockers.length) console.log(c.yellow(`  skip ${t.identifier} — blocked by ${blockers.join(", ")}`));
-    else if (!parseOwnedPaths(t.description ?? "").length) console.log(c.yellow(`  ${t.identifier} — no parseable Owned Paths, treated as owning everything (dispatchable, but runs alone)`));
+  /**
+   * What can start right now, given what is running right now.
+   * Owned Paths overlap is checked at THIS moment, not from a plan computed
+   * earlier — under rolling dispatch the in-flight set changes continuously.
+   *
+   * Two orthogonal gates: `blocked by` relations answer "can this run AT ALL
+   * yet", Owned Paths answers "can it run alongside what's in flight". Both are
+   * read fresh with the queue on every fill, so a blocker merged mid-run
+   * releases its dependents on the next refill, no sweep needed.
+   */
+  function selectable(state, excludeIds, limit) {
+    const busy = state.inProgress.flatMap((i) =>
+      effectiveOwnedPaths(i.description ?? ""),
+    );
+    const out = [];
+    for (const t of state.ready) {
+      if (out.length >= limit) break;
+      if (excludeIds.has(t.identifier)) continue;
+      if (ONE && t.identifier !== ONE) continue;
+      if (openBlockers(t).length) continue;
+      const own = effectiveOwnedPaths(t.description ?? "");
+      if (pathsCollide(own, busy)) continue;
+      out.push({ ...t, own });
+      busy.push(...own);
+    }
+    return out;
   }
-  if (!picked.length) { console.log(c.dim("  nothing to start.\n")); process.exit(0); }
-  console.log(c.bold(`\nwould start ${picked.length} now${REFILL ? ", then refill slots as they free" : ""}:`));
-  for (const t of picked) console.log(`  ${c.green(t.identifier)}  ${t.title.slice(0, 60)}\n    ${c.dim(t.own.join(", "))}`);
-  console.log(c.dim("\ndry run — re-run with --apply\n"));
-  process.exit(0);
-}
 
-// ----------------------------------------------------------------- claim ----
-const me = (await gql(`query{ viewer{ id name } }`))?.viewer;
-const states = (await gql(`query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name } } } }`, { t: repo.team }))?.team?.states?.nodes ?? [];
-const inProgressId = states.find((s) => s.name.toLowerCase() === "in progress")?.id;
-const todoId = states.find((s) => s.name.toLowerCase() === "todo")?.id;
-const blockedId = states.find((s) => s.name.toLowerCase() === "blocked")?.id;
-const allLabels = (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))?.issueLabels?.nodes ?? [];
-const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
-if (!inProgressId) { console.error("no 'In Progress' state on team " + repo.team); process.exit(1); }
+  // ------------------------------------------------------------------- dry ----
+  const first = await fetchState();
+  const firstWorkers = liveWorkerLeases(repo.name);
+  const freeNow = Math.max(0, cap - firstWorkers.length);
+  console.log(
+    c.bold(`\n${repo.name}`) +
+      c.dim(
+        `  cap ${cap} · ${firstWorkers.length} live worker(s) · ${first.inProgress.length} claim(s) · ${freeNow} slot(s) · ${first.ready.length} ready`,
+      ),
+  );
 
-async function claim(t) {
-  // Drop ai:agent-ready on claim. It means "waiting to be picked up", so
-  // keeping it alongside ai:in-progress leaves the ticket asserting two
-  // lifecycle states at once — and it survives all the way to Done, where
-  // CLNT-675 sat carrying both ai:needs-review and ai:agent-ready. One flag,
-  // one value; the same rule the triage hold now follows.
-  const keep = (t.labels?.nodes ?? [])
-    .filter((l) => l.name !== "ai:agent-ready")
-    .map((l) => allLabels.find((x) => x.name === l.name)?.id).filter(Boolean);
-  const want = [...new Set([...keep, labelId("ai:in-progress"), labelId(AGENT_LABEL)].filter(Boolean))];
-  await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-    { id: t.id, in: { stateId: inProgressId, assigneeId: me.id, labelIds: want } });
-  // Linear has no compare-and-swap; this read-back IS the concurrency control.
-  const back = (await gql(`query($id:String!){ issue(id:$id){ assignee{id} } }`, { id: t.id }))?.issue;
-  return back?.assignee?.id === me.id;
-}
-
-/**
- * A failed run must not keep its claim. With the reaper off a timer, a ticket
- * left In Progress after its process died consumes a cap slot until a human
- * notices — three failures and dispatch throughput is silently zero.
- *
- * Only rolls back tickets that still look like OUR claim (In Progress, assigned
- * to us, ai:in-progress present). An agent that legitimately moved its ticket —
- * to Blocked with a question, or to In Review with a PR — keeps that state.
- */
-async function unclaim(t, why, log) {
-  const cur = (await gql(
-    `query($id:String!){ issue(id:$id){ state{name} assignee{id} labels(first:20){nodes{id name}} comments(last:10){nodes{body createdAt}} } }`,
-    { id: t.id }))?.issue;
-  if (!cur || cur.state?.name !== "In Progress" || cur.assignee?.id !== me.id) return false;
-  if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
-
-  const action = computeUnclaimAction({
-    issue: cur,
-    why,
-    log,
-    todoStateId: todoId,
-    blockedStateId: blockedId,
-    allLabels,
-    threshold: DISPATCH_FAILURE_THRESHOLD,
-  });
-
-  await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-    { id: t.id, in: { stateId: action.stateId ?? undefined, assigneeId: null, labelIds: action.labelIds } });
-  await gql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
-    { in: { issueId: t.id, body: action.commentBody } });
-
-  if (action.repeated) {
-    console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} ${c.red("blocked (repeated dispatch failures)")} ${c.dim(`— ${why}`)}`);
-  } else {
-    console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} ${c.yellow("un-claimed")} ${c.dim(`— ${why}`)}`);
+  if (!APPLY) {
+    const picked = selectable(first, new Set(), Math.min(freeNow, MAX));
+    for (const t of first.ready) {
+      const blockers = openBlockers(t);
+      if (blockers.length)
+        console.log(
+          c.yellow(
+            `  skip ${t.identifier} — blocked by ${blockers.join(", ")}`,
+          ),
+        );
+      else if (!parseOwnedPaths(t.description ?? "").length)
+        console.log(
+          c.yellow(
+            `  ${t.identifier} — no parseable Owned Paths, treated as owning everything (dispatchable, but runs alone)`,
+          ),
+        );
+    }
+    if (!picked.length) {
+      console.log(c.dim("  nothing to start.\n"));
+      process.exit(0);
+    }
+    console.log(
+      c.bold(
+        `\nwould start ${picked.length} now${REFILL ? ", then refill slots as they free" : ""}:`,
+      ),
+    );
+    for (const t of picked)
+      console.log(
+        `  ${c.green(t.identifier)}  ${t.title.slice(0, 60)}\n    ${c.dim(t.own.join(", "))}`,
+      );
+    console.log(c.dim("\ndry run — re-run with --apply\n"));
+    process.exit(0);
   }
-  return true;
-}
 
-// ------------------------------------------------------------------ warm ----
-let warmChecked = false;
-/**
- * Warming costs one compile; skipping it costs N. So it only pays from two
- * tickets up, and only once per run — after claiming (minutes here cannot lose
- * a claimed ticket) and before any worktree-up (nothing should clone a template
- * being rewritten underneath it).
- */
-function warmIfWorthIt(count) {
-  if (warmChecked || argv.includes("--no-warm") || !repo.worktree_warm) return;
-  warmChecked = true;
-  if (count < 2) { console.log(c.dim(`  (single ticket — not warming; same compile either way)`)); return; }
-
-  const gate = spawnSync("/bin/bash", ["-lc", `bun orchestrator/warm.mjs --repo ${repo.name} --gate`], { cwd: ROOT, encoding: "utf8" });
-  if (gate.status !== 0) { console.log(c.dim(`  warm cache fresh — ${gate.stdout.trim()}`)); return; }
-  console.log(c.yellow(`\n  ${gate.stdout.trim()}`));
-  console.log(c.dim(`  Compiling once so ${count} worktrees don't.\n`));
-  const r = spawnSync("/bin/bash", ["-lc", `bun orchestrator/warm.mjs --repo ${repo.name} --apply`], { cwd: ROOT, stdio: "inherit" });
-  console.log(r.status === 0 ? c.green(`\n  warm cache refreshed.\n`) : c.yellow(`\n  warm refresh failed — continuing; worktrees will be slower.\n`));
-}
-
-// ------------------------------------------------------------------- run ----
-const LOG_DIR = path.join(homedir(), ".factory/logs");
-mkdirSync(LOG_DIR, { recursive: true });
-const stamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 15);
-const leaseOwner = `${process.pid}-${stamp}`;
-const results = [];
-
-// CIRCUIT BREAKER (policy.circuit_breaker). Environment failures — the
-// worktree template refusing to build — are not ticket-specific: left running,
-// a broken template converts the whole queue into failed claims in minutes.
-const ENV_FAIL_LIMIT = policy?.circuit_breaker?.consecutive_env_failures ?? 2;
-let envFailures = 0;
-let tripped = false;
-
-// Counts a failure that says nothing about the ticket and everything about the
-// machine — a template that won't build, a session that ends before it takes a
-// turn. Ticket-specific failures must NOT come through here: one hard ticket
-// stopping the queue is a worse outcome than letting it fail alone.
-function noteEnvFailure(what) {
-  if (++envFailures >= ENV_FAIL_LIMIT && !tripped) {
-    tripped = true;
-    console.log(c.red(`\n  CIRCUIT BREAKER: ${envFailures} consecutive environment failures (${what}) — no further tickets will be claimed this run. Fix the environment first.\n`));
+  // ----------------------------------------------------------------- claim ----
+  const me = (await gql(`query{ viewer{ id name } }`))?.viewer;
+  const states =
+    (
+      await gql(
+        `query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name } } } }`,
+        { t: repo.team },
+      )
+    )?.team?.states?.nodes ?? [];
+  const inProgressId = states.find(
+    (s) => s.name.toLowerCase() === "in progress",
+  )?.id;
+  const todoId = states.find((s) => s.name.toLowerCase() === "todo")?.id;
+  const blockedId = states.find((s) => s.name.toLowerCase() === "blocked")?.id;
+  const allLabels =
+    (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))
+      ?.issueLabels?.nodes ?? [];
+  const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
+  if (!inProgressId) {
+    console.error("no 'In Progress' state on team " + repo.team);
+    process.exit(1);
   }
-}
 
-async function runTicket(t) {
-  const wt = path.join(expand(repo.worktree_root), t.identifier);
-  const up = spawnSync("/bin/bash", [repo.worktree_up, t.identifier], { cwd: repoPath, encoding: "utf8" });
-  if (up.status !== 0) {
-    const why = (up.stderr || up.stdout || "").trim().split("\n").pop();
-    console.log(c.red(`  ${t.identifier} worktree-up failed: ${why}`));
-    results.push({ id: t.identifier, ok: false, why: "worktree-up failed" });
-    // Must not throw: an unhandled rejection here kills the whole rolling
-    // loop via Promise.race in the main dispatch loop below, taking down
-    // every OTHER in-flight ticket's tracking with it. Same guard as the
-    // other two unclaim() call sites.
-    preserveWip(wt, t.identifier);
-    await unclaim(t, `worktree-up failed: ${why}`).catch(() => {});
-    noteEnvFailure("worktree-up");
-    return;
+  async function claim(t) {
+    // Drop ai:agent-ready on claim. It means "waiting to be picked up", so
+    // keeping it alongside ai:in-progress leaves the ticket asserting two
+    // lifecycle states at once — and it survives all the way to Done, where
+    // CLNT-675 sat carrying both ai:needs-review and ai:agent-ready. One flag,
+    // one value; the same rule the triage hold now follows.
+    const keep = (t.labels?.nodes ?? [])
+      .filter((l) => l.name !== "ai:agent-ready")
+      .map((l) => allLabels.find((x) => x.name === l.name)?.id)
+      .filter(Boolean);
+    const want = [
+      ...new Set(
+        [...keep, labelId("ai:in-progress"), labelId(AGENT_LABEL)].filter(
+          Boolean,
+        ),
+      ),
+    ];
+    await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      {
+        id: t.id,
+        in: { stateId: inProgressId, assigneeId: me.id, labelIds: want },
+      },
+    );
+    // Linear has no compare-and-swap; this read-back IS the concurrency control.
+    const back = (
+      await gql(`query($id:String!){ issue(id:$id){ assignee{id} } }`, {
+        id: t.id,
+      })
+    )?.issue;
+    return back?.assignee?.id === me.id;
   }
-  // NB: a working worktree-up does not clear the streak — only a run that
-  // actually took a turn does (below). Clearing it here let four consecutive
-  // zero-turn sessions through, because each one built its worktree fine.
-  console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} worktree ready ${c.dim(wt)}`);
 
-  const log = path.join(LOG_DIR, `${repo.name}-${t.identifier}-${stamp}.jsonl`);
-  const out = createWriteStream(log);
-  const budget = String(cfg.budget?.per_ticket_usd ?? policy?.budget?.per_ticket_usd ?? 15);
-  // Same hard cap as run-agent.sh: a wedged ticket must not hold its slot
-  // forever. TERM at the limit, KILL 30s later.
-  const maxMin = policy?.limits?.max_run_minutes ?? 45;
+  /**
+   * A failed run must not keep its claim. With the reaper off a timer, a ticket
+   * left In Progress after its process died consumes a cap slot until a human
+   * notices — three failures and dispatch throughput is silently zero.
+   *
+   * Only rolls back tickets that still look like OUR claim (In Progress, assigned
+   * to us, ai:in-progress present). An agent that legitimately moved its ticket —
+   * to Blocked with a question, or to In Review with a PR — keeps that state.
+   */
+  async function unclaim(t, why, log) {
+    const cur = (
+      await gql(
+        `query($id:String!){ issue(id:$id){ state{name} assignee{id} labels(first:20){nodes{id name}} comments(last:10){nodes{body createdAt}} } }`,
+        { id: t.id },
+      )
+    )?.issue;
+    if (!cur || cur.state?.name !== "In Progress" || cur.assignee?.id !== me.id)
+      return false;
+    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+      return false;
 
-  await new Promise((resolve) => {
-    // Spawned without a shell: the prompt is a markdown document full of
-    // backticks and quotes, and there is no quoting of it into `bash -lc`
-    // that stays correct as the command body is edited.
-    // Flags differ per harness; the PROMPT does not. That is the whole reason
-    // the command bodies are harness-neutral markdown, and why run-agent.sh
-    // can already drive agy. Mirrors run-agent.sh's non-claude invocation.
-    let harnessArgs;
-    if (HARNESS === "claude") {
-      harnessArgs = [
-        "-p", promptFor(t.identifier),
-        "--output-format", "stream-json", "--verbose",
-        "--max-budget-usd", budget,
-        "--fallback-model", "sonnet",
-        // --strict makes this file the ONLY source of MCP servers: no user
-        // scope, no project .mcp.json, no claude.ai connectors. What an
-        // unattended agent can reach is declared in git and moves by PR.
-        // Drops the Linear MCP too — tools/linear.mjs replaces it, reached via
-        // the FACTORY_ROOT set below. Mirrors run-agent.sh.
-        "--mcp-config", path.join(ROOT, "config/mcp/claude.json"), "--strict-mcp-config",
-        ...(COMMAND_MODEL ? ["--model", COMMAND_MODEL] : []),
-      ];
-    } else if (HARNESS === "codex") {
-      const model = COMMAND_MODEL && !["sonnet", "opus", "haiku"].includes(COMMAND_MODEL.toLowerCase()) ? COMMAND_MODEL : null;
-      harnessArgs = [
-        "exec", "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "-C", wt,
-        ...(model ? ["--model", model] : []),
-        promptFor(t.identifier),
-      ];
-    } else if (HARNESS === "pi") {
-      const model = COMMAND_MODEL && !["sonnet", "opus", "haiku"].includes(COMMAND_MODEL.toLowerCase()) ? COMMAND_MODEL : null;
-      harnessArgs = [
-        "-p",
-        "--mode", "json",
-        ...(model ? ["--model", model] : []),
-        promptFor(t.identifier),
-      ];
+    const action = computeUnclaimAction({
+      issue: cur,
+      why,
+      log,
+      todoStateId: todoId,
+      blockedStateId: blockedId,
+      allLabels,
+      threshold: DISPATCH_FAILURE_THRESHOLD,
+    });
+
+    await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      {
+        id: t.id,
+        in: {
+          stateId: action.stateId ?? undefined,
+          assigneeId: null,
+          labelIds: action.labelIds,
+        },
+      },
+    );
+    await gql(
+      `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+      { in: { issueId: t.id, body: action.commentBody } },
+    );
+
+    if (action.repeated) {
+      console.log(
+        `${c.dim(clock())} ${c.cyan(t.identifier)} ${c.red("blocked (repeated dispatch failures)")} ${c.dim(`— ${why}`)}`,
+      );
     } else {
-      harnessArgs = [
-        "-p", promptFor(t.identifier),
-        "--output-format", "stream-json",
-        "--dangerously-skip-permissions",
-        "--add-dir", wt,
-        "--print-timeout", `${Math.max(1, maxMin - 2)}m`,
-        // agy receives the command body rather than its frontmatter, so pin
-        // its model explicitly. Other compatible harnesses retain their CLI
-        // defaults until they gain a dedicated adapter.
-        ...(HARNESS === "agy" ? ["--model", "gemini-3.6-flash-medium"] : []),
-      ];
+      console.log(
+        `${c.dim(clock())} ${c.cyan(t.identifier)} ${c.yellow("un-claimed")} ${c.dim(`— ${why}`)}`,
+      );
+    }
+    return true;
+  }
+
+  // ------------------------------------------------------------------ warm ----
+  let warmChecked = false;
+  /**
+   * Warming costs one compile; skipping it costs N. So it only pays from two
+   * tickets up, and only once per run — after claiming (minutes here cannot lose
+   * a claimed ticket) and before any worktree-up (nothing should clone a template
+   * being rewritten underneath it).
+   */
+  function warmIfWorthIt(count) {
+    if (warmChecked || argv.includes("--no-warm") || !repo.worktree_warm)
+      return;
+    warmChecked = true;
+    if (count < 2) {
+      console.log(
+        c.dim(`  (single ticket — not warming; same compile either way)`),
+      );
+      return;
     }
 
-    const harnessBin = (HARNESS === "pi" && !Bun.which("pi")) ? "npx" : HARNESS;
-    const piPreArgs = (HARNESS === "pi" && !Bun.which("pi")) ? ["pi"] : [];
-    const envArgs = [
-      "-u", "ANTHROPIC_API_KEY",
-      "-u", "GEMINI_API_KEY",
-      "-u", "GOOGLE_API_KEY",
-      "-u", "GOOGLE_GENAI_API_KEY",
-      "-u", "OPENAI_API_KEY",
-      "-u", "MISTRAL_API_KEY",
-      "-u", "DEEPSEEK_API_KEY",
-      "-u", "GROQ_API_KEY",
-      "-u", "CLAUDECODE",
-      "-u", "CLAUDE_CODE_ENTRYPOINT",
-      // Agents run in a worktree, not in this checkout, so `bun
-      // tools/linear.mjs` does not resolve for them. The floor tells them to
-      // use "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that true.
-      // Without it, --strict-mcp-config removes the Linear MCP and leaves no
-      // replacement — the control plane goes silent.
-      `FACTORY_ROOT=${ROOT}`,
-      // Run id == transcript basename, same convention as run-agent.sh: the
-      // rollup keys on it, linear.mjs stamps it into comments, the floor puts
-      // it in PR bodies. One key joins Linear/GitHub back to this log (OPS-76).
-      `FACTORY_RUN_ID=${path.basename(log, ".jsonl")}`,
-      harnessBin, ...piPreArgs, ...harnessArgs
-    ];
-    const [bin, args] = TIMEOUT_BIN
-      ? [TIMEOUT_BIN, ["-k", "30s", `${maxMin}m`, "env", ...envArgs]]
-      : ["env", envArgs];
-    const child = spawn(bin, args, { cwd: wt, stdio: ["ignore", "pipe", "pipe"] });
-    children.add(child);
-    // Replace the dispatcher's short setup lease with the actual ticket worker
-    // as soon as it exists. The lease is independent of transcript activity:
-    // a long test or API call can be silent without looking dead.
-    writeWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner, pid: child.pid });
-    // Lifecycle observation (WM-75): fire-and-forget — the runtime being down
-    // must never affect dispatch. eventId is stable within this tick run.
-    void emitFactoryEvent("factory.ticket.dispatched",
-      { repo: repo.name, ticket: t.identifier, harness: HARNESS, worktree: wt },
-      { eventId: `dispatch:${t.identifier}:${stamp}`, subject: t.identifier });
-    let buf = "";
-    let recorded = false;
-    let turnCount = 0;
-    const tag = c.cyan(`[${t.identifier}]`);
-    const processLine = (line) => {
-      if (!line.trim().startsWith("{")) return;
-      let e; try { e = JSON.parse(line); } catch { return; }
-      if (e.type === "assistant") {
-        for (const p of e.message?.content ?? []) {
-          if (p.type === "tool_use") {
-            const d = String(p.input?.command ?? p.input?.file_path ?? p.input?.description ?? "").replace(/\s+/g, " ").slice(0, 66);
-            console.log(`${c.dim(clock())} ${tag} ${p.name} ${c.dim(d)}`);
-          }
-        }
-      }
-      if (HARNESS === "codex") {
-        if (e.type === "turn.started" || e.type === "turn.created") turnCount++;
-        if (e.type === "item.started" && (e.item?.type === "command_execution" || e.item?.type === "call")) {
-          const d = String(e.item.command ?? "").replace(/\s+/g, " ").slice(0, 66);
-          console.log(`${c.dim(clock())} ${tag} bash ${c.dim(d)}`);
-        } else if (e.type === "item.started" && e.item?.type === "mcp_tool_call") {
-          const d = String(e.item.tool ?? "mcp").replace(/\s+/g, " ").slice(0, 66);
-          console.log(`${c.dim(clock())} ${tag} ${d}`);
-        }
-        if (e.type === "turn.completed") {
-          e = { type: "result", subtype: "success", is_error: false, num_turns: turnCount || 1, total_cost_usd: 0, result: "finished" };
-        }
+    const gate = spawnSync(
+      "/bin/bash",
+      ["-lc", `bun orchestrator/warm.mjs --repo ${repo.name} --gate`],
+      { cwd: ROOT, encoding: "utf8" },
+    );
+    if (gate.status !== 0) {
+      console.log(c.dim(`  warm cache fresh — ${gate.stdout.trim()}`));
+      return;
+    }
+    console.log(c.yellow(`\n  ${gate.stdout.trim()}`));
+    console.log(c.dim(`  Compiling once so ${count} worktrees don't.\n`));
+    const r = spawnSync(
+      "/bin/bash",
+      ["-lc", `bun orchestrator/warm.mjs --repo ${repo.name} --apply`],
+      { cwd: ROOT, stdio: "inherit" },
+    );
+    console.log(
+      r.status === 0
+        ? c.green(`\n  warm cache refreshed.\n`)
+        : c.yellow(
+            `\n  warm refresh failed — continuing; worktrees will be slower.\n`,
+          ),
+    );
+  }
+
+  // ------------------------------------------------------------------- run ----
+  const LOG_DIR = path.join(homedir(), ".factory/logs");
+  mkdirSync(LOG_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 15);
+  const leaseOwner = `${process.pid}-${stamp}`;
+  const results = [];
+
+  // CIRCUIT BREAKER (policy.circuit_breaker). Environment failures — the
+  // worktree template refusing to build — are not ticket-specific: left running,
+  // a broken template converts the whole queue into failed claims in minutes.
+  const ENV_FAIL_LIMIT = policy?.circuit_breaker?.consecutive_env_failures ?? 2;
+  let envFailures = 0;
+  let tripped = false;
+
+  // Counts a failure that says nothing about the ticket and everything about the
+  // machine — a template that won't build, a session that ends before it takes a
+  // turn. Ticket-specific failures must NOT come through here: one hard ticket
+  // stopping the queue is a worse outcome than letting it fail alone.
+  function noteEnvFailure(what) {
+    if (++envFailures >= ENV_FAIL_LIMIT && !tripped) {
+      tripped = true;
+      console.log(
+        c.red(
+          `\n  CIRCUIT BREAKER: ${envFailures} consecutive environment failures (${what}) — no further tickets will be claimed this run. Fix the environment first.\n`,
+        ),
+      );
+    }
+  }
+
+  async function runTicket(t) {
+    const wt = path.join(expand(repo.worktree_root), t.identifier);
+    const up = spawnSync("/bin/bash", [repo.worktree_up, t.identifier], {
+      cwd: repoPath,
+      encoding: "utf8",
+    });
+    if (up.status !== 0) {
+      const why = (up.stderr || up.stdout || "").trim().split("\n").pop();
+      console.log(c.red(`  ${t.identifier} worktree-up failed: ${why}`));
+      results.push({ id: t.identifier, ok: false, why: "worktree-up failed" });
+      // Must not throw: an unhandled rejection here kills the whole rolling
+      // loop via Promise.race in the main dispatch loop below, taking down
+      // every OTHER in-flight ticket's tracking with it. Same guard as the
+      // other two unclaim() call sites.
+      preserveWip(wt, t.identifier);
+      await unclaim(t, `worktree-up failed: ${why}`).catch(() => {});
+      noteEnvFailure("worktree-up");
+      return;
+    }
+    // NB: a working worktree-up does not clear the streak — only a run that
+    // actually took a turn does (below). Clearing it here let four consecutive
+    // zero-turn sessions through, because each one built its worktree fine.
+    console.log(
+      `${c.dim(clock())} ${c.cyan(t.identifier)} worktree ready ${c.dim(wt)}`,
+    );
+
+    const log = path.join(
+      LOG_DIR,
+      `${repo.name}-${t.identifier}-${stamp}.jsonl`,
+    );
+    const out = createWriteStream(log);
+    const budget = String(
+      cfg.budget?.per_ticket_usd ?? policy?.budget?.per_ticket_usd ?? 15,
+    );
+    // Same hard cap as run-agent.sh: a wedged ticket must not hold its slot
+    // forever. TERM at the limit, KILL 30s later.
+    const maxMin = policy?.limits?.max_run_minutes ?? 45;
+
+    await new Promise((resolve) => {
+      // Spawned without a shell: the prompt is a markdown document full of
+      // backticks and quotes, and there is no quoting of it into `bash -lc`
+      // that stays correct as the command body is edited.
+      // Flags differ per harness; the PROMPT does not. That is the whole reason
+      // the command bodies are harness-neutral markdown, and why run-agent.sh
+      // can already drive agy. Mirrors run-agent.sh's non-claude invocation.
+      let harnessArgs;
+      if (HARNESS === "claude") {
+        harnessArgs = [
+          "-p",
+          promptFor(t.identifier),
+          "--output-format",
+          "stream-json",
+          "--verbose",
+          "--max-budget-usd",
+          budget,
+          "--fallback-model",
+          "sonnet",
+          // --strict makes this file the ONLY source of MCP servers: no user
+          // scope, no project .mcp.json, no claude.ai connectors. What an
+          // unattended agent can reach is declared in git and moves by PR.
+          // Drops the Linear MCP too — tools/linear.mjs replaces it, reached via
+          // the FACTORY_ROOT set below. Mirrors run-agent.sh.
+          "--mcp-config",
+          path.join(ROOT, "config/mcp/claude.json"),
+          "--strict-mcp-config",
+          ...(COMMAND_MODEL ? ["--model", COMMAND_MODEL] : []),
+        ];
+      } else if (HARNESS === "codex") {
+        const model =
+          COMMAND_MODEL &&
+          !["sonnet", "opus", "haiku"].includes(COMMAND_MODEL.toLowerCase())
+            ? COMMAND_MODEL
+            : null;
+        harnessArgs = [
+          "exec",
+          "--json",
+          "--dangerously-bypass-approvals-and-sandbox",
+          "-C",
+          wt,
+          ...(model ? ["--model", model] : []),
+          promptFor(t.identifier),
+        ];
       } else if (HARNESS === "pi") {
-        if (e.type === "message" && e.message?.role === "assistant") {
-          for (const p of e.message.content ?? []) {
-            if (p.type === "toolCall") {
-              turnCount++;
-              const d = String(p.input?.path ?? p.input?.command ?? p.input?.pattern ?? JSON.stringify(p.input ?? {})).replace(/\s+/g, " ").slice(0, 66);
-              console.log(`${c.dim(clock())} ${tag} ${p.name ?? "tool"} ${c.dim(d)}`);
+        const model =
+          COMMAND_MODEL &&
+          !["sonnet", "opus", "haiku"].includes(COMMAND_MODEL.toLowerCase())
+            ? COMMAND_MODEL
+            : null;
+        harnessArgs = [
+          "-p",
+          "--mode",
+          "json",
+          ...(model ? ["--model", model] : []),
+          promptFor(t.identifier),
+        ];
+      } else {
+        harnessArgs = [
+          "-p",
+          promptFor(t.identifier),
+          "--output-format",
+          "stream-json",
+          "--dangerously-skip-permissions",
+          "--add-dir",
+          wt,
+          "--print-timeout",
+          `${Math.max(1, maxMin - 2)}m`,
+          // agy receives the command body rather than its frontmatter, so pin
+          // its model explicitly. Other compatible harnesses retain their CLI
+          // defaults until they gain a dedicated adapter.
+          ...(HARNESS === "agy" ? ["--model", "gemini-3.6-flash-medium"] : []),
+        ];
+      }
+
+      const harnessBin = HARNESS === "pi" && !Bun.which("pi") ? "npx" : HARNESS;
+      const piPreArgs = HARNESS === "pi" && !Bun.which("pi") ? ["pi"] : [];
+      const envArgs = [
+        "-u",
+        "ANTHROPIC_API_KEY",
+        "-u",
+        "GEMINI_API_KEY",
+        "-u",
+        "GOOGLE_API_KEY",
+        "-u",
+        "GOOGLE_GENAI_API_KEY",
+        "-u",
+        "OPENAI_API_KEY",
+        "-u",
+        "MISTRAL_API_KEY",
+        "-u",
+        "DEEPSEEK_API_KEY",
+        "-u",
+        "GROQ_API_KEY",
+        "-u",
+        "CLAUDECODE",
+        "-u",
+        "CLAUDE_CODE_ENTRYPOINT",
+        // Agents run in a worktree, not in this checkout, so `bun
+        // tools/linear.mjs` does not resolve for them. The floor tells them to
+        // use "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that true.
+        // Without it, --strict-mcp-config removes the Linear MCP and leaves no
+        // replacement — the control plane goes silent.
+        `FACTORY_ROOT=${ROOT}`,
+        // Run id == transcript basename, same convention as run-agent.sh: the
+        // rollup keys on it, linear.mjs stamps it into comments, the floor puts
+        // it in PR bodies. One key joins Linear/GitHub back to this log (OPS-76).
+        `FACTORY_RUN_ID=${path.basename(log, ".jsonl")}`,
+        harnessBin,
+        ...piPreArgs,
+        ...harnessArgs,
+      ];
+      const [bin, args] = TIMEOUT_BIN
+        ? [TIMEOUT_BIN, ["-k", "30s", `${maxMin}m`, "env", ...envArgs]]
+        : ["env", envArgs];
+      const child = spawn(bin, args, {
+        cwd: wt,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      children.add(child);
+      // Replace the dispatcher's short setup lease with the actual ticket worker
+      // as soon as it exists. The lease is independent of transcript activity:
+      // a long test or API call can be silent without looking dead.
+      writeWorkerLease({
+        repo: repo.name,
+        ticket: t.identifier,
+        owner: leaseOwner,
+        pid: child.pid,
+      });
+      // Lifecycle observation (WM-75): fire-and-forget — the runtime being down
+      // must never affect dispatch. eventId is stable within this tick run.
+      void emitFactoryEvent(
+        "factory.ticket.dispatched",
+        {
+          repo: repo.name,
+          ticket: t.identifier,
+          harness: HARNESS,
+          worktree: wt,
+        },
+        { eventId: `dispatch:${t.identifier}:${stamp}`, subject: t.identifier },
+      );
+      let buf = "";
+      let recorded = false;
+      let turnCount = 0;
+      const tag = c.cyan(`[${t.identifier}]`);
+      const processLine = (line) => {
+        if (!line.trim().startsWith("{")) return;
+        let e;
+        try {
+          e = JSON.parse(line);
+        } catch {
+          return;
+        }
+        if (e.type === "assistant") {
+          for (const p of e.message?.content ?? []) {
+            if (p.type === "tool_use") {
+              const d = String(
+                p.input?.command ??
+                  p.input?.file_path ??
+                  p.input?.description ??
+                  "",
+              )
+                .replace(/\s+/g, " ")
+                .slice(0, 66);
+              console.log(`${c.dim(clock())} ${tag} ${p.name} ${c.dim(d)}`);
             }
           }
         }
-        if (e.type === "result" && e.result) {
-          const ok = e.result.exitCode === 0;
-          e = { type: "result", subtype: ok ? "success" : "failed", is_error: !ok, num_turns: turnCount || 1, total_cost_usd: 0, result: ok ? "finished" : "failed" };
+        if (HARNESS === "codex") {
+          if (e.type === "turn.started" || e.type === "turn.created")
+            turnCount++;
+          if (
+            e.type === "item.started" &&
+            (e.item?.type === "command_execution" || e.item?.type === "call")
+          ) {
+            const d = String(e.item.command ?? "")
+              .replace(/\s+/g, " ")
+              .slice(0, 66);
+            console.log(`${c.dim(clock())} ${tag} bash ${c.dim(d)}`);
+          } else if (
+            e.type === "item.started" &&
+            e.item?.type === "mcp_tool_call"
+          ) {
+            const d = String(e.item.tool ?? "mcp")
+              .replace(/\s+/g, " ")
+              .slice(0, 66);
+            console.log(`${c.dim(clock())} ${tag} ${d}`);
+          }
+          if (e.type === "turn.completed") {
+            e = {
+              type: "result",
+              subtype: "success",
+              is_error: false,
+              num_turns: turnCount || 1,
+              total_cost_usd: 0,
+              result: "finished",
+            };
+          }
+        } else if (HARNESS === "pi") {
+          if (e.type === "message" && e.message?.role === "assistant") {
+            for (const p of e.message.content ?? []) {
+              if (p.type === "toolCall") {
+                turnCount++;
+                const d = String(
+                  p.input?.path ??
+                    p.input?.command ??
+                    p.input?.pattern ??
+                    JSON.stringify(p.input ?? {}),
+                )
+                  .replace(/\s+/g, " ")
+                  .slice(0, 66);
+                console.log(
+                  `${c.dim(clock())} ${tag} ${p.name ?? "tool"} ${c.dim(d)}`,
+                );
+              }
+            }
+          }
+          if (e.type === "result" && e.result) {
+            const ok = e.result.exitCode === 0;
+            e = {
+              type: "result",
+              subtype: ok ? "success" : "failed",
+              is_error: !ok,
+              num_turns: turnCount || 1,
+              total_cost_usd: 0,
+              result: ok ? "finished" : "failed",
+            };
+          }
+        } else if (HARNESS !== "claude") {
+          const s = e.event === "step_update" ? (e.step_update ?? {}) : null;
+          if (s?.step_type === "tool" && s.state === "ACTIVE") {
+            const par = s.tool_info?.parameters ?? {};
+            const d = String(
+              par.CommandLine ??
+                par.command ??
+                par.AbsolutePath ??
+                par.path ??
+                "",
+            )
+              .replace(/\s+/g, " ")
+              .slice(0, 66);
+            console.log(
+              `${c.dim(clock())} ${tag} ${s.tool_name ?? "tool"} ${c.dim(d)}`,
+            );
+          }
+          const env =
+            e.event === "result"
+              ? e.result
+              : "status" in e && "num_turns" in e
+                ? e
+                : null;
+          if (!env) return;
+          e = {
+            subtype:
+              String(env.status).toLowerCase() === "success"
+                ? "success"
+                : String(env.status ?? "?"),
+            is_error: String(env.status).toLowerCase() !== "success",
+            num_turns: env.num_turns,
+            total_cost_usd: env.total_cost_usd ?? 0,
+            result: env.response ?? "",
+          };
         }
-      } else if (HARNESS !== "claude") {
-        const s = e.event === "step_update" ? (e.step_update ?? {}) : null;
-        if (s?.step_type === "tool" && s.state === "ACTIVE") {
-          const par = s.tool_info?.parameters ?? {};
-          const d = String(par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path ?? "").replace(/\s+/g, " ").slice(0, 66);
-          console.log(`${c.dim(clock())} ${tag} ${s.tool_name ?? "tool"} ${c.dim(d)}`);
+        if (e.type === "result" || "num_turns" in e) {
+          const turns = e.num_turns ?? 0;
+          const ok = e.subtype === "success" && !e.is_error && turns > 0;
+          console.log(
+            `${c.dim(clock())} ${tag} ${ok ? c.green("done") : c.red("FAILED")} ${c.dim(`${turns} turns ~$${(e.total_cost_usd ?? 0).toFixed(2)}`)}`,
+          );
+          const said = String(e.result ?? "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 120);
+          results.push({
+            id: t.identifier,
+            ok,
+            log,
+            why: ok
+              ? undefined
+              : `${turns} turns, ended ${e.subtype ?? "?"}${e.is_error ? " (error)" : ""}${said ? ` — ${said}` : ""}`,
+          });
+          if (turns === 0)
+            noteEnvFailure("session ended without taking a turn");
+          else if (ok) envFailures = 0;
+          recorded = true;
         }
-        const env = e.event === "result" ? e.result : ("status" in e && "num_turns" in e ? e : null);
-        if (!env) return;
-        e = { subtype: String(env.status).toLowerCase() === "success" ? "success" : String(env.status ?? "?"),
-              is_error: String(env.status).toLowerCase() !== "success",
-              num_turns: env.num_turns, total_cost_usd: env.total_cost_usd ?? 0, result: env.response ?? "" };
-      }
-      if (e.type === "result" || "num_turns" in e) {
-        const turns = e.num_turns ?? 0;
-        const ok = e.subtype === "success" && !e.is_error && turns > 0;
-        console.log(`${c.dim(clock())} ${tag} ${ok ? c.green("done") : c.red("FAILED")} ${c.dim(`${turns} turns ~$${(e.total_cost_usd ?? 0).toFixed(2)}`)}`);
-        const said = String(e.result ?? "").replace(/\s+/g, " ").trim().slice(0, 120);
-        results.push({
-          id: t.identifier, ok, log,
-          why: ok ? undefined : `${turns} turns, ended ${e.subtype ?? "?"}${e.is_error ? " (error)" : ""}${said ? ` — ${said}` : ""}`,
+      };
+      child.stdout.on("data", (d) => {
+        out.write(d);
+        buf += d.toString();
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) processLine(line);
+      });
+      child.stderr.on("data", (d) => out.write(d));
+      observeChildTermination(child, async ({ error, code }) => {
+        children.delete(child);
+        if (error) {
+          const detail = `${error.code ? `${error.code}: ` : ""}${error.message || error}`;
+          const why = `agent spawn failed (${detail})`;
+          console.log(
+            `${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(why)}`,
+          );
+          out.write(`[dispatcher] ${why}\n`);
+          results.push({ id: t.identifier, ok: false, log, why });
+          recorded = true;
+          noteEnvFailure("agent spawn");
+        } else {
+          // The final "result" line isn't guaranteed a trailing newline, so
+          // whatever is still in `buf` when the process exits needs a look too —
+          // otherwise a clean exit with no trailing "\n" silently reports nothing.
+          if (buf.trim()) processLine(buf);
+          // If the child never emitted a parseable result (crash or killed by the
+          // timeout), record it as a failure explicitly. Silence here previously
+          // showed up as "0 ok, 0 failed" — indistinguishable from an empty run.
+          if (!recorded) {
+            console.log(
+              `${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(`no result (exit ${code})`)}`,
+            );
+            results.push({
+              id: t.identifier,
+              ok: false,
+              log,
+              why: `no result emitted (exit ${code})`,
+            });
+          }
+        }
+        out.end();
+        // A failed run must not keep its claim (unclaim() checks the ticket
+        // still looks like ours — Blocked/In Review moves are left alone).
+        const r = results.findLast((x) => x.id === t.identifier);
+        if (r && !r.ok) {
+          preserveWip(wt, t.identifier);
+          await unclaim(t, r.why ?? "run failed", log).catch(() => {});
+        }
+        releaseWorkerLease({
+          repo: repo.name,
+          ticket: t.identifier,
+          owner: leaseOwner,
         });
-        if (turns === 0) noteEnvFailure("session ended without taking a turn");
-        else if (ok) envFailures = 0;
-        recorded = true;
-      }
-    };
-    child.stdout.on("data", (d) => {
-      out.write(d);
-      buf += d.toString();
-      const lines = buf.split("\n");
-      buf = lines.pop() ?? "";
-      for (const line of lines) processLine(line);
+        resolve();
+      });
     });
-    child.stderr.on("data", (d) => out.write(d));
-    observeChildTermination(child, async ({ error, code }) => {
-      children.delete(child);
-      if (error) {
-        const detail = `${error.code ? `${error.code}: ` : ""}${error.message || error}`;
-        const why = `agent spawn failed (${detail})`;
-        console.log(`${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(why)}`);
-        out.write(`[dispatcher] ${why}\n`);
-        results.push({ id: t.identifier, ok: false, log, why });
-        recorded = true;
-        noteEnvFailure("agent spawn");
-      } else {
-        // The final "result" line isn't guaranteed a trailing newline, so
-        // whatever is still in `buf` when the process exits needs a look too —
-        // otherwise a clean exit with no trailing "\n" silently reports nothing.
-        if (buf.trim()) processLine(buf);
-        // If the child never emitted a parseable result (crash or killed by the
-        // timeout), record it as a failure explicitly. Silence here previously
-        // showed up as "0 ok, 0 failed" — indistinguishable from an empty run.
-        if (!recorded) {
-          console.log(`${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(`no result (exit ${code})`)}`);
-          results.push({ id: t.identifier, ok: false, log, why: `no result emitted (exit ${code})` });
+  }
+
+  // --------------------------------------------------------- rolling loop -----
+  const running = new Map(); // identifier -> promise
+  const inFlight = new Map(); // identifier -> ticket, for releasing claims on interrupt
+  const children = new Set(); // spawned agent processes, so shutdown can stop them explicitly
+  let shuttingDown = false;
+
+  /**
+   * Ctrl-C must not leave claims behind.
+   *
+   * The agent processes share our process group, so the same Ctrl-C that stops
+   * the supervisor already stopped them — but the code that releases a claim on
+   * failure lives in THIS process, in each child's close handler. Exiting
+   * immediately skipped it, and three tickets claimed seconds before a Ctrl-C
+   * stayed `In Progress` with nothing running: dispatch slots held by ghosts
+   * until a human noticed, since the reaper needs 45 minutes of silence first.
+   *
+   * So: stop claiming, stop the children, give their own handlers a moment to
+   * release cleanly, then release whatever is still held and leave.
+   */
+  async function shutdown(sig) {
+    if (shuttingDown) process.exit(130); // second Ctrl-C: the operator means it
+    shuttingDown = true;
+    console.log(
+      c.yellow(
+        `\n  ${sig} — releasing ${inFlight.size} claim(s) before exit. Ctrl-C again to abandon them.`,
+      ),
+    );
+
+    for (const ch of children) {
+      try {
+        ch.kill("SIGTERM");
+      } catch {
+        /* intentionally ignored */
+      }
+    }
+
+    const deadline = Date.now() + 10_000;
+    while (running.size && Date.now() < deadline) await Bun.sleep(250);
+
+    for (const [id, t] of [...inFlight]) {
+      releaseWorkerLease({
+        repo: repo.name,
+        ticket: t.identifier,
+        owner: leaseOwner,
+      });
+      const wt = path.join(expand(repo.worktree_root), t.identifier);
+      preserveWip(wt, t.identifier);
+      await unclaim(
+        t,
+        `dispatcher interrupted (${sig}) before the run finished`,
+      ).catch(() => {});
+      console.log(c.dim(`  released ${id}`));
+    }
+    console.log(
+      c.dim(
+        `\nstopped. Claims released; worktrees left in place for the next dispatch.\n`,
+      ),
+    );
+    process.exit(130);
+  }
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  const seen = new Set(); // everything we have claimed this run
+  const warned = new Set(); // skip-warnings already printed, so refills don't repeat them
+  let startedCount = 0;
+  let drained = false;
+
+  /**
+   * Cross-process claim lock, so more than one supervisor can work one repo.
+   *
+   * Linear has no compare-and-swap, so claim() writes the assignee and reads it
+   * back. That works against a foreign agent, and not at all against a second
+   * supervisor of YOUR OWN: both authenticate as the same Linear user (OPS-40),
+   * so the read-back returns our id for both and each concludes it won. Two
+   * agents then enter the same worktree — same branch, same database, same
+   * ports. The slot accounting has the same problem: each dispatcher sees
+   * `cap - inProgress` before the other's claims land, so both fill the cap.
+   *
+   * Both are fixed by serialising the read-decide-claim window on the machine
+   * where the supervisors run. It is short — a Linear query and one update per
+   * ticket — so the second dispatcher waits milliseconds, then re-reads and sees
+   * the first one's claims.
+   *
+   * A holder that dies leaves the file behind, so the lock carries its pid and
+   * is stolen when that process is gone or the lock is older than 2 minutes.
+   */
+  const LOCK = path.join(
+    homedir(),
+    ".factory/locks",
+    `${repo.name}.dispatch.lock`,
+  );
+  mkdirSync(path.dirname(LOCK), { recursive: true });
+
+  const releaseClaimLock = () => {
+    try {
+      unlinkSync(LOCK);
+    } catch {
+      /* intentionally ignored */
+    }
+  };
+
+  async function fill() {
+    if (startedCount >= MAX || tripped || shuttingDown) return;
+    const spent = budgetExhausted(policy);
+    if (spent) {
+      if (!drained)
+        console.log(
+          c.yellow(
+            `\n  ${spent} — draining: running tickets finish, nothing new starts.\n`,
+          ),
+        );
+      drained = true;
+      return;
+    }
+    // Everything from here to the last claim() must be exclusive: read the queue,
+    // decide, claim. Another dispatcher reading in the middle of it would see
+    // slots we are about to take.
+    if (
+      !acquireClaimLock(LOCK, {
+        onStale: (pid) =>
+          console.log(
+            c.yellow(
+              pid === null
+                ? "  corrupt dispatch lock — taking it"
+                : `  stale dispatch lock from pid ${pid} — taking it`,
+            ),
+          ),
+      })
+    ) {
+      console.log(
+        c.dim(
+          `  another dispatcher is claiming for ${repo.name} — skipping this pass`,
+        ),
+      );
+      return;
+    }
+    try {
+      const state = await fetchState();
+      const free = Math.min(
+        cap - liveWorkerLeases(repo.name).length,
+        MAX - startedCount,
+      );
+      if (free <= 0) return;
+
+      // Same warnings the dry run prints — without them, "READY is high but nothing
+      // starts" is invisible in exactly the mode that matters (see F-7). Keyed per
+      // reason: a blocked ticket can unblock mid-run and then be worth re-warning
+      // about its missing Owned Paths, and vice versa.
+      for (const t of state.ready) {
+        if (seen.has(t.identifier)) continue;
+        const blockers = openBlockers(t);
+        if (blockers.length && !warned.has(`${t.identifier}:blocked`)) {
+          warned.add(`${t.identifier}:blocked`);
+          console.log(
+            c.yellow(
+              `  skip ${t.identifier} — blocked by ${blockers.join(", ")}`,
+            ),
+          );
+        } else if (
+          !blockers.length &&
+          !parseOwnedPaths(t.description ?? "").length &&
+          !warned.has(`${t.identifier}:paths`)
+        ) {
+          warned.add(`${t.identifier}:paths`);
+          console.log(
+            c.yellow(
+              `  ${t.identifier} — no parseable Owned Paths, treated as owning everything (dispatchable, but runs alone)`,
+            ),
+          );
         }
       }
-      out.end();
-      // A failed run must not keep its claim (unclaim() checks the ticket
-      // still looks like ours — Blocked/In Review moves are left alone).
-      const r = results.findLast((x) => x.id === t.identifier);
-      if (r && !r.ok) {
-        preserveWip(wt, t.identifier);
-        await unclaim(t, r.why ?? "run failed", log).catch(() => {});
+
+      const picked = selectable(state, seen, free);
+      if (!picked.length) return;
+
+      const claimed = [];
+      for (const t of picked) {
+        if (await claim(t)) {
+          claimed.push(t);
+          seen.add(t.identifier);
+          console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} claimed`);
+        } else
+          console.log(
+            c.yellow(`  ${t.identifier} claim lost to another agent`),
+          );
       }
-      releaseWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner });
-      resolve();
-    });
-  });
-}
+      if (!claimed.length) return;
 
-// --------------------------------------------------------- rolling loop -----
-const running = new Map();   // identifier -> promise
-const inFlight = new Map();  // identifier -> ticket, for releasing claims on interrupt
-const children = new Set();  // spawned agent processes, so shutdown can stop them explicitly
-let shuttingDown = false;
+      warmIfWorthIt(claimed.length);
 
-/**
- * Ctrl-C must not leave claims behind.
- *
- * The agent processes share our process group, so the same Ctrl-C that stops
- * the supervisor already stopped them — but the code that releases a claim on
- * failure lives in THIS process, in each child's close handler. Exiting
- * immediately skipped it, and three tickets claimed seconds before a Ctrl-C
- * stayed `In Progress` with nothing running: dispatch slots held by ghosts
- * until a human noticed, since the reaper needs 45 minutes of silence first.
- *
- * So: stop claiming, stop the children, give their own handlers a moment to
- * release cleanly, then release whatever is still held and leave.
- */
-async function shutdown(sig) {
-  if (shuttingDown) process.exit(130);   // second Ctrl-C: the operator means it
-  shuttingDown = true;
-  console.log(c.yellow(`\n  ${sig} — releasing ${inFlight.size} claim(s) before exit. Ctrl-C again to abandon them.`));
-
-  for (const ch of children) { try { ch.kill("SIGTERM"); } catch { /* intentionally ignored */ } }
-
-  const deadline = Date.now() + 10_000;
-  while (running.size && Date.now() < deadline) await Bun.sleep(250);
-
-  for (const [id, t] of [...inFlight]) {
-    releaseWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner });
-    const wt = path.join(expand(repo.worktree_root), t.identifier);
-    preserveWip(wt, t.identifier);
-    await unclaim(t, `dispatcher interrupted (${sig}) before the run finished`).catch(() => {});
-    console.log(c.dim(`  released ${id}`));
-  }
-  console.log(c.dim(`\nstopped. Claims released; worktrees left in place for the next dispatch.\n`));
-  process.exit(130);
-}
-process.on("SIGINT", () => shutdown("SIGINT"));
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-const seen = new Set();      // everything we have claimed this run
-const warned = new Set();    // skip-warnings already printed, so refills don't repeat them
-let startedCount = 0;
-let drained = false;
-
-/**
- * Cross-process claim lock, so more than one supervisor can work one repo.
- *
- * Linear has no compare-and-swap, so claim() writes the assignee and reads it
- * back. That works against a foreign agent, and not at all against a second
- * supervisor of YOUR OWN: both authenticate as the same Linear user (OPS-40),
- * so the read-back returns our id for both and each concludes it won. Two
- * agents then enter the same worktree — same branch, same database, same
- * ports. The slot accounting has the same problem: each dispatcher sees
- * `cap - inProgress` before the other's claims land, so both fill the cap.
- *
- * Both are fixed by serialising the read-decide-claim window on the machine
- * where the supervisors run. It is short — a Linear query and one update per
- * ticket — so the second dispatcher waits milliseconds, then re-reads and sees
- * the first one's claims.
- *
- * A holder that dies leaves the file behind, so the lock carries its pid and
- * is stolen when that process is gone or the lock is older than 2 minutes.
- */
-const LOCK = path.join(homedir(), ".factory/locks", `${repo.name}.dispatch.lock`);
-mkdirSync(path.dirname(LOCK), { recursive: true });
-
-const releaseClaimLock = () => { try { unlinkSync(LOCK); } catch { /* intentionally ignored */ } };
-
-async function fill() {
-  if (startedCount >= MAX || tripped || shuttingDown) return;
-  const spent = budgetExhausted(policy);
-  if (spent) {
-    if (!drained) console.log(c.yellow(`\n  ${spent} — draining: running tickets finish, nothing new starts.\n`));
-    drained = true;
-    return;
-  }
-  // Everything from here to the last claim() must be exclusive: read the queue,
-  // decide, claim. Another dispatcher reading in the middle of it would see
-  // slots we are about to take.
-  if (!acquireClaimLock(LOCK, {
-    onStale: (pid) => console.log(c.yellow(
-      pid === null
-        ? "  corrupt dispatch lock — taking it"
-        : `  stale dispatch lock from pid ${pid} — taking it`,
-    )),
-  })) {
-    console.log(c.dim(`  another dispatcher is claiming for ${repo.name} — skipping this pass`));
-    return;
-  }
-  try {
-
-  const state = await fetchState();
-  const free = Math.min(cap - liveWorkerLeases(repo.name).length, MAX - startedCount);
-  if (free <= 0) return;
-
-  // Same warnings the dry run prints — without them, "READY is high but nothing
-  // starts" is invisible in exactly the mode that matters (see F-7). Keyed per
-  // reason: a blocked ticket can unblock mid-run and then be worth re-warning
-  // about its missing Owned Paths, and vice versa.
-  for (const t of state.ready) {
-    if (seen.has(t.identifier)) continue;
-    const blockers = openBlockers(t);
-    if (blockers.length && !warned.has(`${t.identifier}:blocked`)) {
-      warned.add(`${t.identifier}:blocked`);
-      console.log(c.yellow(`  skip ${t.identifier} — blocked by ${blockers.join(", ")}`));
-    } else if (!blockers.length && !parseOwnedPaths(t.description ?? "").length && !warned.has(`${t.identifier}:paths`)) {
-      warned.add(`${t.identifier}:paths`);
-      console.log(c.yellow(`  ${t.identifier} — no parseable Owned Paths, treated as owning everything (dispatchable, but runs alone)`));
+      for (const t of claimed) {
+        startedCount++;
+        // Count the claim immediately, including worktree setup, so another local
+        // supervisor cannot observe a free slot in the small gap before spawn.
+        writeWorkerLease({
+          repo: repo.name,
+          ticket: t.identifier,
+          owner: leaseOwner,
+        });
+        inFlight.set(t.identifier, t);
+        const p = runTicket(t).finally(() => {
+          releaseWorkerLease({
+            repo: repo.name,
+            ticket: t.identifier,
+            owner: leaseOwner,
+          });
+          running.delete(t.identifier);
+          inFlight.delete(t.identifier);
+        });
+        running.set(t.identifier, p);
+      }
+    } finally {
+      releaseClaimLock();
     }
   }
 
-  const picked = selectable(state, seen, free);
-  if (!picked.length) return;
+  // A worker lease is deliberately not driven by its JSONL output: agents can
+  // spend minutes in a test runner with no transcript event. The parent remains
+  // responsible for the child, so its heartbeat is the authoritative liveness
+  // signal; a vanished parent naturally lets every lease expire.
+  const leaseHeartbeat = setInterval(() => {
+    for (const t of inFlight.values()) {
+      renewWorkerLease({
+        repo: repo.name,
+        ticket: t.identifier,
+        owner: leaseOwner,
+      });
+    }
+  }, LEASE_HEARTBEAT_MS);
 
-  const claimed = [];
-  for (const t of picked) {
-    if (await claim(t)) { claimed.push(t); seen.add(t.identifier); console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} claimed`); }
-    else console.log(c.yellow(`  ${t.identifier} claim lost to another agent`));
+  // Orphaned agent Chrome holds SingletonLock on the shared profile and blocks
+  // every later browser launch (×43+ failures across 20 runs in friction.mjs).
+  // Sweep before dispatch — only kills Chrome reparented to PID 1.
+  if (APPLY) {
+    const sweep = spawnSync(
+      "/bin/bash",
+      ["-lc", "bun orchestrator/chrome-sweep.mjs --apply"],
+      { cwd: ROOT, encoding: "utf8" },
+    );
+    const line = (sweep.stdout || sweep.stderr || "")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .pop();
+    if (line && !line.includes("no orphaned"))
+      console.log(c.dim(`  chrome-sweep: ${line}`));
   }
-  if (!claimed.length) return;
 
-  warmIfWorthIt(claimed.length);
-
-  for (const t of claimed) {
-    startedCount++;
-    // Count the claim immediately, including worktree setup, so another local
-    // supervisor cannot observe a free slot in the small gap before spawn.
-    writeWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner });
-    inFlight.set(t.identifier, t);
-    const p = runTicket(t).finally(() => {
-      releaseWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner });
-      running.delete(t.identifier);
-      inFlight.delete(t.identifier);
-    });
-    running.set(t.identifier, p);
+  await fill();
+  if (!running.size) {
+    clearInterval(leaseHeartbeat);
+    console.log(c.dim("\n  nothing started.\n"));
+    process.exit(0);
   }
 
-  } finally { releaseClaimLock(); }
-}
-
-// A worker lease is deliberately not driven by its JSONL output: agents can
-// spend minutes in a test runner with no transcript event. The parent remains
-// responsible for the child, so its heartbeat is the authoritative liveness
-// signal; a vanished parent naturally lets every lease expire.
-const leaseHeartbeat = setInterval(() => {
-  for (const t of inFlight.values()) {
-    renewWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner });
+  while (running.size) {
+    await Promise.race(running.values());
+    // A slot just freed. Re-read the queue — triage may have promoted something,
+    // or a finishing agent may have filed follow-up work, while we were busy.
+    if (REFILL && startedCount < MAX) {
+      const before = running.size;
+      await fill();
+      if (running.size > before)
+        console.log(c.dim(`  ${clock()} refilled — ${running.size} in flight`));
+    }
   }
-}, LEASE_HEARTBEAT_MS);
 
-// Orphaned agent Chrome holds SingletonLock on the shared profile and blocks
-// every later browser launch (×43+ failures across 20 runs in friction.mjs).
-// Sweep before dispatch — only kills Chrome reparented to PID 1.
-if (APPLY) {
-  const sweep = spawnSync("/bin/bash", ["-lc", "bun orchestrator/chrome-sweep.mjs --apply"], { cwd: ROOT, encoding: "utf8" });
-  const line = (sweep.stdout || sweep.stderr || "").trim().split("\n").filter(Boolean).pop();
-  if (line && !line.includes("no orphaned")) console.log(c.dim(`  chrome-sweep: ${line}`));
-}
-
-await fill();
-if (!running.size) { clearInterval(leaseHeartbeat); console.log(c.dim("\n  nothing started.\n")); process.exit(0); }
-
-while (running.size) {
-  await Promise.race(running.values());
-  // A slot just freed. Re-read the queue — triage may have promoted something,
-  // or a finishing agent may have filed follow-up work, while we were busy.
-  if (REFILL && startedCount < MAX) {
-    const before = running.size;
-    await fill();
-    if (running.size > before) console.log(c.dim(`  ${clock()} refilled — ${running.size} in flight`));
-  }
-}
-
-console.log(c.bold("\nsummary"));
-for (const r of results) console.log(`  ${r.ok ? c.green("ok  ") : c.red("FAIL")} ${r.id}${r.log ? c.dim("  " + r.log.replace(homedir(), "~")) : ""}${r.why ? c.dim("  " + r.why) : ""}`);
-const failed = results.filter((r) => !r.ok).length;
-  if (tripped) console.log(c.red(`circuit breaker tripped — dispatch stopped after ${envFailures} consecutive environment failures.`));
-  console.log(c.dim(`\n${results.length - failed} ok, ${failed} failed, ${startedCount} started. Merging is a separate stage.\n`));
+  console.log(c.bold("\nsummary"));
+  for (const r of results)
+    console.log(
+      `  ${r.ok ? c.green("ok  ") : c.red("FAIL")} ${r.id}${r.log ? c.dim("  " + r.log.replace(homedir(), "~")) : ""}${r.why ? c.dim("  " + r.why) : ""}`,
+    );
+  const failed = results.filter((r) => !r.ok).length;
+  if (tripped)
+    console.log(
+      c.red(
+        `circuit breaker tripped — dispatch stopped after ${envFailures} consecutive environment failures.`,
+      ),
+    );
+  console.log(
+    c.dim(
+      `\n${results.length - failed} ok, ${failed} failed, ${startedCount} started. Merging is a separate stage.\n`,
+    ),
+  );
   clearInterval(leaseHeartbeat);
   process.exit(failed || tripped ? 1 : 0);
 }

--- a/orchestrator/warm.mjs
+++ b/orchestrator/warm.mjs
@@ -40,7 +40,12 @@ export function parseWarmHead(result) {
 export function parseBehindCount(fetchResult, revListResult) {
   const stdout = String(revListResult?.stdout ?? "").trim();
   const stderr = String(revListResult?.stderr ?? "").trim();
-  if (fetchResult?.status !== 0 || revListResult?.status !== 0 || stderr || !/^\d+$/.test(stdout)) {
+  if (
+    fetchResult?.status !== 0 ||
+    revListResult?.status !== 0 ||
+    stderr ||
+    !/^\d+$/.test(stdout)
+  ) {
     return Infinity;
   }
 
@@ -57,30 +62,40 @@ export function evaluateWarmCache({
   threshold = DEFAULT_THRESHOLD,
 }) {
   const warmHead = warmDirExists ? parseWarmHead(warmHeadResult) : null;
-  const behind = warmHead ? parseBehindCount(fetchResult, revListResult) : Infinity;
+  const behind = warmHead
+    ? parseBehindCount(fetchResult, revListResult)
+    : Infinity;
   const stale = !Number.isFinite(behind) || behind >= threshold;
   return { warmHead, behind, stale, gateExitCode: stale ? 0 : 1 };
 }
 
 const expand = (p) => String(p ?? "").replace(/^~/, homedir());
-const sh = (cmd, cwd) => spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
+const sh = (cmd, cwd) =>
+  spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
 
 export function runWarm({
   argv,
   cfg,
   exists = existsSync,
   shell = sh,
-  applyShell = (script, cwd) => spawnSync("/bin/bash", [script], { cwd, stdio: "inherit" }),
+  applyShell = (script, cwd) =>
+    spawnSync("/bin/bash", [script], { cwd, stdio: "inherit" }),
   log = console.log,
   error = console.error,
 }) {
-  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
   const apply = argv.includes("--apply");
   const gate = argv.includes("--gate");
   const threshold = Number(val("--threshold") ?? DEFAULT_THRESHOLD);
 
   const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
-  if (!repo) { error("--repo required"); return 2; }
+  if (!repo) {
+    error("--repo required");
+    return 2;
+  }
 
   const repoPath = expand(repo.path);
   const warmDir = path.join(expand(repo.worktree_root ?? ""), ".warm");
@@ -90,7 +105,9 @@ export function runWarm({
     if (gate) return repo.worktree_warm ? 0 : 1;
   }
 
-  const warmHeadResult = warmDirExists ? shell("git rev-parse HEAD", warmDir) : null;
+  const warmHeadResult = warmDirExists
+    ? shell("git rev-parse HEAD", warmDir)
+    : null;
   const warmHead = parseWarmHead(warmHeadResult);
   const fetchResult = shell("git fetch --quiet", repoPath);
   const revListResult = warmHead
@@ -104,11 +121,15 @@ export function runWarm({
     threshold,
   });
   const behind = freshness.behind;
-  const age = warmHead ? shell(`git log -1 --format=%ar ${warmHead}`, repoPath).stdout.trim() : "n/a";
+  const age = warmHead
+    ? shell(`git log -1 --format=%ar ${warmHead}`, repoPath).stdout.trim()
+    : "n/a";
 
   if (gate) {
     if (freshness.stale) {
-      const detail = Number.isFinite(behind) ? `${behind} commits behind` : "stale — behind-count unknown";
+      const detail = Number.isFinite(behind)
+        ? `${behind} commits behind`
+        : "stale — behind-count unknown";
       log(`${repo.name}: warm cache ${detail} — refresh`);
       return freshness.gateExitCode;
     }
@@ -119,21 +140,35 @@ export function runWarm({
   log(`\n${repo.name} warm cache`);
   log(`  path:   ${repo.worktree_root}/.warm`);
   log(`  head:   ${warmHead?.slice(0, 8) ?? "-"}  (${age})`);
-  log(`  behind: ${Number.isFinite(behind) ? behind : "n/a"} commit(s) on origin/${repo.base}`);
-  log(freshness.stale
-    ? `  → stale: every new worktree pays a full compile instead of cloning a usable cache`
-    : `  → fresh enough (threshold ${threshold})`);
+  log(
+    `  behind: ${Number.isFinite(behind) ? behind : "n/a"} commit(s) on origin/${repo.base}`,
+  );
+  log(
+    freshness.stale
+      ? `  → stale: every new worktree pays a full compile instead of cloning a usable cache`
+      : `  → fresh enough (threshold ${threshold})`,
+  );
 
-  if (!apply) { log(`\n  re-run with --apply to refresh\n`); return 0; }
+  if (!apply) {
+    log(`\n  re-run with --apply to refresh\n`);
+    return 0;
+  }
 
-  if (!repo.worktree_warm) { error(`\n  ${repo.name} has no worktree_warm script in repos.yaml`); return 2; }
+  if (!repo.worktree_warm) {
+    error(`\n  ${repo.name} has no worktree_warm script in repos.yaml`);
+    return 2;
+  }
 
-  log(`\n  running ${repo.worktree_warm} — this compiles once so that N worktrees don't...\n`);
+  log(
+    `\n  running ${repo.worktree_warm} — this compiles once so that N worktrees don't...\n`,
+  );
   const result = applyShell(repo.worktree_warm, repoPath);
   return result.status ?? 1;
 }
 
 if (import.meta.main) {
-  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
   process.exit(runWarm({ argv: process.argv.slice(2), cfg }));
 }

--- a/orchestrator/warm.test.mjs
+++ b/orchestrator/warm.test.mjs
@@ -41,10 +41,16 @@ describe("warm cache staleness gate", () => {
   });
 
   test.each([
-    ["non-zero rev-list status", { status: 128, stdout: "", stderr: "fatal: bad revision" }],
+    [
+      "non-zero rev-list status",
+      { status: 128, stdout: "", stderr: "fatal: bad revision" },
+    ],
     ["empty rev-list output", ok("  \n")],
     ["unparseable rev-list output", ok("not-a-number\n")],
-    ["rev-list error output", { status: 0, stdout: "2\n", stderr: "warning: unverified" }],
+    [
+      "rev-list error output",
+      { status: 0, stdout: "2\n", stderr: "warning: unverified" },
+    ],
   ])("%s fails closed and exits 0 under --gate", (_name, revListResult) => {
     const result = evaluate({ revListResult });
     expect(result.behind).toBe(Infinity);
@@ -57,22 +63,32 @@ describe("warm cache staleness gate", () => {
   });
 
   test("an unsafe numeric count fails closed", () => {
-    expect(parseBehindCount(ok(), ok("999999999999999999999\n"))).toBe(Infinity);
+    expect(parseBehindCount(ok(), ok("999999999999999999999\n"))).toBe(
+      Infinity,
+    );
   });
 });
 
 describe("warm CLI behavior", () => {
   const cfg = {
-    repos: [{
-      name: "example",
-      path: "/repo",
-      worktree_root: "/warm-root",
-      base: "develop",
-      worktree_warm: "/warm.sh",
-    }],
+    repos: [
+      {
+        name: "example",
+        path: "/repo",
+        worktree_root: "/warm-root",
+        base: "develop",
+        worktree_warm: "/warm.sh",
+      },
+    ],
   };
 
-  function run({ args = ["--gate"], warmDirExists = true, head = ok(`${HEAD}\n`), fetch = ok(), revList = ok("0\n") } = {}) {
+  function run({
+    args = ["--gate"],
+    warmDirExists = true,
+    head = ok(`${HEAD}\n`),
+    fetch = ok(),
+    revList = ok("0\n"),
+  } = {}) {
     const output = [];
     const shell = (command) => {
       if (command === "git rev-parse HEAD") return head;
@@ -105,13 +121,18 @@ describe("warm CLI behavior", () => {
   });
 
   test("--gate reports stale and unknown when rev-list fails", () => {
-    const result = run({ revList: { status: 128, stdout: "", stderr: "fatal: bad revision" } });
+    const result = run({
+      revList: { status: 128, stdout: "", stderr: "fatal: bad revision" },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("stale — behind-count unknown — refresh");
   });
 
   test("non-gate output reports n/a and stale when rev-list fails", () => {
-    const result = run({ args: [], revList: { status: 128, stdout: "", stderr: "fatal" } });
+    const result = run({
+      args: [],
+      revList: { status: 128, stdout: "", stderr: "fatal" },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("behind: n/a commit(s)");
     expect(result.output).toContain("→ stale:");
@@ -120,7 +141,9 @@ describe("warm CLI behavior", () => {
   test("a missing warm directory requests refresh under --gate", () => {
     const result = run({ warmDirExists: false });
     expect(result.exitCode).toBe(0);
-    expect(result.output).toContain("no warm cache at /warm-root/.warm — stale");
+    expect(result.output).toContain(
+      "no warm cache at /warm-root/.warm — stale",
+    );
   });
 
   test("an invalid warm HEAD is stale with an unknown count", () => {
@@ -132,8 +155,17 @@ describe("warm CLI behavior", () => {
 
 describe("warm cache location and HEAD validation", () => {
   test("a missing warm directory is stale", () => {
-    const result = evaluate({ warmDirExists: false, warmHeadResult: null, revListResult: null });
-    expect(result).toMatchObject({ warmHead: null, behind: Infinity, stale: true, gateExitCode: 0 });
+    const result = evaluate({
+      warmDirExists: false,
+      warmHeadResult: null,
+      revListResult: null,
+    });
+    expect(result).toMatchObject({
+      warmHead: null,
+      behind: Infinity,
+      stale: true,
+      gateExitCode: 0,
+    });
   });
 
   test.each([
@@ -142,7 +174,12 @@ describe("warm cache location and HEAD validation", () => {
     ["malformed HEAD", ok("not-an-object-id\n")],
   ])("an invalid warm HEAD (%s) is stale", (_name, warmHeadResult) => {
     const result = evaluate({ warmHeadResult, revListResult: null });
-    expect(result).toMatchObject({ warmHead: null, behind: Infinity, stale: true, gateExitCode: 0 });
+    expect(result).toMatchObject({
+      warmHead: null,
+      behind: Infinity,
+      stale: true,
+      gateExitCode: 0,
+    });
   });
 
   test("SHA-1 and SHA-256 object IDs are accepted", () => {

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -11,28 +11,54 @@
 import { readFileSync, openSync, readSync, closeSync } from "node:fs";
 import path from "node:path";
 
-const trim = (s, n) => String(s ?? "").replace(/\s+/g, " ").slice(0, n);
+const trim = (s, n) =>
+  String(s ?? "")
+    .replace(/\s+/g, " ")
+    .slice(0, n);
 
 function resultEntry(ok, turns, cost, said) {
-  return { kind: "result", ok, turns: turns ?? 0, cost: cost ?? 0, said: trim(said, 120) };
+  return {
+    kind: "result",
+    ok,
+    turns: turns ?? 0,
+    cost: cost ?? 0,
+    said: trim(said, 120),
+  };
 }
 function textEntry(text) {
   return { kind: "text", detail: trim(text, 180) };
 }
 
 /** One raw .jsonl line -> zero or more display entries. Never throws. */
-export function parseLogLine(rawLine, { verbose = false, showTools = true } = {}) {
+export function parseLogLine(
+  rawLine,
+  { verbose = false, showTools = true } = {},
+) {
   const line = String(rawLine ?? "").trim();
   if (!line.startsWith("{")) return [];
   let e;
-  try { e = JSON.parse(line); } catch { return []; }
+  try {
+    e = JSON.parse(line);
+  } catch {
+    return [];
+  }
 
   if (e.type === "assistant") {
     return (e.message?.content ?? []).flatMap((p) => {
       if (showTools && p.type === "tool_use") {
         const inp = p.input ?? {};
         const detail = trim(
-          inp.command ?? inp.CommandLine ?? inp.file_path ?? inp.path ?? inp.TargetFile ?? inp.AbsolutePath ?? inp.query ?? inp.Query ?? inp.pattern ?? inp.description ?? inp.prompt,
+          inp.command ??
+            inp.CommandLine ??
+            inp.file_path ??
+            inp.path ??
+            inp.TargetFile ??
+            inp.AbsolutePath ??
+            inp.query ??
+            inp.Query ??
+            inp.pattern ??
+            inp.description ??
+            inp.prompt,
           66,
         );
         return [{ kind: "tool", tool: p.name, detail }];
@@ -41,29 +67,69 @@ export function parseLogLine(rawLine, { verbose = false, showTools = true } = {}
       return [];
     });
   }
-  if (e.type === "result" || (typeof e.num_turns === "number" && "subtype" in e)) {
-    return [resultEntry(e.subtype === "success" && !e.is_error && (e.num_turns ?? 0) > 0, e.num_turns, e.total_cost_usd, e.result)];
+  if (
+    e.type === "result" ||
+    (typeof e.num_turns === "number" && "subtype" in e)
+  ) {
+    return [
+      resultEntry(
+        e.subtype === "success" && !e.is_error && (e.num_turns ?? 0) > 0,
+        e.num_turns,
+        e.total_cost_usd,
+        e.result,
+      ),
+    ];
   }
 
   if (e.event === "step_update") {
     const s = e.step_update ?? {};
     if (showTools && s.step_type === "tool" && s.state === "ACTIVE") {
       const par = s.tool_info?.parameters ?? {};
-      return [{ kind: "tool", tool: s.tool_name ?? "tool", detail: trim(par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path, 66) }];
+      return [
+        {
+          kind: "tool",
+          tool: s.tool_name ?? "tool",
+          detail: trim(
+            par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path,
+            66,
+          ),
+        },
+      ];
     }
-    if (verbose && s.step_type === "agent_response" && s.text_delta) return [textEntry(s.text_delta)];
+    if (verbose && s.step_type === "agent_response" && s.text_delta)
+      return [textEntry(s.text_delta)];
     return [];
   }
-  const env = e.event === "result" ? e.result : ("status" in e && "num_turns" in e ? e : null);
-  if (env) return [resultEntry(String(env.status).toLowerCase() === "success", env.num_turns, env.total_cost_usd, env.response)];
+  const env =
+    e.event === "result"
+      ? e.result
+      : "status" in e && "num_turns" in e
+        ? e
+        : null;
+  if (env)
+    return [
+      resultEntry(
+        String(env.status).toLowerCase() === "success",
+        env.num_turns,
+        env.total_cost_usd,
+        env.response,
+      ),
+    ];
 
-  if (verbose && e.type === "item.completed" && e.item?.type === "agent_message" && e.item.text) return [textEntry(e.item.text)];
+  if (
+    verbose &&
+    e.type === "item.completed" &&
+    e.item?.type === "agent_message" &&
+    e.item.text
+  )
+    return [textEntry(e.item.text)];
   return [];
 }
 
 /** A display entry -> one line of text for the log-tail pane. */
 export function formatEntry(entry) {
-  if (entry.kind === "tool") return entry.detail ? `${entry.tool} ${entry.detail}` : entry.tool;
+  if (entry.kind === "tool")
+    return entry.detail ? `${entry.tool} ${entry.detail}` : entry.tool;
   if (entry.kind === "text") return `agent — ${entry.detail}`;
   const cost = `${entry.turns} turns ~$${entry.cost.toFixed(2)}`;
   if (entry.ok) return `done — ${cost}`;
@@ -75,14 +141,21 @@ export function latestLogForTicket(logDir, repo, identifier) {
   let best = null;
   let bestMtime = -Infinity;
   let files;
-  try { files = new Bun.Glob(`${repo}-${identifier}-*.jsonl`).scanSync(logDir); } catch { return null; }
+  try {
+    files = new Bun.Glob(`${repo}-${identifier}-*.jsonl`).scanSync(logDir);
+  } catch {
+    return null;
+  }
   for (const f of files) {
     const rest = f.slice(repo.length + 1).replace(/\.jsonl$/, "");
     const match = /^(.+?)-\d{8}-?\d{6}\.?$/.exec(rest);
     if (match && match[1] !== identifier) continue;
     const full = path.join(logDir, f);
     const mtime = Bun.file(full).lastModified;
-    if (mtime > bestMtime) { bestMtime = mtime; best = full; }
+    if (mtime > bestMtime) {
+      bestMtime = mtime;
+      best = full;
+    }
   }
   return best;
 }
@@ -91,8 +164,14 @@ export function latestLogForTicket(logDir, repo, identifier) {
 export function tailEntries(filePath, maxEntries = 40, options) {
   if (!filePath) return [];
   let text;
-  try { text = readFileSync(filePath, "utf8"); } catch { return []; }
-  const entries = text.split("\n").flatMap((line) => parseLogLine(line, options));
+  try {
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  const entries = text
+    .split("\n")
+    .flatMap((line) => parseLogLine(line, options));
   return entries.slice(-maxEntries);
 }
 
@@ -114,9 +193,14 @@ export function buildTicketRows(summary) {
   const hasLeaseData = Array.isArray(summary?.liveWorkerIds);
   const liveWorkers = new Set(summary?.liveWorkerIds ?? []);
   const running = (summary?.inProgressTickets ?? []).map((t) => ({
-    ...t, status: "running", ...(hasLeaseData ? { hasWorker: liveWorkers.has(t.identifier) } : {}),
+    ...t,
+    status: "running",
+    ...(hasLeaseData ? { hasWorker: liveWorkers.has(t.identifier) } : {}),
   }));
-  const review = (summary?.inReviewTickets ?? []).map((t) => ({ ...t, status: "review" }));
+  const review = (summary?.inReviewTickets ?? []).map((t) => ({
+    ...t,
+    status: "review",
+  }));
   return [...running, ...review];
 }
 
@@ -155,12 +239,14 @@ export function agentCapStat(inProgress, slotsFree) {
  * table.
  */
 export function supervisorAlive(psText, repo, defaultRepo) {
-  return String(psText ?? "").split("\n").some((command) => {
-    if (!/(?:^|\s)(?:[^\s]*\/)?run\.mjs\b/.test(command)) return false;
-    const match = /--repo(?:=|\s+)([^\s]+)/.exec(command);
-    if (!match) return repo === defaultRepo;
-    return match[1].split(",").includes(repo);
-  });
+  return String(psText ?? "")
+    .split("\n")
+    .some((command) => {
+      if (!/(?:^|\s)(?:[^\s]*\/)?run\.mjs\b/.test(command)) return false;
+      const match = /--repo(?:=|\s+)([^\s]+)/.exec(command);
+      if (!match) return repo === defaultRepo;
+      return match[1].split(",").includes(repo);
+    });
 }
 
 /** Project progress for the stat strip. `capped` means the counts are floors (a 250-issue page filled up). */
@@ -188,9 +274,16 @@ const stageResultCache = new Map();
  * Returns [{ stage, active, ageMs, lastResult }] in STAGES order; ageMs is
  * null when a stage has never run, lastResult only filled for idle stages.
  */
-export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_000 } = {}) {
+export function stageStatuses(
+  logDir,
+  repo,
+  { now = Date.now(), activeMs = 90_000 } = {},
+) {
   return STAGES.map((stage) => {
-    const glob = stage === "dispatch" ? `${repo}-*-*.jsonl` : `${repo}-factory-${stage}-*.jsonl`;
+    const glob =
+      stage === "dispatch"
+        ? `${repo}-*-*.jsonl`
+        : `${repo}-factory-${stage}-*.jsonl`;
     let best = null;
     let bestMtime = -Infinity;
     try {
@@ -198,9 +291,14 @@ export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_00
         if (stage === "dispatch" && f.includes("-factory-")) continue;
         const full = path.join(logDir, f);
         const mtime = Bun.file(full).lastModified;
-        if (mtime > bestMtime) { bestMtime = mtime; best = full; }
+        if (mtime > bestMtime) {
+          bestMtime = mtime;
+          best = full;
+        }
       }
-    } catch { /* no log dir yet */ }
+    } catch {
+      /* no log dir yet */
+    }
     if (!best) return { stage, active: false, ageMs: null, lastResult: null };
 
     const ageMs = Math.max(0, now - bestMtime);
@@ -212,11 +310,17 @@ export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_00
         lastResult = stageResultCache.get(key);
       } else {
         try {
-          const entries = readFileSync(best, "utf8").split("\n").flatMap(parseLogLine);
-          lastResult = [...entries].reverse().find((e) => e.kind === "result") ?? null;
-        } catch { lastResult = null; }
+          const entries = readFileSync(best, "utf8")
+            .split("\n")
+            .flatMap(parseLogLine);
+          lastResult =
+            [...entries].reverse().find((e) => e.kind === "result") ?? null;
+        } catch {
+          lastResult = null;
+        }
         stageResultCache.set(key, lastResult);
-        if (stageResultCache.size > 64) stageResultCache.delete(stageResultCache.keys().next().value);
+        if (stageResultCache.size > 64)
+          stageResultCache.delete(stageResultCache.keys().next().value);
       }
     }
     return { stage, active, ageMs, lastResult };
@@ -232,7 +336,10 @@ export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_00
 export function visibleWindow(count, selected, max) {
   if (max <= 0) return [0, 0];
   if (count <= max) return [0, count];
-  const start = Math.max(0, Math.min(selected - Math.floor(max / 2), count - max));
+  const start = Math.max(
+    0,
+    Math.min(selected - Math.floor(max / 2), count - max),
+  );
   return [start, start + max];
 }
 
@@ -269,7 +376,18 @@ export function parseReaperOutput(text) {
   return { stale: 0 };
 }
 
-const KNOWN_FACTORY_COMMANDS = new Set([...STAGES, "unblock", "triage", "merge", "reaper", "digest", "janitor", "doctor", "sweep", "warm"]);
+const KNOWN_FACTORY_COMMANDS = new Set([
+  ...STAGES,
+  "unblock",
+  "triage",
+  "merge",
+  "reaper",
+  "digest",
+  "janitor",
+  "doctor",
+  "sweep",
+  "warm",
+]);
 
 /**
  * One entry per agent running RIGHT NOW: every log under logDir for `repo`
@@ -278,7 +396,11 @@ const KNOWN_FACTORY_COMMANDS = new Set([...STAGES, "unblock", "triage", "merge",
  * merge, …); `<repo>-<TICKET-ID>-<stamp>.jsonl` is a dispatch agent working
  * that ticket. Sorted most-recently-active first.
  */
-export function activeAgents(logDir, repo, { now = Date.now(), activeMs = 90_000 } = {}) {
+export function activeAgents(
+  logDir,
+  repo,
+  { now = Date.now(), activeMs = 90_000 } = {},
+) {
   const out = [];
   try {
     for (const f of new Bun.Glob(`${repo}-*.jsonl`).scanSync(logDir)) {
@@ -290,10 +412,28 @@ export function activeAgents(logDir, repo, { now = Date.now(), activeMs = 90_000
       const rest = f.slice(repo.length + 1).replace(/\.jsonl$/, "");
       const stage = /^factory-(.+?)-\d{8}-?\d{6}\.?$/.exec(rest);
       const ticket = /^(.+?)-\d{8}-?\d{6}\.?$/.exec(rest);
-      if (stage && KNOWN_FACTORY_COMMANDS.has(stage[1])) out.push({ stage: stage[1], label: stage[1], identifier: null, file: full, ageMs, harness: peekHarness(full) });
-      else if (ticket) out.push({ stage: "dispatch", label: ticket[1], identifier: ticket[1], file: full, ageMs, harness: peekHarness(full) });
+      if (stage && KNOWN_FACTORY_COMMANDS.has(stage[1]))
+        out.push({
+          stage: stage[1],
+          label: stage[1],
+          identifier: null,
+          file: full,
+          ageMs,
+          harness: peekHarness(full),
+        });
+      else if (ticket)
+        out.push({
+          stage: "dispatch",
+          label: ticket[1],
+          identifier: ticket[1],
+          file: full,
+          ageMs,
+          harness: peekHarness(full),
+        });
     }
-  } catch { /* no log dir yet */ }
+  } catch {
+    /* no log dir yet */
+  }
   return out.sort((a, b) => a.ageMs - b.ageMs);
 }
 
@@ -304,7 +444,12 @@ export function activeAgents(logDir, repo, { now = Date.now(), activeMs = 90_000
  * false -> true transition, so it doesn't nag on every poll while a problem
  * sits unresolved).
  */
-export function needsAttention({ blocked = 0, stages = [], quietTickets = 0, budgetTone } = {}) {
+export function needsAttention({
+  blocked = 0,
+  stages = [],
+  quietTickets = 0,
+  budgetTone,
+} = {}) {
   if (blocked > 0) return true;
   if (stages.some((s) => s.lastResult && !s.lastResult.ok)) return true;
   if (quietTickets > 0) return true;
@@ -324,8 +469,11 @@ export function peekHarness(file) {
     const n = readSync(fd, buf, 0, 160, 0);
     closeSync(fd);
     const head = buf.toString("utf8", 0, n);
-    if (head.includes('"type":"system"') || head.includes('"type":"assistant"')) return "claude";
+    if (head.includes('"type":"system"') || head.includes('"type":"assistant"'))
+      return "claude";
     if (head.includes('"event"') || head.includes("step_update")) return "agy";
-  } catch { /* unreadable — unknown */ }
+  } catch {
+    /* unreadable — unknown */
+  }
   return null;
 }

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -11,9 +11,26 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
-  parseLogLine, formatEntry, tailFormattedLines, tailEntries, entryTone, latestLogForTicket, buildTicketRows, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge, visibleWindow,
-  activeAgents, spendPct, spendTone, agentCapStat, supervisorAlive, needsAttention,
+  parseLogLine,
+  formatEntry,
+  tailFormattedLines,
+  tailEntries,
+  entryTone,
+  latestLogForTicket,
+  buildTicketRows,
+  formatSpend,
+  formatIssueCounts,
+  parseReaperOutput,
+  linearDeepLink,
+  stageStatuses,
+  formatAge,
+  visibleWindow,
+  activeAgents,
+  spendPct,
+  spendTone,
+  agentCapStat,
+  supervisorAlive,
+  needsAttention,
 } from "./watch-lib.mjs";
 
 test("ignores blank lines and non-JSON noise", () => {
@@ -30,29 +47,61 @@ test("ignores malformed JSON instead of throwing", () => {
 test("claude: extracts a tool_use call from an assistant message", () => {
   const line = JSON.stringify({
     type: "assistant",
-    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "npm run lint" } }] },
+    message: {
+      content: [
+        { type: "tool_use", name: "Bash", input: { command: "npm run lint" } },
+      ],
+    },
   });
-  expect(parseLogLine(line)).toEqual([{ kind: "tool", tool: "Bash", detail: "npm run lint" }]);
+  expect(parseLogLine(line)).toEqual([
+    { kind: "tool", tool: "Bash", detail: "npm run lint" },
+  ]);
 });
 
 test("claude: a text-only assistant message yields no entries", () => {
-  const line = JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "thinking..." }] } });
+  const line = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "text", text: "thinking..." }] },
+  });
   expect(parseLogLine(line)).toEqual([]);
 });
 
 test("verbose logs include Claude agent text while compact logs stay tool-only", () => {
-  const line = JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "I will verify the migration first." }] } });
-  expect(parseLogLine(line, { verbose: true })).toEqual([{ kind: "text", detail: "I will verify the migration first." }]);
-  expect(formatEntry(parseLogLine(line, { verbose: true })[0])).toBe("agent — I will verify the migration first.");
+  const line = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [{ type: "text", text: "I will verify the migration first." }],
+    },
+  });
+  expect(parseLogLine(line, { verbose: true })).toEqual([
+    { kind: "text", detail: "I will verify the migration first." },
+  ]);
+  expect(formatEntry(parseLogLine(line, { verbose: true })[0])).toBe(
+    "agent — I will verify the migration first.",
+  );
 });
 
 test("message-focused logs suppress tool calls", () => {
-  const line = JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "git status" } }] } });
+  const line = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [
+        { type: "tool_use", name: "Bash", input: { command: "git status" } },
+      ],
+    },
+  });
   expect(parseLogLine(line, { verbose: true, showTools: false })).toEqual([]);
 });
 
 test("claude: a successful result", () => {
-  const line = JSON.stringify({ type: "result", subtype: "success", is_error: false, num_turns: 12, total_cost_usd: 1.5, result: "done" });
+  const line = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    num_turns: 12,
+    total_cost_usd: 1.5,
+    result: "done",
+  });
   const [entry] = parseLogLine(line);
   expect(entry.kind).toBe("result");
   expect(entry.ok).toBe(true);
@@ -60,7 +109,14 @@ test("claude: a successful result", () => {
 });
 
 test("claude: a failed result includes the trimmed message", () => {
-  const line = JSON.stringify({ type: "result", subtype: "error_max_turns", is_error: true, num_turns: 3, total_cost_usd: 0.4, result: "Unknown command" });
+  const line = JSON.stringify({
+    type: "result",
+    subtype: "error_max_turns",
+    is_error: true,
+    num_turns: 3,
+    total_cost_usd: 0.4,
+    result: "Unknown command",
+  });
   const [entry] = parseLogLine(line);
   expect(entry.ok).toBe(false);
   expect(formatEntry(entry)).toBe("FAILED — 3 turns ~$0.40 — Unknown command");
@@ -69,35 +125,75 @@ test("claude: a failed result includes the trimmed message", () => {
 test("agy: extracts an ACTIVE tool step_update", () => {
   const line = JSON.stringify({
     event: "step_update",
-    step_update: { step_type: "tool", state: "ACTIVE", tool_name: "run_command", tool_info: { parameters: { CommandLine: "bun test" } } },
+    step_update: {
+      step_type: "tool",
+      state: "ACTIVE",
+      tool_name: "run_command",
+      tool_info: { parameters: { CommandLine: "bun test" } },
+    },
   });
-  expect(parseLogLine(line)).toEqual([{ kind: "tool", tool: "run_command", detail: "bun test" }]);
+  expect(parseLogLine(line)).toEqual([
+    { kind: "tool", tool: "run_command", detail: "bun test" },
+  ]);
 });
 
 test("agy: a DONE step_update produces no entry (only ACTIVE tool steps do)", () => {
-  const line = JSON.stringify({ event: "step_update", step_update: { step_type: "tool", state: "DONE", tool_name: "run_command" } });
+  const line = JSON.stringify({
+    event: "step_update",
+    step_update: { step_type: "tool", state: "DONE", tool_name: "run_command" },
+  });
   expect(parseLogLine(line)).toEqual([]);
 });
 
 test("verbose logs include agy agent-response updates", () => {
-  const line = JSON.stringify({ event: "step_update", step_update: { step_type: "agent_response", state: "ACTIVE", text_delta: "Checking the PR now." } });
-  expect(parseLogLine(line, { verbose: true })).toEqual([{ kind: "text", detail: "Checking the PR now." }]);
+  const line = JSON.stringify({
+    event: "step_update",
+    step_update: {
+      step_type: "agent_response",
+      state: "ACTIVE",
+      text_delta: "Checking the PR now.",
+    },
+  });
+  expect(parseLogLine(line, { verbose: true })).toEqual([
+    { kind: "text", detail: "Checking the PR now." },
+  ]);
 });
 
 test("verbose logs include Codex agent messages", () => {
-  const line = JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "I found the failing check." } });
-  expect(parseLogLine(line, { verbose: true })).toEqual([{ kind: "text", detail: "I found the failing check." }]);
+  const line = JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", text: "I found the failing check." },
+  });
+  expect(parseLogLine(line, { verbose: true })).toEqual([
+    { kind: "text", detail: "I found the failing check." },
+  ]);
 });
 
 test("agy: a wrapped result event", () => {
-  const line = JSON.stringify({ event: "result", result: { status: "SUCCESS", num_turns: 5, total_cost_usd: 2, response: "ok" } });
+  const line = JSON.stringify({
+    event: "result",
+    result: {
+      status: "SUCCESS",
+      num_turns: 5,
+      total_cost_usd: 2,
+      response: "ok",
+    },
+  });
   const [entry] = parseLogLine(line);
   expect(entry.ok).toBe(true);
   expect(formatEntry(entry)).toBe("done — 5 turns ~$2.00");
 });
 
 test("agy: an ERROR status formats as failed", () => {
-  const line = JSON.stringify({ event: "result", result: { status: "ERROR", num_turns: 1, total_cost_usd: 0, error: "quota reached" } });
+  const line = JSON.stringify({
+    event: "result",
+    result: {
+      status: "ERROR",
+      num_turns: 1,
+      total_cost_usd: 0,
+      error: "quota reached",
+    },
+  });
   const [entry] = parseLogLine(line);
   expect(entry.ok).toBe(false);
 });
@@ -107,7 +203,20 @@ test("tailFormattedLines reads a file, formats every entry, and caps at maxEntri
   const file = path.join(dir, "sample.jsonl");
   const lines = [];
   for (let i = 0; i < 5; i++) {
-    lines.push(JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: `f${i}.ts` } }] } }));
+    lines.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "Read",
+              input: { file_path: `f${i}.ts` },
+            },
+          ],
+        },
+      }),
+    );
   }
   writeFileSync(file, lines.join("\n"));
   expect(tailFormattedLines(file, 2)).toEqual(["Read f3.ts", "Read f4.ts"]);
@@ -139,11 +248,25 @@ test("latestLogForTicket returns null when nothing matches", () => {
 test("buildTicketRows tags running and in-review tickets and preserves order", () => {
   const summary = {
     inProgressTickets: [{ identifier: "CLNT-1", title: "a" }],
-    inReviewTickets: [{ identifier: "CLNT-2", title: "b", prNumber: 123, prUrl: "https://github.com/acme/app/pull/123" }, { identifier: "CLNT-3", title: "c" }],
+    inReviewTickets: [
+      {
+        identifier: "CLNT-2",
+        title: "b",
+        prNumber: 123,
+        prUrl: "https://github.com/acme/app/pull/123",
+      },
+      { identifier: "CLNT-3", title: "c" },
+    ],
   };
   expect(buildTicketRows(summary)).toEqual([
     { identifier: "CLNT-1", title: "a", status: "running" },
-    { identifier: "CLNT-2", title: "b", prNumber: 123, prUrl: "https://github.com/acme/app/pull/123", status: "review" },
+    {
+      identifier: "CLNT-2",
+      title: "b",
+      prNumber: 123,
+      prUrl: "https://github.com/acme/app/pull/123",
+      status: "review",
+    },
     { identifier: "CLNT-3", title: "c", status: "review" },
   ]);
 });
@@ -151,9 +274,15 @@ test("buildTicketRows tags running and in-review tickets and preserves order", (
 test("buildTicketRows marks an In Progress claim without a live worker lease", () => {
   const rows = buildTicketRows({
     liveWorkerIds: ["CLNT-2"],
-    inProgressTickets: [{ identifier: "CLNT-1", title: "stale" }, { identifier: "CLNT-2", title: "live" }],
+    inProgressTickets: [
+      { identifier: "CLNT-1", title: "stale" },
+      { identifier: "CLNT-2", title: "live" },
+    ],
   });
-  expect(rows.map((row) => [row.identifier, row.hasWorker])).toEqual([["CLNT-1", false], ["CLNT-2", true]]);
+  expect(rows.map((row) => [row.identifier, row.hasWorker])).toEqual([
+    ["CLNT-1", false],
+    ["CLNT-2", true],
+  ]);
 });
 
 test("buildTicketRows tolerates a summary with no tickets", () => {
@@ -172,37 +301,59 @@ test("formatIssueCounts renders done/total and marks capped counts as floors", (
 });
 
 test("parseReaperOutput reads the reclaim count from a dry run", () => {
-  const out = "=== Stale-claim reaper [DRY RUN] threshold=45min ===\n\n  STALE CW-12  61m  agent  title\n\n=== Would reclaim: 2 | Healthy: 3 ===\nRun again with --apply to reclaim these.";
+  const out =
+    "=== Stale-claim reaper [DRY RUN] threshold=45min ===\n\n  STALE CW-12  61m  agent  title\n\n=== Would reclaim: 2 | Healthy: 3 ===\nRun again with --apply to reclaim these.";
   expect(parseReaperOutput(out)).toEqual({ stale: 2 });
 });
 
 test("parseReaperOutput reads the count from an --apply run", () => {
-  expect(parseReaperOutput("=== Reclaimed: 1 | Healthy: 0 ===")).toEqual({ stale: 1 });
+  expect(parseReaperOutput("=== Reclaimed: 1 | Healthy: 0 ===")).toEqual({
+    stale: 1,
+  });
 });
 
 test("parseReaperOutput treats a clean queue or garbage as nothing to reclaim", () => {
-  expect(parseReaperOutput("=== No stale claims among 4 in progress. ===")).toEqual({ stale: 0 });
+  expect(
+    parseReaperOutput("=== No stale claims among 4 in progress. ==="),
+  ).toEqual({ stale: 0 });
   expect(parseReaperOutput("")).toEqual({ stale: 0 });
   expect(parseReaperOutput(null)).toEqual({ stale: 0 });
 });
 
 test("linearDeepLink maps linear.app URLs to the desktop scheme, null otherwise", () => {
-  expect(linearDeepLink("https://linear.app/watt-mind/issue/CLNT-810/clean-up-blog-routing"))
-    .toBe("linear://watt-mind/issue/CLNT-810/clean-up-blog-routing");
+  expect(
+    linearDeepLink(
+      "https://linear.app/watt-mind/issue/CLNT-810/clean-up-blog-routing",
+    ),
+  ).toBe("linear://watt-mind/issue/CLNT-810/clean-up-blog-routing");
   expect(linearDeepLink("https://example.com/issue/X-1")).toBeNull();
   expect(linearDeepLink(undefined)).toBeNull();
 });
 
 test("stageStatuses: fresh log = active, old log = idle with the last result", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
-  const result = JSON.stringify({ type: "result", subtype: "success", is_error: false, num_turns: 4, total_cost_usd: 0.5, result: "ok" });
-  writeFileSync(path.join(dir, "bj29-factory-triage-20260804-120000.jsonl"), result);
+  const result = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    num_turns: 4,
+    total_cost_usd: 0.5,
+    result: "ok",
+  });
+  writeFileSync(
+    path.join(dir, "bj29-factory-triage-20260804-120000.jsonl"),
+    result,
+  );
   writeFileSync(path.join(dir, "bj29-CLNT-1-20260804-120000.jsonl"), result);
   const now = Date.now();
 
   // Written milliseconds ago -> triage and dispatch active, merge never ran.
   const live = stageStatuses(dir, "bj29", { now });
-  expect(live.map((s) => [s.stage, s.active])).toEqual([["triage", true], ["dispatch", true], ["merge", false]]);
+  expect(live.map((s) => [s.stage, s.active])).toEqual([
+    ["triage", true],
+    ["dispatch", true],
+    ["merge", false],
+  ]);
   expect(live[2].ageMs).toBeNull();
 
   // Same files viewed from 10 minutes later -> idle, with the parsed result.
@@ -214,17 +365,34 @@ test("stageStatuses: fresh log = active, old log = idle with the last result", (
 
 test("stageStatuses: dispatch ignores factory-stage logs; failures surface", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
-  const fail = JSON.stringify({ type: "result", subtype: "error_max_turns", is_error: true, num_turns: 2, total_cost_usd: 0.1, result: "boom" });
-  writeFileSync(path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"), fail);
+  const fail = JSON.stringify({
+    type: "result",
+    subtype: "error_max_turns",
+    is_error: true,
+    num_turns: 2,
+    total_cost_usd: 0.1,
+    result: "boom",
+  });
+  writeFileSync(
+    path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"),
+    fail,
+  );
   const later = { now: Date.now() + 10 * 60_000 };
   const s = stageStatuses(dir, "bj29", later);
-  expect(s[1]).toEqual({ stage: "dispatch", active: false, ageMs: null, lastResult: null });
+  expect(s[1]).toEqual({
+    stage: "dispatch",
+    active: false,
+    ageMs: null,
+    lastResult: null,
+  });
   expect(s[2].lastResult?.ok).toBe(false);
   rmSync(dir, { recursive: true, force: true });
 });
 
 test("stageStatuses tolerates a missing log dir", () => {
-  expect(stageStatuses("/no/such/dir", "bj29").every((s) => s.ageMs === null)).toBe(true);
+  expect(
+    stageStatuses("/no/such/dir", "bj29").every((s) => s.ageMs === null),
+  ).toBe(true);
 });
 
 test("formatAge is coarse and never negative-weird", () => {
@@ -236,18 +404,24 @@ test("formatAge is coarse and never negative-weird", () => {
 });
 
 test("visibleWindow keeps the selection in view and clamps at both ends", () => {
-  expect(visibleWindow(5, 2, 10)).toEqual([0, 5]);      // fits — no scrolling
-  expect(visibleWindow(20, 0, 6)).toEqual([0, 6]);      // top
-  expect(visibleWindow(20, 10, 6)).toEqual([7, 13]);    // centred mid-list
-  expect(visibleWindow(20, 19, 6)).toEqual([14, 20]);   // bottom clamp
-  expect(visibleWindow(20, 5, 0)).toEqual([0, 0]);      // degenerate pane
+  expect(visibleWindow(5, 2, 10)).toEqual([0, 5]); // fits — no scrolling
+  expect(visibleWindow(20, 0, 6)).toEqual([0, 6]); // top
+  expect(visibleWindow(20, 10, 6)).toEqual([7, 13]); // centred mid-list
+  expect(visibleWindow(20, 19, 6)).toEqual([14, 20]); // bottom clamp
+  expect(visibleWindow(20, 5, 0)).toEqual([0, 0]); // degenerate pane
 });
 
 test("activeAgents labels stage vs dispatch agents and drops stale logs", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
-  writeFileSync(path.join(dir, "bj29-factory-triage-20260804-164848.jsonl"), "{}");
+  writeFileSync(
+    path.join(dir, "bj29-factory-triage-20260804-164848.jsonl"),
+    "{}",
+  );
   writeFileSync(path.join(dir, "bj29-CLNT-810-20260804143850..jsonl"), "{}"); // double-dot stamp variant
-  writeFileSync(path.join(dir, "bj29-factory-merge-20260804120000.jsonl"), "{}"); // dashless stamp
+  writeFileSync(
+    path.join(dir, "bj29-factory-merge-20260804120000.jsonl"),
+    "{}",
+  ); // dashless stamp
   const live = activeAgents(dir, "bj29");
   expect(live.map((a) => [a.stage, a.label, a.identifier]).sort()).toEqual([
     ["dispatch", "CLNT-810", "CLNT-810"],
@@ -255,7 +429,9 @@ test("activeAgents labels stage vs dispatch agents and drops stale logs", () => 
     ["triage", "triage", null],
   ]);
   // The same files 10 minutes later are nobody's live agent.
-  expect(activeAgents(dir, "bj29", { now: Date.now() + 10 * 60_000 })).toEqual([]);
+  expect(activeAgents(dir, "bj29", { now: Date.now() + 10 * 60_000 })).toEqual(
+    [],
+  );
   rmSync(dir, { recursive: true, force: true });
 });
 
@@ -269,10 +445,10 @@ test("activeAgents tolerates a missing log dir and foreign repos", () => {
 
 test("spendPct and spendTone track the daily cap", () => {
   expect(spendPct(4.2, 40)).toBe(11);
-  expect(spendPct(0, 0)).toBeNull();      // no cap configured -> no percentage
+  expect(spendPct(0, 0)).toBeNull(); // no cap configured -> no percentage
   expect(spendTone(4, 40)).toBeUndefined();
   expect(spendTone(29, 40)).toBe("warn"); // >= 70%
-  expect(spendTone(37, 40)).toBe("bad");  // >= 90%
+  expect(spendTone(37, 40)).toBe("bad"); // >= 90%
   expect(spendTone(4, 0)).toBeUndefined();
 });
 
@@ -291,18 +467,41 @@ test("supervisorAlive scopes foreground run.mjs processes to their repos", () =>
   expect(supervisorAlive(ps, "legalease", "bj29")).toBe(true);
   expect(supervisorAlive(ps, "cashsaas", "bj29")).toBe(true);
   expect(supervisorAlive(ps, "coach-wattz", "bj29")).toBe(false);
-  expect(supervisorAlive("node unrelated-run.mjs --repo bj29", "bj29", "bj29")).toBe(false);
-  expect(supervisorAlive("bun orchestrator/run.mjs --all", "bj29", "bj29")).toBe(true);
-  expect(supervisorAlive("bun orchestrator/run.mjs --all", "legalease", "bj29")).toBe(false);
+  expect(
+    supervisorAlive("node unrelated-run.mjs --repo bj29", "bj29", "bj29"),
+  ).toBe(false);
+  expect(
+    supervisorAlive("bun orchestrator/run.mjs --all", "bj29", "bj29"),
+  ).toBe(true);
+  expect(
+    supervisorAlive("bun orchestrator/run.mjs --all", "legalease", "bj29"),
+  ).toBe(false);
 });
 
 test("tailEntries returns raw entries; entryTone classifies them", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
   const file = path.join(dir, "log.jsonl");
-  writeFileSync(file, [
-    JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }] } }),
-    JSON.stringify({ type: "result", subtype: "success", is_error: false, num_turns: 3, total_cost_usd: 0.1, result: "done" }),
-  ].join("\n"));
+  writeFileSync(
+    file,
+    [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 3,
+        total_cost_usd: 0.1,
+        result: "done",
+      }),
+    ].join("\n"),
+  );
   const entries = tailEntries(file);
   expect(entries.map(entryTone)).toEqual(["tool", "ok"]);
   rmSync(dir, { recursive: true, force: true });
@@ -311,8 +510,12 @@ test("tailEntries returns raw entries; entryTone classifies them", () => {
 test("needsAttention fires on blocked tickets, a failed stage, quiet tickets, or budget in the red", () => {
   expect(needsAttention({})).toBe(false);
   expect(needsAttention({ blocked: 1 })).toBe(true);
-  expect(needsAttention({ stages: [{ lastResult: { ok: false } }] })).toBe(true);
-  expect(needsAttention({ stages: [{ lastResult: { ok: true } }] })).toBe(false);
+  expect(needsAttention({ stages: [{ lastResult: { ok: false } }] })).toBe(
+    true,
+  );
+  expect(needsAttention({ stages: [{ lastResult: { ok: true } }] })).toBe(
+    false,
+  );
   expect(needsAttention({ quietTickets: 1 })).toBe(true);
   expect(needsAttention({ budgetTone: "bad" })).toBe(true);
   expect(needsAttention({ budgetTone: "warn" })).toBe(false);
@@ -321,15 +524,35 @@ test("needsAttention fires on blocked tickets, a failed stage, quiet tickets, or
 test("claude: extracts file and query tool parameters in parseLogLine", () => {
   const fileLine = JSON.stringify({
     type: "assistant",
-    message: { content: [{ type: "tool_use", name: "view_file", input: { TargetFile: "/src/main.ts" } }] },
+    message: {
+      content: [
+        {
+          type: "tool_use",
+          name: "view_file",
+          input: { TargetFile: "/src/main.ts" },
+        },
+      ],
+    },
   });
-  expect(parseLogLine(fileLine)).toEqual([{ kind: "tool", tool: "view_file", detail: "/src/main.ts" }]);
+  expect(parseLogLine(fileLine)).toEqual([
+    { kind: "tool", tool: "view_file", detail: "/src/main.ts" },
+  ]);
 
   const searchLine = JSON.stringify({
     type: "assistant",
-    message: { content: [{ type: "tool_use", name: "grep_search", input: { query: "export default" } }] },
+    message: {
+      content: [
+        {
+          type: "tool_use",
+          name: "grep_search",
+          input: { query: "export default" },
+        },
+      ],
+    },
   });
-  expect(parseLogLine(searchLine)).toEqual([{ kind: "tool", tool: "grep_search", detail: "export default" }]);
+  expect(parseLogLine(searchLine)).toEqual([
+    { kind: "tool", tool: "grep_search", detail: "export default" },
+  ]);
 });
 
 test("activeAgents correctly classifies tickets starting with factory- as dispatch agents", () => {

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -48,9 +48,24 @@ import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
 import { todaysSpendUSD } from "../lib/spend.mjs";
 import {
-  buildTicketRows, latestLogForTicket, tailEntries, entryTone, formatEntry, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge, visibleWindow,
-  activeAgents, spendPct, spendTone, agentCapStat, supervisorAlive, needsAttention,
+  buildTicketRows,
+  latestLogForTicket,
+  tailEntries,
+  entryTone,
+  formatEntry,
+  formatSpend,
+  formatIssueCounts,
+  parseReaperOutput,
+  linearDeepLink,
+  stageStatuses,
+  formatAge,
+  visibleWindow,
+  activeAgents,
+  spendPct,
+  spendTone,
+  agentCapStat,
+  supervisorAlive,
+  needsAttention,
 } from "./watch-lib.mjs";
 
 const LOG_DIR = path.join(homedir(), ".factory/logs");
@@ -60,9 +75,9 @@ const LOG_DIR = path.join(homedir(), ".factory/logs");
 // of 1,440. The log tail remains independently live at three-second cadence.
 const QUEUE_POLL_MS = 60_000;
 const LOG_POLL_MS = 3_000;
-const TAIL_BUFFER = 500;   // entries kept for PgUp scrollback, well beyond one screen
-const LOG_PAGE = 10;       // rows per PgUp/PgDn
-const QUIET_MS = 90_000;   // matches the "quiet" threshold TicketList already renders
+const TAIL_BUFFER = 500; // entries kept for PgUp scrollback, well beyond one screen
+const LOG_PAGE = 10; // rows per PgUp/PgDn
+const QUIET_MS = 90_000; // matches the "quiet" threshold TicketList already renders
 
 const argv = process.argv.slice(2);
 const val = (f) => {
@@ -76,11 +91,23 @@ const val = (f) => {
 const REPO_FILTER = val("--repo") ?? argv.find((a) => !a.startsWith("-"));
 
 const policy = (() => {
-  try { return Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8")); } catch { return {}; }
+  try {
+    return Bun.YAML.parse(
+      readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"),
+    );
+  } catch {
+    return {};
+  }
 })();
 const PER_DAY_USD = policy?.budget?.per_day_usd ?? 0;
 const SUPERVISOR_DEFAULT_REPO = (() => {
-  try { return Bun.YAML.parse(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"))?.defaults?.repo; } catch { return undefined; }
+  try {
+    return Bun.YAML.parse(
+      readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"),
+    )?.defaults?.repo;
+  } catch {
+    return undefined;
+  }
 })();
 
 const clock = () => new Date().toTimeString().slice(0, 8);
@@ -88,7 +115,11 @@ const clock = () => new Date().toTimeString().slice(0, 8);
 async function fetchQueue() {
   const args = ["orchestrator/queue.mjs", "--json"];
   if (REPO_FILTER) args.push("--repo", REPO_FILTER);
-  const p = Bun.spawn(["bun", ...args], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+  const p = Bun.spawn(["bun", ...args], {
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [out, err, code] = await Promise.all([
     new Response(p.stdout).text(),
     new Response(p.stderr).text(),
@@ -99,11 +130,20 @@ async function fetchQueue() {
 }
 
 function StatChip({ label, value, tone }) {
-  const color = tone === "warn" ? "yellow" : tone === "bad" ? "red" : tone === "good" ? "green" : undefined;
+  const color =
+    tone === "warn"
+      ? "yellow"
+      : tone === "bad"
+        ? "red"
+        : tone === "good"
+          ? "green"
+          : undefined;
   return (
     <Box marginRight={2}>
       <Text dimColor>{label} </Text>
-      <Text color={color} bold={Boolean(tone)}>{value}</Text>
+      <Text color={color} bold={Boolean(tone)}>
+        {value}
+      </Text>
     </Box>
   );
 }
@@ -114,8 +154,13 @@ function RepoTabs({ repos, selected }) {
     <Box marginBottom={1}>
       {repos.map((r, i) => (
         <Box key={r} marginRight={2}>
-          <Text bold={i === selected} color={i === selected ? "green" : undefined} dimColor={i !== selected}>
-            {i === selected ? "▶ " : "  "}{r}
+          <Text
+            bold={i === selected}
+            color={i === selected ? "green" : undefined}
+            dimColor={i !== selected}
+          >
+            {i === selected ? "▶ " : "  "}
+            {r}
           </Text>
         </Box>
       ))}
@@ -132,15 +177,50 @@ function QueueStrip({ summary, worker }) {
   return (
     <Box>
       <StatChip label="workers" value={agents.text} tone={agents.tone} />
-      <StatChip label="claims" value={summary.inProgress} tone={summary.orphanedClaims ? "warn" : undefined} />
-      <StatChip label="worker" value={worker == null ? "?" : worker ? "connected" : "offline"} tone={worker == null ? "warn" : worker ? "good" : "bad"} />
-      <StatChip label="ready" value={summary.ready} tone={summary.ready ? "good" : undefined} />
-      <StatChip label="held" value={summary.readyHeld ?? 0} tone={summary.readyHeld ? "warn" : undefined} />
-      <StatChip label="review" value={summary.inReview} tone={summary.inReview ? "warn" : undefined} />
+      <StatChip
+        label="claims"
+        value={summary.inProgress}
+        tone={summary.orphanedClaims ? "warn" : undefined}
+      />
+      <StatChip
+        label="worker"
+        value={worker == null ? "?" : worker ? "connected" : "offline"}
+        tone={worker == null ? "warn" : worker ? "good" : "bad"}
+      />
+      <StatChip
+        label="ready"
+        value={summary.ready}
+        tone={summary.ready ? "good" : undefined}
+      />
+      <StatChip
+        label="held"
+        value={summary.readyHeld ?? 0}
+        tone={summary.readyHeld ? "warn" : undefined}
+      />
+      <StatChip
+        label="review"
+        value={summary.inReview}
+        tone={summary.inReview ? "warn" : undefined}
+      />
       <StatChip label="triage" value={summary.triage} />
-      <StatChip label="blocked" value={summary.blocked} tone={summary.blocked ? "bad" : undefined} />
-      <StatChip label="PRs" value={summary.openPRs} tone={summary.openPRs ? "warn" : undefined} />
-      <StatChip label="done" value={formatIssueCounts(summary.done, summary.total, summary.countCapped)} />
+      <StatChip
+        label="blocked"
+        value={summary.blocked}
+        tone={summary.blocked ? "bad" : undefined}
+      />
+      <StatChip
+        label="PRs"
+        value={summary.openPRs}
+        tone={summary.openPRs ? "warn" : undefined}
+      />
+      <StatChip
+        label="done"
+        value={formatIssueCounts(
+          summary.done,
+          summary.total,
+          summary.countCapped,
+        )}
+      />
     </Box>
   );
 }
@@ -168,16 +248,29 @@ function StageStrip({ stages, waiting, counts }) {
         return (
           <Box key={s.stage} marginRight={2}>
             {s.active ? (
-              <Text color="green">● {s.stage}{n > 1 ? ` ×${n}` : ""}</Text>
+              <Text color="green">
+                ● {s.stage}
+                {n > 1 ? ` ×${n}` : ""}
+              </Text>
             ) : backlog > 0 ? (
               <Text color="yellow">
                 ○ {s.stage} {formatAge(s.ageMs)} — {backlog} waiting
-                {failed ? <Text color="red" bold> FAIL</Text> : null}
+                {failed ? (
+                  <Text color="red" bold>
+                    {" "}
+                    FAIL
+                  </Text>
+                ) : null}
               </Text>
             ) : (
               <Text dimColor>
                 ○ {s.stage} <Text>{formatAge(s.ageMs)}</Text>
-                {failed ? <Text color="red" bold> FAIL</Text> : null}
+                {failed ? (
+                  <Text color="red" bold>
+                    {" "}
+                    FAIL
+                  </Text>
+                ) : null}
               </Text>
             )}
           </Box>
@@ -194,16 +287,31 @@ const SHORTCUTS = [
   ["o", "open the selected ticket in Linear (desktop app, browser fallback)"],
   ["P", "open the selected ticket's linked pull request in the browser"],
   ["p", "open this repo's GitHub pull requests page in the browser"],
-  ["d", "list dispatchable tickets; select one and press y to launch its agent"],
+  [
+    "d",
+    "list dispatchable tickets; select one and press y to launch its agent",
+  ],
   ["s", "show Linear workflow status and GitHub PR stats for this repo"],
   ["c", "copy the selected ticket's identifier to the clipboard"],
   ["r", "refresh queue + spend now"],
   ["x", "run the stale-claim reaper (dry run) for this repo's team"],
-  ["y", "confirm reaper --apply — only offered when the dry run found stale claims"],
-  ["b", "blocked-tickets digest for this repo — every hold, its question, its age"],
-  ["u", "launch the unblock sweep agent for this repo (spawns immediately, no dry run)"],
+  [
+    "y",
+    "confirm reaper --apply — only offered when the dry run found stale claims",
+  ],
+  [
+    "b",
+    "blocked-tickets digest for this repo — every hold, its question, its age",
+  ],
+  [
+    "u",
+    "launch the unblock sweep agent for this repo (spawns immediately, no dry run)",
+  ],
   ["t", "launch a triage pass for this repo"],
-  ["m", "merge every open PR for this repo, including escalated PRs (then press y to confirm)"],
+  [
+    "m",
+    "merge every open PR for this repo, including escalated PRs (then press y to confirm)",
+  ],
   ["v", "toggle the log tail between agent messages and compact tool activity"],
   ["PgUp/PgDn", "scroll the log tail; PgUp stops following live output"],
   ["G", "jump the log tail back to live (re-follow)"],
@@ -215,11 +323,21 @@ const SHORTCUTS = [
 
 function HelpPane() {
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor="cyan" paddingX={1}>
-      <Text bold color="cyan">keyboard shortcuts</Text>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        keyboard shortcuts
+      </Text>
       {SHORTCUTS.map(([keys, what]) => (
         <Text key={keys}>
-          <Text bold color="cyan">{keys.padEnd(6)}</Text>
+          <Text bold color="cyan">
+            {keys.padEnd(6)}
+          </Text>
           {what}
         </Text>
       ))}
@@ -243,11 +361,21 @@ function ReaperPane({ reaper }) {
   }[reaper.phase];
   const canApply = reaper.phase === "dry-done" && reaper.stale > 0;
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={reaper.phase === "error" ? "red" : "yellow"} paddingX={1}>
-      <Text bold color={reaper.phase === "error" ? "red" : "yellow"}>{title}</Text>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={reaper.phase === "error" ? "red" : "yellow"}
+      paddingX={1}
+    >
+      <Text bold color={reaper.phase === "error" ? "red" : "yellow"}>
+        {title}
+      </Text>
       {reaper.lines.length === 0 && <Text dimColor>running…</Text>}
       {reaper.lines.map((line, i) => (
-        <Text key={i} wrap="truncate-end">{line}</Text>
+        <Text key={i} wrap="truncate-end">
+          {line}
+        </Text>
       ))}
       <Text dimColor>{canApply ? "y reclaim these · " : ""}esc close</Text>
     </Box>
@@ -271,13 +399,28 @@ function DigestPane({ digest, height }) {
   const maxLines = isTruncated ? Math.max(1, height - 4) : budget;
   const shown = digest.lines.slice(0, maxLines);
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={digest.phase === "error" ? "red" : "cyan"} paddingX={1}>
-      <Text bold color={digest.phase === "error" ? "red" : "cyan"}>{title}</Text>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={digest.phase === "error" ? "red" : "cyan"}
+      paddingX={1}
+    >
+      <Text bold color={digest.phase === "error" ? "red" : "cyan"}>
+        {title}
+      </Text>
       {digest.lines.length === 0 && <Text dimColor>running…</Text>}
       {shown.map((line, i) => (
-        <Text key={i} wrap="truncate-end">{line}</Text>
+        <Text key={i} wrap="truncate-end">
+          {line}
+        </Text>
       ))}
-      {digest.lines.length > shown.length && <Text dimColor>… {digest.lines.length - shown.length} more — run `bun orchestrator/digest.mjs` for the full report</Text>}
+      {digest.lines.length > shown.length && (
+        <Text dimColor>
+          … {digest.lines.length - shown.length} more — run `bun
+          orchestrator/digest.mjs` for the full report
+        </Text>
+      )}
       <Text dimColor>esc close</Text>
     </Box>
   );
@@ -292,14 +435,28 @@ function DigestPane({ digest, height }) {
 function UnblockPane({ unblock }) {
   const failed = unblock.phase === "error";
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={failed ? "red" : "green"} paddingX={1}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={failed ? "red" : "green"}
+      paddingX={1}
+    >
       <Text bold color={failed ? "red" : "green"}>
-        {failed ? "unblock sweep — failed to launch" : `unblock sweep launched (${unblock.repo})`}
+        {failed
+          ? "unblock sweep — failed to launch"
+          : `unblock sweep launched (${unblock.repo})`}
       </Text>
       {unblock.lines.map((line, i) => (
-        <Text key={i} wrap="truncate-end">{line}</Text>
+        <Text key={i} wrap="truncate-end">
+          {line}
+        </Text>
       ))}
-      {!failed && <Text dimColor>it will appear under agents shortly — select it there to tail its log</Text>}
+      {!failed && (
+        <Text dimColor>
+          it will appear under agents shortly — select it there to tail its log
+        </Text>
+      )}
       <Text dimColor>esc close</Text>
     </Box>
   );
@@ -308,14 +465,28 @@ function UnblockPane({ unblock }) {
 function TriagePane({ triage }) {
   const failed = triage.phase === "error";
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={failed ? "red" : "green"} paddingX={1}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={failed ? "red" : "green"}
+      paddingX={1}
+    >
       <Text bold color={failed ? "red" : "green"}>
-        {failed ? "triage — failed to launch" : `triage launched (${triage.repo})`}
+        {failed
+          ? "triage — failed to launch"
+          : `triage launched (${triage.repo})`}
       </Text>
       {triage.lines.map((line, i) => (
-        <Text key={i} wrap="truncate-end">{line}</Text>
+        <Text key={i} wrap="truncate-end">
+          {line}
+        </Text>
       ))}
-      {!failed && <Text dimColor>it will appear under agents shortly — select it there to tail its log</Text>}
+      {!failed && (
+        <Text dimColor>
+          it will appear under agents shortly — select it there to tail its log
+        </Text>
+      )}
       <Text dimColor>esc close</Text>
     </Box>
   );
@@ -330,17 +501,34 @@ function MergeAllPane({ mergeAll }) {
   const failed = mergeAll.phase === "error";
   const launched = mergeAll.phase === "launched";
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={failed ? "red" : launched ? "green" : "yellow"} paddingX={1}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={failed ? "red" : launched ? "green" : "yellow"}
+      paddingX={1}
+    >
       <Text bold color={failed ? "red" : launched ? "green" : "yellow"}>
-        {failed ? "merge-all — failed to launch" : launched ? `merge-all launched (${mergeAll.repo})` : `merge all open PRs (${mergeAll.repo})`}
+        {failed
+          ? "merge-all — failed to launch"
+          : launched
+            ? `merge-all launched (${mergeAll.repo})`
+            : `merge all open PRs (${mergeAll.repo})`}
       </Text>
       {mergeAll.lines.map((line, i) => (
-        <Text key={i} wrap="truncate-end">{line}</Text>
+        <Text key={i} wrap="truncate-end">
+          {line}
+        </Text>
       ))}
       {launched ? (
-        <Text dimColor>including escalated PRs — select the merge agent shortly to tail its log · esc close</Text>
+        <Text dimColor>
+          including escalated PRs — select the merge agent shortly to tail its
+          log · esc close
+        </Text>
       ) : (
-        <Text dimColor>y launch agent (review + CI checks still apply) · esc cancel</Text>
+        <Text dimColor>
+          y launch agent (review + CI checks still apply) · esc cancel
+        </Text>
       )}
     </Box>
   );
@@ -350,31 +538,69 @@ function DispatchPane({ dispatch, height }) {
   const failed = dispatch.phase === "error";
   const launched = dispatch.phase === "launched";
   const maxRows = Math.max(1, Math.floor((height - 4) / 2));
-  const [start, end] = visibleWindow(dispatch.tickets.length, dispatch.selected, maxRows);
+  const [start, end] = visibleWindow(
+    dispatch.tickets.length,
+    dispatch.selected,
+    maxRows,
+  );
   const tickets = dispatch.tickets.slice(start, end);
   const selected = dispatch.tickets[dispatch.selected];
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={failed ? "red" : launched ? "green" : "cyan"} paddingX={1}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor={failed ? "red" : launched ? "green" : "cyan"}
+      paddingX={1}
+    >
       <Text bold color={failed ? "red" : launched ? "green" : "cyan"}>
-        {failed ? "dispatch — failed to launch" : launched ? `dispatch launched — ${dispatch.ticket.identifier}` : `dispatchable now (${dispatch.repo})`}
+        {failed
+          ? "dispatch — failed to launch"
+          : launched
+            ? `dispatch launched — ${dispatch.ticket.identifier}`
+            : `dispatchable now (${dispatch.repo})`}
       </Text>
-      {failed ? dispatch.lines.map((line, i) => <Text key={i} wrap="truncate-end">{line}</Text>) : tickets.length ? (
+      {failed ? (
+        dispatch.lines.map((line, i) => (
+          <Text key={i} wrap="truncate-end">
+            {line}
+          </Text>
+        ))
+      ) : tickets.length ? (
         <>
           {start > 0 && <Text dimColor>▲ {start} more</Text>}
           {tickets.map((ticket, idx) => {
             const i = start + idx;
             return (
               <Box key={ticket.identifier} flexDirection="column">
-                <Text inverse={!launched && i === dispatch.selected} color={!launched && i === dispatch.selected ? "green" : undefined}>▶ {ticket.identifier}</Text>
-                <Text dimColor wrap="truncate-end">  {ticket.title}</Text>
+                <Text
+                  inverse={!launched && i === dispatch.selected}
+                  color={
+                    !launched && i === dispatch.selected ? "green" : undefined
+                  }
+                >
+                  ▶ {ticket.identifier}
+                </Text>
+                <Text dimColor wrap="truncate-end">
+                  {" "}
+                  {ticket.title}
+                </Text>
               </Box>
             );
           })}
-          {end < dispatch.tickets.length && <Text dimColor>▼ {dispatch.tickets.length - end} more</Text>}
+          {end < dispatch.tickets.length && (
+            <Text dimColor>▼ {dispatch.tickets.length - end} more</Text>
+          )}
         </>
-      ) : <Text dimColor>no ticket is dispatchable right now</Text>}
+      ) : (
+        <Text dimColor>no ticket is dispatchable right now</Text>
+      )}
       <Text dimColor>
-        {launched ? "the ticket agent will appear shortly — esc close" : selected ? "↑/↓ select · y launch one agent · o open in Linear · esc close" : "esc close"}
+        {launched
+          ? "the ticket agent will appear shortly — esc close"
+          : selected
+            ? "↑/↓ select · y launch one agent · o open in Linear · esc close"
+            : "esc close"}
       </Text>
     </Box>
   );
@@ -389,22 +615,37 @@ function StatsPane({ summary }) {
     ["In Progress", summary.inProgress ?? 0],
     ["In Review", summary.inReview ?? 0],
     ["Blocked", summary.blocked ?? 0],
-    ["Done", `${summary.done ?? 0}/${summary.total ?? 0}${summary.countCapped ? "+" : ""}`],
+    [
+      "Done",
+      `${summary.done ?? 0}/${summary.total ?? 0}${summary.countCapped ? "+" : ""}`,
+    ],
     ["Open PRs", summary.allOpenPRs ?? 0],
     ["Merge-eligible PRs", summary.openPRs ?? 0],
     ["Draft PRs", summary.draftPRs ?? 0],
     ["Escalated PRs", summary.escalatedPRs ?? 0],
   ];
   return (
-    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor="cyan" paddingX={1}>
-      <Text bold color="cyan">repo stats — {summary?.repo}</Text>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        repo stats — {summary?.repo}
+      </Text>
       <Box marginTop={1}>
         <Text bold>{"Linear / GitHub".padEnd(24)} count</Text>
       </Box>
       {rows.map(([label, value]) => (
-        <Text key={label}>{String(label).padEnd(24)} {value}</Text>
+        <Text key={label}>
+          {String(label).padEnd(24)} {value}
+        </Text>
       ))}
-      <Text dimColor>open PRs includes drafts and escalated PRs · esc close</Text>
+      <Text dimColor>
+        open PRs includes drafts and escalated PRs · esc close
+      </Text>
     </Box>
   );
 }
@@ -412,7 +653,11 @@ function StatsPane({ summary }) {
 async function runReaperProcess(team, apply) {
   const args = ["orchestrator/reaper.mjs", "--team", team];
   if (apply) args.push("--apply");
-  const p = Bun.spawn(["bun", ...args], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+  const p = Bun.spawn(["bun", ...args], {
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [out, err] = await Promise.all([
     new Response(p.stdout).text(),
     new Response(p.stderr).text(),
@@ -421,7 +666,15 @@ async function runReaperProcess(team, apply) {
   return { out, err };
 }
 
-function TicketList({ stageAgents, rows, ready, blocked, ages, selected, height }) {
+function TicketList({
+  stageAgents,
+  rows,
+  ready,
+  blocked,
+  ages,
+  selected,
+  height,
+}) {
   // Budget in rows: agents section (1 header + 1 per agent), 1 in-flight
   // header, 2 per ticket, 3 for the ready section, 2 for the blocked section
   // (header + one line each, capped), 2 for the more-above/below markers.
@@ -429,8 +682,14 @@ function TicketList({ stageAgents, rows, ready, blocked, ages, selected, height 
   // the TUI into terminal scrollback.
   const agentReserve = stageAgents.length > 0 ? stageAgents.length + 1 : 0;
   const readyReserve = ready?.length > 0 ? 3 : 0;
-  const blockedReserve = blocked?.length > 0 ? Math.min(blocked.length, 3) + 1 : 0;
-  const maxRows = Math.max(1, Math.floor((height - agentReserve - 1 - readyReserve - blockedReserve - 2) / 2));
+  const blockedReserve =
+    blocked?.length > 0 ? Math.min(blocked.length, 3) + 1 : 0;
+  const maxRows = Math.max(
+    1,
+    Math.floor(
+      (height - agentReserve - 1 - readyReserve - blockedReserve - 2) / 2,
+    ),
+  );
   const ticketSel = Math.max(0, selected - stageAgents.length);
   const [start, end] = visibleWindow(rows.length, ticketSel, maxRows);
   return (
@@ -448,8 +707,8 @@ function TicketList({ stageAgents, rows, ready, blocked, ages, selected, height 
         </Box>
       )}
       <Text dimColor>in flight</Text>
-      {rows.length === 0 && <Text dimColor>  nothing running or in review</Text>}
-      {start > 0 && <Text dimColor>  ▲ {start} more</Text>}
+      {rows.length === 0 && <Text dimColor> nothing running or in review</Text>}
+      {start > 0 && <Text dimColor> ▲ {start} more</Text>}
       {rows.slice(start, end).map((t, idx) => {
         const i = start + idx;
         const isSel = stageAgents.length + i === selected;
@@ -457,40 +716,75 @@ function TicketList({ stageAgents, rows, ready, blocked, ages, selected, height 
         // A running ticket whose log went quiet is the thing to look at — the
         // agent may be thinking, or gone (the reaper fires at 45m of Linear
         // silence; this is the earlier, cheaper tell).
-        const quiet = t.status === "running" && t.hasWorker && age != null && age >= 90_000;
+        const quiet =
+          t.status === "running" && t.hasWorker && age != null && age >= 90_000;
         const noWorker = t.status === "running" && !t.hasWorker;
-        const dot = t.status === "running" ? (noWorker || quiet ? "◌" : "●") : "◐";
-        const dotColor = t.status === "running" ? (noWorker ? "red" : quiet ? "yellow" : "green") : "yellow";
-        const note = t.status !== "running" ? "in review"
-          : noWorker ? "claim only — no worker"
-          : age == null ? "running — no log"
-          : quiet ? `quiet ${formatAge(age)}`
-          : `running ${formatAge(age)}`;
+        const dot =
+          t.status === "running" ? (noWorker || quiet ? "◌" : "●") : "◐";
+        const dotColor =
+          t.status === "running"
+            ? noWorker
+              ? "red"
+              : quiet
+                ? "yellow"
+                : "green"
+            : "yellow";
+        const note =
+          t.status !== "running"
+            ? "in review"
+            : noWorker
+              ? "claim only — no worker"
+              : age == null
+                ? "running — no log"
+                : quiet
+                  ? `quiet ${formatAge(age)}`
+                  : `running ${formatAge(age)}`;
         return (
           <Box key={t.identifier} flexDirection="column" marginBottom={0}>
             <Text inverse={isSel}>
               <Text color={dotColor}>{dot}</Text> {t.identifier}{" "}
-              <Text dimColor color={noWorker ? "red" : quiet ? "yellow" : undefined}>{note}</Text>
-              {t.prNumber ? <Text color="magenta"> [PR: #{t.prNumber}]</Text> : null}
+              <Text
+                dimColor
+                color={noWorker ? "red" : quiet ? "yellow" : undefined}
+              >
+                {note}
+              </Text>
+              {t.prNumber ? (
+                <Text color="magenta"> [PR: #{t.prNumber}]</Text>
+              ) : null}
             </Text>
-            <Text dimColor wrap="truncate-end">  {t.title}</Text>
+            <Text dimColor wrap="truncate-end">
+              {" "}
+              {t.title}
+            </Text>
           </Box>
         );
       })}
-      {end < rows.length && <Text dimColor>  ▼ {rows.length - end} more</Text>}
+      {end < rows.length && <Text dimColor> ▼ {rows.length - end} more</Text>}
       {ready?.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text dimColor>ready to dispatch</Text>
-          <Text dimColor wrap="truncate-end">  {ready.join(" · ")}</Text>
+          <Text dimColor wrap="truncate-end">
+            {" "}
+            {ready.join(" · ")}
+          </Text>
         </Box>
       )}
       {blocked?.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text dimColor>blocked</Text>
           {blocked.slice(0, 3).map((t) => (
-            <Text key={t.identifier} color="red" wrap="truncate-end">  ⛔ {t.identifier} — {t.title}</Text>
+            <Text key={t.identifier} color="red" wrap="truncate-end">
+              {" "}
+              ⛔ {t.identifier} — {t.title}
+            </Text>
           ))}
-          {blocked.length > 3 && <Text dimColor>  … {blocked.length - 3} more — press b for the full digest</Text>}
+          {blocked.length > 3 && (
+            <Text dimColor>
+              {" "}
+              … {blocked.length - 3} more — press b for the full digest
+            </Text>
+          )}
         </Box>
       )}
     </Box>
@@ -511,13 +805,26 @@ function LogTail({ label, entries, scrollOffset, height, mode }) {
   return (
     <Box flexDirection="column" width="58%">
       <Text dimColor>
-        {label ? `log tail — ${label}` : "log tail"} <Text dimColor>({mode === "messages" ? "agent messages" : "tool activity"}; v toggle)</Text>
-        {label && !following && <Text color="yellow"> — scrolled (G to follow)</Text>}
+        {label ? `log tail — ${label}` : "log tail"}{" "}
+        <Text dimColor>
+          ({mode === "messages" ? "agent messages" : "tool activity"}; v toggle)
+        </Text>
+        {label && !following && (
+          <Text color="yellow"> — scrolled (G to follow)</Text>
+        )}
       </Text>
-      {!label && <Text dimColor>  select a ticket or agent to tail its log</Text>}
-      {label && entries.length === 0 && <Text dimColor>  no log yet</Text>}
+      {!label && (
+        <Text dimColor> select a ticket or agent to tail its log</Text>
+      )}
+      {label && entries.length === 0 && <Text dimColor> no log yet</Text>}
       {shown.map((entry, i) => (
-        <Text key={start + i} wrap="truncate-end" color={TONE_COLOR[entryTone(entry)]}>{formatEntry(entry)}</Text>
+        <Text
+          key={start + i}
+          wrap="truncate-end"
+          color={TONE_COLOR[entryTone(entry)]}
+        >
+          {formatEntry(entry)}
+        </Text>
       ))}
     </Box>
   );
@@ -575,13 +882,19 @@ function App() {
     pollRef.current = poll;
     poll();
     const id = setInterval(poll, QUEUE_POLL_MS);
-    return () => { cancelled = true; clearInterval(id); };
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
     // rowIdx is not clamped here — it's clamped at render time against the
     // current agents+tickets list, which this effect can't see.
   }, []);
 
   useEffect(() => {
-    const id = setInterval(() => setSpend(todaysSpendUSD(LOG_DIR)), LOG_POLL_MS);
+    const id = setInterval(
+      () => setSpend(todaysSpendUSD(LOG_DIR)),
+      LOG_POLL_MS,
+    );
     setSpend(todaysSpendUSD(LOG_DIR));
     return () => clearInterval(id);
   }, []);
@@ -601,22 +914,42 @@ function App() {
   const allCount = stageAgents.length + rows.length;
   const selIdx = Math.min(rowIdx, Math.max(0, allCount - 1));
   const selAgent = selIdx < stageAgents.length ? stageAgents[selIdx] : null;
-  const selTicketRow = selAgent ? null : rows[selIdx - stageAgents.length] ?? null;
+  const selTicketRow = selAgent
+    ? null
+    : (rows[selIdx - stageAgents.length] ?? null);
   const selectedTicket = selTicketRow?.identifier ?? null;
 
   useEffect(() => {
-    if (!summary?.repo) { setStages(null); setWorker(null); setAgents([]); setTicketAges({}); return; }
+    if (!summary?.repo) {
+      setStages(null);
+      setWorker(null);
+      setAgents([]);
+      setTicketAges({});
+      return;
+    }
     const scan = () => {
       setStages(stageStatuses(LOG_DIR, summary.repo));
       try {
         const p = Bun.spawnSync(["ps", "-axo", "command="]);
-        setWorker(p.exitCode === 0 ? supervisorAlive(p.stdout.toString(), summary.repo, SUPERVISOR_DEFAULT_REPO) : null);
-      } catch { setWorker(null); }
+        setWorker(
+          p.exitCode === 0
+            ? supervisorAlive(
+                p.stdout.toString(),
+                summary.repo,
+                SUPERVISOR_DEFAULT_REPO,
+              )
+            : null,
+        );
+      } catch {
+        setWorker(null);
+      }
       setAgents(activeAgents(LOG_DIR, summary.repo));
       const ages = {};
       for (const t of summary.inProgressTickets ?? []) {
         const f = latestLogForTicket(LOG_DIR, summary.repo, t.identifier);
-        ages[t.identifier] = f ? Math.max(0, Date.now() - Bun.file(f).lastModified) : null;
+        ages[t.identifier] = f
+          ? Math.max(0, Date.now() - Bun.file(f).lastModified)
+          : null;
       }
       setTicketAges(ages);
     };
@@ -626,10 +959,19 @@ function App() {
   }, [summary]);
 
   const budgetTone = spendTone(spend, PER_DAY_USD);
-  const quietTickets = rows.filter((t) => t.status === "running" && (
-    !t.hasWorker || (ticketAges[t.identifier] != null && ticketAges[t.identifier] >= QUIET_MS)
-  )).length;
-  const attention = needsAttention({ blocked: summary?.blocked ?? 0, stages: stages ?? [], quietTickets, budgetTone });
+  const quietTickets = rows.filter(
+    (t) =>
+      t.status === "running" &&
+      (!t.hasWorker ||
+        (ticketAges[t.identifier] != null &&
+          ticketAges[t.identifier] >= QUIET_MS)),
+  ).length;
+  const attention = needsAttention({
+    blocked: summary?.blocked ?? 0,
+    stages: stages ?? [],
+    quietTickets,
+    budgetTone,
+  });
 
   // Terminal tab title (OSC 0) follows the selected repo and gets a "⚠"
   // prefix for as long as `attention` holds. The bell is separate and rings
@@ -638,23 +980,36 @@ function App() {
   useEffect(() => {
     if (process.stdout.isTTY) {
       const prefix = attention ? "⚠ " : "";
-      process.stdout.write(`\x1b]0;${prefix}factory watch${summary?.repo ? ` — ${summary.repo}` : ""}\x07`);
+      process.stdout.write(
+        `\x1b]0;${prefix}factory watch${summary?.repo ? ` — ${summary.repo}` : ""}\x07`,
+      );
     }
-    if (attention && !wasAttention.current && process.stdout.isTTY) process.stdout.write("\x07");
+    if (attention && !wasAttention.current && process.stdout.isTTY)
+      process.stdout.write("\x07");
     wasAttention.current = attention;
   }, [summary?.repo, attention]);
 
   const selKey = selAgent ? selAgent.file : selectedTicket;
-  useEffect(() => { setScrollOffset(0); }, [selKey, summary?.repo]); // switching selection re-follows live output
+  useEffect(() => {
+    setScrollOffset(0);
+  }, [selKey, summary?.repo]); // switching selection re-follows live output
   useEffect(() => {
     const tail = () => {
-      if (!summary || (!selAgent && !selectedTicket)) { setLogEntries([]); logFileRef.current = null; return; }
-      const file = selAgent ? selAgent.file : latestLogForTicket(LOG_DIR, summary.repo, selectedTicket);
+      if (!summary || (!selAgent && !selectedTicket)) {
+        setLogEntries([]);
+        logFileRef.current = null;
+        return;
+      }
+      const file = selAgent
+        ? selAgent.file
+        : latestLogForTicket(LOG_DIR, summary.repo, selectedTicket);
       logFileRef.current = file;
-      setLogEntries(tailEntries(file, TAIL_BUFFER, {
-        verbose: logMode === "messages",
-        showTools: logMode === "tools",
-      }));
+      setLogEntries(
+        tailEntries(file, TAIL_BUFFER, {
+          verbose: logMode === "messages",
+          showTools: logMode === "tools",
+        }),
+      );
     };
     tail();
     const id = setInterval(tail, LOG_POLL_MS);
@@ -669,26 +1024,44 @@ function App() {
       setReaper({
         phase: apply ? "applied" : "dry-done",
         team,
-        lines: text.split("\n").filter((l) => l.trim() !== "").slice(-16),
+        lines: text
+          .split("\n")
+          .filter((l) => l.trim() !== "")
+          .slice(-16),
         stale: parseReaperOutput(out).stale,
       });
       // A reclaim changes the queue right now — don't leave the strip stale
       // for up to 20s claiming the ticket is still In Progress.
       if (apply) pollRef.current?.();
     } catch (e) {
-      setReaper({ phase: "error", team, lines: [String(e.message ?? e)], stale: 0 });
+      setReaper({
+        phase: "error",
+        team,
+        lines: [String(e.message ?? e)],
+        stale: 0,
+      });
     }
   };
 
   const startDigest = async (repo) => {
     setDigest({ phase: "running", repo, lines: [] });
     try {
-      const p = Bun.spawn(["bun", "orchestrator/digest.mjs", "--repo", repo], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+      const p = Bun.spawn(["bun", "orchestrator/digest.mjs", "--repo", repo], {
+        cwd: ROOT,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
       const [out, err, code] = await Promise.all([
-        new Response(p.stdout).text(), new Response(p.stderr).text(), p.exited,
+        new Response(p.stdout).text(),
+        new Response(p.stderr).text(),
+        p.exited,
       ]);
       const text = (code === 0 ? out : out + `\n${err}`).trimEnd();
-      setDigest({ phase: code === 0 ? "done" : "error", repo, lines: text.split("\n").filter((l) => l.trim() !== "") });
+      setDigest({
+        phase: code === 0 ? "done" : "error",
+        repo,
+        lines: text.split("\n").filter((l) => l.trim() !== ""),
+      });
     } catch (e) {
       setDigest({ phase: "error", repo, lines: [String(e.message ?? e)] });
     }
@@ -700,18 +1073,36 @@ function App() {
   // 3s (harness missing, bad flags) is reported back here.
   const startUnblock = (repo) => {
     try {
-      const p = Bun.spawn(["bash", "runners/run-agent.sh", "--repo", repo, "--command", "factory-unblock", "--read-only", "--args", "10"],
-        { cwd: ROOT, stdout: "ignore", stderr: "pipe" });
+      const p = Bun.spawn(
+        [
+          "bash",
+          "runners/run-agent.sh",
+          "--repo",
+          repo,
+          "--command",
+          "factory-unblock",
+          "--read-only",
+          "--args",
+          "10",
+        ],
+        { cwd: ROOT, stdout: "ignore", stderr: "pipe" },
+      );
       setUnblock({ phase: "launched", repo, lines: [] });
       const born = Date.now();
-      p.exited.then(async (code) => {
-        if (code !== 0 && Date.now() - born < 3000) {
-          const err = await new Response(p.stderr).text();
-          setUnblock({ phase: "error", repo, lines: err.trim().split("\n").slice(-8) });
-        }
-      }).catch((e) => {
-        setUnblock({ phase: "error", repo, lines: [String(e.message ?? e)] });
-      });
+      p.exited
+        .then(async (code) => {
+          if (code !== 0 && Date.now() - born < 3000) {
+            const err = await new Response(p.stderr).text();
+            setUnblock({
+              phase: "error",
+              repo,
+              lines: err.trim().split("\n").slice(-8),
+            });
+          }
+        })
+        .catch((e) => {
+          setUnblock({ phase: "error", repo, lines: [String(e.message ?? e)] });
+        });
     } catch (e) {
       setUnblock({ phase: "error", repo, lines: [String(e.message ?? e)] });
     }
@@ -719,19 +1110,37 @@ function App() {
 
   const startTriage = (repo) => {
     try {
-      const p = Bun.spawn(["bash", "runners/run-agent.sh", "--repo", repo, "--command", "factory-triage", "--read-only", "--args", "5"],
-        { cwd: ROOT, stdout: "ignore", stderr: "pipe" });
+      const p = Bun.spawn(
+        [
+          "bash",
+          "runners/run-agent.sh",
+          "--repo",
+          repo,
+          "--command",
+          "factory-triage",
+          "--read-only",
+          "--args",
+          "5",
+        ],
+        { cwd: ROOT, stdout: "ignore", stderr: "pipe" },
+      );
       setTriage({ phase: "launched", repo, lines: [] });
       const born = Date.now();
-      p.exited.then(async (code) => {
-        if (code !== 0 && Date.now() - born < 3000) {
-          const err = await new Response(p.stderr).text();
-          setTriage({ phase: "error", repo, lines: err.trim().split("\n").slice(-8) });
-        }
-        pollRef.current?.();
-      }).catch((e) => {
-        setTriage({ phase: "error", repo, lines: [String(e.message ?? e)] });
-      });
+      p.exited
+        .then(async (code) => {
+          if (code !== 0 && Date.now() - born < 3000) {
+            const err = await new Response(p.stderr).text();
+            setTriage({
+              phase: "error",
+              repo,
+              lines: err.trim().split("\n").slice(-8),
+            });
+          }
+          pollRef.current?.();
+        })
+        .catch((e) => {
+          setTriage({ phase: "error", repo, lines: [String(e.message ?? e)] });
+        });
     } catch (e) {
       setTriage({ phase: "error", repo, lines: [String(e.message ?? e)] });
     }
@@ -739,18 +1148,39 @@ function App() {
 
   const startMergeAll = (repo) => {
     try {
-      const p = Bun.spawn(["bash", "runners/run-agent.sh", "--repo", repo, "--command", "factory-merge", "--args", "--include-escalated"],
-        { cwd: ROOT, stdout: "ignore", stderr: "pipe" });
+      const p = Bun.spawn(
+        [
+          "bash",
+          "runners/run-agent.sh",
+          "--repo",
+          repo,
+          "--command",
+          "factory-merge",
+          "--args",
+          "--include-escalated",
+        ],
+        { cwd: ROOT, stdout: "ignore", stderr: "pipe" },
+      );
       setMergeAll({ phase: "launched", repo, lines: [] });
       const born = Date.now();
-      p.exited.then(async (code) => {
-        if (code !== 0 && Date.now() - born < 3000) {
-          const err = await new Response(p.stderr).text();
-          setMergeAll({ phase: "error", repo, lines: err.trim().split("\n").slice(-8) });
-        }
-      }).catch((e) => {
-        setMergeAll({ phase: "error", repo, lines: [String(e.message ?? e)] });
-      });
+      p.exited
+        .then(async (code) => {
+          if (code !== 0 && Date.now() - born < 3000) {
+            const err = await new Response(p.stderr).text();
+            setMergeAll({
+              phase: "error",
+              repo,
+              lines: err.trim().split("\n").slice(-8),
+            });
+          }
+        })
+        .catch((e) => {
+          setMergeAll({
+            phase: "error",
+            repo,
+            lines: [String(e.message ?? e)],
+          });
+        });
     } catch (e) {
       setMergeAll({ phase: "error", repo, lines: [String(e.message ?? e)] });
     }
@@ -758,21 +1188,48 @@ function App() {
 
   const startDispatch = (repo, ticket) => {
     try {
-      const p = Bun.spawn(["bun", "orchestrator/tick.mjs", "--repo", repo, "--apply", "--ticket", ticket.identifier, "--max", "1", "--no-refill"],
-        { cwd: ROOT, stdout: "ignore", stderr: "pipe" });
+      const p = Bun.spawn(
+        [
+          "bun",
+          "orchestrator/tick.mjs",
+          "--repo",
+          repo,
+          "--apply",
+          "--ticket",
+          ticket.identifier,
+          "--max",
+          "1",
+          "--no-refill",
+        ],
+        { cwd: ROOT, stdout: "ignore", stderr: "pipe" },
+      );
       setDispatch((current) => ({ ...current, phase: "launched", ticket }));
       const born = Date.now();
-      p.exited.then(async (code) => {
-        if (code !== 0 && Date.now() - born < 3000) {
-          const err = await new Response(p.stderr).text();
-          setDispatch((current) => ({ ...current, phase: "error", lines: err.trim().split("\n").slice(-8) }));
-        }
-        pollRef.current?.();
-      }).catch((e) => {
-        setDispatch((current) => ({ ...current, phase: "error", lines: [String(e.message ?? e)] }));
-      });
+      p.exited
+        .then(async (code) => {
+          if (code !== 0 && Date.now() - born < 3000) {
+            const err = await new Response(p.stderr).text();
+            setDispatch((current) => ({
+              ...current,
+              phase: "error",
+              lines: err.trim().split("\n").slice(-8),
+            }));
+          }
+          pollRef.current?.();
+        })
+        .catch((e) => {
+          setDispatch((current) => ({
+            ...current,
+            phase: "error",
+            lines: [String(e.message ?? e)],
+          }));
+        });
     } catch (e) {
-      setDispatch((current) => ({ ...current, phase: "error", lines: [String(e.message ?? e)] }));
+      setDispatch((current) => ({
+        ...current,
+        phase: "error",
+        lines: [String(e.message ?? e)],
+      }));
     }
   };
 
@@ -782,7 +1239,10 @@ function App() {
       if (key.escape || input === "?") setShowHelp(false);
       return;
     }
-    if (input === "?") { setShowHelp(true); return; }
+    if (input === "?") {
+      setShowHelp(true);
+      return;
+    }
     if (showStats) {
       if (key.escape || input === "s") setShowStats(false);
       return;
@@ -800,68 +1260,138 @@ function App() {
       return;
     }
     if (dispatch) {
-      if (key.escape) { setDispatch(null); return; }
+      if (key.escape) {
+        setDispatch(null);
+        return;
+      }
       if (dispatch.phase !== "list") return;
-      if (key.upArrow) setDispatch((current) => ({ ...current, selected: Math.max(0, current.selected - 1) }));
-      if (key.downArrow) setDispatch((current) => ({ ...current, selected: Math.min(Math.max(0, current.tickets.length - 1), current.selected + 1) }));
+      if (key.upArrow)
+        setDispatch((current) => ({
+          ...current,
+          selected: Math.max(0, current.selected - 1),
+        }));
+      if (key.downArrow)
+        setDispatch((current) => ({
+          ...current,
+          selected: Math.min(
+            Math.max(0, current.tickets.length - 1),
+            current.selected + 1,
+          ),
+        }));
       const ticket = dispatch.tickets[dispatch.selected];
       if (input === "o" && ticket?.url) {
         const deep = linearDeepLink(ticket.url);
-        const p = Bun.spawn(["open", deep ?? ticket.url], { stdout: "ignore", stderr: "ignore" });
-        if (deep) p.exited.then((code) => { if (code !== 0) Bun.spawn(["open", ticket.url], { stdout: "ignore", stderr: "ignore" }); });
+        const p = Bun.spawn(["open", deep ?? ticket.url], {
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+        if (deep)
+          p.exited.then((code) => {
+            if (code !== 0)
+              Bun.spawn(["open", ticket.url], {
+                stdout: "ignore",
+                stderr: "ignore",
+              });
+          });
       }
       if (input === "y" && ticket) startDispatch(dispatch.repo, ticket);
       return;
     }
     if (mergeAll) {
       if (key.escape) setMergeAll(null);
-      if (input === "y" && mergeAll.phase === "confirm") startMergeAll(mergeAll.repo);
+      if (input === "y" && mergeAll.phase === "confirm")
+        startMergeAll(mergeAll.repo);
       return;
     }
     if (reaper) {
       // The pane owns the keyboard while it's up: esc closes it (instead of
       // quitting), y confirms --apply, and only off a dry run that found work.
       if (key.escape) setReaper(null);
-      if (input === "y" && reaper.phase === "dry-done" && reaper.stale > 0) startReaper(reaper.team, true);
+      if (input === "y" && reaper.phase === "dry-done" && reaper.stale > 0)
+        startReaper(reaper.team, true);
       return;
     }
     if (key.escape) process.exit(0);
-    if (input === "r") { pollRef.current?.(); setSpend(todaysSpendUSD(LOG_DIR)); }
-    if (input === "v") setLogMode((mode) => mode === "messages" ? "tools" : "messages");
+    if (input === "r") {
+      pollRef.current?.();
+      setSpend(todaysSpendUSD(LOG_DIR));
+    }
+    if (input === "v")
+      setLogMode((mode) => (mode === "messages" ? "tools" : "messages"));
     if (input === "o") {
       const url = selTicketRow?.url;
       if (url) {
         // Desktop app first; if the linear:// handler isn't registered, `open`
         // exits non-zero and the https URL goes to the browser instead.
         const deep = linearDeepLink(url);
-        const p = Bun.spawn(["open", deep ?? url], { stdout: "ignore", stderr: "ignore" });
-        if (deep) p.exited.then((code) => { if (code !== 0) Bun.spawn(["open", url], { stdout: "ignore", stderr: "ignore" }); });
+        const p = Bun.spawn(["open", deep ?? url], {
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+        if (deep)
+          p.exited.then((code) => {
+            if (code !== 0)
+              Bun.spawn(["open", url], { stdout: "ignore", stderr: "ignore" });
+          });
       }
     }
     if (input === "P" && selTicketRow?.prUrl) {
-      Bun.spawn(["open", selTicketRow.prUrl], { stdout: "ignore", stderr: "ignore" });
+      Bun.spawn(["open", selTicketRow.prUrl], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
     }
     if (input === "p" && summary?.github) {
-      Bun.spawn(["open", `https://github.com/${summary.github}/pulls`], { stdout: "ignore", stderr: "ignore" });
+      Bun.spawn(["open", `https://github.com/${summary.github}/pulls`], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
     }
     if (input === "x" && summary?.team) startReaper(summary.team, false);
     if (input === "b" && summary?.repo) startDigest(summary.repo);
     if (input === "u" && summary?.repo) startUnblock(summary.repo);
     if (input === "t" && summary?.repo) startTriage(summary.repo);
-    if (input === "m" && summary?.repo) setMergeAll({ phase: "confirm", repo: summary.repo, lines: [] });
-    if (input === "d" && summary?.repo) setDispatch({ phase: "list", repo: summary.repo, tickets: summary.startableTickets ?? [], selected: 0, lines: [] });
+    if (input === "m" && summary?.repo)
+      setMergeAll({ phase: "confirm", repo: summary.repo, lines: [] });
+    if (input === "d" && summary?.repo)
+      setDispatch({
+        phase: "list",
+        repo: summary.repo,
+        tickets: summary.startableTickets ?? [],
+        selected: 0,
+        lines: [],
+      });
     if (input === "s" && summary?.repo) setShowStats(true);
     if (input === "c" && selTicketRow?.identifier) {
       try {
-        Bun.spawnSync(["pbcopy"], { stdin: Buffer.from(selTicketRow.identifier), stdout: "ignore", stderr: "ignore" });
-      } catch { /* no clipboard available — nothing to fall back to here */ }
+        Bun.spawnSync(["pbcopy"], {
+          stdin: Buffer.from(selTicketRow.identifier),
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+      } catch {
+        /* no clipboard available — nothing to fall back to here */
+      }
     }
-    if (key.leftArrow) { setRepoIdx((i) => Math.max(0, i - 1)); setRowIdx(0); }
-    if (key.rightArrow) { setRepoIdx((i) => Math.max(0, Math.min(summaries.length - 1, i + 1))); setRowIdx(0); }
-    if (/^[1-9]$/.test(input) && Number(input) - 1 < summaries.length) { setRepoIdx(Number(input) - 1); setRowIdx(0); }
+    if (key.leftArrow) {
+      setRepoIdx((i) => Math.max(0, i - 1));
+      setRowIdx(0);
+    }
+    if (key.rightArrow) {
+      setRepoIdx((i) => Math.max(0, Math.min(summaries.length - 1, i + 1)));
+      setRowIdx(0);
+    }
+    if (/^[1-9]$/.test(input) && Number(input) - 1 < summaries.length) {
+      setRepoIdx(Number(input) - 1);
+      setRowIdx(0);
+    }
     if (key.upArrow) setRowIdx(Math.max(0, selIdx - 1));
-    if (key.downArrow) setRowIdx(Math.min(Math.max(0, allCount - 1), selIdx + 1));
-    if (key.pageUp) setScrollOffset((o) => Math.min(Math.max(0, logEntries.length - 1), o + LOG_PAGE));
+    if (key.downArrow)
+      setRowIdx(Math.min(Math.max(0, allCount - 1), selIdx + 1));
+    if (key.pageUp)
+      setScrollOffset((o) =>
+        Math.min(Math.max(0, logEntries.length - 1), o + LOG_PAGE),
+      );
     if (key.pageDown) setScrollOffset((o) => Math.max(0, o - LOG_PAGE));
     if (input === "G") setScrollOffset(0);
     if (key.return && logFileRef.current) {
@@ -871,21 +1401,38 @@ function App() {
       const file = logFileRef.current;
       if (existsSync(file)) {
         process.stdout.write("\x1b[?1049l");
-        Bun.spawnSync([process.env.PAGER || "less", "-R", "+G", file], { stdout: "inherit", stdin: "inherit", stderr: "inherit" });
+        Bun.spawnSync([process.env.PAGER || "less", "-R", "+G", file], {
+          stdout: "inherit",
+          stdin: "inherit",
+          stderr: "inherit",
+        });
         process.stdout.write("\x1b[?1049h\x1b[2J\x1b[H");
       }
     }
   });
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} width={width} height={height}>
-      <Text bold color={attention ? "yellow" : undefined}>{attention ? "⚠ " : ""}factory — foreground monitor</Text>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="gray"
+      paddingX={1}
+      width={width}
+      height={height}
+    >
+      <Text bold color={attention ? "yellow" : undefined}>
+        {attention ? "⚠ " : ""}factory — foreground monitor
+      </Text>
       <RepoTabs repos={summaries.map((s) => s.repo)} selected={repoIdx} />
       <QueueStrip summary={summary} worker={worker} />
       <StageStrip
         stages={stages}
         counts={{ dispatch: agents.filter((a) => a.identifier).length }}
-        waiting={{ triage: summary?.triageState ?? 0, dispatch: summary?.startable?.length ?? 0, merge: summary?.openPRs ?? 0 }}
+        waiting={{
+          triage: summary?.triageState ?? 0,
+          dispatch: summary?.startable?.length ?? 0,
+          merge: summary?.openPRs ?? 0,
+        }}
       />
       <Box marginTop={1} marginBottom={1} flexGrow={1}>
         {showHelp ? (
@@ -906,8 +1453,26 @@ function App() {
           <DispatchPane dispatch={dispatch} height={paneHeight} />
         ) : (
           <>
-            <TicketList stageAgents={stageAgents} rows={rows} ready={summary?.startable} blocked={summary?.blockedTickets} ages={ticketAges} selected={selIdx} height={paneHeight} />
-            <LogTail label={selAgent ? `${selAgent.label} agent${selAgent.harness ? ` (${selAgent.harness})` : ""}` : selectedTicket} entries={logEntries} scrollOffset={scrollOffset} height={paneHeight} mode={logMode} />
+            <TicketList
+              stageAgents={stageAgents}
+              rows={rows}
+              ready={summary?.startable}
+              blocked={summary?.blockedTickets}
+              ages={ticketAges}
+              selected={selIdx}
+              height={paneHeight}
+            />
+            <LogTail
+              label={
+                selAgent
+                  ? `${selAgent.label} agent${selAgent.harness ? ` (${selAgent.harness})` : ""}`
+                  : selectedTicket
+              }
+              entries={logEntries}
+              scrollOffset={scrollOffset}
+              height={paneHeight}
+              mode={logMode}
+            />
           </>
         )}
       </Box>
@@ -915,13 +1480,27 @@ function App() {
         <Text dimColor>
           spend {formatSpend(spend, PER_DAY_USD)}
           {spendPct(spend, PER_DAY_USD) != null && (
-            <Text color={budgetTone === "bad" ? "red" : budgetTone === "warn" ? "yellow" : undefined}> ({spendPct(spend, PER_DAY_USD)}%)</Text>
-          )}
-          {" "}today
-          {error ? <Text color="red">  ! {error.slice(0, 50)}</Text> : null}
+            <Text
+              color={
+                budgetTone === "bad"
+                  ? "red"
+                  : budgetTone === "warn"
+                    ? "yellow"
+                    : undefined
+              }
+            >
+              {" "}
+              ({spendPct(spend, PER_DAY_USD)}%)
+            </Text>
+          )}{" "}
+          today
+          {error ? <Text color="red"> ! {error.slice(0, 50)}</Text> : null}
         </Text>
         <Text dimColor>
-          {lastPoll ? `updated ${lastPoll}${lastPollMs != null ? ` · next ${Math.max(0, Math.ceil((QUEUE_POLL_MS - (nowTick - lastPollMs)) / 1000))}s` : ""}` : "loading…"}  ? shortcuts · q quit
+          {lastPoll
+            ? `updated ${lastPoll}${lastPollMs != null ? ` · next ${Math.max(0, Math.ceil((QUEUE_POLL_MS - (nowTick - lastPollMs)) / 1000))}s` : ""}`
+            : "loading…"}{" "}
+          ? shortcuts · q quit
         </Text>
       </Box>
     </Box>
@@ -932,8 +1511,16 @@ function App() {
 // behaviour), so the shell prompt and scrollback are untouched underneath and
 // come back intact on exit — however the process ends.
 process.stdout.write("\x1b[?1049h\x1b[H");
-const cleanupTerminal = () => { process.stdout.write("\x1b[?1049l\x1b]0;\x07"); };
+const cleanupTerminal = () => {
+  process.stdout.write("\x1b[?1049l\x1b]0;\x07");
+};
 process.on("exit", cleanupTerminal);
-process.on("SIGINT", () => { cleanupTerminal(); process.exit(0); });
-process.on("SIGTERM", () => { cleanupTerminal(); process.exit(0); });
+process.on("SIGINT", () => {
+  cleanupTerminal();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  cleanupTerminal();
+  process.exit(0);
+});
 render(<App />);

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -24,8 +24,17 @@ const c = {
 
 function sh(args, cwd = ROOT) {
   try {
-    const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
-    return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+    const result = Bun.spawnSync({
+      cmd: args,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      ok: result.exitCode === 0,
+      out: result.stdout.toString().trim(),
+      err: result.stderr.toString().trim(),
+    };
   } catch (err) {
     return { ok: false, out: "", err: String(err) };
   }
@@ -51,22 +60,38 @@ export async function runWatchdogCheck({
 
   // 1. Control API Health
   try {
-    const res = await fetch(`http://${host}:${port}/health`, { signal: AbortSignal.timeout(3000) });
+    const res = await fetch(`http://${host}:${port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
     if (res.ok) {
       metrics.apiOk = true;
     } else {
-      issues.push({ severity: "CRITICAL", code: "API_ERROR", message: `Control API returned HTTP ${res.status}` });
+      issues.push({
+        severity: "CRITICAL",
+        code: "API_ERROR",
+        message: `Control API returned HTTP ${res.status}`,
+      });
     }
   } catch (err) {
-    issues.push({ severity: "CRITICAL", code: "API_DOWN", message: `Control API on :${port} unreachable: ${err.message}` });
+    issues.push({
+      severity: "CRITICAL",
+      code: "API_DOWN",
+      message: `Control API on :${port} unreachable: ${err.message}`,
+    });
   }
 
   // 2. Web UI Health
   try {
-    const webRes = await fetch(`http://${host}:${webPort}/`, { signal: AbortSignal.timeout(2000) });
+    const webRes = await fetch(`http://${host}:${webPort}/`, {
+      signal: AbortSignal.timeout(2000),
+    });
     metrics.webOk = webRes.ok || webRes.status === 404;
   } catch {
-    issues.push({ severity: "WARNING", code: "WEB_DOWN", message: `Web UI on :${webPort} unreachable` });
+    issues.push({
+      severity: "WARNING",
+      code: "WEB_DOWN",
+      message: `Web UI on :${webPort} unreachable`,
+    });
   }
 
   // If API is down, we cannot perform status/workers checks
@@ -77,15 +102,25 @@ export async function runWatchdogCheck({
   // 3. Workers & Runs Status from API
   try {
     const [statusRes, workersRes, runningRes] = await Promise.all([
-      fetch(`http://${host}:${port}/status`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
-      fetch(`http://${host}:${port}/workers`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
-      fetch(`http://${host}:${port}/runs?state=RUNNING`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+      fetch(`http://${host}:${port}/status`, {
+        signal: AbortSignal.timeout(3000),
+      }).then((r) => r.json()),
+      fetch(`http://${host}:${port}/workers`, {
+        signal: AbortSignal.timeout(3000),
+      }).then((r) => r.json()),
+      fetch(`http://${host}:${port}/runs?state=RUNNING`, {
+        signal: AbortSignal.timeout(3000),
+      }).then((r) => r.json()),
     ]);
 
     const workers = workersRes?.workers ?? [];
     metrics.workersCount = workers.length;
     if (workers.length === 0) {
-      issues.push({ severity: "CRITICAL", code: "NO_WORKERS", message: "No live workers registered in event runtime" });
+      issues.push({
+        severity: "CRITICAL",
+        code: "NO_WORKERS",
+        message: "No live workers registered in event runtime",
+      });
     }
 
     const runs = runningRes?.runs ?? [];
@@ -101,7 +136,9 @@ export async function runWatchdogCheck({
 
     metrics.wedgedRuns = wedged.length;
     for (const w of wedged) {
-      const ageMin = Math.round((now - new Date(w.created_at).getTime()) / 60000);
+      const ageMin = Math.round(
+        (now - new Date(w.created_at).getTime()) / 60000,
+      );
       issues.push({
         severity: "CRITICAL",
         code: "WEDGED_RUN",
@@ -111,7 +148,11 @@ export async function runWatchdogCheck({
 
     metrics.queuedRuns = statusRes?.runs?.byState?.QUEUED ?? 0;
     const idleWorkers = workers.filter((w) => w.state === "idle").length;
-    if (metrics.queuedRuns > 0 && idleWorkers > 0 && metrics.runningRuns === 0) {
+    if (
+      metrics.queuedRuns > 0 &&
+      idleWorkers > 0 &&
+      metrics.runningRuns === 0
+    ) {
       issues.push({
         severity: "WARNING",
         code: "IDLE_STALL",
@@ -138,16 +179,38 @@ export async function runWatchdogCheck({
       }
     }
   } catch (err) {
-    issues.push({ severity: "WARNING", code: "STATUS_FETCH_ERROR", message: `Failed fetching status details: ${err.message}` });
+    issues.push({
+      severity: "WARNING",
+      code: "STATUS_FETCH_ERROR",
+      message: `Failed fetching status details: ${err.message}`,
+    });
   }
 
   // 4. CI Runner Fleet Check
   if (checkShadowFleet) {
     try {
-      const ciqRes = sh(["gh", "run", "list", "--repo", "watt-mind/factory", "--limit", "10", "--json", "status", "-q", "[.[] | select(.status==\"queued\")] | length"]);
+      const ciqRes = sh([
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        "watt-mind/factory",
+        "--limit",
+        "10",
+        "--json",
+        "status",
+        "-q",
+        '[.[] | select(.status=="queued")] | length',
+      ]);
       const queuedCount = parseInt(ciqRes.out, 10) || 0;
       if (queuedCount > 2) {
-        const shadowRes = sh(["gh", "api", "orgs/watt-mind/actions/runners", "--jq", "[.runners[] | select(.labels | map(.name) | index(\"shadow\")) | select(.status==\"online\")] | length"]);
+        const shadowRes = sh([
+          "gh",
+          "api",
+          "orgs/watt-mind/actions/runners",
+          "--jq",
+          '[.runners[] | select(.labels | map(.name) | index("shadow")) | select(.status=="online")] | length',
+        ]);
         const onlineShadows = parseInt(shadowRes.out, 10) || 0;
         if (onlineShadows === 0) {
           issues.push({
@@ -157,7 +220,9 @@ export async function runWatchdogCheck({
           });
         }
       }
-    } catch { /* intentionally ignored */ }
+    } catch {
+      /* intentionally ignored */
+    }
   }
 
   const hasCritical = issues.some((i) => i.severity === "CRITICAL");
@@ -173,13 +238,19 @@ export function formatWatchdogReport(result) {
   const ts = new Date().toUTCString();
   if (result.ok && result.issues.length === 0) {
     lines.push(`${c.green("✓")} ${c.bold("WATCHDOG OK")} — ${ts}`);
-    lines.push(`  Workers: ${result.metrics.workersCount} | Running: ${result.metrics.runningRuns} | Wedged: ${result.metrics.wedgedRuns}`);
+    lines.push(
+      `  Workers: ${result.metrics.workersCount} | Running: ${result.metrics.runningRuns} | Wedged: ${result.metrics.wedgedRuns}`,
+    );
   } else {
-    const badge = result.ok ? c.yellow("! WATCHDOG WARNING") : c.red("✗ WATCHDOG CRITICAL");
+    const badge = result.ok
+      ? c.yellow("! WATCHDOG WARNING")
+      : c.red("✗ WATCHDOG CRITICAL");
     lines.push(`${badge} — ${ts}`);
     for (const issue of result.issues) {
       const col = issue.severity === "CRITICAL" ? c.red : c.yellow;
-      lines.push(`  ${col(`[${issue.severity}]`)} ${c.bold(issue.code)}: ${issue.message}`);
+      lines.push(
+        `  ${col(`[${issue.severity}]`)} ${c.bold(issue.code)}: ${issue.message}`,
+      );
     }
   }
   return lines.join("\n");
@@ -189,7 +260,9 @@ export async function sendWatchdogNotification(issues) {
   const critical = issues.filter((i) => i.severity === "CRITICAL");
   if (critical.length === 0) return;
 
-  const eventType = critical.some((i) => i.code === "FLEET_OFFLINE" || i.code === "API_DOWN")
+  const eventType = critical.some(
+    (i) => i.code === "FLEET_OFFLINE" || i.code === "API_DOWN",
+  )
     ? "CIRCUIT BREAKER"
     : "BLOCKED";
 
@@ -213,7 +286,8 @@ if (import.meta.main) {
   const once = argv.includes("--once");
   const shouldNotify = argv.includes("--notify");
   const intervalIdx = argv.indexOf("--interval-sec");
-  const intervalSec = intervalIdx !== -1 ? parseInt(argv[intervalIdx + 1], 10) || 300 : 300;
+  const intervalSec =
+    intervalIdx !== -1 ? parseInt(argv[intervalIdx + 1], 10) || 300 : 300;
 
   async function tick() {
     const result = await runWatchdogCheck();
@@ -233,7 +307,11 @@ if (import.meta.main) {
     const result = await tick();
     process.exit(result.ok ? 0 : 1);
   } else {
-    console.log(c.bold(`Starting factory watchdog daemon (checking every ${intervalSec}s)...`));
+    console.log(
+      c.bold(
+        `Starting factory watchdog daemon (checking every ${intervalSec}s)...`,
+      ),
+    );
     await tick();
     setInterval(async () => {
       await tick();

--- a/orchestrator/workers.mjs
+++ b/orchestrator/workers.mjs
@@ -97,37 +97,67 @@ try {
 
   if (nodesMap.size === 0) {
     if (JSON_OUT) {
-      console.log(JSON.stringify({ nodes: [], count: 0, message: "no nodes configured in config/nodes.yaml" }, null, 2));
+      console.log(
+        JSON.stringify(
+          {
+            nodes: [],
+            count: 0,
+            message: "no nodes configured in config/nodes.yaml",
+          },
+          null,
+          2,
+        ),
+      );
     } else {
-      console.log(c.yellow("No remote worker nodes configured in config/nodes.yaml"));
+      console.log(
+        c.yellow("No remote worker nodes configured in config/nodes.yaml"),
+      );
     }
     process.exit(0);
   }
 
   const selectedNodes = targetNode
-    ? (nodesMap.has(targetNode) ? [nodesMap.get(targetNode)] : null)
+    ? nodesMap.has(targetNode)
+      ? [nodesMap.get(targetNode)]
+      : null
     : Array.from(nodesMap.values());
 
   if (!selectedNodes) {
-    console.error(c.red(`Error: unknown node "${targetNode}". Configured nodes: ${Array.from(nodesMap.keys()).join(", ")}`));
+    console.error(
+      c.red(
+        `Error: unknown node "${targetNode}". Configured nodes: ${Array.from(nodesMap.keys()).join(", ")}`,
+      ),
+    );
     process.exit(1);
   }
 
   const localSha = getLocalTrunkSha();
 
   if (command === "list") {
-    const probes = selectedNodes.map((node) => probeRemoteNode(node, { localTrunkSha: localSha }));
+    const probes = selectedNodes.map((node) =>
+      probeRemoteNode(node, { localTrunkSha: localSha }),
+    );
 
     if (JSON_OUT) {
-      console.log(JSON.stringify({
-        timestamp: new Date().toISOString(),
-        localTrunkSha: localSha,
-        nodes: probes,
-      }, null, 2));
+      console.log(
+        JSON.stringify(
+          {
+            timestamp: new Date().toISOString(),
+            localTrunkSha: localSha,
+            nodes: probes,
+          },
+          null,
+          2,
+        ),
+      );
       process.exit(0);
     }
 
-    console.log(c.bold(`factory workers — remote worker fleet (${probes.length} configured)`));
+    console.log(
+      c.bold(
+        `factory workers — remote worker fleet (${probes.length} configured)`,
+      ),
+    );
     if (localSha) {
       console.log(c.dim(`Local trunk SHA: ${localSha.slice(0, 8)}`));
     }
@@ -135,13 +165,19 @@ try {
 
     console.log(
       c.dim("  ") +
-      c.bold(pad("NODE", 16)) + "  " +
-      c.bold(pad("HOST", 22)) + "  " +
-      c.bold(pad("STATUS", 14)) + "  " +
-      c.bold(pad("SKEW", 12)) + "  " +
-      c.bold(pad("BRANCH / SHA", 24)) + "  " +
-      c.bold(pad("WORKER", 10)) + "  " +
-      c.bold("LABELS"),
+        c.bold(pad("NODE", 16)) +
+        "  " +
+        c.bold(pad("HOST", 22)) +
+        "  " +
+        c.bold(pad("STATUS", 14)) +
+        "  " +
+        c.bold(pad("SKEW", 12)) +
+        "  " +
+        c.bold(pad("BRANCH / SHA", 24)) +
+        "  " +
+        c.bold(pad("WORKER", 10)) +
+        "  " +
+        c.bold("LABELS"),
     );
 
     for (const p of probes) {
@@ -181,13 +217,19 @@ try {
 
       console.log(
         "  " +
-        pad(p.name, 16) + "  " +
-        pad(p.host, 22) + "  " +
-        pad(statusStr, 23) + "  " +
-        pad(skewStr, 21) + "  " +
-        pad(branchSha, 24) + "  " +
-        pad(workerStr, 19) + "  " +
-        c.dim(labelsStr),
+          pad(p.name, 16) +
+          "  " +
+          pad(p.host, 22) +
+          "  " +
+          pad(statusStr, 23) +
+          "  " +
+          pad(skewStr, 21) +
+          "  " +
+          pad(branchSha, 24) +
+          "  " +
+          pad(workerStr, 19) +
+          "  " +
+          c.dim(labelsStr),
       );
     }
     console.log();
@@ -197,7 +239,8 @@ try {
   if (command === "deploy") {
     const results = [];
     for (const node of selectedNodes) {
-      if (!JSON_OUT) console.log(c.cyan(`Deploying to node ${node.name} (${node.host})...`));
+      if (!JSON_OUT)
+        console.log(c.cyan(`Deploying to node ${node.name} (${node.host})...`));
       const res = deployRemoteWorker(node, { ref: targetRef });
       results.push(res);
       if (!JSON_OUT) {
@@ -215,14 +258,19 @@ try {
   if (command === "start") {
     const results = [];
     for (const node of selectedNodes) {
-      if (!JSON_OUT) console.log(c.cyan(`Starting worker on node ${node.name}...`));
+      if (!JSON_OUT)
+        console.log(c.cyan(`Starting worker on node ${node.name}...`));
       const res = startRemoteWorker(node);
       results.push(res);
       if (!JSON_OUT) {
         if (res.ok) {
-          console.log(c.green(`✓ Worker started on ${node.name} (PID ${res.pid})`));
+          console.log(
+            c.green(`✓ Worker started on ${node.name} (PID ${res.pid})`),
+          );
         } else {
-          console.log(c.red(`✗ Failed to start worker on ${node.name}: ${res.error}`));
+          console.log(
+            c.red(`✗ Failed to start worker on ${node.name}: ${res.error}`),
+          );
         }
       }
     }
@@ -233,14 +281,17 @@ try {
   if (command === "stop") {
     const results = [];
     for (const node of selectedNodes) {
-      if (!JSON_OUT) console.log(c.cyan(`Stopping worker on node ${node.name}...`));
+      if (!JSON_OUT)
+        console.log(c.cyan(`Stopping worker on node ${node.name}...`));
       const res = stopRemoteWorker(node);
       results.push(res);
       if (!JSON_OUT) {
         if (res.ok) {
           console.log(c.green(`✓ Worker stopped on ${node.name}`));
         } else {
-          console.log(c.red(`✗ Failed to stop worker on ${node.name}: ${res.error}`));
+          console.log(
+            c.red(`✗ Failed to stop worker on ${node.name}: ${res.error}`),
+          );
         }
       }
     }
@@ -251,14 +302,25 @@ try {
   if (command === "update" || command === "restart") {
     const results = [];
     for (const node of selectedNodes) {
-      if (!JSON_OUT) console.log(c.cyan(`Updating/restarting worker on node ${node.name}...`));
+      if (!JSON_OUT)
+        console.log(
+          c.cyan(`Updating/restarting worker on node ${node.name}...`),
+        );
       const res = updateRemoteWorker(node, { ref: targetRef });
       results.push(res);
       if (!JSON_OUT) {
         if (res.ok) {
-          console.log(c.green(`✓ Node ${node.name} updated and worker restarted (PID ${res.pid})`));
+          console.log(
+            c.green(
+              `✓ Node ${node.name} updated and worker restarted (PID ${res.pid})`,
+            ),
+          );
         } else {
-          console.log(c.red(`✗ Failed on step "${res.step}" for node ${node.name}: ${res.error}`));
+          console.log(
+            c.red(
+              `✗ Failed on step "${res.step}" for node ${node.name}: ${res.error}`,
+            ),
+          );
         }
       }
     }
@@ -266,7 +328,11 @@ try {
     process.exit(results.every((r) => r.ok) ? 0 : 1);
   }
 
-  console.error(c.red(`Unknown command "${command}". Run "factory workers --help" for usage.`));
+  console.error(
+    c.red(
+      `Unknown command "${command}". Run "factory workers --help" for usage.`,
+    ),
+  );
   process.exit(1);
 } catch (err) {
   console.error(c.red(`factory workers error: ${err.message}`));

--- a/orchestrator/workers.test.mjs
+++ b/orchestrator/workers.test.mjs
@@ -44,7 +44,10 @@ describe("orchestrator/workers CLI", () => {
   });
 
   test("factory workers returns warning when no nodes configured in plain text mode", () => {
-    const emptyConfig = path.join(tmpdir(), `empty-nodes-txt-${Date.now()}.yaml`);
+    const emptyConfig = path.join(
+      tmpdir(),
+      `empty-nodes-txt-${Date.now()}.yaml`,
+    );
     writeFileSync(emptyConfig, "nodes: {}\n");
 
     try {
@@ -58,7 +61,9 @@ describe("orchestrator/workers CLI", () => {
         },
       });
       expect(res.exitCode).toBe(0);
-      expect(res.stdout.toString()).toContain("No remote worker nodes configured");
+      expect(res.stdout.toString()).toContain(
+        "No remote worker nodes configured",
+      );
     } finally {
       rmSync(emptyConfig, { force: true });
     }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "sync-floor": "bun build/emit.mjs --sync-floor",
     "economics": "bun orchestrator/economics.mjs",
     "schedule": "bun deploy/gen.mjs",
-    "format:check": "prettier --check 'shared/**/*.md'",
-    "format": "prettier --write 'shared/**/*.md'",
+    "format:check": "prettier --check .",
+    "format": "prettier --write .",
     "test": "bun test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/runners/report.mjs
+++ b/runners/report.mjs
@@ -22,32 +22,59 @@ const logFile = argv.includes("--log") ? argv[argv.indexOf("--log") + 1] : null;
 // {event:"step_update",step_update:{step_type:"tool",tool_name,state}} and a
 // final {status:"SUCCESS",response,num_turns}. Same information, different
 // shape — normalise here rather than teaching every caller both.
-const HARNESS = argv.includes("--harness") ? argv[argv.indexOf("--harness") + 1] : "claude";
+const HARNESS = argv.includes("--harness")
+  ? argv[argv.indexOf("--harness") + 1]
+  : "claude";
 
 const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`, cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
   magenta: (s) => `\x1b[35m${s}\x1b[0m`,
 };
 const clock = () => new Date().toTimeString().slice(0, 8);
-const oneLine = (s, n = 100) => String(s ?? "").replace(/\s+/g, " ").trim().slice(0, n);
+const oneLine = (s, n = 100) =>
+  String(s ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, n);
 
 /** A compact, honest summary of what a tool call is about to do. */
 function describeTool(name, input = {}) {
   switch (name) {
-    case "Bash":       return oneLine(input.command);
-    case "Read":       return oneLine(input.file_path);
+    case "Bash":
+      return oneLine(input.command);
+    case "Read":
+      return oneLine(input.file_path);
     case "Edit":
-    case "Write":      return oneLine(input.file_path);
+    case "Write":
+      return oneLine(input.file_path);
     case "Glob":
-    case "Grep":       return oneLine(input.pattern) + (input.path ? c.dim(` in ${oneLine(input.path, 40)}`) : "");
-    case "Task":       return oneLine(input.description);
-    case "WebFetch":   return oneLine(input.url);
+    case "Grep":
+      return (
+        oneLine(input.pattern) +
+        (input.path ? c.dim(` in ${oneLine(input.path, 40)}`) : "")
+      );
+    case "Task":
+      return oneLine(input.description);
+    case "WebFetch":
+      return oneLine(input.url);
     default: {
       // MCP tools carry the interesting bit in varied fields; show something.
-      const k = ["query", "title", "id", "identifier", "issueId", "description"].find((x) => input[x]);
-      return k ? oneLine(input[k], 80) : c.dim(Object.keys(input).slice(0, 4).join(", "));
+      const k = [
+        "query",
+        "title",
+        "id",
+        "identifier",
+        "issueId",
+        "description",
+      ].find((x) => input[x]);
+      return k
+        ? oneLine(input[k], 80)
+        : c.dim(Object.keys(input).slice(0, 4).join(", "));
     }
   }
 }
@@ -70,26 +97,53 @@ if (buf.trim()) handle(buf);
 function handle(line) {
   const t = line.trim();
   if (!t) return;
-  if (logFile) { try { appendFileSync(logFile, t + "\n"); } catch { /* intentionally ignored */ } }
-  if (!t.startsWith("{")) { if (t) console.log(c.dim("  " + oneLine(t, 160))); return; }
+  if (logFile) {
+    try {
+      appendFileSync(logFile, t + "\n");
+    } catch {
+      /* intentionally ignored */
+    }
+  }
+  if (!t.startsWith("{")) {
+    if (t) console.log(c.dim("  " + oneLine(t, 160)));
+    return;
+  }
 
   let e;
-  try { e = JSON.parse(t); } catch { return; }
+  try {
+    e = JSON.parse(t);
+  } catch {
+    return;
+  }
 
   // ---- Codex ----------------------------------------------------------
   if (HARNESS === "codex") {
-    if (e.type === "turn.started" || e.type === "turn.created") { turns++; return; }
+    if (e.type === "turn.started" || e.type === "turn.created") {
+      turns++;
+      return;
+    }
     if (e.type === "item.started" || e.type === "item.completed") {
       const item = e.item ?? {};
-      if (e.type === "item.started" && (item.type === "command_execution" || item.type === "call")) {
+      if (
+        e.type === "item.started" &&
+        (item.type === "command_execution" || item.type === "call")
+      ) {
         const name = "bash";
         toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
-        console.log(`  ${c.dim(clock())} ${c.cyan(name)} ${oneLine(item.command, 90)}`);
+        console.log(
+          `  ${c.dim(clock())} ${c.cyan(name)} ${oneLine(item.command, 90)}`,
+        );
       } else if (e.type === "item.started" && item.type === "mcp_tool_call") {
         const name = item.tool ?? "mcp";
         toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
-        console.log(`  ${c.dim(clock())} ${c.cyan(name)} ${describeTool(name, item.arguments ?? {})}`);
-      } else if (e.type === "item.completed" && item.type === "agent_message" && item.text) {
+        console.log(
+          `  ${c.dim(clock())} ${c.cyan(name)} ${describeTool(name, item.arguments ?? {})}`,
+        );
+      } else if (
+        e.type === "item.completed" &&
+        item.type === "agent_message" &&
+        item.text
+      ) {
         console.log(`  ${c.dim(clock())} ${oneLine(item.text, 160)}`);
       }
       return;
@@ -97,7 +151,12 @@ function handle(line) {
     if (e.type === "turn.completed") {
       const usage = e.usage ?? {};
       const totalTok = (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
-      envelope = { status: "SUCCESS", num_turns: turns || 1, duration_seconds: 0, usage: { total_tokens: totalTok } };
+      envelope = {
+        status: "SUCCESS",
+        num_turns: turns || 1,
+        duration_seconds: 0,
+        usage: { total_tokens: totalTok },
+      };
     }
     return;
   }
@@ -114,7 +173,9 @@ function handle(line) {
           turns++;
           const name = part.name ?? "tool";
           toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
-          console.log(`  ${c.dim(clock())} ${c.cyan(name)} ${describeTool(name, part.input)}`);
+          console.log(
+            `  ${c.dim(clock())} ${c.cyan(name)} ${describeTool(name, part.input)}`,
+          );
         } else if (part.type === "text" && part.text?.trim()) {
           console.log(`  ${c.dim(clock())} ${oneLine(part.text, 160)}`);
         }
@@ -137,7 +198,11 @@ function handle(line) {
   // ---- Antigravity (agy) ----------------------------------------------
   if (HARNESS !== "claude") {
     if (e.event === "init") {
-      console.log(c.dim(`  ${clock()} conversation ${String(e.conversation_id).slice(0, 8)} · ${(e.init?.tools ?? []).length} tools`));
+      console.log(
+        c.dim(
+          `  ${clock()} conversation ${String(e.conversation_id).slice(0, 8)} · ${(e.init?.tools ?? []).length} tools`,
+        ),
+      );
       return;
     }
     if (e.event === "step_update") {
@@ -148,8 +213,15 @@ function handle(line) {
         toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
         const par = s.tool_info?.parameters ?? {};
         const brief = oneLine(
-          par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path ?? par.Query ?? par.query ??
-          (Object.keys(par).length ? JSON.stringify(par) : ""), 90);
+          par.CommandLine ??
+            par.command ??
+            par.AbsolutePath ??
+            par.path ??
+            par.Query ??
+            par.query ??
+            (Object.keys(par).length ? JSON.stringify(par) : ""),
+          90,
+        );
         console.log(`  ${c.dim(clock())} ${c.cyan(name)} ${brief}`);
       }
       if (s.step_type === "agent_response" && s.state === "DONE" && s.text) {
@@ -164,7 +236,11 @@ function handle(line) {
   }
 
   if (e.type === "system" && e.subtype === "init") {
-    console.log(c.dim(`  ${clock()} session ${e.session_id?.slice(0, 8)} · model ${e.model ?? "?"} · ${(e.tools ?? []).length} tools`));
+    console.log(
+      c.dim(
+        `  ${clock()} session ${e.session_id?.slice(0, 8)} · model ${e.model ?? "?"} · ${(e.tools ?? []).length} tools`,
+      ),
+    );
     return;
   }
 
@@ -172,9 +248,13 @@ function handle(line) {
   // into how much of the usage window is left.
   if (e.type === "rate_limit_event") {
     const i = e.rate_limit_info ?? {};
-    const resets = i.resetsAt ? new Date(i.resetsAt * 1000).toTimeString().slice(0, 5) : "?";
+    const resets = i.resetsAt
+      ? new Date(i.resetsAt * 1000).toTimeString().slice(0, 5)
+      : "?";
     const label = `rate limit: ${i.status} (${i.rateLimitType}, resets ${resets})`;
-    console.log(i.status === "allowed" ? c.dim(`  ${label}`) : c.yellow(`  ! ${label}`));
+    console.log(
+      i.status === "allowed" ? c.dim(`  ${label}`) : c.yellow(`  ! ${label}`),
+    );
     return;
   }
 
@@ -185,7 +265,9 @@ function handle(line) {
       } else if (part.type === "tool_use") {
         turns++;
         toolCounts.set(part.name, (toolCounts.get(part.name) ?? 0) + 1);
-        console.log(`  ${c.dim(clock())} ${c.cyan(part.name)} ${describeTool(part.name, part.input)}`);
+        console.log(
+          `  ${c.dim(clock())} ${c.cyan(part.name)} ${describeTool(part.name, part.input)}`,
+        );
       }
     }
     return;
@@ -194,23 +276,30 @@ function handle(line) {
   if (e.type === "user") {
     for (const part of e.message?.content ?? []) {
       if (part.type !== "tool_result") continue;
-      const body = typeof part.content === "string"
-        ? part.content
-        : (part.content ?? []).map((x) => x.text ?? "").join(" ");
+      const body =
+        typeof part.content === "string"
+          ? part.content
+          : (part.content ?? []).map((x) => x.text ?? "").join(" ");
       const isErr = part.is_error;
       const shown = oneLine(body, 120);
-      if (shown) console.log(`         ${isErr ? c.red("→ " + shown) : c.dim("→ " + shown)}`);
+      if (shown)
+        console.log(
+          `         ${isErr ? c.red("→ " + shown) : c.dim("→ " + shown)}`,
+        );
     }
     return;
   }
 
   // The final envelope has no "type" in some versions; detect by its fields.
-  if (e.type === "result" || "num_turns" in e || "total_cost_usd" in e) envelope = e;
+  if (e.type === "result" || "num_turns" in e || "total_cost_usd" in e)
+    envelope = e;
 }
 
 console.log();
 if (!envelope) {
-  console.error(c.red("  no result envelope — the run produced no final status."));
+  console.error(
+    c.red("  no result envelope — the run produced no final status."),
+  );
   process.exit(1);
 }
 
@@ -219,9 +308,17 @@ const result = String(envelope.result ?? envelope.response ?? "");
 if (HARNESS !== "claude") {
   const ok = envelope.status === "SUCCESS" && (envelope.num_turns ?? 0) > 0;
   if (result) console.log(result + "\n");
-  const toolsUsed = [...toolCounts.entries()].sort((a, b) => b[1] - a[1]).map(([n, k]) => `${n}×${k}`).join(" ");
-  console.log("  " + (ok ? c.green("ok") : c.red(`FAILED: ${envelope.status ?? "unknown"}`)) +
-    c.dim(`   ${envelope.num_turns ?? 0} turns   ${(envelope.duration_seconds ?? 0).toFixed(0)}s   ${envelope.usage?.total_tokens ?? 0} tokens`));
+  const toolsUsed = [...toolCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([n, k]) => `${n}×${k}`)
+    .join(" ");
+  console.log(
+    "  " +
+      (ok ? c.green("ok") : c.red(`FAILED: ${envelope.status ?? "unknown"}`)) +
+      c.dim(
+        `   ${envelope.num_turns ?? 0} turns   ${(envelope.duration_seconds ?? 0).toFixed(0)}s   ${envelope.usage?.total_tokens ?? 0} tokens`,
+      ),
+  );
   if (toolsUsed) console.log(c.dim(`  tools: ${toolsUsed}`));
   if (logFile) console.log(c.dim(`  transcript: ${logFile}`));
   console.log();
@@ -230,7 +327,11 @@ if (HARNESS !== "claude") {
 
 const unknownCommand = /^Unknown command:/.test(result);
 const didNothing = (envelope.num_turns ?? 0) === 0;
-const ok = envelope.subtype === "success" && !envelope.is_error && !unknownCommand && !didNothing;
+const ok =
+  envelope.subtype === "success" &&
+  !envelope.is_error &&
+  !unknownCommand &&
+  !didNothing;
 
 if (result && !unknownCommand) console.log(result + "\n");
 
@@ -238,13 +339,21 @@ if (unknownCommand) {
   console.error(c.red(`  ${result}`));
   console.error(c.dim("  Fix: bun build/emit.mjs --link-repos"));
 } else if (didNothing) {
-  console.error(c.yellow("  Zero turns — the session started and did nothing."));
+  console.error(
+    c.yellow("  Zero turns — the session started and did nothing."),
+  );
 }
 
-const tools = [...toolCounts.entries()].sort((a, b) => b[1] - a[1]).map(([n, k]) => `${n}×${k}`).join(" ");
+const tools = [...toolCounts.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .map(([n, k]) => `${n}×${k}`)
+  .join(" ");
 console.log(
-  "  " + (ok ? c.green("ok") : c.red("FAILED")) +
-  c.dim(`   ${envelope.num_turns ?? 0} turns   ~$${(envelope.total_cost_usd ?? 0).toFixed(3)} notional   ${((envelope.duration_ms ?? 0) / 1000).toFixed(0)}s`)
+  "  " +
+    (ok ? c.green("ok") : c.red("FAILED")) +
+    c.dim(
+      `   ${envelope.num_turns ?? 0} turns   ~$${(envelope.total_cost_usd ?? 0).toFixed(3)} notional   ${((envelope.duration_ms ?? 0) / 1000).toFixed(0)}s`,
+    ),
 );
 if (tools) console.log(c.dim(`  tools: ${tools}`));
 if (logFile) console.log(c.dim(`  transcript: ${logFile}`));

--- a/tools/dispatch.mjs
+++ b/tools/dispatch.mjs
@@ -61,26 +61,38 @@ async function api(path, options = {}) {
       json = null;
     }
     if (!res.ok) {
-      const err = json?.error || (Array.isArray(json?.errors) ? json.errors.join("; ") : `HTTP ${res.status}`);
+      const err =
+        json?.error ||
+        (Array.isArray(json?.errors)
+          ? json.errors.join("; ")
+          : `HTTP ${res.status}`);
       die(`control API error on ${path}: ${err}`);
     }
     return json;
   } catch (e) {
-    die(`failed to reach event runtime on port ${port} — is 'factory serve' running? (${e.message})`);
+    die(
+      `failed to reach event runtime on port ${port} — is 'factory serve' running? (${e.message})`,
+    );
   }
 }
 
 async function streamTrace(runId) {
-  console.log(`\n==> Streaming live trace for run ${runId} (Ctrl+C to detach)...\n`);
+  console.log(
+    `\n==> Streaming live trace for run ${runId} (Ctrl+C to detach)...\n`,
+  );
   let since = 0;
   let finished = false;
 
   while (!finished) {
-    const trace = await api(`/runs/${encodeURIComponent(runId)}/trace?since=${since}&limit=100`);
+    const trace = await api(
+      `/runs/${encodeURIComponent(runId)}/trace?since=${since}&limit=100`,
+    );
     if (trace?.entries) {
       for (const entry of trace.entries) {
         since = Math.max(since, entry.seq);
-        const time = entry.occurred_at ? new Date(entry.occurred_at).toLocaleTimeString() : "";
+        const time = entry.occurred_at
+          ? new Date(entry.occurred_at).toLocaleTimeString()
+          : "";
         const type = entry.type || "trace";
         let detail;
         if (entry.data?.text) detail = entry.data.text;
@@ -97,7 +109,9 @@ async function streamTrace(runId) {
     if (run && ["COMPLETED", "FAILED", "CANCELLED"].includes(run.state)) {
       // Not `finished = true`: the `break` below exits the loop directly, so
       // the while(!finished) condition is never re-evaluated after this branch.
-      console.log(`\n==> Run ${runId} settled: ${run.state} (${run.reasonCode || "ok"})`);
+      console.log(
+        `\n==> Run ${runId} settled: ${run.state} (${run.reasonCode || "ok"})`,
+      );
       if (run.state !== "COMPLETED") {
         process.exit(1);
       }
@@ -112,7 +126,9 @@ async function findRunForEvent(source, eventId, maxWaitMs = 10000) {
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
     const res = await api(`/proposals`);
-    const proposal = (res.proposals || []).find((p) => p.eventSource === source && p.eventId === eventId);
+    const proposal = (res.proposals || []).find(
+      (p) => p.eventSource === source && p.eventId === eventId,
+    );
     if (proposal?.runId) {
       return proposal.runId;
     }
@@ -155,12 +171,17 @@ async function main() {
       payload = { repos: [repo] };
       break;
     case "janitor":
-      eventType = values.apply ? "factory.janitor-apply.requested" : "factory.janitor-scan.requested";
+      eventType = values.apply
+        ? "factory.janitor-apply.requested"
+        : "factory.janitor-scan.requested";
       payload = { repo };
       break;
     case "event": {
       eventType = positionals[1];
-      if (!eventType) die("missing event type for 'event' action. Usage: factory dispatch event <type>");
+      if (!eventType)
+        die(
+          "missing event type for 'event' action. Usage: factory dispatch event <type>",
+        );
       if (values.payload) {
         try {
           payload = JSON.parse(values.payload);
@@ -207,7 +228,9 @@ async function main() {
     if (runId) {
       await streamTrace(runId);
     } else {
-      console.log(`Event admitted. Check status via: factory events ps or web UI http://127.0.0.1:${port}`);
+      console.log(
+        `Event admitted. Check status via: factory events ps or web UI http://127.0.0.1:${port}`,
+      );
     }
   } else {
     console.log(`\nView live status: http://127.0.0.1:${port}/#/events`);

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -66,7 +66,9 @@ const CACHE_TTL_MS = 15 * 60 * 1000;
 function cacheGet(key) {
   if (process.env.LINEAR_NO_CACHE) return null;
   try {
-    const { at, value } = JSON.parse(readFileSync(path.join(CACHE_DIR, `${key}.json`), "utf8"));
+    const { at, value } = JSON.parse(
+      readFileSync(path.join(CACHE_DIR, `${key}.json`), "utf8"),
+    );
     return Date.now() - at < CACHE_TTL_MS ? value : null;
   } catch {
     return null;
@@ -76,7 +78,10 @@ function cacheGet(key) {
 function cacheSet(key, value) {
   try {
     mkdirSync(CACHE_DIR, { recursive: true });
-    writeFileSync(path.join(CACHE_DIR, `${key}.json`), JSON.stringify({ at: Date.now(), value }));
+    writeFileSync(
+      path.join(CACHE_DIR, `${key}.json`),
+      JSON.stringify({ at: Date.now(), value }),
+    );
   } catch {
     // Cache is an optimization, never a dependency — a write failure must not fail the verb.
   }
@@ -85,7 +90,16 @@ function cacheSet(key, value) {
 // The eight values that resolve; `type:chore` fails the mutation. Kept here as
 // well as in the floor because a typo should fail locally with a list of the
 // valid options, not as an opaque API error three seconds later.
-export const TYPE_LABELS = ["bug", "feature", "ui-ux", "security", "performance", "maintenance", "docs", "a11y"];
+export const TYPE_LABELS = [
+  "bug",
+  "feature",
+  "ui-ux",
+  "security",
+  "performance",
+  "maintenance",
+  "docs",
+  "a11y",
+];
 export const SOURCE_LABELS = ["agent", "human", "sentry", "client-support"];
 
 /** Reject label typos before the API does, with a useful message. */
@@ -109,7 +123,11 @@ export function validateLabels(names) {
  * the labels you want added silently removes every other label on the ticket.
  * That is the sharp edge this function exists to blunt.
  */
-export function resolveLabelIds(currentNames, { add = [], remove = [] }, allLabels) {
+export function resolveLabelIds(
+  currentNames,
+  { add = [], remove = [] },
+  allLabels,
+) {
   const idOf = (n) => allLabels.find((l) => l.name === n)?.id;
   const dropped = new Set(remove);
   const kept = currentNames.filter((n) => !dropped.has(n));
@@ -126,7 +144,8 @@ export function resolveLabelIds(currentNames, { add = [], remove = [] }, allLabe
  * filters unresolved label ids out, so a wrong name just means the ticket never
  * says which harness holds it.
  */
-export const agentLabel = (harness) => `agent:${harness === "claude" ? "claude-code" : harness}`;
+export const agentLabel = (harness) =>
+  `agent:${harness === "claude" ? "claude-code" : harness}`;
 
 /**
  * Claiming drops `ai:agent-ready` and adds `ai:in-progress` + the agent label.
@@ -138,7 +157,10 @@ export function claimLabels(currentNames, harness) {
   const mine = agentLabel(harness);
   return {
     add: ["ai:in-progress", mine],
-    remove: ["ai:agent-ready", ...currentNames.filter((n) => n.startsWith("agent:") && n !== mine)],
+    remove: [
+      "ai:agent-ready",
+      ...currentNames.filter((n) => n.startsWith("agent:") && n !== mine),
+    ],
   };
 }
 
@@ -167,7 +189,7 @@ export function formatComment(c) {
 export function formatComments(nodesOrIssue) {
   const nodes = Array.isArray(nodesOrIssue)
     ? nodesOrIssue
-    : nodesOrIssue?.comments?.nodes ?? [];
+    : (nodesOrIssue?.comments?.nodes ?? []);
   if (!nodes.length) return "(no comments)";
   return nodes.map(formatComment).join("\n\n---\n\n");
 }
@@ -201,7 +223,10 @@ export function closureCheckMessages(issue) {
   const key = `${repo.name}::${repo.ownedPathsPolicy.pinManifests?.join(",") || ""}`;
   if (!PATH_REQUIREMENTS_CACHE.has(key)) {
     const requirements = repo.ownedPathsPolicy.pinManifests?.length
-      ? readPinManifestRequirements(repo.path, repo.ownedPathsPolicy.pinManifests)
+      ? readPinManifestRequirements(
+          repo.path,
+          repo.ownedPathsPolicy.pinManifests,
+        )
       : [];
     PATH_REQUIREMENTS_CACHE.set(key, requirements);
   }
@@ -220,9 +245,15 @@ export function appendIssueDetail(currentDescription, rawDetail) {
   if (!detail) throw new Error("detail must not be empty");
 
   const current = currentDescription ?? "";
-  if (current.includes(detail)) return { description: current, appended: false };
+  if (current.includes(detail))
+    return { description: current, appended: false };
 
-  const separator = current.length === 0 || current.endsWith("\n\n") ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+  const separator =
+    current.length === 0 || current.endsWith("\n\n")
+      ? ""
+      : current.endsWith("\n")
+        ? "\n"
+        : "\n\n";
   return { description: `${current}${separator}${detail}\n`, appended: true };
 }
 
@@ -236,13 +267,18 @@ const COMMENTS_FIELDS = `id identifier title
   comments(first:50){ nodes{ id body createdAt user{ id name } } }`;
 
 async function issueByKey(key) {
-  const d = await gql(`query($k:String!){ issue(id:$k){ ${ISSUE_FIELDS} } }`, { k: key });
+  const d = await gql(`query($k:String!){ issue(id:$k){ ${ISSUE_FIELDS} } }`, {
+    k: key,
+  });
   if (!d?.issue) throw new Error(`no such issue: ${key}`);
   return d.issue;
 }
 
 async function issueCommentsByKey(key) {
-  const d = await gql(`query($k:String!){ issue(id:$k){ ${COMMENTS_FIELDS} } }`, { k: key });
+  const d = await gql(
+    `query($k:String!){ issue(id:$k){ ${COMMENTS_FIELDS} } }`,
+    { k: key },
+  );
   if (!d?.issue) throw new Error(`no such issue: ${key}`);
   return d.issue;
 }
@@ -254,7 +290,10 @@ async function statesFor(teamKey, force = false) {
     const cached = cacheGet(`states-${teamKey}`);
     if (cached) return cached;
   }
-  const d = await gql(`query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } } } } }`, { t: teamKey });
+  const d = await gql(
+    `query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } } } } }`,
+    { t: teamKey },
+  );
   const team = d?.teams?.nodes?.[0];
   if (!team) throw new Error(`no such team: ${teamKey}`);
   const result = { teamId: team.id, states: team.states?.nodes ?? [] };
@@ -272,7 +311,9 @@ async function allLabels(force = false) {
       return cached;
     }
   }
-  const v = (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))?.issueLabels?.nodes ?? [];
+  const v =
+    (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))
+      ?.issueLabels?.nodes ?? [];
   allLabelsCache.v = v;
   cacheSet("labels", v);
   return v;
@@ -285,15 +326,28 @@ async function applyLabels(issue, add, remove) {
   let missing = add.filter((n) => !all.some((l) => l.name === n));
   if (missing.length) all = await allLabels(true); // stale cache? refetch once before failing
   missing = add.filter((n) => !all.some((l) => l.name === n));
-  if (missing.length) throw new Error(`label(s) do not exist in this workspace: ${missing.join(", ")}`);
+  if (missing.length)
+    throw new Error(
+      `label(s) do not exist in this workspace: ${missing.join(", ")}`,
+    );
   const current = (issue.labels?.nodes ?? []).map((l) => l.name);
   return resolveLabelIds(current, { add, remove }, all);
 }
 
 // ------------------------------------------------------------------ verbs ---
 const VALUE_FLAGS = new Set([
-  "add", "agent", "area", "body", "label", "project", "remove",
-  "source", "team", "title", "type", "var",
+  "add",
+  "agent",
+  "area",
+  "body",
+  "label",
+  "project",
+  "remove",
+  "source",
+  "team",
+  "title",
+  "type",
+  "var",
 ]);
 
 /** Return command arguments that are not flags or values consumed by flags. */
@@ -317,10 +371,14 @@ const flag = (name, dflt = null) => {
   const i = argv.indexOf(`--${name}`);
   return i === -1 ? dflt : argv[i + 1];
 };
-const flagAll = (name) => argv.flatMap((a, i) => (a === `--${name}` ? [argv[i + 1]] : [])).filter(Boolean);
+const flagAll = (name) =>
+  argv
+    .flatMap((a, i) => (a === `--${name}` ? [argv[i + 1]] : []))
+    .filter(Boolean);
 const has = (name) => argv.includes(`--${name}`);
 const JSON_OUT = has("json");
-const out = (obj, text) => console.log(JSON_OUT ? JSON.stringify(obj, null, 2) : text);
+const out = (obj, text) =>
+  console.log(JSON_OUT ? JSON.stringify(obj, null, 2) : text);
 
 // Attribution stamp (OPS-76). Factory spawns set FACTORY_RUN_ID to the
 // transcript basename, and the rollup keys on the same string — so stamping it
@@ -353,23 +411,42 @@ const VERBS = {
     const harness = flag("agent", "claude");
     const issue = await issueByKey(key);
     const { states } = await statesFor(teamOf(key));
-    const inProgress = states.find((s) => s.name.toLowerCase() === "in progress");
-    if (!inProgress) throw new Error(`team ${teamOf(key)} has no "In Progress" state`);
+    const inProgress = states.find(
+      (s) => s.name.toLowerCase() === "in progress",
+    );
+    if (!inProgress)
+      throw new Error(`team ${teamOf(key)} has no "In Progress" state`);
 
     const me = (await gql(`query{ viewer{ id name } }`))?.viewer;
-    const { add, remove } = claimLabels((issue.labels?.nodes ?? []).map((l) => l.name), harness);
+    const { add, remove } = claimLabels(
+      (issue.labels?.nodes ?? []).map((l) => l.name),
+      harness,
+    );
     const labelIds = await applyLabels(issue, add, remove);
 
-    await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-      { id: issue.id, in: { stateId: inProgress.id, assigneeId: me.id, labelIds } });
+    await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      {
+        id: issue.id,
+        in: { stateId: inProgress.id, assigneeId: me.id, labelIds },
+      },
+    );
 
     // Linear has no compare-and-swap, so this read-back IS the concurrency
     // control. Enforced here rather than asked of the agent in prose: a claim
     // that skips it is how two agents end up in one worktree.
-    const back = (await gql(`query($id:String!){ issue(id:$id){ assignee{ id name } } }`, { id: issue.id }))?.issue;
+    const back = (
+      await gql(`query($id:String!){ issue(id:$id){ assignee{ id name } } }`, {
+        id: issue.id,
+      })
+    )?.issue;
     const won = back?.assignee?.id === me.id;
-    out({ ok: won, identifier: key, assignee: back?.assignee?.name ?? null },
-      won ? `claimed ${key} as ${me.name}` : `LOST RACE on ${key} — now assigned to ${back?.assignee?.name ?? "someone else"}; take the next ticket`);
+    out(
+      { ok: won, identifier: key, assignee: back?.assignee?.name ?? null },
+      won
+        ? `claimed ${key} as ${me.name}`
+        : `LOST RACE on ${key} — now assigned to ${back?.assignee?.name ?? "someone else"}; take the next ticket`,
+    );
     if (!won) process.exit(1);
   },
 
@@ -378,41 +455,65 @@ const VERBS = {
     const body = positional[1];
     if (!body) throw new Error(`usage: comment <ISSUE-ID> "<text>"`);
     const issue = await issueByKey(key);
-    await gql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
-      { in: { issueId: issue.id, body: stampRun(body) } });
+    await gql(
+      `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+      { in: { issueId: issue.id, body: stampRun(body) } },
+    );
     out({ ok: true, identifier: key }, `commented on ${key}`);
   },
 
   async detail() {
     const key = positional[0];
     const rawDetail = positional[1];
-    if (!key || !rawDetail) throw new Error(`usage: detail <ISSUE-ID> "<markdown>"`);
+    if (!key || !rawDetail)
+      throw new Error(`usage: detail <ISSUE-ID> "<markdown>"`);
     const issue = await issueByKey(key);
-    const { description, appended } = appendIssueDetail(issue.description, rawDetail);
+    const { description, appended } = appendIssueDetail(
+      issue.description,
+      rawDetail,
+    );
     if (!appended) {
-      out({ ok: true, identifier: key, appended: false }, `${key} detail already present`);
+      out(
+        { ok: true, identifier: key, appended: false },
+        `${key} detail already present`,
+      );
       return;
     }
-    const updated = await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-      { id: issue.id, in: { description } });
-    if (!updated?.issueUpdate?.success) throw new Error(`failed to append detail to ${key}`);
-    out({ ok: true, identifier: key, appended: true }, `${key} detail appended`);
+    const updated = await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: { description } },
+    );
+    if (!updated?.issueUpdate?.success)
+      throw new Error(`failed to append detail to ${key}`);
+    out(
+      { ok: true, identifier: key, appended: true },
+      `${key} detail appended`,
+    );
   },
 
   async labels() {
     const key = positional[0];
-    if (!key) throw new Error(`usage: labels <ISSUE-ID> [--add <label>] [--remove <label>]`);
+    if (!key)
+      throw new Error(
+        `usage: labels <ISSUE-ID> [--add <label>] [--remove <label>]`,
+      );
     const issue = await issueByKey(key);
-    const add = flagAll("add"), remove = flagAll("remove");
+    const add = flagAll("add"),
+      remove = flagAll("remove");
     if (!add.length && !remove.length) {
       const current = (issue.labels?.nodes ?? []).map((l) => l.name);
       out(current, current.join(" ") || "(none)");
       return;
     }
     const labelIds = await applyLabels(issue, add, remove);
-    await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-      { id: issue.id, in: { labelIds } });
-    out({ ok: true, identifier: key, added: add, removed: remove }, `${key} labels updated`);
+    await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: { labelIds } },
+    );
+    out(
+      { ok: true, identifier: key, added: add, removed: remove },
+      `${key} labels updated`,
+    );
   },
 
   async label() {
@@ -422,48 +523,74 @@ const VERBS = {
   async state() {
     const key = positional[0];
     const wanted = positional[1];
-    const add = flagAll("add"), remove = flagAll("remove");
-    if (!key) throw new Error(`usage: state <ISSUE-ID> ["<State Name>"] [--add label] [--remove label]`);
+    const add = flagAll("add"),
+      remove = flagAll("remove");
+    if (!key)
+      throw new Error(
+        `usage: state <ISSUE-ID> ["<State Name>"] [--add label] [--remove label]`,
+      );
     if (!wanted && !add.length && !remove.length && !has("unassign")) {
-      throw new Error(`usage: state <ISSUE-ID> "<State Name>" [--add label] [--remove label]`);
+      throw new Error(
+        `usage: state <ISSUE-ID> "<State Name>" [--add label] [--remove label]`,
+      );
     }
     const issue = await issueByKey(key);
     const input = {};
     let target = null;
     if (wanted) {
       let { states } = await statesFor(teamOf(key));
-      target = states.find((s) => s.name.toLowerCase() === wanted.toLowerCase());
+      target = states.find(
+        (s) => s.name.toLowerCase() === wanted.toLowerCase(),
+      );
       if (!target) ({ states } = await statesFor(teamOf(key), true)); // stale cache? refetch once before failing
-      target = states.find((s) => s.name.toLowerCase() === wanted.toLowerCase());
-      if (!target) throw new Error(`no state "${wanted}" on team ${teamOf(key)} — have: ${states.map((s) => s.name).join(", ")}`);
+      target = states.find(
+        (s) => s.name.toLowerCase() === wanted.toLowerCase(),
+      );
+      if (!target)
+        throw new Error(
+          `no state "${wanted}" on team ${teamOf(key)} — have: ${states.map((s) => s.name).join(", ")}`,
+        );
       input.stateId = target.id;
     }
 
     if (add.includes("ai:agent-ready")) {
       const gaps = closureCheckMessages(issue);
       if (gaps.length) {
-        throw new Error(`Cannot add ai:agent-ready on ${key}: Owned Paths closure policy not satisfied:\n${gaps.map((g) => `- ${g}`).join("\n")}`);
+        throw new Error(
+          `Cannot add ai:agent-ready on ${key}: Owned Paths closure policy not satisfied:\n${gaps.map((g) => `- ${g}`).join("\n")}`,
+        );
       }
     }
 
-    if (add.length || remove.length) input.labelIds = await applyLabels(issue, add, remove);
+    if (add.length || remove.length)
+      input.labelIds = await applyLabels(issue, add, remove);
     if (has("unassign")) input.assigneeId = null;
 
-    await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-      { id: issue.id, in: input });
+    await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: input },
+    );
     const msg = target ? `${key} -> ${target.name}` : `${key} labels updated`;
-    out({ ok: true, identifier: key, ...(target ? { state: target.name } : {}) }, msg);
+    out(
+      { ok: true, identifier: key, ...(target ? { state: target.name } : {}) },
+      msg,
+    );
   },
 
   async file() {
     const team = flag("team");
     const title = flag("title");
-    if (!team || !title) throw new Error(`usage: file --team CLNT --title "..." [--body "..."] [--type bug] [--area x] [--source agent] [--todo]`);
+    if (!team || !title)
+      throw new Error(
+        `usage: file --team CLNT --title "..." [--body "..."] [--type bug] [--area x] [--source agent] [--todo]`,
+      );
 
     const { teamId, states } = await statesFor(team);
     // New findings land in Triage unless they already meet the agent-ready bar.
     const stateName = has("todo") ? "Todo" : "Triage";
-    const target = states.find((s) => s.name.toLowerCase() === stateName.toLowerCase());
+    const target = states.find(
+      (s) => s.name.toLowerCase() === stateName.toLowerCase(),
+    );
 
     const wanted = [
       ...(flag("type") ? [`type:${flag("type")}`] : []),
@@ -476,20 +603,30 @@ const VERBS = {
     if (bad.length) throw new Error("invalid label(s):\n  " + bad.join("\n  "));
     const all = await allLabels();
     const missing = wanted.filter((n) => !all.some((l) => l.name === n));
-    if (missing.length) throw new Error(`label(s) do not exist in this workspace: ${missing.join(", ")}`);
+    if (missing.length)
+      throw new Error(
+        `label(s) do not exist in this workspace: ${missing.join(", ")}`,
+      );
 
     const d = await gql(
       `mutation($in:IssueCreateInput!){ issueCreate(input:$in){ success issue{ identifier url } } }`,
-      { in: {
-        teamId, title,
-        description: stampRun(flag("body", "")),
-        stateId: target?.id,
-        labelIds: resolveLabelIds([], { add: wanted }, all),
-        ...(flag("project") ? { projectId: flag("project") } : {}),
-      } });
+      {
+        in: {
+          teamId,
+          title,
+          description: stampRun(flag("body", "")),
+          stateId: target?.id,
+          labelIds: resolveLabelIds([], { add: wanted }, all),
+          ...(flag("project") ? { projectId: flag("project") } : {}),
+        },
+      },
+    );
     const created = d?.issueCreate?.issue;
     if (!created) throw new Error("issueCreate returned no issue");
-    out({ ok: true, ...created }, `filed ${created.identifier} in ${stateName}  ${created.url}`);
+    out(
+      { ok: true, ...created },
+      `filed ${created.identifier} in ${stateName}  ${created.url}`,
+    );
   },
 
   async queue() {
@@ -499,19 +636,26 @@ const VERBS = {
     // the dispatcher uses; agents must not invent their own.
     const d = await gql(
       `query($t:String!){ issues(first:100, filter:{ team:{key:{eq:$t}}, state:{name:{eq:"Todo"}}, assignee:{null:true} }){ nodes{ ${ISSUE_FIELDS} } } }`,
-      { t: team });
+      { t: team },
+    );
     const ready = (d?.issues?.nodes ?? []).filter((i) =>
-      (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"));
-    out(ready, ready.length
-      ? ready.map((i) => `${i.identifier}  ${i.title}`).join("\n")
-      : "no agent-ready tickets");
+      (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"),
+    );
+    out(
+      ready,
+      ready.length
+        ? ready.map((i) => `${i.identifier}  ${i.title}`).join("\n")
+        : "no agent-ready tickets",
+    );
   },
 
   async raw() {
-    const vars = Object.fromEntries(flagAll("var").map((kv) => {
-      const i = kv.indexOf("=");
-      return [kv.slice(0, i), kv.slice(i + 1)];
-    }));
+    const vars = Object.fromEntries(
+      flagAll("var").map((kv) => {
+        const i = kv.indexOf("=");
+        return [kv.slice(0, i), kv.slice(i + 1)];
+      }),
+    );
     console.log(JSON.stringify(await gql(positional[0], vars), null, 2));
   },
 };
@@ -519,7 +663,9 @@ const VERBS = {
 if (import.meta.main) {
   if (!verb || has("help") || !VERBS[verb]) {
     console.log(`verbs: ${Object.keys(VERBS).join(", ")}\n`);
-    console.log(import.meta.file ? "see the header of tools/linear.mjs for usage" : "");
+    console.log(
+      import.meta.file ? "see the header of tools/linear.mjs for usage" : "",
+    );
     process.exit(verb && !VERBS[verb] ? 2 : 0);
   }
   try {

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -37,7 +37,11 @@ const LABELS = [
 
 // ------------------------------------------------------------ label math ---
 test("adding a label KEEPS the labels already on the ticket", () => {
-  const ids = resolveLabelIds(["type:bug", "area:api"], { add: ["ai:needs-review"] }, LABELS);
+  const ids = resolveLabelIds(
+    ["type:bug", "area:api"],
+    { add: ["ai:needs-review"] },
+    LABELS,
+  );
   expect(ids).toContain("l-bug");
   expect(ids).toContain("l-area");
   expect(ids).toContain("l-review");
@@ -45,14 +49,22 @@ test("adding a label KEEPS the labels already on the ticket", () => {
 });
 
 test("removing takes out only the named label", () => {
-  const ids = resolveLabelIds(["type:bug", "ai:agent-ready"], { remove: ["ai:agent-ready"] }, LABELS);
+  const ids = resolveLabelIds(
+    ["type:bug", "ai:agent-ready"],
+    { remove: ["ai:agent-ready"] },
+    LABELS,
+  );
   expect(ids).toEqual(["l-bug"]);
 });
 
 test("unknown label names are dropped rather than sent as undefined ids", () => {
   // A stale label removed from the workspace must not become `undefined` in the
   // mutation array — Linear rejects the whole update, losing the state change.
-  const ids = resolveLabelIds(["type:bug", "area:deleted-label"], { add: [] }, LABELS);
+  const ids = resolveLabelIds(
+    ["type:bug", "area:deleted-label"],
+    { add: [] },
+    LABELS,
+  );
   expect(ids).toEqual(["l-bug"]);
 });
 
@@ -76,17 +88,28 @@ test("claiming drops agent-ready and adds in-progress plus the harness label", (
   expect(add).toEqual(["ai:in-progress", "agent:claude-code"]);
   expect(remove).toContain("ai:agent-ready");
 
-  const ids = resolveLabelIds(["ai:agent-ready", "type:bug"], { add, remove }, LABELS);
+  const ids = resolveLabelIds(
+    ["ai:agent-ready", "type:bug"],
+    { add, remove },
+    LABELS,
+  );
   expect(ids).toContain("l-prog");
   expect(ids).toContain("l-claude");
-  expect(ids).toContain("l-bug");           // curated label survives
-  expect(ids).not.toContain("l-ready");     // lifecycle flag replaced
+  expect(ids).toContain("l-bug"); // curated label survives
+  expect(ids).not.toContain("l-ready"); // lifecycle flag replaced
 });
 
 test("re-claiming on a different harness does not leave two agent:* labels", () => {
-  const { add, remove } = claimLabels(["agent:codex", "ai:in-progress"], "claude");
+  const { add, remove } = claimLabels(
+    ["agent:codex", "ai:in-progress"],
+    "claude",
+  );
   expect(remove).toContain("agent:codex");
-  const ids = resolveLabelIds(["agent:codex", "ai:in-progress"], { add, remove }, LABELS);
+  const ids = resolveLabelIds(
+    ["agent:codex", "ai:in-progress"],
+    { add, remove },
+    LABELS,
+  );
   expect(ids).toContain("l-claude");
   expect(ids).not.toContain("l-codex");
 });
@@ -110,8 +133,11 @@ test("an unknown source:* is rejected; area:* is free-form and is not", () => {
 // -------------------------------------------------------------- rendering ---
 test("formatTicket shows the fields the protocol acts on", () => {
   const text = formatTicket({
-    identifier: "CLNT-616", title: "Fix login", url: "https://linear.app/x/CLNT-616",
-    state: { name: "Todo" }, assignee: null,
+    identifier: "CLNT-616",
+    title: "Fix login",
+    url: "https://linear.app/x/CLNT-616",
+    state: { name: "Todo" },
+    assignee: null,
     labels: { nodes: [{ name: "ai:agent-ready" }] },
   });
   expect(text).toContain("CLNT-616");
@@ -187,30 +213,54 @@ test("formatComments accepts issue object containing comments nodes", () => {
 
 // ------------------------------------------------------- argument parsing ---
 test("state label-only updates do not parse flag values as positional arguments", () => {
-  expect(parsePositionalArgs([
-    "state", "WM-250", "--add", "ai:needs-review", "--remove", "ai:in-progress",
-  ])).toEqual(["WM-250"]);
+  expect(
+    parsePositionalArgs([
+      "state",
+      "WM-250",
+      "--add",
+      "ai:needs-review",
+      "--remove",
+      "ai:in-progress",
+    ]),
+  ).toEqual(["WM-250"]);
 });
 
 test("state and label updates preserve the explicit state positional argument", () => {
-  expect(parsePositionalArgs([
-    "state", "WM-250", "In Review", "--add", "ai:needs-review",
-  ])).toEqual(["WM-250", "In Review"]);
+  expect(
+    parsePositionalArgs([
+      "state",
+      "WM-250",
+      "In Review",
+      "--add",
+      "ai:needs-review",
+    ]),
+  ).toEqual(["WM-250", "In Review"]);
 });
 
 test("values for other flags are not treated as positional arguments", () => {
-  expect(parsePositionalArgs([
-    "claim", "WM-250", "--agent", "codex", "--json",
-  ])).toEqual(["WM-250"]);
-  expect(parsePositionalArgs([
-    "file", "--team", "WM", "--title", "A title", "--todo",
-  ])).toEqual([]);
+  expect(
+    parsePositionalArgs(["claim", "WM-250", "--agent", "codex", "--json"]),
+  ).toEqual(["WM-250"]);
+  expect(
+    parsePositionalArgs([
+      "file",
+      "--team",
+      "WM",
+      "--title",
+      "A title",
+      "--todo",
+    ]),
+  ).toEqual([]);
 });
 
 // -------------------------------------------------------- label mutations ---
 test("label edits support both addition and removal without touching other labels", () => {
   const current = ["type:bug", "area:api", "ai:in-progress"];
-  const ids = resolveLabelIds(current, { add: ["ai:needs-review"], remove: ["ai:in-progress"] }, LABELS);
+  const ids = resolveLabelIds(
+    current,
+    { add: ["ai:needs-review"], remove: ["ai:in-progress"] },
+    LABELS,
+  );
   expect(ids).toContain("l-bug");
   expect(ids).toContain("l-area");
   expect(ids).toContain("l-review");
@@ -224,12 +274,22 @@ test("closure check blocks ai:agent-ready when Owned Paths closure policy is inc
   const previous = process.env.FACTORY_REPOS_ROOT;
   try {
     mkdirSync(path.join(root, "config"), { recursive: true });
-    mkdirSync(path.join(repoPath, "event-runtime", "agents"), { recursive: true });
-    mkdirSync(path.join(repoPath, "event-runtime", "schemas"), { recursive: true });
-    writeFileSync(path.join(repoPath, "event-runtime", "agents", "triage-scan.json"), `${JSON.stringify({
-      pins: { "event-runtime/schemas/triage-scan.output.json": "x" },
-    })}\n`);
-    writeFileSync(path.join(root, "config", "repos.yaml"), `repos:\n  - name: wm\n    path: ${repoPath}\n    team: WM\n    project: Tests\n    owned_paths_policy:\n      direct:\n        - source: shared/**\n          requires:\n            - dist/**\n      pin_manifests:\n        - event-runtime/agents/*.json\n`);
+    mkdirSync(path.join(repoPath, "event-runtime", "agents"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(repoPath, "event-runtime", "schemas"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(repoPath, "event-runtime", "agents", "triage-scan.json"),
+      `${JSON.stringify({
+        pins: { "event-runtime/schemas/triage-scan.output.json": "x" },
+      })}\n`,
+    );
+    writeFileSync(
+      path.join(root, "config", "repos.yaml"),
+      `repos:\n  - name: wm\n    path: ${repoPath}\n    team: WM\n    project: Tests\n    owned_paths_policy:\n      direct:\n        - source: shared/**\n          requires:\n            - dist/**\n      pin_manifests:\n        - event-runtime/agents/*.json\n`,
+    );
 
     process.env.FACTORY_REPOS_ROOT = root;
     __resetLinearReposCache();
@@ -240,13 +300,16 @@ test("closure check blocks ai:agent-ready when Owned Paths closure policy is inc
         project: { name: "Tests" },
         description: "## Owned Paths\n- shared/**\n",
       }),
-    ).toEqual(["Missing required Owned Paths entry: dist/** (required by shared/**)"]);
+    ).toEqual([
+      "Missing required Owned Paths entry: dist/** (required by shared/**)",
+    ]);
 
     expect(
       closureCheckMessages({
         team: { key: "WM" },
         project: { name: "Tests" },
-        description: "## Owned Paths\n- shared/**\n- event-runtime/schemas/triage-scan.output.json\n- dist/**\n",
+        description:
+          "## Owned Paths\n- shared/**\n- event-runtime/schemas/triage-scan.output.json\n- dist/**\n",
       }),
     ).toEqual([
       "Missing required Owned Paths entry: event-runtime/agents/triage-scan.json (required by event-runtime/schemas/triage-scan.output.json from event-runtime/agents/triage-scan.json)",
@@ -260,4 +323,3 @@ test("closure check blocks ai:agent-ready when Owned Paths closure policy is inc
     rmSync(root, { recursive: true, force: true });
   }
 });
-

--- a/tools/security-env.mjs
+++ b/tools/security-env.mjs
@@ -18,7 +18,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+const cfg = Bun.YAML.parse(
+  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+);
 
 const target = realpathSync(process.argv[2] || process.cwd());
 const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
@@ -28,7 +30,10 @@ const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
 const remote = (() => {
   const r = Bun.spawnSync(["git", "-C", target, "remote", "get-url", "origin"]);
   if (r.exitCode !== 0) return null;
-  const m = r.stdout.toString().trim().match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?$/);
+  const m = r.stdout
+    .toString()
+    .trim()
+    .match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?$/);
   return m ? m[1] : null;
 })();
 
@@ -37,11 +42,18 @@ for (const repo of cfg.repos || []) {
   try {
     const repoPath = expand(repo.path);
     byPath = target === repoPath || target.startsWith(repoPath + path.sep);
-  } catch { /* intentionally ignored */ }
+  } catch {
+    /* intentionally ignored */
+  }
   if (!byPath && !(remote && repo.github === remote)) continue;
   const sec = repo.security || {};
-  if (sec.semgrep_args) console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
-  if (sec.gitleaks_args) console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
-  if (sec.python_version) console.log(`export PYTHON_VERSION=${JSON.stringify(String(sec.python_version))}`);
+  if (sec.semgrep_args)
+    console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
+  if (sec.gitleaks_args)
+    console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
+  if (sec.python_version)
+    console.log(
+      `export PYTHON_VERSION=${JSON.stringify(String(sec.python_version))}`,
+    );
   break;
 }

--- a/update-desc.mjs
+++ b/update-desc.mjs
@@ -5,6 +5,8 @@ const key = process.argv[2];
 const description = fs.readFileSync(process.argv[3], "utf8");
 
 const d = await gql(`query($k:String!){ issue(id:$k){ id } }`, { k: key });
-await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`, 
-  { id: d.issue.id, in: { description } });
+await gql(
+  `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+  { id: d.issue.id, in: { description } },
+);
 console.log("Updated", key);


### PR DESCRIPTION
Fixes WM-610

## Summary
- Configure `.prettierrc` and `.prettierignore` at repository root (ignoring `node_modules/`, `dist/`, `graphify-out/`, `bun.lock`, `deploy/launchd/`, `.factory/`).
- Update root `package.json` scripts: `format:check` runs `prettier --check .` across code and markdown files; `format` runs `prettier --write .`.
- Reformat all tracked codebase files with Prettier.
- Re-pin agent definitions in `event-runtime/agents/*.json` to match reformatted prompts and schemas.
- Update baseline registry digests in `event-runtime/lib/registry.test.mjs` and fix commit format in `bin/worktree-checkout.test.mjs`.

## Verification
`bun run format:check` — pass (All matched files use Prettier code style!)
`bun run lint` — pass (0 errors)
`cd event-runtime/web && bun run build` — pass
`bun test` — pass (2500 pass, 0 fail)
`bun run check` — pass (90 generated files match shared/)

UX critique: skipped — codebase-wide code formatting and Prettier check configuration; no user-facing UI or flow changes