### PR TITLE
fix(worktree): retry metadata read races (WM-622)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -844,6 +844,41 @@ test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
   }
 });
 
+test("worktree_add retries transient worktree metadata read races", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "factory-wt-metadata-race-"));
+  const attemptsFile = path.join(tempDir, "attempts");
+  const worktreePath = path.join(tempDir, "checkout");
+
+  try {
+    const r = sh(`
+      git() {
+        if [[ "$*" == *" show-ref --verify --quiet refs/heads/feat/WM-TEST"* ]]; then
+          return 1
+        fi
+        if [[ "$*" == *" worktree add "* ]]; then
+          local attempts=0
+          [[ -f "$MOCK_GIT_ATTEMPTS" ]] && attempts=$(cat "$MOCK_GIT_ATTEMPTS")
+          attempts=$((attempts + 1))
+          printf '%s\n' "$attempts" >"$MOCK_GIT_ATTEMPTS"
+          if [[ "$attempts" -eq 1 ]]; then
+            printf '%s\n' 'fatal: failed to read .git/worktrees/PARA-123/commondir: Success' >&2
+            return 1
+          fi
+          return 0
+        fi
+        return 1
+      }
+      worktree_add "${worktreePath}" "feat/WM-TEST" "origin/develop" "/repo"
+    `, { MOCK_GIT_ATTEMPTS: attemptsFile });
+
+    expect(r.status).toBe(0);
+    expect(readFileSync(attemptsFile, "utf8").trim()).toBe("2");
+    expect(r.stderr).toContain("git worktree add hit lock contention (attempt 1/6)");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("high concurrency worktree-up --checkout-only with 4 parallel bring-ups succeeds", async () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-4conc-"));
   const tickets = [
@@ -1080,4 +1115,3 @@ test("worktree-down refuses dirty worktree without --force and cleans up with --
     Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticketId}`] });
   }
 });
-

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -64,7 +64,7 @@ worktree_add() { # <worktree> <branch> <base-ref> [repo]
       return 0
     fi
     if [[ $attempt -lt $max_attempts ]] \
-      && grep -qiE '\.lock|could not lock|cannot lock|unable to create|another git process|temporarily unavailable|resource deadlock|resource temporarily unavailable|device or resource busy|already exists' <<<"$err"; then
+      && grep -qiE '\.lock|could not lock|cannot lock|unable to create|another git process|temporarily unavailable|resource deadlock|resource temporarily unavailable|device or resource busy|already exists|failed to read .*\.git/worktrees|commondir' <<<"$err"; then
       local delay_idx=$((attempt - 1))
       [[ $delay_idx -ge ${#delays[@]} ]] && delay_idx=$((${#delays[@]} - 1))
       warn "git worktree add hit lock contention (attempt $attempt/$max_attempts) — retrying in ${delays[$delay_idx]}s"
@@ -777,5 +777,4 @@ locked_bun_install() { # <dir>
 }
 
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-daemons.sh"
-
 


### PR DESCRIPTION
## Summary
- retry transient `.git/worktrees/*/commondir` read races during `git worktree add`
- add deterministic coverage that simulates the CI failure and verifies a successful retry

## Verification
- `bun test bin/worktree-checkout.test.mjs` — 28 pass, 0 fail

UX critique: skipped — infrastructure-only worktree provisioning change with no user-facing surface

Fixes WM-622