### PR TITLE
fix(web): SHA click opens artifact inspector (WM-699)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -163,7 +163,7 @@ describe("Artifacts inventory (WM-207)", () => {
     }
     expect(view.queryByRole("columnheader", { name: "Orphan" })).toBeNull();
     const download = view.getByRole("link", {
-      name: `Download artifact ${"a".repeat(64)}`,
+      name: "Download aaaaaaaaaaaa.report",
     });
     expect(download.getAttribute("href")).toContain(
       `/api/artifacts/${"a".repeat(64)}`,
@@ -179,8 +179,8 @@ describe("Artifacts inventory (WM-207)", () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
-    const downloads = view.getAllByRole("link", { name: /Download artifact/ });
-    expect(downloads.map((link) => link.textContent)).toEqual([
+    const shas = view.getAllByRole("link", { name: /^[0-9a-f]{12}$/ });
+    expect(shas.map((link) => link.textContent)).toEqual([
       "cccccccccccc",
       "bbbbbbbbbbbb",
       "aaaaaaaaaaaa",
@@ -294,6 +294,108 @@ describe("Artifacts inventory (WM-207)", () => {
     );
     fireEvent.click(runLink.getByRole("link", { name: "Open" }));
     expect(window.location.hash).toBe(`#/${`artifacts/${"b".repeat(64)}`}`);
+  });
+});
+
+describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
+  const SHA_A = "a".repeat(64);
+
+  test("the SHA is a deep link into the inspector, not a download", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("line one\nline two", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const sha = view.getByRole("link", { name: "aaaaaaaaaaaa" });
+    expect(sha.getAttribute("href")).toBe(`#/artifacts/${SHA_A}`);
+    expect(sha.hasAttribute("download")).toBe(false);
+
+    fireEvent.click(sha);
+    expect(window.location.hash).toBe(`#/artifacts/${SHA_A}`);
+    expect(
+      await view.findByRole("region", { name: "Artifact content" }),
+    ).toBeTruthy();
+  });
+
+  test("the row download control does not select the row", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const download = view.getByRole("link", {
+      name: "Download aaaaaaaaaaaa.report",
+    });
+    expect(download.getAttribute("download")).toBe("aaaaaaaaaaaa.report");
+    expect(download.getAttribute("href")).toContain(
+      `/api/artifacts/${SHA_A}?name=`,
+    );
+
+    fireEvent.click(download);
+    expect(window.location.hash).not.toContain(SHA_A);
+    expect(
+      view.queryByRole("region", { name: "Artifact metadata" }),
+    ).toBeNull();
+  });
+
+  test("rows take Tab focus and select on Enter and Space", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("line one", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const row = view.getByText("1.0 KB").closest("tr");
+    expect(row?.getAttribute("tabindex")).toBe("0");
+
+    fireEvent.keyDown(row!, { key: "Enter" });
+    expect(window.location.hash).toBe(`#/artifacts/${SHA_A}`);
+    expect(
+      await view.findByRole("region", { name: "Artifact content" }),
+    ).toBeTruthy();
+
+    window.location.hash = "#/artifacts";
+    fireEvent.keyDown(view.getByText("512 B").closest("tr")!, { key: " " });
+    expect(window.location.hash).toBe(`#/artifacts/${"c".repeat(64)}`);
+  });
+
+  test("a modified click leaves the current view for the browser to handle", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    fireEvent.click(view.getByText("1.0 KB").closest("tr")!, {
+      metaKey: true,
+    });
+    expect(window.location.hash).toBe("#/artifacts");
+    expect(
+      view.queryByRole("region", { name: "Artifact metadata" }),
+    ).toBeNull();
+  });
+
+  test("a binary artifact offers metadata and a download instead of a text preview", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("PK\u0003\u0004\u0000\u0000\uFFFD\uFFFD\u0001\u0002", {
+          status: 200,
+        }),
+    ) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+
+    expect(await view.findByText(/cannot be previewed/i)).toBeTruthy();
+    expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
+    expect(
+      view.queryByRole("combobox", { name: "Search artifact content" }),
+    ).toBeNull();
+
+    const prominent = view.getByRole("link", { name: "Download file" });
+    expect(prominent.getAttribute("href")).toContain(
+      `/api/artifacts/${SHA_A}?name=aaaaaaaaaaaa.report`,
+    );
+    expect(prominent.getAttribute("download")).toBe("aaaaaaaaaaaa.report");
+    expect(
+      view.getByRole("region", { name: "Artifact metadata" }).textContent,
+    ).toContain("1.0 KB");
+    expect(view.getByRole("link", { name: "Download" })).toBeTruthy();
   });
 });
 

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -135,9 +135,31 @@ function artifactShaFromHash(hash = window.location.hash): string | null {
   }
 }
 
