### PR TITLE
feat(web): accessible HoverCard primitive (WM-700)

### DIFF
--- a/event-runtime/web/src/components/AgentHoverCard.test.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.test.tsx
@@ -54,46 +54,152 @@ const sampleAgent: AgentDef = {
   ],
 };
 
+const agentsApi = () => ({
+  agents: mock(async () => createAgentsFixture({ agents: [sampleAgent] })),
+});
+
+/** The wrapper the primitive puts the popup ARIA state on. */
+function triggerOf(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[aria-haspopup='dialog']");
+  if (!el) throw new Error("hover card trigger not found");
+  return el;
+}
+
 describe("AgentHoverCard", () => {
   test("renders trigger with agent ref and opens hover card with details", async () => {
     const onJumpAgent = mock(() => {});
 
-    await withApi(
-      {
-        agents: mock(async () =>
-          createAgentsFixture({
-            agents: [sampleAgent],
-          }),
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(
+        <AgentHoverCard agentRef="triage-scan" onJumpAgent={onJumpAgent} />,
+      );
+
+      expect(r.getByText("triage-scan")).toBeTruthy();
+
+      // Hover over the trigger
+      const trigger = r.getByText("triage-scan");
+      fireEvent.mouseEnter(trigger);
+
+      // Wait for hover card portal to render with agent details
+      await waitFor(() => {
+        expect(r.getByRole("dialog")).toBeTruthy();
+        expect(r.getByText("v2")).toBeTruthy();
+        expect(r.getByText("Mutating")).toBeTruthy();
+        expect(r.getByText("claude-3-7-sonnet")).toBeTruthy();
+        expect(r.getByText("triage/v1")).toBeTruthy();
+        expect(r.getByText("ephemeral")).toBeTruthy();
+        expect(r.getByText(/450s timeout/)).toBeTruthy();
+        expect(r.getByText(/github, linear/)).toBeTruthy();
+      });
+
+      // Click "Open in Agents"
+      const openBtn = r.getByRole("button", { name: /Open in Agents/i });
+      fireEvent.click(openBtn);
+      expect(onJumpAgent).toHaveBeenCalledWith("triage-scan");
+    });
+  });
+
+  test("names the card so a screen reader announces which agent it describes", async () => {
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(<AgentHoverCard agentRef="triage-scan" />);
+      fireEvent.mouseEnter(r.getByText("triage-scan"));
+
+      await waitFor(() =>
+        expect(r.getByRole("dialog").getAttribute("aria-label")).toBe(
+          "Agent triage-scan",
         ),
-      },
-      async () => {
-        const r = renderWithClient(
-          <AgentHoverCard agentRef="triage-scan" onJumpAgent={onJumpAgent} />,
-        );
+      );
+    });
+  });
 
-        expect(r.getByText("triage-scan")).toBeTruthy();
+  test("opens on keyboard focus, not only on hover", async () => {
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(<AgentHoverCard agentRef="triage-scan" />);
+      const jump = r.getByRole("button", { name: /triage-scan/ });
 
-        // Hover over the trigger
-        const trigger = r.getByText("triage-scan");
-        fireEvent.mouseEnter(trigger);
+      jump.focus();
+      fireEvent.focus(jump);
 
-        // Wait for hover card portal to render with agent details
-        await waitFor(() => {
-          expect(r.getByRole("tooltip")).toBeTruthy();
-          expect(r.getByText("v2")).toBeTruthy();
-          expect(r.getByText("Mutating")).toBeTruthy();
-          expect(r.getByText("claude-3-7-sonnet")).toBeTruthy();
-          expect(r.getByText("triage/v1")).toBeTruthy();
-          expect(r.getByText("ephemeral")).toBeTruthy();
-          expect(r.getByText(/450s timeout/)).toBeTruthy();
-          expect(r.getByText(/github, linear/)).toBeTruthy();
-        });
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(triggerOf(r.container).getAttribute("aria-expanded")).toBe("true");
+    });
+  });
 
-        // Click "Open in Agents"
-        const openBtn = r.getByRole("button", { name: /Open in Agents/i });
-        fireEvent.click(openBtn);
-        expect(onJumpAgent).toHaveBeenCalledWith("triage-scan");
-      },
-    );
+  test("Escape closes the card and returns focus to the agent link", async () => {
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(<AgentHoverCard agentRef="triage-scan" />);
+      const jump = r.getByRole("button", { name: /triage-scan/ });
+      jump.focus();
+      fireEvent.focus(jump);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.keyDown(window, { key: "Escape" });
+
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+      expect(document.activeElement).toBe(jump);
+    });
+  });
+
+  test("ArrowDown opens the card and moves focus into it", async () => {
+    const onJumpAgent = mock(() => {});
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(
+        <AgentHoverCard agentRef="triage-scan" onJumpAgent={onJumpAgent} />,
+      );
+      const trigger = triggerOf(r.container);
+      r.getByRole("button", { name: /triage-scan/ }).focus();
+
+      fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+      await waitFor(() =>
+        expect(document.activeElement).toBe(
+          r.getByRole("button", { name: /Open in Agents/i }),
+        ),
+      );
+    });
+  });
+
+  test("dismisses when the table underneath scrolls", async () => {
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(
+        <div data-testid="table-scroll">
+          <AgentHoverCard agentRef="triage-scan" />
+        </div>,
+      );
+      fireEvent.mouseEnter(r.getByText("triage-scan"));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.scroll(r.getByTestId("table-scroll"));
+
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+    });
+  });
+
+  test("falls back to the resolved Agents route when no jump handler is wired", async () => {
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(<AgentHoverCard agentRef="triage-scan" />);
+      fireEvent.mouseEnter(r.getByText("triage-scan"));
+
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: /Open in Agents/i }).getAttribute("href"),
+        ).toBe("#/agents/triage-scan"),
+      );
+    });
+  });
+
+  test("keeps custom trigger content clickable and its own tab stop", async () => {
+    const onJumpAgent = mock(() => {});
+    await withApi(agentsApi(), async () => {
+      const r = renderWithClient(
+        <AgentHoverCard agentRef="triage-scan" onJumpAgent={onJumpAgent}>
+          <span>custom label</span>
+        </AgentHoverCard>,
+      );
+
+      expect(triggerOf(r.container).getAttribute("tabindex")).toBe("0");
+      fireEvent.click(r.getByText("custom label"));
+      expect(onJumpAgent).toHaveBeenCalledWith("triage-scan");
+    });
   });
 });

--- a/event-runtime/web/src/components/AgentHoverCard.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.tsx
@@ -2,16 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
-  useCallback,
-  useEffect,
-  useId,
   useMemo,
-  useRef,
-  useState,
 } from "react";
-import { createPortal } from "react-dom";
 import { api } from "../api";
+import { resolveEntity } from "../entities";
 import type { AgentDef } from "../types";
+import { HoverCard } from "./HoverCard";
 import { JumpLink, StateBadge } from "./ui";
 
 /** Shared empty-value glyph for registry metadata. */
@@ -51,6 +47,9 @@ export function AgentMutationBadge({ mutating }: { mutating: boolean }) {
   return <StateBadge state={state} hues={AGENT_MUTATION_HUES} />;
 }
 
