### PR TITLE
fix(web): preserve short text artifact previews

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -397,6 +397,32 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
     ).toContain("1.0 KB");
     expect(view.getByRole("link", { name: "Download" })).toBeTruthy();
   });
+
+  test("short text with one replacement character remains previewable", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("partially decoded: \uFFFD", { status: 200 }),
+    ) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+
+    const preview = await view.findByRole("region", {
+      name: "Artifact content",
+    });
+    expect(preview.textContent).toContain("partially decoded: \uFFFD");
+    expect(view.queryByText(/cannot be previewed/i)).toBeNull();
+  });
+
+  test("a long sample with more than two percent replacement characters uses the binary fallback", async () => {
+    const raw = `${"a".repeat(4000)}${"\uFFFD".repeat(96)}trailing text`;
+    globalThis.fetch = mock(
+      async () => new Response(raw, { status: 200 }),
+    ) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+
+    expect(await view.findByText(/cannot be previewed/i)).toBeTruthy();
+    expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
+  });
 });
 
 describe("Artifacts inspector renders a view for the producing agent's artifact (WM-455)", () => {

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -159,7 +159,7 @@ function looksBinary(raw: string): boolean {
   if (!sample) return false;
   if (sample.includes("\u0000")) return true;
   const undecodable = sample.replace(/[^\uFFFD]/g, "").length;
-  return undecodable / sample.length > 0.02;
+  return undecodable / Math.max(sample.length, 50) > 0.02;
 }
 
 function containsArtifactHash(


### PR DESCRIPTION
## Summary
- add a 50-character effective sample floor to the U+FFFD binary heuristic
- keep NUL detection and long-sample >2% fallback behavior intact
- cover short-readable and long-binary replacement-character cases

Fixes WM-737

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — 16 pass, 0 fail

## UX critique
UX critique: required — SHIP (round 1)

Evidence:
- http://127.0.0.1:7645/#/artifacts/d1e71f09f8a37e2d8c06e9d58784c61062e37b2bb78a1405e024ca05f844da04
- `/tmp/WM-737-artifact-preview-content.png`

The critic browser-tested the exact short U+FFFD artifact, copy, download, close, and a normal transcript artifact. Unrelated singular-count polish was filed as WM-750.