### PR TITLE
ui(web): keep in-flight Runs rows to one line (WM-725)

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1194,3 +1194,69 @@ describe("Runs long-list window (WM-563)", () => {
     );
   });
 });
+
+describe("Runs in-flight row height (WM-725)", () => {
+  function cellFor(
+    r: ReturnType<typeof renderRuns>,
+    runId: string,
+    label: string,
+  ): HTMLTableCellElement {
+    const index = [...r.container.querySelectorAll("thead th")].findIndex(
+      (th) => (th.textContent ?? "").startsWith(label),
+    );
+    expect(index).toBeGreaterThanOrEqual(0);
+    const row = r.container
+      .querySelector(`td[title="${runId}"]`)
+      ?.closest("tr");
+    expect(row).toBeTruthy();
+    return row!.querySelectorAll("td")[index] as HTMLTableCellElement;
+  }
+
+  // The State column is one line: the badge plus the optional `proposal` jump
+  // link (WM-505). A second line of clocks stacked under the badge made every
+  // in-flight row taller than the terminal rows around it, and repeated a
+  // countdown the Remaining column already owns.
+  test("in-flight State cell stays one line and Remaining carries the countdown", async () => {
+    const now = Date.now();
+    const hang = stubListItem("run_hang", "RUNNING", {
+      startedAt: new Date(now - 2 * 60_000).toISOString(),
+      deadlineAt: new Date(now + 9 * 60_000).toISOString(),
+      leaseExpiresAt: new Date(now + 60_000).toISOString(),
+      timeoutSeconds: 600,
+    });
+    const done = stubListItem("run_done", "COMPLETED");
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [hang, done] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() =>
+          expect(
+            r.container.querySelector('td[title="run_hang"]'),
+          ).toBeTruthy(),
+        );
+
+        const state = cellFor(r, "run_hang", "State");
+        expect(state.textContent).not.toContain("timeout in");
+        expect(state.textContent).not.toContain("reaped in");
+        expect(state.textContent).toBe("RUNNING");
+        // Same block count as the terminal row beside it: one line each, so
+        // the two rows are the same height.
+        expect(state.querySelectorAll("div").length).toBe(
+          cellFor(r, "run_done", "State").querySelectorAll("div").length,
+        );
+
+        // The urgency did not disappear with the second line — Remaining shows
+        // the budget and the lease together, still on one line.
+        const remaining = cellFor(r, "run_hang", "Remaining");
+        expect(remaining.textContent).toMatch(/\b9m\b/);
+        expect(remaining.textContent).toContain("lease");
+        expect(remaining.querySelectorAll("div").length).toBe(0);
+        expect(remaining.className).toContain("whitespace-nowrap");
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1224,11 +1224,19 @@ describe("Runs in-flight row height (WM-725)", () => {
       leaseExpiresAt: new Date(now + 60_000).toISOString(),
       timeoutSeconds: 600,
     });
+    // The ordinary case: the lease is minted for the budget plus a grace, so it
+    // fires after the budget and has nothing to add to the row.
+    const calm = stubListItem("run_calm", "RUNNING", {
+      startedAt: new Date(now - 2 * 60_000).toISOString(),
+      deadlineAt: new Date(now + 9 * 60_000).toISOString(),
+      leaseExpiresAt: new Date(now + 11 * 60_000).toISOString(),
+      timeoutSeconds: 600,
+    });
     const done = stubListItem("run_done", "COMPLETED");
 
     await withApi(
       {
-        runs: async () => ({ runs: [hang, done] }),
+        runs: async () => ({ runs: [hang, calm, done] }),
         status: async () => createStatusFixture(),
       },
       async () => {
@@ -1256,6 +1264,14 @@ describe("Runs in-flight row height (WM-725)", () => {
         expect(remaining.textContent).toContain("lease");
         expect(remaining.querySelectorAll("div").length).toBe(0);
         expect(remaining.className).toContain("whitespace-nowrap");
+
+        // A lease that outlives the budget is not the binding deadline, so it
+        // stays off the row rather than padding the column with a number the
+        // operator cannot act on.
+        const calmRemaining = cellFor(r, "run_calm", "Remaining");
+        expect(calmRemaining.textContent).toMatch(/\b9m\b/);
+        expect(calmRemaining.textContent).not.toContain("lease");
+        expect(cellFor(r, "run_calm", "State").textContent).toBe("RUNNING");
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -39,14 +39,13 @@ import {
   useProposalAgent,
 } from "../components/ApprovalRisk";
 import {
-  BudgetClock,
   IN_FLIGHT,
-  LeaseClock,
   RunDetailBlocks,
   RunFailureBanner,
   clockTo,
   isCancellable,
   pinnedModelText,
+  type Clock,
 } from "../components/RunDetailBlocks";
 import { readPinnedRuns, savePinnedRuns } from "../components/ContextTabs";
 import type { OperatorContext } from "../context";
@@ -58,7 +57,7 @@ import {
 } from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import type { Proposal, RunListItem, RunState } from "../types";
-import { EMPTY, formatRelative } from "../format";
+import { EMPTY, formatDuration, formatRelative } from "../format";
 import {
   Button,
   CopyActions,
@@ -271,43 +270,83 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   ],
 };
 
-function RemainingCell({
-  deadlineAt,
-  now,
-}: {
-  deadlineAt?: string | null;
-  now: number;
-}) {
-  if (!deadlineAt) return <span>—</span>;
-  const left = Math.max(0, Date.parse(deadlineAt) - now);
-  if (!Number.isFinite(left)) return <span>—</span>;
-  const minutes = Math.ceil(left / 60_000);
-  return (
-    <span title={deadlineAt}>
-      {minutes >= 60
-        ? `${Math.floor(minutes / 60)}h ${minutes % 60}m`
-        : `${minutes}m`}
-    </span>
-  );
+/** Minutes, coarse enough that a row-level countdown does not tick every second. */
+const leftLabel = (leftMs: number) => {
+  const minutes = Math.ceil(leftMs / 60_000);
+  return minutes >= 60
+    ? `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+    : `${minutes}m`;
+};
+
+type RemainingPart = { text: string; title: string; hue?: string };
+
+/**
+ * The compact form of the detail pane's `BudgetClock`, on the same thresholds
+ * so the two never disagree: the full phrasing moves to the cell's title.
+ */
+function budgetPart(c: Clock, timeoutSeconds: number): RemainingPart | null {
+  if (c.kind === "off") return null;
+  if (c.kind === "spent")
+    return { text: "spent", title: "budget spent", hue: "var(--hue-err)" };
+  // The last tenth of the declared budget — long enough to notice on a long run.
+  const hue =
+    timeoutSeconds > 0 && c.leftMs <= timeoutSeconds * 100
+      ? "var(--hue-warn)"
+      : undefined;
+  return {
+    text: leftLabel(c.leftMs),
+    title: `timeout in ${formatDuration(c.leftMs / 1000)}`,
+    hue,
+  };
 }
 
-function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
+/** The lease only earns row space when it can outrun the budget. */
+function leasePart(c: Clock, budgetSpent: boolean): RemainingPart | null {
+  if (c.kind === "off") return null;
+  if (c.kind === "spent")
+    return { text: "lease due", title: "reap due", hue: "var(--hue-err)" };
+  return {
+    text: `lease ${leftLabel(c.leftMs)}`,
+    title: `reaped in ${formatDuration(c.leftMs / 1000)}`,
+    hue: budgetSpent ? "var(--hue-warn)" : undefined,
+  };
+}
+
+/**
+ * The one place a row says how long an in-flight attempt has left (WM-725).
+ * Budget and lease share this single line: stacking a second line of clocks
+ * under the State badge made every in-flight row taller than the terminal rows
+ * around it, for a number this column already carried.
+ */
+function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
   const { startedAt, leaseExpiresAt, deadlineAt, timeoutSeconds = 0 } = r;
-  const t = deadlineAt
+  const budgetClock = deadlineAt
     ? clockTo(deadlineAt, 0, now)
     : startedAt && timeoutSeconds > 0
       ? clockTo(startedAt, timeoutSeconds * 1000, now)
       : null;
-  const l = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
-  const hasT = t && t.kind !== "off";
-  const hasL = l && l.kind !== "off";
-  if (!hasT && !hasL) return null;
+  const leaseClock = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
+  const budget = budgetClock && budgetPart(budgetClock, timeoutSeconds);
+  const lease =
+    leaseClock && leasePart(leaseClock, budgetClock?.kind === "spent");
+  if (!budget && !lease) return <span>{EMPTY}</span>;
+
   return (
-    <div className="mt-0.5 flex items-center gap-1.5 text-[11px] tabular-nums text-(--text-faint)">
-      {hasT && <BudgetClock c={t} timeoutSeconds={timeoutSeconds} />}
-      {hasT && hasL && <span>·</span>}
-      {hasL && <LeaseClock c={l} urgent={t?.kind === "spent"} />}
-    </div>
+    <span
+      className="inline-flex items-baseline gap-1"
+      title={[budget?.title, lease?.title].filter(Boolean).join(" · ")}
+    >
+      {budget && <span style={{ color: budget.hue }}>{budget.text}</span>}
+      {budget && lease && <span className="text-(--text-faint)">·</span>}
+      {lease && (
+        <span
+          className="text-[11px] text-(--text-faint)"
+          style={{ color: lease.hue }}
+        >
+          {lease.text}
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -1035,15 +1074,12 @@ export function Runs({
                             return null;
                           })()}
                       </div>
-                      {IN_FLIGHT.includes(r.state) && (
-                        <RowDeadlines r={r} now={now} />
-                      )}
                     </td>
                   )}
                   {show.has("remaining") && (
-                    <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="max-w-36 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
                       {IN_FLIGHT.includes(r.state) ? (
-                        <RemainingCell deadlineAt={r.deadlineAt} now={now} />
+                        <RemainingCell r={r} now={now} />
                       ) : (
                         ""
                       )}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -300,15 +300,20 @@ function budgetPart(c: Clock, timeoutSeconds: number): RemainingPart | null {
   };
 }
 
-/** The lease only earns row space when it can outrun the budget. */
-function leasePart(c: Clock, budgetSpent: boolean): RemainingPart | null {
+/**
+ * The lease is minted at claim for the budget plus a grace, so it usually
+ * expires after the budget and adds nothing to the row. It earns its half of
+ * the line only when it is the deadline that will actually fire first.
+ */
+function leasePart(c: Clock, budget: Clock | null): RemainingPart | null {
   if (c.kind === "off") return null;
   if (c.kind === "spent")
     return { text: "lease due", title: "reap due", hue: "var(--hue-err)" };
+  if (budget?.kind === "live" && c.leftMs >= budget.leftMs) return null;
   return {
     text: `lease ${leftLabel(c.leftMs)}`,
     title: `reaped in ${formatDuration(c.leftMs / 1000)}`,
-    hue: budgetSpent ? "var(--hue-warn)" : undefined,
+    hue: budget?.kind === "spent" ? "var(--hue-warn)" : undefined,
   };
 }
 
@@ -327,8 +332,7 @@ function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
       : null;
   const leaseClock = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
   const budget = budgetClock && budgetPart(budgetClock, timeoutSeconds);
-  const lease =
-    leaseClock && leasePart(leaseClock, budgetClock?.kind === "spent");
+  const lease = leaseClock && leasePart(leaseClock, budgetClock);
   if (!budget && !lease) return <span>{EMPTY}</span>;
 
   return (


### PR DESCRIPTION
An in-flight row on `#/runs` rendered a second line under the State badge —
`timeout in 8m · reaped in 1m` — which made every RUNNING/LEASED/VERIFYING row
taller than the terminal rows around it, and repeated a countdown the Remaining
column already carried.

State is one line again: the badge, plus the optional `proposal` jump link
(WM-505). The urgency moves to Remaining, which becomes the single place a row
says how long an attempt has left.

## What changed

- `RowDeadlines` is gone. Nothing stacks under the State badge any more.
- `RemainingCell` now reads the same clocks the removed line did — including the
  `startedAt + timeoutSeconds` fallback for rows with no explicit `deadlineAt`,
  which the old Remaining column did not have — and renders them on **one**
  line. Hues and thresholds match the detail pane's `BudgetClock`/`LeaseClock`
  (warn inside the last tenth of the budget, error on `spent`/`lease due`), and
  the fuller phrasing (`timeout in 9m 52s`) moves to the cell's `title`.
- The lease only takes half that line when it is the deadline that will actually
  fire first. It is minted at claim for the budget plus a fixed grace, so it
  normally expires *after* the budget; printing it on every row spent the column
  on a number the operator cannot act on, and in this `table-fixed` layout a long
  pair like `1h 20m · lease 1h 5m` would have overrun into the next column. A
  binding lease still reads `8m · lease 1m` on that same single line.
- `RunDetailBlocks.tsx` is untouched — the detail pane's clocks are unchanged.

## Verification

`cd event-runtime/web && bun test src/views/Runs.test.tsx` — **25 pass, 0 fail**.

The new regression test was observed failing on the pre-fix tree first: the
RUNNING row's State cell read `RUNNINGtimeout in 9m·reaped in 1m`. The lease
suppression assertion was falsified separately by disabling that one guard,
which made the row read `9m·lease 11m` again.

Also green: `tsc --noEmit`, the full web suite (870 pass), `bun run lint`
(0 errors, no new warnings in the changed files), and `factory security`.

## UX critique

Required — **SHIP**, across two rounds in a real browser at 1440px against the
seeded demo.

- Round 1 (the row-height fix): RUNNING row measured **34px**, identical to
  every terminal row and uniform across all 45 rows; State cell single-line;
  Remaining read `9m · lease 11m` on one line with no wrap and no horizontal
  scroll (`scrollWidth === clientWidth === 1440`).
- Round 2 (the lease refinement): parity and single-line State unchanged at
  34px; Remaining now reads `10m` alone for a run whose lease outlives its
  budget, tooltip `timeout in 9m 52s`; no new layout regressions.

The critique also flagged that a PROPOSED row's `proposal` jump link is clipped
invisible by the State cell's `overflow-hidden`. That is **pre-existing, not
caused by this PR** — the table is `table-fixed`, so cell content never
influences column width and removing the clock line cannot have taken room from
the link. Filed as WM-731.

Fixes WM-725