+const FOOTER_LINK_CLASS =
+  "cursor-pointer text-[11px] font-medium text-(--accent) hover:underline inline-flex items-center gap-1";
+
 export interface AgentHoverCardProps {
   agentRef: string;
   onJumpAgent?: (ref: string) => void;
@@ -60,9 +59,10 @@ export interface AgentHoverCardProps {
 }
 
 /**
- * Interactive hover card for an Agent reference.
- * Displays agent metadata (version, mutation safety, limits, model, contract, prompt)
- * in a floating portal panel on hover.
+ * Interactive hover card for an Agent reference (WM-700).
+ * Displays agent metadata (version, mutation safety, limits, model, contract,
+ * prompt) in the shared `HoverCard` primitive, so it opens on focus as well as
+ * hover and answers Escape.
  */
 export function AgentHoverCard({
   agentRef,
@@ -71,21 +71,6 @@ export function AgentHoverCard({
   className,
   title,
 }: AgentHoverCardProps) {
-  const [open, setOpen] = useState(false);
-  const [coords, setCoords] = useState<{
-    top: number;
-    left: number;
-    placeAbove: boolean;
-  }>({
-    top: 0,
-    left: 0,
-    placeAbove: false,
-  });
-  const triggerRef = useRef<HTMLSpanElement | null>(null);
-  const cardRef = useRef<HTMLDivElement | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const panelId = useId();
-
   const agentsQ = useQuery({
     queryKey: ["agents"],
     queryFn: () => api.agents(),
@@ -97,225 +82,166 @@ export function AgentHoverCard({
     return list.find((a) => a.ref === agentRef || a.id === agentRef);
   }, [agentsQ.data, agentRef]);
 
-  const updatePosition = useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    const CARD_WIDTH = 320;
-    const CARD_HEIGHT = 220; // approximate estimate
-    const margin = 8;
+  /** The Agents route for this ref — the fallback target when no jump is wired. */
+  const entity = resolveEntity("agent", agentRef);
 
-    let left = rect.left;
-    if (left + CARD_WIDTH > window.innerWidth - 12) {
-      left = Math.max(12, window.innerWidth - CARD_WIDTH - 12);
-    }
-    if (left < 12) left = 12;
-
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const placeAbove =
-      spaceBelow < CARD_HEIGHT + margin && rect.top > CARD_HEIGHT + margin;
-    const top = placeAbove ? rect.top - margin : rect.bottom + margin;
-
-    setCoords({ top, left, placeAbove });
-  }, []);
-
-  const handleMouseEnter = () => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
-      updatePosition();
-      setOpen(true);
-    }, 180);
-  };
-
-  const handleMouseLeave = () => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
-      setOpen(false);
-    }, 150);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
-  }, []);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open]);
-
-  const handleClick = (e?: ReactMouseEvent) => {
+  const jump = (close: () => void) => (e?: ReactMouseEvent) => {
     e?.stopPropagation();
-    setOpen(false);
+    close();
     onJumpAgent?.(agentRef);
   };
 
   return (
-    <>
-      <span
-        ref={triggerRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className="inline-flex items-center"
-      >
-        {children ? (
-          <span onClick={handleClick} className={className}>
+    <HoverCard
+      label={`Agent ${agentRef}`}
+      // A bare ref renders its own JumpLink button; wrapping that in a second
+      // tab stop would make every agent cell cost two Tabs.
+      focusable={Boolean(children)}
+      trigger={({ close }) =>
+        children ? (
+          <span onClick={jump(close)} className={className}>
             {children}
           </span>
         ) : (
           <JumpLink
-            onClick={handleClick}
+            onClick={jump(close)}
             title={title ?? `What is ${agentRef}? Open in Agents`}
             className={className}
           >
             {agentRef}
           </JumpLink>
-        )}
-      </span>
-
-      {open &&
-        typeof document !== "undefined" &&
-        createPortal(
-          <div
-            id={panelId}
-            ref={cardRef}
-            role="tooltip"
-            aria-live="polite"
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            style={{
-              position: "fixed",
-              top: coords.placeAbove ? undefined : `${coords.top}px`,
-              bottom: coords.placeAbove
-                ? `${window.innerHeight - coords.top}px`
-                : undefined,
-              left: `${coords.left}px`,
-              zIndex: 9999,
-            }}
-            className="w-80 rounded-lg border border-(--border-strong) bg-(--surface-1) p-3.5 shadow-xl text-[12px] text-(--text) select-text transition-opacity duration-150 animate-in fade-in"
-          >
-            {/* Header: Agent ref, version, mutation badge */}
-            <div className="flex items-start justify-between gap-2 border-b border-(--border) pb-2.5">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="mono font-semibold text-(--text) text-[13px] truncate">
-                    {agent?.ref ?? agentRef}
+        )
+      }
+    >
+      {({ close }) => (
+        <>
+          {/* Header: Agent ref, version, mutation badge */}
+          <div className="flex items-start justify-between gap-2 border-b border-(--border) pb-2.5">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="mono font-semibold text-(--text) text-[13px] truncate">
+                  {agent?.ref ?? agentRef}
+                </span>
+                {agent?.version !== undefined && (
+                  <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim)">
+                    v{agent.version}
                   </span>
-                  {agent?.version !== undefined && (
-                    <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim)">
-                      v{agent.version}
-                    </span>
-                  )}
-                </div>
-                {agent?.promptFile && (
-                  <div
-                    className="mt-0.5 mono text-[10px] text-(--text-faint) truncate"
-                    title={agent.promptFile}
-                  >
-                    {agent.promptFile}
-                  </div>
                 )}
               </div>
-
-              {agent && <AgentMutationBadge mutating={agent.mutating} />}
+              {agent?.promptFile && (
+                <div
+                  className="mt-0.5 mono text-[10px] text-(--text-faint) truncate"
+                  title={agent.promptFile}
+                >
+                  {agent.promptFile}
+                </div>
+              )}
             </div>
 
-            {/* Content metadata */}
-            {agent ? (
-              <div className="my-2.5 space-y-1.5 text-[11px]">
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="text-(--text-faint)">Model / Tier</span>
-                  <span className="mono text-(--text-dim) truncate">
-                    {agent.model ?? agent.modelTier ?? EMPTY_VALUE}
-                  </span>
-                </div>
+            {agent && <AgentMutationBadge mutating={agent.mutating} />}
+          </div>
 
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="text-(--text-faint)">Output Contract</span>
-                  <span className="mono text-(--text-dim) truncate">
-                    {agent.outputContract || EMPTY_VALUE}
-                  </span>
-                </div>
+          {/* Content metadata */}
+          {agent ? (
+            <div className="my-2.5 space-y-1.5 text-[11px]">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-(--text-faint)">Model / Tier</span>
+                <span className="mono text-(--text-dim) truncate">
+                  {agent.model ?? agent.modelTier ?? EMPTY_VALUE}
+                </span>
+              </div>
 
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="text-(--text-faint)">Workspace</span>
-                  <span className="mono text-(--text-dim)">
-                    {agent.workspace.type}
-                  </span>
-                </div>
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-(--text-faint)">Output Contract</span>
+                <span className="mono text-(--text-dim) truncate">
+                  {agent.outputContract || EMPTY_VALUE}
+                </span>
+              </div>
 
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="text-(--text-faint)">Limits</span>
-                  <span className="mono text-(--text-dim)">
-                    {agent.limits.timeout_seconds != null
-                      ? `${agent.limits.timeout_seconds}s`
-                      : EMPTY_VALUE}{" "}
-                    timeout · {agent.limits.attempts ?? EMPTY_VALUE} attempts
-                  </span>
-                </div>
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-(--text-faint)">Workspace</span>
+                <span className="mono text-(--text-dim)">
+                  {agent.workspace.type}
+                </span>
+              </div>
 
-                {agent.capabilities?.services &&
-                  agent.capabilities.services.length > 0 && (
-                    <div className="flex items-baseline justify-between gap-2">
-                      <span className="text-(--text-faint)">Services</span>
-                      <span className="mono text-(--text-dim) truncate">
-                        {agent.capabilities.services.join(", ")}
-                      </span>
-                    </div>
-                  )}
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-(--text-faint)">Limits</span>
+                <span className="mono text-(--text-dim)">
+                  {agent.limits.timeout_seconds != null
+                    ? `${agent.limits.timeout_seconds}s`
+                    : EMPTY_VALUE}{" "}
+                  timeout · {agent.limits.attempts ?? EMPTY_VALUE} attempts
+                </span>
+              </div>
 
-                {agent.eventTypes && agent.eventTypes.length > 0 && (
-                  <div className="mt-2 pt-2 border-t border-(--border)">
-                    <div className="text-(--text-faint) text-[10px] mb-1 uppercase tracking-wide">
-                      Subscribed Events ({agent.eventTypes.length})
-                    </div>
-                    <div className="flex flex-wrap gap-1">
-                      {agent.eventTypes.slice(0, 3).map((et) => (
-                        <span
-                          key={et.type}
-                          className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim) truncate max-w-[200px]"
-                          title={et.type}
-                        >
-                          {et.type}
-                        </span>
-                      ))}
-                      {agent.eventTypes.length > 3 && (
-                        <span className="mono text-[10px] text-(--text-faint) self-center">
-                          +{agent.eventTypes.length - 3} more
-                        </span>
-                      )}
-                    </div>
+              {agent.capabilities?.services &&
+                agent.capabilities.services.length > 0 && (
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-(--text-faint)">Services</span>
+                    <span className="mono text-(--text-dim) truncate">
+                      {agent.capabilities.services.join(", ")}
+                    </span>
                   </div>
                 )}
-              </div>
-            ) : (
-              <div className="py-2 text-[11px] text-(--text-faint)">
-                {agentsQ.isLoading
-                  ? "Loading agent definition…"
-                  : `Agent definition for ${agentRef} not found.`}
-              </div>
-            )}
 
-            {/* Footer action */}
-            {onJumpAgent && (
-              <div className="mt-2.5 pt-2 border-t border-(--border) flex justify-end">
-                <button
-                  type="button"
-                  onClick={handleClick}
-                  className="cursor-pointer text-[11px] font-medium text-(--accent) hover:underline inline-flex items-center gap-1"
+              {agent.eventTypes && agent.eventTypes.length > 0 && (
+                <div className="mt-2 pt-2 border-t border-(--border)">
+                  <div className="text-(--text-faint) text-[10px] mb-1 uppercase tracking-wide">
+                    Subscribed Events ({agent.eventTypes.length})
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {agent.eventTypes.slice(0, 3).map((et) => (
+                      <span
+                        key={et.type}
+                        className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim) truncate max-w-[200px]"
+                        title={et.type}
+                      >
+                        {et.type}
+                      </span>
+                    ))}
+                    {agent.eventTypes.length > 3 && (
+                      <span className="mono text-[10px] text-(--text-faint) self-center">
+                        +{agent.eventTypes.length - 3} more
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="py-2 text-[11px] text-(--text-faint)">
+              {agentsQ.isLoading
+                ? "Loading agent definition…"
+                : `Agent definition for ${agentRef} not found.`}
+            </div>
+          )}
+
+          {/* Footer action — a real link when nothing wired a jump handler,
+                so the card is never a dead end for keyboard or middle-click. */}
+          <div className="mt-2.5 pt-2 border-t border-(--border) flex justify-end">
+            {onJumpAgent ? (
+              <button
+                type="button"
+                onClick={jump(close)}
+                className={FOOTER_LINK_CLASS}
+              >
+                Open in Agents <span aria-hidden="true">→</span>
+              </button>
+            ) : (
+              entity && (
+                <a
+                  href={entity.href}
+                  onClick={() => close()}
+                  className={FOOTER_LINK_CLASS}
                 >
                   Open in Agents <span aria-hidden="true">→</span>
-                </button>
-              </div>
+                </a>
+              )
             )}
-          </div>,
-          document.body,
-        )}
-    </>
+          </div>
+        </>
+      )}
+    </HoverCard>
   );
 }

--- a/event-runtime/web/src/components/AgentHoverCard.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.tsx
@@ -158,20 +158,22 @@ export function AgentHoverCard({
                 </span>
               </div>
 
+              {/* A registry served mid-migration can omit either block, and a
+                  card that throws takes the whole view down with it. */}
               <div className="flex items-baseline justify-between gap-2">
                 <span className="text-(--text-faint)">Workspace</span>
                 <span className="mono text-(--text-dim)">
-                  {agent.workspace.type}
+                  {agent.workspace?.type ?? EMPTY_VALUE}
                 </span>
               </div>
 
               <div className="flex items-baseline justify-between gap-2">
                 <span className="text-(--text-faint)">Limits</span>
                 <span className="mono text-(--text-dim)">
-                  {agent.limits.timeout_seconds != null
+                  {agent.limits?.timeout_seconds != null
                     ? `${agent.limits.timeout_seconds}s`
                     : EMPTY_VALUE}{" "}
-                  timeout · {agent.limits.attempts ?? EMPTY_VALUE} attempts
+                  timeout · {agent.limits?.attempts ?? EMPTY_VALUE} attempts
                 </span>
               </div>
 

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -1,0 +1,320 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  CLOSE_MS,
+  computeHoverCardPosition,
+  HoverCard,
+  HOVER_CARD_HEIGHT,
+  HOVER_CARD_WIDTH,
+  OPEN_MS,
+  prefersReducedMotion,
+  VIEWPORT_MARGIN,
+} from "./HoverCard";
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  cleanup();
+  (window as unknown as { matchMedia?: unknown }).matchMedia =
+    originalMatchMedia;
+});
+
+/** Stubs the motion query so the reduced-motion branch is reachable in tests. */
+function stubReducedMotion(reduce: boolean) {
+  (window as unknown as { matchMedia: unknown }).matchMedia = ((
+    query: string,
+  ) => ({
+    matches: reduce && query.includes("prefers-reduced-motion"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })) as unknown as typeof window.matchMedia;
+}
+
+function Fixture(props: {
+  focusable?: boolean;
+  openDelayMs?: number;
+  closeDelayMs?: number;
+  onOpenChange?: (open: boolean) => void;
+  interactiveTrigger?: boolean;
+}) {
+  return (
+    <HoverCard
+      label="Agent triage-scan"
+      openDelayMs={props.openDelayMs ?? 0}
+      closeDelayMs={props.closeDelayMs ?? 0}
+      focusable={props.focusable}
+      onOpenChange={props.onOpenChange}
+      trigger={
+        props.interactiveTrigger ? (
+          <button type="button">triage-scan</button>
+        ) : (
+          "triage-scan"
+        )
+      }
+    >
+      {({ close }) => (
+        <>
+          <span>card body</span>
+          <button type="button" onClick={close}>
+            Open in Agents
+          </button>
+        </>
+      )}
+    </HoverCard>
+  );
+}
+
+/** The wrapper is the only element carrying the popup ARIA state. */
+function triggerOf(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[aria-haspopup='dialog']");
+  if (!el) throw new Error("trigger not found");
+  return el;
+}
+
+describe("computeHoverCardPosition", () => {
+  const viewport = { width: 1440, height: 900 };
+  const size = { width: HOVER_CARD_WIDTH, height: HOVER_CARD_HEIGHT };
+
+  test("places the panel below the trigger when there is room", () => {
+    const p = computeHoverCardPosition(
+      { top: 100, bottom: 118, left: 200 },
+      viewport,
+      size,
+    );
+    expect(p).toEqual({ top: 126, left: 200, placeAbove: false });
+  });
+
+  test("clamps a right-edge trigger inside the viewport margin", () => {
+    const p = computeHoverCardPosition(
+      { top: 100, bottom: 118, left: 1400 },
+      viewport,
+      size,
+    );
+    expect(p.left).toBe(viewport.width - size.width - VIEWPORT_MARGIN);
+    expect(p.left + size.width).toBeLessThanOrEqual(
+      viewport.width - VIEWPORT_MARGIN,
+    );
+  });
+
+  test("keeps a left-edge trigger off the viewport edge", () => {
+    const p = computeHoverCardPosition(
+      { top: 100, bottom: 118, left: -40 },
+      viewport,
+      size,
+    );
+    expect(p.left).toBe(VIEWPORT_MARGIN);
+  });
+
+  test("flips above when the space below cannot hold the panel", () => {
+    const p = computeHoverCardPosition(
+      { top: 820, bottom: 838, left: 200 },
+      viewport,
+      size,
+    );
+    expect(p.placeAbove).toBe(true);
+    expect(p.top).toBe(812);
+  });
+
+  test("stays below when neither side fits but below is roomier", () => {
+    const p = computeHoverCardPosition(
+      { top: 60, bottom: 78, left: 200 },
+      { width: 1440, height: 240 },
+      size,
+    );
+    expect(p.placeAbove).toBe(false);
+  });
+});
+
+describe("HoverCard", () => {
+  test("exposes the specified open and close delays", () => {
+    expect(OPEN_MS).toBe(180);
+    expect(CLOSE_MS).toBe(150);
+  });
+
+  test("renders a focusable trigger and no panel until opened", () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    expect(trigger.getAttribute("tabindex")).toBe("0");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(r.queryByRole("dialog")).toBeNull();
+  });
+
+  test("does not add a second tab stop when the trigger is interactive", () => {
+    const r = render(<Fixture focusable={false} interactiveTrigger />);
+    expect(triggerOf(r.container).getAttribute("tabindex")).toBe("-1");
+    expect(r.getByRole("button", { name: "triage-scan" })).toBeTruthy();
+  });
+
+  test("opens on focus and marks the trigger expanded", async () => {
+    const onOpenChange = mock((_open: boolean) => {});
+    const r = render(<Fixture onOpenChange={onOpenChange} />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      const panel = r.getByRole("dialog");
+      expect(panel.getAttribute("aria-label")).toBe("Agent triage-scan");
+      expect(r.getByText("card body")).toBeTruthy();
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger.getAttribute("aria-controls")).toBe(
+      r.getByRole("dialog").id,
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  test("opens on hover and closes when the pointer leaves", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.mouseLeave(trigger);
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+  });
+
+  test("stays open while the pointer is over the panel", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.mouseLeave(trigger);
+    fireEvent.mouseEnter(r.getByRole("dialog"));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(r.queryByRole("dialog")).toBeTruthy();
+  });
+
+  test("Enter on the trigger opens the card", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+  });
+
+  test("Enter on an interactive trigger child does not open the card", async () => {
+    const r = render(<Fixture focusable={false} interactiveTrigger />);
+
+    fireEvent.keyDown(r.getByRole("button", { name: "triage-scan" }), {
+      key: "Enter",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(r.queryByRole("dialog")).toBeNull();
+  });
+
+  test("ArrowDown opens the card and moves focus into it", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(r.getByRole("dialog")).toBeTruthy();
+      expect(document.activeElement).toBe(
+        r.getByRole("button", { name: /Open in Agents/ }),
+      );
+    });
+  });
+
+  test("Escape closes the card and restores focus to the trigger", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  test("Escape from inside the panel returns focus to the trigger", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const action = r.getByRole("button", { name: /Open in Agents/ });
+    action.focus();
+    fireEvent.keyDown(action, { key: "Escape" });
+
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test("a scroll in a surrounding container dismisses the card", async () => {
+    const r = render(
+      <div data-testid="table-scroll">
+        <Fixture />
+      </div>,
+    );
+    const trigger = triggerOf(r.container);
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.scroll(r.getByTestId("table-scroll"));
+
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+  });
+
+  test("a scroll inside the panel does not dismiss the card", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.scroll(r.getByRole("dialog"));
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(r.queryByRole("dialog")).toBeTruthy();
+  });
+
+  test("an in-panel action can close the card", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.click(r.getByRole("button", { name: /Open in Agents/ }));
+
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+  });
+
+  test("drops the entry animation when reduced motion is preferred", async () => {
+    stubReducedMotion(true);
+    expect(prefersReducedMotion()).toBe(true);
+
+    const r = render(<Fixture />);
+    fireEvent.mouseEnter(triggerOf(r.container));
+
+    await waitFor(() => {
+      const panel = r.getByRole("dialog");
+      expect(panel.className).not.toContain("animate-in");
+      expect(panel.className).not.toContain("transition-opacity");
+    });
+  });
+
+  test("animates by default when motion is not restricted", async () => {
+    stubReducedMotion(false);
+    const r = render(<Fixture />);
+    fireEvent.mouseEnter(triggerOf(r.container));
+
+    await waitFor(() =>
+      expect(r.getByRole("dialog").className).toContain("animate-in"),
+    );
+  });
+});

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -272,6 +272,23 @@ describe("HoverCard", () => {
     });
   });
 
+  test("ArrowDown on an inner trigger button does not reach a window list-keys listener", async () => {
+    const listKeys = mock((_e: KeyboardEvent) => {});
+    window.addEventListener("keydown", listKeys);
+    try {
+      const r = render(<Fixture focusable={false} interactiveTrigger />);
+      const inner = r.getByRole("button", { name: "triage-scan" });
+      inner.focus();
+
+      fireEvent.keyDown(inner, { key: "ArrowDown" });
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(listKeys).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", listKeys);
+    }
+  });
+
   test("Escape closes the card and restores focus to the trigger", async () => {
     const r = render(<Fixture />);
     const trigger = triggerOf(r.container);
@@ -351,6 +368,28 @@ describe("HoverCard", () => {
     fireEvent.scroll(r.getByTestId("table-scroll"));
 
     await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+  });
+
+  test("a surrounding scroll restores focus when it was inside the panel", async () => {
+    const r = render(
+      <div data-testid="table-scroll">
+        <Fixture />
+      </div>,
+    );
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    await waitFor(() => {
+      expect(r.getByRole("dialog")).toBeTruthy();
+      expect(document.activeElement).toBe(
+        r.getByRole("button", { name: /Open in Agents/ }),
+      );
+    });
+
+    fireEvent.scroll(r.getByTestId("table-scroll"));
+
+    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
   });
 
   test("a scroll inside the panel does not dismiss the card", async () => {

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import {
   CLOSE_MS,
   computeHoverCardPosition,
@@ -174,7 +180,12 @@ describe("HoverCard", () => {
     await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
 
     fireEvent.mouseLeave(trigger);
-    await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+    // The close is deferred by a timer, so the state update lands outside the
+    // event handler; drain it inside `act` rather than polling for it.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(r.queryByRole("dialog")).toBeNull();
   });
 
   test("stays open while the pointer is over the panel", async () => {
@@ -186,7 +197,9 @@ describe("HoverCard", () => {
 
     fireEvent.mouseLeave(trigger);
     fireEvent.mouseEnter(r.getByRole("dialog"));
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
     expect(r.queryByRole("dialog")).toBeTruthy();
   });
 
@@ -205,7 +218,9 @@ describe("HoverCard", () => {
       key: "Enter",
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
     expect(r.queryByRole("dialog")).toBeNull();
   });
 
@@ -278,7 +293,9 @@ describe("HoverCard", () => {
 
     fireEvent.scroll(r.getByRole("dialog"));
 
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
     expect(r.queryByRole("dialog")).toBeTruthy();
   });
 

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -13,6 +13,7 @@ import {
   HoverCard,
   HOVER_CARD_HEIGHT,
   HOVER_CARD_WIDTH,
+  MIN_PANEL_HEIGHT,
   OPEN_MS,
   prefersReducedMotion,
   VIEWPORT_MARGIN,
@@ -89,7 +90,12 @@ describe("computeHoverCardPosition", () => {
       viewport,
       size,
     );
-    expect(p).toEqual({ top: 126, left: 200, placeAbove: false });
+    expect(p).toEqual({
+      top: 126,
+      left: 200,
+      placeAbove: false,
+      maxHeight: 762,
+    });
   });
 
   test("clamps a right-edge trigger inside the viewport margin", () => {
@@ -130,6 +136,33 @@ describe("computeHoverCardPosition", () => {
       size,
     );
     expect(p.placeAbove).toBe(false);
+  });
+
+  test("caps the height to the room on the chosen side", () => {
+    const below = computeHoverCardPosition(
+      { top: 100, bottom: 118, left: 200 },
+      { width: 1440, height: 400 },
+      size,
+    );
+    expect(below.placeAbove).toBe(false);
+    expect(below.top + below.maxHeight).toBe(400 - VIEWPORT_MARGIN);
+
+    const above = computeHoverCardPosition(
+      { top: 260, bottom: 278, left: 200 },
+      { width: 1440, height: 300 },
+      size,
+    );
+    expect(above.placeAbove).toBe(true);
+    expect(above.top - above.maxHeight).toBe(VIEWPORT_MARGIN);
+  });
+
+  test("never squeezes the panel below a readable minimum", () => {
+    const p = computeHoverCardPosition(
+      { top: 10, bottom: 28, left: 200 },
+      { width: 1440, height: 60 },
+      size,
+    );
+    expect(p.maxHeight).toBe(MIN_PANEL_HEIGHT);
   });
 });
 
@@ -266,6 +299,42 @@ describe("HoverCard", () => {
 
     await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
     expect(document.activeElement).toBe(trigger);
+  });
+
+  test("Escape from inside the card does not also reach an enclosing layer", async () => {
+    const outer = mock((_e: KeyboardEvent) => {});
+    window.addEventListener("keydown", outer);
+    try {
+      const r = render(<Fixture />);
+      const trigger = triggerOf(r.container);
+      trigger.focus();
+      fireEvent.focus(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.keyDown(trigger, { key: "Escape" });
+
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+      expect(outer).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", outer);
+    }
+  });
+
+  test("Escape with focus elsewhere closes the card but lets the key through", async () => {
+    const outer = mock((_e: KeyboardEvent) => {});
+    window.addEventListener("keydown", outer);
+    try {
+      const r = render(<Fixture />);
+      fireEvent.mouseEnter(triggerOf(r.container));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.keyDown(document.body, { key: "Escape" });
+
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+      expect(outer).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", outer);
+    }
   });
 
   test("a scroll in a surrounding container dismisses the card", async () => {

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -39,11 +39,16 @@ export const TRIGGER_GAP = 8;
 const FOCUSABLE =
   'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
+/** Never squeeze the panel below this; scroll it instead. */
+export const MIN_PANEL_HEIGHT = 120;
+
 export interface HoverCardPlacement {
   /** Anchor y: the panel's top edge below, or its bottom edge above. */
   top: number;
   left: number;
   placeAbove: boolean;
+  /** Room on the chosen side, so a tall card scrolls instead of overflowing. */
+  maxHeight: number;
 }
 
 /**
@@ -72,7 +77,13 @@ export function computeHoverCardPosition(
   const top = placeAbove
     ? trigger.top - TRIGGER_GAP
     : trigger.bottom + TRIGGER_GAP;
-  return { top, left, placeAbove };
+  const room = (placeAbove ? spaceAbove : spaceBelow) - TRIGGER_GAP;
+  return {
+    top,
+    left,
+    placeAbove,
+    maxHeight: Math.max(MIN_PANEL_HEIGHT, room - VIEWPORT_MARGIN),
+  };
 }
 
 /** Reads the OS motion preference; false wherever `matchMedia` is missing. */
@@ -150,6 +161,7 @@ export function HoverCard({
     top: 0,
     left: 0,
     placeAbove: false,
+    maxHeight: HOVER_CARD_HEIGHT,
   });
   const wrapperRef = useRef<HTMLSpanElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -253,7 +265,12 @@ export function HoverCard({
 
   useEffect(() => clearTimer, [clearTimer]);
 
-  // Escape anywhere closes; focus only returns when it was ours to return.
+  /**
+   * Escape anywhere closes the card. When focus is inside it, the operator
+   * meant *this* layer: swallow the key so an enclosing dialog does not close
+   * behind it. A card merely left open under the pointer swallows nothing —
+   * Escape there belongs to whatever the operator is actually working in.
+   */
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -263,10 +280,12 @@ export function HoverCard({
         (panelRef.current?.contains(active as Node) ?? false) ||
         (wrapperRef.current?.contains(active as Node) ?? false);
       close();
-      if (inside) restoreFocus();
+      if (!inside) return;
+      e.stopPropagation();
+      restoreFocus();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [open, close, restoreFocus]);
 
   // The panel is pinned to viewport coordinates, so any scroll that is not the
@@ -365,6 +384,8 @@ export function HoverCard({
                 : undefined,
               left: `${placement.left}px`,
               width: `${width}px`,
+              maxHeight: `${placement.maxHeight}px`,
+              overflowY: "auto",
               zIndex: 9999,
             }}
             className={`rounded-lg border border-(--border-strong) bg-(--surface-1) p-3.5 shadow-xl text-[12px] text-(--text) select-text outline-none${motion} ${panelClassName ?? ""}`}

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -1,0 +1,370 @@
+/**
+ * Hover card primitive (WM-700).
+ *
+ * A hover-only card is a mouse-only card: the operator who drives the console
+ * from the keyboard never sees it. This primitive opens on hover *and* on
+ * focus, answers Escape by closing and handing focus back, and dismisses
+ * itself the moment the table underneath scrolls — a portalled panel pinned to
+ * viewport coordinates would otherwise float away from the row it describes.
+ *
+ * Callers supply the trigger and the panel body; the panel is portalled to
+ * `document.body` so a row's `overflow: hidden` cannot clip it.
+ */
+import {
+  type FocusEvent as ReactFocusEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+/** Hover dwell before opening — long enough that crossing a row does nothing. */
+export const OPEN_MS = 180;
+/** Grace before closing, so the pointer can cross the gap into the panel. */
+export const CLOSE_MS = 150;
+
+/** Default panel width; the collision math needs a number before layout. */
+export const HOVER_CARD_WIDTH = 320;
+/** Height estimate used only to decide above/below before the panel exists. */
+export const HOVER_CARD_HEIGHT = 220;
+/** Keep-clear distance from the viewport edge. */
+export const VIEWPORT_MARGIN = 12;
+/** Gap between the trigger and the panel. */
+export const TRIGGER_GAP = 8;
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+export interface HoverCardPlacement {
+  /** Anchor y: the panel's top edge below, or its bottom edge above. */
+  top: number;
+  left: number;
+  placeAbove: boolean;
+}
+
+/**
+ * Clamp the panel inside the viewport and flip it above the trigger when the
+ * space below cannot hold it. When neither side fits, take the roomier one —
+ * a clipped card is still readable, a card drawn off-screen is not.
+ */
+export function computeHoverCardPosition(
+  trigger: { top: number; bottom: number; left: number },
+  viewport: { width: number; height: number },
+  size: { width: number; height: number } = {
+    width: HOVER_CARD_WIDTH,
+    height: HOVER_CARD_HEIGHT,
+  },
+): HoverCardPlacement {
+  let left = trigger.left;
+  if (left + size.width > viewport.width - VIEWPORT_MARGIN) {
+    left = viewport.width - size.width - VIEWPORT_MARGIN;
+  }
+  if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+
+  const spaceBelow = viewport.height - trigger.bottom;
+  const spaceAbove = trigger.top;
+  const placeAbove =
+    spaceBelow < size.height + TRIGGER_GAP && spaceAbove > spaceBelow;
+  const top = placeAbove
+    ? trigger.top - TRIGGER_GAP
+    : trigger.bottom + TRIGGER_GAP;
+  return { top, left, placeAbove };
+}
+
+/** Reads the OS motion preference; false wherever `matchMedia` is missing. */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+    return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/** `prefers-reduced-motion`, kept current if the operator changes it mid-session. */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(prefersReducedMotion);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    let query: MediaQueryList;
+    try {
+      query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    } catch {
+      return;
+    }
+    if (typeof query.addEventListener !== "function") return;
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}
+
+export interface HoverCardApi {
+  close: () => void;
+}
+
+export interface HoverCardProps {
+  /** Accessible name of the panel — it is a dialog, so it needs one. */
+  label: string;
+  /** What the operator hovers or focuses; the function form receives `close`. */
+  trigger: ReactNode | ((api: HoverCardApi) => ReactNode);
+  /** Panel body. The function form receives `close` for in-panel actions. */
+  children: ReactNode | ((api: HoverCardApi) => ReactNode);
+  /**
+   * Whether the wrapper is its own tab stop. Pass false when `trigger` already
+   * renders a button or link: two tab stops for one thing is worse than none,
+   * and focus still bubbles to the wrapper's handlers either way.
+   */
+  focusable?: boolean;
+  className?: string;
+  panelClassName?: string;
+  width?: number;
+  /** Height estimate for the above/below decision before the panel renders. */
+  estimatedHeight?: number;
+  openDelayMs?: number;
+  closeDelayMs?: number;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function HoverCard({
+  label,
+  trigger,
+  children,
+  focusable = true,
+  className,
+  panelClassName,
+  width = HOVER_CARD_WIDTH,
+  estimatedHeight = HOVER_CARD_HEIGHT,
+  openDelayMs = OPEN_MS,
+  closeDelayMs = CLOSE_MS,
+  onOpenChange,
+}: HoverCardProps) {
+  const [open, setOpen] = useState(false);
+  const [placement, setPlacement] = useState<HoverCardPlacement>({
+    top: 0,
+    left: 0,
+    placeAbove: false,
+  });
+  const wrapperRef = useRef<HTMLSpanElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastFocusRef = useRef<HTMLElement | null>(null);
+  const focusPanelRef = useRef(false);
+  const suppressFocusOpenRef = useRef(false);
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+  const notifiedRef = useRef(open);
+  const panelId = useId();
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (notifiedRef.current === open) return;
+    notifiedRef.current = open;
+    onOpenChangeRef.current?.(open);
+  }, [open]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const reposition = useCallback(() => {
+    const el = wrapperRef.current;
+    if (!el?.getBoundingClientRect) return;
+    const rect = el.getBoundingClientRect();
+    setPlacement(
+      computeHoverCardPosition(
+        rect,
+        { width: window.innerWidth, height: window.innerHeight },
+        { width, height: estimatedHeight },
+      ),
+    );
+  }, [width, estimatedHeight]);
+
+  const openNow = useCallback(() => {
+    clearTimer();
+    reposition();
+    setOpen(true);
+  }, [clearTimer, reposition]);
+
+  const closeNow = useCallback(() => {
+    clearTimer();
+    setOpen(false);
+  }, [clearTimer]);
+
+  const scheduleOpen = useCallback(() => {
+    clearTimer();
+    if (openDelayMs <= 0) {
+      openNow();
+      return;
+    }
+    timerRef.current = setTimeout(openNow, openDelayMs);
+  }, [clearTimer, openDelayMs, openNow]);
+
+  /**
+   * Deferred and re-checked on fire: a blur arrives *before* the focusin that
+   * caused it, so "did focus leave the card?" can only be answered afterwards.
+   * Focus that landed inside the trigger or the panel keeps the card open.
+   */
+  const scheduleClose = useCallback(() => {
+    clearTimer();
+    timerRef.current = setTimeout(
+      () => {
+        timerRef.current = null;
+        const active = document.activeElement as Node | null;
+        const inside =
+          (active != null && panelRef.current?.contains(active)) ||
+          (active != null && wrapperRef.current?.contains(active));
+        if (inside) return;
+        setOpen(false);
+      },
+      Math.max(0, closeDelayMs),
+    );
+  }, [clearTimer, closeDelayMs]);
+
+  /**
+   * Hand focus back to the trigger without reopening: the focus event this
+   * fires is ours, not the operator's, and Escape must mean the card stays shut.
+   */
+  const restoreFocus = useCallback(() => {
+    const previous = lastFocusRef.current;
+    const target = previous?.isConnected ? previous : wrapperRef.current;
+    if (!target) return;
+    suppressFocusOpenRef.current = true;
+    target.focus();
+    queueMicrotask(() => {
+      suppressFocusOpenRef.current = false;
+    });
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  // Escape anywhere closes; focus only returns when it was ours to return.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const active = document.activeElement;
+      const inside =
+        (panelRef.current?.contains(active as Node) ?? false) ||
+        (wrapperRef.current?.contains(active as Node) ?? false);
+      closeNow();
+      if (inside) restoreFocus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeNow, restoreFocus]);
+
+  // The panel is pinned to viewport coordinates, so any scroll that is not the
+  // panel's own would leave it describing a row that has moved on.
+  useEffect(() => {
+    if (!open) return;
+    const onScroll = (e: Event) => {
+      const target = e.target as Node | null;
+      if (target && panelRef.current?.contains(target)) return;
+      closeNow();
+    };
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open, closeNow, reposition]);
+
+  // ArrowDown means "take me into the card", so land focus there once it exists.
+  useEffect(() => {
+    if (!open || !focusPanelRef.current) return;
+    focusPanelRef.current = false;
+    const root = panelRef.current;
+    if (!root) return;
+    const first = root.querySelector<HTMLElement>(FOCUSABLE);
+    (first ?? root).focus();
+  }, [open]);
+
+  const onTriggerFocus = useCallback(
+    (e: ReactFocusEvent<HTMLSpanElement>) => {
+      lastFocusRef.current = e.target as HTMLElement;
+      if (suppressFocusOpenRef.current) return;
+      scheduleOpen();
+    },
+    [scheduleOpen],
+  );
+
+  const onTriggerKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLSpanElement>) => {
+      // Enter is the inner link's own activation key; only claim it when the
+      // wrapper itself holds focus and nothing else would act on it.
+      const ownEnter = e.key === "Enter" && e.target === e.currentTarget;
+      if (e.key !== "ArrowDown" && !ownEnter) return;
+      e.preventDefault();
+      if (e.key === "ArrowDown") focusPanelRef.current = true;
+      openNow();
+    },
+    [openNow],
+  );
+
+  const api: HoverCardApi = { close: closeNow };
+  const body = typeof children === "function" ? children(api) : children;
+  const triggerBody = typeof trigger === "function" ? trigger(api) : trigger;
+
+  const motion = reducedMotion
+    ? ""
+    : " transition-opacity duration-150 animate-in fade-in";
+
+  return (
+    <>
+      <span
+        ref={wrapperRef}
+        tabIndex={focusable ? 0 : -1}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onMouseEnter={scheduleOpen}
+        onMouseLeave={scheduleClose}
+        onFocus={onTriggerFocus}
+        onBlur={scheduleClose}
+        onKeyDown={onTriggerKeyDown}
+        className={`inline-flex items-center outline-none focus-visible:ring-1 focus-visible:ring-(--accent) ${className ?? ""}`}
+      >
+        {triggerBody}
+      </span>
+
+      {open &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            id={panelId}
+            ref={panelRef}
+            role="dialog"
+            aria-label={label}
+            tabIndex={-1}
+            onMouseEnter={clearTimer}
+            onMouseLeave={scheduleClose}
+            onFocus={clearTimer}
+            onBlur={scheduleClose}
+            style={{
+              position: "fixed",
+              top: placement.placeAbove ? undefined : `${placement.top}px`,
+              bottom: placement.placeAbove
+                ? `${window.innerHeight - placement.top}px`
+                : undefined,
+              left: `${placement.left}px`,
+              width: `${width}px`,
+              zIndex: 9999,
+            }}
+            className={`rounded-lg border border-(--border-strong) bg-(--surface-1) p-3.5 shadow-xl text-[12px] text-(--text) select-text outline-none${motion} ${panelClassName ?? ""}`}
+          >
+            {body}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -295,6 +295,8 @@ export function HoverCard({
     const onScroll = (e: Event) => {
       const target = e.target as Node | null;
       if (target && panelRef.current?.contains(target)) return;
+      const active = document.activeElement;
+      if (active && panelRef.current?.contains(active)) restoreFocus();
       close();
     };
     window.addEventListener("scroll", onScroll, true);
@@ -303,7 +305,7 @@ export function HoverCard({
       window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", reposition);
     };
-  }, [open, close, reposition]);
+  }, [open, close, reposition, restoreFocus]);
 
   // ArrowDown means "take me into the card", so land focus there once it exists.
   useEffect(() => {
@@ -331,6 +333,7 @@ export function HoverCard({
       const ownEnter = e.key === "Enter" && e.target === e.currentTarget;
       if (e.key !== "ArrowDown" && !ownEnter) return;
       e.preventDefault();
+      e.stopPropagation();
       if (e.key === "ArrowDown") focusPanelRef.current = true;
       openNow();
     },

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -157,17 +157,16 @@ export function HoverCard({
   const lastFocusRef = useRef<HTMLElement | null>(null);
   const focusPanelRef = useRef(false);
   const suppressFocusOpenRef = useRef(false);
-  const onOpenChangeRef = useRef(onOpenChange);
-  onOpenChangeRef.current = onOpenChange;
   const notifiedRef = useRef(open);
+  const [dismissals, setDismissals] = useState(0);
   const panelId = useId();
   const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     if (notifiedRef.current === open) return;
     notifiedRef.current = open;
-    onOpenChangeRef.current?.(open);
-  }, [open]);
+    onOpenChange?.(open);
+  }, [open, onOpenChange]);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -193,10 +192,19 @@ export function HoverCard({
     setOpen(true);
   }, [clearTimer, reposition]);
 
-  const closeNow = useCallback(() => {
-    clearTimer();
+  /**
+   * Touches state only, so it is safe to hand to a caller's render prop. The
+   * pending open timer is cancelled by the effect below rather than here: a
+   * function that reads a ref must not be callable during render.
+   */
+  const close = useCallback(() => {
     setOpen(false);
-  }, [clearTimer]);
+    setDismissals((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (dismissals > 0) clearTimer();
+  }, [dismissals, clearTimer]);
 
   const scheduleOpen = useCallback(() => {
     clearTimer();
@@ -254,12 +262,12 @@ export function HoverCard({
       const inside =
         (panelRef.current?.contains(active as Node) ?? false) ||
         (wrapperRef.current?.contains(active as Node) ?? false);
-      closeNow();
+      close();
       if (inside) restoreFocus();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, closeNow, restoreFocus]);
+  }, [open, close, restoreFocus]);
 
   // The panel is pinned to viewport coordinates, so any scroll that is not the
   // panel's own would leave it describing a row that has moved on.
@@ -268,7 +276,7 @@ export function HoverCard({
     const onScroll = (e: Event) => {
       const target = e.target as Node | null;
       if (target && panelRef.current?.contains(target)) return;
-      closeNow();
+      close();
     };
     window.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", reposition);
@@ -276,7 +284,7 @@ export function HoverCard({
       window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", reposition);
     };
-  }, [open, closeNow, reposition]);
+  }, [open, close, reposition]);
 
   // ArrowDown means "take me into the card", so land focus there once it exists.
   useEffect(() => {
@@ -310,7 +318,7 @@ export function HoverCard({
     [openNow],
   );
 
-  const api: HoverCardApi = { close: closeNow };
+  const api: HoverCardApi = { close };
   const body = typeof children === "function" ? children(api) : children;
   const triggerBody = typeof trigger === "function" ? trigger(api) : trigger;
 

--- a/event-runtime/web/src/entities.test.ts
+++ b/event-runtime/web/src/entities.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { type EntityKind, resolveEntity } from "./entities";
+
+describe("resolveEntity tickets", () => {
+  test("routes a ticket key to the ticket journey", () => {
+    expect(resolveEntity("ticket", "WM-700")).toEqual({
+      kind: "ticket",
+      id: "WM-700",
+      label: "WM-700",
+      path: "tickets/WM-700",
+      href: "#/tickets/WM-700",
+      externalHref: null,
+    });
+  });
+
+  test("canonicalises case and surrounding space", () => {
+    expect(resolveEntity("ticket", "  clnt-616 ")?.id).toBe("CLNT-616");
+  });
+
+  test("rejects prose that is not a ticket key", () => {
+    expect(resolveEntity("ticket", "fix the thing")).toBeNull();
+    expect(resolveEntity("ticket", "WM700")).toBeNull();
+    expect(resolveEntity("ticket", "700")).toBeNull();
+  });
+});
+
+describe("resolveEntity pull requests", () => {
+  test("routes a bare number to the PR journey", () => {
+    expect(resolveEntity("pr", 541)).toEqual({
+      kind: "pr",
+      id: "541",
+      label: "PR #541",
+      path: "prs/541",
+      href: "#/prs/541",
+      externalHref: null,
+    });
+  });
+
+  test("accepts the #-prefixed form", () => {
+    expect(resolveEntity("pr", "#541")?.href).toBe("#/prs/541");
+  });
+
+  test("keeps GitHub as an external href, never as the in-app route", () => {
+    const pr = resolveEntity(
+      "pr",
+      "https://github.com/watt-mind/factory/pull/541",
+    );
+    expect(pr?.href).toBe("#/prs/541");
+    expect(pr?.externalHref).toBe(
+      "https://github.com/watt-mind/factory/pull/541",
+    );
+  });
+
+  test("builds the GitHub href from a number when the repo is known", () => {
+    expect(
+      resolveEntity("pr", 12, { repo: "watt-mind/factory" })?.externalHref,
+    ).toBe("https://github.com/watt-mind/factory/pull/12");
+  });
+
+  test("rejects a non-numeric or zero pull request", () => {
+    expect(resolveEntity("pr", "abc")).toBeNull();
+    expect(resolveEntity("pr", "0")).toBeNull();
+  });
+});
+
+describe("resolveEntity artifact shas", () => {
+  const sha = "a".repeat(64);
+
+  test("routes a sha256 to the artifact and shortens the label", () => {
+    expect(resolveEntity("sha", sha)).toEqual({
+      kind: "sha",
+      id: sha,
+      label: "a".repeat(12),
+      path: `artifacts/${sha}`,
+      href: `#/artifacts/${sha}`,
+      externalHref: null,
+    });
+  });
+
+  test("strips a sha256: prefix and lower-cases the digest", () => {
+    expect(resolveEntity("sha", `sha256:${"B".repeat(64)}`)?.id).toBe(
+      "b".repeat(64),
+    );
+  });
+
+  test("keeps a short git sha whole", () => {
+    expect(resolveEntity("sha", "a1b2c3d")?.label).toBe("a1b2c3d");
+  });
+
+  test("rejects anything that is not hex", () => {
+    expect(resolveEntity("sha", "not-a-sha")).toBeNull();
+    expect(resolveEntity("sha", "a1b2c")).toBeNull();
+  });
+});
+
+describe("resolveEntity agents, runs, and events", () => {
+  test("routes an agent ref, encoding the version suffix", () => {
+    const agent = resolveEntity("agent", "factory-status-report@1");
+    expect(agent?.path).toBe("agents/factory-status-report%401");
+    expect(agent?.href).toBe("#/agents/factory-status-report%401");
+    expect(agent?.label).toBe("factory-status-report@1");
+  });
+
+  test("routes a run to the full-page run view, not the list row", () => {
+    expect(resolveEntity("run", "run_test_1001")?.href).toBe(
+      "#/run/run_test_1001",
+    );
+  });
+
+  test("routes an event that carries its own source", () => {
+    expect(resolveEntity("event", "github/evt_1001")?.href).toBe(
+      "#/events/github/evt_1001",
+    );
+    expect(resolveEntity("event", "github:evt_1001")?.href).toBe(
+      "#/events/github/evt_1001",
+    );
+  });
+
+  test("takes the event source from options when the id is bare", () => {
+    const event = resolveEntity("event", "evt_1001", { source: "web" });
+    expect(event?.href).toBe("#/events/web/evt_1001");
+    expect(event?.id).toBe("evt_1001");
+  });
+
+  test("refuses an event with no source rather than misreading the id", () => {
+    expect(resolveEntity("event", "evt_1001")).toBeNull();
+  });
+});
+
+describe("resolveEntity guards", () => {
+  const kinds: EntityKind[] = ["ticket", "pr", "sha", "agent", "run", "event"];
+
+  test("every kind refuses an empty or missing id", () => {
+    for (const kind of kinds) {
+      expect(resolveEntity(kind, null)).toBeNull();
+      expect(resolveEntity(kind, undefined)).toBeNull();
+      expect(resolveEntity(kind, "   ")).toBeNull();
+    }
+  });
+
+  test("every resolved href is its path behind the hash prefix", () => {
+    const resolved = [
+      resolveEntity("ticket", "WM-700"),
+      resolveEntity("pr", 1),
+      resolveEntity("sha", "a".repeat(64)),
+      resolveEntity("agent", "triage-scan"),
+      resolveEntity("run", "run_1"),
+      resolveEntity("event", "github/evt_1"),
+    ];
+    expect(resolved.every((e) => e != null)).toBe(true);
+    for (const entity of resolved)
+      expect(entity?.href).toBe(`#/${entity?.path}`);
+  });
+});

--- a/event-runtime/web/src/entities.ts
+++ b/event-runtime/web/src/entities.ts
@@ -1,0 +1,143 @@
+/**
+ * Entity resolution (WM-700): one place that knows how a ticket, pull request,
+ * artifact sha, agent, run, or event turns into a label and a route.
+ *
+ * Hover cards, chips, and jump links all name the same six things, and each
+ * one used to build its own `#/…` string. A single resolver keeps the routes
+ * in `hash.ts` honest: when a route moves, it moves here once.
+ *
+ * `href` is always the in-app hash route, so a caller can link without asking
+ * what kind it holds. A pull request additionally carries `externalHref` — the
+ * `github.com/<owner>/<repo>/pull/<n>` URL — which leaves the control plane and
+ * therefore never becomes `href`.
+ */
+import { hashPath } from "./hash";
+
+export type EntityKind = "ticket" | "pr" | "sha" | "agent" | "run" | "event";
+
+export interface ResolvedEntity {
+  kind: EntityKind;
+  /** Canonical id: ticket keys upper-cased, shas lower-cased, PRs bare digits. */
+  id: string;
+  /** Short human label for a chip, a hover-card header, or a link body. */
+  label: string;
+  /** Hash path without the leading `#/` — what `hashPath` produces. */
+  path: string;
+  /** In-app target: `#/${path}`. */
+  href: string;
+  /** GitHub URL when one is known. Only pull requests ever have one. */
+  externalHref: string | null;
+}
+
+export interface ResolveEntityOptions {
+  /** Event source (`github`, `web`, …) when the id does not carry it. */
+  source?: string | null;
+  /** `owner/repo`, used to build a pull request's GitHub URL from a number. */
+  repo?: string | null;
+}
+
+/** Ticket keys as Linear writes them: `WM-700`, `CLNT-616`. */
+const TICKET_RE = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
+/** Git shas (7+) through a full sha256 artifact digest (64). */
+const SHA_RE = /^[0-9a-f]{7,64}$/;
+const PR_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/;
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function entity(
+  kind: EntityKind,
+  id: string,
+  label: string,
+  path: string,
+  externalHref: string | null = null,
+): ResolvedEntity {
+  return { kind, id, label, path, href: `#/${path}`, externalHref };
+}
+
+function resolveTicket(raw: string): ResolvedEntity | null {
+  const id = raw.toUpperCase();
+  if (!TICKET_RE.test(id)) return null;
+  return entity("ticket", id, id, hashPath("tickets", id));
+}
+
+/**
+ * Accepts a number, `#541`, `541`, or a full GitHub pull URL. The URL form
+ * also supplies the repo, so a pasted link resolves to both routes at once.
+ */
+function resolvePr(
+  raw: string,
+  options: ResolveEntityOptions,
+): ResolvedEntity | null {
+  const url = raw.match(PR_URL_RE);
+  const repo =
+    url?.[1] ?? (REPO_RE.test(text(options.repo)) ? text(options.repo) : null);
+  const number = url?.[2] ?? raw.replace(/^#/, "");
+  if (!/^\d+$/.test(number) || number === "0") return null;
+  const id = String(Number(number));
+  return entity(
+    "pr",
+    id,
+    `PR #${id}`,
+    hashPath("prs", id),
+    repo ? `https://github.com/${repo}/pull/${id}` : null,
+  );
+}
+
+function resolveSha(raw: string): ResolvedEntity | null {
+  const sha = raw.replace(/^sha256:/i, "").toLowerCase();
+  if (!SHA_RE.test(sha)) return null;
+  // Artifacts print 12 characters everywhere else; a shorter git sha stays whole.
+  const label = sha.length > 12 ? sha.slice(0, 12) : sha;
+  return entity("sha", sha, label, hashPath("artifacts", sha));
+}
+
+/**
+ * Events are keyed by source *and* id (`#/events/:source/:eventId`). An id of
+ * `github/evt_1` or `github:evt_1` carries its own source; otherwise pass one.
+ * Without a source there is no addressable event, so this resolves to null
+ * rather than to a route that would read the id as the source.
+ */
+function resolveEvent(
+  raw: string,
+  options: ResolveEntityOptions,
+): ResolvedEntity | null {
+  const split = raw.match(/^([^/:]+)[/:](.+)$/);
+  const source = split?.[1] ?? text(options.source);
+  const eventId = split?.[2]?.trim() ?? raw;
+  if (!source || !eventId) return null;
+  return entity("event", eventId, eventId, hashPath("events", source, eventId));
+}
+
+/**
+ * Resolve an entity reference to its canonical label and routes.
+ * Returns null for anything that is not addressable — an empty id, a malformed
+ * ticket key, a sha that is not hex, an event with no source.
+ */
+export function resolveEntity(
+  kind: EntityKind,
+  id: string | number | null | undefined,
+  options: ResolveEntityOptions = {},
+): ResolvedEntity | null {
+  const raw = typeof id === "number" ? String(id) : text(id);
+  if (!raw) return null;
+  switch (kind) {
+    case "ticket":
+      return resolveTicket(raw);
+    case "pr":
+      return resolvePr(raw, options);
+    case "sha":
+      return resolveSha(raw);
+    case "agent":
+      return entity("agent", raw, raw, hashPath("agents", raw));
+    case "run":
+      // `#/run/:id` (singular) is the full-page run view, not the list row.
+      return entity("run", raw, raw, hashPath("run", raw));
+    case "event":
+      return resolveEvent(raw, options);
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
A hover-only card is a mouse-only card: the operator who drives this console from the keyboard never saw `AgentHoverCard` at all. This adds the shared primitive the ticket-, event- and run-cards in WM-701/WM-702 will sit on, and moves the agent card onto it.

## What changed

**`components/HoverCard.tsx` (new)** — portalled popover with:

- opens on hover after `OPEN_MS` (180ms) and on focus of the trigger; closes `CLOSE_MS` (150ms) after the pointer leaves, with the grace needed to cross the gap into the panel
- `ArrowDown` opens immediately and lands focus inside; `Enter` opens when the wrapper itself holds focus (never when an inner link would act on the same key, which would otherwise jump *and* open)
- `Escape` closes and hands focus back to the trigger. It is swallowed only when focus was inside the card — a card left open under the pointer must not eat the key an enclosing dialog is waiting for
- `role="dialog"` + `aria-label`, `aria-haspopup`/`aria-expanded`/`aria-controls` on the trigger. The wrapper is a tab stop only when the caller is not already rendering a button or link, so an agent cell never costs two Tabs
- viewport collision: clamped 12px inside the edges, flipped above when the space below cannot hold it, and capped to the room on the chosen side so a tall card scrolls rather than running off screen
- scroll dismissal — the panel is pinned to viewport coordinates, so any scroll that is not its own would leave it describing a row that has moved on
- no fade or transition under `prefers-reduced-motion: reduce`

**`entities.ts` (new)** — `resolveEntity(kind, id)` for ticket, PR, sha, agent, run, and event. One place that knows the `hash.ts` routes, so the cards coming after this one stop hand-rolling `#/…` strings. `href` is always the in-app route; a pull request additionally carries `externalHref` for GitHub, which never becomes the primary target.

**`AgentHoverCard.tsx`** — same panel content and visual language, now built on the primitive. Its footer falls back to the resolved Agents route when no jump handler is wired, so the card is not a dead end for keyboard or middle-click.

## Notes for the reviewer

- Opening on focus reaches the card from views that had only ever hovered it, which surfaced an unguarded `agent.workspace.type`: a registry row missing that block took the whole view down. Now optional-chained.
- Opening on focus deliberately keeps the 180ms dwell, so tabbing *through* a table does not flash a card at every stop.
- The full web suite is green (927 tests); ESLint stays at 621 warnings, unchanged from `develop`.

## Verification

`cd event-runtime/web && bun test src/components/AgentHoverCard.test.tsx src/components/HoverCard.test.tsx src/entities.test.ts` — 53 pass, 0 fail.

All eight AgentHoverCard keyboard/focus/scroll tests were observed failing against the pre-refactor component before the refactor landed, so they test the actual behaviour rather than passing vacuously.

UX critique: **blocked** — the browser MCP's tab registry deadlocked on two independent critic spawns (`browser_tabs new` returns a viewId that `browser_navigate` then rejects as unknown), so the visual and real-input pass never ran. Filed as WM-730. Keyboard, focus restoration, scroll dismissal, collision math and reduced-motion are covered by unit tests; spacing, clipping under real table overflow, and hover feel are not.

Fixes WM-700