### PR TITLE
chore(event-runtime): harden sandbox follow-ups

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -54,6 +54,7 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { PassThrough } from "node:stream";
 import { FACTORY_ROOT } from "../config.mjs";
+import { normalizePolicy } from "../sandbox/gondolin.mjs";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
 import {
   guestBinary,
@@ -608,9 +609,6 @@ async function executeSandboxed({
   abortSignal,
   runSandbox,
 }) {
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
-  writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
-
   if (resume?.sessionId) {
     onTrace?.("lifecycle", {
       note: "sandbox_resume_unavailable",
@@ -618,6 +616,13 @@ async function executeSandboxed({
     });
   }
   const bin = guestBinary(def, "pi");
+  // Validate all definition-controlled guest configuration before creating a
+  // workspace prompt. runInSandbox normalizes again at its trust boundary;
+  // this preflight also covers injected VM runners used by tests and leaves
+  // no stray prompt behind when the definition itself is invalid.
+  normalizePolicy(def.sandbox, { workspaceDir });
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
   const argv = [
     bin,
     ...buildPiArgv({ def, model: spec?.model, resumeSessionId: null }),

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -8,13 +8,7 @@
  * behaviour is proven in pi.test.mjs behind `preflight()`.
  */
 import { describe, expect, test } from "bun:test";
-import {
-  existsSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
@@ -301,26 +295,32 @@ describe("runSandboxed", () => {
  * means the adapter ignored the block, which is the WM-313 defect.
  */
 describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
-  const dir = import.meta.dir;
-  const modules = readdirSync(dir)
-    .filter(
-      (f) =>
-        f.endsWith(".mjs") && !f.endsWith(".test.mjs") && f !== "sandboxed.mjs",
-    )
-    .map((f) => f.replace(/\.mjs$/, ""));
+  // This is the adapter registry loaded by cli/work.mjs and cli/serve.mjs.
+  // Keep it explicit: helper modules added beside adapters must not silently
+  // become executable conformance targets merely because of their filename.
+  const modules = [
+    "actions",
+    "agy",
+    "claude",
+    "command",
+    "cursor",
+    "fake",
+    "pi",
+  ];
 
-  test("the sweep sees the adapters the worker can load", () => {
-    expect(modules).toEqual(
-      expect.arrayContaining([
-        "actions",
-        "agy",
-        "claude",
-        "command",
-        "cursor",
-        "fake",
-        "pi",
-      ]),
-    );
+  test("the explicit sweep registry matches both production worker entry points", () => {
+    const registeredAdapters = (relativePath) => {
+      const source = readFileSync(
+        path.resolve(import.meta.dir, relativePath),
+        "utf8",
+      );
+      const declaration = source.match(/const adapters = \{([^}]+)\};/);
+      expect(declaration).not.toBeNull();
+      return declaration[1].split(",").map((name) => name.trim());
+    };
+
+    expect(registeredAdapters("../../cli/work.mjs")).toEqual(modules);
+    expect(registeredAdapters("../../cli/serve.mjs")).toEqual(modules);
   });
 
   for (const name of modules) {
@@ -384,4 +384,60 @@ describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
       }
     });
   }
+});
+
+describe("pi sandbox prompt staging", () => {
+  test("invalid guest binary configuration leaves no prompt file", async () => {
+    const { execute, SANDBOX_PROMPT_FILE } = await import("./pi.mjs");
+    const workspaceDir = ws();
+    const promptPath = path.join(workspaceDir, "source-prompt.md");
+    writeFileSync(promptPath, "prompt", "utf8");
+
+    await expect(
+      execute({
+        spec: { agent: "pi-invalid-binary@1" },
+        def: {
+          ...sandboxDef({ ref: "pi-invalid-binary@1", promptPath }),
+          sandbox: {
+            provider: "gondolin",
+            allowedHosts: [],
+            guestBinaries: { pi: "pi" },
+          },
+        },
+        workspaceDir,
+        timeoutMs: 1000,
+        runSandbox: async () => {
+          throw new Error("VM boundary must not be reached");
+        },
+      }),
+    ).rejects.toThrow(/absolute guest path/);
+    expect(existsSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE))).toBe(
+      false,
+    );
+  });
+
+  test("invalid sandbox policy leaves no prompt file", async () => {
+    const { execute, SANDBOX_PROMPT_FILE } = await import("./pi.mjs");
+    const workspaceDir = ws();
+    const promptPath = path.join(workspaceDir, "source-prompt.md");
+    writeFileSync(promptPath, "prompt", "utf8");
+
+    await expect(
+      execute({
+        spec: { agent: "pi-invalid-policy@1" },
+        def: {
+          ...sandboxDef({ ref: "pi-invalid-policy@1", promptPath }),
+          sandbox: { provider: "invalid", allowedHosts: [] },
+        },
+        workspaceDir,
+        timeoutMs: 1000,
+        runSandbox: async () => {
+          throw new Error("VM boundary must not be reached");
+        },
+      }),
+    ).rejects.toThrow(/unknown sandbox provider/);
+    expect(existsSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE))).toBe(
+      false,
+    );
+  });
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -47,6 +47,7 @@ import { traceRecorder } from "./trace.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
 import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
 import {
+  assertSandboxWorkspaceSupported,
   createWorkspace,
   destroyWorkspace,
   PathViolation,
@@ -60,7 +61,10 @@ import { templateFor } from "./decision-templates.mjs";
  * it here (workspace-relative); the verifier includes it when present. The
  * agent does not have to declare its own transcript.
  */
-const RUNTIME_ARTIFACTS = [{ kind: "transcript", path: ".transcript.json" }];
+const RUNTIME_ARTIFACTS = [
+  { kind: "transcript", path: ".transcript.json" },
+  { kind: "sandbox-console", path: ".sandbox-console.log" },
+];
 
 /** Grace added to the execution deadline before a lease is considered abandoned. */
 export const LEASE_GRACE_SECONDS = 120;
@@ -423,6 +427,8 @@ const ENVIRONMENT_FAILURES = new Set([
 const AGENT_FAILURES = new Set(["contract_violation"]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
+  "sandbox_unsupported",
+  "worktree_sandbox_unsupported",
   "unknown_adapter",
   "agent_definition_mismatch",
   "workspace_integrity_violation",
@@ -1960,6 +1966,7 @@ export async function executeClaimed(
       workerLeasesDir: leasesDir,
     });
     workspaceDir = created.dir;
+    assertSandboxWorkspaceSupported(workspaceDir, def);
     checkoutPath = created.checkout?.path ?? null;
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
     worktreeRecord = created.worktree ?? null;
@@ -2645,13 +2652,20 @@ export async function executeClaimed(
     // lib/adapters/pi.mjs's CliNotFoundError) before ever spawning a child.
     // No `requeue`: retrying on the same worker just fails the same way.
     const isCliNotFound = err?.code === "cli_not_found";
+    const isSandboxUnsupported = err?.code === "sandbox_unsupported";
+    const isWorktreeSandboxUnsupported =
+      err?.code === "worktree_sandbox_unsupported";
     const isWorkspaceProvisioning =
       err?.code === "workspace_provisioning_error";
     const reasonCode = isCliNotFound
       ? "cli_not_found"
-      : isWorkspaceProvisioning
-        ? "workspace_provisioning_error"
-        : "adapter_error";
+      : isSandboxUnsupported
+        ? "sandbox_unsupported"
+        : isWorktreeSandboxUnsupported
+          ? "worktree_sandbox_unsupported"
+          : isWorkspaceProvisioning
+            ? "workspace_provisioning_error"
+            : "adapter_error";
     const journalReason = `${reasonCode}: ${err?.message ?? String(err)}`;
     let res;
     try {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -19,6 +19,7 @@ import {
 } from "./adapters/claude.mjs";
 import * as fake from "./adapters/fake.mjs";
 import { buildPiArgv, execute as executePi } from "./adapters/pi.mjs";
+import { SandboxUnsupportedError } from "./adapters/sandboxed.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
 import { admitEvent } from "./intake.mjs";
 import { planEvent } from "./planner.mjs";
@@ -550,6 +551,34 @@ describe("worker", () => {
       state: "REFUSED",
       agent: spec.agent,
     });
+  });
+
+  test("sandbox console is stored as a runtime artifact when present", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ input: { repos: ["refuse"] } }));
+    const consoleAdapter = {
+      async execute(args) {
+        const outcome = await fake.execute(args);
+        writeFileSync(
+          path.join(args.workspaceDir, ".sandbox-console.log"),
+          "guest console evidence\n",
+          "utf8",
+        );
+        return outcome;
+      },
+    };
+
+    await runOnce(db, registry, { fake: consoleAdapter }, opts());
+    const parsed = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(spec.runId).result_json,
+    );
+    expect(parsed.artifacts.map((entry) => entry.kind)).toEqual([
+      "transcript",
+      "sandbox-console",
+    ]);
+    expect(parsed.artifacts[1].sha256).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("needs_human preserves a valid authored ask, while an invalid ask falls back with its errors", async () => {
@@ -1618,6 +1647,8 @@ describe("worker", () => {
     expect(classifyFailureCause("contract_violation")).toBe("agent_error");
     for (const reason of [
       "cli_not_found",
+      "sandbox_unsupported",
+      "worktree_sandbox_unsupported",
       "unknown_adapter",
       "agent_definition_mismatch",
       "policy_denied:Bash",
@@ -1667,6 +1698,41 @@ describe("worker", () => {
         )
         .all(spec.runId),
     ).toEqual([{ reason_code: "adapter_error" }, { reason_code: "ok" }]);
+  });
+
+  test("SandboxUnsupportedError is fatal and never requeues", async () => {
+    const db = openDb(":memory:");
+    const unsupportedAdapter = {
+      async execute() {
+        throw new SandboxUnsupportedError("unsupported", "test adapter");
+      },
+    };
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "unsupported",
+        maxAttempts: 5,
+        maxEnvironmentRetries: 5,
+      }),
+    );
+
+    const summary = await runOnce(
+      db,
+      registry,
+      { unsupported: unsupportedAdapter },
+      opts(),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "sandbox_unsupported",
+    });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(claimNext(db, opts())).toBeNull();
+    expect(
+      lifecycleOf(db, spec.runId).some((event) =>
+        event.reason?.startsWith("retry:"),
+      ),
+    ).toBe(false);
   });
 
   test("repeated environment failures dead-letter after the dedicated retry ceiling", async () => {
@@ -4331,6 +4397,62 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
         .get(spec.runId).reason_code,
     ).toBe("workspace_provisioning_error");
+  });
+
+  test("sandboxed execution against a worktree workspace is refused typed before the adapter runs", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(
+      path.join(os.tmpdir(), "evrt-sandbox-wt-locks-"),
+    );
+    let executed = false;
+    const observingAdapter = {
+      async execute() {
+        executed = true;
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const sandboxRegistry = {
+      ...registry,
+      agents: new Map(registry.agents),
+    };
+    sandboxRegistry.agents.set("dispatch@1", {
+      ...getAgent(registry, "dispatch@1"),
+      sandbox: { provider: "gondolin", allowedHosts: [] },
+    });
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        input: { repo: "wt-worker", ticket: "WM-733" },
+        maxEnvironmentRetries: 5,
+      }),
+    );
+
+    const summary = await runOnce(
+      db,
+      sandboxRegistry,
+      { fake: observingAdapter },
+      opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-733"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
+
+    expect(executed).toBe(false);
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "worktree_sandbox_unsupported",
+    });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(
+      lifecycleOf(db, spec.runId).some((event) =>
+        event.reason?.startsWith("retry:"),
+      ),
+    ).toBe(false);
   });
 
   test("filesystem failures after worktree_up remain typed workspace provisioning errors", async () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -57,6 +57,18 @@ export class WorktreeError extends Error {
   }
 }
 
