### PR TITLE
fix(decision): require text for answer effects (WM-716)

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -200,6 +200,8 @@ classification (which also has `const`, `string-array`, `json`): a decision is
 answered in seconds by a person, not authored as a payload. `json` in
 particular is excluded — if an agent needs a structured object from the
 operator, it should ask the two or three questions that object is made of.
+Every `answer` and `reject_proposal` option must have an applicable required
+`text` field, accounting for `whenOption` gating.
 Adding a kind is a schema bump plus a renderer case; the vocabulary is
 expected to grow slowly, if at all.
 
@@ -211,15 +213,18 @@ Every option carries exactly one `effect` from this closed set. The renderer
 does not know what an effect does; the API does, and applies it in the same
 transaction that stores the response.
 
-| Effect             | What the runtime does                                                                                                                                                                                          | Legal only when the item has            |
-| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
-| `authorise`        | Records the authorisation (§3.1) and emits a `factory.dispatch.requested` envelope for `refs.issue` on `refs.repo` with `humanDecision` in the payload (§5). The item resolves as `operator:authorised`.       | `refs.issue`, `refs.repo`, `refs.runId` |
-| `send_to_triage`   | Moves `refs.issue` to `Triage`, removes `ai:agent-ready`, comments the operator's fields (`tools/linear.mjs`). Resolves as `operator:triaged`.                                                                 | `refs.issue`                            |
-| `answer`           | Comments the operator's `text` field(s) on `refs.issue`, moves it `Blocked → Todo` (WM-287's "Answer" verb, unchanged). Resolves as `operator:answered`.                                                       | `refs.issue`                            |
-| `requeue`          | `POST /events/requeue` for `refs.eventSource`/`refs.eventId` (existing planner path). Resolves as `operator:requeued`.                                                                                         | `refs.eventSource`, `refs.eventId`      |
-| `approve_proposal` | `approveProposal(refs.proposalId)`; an expired proposal takes the existing SpecDiff re-plan path and the item stays open until that second approval — never auto-approve. Resolves as `operator:approved`.     | `refs.proposalId`                       |
-| `reject_proposal`  | `rejectProposal(refs.proposalId, reason)` with the operator's `text` field as the reason (required — the request validator enforces a required `text` field for this effect). Resolves as `operator:rejected`. | `refs.proposalId`                       |
-| `dismiss`          | Resolves the item as `operator:dismissed`, records the fields, touches nothing else. Every default template offers it; agents are told to offer it.                                                            | —                                       |
+| Effect             | What the runtime does                                                                                                                                                                                      | Legal only when the item has            |
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
+| `authorise`        | Records the authorisation (§3.1) and emits a `factory.dispatch.requested` envelope for `refs.issue` on `refs.repo` with `humanDecision` in the payload (§5). The item resolves as `operator:authorised`.   | `refs.issue`, `refs.repo`, `refs.runId` |
+| `send_to_triage`   | Moves `refs.issue` to `Triage`, removes `ai:agent-ready`, comments the operator's fields (`tools/linear.mjs`). Resolves as `operator:triaged`.                                                             | `refs.issue`                            |
+| `answer`           | Comments the operator's `text` field(s) on `refs.issue` (at least one applicable field is required), moves it `Blocked → Todo` (WM-287's "Answer" verb, unchanged). Resolves as `operator:answered`.       | `refs.issue`                            |
+| `requeue`          | `POST /events/requeue` for `refs.eventSource`/`refs.eventId` (existing planner path). Resolves as `operator:requeued`.                                                                                     | `refs.eventSource`, `refs.eventId`      |
+| `approve_proposal` | `approveProposal(refs.proposalId)`; an expired proposal takes the existing SpecDiff re-plan path and the item stays open until that second approval — never auto-approve. Resolves as `operator:approved`. | `refs.proposalId`                       |
+| `reject_proposal`  | `rejectProposal(refs.proposalId, reason)` with the operator's applicable required `text` field as the reason. Resolves as `operator:rejected`.                                                             | `refs.proposalId`                       |
+| `dismiss`          | Resolves the item as `operator:dismissed`, records the fields, touches nothing else. Every default template offers it; agents are told to offer it.                                                        | —                                       |
+
+For both `answer` and `reject_proposal`, the applicable required `text` field
+rule accounts for `whenOption` gating before the effect is offered.
 
 Effect legality is checked when the _request_ is created, not when the
 response arrives: an agent that offers `requeue` on an item with no event refs

--- a/event-runtime/lib/decision.mjs
+++ b/event-runtime/lib/decision.mjs
@@ -248,19 +248,18 @@ function checkRequest(request, { refs, checkEffectLegality }) {
     }
   }
 
