### PR TITLE
fix(web): don't flash disconnected while health is pending (WM-724)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -39,6 +39,10 @@ const STATUS: StatusView = {
 
 const HEALTH = { ok: true, policyVersion: "test", env: ENV };
 let currentStatus = STATUS;
+// "pending" never resolves, which is what a first load looks like before
+// /api/health answers; "error" is a runtime that answered with a failure.
+let healthMode: "ok" | "pending" | "error" = "ok";
+let healthCalls = 0;
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {
@@ -66,9 +70,20 @@ function renderApp() {
 
 beforeEach(() => {
   currentStatus = STATUS;
+  healthMode = "ok";
+  healthCalls = 0;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input);
-    if (url.includes("/api/health")) return jsonResponse(HEALTH);
+    if (url.includes("/api/health")) {
+      healthCalls += 1;
+      if (healthMode === "pending") return new Promise<Response>(() => {});
+      if (healthMode === "error")
+        return new Response(JSON.stringify({ error: "runtime down" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        });
+      return jsonResponse(HEALTH);
+    }
     if (url.includes("/api/status")) return jsonResponse(currentStatus);
     if (url.includes("/api/agents")) {
       return jsonResponse({
@@ -251,6 +266,78 @@ describe("bottom status bar", () => {
     expect(themeButton.getAttribute("aria-label")).toBe(
       "Theme: dark. Switch to light.",
     );
+  });
+});
+
+describe("health connection chrome (WM-724)", () => {
+  // The chip is the only styled button in the sidebar header; its label is the
+  // connection word, so the text query doubles as the state assertion.
+  const statusDot = (statusBar: HTMLElement) =>
+    statusBar.querySelector<HTMLElement>("span.rounded-full")!;
+
+  test("a pending first load reads as connecting, not disconnected", async () => {
+    healthMode = "pending";
+    const utils = renderApp();
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+
+    // The status fixture lands while health is still in flight — that is the
+    // exact window in which the old chrome flashed an outage.
+    await waitFor(() => {
+      expect(
+        utils.sidebar.getByRole("button", { name: "Proposals" }).textContent,
+      ).toContain("9");
+    });
+
+    const chip = utils.sidebar.getByText("connecting");
+    expect(chip.getAttribute("style")).not.toContain("--hue-err");
+    expect(utils.sidebar.queryByText("disconnected")).toBeNull();
+    expect(chip.getAttribute("title")).not.toContain("runtime unreachable");
+
+    expect(statusDot(statusBar).getAttribute("style")).not.toContain(
+      "--hue-err",
+    );
+    expect(statusBar.textContent).not.toContain("runtime unreachable");
+    expect(statusBar.textContent).toContain("connecting");
+
+    // No banner either — pending is not a failure anywhere in the chrome.
+    expect(utils.queryByText(/Runtime unreachable —/)).toBeNull();
+  });
+
+  test("a failed health check turns chip, status bar and banner red together", async () => {
+    healthMode = "error";
+    const utils = renderApp();
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+
+    await waitFor(() => {
+      expect(utils.sidebar.getByText("disconnected")).toBeTruthy();
+    });
+    expect(
+      utils.sidebar.getByText("disconnected").getAttribute("style"),
+    ).toContain("--hue-err");
+    expect(statusDot(statusBar).getAttribute("style")).toContain("--hue-err");
+    expect(statusBar.textContent).toContain("runtime unreachable");
+    expect(utils.getByText(/Runtime unreachable —/)).toBeTruthy();
+
+    const before = healthCalls;
+    fireEvent.click(utils.getByRole("button", { name: "Retry" }));
+    await waitFor(() => {
+      expect(healthCalls).toBeGreaterThan(before);
+    });
+  });
+
+  test("a healthy runtime names the env on the chip and connects in the status bar", async () => {
+    const utils = renderApp();
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+
+    await waitFor(() => {
+      expect(utils.sidebar.getByText("dev")).toBeTruthy();
+    });
+    const chip = utils.sidebar.getByText("dev");
+    expect(chip.getAttribute("style")).not.toContain("--hue-err");
+    expect(chip.getAttribute("title")).toContain("/tmp/factory");
+    expect(statusDot(statusBar).getAttribute("style")).toContain("--hue-ok");
+    expect(statusBar.textContent).toContain("connected · test");
+    expect(utils.queryByText(/Runtime unreachable —/)).toBeNull();
   });
 });
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -342,9 +342,11 @@ export function App() {
     retry: false,
   });
   const connected = health.isSuccess;
-  // Banner only after a failed fetch — first-load pending must not flash
-  // "unreachable" over an empty factory.
-  const healthFailed = !connected && !health.isPending;
+  // A first load that has not answered yet is "connecting", not "down". Every
+  // piece of connection chrome — chip, status bar, banner — reads this rather
+  // than !connected, so an in-flight /health never flashes an outage.
+  const healthPending = health.isPending;
+  const healthFailed = !connected && !healthPending;
 
   const status = useQuery({
     queryKey: ["status"],
@@ -421,18 +423,22 @@ export function App() {
   };
 
   const env = health.data?.env;
-  const envHue = !connected
-    ? "var(--hue-err)"
-    : env?.name === "live"
+  const envHue = connected
+    ? env?.name === "live"
       ? "var(--hue-warn)"
-      : "var(--hue-info)";
-  const envLabel = !connected
-    ? "disconnected"
-    : env
+      : "var(--hue-info)"
+    : healthPending
+      ? "var(--text-dim)"
+      : "var(--hue-err)";
+  const envLabel = connected
+    ? env
       ? env.adapter
         ? `${env.name} · ${env.adapter}`
         : env.name
-      : "…";
+      : "…"
+    : healthPending
+      ? "connecting"
+      : "disconnected";
 
   const goArmed = useGoSequences(
     useMemo(() => {
@@ -619,7 +625,9 @@ export function App() {
               title={
                 env
                   ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
-                  : "runtime unreachable"
+                  : healthPending
+                    ? "connecting to the runtime…"
+                    : "runtime unreachable"
               }
               style={{
                 color: envHue,
@@ -999,7 +1007,11 @@ export function App() {
             <span
               className="size-2 shrink-0 rounded-full"
               style={{
-                background: connected ? "var(--hue-ok)" : "var(--hue-err)",
+                background: connected
+                  ? "var(--hue-ok)"
+                  : healthPending
+                    ? "var(--text-dim)"
+                    : "var(--hue-err)",
               }}
             />
             {connected ? (
@@ -1029,6 +1041,8 @@ export function App() {
                   </span>
                 )}
               </span>
+            ) : healthPending ? (
+              <span>connecting…</span>
             ) : (
               <span style={{ color: "var(--hue-err)" }}>
                 runtime unreachable


### PR DESCRIPTION
## Summary

`connected = health.isSuccess` meant every connection surface treated "the
first `/api/health` has not answered yet" the same as "the runtime is down".
On first load the sidebar env chip flashed `DISCONNECTED` in `--hue-err` with
a "runtime unreachable" tooltip, and the status bar showed an error-hue dot
with the words "runtime unreachable" — over a runtime that was simply still
connecting. The banner already got this right (`healthFailed = !connected &&
!health.isPending`), so the three surfaces disagreed with each other.

The chip and status bar now read the same distinction the banner does:

- **pending** — chip `connecting` in `--text-dim`, tooltip "connecting to the
  runtime…", dim status-bar dot, copy "connecting…", no banner
- **failed** — unchanged: chip `disconnected`, status bar "runtime
  unreachable", red banner with a working Retry, all in `--hue-err`
- **success** — unchanged: chip `live · fake`, status bar "connected · git:…"

## Test plan

- `cd event-runtime/web && bun test src/App.test.tsx` — 20 pass, 0 fail.
- New `health connection chrome (WM-724)` block covers pending, failed and
  success, asserting hue (via the rendered style attribute), copy, tooltip,
  banner presence and that Retry actually refetches.
- Negative test: the pending assertion was observed **failing** against
  pre-fix `App.tsx` (chip rendered `style="color: var(--hue-err)"`,
  `title="runtime unreachable"`, label `disconnected`) before the fix was
  applied.
- UX critique (desktop ~1440, live UI on the fake adapter): **SHIP** — no
  DISCONNECTED or "runtime unreachable" flash at any probe point during
  reload with `/api/health` held in flight; failed state still unambiguous
  across chip, status bar and banner with a working Retry. Its one polish
  finding (the chip looks clickable but no-ops when there is no `env.home`)
  is pre-existing and out of scope — filed as WM-728.

Fixes WM-724