### PR TITLE
fix(web): enlarge artifact download target (WM-733)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -329,6 +329,8 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
     expect(download.getAttribute("href")).toContain(
       `/api/artifacts/${SHA_A}?name=`,
     );
+    expect(download.classList.contains("h-6")).toBe(true);
+    expect(download.classList.contains("w-6")).toBe(true);
 
     fireEvent.click(download);
     expect(window.location.hash).not.toContain(SHA_A);

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -616,7 +616,7 @@ export function Artifacts({
                         onClick={(event) => event.stopPropagation()}
                         aria-label={`Download ${name}`}
                         title={`Download ${name}`}
-                        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-(--border) text-(--text-faint) hover:border-(--border-strong) hover:text-(--accent)"
+                        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-(--border) text-(--text-faint) hover:border-(--border-strong) hover:text-(--accent)"
                       >
                         <span aria-hidden="true">↓</span>
                       </a>


### PR DESCRIPTION
## Summary
- enlarge each artifact-row download control from 20×20 to 24×24 CSS pixels
- add regression assertions for the `h-6 w-6` target size while retaining the row-selection interaction test

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx`

UX critique: skipped — isolated hit-target styling; no user flow or state transition changed

Fixes WM-733