+/** A worktree checkout is outside the mounted workspace and dangles in a VM. */
+export class WorktreeSandboxUnsupportedError extends Error {
+  constructor(workspaceDir) {
+    super(
+      `sandboxed execution cannot use worktree workspace ${workspaceDir}: its checkout is a symlink outside the mounted workspace`,
+    );
+    this.name = "WorktreeSandboxUnsupportedError";
+    this.code = "worktree_sandbox_unsupported";
+    this.workspaceDir = workspaceDir;
+  }
+}
+
 // eslint-disable-next-line no-control-regex -- \x1b is the ANSI escape byte being stripped, not a typo
 const ANSI_ESCAPE = /\x1b\[[0-9;]*m/g;
 const WARNING_LINE = /^warn:\s*/i;
@@ -139,6 +151,23 @@ export function resolveInputRef(input, expr) {
  * worker that dies and restarts must still know what to tear down.
  */
 const WORKTREE_MARKER = ".worktree.json";
+/**
+ * Refuse sandbox execution when materialization recorded a delegated worktree.
+ * Only the attempt workspace is mounted in the guest, while the checkout link
+ * points at the repo-owned worktree root outside it, so following it there
+ * would fail. A malformed non-null sandbox block still counts as a request;
+ * policy validation must not turn isolation off by accident.
+ */
+export function assertSandboxWorkspaceSupported(workspaceDir, def) {
+  const sandboxRequested = def?.sandbox !== undefined && def?.sandbox !== null;
+  if (
+    sandboxRequested &&
+    existsSync(path.join(workspaceDir, WORKTREE_MARKER))
+  ) {
+    throw new WorktreeSandboxUnsupportedError(workspaceDir);
+  }
+}
+
 /**
  * Return competing runtime ownership for a ticket, excluding the run currently
  * provisioning its own workspace. The shared worker lease is the fast local

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -12,7 +12,9 @@ import os from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import {
+  assertSandboxWorkspaceSupported,
   PathViolation,
+  WorktreeSandboxUnsupportedError,
   WorktreeError,
   createWorkspace,
   destroyWorkspace,
@@ -313,6 +315,25 @@ describe("worktree workspaces (WM-108)", () => {
     expect(
       JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).ticket,
     ).toBe("WM-1");
+    expect(destroyWorkspace(dir)).toBe(true);
+  });
+
+  test("a sandboxed definition is refused when the workspace carries a worktree marker", () => {
+    const { dir } = make("wtrepo", "WM-1-SANDBOX", "run_wt1_sandbox");
+    expect(() =>
+      assertSandboxWorkspaceSupported(dir, {
+        sandbox: { provider: "gondolin" },
+      }),
+    ).toThrow(WorktreeSandboxUnsupportedError);
+    try {
+      assertSandboxWorkspaceSupported(dir, {
+        sandbox: { provider: "gondolin" },
+      });
+    } catch (err) {
+      expect(err.code).toBe("worktree_sandbox_unsupported");
+      expect(err.workspaceDir).toBe(dir);
+    }
+    expect(() => assertSandboxWorkspaceSupported(dir, {})).not.toThrow();
     expect(destroyWorkspace(dir)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- persist sandbox guest console logs as runtime artifacts and make unsupported sandbox failures non-requeueable
- refuse sandbox execution for delegated worktree workspaces with a typed failure
- use an explicit, production-checked adapter conformance registry and validate Pi sandbox config before staging its prompt
- add unit and integration regressions for all follow-up behaviors

## Verification
- `bun test event-runtime/lib/adapters event-runtime/lib/sandbox event-runtime/lib/worker.test.mjs event-runtime/lib/workspace.test.mjs` — 358 pass, 9 skipped (real VM unavailable), 0 fail

UX critique: skipped — backend/runtime-only change with no user-facing flow

Fixes WM-636