-  for (const [index, option] of request.options.entries()) {
-    if (option.effect !== "reject_proposal") continue;
-    const reasonField = fields.some(
+  for (const option of request.options) {
+    if (option.effect !== "answer" && option.effect !== "reject_proposal")
+      continue;
+    const textField = fields.some(
       (field) =>
         field.kind === "text" &&
         field.required === true &&
         (field.whenOption === undefined ||
           field.whenOption.includes(option.id)),
     );
-    if (!reasonField) {
-      errors.push(
-        `$.options[${index}].effect: "reject_proposal" requires an applicable required text field`,
-      );
+    if (!textField) {
+      errors.push(`option_requires_text:${option.id}`);
     }
   }
 

--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -116,12 +116,12 @@ function requestForEffect(effect) {
     };
   }
   const request = dismissRequest({ options: [option] });
-  if (effect === "reject_proposal") {
+  if (effect === "answer" || effect === "reject_proposal") {
     request.fields = [
       {
-        id: "reason",
+        id: "text",
         kind: "text",
-        label: "Reason",
+        label: "Text",
         required: true,
         whenOption: ["choice"],
       },
@@ -351,38 +351,42 @@ describe("validateDecisionRequest", () => {
     }
   });
 
-  test("reject_proposal requires an applicable required text field", () => {
-    expect(
-      validateDecisionRequest(requestForEffect("reject_proposal"), {
-        refs: ALL_REFS,
-      }).valid,
-    ).toBe(true);
+  test("answer and reject_proposal require an applicable required text field", () => {
+    for (const effect of ["answer", "reject_proposal"]) {
+      expect(
+        validateDecisionRequest(requestForEffect(effect), {
+          refs: ALL_REFS,
+        }).valid,
+      ).toBe(true);
 
-    const absent = requestForEffect("reject_proposal");
-    absent.fields = [];
-    expectInvalid(absent);
+      const absent = requestForEffect(effect);
+      absent.fields = [];
+      expect(
+        validateDecisionRequest(absent, { refs: ALL_REFS }).errors,
+      ).toContain("option_requires_text:choice");
 
-    const optional = requestForEffect("reject_proposal");
-    optional.fields[0].required = false;
-    expectInvalid(optional);
+      const optional = requestForEffect(effect);
+      optional.fields[0].required = false;
+      expectInvalid(optional);
 
-    const wrongKind = requestForEffect("reject_proposal");
-    wrongKind.fields[0] = {
-      id: "reason",
-      kind: "confirm",
-      label: "Reason",
-      required: true,
-    };
-    expectInvalid(wrongKind);
+      const wrongKind = requestForEffect(effect);
+      wrongKind.fields[0] = {
+        id: "text",
+        kind: "confirm",
+        label: "Text",
+        required: true,
+      };
+      expectInvalid(wrongKind);
 
-    const gatedElsewhere = requestForEffect("reject_proposal");
-    gatedElsewhere.options.push({
-      id: "other",
-      label: "Other",
-      effect: "dismiss",
-    });
-    gatedElsewhere.fields[0].whenOption = ["other"];
-    expectInvalid(gatedElsewhere);
+      const gatedElsewhere = requestForEffect(effect);
+      gatedElsewhere.options.push({
+        id: "other",
+        label: "Other",
+        effect: "dismiss",
+      });
+      gatedElsewhere.fields[0].whenOption = ["other"];
+      expectInvalid(gatedElsewhere);
+    }
   });
 
   test("enforces field count, ids, kind-specific keys, choices, and numeric relations", () => {
@@ -624,6 +628,14 @@ describe("decisionRequestHash", () => {
       expect(decisionRequestHash(fixture.request), fixture.name).toBe(
         fixture.hash,
       );
+      if (fixture.requestValid !== undefined) {
+        expect(
+          validateDecisionRequest(fixture.request, {
+            refs: fixture.refs ?? {},
+          }).valid,
+          `${fixture.name}/request`,
+        ).toBe(fixture.requestValid);
+      }
       for (const response of fixture.responses) {
         expect(
           validateDecisionResponse(response.value, fixture.request).valid,

--- a/event-runtime/lib/fixtures/decision-cases.json
+++ b/event-runtime/lib/fixtures/decision-cases.json
@@ -108,6 +108,18 @@
           }
         }
       ]
+    },
+    {
+      "name": "answer-without-required-text",
+      "request": {
+        "schemaVersion": "factory.decision-request/v1",
+        "question": "What should unblock WM-716?",
+        "options": [{ "id": "answer", "label": "Answer", "effect": "answer" }]
+      },
+      "refs": { "issue": "WM-716" },
+      "requestValid": false,
+      "hash": "sha256:0d884a94bcedf4c4e03df2865afc0443df8de1c52f19802cd90020b2df46bfca",
+      "responses": []
     }
   ]
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -589,6 +589,17 @@ describe("worker", () => {
         { id: "answer", label: "Answer the agent", effect: "answer" },
         { id: "dismiss", label: "Not now", effect: "dismiss" },
       ],
+      // An `answer` option needs an applicable required text field (WM-716)
+      // for this to remain the *valid* ask.
+      fields: [
+        {
+          id: "reply",
+          kind: "text",
+          label: "Your answer",
+          required: true,
+          whenOption: ["answer"],
+        },
+      ],
     };
     const invalid = { ...authored, recommended: "missing" };
     const refusingAdapter = (decision) => ({


### PR DESCRIPTION
## Summary
- require applicable required text fields for both `answer` and `reject_proposal` decision options
- cover gated, absent, optional, and mismatched fields plus a shared negative fixture
- document the cross-field contract; browser-port parity follow-up filed as WM-753

## Verification
- `bun test event-runtime/lib/decision.test.mjs && bun test event-runtime/web && bun run format:check`

UX critique: skipped — backend contract validation and documentation only; no user-facing flow changed.

Fixes WM-716