### PR TITLE
fix(web): disable raw copy for binary artifacts

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -417,6 +417,11 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
       view.getByRole("region", { name: "Artifact metadata" }).textContent,
     ).toContain("1.0 KB");
     expect(view.getByRole("link", { name: "Download" })).toBeTruthy();
+    expect(
+      view
+        .getByRole("button", { name: "Copy Raw Content" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
   });
 
   test("short text with one replacement character remains previewable", async () => {

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -756,7 +756,7 @@ export function Artifacts({
                 Download
               </a>
               <Button
-                disabled={contentQ.data === undefined}
+                disabled={contentQ.data === undefined || binary}
                 onClick={() =>
                   copyText(contentQ.data ?? "", "raw artifact content")
                 }


### PR DESCRIPTION
## Summary
- disable Copy Raw Content when artifact bytes are classified as binary
- cover the binary inspector state with a regression assertion

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — 14 pass, 0 fail

UX critique: required — SHIP
Evidence: http://127.0.0.1:7717/#/artifacts/012221cc7427ec959e68464904337e9d7ca23b6d469d12298943d3c2d41fe7b1 and /tmp/WM-736-binary-artifact.png

Fixes WM-736