### PR TITLE
fix(web): avoid duplicate artifact SHA history entries

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -318,6 +318,19 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
     ).toBeTruthy();
   });
 
+  test("the SHA link leaves hash assignment to browser navigation", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const sha = view.getByRole("link", { name: "aaaaaaaaaaaa" });
+    // Suppress only the anchor's default navigation. The click still bubbles,
+    // so a row handler that also assigns the hash makes this assertion fail.
+    sha.addEventListener("click", (event) => event.preventDefault());
+
+    fireEvent.click(sha);
+    expect(window.location.hash).toBe("#/artifacts");
+  });
+
   test("the row download control does not select the row", async () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -581,10 +581,15 @@ export function Artifacts({
                 <tr
                   key={artifact.sha256}
                   tabIndex={0}
-                  // A modified click on the SHA link is the browser's to handle
-                  // (new tab, copy link) — selecting here would navigate this
-                  // tab out from under it.
+                  // Link clicks are the browser's to handle. Assigning the
+                  // hash here as well as through the SHA anchor's default
+                  // navigation would add two history entries.
                   onClick={(event) => {
+                    if (
+                      event.target instanceof Element &&
+                      event.target.closest("a")
+                    )
+                      return;
                     if (event.metaKey || event.ctrlKey || event.shiftKey)
                       return;
                     selectArtifact(artifact.sha256);


### PR DESCRIPTION
## Summary
- let artifact SHA anchors own their browser navigation instead of also running the row selector
- keep non-link row clicks and modifier guards unchanged
- add a regression test proving SHA clicks do not trigger row hash assignment

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — pass, 15 tests

UX critique: required — SHIP; evidence: http://127.0.0.1:7771/#/artifacts (observed one history entry and one-Back recovery)

Fixes WM-734