### PR TITLE
feat(event-runtime-web): render generic inbox decisions

### DIFF
--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   DECISION_REQUEST_SCHEMA,
   DECISION_RESPONSE_SCHEMA,
@@ -10,6 +11,13 @@ import {
   validateDecisionResponse,
 } from "./decision.mjs";
 import { validate } from "./schema.mjs";
+
+const SHARED_CASES = JSON.parse(
+  readFileSync(
+    new URL("./fixtures/decision-cases.json", import.meta.url),
+    "utf8",
+  ),
+).cases;
 
 const EXAMPLE_REQUEST = {
   schemaVersion: "factory.decision-request/v1",
@@ -609,6 +617,20 @@ describe("decisionRequestHash", () => {
     expect(decisionRequestHash(RESPONSE_REQUEST)).toMatch(
       /^sha256:[a-f0-9]{64}$/,
     );
+  });
+
+  test("matches every shared browser fixture", () => {
+    for (const fixture of SHARED_CASES) {
+      expect(decisionRequestHash(fixture.request), fixture.name).toBe(
+        fixture.hash,
+      );
+      for (const response of fixture.responses) {
+        expect(
+          validateDecisionResponse(response.value, fixture.request).valid,
+          `${fixture.name}/${response.name}`,
+        ).toBe(response.valid);
+      }
+    }
   });
 });
 

