### PR TITLE
ops(event-runtime): route merge-scan and merge-fix to claude/sonnet (WM-722)

### DIFF
--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -115,7 +115,7 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
-    "adapter": "pi",
+    "adapter": "claude",
     "idempotencyScope": ["correlationId", "inputHash"],
     "proposalTtlSeconds": 1800
   },
@@ -133,7 +133,7 @@
   },
   "factory.merge-fix.requested": {
     "agent": "merge-fix@1",
-    "adapter": "pi",
+    "adapter": "claude",
     "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -138,8 +138,9 @@ describe("registry", () => {
     // to the affected definitions while preserving their refs and pins
     // (digest regenerated on top of the #559 baseline).
     // Regenerated after WM-610 prettier reformat of code and markdown files.
+    // Regenerated (WM-722): merge-scan/merge-fix adapter pi→claude; event-types.json is a registry input.
     const expected =
-      "sha256:f618f5d7bbcbdac48dadf5ed490ebeefee9734ac9f78e535ef5bb29ba9ee414b";
+      "sha256:c9df6589c6a12567263dccbfc737b6a6acbb8132e0ac9216dbb7a35e527f6fbf";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -341,11 +341,11 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {
     expect(registry.eventTypes["factory.merge.requested"]).toMatchObject({
       agent: "merge-scan@2",
-      adapter: "pi",
+      adapter: "claude",
     });
     expect(registry.eventTypes["factory.merge-fix.requested"]).toMatchObject({
       agent: "merge-fix@1",
-      adapter: "pi",
+      adapter: "claude",
     });
     expect(registry.eventTypes["factory.merge-apply.requested"].agent).toBe(
       "merge-apply@2",
@@ -655,7 +655,7 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       const summary = await runOnce(
         db,
         registry,
-        { pi: adapter },
+        { claude: adapter },
         { workspacesRoot: workspaces, owner: "merge-test", policyVersion: PV },
       );
 

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -458,16 +458,27 @@ describe("work-scan registration (WM-110)", () => {
     );
   });
 
-  test("every LLM route is the pi adapter; command/actions routes are untouched (WM-215)", () => {
+  test("every LLM route is the pi adapter except the WM-722 merge exceptions; command/actions routes are untouched (WM-215)", () => {
     const byAdapter = {};
     for (const mapping of Object.values(registry.eventTypes)) {
       if (!mapping.agent) continue;
       (byAdapter[mapping.adapter] ??= []).push(mapping.agent);
     }
-    // No committed route rides claude. It stays a supported adapter — the
-    // per-route exception and `--adapter-override claude` both select it —
-    // but the default harness is pi.
-    expect(byAdapter.claude).toBeUndefined();
+    // The default harness is pi. The only committed claude routes are the
+    // WM-722 merge-scan/merge-fix exceptions (standard tier → sonnet); any
+    // other route riding claude must be an explicit, reviewed decision.
+    expect([...byAdapter.claude].sort()).toEqual([
+      "merge-fix@1",
+      "merge-scan@2",
+    ]);
+    for (const ref of byAdapter.claude) {
+      const resolved = resolveModel(
+        registry.agents.get(ref),
+        "claude",
+        registry.modelTiers,
+      );
+      expect(resolved).toBe(registry.modelTiers.claude.standard);
+    }
     expect(byAdapter.pi.length).toBeGreaterThan(0);
     // Every pi route resolves a model: loadRegistry fails closed otherwise,
     // but assert the values so a silently-null resolution can't pass.


### PR DESCRIPTION
Move `merge-scan@2` and `merge-fix@1` from adapter `pi` to adapter `claude`. Both agents are already `model_tier: standard`, so they resolve to Sonnet via the existing `models.claude.standard: sonnet` tier map in `config/policy.yaml` (untouched).

## Handoff

**Files**
- `event-runtime/event-types.json` — `factory.merge.requested` and `factory.merge-fix.requested`: `"adapter": "pi"` → `"claude"`. Nothing else.
- `event-runtime/merge.test.mjs` — mapping assertions and the WM-425 workspace test's stub adapter key (`{ pi: adapter }` → `{ claude: adapter }`).
- `event-runtime/lib/registry.test.mjs` — zero-pack digest regenerated (event-types.json is a registry input); comment added per the test's own rule. New digest `sha256:c9df6589c6a12567263dccbfc737b6a6acbb8132e0ac9216dbb7a35e527f6fbf`.
- `event-runtime/work.test.mjs` — the WM-215 "no committed route rides claude" assertion now pins the claude route set to exactly `["merge-fix@1", "merge-scan@2"]` and asserts each resolves to `modelTiers.claude.standard`. Any further claude route must be an explicit reviewed change.

**Resolution proof**
```
factory.merge.requested claude standard sonnet
factory.merge-fix.requested claude standard sonnet
```

**Verification**
```
bun test event-runtime/merge.test.mjs event-runtime/lib/registry.test.mjs event-runtime/work.test.mjs
 83 pass / 0 fail
bun build/emit.mjs --check   -> ok — 90 generated files match shared/ (exit 0)
bun event-runtime/cli.mjs update-pins -> pins already current
bun test (full) -> 2504 pass, 9 skip, 1 fail before the work.test.mjs update (that one assertion); re-run of the three touched files green.
```

**Risks**
- Requires full stack restart to pick up the new adapter routing; drain first.
- The `--check` floor-delivery warning about stale AGENTS.md in the main checkout is pre-existing and unrelated.

Fixes WM-722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz
