### PR TITLE
feat(worker): mechanically verify dispatch handoffs — run the ticket's Verification Command and refuse on red (WM-718)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -37,6 +37,18 @@ dispatch:
   # Merging stays serialized (max_concurrent_merges below), which is where real
   # conflicts are caught.
   owned_paths_collision: advisory
+  # Owned Paths conformance at handoff (WM-718). After a dispatch agent
+  # returns PR_OPEN the worker diffs merge-base(origin/<base>)..HEAD in the
+  # worktree against the ticket's parsed Owned Paths.
+  #   advisory — files outside the set are listed in the worker-authored
+  #              Handoff verification comment as "Owned Paths deviations" and
+  #              the run completes. Default when this key is absent.
+  #   strict   — any deviation refuses the handoff (handoff_owned_paths_violation):
+  #              the PR is held as draft and the ticket returns to Todo + agent-ready.
+  # Advisory to start: surfacing the deviation is what was missing (#558's
+  # 800-line reflow, #593's four out-of-scope files went unnoticed); refusing
+  # is one key flip once the listing proves accurate.
+  owned_paths_conformance: advisory
 
 concurrency:
   # Per-repo admission ceiling. Actual execution remains bounded by worker

--- a/docs/event-runtime-worker-protocol.md
+++ b/docs/event-runtime-worker-protocol.md
@@ -389,7 +389,9 @@ agent, the spec is fine).
 On pass and on failure alike the worker posts a **worker-authored**
 `## Handoff verification (worker-observed)` comment on the ticket: the
 command it ran, the exit code, the last 40 lines of output, the web-build
-result, the file count against `origin/<base>`, and the Owned Paths deviations.
+result, the file count against `origin/<base>`, the Owned Paths deviations,
+and — when known — the ticket's description hash at claim time, so a reader
+can tell whether the ticket was amended after the agent claimed it.
 The agent's own `artifact.verification` claim is quoted below it labelled
 `agent-reported`; it never becomes the Verification line. On pass the accepted
 result's `verification.checks` gains `repo_verify_passed`,

--- a/docs/event-runtime-worker-protocol.md
+++ b/docs/event-runtime-worker-protocol.md
@@ -345,6 +345,57 @@ Successful response (`200`):
 }
 ```
 
+### 7a. Handoff verification for dispatch runs (WM-718)
+
+A `dispatch@1` result whose artifact says `outcome: "PR_OPEN"` is a handoff:
+the agent claims the ticket is implemented, verified, and under review. The
+worker does not take that on trust. Before such a result is submitted as
+`completed`, the worker — ordinary code in `event-runtime/lib/verify.mjs`,
+outside the model process — runs in the delegated worktree, in this order:
+
+1. the repo's declared `verify:` command from `config/repos.yaml` (the
+   pre-existing §9 gate; a failure that matches the recorded red baseline is
+   still `baseline_red`, still blocks the ticket);
+2. the ticket's own `## Verification Command` (parsed at claim time from the
+   ticket description — a fenced block or a single line under that heading —
+   and persisted on the worktree record), exactly as written;
+3. `cd event-runtime/web && bun run build` (tsc + vite) when
+   `git diff --name-only merge-base(origin/<base>, HEAD)..HEAD` touches
+   `event-runtime/web/src/**`, regardless of what the ticket's command covers;
+4. Owned Paths conformance: the same diff against the ticket's parsed Owned
+   Paths. Files outside the set are listed as deviations; under
+   `dispatch.owned_paths_conformance: strict` (config/policy.yaml, default
+   `advisory`) they refuse the handoff.
+
+Each command runs with the repo-verify timeout (`FACTORY_REPO_VERIFY_TIMEOUT_MS`,
+default 600 s) and its full output lands in the workspace (`.verify.log`,
+`.verify.ticket.log`, `.verify.web.log`). Failure-shaped outcomes:
+
+| condition                                                  | reasonCode                         |
+| ---------------------------------------------------------- | ---------------------------------- |
+| any of the commands exits non-zero or times out            | `handoff_verification_failed`      |
+| no ticket command parses **and** the repo has no `verify:` | `handoff_verification_unspecified` |
+| deviations under `owned_paths_conformance: strict`         | `handoff_owned_paths_violation`    |
+
+These are agent errors (bounded by `maxAttempts`, never an environment retry).
+The run is FAILED with no accepted result — nothing downstream chains a review
+— and the journal reason carries the last lines of the failing output. Because
+the agent opens the PR itself and has already moved the ticket to In Review,
+the worker then applies the structural hold: the PR is converted to draft with
+a comment quoting the observed failure (`gh pr ready --undo`), and the ticket
+returns to **Todo + `ai:agent-ready`** (not Blocked — the harness caught the
+agent, the spec is fine).
+
+On pass and on failure alike the worker posts a **worker-authored**
+`## Handoff verification (worker-observed)` comment on the ticket: the
+command it ran, the exit code, the last 40 lines of output, the web-build
+result, the file count against `origin/<base>`, and the Owned Paths deviations.
+The agent's own `artifact.verification` claim is quoted below it labelled
+`agent-reported`; it never becomes the Verification line. On pass the accepted
+result's `verification.checks` gains `repo_verify_passed`,
+`ticket_verify_passed`, `web_build_passed`, and either `owned_paths_conformant`
+or `owned_paths_deviations_advisory`, as applicable.
+
 ## 8. Durable worker result buffer
 
 A successful adapter exit is not durable until its result can survive both a

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -23,7 +23,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:552d1354c1fb9b95e961853c67544beae5bd7ae93850abbdbfa577b1d122a730",
+    "agents/dispatch.md": "sha256:13aed898b1fd8aa61cd6d9a688d07de4715693775f7498d96a1852b3a9c755be",
     "schemas/dispatch.input.json": "sha256:386b565acd89e60e674d6a5516b872cb46b3bed0fbe05510d299f4d63ee028be",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -23,7 +23,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:34a2625aa17cfaa536dc740e527ef333334aaeab22c99cf4ffa71d8501c3b5e1",
+    "agents/dispatch.md": "sha256:552d1354c1fb9b95e961853c67544beae5bd7ae93850abbdbfa577b1d122a730",
     "schemas/dispatch.input.json": "sha256:386b565acd89e60e674d6a5516b872cb46b3bed0fbe05510d299f4d63ee028be",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -35,9 +35,18 @@ steal a claim, never queue behind the holder.
    `Owned Paths`. Work discovered outside that set becomes a new `Triage`
    issue (`tools/linear.mjs file`) — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`, run inside
-   `./repo`. Never proceed past failing output; never weaken a test to get
-   green. The runtime re-runs the repo's declared verify command after you —
-   your report is not the evidence, the output is.
+   `./repo` on the final tree (after your last commit), **and** the full
+   `bun test` (or the repo's full suite) before you return. Never proceed
+   past failing output; never weaken a test to get green. **The worker
+   verifies the handoff mechanically after you return:** it re-runs the
+   repo's declared verify command and the ticket's exact
+   `Verification Command`, runs `cd event-runtime/web && bun run build` when
+   your diff touches `event-runtime/web/src/**`, and diffs
+   `origin/<base>..HEAD` against the ticket's Owned Paths. A non-zero exit
+   fails the run (`handoff_verification_failed`), converts your PR to a
+   draft with the observed output quoted, and returns the ticket to Todo +
+   `ai:agent-ready`. Your report is not the evidence, the output is — and
+   the worker reads the exit code itself.
 4. **Run the UX gate when required.** A critique is required when the change
    introduces or materially changes a user-completable flow, interaction,
    state transition, error/recovery path, responsive layout, authentication,
@@ -89,6 +98,14 @@ shell` means the spawn prompt was defective: correct its path/launch details
    - Files: <n> changed, all within Owned Paths
    - Risks: <reviewer focus, or "none known">
    ```
+
+   The Verification line that counts is **worker-authored**: after you
+   return, the worker posts `## Handoff verification (worker-observed)` on
+   the ticket with the command it ran, the exit code, the last 40 lines of
+   output, the file count against `origin/<base>`, and any Owned Paths
+   deviations. Your own line above is kept as `agent-reported` commentary; it
+   cannot assert a pass the worker did not observe, so make sure the tree you
+   push is the tree that passed.
 
    Then move the ticket to `In Review` + `ai:needs-review`, removing
    `ai:in-progress`.

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -141,8 +141,13 @@ describe("registry", () => {
     // Regenerated (WM-722): merge-scan/merge-fix adapter pi→claude; event-types.json is a registry input.
     // Regenerated (WM-391): dispatch admits and documents bounded humanDecision authorisations.
     // Regenerated (WM-694): dispatch input admits a pinned per-ticket modelTier override.
+    // Regenerated for WM-718 (rebase onto the WM-722 baseline above):
+    // agents/dispatch.md now states that the worker verifies the handoff
+    // mechanically (re-pinned dispatch.json). Registry input change only;
+    // both changes are registry inputs to the same merged-view digest,
+    // hence one combined regeneration here.
     const expected =
-      "sha256:8d3f8ca1951587fcbd646c3e97590c2daa631be129b867e17e0e8787d66da1cd";
+      "sha256:PLACEHOLDER_WILL_BE_COMPUTED";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -159,8 +164,11 @@ describe("registry", () => {
     const def = registry.agents.get("dispatch@1");
     expect(def.pack).toBe("event-runtime");
     expect(Object.keys(def)).not.toContain("pack");
+    // WM-718 changed dispatch@1's prompt content (agents/dispatch.md), so its
+    // pin — and therefore this defHash — legitimately moved, exactly as it did
+    // for WM-610. Still not a provenance break: `pack` stays non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:614eccc3078f9d4d71eb6349d03e45020ff083f54546dbe15d9c1ce3d981d6f2",
+      "sha256:PLACEHOLDER_WILL_BE_COMPUTED",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -147,7 +147,7 @@ describe("registry", () => {
     // both changes are registry inputs to the same merged-view digest,
     // hence one combined regeneration here.
     const expected =
-      "sha256:PLACEHOLDER_WILL_BE_COMPUTED";
+      "sha256:065ec74d0146e2e98a10d9f907e22bd78d4417523c78d6b3d647ba39e6123ca0";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -147,7 +147,7 @@ describe("registry", () => {
     // both changes are registry inputs to the same merged-view digest,
     // hence one combined regeneration here.
     const expected =
-      "sha256:065ec74d0146e2e98a10d9f907e22bd78d4417523c78d6b3d647ba39e6123ca0";
+      "sha256:14b3b1fa08de22a5e949814722b9da1618e9a94dd7717decd5faa3cd718d7579";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -168,7 +168,7 @@ describe("registry", () => {
     // pin — and therefore this defHash — legitimately moved, exactly as it did
     // for WM-610. Still not a provenance break: `pack` stays non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:PLACEHOLDER_WILL_BE_COMPUTED",
+      "sha256:cf85bb4e0cc3ca02a05ad9f780beed32daf80e86500136d84d19643ef46ae4ed",
     );
   });
 

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -10,11 +10,13 @@
  * partial acceptances. These checks verify form, not truth (§9): semantic
  * evidence checking is slice 2.
  */
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { globToRegExp } from "../../orchestrator/owned-paths.mjs";
 import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { validateDecisionRequest } from "./decision.mjs";
+import { reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { PathViolation, safeJoin } from "./workspace.mjs";
 
@@ -61,12 +63,227 @@ export const REFUSAL_REASONS = [
 ];
 
 export class ContractViolation extends Error {
-  constructor(violations, { reasonCode = "contract_violation" } = {}) {
+  constructor(
+    violations,
+    { reasonCode = "contract_violation", handoff = null } = {},
+  ) {
     super(`contract violation: ${violations.join("; ")}`);
     this.name = "ContractViolation";
     this.violations = violations;
     this.reasonCode = reasonCode;
+    // WM-718: when the handoff gate refuses, the worker-observed verification
+    // (commands, exit codes, output tails, diff, deviations) rides along so
+    // the worker can post it on the ticket and hold the PR.
+    if (handoff) this.handoff = handoff;
   }
+}
+
+/**
+ * Handoff verification (WM-718). The dispatch agent's `## Handoff` used to
+ * claim "Verification: pass" for commands it had not run on the final tree
+ * (3 of 10 PRs on 2026-08-18 failed CI on exactly the check the ticket named).
+ * The repo `verify:` gate below is deliberately a subset of CI (WM-528), so
+ * it let those through. This is the same check made honest: the WORKER runs
+ * the ticket's own Verification Command, the web build when the diff reaches
+ * `event-runtime/web/src/**`, and compares the diff with the ticket's Owned
+ * Paths — and authors the Verification line itself.
+ */
+export const HANDOFF_REASON_CODES = new Set([
+  "handoff_verification_failed",
+  "handoff_verification_unspecified",
+  "handoff_owned_paths_violation",
+]);
+export const HANDOFF_TAIL_LINES = 40;
+export const HANDOFF_WEB_SRC_PREFIX = "event-runtime/web/src/";
+export const HANDOFF_WEB_BUILD_DIR = "event-runtime/web";
+export const HANDOFF_WEB_BUILD_COMMAND = "bun run build";
+export const DEFAULT_OWNED_PATHS_CONFORMANCE = "advisory";
+export const HANDOFF_COMMENT_HEADING =
+  "## Handoff verification (worker-observed)";
+
+/** `dispatch.owned_paths_conformance` in config/policy.yaml: advisory (default) | strict. */
+export function policyOwnedPathsConformance(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return DEFAULT_OWNED_PATHS_CONFORMANCE;
+  try {
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch
+      ?.owned_paths_conformance;
+    return value === "strict" ? "strict" : DEFAULT_OWNED_PATHS_CONFORMANCE;
+  } catch {
+    return DEFAULT_OWNED_PATHS_CONFORMANCE;
+  }
+}
+
+/** Last N non-empty lines of a command's output, ANSI stripped. */
+export function outputTail(output, lines = HANDOFF_TAIL_LINES) {
+  return (
+    String(output ?? "")
+      // eslint-disable-next-line no-control-regex -- \x1b is the ANSI escape byte being stripped, not a typo
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line.trim().length > 0)
+      .slice(-lines)
+      .join("\n")
+  );
+}
+
+/**
+ * Run one handoff command as ordinary code in the worktree, capturing the
+ * whole output to `logPath` and returning an observation the worker can quote.
+ */
+function runHandoffCommand({ command, cwd, logPath, timeoutMs }) {
+  const fd = openSync(logPath, "w");
+  let res;
+  try {
+    res = spawnSync("/bin/bash", ["-c", command], {
+      cwd,
+      stdio: ["ignore", fd, fd],
+      timeout: timeoutMs,
+    });
+  } finally {
+    closeSync(fd);
+  }
+  const output = readFileSync(logPath, "utf8");
+  const timedOut = res.error?.code === "ETIMEDOUT";
+  const exitCode = timedOut ? null : (res.status ?? (res.error ? 1 : 0));
+  return {
+    command,
+    cwd,
+    exitCode,
+    timedOut,
+    passed: !timedOut && exitCode === 0,
+    output,
+    tail: outputTail(output),
+    logPath,
+  };
+}
+
+/**
+ * Files the PR carries: `merge-base(origin/<base>, HEAD)..HEAD` in the
+ * worktree. `null` files means the diff could not be computed (not a git
+ * checkout, unknown base) — reported, never silently treated as empty.
+ */
+export function changedFilesSince({ worktreePath, base }) {
+  const git = (args) =>
+    execFileSync("git", args, {
+      cwd: worktreePath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60_000,
+    }).trim();
+  const candidates = base ? [`origin/${base}`, base] : [];
+  for (const ref of candidates) {
+    try {
+      const mergeBase = git(["merge-base", ref, "HEAD"]);
+      const out = git(["diff", "--name-only", `${mergeBase}..HEAD`]);
+      const files = out ? out.split("\n").filter(Boolean) : [];
+      return { ok: true, baseRef: ref, mergeBase, files };
+    } catch (err) {
+      const stderr = String(err?.stderr ?? err?.message ?? "")
+        .trim()
+        .split("\n")
+        .pop();
+      if (ref === candidates.at(-1))
+        return { ok: false, baseRef: ref, files: null, error: stderr };
+    }
+  }
+  return {
+    ok: false,
+    baseRef: null,
+    files: null,
+    error: base ? "base unresolved" : "no base branch on the worktree record",
+  };
+}
+
+/** Files outside every Owned Paths glob (`**` owns everything). */
+export function ownedPathsDeviations(files = [], ownedPaths = []) {
+  if (!Array.isArray(files)) return [];
+  const globs = (ownedPaths ?? []).map((g) => String(g).trim()).filter(Boolean);
+  if (globs.length === 0 || globs.includes("**")) return [];
+  const matchers = globs.map((g) => globToRegExp(g));
+  return files.filter((file) => !matchers.some((re) => re.test(file)));
+}
+
+function fenceBlock(text) {
+  const body = String(text ?? "").trim() || "(no output)";
+  return `\`\`\`\n${body}\n\`\`\``;
+}
+
+function commandLine(label, obs) {
+  if (!obs) return null;
+  const verdict = obs.timedOut
+    ? "TIMED OUT"
+    : obs.passed
+      ? "exit 0 (pass)"
+      : `exit ${obs.exitCode} (FAIL)`;
+  return `- ${label}: \`${obs.command}\` — ${verdict}`;
+}
+
+/**
+ * The worker-authored Handoff verification (WM-718). Composed only from what
+ * the worker observed; the agent's own claim, when present, is kept below it
+ * labelled agent-reported and never becomes the Verification line.
+ */
+export function composeHandoffVerification(handoff) {
+  const lines = [HANDOFF_COMMENT_HEADING];
+  const primary = handoff.verification;
+  if (primary) {
+    lines.push(commandLine("Verification", primary));
+    lines.push(fenceBlock(primary.tail));
+    if (primary.source === "repo_verify") {
+      lines.push(
+        "  (no `## Verification Command` parsed on the ticket — the repo `verify:` command stood in for it)",
+      );
+    }
+  } else if (handoff.reasonCode === "handoff_verification_unspecified") {
+    lines.push(
+      "- Verification: NONE — the ticket has no parseable `## Verification Command` and the repo declares no `verify:` command; the handoff is refused (fail-closed).",
+    );
+  }
+  if (handoff.repoVerify && handoff.repoVerify !== primary)
+    lines.push(commandLine("Repo verify", handoff.repoVerify));
+  if (handoff.webBuild) {
+    lines.push(
+      commandLine(
+        `Web build (${HANDOFF_WEB_SRC_PREFIX}** changed)`,
+        handoff.webBuild,
+      ),
+    );
+    if (!handoff.webBuild.passed) lines.push(fenceBlock(handoff.webBuild.tail));
+  } else if (handoff.diff?.ok) {
+    lines.push(`- Web build: skipped (no ${HANDOFF_WEB_SRC_PREFIX}** changes)`);
+  }
+  if (handoff.diff?.ok) {
+    const n = handoff.diff.files.length;
+    lines.push(
+      `- Files: ${n} changed vs ${handoff.diff.baseRef} (${handoff.diff.mergeBase.slice(0, 12)})`,
+    );
+    const deviations = handoff.ownedPathsDeviations ?? [];
+    if (!handoff.ownedPathsKnown) {
+      lines.push(
+        "- Owned Paths deviations: unknown (ticket Owned Paths did not parse)",
+      );
+    } else if (deviations.length === 0) {
+      lines.push("- Owned Paths deviations: none");
+    } else {
+      lines.push(
+        `- Owned Paths deviations (${handoff.ownedPathsConformance}): ${deviations.length} file(s) outside the ticket's Owned Paths`,
+      );
+      for (const file of deviations) lines.push(`  - \`${file}\``);
+    }
+  } else {
+    lines.push(
+      `- Files: diff unavailable (${handoff.diff?.error ?? "unknown"}); Owned Paths deviations: unknown`,
+    );
+  }
+  const claim = handoff.agentReported;
+  if (claim && (claim.command || claim.output)) {
+    lines.push(
+      `- agent-reported: \`${claim.command ?? "(no command)"}\` — ${claim.passed === true ? "pass" : "not passed"}${claim.output ? `, ${String(claim.output).split("\n").filter(Boolean).slice(-1)[0]}` : ""}`,
+    );
+  }
+  return lines.filter((line) => line !== null).join("\n");
 }
 
 function normalizeFailureOutput(output) {
@@ -635,37 +852,166 @@ function verifyCompleted({
     }
   }
 
-  let repoVerifyPassed = false;
-  if (worktreeRecord?.verify && candidate.artifact?.outcome === "PR_OPEN") {
+  // Handoff gate (WM-718): a PR_OPEN result from a real worktree run is
+  // verified by the worker, not by the agent's say-so. A bare `{}` record is
+  // the worker's timeout preflight asking for form-only checks — no gate.
+  const handoffChecks = [];
+  let handoff = null;
+  const isHandoff =
+    candidate.artifact?.outcome === "PR_OPEN" &&
+    Boolean(
+      worktreeRecord &&
+      (worktreeRecord.path || worktreeRecord.verify || worktreeRecord.repo),
+    );
+  if (isHandoff) {
     const worktreePath =
       worktreeRecord.path && existsSync(worktreeRecord.path)
         ? worktreeRecord.path
         : path.join(workspaceDir, "repo");
-    const verifyLogPath = path.join(workspaceDir, ".verify.log");
-    const verifyLogFd = openSync(verifyLogPath, "w");
-    let vres;
-    try {
-      vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], {
-        cwd: worktreePath,
-        stdio: ["ignore", verifyLogFd, verifyLogFd],
-        timeout: verifyTimeoutMs,
-      });
-    } finally {
-      closeSync(verifyLogFd);
-    }
-    const output = readFileSync(verifyLogPath, "utf8");
-    if (vres.error?.code === "ETIMEDOUT" || vres.status !== 0) {
-      const timedOut = vres.error?.code === "ETIMEDOUT";
-      const why = timedOut
+    const ticketCommand =
+      typeof worktreeRecord.handoff?.verificationCommand === "string" &&
+      worktreeRecord.handoff.verificationCommand.trim()
+        ? worktreeRecord.handoff.verificationCommand.trim()
+        : null;
+    const ownedPaths = Array.isArray(worktreeRecord.handoff?.ownedPaths)
+      ? worktreeRecord.handoff.ownedPaths
+      : [];
+    const ownedPathsKnown =
+      worktreeRecord.handoff?.ownedPathsParsed === true ||
+      (ownedPaths.length > 0 && !ownedPaths.includes("**"));
+    const conformance = policyOwnedPathsConformance();
+    const claim = candidate.artifact?.verification ?? null;
+    handoff = {
+      ticket: worktreeRecord.ticket ?? spec.input?.ticket ?? null,
+      repo: worktreeRecord.repo ?? spec.input?.repo ?? null,
+      github: worktreeRecord.github ?? null,
+      prNumber: candidate.artifact?.prNumber ?? null,
+      prUrl: candidate.artifact?.prUrl ?? null,
+      verification: null,
+      repoVerify: null,
+      webBuild: null,
+      diff: null,
+      ownedPaths,
+      ownedPathsKnown,
+      ownedPathsConformance: conformance,
+      ownedPathsDeviations: [],
+      agentReported: claim
+        ? {
+            command: claim.command ?? null,
+            passed: claim.passed === true,
+            output: claim.output ?? null,
+          }
+        : null,
+      reasonCode: null,
+    };
+    const refuse = (reasonCode, violation) => {
+      handoff.reasonCode = reasonCode;
+      throw new ContractViolation([violation], { reasonCode, handoff });
+    };
+    const failureWhy = (obs) =>
+      obs.timedOut
         ? `timed out after ${verifyTimeoutMs}ms`
-        : repoVerifyFailureExcerpt(output) || `exit ${vres.status}`;
-      const baselineStillRed =
-        !timedOut && matchesRedBaseline(worktreeRecord.baseline, output);
-      throw new ContractViolation([`repo_verify_failed: ${why}`], {
-        reasonCode: baselineStillRed ? "baseline_red" : "contract_violation",
-      });
+        : repoVerifyFailureExcerpt(obs.output) || `exit ${obs.exitCode}`;
+
+    // Fail-closed: something must stand behind the Verification line.
+    if (!worktreeRecord.verify && !ticketCommand) {
+      refuse(
+        "handoff_verification_unspecified",
+        "handoff_verification_unspecified: the ticket has no parseable `## Verification Command` and the repo declares no `verify:` command",
+      );
     }
-    repoVerifyPassed = true;
+
+    // 1. The repo's own verify command (the pre-WM-718 gate, kept as-is: it
+    //    is what the red-baseline logic is keyed on).
+    if (worktreeRecord.verify) {
+      const obs = runHandoffCommand({
+        command: worktreeRecord.verify,
+        cwd: worktreePath,
+        logPath: path.join(workspaceDir, ".verify.log"),
+        timeoutMs: verifyTimeoutMs,
+      });
+      obs.source = "repo_verify";
+      handoff.repoVerify = obs;
+      if (!obs.passed) {
+        const baselineStillRed =
+          !obs.timedOut &&
+          matchesRedBaseline(worktreeRecord.baseline, obs.output);
+        handoff.reasonCode = baselineStillRed
+          ? "baseline_red"
+          : "handoff_verification_failed";
+        throw new ContractViolation(
+          [`repo_verify_failed: ${failureWhy(obs)}`],
+          { reasonCode: handoff.reasonCode, handoff },
+        );
+      }
+      handoffChecks.push("repo_verify_passed");
+    }
+
+    // 2. The ticket's exact Verification Command on the final tree.
+    if (ticketCommand) {
+      const obs = runHandoffCommand({
+        command: ticketCommand,
+        cwd: worktreePath,
+        logPath: path.join(workspaceDir, ".verify.ticket.log"),
+        timeoutMs: verifyTimeoutMs,
+      });
+      obs.source = "ticket";
+      handoff.verification = obs;
+      if (!obs.passed) {
+        refuse(
+          "handoff_verification_failed",
+          `ticket_verify_failed: ${failureWhy(obs)}`,
+        );
+      }
+      handoffChecks.push("ticket_verify_passed");
+    } else {
+      handoff.verification = handoff.repoVerify;
+    }
+
+    // 3. What the PR actually carries.
+    handoff.diff = changedFilesSince({
+      worktreePath,
+      base: worktreeRecord.base ?? null,
+    });
+    const files = handoff.diff.files ?? [];
+
+    // 4. tsc + vite for anything under event-runtime/web/src/** — the check
+    //    #593 failed on, regardless of what the ticket's command covers.
+    if (
+      files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
+      existsSync(path.join(worktreePath, HANDOFF_WEB_BUILD_DIR, "package.json"))
+    ) {
+      const obs = runHandoffCommand({
+        command: HANDOFF_WEB_BUILD_COMMAND,
+        cwd: path.join(worktreePath, HANDOFF_WEB_BUILD_DIR),
+        logPath: path.join(workspaceDir, ".verify.web.log"),
+        timeoutMs: verifyTimeoutMs,
+      });
+      obs.command = `cd ${HANDOFF_WEB_BUILD_DIR} && ${HANDOFF_WEB_BUILD_COMMAND}`;
+      handoff.webBuild = obs;
+      if (!obs.passed) {
+        refuse(
+          "handoff_verification_failed",
+          `web_build_failed: ${failureWhy(obs)}`,
+        );
+      }
+      handoffChecks.push("web_build_passed");
+    }
+
+    // 5. Owned Paths conformance: listed always; refused under strict.
+    if (handoff.diff.ok && ownedPathsKnown) {
+      handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths);
+      if (handoff.ownedPathsDeviations.length === 0) {
+        handoffChecks.push("owned_paths_conformant");
+      } else if (conformance === "strict") {
+        refuse(
+          "handoff_owned_paths_violation",
+          `owned_paths_violation: ${handoff.ownedPathsDeviations.length} file(s) outside the ticket's Owned Paths: ${handoff.ownedPathsDeviations.join(", ")}`,
+        );
+      } else {
+        handoffChecks.push("owned_paths_deviations_advisory");
+      }
+    }
   }
 
   // Runtime-injected artifacts (e.g. the adapter's transcript): best-effort —
@@ -728,7 +1074,7 @@ function verifyCompleted({
         ...(SEMANTIC_CHECKS[spec.outputContract]
           ? ["evidence_recomputed"]
           : []),
-        ...(repoVerifyPassed ? ["repo_verify_passed"] : []),
+        ...handoffChecks,
       ],
     },
     artifacts: collected,
@@ -741,5 +1087,10 @@ function verifyCompleted({
     journalHead,
     verificationStatus: "passed",
   };
-  return { kind: "completed", result, receipt };
+  return {
+    kind: "completed",
+    result,
+    receipt,
+    ...(handoff ? { handoff } : {}),
+  };
 }

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -159,33 +159,66 @@ function runHandoffCommand({ command, cwd, logPath, timeoutMs }) {
   };
 }
 
+/** Best-effort timeout for the pre-diff `git fetch origin <base>` (F4). */
+const FETCH_BASE_TIMEOUT_MS = 10_000;
+
 /**
  * Files the PR carries: `merge-base(origin/<base>, HEAD)..HEAD` in the
  * worktree. `null` files means the diff could not be computed (not a git
  * checkout, unknown base) — reported, never silently treated as empty.
+ *
+ * `origin/<base>` in the worktree can be stale by the time the handoff gate
+ * runs — the worktree was materialized once, but develop keeps moving while
+ * the agent works. A quiet, best-effort `git fetch origin <base>` right
+ * before computing merge-base keeps the deviation diff honest against
+ * current develop; a fetch failure (offline, auth, timeout) never blocks the
+ * gate — it proceeds against the local ref and says so via `base_ref_stale`.
+ *
+ * `git` defaults to the real `execFileSync` runner and exists only so tests
+ * can inject a stub that records call order and fails the fetch on cue.
  */
-export function changedFilesSince({ worktreePath, base }) {
-  const git = (args) =>
+export function changedFilesSince({
+  worktreePath,
+  base,
+  git = (args, { timeout = 60_000 } = {}) =>
     execFileSync("git", args, {
       cwd: worktreePath,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      timeout: 60_000,
-    }).trim();
+      timeout,
+    }).trim(),
+}) {
+  let baseRefStale = false;
+  if (base) {
+    try {
+      git(["fetch", "--quiet", "origin", base], {
+        timeout: FETCH_BASE_TIMEOUT_MS,
+      });
+    } catch {
+      baseRefStale = true;
+    }
+  }
+  const staleField = baseRefStale ? { base_ref_stale: true } : {};
   const candidates = base ? [`origin/${base}`, base] : [];
   for (const ref of candidates) {
     try {
       const mergeBase = git(["merge-base", ref, "HEAD"]);
       const out = git(["diff", "--name-only", `${mergeBase}..HEAD`]);
       const files = out ? out.split("\n").filter(Boolean) : [];
-      return { ok: true, baseRef: ref, mergeBase, files };
+      return { ok: true, baseRef: ref, mergeBase, files, ...staleField };
     } catch (err) {
       const stderr = String(err?.stderr ?? err?.message ?? "")
         .trim()
         .split("\n")
         .pop();
       if (ref === candidates.at(-1))
-        return { ok: false, baseRef: ref, files: null, error: stderr };
+        return {
+          ok: false,
+          baseRef: ref,
+          files: null,
+          error: stderr,
+          ...staleField,
+        };
     }
   }
   return {
@@ -193,6 +226,7 @@ export function changedFilesSince({ worktreePath, base }) {
     baseRef: null,
     files: null,
     error: base ? "base unresolved" : "no base branch on the worktree record",
+    ...staleField,
   };
 }
 
@@ -275,6 +309,11 @@ export function composeHandoffVerification(handoff) {
   } else {
     lines.push(
       `- Files: diff unavailable (${handoff.diff?.error ?? "unknown"}); Owned Paths deviations: unknown`,
+    );
+  }
+  if (handoff.descriptionHash) {
+    lines.push(
+      `- ticket description hash at claim: \`${handoff.descriptionHash}\``,
     );
   }
   const claim = handoff.agentReported;
@@ -895,6 +934,7 @@ function verifyCompleted({
       ownedPathsKnown,
       ownedPathsConformance: conformance,
       ownedPathsDeviations: [],
+      descriptionHash: worktreeRecord.handoff?.descriptionHash ?? null,
       agentReported: claim
         ? {
             command: claim.command ?? null,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -989,6 +989,52 @@ describe("handoff verification helpers (WM-718)", () => {
     ).toContain("no base branch");
   });
 
+  test("changedFilesSince fetches origin/<base> before computing merge-base (WM-718 F4)", () => {
+    const calls = [];
+    const gitStub = (args) => {
+      calls.push(args);
+      if (args[0] === "fetch") return "";
+      if (args[0] === "merge-base") return "deadbeef";
+      if (args[0] === "diff") return "a.txt\nb.txt";
+      throw new Error(`unexpected git call: ${args.join(" ")}`);
+    };
+    const diff = changedFilesSince({
+      worktreePath: "/irrelevant",
+      base: "develop",
+      git: gitStub,
+    });
+    expect(diff.ok).toBe(true);
+    expect(diff.files).toEqual(["a.txt", "b.txt"]);
+    expect(diff.base_ref_stale).toBeUndefined();
+    // The fetch must precede the merge-base computation it is meant to keep
+    // honest — not race it, not follow it.
+    expect(calls[0]).toEqual(["fetch", "--quiet", "origin", "develop"]);
+    expect(calls[1][0]).toBe("merge-base");
+  });
+
+  test("changedFilesSince proceeds on the local ref and flags base_ref_stale when the fetch fails (WM-718 F4)", () => {
+    const calls = [];
+    const gitStub = (args) => {
+      calls.push(args);
+      if (args[0] === "fetch") throw new Error("network unreachable");
+      if (args[0] === "merge-base") return "deadbeef";
+      if (args[0] === "diff") return "a.txt";
+      throw new Error(`unexpected git call: ${args.join(" ")}`);
+    };
+    const diff = changedFilesSince({
+      worktreePath: "/irrelevant",
+      base: "develop",
+      git: gitStub,
+    });
+    expect(diff.ok).toBe(true);
+    expect(diff.base_ref_stale).toBe(true);
+    // Still computed against the local origin/develop ref — a fetch failure
+    // degrades, it never blocks the gate.
+    expect(diff.baseRef).toBe("origin/develop");
+    expect(calls[0][0]).toBe("fetch");
+    expect(calls[1]).toEqual(["merge-base", "origin/develop", "HEAD"]);
+  });
+
   test("policyOwnedPathsConformance defaults to advisory and only 'strict' tightens", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-policy-"));
     expect(policyOwnedPathsConformance(root)).toBe("advisory");
@@ -1029,6 +1075,7 @@ describe("handoff verification helpers (WM-718)", () => {
       ownedPathsKnown: true,
       ownedPathsConformance: "advisory",
       ownedPathsDeviations: ["docs/b.md"],
+      descriptionHash: "sha256:deadbeef",
       agentReported: { command: "bun test", passed: true, output: "all green" },
     });
     const lines = body.split("\n");
@@ -1046,6 +1093,11 @@ describe("handoff verification helpers (WM-718)", () => {
       "- Owned Paths deviations (advisory): 1 file(s) outside the ticket's Owned Paths",
     );
     expect(body).toContain("  - `docs/b.md`");
+    // WM-718 F5: descriptionHash is otherwise dead — this is the one place
+    // it is read, so a reader can tell if the ticket was amended after claim.
+    expect(body).toContain(
+      "- ticket description hash at claim: `sha256:deadbeef`",
+    );
     expect(body).toContain("- agent-reported: `bun test` — pass, all green");
     expect(lines.filter((l) => l.startsWith("- Verification:"))).toHaveLength(
       1,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -4,9 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { hashJson, sha256Hex } from "./canonical.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
+import { execFileSync } from "node:child_process";
 import {
   ContractViolation,
+  changedFilesSince,
+  composeHandoffVerification,
   normalizeFailureOutput,
+  outputTail,
+  ownedPathsDeviations,
+  policyOwnedPathsConformance,
   verifyResult,
 } from "./verify.mjs";
 
@@ -713,6 +719,10 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
+  // WM-718: a post-agent repo verify failure at handoff is the handoff gate
+  // refusing (`handoff_verification_failed`), no longer a generic
+  // `contract_violation` — same FAILED path, but named so the ticket goes back
+  // to Todo + ai:agent-ready and the PR is held as draft.
   test("shared baseline output plus a new failure does not classify as baseline_red", () => {
     const dir = worktreeWorkspace(
       "printf 'entry chunk exceeds budget\\nnew failure in CI\\n' >&2; exit 9",
@@ -733,11 +743,12 @@ describe("worktree baseline verification (WM-334)", () => {
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("contract_violation");
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+      expect(err.handoff.repoVerify.exitCode).toBe(9);
     }
   });
 
-  test("an unrelated post-agent failure remains an ordinary contract violation", () => {
+  test("an unrelated post-agent failure refuses the handoff (not baseline_red)", () => {
     const dir = worktreeWorkspace(
       "printf 'new test regression\\nerror: script \"build\" exited with code 1\\n' >&2; exit 9",
       {
@@ -758,7 +769,8 @@ describe("worktree baseline verification (WM-334)", () => {
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("contract_violation");
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+      expect(err.violations[0]).toStartWith("repo_verify_failed:");
     }
   });
 
@@ -920,5 +932,123 @@ describe("evidence retention (OPS-206)", () => {
     } catch (err) {
       expect(err.violations[0]).toStartWith("evidence_too_large:");
     }
+  });
+});
+
+describe("handoff verification helpers (WM-718)", () => {
+  test("outputTail keeps the last N non-empty lines, ANSI stripped", () => {
+    const out = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join(
+      "\n\n",
+    );
+    const tail = outputTail(`\u001b[31m${out}\u001b[0m\n`);
+    expect(tail.split("\n")).toHaveLength(40);
+    expect(tail.startsWith("line 11")).toBe(true);
+    expect(tail).not.toContain("\u001b");
+  });
+
+  test("ownedPathsDeviations: files outside every glob; ** or unknown owns everything", () => {
+    const files = ["src/a.mjs", "docs/x.md", "web/src/App.tsx", "Makefile"];
+    expect(ownedPathsDeviations(files, ["src/**", "web/src/*.tsx"])).toEqual([
+      "docs/x.md",
+      "Makefile",
+    ]);
+    expect(ownedPathsDeviations(files, ["**"])).toEqual([]);
+    expect(ownedPathsDeviations(files, [])).toEqual([]);
+    expect(ownedPathsDeviations(null, ["src/**"])).toEqual([]);
+  });
+
+  test("changedFilesSince diffs merge-base(origin/<base>)..HEAD and reports an unusable tree instead of guessing", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-diff-"));
+    const git = (...args) => execFileSync("git", args, { cwd: dir });
+    git("init", "-q", "-b", "develop");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(path.join(dir, "base.txt"), "base\n");
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/develop", "HEAD");
+    git("checkout", "-qb", "feat/x");
+    mkdirSync(path.join(dir, "src"));
+    writeFileSync(path.join(dir, "src", "new.mjs"), "x\n");
+    writeFileSync(path.join(dir, "base.txt"), "changed\n");
+    git("add", "-A");
+    git("commit", "-qm", "work");
+    // Uncommitted noise is not part of the PR and is not counted.
+    writeFileSync(path.join(dir, "scratch.txt"), "wip\n");
+    const diff = changedFilesSince({ worktreePath: dir, base: "develop" });
+    expect(diff.ok).toBe(true);
+    expect(diff.baseRef).toBe("origin/develop");
+    expect(diff.files).toEqual(["base.txt", "src/new.mjs"]);
+
+    const notGit = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-nogit-"));
+    const none = changedFilesSince({ worktreePath: notGit, base: "develop" });
+    expect(none.ok).toBe(false);
+    expect(none.files).toBeNull();
+    expect(
+      changedFilesSince({ worktreePath: dir, base: null }).error,
+    ).toContain("no base branch");
+  });
+
+  test("policyOwnedPathsConformance defaults to advisory and only 'strict' tightens", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-policy-"));
+    expect(policyOwnedPathsConformance(root)).toBe("advisory");
+    mkdirSync(path.join(root, "config"));
+    const file = path.join(root, "config", "policy.yaml");
+    writeFileSync(file, "dispatch:\n  owned_paths_conformance: strict\n");
+    expect(policyOwnedPathsConformance(root)).toBe("strict");
+    writeFileSync(file, "dispatch:\n  owned_paths_conformance: bogus\n");
+    expect(policyOwnedPathsConformance(root)).toBe("advisory");
+    writeFileSync(file, "dispatch: [not: valid\n");
+    expect(policyOwnedPathsConformance(root)).toBe("advisory");
+  });
+
+  test("composeHandoffVerification is built from observation; the agent's claim is only agent-reported", () => {
+    const body = composeHandoffVerification({
+      verification: {
+        source: "ticket",
+        command: "bun test",
+        exitCode: 1,
+        timedOut: false,
+        passed: false,
+        tail: "(fail) x > y\n1 fail",
+      },
+      repoVerify: {
+        source: "repo_verify",
+        command: "bun test event-runtime/lib",
+        exitCode: 0,
+        passed: true,
+        tail: "ok",
+      },
+      webBuild: null,
+      diff: {
+        ok: true,
+        baseRef: "origin/develop",
+        mergeBase: "abcdef1234567890",
+        files: ["a.mjs", "docs/b.md"],
+      },
+      ownedPathsKnown: true,
+      ownedPathsConformance: "advisory",
+      ownedPathsDeviations: ["docs/b.md"],
+      agentReported: { command: "bun test", passed: true, output: "all green" },
+    });
+    const lines = body.split("\n");
+    expect(lines[0]).toBe("## Handoff verification (worker-observed)");
+    expect(lines[1]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
+    expect(body).toContain("(fail) x > y");
+    expect(body).toContain(
+      "- Repo verify: `bun test event-runtime/lib` — exit 0 (pass)",
+    );
+    expect(body).toContain("- Web build: skipped");
+    expect(body).toContain(
+      "- Files: 2 changed vs origin/develop (abcdef123456)",
+    );
+    expect(body).toContain(
+      "- Owned Paths deviations (advisory): 1 file(s) outside the ticket's Owned Paths",
+    );
+    expect(body).toContain("  - `docs/b.md`");
+    expect(body).toContain("- agent-reported: `bun test` — pass, all green");
+    expect(lines.filter((l) => l.startsWith("- Verification:"))).toHaveLength(
+      1,
+    );
   });
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1350,8 +1350,16 @@ function defaultCommentTicket({ ticket, body }) {
  * no-op here. Return it to Todo + ai:agent-ready — the harness caught the
  * agent, the spec is fine — and leave the worker-observed verification as
  * the record of why. Never Blocked.
+ *
+ * `runCli` defaults to the real `runLinearCli` and exists only so tests can
+ * inject a stub that fails the first call without touching Linear.
  */
-function defaultReturnHandoffTicket({ ticket, body, fetchTicket }) {
+export function defaultReturnHandoffTicket({
+  ticket,
+  body,
+  fetchTicket,
+  runCli = runLinearCli,
+}) {
   try {
     const cur =
       typeof fetchTicket === "function"
@@ -1371,18 +1379,46 @@ function defaultReturnHandoffTicket({ ticket, body, fetchTicket }) {
       "--remove",
       "ai:needs-review",
     ];
+    let agentReadyRestored = true;
+    let labelWarning = null;
     try {
-      runLinearCli(args);
+      runCli(args);
     } catch {
-      // `--add ai:agent-ready` re-runs the Owned Paths closure check; a
-      // ticket that dispatched already passed it, but never let a label
-      // policy strand the ticket In Review with a held PR.
-      runLinearCli(
+      // `--add ai:agent-ready` can fail independently of the state move
+      // (e.g. the Owned Paths closure check re-running on `--add`). Retry as
+      // two separate calls — state+unassign+removes first, then the label
+      // add on its own — so a labels-endpoint failure never silently strands
+      // the ticket Todo/unassigned WITHOUT the label that makes it
+      // dispatchable again.
+      runCli(
         args.filter((a, i) => !(a === "--add" || args[i - 1] === "--add")),
       );
+      try {
+        runCli(["labels", ticket, "--add", "ai:agent-ready"]);
+      } catch (err) {
+        agentReadyRestored = false;
+        labelWarning = String(err?.stderr ?? err?.message ?? err)
+          .trim()
+          .split("\n")
+          .pop();
+        // This must never be silent: the ticket is now Todo/unassigned
+        // without the label that makes it dispatchable, and nothing else
+        // will notice.
+        console.error(
+          `[worker] ai:agent-ready NOT restored on ${ticket} after handoff return: ${labelWarning}`,
+        );
+      }
     }
-    if (body) runLinearCli(["comment", ticket, body]);
-    return true;
+    const finalBody = agentReadyRestored
+      ? body
+      : [
+          body,
+          `**ai:agent-ready NOT restored** — the label add failed after the ticket returned to Todo (${labelWarning ?? "unknown error"}). This ticket will not redispatch until the label is added manually.`,
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+    if (finalBody) runCli(["comment", ticket, finalBody]);
+    return { ok: true, agentReadyRestored, warning: labelWarning };
   } catch {
     return false;
   }
@@ -2449,7 +2485,7 @@ export async function executeClaimed(
         HANDOFF_REASON_CODES.has(err.reasonCode)
           ? err.reasonCode
           : "contract_violation";
-      const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
+      let failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
       const handoff = err.handoff ?? null;
       const handoffBody = handoff
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${err.violations.join("; ")}`
@@ -2476,13 +2512,19 @@ export async function executeClaimed(
       if (mayMutateClaimedTicket()) {
         if (HANDOFF_REASON_CODES.has(reasonCode)) {
           try {
-            returnHandoffTicketFn({
+            const returned = returnHandoffTicketFn({
               repo: repoName,
               ticket: ticketId,
               why: failureReason,
               body: `${handoffBody}\n\nClaim released back to Todo + ai:agent-ready.`,
               handoff,
             });
+            // Surface a failed label restore in the journal/returned summary
+            // too — the comment posted on the ticket is not the only place a
+            // human (or the next dispatch pass) looks.
+            if (returned && returned.agentReadyRestored === false) {
+              failureReason = `${failureReason} (ai:agent-ready NOT restored: ${returned.warning ?? "unknown error"})`;
+            }
           } catch {
             /* intentionally ignored */
           }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -44,7 +44,17 @@ import {
 import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
-import { ContractViolation, verifyResult } from "./verify.mjs";
+import {
+  ContractViolation,
+  composeHandoffVerification,
+  HANDOFF_REASON_CODES,
+  verifyResult,
+} from "./verify.mjs";
+import {
+  effectiveOwnedPaths,
+  parseOwnedPaths,
+  parseVerificationCommand,
+} from "../../orchestrator/owned-paths.mjs";
 import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
 import {
   assertSandboxWorkspaceSupported,
@@ -424,7 +434,10 @@ const ENVIRONMENT_FAILURES = new Set([
   "linear_unconfigured",
   "registry_stale",
 ]);
-const AGENT_FAILURES = new Set(["contract_violation"]);
+// The handoff gate (WM-718) catching the agent's own red is an agent error:
+// bounded by maxAttempts like any contract violation, never an environment
+// retry and never fatal — the ticket is already back in Todo + agent-ready.
+const AGENT_FAILURES = new Set(["contract_violation", ...HANDOFF_REASON_CODES]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
   "sandbox_unsupported",
@@ -1294,6 +1307,112 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
   }
 }
 
+function defaultFetchTicket(ticket) {
+  return JSON.parse(runLinearCli(["get", ticket, "--json"]));
+}
+
+/**
+ * The claim-time facts the handoff gate (WM-718) needs and the run spec does
+ * not carry: the ticket's Verification Command and Owned Paths. Read once
+ * here, persisted on the worktree record, so verify.mjs runs exactly what the
+ * agent was told to run. A read failure degrades to "no ticket command" (the
+ * repo `verify:` still gates) rather than killing a run before it started.
+ */
+function ticketHandoffContext(ticket, fetchTicket) {
+  try {
+    const cur = fetchTicket(ticket);
+    const description = cur?.description ?? "";
+    const parsed = parseOwnedPaths(description);
+    return {
+      verificationCommand: parseVerificationCommand(description),
+      ownedPaths: effectiveOwnedPaths(description),
+      ownedPathsParsed: parsed.length > 0,
+      descriptionHash: hashJson(description),
+    };
+  } catch (err) {
+    return {
+      verificationCommand: null,
+      ownedPaths: ["**"],
+      ownedPathsParsed: false,
+      unavailable: String(err?.message ?? err),
+    };
+  }
+}
+
+function defaultCommentTicket({ ticket, body }) {
+  runLinearCli(["comment", ticket, body]);
+  return true;
+}
+
+/**
+ * The handoff gate refused (WM-718): the agent already moved the ticket to
+ * In Review, so the ordinary un-claim (which only acts on In Progress) is a
+ * no-op here. Return it to Todo + ai:agent-ready — the harness caught the
+ * agent, the spec is fine — and leave the worker-observed verification as
+ * the record of why. Never Blocked.
+ */
+function defaultReturnHandoffTicket({ ticket, body, fetchTicket }) {
+  try {
+    const cur =
+      typeof fetchTicket === "function"
+        ? fetchTicket(ticket)
+        : defaultFetchTicket(ticket);
+    const state = cur?.state?.name;
+    if (!cur || !["In Progress", "In Review"].includes(state)) return false;
+    const args = [
+      "state",
+      ticket,
+      "Todo",
+      "--unassign",
+      "--add",
+      "ai:agent-ready",
+      "--remove",
+      "ai:in-progress",
+      "--remove",
+      "ai:needs-review",
+    ];
+    try {
+      runLinearCli(args);
+    } catch {
+      // `--add ai:agent-ready` re-runs the Owned Paths closure check; a
+      // ticket that dispatched already passed it, but never let a label
+      // policy strand the ticket In Review with a held PR.
+      runLinearCli(
+        args.filter((a, i) => !(a === "--add" || args[i - 1] === "--add")),
+      );
+    }
+    if (body) runLinearCli(["comment", ticket, body]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Convert an already-opened PR to draft and say why, so nobody merges a red handoff. */
+function defaultHoldPullRequest({ github, prNumber, body }) {
+  if (!github || !Number.isInteger(prNumber)) return false;
+  const gh = (args) =>
+    execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: workerSubprocessTimeoutMs(),
+    });
+  let held = false;
+  try {
+    gh(["pr", "ready", "--undo", String(prNumber), "--repo", github]);
+    held = true;
+  } catch {
+    /* already a draft, or gh unavailable — the comment still lands */
+  }
+  try {
+    gh(["pr", "comment", String(prNumber), "--repo", github, "--body", body]);
+    held = true;
+  } catch {
+    /* intentionally ignored */
+  }
+  return held;
+}
+
 const BASELINE_COMMENT_MARKER = "wm:baseline:red:";
 
 function baselineFailureSignature({ why, log = null, baseline = null }) {
@@ -1463,6 +1582,11 @@ export async function executeClaimed(
       countLeases: () => 0,
       claimTicket: () => ({ ok: true }),
       unclaimTicket: () => true,
+      // The stub never reaches Linear or GitHub — including the WM-718
+      // handoff comment, PR hold, and ticket return.
+      commentTicket: () => true,
+      returnHandoffTicket: () => true,
+      holdPullRequest: () => false,
     };
   }
   const linearConfigured =
@@ -1491,6 +1615,18 @@ export async function executeClaimed(
         ...args,
         fetchTicket: dispatchOpts?.fetchTicket,
       }));
+  const fetchTicketFn = dispatchOpts?.fetchTicket ?? defaultFetchTicket;
+  const commentTicketFn = dispatchOpts?.commentTicket ?? defaultCommentTicket;
+  const returnHandoffTicketFn =
+    dispatchOpts?.returnHandoffTicket ??
+    ((args) =>
+      defaultReturnHandoffTicket({
+        ...args,
+        fetchTicket: dispatchOpts?.fetchTicket,
+      }));
+  const holdPullRequestFn =
+    dispatchOpts?.holdPullRequest ?? defaultHoldPullRequest;
+  let handoffContext = null;
 
   const nowFn = typeof now === "function" ? now : () => now ?? Date.now();
 
@@ -1928,6 +2064,7 @@ export async function executeClaimed(
         }
 
         ticketClaimed = true;
+        handoffContext = ticketHandoffContext(ticketId, fetchTicketFn);
         writeWorkerLease({
           repo: repoName,
           ticket: ticketId,
@@ -1969,7 +2106,12 @@ export async function executeClaimed(
     assertSandboxWorkspaceSupported(workspaceDir, def);
     checkoutPath = created.checkout?.path ?? null;
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
-    worktreeRecord = created.worktree ?? null;
+    worktreeRecord = created.worktree
+      ? {
+          ...created.worktree,
+          ...(handoffContext ? { handoff: handoffContext } : {}),
+        }
+      : null;
     db.query(
       `UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`,
     ).run(workspaceDir, runId, attempt);
@@ -2303,12 +2445,48 @@ export async function executeClaimed(
     } catch (err) {
       if (!(err instanceof ContractViolation)) throw err;
       const reasonCode =
-        err.reasonCode === "baseline_red"
-          ? "baseline_red"
+        err.reasonCode === "baseline_red" ||
+        HANDOFF_REASON_CODES.has(err.reasonCode)
+          ? err.reasonCode
           : "contract_violation";
       const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
+      const handoff = err.handoff ?? null;
+      const handoffBody = handoff
+        ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${err.violations.join("; ")}`
+        : null;
+      // WM-718: the PR is the agent's, already opened; the structural hold is
+      // to draft it and quote the observed failure where the reviewer looks.
+      if (
+        HANDOFF_REASON_CODES.has(reasonCode) &&
+        handoff?.prNumber &&
+        mayMutateClaimedTicket()
+      ) {
+        try {
+          holdPullRequestFn({
+            repo: repoName,
+            github: handoff.github,
+            prNumber: handoff.prNumber,
+            prUrl: handoff.prUrl,
+            body: `${handoffBody}\n\nConverted to draft by the factory worker: the handoff did not verify.`,
+          });
+        } catch {
+          /* intentionally ignored */
+        }
+      }
       if (mayMutateClaimedTicket()) {
-        if (reasonCode === "baseline_red") {
+        if (HANDOFF_REASON_CODES.has(reasonCode)) {
+          try {
+            returnHandoffTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              why: failureReason,
+              body: `${handoffBody}\n\nClaim released back to Todo + ai:agent-ready.`,
+              handoff,
+            });
+          } catch {
+            /* intentionally ignored */
+          }
+        } else if (reasonCode === "baseline_red") {
           try {
             blockTicketFn({
               repo: repoName,
@@ -2385,7 +2563,14 @@ export async function executeClaimed(
       });
       cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "FAILED", reasonCode };
+      return {
+        runId,
+        attempt,
+        terminalState: "FAILED",
+        reasonCode,
+        detail: failureReason,
+        ...(handoff ? { handoff } : {}),
+      };
     }
 
     if (verified.kind === "refused") {
@@ -2504,6 +2689,23 @@ export async function executeClaimed(
       };
     }
 
+    // WM-718: the Handoff's Verification line is worker-authored. Post what
+    // was observed on the ticket; the agent's claim rides below it labelled
+    // agent-reported. Best effort — a comment failure never fails a verified
+    // run.
+    if (verified.handoff && mayMutateClaimedTicket()) {
+      try {
+        commentTicketFn({
+          repo: repoName,
+          ticket: ticketId,
+          body: composeHandoffVerification(verified.handoff),
+          handoff: verified.handoff,
+        });
+      } catch {
+        /* intentionally ignored */
+      }
+    }
+
     // Copy verified artifact files into the durable content-addressed store
     // (§7) BEFORE the workspace dies and before the row referencing them
     // commits. Orphans from a failed commit are harmless; dead links are not.
@@ -2609,6 +2811,7 @@ export async function executeClaimed(
       terminalState: "COMPLETED",
       reasonCode: "ok",
       receipt: published.receipt,
+      ...(verified.handoff ? { handoff: verified.handoff } : {}),
     };
   } catch (err) {
     if (mayMutateClaimedTicket()) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3826,7 +3826,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     expect(result.verification.checks).toContain("repo_verify_passed");
   });
 
-  test("failing repo verify command triggers contract_violation failure", async () => {
+  // WM-718: at handoff (PR_OPEN) a red repo verify is the handoff gate
+  // refusing — named `handoff_verification_failed` so the ticket returns to
+  // Todo + ai:agent-ready and the PR is held; still FAILED, still no result row.
+  test("failing repo verify command at handoff fails handoff_verification_failed", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-fverify-locks-"));
     const leaseDir = mkdtempSync(
@@ -3856,7 +3859,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     );
 
     expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("contract_violation");
+    expect(summary.reasonCode).toBe("handoff_verification_failed");
+    expect(summary.detail).toContain("repo_verify_failed");
+    expect(summary.handoff.repoVerify.exitCode).toBe(42);
   });
 
   test("a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red", async () => {
@@ -4855,5 +4860,487 @@ describe("reload watcher (WM-213)", () => {
 
   test("CODE_RELOAD_EXIT is a code no ordinary worker exit uses", () => {
     expect(CODE_RELOAD_EXIT).toBe(75);
+  });
+});
+
+describe("handoff verification gate (WM-718)", () => {
+  let factoryRoot;
+  let repoDir;
+  let wtRoot;
+  let previousReposRoot;
+
+  const OWNED = "## Owned Paths\n- src/feature/**\n- event-runtime/web/**\n\n";
+  const withCommand = (cmd) =>
+    `${OWNED}## Verification Command\n\n\`\`\`\n${cmd}\n\`\`\`\n`;
+
+  beforeAll(() => {
+    factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-factory-"));
+    repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-repo-"));
+    wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-trees-"));
+    mkdirSync(path.join(repoDir, "bin"), { recursive: true });
+    // A real git worktree with an `origin/develop` ref, so the gate can diff
+    // merge-base..HEAD exactly as it does for a repo-owned worktree_up.
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up.sh"),
+      [
+        "#!/bin/bash",
+        "set -e",
+        `WT="${wtRoot}/$1"`,
+        'mkdir -p "$WT" && cd "$WT"',
+        "git init -q -b develop",
+        "git config user.email factory@test && git config user.name factory",
+        "mkdir -p src/feature event-runtime/web/src",
+        "echo base > src/feature/base.txt",
+        `printf '%s\\n' '{"name":"web","private":true,"scripts":{"build":"echo web_built:$PWD >> ${repoDir}/web-builds.log"}}' > event-runtime/web/package.json`,
+        "echo 'export const x = 1;' > event-runtime/web/src/index.ts",
+        "git add -A && git commit -qm base",
+        "git update-ref refs/remotes/origin/develop HEAD",
+        'git checkout -qb "feat/$1"',
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-down.sh"),
+      `#!/bin/bash\nrm -rf "${wtRoot}/$1"\n`,
+    );
+    mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+    writeFileSync(path.join(factoryRoot, "config", "policy.yaml"), "{}\n");
+    writeFileSync(
+      path.join(factoryRoot, "config", "repos.yaml"),
+      `repos:\n` +
+        `  - name: wt-handoff\n    path: ${repoDir}\n    github: watt-mind/wt-handoff\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo repo_verified\n    escalate_paths: []\n` +
+        `  - name: wt-handoff-noverify\n    path: ${repoDir}\n    github: watt-mind/wt-handoff-noverify\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    escalate_paths: []\n`,
+    );
+    previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = factoryRoot;
+  });
+
+  afterAll(() => {
+    if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  });
+
+  const setPolicy = (yaml) =>
+    writeFileSync(path.join(factoryRoot, "config", "policy.yaml"), yaml);
+
+  function handoffSpec({ repo = "wt-handoff", ticket }) {
+    const runId = `run_handoff_${++seq}_${Math.random().toString(36).slice(2)}`;
+    const input = { repo, ticket };
+    return {
+      schemaVersion: "factory.run-spec/v1",
+      runId,
+      agent: "dispatch@1",
+      input,
+      inputHash: hashJson(input),
+      workspace: {
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      },
+      adapter: "fake",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.dispatch-result/v1",
+      capabilities: ["linear:write", "repo:write", "github:write"],
+      timeoutSeconds: 5,
+      maxAttempts: 1,
+      idempotencyKey: `idem-${runId}`,
+    };
+  }
+
+  /** A fake dispatch agent: writes files, commits, claims whatever it likes. */
+  function agent({ files = {}, claim = {}, prNumber = 77 }) {
+    return {
+      async execute({ spec, workspaceDir }) {
+        writeFileSync(
+          path.join(workspaceDir, ".transcript.json"),
+          `{"fake":"handoff transcript"}\n`,
+        );
+        const repo = path.join(workspaceDir, "repo");
+        for (const [rel, content] of Object.entries(files)) {
+          mkdirSync(path.dirname(path.join(repo, rel)), { recursive: true });
+          writeFileSync(path.join(repo, rel), content);
+        }
+        execFileSync("git", ["add", "-A"], { cwd: repo });
+        execFileSync(
+          "git",
+          ["commit", "-qm", `implement ${spec.input.ticket}`],
+          {
+            cwd: repo,
+          },
+        );
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          `${JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "PR_OPEN",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/${prNumber}`,
+              prNumber,
+              verification: {
+                command: "bash run-tests.sh",
+                passed: true,
+                output: "all green",
+                ...claim,
+              },
+              summary: `implemented ${spec.input.ticket}`,
+              uxCritique: {
+                status: "skipped",
+                verdict: null,
+                evidence: [],
+                rounds: 0,
+                prReady: true,
+              },
+            },
+            evidence: { commands: ["bash run-tests.sh"] },
+          })}\n`,
+        );
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+  }
+
+  async function dispatch({ spec, adapter, description, hooks = {} }) {
+    const db = openDb(":memory:");
+    queueRun(db, spec);
+    const calls = { unclaim: [], returned: [], held: [], comments: [] };
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: adapter },
+      opts({
+        dispatch: {
+          locksDir: mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-locks-")),
+          leasesDir: mkdtempSync(
+            path.join(os.tmpdir(), "evrt-handoff-leases-"),
+          ),
+          fetchTicket: () => ({
+            identifier: spec.input.ticket,
+            state: { name: "Todo" },
+            assignee: null,
+            labels: { nodes: [{ name: "ai:agent-ready" }] },
+            description,
+          }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+          unclaimTicket: (p) => (calls.unclaim.push(p), false),
+          returnHandoffTicket: (p) => (calls.returned.push(p), true),
+          holdPullRequest: (p) => (calls.held.push(p), true),
+          commentTicket: (p) => (calls.comments.push(p), true),
+          ...hooks,
+        },
+      }),
+    );
+    return { db, summary, calls };
+  }
+
+  test("a fake agent that leaves a failing test is refused handoff_verification_failed: no result row, ticket back to Todo + agent-ready, PR held, tail in the receipt", async () => {
+    const spec = handoffSpec({ ticket: "WM-7181" });
+    const { db, summary, calls } = await dispatch({
+      spec,
+      description: withCommand("bash run-tests.sh"),
+      adapter: agent({
+        files: {
+          "src/feature/impl.txt": "done\n",
+          "run-tests.sh":
+            'echo "suite start"\necho "(fail) totals > rejects an invalid total"\necho "1 fail" >&2\nexit 1\n',
+        },
+      }),
+    });
+
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("handoff_verification_failed");
+    expect(summary.detail).toContain("ticket_verify_failed");
+    expect(summary.handoff.verification.command).toBe("bash run-tests.sh");
+    expect(summary.handoff.verification.exitCode).toBe(1);
+    expect(summary.handoff.verification.tail).toContain(
+      "(fail) totals > rejects an invalid total",
+    );
+    // The repo verify passed; the ticket's own command is what caught it.
+    expect(summary.handoff.repoVerify.passed).toBe(true);
+
+    // No PR_OPEN result was published — nothing downstream chains a review.
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
+        .get(spec.runId).n,
+    ).toBe(0);
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("handoff_verification_failed");
+    const journal = lifecycleOf(db, spec.runId)
+      .map((row) => row.reason)
+      .join("\n");
+    expect(journal).toContain("(fail) totals > rejects an invalid total");
+    expect(classifyFailureCause("handoff_verification_failed")).toBe(
+      "agent_error",
+    );
+
+    // Ticket returned (Todo + agent-ready), never Blocked, never the plain unclaim.
+    expect(calls.returned).toHaveLength(1);
+    expect(calls.returned[0].ticket).toBe("WM-7181");
+    expect(calls.returned[0].body).toContain(
+      "## Handoff verification (worker-observed)",
+    );
+    expect(calls.returned[0].body).toContain(
+      "(fail) totals > rejects an invalid total",
+    );
+    expect(calls.returned[0].body).toContain("Todo + ai:agent-ready");
+    expect(calls.unclaim).toHaveLength(0);
+    // The agent's PR is converted to draft with the observed failure quoted.
+    expect(calls.held).toHaveLength(1);
+    expect(calls.held[0]).toMatchObject({
+      prNumber: 77,
+      github: "watt-mind/wt-handoff",
+    });
+    expect(calls.held[0].body).toContain("exit 1 (FAIL)");
+    expect(calls.comments).toHaveLength(0);
+  });
+
+  test("no Verification Command and no repo verify: refused handoff_verification_unspecified (fail-closed)", async () => {
+    const spec = handoffSpec({
+      repo: "wt-handoff-noverify",
+      ticket: "WM-7182",
+    });
+    const { summary, calls } = await dispatch({
+      spec,
+      description: OWNED,
+      adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
+    });
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("handoff_verification_unspecified");
+    expect(calls.returned).toHaveLength(1);
+    expect(calls.held).toHaveLength(1);
+    expect(calls.returned[0].body).toContain("Verification: NONE");
+  });
+
+  test("without a Verification Command the repo verify stands in and the run completes with a worker-observed line", async () => {
+    const spec = handoffSpec({ ticket: "WM-7183" });
+    const { db, summary, calls } = await dispatch({
+      spec,
+      description: OWNED,
+      adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
+    });
+    expect(summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(spec.runId).result_json,
+    );
+    expect(result.verification.checks).toContain("repo_verify_passed");
+    expect(result.verification.checks).not.toContain("ticket_verify_passed");
+    expect(calls.comments).toHaveLength(1);
+    expect(calls.comments[0].body).toContain(
+      "- Verification: `echo repo_verified` — exit 0 (pass)",
+    );
+    expect(calls.comments[0].body).toContain("repo `verify:` command stood in");
+  });
+
+  test("a change under event-runtime/web/src/** runs the web build and a red build refuses the handoff", async () => {
+    const description = withCommand("bash run-tests.sh");
+    const files = {
+      "run-tests.sh": "echo ok\n",
+      "event-runtime/web/src/index.ts": "export const x: number = 2;\n",
+    };
+    // Green build: gate runs it (marker written) and records the check.
+    const green = handoffSpec({ ticket: "WM-7184" });
+    const g = await dispatch({
+      spec: green,
+      description,
+      adapter: agent({ files }),
+    });
+    expect(g.summary.terminalState).toBe("COMPLETED");
+    const builds = () =>
+      existsSync(path.join(repoDir, "web-builds.log"))
+        ? readFileSync(path.join(repoDir, "web-builds.log"), "utf8")
+        : "";
+    expect(builds()).toContain(
+      "web_built:" + path.join(wtRoot, "WM-7184", "event-runtime/web"),
+    );
+    const result = JSON.parse(
+      g.db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(green.runId).result_json,
+    );
+    expect(result.verification.checks).toEqual(
+      expect.arrayContaining(["ticket_verify_passed", "web_build_passed"]),
+    );
+    expect(g.calls.comments[0].body).toContain(
+      "- Web build (event-runtime/web/src/** changed): `cd event-runtime/web && bun run build` — exit 0 (pass)",
+    );
+
+    // Red build (tsc-style error) even though the ticket's command is green.
+    const red = handoffSpec({ ticket: "WM-7185" });
+    const r = await dispatch({
+      spec: red,
+      description,
+      adapter: agent({
+        files: {
+          ...files,
+          "event-runtime/web/package.json":
+            '{"name":"web","private":true,"scripts":{"build":"echo \'src/index.ts(1,14): error TS6133: unused local\' >&2; exit 2"}}\n',
+        },
+      }),
+    });
+    expect(r.summary.terminalState).toBe("FAILED");
+    expect(r.summary.reasonCode).toBe("handoff_verification_failed");
+    expect(r.summary.detail).toContain("web_build_failed");
+    expect(r.summary.detail).toContain("error TS6133");
+    expect(r.summary.handoff.webBuild.exitCode).toBe(2);
+    expect(r.calls.held).toHaveLength(1);
+    expect(r.calls.returned).toHaveLength(1);
+
+    // No web/src change: the build is not run at all.
+    const skip = handoffSpec({ ticket: "WM-7186" });
+    const s = await dispatch({
+      spec: skip,
+      description,
+      adapter: agent({
+        files: { "run-tests.sh": "echo ok\n", "src/feature/x.txt": "x\n" },
+      }),
+    });
+    expect(s.summary.terminalState).toBe("COMPLETED");
+    expect(builds()).not.toContain("WM-7186");
+    expect(s.calls.comments[0].body).toContain("- Web build: skipped");
+  });
+
+  test("the Handoff Verification line is worker-authored: the agent's 'pass' claim cannot override an observed red, and rides below labelled agent-reported", async () => {
+    const description = withCommand("bash run-tests.sh");
+    const failing = handoffSpec({ ticket: "WM-7187" });
+    const f = await dispatch({
+      spec: failing,
+      description,
+      adapter: agent({
+        files: { "run-tests.sh": 'echo "regression in totals"; exit 3\n' },
+        claim: {
+          command: "bash run-tests.sh",
+          passed: true,
+          output: "pass, 2045 tests green",
+        },
+      }),
+    });
+    expect(f.summary.terminalState).toBe("FAILED");
+    const body = f.calls.returned[0].body;
+    const verificationLine = body
+      .split("\n")
+      .find((l) => l.startsWith("- Verification:"));
+    expect(verificationLine).toBe(
+      "- Verification: `bash run-tests.sh` — exit 3 (FAIL)",
+    );
+    expect(body).toContain("regression in totals");
+    expect(body).toContain(
+      "- agent-reported: `bash run-tests.sh` — pass, pass, 2045 tests green",
+    );
+    expect(body).not.toContain("- Verification: `bash run-tests.sh` — pass");
+
+    // Green run: the line still comes from the worker's observation, and a
+    // claim naming a different command is quoted only as agent-reported.
+    const passing = handoffSpec({ ticket: "WM-7188" });
+    const p = await dispatch({
+      spec: passing,
+      description,
+      adapter: agent({
+        files: { "run-tests.sh": 'echo "42 tests, 0 failures"\n' },
+        claim: {
+          command: "bun test --only-my-file",
+          passed: true,
+          output: "green",
+        },
+      }),
+    });
+    expect(p.summary.terminalState).toBe("COMPLETED");
+    const okBody = p.calls.comments[0].body;
+    expect(
+      okBody.split("\n").find((l) => l.startsWith("- Verification:")),
+    ).toBe("- Verification: `bash run-tests.sh` — exit 0 (pass)");
+    expect(okBody).toContain("42 tests, 0 failures");
+    expect(okBody).toContain(
+      "- agent-reported: `bun test --only-my-file` — pass, green",
+    );
+  });
+
+  test("Owned Paths deviations are computed from the diff: listed under advisory (default), refused under strict", async () => {
+    const description = withCommand("bash run-tests.sh");
+    const files = {
+      "run-tests.sh": "echo ok\n",
+      "src/feature/impl.txt": "done\n",
+      "docs/stray.md": "out of scope reflow\n",
+      "orchestrator/tick.mjs": "// out of scope\n",
+    };
+    setPolicy("{}\n"); // key absent → advisory
+    const adv = handoffSpec({ ticket: "WM-7189" });
+    const a = await dispatch({
+      spec: adv,
+      description,
+      adapter: agent({ files }),
+    });
+    expect(a.summary.terminalState).toBe("COMPLETED");
+    expect(a.summary.handoff.ownedPathsDeviations).toEqual([
+      "docs/stray.md",
+      "orchestrator/tick.mjs",
+      "run-tests.sh",
+    ]);
+    const result = JSON.parse(
+      a.db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(adv.runId).result_json,
+    );
+    expect(result.verification.checks).toContain(
+      "owned_paths_deviations_advisory",
+    );
+    const body = a.calls.comments[0].body;
+    expect(body).toContain("- Files: 4 changed vs origin/develop");
+    expect(body).toContain("- Owned Paths deviations (advisory): 3 file(s)");
+    expect(body).toContain("  - `docs/stray.md`");
+    expect(body).toContain("  - `orchestrator/tick.mjs`");
+    expect(body).toContain("  - `run-tests.sh`");
+    expect(body).not.toContain("  - `src/feature/impl.txt`");
+
+    setPolicy("dispatch:\n  owned_paths_conformance: strict\n");
+    try {
+      const strict = handoffSpec({ ticket: "WM-7190" });
+      const s = await dispatch({
+        spec: strict,
+        description,
+        adapter: agent({ files }),
+      });
+      expect(s.summary.terminalState).toBe("FAILED");
+      expect(s.summary.reasonCode).toBe("handoff_owned_paths_violation");
+      expect(s.summary.detail).toContain("docs/stray.md");
+      expect(s.calls.returned).toHaveLength(1);
+      expect(s.calls.held).toHaveLength(1);
+      expect(s.calls.returned[0].body).toContain(
+        "Owned Paths deviations (strict): 3 file(s)",
+      );
+    } finally {
+      setPolicy("{}\n");
+    }
+
+    // Conformant diff: no deviations, the check is recorded.
+    const clean = handoffSpec({ ticket: "WM-7191" });
+    const c = await dispatch({
+      spec: clean,
+      description: `## Owned Paths\n- src/feature/**\n- run-tests.sh\n\n## Verification Command\n\n\`\`\`\nbash run-tests.sh\n\`\`\`\n`,
+      adapter: agent({
+        files: { "run-tests.sh": "echo ok\n", "src/feature/y.txt": "y\n" },
+      }),
+    });
+    expect(c.summary.terminalState).toBe("COMPLETED");
+    expect(c.calls.comments[0].body).toContain(
+      "- Owned Paths deviations: none",
+    );
   });
 });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -5169,7 +5170,8 @@ describe("handoff verification gate (WM-718)", () => {
         ? readFileSync(path.join(repoDir, "web-builds.log"), "utf8")
         : "";
     expect(builds()).toContain(
-      "web_built:" + path.join(wtRoot, "WM-7184", "event-runtime/web"),
+      "web_built:" +
+        path.join(realpathSync(wtRoot), "WM-7184", "event-runtime/web"),
     );
     const result = JSON.parse(
       g.db

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -48,6 +48,7 @@ import {
   createReloadWatcher,
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultLocksDir,
+  defaultReturnHandoffTicket,
   dispatchLockPath,
   DYNAMIC_DEADLINE_ADAPTERS,
   executeClaimed,
@@ -5342,5 +5343,119 @@ describe("handoff verification gate (WM-718)", () => {
     expect(c.calls.comments[0].body).toContain(
       "- Owned Paths deviations: none",
     );
+  });
+});
+
+// The describe block above only exercises the handoff gate through mocked
+// hooks (claimTicket/returnHandoffTicket/etc all stubbed by `dispatch()`).
+// `defaultReturnHandoffTicket` is the one production path none of that
+// touches, and it has a real bug shape: the combined
+// state+unassign+removes+add-label Linear call can fail on the label half
+// alone (WM-718 F2). These tests drive the real function with a `runCli`
+// stub that fails on cue, never mocking the function itself.
+describe("defaultReturnHandoffTicket (WM-718 F2)", () => {
+  const COMBINED_ARGS = [
+    "state",
+    "WM-9001",
+    "Todo",
+    "--unassign",
+    "--add",
+    "ai:agent-ready",
+    "--remove",
+    "ai:in-progress",
+    "--remove",
+    "ai:needs-review",
+  ];
+  const BASE_ARGS = [
+    "state",
+    "WM-9001",
+    "Todo",
+    "--unassign",
+    "--remove",
+    "ai:in-progress",
+    "--remove",
+    "ai:needs-review",
+  ];
+
+  test("retries as two separate calls and restores ai:agent-ready when the combined call fails", () => {
+    const calls = [];
+    const runCli = (args) => {
+      calls.push(args);
+      if (calls.length === 1) throw new Error("linear: rate limited");
+      return "";
+    };
+    const result = defaultReturnHandoffTicket({
+      ticket: "WM-9001",
+      body: "handoff refused",
+      fetchTicket: () => ({ state: { name: "In Review" } }),
+      runCli,
+    });
+    expect(result).toEqual({
+      ok: true,
+      agentReadyRestored: true,
+      warning: null,
+    });
+    // The first (failed) combined attempt, then the state move split from
+    // the label add, then the comment — never a silent drop of the label.
+    expect(calls).toEqual([
+      COMBINED_ARGS,
+      BASE_ARGS,
+      ["labels", "WM-9001", "--add", "ai:agent-ready"],
+      ["comment", "WM-9001", "handoff refused"],
+    ]);
+  });
+
+  test("surfaces the failure loudly when the label restore also fails", () => {
+    const calls = [];
+    const runCli = (args) => {
+      calls.push([...args]);
+      if (args[0] === "state" && args.includes("--add")) {
+        throw new Error("combined call failed");
+      }
+      if (args[0] === "labels") {
+        throw new Error("labels endpoint down");
+      }
+      return "";
+    };
+    const loud = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => loud.push(args.join(" "));
+    let result;
+    try {
+      result = defaultReturnHandoffTicket({
+        ticket: "WM-9001",
+        body: "handoff refused",
+        fetchTicket: () => ({ state: { name: "In Progress" } }),
+        runCli,
+      });
+    } finally {
+      console.error = originalConsoleError;
+    }
+    // Never silent: the run's own return value says so...
+    expect(result.ok).toBe(true);
+    expect(result.agentReadyRestored).toBe(false);
+    expect(result.warning).toContain("labels endpoint down");
+    // ...the worker's own log says so...
+    expect(
+      loud.some((line) => line.includes("ai:agent-ready NOT restored")),
+    ).toBe(true);
+    // ...and the ticket itself still moved to Todo (unassigned, un-labeled)
+    // rather than being stranded In Progress/In Review.
+    expect(calls).toContainEqual(BASE_ARGS);
+    const commentCall = calls.find((c) => c[0] === "comment");
+    expect(commentCall).toBeDefined();
+    expect(commentCall[2]).toContain("ai:agent-ready NOT restored");
+  });
+
+  test("is a no-op when the ticket already left In Progress/In Review", () => {
+    const calls = [];
+    const result = defaultReturnHandoffTicket({
+      ticket: "WM-9001",
+      body: "handoff refused",
+      fetchTicket: () => ({ state: { name: "Done" } }),
+      runCli: (args) => (calls.push(args), ""),
+    });
+    expect(result).toBe(false);
+    expect(calls).toHaveLength(0);
   });
 });

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -344,6 +344,10 @@ function materializeWorktree({
     repoPath: repo.path,
     down: repo.worktreeDown,
     verify: repo.verify,
+    // The handoff gate (WM-718) diffs the final tree against the repo's base
+    // branch and addresses the opened PR by its GitHub slug.
+    base: repo.base ?? null,
+    github: repo.github ?? null,
   };
   // Persist teardown facts before bring-up starts. A script can create its
   // worktree and daemons before timing out; the marker lets the janitor find

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -308,6 +308,10 @@ describe("worktree workspaces (WM-108)", () => {
       repoPath: repoDir,
       down: "bin/worktree-down.sh",
       verify: "echo verified",
+      // WM-718: the handoff gate diffs against `base` and holds the PR by
+      // its GitHub slug (null when repos.yaml declares none).
+      base: "develop",
+      github: null,
     });
     const link = path.join(dir, "repo");
     expect(lstatSync(link).isSymbolicLink()).toBe(true);

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -102,6 +102,80 @@ export function effectiveOwnedPaths(description = "") {
   return own.length ? own : ["**"];
 }
 
+/**
+ * Extract the ticket's Verification Command (WM-718) from a Linear issue
+ * description: the section headed `Verification Command` (or `Verification`,
+ * levels 2-4), read as either a fenced ``` block, a single line wrapped in
+ * backticks, or — failing both — the first bare non-prose line. Multi-line
+ * fenced blocks are joined with ` && ` (comment lines dropped, backslash
+ * continuations rejoined) so "all of these must pass" is what actually runs.
+ * Returns null when the section is missing or holds nothing runnable; the
+ * worker's handoff gate then falls back to the repo's `verify:` command and,
+ * absent both, refuses the handoff (fail-closed).
+ */
+export function parseVerificationCommand(description = "") {
+  const section = String(description ?? "")
+    .split(/^#{2,4}\s+/m)
+    .find((s) => {
+      const heading = s.split("\n")[0];
+      return /^Verification(\s+Command)?\s*:?\s*$/i.test(heading.trim());
+    });
+  if (!section) return null;
+
+  const body = section.split("\n").slice(1);
+  const fenced = [];
+  let inFence = false;
+  let sawFence = false;
+  for (const raw of body) {
+    if (/^\s*```/.test(raw)) {
+      if (inFence) break;
+      inFence = true;
+      sawFence = true;
+      continue;
+    }
+    if (inFence) fenced.push(raw);
+  }
+  if (sawFence) return joinCommandLines(fenced);
+
+  for (const raw of body) {
+    const line = raw.trim();
+    if (!line) continue;
+    const ticked = /^`([^`]+)`\.?$/.exec(line);
+    if (ticked) return normalizeCommandLine(ticked[1]);
+    // A bare line: accept only when it does not read as prose.
+    if (/[.!?]$/.test(line) && !/\)$/.test(line)) return null;
+    return normalizeCommandLine(line) || null;
+  }
+  return null;
+}
+
+function normalizeCommandLine(line) {
+  return String(line ?? "")
+    .trim()
+    .replace(/^\$\s+/, "")
+    .trim();
+}
+
+function joinCommandLines(lines) {
+  const commands = [];
+  let pending = "";
+  for (const raw of lines) {
+    let line = raw.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+    if (!pending && /^\s*#/.test(line)) continue;
+    line = pending ? `${pending} ${line.trim()}` : normalizeCommandLine(line);
+    if (line.endsWith("\\")) {
+      pending = line.slice(0, -1).trimEnd();
+      continue;
+    }
+    pending = "";
+    if (line) commands.push(line);
+  }
+  if (pending) commands.push(pending);
+  if (commands.length === 0) return null;
+  return commands.length === 1 ? commands[0] : commands.join(" && ");
+}
+
 /** Escape regex metacharacters that are not glob syntax. */
 function escapeLiteral(s) {
   return s.replace(/[.+^${}()|[\]\\]/g, "\\$&");

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -15,6 +15,7 @@ import {
   hardPathConflicts,
   pathOverlaps,
   parseOwnedPaths,
+  parseVerificationCommand,
   effectiveOwnedPaths,
   globsOverlap,
   pathsCollide,
@@ -329,4 +330,53 @@ test("hardPathConflicts: ** on either side — nothing else", () => {
   // `**` on either side is hard against anything it reaches.
   expectTrue(hardPathConflicts(["**"], ["docs/a.md"]).length === 1);
   expectTrue(hardPathConflicts(["docs/a.md"], ["**"]).length === 1);
+});
+
+// WM-718: the worker runs the ticket's own Verification Command at handoff, so
+// it has to read the same section every agent has been reading by eye.
+test("parseVerificationCommand: fenced block under '## Verification Command'", () => {
+  expectEqual(
+    parseVerificationCommand(
+      "## Owned Paths\n- src/**\n\n## Verification Command\n\n```\ncd event-runtime/web && bun run build && bun test\n```\n\nPriority: High\n",
+    ),
+    "cd event-runtime/web && bun run build && bun test",
+  );
+});
+
+test("parseVerificationCommand: '## Verification' heading, backticked single line, prose after it ignored", () => {
+  expectEqual(
+    parseVerificationCommand(
+      "## Verification\n\n`bun test orchestrator/repos-config.test.mjs`\nAlso confirm bun 1.3.14 accepts `bun test event-runtime/lib`.\n",
+    ),
+    "bun test orchestrator/repos-config.test.mjs",
+  );
+});
+
+test("parseVerificationCommand: multi-line fenced block joins with && and drops comments/continuations", () => {
+  expectEqual(
+    parseVerificationCommand(
+      "### Verification Command\n```bash\n# unit slice first\n$ bun test event-runtime/lib \\\n    --timeout 20000\nbun build/emit.mjs --check\n```\n",
+    ),
+    "bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check",
+  );
+});
+
+test("parseVerificationCommand: bare command line accepted, prose and missing section rejected", () => {
+  expectEqual(
+    parseVerificationCommand("## Verification Command\nbun test\n"),
+    "bun test",
+  );
+  expectEqual(
+    parseVerificationCommand(
+      "## Verification Command\nRun the usual suite and eyeball the output.\n",
+    ),
+    null,
+  );
+  expectEqual(parseVerificationCommand("## Owned Paths\n- a.mjs\n"), null);
+  expectEqual(parseVerificationCommand("## Verification\n\n```\n```\n"), null);
+  // "Verification Evidence"-style headings are not the command section.
+  expectEqual(
+    parseVerificationCommand("## Verification evidence\n`bun test`\n"),
+    null,
+  );
 });


### PR DESCRIPTION
Fixes WM-718

## What

The dispatch agent's `## Handoff` claimed "Verification: pass" for commands it had not run on the final tree (#578, #593, #558). The end-of-run gate that already existed — `verifyCompleted` in `event-runtime/lib/verify.mjs` running the repo `verify:` — is a deliberate subset of CI (WM-528), so it let those through. This PR **extends that gate** rather than adding a parallel one:

- **AC1** After a `PR_OPEN` result the worker runs the ticket's parsed `## Verification Command` (new `parseVerificationCommand` in `orchestrator/owned-paths.mjs`; fetched at claim time and persisted on the worktree record as `handoff`) in the worktree with the repo-verify timeout. Non-zero → run FAILED `handoff_verification_failed` (agent_error class, no result row, output tail in the journal reason and the returned summary), the agent's already-opened PR is converted to draft with the observed failure quoted (`gh pr ready --undo` + `gh pr comment`), and the ticket returns to **Todo + `ai:agent-ready`** (new `returnHandoffTicket`; the plain unclaim only acts on In Progress, and by PR_OPEN the agent has moved it to In Review). No ticket command → the repo `verify:` stands in; neither → `handoff_verification_unspecified` (fail-closed).
- **AC2** `cd event-runtime/web && bun run build` runs when `merge-base(origin/<base>)..HEAD` touches `event-runtime/web/src/**`, gating the same way (`web_build_failed`).
- **AC3** The worker posts `## Handoff verification (worker-observed)` on the ticket (pass and fail): command, exit code, last 40 lines, web build, file count vs `origin/<base>`, deviations. The agent's `artifact.verification` claim is quoted below it as `agent-reported` and never becomes the Verification line.
- **AC4** Owned Paths deviations computed from the diff; listed under `dispatch.owned_paths_conformance: advisory` (new key, default when absent, set advisory in `config/policy.yaml`); refused `handoff_owned_paths_violation` under `strict`.
- **AC5** `agents/dispatch.md` updated (worker verifies the handoff; run the exact command + full `bun test` on the final tree), `dispatch.json` re-pinned, `docs/event-runtime-worker-protocol.md` §7a added.

Reason-code note: a red repo `verify:` at handoff is now `handoff_verification_failed` too (was `contract_violation`); `baseline_red` is unchanged. Terminal state stays FAILED (the existing gate's shape) rather than REFUSED — same un-claim/no-result semantics, plus the PR hold and Todo+agent-ready return.

## Handoff

- Verification: `bun event-runtime/cli.mjs update-pins && bun test event-runtime/lib/worker.test.mjs event-runtime/lib/verify.test.mjs orchestrator/owned-paths.test.mjs event-runtime/lib/registry.test.mjs && bun build/emit.mjs --check` — pass (204 tests, emit check exit 0).
- Full `bun test --timeout 20000` on the pushed tree: 2510 pass / 9 skip / 0 fail (2519 tests, 177 files, 139 s). No WM-689 flakes hit.
- Tests, each confirmed failing against `origin/develop` before the change (ran the new test files against a scratch checkout): fake agent leaving a failing test → `handoff_verification_failed`, no result row, ticket returned, PR held, tail in receipt (was COMPLETED); no command + no verify → `handoff_verification_unspecified`; web/src change runs the build, red build refuses, no web change skips it; worker-authored Verification line vs agent "pass" claim; deviations listed under advisory, refused under strict; parser tests (`parseVerificationCommand` did not exist).
- Files: 13 changed.
- **Owned Paths deviations** (named per the ticket): `orchestrator/owned-paths.mjs` + `.test.mjs` (the `parseVerificationCommand` parser next to `parseOwnedPaths`), `event-runtime/lib/workspace.mjs` + `.test.mjs` (`base`/`github` on the worktree record so the gate can diff and address the PR), `event-runtime/lib/registry.test.mjs` (digest baseline).
- **Registry digest regenerated** (`registry.test.mjs`): `agents/dispatch.md` is a registry input and was changed to state the worker verifies the handoff; `dispatch.json` re-pinned via `update-pins`. Zero-pack digest and the dispatch@1 defHash constant updated, exactly as WM-610 did — no provenance change (`pack` remains non-enumerable).
- Risks: the handoff gate adds the ticket's command on top of the repo verify (wall time per dispatch grows by that command; WM-528's load-flake concern applies to tickets whose command is the full suite). `event-runtime/web/src/reasons.ts` has no humanized label for the three new reason codes (not in Owned Paths — follow-up). The stubbed dispatch (`FACTORY_DISPATCH_STUB`/fake adapter) stubs the new comment/hold/return hooks so it never reaches Linear/GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz

