### PR TITLE
fix(web): make Projects responsive on mobile (WM-169)

### DIFF
--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -549,3 +549,69 @@ describe("Projects mode tabs and hotkeys (WM-234)", () => {
   });
 });
 
+describe("Projects mobile layout (WM-169)", () => {
+  test("provides a mobile mode select synchronized with tabs and keyboard shortcuts", async () => {
+    await withApi(
+      {
+        repos: async () => ({
+          repos: [
+            repo({ name: "r-dispatch", reportOnly: false }),
+            repo({ name: "r-report", reportOnly: true }),
+          ],
+        }),
+      },
+      async () => {
+        const r = renderProjects();
+        await r.findByText("r-dispatch");
+
+        const select = r.getByRole("combobox", { name: "Project mode" }) as HTMLSelectElement;
+        const tablist = r.getByRole("tablist", { name: "Project mode" });
+        const tabs = r.getAllByRole("tab");
+
+        expect(select.className).toContain("sm:hidden");
+        expect(tablist.className).toContain("hidden");
+        expect(tablist.className).toContain("sm:flex");
+        expect(select.value).toBe("ALL");
+
+        fireEvent.change(select, { target: { value: "DISPATCHABLE" } });
+        expect(select.value).toBe("DISPATCHABLE");
+        expect(tabs[1].getAttribute("aria-selected")).toBe("true");
+        expect(r.getByText("r-dispatch")).toBeTruthy();
+        expect(r.queryByText("r-report")).toBeNull();
+
+        fireEvent.keyDown(document.body, { key: "]" });
+        expect(select.value).toBe("REPORT_ONLY");
+        expect(tabs[2].getAttribute("aria-selected")).toBe("true");
+
+        fireEvent.keyDown(document.body, { key: "1" });
+        expect(select.value).toBe("ALL");
+        expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+
+        fireEvent.click(tabs[2]);
+        expect(select.value).toBe("REPORT_ONLY");
+      },
+    );
+  });
+
+  test("contains the full table in the existing horizontal scroller", async () => {
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects();
+      const table = await r.findByRole("table", { name: "Projects table" });
+
+      expect(table.className).toContain("min-w-");
+      expect(table.parentElement?.className).toContain("overflow-auto");
+    });
+  });
+
+  test("keeps the selected project detail pane within the mobile viewport", async () => {
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects("factory");
+      await r.findByText("Quick Dispatch (Agent Tasks)");
+
+      const pane = r.container.querySelector("aside");
+      expect(pane?.className).toContain("w-full");
+      expect(pane?.className).toContain("max-w-full");
+      expect(pane?.className).toContain("sm:w-[540px]");
+    });
+  });
+});

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -398,7 +398,19 @@ export function Projects({
               subject={{ label: "Projects", plural: true }}
             />
             <div className="mb-3 flex flex-wrap items-center gap-2">
-              <div className="flex min-w-0 flex-1 flex-wrap gap-1 text-[12px]" role="tablist" aria-label="Project mode">
+              <select
+                aria-label="Project mode"
+                value={filterMode}
+                onChange={(event) => setFilterMode(event.target.value as ProjectMode)}
+                className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
+              >
+                {PROJECT_MODES.map((mode) => (
+                  <option key={mode} value={mode}>
+                    {mode === "ALL" ? "All" : mode === "DISPATCHABLE" ? "Dispatchable" : "Report-Only"} {modeCounts[mode]}
+                  </option>
+                ))}
+              </select>
+              <div className="hidden min-w-0 flex-1 gap-1 text-[12px] sm:flex" role="tablist" aria-label="Project mode">
                 {PROJECT_MODES.map((mode, idx) => (
                   <button
                     key={mode}
@@ -430,7 +442,7 @@ export function Projects({
           </>
         }
       >
-        <table className="w-full border-separate border-spacing-0">
+        <table aria-label="Projects table" className="w-full min-w-[760px] border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {PROJECTS_SORT.columns.map((column) => {
@@ -511,7 +523,7 @@ export function Projects({
 
       {sel && (
         <DetailPane
-          widthClass="w-[540px]"
+          widthClass="w-full max-w-full sm:w-[540px]"
           title={
             <div className="flex items-center gap-2">
               <span className="mono font-semibold" title={sel.name}>

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -530,7 +530,10 @@ export function Projects({
           </>
         }
       >
-        <table aria-label="Projects table" className="w-full min-w-[760px] border-separate border-spacing-0">
+        <table
+          aria-label="Projects table"
+          className="w-full min-w-[760px] border-separate border-spacing-0"
+        >
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {PROJECTS_SORT.columns.map((column) => {


### PR DESCRIPTION
## Summary
- add a mobile Project mode select synchronized with desktop tabs and keyboard shortcuts
- preserve all six table columns with horizontal scrolling at narrow widths
- constrain repository details to the mobile viewport
- add responsive control, scrolling, pane, and keyboard regression coverage

## Verification
- `bun test event-runtime/web` — 865 pass, 0 fail
- `bun run lint` — 0 errors (existing warnings remain)
- `factory security` — pass

UX critique: required — NOT-ASSESSED; isolated Chromium exited before DevTools became available, so no browser evidence was produced. This PR remains draft.

Fixes WM-169