### PR TITLE
fix(workspace): recognize retry worker's own lease

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1956,6 +1956,8 @@ export async function executeClaimed(
       workspace: spec.workspace,
       artifactStore,
       adapter: adapterKey,
+      ticketLeaseOwner,
+      workerLeasesDir: leasesDir,
     });
     workspaceDir = created.dir;
     checkoutPath = created.checkout?.path ?? null;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3514,6 +3514,12 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       retryExecution = runOnce(db, registry, { fake: retryAdapter }, o);
       await secondStarted;
       expect(claimCalls).toBe(1);
+      expect(
+        readFileSync(callsLog, "utf8")
+          .trim()
+          .split("\n")
+          .filter((call) => call === "up WM-621"),
+      ).toHaveLength(2);
       expect(lifecycleOf(db, spec.runId)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -23,6 +23,7 @@ import { leaseDir, liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { canonicalJson } from "./canonical.mjs";
 import { materializeArtifact } from "./artifacts.mjs";
 import { artifactsRoot, dbPath, FACTORY_ROOT } from "./config.mjs";
+import { TERMINAL_STATES } from "./lifecycle.mjs";
 import { getRepo, loadRepos } from "./repos.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 import { findPriorResumeContext } from "./transcripts.mjs";
@@ -138,15 +139,6 @@ export function resolveInputRef(input, expr) {
  * worker that dies and restarts must still know what to tear down.
  */
 const WORKTREE_MARKER = ".worktree.json";
-const ACTIVE_RUN_STATES = new Set([
-  "PROPOSED",
-  "APPROVED",
-  "QUEUED",
-  "LEASED",
-  "RUNNING",
-  "VERIFYING",
-]);
-
 /**
  * Return competing runtime ownership for a ticket, excluding the run currently
  * provisioning its own workspace. The shared worker lease is the fast local
@@ -157,26 +149,20 @@ export function detectWorktreeOwnershipConflict({
   repo,
   ticket,
   runId,
-  attempt,
+  leaseOwner = null,
   databasePath = dbPath(),
-  leases = liveWorkerLeases(repo),
+  leasesDir,
+  leases = liveWorkerLeases(repo, { dir: leasesDir }),
 } = {}) {
-  let currentLeaseOwner = null;
   const runs = [];
   if (existsSync(databasePath)) {
     let db;
     try {
       db = new Database(databasePath, { readonly: true });
-      currentLeaseOwner =
-        db
-          .query(
-            `SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`,
-          )
-          .get(runId, attempt)?.lease_owner ?? null;
       for (const row of db
         .query(`SELECT run_id, state, spec_json FROM runs`)
         .all()) {
-        if (row.run_id === runId || !ACTIVE_RUN_STATES.has(row.state)) continue;
+        if (row.run_id === runId || TERMINAL_STATES.has(row.state)) continue;
         let input;
         try {
           input = JSON.parse(row.spec_json)?.input;
@@ -200,11 +186,24 @@ export function detectWorktreeOwnershipConflict({
 
   const competingLeases = leases
     .filter((lease) => lease?.repo === repo && lease?.ticket === ticket)
-    .filter((lease) =>
-      currentLeaseOwner
-        ? lease.owner !== currentLeaseOwner
-        : lease.pid !== process.pid,
-    )
+    .filter((lease) => {
+      // A lease identity is only local to this worker process. Even an exact
+      // owner match from another pid is competing ownership, while pid alone
+      // remains the compatibility fallback when no explicit owner is known.
+      if (lease.pid !== process.pid) return true;
+      if (!leaseOwner) return false;
+      if (lease.owner === leaseOwner) return false;
+
+      // Legacy callers may provide the base attempts.lease_owner while the
+      // durable lease stores owner:runId:fencingToken. Match both the base and
+      // run identity so a newer attempt on the same worker still conflicts.
+      const prefix = `${leaseOwner}:`;
+      if (typeof lease.owner !== "string" || !lease.owner.startsWith(prefix))
+        return true;
+      const identity = lease.owner.slice(prefix.length);
+      const tokenSeparator = identity.lastIndexOf(":");
+      return tokenSeparator <= 0 || identity.slice(0, tokenSeparator) !== runId;
+    })
     .map((lease) => ({ owner: lease.owner, pid: lease.pid }));
   if (runs.length === 0 && competingLeases.length === 0) return null;
   return {
@@ -274,6 +273,8 @@ function materializeWorktree({
   timeoutMs,
   runId,
   attempt,
+  ticketLeaseOwner,
+  workerLeasesDir,
   ownershipConflict,
   preservationComment,
 }) {
@@ -297,6 +298,8 @@ function materializeWorktree({
       ticket,
       runId,
       attempt,
+      leaseOwner: ticketLeaseOwner,
+      leasesDir: workerLeasesDir,
     });
     if (conflict) {
       throw new WorktreeError(
@@ -469,6 +472,8 @@ export function createWorkspace({
   artifactStore = artifactsRoot(),
   worktreeTimeoutMs = worktreeScriptTimeoutMs(),
   adapter = null,
+  ticketLeaseOwner = null,
+  workerLeasesDir,
   worktreeOwnershipConflict = detectWorktreeOwnershipConflict,
   worktreePreservationComment = commentOnPreservedWorktree,
 }) {
@@ -529,6 +534,8 @@ export function createWorkspace({
         timeoutMs: worktreeTimeoutMs,
         runId,
         attempt,
+        ticketLeaseOwner,
+        workerLeasesDir,
         ownershipConflict: worktreeOwnershipConflict,
         preservationComment: worktreePreservationComment,
       });

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -50,7 +50,7 @@ describe("safeJoin", () => {
   });
 });
 
-test("detectWorktreeOwnershipConflict excludes self but reports competing runs and leases", () => {
+test("detectWorktreeOwnershipConflict identifies the current run's compound lease", () => {
   const root = tmpRoot();
   const databasePath = path.join(root, "runtime.db");
   const db = new Database(databasePath);
@@ -65,11 +65,10 @@ test("detectWorktreeOwnershipConflict excludes self but reports competing runs a
     spec,
   );
   db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run(
-    "run_other",
-    "VERIFYING",
+    "run_done",
+    "COMPLETED",
     spec,
   );
-  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_done", "FAILED", spec);
   db.query(`INSERT INTO attempts VALUES (?, ?, ?)`).run(
     "run_self",
     1,
@@ -77,43 +76,74 @@ test("detectWorktreeOwnershipConflict excludes self but reports competing runs a
   );
   db.close();
 
-  const conflict = detectWorktreeOwnershipConflict({
+  const ownLease = {
     repo: "factory",
     ticket: "WM-627",
-    runId: "run_self",
-    attempt: 1,
-    databasePath,
-    leases: [
-      {
-        repo: "factory",
-        ticket: "WM-627",
-        owner: "worker_self",
-        pid: process.pid,
-      },
-      { repo: "factory", ticket: "WM-627", owner: "worker_other", pid: 42 },
-    ],
-  });
-  expect(conflict).toMatchObject({
-    runs: [{ runId: "run_other", state: "VERIFYING" }],
-    leases: [{ owner: "worker_other", pid: 42 }],
-  });
+    owner: "worker_self:run_self:7",
+    pid: process.pid,
+  };
   expect(
     detectWorktreeOwnershipConflict({
       repo: "factory",
       ticket: "WM-627",
       runId: "run_self",
-      attempt: 1,
+      leaseOwner: ownLease.owner,
       databasePath,
-      leases: [
-        {
-          repo: "factory",
-          ticket: "WM-627",
-          owner: "worker_self",
-          pid: process.pid,
-        },
-      ],
-    })?.runs,
-  ).toEqual([{ runId: "run_other", state: "VERIFYING" }]);
+      leases: [ownLease],
+    }),
+  ).toBeNull();
+
+  // The base attempts owner remains supported, but the encoded run id must
+  // match. A later run on the same worker is competing ownership.
+  expect(
+    detectWorktreeOwnershipConflict({
+      repo: "factory",
+      ticket: "WM-627",
+      runId: "run_self",
+      leaseOwner: "worker_self",
+      databasePath,
+      leases: [ownLease],
+    }),
+  ).toBeNull();
+  expect(
+    detectWorktreeOwnershipConflict({
+      repo: "factory",
+      ticket: "WM-627",
+      runId: "run_self",
+      leaseOwner: "worker_self",
+      databasePath,
+      leases: [{ ...ownLease, owner: "worker_self:run_other:8" }],
+    })?.leases,
+  ).toEqual([{ owner: "worker_self:run_other:8", pid: process.pid }]);
+
+  expect(
+    detectWorktreeOwnershipConflict({
+      repo: "factory",
+      ticket: "WM-627",
+      runId: "run_self",
+      leaseOwner: ownLease.owner,
+      databasePath,
+      leases: [{ ...ownLease, pid: process.pid + 1 }],
+    })?.leases,
+  ).toEqual([{ owner: ownLease.owner, pid: process.pid + 1 }]);
+
+  const competingDb = new Database(databasePath);
+  competingDb
+    .query(`INSERT INTO runs VALUES (?, ?, ?)`)
+    .run("run_other", "FAILED", spec);
+  competingDb.close();
+  const conflict = detectWorktreeOwnershipConflict({
+    repo: "factory",
+    ticket: "WM-627",
+    runId: "run_self",
+    leaseOwner: ownLease.owner,
+    databasePath,
+    leases: [ownLease],
+  });
+  expect(conflict).toMatchObject({
+    runs: [{ runId: "run_other", state: "FAILED" }],
+    leases: [],
+  });
 });
 
 describe("createWorkspace / destroyWorkspace", () => {


### PR DESCRIPTION
## Summary
- thread the worker ticket lease identity and lease directory into workspace ownership checks
- recognize only the current run/process lease while preserving competing-run protection
- add workspace and worker retry regressions for existing worktrees

## Verification
- `bun test event-runtime/lib/workspace.test.mjs event-runtime/lib/worker.test.mjs && bun test && bun run format:check`
- 123 focused tests passed; full suite: 2495 passed, 9 skipped; Prettier check passed

UX critique: skipped — internal backend/runtime change with no user-facing flow

Fixes WM-717