### PR TITLE
fix(web): stop ArrowDown/ArrowUp leaking from the HoverCard panel (WM-751)

### DIFF
--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -289,6 +289,30 @@ describe("HoverCard", () => {
     }
   });
 
+  test("ArrowDown and ArrowUp inside the open panel do not reach a window list-keys listener", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const action = await waitFor(() =>
+      r.getByRole("button", { name: /Open in Agents/ }),
+    );
+    expect(document.activeElement).toBe(action);
+
+    // Registered only once the card is open, so a leak from the panel cannot be
+    // mistaken for the trigger-side one the previous test already covers.
+    const listKeys = mock((_e: KeyboardEvent) => {});
+    window.addEventListener("keydown", listKeys);
+    try {
+      fireEvent.keyDown(action, { key: "ArrowDown" });
+      fireEvent.keyDown(action, { key: "ArrowUp" });
+      expect(listKeys).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", listKeys);
+    }
+  });
+
   test("Escape closes the card and restores focus to the trigger", async () => {
     const r = render(<Fixture />);
     const trigger = triggerOf(r.container);

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -340,6 +340,22 @@ export function HoverCard({
     [openNow],
   );
 
+  /**
+   * The panel is portalled, so React dispatches its events from
+   * `document.body` — but the *native* event carries on to `window`, where the
+   * table's `useListKeys` is listening. Without this, a second ArrowDown after
+   * landing in the card silently moves the selected row underneath it. Only
+   * propagation is stopped: the default is the panel's own scroll, which a card
+   * taller than its `maxHeight` needs.
+   */
+  const onPanelKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      e.stopPropagation();
+    },
+    [],
+  );
+
   const api: HoverCardApi = { close };
   const body = typeof children === "function" ? children(api) : children;
   const triggerBody = typeof trigger === "function" ? trigger(api) : trigger;
@@ -379,6 +395,7 @@ export function HoverCard({
             onMouseLeave={scheduleClose}
             onFocus={clearTimer}
             onBlur={scheduleClose}
+            onKeyDown={onPanelKeyDown}
             style={{
               position: "fixed",
               top: placement.placeAbove ? undefined : `${placement.top}px`,


### PR DESCRIPTION
## What

`ArrowDown` inside an open HoverCard still moved the table row underneath it.

[WM-700](https://linear.app/watt-mind/issue/WM-700) stopped the arrows on the **trigger**. The **panel** had no `onKeyDown` at all, and because it is portalled, React dispatches its events from `document.body` while the native event carries on to `window` — which is exactly where a table's `useListKeys` listens (`hooks.ts` ~176, bubble phase). So the sequence "ArrowDown to enter the card, ArrowDown again" silently moved the selected row behind the open card.

One `onKeyDown` on the panel stops propagation for `ArrowDown` / `ArrowUp`, and only propagation — the default is the panel's own scroll, which a card taller than its `maxHeight` needs, and a scroll originating inside the panel is already exempt from the dismiss-on-scroll handler.

`hooks.ts` is untouched; the panel-side stop is sufficient because `useListKeys` binds `keydown` in the bubble phase.

## Scope

Deliberately just the ArrowDown/ArrowUp leak. Tab-out is [WM-752](https://linear.app/watt-mind/issue/WM-752) (concurrent sibling on the same files). Two files changed, both inside the ticket's Owned Paths.

## Test plan

- [x] New test fires `ArrowDown` and `ArrowUp` on an in-panel control with a `window` keydown listener and asserts it is not called. The listener is registered only after the card opens, so a panel leak cannot be masked by the trigger-side fix the neighbouring test already covers.
- [x] **Observed failing before the fix** on `origin/develop@8df5975`: `Expected number of calls: 0 / Received number of calls: 2` — both arrows leaked.
- [x] `cd event-runtime/web && bun test src/components/HoverCard.test.tsx` — 28 pass, 0 fail.
- [x] `bunx tsc --noEmit` clean; `bun run lint` 0 errors; `factory security` (gitleaks + semgrep + actionlint) pass.

## Notes for the reviewer

`cd event-runtime/web && bun test` (full suite) reds 2 tests in `Proposals.test.tsx`. **Pre-existing on `origin/develop@8df5975`** — confirmed by reverting `HoverCard.tsx` to HEAD and re-running, same two failures. They are ~4s tests against bun's 5s default and pass in isolation. Filed as [WM-757](https://linear.app/watt-mind/issue/WM-757).

The remaining `useListKeys` bindings (`j`, `k`, `o`, and per-view verbs such as `a` = approve in Proposals) still leak from the panel — outside this ticket's acceptance criteria, filed as [WM-756](https://linear.app/watt-mind/issue/WM-756).

Fixes WM-751