### PR TITLE
feat(event-runtime): apply inbox decision effects (WM-391)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -23,8 +23,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:ca3d1eb3dd65baacda9dc981425bf344828c79d25e05fcad58759a293fad323f",
-    "schemas/dispatch.input.json": "sha256:b5c0643c0ed41272900b4d31947b0b1e96a45c092623514b6e14ef20a8bdf485",
+    "agents/dispatch.md": "sha256:34a2625aa17cfaa536dc740e527ef333334aaeab22c99cf4ffa71d8501c3b5e1",
+    "schemas/dispatch.input.json": "sha256:7287e8fa923036b1a4f887efef9540a65bf09c03e0e219907e160efa3272f26f",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }
 }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -112,6 +112,15 @@ migrations, or production infra: stop without pushing, comment the finding on
 the ticket, and refuse (`reasonCode: "needs_human"`). Those diffs are never
 landed without a human.
 
+If the input carries `humanDecision.authorisation` for this ticket, the
+operator has already seen that escalation. Compare
+`authorisation.descriptionHash` with the SHA-256 of the ticket's current
+description. If it matches, proceed only inside `authorisation.paths` (and the
+ticket's Owned Paths), and quote the authorisation's inbox item id and
+`decidedAt` in the PR body. If it does not match, refuse with a fresh decision
+request whose `context` says the ticket changed after approval; never reuse an
+authorisation for a different ticket description.
+
 ## 3. When it goes wrong
 
 Do not open a PR on a guess. Comment the ticket with the specific decision,

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -43,7 +43,11 @@ import {
 } from "./config.mjs";
 import { githubWebhookSecret } from "./intake.mjs";
 import { decideInboxItem, getInboxItem, retryInboxDecision } from "./inbox.mjs";
-import { applyDecisionEffect } from "./decision-effects.mjs";
+import {
+  applyDecisionEffect,
+  decisionEffectPlanner,
+  linearDecisionTransport,
+} from "./decision-effects.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos, reposRoot } from "./repos.mjs";
@@ -82,6 +86,8 @@ export function createApi({
   inboxCommand = notifyCommand(),
   inboxWebUrl = process.env.FACTORY_WEB_URL,
   inboxApplyEffect = applyDecisionEffect,
+  inboxLinear = linearDecisionTransport,
+  inboxPlanner = null,
   // Config inventory follows the same checkout override as repos/registry.
   configRoot = reposRoot(),
   // Root of the config/policy.yaml the run endpoints consult (tests point it elsewhere).
@@ -90,6 +96,8 @@ export function createApi({
   const actor = "operator";
   const registryLoadedAt = new Date(now()).toISOString();
   const storeStatsTtlMs = 10_000;
+  const composedInboxPlanner =
+    inboxPlanner ?? decisionEffectPlanner(registry, { onEvent, policyVersion });
   let cachedStoreStats = null;
   let cachedStoreStatsAt = 0;
 
@@ -166,6 +174,12 @@ export function createApi({
           const id = decodeURIComponent(decisionMatch[1]);
           try {
             let result;
+            const applyEffect = (effectDb, item, response) =>
+              inboxApplyEffect(effectDb, item, response, {
+                linear: inboxLinear,
+                planner: composedInboxPlanner,
+                now: nowMs,
+              });
             if (decisionMatch[2] === "retry") {
               const raw = await readBody(req);
               if (raw.length > 0) {
@@ -178,7 +192,7 @@ export function createApi({
               }
               result = retryInboxDecision(db, id, {
                 now: nowMs,
-                applyEffect: inboxApplyEffect,
+                applyEffect,
               });
             } else {
               const parsed = parseJson(await readBody(req));
@@ -190,7 +204,7 @@ export function createApi({
               result = decideInboxItem(db, id, parsed.value, {
                 now: nowMs,
                 decidedBy: actor,
-                applyEffect: inboxApplyEffect,
+                applyEffect,
               });
             }
             return send(200, result);

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -38,6 +38,7 @@ import { cpSync } from "node:fs";
 import { emitDueTicks } from "./schedules.mjs";
 import { createInboxItem } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
+import { hashJson } from "./canonical.mjs";
 import { spawnTracked } from "./test-helpers-process.mjs";
 
 describe("inbox decision API (WM-390)", () => {
@@ -139,6 +140,102 @@ describe("inbox decision API (WM-390)", () => {
       });
       expect(retry.status).toBe(409);
       expect((await retry.json()).error).toBe("not_decided");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("authorise admits an inbox-sourced dispatch through the ordinary intake", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const testRegistry = { ...registry, agents: new Map(registry.agents) };
+    testRegistry.agents.set("dispatch@1", {
+      ...registry.agents.get("dispatch@1"),
+      // Keep this API/intake proof local: worktree dispatch eligibility is
+      // independently covered by dispatch tests and requires live Linear.
+      workspace: { type: "ephemeral" },
+    });
+    const s = await makeServer({
+      now: () => nowMs,
+      registry: testRegistry,
+      inboxLinear: {
+        get: () => ({ description: "## Owned Paths\n- src/feature/**\n" }),
+      },
+    });
+    const authorise = {
+      schemaVersion: "factory.decision-request/v1",
+      question: "May the agent proceed?",
+      options: [
+        {
+          id: "authorise",
+          label: "Authorise",
+          effect: "authorise",
+          scope: {
+            paths: ["src/feature/**"],
+            summary: "Implement the approved feature",
+          },
+        },
+      ],
+    };
+    try {
+      createInboxItem(
+        s.db,
+        {
+          kind: "ESCALATED",
+          title: "Authorise dispatch",
+          refs: { issue: "WM-313", repo: "factory", runId: "run_refused" },
+          decision: authorise,
+        },
+        { id: "api_authorise" },
+      );
+      const res = await fetch(s.url("/inbox/api_authorise/decide"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: decisionRequestHash(authorise),
+          optionId: "authorise",
+          fields: {},
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        item: { resolvedBy: "operator:authorise" },
+        effect: { outcome: "applied", detail: "dispatched" },
+      });
+      const admitted = s.db
+        .query(
+          "SELECT source, event_id, correlation_id, envelope_json FROM events WHERE source = 'inbox'",
+        )
+        .get();
+      expect(admitted).toMatchObject({
+        source: "inbox",
+        event_id: "api_authorise",
+        correlation_id: "api_authorise",
+      });
+      expect(s.onEvents).toContain("admitted");
+      const envelope = JSON.parse(admitted.envelope_json);
+      expect(envelope.payload.humanDecision).toMatchObject({
+        schemaVersion: "factory.human-decision/v1",
+        inboxItemId: "api_authorise",
+        authorisation: {
+          ticket: "WM-313",
+          repo: "factory",
+          refusedRunId: "run_refused",
+        },
+      });
+      expect(
+        planAdmittedEvents(s.db, testRegistry, {
+          now: nowMs,
+          policyVersion: PV,
+        }),
+      ).toMatchObject({ planned: 1, failed: 0 });
+      const spec = JSON.parse(
+        s.db.query("SELECT spec_json FROM runs").get().spec_json,
+      );
+      expect(spec.input.humanDecision.inboxItemId).toBe("api_authorise");
+      expect(spec.inputHash).not.toBe(
+        hashJson({ repo: "factory", ticket: "WM-313" }),
+      );
     } finally {
       s.close();
     }

--- a/event-runtime/lib/decision-effects.mjs
+++ b/event-runtime/lib/decision-effects.mjs
@@ -1,17 +1,276 @@
+/** Runtime-owned effects for inbox decisions (docs/event-runtime-inbox.md §3). */
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import { hashBytes } from "./canonical.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
+import { admitExternalEvent } from "./intake.mjs";
+import { requeueEvent } from "./planner.mjs";
+import { approveProposal, rejectProposal } from "./proposals.mjs";
+
+const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
+
+function runLinear(args) {
+  try {
+    return execFileSync("bun", [linearCli(), ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 20_000,
+    });
+  } catch (err) {
+    const message =
+      String(err?.stderr ?? "")
+        .trim()
+        .split("\n")
+        .pop() || err.message;
+    throw new Error(`linear_${args[0]}_failed: ${message}`, { cause: err });
+  }
+}
+
+/** Synchronous Linear transport: decision application runs inside a DB transaction. */
+export const linearDecisionTransport = {
+  get(issue) {
+    return JSON.parse(runLinear(["get", issue, "--json"]));
+  },
+  triage(issue, comment) {
+    runLinear(["triage", issue, "--comment", comment]);
+    return { ok: true };
+  },
+  answer(issue, text) {
+    runLinear(["answer", issue, text]);
+    return { ok: true };
+  },
+};
+
+/** Bind runtime operations that need the loaded registry. */
+export function decisionEffectPlanner(
+  registry,
+  { onEvent = () => {}, policyVersion = "unknown" } = {},
+) {
+  return {
+    admit(db, envelope, { now } = {}) {
+      const outcome = admitExternalEvent(db, registry, envelope, { now });
+      if (outcome.admitted) onEvent("admitted");
+      return outcome;
+    },
+    requeue(db, refs, options) {
+      const outcome = requeueEvent(db, refs, options);
+      onEvent("requeued");
+      return outcome;
+    },
+    approveProposal(db, id, options) {
+      return approveProposal(db, registry, id, {
+        ...options,
+        policyVersion,
+      });
+    },
+    rejectProposal(db, id, options) {
+      return rejectProposal(db, id, { ...options, policyVersion });
+    },
+  };
+}
+
+function resolveNow(now) {
+  return typeof now === "function" ? now() : now;
+}
+
+function textFields(item, response) {
+  const fields = item?.decision?.fields ?? [];
+  return fields
+    .filter((field) => field.kind === "text")
+    .map((field) => response?.fields?.[field.id])
+    .filter((value) => typeof value === "string" && value.trim() !== "")
+    .join("\n\n");
+}
+
+function authorisedPaths(option, item, response) {
+  const scoped = option.scope.paths;
+  const gatedPathFields = (item.decision.fields ?? []).filter(
+    (field) =>
+      field.kind === "multi-choice" &&
+      Array.isArray(field.whenOption) &&
+      field.whenOption.includes(option.id),
+  );
+  if (gatedPathFields.length === 0) return [...scoped];
+
+  const selected = new Set();
+  for (const field of gatedPathFields) {
+    const ids = new Set(response.fields?.[field.id] ?? []);
+    for (const choice of field.choices ?? []) {
+      if (ids.has(choice.id)) selected.add(choice.label);
+    }
+  }
+  return scoped.filter((scopedPath) => selected.has(scopedPath));
+}
+
+function transportSucceeded(result, operation) {
+  if (result === false || result?.ok === false) {
+    throw new Error(result?.error ?? `${operation} failed`);
+  }
+  return result;
+}
+
+function authorise(db, item, response, option, { linear, planner, now }) {
+  const issue = transportSucceeded(linear.get(item.refs.issue), "linear get");
+  if (!issue || typeof issue.description !== "string") {
+    throw new Error(
+      `linear description unavailable for ${item.refs.issue} at decision time`,
+    );
+  }
+
+  const decidedAt = response.decidedAt ?? new Date(now).toISOString();
+  const authorisation = {
+    ticket: item.refs.issue,
+    repo: item.refs.repo,
+    descriptionHash: hashBytes(issue.description),
+    paths: authorisedPaths(option, item, response),
+    summary: option.scope.summary,
+    insight: textFields(item, response),
+    refusedRunId: item.refs.runId,
+    decidedBy: response.decidedBy ?? "operator",
+    decidedAt,
+  };
+  const envelope = {
+    schemaVersion: "factory.event/v1",
+    eventId: item.id,
+    type: "factory.dispatch.requested",
+    source: "inbox",
+    subject: item.refs.issue,
+    occurredAt: new Date(now).toISOString(),
+    correlationId: item.id,
+    causationId: item.refs.runId,
+    payload: {
+      repo: item.refs.repo,
+      ticket: item.refs.issue,
+      humanDecision: {
+        schemaVersion: "factory.human-decision/v1",
+        inboxItemId: item.id,
+        authorisation,
+      },
+    },
+  };
+  const admitted = transportSucceeded(
+    planner.admit(db, envelope, { now }),
+    "dispatch admission",
+  );
+  if (!admitted?.admitted && !admitted?.duplicate) {
+    throw new Error(
+      `dispatch admission failed: ${(admitted?.errors ?? ["no outcome"]).join("; ")}`,
+    );
+  }
+  return { detail: admitted.duplicate ? "already_admitted" : "dispatched" };
+}
+
 /**
- * Runtime-owned effects for inbox decisions.
+ * Apply one validated decision response.
  *
- * WM-391 fills in the stateful effects. This seam deliberately ships only the
- * side-effect-free dismiss operation; unsupported effects leave their item
- * open and can be retried after that implementation lands.
+ * Stateful callers inject `{ linear, planner }`; keeping the dependencies at
+ * the seam makes every transport failure deterministic in tests and lets the
+ * inbox ledger record it without resolving the item.
  */
-export function applyDecisionEffect(_db, item, response) {
+export function applyDecisionEffect(
+  db,
+  item,
+  response,
+  { linear, planner, now = Date.now() } = {},
+) {
   const option = item?.decision?.options?.find(
     (candidate) => candidate.id === response?.optionId,
   );
   const kind = option?.effect ?? "unknown";
   if (kind === "dismiss") return { kind, outcome: "applied" };
-  return { kind, outcome: "unsupported" };
+
+  // The WM-390 ledger still calls this seam directly in non-composed contexts.
+  // Preserve its retryable sentinel there; the runtime API always injects both
+  // transports and therefore returns only applied/failed for real effects.
+  if (!linear && !planner) return { kind, outcome: "unsupported" };
+
+  const at = resolveNow(now);
+  try {
+    let detail;
+    let newProposalId;
+    switch (kind) {
+      case "authorise":
+        detail = authorise(db, item, response, option, {
+          linear,
+          planner,
+          now: at,
+        }).detail;
+        break;
+      case "send_to_triage": {
+        const text =
+          textFields(item, response) ||
+          `Operator sent ${item.refs.issue} to Triage from inbox ${item.id}.`;
+        transportSucceeded(
+          linear.triage(item.refs.issue, text),
+          "linear triage",
+        );
+        break;
+      }
+      case "answer":
+        transportSucceeded(
+          linear.answer(item.refs.issue, textFields(item, response)),
+          "linear answer",
+        );
+        break;
+      case "requeue":
+        transportSucceeded(
+          planner.requeue(
+            db,
+            {
+              source: item.refs.eventSource,
+              eventId: item.refs.eventId,
+            },
+            { actor: "operator", now: at },
+          ),
+          "event requeue",
+        );
+        break;
+      case "approve_proposal": {
+        const approved = transportSucceeded(
+          planner.approveProposal(db, item.refs.proposalId, {
+            actor: "operator",
+            now: at,
+          }),
+          "proposal approval",
+        );
+        if (approved?.replanned && approved?.approved === false) {
+          detail = "replanned_awaiting_approval";
+          newProposalId = approved?.proposal?.id;
+          if (!newProposalId) {
+            throw new Error(
+              "proposal re-plan did not return the fresh proposal id",
+            );
+          }
+        }
+        break;
+      }
+      case "reject_proposal":
+        transportSucceeded(
+          planner.rejectProposal(db, item.refs.proposalId, {
+            actor: "operator",
+            reason: textFields(item, response),
+            now: at,
+          }),
+          "proposal rejection",
+        );
+        break;
+      default:
+        throw new Error(`unknown decision effect: ${kind}`);
+    }
+    return {
+      kind,
+      outcome: "applied",
+      ...(detail ? { detail } : {}),
+      ...(newProposalId ? { newProposalId } : {}),
+    };
+  } catch (err) {
+    return {
+      kind,
+      outcome: "failed",
+      error: err?.message ?? String(err),
+    };
+  }
 }
 
 export default applyDecisionEffect;

--- a/event-runtime/lib/decision-effects.test.mjs
+++ b/event-runtime/lib/decision-effects.test.mjs
@@ -1,24 +1,317 @@
 import { describe, expect, test } from "bun:test";
+import { hashBytes, hashJson } from "./canonical.mjs";
 import { applyDecisionEffect } from "./decision-effects.mjs";
+import { decisionRequestHash } from "./decision.mjs";
+import { openDb } from "./db.mjs";
+import {
+  createInboxItem,
+  decideInboxItem,
+  retryInboxDecision,
+} from "./inbox.mjs";
 
-describe("decision effect seam (WM-390)", () => {
-  const item = {
+const NOW = Date.parse("2026-08-18T12:00:00.000Z");
+
+function item(effect, overrides = {}) {
+  const option = {
+    id: "choose",
+    label: "Choose",
+    effect,
+    ...(effect === "authorise"
+      ? {
+          scope: {
+            paths: ["src/a.ts", "src/b.ts"],
+            summary: "Change the bounded implementation",
+          },
+        }
+      : {}),
+  };
+  return {
+    id: "inbox_391",
+    refs: {
+      issue: "WM-313",
+      repo: "factory",
+      runId: "run_refused",
+      eventSource: "linear",
+      eventId: "delivery-313",
+      proposalId: "prop_313",
+    },
     decision: {
-      options: [
-        { id: "later", effect: "dismiss" },
-        { id: "go", effect: "authorise" },
+      schemaVersion: "factory.decision-request/v1",
+      question: "Proceed?",
+      options: [option],
+      fields: [
+        {
+          id: "insight",
+          kind: "text",
+          label: "Insight",
+          required: false,
+        },
+        {
+          id: "paths",
+          kind: "multi-choice",
+          label: "Paths",
+          required: true,
+          whenOption: ["choose"],
+          choices: [
+            { id: "a", label: "src/a.ts" },
+            { id: "b", label: "src/b.ts" },
+          ],
+        },
       ],
     },
+    ...overrides,
   };
+}
 
-  test("dismiss is applied and other effects remain explicitly unsupported", () => {
-    expect(applyDecisionEffect(null, item, { optionId: "later" })).toEqual({
+function response(fields = {}) {
+  return {
+    schemaVersion: "factory.decision-response/v1",
+    requestHash: "sha256:" + "0".repeat(64),
+    optionId: "choose",
+    fields,
+    decidedBy: "operator:laszlo",
+    decidedAt: new Date(NOW).toISOString(),
+  };
+}
+
+describe("runtime decision effects", () => {
+  test("applies dismiss, Linear writes, requeue, approve, and reject through injected transports", () => {
+    const calls = [];
+    const linear = {
+      triage: (...args) => calls.push(["triage", ...args]),
+      answer: (...args) => calls.push(["answer", ...args]),
+    };
+    const planner = {
+      requeue: (...args) => calls.push(["requeue", ...args]),
+      approveProposal: (...args) => {
+        calls.push(["approve", ...args]);
+        return { approved: true };
+      },
+      rejectProposal: (...args) => calls.push(["reject", ...args]),
+    };
+
+    expect(applyDecisionEffect(null, item("dismiss"), response())).toEqual({
       kind: "dismiss",
       outcome: "applied",
     });
-    expect(applyDecisionEffect(null, item, { optionId: "go" })).toEqual({
-      kind: "authorise",
-      outcome: "unsupported",
+    expect(
+      applyDecisionEffect(
+        null,
+        item("send_to_triage"),
+        response({ insight: "Needs a tighter scope" }),
+        { linear, planner, now: NOW },
+      ),
+    ).toEqual({ kind: "send_to_triage", outcome: "applied" });
+    expect(
+      applyDecisionEffect(
+        null,
+        item("answer"),
+        response({ insight: "Use the existing seam" }),
+        { linear, planner, now: NOW },
+      ),
+    ).toEqual({ kind: "answer", outcome: "applied" });
+    expect(
+      applyDecisionEffect(null, item("requeue"), response(), {
+        linear,
+        planner,
+        now: NOW,
+      }),
+    ).toEqual({ kind: "requeue", outcome: "applied" });
+    expect(
+      applyDecisionEffect(null, item("approve_proposal"), response(), {
+        linear,
+        planner,
+        now: NOW,
+      }),
+    ).toEqual({ kind: "approve_proposal", outcome: "applied" });
+    expect(
+      applyDecisionEffect(
+        null,
+        item("reject_proposal"),
+        response({ insight: "Spec is stale" }),
+        { linear, planner, now: NOW },
+      ),
+    ).toEqual({ kind: "reject_proposal", outcome: "applied" });
+
+    expect(calls[0]).toEqual(["triage", "WM-313", "Needs a tighter scope"]);
+    expect(calls[1]).toEqual(["answer", "WM-313", "Use the existing seam"]);
+    expect(calls[2][1]).toBeNull();
+    expect(calls[2][2]).toEqual({
+      source: "linear",
+      eventId: "delivery-313",
     });
+    expect(calls[3][2]).toBe("prop_313");
+    expect(calls[4][3]).toMatchObject({
+      actor: "operator",
+      reason: "Spec is stale",
+      now: NOW,
+    });
+  });
+
+  test("expired proposal re-plan is applied but requires a second approval", () => {
+    const result = applyDecisionEffect(
+      null,
+      item("approve_proposal"),
+      response(),
+      {
+        linear: {},
+        planner: {
+          approveProposal: () => ({
+            approved: false,
+            replanned: true,
+            proposal: { id: "prop_fresh" },
+          }),
+        },
+        now: NOW,
+      },
+    );
+    expect(result).toEqual({
+      kind: "approve_proposal",
+      outcome: "applied",
+      detail: "replanned_awaiting_approval",
+      newProposalId: "prop_fresh",
+    });
+  });
+
+  test("authorise binds the live description, selected paths, text, and refused run into a new dispatch payload", () => {
+    let envelope;
+    const decisionItem = item("authorise");
+    const refusedInputHash = hashJson({ repo: "factory", ticket: "WM-313" });
+    const result = applyDecisionEffect(
+      null,
+      decisionItem,
+      response({ paths: ["b"], insight: "Keep the adapter synchronous" }),
+      {
+        linear: { get: () => ({ description: "Current Linear body" }) },
+        planner: {
+          admit: (_db, value) => {
+            envelope = value;
+            return { admitted: true, duplicate: false };
+          },
+        },
+        now: NOW,
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "authorise",
+      outcome: "applied",
+      detail: "dispatched",
+    });
+    expect(envelope).toMatchObject({
+      schemaVersion: "factory.event/v1",
+      eventId: "inbox_391",
+      type: "factory.dispatch.requested",
+      source: "inbox",
+      subject: "WM-313",
+      correlationId: "inbox_391",
+      causationId: "run_refused",
+      payload: {
+        repo: "factory",
+        ticket: "WM-313",
+        humanDecision: {
+          schemaVersion: "factory.human-decision/v1",
+          inboxItemId: "inbox_391",
+          authorisation: {
+            ticket: "WM-313",
+            repo: "factory",
+            descriptionHash: hashBytes("Current Linear body"),
+            paths: ["src/b.ts"],
+            summary: "Change the bounded implementation",
+            insight: "Keep the adapter synchronous",
+            refusedRunId: "run_refused",
+            decidedBy: "operator:laszlo",
+            decidedAt: new Date(NOW).toISOString(),
+          },
+        },
+      },
+    });
+    expect(hashJson(envelope.payload)).not.toBe(refusedInputHash);
+  });
+
+  test("authorise fails closed before admission when Linear has no description", () => {
+    let admitted = false;
+    const result = applyDecisionEffect(
+      null,
+      item("authorise"),
+      response({ paths: ["a"] }),
+      {
+        linear: { get: () => ({ description: null }) },
+        planner: {
+          admit: () => {
+            admitted = true;
+          },
+        },
+        now: NOW,
+      },
+    );
+    expect(result).toMatchObject({
+      kind: "authorise",
+      outcome: "failed",
+      error: expect.stringContaining("description unavailable"),
+    });
+    expect(admitted).toBe(false);
+  });
+
+  test("transport failure stays open with the response recorded and retry resolves", () => {
+    const db = openDb(":memory:");
+    const request = {
+      schemaVersion: "factory.decision-request/v1",
+      question: "Send to triage?",
+      options: [
+        {
+          id: "choose",
+          label: "Triage",
+          effect: "send_to_triage",
+        },
+      ],
+    };
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "Failure-safe effect",
+        refs: { issue: "WM-313" },
+        decision: request,
+      },
+      { id: "retry_effect" },
+    );
+    let fail = true;
+    const applyEffect = (effectDb, effectItem, effectResponse) =>
+      applyDecisionEffect(effectDb, effectItem, effectResponse, {
+        linear: {
+          triage: () => {
+            if (fail) throw new Error("Linear unavailable");
+            return { ok: true };
+          },
+        },
+        planner: {},
+        now: NOW,
+      });
+    const first = decideInboxItem(
+      db,
+      "retry_effect",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "choose",
+        fields: {},
+      },
+      { now: NOW, applyEffect },
+    );
+    expect(first.effect).toMatchObject({
+      outcome: "failed",
+      error: "Linear unavailable",
+    });
+    expect(first.item.resolvedAt).toBeNull();
+    expect(first.item.response.effect.error).toBe("Linear unavailable");
+
+    fail = false;
+    const retried = retryInboxDecision(db, "retry_effect", {
+      now: NOW + 1,
+      applyEffect,
+    });
+    expect(retried.effect.outcome).toBe("applied");
+    expect(retried.item.resolvedBy).toBe("operator:send_to_triage");
   });
 });

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -139,8 +139,9 @@ describe("registry", () => {
     // (digest regenerated on top of the #559 baseline).
     // Regenerated after WM-610 prettier reformat of code and markdown files.
     // Regenerated (WM-722): merge-scan/merge-fix adapter pi→claude; event-types.json is a registry input.
+    // Regenerated (WM-391): dispatch admits and documents bounded humanDecision authorisations.
     const expected =
-      "sha256:c9df6589c6a12567263dccbfc737b6a6acbb8132e0ac9216dbb7a35e527f6fbf";
+      "sha256:44e8dce58d2e4efd92f8e8a7b9483aa219ab32840b3aec34b41ee2c8782dc9a6";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -158,7 +159,7 @@ describe("registry", () => {
     expect(def.pack).toBe("event-runtime");
     expect(Object.keys(def)).not.toContain("pack");
     expect(computeDefHash(def)).toBe(
-      "sha256:0314e7e591bb4942e04a86a1211b28469d6ce750b3e9384db82380eaf396ec95",
+      "sha256:93df77f053690c1c2463fea4d497ec9c742fd9200ac369d1682ac575596b4129",
     );
   });
 

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -14,6 +14,79 @@
       "pattern": "^[A-Z]+-[0-9]+$",
       "description": "Linear issue identifier to implement; must be Todo + ai:agent-ready + unassigned at plan time (docs/event-runtime-dispatch.md §2)"
     },
+    "humanDecision": {
+      "type": "object",
+      "required": ["schemaVersion", "inboxItemId", "authorisation"],
+      "additionalProperties": false,
+      "description": "Single-use operator authorisation attached by an inbox re-dispatch (docs/event-runtime-inbox.md §3.1 and §5)",
+      "properties": {
+        "schemaVersion": {
+          "const": "factory.human-decision/v1"
+        },
+        "inboxItemId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authorisation": {
+          "type": "object",
+          "required": [
+            "ticket",
+            "repo",
+            "descriptionHash",
+            "paths",
+            "summary",
+            "insight",
+            "refusedRunId",
+            "decidedBy",
+            "decidedAt"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "ticket": {
+              "type": "string",
+              "pattern": "^[A-Z]+-[0-9]+$"
+            },
+            "repo": {
+              "type": "string",
+              "minLength": 1
+            },
+            "descriptionHash": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "paths": {
+              "type": "array",
+              "minItems": 0,
+              "maxItems": 32,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "summary": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500
+            },
+            "insight": {
+              "type": "string"
+            },
+            "refusedRunId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decidedBy": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decidedAt": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
     "repoPin": {
       "type": "object",
       "required": ["repo", "sha"],

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -6,6 +6,8 @@
  *   bun tools/linear.mjs comments CLNT-616
  *   bun tools/linear.mjs claim CLNT-616 --agent claude
  *   bun tools/linear.mjs comment CLNT-616 "verified: 42 tests pass"
+ *   bun tools/linear.mjs triage CLNT-616 --comment "Owned Paths need revision"
+ *   bun tools/linear.mjs answer CLNT-616 "Use the existing token cache"
  *   bun tools/linear.mjs detail CLNT-616 "## Acceptance criteria\n- [ ] ..."
  *   bun tools/linear.mjs labels CLNT-616 --add ai:needs-review --remove ai:in-progress
  *   bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
@@ -340,6 +342,7 @@ const VALUE_FLAGS = new Set([
   "agent",
   "area",
   "body",
+  "comment",
   "label",
   "project",
   "remove",
@@ -460,6 +463,62 @@ const VERBS = {
       { in: { issueId: issue.id, body: stampRun(body) } },
     );
     out({ ok: true, identifier: key }, `commented on ${key}`);
+  },
+
+  async triage() {
+    const key = positional[0];
+    const comment = flag("comment");
+    if (!key || comment === null)
+      throw new Error(`usage: triage <ISSUE-ID> --comment "<text>"`);
+    const issue = await issueByKey(key);
+    let { states } = await statesFor(teamOf(key));
+    let target = states.find((s) => s.name.toLowerCase() === "triage");
+    if (!target) ({ states } = await statesFor(teamOf(key), true));
+    target = states.find((s) => s.name.toLowerCase() === "triage");
+    if (!target) throw new Error(`team ${teamOf(key)} has no "Triage" state`);
+    const labelIds = await applyLabels(issue, [], ["ai:agent-ready"]);
+    const updated = await gql(
+      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: { stateId: target.id, labelIds } },
+    );
+    if (!updated?.issueUpdate?.success)
+      throw new Error(`failed to move ${key} to Triage`);
+    if (comment.trim()) {
+      const commented = await gql(
+        `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+        { in: { issueId: issue.id, body: stampRun(comment) } },
+      );
+      if (!commented?.commentCreate?.success)
+        throw new Error(`failed to comment on ${key}`);
+    }
+    out({ ok: true, identifier: key }, `${key} -> Triage`);
+  },
+
+  async answer() {
+    const key = positional[0];
+    const text = positional[1];
+    if (!key || !text) throw new Error(`usage: answer <ISSUE-ID> "<text>"`);
+    const issue = await issueByKey(key);
+    if (issue.state?.name?.toLowerCase() === "blocked") {
+      let { states } = await statesFor(teamOf(key));
+      let target = states.find((s) => s.name.toLowerCase() === "todo");
+      if (!target) ({ states } = await statesFor(teamOf(key), true));
+      target = states.find((s) => s.name.toLowerCase() === "todo");
+      if (!target) throw new Error(`team ${teamOf(key)} has no "Todo" state`);
+      const updated = await gql(
+        `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+        { id: issue.id, in: { stateId: target.id } },
+      );
+      if (!updated?.issueUpdate?.success)
+        throw new Error(`failed to move ${key} to Todo`);
+    }
+    const commented = await gql(
+      `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+      { in: { issueId: issue.id, body: stampRun(text) } },
+    );
+    if (!commented?.commentCreate?.success)
+      throw new Error(`failed to comment on ${key}`);
+    out({ ok: true, identifier: key }, `answered ${key}`);
   },
 
   async detail() {

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -251,6 +251,17 @@ test("values for other flags are not treated as positional arguments", () => {
       "--todo",
     ]),
   ).toEqual([]);
+  expect(
+    parsePositionalArgs([
+      "triage",
+      "WM-313",
+      "--comment",
+      "Scope needs revision",
+    ]),
+  ).toEqual(["WM-313"]);
+  expect(
+    parsePositionalArgs(["answer", "WM-313", "Use the existing seam"]),
+  ).toEqual(["WM-313", "Use the existing seam"]);
 });
 
 // -------------------------------------------------------- label mutations ---


### PR DESCRIPTION
## Summary
- apply every runtime-owned inbox decision effect through injected Linear/planner transports, preserving failed responses for retry
- emit bounded `humanDecision` re-dispatch inputs and teach the dispatch agent to honor their ticket/hash/path binding
- add Linear `triage`/`answer` verbs, API/intake coverage, schema pins, and registry baselines

## Verification
- `bun test event-runtime/lib tools && bun test && bun build/emit.mjs --check && bun run format:check`
  - pass: 2532 tests, 9 environment-gated sandbox tests skipped; 90 generated files current; Prettier clean

UX critique: skipped — backend/runtime contract change with no user-facing flow.

Registry digest reason: WM-391 changes the pinned dispatch prompt and input schema to admit bounded human-decision authorisations.

Fixes WM-391