--- a/event-runtime/lib/fixtures/decision-cases.json
+++ b/event-runtime/lib/fixtures/decision-cases.json
@@ -1,0 +1,113 @@
+{
+  "cases": [
+    {
+      "name": "section-2.1-authorise",
+      "request": {
+        "schemaVersion": "factory.decision-request/v1",
+        "question": "WM-313 changes how the pi adapter reads FACTORY_EVENT_SECRET. May I proceed?",
+        "context": "The ticket moves secret handling from env to a file the worker mounts…\n\nRisk: a wrong path leaks the secret into the run journal.",
+        "recommended": "authorise",
+        "options": [
+          {
+            "id": "authorise",
+            "label": "Authorise within these paths",
+            "description": "Re-dispatch me with your approval bound to WM-313 as written now.",
+            "effect": "authorise",
+            "tone": "primary",
+            "scope": {
+              "paths": [
+                "event-runtime/lib/adapters/pi.mjs",
+                "event-runtime/lib/security-env.mjs"
+              ],
+              "summary": "Read the event secret from FACTORY_EVENT_SECRET_FILE when set; never log its value."
+            }
+          },
+          {
+            "id": "triage",
+            "label": "Send back to Triage",
+            "description": "The ticket should be re-scoped before anyone touches this.",
+            "effect": "send_to_triage",
+            "tone": "neutral"
+          },
+          {
+            "id": "dismiss",
+            "label": "Not now",
+            "effect": "dismiss",
+            "tone": "neutral"
+          }
+        ],
+        "fields": [
+          {
+            "id": "insight",
+            "kind": "text",
+            "label": "Anything I should know before I start",
+            "placeholder": "e.g. the file path convention, or a test to add",
+            "required": false,
+            "maxLength": 2000
+          },
+          {
+            "id": "paths",
+            "kind": "multi-choice",
+            "label": "Restrict me to",
+            "choices": [
+              { "id": "pi", "label": "event-runtime/lib/adapters/pi.mjs" },
+              { "id": "env", "label": "event-runtime/lib/security-env.mjs" }
+            ],
+            "required": true,
+            "whenOption": ["authorise"]
+          },
+          {
+            "id": "confirm",
+            "kind": "confirm",
+            "label": "I understand this changes secret handling on every worker",
+            "required": true,
+            "whenOption": ["authorise"]
+          }
+        ]
+      },
+      "hash": "sha256:22f0c1d578d4277a62531859bf8028821329225ef439a7a05e8657969ddec614",
+      "responses": [
+        {
+          "name": "valid-authorise",
+          "valid": true,
+          "value": {
+            "schemaVersion": "factory.decision-response/v1",
+            "requestHash": "sha256:22f0c1d578d4277a62531859bf8028821329225ef439a7a05e8657969ddec614",
+            "optionId": "authorise",
+            "fields": {
+              "insight": "Use the mounted secret file.",
+              "paths": ["pi"],
+              "confirm": true
+            },
+            "decidedBy": "operator",
+            "decidedAt": "2026-08-16T12:41:07.000Z"
+          }
+        },
+        {
+          "name": "missing-confirm",
+          "valid": false,
+          "value": {
+            "schemaVersion": "factory.decision-response/v1",
+            "requestHash": "sha256:22f0c1d578d4277a62531859bf8028821329225ef439a7a05e8657969ddec614",
+            "optionId": "authorise",
+            "fields": { "paths": ["pi"] },
+            "decidedBy": "operator",
+            "decidedAt": "2026-08-16T12:41:07.000Z"
+          }
+        },
+        {
+          "name": "gated-fields-omitted-for-dismiss",
+          "valid": true,
+          "value": {
+            "schemaVersion": "factory.decision-response/v1",
+            "requestHash": "sha256:22f0c1d578d4277a62531859bf8028821329225ef439a7a05e8657969ddec614",
+            "optionId": "dismiss",
+            "fields": {},
+            "decidedBy": "operator",
+            "decidedAt": "2026-08-16T12:41:07.000Z"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -6,6 +6,8 @@ import type {
   ApproveOutcome,
   CancelOutcome,
   EnvIdentity,
+  DecisionEffect,
+  DecisionResponseInput,
   InboxItem,
   InboxStatus,
   JournalView,
@@ -243,6 +245,25 @@ export const api = {
       prNumbers === undefined ? {} : { prNumbers },
     ),
 };
+
+// Decision detail endpoints are named exports so the generic API test harness
+// does not need an unrelated mock every time this self-contained flow grows.
+export const getInboxItem = (id: string) =>
+  call<{ item: InboxItem }>("GET", `/inbox/${encodeURIComponent(id)}`);
+
+export const decideInboxItem = (id: string, response: DecisionResponseInput) =>
+  call<{ item: InboxItem; effect: DecisionEffect }>(
+    "POST",
+    `/inbox/${encodeURIComponent(id)}/decide`,
+    response,
+  );
+
+export const retryInboxDecision = (id: string) =>
+  call<{ item: InboxItem; effect: DecisionEffect }>(
+    "POST",
+    `/inbox/${encodeURIComponent(id)}/decide/retry`,
+    {},
+  );
 
 export interface ScheduleItem {
   loop: string;

--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -1,0 +1,320 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { ApiError } from "../api";
+import type { DecisionRequest, InboxItem } from "../types";
+import { decisionRequestHash } from "../lib/decision";
+import { DecisionCard } from "./DecisionCard";
+
+const request: DecisionRequest = {
+  schemaVersion: "factory.decision-request/v1",
+  question:
+    "WM-313 changes how the pi adapter reads FACTORY_EVENT_SECRET. May I proceed?",
+  context:
+    "The ticket moves secret handling from env to a file the worker mounts…\n\nRisk: a wrong path leaks the secret into the run journal.",
+  recommended: "authorise",
+  options: [
+    {
+      id: "triage",
+      label: "Send back to Triage",
+      description: "The ticket should be re-scoped before anyone touches this.",
+      effect: "send_to_triage",
+      tone: "neutral",
+    },
+    {
+      id: "authorise",
+      label: "Authorise within these paths",
+      description:
+        "Re-dispatch me with your approval bound to WM-313 as written now.",
+      effect: "authorise",
+      tone: "primary",
+      scope: {
+        paths: [
+          "event-runtime/lib/adapters/pi.mjs",
+          "event-runtime/lib/security-env.mjs",
+        ],
+        summary:
+          "Read the event secret from FACTORY_EVENT_SECRET_FILE when set; never log its value.",
+      },
+    },
+    { id: "dismiss", label: "Not now", effect: "dismiss", tone: "neutral" },
+  ],
+  fields: [
+    {
+      id: "insight",
+      kind: "text",
+      label: "Anything I should know before I start",
+      placeholder: "e.g. the file path convention, or a test to add",
+      required: false,
+      maxLength: 2000,
+    },
+    {
+      id: "paths",
+      kind: "multi-choice",
+      label: "Restrict me to",
+      choices: [
+        { id: "pi", label: "event-runtime/lib/adapters/pi.mjs" },
+        { id: "env", label: "event-runtime/lib/security-env.mjs" },
+      ],
+      required: true,
+      whenOption: ["authorise"],
+    },
+    {
+      id: "confirm",
+      kind: "confirm",
+      label: "I understand this changes secret handling on every worker",
+      required: true,
+      whenOption: ["authorise"],
+    },
+  ],
+};
+
+function item(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: "inbox_decision",
+    kind: "decision_needed",
+    severity: "normal",
+    title: "Decision needed",
+    body: null,
+    refs: {},
+    source: "agent:run_1",
+    createdAt: "2026-08-16T12:40:00.000Z",
+    ackedAt: null,
+    resolvedAt: null,
+    resolvedBy: null,
+    delivery: {},
+    decision: request,
+    response: null,
+    decidedAt: null,
+    decidedBy: null,
+    ...overrides,
+  };
+}
+
+let apiCalls: NonNullable<
+  React.ComponentProps<typeof DecisionCard>["apiCalls"]
+>;
+
+beforeEach(() => {
+  apiCalls = {
+    decide: mock(async () => ({
+      item: item(),
+      effect: { kind: "authorise", outcome: "applied" },
+    })),
+    get: mock(async () => ({
+      item: item({
+        resolvedAt: "2026-08-16T12:41:07.000Z",
+        resolvedBy: "operator:authorise",
+        response: {
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: decisionRequestHash(request),
+          optionId: "authorise",
+          fields: { paths: ["pi"], confirm: true },
+          decidedBy: "operator",
+          decidedAt: "2026-08-16T12:41:07.000Z",
+          effect: { kind: "authorise", outcome: "applied" },
+        },
+      }),
+    })),
+    retry: mock(async () => ({
+      item: item(),
+      effect: { kind: "authorise", outcome: "applied" },
+    })),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DecisionCard", () => {
+  test("renders the §2.1 options recommended-first and gates its fields", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+    const optionButtons = view
+      .getByRole("group", { name: "Options" })
+      .querySelectorAll("button");
+    expect(optionButtons).toHaveLength(3);
+    expect(optionButtons[0].textContent).toContain(
+      "Authorise within these paths",
+    );
+    expect(optionButtons[0].textContent).toContain("suggested");
+    expect(optionButtons[1].textContent).toContain("Send back to Triage");
+    expect(optionButtons[2].textContent).toContain("Not now");
+    expect(view.queryByText("Restrict me to")).toBeNull();
+    expect(
+      view.queryByLabelText(/I understand this changes secret handling/),
+    ).toBeNull();
+
+    fireEvent.click(optionButtons[0]);
+    expect(view.getByRole("group", { name: /Restrict me to/ })).toBeTruthy();
+    expect(
+      view.getByLabelText(/I understand this changes secret handling/),
+    ).toBeTruthy();
+  });
+
+  test("keeps submit disabled until confirmation and at least one path are chosen", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+    const submit = view.getByRole("button", {
+      name: "Authorise within these paths",
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(view.getByLabelText("event-runtime/lib/adapters/pi.mjs"));
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(
+      view.getByLabelText(/I understand this changes secret handling/),
+    );
+    expect(submit.disabled).toBe(false);
+  });
+
+  test("posts the response contract then refetches before rendering the record", async () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+    fireEvent.click(view.getByLabelText("event-runtime/lib/adapters/pi.mjs"));
+    fireEvent.click(
+      view.getByLabelText(/I understand this changes secret handling/),
+    );
+    fireEvent.click(
+      view.getByRole("button", { name: "Authorise within these paths" }),
+    );
+
+    await waitFor(() => expect(apiCalls.decide).toHaveBeenCalledTimes(1));
+    expect(apiCalls.decide).toHaveBeenCalledWith("inbox_decision", {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "authorise",
+      fields: { paths: ["pi"], confirm: true },
+    });
+    await waitFor(() => expect(apiCalls.get).toHaveBeenCalledTimes(1));
+    await waitFor(() => view.getByRole("region", { name: "Decision record" }));
+    expect(view.getByText("Effect applied")).toBeTruthy();
+  });
+
+  test("refetches and asks the operator to re-read a stale request", async () => {
+    const changed: DecisionRequest = {
+      ...request,
+      question: "The scope changed. Continue?",
+    };
+    apiCalls.decide = mock(async () => {
+      throw new ApiError("stale_request", 409);
+    });
+    apiCalls.get = mock(async () => ({
+      item: item({ decision: changed, response: null }),
+    }));
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+    fireEvent.click(view.getByLabelText("event-runtime/lib/adapters/pi.mjs"));
+    fireEvent.click(
+      view.getByLabelText(/I understand this changes secret handling/),
+    );
+    fireEvent.click(
+      view.getByRole("button", { name: "Authorise within these paths" }),
+    );
+    await waitFor(() =>
+      view.getByText("This question changed — please re-read"),
+    );
+    expect(view.getByText("The scope changed. Continue?")).toBeTruthy();
+  });
+
+  test("number keys select only from card focus, not from a text field", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+    const card = view.getByRole("region", { name: "Decision" });
+    const optionButtons = view
+      .getByRole("group", { name: "Options" })
+      .querySelectorAll("button");
+    fireEvent.keyDown(card, { key: "2" });
+    expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
+    const text = view.getByLabelText("Anything I should know before I start");
+    fireEvent.keyDown(text, { key: "3" });
+    expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("shows a failed effect and retries it before refetching the record", async () => {
+    const failed = {
+      schemaVersion: "factory.decision-response/v1" as const,
+      requestHash: decisionRequestHash(request),
+      optionId: "dismiss",
+      fields: {},
+      decidedBy: "operator",
+      decidedAt: "2026-08-16T12:41:07.000Z",
+      effect: {
+        kind: "dismiss",
+        outcome: "failed",
+        error: "temporary failure",
+      },
+    };
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        response={failed}
+        apiCalls={apiCalls}
+      />,
+    );
+    expect(view.getByText(/temporary failure/)).toBeTruthy();
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(apiCalls.retry).toHaveBeenCalledWith("inbox_decision"),
+    );
+    await waitFor(() =>
+      expect(apiCalls.get).toHaveBeenCalledWith("inbox_decision"),
+    );
+  });
+
+  test("renders an auto-superseded decision without treating it as an answer", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        response={{
+          superseded: true,
+          reason: "auto:proposal_closed",
+          decidedBy: "auto:proposal_closed",
+          decidedAt: "2026-08-16T12:41:07.000Z",
+        }}
+        apiCalls={apiCalls}
+      />,
+    );
+    expect(
+      view.getByText("This question no longer needs an answer."),
+    ).toBeTruthy();
+    expect(view.getByText("auto:proposal_closed")).toBeTruthy();
+    expect(view.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+});

--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -246,7 +246,7 @@ describe("DecisionCard", () => {
     expect(view.getByText("The scope changed. Continue?")).toBeTruthy();
   });
 
-  test("number keys select only from card focus, not from a text field", () => {
+  test("number keys select from anywhere in the view, beat the view's own bubble-phase bindings, and never from a text field", () => {
     const view = render(
       <DecisionCard
         itemId="inbox_decision"
@@ -254,15 +254,45 @@ describe("DecisionCard", () => {
         apiCalls={apiCalls}
       />,
     );
-    const card = view.getByRole("region", { name: "Decision" });
-    const optionButtons = view
-      .getByRole("group", { name: "Options" })
-      .querySelectorAll("button");
-    fireEvent.keyDown(card, { key: "2" });
-    expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
-    const text = view.getByLabelText("Anything I should know before I start");
-    fireEvent.keyDown(text, { key: "3" });
-    expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
+    // Stand-in for Inbox's status-tab listener (bubble phase on window): with
+    // an undecided card open it must not see the number keys.
+    const tabListener = mock(() => {});
+    window.addEventListener("keydown", tabListener);
+    try {
+      const optionButtons = view
+        .getByRole("group", { name: "Options" })
+        .querySelectorAll("button");
+      fireEvent.keyDown(document.body, { key: "2" });
+      expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
+      expect(tabListener).not.toHaveBeenCalled();
+      const text = view.getByLabelText("Anything I should know before I start");
+      fireEvent.keyDown(text, { key: "3" });
+      expect(optionButtons[1].getAttribute("aria-pressed")).toBe("true");
+      expect(tabListener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("keydown", tabListener);
+    }
+  });
+
+  test("an unapplied effect (WM-390's `unsupported` stub) is retryable, not just `failed`", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        response={{
+          schemaVersion: "factory.decision-response/v1" as const,
+          requestHash: decisionRequestHash(request),
+          optionId: "authorise",
+          fields: { paths: ["pi"], confirm: true },
+          decidedBy: "operator",
+          decidedAt: "2026-08-16T12:41:07.000Z",
+          effect: { kind: "authorise", outcome: "unsupported" },
+        }}
+        apiCalls={apiCalls}
+      />,
+    );
+    expect(view.getByText(/Effect unsupported/)).toBeTruthy();
+    expect(view.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
   test("shows a failed effect and retries it before refetching the record", async () => {

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   ApiError,
   decideInboxItem,
@@ -100,13 +100,22 @@ export function DecisionCard({
   const [retrying, setRetrying] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
-  useEffect(() => {
+  // Reset the card when it is pointed at a different item, a changed request,
+  // or a fresh response from the parent's refetch — during render, per the
+  // React "adjusting state when a prop changes" pattern, not in an effect.
+  const [tracked, setTracked] = useState({ itemId, requestHash, response });
+  if (
+    tracked.itemId !== itemId ||
+    tracked.requestHash !== requestHash ||
+    tracked.response !== response
+  ) {
+    setTracked({ itemId, requestHash, response });
     setCurrentRequest(request);
     setCurrentResponse(response);
     setSelected(null);
     setValues(initialValues(request));
     setMessage(null);
-  }, [itemId, requestHash, response]);
+  }
 
   const options = useMemo(() => {
     const recommended = currentRequest.recommended;

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -1,0 +1,565 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ApiError,
+  decideInboxItem,
+  getInboxItem,
+  retryInboxDecision,
+} from "../api";
+import type {
+  DecisionField,
+  DecisionRequest,
+  DecisionResponseInput,
+  InboxDecisionResponse,
+  InboxItem,
+} from "../types";
+import {
+  applicableFields,
+  fieldErrors,
+  initialValues,
+  type DecisionValues,
+} from "../lib/decisionForm";
+import { decisionRequestHash } from "../lib/decision";
+import { MarkdownView } from "./RunTrace";
+import { Button } from "./ui";
+
+export interface DecisionCardProps {
+  itemId: string;
+  request: DecisionRequest;
+  response?: InboxDecisionResponse | null;
+  connected?: boolean;
+  onItemChange?: (item: InboxItem) => void;
+  apiCalls?: {
+    get: typeof getInboxItem;
+    decide: typeof decideInboxItem;
+    retry: typeof retryInboxDecision;
+  };
+}
+
+const controlClass =
+  "w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)";
+
+function responseFields(
+  request: DecisionRequest,
+  optionId: string,
+  values: DecisionValues,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  for (const field of applicableFields(request, optionId)) {
+    const value = values[field.id];
+    const empty =
+      value === "" ||
+      value === undefined ||
+      (Array.isArray(value) && value.length === 0) ||
+      (field.kind === "confirm" && value === false);
+    if (!empty || field.required) fields[field.id] = value;
+  }
+  return fields;
+}
+
+function displayValue(
+  field: DecisionField | undefined,
+  value: unknown,
+): string {
+  if (field?.kind === "single-choice")
+    return (
+      field.choices.find((choice) => choice.id === value)?.label ??
+      String(value)
+    );
+  if (field?.kind === "multi-choice" && Array.isArray(value))
+    return value
+      .map(
+        (id) =>
+          field.choices.find((choice) => choice.id === id)?.label ?? String(id),
+      )
+      .join(", ");
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+}
+
+export function DecisionCard({
+  itemId,
+  request,
+  response = null,
+  connected = true,
+  onItemChange,
+  apiCalls = {
+    get: getInboxItem,
+    decide: decideInboxItem,
+    retry: retryInboxDecision,
+  },
+}: DecisionCardProps) {
+  const requestHash = decisionRequestHash(request);
+  const [currentRequest, setCurrentRequest] = useState(request);
+  const [currentResponse, setCurrentResponse] = useState(response);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [values, setValues] = useState<DecisionValues>(() =>
+    initialValues(request),
+  );
+  const [pending, setPending] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCurrentRequest(request);
+    setCurrentResponse(response);
+    setSelected(null);
+    setValues(initialValues(request));
+    setMessage(null);
+  }, [itemId, requestHash, response]);
+
+  const options = useMemo(() => {
+    const recommended = currentRequest.recommended;
+    return [...currentRequest.options].sort((left, right) => {
+      if (left.id === recommended) return -1;
+      if (right.id === recommended) return 1;
+      return 0;
+    });
+  }, [currentRequest]);
+  const visibleFields = selected
+    ? applicableFields(currentRequest, selected)
+    : [];
+  const errors = selected ? fieldErrors(currentRequest, selected, values) : {};
+  const invalidReason = !selected
+    ? "Choose an option to continue."
+    : (Object.values(errors)[0] ?? null);
+
+  const refresh = async (): Promise<InboxItem> => {
+    const { item } = await apiCalls.get(itemId);
+    if (item.decision) setCurrentRequest(item.decision);
+    setCurrentResponse(item.response ?? null);
+    onItemChange?.(item);
+    return item;
+  };
+
+  const submit = async () => {
+    if (!selected || invalidReason || pending || !connected) return;
+    setPending(true);
+    setMessage(null);
+    const body: DecisionResponseInput = {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(currentRequest),
+      optionId: selected,
+      fields: responseFields(currentRequest, selected, values),
+    };
+    try {
+      await apiCalls.decide(itemId, body);
+      await refresh();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.message === "stale_request"
+      ) {
+        const item = await refresh();
+        const nextRequest = item.decision ?? currentRequest;
+        setSelected(null);
+        setValues(initialValues(nextRequest));
+        setMessage("This question changed — please re-read");
+      } else {
+        setMessage((error as Error).message);
+      }
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const retry = async () => {
+    if (retrying || !connected) return;
+    setRetrying(true);
+    setMessage(null);
+    try {
+      await apiCalls.retry(itemId);
+      await refresh();
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const update = (id: string, value: unknown) =>
+    setValues((previous) => ({ ...previous, [id]: value }));
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    if (target.closest("input, textarea, select, [contenteditable=true]"))
+      return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    const number = Number(event.key);
+    if (number < 1 || number > 6 || !options[number - 1]) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setSelected(options[number - 1].id);
+    setMessage(null);
+  };
+
+  if (currentResponse) {
+    if ("superseded" in currentResponse) {
+      return (
+        <section
+          aria-label="Decision record"
+          className="rounded-md border border-(--border) bg-(--surface-0) p-3"
+        >
+          <h2 className="text-[14px] font-semibold text-(--text)">
+            {currentRequest.question}
+          </h2>
+          <div className="mt-3 rounded-md bg-(--surface-1) p-3 text-[12px]">
+            <div className="font-semibold text-(--text)">
+              This question no longer needs an answer.
+            </div>
+            <div className="mt-1 text-(--text-dim)">
+              Superseded by {currentResponse.decidedBy} ·{" "}
+              {new Date(currentResponse.decidedAt).toLocaleString()}
+            </div>
+            <div className="mono mt-2 text-[11px] text-(--text-faint)">
+              {currentResponse.reason}
+            </div>
+          </div>
+        </section>
+      );
+    }
+    const option = currentRequest.options.find(
+      (candidate) => candidate.id === currentResponse.optionId,
+    );
+    const fieldsById = new Map(
+      (currentRequest.fields ?? []).map((field) => [field.id, field]),
+    );
+    const failed = currentResponse.effect?.outcome === "failed";
+    return (
+      <section
+        aria-label="Decision record"
+        className="rounded-md border border-(--border) bg-(--surface-0) p-3"
+      >
+        <h2 className="text-[14px] font-semibold text-(--text)">
+          {currentRequest.question}
+        </h2>
+        <div className="mt-3 rounded-md bg-(--surface-1) p-3 text-[12px]">
+          <div className="font-semibold text-(--text)">
+            {option?.label ?? currentResponse.optionId}
+          </div>
+          <div className="mt-1 text-(--text-dim)">
+            Decided by {currentResponse.decidedBy} ·{" "}
+            {new Date(currentResponse.decidedAt).toLocaleString()}
+          </div>
+          {Object.entries(currentResponse.fields).length > 0 && (
+            <dl className="mt-3 space-y-1.5">
+              {Object.entries(currentResponse.fields).map(([id, value]) => (
+                <div key={id}>
+                  <dt className="text-[11px] text-(--text-faint)">
+                    {fieldsById.get(id)?.label ?? id}
+                  </dt>
+                  <dd className="whitespace-pre-wrap break-words text-(--text)">
+                    {displayValue(fieldsById.get(id), value)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          {currentResponse.effect && (
+            <div
+              className="mt-3 rounded border px-2.5 py-2"
+              style={{
+                borderColor: failed ? "var(--hue-err)" : "var(--hue-ok)",
+                color: failed ? "var(--hue-err)" : "var(--hue-ok)",
+              }}
+            >
+              Effect {currentResponse.effect.outcome}
+              {currentResponse.effect.error
+                ? ` — ${currentResponse.effect.error}`
+                : ""}
+            </div>
+          )}
+          {failed && (
+            <div className="mt-3">
+              <Button
+                variant="danger"
+                disabled={!connected || retrying}
+                onClick={() => void retry()}
+              >
+                {retrying ? "Retrying…" : "Retry"}
+              </Button>
+            </div>
+          )}
+          {message && <div className="mt-2 text-(--hue-err)">{message}</div>}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Decision"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      className="rounded-md border border-(--border) bg-(--surface-0) p-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+    >
+      <h2 className="text-[14px] font-semibold text-(--text)">
+        {currentRequest.question}
+      </h2>
+      {currentRequest.context && (
+        <MarkdownView
+          text={currentRequest.context}
+          allowToggle={false}
+          className="mt-2"
+        />
+      )}
+
+      <div className="mt-3 space-y-1.5" role="group" aria-label="Options">
+        {options.map((option, index) => {
+          const chosen = option.id === selected;
+          const tone = option.tone ?? "neutral";
+          const hue =
+            tone === "primary"
+              ? "var(--accent)"
+              : tone === "danger"
+                ? "var(--hue-err)"
+                : "var(--border-strong)";
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={chosen}
+              onClick={() => {
+                setSelected(option.id);
+                setMessage(null);
+              }}
+              className="flex w-full cursor-pointer items-start gap-2 rounded-md border bg-(--surface-1) px-2.5 py-2 text-left text-[12px] outline-none hover:bg-(--surface-2) focus-visible:ring-2 focus-visible:ring-(--accent)"
+              style={{
+                borderColor: chosen ? hue : "var(--border)",
+                boxShadow: chosen ? `inset 3px 0 ${hue}` : undefined,
+              }}
+            >
+              <span className="mono mt-0.5 text-[10px] text-(--text-faint)">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="font-medium text-(--text)">
+                  <span
+                    style={{
+                      color:
+                        tone === "primary"
+                          ? "var(--accent)"
+                          : tone === "danger"
+                            ? "var(--hue-err)"
+                            : "var(--text)",
+                    }}
+                  >
+                    {option.label}
+                  </span>
+                </span>
+                {option.id === currentRequest.recommended && (
+                  <span className="ml-2 rounded bg-(--surface-3) px-1.5 py-0.5 text-[10px] text-(--accent)">
+                    suggested
+                  </span>
+                )}
+                {option.description && (
+                  <span className="mt-0.5 block text-(--text-dim)">
+                    {option.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {selected && visibleFields.length > 0 && (
+        <div className="mt-4 space-y-3">
+          {visibleFields.map((field) => (
+            <DecisionFieldControl
+              key={field.id}
+              field={field}
+              value={values[field.id]}
+              onChange={(value) => update(field.id, value)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Button
+          variant="primary"
+          disabled={!connected || pending || invalidReason !== null}
+          onClick={() => void submit()}
+        >
+          {pending
+            ? "Submitting…"
+            : selected
+              ? currentRequest.options.find((option) => option.id === selected)
+                  ?.label
+              : "Choose an option"}
+        </Button>
+        {invalidReason && (
+          <span className="text-[11px] text-(--text-faint)" role="status">
+            {invalidReason}
+          </span>
+        )}
+      </div>
+      {message && (
+        <div
+          className="mt-3 rounded border border-(--hue-warn) px-2.5 py-2 text-[12px] text-(--hue-warn)"
+          role="alert"
+        >
+          {message}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DecisionFieldControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: DecisionField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const required = field.required ? " *" : "";
+  if (field.kind === "confirm") {
+    return (
+      <label className="flex cursor-pointer items-start gap-2 text-[12px] text-(--text)">
+        <input
+          type="checkbox"
+          checked={value === true}
+          onChange={(event) => onChange(event.target.checked)}
+          className="mt-0.5"
+        />
+        <span>
+          {field.label}
+          {required}
+        </span>
+      </label>
+    );
+  }
+  if (field.kind === "multi-choice") {
+    const chosen = Array.isArray(value) ? (value as string[]) : [];
+    return (
+      <fieldset>
+        <legend className="mb-1 text-[12px] font-medium text-(--text)">
+          {field.label}
+          {required}
+        </legend>
+        <div className="space-y-1">
+          {field.choices.map((choice) => (
+            <label
+              key={choice.id}
+              className="flex cursor-pointer items-start gap-2 rounded px-1 py-0.5 text-[12px] hover:bg-(--surface-1)"
+            >
+              <input
+                type="checkbox"
+                checked={chosen.includes(choice.id)}
+                onChange={(event) =>
+                  onChange(
+                    event.target.checked
+                      ? [...chosen, choice.id]
+                      : chosen.filter((id) => id !== choice.id),
+                  )
+                }
+                className="mt-0.5"
+              />
+              <span>
+                <span className="text-(--text)">{choice.label}</span>
+                {choice.description && (
+                  <span className="block text-(--text-dim)">
+                    {choice.description}
+                  </span>
+                )}
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+    );
+  }
+  if (field.kind === "single-choice" && field.choices.length <= 5) {
+    return (
+      <fieldset>
+        <legend className="mb-1 text-[12px] font-medium text-(--text)">
+          {field.label}
+          {required}
+        </legend>
+        <div className="space-y-1">
+          {field.choices.map((choice) => (
+            <label
+              key={choice.id}
+              className="flex cursor-pointer gap-2 text-[12px]"
+            >
+              <input
+                type="radio"
+                name={field.id}
+                value={choice.id}
+                checked={value === choice.id}
+                onChange={() => onChange(choice.id)}
+              />
+              <span>{choice.label}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+    );
+  }
+  if (field.kind === "single-choice") {
+    return (
+      <label className="block text-[12px] font-medium text-(--text)">
+        {field.label}
+        {required}
+        <select
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.target.value)}
+          className={`${controlClass} mt-1`}
+        >
+          <option value="">Choose…</option>
+          {field.choices.map((choice) => (
+            <option key={choice.id} value={choice.id}>
+              {choice.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+  if (field.kind === "number") {
+    return (
+      <label className="block text-[12px] font-medium text-(--text)">
+        {field.label}
+        {required}
+        <input
+          type="number"
+          value={typeof value === "number" ? String(value) : ""}
+          min={field.minimum}
+          max={field.maximum}
+          step={field.integer ? 1 : "any"}
+          onChange={(event) =>
+            onChange(
+              event.target.value === "" ? "" : event.target.valueAsNumber,
+            )
+          }
+          className={`${controlClass} mt-1`}
+        />
+      </label>
+    );
+  }
+  const common = {
+    value: typeof value === "string" ? value : "",
+    placeholder: field.placeholder,
+    maxLength: field.maxLength,
+    onChange: (
+      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => onChange(event.target.value),
+    className: `${controlClass} mt-1`,
+  };
+  return (
+    <label className="block text-[12px] font-medium text-(--text)">
+      {field.label}
+      {required}
+      {field.maxLength !== undefined && field.maxLength <= 120 ? (
+        <input type="text" {...common} />
+      ) : (
+        <textarea rows={3} {...common} />
+      )}
+    </label>
+  );
+}

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -1,4 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { keyGuard } from "../hooks";
+import { goPrefixActive } from "../goSequence";
 import {
   ApiError,
   decideInboxItem,
@@ -190,18 +192,28 @@ export function DecisionCard({
   const update = (id: string, value: unknown) =>
     setValues((previous) => ({ ...previous, [id]: value }));
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const target = event.target as HTMLElement;
-    if (target.closest("input, textarea, select, [contenteditable=true]"))
-      return;
-    if (event.metaKey || event.ctrlKey || event.altKey) return;
-    const number = Number(event.key);
-    if (number < 1 || number > 6 || !options[number - 1]) return;
-    event.preventDefault();
-    event.stopPropagation();
-    setSelected(options[number - 1].id);
-    setMessage(null);
-  };
+  // While an undecided card is on screen the number keys 1–6 pick its options
+  // from anywhere in the view — the operator arrives via the list row, not by
+  // focusing the card. Capture phase on window so the Inbox status-tab
+  // binding (bubble phase on window) never sees them; text fields, modifiers
+  // and the `g` prefix still win.
+  const undecided = !currentResponse;
+  useEffect(() => {
+    if (!undecided) return;
+    function onKey(event: KeyboardEvent) {
+      if (keyGuard(event) || goPrefixActive()) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const number = Number(event.key);
+      if (number < 1 || number > 6 || !options[number - 1]) return;
+      event.preventDefault();
+      event.stopPropagation();
+      setSelected(options[number - 1].id);
+      setMessage(null);
+    }
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKey, { capture: true });
+  }, [undecided, options]);
 
   if (currentResponse) {
     if ("superseded" in currentResponse) {
@@ -234,7 +246,14 @@ export function DecisionCard({
     const fieldsById = new Map(
       (currentRequest.fields ?? []).map((field) => [field.id, field]),
     );
-    const failed = currentResponse.effect?.outcome === "failed";
+    // Anything the runtime did not apply is retryable (the server's own rule
+    // for /decide/retry is "not already applied"), so gate on that rather
+    // than the single "failed" value — WM-390's stub still answers
+    // "unsupported" for most effects until WM-391 lands.
+    const failed =
+      currentResponse.effect !== undefined &&
+      currentResponse.effect !== null &&
+      currentResponse.effect.outcome !== "applied";
     return (
       <section
         aria-label="Decision record"
@@ -299,9 +318,7 @@ export function DecisionCard({
   return (
     <section
       aria-label="Decision"
-      tabIndex={0}
-      onKeyDown={onKeyDown}
-      className="rounded-md border border-(--border) bg-(--surface-0) p-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+      className="rounded-md border border-(--border) bg-(--surface-0) p-3"
     >
       <h2 className="text-[14px] font-semibold text-(--text)">
         {currentRequest.question}

--- a/event-runtime/web/src/lib/decision.test.ts
+++ b/event-runtime/web/src/lib/decision.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { DecisionRequest, DecisionResponse } from "../types";
+import { decisionRequestHash, validateDecisionResponse } from "./decision";
+
+interface SharedCase {
+  name: string;
+  request: DecisionRequest;
+  hash: string;
+  responses: { name: string; valid: boolean; value: DecisionResponse }[];
+}
+
+const cases = JSON.parse(
+  readFileSync(
+    new URL("../../../lib/fixtures/decision-cases.json", import.meta.url),
+    "utf8",
+  ),
+).cases as SharedCase[];
+
+describe("browser decision port", () => {
+  test("agrees with the server fixture hashes and response verdicts", () => {
+    for (const fixture of cases) {
+      expect(decisionRequestHash(fixture.request), fixture.name).toBe(
+        fixture.hash,
+      );
+      for (const response of fixture.responses) {
+        expect(
+          validateDecisionResponse(response.value, fixture.request).valid,
+          `${fixture.name}/${response.name}`,
+        ).toBe(response.valid);
+      }
+    }
+  });
+
+  test("canonical key ordering does not change the hash", () => {
+    const request = cases[0].request;
+    const reordered = {
+      options: request.options,
+      question: request.question,
+      fields: request.fields,
+      recommended: request.recommended,
+      context: request.context,
+      schemaVersion: request.schemaVersion,
+    } as DecisionRequest;
+    expect(decisionRequestHash(reordered)).toBe(decisionRequestHash(request));
+  });
+
+  test("malformed choice fields return invalid instead of throwing", () => {
+    const malformed = structuredClone(cases[0].request) as unknown as {
+      fields: Record<string, unknown>[];
+    };
+    malformed.fields[1] = {
+      id: "paths",
+      kind: "multi-choice",
+      label: "Paths",
+    };
+    const response = cases[0].responses[0].value;
+    expect(() =>
+      validateDecisionResponse(
+        response,
+        malformed as unknown as DecisionRequest,
+      ),
+    ).not.toThrow();
+    expect(
+      validateDecisionResponse(
+        response,
+        malformed as unknown as DecisionRequest,
+      ).valid,
+    ).toBe(false);
+  });
+});

--- a/event-runtime/web/src/lib/decision.ts
+++ b/event-runtime/web/src/lib/decision.ts
@@ -1,0 +1,526 @@
+/**
+ * Browser port of event-runtime/lib/decision.mjs response validation and
+ * request hashing. Keep the validation rules in sync with the runtime.
+ */
+import type {
+  DecisionField,
+  DecisionRequest,
+  DecisionResponse,
+} from "../types";
+import { validate, type ValidationResult } from "./schema";
+
+const ID_SCHEMA = { type: "string", pattern: "^[a-z][a-z0-9_-]{0,31}$" };
+const CHOICE_SCHEMA = {
+  type: "object",
+  required: ["id", "label"],
+  additionalProperties: false,
+  properties: {
+    id: ID_SCHEMA,
+    label: { type: "string", minLength: 1, maxLength: 60 },
+    description: { type: "string", maxLength: 280 },
+  },
+};
+const DECISION_REQUEST_SCHEMA = {
+  type: "object",
+  required: ["schemaVersion", "question", "options"],
+  additionalProperties: false,
+  properties: {
+    schemaVersion: { const: "factory.decision-request/v1" },
+    question: { type: "string", minLength: 1, maxLength: 280 },
+    context: { type: "string", maxLength: 8192 },
+    recommended: ID_SCHEMA,
+    options: {
+      type: "array",
+      minItems: 1,
+      maxItems: 6,
+      items: {
+        type: "object",
+        required: ["id", "label", "effect"],
+        additionalProperties: false,
+        properties: {
+          id: ID_SCHEMA,
+          label: { type: "string", minLength: 1, maxLength: 60 },
+          description: { type: "string", maxLength: 280 },
+          effect: {
+            enum: [
+              "authorise",
+              "send_to_triage",
+              "answer",
+              "requeue",
+              "approve_proposal",
+              "reject_proposal",
+              "dismiss",
+            ],
+          },
+          tone: { enum: ["primary", "danger", "neutral"] },
+          scope: {
+            type: "object",
+            required: ["paths", "summary"],
+            additionalProperties: false,
+            properties: {
+              paths: {
+                type: "array",
+                minItems: 1,
+                maxItems: 32,
+                items: { type: "string", minLength: 1 },
+              },
+              summary: { type: "string", minLength: 1, maxLength: 500 },
+            },
+          },
+        },
+      },
+    },
+    fields: {
+      type: "array",
+      minItems: 0,
+      maxItems: 6,
+      items: {
+        type: "object",
+        required: ["id", "kind", "label"],
+        additionalProperties: false,
+        properties: {
+          id: ID_SCHEMA,
+          kind: {
+            enum: [
+              "text",
+              "single-choice",
+              "multi-choice",
+              "confirm",
+              "number",
+            ],
+          },
+          label: { type: "string", minLength: 1, maxLength: 60 },
+          required: { type: "boolean" },
+          whenOption: {
+            type: "array",
+            minItems: 1,
+            maxItems: 6,
+            items: ID_SCHEMA,
+          },
+          placeholder: { type: "string", maxLength: 280 },
+          maxLength: { type: "integer", minimum: 1, maximum: 8192 },
+          choices: {
+            type: "array",
+            minItems: 1,
+            maxItems: 24,
+            items: CHOICE_SCHEMA,
+          },
+          minItems: { type: "integer", minimum: 0, maximum: 24 },
+          maxItems: { type: "integer", minimum: 0, maximum: 24 },
+          minimum: { type: "number" },
+          maximum: { type: "number" },
+          integer: { type: "boolean" },
+        },
+      },
+    },
+  },
+};
+
+const DECISION_RESPONSE_SCHEMA = {
+  type: "object",
+  required: [
+    "schemaVersion",
+    "requestHash",
+    "optionId",
+    "fields",
+    "decidedBy",
+    "decidedAt",
+  ],
+  additionalProperties: false,
+  properties: {
+    schemaVersion: { const: "factory.decision-response/v1" },
+    requestHash: { type: "string", pattern: "^sha256:[a-f0-9]{64}$" },
+    optionId: { type: "string", pattern: "^[a-z][a-z0-9_-]{0,31}$" },
+    fields: { type: "object", additionalProperties: {} },
+    decidedBy: { type: "string", minLength: 1, maxLength: 120 },
+    decidedAt: {
+      type: "string",
+      pattern:
+        "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$",
+    },
+  },
+};
+
+const hasOwn = (value: unknown, key: string): boolean =>
+  value !== null &&
+  typeof value === "object" &&
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const COMMON_FIELD_KEYS = new Set([
+  "id",
+  "kind",
+  "label",
+  "required",
+  "whenOption",
+]);
+const FIELD_KEYS: Record<DecisionField["kind"], Set<string>> = {
+  text: new Set([...COMMON_FIELD_KEYS, "placeholder", "maxLength"]),
+  "single-choice": new Set([...COMMON_FIELD_KEYS, "choices"]),
+  "multi-choice": new Set([
+    ...COMMON_FIELD_KEYS,
+    "choices",
+    "minItems",
+    "maxItems",
+  ]),
+  confirm: COMMON_FIELD_KEYS,
+  number: new Set([...COMMON_FIELD_KEYS, "minimum", "maximum", "integer"]),
+};
+
+function result(errors: string[]): ValidationResult {
+  return { valid: errors.length === 0, errors };
+}
+
+function duplicateValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+/** The response port re-checks the semantic request rules needed at answer time. */
+function checkRequest(request: DecisionRequest): ValidationResult {
+  const shape = validate(DECISION_REQUEST_SCHEMA, request);
+  if (!shape.valid) return shape;
+  const errors: string[] = [];
+  if (
+    request.context !== undefined &&
+    new TextEncoder().encode(request.context).byteLength > 8 * 1024
+  ) {
+    errors.push("$.context: longer than 8192 bytes when encoded as UTF-8");
+  }
+  const optionIds = request.options.map((option) => option.id);
+  const optionIdSet = new Set(optionIds);
+  for (const id of duplicateValues(optionIds))
+    errors.push(`$.options: duplicate option id "${id}"`);
+  if (
+    request.recommended !== undefined &&
+    !optionIdSet.has(request.recommended)
+  )
+    errors.push(`$.recommended: unknown option id "${request.recommended}"`);
+
+  for (const [index, option] of request.options.entries()) {
+    const path = `$.options[${index}]`;
+    const hasScope = hasOwn(option, "scope");
+    if (option.effect === "authorise" && !hasScope)
+      errors.push(`${path}.scope: required for effect "authorise"`);
+    else if (option.effect !== "authorise" && hasScope)
+      errors.push(`${path}.scope: only allowed for effect "authorise"`);
+    if (option.effect === "authorise" && option.scope) {
+      for (const scopedPath of option.scope.paths) {
+        const segments = scopedPath.split(/[\\/]/);
+        if (
+          scopedPath.startsWith("/") ||
+          scopedPath.startsWith("\\") ||
+          /^[a-zA-Z]:[\\/]/.test(scopedPath) ||
+          segments.includes("..")
+        ) {
+          errors.push(
+            `${path}.scope.paths: path must be repo-relative: "${scopedPath}"`,
+          );
+        }
+      }
+    }
+  }
+
+  const fields = request.fields ?? [];
+  for (const id of duplicateValues(fields.map((field) => field.id)))
+    errors.push(`$.fields: duplicate field id "${id}"`);
+  for (const [index, field] of fields.entries()) {
+    const path = `$.fields[${index}]`;
+    for (const key of Object.keys(field)) {
+      if (!FIELD_KEYS[field.kind].has(key))
+        errors.push(`${path}.${key}: not allowed for kind "${field.kind}"`);
+    }
+    if (field.whenOption !== undefined) {
+      for (const id of duplicateValues(field.whenOption))
+        errors.push(`${path}.whenOption: duplicate option id "${id}"`);
+      for (const id of field.whenOption) {
+        if (!optionIdSet.has(id))
+          errors.push(`${path}.whenOption: unknown option id "${id}"`);
+      }
+    }
+    if (field.kind === "single-choice" || field.kind === "multi-choice") {
+      if (field.choices === undefined) {
+        errors.push(`${path}.choices: required for kind "${field.kind}"`);
+      } else {
+        const minimum = field.kind === "single-choice" ? 2 : 1;
+        const maximum = field.kind === "single-choice" ? 12 : 24;
+        if (field.choices.length < minimum || field.choices.length > maximum)
+          errors.push(
+            `${path}.choices: ${field.kind} requires ${minimum}–${maximum} choices`,
+          );
+        for (const id of duplicateValues(
+          field.choices.map((choice) => choice.id),
+        ))
+          errors.push(`${path}.choices: duplicate choice id "${id}"`);
+      }
+    }
+    if (field.kind === "multi-choice" && field.choices !== undefined) {
+      const minimum = field.minItems ?? 0;
+      const maximum = field.maxItems ?? field.choices.length;
+      if (minimum > maximum)
+        errors.push(`${path}: minItems cannot exceed maxItems`);
+      if (minimum > field.choices.length)
+        errors.push(`${path}.minItems: cannot exceed the number of choices`);
+      if (maximum > field.choices.length)
+        errors.push(`${path}.maxItems: cannot exceed the number of choices`);
+    }
+    if (
+      field.kind === "number" &&
+      field.minimum !== undefined &&
+      field.maximum !== undefined &&
+      field.minimum > field.maximum
+    )
+      errors.push(`${path}: minimum cannot exceed maximum`);
+  }
+  for (const [index, option] of request.options.entries()) {
+    if (option.effect !== "reject_proposal") continue;
+    const reasonField = fields.some(
+      (field) =>
+        field.kind === "text" &&
+        field.required === true &&
+        (field.whenOption === undefined ||
+          field.whenOption.includes(option.id)),
+    );
+    if (!reasonField)
+      errors.push(
+        `$.options[${index}].effect: "reject_proposal" requires an applicable required text field`,
+      );
+  }
+  return result(errors);
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortValue(value, "$"));
+}
+
+function sortValue(value: unknown, path: string): unknown {
+  if (value === undefined)
+    throw new TypeError(
+      `undefined at ${path} is not representable in canonical JSON`,
+    );
+  if (value === null || typeof value !== "object") {
+    if (typeof value === "number" && !Number.isFinite(value))
+      throw new TypeError(
+        `non-finite number at ${path} is not representable in canonical JSON`,
+      );
+    if (typeof value === "bigint")
+      throw new TypeError(
+        `bigint at ${path} is not representable in canonical JSON`,
+      );
+    return value;
+  }
+  if (Array.isArray(value))
+    return value.map((entry, index) => sortValue(entry, `${path}[${index}]`));
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const entry = (value as Record<string, unknown>)[key];
+    if (entry === undefined) continue;
+    sorted[key] = sortValue(entry, `${path}.${key}`);
+  }
+  return sorted;
+}
+
+const SHA256_INITIAL = [
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+  0x1f83d9ab, 0x5be0cd19,
+];
+const SHA256_K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+const rotateRight = (value: number, bits: number): number =>
+  (value >>> bits) | (value << (32 - bits));
+
+function sha256Hex(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  const bitLength = bytes.length * 8;
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000));
+  view.setUint32(paddedLength - 4, bitLength >>> 0);
+  const hash = [...SHA256_INITIAL];
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i++) words[i] = view.getUint32(offset + i * 4);
+    for (let i = 16; i < 64; i++) {
+      const s0 =
+        rotateRight(words[i - 15], 7) ^
+        rotateRight(words[i - 15], 18) ^
+        (words[i - 15] >>> 3);
+      const s1 =
+        rotateRight(words[i - 2], 17) ^
+        rotateRight(words[i - 2], 19) ^
+        (words[i - 2] >>> 10);
+      words[i] = (words[i - 16] + s0 + words[i - 7] + s1) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let i = 0; i < 64; i++) {
+      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const temp1 = (h + s1 + choice + SHA256_K[i] + words[i]) >>> 0;
+      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + majority) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+  return hash.map((word) => word.toString(16).padStart(8, "0")).join("");
+}
+
+/** The identity a response binds to: canonical-JSON sha256. */
+export function decisionRequestHash(request: DecisionRequest): string {
+  return `sha256:${sha256Hex(canonicalJson(request))}`;
+}
+
+function validateFieldValue(
+  field: DecisionField,
+  value: unknown,
+  path: string,
+  errors: string[],
+): void {
+  if (field.kind === "text") {
+    if (typeof value !== "string") {
+      errors.push(`${path}: expected string`);
+      return;
+    }
+    const maximum = field.maxLength ?? 2000;
+    if (field.required === true && value.length === 0)
+      errors.push(`${path}: required text must not be empty`);
+    if (value.length > maximum)
+      errors.push(`${path}: longer than maxLength ${maximum}`);
+    return;
+  }
+  if (field.kind === "single-choice") {
+    if (typeof value !== "string") {
+      errors.push(`${path}: expected a choice id string`);
+      return;
+    }
+    if (!field.choices.some((choice) => choice.id === value))
+      errors.push(`${path}: unknown choice id "${value}"`);
+    return;
+  }
+  if (field.kind === "multi-choice") {
+    if (!Array.isArray(value)) {
+      errors.push(`${path}: expected an array of choice ids`);
+      return;
+    }
+    if (!value.every((entry) => typeof entry === "string")) {
+      errors.push(`${path}: every choice id must be a string`);
+      return;
+    }
+    for (const id of duplicateValues(value))
+      errors.push(`${path}: duplicate choice id "${id}"`);
+    const choices = new Set(field.choices.map((choice) => choice.id));
+    for (const id of value) {
+      if (!choices.has(id)) errors.push(`${path}: unknown choice id "${id}"`);
+    }
+    const minimum = field.minItems ?? (field.required === true ? 1 : 0);
+    const maximum = field.maxItems ?? field.choices.length;
+    if (value.length < minimum)
+      errors.push(`${path}: fewer than minItems ${minimum}`);
+    if (value.length > maximum)
+      errors.push(`${path}: more than maxItems ${maximum}`);
+    return;
+  }
+  if (field.kind === "confirm") {
+    if (typeof value !== "boolean") errors.push(`${path}: expected boolean`);
+    else if (field.required === true && value !== true)
+      errors.push(`${path}: required confirmation must be true`);
+    return;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    errors.push(`${path}: expected a finite number`);
+    return;
+  }
+  if (field.minimum !== undefined && value < field.minimum)
+    errors.push(`${path}: below minimum ${field.minimum}`);
+  if (field.maximum !== undefined && value > field.maximum)
+    errors.push(`${path}: above maximum ${field.maximum}`);
+  if (field.integer === true && !Number.isInteger(value))
+    errors.push(`${path}: expected an integer`);
+}
+
+/** Validate one operator response against the exact request it answers. */
+export function validateDecisionResponse(
+  response: DecisionResponse,
+  request: DecisionRequest,
+): ValidationResult {
+  const responseShape = validate(DECISION_RESPONSE_SCHEMA, response);
+  if (!responseShape.valid) return responseShape;
+  const requestCheck = checkRequest(request);
+  if (!requestCheck.valid)
+    return result(requestCheck.errors.map((error) => `request ${error}`));
+
+  const errors: string[] = [];
+  if (response.requestHash !== decisionRequestHash(request))
+    errors.push("$.requestHash: does not match request");
+  const option = request.options.find(
+    (candidate) => candidate.id === response.optionId,
+  );
+  if (option === undefined) {
+    errors.push(`$.optionId: unknown option id "${response.optionId}"`);
+    return result(errors);
+  }
+  const declaredFields = new Map(
+    (request.fields ?? []).map((field) => [field.id, field]),
+  );
+  const applicable = (request.fields ?? []).filter(
+    (field) =>
+      field.whenOption === undefined || field.whenOption.includes(option.id),
+  );
+  const applicableIds = new Set(applicable.map((field) => field.id));
+  for (const key of Object.keys(response.fields)) {
+    if (!declaredFields.has(key))
+      errors.push(`$.fields.${key}: undeclared field`);
+    else if (!applicableIds.has(key))
+      errors.push(
+        `$.fields.${key}: field does not apply to option "${option.id}"`,
+      );
+  }
+  for (const field of applicable) {
+    const present = hasOwn(response.fields, field.id);
+    if (!present) {
+      if (field.required === true)
+        errors.push(`$.fields.${field.id}: required field is missing`);
+      continue;
+    }
+    validateFieldValue(
+      field,
+      response.fields[field.id],
+      `$.fields.${field.id}`,
+      errors,
+    );
+  }
+  return result(errors);
+}

--- a/event-runtime/web/src/lib/decisionForm.test.ts
+++ b/event-runtime/web/src/lib/decisionForm.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import type { DecisionRequest } from "../types";
+import { applicableFields, fieldErrors, initialValues } from "./decisionForm";
+
+const request: DecisionRequest = {
+  schemaVersion: "factory.decision-request/v1",
+  question: "Choose",
+  options: [
+    { id: "go", label: "Go", effect: "dismiss" },
+    { id: "stop", label: "Stop", effect: "dismiss" },
+  ],
+  fields: [
+    { id: "note", kind: "text", label: "Note" },
+    {
+      id: "paths",
+      kind: "multi-choice",
+      label: "Paths",
+      choices: [
+        { id: "a", label: "A" },
+        { id: "b", label: "B" },
+        { id: "c", label: "C" },
+      ],
+      minItems: 1,
+      maxItems: 2,
+      whenOption: ["go"],
+    },
+    {
+      id: "confirm",
+      kind: "confirm",
+      label: "Confirm",
+      required: true,
+      whenOption: ["go"],
+    },
+    {
+      id: "count",
+      kind: "number",
+      label: "Count",
+      minimum: 2,
+      maximum: 4,
+      integer: true,
+    },
+  ],
+};
+
+describe("decision form helpers", () => {
+  test("gates fields by whenOption while preserving declaration order", () => {
+    expect(applicableFields(request, "go").map((field) => field.id)).toEqual([
+      "note",
+      "paths",
+      "confirm",
+      "count",
+    ]);
+    expect(applicableFields(request, "stop").map((field) => field.id)).toEqual([
+      "note",
+      "count",
+    ]);
+  });
+
+  test("seeds a value appropriate to every widget", () => {
+    expect(initialValues(request)).toEqual({
+      note: "",
+      paths: [],
+      confirm: false,
+      count: "",
+    });
+  });
+
+  test("requires true confirmation and enforces multi-choice min/max", () => {
+    const values = initialValues(request);
+    expect(fieldErrors(request, "go", values)).toMatchObject({
+      paths: expect.any(String),
+      confirm: expect.any(String),
+    });
+    values.paths = ["a", "b", "c"];
+    values.confirm = true;
+    expect(fieldErrors(request, "go", values).paths).toContain(
+      "no more than 2",
+    );
+    values.paths = ["a"];
+    expect(fieldErrors(request, "go", values)).toEqual({});
+  });
+
+  test("enforces number bounds and integer values", () => {
+    const values = initialValues(request);
+    values.count = 1;
+    expect(fieldErrors(request, "stop", values).count).toContain("at least 2");
+    values.count = 5;
+    expect(fieldErrors(request, "stop", values).count).toContain("at most 4");
+    values.count = 2.5;
+    expect(fieldErrors(request, "stop", values).count).toContain(
+      "whole number",
+    );
+    values.count = 3;
+    expect(fieldErrors(request, "stop", values)).toEqual({});
+  });
+});

--- a/event-runtime/web/src/lib/decisionForm.ts
+++ b/event-runtime/web/src/lib/decisionForm.ts
@@ -1,0 +1,106 @@
+/** Pure field gating and validation for the closed decision widget vocabulary. */
+import type { DecisionField, DecisionRequest } from "../types";
+
+export type DecisionValues = Record<string, unknown>;
+export type DecisionFieldErrors = Record<string, string>;
+
+export function applicableFields(
+  request: DecisionRequest,
+  optionId: string,
+): DecisionField[] {
+  return (request.fields ?? []).filter(
+    (field) =>
+      field.whenOption === undefined || field.whenOption.includes(optionId),
+  );
+}
+
+export function initialValues(request: DecisionRequest): DecisionValues {
+  return Object.fromEntries(
+    (request.fields ?? []).map((field) => {
+      switch (field.kind) {
+        case "text":
+        case "single-choice":
+        case "number":
+          return [field.id, ""];
+        case "multi-choice":
+          return [field.id, []];
+        case "confirm":
+          return [field.id, false];
+      }
+    }),
+  );
+}
+
+export function fieldErrors(
+  request: DecisionRequest,
+  optionId: string,
+  values: DecisionValues,
+): DecisionFieldErrors {
+  const errors: DecisionFieldErrors = {};
+  for (const field of applicableFields(request, optionId)) {
+    const value = values[field.id];
+    if (field.kind === "text") {
+      if (typeof value !== "string") errors[field.id] = "Enter text.";
+      else if (field.required && value.length === 0)
+        errors[field.id] = `${field.label} is required.`;
+      else if (value.length > (field.maxLength ?? 2000))
+        errors[field.id] =
+          `${field.label} must be at most ${field.maxLength ?? 2000} characters.`;
+      continue;
+    }
+
+    if (field.kind === "single-choice") {
+      if (field.required && (typeof value !== "string" || value === ""))
+        errors[field.id] = `Choose one option for ${field.label}.`;
+      else if (
+        value !== "" &&
+        (typeof value !== "string" ||
+          !field.choices.some((choice) => choice.id === value))
+      )
+        errors[field.id] = `Choose a valid option for ${field.label}.`;
+      continue;
+    }
+
+    if (field.kind === "multi-choice") {
+      if (!Array.isArray(value)) {
+        errors[field.id] = `Choose options for ${field.label}.`;
+        continue;
+      }
+      const minimum = field.minItems ?? (field.required ? 1 : 0);
+      const maximum = field.maxItems ?? field.choices.length;
+      if (value.length < minimum)
+        errors[field.id] = `Choose at least ${minimum} for ${field.label}.`;
+      else if (value.length > maximum)
+        errors[field.id] = `Choose no more than ${maximum} for ${field.label}.`;
+      else if (
+        value.some(
+          (id) =>
+            typeof id !== "string" ||
+            !field.choices.some((choice) => choice.id === id),
+        )
+      )
+        errors[field.id] = `Choose valid options for ${field.label}.`;
+      continue;
+    }
+
+    if (field.kind === "confirm") {
+      if (field.required && value !== true)
+        errors[field.id] = `${field.label} must be confirmed.`;
+      continue;
+    }
+
+    if (value === "" || value === undefined) {
+      if (field.required) errors[field.id] = `${field.label} is required.`;
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isFinite(value))
+      errors[field.id] = `${field.label} must be a number.`;
+    else if (field.minimum !== undefined && value < field.minimum)
+      errors[field.id] = `${field.label} must be at least ${field.minimum}.`;
+    else if (field.maximum !== undefined && value > field.maximum)
+      errors[field.id] = `${field.label} must be at most ${field.maximum}.`;
+    else if (field.integer && !Number.isInteger(value))
+      errors[field.id] = `${field.label} must be a whole number.`;
+  }
+  return errors;
+}

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -3,9 +3,10 @@
 // `g y` (the last sound in "artifact") so it does not compete with list `k`.
 // Workers keeps its natural `g w`: `w` is no view's list verb. Inbox takes
 // `g n` ("needs you"): `n` is no view's list verb either, and `g i` is the
-// In-flight context chord (WM-235). Number keys 1–6 belong to a focused
-// DecisionCard; it stops propagation there so Inbox's 1–4 status tabs keep
-// their existing binding everywhere else.
+// In-flight context chord (WM-235). Number keys 1–6 belong to an undecided
+// DecisionCard whenever one is on screen (capture-phase window listener, so
+// Inbox's 1–4 status tabs never see them); with no open card the tabs keep
+// their existing binding.
 export const NAV = [
   { key: "overview", label: "Overview", go: "o" },
   { key: "inbox", label: "Inbox", go: "n" },

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -3,7 +3,9 @@
 // `g y` (the last sound in "artifact") so it does not compete with list `k`.
 // Workers keeps its natural `g w`: `w` is no view's list verb. Inbox takes
 // `g n` ("needs you"): `n` is no view's list verb either, and `g i` is the
-// In-flight context chord (WM-235).
+// In-flight context chord (WM-235). Number keys 1–6 belong to a focused
+// DecisionCard; it stops propagation there so Inbox's 1–4 status tabs keep
+// their existing binding everywhere else.
 export const NAV = [
   { key: "overview", label: "Overview", go: "o" },
   { key: "inbox", label: "Inbox", go: "n" },

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -660,6 +660,105 @@ export interface InboxDelivery {
   };
 }
 
+export type DecisionTone = "primary" | "danger" | "neutral";
+export type DecisionEffectKind =
+  | "authorise"
+  | "send_to_triage"
+  | "answer"
+  | "requeue"
+  | "approve_proposal"
+  | "reject_proposal"
+  | "dismiss";
+
+export interface DecisionChoice {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface DecisionFieldBase {
+  id: string;
+  label: string;
+  required?: boolean;
+  whenOption?: string[];
+}
+
+export type DecisionField =
+  | (DecisionFieldBase & {
+      kind: "text";
+      placeholder?: string;
+      maxLength?: number;
+    })
+  | (DecisionFieldBase & {
+      kind: "single-choice";
+      choices: DecisionChoice[];
+    })
+  | (DecisionFieldBase & {
+      kind: "multi-choice";
+      choices: DecisionChoice[];
+      minItems?: number;
+      maxItems?: number;
+    })
+  | (DecisionFieldBase & { kind: "confirm" })
+  | (DecisionFieldBase & {
+      kind: "number";
+      minimum?: number;
+      maximum?: number;
+      integer?: boolean;
+    });
+
+export interface DecisionOption {
+  id: string;
+  label: string;
+  description?: string;
+  effect: DecisionEffectKind;
+  tone?: DecisionTone;
+  scope?: { paths: string[]; summary: string };
+}
+
+export interface DecisionRequest {
+  schemaVersion: "factory.decision-request/v1";
+  question: string;
+  context?: string;
+  recommended?: string;
+  options: DecisionOption[];
+  fields?: DecisionField[];
+}
+
+export interface DecisionEffect {
+  kind: DecisionEffectKind | string;
+  outcome: "applied" | "failed" | string;
+  error?: string;
+  retryAttempt?: number;
+  [key: string]: unknown;
+}
+
+export interface DecisionResponse {
+  schemaVersion: "factory.decision-response/v1";
+  requestHash: string;
+  optionId: string;
+  fields: Record<string, unknown>;
+  decidedBy: string;
+  decidedAt: string;
+  effect?: DecisionEffect;
+}
+
+export interface DecisionSupersededResponse {
+  superseded: true;
+  reason: string;
+  decidedBy: string;
+  decidedAt: string;
+}
+
+export type InboxDecisionResponse =
+  DecisionResponse | DecisionSupersededResponse;
+
+/** The browser sends this shape; the API supplies actor and timestamp. */
+export type DecisionResponseInput = Omit<
+  DecisionResponse,
+  "decidedBy" | "decidedAt" | "effect"
+>;
+
 /** One row of the human inbox ledger (GET /inbox). */
 export interface InboxItem {
   id: string;
@@ -675,4 +774,9 @@ export interface InboxItem {
   resolvedAt: string | null;
   resolvedBy: string | null;
   delivery: InboxDelivery;
+  decision?: DecisionRequest | null;
+  response?: InboxDecisionResponse | null;
+  decidedAt?: string | null;
+  decidedBy?: string | null;
+  dedupeKey?: string | null;
 }

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -506,6 +506,40 @@ describe("Inbox view", () => {
     expect(view.getByText("decide X")).toBeTruthy();
   });
 
+  test("marks undecided rows and replaces ack/resolve with the decision card", async () => {
+    ledger = [
+      item({
+        id: "inbox_decision",
+        kind: "decision_needed",
+        title: "DECISION NEEDED choose a recovery",
+        decision: {
+          schemaVersion: "factory.decision-request/v1",
+          question: "Which recovery should run?",
+          options: [
+            { id: "retry", label: "Try again", effect: "dismiss" },
+            { id: "dismiss", label: "Not now", effect: "dismiss" },
+          ],
+        },
+        response: null,
+      }),
+    ];
+    const { view } = renderInbox({ focusItemId: "inbox_decision" });
+    await waitFor(() => view.getByText("Which recovery should run?"));
+    expect(view.getByLabelText("Decision required").textContent).toBe("?");
+    expect(view.queryByRole("button", { name: /^Ack/ })).toBeNull();
+    expect(view.queryByRole("button", { name: /Resolve…/ })).toBeNull();
+    const card = view.getByRole("region", { name: "Decision" });
+    fireEvent.keyDown(card, { key: "2" });
+    expect(view.getByRole("tab", { selected: true }).textContent).toContain(
+      "Open",
+    );
+    expect(
+      within(card)
+        .getAllByRole("button", { name: /Not now/ })[0]
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
   test("a acks the selected item and the ledger, not the UI, flips its status", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_open_1" });
     await waitFor(() => view.getByRole("button", { name: /^Ack/ }));

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -24,6 +24,7 @@ import {
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
+import { DecisionCard } from "../components/DecisionCard";
 import {
   INBOX_FACETS,
   matchesFilterQuery,
@@ -436,10 +437,10 @@ export function Inbox({
     [visible, selectedIds],
   );
   const ackableSelected = selectedRows.filter(
-    (it) => itemStatus(it) === "open",
+    (it) => itemStatus(it) === "open" && !it.decision,
   );
   const resolvableSelected = selectedRows.filter(
-    (it) => itemStatus(it) !== "resolved",
+    (it) => itemStatus(it) !== "resolved" && !it.decision,
   );
 
   useEffect(() => {
@@ -517,9 +518,17 @@ export function Inbox({
   });
 
   const canAck =
-    !!sel && connected && itemStatus(sel) === "open" && !ack.isPending;
+    !!sel &&
+    !sel.decision &&
+    connected &&
+    itemStatus(sel) === "open" &&
+    !ack.isPending;
   const canResolve =
-    !!sel && connected && itemStatus(sel) !== "resolved" && !resolve.isPending;
+    !!sel &&
+    !sel.decision &&
+    connected &&
+    itemStatus(sel) !== "resolved" &&
+    !resolve.isPending;
 
   const handleBulkAck = async () => {
     if (!connected || bulkAcking || ackableSelected.length === 0) return;
@@ -910,6 +919,14 @@ export function Inbox({
                               className="truncate text-(--text)"
                               title={item.title}
                             >
+                              {item.decision && !item.response && (
+                                <span
+                                  className="mono mr-1.5 text-(--hue-warn)"
+                                  aria-label="Decision required"
+                                >
+                                  ?
+                                </span>
+                              )}
                               {displayTitle(item)}
                             </div>
                           </td>
@@ -1043,7 +1060,7 @@ export function Inbox({
             </nav>
           }
           actions={
-            itemStatus(sel) !== "resolved" ? (
+            !sel.decision && itemStatus(sel) !== "resolved" ? (
               <div className="flex items-center gap-1.5">
                 <Button
                   disabled={!canResolve}
@@ -1123,6 +1140,18 @@ export function Inbox({
               )}
             </div>
           </Section>
+
+          {sel.decision && (
+            <Section title="Decision" card={false}>
+              <DecisionCard
+                itemId={sel.id}
+                request={sel.decision}
+                response={sel.response}
+                connected={connected}
+                onItemChange={invalidate}
+              />
+            </Section>
+          )}
 
           {Object.keys(sel.refs).length > 0 && (
             <Section title="References" icons>


### PR DESCRIPTION
Fixes WM-392

Adds the kind-agnostic DecisionCard flow, browser/server decision validation parity fixtures, schema-driven fields, submit/stale/retry handling, and Inbox integration.

Verification: `bun test event-runtime/web event-runtime/lib/decision.test.mjs event-runtime/lib/api.test.mjs && bun run --cwd event-runtime/web build && bun build/emit.mjs --check && bun run format:check` — pass (909 tests, build, generated files, formatting).

UX critique: required — NOT-ASSESSED; Chrome exited before DevTools became available while opening the verified worktree URL, so the flow could not be driven. PR intentionally remains draft.

Follow-up filed: WM-711 for the API mock harness closure gap discovered outside Owned Paths.