### PR TITLE
feat(event-runtime): add inbox actions by kind

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -42,7 +42,12 @@ import {
   webhookSecret,
 } from "./config.mjs";
 import { githubWebhookSecret } from "./intake.mjs";
-import { decideInboxItem, getInboxItem, retryInboxDecision } from "./inbox.mjs";
+import {
+  bindInboxProposal,
+  decideInboxItem,
+  getInboxItem,
+  retryInboxDecision,
+} from "./inbox.mjs";
 import {
   applyDecisionEffect,
   decisionEffectPlanner,
@@ -283,6 +288,18 @@ export function createApi({
           );
           if (!schedule) return send(status, body);
           const repo = registry.schedules?.[loop]?.payload?.repo;
+          if (
+            loop.startsWith("ship-") &&
+            typeof repo === "string" &&
+            repo !== "" &&
+            typeof body?.proposalId === "string"
+          ) {
+            bindInboxProposal(db, {
+              kind: "RC READY",
+              repo,
+              proposalId: body.proposalId,
+            });
+          }
           return send(status, {
             ...body,
             schedule: {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -308,6 +308,43 @@ describe("schedule trigger metadata (WM-259)", () => {
       s.close();
     }
   });
+
+  test("Ship uses the existing schedule route and correlates its proposal to RC READY", async () => {
+    const s = await makeServer({
+      now: () => Date.parse("2026-08-18T12:00:00Z"),
+    });
+    try {
+      createInboxItem(
+        s.db,
+        {
+          kind: "RC READY",
+          title: "bj29 is ready to ship",
+          refs: { repo: "bj29" },
+        },
+        { id: "rc-ready-api" },
+      );
+      const response = await fetch(s.url("/schedules/ship-bj29/run"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({ loop: "ship-bj29", admitted: true });
+      expect(typeof body.proposalId).toBe("string");
+      expect(
+        JSON.parse(
+          s.db
+            .query(
+              "SELECT refs_json FROM inbox_items WHERE id = 'rc-ready-api'",
+            )
+            .get().refs_json,
+        ),
+      ).toEqual({ repo: "bj29", proposalId: body.proposalId });
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("artifact-view sidecar on GET /agents (WM-454)", () => {

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -6,7 +6,9 @@
  * broken, while notify_log continues to provide runtime-notification dedup.
  */
 import { randomUUID } from "node:crypto";
-import { gql } from "../../orchestrator/reaper.mjs";
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 import {
   decisionRequestHash,
   validateDecisionRequest,
@@ -861,8 +863,68 @@ function laterCiSuccess(db, row, refs) {
   });
 }
 
+const LINEAR_API_URL = "https://api.linear.app/graphql";
+
+function resolveLinearApiKey({
+  env = process.env,
+  envFile = path.join(homedir(), "Develop", "hdkiller", ".env"),
+} = {}) {
+  if (env.LINEAR_API_KEY) return env.LINEAR_API_KEY;
+  if (!existsSync(envFile)) return null;
+
+  try {
+    for (const line of readFileSync(envFile, "utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("="))
+        continue;
+      const idx = trimmed.indexOf("=");
+      if (trimmed.slice(0, idx).trim() !== "LINEAR_API_KEY") continue;
+      const value = trimmed
+        .slice(idx + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, "");
+      if (!value) return null;
+      env.LINEAR_API_KEY = value;
+      return value;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export async function linearGql(query, variables = {}) {
+  const apiKey = resolveLinearApiKey();
+  if (!apiKey) {
+    throw new Error(
+      "Linear API error: LINEAR_API_KEY not found in env or ~/Develop/hdkiller/.env",
+    );
+  }
+  const res = await fetch(LINEAR_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`Linear API HTTP ${res.status}: ${res.statusText}`);
+  }
+  const body = await res.json();
+  if (body.errors?.length) {
+    throw new Error(
+      `Linear GraphQL error: ${body.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  return body.data;
+}
+
 /** One bounded GraphQL request for the distinct Linear referents in this poll. */
-export async function fetchLinearInboxIssues(issueIds, { request = gql } = {}) {
+export async function fetchLinearInboxIssues(
+  issueIds,
+  { request = linearGql } = {},
+) {
   if (!Array.isArray(issueIds) || issueIds.length === 0) return [];
   const declarations = issueIds.map((_, index) => `$i${index}:String!`);
   const fields = issueIds.map(
@@ -881,14 +943,27 @@ export async function fetchLinearInboxIssues(issueIds, { request = gql } = {}) {
     .filter(Boolean);
 }
 
-function linearIssueResolved(kind, issue) {
+function linearIssueResolved(row, issue, db) {
   const state = issue?.state?.name;
   if (typeof state !== "string" || state === "") return false;
-  if (kind === "BLOCKED") return state !== "Blocked";
-  if (kind === "ESCALATED") {
+  if (row.kind === "BLOCKED") return state !== "Blocked";
+  if (row.kind === "ESCALATED") {
+    const delivery = parseObject(row.delivery_json);
     const labels = (issue?.labels?.nodes ?? []).map((label) => label.name);
+    const hasEscalatedLabel = labels.includes("ai:escalated");
+    if (hasEscalatedLabel && !delivery.seenEscalated) {
+      delivery.seenEscalated = true;
+      if (db) {
+        db.query("UPDATE inbox_items SET delivery_json = ? WHERE id = ?").run(
+          JSON.stringify(delivery),
+          row.id,
+        );
+        row.delivery_json = JSON.stringify(delivery);
+      }
+    }
     return (
-      issue?.state?.type === "completed" || !labels.includes("ai:escalated")
+      Boolean(delivery.seenEscalated) &&
+      (issue?.state?.type === "completed" || !hasEscalatedLabel)
     );
   }
   return false;
@@ -902,7 +977,7 @@ export function reconcileInbox(
   const resolved = [];
   const rows = db
     .query(
-      `SELECT id, kind, refs_json, decision_json, response_json, created_at FROM inbox_items
+      `SELECT id, kind, refs_json, decision_json, response_json, delivery_json, created_at FROM inbox_items
      WHERE resolved_at IS NULL
        AND kind IN (
          'decision_needed', 'proposal_expired', 'human_needed', 'BLOCKED',
@@ -963,7 +1038,7 @@ export function reconcileInbox(
       const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
       for (const { row, refs } of linearRows) {
         const issue = byId.get(refs.issue);
-        if (!issue || !linearIssueResolved(row.kind, issue)) continue;
+        if (!issue || !linearIssueResolved(row, issue, db)) continue;
         const resolvedBy =
           row.kind === "BLOCKED"
             ? "auto:linear_unblocked"

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -6,6 +6,7 @@
  * broken, while notify_log continues to provide runtime-notification dedup.
  */
 import { randomUUID } from "node:crypto";
+import { gql } from "../../orchestrator/reaper.mjs";
 import {
   decisionRequestHash,
   validateDecisionRequest,
@@ -707,6 +708,49 @@ export function inboxCounts(db) {
   };
 }
 
+/** Attach an ad-hoc schedule's watched proposal to the open item that spawned it. */
+export function bindInboxProposal(db, { kind, repo, proposalId }) {
+  requiredString(kind, "kind");
+  requiredString(repo, "repo");
+  requiredString(proposalId, "proposalId");
+  const row = db
+    .query(
+      `SELECT id FROM inbox_items
+       WHERE kind = ? AND resolved_at IS NULL
+         AND json_extract(refs_json, '$.repo') = ?
+       ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+    )
+    .get(kind, repo);
+  if (!row) return null;
+  return bindProposalToItem(db, row.id, proposalId);
+}
+
+function bindProposalToItem(db, id, proposalId) {
+  db.query(
+    `UPDATE inbox_items
+     SET refs_json = json_set(
+       CASE WHEN json_valid(refs_json) THEN refs_json ELSE '{}' END,
+       '$.proposalId', ?
+     )
+     WHERE id = ? AND resolved_at IS NULL`,
+  ).run(proposalId, id);
+  return getInboxItem(db, id);
+}
+
+function correlatedProposal(db, inboxItemId) {
+  return (
+    db
+      .query(
+        `SELECT p.id FROM events e
+         JOIN proposals p
+           ON p.event_source = e.source AND p.event_id = e.event_id
+         WHERE e.correlation_id = ?
+         ORDER BY p.created_at DESC, p.rowid DESC LIMIT 1`,
+      )
+      .get(inboxItemId)?.id ?? null
+  );
+}
+
 function telegramMessage(item, webUrl) {
   const lines = [item.title];
   if (item.body) lines.push(item.body);
@@ -768,17 +812,106 @@ export async function deliverInboxItem(
   };
 }
 
-/** Resolve runtime-owned asks when their authoritative referent stops waiting. */
-export function reconcileInbox(db, { now = Date.now() } = {}) {
+const LINEAR_POLL_INTERVAL_MS = 60_000;
+const linearPollAt = new WeakMap();
+
+function prNumber(ref) {
+  if (typeof ref !== "string") return null;
+  const match =
+    /^(?:PR\s*)?#?(\d+)$/i.exec(ref.trim()) ??
+    /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref);
+  return match ? Number(match[1]) : null;
+}
+
+function completedShipProposal(db, proposalId) {
+  return Boolean(
+    db
+      .query(
+        `SELECT 1 FROM proposals p
+         JOIN runs r ON r.run_id = p.run_id
+         WHERE p.id = ? AND r.state = 'COMPLETED'`,
+      )
+      .get(proposalId),
+  );
+}
+
+function laterCiSuccess(db, row, refs) {
+  const pr = prNumber(refs.pr);
+  if (!refs.repo || !pr) return false;
+  const events = db
+    .query(
+      `SELECT subject, envelope_json FROM events
+       WHERE source = 'github'
+         AND type = 'factory.merge.requested'
+         AND admitted_at > ?
+       ORDER BY admitted_at, rowid`,
+    )
+    .all(row.created_at);
+  return events.some((event) => {
+    const envelope = parseObject(event.envelope_json);
+    const payload = envelope.payload;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload))
+      return false;
+    const repo = payload.repo ?? event.subject;
+    return (
+      repo === refs.repo &&
+      Array.isArray(payload.prNumbers) &&
+      payload.prNumbers.some((number) => Number(number) === pr)
+    );
+  });
+}
+
+/** One bounded GraphQL request for the distinct Linear referents in this poll. */
+export async function fetchLinearInboxIssues(issueIds, { request = gql } = {}) {
+  if (!Array.isArray(issueIds) || issueIds.length === 0) return [];
+  const declarations = issueIds.map((_, index) => `$i${index}:String!`);
+  const fields = issueIds.map(
+    (_, index) =>
+      `i${index}: issue(id:$i${index}) { identifier state { name type } labels { nodes { name } } }`,
+  );
+  const variables = Object.fromEntries(
+    issueIds.map((issue, index) => [`i${index}`, issue]),
+  );
+  const data = await request(
+    `query(${declarations.join(",")}) { ${fields.join("\n")} }`,
+    variables,
+  );
+  return issueIds
+    .map((issue, index) => data?.[`i${index}`] ?? null)
+    .filter(Boolean);
+}
+
+function linearIssueResolved(kind, issue) {
+  const state = issue?.state?.name;
+  if (typeof state !== "string" || state === "") return false;
+  if (kind === "BLOCKED") return state !== "Blocked";
+  if (kind === "ESCALATED") {
+    const labels = (issue?.labels?.nodes ?? []).map((label) => label.name);
+    return (
+      issue?.state?.type === "completed" || !labels.includes("ai:escalated")
+    );
+  }
+  return false;
+}
+
+/** Resolve asks when their runtime-owned or externally polled referent moves on. */
+export function reconcileInbox(
+  db,
+  { now = Date.now(), linearIssues = fetchLinearInboxIssues } = {},
+) {
   const resolved = [];
   const rows = db
     .query(
-      `SELECT id, kind, refs_json, decision_json, response_json FROM inbox_items
+      `SELECT id, kind, refs_json, decision_json, response_json, created_at FROM inbox_items
      WHERE resolved_at IS NULL
-       AND kind IN ('decision_needed', 'proposal_expired', 'human_needed', 'BLOCKED')
+       AND kind IN (
+         'decision_needed', 'proposal_expired', 'human_needed', 'BLOCKED',
+         'ESCALATED', 'CI RED', 'RC READY'
+       )
      ORDER BY created_at, rowid`,
     )
     .all();
+  const linearRows = [];
   for (const row of rows) {
     // Pending decisions are not skipped: once the referent stops waiting the
     // ask is moot and resolveInboxItem records it as superseded (auto:*).
@@ -791,16 +924,54 @@ export function reconcileInbox(db, { now = Date.now() } = {}) {
         .get(refs.proposalId);
       if (proposal && proposal.status !== "open")
         resolvedBy = "auto:proposal_decided";
+    } else if (row.kind === "CI RED") {
+      if (!refs.proposalId) {
+        const proposalId = correlatedProposal(db, row.id);
+        if (proposalId) {
+          bindProposalToItem(db, row.id, proposalId);
+          refs.proposalId = proposalId;
+        }
+      }
+      if (laterCiSuccess(db, row, refs)) resolvedBy = "auto:ci_green";
+    } else if (row.kind === "RC READY") {
+      if (refs.proposalId && completedShipProposal(db, refs.proposalId))
+        resolvedBy = "auto:ship_completed";
     } else if (refs.eventSource && refs.eventId) {
       const event = db
         .query("SELECT status FROM events WHERE source = ? AND event_id = ?")
         .get(refs.eventSource, refs.eventId);
       if (event && event.status !== "human_needed")
         resolvedBy = "auto:event_requeued";
+    } else if (
+      (row.kind === "BLOCKED" || row.kind === "ESCALATED") &&
+      refs.issue
+    ) {
+      linearRows.push({ row, refs });
     }
     if (!resolvedBy) continue;
     resolveInboxItem(db, row.id, { now, resolvedBy });
     resolved.push({ id: row.id, resolvedBy });
   }
-  return resolved;
+
+  if (linearRows.length === 0) return resolved;
+  const lastPoll = linearPollAt.get(db) ?? -Infinity;
+  if (now - lastPoll < LINEAR_POLL_INTERVAL_MS) return resolved;
+  linearPollAt.set(db, now);
+  const issueIds = [...new Set(linearRows.map(({ refs }) => refs.issue))];
+  return Promise.resolve(linearIssues(issueIds))
+    .then((issues) => {
+      const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
+      for (const { row, refs } of linearRows) {
+        const issue = byId.get(refs.issue);
+        if (!issue || !linearIssueResolved(row.kind, issue)) continue;
+        const resolvedBy =
+          row.kind === "BLOCKED"
+            ? "auto:linear_unblocked"
+            : "auto:linear_escalation_cleared";
+        resolveInboxItem(db, row.id, { now, resolvedBy });
+        resolved.push({ id: row.id, resolvedBy });
+      }
+      return resolved;
+    })
+    .catch(() => resolved);
 }

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -539,15 +539,24 @@ describe("human inbox ledger (WM-285)", () => {
       },
     ];
     expect(
-      await reconcileInbox(db, { now: 180_000, linearIssues: unescalatedIssues }),
-    ).toEqual([{ id: "escalated", resolvedBy: "auto:linear_escalation_cleared" }]);
+      await reconcileInbox(db, {
+        now: 180_000,
+        linearIssues: unescalatedIssues,
+      }),
+    ).toEqual([
+      { id: "escalated", resolvedBy: "auto:linear_escalation_cleared" },
+    ]);
     expect(getInboxItem(db, "escalated").resolvedAt).not.toBeNull();
 
     // ESCALATED without observed transition: mere absence of label on creation does not resolve
     const unescalatedFromStartDb = openDb(":memory:");
     createInboxItem(
       unescalatedFromStartDb,
-      { kind: "ESCALATED", title: "fresh escalation", refs: { issue: "WM-20" } },
+      {
+        kind: "ESCALATED",
+        title: "fresh escalation",
+        refs: { issue: "WM-20" },
+      },
       { id: "fresh-escalated", now: 1000 },
     );
     const noLabelIssues = async () => [

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -3,6 +3,7 @@ import { openDb } from "./db.mjs";
 import {
   INBOX_KINDS,
   ackInboxItem,
+  bindInboxProposal,
   createInboxItem,
   decideInboxItem,
   deliverInboxItem,
@@ -481,6 +482,143 @@ describe("human inbox ledger (WM-285)", () => {
     expect(getInboxItem(db, "tick-item").resolvedBy).toBe(
       "auto:proposal_decided",
     );
+  });
+
+  test("Linear referents poll distinct open issues at most once per minute and fail open", async () => {
+    const db = openDb(":memory:");
+    for (const [id, kind, issue] of [
+      ["blocked", "BLOCKED", "WM-10"],
+      ["escalated", "ESCALATED", "WM-11"],
+      ["duplicate", "BLOCKED", "WM-10"],
+    ]) {
+      createInboxItem(
+        db,
+        { kind, title: id, refs: { issue } },
+        { id, now: 1000 },
+      );
+    }
+    const calls = [];
+    const linearIssues = async (ids) => {
+      calls.push(ids);
+      return [
+        {
+          identifier: "WM-10",
+          state: { name: "Todo", type: "unstarted" },
+          labels: { nodes: [] },
+        },
+        {
+          identifier: "WM-11",
+          state: { name: "In Progress", type: "started" },
+          labels: { nodes: [{ name: "ai:escalated" }] },
+        },
+      ];
+    };
+
+    expect(await reconcileInbox(db, { now: 60_000, linearIssues })).toEqual([
+      { id: "blocked", resolvedBy: "auto:linear_unblocked" },
+      { id: "duplicate", resolvedBy: "auto:linear_unblocked" },
+    ]);
+    expect(calls).toEqual([["WM-10", "WM-11"]]);
+    expect(await reconcileInbox(db, { now: 100_000, linearIssues })).toEqual(
+      [],
+    );
+    expect(calls).toHaveLength(1);
+
+    const failingDb = openDb(":memory:");
+    createInboxItem(
+      failingDb,
+      { kind: "BLOCKED", title: "stay open", refs: { issue: "WM-12" } },
+      { id: "transport-error", now: 1000 },
+    );
+    expect(
+      await reconcileInbox(failingDb, {
+        now: 60_000,
+        linearIssues: async () => {
+          throw new Error("offline");
+        },
+      }),
+    ).toEqual([]);
+    expect(getInboxItem(failingDb, "transport-error").resolvedAt).toBeNull();
+  });
+
+  test("CI success and the proposal spawned by Ship auto-resolve their matching items", async () => {
+    const db = openDb(":memory:");
+    createInboxItem(
+      db,
+      {
+        kind: "CI RED",
+        title: "red",
+        refs: { repo: "factory", pr: "PR #607" },
+      },
+      { id: "ci-red", now: 1000 },
+    );
+    const successAt = new Date(2000).toISOString();
+    const success = {
+      schemaVersion: "factory.event/v1",
+      eventId: "merge-pr:factory:607:abc",
+      type: "factory.merge.requested",
+      source: "github",
+      subject: "factory",
+      occurredAt: successAt,
+      correlationId: "merge-pr:factory:607:abc",
+      payload: { repo: "factory", prNumbers: [607] },
+    };
+    db.query(
+      `INSERT INTO events
+       (source, event_id, type, subject, occurred_at, received_at,
+        correlation_id, envelope_json, payload_hash, status, admitted_at)
+       VALUES ('github', ?, ?, 'factory', ?, ?, ?, ?, 'sha256:green', 'admitted', ?)`,
+    ).run(
+      success.eventId,
+      success.type,
+      successAt,
+      successAt,
+      success.correlationId,
+      JSON.stringify(success),
+      successAt,
+    );
+    const rerunAt = new Date(1500).toISOString();
+    db.query(
+      `INSERT INTO events
+       (source, event_id, type, subject, occurred_at, received_at,
+        correlation_id, envelope_json, payload_hash, status, admitted_at)
+       VALUES ('inbox', 'rerun-request', 'factory.ci-rerun.requested', 'factory',
+               ?, ?, 'ci-red', '{}', 'sha256:rerun', 'planned', ?)`,
+    ).run(rerunAt, rerunAt, rerunAt);
+    db.query(
+      `INSERT INTO proposals
+       (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES ('rerun-proposal', 'inbox', 'rerun-request', 'run', 'open', ?, 1800)`,
+    ).run(rerunAt);
+
+    createInboxItem(
+      db,
+      { kind: "RC READY", title: "ready", refs: { repo: "factory" } },
+      { id: "rc-ready", now: 1000 },
+    );
+    expect(
+      bindInboxProposal(db, {
+        kind: "RC READY",
+        repo: "factory",
+        proposalId: "ship-proposal",
+      })?.refs,
+    ).toMatchObject({ repo: "factory", proposalId: "ship-proposal" });
+    db.query(
+      `INSERT INTO runs
+       (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+       VALUES ('ship-run', 'ship-key', '{}', 'sha256:ship', 'COMPLETED', ?, ?)`,
+    ).run(successAt, successAt);
+    db.query(
+      `INSERT INTO proposals
+       (id, event_source, event_id, decision, run_id, status, created_at, ttl_seconds)
+       VALUES ('ship-proposal', 'operator', 'ship-event', 'run', 'ship-run', 'approved', ?, 1800)`,
+    ).run(successAt);
+
+    expect(await reconcileInbox(db, { now: 3000 })).toEqual([
+      { id: "ci-red", resolvedBy: "auto:ci_green" },
+      { id: "rc-ready", resolvedBy: "auto:ship_completed" },
+    ]);
+    expect(getInboxItem(db, "ci-red").refs.proposalId).toBe("rerun-proposal");
   });
 });
 

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -13,6 +13,8 @@ import {
   reconcileInbox,
   retryInboxDecision,
   resolveInboxItem,
+  fetchLinearInboxIssues,
+  linearGql,
 } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 import { templateFor } from "./decision-templates.mjs";
@@ -524,6 +526,47 @@ describe("human inbox ledger (WM-285)", () => {
     );
     expect(calls).toHaveLength(1);
 
+    // ESCALATED transition: initial poll with ai:escalated registers seenEscalated without resolving
+    expect(getInboxItem(db, "escalated").resolvedAt).toBeNull();
+    expect(getInboxItem(db, "escalated").delivery.seenEscalated).toBe(true);
+
+    // ESCALATED transition: subsequent poll with ai:escalated removed resolves the item
+    const unescalatedIssues = async () => [
+      {
+        identifier: "WM-11",
+        state: { name: "In Progress", type: "started" },
+        labels: { nodes: [] },
+      },
+    ];
+    expect(
+      await reconcileInbox(db, { now: 180_000, linearIssues: unescalatedIssues }),
+    ).toEqual([{ id: "escalated", resolvedBy: "auto:linear_escalation_cleared" }]);
+    expect(getInboxItem(db, "escalated").resolvedAt).not.toBeNull();
+
+    // ESCALATED without observed transition: mere absence of label on creation does not resolve
+    const unescalatedFromStartDb = openDb(":memory:");
+    createInboxItem(
+      unescalatedFromStartDb,
+      { kind: "ESCALATED", title: "fresh escalation", refs: { issue: "WM-20" } },
+      { id: "fresh-escalated", now: 1000 },
+    );
+    const noLabelIssues = async () => [
+      {
+        identifier: "WM-20",
+        state: { name: "In Progress", type: "started" },
+        labels: { nodes: [] },
+      },
+    ];
+    expect(
+      await reconcileInbox(unescalatedFromStartDb, {
+        now: 60_000,
+        linearIssues: noLabelIssues,
+      }),
+    ).toEqual([]);
+    expect(
+      getInboxItem(unescalatedFromStartDb, "fresh-escalated").resolvedAt,
+    ).toBeNull();
+
     const failingDb = openDb(":memory:");
     createInboxItem(
       failingDb,
@@ -539,6 +582,29 @@ describe("human inbox ledger (WM-285)", () => {
       }),
     ).toEqual([]);
     expect(getInboxItem(failingDb, "transport-error").resolvedAt).toBeNull();
+
+    // fetchLinearInboxIssues empty handling and custom safe request function
+    expect(await fetchLinearInboxIssues([])).toEqual([]);
+    const mockGql = async (query, vars) => {
+      expect(query).toContain("query($i0:String!)");
+      expect(vars).toEqual({ i0: "WM-99" });
+      return {
+        i0: {
+          identifier: "WM-99",
+          state: { name: "Done", type: "completed" },
+          labels: { nodes: [] },
+        },
+      };
+    };
+    expect(
+      await fetchLinearInboxIssues(["WM-99"], { request: mockGql }),
+    ).toEqual([
+      {
+        identifier: "WM-99",
+        state: { name: "Done", type: "completed" },
+        labels: { nodes: [] },
+      },
+    ]);
   });
 
   test("CI success and the proposal spawned by Ship auto-resolve their matching items", async () => {

--- a/event-runtime/web/src/components/InboxActions.test.tsx
+++ b/event-runtime/web/src/components/InboxActions.test.tsx
@@ -1,0 +1,226 @@
+import "../test-dom";
+import { afterEach, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import type { AdmittedEvent, InboxItem } from "../types";
+import { InboxActions, ciRerunEnvelope, replayEnvelope } from "./InboxActions";
+
+afterEach(cleanup);
+
+const item = (overrides: Partial<InboxItem> = {}): InboxItem => ({
+  id: "inbox_action",
+  kind: "CI RED",
+  severity: "normal",
+  title: "Action",
+  body: null,
+  refs: {},
+  source: "serve:notify",
+  createdAt: "2026-08-18T10:00:00.000Z",
+  ackedAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  delivery: {},
+  ...overrides,
+});
+
+const event: AdmittedEvent = {
+  source: "github",
+  eventId: "failed-1",
+  type: "github.workflow-run.failed",
+  subject: "ci",
+  status: "admitted",
+  occurredAt: "2026-08-18T10:00:00.000Z",
+  receivedAt: "2026-08-18T10:00:00.000Z",
+  correlationId: "failed-1",
+  planFailures: 0,
+  lastPlanError: null,
+  admittedAt: "2026-08-18T10:00:00.000Z",
+  proposalId: null,
+  runId: null,
+  envelope: {
+    schemaVersion: "factory.event/v1",
+    eventId: "failed-1",
+    type: "github.workflow-run.failed",
+    source: "github",
+    occurredAt: "2026-08-18T10:00:00.000Z",
+    correlationId: "failed-1",
+    payload: { repo: "watt-mind/factory", runId: 987 },
+  },
+  repos: ["factory"],
+};
+
+const NOW = Date.parse("2026-08-18T12:00:00.000Z");
+
+test("builds fresh replay and CI-rerun envelopes correlated to the inbox item", () => {
+  const source = item({
+    kind: "human_needed",
+    refs: { eventSource: "github", eventId: "failed-1" },
+  });
+  expect(replayEnvelope(source, event, NOW)).toMatchObject({
+    eventId: `inbox-${source.id}-${NOW}`,
+    source: "inbox",
+    correlationId: source.id,
+    causationId: "failed-1",
+    type: "github.workflow-run.failed",
+  });
+  expect(
+    ciRerunEnvelope(
+      item({ refs: { repo: "fallback/repo", pr: "PR #42" } }),
+      event,
+      NOW,
+    ),
+  ).toMatchObject({
+    type: "factory.ci-rerun.requested",
+    source: "inbox",
+    correlationId: "inbox_action",
+    payload: { repo: "watt-mind/factory", runId: 987 },
+  });
+});
+
+test("renders only diagnose-first jump/resolve chrome and explains escalations", () => {
+  const calls = {
+    events: mock(async () => ({ events: [] })),
+    replay: mock(async (_envelope: unknown) => ({
+      admitted: true,
+      duplicate: false,
+      eventId: "x",
+    })),
+    triggerSchedule: mock(async (_loop: string) => ({}) as never),
+  };
+  const escalated = render(
+    <InboxActions
+      item={item({ kind: "ESCALATED", refs: { issue: "WM-287", pr: "607" } })}
+      connected
+      prUrl="https://github.com/watt-mind/factory/pull/607"
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={calls}
+    />,
+  );
+  expect(escalated.getByText("Open PR")).toBeTruthy();
+  expect(escalated.getByText("Open issue")).toBeTruthy();
+  expect(escalated.getByText(/deliberately cannot merge/)).toBeTruthy();
+  expect(escalated.queryByRole("button")).toBeNull();
+  escalated.unmount();
+
+  const resolve = mock(() => {});
+  const smoke = render(
+    <InboxActions
+      item={item({ kind: "SMOKE RED", refs: { issue: "WM-287" } })}
+      connected
+      onResolve={resolve}
+      onItemChange={() => {}}
+      apiCalls={calls}
+    />,
+  );
+  fireEvent.click(smoke.getByRole("button", { name: "Resolve…" }));
+  expect(resolve).toHaveBeenCalledTimes(1);
+  expect(smoke.queryByText(/retry/i)).toBeNull();
+});
+
+test("Replay, Rerun CI, and Ship use their existing API request shapes and refetch", async () => {
+  const replay = mock(async (_envelope: unknown) => ({
+    admitted: true,
+    duplicate: false,
+    eventId: "new",
+  }));
+  const triggerSchedule = mock(async (_loop: string) => ({}) as never);
+  const apiCalls = {
+    events: mock(async () => ({ events: [event] })),
+    replay,
+    triggerSchedule,
+  };
+  const changed = mock(() => {});
+
+  const replayView = render(
+    <InboxActions
+      item={item({
+        kind: "human_needed",
+        refs: { eventSource: "github", eventId: "failed-1" },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={changed}
+      apiCalls={apiCalls}
+      now={() => NOW}
+    />,
+  );
+  fireEvent.click(replayView.getByRole("button", { name: "Replay" }));
+  await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+  expect(replay.mock.calls[0][0]).toMatchObject({
+    source: "inbox",
+    correlationId: "inbox_action",
+  });
+  replayView.unmount();
+
+  const ciView = render(
+    <InboxActions
+      item={item({
+        refs: {
+          repo: "watt-mind/factory",
+          pr: "987",
+          eventSource: "github",
+          eventId: "failed-1",
+        },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={changed}
+      apiCalls={apiCalls}
+      now={() => NOW}
+    />,
+  );
+  fireEvent.click(ciView.getByRole("button", { name: "Rerun CI" }));
+  await waitFor(() => expect(replay).toHaveBeenCalledTimes(2));
+  expect(replay.mock.calls[1][0]).toMatchObject({
+    type: "factory.ci-rerun.requested",
+    payload: { repo: "watt-mind/factory", runId: 987 },
+  });
+  expect(ciView.getByText("Request created")).toBeTruthy();
+  expect(ciView.queryByRole("button", { name: "Rerun CI" })).toBeNull();
+  ciView.unmount();
+
+  const shipView = render(
+    <InboxActions
+      item={item({ kind: "RC READY", refs: { repo: "factory" } })}
+      connected
+      onResolve={() => {}}
+      onItemChange={changed}
+      apiCalls={apiCalls}
+    />,
+  );
+  fireEvent.click(shipView.getByRole("button", { name: "Ship" }));
+  await waitFor(() =>
+    expect(triggerSchedule).toHaveBeenCalledWith("ship-factory"),
+  );
+  expect(shipView.getByText("Request created")).toBeTruthy();
+  expect(shipView.queryByRole("button", { name: "Ship" })).toBeNull();
+  expect(changed).toHaveBeenCalledTimes(3);
+});
+
+test("an item already correlated to a proposal replaces its mutating action", () => {
+  const apiCalls = {
+    events: mock(async () => ({ events: [] })),
+    replay: mock(async (_envelope: unknown) => ({
+      admitted: true,
+      duplicate: false,
+      eventId: "x",
+    })),
+    triggerSchedule: mock(async (_loop: string) => ({}) as never),
+  };
+  const view = render(
+    <InboxActions
+      item={item({
+        kind: "RC READY",
+        refs: { repo: "factory", proposalId: "prop_ship" },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+    />,
+  );
+  expect(view.getByText("Open proposal").getAttribute("href")).toBe(
+    "#/proposals/prop_ship",
+  );
+  expect(view.queryByRole("button", { name: "Ship" })).toBeNull();
+});

--- a/event-runtime/web/src/components/InboxActions.test.tsx
+++ b/event-runtime/web/src/components/InboxActions.test.tsx
@@ -261,7 +261,10 @@ test("Rerun CI maps a short repo name to its GitHub slug, and Ship refuses a rep
   };
   const rerun = render(
     <InboxActions
-      item={item({ kind: "CI RED", refs: { repo: "factory", runId: "123", pr: "PR #123" } })}
+      item={item({
+        kind: "CI RED",
+        refs: { repo: "factory", runId: "123", pr: "PR #123" },
+      })}
       connected
       onResolve={() => {}}
       onItemChange={() => {}}
@@ -271,7 +274,9 @@ test("Rerun CI maps a short repo name to its GitHub slug, and Ship refuses a rep
   );
   fireEvent.click(rerun.getByRole("button", { name: "Rerun CI" }));
   await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
-  const envelope = replay.mock.calls[0][0] as { payload: { repo: string; runId: string } };
+  const envelope = replay.mock.calls[0][0] as {
+    payload: { repo: string; runId: string };
+  };
   expect(envelope.payload.repo).toBe("watt-mind/factory");
   expect(envelope.payload.runId).toBe("123");
   expect(() =>

--- a/event-runtime/web/src/components/InboxActions.test.tsx
+++ b/event-runtime/web/src/components/InboxActions.test.tsx
@@ -85,6 +85,8 @@ test("renders only diagnose-first jump/resolve chrome and explains escalations",
       eventId: "x",
     })),
     triggerSchedule: mock(async (_loop: string) => ({}) as never),
+    repos: mock(async () => ({ repos: [] }) as never),
+    schedules: mock(async () => ({ schedules: [] }) as never),
   };
   const escalated = render(
     <InboxActions
@@ -128,6 +130,15 @@ test("Replay, Rerun CI, and Ship use their existing API request shapes and refet
     events: mock(async () => ({ events: [event] })),
     replay,
     triggerSchedule,
+    repos: mock(
+      async () =>
+        ({
+          repos: [{ name: "factory", github: "watt-mind/factory" }],
+        }) as never,
+    ),
+    schedules: mock(
+      async () => ({ schedules: [{ loop: "ship-factory" }] }) as never,
+    ),
   };
   const changed = mock(() => {});
 
@@ -206,6 +217,8 @@ test("an item already correlated to a proposal replaces its mutating action", ()
       eventId: "x",
     })),
     triggerSchedule: mock(async (_loop: string) => ({}) as never),
+    repos: mock(async () => ({ repos: [] }) as never),
+    schedules: mock(async () => ({ schedules: [] }) as never),
   };
   const view = render(
     <InboxActions
@@ -223,4 +236,59 @@ test("an item already correlated to a proposal replaces its mutating action", ()
     "#/proposals/prop_ship",
   );
   expect(view.queryByRole("button", { name: "Ship" })).toBeNull();
+});
+
+test("Rerun CI maps a short repo name to its GitHub slug, and Ship refuses a repo with no ship schedule", async () => {
+  const replay = mock(async (_envelope: unknown) => ({
+    admitted: true,
+    duplicate: false,
+    eventId: "new",
+  }));
+  const triggerSchedule = mock(async (_loop: string) => ({}) as never);
+  const apiCalls = {
+    events: mock(async () => ({ events: [] })),
+    replay,
+    triggerSchedule,
+    repos: mock(
+      async () =>
+        ({
+          repos: [{ name: "factory", github: "watt-mind/factory" }],
+        }) as never,
+    ),
+    schedules: mock(
+      async () => ({ schedules: [{ loop: "ship-bj29" }] }) as never,
+    ),
+  };
+  const rerun = render(
+    <InboxActions
+      item={item({ kind: "CI RED", refs: { repo: "factory", pr: "PR #123" } })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+      now={() => 1_700_000_000_000}
+    />,
+  );
+  fireEvent.click(rerun.getByRole("button", { name: "Rerun CI" }));
+  await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+  const envelope = replay.mock.calls[0][0] as { payload: { repo: string } };
+  expect(envelope.payload.repo).toBe("watt-mind/factory");
+  cleanup();
+
+  const ship = render(
+    <InboxActions
+      item={item({ kind: "RC READY", refs: { repo: "factory" } })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+    />,
+  );
+  fireEvent.click(ship.getByRole("button", { name: "Ship" }));
+  await waitFor(() =>
+    expect(
+      ship.getByText(/No ship schedule is configured for "factory"/),
+    ).toBeTruthy(),
+  );
+  expect(triggerSchedule).not.toHaveBeenCalled();
 });

--- a/event-runtime/web/src/components/InboxActions.test.tsx
+++ b/event-runtime/web/src/components/InboxActions.test.tsx
@@ -261,7 +261,7 @@ test("Rerun CI maps a short repo name to its GitHub slug, and Ship refuses a rep
   };
   const rerun = render(
     <InboxActions
-      item={item({ kind: "CI RED", refs: { repo: "factory", pr: "PR #123" } })}
+      item={item({ kind: "CI RED", refs: { repo: "factory", runId: "123", pr: "PR #123" } })}
       connected
       onResolve={() => {}}
       onItemChange={() => {}}
@@ -271,8 +271,15 @@ test("Rerun CI maps a short repo name to its GitHub slug, and Ship refuses a rep
   );
   fireEvent.click(rerun.getByRole("button", { name: "Rerun CI" }));
   await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
-  const envelope = replay.mock.calls[0][0] as { payload: { repo: string } };
+  const envelope = replay.mock.calls[0][0] as { payload: { repo: string; runId: string } };
   expect(envelope.payload.repo).toBe("watt-mind/factory");
+  expect(envelope.payload.runId).toBe("123");
+  expect(() =>
+    ciRerunEnvelope(
+      item({ refs: { repo: "watt-mind/factory", pr: "PR #123" } }),
+      null,
+    ),
+  ).toThrow("Rerun CI needs the failed workflow run reference");
   cleanup();
 
   const ship = render(

--- a/event-runtime/web/src/components/InboxActions.tsx
+++ b/event-runtime/web/src/components/InboxActions.tsx
@@ -1,0 +1,233 @@
+import { useState } from "react";
+import { api } from "../api";
+import type { AdmittedEvent, InboxItem } from "../types";
+import { Button, JumpLink, VerbError } from "./ui";
+
+type ActionApi = Pick<typeof api, "events" | "replay" | "triggerSchedule">;
+
+const PLAIN_ACTION_KINDS = new Set([
+  "human_needed",
+  "CI RED",
+  "RC READY",
+  "ESCALATED",
+  "SMOKE RED",
+  "CIRCUIT BREAKER",
+]);
+
+export function hasInboxPlainActions(kind: string): boolean {
+  return PLAIN_ACTION_KINDS.has(kind);
+}
+
+function referencedEvent(
+  events: AdmittedEvent[],
+  item: InboxItem,
+): AdmittedEvent | null {
+  if (!item.refs.eventSource || !item.refs.eventId) return null;
+  return (
+    events.find(
+      (event) =>
+        event.source === item.refs.eventSource &&
+        event.eventId === item.refs.eventId,
+    ) ?? null
+  );
+}
+
+function payloadOf(event: AdmittedEvent | null): Record<string, unknown> {
+  const payload = event?.envelope?.payload;
+  return payload && typeof payload === "object" && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : {};
+}
+
+function freshId(item: InboxItem, now: number): string {
+  return `inbox-${item.id}-${now}`;
+}
+
+export function replayEnvelope(
+  item: InboxItem,
+  event: AdmittedEvent,
+  now = Date.now(),
+): Record<string, unknown> {
+  return {
+    ...event.envelope,
+    eventId: freshId(item, now),
+    source: "inbox",
+    occurredAt: new Date(now).toISOString(),
+    correlationId: item.id,
+    causationId: event.eventId,
+  };
+}
+
+export function ciRerunEnvelope(
+  item: InboxItem,
+  event: AdmittedEvent | null,
+  now = Date.now(),
+): Record<string, unknown> {
+  const original = payloadOf(event);
+  const repo = original.repo ?? item.refs.repo;
+  const runId = original.runId ?? item.refs.pr?.match(/\d+/)?.[0];
+  if (typeof repo !== "string" || repo === "")
+    throw new Error("Rerun CI needs a repository reference");
+  if (
+    (typeof runId !== "string" && typeof runId !== "number") ||
+    String(runId).trim() === ""
+  ) {
+    throw new Error("Rerun CI needs the failed workflow run reference");
+  }
+  const eventId = freshId(item, now);
+  return {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type: "factory.ci-rerun.requested",
+    source: "inbox",
+    subject: repo,
+    occurredAt: new Date(now).toISOString(),
+    correlationId: item.id,
+    causationId: item.refs.eventId ?? null,
+    payload: { repo, runId },
+  };
+}
+
+export function InboxActions({
+  item,
+  connected,
+  prUrl,
+  onResolve,
+  onItemChange,
+  apiCalls = api,
+  now = Date.now,
+}: {
+  item: InboxItem;
+  connected: boolean;
+  prUrl?: string | null;
+  onResolve: () => void;
+  onItemChange: () => void;
+  apiCalls?: ActionApi;
+  now?: () => number;
+}) {
+  const [pending, setPending] = useState<string | null>(null);
+  const [completed, setCompleted] = useState<string | null>(null);
+  const [error, setError] = useState<unknown>(null);
+
+  const run = async (label: string, action: () => Promise<unknown>) => {
+    setPending(label);
+    setError(null);
+    try {
+      await action();
+      setCompleted(label);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setPending(null);
+      onItemChange();
+    }
+  };
+
+  const loadReferencedEvent = async () => {
+    const { events } = await apiCalls.events();
+    return referencedEvent(events, item);
+  };
+
+  const replay = () =>
+    run("Replay", async () => {
+      const event = await loadReferencedEvent();
+      if (!event) throw new Error("Referenced event is no longer available");
+      await apiCalls.replay(replayEnvelope(item, event, now()));
+    });
+
+  const rerunCi = () =>
+    run("Rerun CI", async () => {
+      const event =
+        item.refs.eventSource && item.refs.eventId
+          ? await loadReferencedEvent()
+          : null;
+      await apiCalls.replay(ciRerunEnvelope(item, event, now()));
+    });
+
+  const ship = () =>
+    run("Ship", async () => {
+      if (!item.refs.repo) throw new Error("Ship needs a repository reference");
+      await apiCalls.triggerSchedule(`ship-${item.refs.repo}`);
+    });
+
+  const issueUrl = item.refs.issue
+    ? `https://linear.app/watt-mind/issue/${encodeURIComponent(item.refs.issue)}`
+    : null;
+  const jumpChips =
+    item.kind === "ESCALATED" ||
+    item.kind === "SMOKE RED" ||
+    item.kind === "CIRCUIT BREAKER";
+
+  if (!hasInboxPlainActions(item.kind)) return null;
+
+  const proposalCreated = completed !== null || Boolean(item.refs.proposalId);
+
+  return (
+    <div className="space-y-2 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2.5">
+      {item.kind === "ESCALATED" && (
+        <p className="text-[12px] leading-relaxed text-(--text-dim)">
+          This escalation must be reviewed at its source. The inbox deliberately
+          cannot merge the pull request.
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        {jumpChips && prUrl && (
+          <JumpLink href={prUrl} title="Open pull request">
+            Open PR
+          </JumpLink>
+        )}
+        {jumpChips && issueUrl && (
+          <JumpLink href={issueUrl} title="Open issue in Linear">
+            Open issue
+          </JumpLink>
+        )}
+        {item.kind === "human_needed" && (
+          <Button
+            disabled={!connected || pending !== null}
+            onClick={() => void replay()}
+          >
+            {pending === "Replay" ? "Replaying…" : "Replay"}
+          </Button>
+        )}
+        {item.kind === "CI RED" && !proposalCreated && (
+          <Button
+            variant="primary"
+            disabled={!connected || pending !== null}
+            onClick={() => void rerunCi()}
+          >
+            {pending === "Rerun CI" ? "Injecting…" : "Rerun CI"}
+          </Button>
+        )}
+        {item.kind === "RC READY" && !proposalCreated && (
+          <Button
+            variant="primary"
+            disabled={!connected || pending !== null}
+            onClick={() => void ship()}
+          >
+            {pending === "Ship" ? "Starting…" : "Ship"}
+          </Button>
+        )}
+        {(item.kind === "CI RED" || item.kind === "RC READY") &&
+          proposalCreated &&
+          (item.refs.proposalId ? (
+            <JumpLink
+              href={`#/proposals/${encodeURIComponent(item.refs.proposalId)}`}
+              title="Open the watched proposal"
+            >
+              Open proposal
+            </JumpLink>
+          ) : (
+            <span className="text-[12px] font-medium text-(--hue-ok)">
+              Request created
+            </span>
+          ))}
+        {(item.kind === "SMOKE RED" || item.kind === "CIRCUIT BREAKER") && (
+          <Button disabled={!connected || pending !== null} onClick={onResolve}>
+            Resolve…
+          </Button>
+        )}
+      </div>
+      {error != null && <VerbError error={error} />}
+    </div>
+  );
+}

--- a/event-runtime/web/src/components/InboxActions.tsx
+++ b/event-runtime/web/src/components/InboxActions.tsx
@@ -87,7 +87,7 @@ export function ciRerunEnvelope(
     throw new Error(
       `Rerun CI needs the GitHub owner/name for "${ref}" — config/repos.yaml declares no github remote for it`,
     );
-  const runId = original.runId ?? item.refs.pr?.match(/\d+/)?.[0];
+  const runId = original.runId ?? item.refs.runId;
   if (
     (typeof runId !== "string" && typeof runId !== "number") ||
     String(runId).trim() === ""

--- a/event-runtime/web/src/components/InboxActions.tsx
+++ b/event-runtime/web/src/components/InboxActions.tsx
@@ -3,7 +3,10 @@ import { api } from "../api";
 import type { AdmittedEvent, InboxItem } from "../types";
 import { Button, JumpLink, VerbError } from "./ui";
 
-type ActionApi = Pick<typeof api, "events" | "replay" | "triggerSchedule">;
+type ActionApi = Pick<
+  typeof api,
+  "events" | "replay" | "triggerSchedule" | "repos" | "schedules"
+>;
 
 const PLAIN_ACTION_KINDS = new Set([
   "human_needed",
@@ -13,6 +16,10 @@ const PLAIN_ACTION_KINDS = new Set([
   "SMOKE RED",
   "CIRCUIT BREAKER",
 ]);
+
+// Jump chips read as links, not stray mono text: pill border + underline on hover.
+const CHIP_CLASS =
+  "inline-flex items-center rounded-full border border-(--border-strong) px-2 py-0.5 text-[11px] text-(--text) hover:border-(--accent) hover:underline";
 
 export function hasInboxPlainActions(kind: string): boolean {
   return PLAIN_ACTION_KINDS.has(kind);
@@ -58,16 +65,29 @@ export function replayEnvelope(
   };
 }
 
+/**
+ * `factory.ci-rerun.requested` wants the GitHub `owner/name` slug, not the
+ * config/repos.yaml short name most inbox refs carry; `slugFor` maps one to
+ * the other (from `GET /repos`) when the referenced event has no slug of its
+ * own.
+ */
 export function ciRerunEnvelope(
   item: InboxItem,
   event: AdmittedEvent | null,
   now = Date.now(),
+  slugFor: (repo: string) => string | null = (repo) =>
+    repo.includes("/") ? repo : null,
 ): Record<string, unknown> {
   const original = payloadOf(event);
-  const repo = original.repo ?? item.refs.repo;
-  const runId = original.runId ?? item.refs.pr?.match(/\d+/)?.[0];
-  if (typeof repo !== "string" || repo === "")
+  const ref = original.repo ?? item.refs.repo;
+  if (typeof ref !== "string" || ref === "")
     throw new Error("Rerun CI needs a repository reference");
+  const repo = ref.includes("/") ? ref : slugFor(ref);
+  if (!repo)
+    throw new Error(
+      `Rerun CI needs the GitHub owner/name for "${ref}" — config/repos.yaml declares no github remote for it`,
+    );
+  const runId = original.runId ?? item.refs.pr?.match(/\d+/)?.[0];
   if (
     (typeof runId !== "string" && typeof runId !== "number") ||
     String(runId).trim() === ""
@@ -141,13 +161,22 @@ export function InboxActions({
         item.refs.eventSource && item.refs.eventId
           ? await loadReferencedEvent()
           : null;
-      await apiCalls.replay(ciRerunEnvelope(item, event, now()));
+      const { repos } = await apiCalls.repos();
+      const slugFor = (name: string) =>
+        repos.find((repo) => repo.name === name)?.github ?? null;
+      await apiCalls.replay(ciRerunEnvelope(item, event, now(), slugFor));
     });
 
   const ship = () =>
     run("Ship", async () => {
       if (!item.refs.repo) throw new Error("Ship needs a repository reference");
-      await apiCalls.triggerSchedule(`ship-${item.refs.repo}`);
+      const loop = `ship-${item.refs.repo}`;
+      const { schedules } = await apiCalls.schedules();
+      if (!schedules.some((schedule) => schedule.loop === loop))
+        throw new Error(
+          `No ship schedule is configured for "${item.refs.repo}" (expected "${loop}" in event-runtime/schedules.json) — this repo cannot be shipped from the inbox`,
+        );
+      await apiCalls.triggerSchedule(loop);
     });
 
   const issueUrl = item.refs.issue
@@ -167,17 +196,26 @@ export function InboxActions({
       {item.kind === "ESCALATED" && (
         <p className="text-[12px] leading-relaxed text-(--text-dim)">
           This escalation must be reviewed at its source. The inbox deliberately
-          cannot merge the pull request.
+          cannot merge{" "}
+          {prUrl ? "the pull request." : "or approve anything on its behalf."}
         </p>
       )}
       <div className="flex flex-wrap items-center gap-2">
         {jumpChips && prUrl && (
-          <JumpLink href={prUrl} title="Open pull request">
+          <JumpLink
+            href={prUrl}
+            title="Open pull request"
+            className={CHIP_CLASS}
+          >
             Open PR
           </JumpLink>
         )}
         {jumpChips && issueUrl && (
-          <JumpLink href={issueUrl} title="Open issue in Linear">
+          <JumpLink
+            href={issueUrl}
+            title="Open issue in Linear"
+            className={CHIP_CLASS}
+          >
             Open issue
           </JumpLink>
         )}
@@ -213,6 +251,7 @@ export function InboxActions({
             <JumpLink
               href={`#/proposals/${encodeURIComponent(item.refs.proposalId)}`}
               title="Open the watched proposal"
+              className={CHIP_CLASS}
             >
               Open proposal
             </JumpLink>

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -16,6 +16,7 @@ import {
   displayTitle,
   groupItems,
   groupOf,
+  inboxActionPrHref,
   inboxAge,
   itemStatus,
   matchesTab,
@@ -217,6 +218,15 @@ describe("inbox pure helpers", () => {
     expect(
       prHref(item({ id: "bare", kind: "CI RED", refs: { pr: "PR#125" } })),
     ).toBeNull();
+    expect(
+      inboxActionPrHref(
+        item({
+          id: "action",
+          kind: "SMOKE RED",
+          refs: { repo: "factory", pr: "607" },
+        }),
+      ),
+    ).toBe("https://github.com/watt-mind/factory/pull/607");
   });
 
   test("Inbox age preserves hour precision after 24 hours", () => {
@@ -501,7 +511,8 @@ describe("Inbox view", () => {
     expect(
       view.getByText("Telegram: not attempted".replace(/^Telegram: /, "")),
     ).toBeTruthy();
-    expect(view.getByRole("button", { name: /Resolve…/ })).toBeTruthy();
+    expect(view.getByText(/inbox deliberately cannot merge/)).toBeTruthy();
+    expect(view.queryByRole("button", { name: /Resolve…/ })).toBeNull();
     expect(view.queryByRole("button", { name: /^Ack/ })).toBeNull();
   });
 
@@ -662,7 +673,7 @@ describe("Inbox view", () => {
     expect(api.ackInbox).not.toHaveBeenCalled();
   });
 
-  test("A acks each selected id sequentially", async () => {
+  test("A acks selected legacy rows without acking per-kind action rows", async () => {
     const calls: string[] = [];
     api.ackInbox = mock(async (id: string) => {
       calls.push(id);
@@ -683,18 +694,15 @@ describe("Inbox view", () => {
       );
     });
 
-    await waitFor(() =>
-      expect(calls).toEqual(["inbox_open_1", "inbox_open_2"]),
-    );
+    await waitFor(() => expect(calls).toEqual(["inbox_open_1"]));
     expect(
-      view.getByRole("button", { name: "Ack: 2 done / 0 failed" }),
+      view.getByRole("button", { name: "Ack: 1 done / 0 failed" }),
     ).toBeTruthy();
   });
 
-  test("bulk ack reports one done / failed summary toast", async () => {
+  test("bulk ack reports a failure for the eligible subset", async () => {
     api.ackInbox = mock(async (id: string) => {
-      if (id === "inbox_open_2") throw new Error("race");
-      return { item: ledger.find((it) => it.id === id)! };
+      throw new Error(`race: ${id}`);
     });
     const { view } = renderInbox();
     await waitFor(() => view.getByLabelText("Select all inbox items"));
@@ -702,9 +710,9 @@ describe("Inbox view", () => {
 
     fireEvent.click(view.getByRole("button", { name: /^Ack$/ }));
 
-    await waitFor(() => expect(api.ackInbox).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.ackInbox).toHaveBeenCalledTimes(1));
     expect(
-      view.getByRole("button", { name: "Ack: 1 done / 1 failed" }),
+      view.getByRole("button", { name: "Ack: 0 done / 1 failed" }),
     ).toBeTruthy();
   });
 

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -25,6 +25,7 @@ import {
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { DecisionCard } from "../components/DecisionCard";
+import { hasInboxPlainActions, InboxActions } from "../components/InboxActions";
 import {
   INBOX_FACETS,
   matchesFilterQuery,
@@ -294,6 +295,15 @@ export function prHref(item: InboxItem): string | null {
   return number && repo ? `https://github.com/${repo}/pull/${number}` : null;
 }
 
+/** Per-kind action chips may trust a digits-only refs.pr once refs.repo resolves. */
+export function inboxActionPrHref(item: InboxItem): string | null {
+  const existing = prHref(item);
+  if (existing) return existing;
+  const number = /^\d+$/.exec(item.refs.pr?.trim() ?? "")?.[0];
+  const repo = githubRepo(item);
+  return number && repo ? `https://github.com/${repo}/pull/${number}` : null;
+}
+
 function refPrefixIsVisible(prefix: string, item: InboxItem): boolean {
   const tokens = prefix.split(/\s*\/\s*/);
   return tokens.every((token) => {
@@ -448,10 +458,18 @@ export function Inbox({
     [visible, selectedIds],
   );
   const ackableSelected = selectedRows.filter(
-    (it) => itemStatus(it) === "open" && !it.decision,
+    (it) =>
+      itemStatus(it) === "open" &&
+      !it.decision &&
+      !hasInboxPlainActions(it.kind),
   );
   const resolvableSelected = selectedRows.filter(
-    (it) => itemStatus(it) !== "resolved" && !it.decision,
+    (it) =>
+      itemStatus(it) !== "resolved" &&
+      !it.decision &&
+      (!hasInboxPlainActions(it.kind) ||
+        it.kind === "SMOKE RED" ||
+        it.kind === "CIRCUIT BREAKER"),
   );
 
   useEffect(() => {
@@ -535,12 +553,16 @@ export function Inbox({
   const canAck =
     !!sel &&
     !sel.decision &&
+    !hasInboxPlainActions(sel.kind) &&
     connected &&
     itemStatus(sel) === "open" &&
     !ack.isPending;
   const canResolve =
     !!sel &&
     !sel.decision &&
+    (!hasInboxPlainActions(sel.kind) ||
+      sel.kind === "SMOKE RED" ||
+      sel.kind === "CIRCUIT BREAKER") &&
     connected &&
     itemStatus(sel) !== "resolved" &&
     !resolve.isPending;
@@ -1099,7 +1121,9 @@ export function Inbox({
             </nav>
           }
           actions={
-            !sel.decision && itemStatus(sel) !== "resolved" ? (
+            !sel.decision &&
+            !hasInboxPlainActions(sel.kind) &&
+            itemStatus(sel) !== "resolved" ? (
               <div className="flex items-center gap-1.5">
                 <Button disabled={!canResolve} onClick={openResolve}>
                   Resolve…{" "}
@@ -1128,6 +1152,18 @@ export function Inbox({
           utility={<CopyActions id={sel.id} idLabel="inbox item id" />}
           close={<Button onClick={() => onSelectItem(null)}>Close</Button>}
         >
+          {hasInboxPlainActions(sel.kind) && itemStatus(sel) !== "resolved" && (
+            <Section title="Actions" card={false}>
+              <InboxActions
+                item={sel}
+                connected={connected}
+                prUrl={inboxActionPrHref(sel)}
+                onResolve={() => setConfirmResolve(true)}
+                onItemChange={invalidate}
+              />
+            </Section>
+          )}
+
           <Section title="Item" icons>
             <KV
               k="kind"

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -1155,6 +1155,9 @@ export function Inbox({
           {hasInboxPlainActions(sel.kind) && itemStatus(sel) !== "resolved" && (
             <Section title="Actions" card={false}>
               <InboxActions
+                // Per-item state: a failed verb on one item must not follow
+                // the operator to the next.
+                key={sel.id}
                 item={sel}
                 connected={connected}
                 prUrl={inboxActionPrHref(sel)}


### PR DESCRIPTION
## Summary
- add kind-specific Inbox chrome for Replay, Rerun CI, watched Ship, escalation jumps, and diagnose-first resolution
- correlate CI/Ship proposals back to their inbox items and prevent duplicate action submissions
- add bounded fail-open Linear polling plus CI-success and completed-ship auto-resolution
- preserve generic DecisionCard effects for proposal, requeue, and answer flows

## Verification
- `bun test event-runtime/lib event-runtime/web` — 1923 pass, 9 skipped, 0 fail
- `cd event-runtime/web && bunx tsc --noEmit` — pass

## UX
UX critique: required — NOT-ASSESSED

Round 1 returned FIX-FIRST with browser evidence at `http://127.0.0.1:7787/#/inbox` and `/tmp/WM-287-smoke-red-actions.png`; all in-scope findings were addressed (PR chips, post-submit proposal state, and action priority). Round 2 drove the updated live app but exceeded its critic turn budget before returning a verdict, so this PR remains draft rather than treating incomplete review as approval.

Fixes WM-287
