### PR TITLE
fix(web): return Tab out of a hover card to the trigger (WM-752)

### DIFF
--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   render,
   waitFor,
@@ -45,6 +46,8 @@ function Fixture(props: {
   closeDelayMs?: number;
   onOpenChange?: (open: boolean) => void;
   interactiveTrigger?: boolean;
+  /** Two in-card controls, so the first and last tab stops are distinct. */
+  secondAction?: boolean;
 }) {
   return (
     <HoverCard
@@ -67,6 +70,7 @@ function Fixture(props: {
           <button type="button" onClick={close}>
             Open in Agents
           </button>
+          {props.secondAction ? <button type="button">Copy id</button> : null}
         </>
       )}
     </HoverCard>
@@ -441,6 +445,79 @@ describe("HoverCard", () => {
     fireEvent.click(r.getByRole("button", { name: /Open in Agents/ }));
 
     await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+  });
+
+  test("Tab from the last in-card control returns focus to the trigger", async () => {
+    const r = render(<Fixture secondAction />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const last = r.getByRole("button", { name: "Copy id" });
+    last.focus();
+    fireEvent.keyDown(last, { key: "Tab" });
+
+    expect(document.activeElement).toBe(trigger);
+    // Focus landing on the trigger is not focus leaving the card, so the
+    // deferred close must not fire behind it; the next Tab is what dismisses it.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(r.queryByRole("dialog")).toBeTruthy();
+  });
+
+  test("Shift+Tab from the first in-card control returns focus to the trigger", async () => {
+    const r = render(<Fixture secondAction />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const first = r.getByRole("button", { name: /Open in Agents/ });
+    first.focus();
+    fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test("Tab between two in-card controls is left to the browser", async () => {
+    const r = render(<Fixture secondAction />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const first = r.getByRole("button", { name: /Open in Agents/ });
+    first.focus();
+    const event = createEvent.keyDown(first, { key: "Tab" });
+    fireEvent(first, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(first);
+  });
+
+  test("Tab from a card with no controls returns focus to the trigger", async () => {
+    const r = render(
+      <HoverCard
+        label="Agent triage-scan"
+        openDelayMs={0}
+        closeDelayMs={0}
+        trigger="triage-scan"
+      >
+        <span>card body</span>
+      </HoverCard>,
+    );
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const panel = await waitFor(() => r.getByRole("dialog"));
+    expect(document.activeElement).toBe(panel);
+
+    fireEvent.keyDown(panel, { key: "Tab" });
+
+    expect(document.activeElement).toBe(trigger);
   });
 
   test("drops the entry animation when reduced motion is preferred", async () => {

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -8,7 +8,9 @@
  * viewport coordinates would otherwise float away from the row it describes.
  *
  * Callers supply the trigger and the panel body; the panel is portalled to
- * `document.body` so a row's `overflow: hidden` cannot clip it.
+ * `document.body` so a row's `overflow: hidden` cannot clip it — which is also
+ * why Tab at the card's edges has to be steered back to the trigger, since the
+ * portal puts the panel's tab stops after everything else in the document.
  */
 import {
   type FocusEvent as ReactFocusEvent,
@@ -347,13 +349,36 @@ export function HoverCard({
    * landing in the card silently moves the selected row underneath it. Only
    * propagation is stopped: the default is the panel's own scroll, which a card
    * taller than its `maxHeight` needs.
+   *
+   * Tab at either edge is a different leak: the portal sits at the end of
+   * `document.body`, so the browser would step out of the document instead of
+   * continuing from the trigger. Hand focus back there; Tab between two
+   * in-card controls is the browser's to handle.
    */
   const onPanelKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
-      e.stopPropagation();
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.stopPropagation();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const root = panelRef.current;
+      if (!root) return;
+      const stops = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+      const active = document.activeElement;
+      // A card with nothing focusable holds focus on the panel itself, so
+      // either direction is an edge. Otherwise only the far end is: forward
+      // from the panel root still walks into the card, as the DOM order says.
+      const atEdge =
+        stops.length === 0 ||
+        (e.shiftKey
+          ? active === stops[0] || active === root
+          : active === stops[stops.length - 1]);
+      if (!atEdge) return;
+      e.preventDefault();
+      restoreFocus();
     },
-    [],
+    [restoreFocus],
   );
 
   const api: HoverCardApi = { close };


### PR DESCRIPTION
## Summary

The hover-card panel is `createPortal(..., document.body)`, which puts its tab stops after everything else in the page. Tab from the last in-card control therefore walked out of the document instead of continuing near the trigger, and Shift+Tab from the first control did the same in reverse.

A non-modal `role="dialog"` needs no focus trap, so this is not one: a keydown handler on the panel intercepts Tab **only at the card's edges** and hands focus back to the trigger (the element that was focused when the card opened, falling back to the wrapper). The next Tab then continues from the trigger's own place in the page. Tab between two in-card controls is left entirely to the browser.

A card with nothing focusable holds focus on the panel itself, so both directions are an edge there. Forward Tab from the panel root when the card *does* have controls is not intercepted — DOM order already walks into the card.

Focus landing on the trigger is not focus leaving the card, so the deferred close does not fire behind it; the card stays open until the operator tabs on.

Scope: Tab-out only. The ARIA wrapper ([WM-741](https://linear.app/watt-mind/issue/WM-741)) and the ArrowDown leak ([WM-751](https://linear.app/watt-mind/issue/WM-751)) are separate tickets on the same files.

## Test plan

- [x] `cd event-runtime/web && bun test src/components/HoverCard.test.tsx` — 31 pass / 0 fail (was 27).
- [x] Negative first: the three new behavioural tests (Tab from last control, Shift+Tab from first control, Tab from a control-less card) were observed failing on the pre-fix tree. The fourth new test is a guard that Tab *between* two in-card controls is not intercepted, and passes either way by design.
- [x] Consumers unaffected: `AgentHoverCard.test.tsx` + `Agents.test.tsx` — 21 pass.
- [x] `bun run lint` — 0 errors, no new warnings in the changed files.
- [x] `factory security` — gitleaks, semgrep, actionlint all pass.

UX critique: skipped — keyboard focus management with no visual surface, and the critic was blocked on WM-726.

Fixes WM-752