+function artifactInspectorHash(sha256: string): string {
+  return `#/artifacts/${encodeURIComponent(sha256)}`;
+}
+
 function openArtifactInspector(sha256: string) {
   if (!ARTIFACT_HASH.test(sha256)) return;
-  window.location.hash = `#/artifacts/${encodeURIComponent(sha256)}`;
+  window.location.hash = artifactInspectorHash(sha256);
+}
+
+/** The name a downloaded copy gets: short SHA plus the first kind as extension. */
+function downloadName(sha256: string, kinds: string[]): string {
+  return `${sha256.slice(0, 12)}${kinds[0] ? `.${kinds[0]}` : ""}`;
+}
+
+/**
+ * Bytes the text viewer cannot honestly draw. `Response.text()` decodes as
+ * UTF-8, so a zip or an image comes back as NULs and U+FFFD replacements —
+ * rendering that as numbered lines is noise the operator has to scroll past.
+ */
+function looksBinary(raw: string): boolean {
+  const sample = raw.slice(0, 4096);
+  if (!sample) return false;
+  if (sample.includes("\u0000")) return true;
+  const undecodable = sample.replace(/[^\uFFFD]/g, "").length;
+  return undecodable / sample.length > 0.02;
 }
 
 function containsArtifactHash(
@@ -331,8 +353,12 @@ export function Artifacts({
     [linkedEvents, producerRunIds],
   );
   const selectedKinds = selected ? kindsOf(selected) : [];
+  const selectedName = selectedSha
+    ? downloadName(selectedSha, selectedKinds)
+    : "";
+  const binary = contentQ.data !== undefined && looksBinary(contentQ.data);
   const preview =
-    contentQ.data === undefined
+    contentQ.data === undefined || binary
       ? null
       : formattedContent(contentQ.data, selectedKinds);
   const parsedArtifact = useMemo(
@@ -550,13 +576,27 @@ export function Artifacts({
           <tbody>
             {ordered.map((artifact) => {
               const artifactKinds = kindsOf(artifact);
-              const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
+              const name = downloadName(artifact.sha256, artifactKinds);
               return (
                 <tr
                   key={artifact.sha256}
-                  onClick={() => selectArtifact(artifact.sha256)}
+                  tabIndex={0}
+                  // A modified click on the SHA link is the browser's to handle
+                  // (new tab, copy link) — selecting here would navigate this
+                  // tab out from under it.
+                  onClick={(event) => {
+                    if (event.metaKey || event.ctrlKey || event.shiftKey)
+                      return;
+                    selectArtifact(artifact.sha256);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    if (event.target !== event.currentTarget) return;
+                    event.preventDefault();
+                    selectArtifact(artifact.sha256);
+                  }}
                   aria-selected={artifact.sha256 === selectedSha}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
+                  className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
                 >
                   <td
                     className="mono max-w-48 border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
@@ -564,13 +604,21 @@ export function Artifacts({
                   >
                     <span className="inline-flex items-center gap-2">
                       <a
+                        href={artifactInspectorHash(artifact.sha256)}
+                        className="text-(--accent) hover:underline"
+                        title={`Inspect ${artifact.sha256}`}
+                      >
+                        {artifact.sha256.slice(0, 12)}
+                      </a>
+                      <a
                         href={artifactUrl(artifact.sha256, name)}
                         download={name}
                         onClick={(event) => event.stopPropagation()}
-                        className="text-(--accent) hover:underline"
-                        aria-label={`Download artifact ${artifact.sha256}`}
+                        aria-label={`Download ${name}`}
+                        title={`Download ${name}`}
+                        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-(--border) text-(--text-faint) hover:border-(--border-strong) hover:text-(--accent)"
                       >
-                        {artifact.sha256.slice(0, 12)}
+                        <span aria-hidden="true">↓</span>
                       </a>
                       {!artifact.referenced && (
                         <span
@@ -694,11 +742,8 @@ export function Artifacts({
           actions={
             <>
               <a
-                href={artifactUrl(
-                  selectedSha,
-                  `${selectedSha.slice(0, 12)}${selectedKinds[0] ? `.${selectedKinds[0]}` : ""}`,
-                )}
-                download
+                href={artifactUrl(selectedSha, selectedName)}
+                download={selectedName}
                 className="inline-flex rounded-md border border-(--border-strong) px-2.5 py-1.5 text-[12px] font-medium hover:bg-(--surface-2)"
               >
                 Download
@@ -870,12 +915,14 @@ export function Artifacts({
                 <p className="mt-0.5 text-[11px] text-(--text-faint)">
                   {viewShown
                     ? `${producerAgent?.outputView?.title ?? "view"} · ${producerAgent?.ref}`
-                    : matchCount === null
-                      ? `${previewLines.length.toLocaleString()} lines`
-                      : `${matchCount.toLocaleString()} matching lines`}
+                    : binary
+                      ? "not text"
+                      : matchCount === null
+                        ? `${previewLines.length.toLocaleString()} lines`
+                        : `${matchCount.toLocaleString()} matching lines`}
                 </p>
               </div>
-              {!viewShown && (
+              {!viewShown && !binary && (
                 <FilterInput
                   value={contentSearch}
                   onChange={setContentSearch}
@@ -893,6 +940,36 @@ export function Artifacts({
               <div className="mt-3 text-[12px] text-(--hue-err)">
                 Could not load artifact content:{" "}
                 {(contentQ.error as Error).message}
+              </div>
+            )}
+            {binary && (
+              <div className="mt-3 rounded-md border border-(--border) bg-(--surface-0) p-4 text-[12px]">
+                <p className="text-(--text-dim)">
+                  These bytes cannot be previewed as text. Download the file to
+                  open it in a local viewer.
+                </p>
+                <dl className="mono mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-[11.5px]">
+                  <dt className="text-(--text-faint)">File</dt>
+                  <dd className="break-all">{selectedName}</dd>
+                  <dt className="text-(--text-faint)">Size</dt>
+                  <dd>
+                    {selected ? formatBytes(selected.sizeBytes) : "unknown"}
+                  </dd>
+                  <dt className="text-(--text-faint)">Kinds</dt>
+                  <dd>
+                    {selectedKinds.length
+                      ? selectedKinds.join(", ")
+                      : "unknown"}
+                  </dd>
+                </dl>
+                <a
+                  href={artifactUrl(selectedSha, selectedName)}
+                  download={selectedName}
+                  aria-label="Download file"
+                  className="mt-3 inline-flex rounded-md border border-transparent bg-(--accent) px-3 py-1.5 text-[12px] font-medium text-(--on-accent) hover:opacity-90"
+                >
+                  Download file
+                </a>
               </div>
             )}
             {preview !== null && (


### PR DESCRIPTION
## Problem

On `#/artifacts`, the SHA was the one obvious thing to click — and clicking it fired a browser file download instead of opening the split-pane inspector. The SHA text was wrapped in `<a href={artifactUrl(...)} download>` with `stopPropagation()`, which intercepted the click before the row's selection handler ever saw it.

## Change

- **The SHA is now a deep link into the inspector.** `<a href="#/artifacts/<sha256>">`, no `download`, no `stopPropagation()` — a left-click selects the row and opens the split pane, and because it is a real link, middle-click, Cmd-click and "Copy link address" all still do the right thing.
- **The row `onClick` skips modified clicks.** Without this, a Cmd-click that opens a background tab would also navigate the current one out from under the operator.
- **Downloading moved to an explicit per-row control** — a small `↓` link next to the SHA with `aria-label="Download <name>"` and `stopPropagation()`, so it downloads without selecting the row.
- **Rows are keyboard reachable**: `tabIndex={0}`, a `focus-visible` ring, and Enter/Space selects. The key handler is scoped to the row itself so Enter on an inner link or button still behaves normally.
- **Non-text artifacts no longer render as a page of U+FFFD.** When the fetched bytes contain NUL or decode with a high replacement-character ratio, the inspector shows file name, size and kinds plus a prominent "Download file" button, and drops the content-search box that would have nothing to search.
- The inspector toolbar keeps its primary `Download` action, `Copy Raw Content`, `Copy SHA-256`, and the `ArtifactPanel` Raw/View toggle — untouched. The toolbar download name is now derived from a shared `downloadName()` helper rather than being rebuilt inline.

## Verification

```
cd event-runtime/web && bun test src/views/Artifacts.test.tsx
```

14 pass, 0 fail, 80 `expect()` calls. Full web suite is also green (874 pass, 0 fail across 59 files), plus `bun run format:check`, `bun run lint` (0 errors) and `tsc --noEmit`.

**Negative testing:** all 7 new/changed assertions were observed failing against the pre-fix component (7 pass / 7 fail) before `Artifacts.tsx` was touched — the SHA link test failed because the link's accessible name was `Download artifact <sha>` and its `href` pointed at `/api/artifacts/...`, which is exactly the reported bug.

Five new regression tests cover: the SHA href and the absence of a `download` attribute plus the click opening the inspector; the row download control not selecting the row; Tab focus and Enter/Space selection; a modified click being left to the browser; and the binary fallback showing metadata and a download instead of a text preview.

## UX critique

Required, but **NOT-ASSESSED** — the `cursor-ide-browser` MCP bridge returned `No browser tab available` for every call (`browser_navigate` with and without `newTab`, `browser_tabs list`, `browser_cdp`), reproduced in both the critic subagent and this session, while the app itself was healthy (`http://127.0.0.1:7751/` → 200, seeded inventory served). Filed as WM-726. The interaction contract is covered by the happy-dom tests above; what went unreviewed is the purely visual side — the `↓` icon's clarity and hit target, and the focus-ring appearance.

## Risks

Look first at the `↓` download affordance: it is a 20×20 icon-only control, so if it reads as ambiguous or too small in the browser that is a follow-up polish item rather than something the tests can catch. Second, `looksBinary()` uses a heuristic (NUL byte, or >2% U+FFFD in the first 4KB) — a text artifact that legitimately contains replacement characters above that ratio would be shown as non-previewable, with the raw bytes still one download away.

Fixes WM-699