### PR TITLE
fix(web): distinguish pending proposal health

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -40,6 +40,9 @@ const STATUS: StatusView = {
 };
 
 const HEALTH = { ok: true, policyVersion: "test", env: ENV };
+// One approvable open proposal, so the proposals route renders the detail pane
+// whose Approve button carries the health-derived tooltip (WM-738).
+const OPEN_PROPOSAL_ID = "prop_health_wiring";
 let currentStatus = STATUS;
 // "pending" never resolves, which is what a first load looks like before
 // /api/health answers; "error" is a runtime that answered with a failure.
@@ -69,6 +72,8 @@ function renderApp() {
   // Scope queries to the sidebar landmark: views render their own controls
   // (Overview has a "Graph" button too) and must not satisfy nav assertions.
   const sidebar = within(utils.getByRole("navigation", { name: "Primary" }));
+  // Exposed so a test can drive a poll tick itself instead of waiting out the
+  // 2s refetch interval.
   return { ...utils, sidebar, queryClient };
 }
 
@@ -90,6 +95,24 @@ beforeEach(() => {
       return jsonResponse(HEALTH);
     }
     if (url.includes("/api/status")) return jsonResponse(currentStatus);
+    if (url.includes("/api/proposals")) {
+      // `?status=all` is the decided-history join; only the open list carries
+      // the proposal the detail pane selects. created_at is minted per request
+      // so the fixture's TTL never lapses mid-suite.
+      if (url.includes("status=")) return jsonResponse({ proposals: [] });
+      return jsonResponse({
+        proposals:
+          currentProposals.length > 0
+            ? currentProposals
+            : [
+                createProposalFixture({
+                  id: OPEN_PROPOSAL_ID,
+                  created_at: new Date().toISOString(),
+                  ttl_seconds: 300,
+                }),
+              ],
+      });
+    }
     if (url.includes("/api/agents")) {
       return jsonResponse({
         agents: [],
@@ -101,8 +124,6 @@ beforeEach(() => {
       });
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
-    if (url.includes("/api/proposals"))
-      return jsonResponse({ proposals: currentProposals });
     if (url.includes("/api/runs?ticket=")) {
       const ticket =
         new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
@@ -399,6 +420,82 @@ describe("health connection chrome (WM-724)", () => {
     expect(statusDot(statusBar).getAttribute("style")).toContain("--hue-ok");
     expect(statusBar.textContent).toContain("connected · test");
     expect(utils.queryByText(/Runtime unreachable —/)).toBeNull();
+  });
+});
+
+describe("Proposals approval tooltip health wiring (WM-738)", () => {
+  // The tooltip sits on the wrapper span around the Approve button, because a
+  // disabled button does not fire hover events (Proposals.tsx).
+  const approvalTooltip = (utils: ReturnType<typeof renderApp>) =>
+    utils
+      .getByRole("button", { name: /^Approve/ })
+      .parentElement?.getAttribute("title");
+
+  async function renderProposalDetail() {
+    window.location.hash = `#/proposals/${OPEN_PROPOSAL_ID}`;
+    const utils = renderApp();
+    await utils.findByRole("button", { name: /^Approve/ });
+    return utils;
+  }
+
+  test("a pending first load says approval is waiting to connect", async () => {
+    healthMode = "pending";
+    const utils = await renderProposalDetail();
+    await waitFor(() => {
+      expect(approvalTooltip(utils)).toBe(
+        "Approval is unavailable while connecting.",
+      );
+    });
+  });
+
+  test("a failed health check says approval is unavailable while disconnected", async () => {
+    healthMode = "error";
+    const utils = await renderProposalDetail();
+    await waitFor(() => {
+      expect(approvalTooltip(utils)).toBe(
+        "Approval is unavailable while disconnected.",
+      );
+    });
+  });
+
+  // The regression WM-738 shipped: the tooltip was wired to
+  // `isPending || isFetching`, so a runtime that died under a live console
+  // downgraded its own outage to "connecting" on every 2s poll. Only
+  // `isPending` means "first load, nothing heard back yet"; `isFetching` is
+  // true again the moment any poll starts, outage or not.
+  test("a failed poll that is refetching still reads as disconnected, not connecting", async () => {
+    const utils = await renderProposalDetail();
+    await waitFor(() => {
+      expect(utils.sidebar.getByText("dev")).toBeTruthy();
+    });
+    expect(approvalTooltip(utils)).toBeNull();
+
+    // The runtime dies under a console that had already connected.
+    healthMode = "error";
+    await act(async () => {
+      await utils.queryClient.refetchQueries({ queryKey: ["health"] });
+    });
+    await waitFor(() => {
+      expect(approvalTooltip(utils)).toBe(
+        "Approval is unavailable while disconnected.",
+      );
+    });
+
+    // The poll after that is in flight and stays that way: fetching, but still
+    // nothing heard back. This is the state the two signals disagree about.
+    healthMode = "pending";
+    const before = healthCalls;
+    void utils.queryClient.refetchQueries({ queryKey: ["health"] });
+    await waitFor(() => {
+      expect(healthCalls).toBeGreaterThan(before);
+    });
+
+    expect(approvalTooltip(utils)).toBe(
+      "Approval is unavailable while disconnected.",
+    );
+    // The chrome must agree with the tooltip — both read the same signal.
+    expect(utils.sidebar.getByText("disconnected")).toBeTruthy();
+    expect(utils.sidebar.queryByText("connecting")).toBeNull();
   });
 });
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -757,7 +757,7 @@ export function App() {
               >
                 <Proposals
                   connected={connected}
-                  healthPending={health.isPending || health.isFetching}
+                  healthPending={healthPending}
                   context={context}
                   onRunQueued={jumpToRun}
                   focusProposalId={focusProposalId}

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -757,6 +757,7 @@ export function App() {
               >
                 <Proposals
                   connected={connected}
+                  healthPending={health.isPending || health.isFetching}
                   context={context}
                   onRunQueued={jumpToRun}
                   focusProposalId={focusProposalId}

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -62,6 +62,7 @@ function renderProposals(props: Partial<Parameters<typeof Proposals>[0]> = {}) {
   return renderWithClient(
     <Proposals
       connected={true}
+      healthPending={false}
       context={{ kind: "all" }}
       onRunQueued={noop}
       focusProposalId={null}
@@ -74,6 +75,48 @@ function renderProposals(props: Partial<Parameters<typeof Proposals>[0]> = {}) {
     />,
   );
 }
+
+describe("Proposals approval availability (WM-738)", () => {
+  const proposal = stubProposal("prop_health_state");
+
+  async function approvalTitle(props: {
+    connected: boolean;
+    healthPending: boolean;
+  }) {
+    return withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => stubStatus(),
+      },
+      async () => {
+        const r = renderProposals({
+          ...props,
+          focusProposalId: proposal.id,
+        });
+        const approve = await r.findByRole("button", { name: /^Approve/ });
+        return approve.parentElement?.getAttribute("title");
+      },
+    );
+  }
+
+  test("pending health says approval is waiting to connect", async () => {
+    expect(
+      await approvalTitle({ connected: false, healthPending: true }),
+    ).toBe("Approval is unavailable while connecting.");
+  });
+
+  test("failed health says approval is unavailable while disconnected", async () => {
+    expect(
+      await approvalTitle({ connected: false, healthPending: false }),
+    ).toBe("Approval is unavailable while disconnected.");
+  });
+
+  test("successful health leaves approval enabled without a tooltip", async () => {
+    expect(
+      await approvalTitle({ connected: true, healthPending: false }),
+    ).toBeNull();
+  });
+});
 
 describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
   let origProposals: typeof api.proposals;
@@ -626,6 +669,7 @@ describe("Proposals selection safety under focus and expiry (WM-547)", () => {
     r.rerender(
       <Proposals
         connected={true}
+        healthPending={false}
         context={{ kind: "all" }}
         onRunQueued={noop}
         focusProposalId={focusProposalId}
@@ -813,6 +857,7 @@ describe("Proposals component harness: cross-tab reveal", () => {
         rerender(
           <Proposals
             connected={true}
+            healthPending={false}
             context={{ kind: "all" }}
             onRunQueued={noop}
             focusProposalId="prop_decided_1"
@@ -874,6 +919,7 @@ describe("Proposals component harness: cross-tab reveal", () => {
         rerender(
           <Proposals
             connected={true}
+            healthPending={false}
             context={{ kind: "all" }}
             onRunQueued={noop}
             focusProposalId="prop_2"
@@ -934,6 +980,7 @@ describe("Proposals component harness: cross-tab reveal", () => {
         rerender(
           <Proposals
             connected={true}
+            healthPending={false}
             context={{ kind: "all" }}
             onRunQueued={noop}
             focusProposalId="prop_1"
@@ -1471,6 +1518,7 @@ describe("Proposals single-proposal reject dialog hotkeys (WM-236)", () => {
     r.rerender(
       <Proposals
         connected={false}
+        healthPending={false}
         context={{ kind: "all" }}
         onRunQueued={noop}
         focusProposalId="prop_reject_disconn"

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -100,9 +100,9 @@ describe("Proposals approval availability (WM-738)", () => {
   }
 
   test("pending health says approval is waiting to connect", async () => {
-    expect(
-      await approvalTitle({ connected: false, healthPending: true }),
-    ).toBe("Approval is unavailable while connecting.");
+    expect(await approvalTitle({ connected: false, healthPending: true })).toBe(
+      "Approval is unavailable while connecting.",
+    );
   });
 
   test("failed health says approval is unavailable while disconnected", async () => {

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -225,6 +225,7 @@ const HISTORY_DISPLAY: DisplayConfig<Proposal> = {
  */
 export function Proposals({
   connected,
+  healthPending,
   context,
   onRunQueued,
   focusProposalId,
@@ -236,6 +237,7 @@ export function Proposals({
   rejumpEpoch,
 }: {
   connected: boolean;
+  healthPending: boolean;
   context: OperatorContext;
   onRunQueued: (runId: string) => void;
   focusProposalId: string | null;
@@ -766,7 +768,9 @@ export function Proposals({
     : sel && staleState(sel)
       ? `This proposal's run is already ${staleState(sel)} and can no longer be approved.`
       : !connected
-        ? "Approval is unavailable while disconnected."
+        ? healthPending
+          ? "Approval is unavailable while connecting."
+          : "Approval is unavailable while disconnected."
         : undefined;
   const openApprove = () => {
     if (!sel || !connected || proposalIsExpired(sel) || staleState(sel)) return;


### PR DESCRIPTION
Fixes WM-738

Threads the health pending/fetching state into Proposals so disabled approval says connecting while health is in flight and preserves disconnected copy after a genuine failure. Adds pending, failed, and success coverage.

Verification: `cd event-runtime/web && bun test src/views/Proposals.test.tsx src/App.test.tsx` — 54 pass.

UX critique: required — FIX-FIRST unresolved after 2 rounds. The critic observed a stale pre-build bundle on retry at http://127.0.0.1:7741/#/proposals/prop_2afc1054-ab5a-4171-a635-0989340102be (`/tmp/WM-738-round2-retry-pending.png`); the production bundle was rebuilt after that round, but the two-round cap means this remains draft pending an evidence-backed rerun.