### PR TITLE
fix(web): preserve project in artifact inspector hash

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -300,6 +300,27 @@ describe("Artifacts inventory (WM-207)", () => {
 describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
   const SHA_A = "a".repeat(64);
 
+  test("opening and closing the inspector preserves project context (WM-748)", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("line one", { status: 200 }),
+    ) as unknown as typeof fetch;
+    window.location.hash = "#/artifacts?project=factory";
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const sha = view.getByRole("link", { name: "aaaaaaaaaaaa" });
+    expect(sha.getAttribute("href")).toBe(
+      `#/artifacts/${SHA_A}?project=factory`,
+    );
+
+    fireEvent.click(view.getByText("1.0 KB").closest("tr")!);
+    expect(window.location.hash).toBe(
+      `#/artifacts/${SHA_A}?project=factory`,
+    );
+    fireEvent.click(await view.findByRole("button", { name: "Close" }));
+    expect(window.location.hash).toBe("#/artifacts?project=factory");
+  });
+
   test("the SHA is a deep link into the inspector, not a download", async () => {
     globalThis.fetch = mock(
       async () => new Response("line one\nline two", { status: 200 }),

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -314,9 +314,7 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
     );
 
     fireEvent.click(view.getByText("1.0 KB").closest("tr")!);
-    expect(window.location.hash).toBe(
-      `#/artifacts/${SHA_A}?project=factory`,
-    );
+    expect(window.location.hash).toBe(`#/artifacts/${SHA_A}?project=factory`);
     fireEvent.click(await view.findByRole("button", { name: "Close" }));
     expect(window.location.hash).toBe("#/artifacts?project=factory");
   });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -24,6 +24,7 @@ import {
   type DisplayConfig,
 } from "../displayOptions";
 import { EMPTY, formatBytes, formatRelative } from "../format";
+import { hashPath, hashProject, withProject } from "../hash";
 import { refetchIntervals, useDisplayOptions, useNow } from "../hooks";
 import { viewApplies } from "../lib/artifactView";
 import type {
@@ -136,7 +137,10 @@ function artifactShaFromHash(hash = window.location.hash): string | null {
 }
 
 function artifactInspectorHash(sha256: string): string {
-  return `#/artifacts/${encodeURIComponent(sha256)}`;
+  return `#/${withProject(
+    hashPath("artifacts", sha256),
+    hashProject(window.location.hash),
+  )}`;
 }
 
 function openArtifactInspector(sha256: string) {
@@ -396,7 +400,10 @@ export function Artifacts({
   const closeInspector = () => {
     setSelectedSha(null);
     setContentSearch("");
-    window.location.hash = "#/artifacts";
+    window.location.hash = `#/${withProject(
+      "artifacts",
+      hashProject(window.location.hash),
+    )}`;
   };
 
   const fallbackMetrics = useMemo(


### PR DESCRIPTION
Fixes WM-748

Preserves the active `?project=` context when opening and closing the Artifacts SHA inspector. Adds regression coverage for SHA href, row selection, and Close navigation.

Verification: `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — 15 pass, 0 fail.

UX critique: required — SHIP
Evidence: http://127.0.0.1:7559/#/artifacts/6560a55dbea6d98eef4e164a7e1c318556bfcc4d05e82b383e8c84f65b6828f3?project=factory