### PR TITLE
ui(event-runtime-web): show full repository config

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1292,13 +1292,20 @@ worktrees a repo owns.
   team, and GitHub slug. `j`/`k` move, `c` copies the repo name,
   `#/projects/:name` is shareable per §10.8, and the empty state names the
   file that is empty (`config/repos.yaml`) rather than saying "no results".
-- **Detail panel.** **Configuration** — path (click to copy), GitHub link,
-  base and deploy branch, execution mode spelled out ("Autonomous
-  Dispatchable" / "Report Only (Watched)"), max in flight, worktree root, and
-  the verify command verbatim, since a paraphrased verify command is worse
-  than none. **Worktree Automation Scripts** renders `up`/`down`/`warm` as
-  three present-or-absent tiles: the shape of a repo's automation is
-  something you check before dispatching to it, not after.
+- **Detail panel.** Repository settings are grouped by what they govern, and
+  every group names `config/repos.yaml` as its source. **Dispatch** shows the
+  dispatchable/report-only mode, effective max in flight and whether it came
+  from the repo or the planner default, base branch, worktree root and script
+  capabilities, and the verify command verbatim. **Merge gate** shows the
+  `merge_ci` workflow and required checks plus every `escalate_paths` glob;
+  missing `escalate_paths` warns that every PR escalates, while an explicit
+  empty list says so. **Owned paths policy** shows direct source/required-path
+  rules and pin manifests, or the default. **Deploy & smoke** shows deploy
+  branch, the allow-listed deployment URL/branch/revision field, smoke
+  workflow/URL/deadline. **Security** currently allow-lists only
+  `python_version`, or states that defaults apply. Long path/check lists are
+  untruncated monospace chips inside their own scrolling containers, and all
+  other absent values use the shared empty-value placeholder.
 - **Janitor, Dry before Apply (OPS-362).** `POST /repos/:name/janitor` — §2's
   one mutation exception, specified in §7 — is wired as two buttons in an
   order the UI enforces rather than suggests: **Run Dry Janitor** first, and

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -97,10 +97,23 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         deployBranch: "master",
         reportOnly: false,
         maxInFlight: 20,
+        effective: {
+          maxInFlight: 20,
+          maxInFlightSource: "repo",
+        },
         smokeDeadlineSeconds: null,
+        smokeWorkflow: null,
+        smokeUrl: null,
+        deployment: null,
+        security: null,
         mergeCi: {
           workflow: "CI",
           requiredChecks: ["Shadow runner fleet available", "Verify"],
+        },
+        escalatePaths: ["src/auth/**"],
+        ownedPathsPolicy: {
+          direct: [],
+          pinManifests: [],
         },
         worktreeRoot: path.join(
           process.env.HOME ?? "",
@@ -114,11 +127,16 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
       expect(rows[1]).toMatchObject({
         reportOnly: true,
         maxInFlight: null,
+        effective: {
+          maxInFlight: 3,
+          maxInFlightSource: "default",
+        },
         mergeCi: null,
+        escalatePaths: null,
         hasWorktreeDown: false,
       });
-      // Merge-policy paths are config, not registry: the wire never carries them.
-      expect(JSON.stringify(rows)).not.toContain("src/auth");
+      // Wire names are deliberate camelCase projections, never raw YAML keys.
+      expect(JSON.stringify(rows)).not.toContain("escalate_paths");
     } finally {
       close();
       server.close();

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "./config.mjs";
+import { DEFAULT_MAX_IN_FLIGHT } from "./planner.mjs";
 
 export class RepoError extends Error {
   constructor(message) {
@@ -126,6 +127,9 @@ function normalizeOwnedPathsPolicy(raw = {}, repoName, file) {
  *                        deployBranch: string|null, team: string|null, project: string|null,
  *                        reportOnly: boolean, maxInFlight: number|null, smokeDeadlineSeconds: number|null,
  *                        mergeCi: {workflow: string, requiredChecks: string[]}|null,
+ *                        escalatePaths: string[]|null, smokeWorkflow: string|null, smokeUrl: string|null,
+ *                        deployment: {url: string|null, branch: string|null, revisionField: string|null}|null,
+ *                        security: {pythonVersion: string|null}|null,
  *                        worktreeRoot: string|null, worktreeUp: string|null, worktreeDown: string|null,
  *                        worktreeWarm: string|null, verify: string|null,
  *                        ownedPathsPolicy: { direct: Array<{source: string, requires: string[]}>, pinManifests: string[] }}>
@@ -192,6 +196,46 @@ export function loadRepos({ root = reposRoot() } = {}) {
       }
       mergeCi = { workflow, requiredChecks: [...requiredChecks] };
     }
+    let escalatePaths = null;
+    if (entry.escalate_paths !== undefined && entry.escalate_paths !== null) {
+      if (
+        !Array.isArray(entry.escalate_paths) ||
+        !entry.escalate_paths.every(
+          (glob) => typeof glob === "string" && glob.trim().length > 0,
+        )
+      ) {
+        throw new RepoError(
+          `${file}: repo ${entry.name} escalate_paths must be an array of non-empty path globs`,
+        );
+      }
+      escalatePaths = [...entry.escalate_paths];
+    }
+    let deployment = null;
+    if (entry.deployment !== undefined && entry.deployment !== null) {
+      if (
+        typeof entry.deployment !== "object" ||
+        Array.isArray(entry.deployment)
+      ) {
+        throw new RepoError(
+          `${file}: repo ${entry.name} deployment must be an object`,
+        );
+      }
+      deployment = {
+        url: entry.deployment.url ?? null,
+        branch: entry.deployment.branch ?? null,
+        revisionField: entry.deployment.revision_field ?? null,
+      };
+    }
+    let security = null;
+    if (entry.security !== undefined && entry.security !== null) {
+      if (typeof entry.security !== "object" || Array.isArray(entry.security)) {
+        throw new RepoError(
+          `${file}: repo ${entry.name} security must be an object`,
+        );
+      }
+      // Deliberate allow-list: never pass through credential-shaped additions.
+      security = { pythonVersion: entry.security.python_version ?? null };
+    }
     repos.set(entry.name, {
       name: entry.name,
       path: expandHome(entry.path),
@@ -208,7 +252,12 @@ export function loadRepos({ root = reposRoot() } = {}) {
       // inventing a number here would state a limit this file never set.
       maxInFlight,
       smokeDeadlineSeconds,
+      smokeWorkflow: entry.smoke_workflow ?? null,
+      smokeUrl: entry.smoke_url ?? null,
+      deployment,
+      security,
       mergeCi,
+      escalatePaths,
       worktreeRoot: entry.worktree_root
         ? expandHome(entry.worktree_root)
         : null,
@@ -231,7 +280,7 @@ export function loadRepos({ root = reposRoot() } = {}) {
  * repos.yaml entry, in file order.
  *
  * An explicit allow-list, not the parsed entry: repos.yaml also carries
- * `escalate_paths`, `security`, and whatever the next policy field turns out to
+ * credential-bearing settings and whatever the next policy field turns out to
  * be, and a passthrough would publish each new key the moment someone adds it.
  * Nothing here reads `.env` or any credential — these are paths, branches, and
  * commands the repo already documents.
@@ -251,8 +300,18 @@ export function reposView(repos) {
     deployBranch: repo.deployBranch,
     reportOnly: repo.reportOnly,
     maxInFlight: repo.maxInFlight,
+    effective: {
+      maxInFlight: repo.maxInFlight ?? DEFAULT_MAX_IN_FLIGHT,
+      maxInFlightSource: repo.maxInFlight === null ? "default" : "repo",
+    },
     smokeDeadlineSeconds: repo.smokeDeadlineSeconds,
+    smokeWorkflow: repo.smokeWorkflow,
+    smokeUrl: repo.smokeUrl,
+    deployment: repo.deployment,
+    security: repo.security,
     mergeCi: repo.mergeCi,
+    escalatePaths: repo.escalatePaths,
+    ownedPathsPolicy: repo.ownedPathsPolicy,
     worktreeRoot: repo.worktreeRoot,
     hasWorktreeUp: repo.worktreeUp !== null,
     hasWorktreeDown: repo.worktreeDown !== null,

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -196,18 +196,20 @@ export function loadRepos({ root = reposRoot() } = {}) {
       }
       mergeCi = { workflow, requiredChecks: [...requiredChecks] };
     }
+    // Read-only projection for the view. A malformed list is NOT a load
+    // error here: one repo's bad escalate_paths must not take the whole
+    // registry down (and every other repo's dispatch with it). The strict,
+    // fail-closed check stays where the gate is evaluated — the planner's
+    // escalate_paths reader (planner.mjs, `escalate_paths_intersect` /
+    // `escalate_paths_unverifiable`), at plan time, for that repo alone. Malformed → null, i.e. "not
+    // declared / cannot be evaluated", which is exactly how the gate treats it.
     let escalatePaths = null;
-    if (entry.escalate_paths !== undefined && entry.escalate_paths !== null) {
-      if (
-        !Array.isArray(entry.escalate_paths) ||
-        !entry.escalate_paths.every(
-          (glob) => typeof glob === "string" && glob.trim().length > 0,
-        )
-      ) {
-        throw new RepoError(
-          `${file}: repo ${entry.name} escalate_paths must be an array of non-empty path globs`,
-        );
-      }
+    if (
+      Array.isArray(entry.escalate_paths) &&
+      entry.escalate_paths.every(
+        (glob) => typeof glob === "string" && glob.trim().length > 0,
+      )
+    ) {
       escalatePaths = [...entry.escalate_paths];
     }
     let deployment = null;

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -45,6 +45,14 @@ const YAML = `repos:
     worktree_root: ~/Develop/.worktrees/full
     max_in_flight: 20
     verify: npm run typecheck
+    smoke_workflow: smoke-prod.yml
+    smoke_url: https://full.example.com/healthz
+    smoke_deadline_seconds: 420
+    deployment:
+      url: https://full.example.com
+      branch: master
+      revision_field: revision
+      webhook_secret: never-publish-deployment-secret
     owned_paths_policy:
       direct:
         - source: shared/**
@@ -60,6 +68,7 @@ const YAML = `repos:
         - Verify
     security:
       python_version: "3.12"
+      api_token: never-publish-security-token
     escalate_paths:
       - src/auth/**
 
@@ -84,11 +93,20 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       deployBranch: "master",
       reportOnly: false,
       maxInFlight: 20,
-      smokeDeadlineSeconds: null,
+      smokeDeadlineSeconds: 420,
+      smokeWorkflow: "smoke-prod.yml",
+      smokeUrl: "https://full.example.com/healthz",
+      deployment: {
+        url: "https://full.example.com",
+        branch: "master",
+        revisionField: "revision",
+      },
+      security: { pythonVersion: "3.12" },
       mergeCi: {
         workflow: "CI",
         requiredChecks: ["Shadow runner fleet available", "Verify"],
       },
+      escalatePaths: ["src/auth/**"],
       worktreeRoot: path.join(home, "Develop/.worktrees/full"),
       worktreeUp: "bin/worktree-up.sh",
       worktreeDown: "bin/worktree-down.sh",
@@ -116,7 +134,12 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       // fabricated one here would read as a limit repos.yaml never set.
       maxInFlight: null,
       smokeDeadlineSeconds: null,
+      smokeWorkflow: null,
+      smokeUrl: null,
+      deployment: null,
+      security: null,
       mergeCi: null,
+      escalatePaths: null,
       worktreeRoot: null,
       worktreeDown: null,
       verify: null,
@@ -340,11 +363,14 @@ describe("reposView is what the control API serves", () => {
     expect(rows[0]).not.toHaveProperty("worktreeDown");
   });
 
-  test("the projection is an allow-list, so policy keys cannot leak by being added", () => {
+  test("the projection is an allow-list containing only deliberately published config", () => {
     for (const row of rows) {
       expect(Object.keys(row).sort()).toEqual([
         "base",
         "deployBranch",
+        "deployment",
+        "effective",
+        "escalatePaths",
         "github",
         "hasWorktreeDown",
         "hasWorktreeUp",
@@ -352,10 +378,14 @@ describe("reposView is what the control API serves", () => {
         "maxInFlight",
         "mergeCi",
         "name",
+        "ownedPathsPolicy",
         "path",
         "project",
         "reportOnly",
+        "security",
         "smokeDeadlineSeconds",
+        "smokeUrl",
+        "smokeWorkflow",
         "team",
         "verify",
         "worktreeRoot",
@@ -363,8 +393,45 @@ describe("reposView is what the control API serves", () => {
     }
     const serialized = JSON.stringify(rows);
     expect(serialized).not.toContain("escalate_paths");
-    expect(serialized).not.toContain("src/auth");
     expect(serialized).not.toContain("python_version");
+    expect(serialized).not.toContain("never-publish-deployment-secret");
+    expect(serialized).not.toContain("never-publish-security-token");
+  });
+
+  test("policy fields preserve escalate_paths null versus empty and allow-list security", () => {
+    expect(rows[0]).toMatchObject({
+      escalatePaths: ["src/auth/**"],
+      ownedPathsPolicy: {
+        direct: [
+          { source: "shared/**", requires: ["dist/**", "plugins/core/**"] },
+        ],
+        pinManifests: ["event-runtime/agents/*.json"],
+      },
+      security: { pythonVersion: "3.12" },
+    });
+    expect(rows[1]).toMatchObject({ escalatePaths: null, security: null });
+
+    const explicit = reposView(
+      loadRepos({
+        root: factoryRoot(`repos:
+  - name: none
+    path: /tmp/none
+    escalate_paths: []
+`),
+      }),
+    );
+    expect(explicit[0].escalatePaths).toEqual([]);
+  });
+
+  test("effective max in flight identifies repo values and the planner default", () => {
+    expect(rows[0].effective).toEqual({
+      maxInFlight: 20,
+      maxInFlightSource: "repo",
+    });
+    expect(rows[1].effective).toEqual({
+      maxInFlight: 3,
+      maxInFlightSource: "default",
+    });
   });
 
   test("the dispatch/report-only distinction survives the wire", () => {

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -221,6 +221,31 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
     }
   });
 
+  test("a malformed escalate_paths on one repo reads as null and never fails the whole registry load", () => {
+    // The plan-time gate is the strict reader (fail closed for THAT repo); the
+    // view must not turn one bad list into repo_unknown for every repo.
+    const repos = loadRepos({
+      root: factoryRoot(`repos:
+  - name: good
+    path: /tmp/good
+    escalate_paths: [src/auth/**]
+  - name: explicit-none
+    path: /tmp/none
+    escalate_paths: []
+  - name: malformed
+    path: /tmp/bad
+    escalate_paths: not-a-list
+  - name: undeclared
+    path: /tmp/undeclared
+`),
+    });
+    expect(repos.size).toBe(4);
+    expect(repos.get("good").escalatePaths).toEqual(["src/auth/**"]);
+    expect(repos.get("explicit-none").escalatePaths).toEqual([]);
+    expect(repos.get("malformed").escalatePaths).toBeNull();
+    expect(repos.get("undeclared").escalatePaths).toBeNull();
+  });
+
   test("owned_paths_policy is parsed and validated, defaulting to empty when absent", () => {
     const repos = loadRepos({
       root: factoryRoot(`repos:

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -15,7 +15,7 @@ import type {
   OutboxRow,
   JanitorResult,
   Proposal,
-  RepoItem,
+  RepoItem as BaseRepoItem,
   RunDetail,
   RunListItem,
   StatusView,
@@ -59,6 +59,29 @@ export interface ConfigView {
     scheduleCount: number;
   };
   sections: ConfigSection[];
+}
+
+/** Deliberately allow-listed repository settings returned by GET /repos. */
+export interface RepoItem extends BaseRepoItem {
+  effective?: {
+    maxInFlight: number;
+    maxInFlightSource: "repo" | "default";
+  };
+  smokeDeadlineSeconds?: number | null;
+  smokeWorkflow?: string | null;
+  smokeUrl?: string | null;
+  deployment?: {
+    url: string | null;
+    branch: string | null;
+    revisionField: string | null;
+  } | null;
+  security?: { pythonVersion: string | null } | null;
+  mergeCi?: { workflow: string; requiredChecks: string[] } | null;
+  escalatePaths?: string[] | null;
+  ownedPathsPolicy?: {
+    direct: { source: string; requires: string[] }[];
+    pinManifests: string[];
+  };
 }
 
 type CachedResponse = { etag: string; body: unknown };

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -3,7 +3,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { Projects } from "./Projects";
 import { renderWithClient, restoreApi, withApi } from "../test-render";
-import type { JanitorResult, RepoItem } from "../types";
+import type { JanitorResult } from "../types";
+import type { RepoItem } from "../api";
 import { CONTEXT_STORAGE_KEY } from "../context";
 import { goPrefix } from "../goSequence";
 
@@ -28,6 +29,15 @@ function repo(overrides: Partial<RepoItem> = {}): RepoItem {
     deployBranch: "master",
     reportOnly: false,
     maxInFlight: null,
+    effective: { maxInFlight: 3, maxInFlightSource: "default" },
+    smokeDeadlineSeconds: null,
+    smokeWorkflow: null,
+    smokeUrl: null,
+    deployment: null,
+    security: null,
+    mergeCi: null,
+    escalatePaths: [],
+    ownedPathsPolicy: { direct: [], pinManifests: [] },
     worktreeRoot: "/tmp/worktrees/factory",
     hasWorktreeUp: true,
     hasWorktreeDown: true,
@@ -36,6 +46,98 @@ function repo(overrides: Partial<RepoItem> = {}): RepoItem {
     ...overrides,
   };
 }
+
+describe("Projects repository policy configuration (WM-703)", () => {
+  test("groups configured values by what they govern and identifies their source", async () => {
+    await withApi(
+      {
+        repos: async () => ({
+          repos: [
+            repo({
+              effective: { maxInFlight: 20, maxInFlightSource: "repo" },
+              mergeCi: {
+                workflow: "CI",
+                requiredChecks: ["Shadow runner fleet available", "Verify"],
+              },
+              escalatePaths: [
+                "src/auth/email-and-pass/**",
+                "app/migrations/**",
+              ],
+              ownedPathsPolicy: {
+                direct: [
+                  {
+                    source: "shared/**",
+                    requires: ["dist/**", "plugins/core/**"],
+                  },
+                ],
+                pinManifests: ["event-runtime/agents/*.json"],
+              },
+              deployBranch: "master",
+              smokeWorkflow: "smoke-prod.yml",
+              smokeUrl: "https://example.com/healthz",
+              smokeDeadlineSeconds: 600,
+              deployment: {
+                url: "https://example.com",
+                branch: "master",
+                revisionField: "revision",
+              },
+              security: { pythonVersion: "3.12" },
+            }),
+          ],
+        }),
+      },
+      async () => {
+        const r = renderProjects("factory");
+        await r.findByText("Dispatch");
+
+        for (const title of [
+          "Dispatch",
+          "Merge gate",
+          "Owned paths policy",
+          "Deploy & smoke",
+          "Security",
+        ]) {
+          expect(r.getByText(title)).toBeTruthy();
+        }
+        expect(r.getAllByText("config/repos.yaml").length).toBe(5);
+        expect(r.getByText("repo value")).toBeTruthy();
+        expect(r.getByText("Shadow runner fleet available")).toBeTruthy();
+        expect(r.getByText("src/auth/email-and-pass/**")).toBeTruthy();
+        expect(r.getByText("shared/**")).toBeTruthy();
+        expect(r.getByText("event-runtime/agents/*.json")).toBeTruthy();
+        expect(r.getByText("smoke-prod.yml")).toBeTruthy();
+        expect(r.getByText("3.12")).toBeTruthy();
+      },
+    );
+  });
+
+  test("warns when escalate_paths is absent", async () => {
+    await withApi(
+      { repos: async () => ({ repos: [repo({ escalatePaths: null })] }) },
+      async () => {
+        const r = renderProjects("factory");
+        expect(
+          await r.findByText(
+            "escalate_paths not declared — every PR escalates",
+          ),
+        ).toBeTruthy();
+      },
+    );
+  });
+
+  test("distinguishes an explicitly empty escalate_paths list", async () => {
+    await withApi(
+      { repos: async () => ({ repos: [repo({ escalatePaths: [] })] }) },
+      async () => {
+        const r = renderProjects("factory");
+        expect(await r.findByText("explicitly none")).toBeTruthy();
+        expect(
+          r.queryByText("escalate_paths not declared — every PR escalates"),
+        ).toBeNull();
+      },
+    );
+  });
+});
 
 function janitor(overrides: Partial<JanitorResult> = {}): JanitorResult {
   return {
@@ -705,7 +807,10 @@ describe("Projects mobile layout (WM-169)", () => {
       const pane = r.container.querySelector("aside");
       expect(pane?.className).toContain("w-full");
       expect(pane?.className).toContain("max-w-full");
-      expect(pane?.className).toContain("sm:w-[540px]");
+      expect(pane?.className).toContain("lg:w-[540px]");
+      expect(r.getByTestId("projects-list-pane").className).toContain(
+        "hidden lg:flex",
+      );
     });
   });
 });

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -15,6 +15,7 @@ import { setContextActions } from "../palette";
 import type { JanitorResult, RepoItem } from "../types";
 import { ScopeCaption } from "../components/ContextTabs";
 import { Button as PrimitiveButton } from "../components/ui";
+import { EMPTY } from "../format";
 
 const PROJECT_MODES = ["ALL", "DISPATCHABLE", "REPORT_ONLY"] as const;
 type ProjectMode = (typeof PROJECT_MODES)[number];
@@ -54,6 +55,34 @@ const worktreeScripts = (repo: RepoItem) =>
   ]
     .filter(Boolean)
     .join(" · ");
+
+const emptyValue = <span className="text-(--text-faint)">{EMPTY}</span>;
+
+function ConfigSource() {
+  return (
+    <div className="mb-2 border-b border-(--border) pb-1.5 text-[10px] text-(--text-faint)">
+      Source: <code className="mono text-(--text-dim)">config/repos.yaml</code>
+    </div>
+  );
+}
+
+function ConfigList({ values }: { values: string[] }) {
+  if (values.length === 0) return emptyValue;
+  return (
+    <div className="max-w-full overflow-x-auto pb-1">
+      <div className="flex w-max min-w-full flex-wrap gap-1.5">
+        {values.map((value) => (
+          <code
+            key={value}
+            className="mono whitespace-nowrap rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px] text-(--text-dim)"
+          >
+            {value}
+          </code>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 const defaultProjectOrder = (a: RepoItem, b: RepoItem) =>
   Number(a.reportOnly) - Number(b.reportOnly) ||
@@ -477,184 +506,189 @@ export function Projects({
 
   return (
     <div className="flex h-full min-w-0">
-      <ListPane
-        chrome={
-          <>
-            <h1 className="display mb-4 text-h1 font-semibold">Projects</h1>
-            <ScopeCaption
-              context={context}
-              surface="registry"
-              subject={{ label: "Projects", plural: true }}
-            />
-            <ListToolbar
-              tabs={
-                <>
-                  <select
-                    aria-label="Project mode"
-                    value={filterMode}
-                    onChange={(event) =>
-                      setFilterMode(event.target.value as ProjectMode)
-                    }
-                    className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
-                  >
-                    {PROJECT_MODES.map((mode) => (
-                      <option key={mode} value={mode}>
-                        {mode === "ALL"
-                          ? "All"
-                          : mode === "DISPATCHABLE"
-                            ? "Dispatchable"
-                            : "Report-Only"}{" "}
-                        {modeCounts[mode]}
-                      </option>
-                    ))}
-                  </select>
-                  <div
-                    className="hidden w-max flex-nowrap gap-1 whitespace-nowrap text-[12px] sm:flex"
-                    role="tablist"
-                    aria-label="Project mode"
-                  >
-                    {PROJECT_MODES.map((mode, idx) => (
-                      <PrimitiveButton
-                        bare
-                        key={mode}
-                        type="button"
-                        role="tab"
-                        aria-selected={filterMode === mode}
-                        onClick={() => setFilterMode(mode)}
-                        className={`shrink-0 rounded-md px-2.5 py-1 font-medium transition-colors ${
-                          filterMode === mode
-                            ? "bg-(--surface-3) text-(--text)"
-                            : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                        }`}
-                      >
-                        {mode === "ALL"
-                          ? "All"
-                          : mode === "DISPATCHABLE"
-                            ? "Dispatchable"
-                            : "Report-Only"}
-                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                          {modeCounts[mode]}
-                        </span>
-                        <span
-                          aria-hidden="true"
-                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
-                        >
-                          {idx + 1}
-                        </span>
-                      </PrimitiveButton>
-                    ))}
-                  </div>
-                </>
-              }
-              tools={
-                <FilterInput
-                  value={filter}
-                  onChange={setFilter}
-                  placeholder="Filter repo, project, team, github… (/)"
-                  label="Filter repositories"
-                />
-              }
-            />
-          </>
-        }
+      <div
+        data-testid="projects-list-pane"
+        className={`min-h-0 min-w-0 flex-1 ${sel ? "hidden lg:flex" : "flex"}`}
       >
-        <Table
-          aria-label="Projects table"
-          className="w-full min-w-[760px] border-separate border-spacing-0"
-        >
-          <thead>
-            <tr className="text-left">
-              {PROJECTS_SORT.columns.map((column) => {
-                const field = PROJECTS_SORT.sorts.find(
-                  (candidate) => candidate.column === column.key,
-                )!;
-                return (
-                  <Th
-                    key={column.key}
-                    label={column.label}
-                    dir={sort.sortBy === field.key ? sort.sortDir : null}
-                    onSort={() =>
-                      setSort((state) =>
-                        cycleColumnSort(PROJECTS_SORT, state, column.key),
-                      )
-                    }
+        <ListPane
+          chrome={
+            <>
+              <h1 className="display mb-4 text-h1 font-semibold">Projects</h1>
+              <ScopeCaption
+                context={context}
+                surface="registry"
+                subject={{ label: "Projects", plural: true }}
+              />
+              <ListToolbar
+                tabs={
+                  <>
+                    <select
+                      aria-label="Project mode"
+                      value={filterMode}
+                      onChange={(event) =>
+                        setFilterMode(event.target.value as ProjectMode)
+                      }
+                      className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
+                    >
+                      {PROJECT_MODES.map((mode) => (
+                        <option key={mode} value={mode}>
+                          {mode === "ALL"
+                            ? "All"
+                            : mode === "DISPATCHABLE"
+                              ? "Dispatchable"
+                              : "Report-Only"}{" "}
+                          {modeCounts[mode]}
+                        </option>
+                      ))}
+                    </select>
+                    <div
+                      className="hidden w-max flex-nowrap gap-1 whitespace-nowrap text-[12px] sm:flex"
+                      role="tablist"
+                      aria-label="Project mode"
+                    >
+                      {PROJECT_MODES.map((mode, idx) => (
+                        <PrimitiveButton
+                          bare
+                          key={mode}
+                          type="button"
+                          role="tab"
+                          aria-selected={filterMode === mode}
+                          onClick={() => setFilterMode(mode)}
+                          className={`shrink-0 rounded-md px-2.5 py-1 font-medium transition-colors ${
+                            filterMode === mode
+                              ? "bg-(--surface-3) text-(--text)"
+                              : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+                          }`}
+                        >
+                          {mode === "ALL"
+                            ? "All"
+                            : mode === "DISPATCHABLE"
+                              ? "Dispatchable"
+                              : "Report-Only"}
+                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                            {modeCounts[mode]}
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                          >
+                            {idx + 1}
+                          </span>
+                        </PrimitiveButton>
+                      ))}
+                    </div>
+                  </>
+                }
+                tools={
+                  <FilterInput
+                    value={filter}
+                    onChange={setFilter}
+                    placeholder="Filter repo, project, team, github… (/)"
+                    label="Filter repositories"
                   />
+                }
+              />
+            </>
+          }
+        >
+          <Table
+            aria-label="Projects table"
+            className="w-full min-w-[760px] border-separate border-spacing-0"
+          >
+            <thead>
+              <tr className="text-left">
+                {PROJECTS_SORT.columns.map((column) => {
+                  const field = PROJECTS_SORT.sorts.find(
+                    (candidate) => candidate.column === column.key,
+                  )!;
+                  return (
+                    <Th
+                      key={column.key}
+                      label={column.label}
+                      dir={sort.sortBy === field.key ? sort.sortDir : null}
+                      onSort={() =>
+                        setSort((state) =>
+                          cycleColumnSort(PROJECTS_SORT, state, column.key),
+                        )
+                      }
+                    />
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((r, i) => {
+                return (
+                  <tr
+                    key={r.name}
+                    onClick={() => onSelectRepo(r.name)}
+                    aria-selected={i === selectedIndex}
+                    className={`cursor-pointer hover:bg-(--surface-1) ${i === selectedIndex ? "row-selected" : ""}`}
+                  >
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-semibold text-(--text)">
+                      {r.name}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      {r.team ? (
+                        <span className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11px] font-medium text-(--text-dim)">
+                          {r.team}
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      {projectTarget(r)}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <span
+                        className="rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+                        style={
+                          r.reportOnly
+                            ? {
+                                color: "var(--text-faint)",
+                                background:
+                                  "color-mix(in oklch, var(--text-faint) 12%, transparent)",
+                              }
+                            : {
+                                color: "var(--hue-ok)",
+                                background:
+                                  "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
+                              }
+                        }
+                      >
+                        {r.reportOnly ? "Report Only" : "Dispatchable"}
+                      </span>
+                    </td>
+                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      {r.base}
+                      {r.deployBranch ? ` → ${r.deployBranch}` : ""}
+                    </td>
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-xs text-(--text-faint)">
+                      {worktreeScripts(r) || (
+                        <span className="text-(--text-faint)">—</span>
+                      )}
+                    </td>
+                  </tr>
                 );
               })}
-            </tr>
-          </thead>
-          <tbody>
-            {visible.map((r, i) => {
-              return (
-                <tr
-                  key={r.name}
-                  onClick={() => onSelectRepo(r.name)}
-                  aria-selected={i === selectedIndex}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${i === selectedIndex ? "row-selected" : ""}`}
-                >
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap font-semibold text-(--text)">
-                    {r.name}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    {r.team ? (
-                      <span className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11px] font-medium text-(--text-dim)">
-                        {r.team}
-                      </span>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                    {projectTarget(r)}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                    <span
-                      className="rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
-                      style={
-                        r.reportOnly
-                          ? {
-                              color: "var(--text-faint)",
-                              background:
-                                "color-mix(in oklch, var(--text-faint) 12%, transparent)",
-                            }
-                          : {
-                              color: "var(--hue-ok)",
-                              background:
-                                "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
-                            }
-                      }
-                    >
-                      {r.reportOnly ? "Report Only" : "Dispatchable"}
-                    </span>
-                  </td>
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                    {r.base}
-                    {r.deployBranch ? ` → ${r.deployBranch}` : ""}
-                  </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-xs text-(--text-faint)">
-                    {worktreeScripts(r) || (
-                      <span className="text-(--text-faint)">—</span>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
-            {visible.length === 0 && (
-              <ListEmpty
-                colSpan={6}
-                query={query}
-                filtered={repos.length > 0}
-                noun="repositories"
-                empty="No configured repositories in config/repos.yaml."
-              />
-            )}
-          </tbody>
-        </Table>
-      </ListPane>
+              {visible.length === 0 && (
+                <ListEmpty
+                  colSpan={6}
+                  query={query}
+                  filtered={repos.length > 0}
+                  noun="repositories"
+                  empty="No configured repositories in config/repos.yaml."
+                />
+              )}
+            </tbody>
+          </Table>
+        </ListPane>
+      </div>
 
       {sel && (
         <DetailPane
-          widthClass="w-full max-w-full sm:w-[540px]"
+          widthClass="w-full max-w-full lg:w-[540px]"
           title={
             <div className="flex items-center gap-2">
               <span className="mono font-semibold" title={sel.name}>
@@ -770,10 +804,11 @@ export function Projects({
               </div>
             </Section>
 
-            <Section id="project-configuration" title="Configuration" icons>
+            <Section id="project-configuration" title="Dispatch" icons>
+              <ConfigSource />
               <KV k="Name" v={sel.name} />
-              {sel.project && <KV k="Project" v={sel.project} />}
-              {sel.team && <KV k="Team" v={sel.team} />}
+              <KV k="Project" v={sel.project ?? emptyValue} />
+              <KV k="Team" v={sel.team ?? emptyValue} />
               <KV
                 k="Path"
                 v={
@@ -786,10 +821,10 @@ export function Projects({
                   </span>
                 }
               />
-              {sel.github && (
-                <KV
-                  k="GitHub"
-                  v={
+              <KV
+                k="GitHub"
+                v={
+                  sel.github ? (
                     <a
                       href={`https://github.com/${sel.github}`}
                       target="_blank"
@@ -798,13 +833,12 @@ export function Projects({
                     >
                       {sel.github}
                     </a>
-                  }
-                />
-              )}
+                  ) : (
+                    emptyValue
+                  )
+                }
+              />
               <KV k="Base branch" v={sel.base} />
-              {sel.deployBranch && (
-                <KV k="Deploy branch" v={sel.deployBranch} />
-              )}
               <KV
                 k="Execution mode"
                 v={
@@ -822,60 +856,171 @@ export function Projects({
                   </span>
                 }
               />
-              {sel.maxInFlight !== null && (
-                <KV k="Max in flight" v={sel.maxInFlight} />
-              )}
-              {sel.worktreeRoot && (
-                <KV k="Worktrees root" v={sel.worktreeRoot} />
-              )}
-              {sel.verify && (
-                <div className="mt-2">
-                  <div className="text-[11px] text-(--text-faint)">
-                    Verification Command
-                  </div>
-                  <pre className="mono mt-1 overflow-auto rounded bg-(--surface-0) p-2 text-[11px] text-(--text-dim)">
+              <KV
+                k="Max in flight"
+                v={
+                  <span className="flex flex-wrap items-center gap-1.5">
+                    <span className="mono text-(--text)">
+                      {sel.effective?.maxInFlight ?? sel.maxInFlight ?? EMPTY}
+                    </span>
+                    <span className="rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-faint)">
+                      {(sel.effective?.maxInFlightSource ??
+                        (sel.maxInFlight === null ? "default" : "repo")) ===
+                      "repo"
+                        ? "repo value"
+                        : "default · planner.mjs"}
+                    </span>
+                  </span>
+                }
+              />
+              <KV k="Worktrees root" v={sel.worktreeRoot ?? emptyValue} />
+              <KV
+                k="worktree_up"
+                v={sel.hasWorktreeUp ? "configured" : emptyValue}
+              />
+              <KV
+                k="worktree_down"
+                v={sel.hasWorktreeDown ? "configured" : emptyValue}
+              />
+              <KV
+                k="worktree_warm"
+                v={sel.hasWorktreeWarm ? "configured" : emptyValue}
+              />
+              <div className="mt-2">
+                <div className="text-[11px] text-(--text-faint)">
+                  Verification command
+                </div>
+                {sel.verify ? (
+                  <pre className="mono mt-1 overflow-auto rounded bg-(--surface-1) p-2 text-[11px] text-(--text-dim)">
                     {sel.verify}
                   </pre>
+                ) : (
+                  <div className="mt-1">{emptyValue}</div>
+                )}
+              </div>
+            </Section>
+
+            <Section title="Merge gate">
+              <ConfigSource />
+              <KV
+                k="merge_ci workflow"
+                v={sel.mergeCi?.workflow ?? emptyValue}
+              />
+              <div className="py-[3px]">
+                <div className="mb-1 text-(--text-faint)">Required checks</div>
+                {sel.mergeCi ? (
+                  <ConfigList values={sel.mergeCi.requiredChecks} />
+                ) : (
+                  <div className="text-[11px] text-(--text-dim)">
+                    no configured checks — merge waits on repo default
+                  </div>
+                )}
+              </div>
+              <div className="mt-2 border-t border-(--border) pt-2">
+                <div className="mb-1 text-(--text-faint)">escalate_paths</div>
+                {sel.escalatePaths == null ? (
+                  <div
+                    className="rounded border px-2 py-1.5 text-[11px] font-medium"
+                    style={{
+                      borderColor: "var(--hue-warn)",
+                      color: "var(--hue-warn)",
+                      background:
+                        "color-mix(in oklch, var(--hue-warn) 8%, transparent)",
+                    }}
+                  >
+                    escalate_paths not declared — every PR escalates
+                  </div>
+                ) : sel.escalatePaths.length === 0 ? (
+                  <div className="text-[11px] text-(--text-dim)">
+                    explicitly none
+                  </div>
+                ) : (
+                  <ConfigList values={sel.escalatePaths} />
+                )}
+              </div>
+            </Section>
+
+            <Section title="Owned paths policy">
+              <ConfigSource />
+              {(sel.ownedPathsPolicy?.direct.length ?? 0) === 0 &&
+              (sel.ownedPathsPolicy?.pinManifests.length ?? 0) === 0 ? (
+                <div className="text-[12px] text-(--text-dim)">default</div>
+              ) : (
+                <div className="space-y-2">
+                  <div>
+                    <div className="mb-1 text-(--text-faint)">
+                      Direct sources
+                    </div>
+                    {(sel.ownedPathsPolicy?.direct.length ?? 0) > 0 ? (
+                      <div className="max-w-full space-y-1 overflow-x-auto pb-1">
+                        {sel.ownedPathsPolicy?.direct.map((rule) => (
+                          <div
+                            key={rule.source}
+                            className="mono w-max whitespace-nowrap text-[11px] text-(--text-dim)"
+                          >
+                            <code className="rounded bg-(--surface-1) px-1.5 py-0.5">
+                              {rule.source}
+                            </code>
+                            <span className="px-1.5 text-(--text-faint)">
+                              requires
+                            </span>
+                            {rule.requires.map((required) => (
+                              <code
+                                key={required}
+                                className="mr-1 rounded bg-(--surface-1) px-1.5 py-0.5"
+                              >
+                                {required}
+                              </code>
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      emptyValue
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-1 text-(--text-faint)">
+                      Pin manifests
+                    </div>
+                    <ConfigList
+                      values={sel.ownedPathsPolicy?.pinManifests ?? []}
+                    />
+                  </div>
                 </div>
               )}
             </Section>
 
-            <Section title="Worktree Automation Scripts">
-              <div className="grid grid-cols-3 gap-2 text-center text-[12px]">
-                <div
-                  className="rounded border border-(--border) p-2"
-                  style={{ opacity: sel.hasWorktreeUp ? 1 : 0.4 }}
-                >
-                  <div className="text-[11px] text-(--text-faint) uppercase">
-                    Up Script
-                  </div>
-                  <div className="font-semibold">
-                    {sel.hasWorktreeUp ? "Present" : "None"}
-                  </div>
-                </div>
-                <div
-                  className="rounded border border-(--border) p-2"
-                  style={{ opacity: sel.hasWorktreeDown ? 1 : 0.4 }}
-                >
-                  <div className="text-[11px] text-(--text-faint) uppercase">
-                    Down Script
-                  </div>
-                  <div className="font-semibold">
-                    {sel.hasWorktreeDown ? "Present" : "None"}
-                  </div>
-                </div>
-                <div
-                  className="rounded border border-(--border) p-2"
-                  style={{ opacity: sel.hasWorktreeWarm ? 1 : 0.4 }}
-                >
-                  <div className="text-[11px] text-(--text-faint) uppercase">
-                    Warm Script
-                  </div>
-                  <div className="font-semibold">
-                    {sel.hasWorktreeWarm ? "Present" : "None"}
-                  </div>
-                </div>
-              </div>
+            <Section title="Deploy & smoke">
+              <ConfigSource />
+              <KV k="Deploy branch" v={sel.deployBranch ?? emptyValue} />
+              <KV k="Deployment URL" v={sel.deployment?.url ?? emptyValue} />
+              <KV
+                k="Deployment branch"
+                v={sel.deployment?.branch ?? emptyValue}
+              />
+              <KV
+                k="Revision field"
+                v={sel.deployment?.revisionField ?? emptyValue}
+              />
+              <KV k="Smoke workflow" v={sel.smokeWorkflow ?? emptyValue} />
+              <KV k="Smoke URL" v={sel.smokeUrl ?? emptyValue} />
+              <KV
+                k="Smoke deadline"
+                v={
+                  sel.smokeDeadlineSeconds == null
+                    ? emptyValue
+                    : `${sel.smokeDeadlineSeconds} seconds`
+                }
+              />
+            </Section>
+
+            <Section title="Security">
+              <ConfigSource />
+              <KV
+                k="python_version"
+                v={sel.security?.pythonVersion ?? "defaults"}
+              />
             </Section>
 
             <Section

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -60,7 +60,7 @@ const emptyValue = <span className="text-(--text-faint)">{EMPTY}</span>;
 
 function ConfigSource() {
   return (
-    <div className="mb-2 border-b border-(--border) pb-1.5 text-[10px] text-(--text-faint)">
+    <div className="mb-2 border-b border-(--border) pb-1.5 text-[11px] text-(--text-faint)">
       Source: <code className="mono text-(--text-dim)">config/repos.yaml</code>
     </div>
   );
@@ -863,7 +863,7 @@ export function Projects({
                     <span className="mono text-(--text)">
                       {sel.effective?.maxInFlight ?? sel.maxInFlight ?? EMPTY}
                     </span>
-                    <span className="rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-faint)">
+                    <span className="rounded bg-(--surface-2) px-1.5 py-0.5 text-[11px] text-(--text-faint)">
                       {(sel.effective?.maxInFlightSource ??
                         (sel.maxInFlight === null ? "default" : "repo")) ===
                       "repo"


### PR DESCRIPTION
## Summary
- widen the allow-listed repository registry view with merge/escalation, owned-path, deploy/smoke, security, and effective concurrency settings
- group the Projects detail panel by operational concern with source annotations, explicit escalation states, and untruncated policy lists
- keep the responsive detail flow readable and update API/UI tests plus the web UI specification

## Verification
- `bun test event-runtime/lib/repos.test.mjs event-runtime/web/src/views/Projects.test.tsx && (cd event-runtime/web && bun run build)` — pass (43 tests; TypeScript and Vite production build green)
- `bun test event-runtime/lib/api-registry.test.mjs event-runtime/lib/api-config.test.mjs` — pass (13 tests)

UX critique: required — SHIP after 2 rounds; evidence: `http://127.0.0.1:7709/#/projects/factory`, `/tmp/WM-703-round2-narrow.png`, `/tmp/WM-703-round2-narrow-merge-gate.png`

Reviewer focus: `repos.mjs` imports the planner's exported default so the effective value cannot drift; WM-755 tracks moving that binding to a dependency-neutral module outside this ticket's Owned Paths.

Fixes WM-703
