### PR TITLE
fix(web): clip and correctly sort Remaining cells

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -191,6 +191,39 @@ describe("Runs sortable columns (OPS-492)", () => {
       },
     );
   });
+
+  test("Remaining sorts a started-at timeout fallback among explicit deadlines", async () => {
+    const now = Date.now();
+    const early = stubListItem("run_early", "RUNNING", {
+      deadlineAt: new Date(now + 5 * 60_000).toISOString(),
+    });
+    const fallback = stubListItem("run_fallback", "RUNNING", {
+      deadlineAt: null,
+      startedAt: new Date(now).toISOString(),
+      timeoutSeconds: 600,
+    });
+    const late = stubListItem("run_late", "RUNNING", {
+      deadlineAt: new Date(now + 15 * 60_000).toISOString(),
+    });
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [early, fallback, late] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() => r.getByRole("columnheader", { name: /Remaining/ }));
+
+        fireEvent.click(r.getByRole("button", { name: /Remaining/ }));
+        expect(
+          Array.from(
+            r.container.querySelectorAll("tbody tr td:first-child"),
+          ).map((cell) => cell.getAttribute("title")),
+        ).toEqual(["run_early", "run_fallback", "run_late"]);
+      },
+    );
+  });
 });
 
 describe("Runs table short run ids (WM-96)", () => {
@@ -1264,6 +1297,7 @@ describe("Runs in-flight row height (WM-725)", () => {
         expect(remaining.textContent).toContain("lease");
         expect(remaining.querySelectorAll("div").length).toBe(0);
         expect(remaining.className).toContain("whitespace-nowrap");
+        expect(remaining.className).toContain("overflow-hidden");
 
         // A lease that outlives the budget is not the binding deadline, so it
         // stays off the row rather than padding the column with a number the

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -179,9 +179,7 @@ const rowModel = (r: RunListItem) => pinnedModelText(r.adapter, r.model);
 const remainingDeadline = (r: RunListItem): string => {
   if (r.deadlineAt) return r.deadlineAt;
   if (!r.startedAt || !r.timeoutSeconds || r.timeoutSeconds <= 0) return "";
-  const deadline = new Date(
-    Date.parse(r.startedAt) + r.timeoutSeconds * 1000,
-  );
+  const deadline = new Date(Date.parse(r.startedAt) + r.timeoutSeconds * 1000);
   return Number.isNaN(deadline.getTime()) ? "" : deadline.toISOString();
 };
 

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -175,6 +175,16 @@ export function tabForRunState(state: string): RunTab {
  */
 const rowModel = (r: RunListItem) => pinnedModelText(r.adapter, r.model);
 
+/** The budget deadline shared by the Remaining display and its sort order. */
+const remainingDeadline = (r: RunListItem): string => {
+  if (r.deadlineAt) return r.deadlineAt;
+  if (!r.startedAt || !r.timeoutSeconds || r.timeoutSeconds <= 0) return "";
+  const deadline = new Date(
+    Date.parse(r.startedAt) + r.timeoutSeconds * 1000,
+  );
+  return Number.isNaN(deadline.getTime()) ? "" : deadline.toISOString();
+};
+
 /**
  * Grouping/ordering/columns (OPS-493). One config for every status tab: the
  * tabs only filter rows, the column set never changes with them.
@@ -212,7 +222,7 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
     {
       key: "remaining",
       label: "Remaining",
-      get: (r) => r.deadlineAt ?? "",
+      get: remainingDeadline,
       column: "remaining",
     },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
@@ -324,12 +334,9 @@ function leasePart(c: Clock, budget: Clock | null): RemainingPart | null {
  * around it, for a number this column already carried.
  */
 function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
-  const { startedAt, leaseExpiresAt, deadlineAt, timeoutSeconds = 0 } = r;
-  const budgetClock = deadlineAt
-    ? clockTo(deadlineAt, 0, now)
-    : startedAt && timeoutSeconds > 0
-      ? clockTo(startedAt, timeoutSeconds * 1000, now)
-      : null;
+  const { leaseExpiresAt, timeoutSeconds = 0 } = r;
+  const deadline = remainingDeadline(r);
+  const budgetClock = deadline ? clockTo(deadline, 0, now) : null;
   const leaseClock = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
   const budget = budgetClock && budgetPart(budgetClock, timeoutSeconds);
   const lease = leaseClock && leasePart(leaseClock, budgetClock);
@@ -1081,7 +1088,7 @@ export function Runs({
                     </td>
                   )}
                   {show.has("remaining") && (
-                    <td className="max-w-36 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="max-w-36 overflow-hidden whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
                       {IN_FLIGHT.includes(r.state) ? (
                         <RemainingCell r={r} now={now} />
                       ) : (


### PR DESCRIPTION
## Summary
- clip long Remaining values inside the fixed table column
- share the displayed deadline fallback with Remaining sorting
- cover overflow and startedAt + timeoutSeconds sorting regressions

## Verification
- `cd event-runtime/web && bun test src/views/Runs.test.tsx` — 26 pass, 0 fail
- `cd event-runtime/web && bun run build` — typecheck and production build pass

UX critique: required — SHIP; evidence: http://127.0.0.1:7583/#/runs and /tmp/WM-746-runs-remaining-sort-asc.png

Fixes WM-746