### PR TITLE
feat(event-runtime): route dispatch models per ticket

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -90,6 +90,25 @@ asymmetry collapses when per-agent Linear identities land (OPS-40); until
 then it is stated here so nobody "fixes" either side to match the other. See
 §9.
 
+### Per-ticket model tier
+
+A `factory.dispatch.requested` run may override the dispatch agent's default
+model tier without changing the agent definition. The effective tier is chosen
+at plan time with this precedence: payload `modelTier` > the ticket's single
+`tier:<strong|standard|light>` label > the definition's `model_tier`. The
+planner records the winning source as
+`evidence.checks.model_tier_source` (`payload`, `label`, or `definition`) and
+pins both the effective `modelTier` and its resolved concrete `model` in the
+RunSpec.
+
+The `tier:*` label vocabulary is closed and must equal the tier keys accepted
+by `config/policy.yaml` (`strong`, `standard`, and `light`). More than one
+`tier:*` label, or any other `tier:` value, refuses dispatch with the typed
+reason `ticket_tier_invalid`; an explicit payload override does not make an
+invalid ticket label safe. As with definition tiers, a valid label whose tier
+has no mapping for the routed adapter fails closed rather than falling back to
+an adapter default.
+
 ---
 
 ## 3. Capacity: one budget, checked at plan and again at execute

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -401,7 +401,10 @@ exact model; `GET /agents` and `cli.mjs agents` show the declared tier and the
 per-route resolved value. Resolution order: per-definition `"model"` override
 (the one escape hatch for an exact id — both fields may coexist, the override
 wins) > tier map > adapter default (absent fields = no spec fields = today's
-behavior). A declared tier with no mapping for a routed model-consuming
+behavior). Repository dispatches can additionally select a per-ticket tier;
+the payload/label precedence, evidence, and typed refusal rules are defined in
+[event-runtime-dispatch.md](event-runtime-dispatch.md#per-ticket-model-tier).
+A declared tier with no mapping for a routed model-consuming
 adapter is a **load error, fail closed** — never a silent fall-through to the
 adapter default. Only the LLM adapters (`claude`, `pi`, `agy`, `cursor`) consume models; on
 `command`/`actions`/`fake` routes a declared tier is recorded as not

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -24,7 +24,7 @@
   "mutating": true,
   "pins": {
     "agents/dispatch.md": "sha256:34a2625aa17cfaa536dc740e527ef333334aaeab22c99cf4ffa71d8501c3b5e1",
-    "schemas/dispatch.input.json": "sha256:7287e8fa923036b1a4f887efef9540a65bf09c03e0e219907e160efa3272f26f",
+    "schemas/dispatch.input.json": "sha256:386b565acd89e60e674d6a5516b872cb46b3bed0fbe05510d299f4d63ee028be",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }
 }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -40,7 +40,12 @@ import {
   idempotencyKeyForNewRun,
   resolveIdempotency,
 } from "./lifecycle.mjs";
-import { getAgent, getEventType, resolveModel } from "./registry.mjs";
+import {
+  getAgent,
+  getEventType,
+  MODEL_TIERS,
+  resolveModel,
+} from "./registry.mjs";
 import { pinRepo } from "./repository.mjs";
 import {
   RepoError,
@@ -108,6 +113,7 @@ export function buildRunSpec(
     adapterOverride,
     now = Date.now(),
     approvalPolicy = null,
+    modelTierOverride,
   } = {},
 ) {
   const def = getAgent(registry, mapping.agent);
@@ -159,10 +165,18 @@ export function buildRunSpec(
     // override: `--adapter-override fake` substitutes execution, and the fake
     // ignores the model; the spec still records what was routed. A null model
     // means the routed adapter takes none (not applicable).
-    ...(def.model_tier !== undefined || def.model !== undefined
+    ...(modelTierOverride !== undefined ||
+    def.model_tier !== undefined ||
+    def.model !== undefined
       ? {
-          modelTier: def.model_tier ?? null,
-          model: resolveModel(def, mapping.adapter, registry.modelTiers),
+          modelTier: modelTierOverride ?? def.model_tier ?? null,
+          model: resolveModel(
+            modelTierOverride === undefined
+              ? def
+              : { ...def, model_tier: modelTierOverride },
+            mapping.adapter,
+            registry.modelTiers,
+          ),
         }
       : {}),
     timeoutSeconds: def.limits.timeout_seconds,
@@ -480,6 +494,39 @@ function evidenceTicket(ticket, ticketId) {
   };
 }
 
+/**
+ * Parse the closed per-ticket model-tier label vocabulary. A ticket may carry
+ * either no tier label or exactly one valid `tier:<MODEL_TIERS>` label. The
+ * full matching label set is returned so refusal evidence explains malformed
+ * and duplicate declarations without relying on a lossy first-match rule.
+ */
+export function ticketModelTier(labels) {
+  const tierLabels = (labels ?? []).filter(
+    (label) => typeof label === "string" && label.startsWith("tier:"),
+  );
+  if (tierLabels.length === 0) {
+    return { ok: true, tier: undefined, labels: [] };
+  }
+  if (tierLabels.length !== 1) {
+    return {
+      ok: false,
+      tier: undefined,
+      labels: tierLabels,
+      detail: `ticket has multiple tier labels: ${tierLabels.join(", ")}`,
+    };
+  }
+  const tier = tierLabels[0].slice("tier:".length);
+  if (!MODEL_TIERS.includes(tier)) {
+    return {
+      ok: false,
+      tier: undefined,
+      labels: tierLabels,
+      detail: `ticket tier label ${JSON.stringify(tierLabels[0])} must be one of ${MODEL_TIERS.map((value) => `tier:${value}`).join(", ")}`,
+    };
+  }
+  return { ok: true, tier, labels: tierLabels };
+}
+
 function evidenceInFlight(issue) {
   const description = issue.description ?? "";
   const parsed = parseOwnedPaths(description);
@@ -572,6 +619,22 @@ export function worktreeDispatchAutoEligibility(
   evidence.ticket = evidenceTicket(ticket, payload?.ticket);
   if (!ticket) return refusal("ticket_not_found", evidence, "human_needed");
   evidence.checks.ticket_found = true;
+
+  const ticketTier = ticketModelTier(evidence.ticket.labels);
+  evidence.ticket.modelTierLabels = ticketTier.labels;
+  evidence.ticket.modelTier = ticketTier.tier ?? null;
+  if (!ticketTier.ok) {
+    evidence.checks.ticket_tier_valid = false;
+    evidence.checks.model_tier_source = null;
+    return refusal("ticket_tier_invalid", evidence, "noop", ticketTier.detail);
+  }
+  evidence.checks.ticket_tier_valid = true;
+  evidence.checks.model_tier_source =
+    payload?.modelTier !== undefined
+      ? "payload"
+      : ticketTier.tier !== undefined
+        ? "label"
+        : "definition";
 
   // A lease-loss retry is the one exception to the ordinary Todo/unassigned
   // admission rule. The prior attempt already performed the Linear claim, so
@@ -1050,7 +1113,7 @@ export function planEvent(
   // write lock across a network round trip. The verdict is applied inside the
   // transaction only when the event is still admitted there — a raced plan
   // simply discards it via the idempotent early return.
-  let worktreeRefusal = null;
+  let worktreeEligibility = null;
   {
     const row = db
       .query(
@@ -1073,11 +1136,10 @@ export function planEvent(
         typeof preEnvelope.payload?.ticket === "string" &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
-        const eligibility = worktreeDispatchAutoEligibility(
+        worktreeEligibility = worktreeDispatchAutoEligibility(
           preEnvelope.payload,
           dispatch,
         );
-        worktreeRefusal = eligibility.ok ? null : eligibility.refusal;
       }
     }
   }
@@ -1274,6 +1336,8 @@ export function planEvent(
     // WM-108), computed above outside this transaction. Refusals are typed
     // and carry their reason; a null verdict means every check passed at the
     // moment of the read — the doc's execute-time re-check owns the TTL gap.
+    const worktreeRefusal =
+      worktreeEligibility?.ok === false ? worktreeEligibility.refusal : null;
     if (worktreeGateFor(def) === "dispatch" && worktreeRefusal) {
       if (worktreeRefusal.decision === "human_needed") {
         return humanNeeded(db, event, worktreeRefusal.reason, at, ttlSeconds);
@@ -1421,6 +1485,7 @@ export function planEvent(
     const runId = newRunId();
 
     let approvalPolicy = null;
+    let dispatchEvidence = worktreeEligibility?.evidence ?? null;
     if (envelope.source === "chain") {
       approvalPolicy = buildChainApprovalPolicy(envelope.type, {
         source: envelope.source,
@@ -1446,8 +1511,20 @@ export function planEvent(
           ...approvalPolicy,
           dispatchEvidence: result.evidence,
         };
+        dispatchEvidence = result.evidence;
       }
     }
+
+    // Per-ticket routing applies only to factory dispatch. The payload is
+    // already schema-validated above; ticket labels were validated by the
+    // dispatch gate. Passing no override preserves every other event's spec,
+    // and dispatches with neither source retain the definition-only behavior.
+    const modelTierOverride =
+      envelope.type === "factory.dispatch.requested"
+        ? (payload.modelTier ??
+          dispatchEvidence?.ticket?.modelTier ??
+          undefined)
+        : undefined;
 
     const spec = {
       ...buildRunSpec(registry, pinnedEnvelope, mapping, {
@@ -1456,6 +1533,7 @@ export function planEvent(
         adapterOverride,
         now,
         approvalPolicy,
+        modelTierOverride,
       }),
       idempotencyKey,
     };

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hashJson } from "./canonical.mjs";
+import { canonicalJson, hashJson } from "./canonical.mjs";
 import { DEAD_LETTER_AFTER } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
@@ -764,6 +764,137 @@ describe("planEvent worktree gate (WM-108)", () => {
     payload,
   });
 
+  const tierRepo =
+    `repos:\n  - name: tiered\n    path: /tmp/nowhere\n    base: develop\n` +
+    `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+    `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`;
+
+  const tierTicket = (tierLabels = []) => ({
+    identifier: "WM-694",
+    state: { name: "Todo" },
+    assignee: null,
+    labels: {
+      nodes: [
+        { name: "ai:agent-ready" },
+        ...tierLabels.map((name) => ({ name })),
+      ],
+    },
+    description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+  });
+
+  const tierDispatch = (tierLabels = []) => ({
+    countLeases: () => 0,
+    budgetRefusal: () => null,
+    fetchTicket: () => tierTicket(tierLabels),
+    fetchInFlight: () => [],
+  });
+
+  test("dispatch model tier precedence is payload > ticket label > definition and records its source (WM-694)", () => {
+    withReposRoot(tierRepo, () => {
+      const cases = [
+        {
+          eventId: "tier-definition",
+          payload: { repo: "tiered", ticket: "WM-694" },
+          labels: [],
+          source: "definition",
+          tier: "strong",
+          model: "openai-codex/gpt-5.6-sol",
+        },
+        {
+          eventId: "tier-label",
+          payload: { repo: "tiered", ticket: "WM-694" },
+          labels: ["tier:light"],
+          source: "label",
+          tier: "light",
+          model: "openai-codex/gpt-5.6-luna",
+        },
+        {
+          eventId: "tier-payload",
+          payload: {
+            repo: "tiered",
+            ticket: "WM-694",
+            modelTier: "standard",
+          },
+          labels: ["tier:light"],
+          source: "payload",
+          tier: "standard",
+          model: "openai-codex/gpt-5.6-terra",
+        },
+      ];
+
+      for (const item of cases) {
+        const eligibility = worktreeDispatchAutoEligibility(
+          item.payload,
+          tierDispatch(item.labels),
+        );
+        expect(eligibility.ok).toBe(true);
+        expect(eligibility.evidence.checks.model_tier_source).toBe(item.source);
+
+        const db = openDb(":memory:");
+        const ref = admit(db, {
+          type: "factory.dispatch.requested",
+          eventId: item.eventId,
+          correlationId: item.eventId,
+          payload: item.payload,
+        });
+        const outcome = planEvent(db, registry, ref, {
+          now: NOW,
+          policyVersion: "git:test",
+          dispatch: tierDispatch(item.labels),
+        });
+        const spec = JSON.parse(outcome.proposal.spec_json);
+        expect(spec.modelTier).toBe(item.tier);
+        expect(spec.model).toBe(item.model);
+      }
+    });
+  });
+
+  test("duplicate or unknown ticket tier labels refuse with typed evidence (WM-694)", () => {
+    withReposRoot(tierRepo, () => {
+      for (const labels of [["tier:light", "tier:standard"], ["tier:turbo"]]) {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "WM-694", modelTier: "strong" },
+          tierDispatch(labels),
+        );
+        expect(result.refusal.reason).toBe("ticket_tier_invalid");
+        expect(result.evidence.checks).toMatchObject({
+          ticket_tier_valid: false,
+          model_tier_source: null,
+        });
+        expect(result.evidence.ticket.modelTierLabels).toEqual(labels);
+      }
+    });
+  });
+
+  test("a label tier with no routed-adapter mapping fails closed (WM-694)", () => {
+    withReposRoot(tierRepo, () => {
+      const missingLight = {
+        ...registry,
+        modelTiers: {
+          ...registry.modelTiers,
+          pi: {
+            strong: registry.modelTiers.pi.strong,
+            standard: registry.modelTiers.pi.standard,
+          },
+        },
+      };
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "tier-label-unmapped",
+        correlationId: "tier-label-unmapped",
+        payload: { repo: "tiered", ticket: "WM-694" },
+      });
+      expect(() =>
+        planEvent(db, missingLight, ref, {
+          now: NOW,
+          dispatch: tierDispatch(["tier:light"]),
+        }),
+      ).toThrow(/model_tier "light" has no mapping for adapter "pi"/);
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+
   test("a dispatch-exempt worktree agent bypasses dispatch-only planning checks", () => {
     withReposRoot(
       `repos:\n  - name: repairable\n    path: /tmp/nowhere\n    base: develop\n`,
@@ -1444,6 +1575,26 @@ describe("planEvent model pinning (WM-135)", () => {
 });
 
 describe("buildRunSpec", () => {
+  test("a dispatch with no per-ticket tier source stays byte-identical to the definition-only spec (WM-694)", () => {
+    const mapping = registry.eventTypes["factory.dispatch.requested"];
+    const dispatch = envelope({
+      eventId: "dispatch-baseline",
+      type: "factory.dispatch.requested",
+      source: "operator",
+      subject: "WM-694",
+      correlationId: "dispatch-baseline",
+      payload: { repo: "factory", ticket: "WM-694" },
+    });
+    const spec = buildRunSpec(registry, dispatch, mapping, {
+      runId: "run_baseline",
+      policyVersion: "git:test",
+      now: 0,
+    });
+    expect(canonicalJson(spec)).toBe(
+      '{"adapter":"pi","agent":"dispatch@1","capabilities":["linear:write","repo:write","github:write"],"idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"openai-codex/gpt-5.6-sol","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+    );
+  });
+
   test("is pure and honors adapterOverride", () => {
     const mapping = registry.eventTypes["factory.status-report.requested"];
     const opts = { runId: "run_x", policyVersion: "git:abc", now: NOW };

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -140,8 +140,9 @@ describe("registry", () => {
     // Regenerated after WM-610 prettier reformat of code and markdown files.
     // Regenerated (WM-722): merge-scan/merge-fix adapter pi→claude; event-types.json is a registry input.
     // Regenerated (WM-391): dispatch admits and documents bounded humanDecision authorisations.
+    // Regenerated (WM-694): dispatch input admits a pinned per-ticket modelTier override.
     const expected =
-      "sha256:44e8dce58d2e4efd92f8e8a7b9483aa219ab32840b3aec34b41ee2c8782dc9a6";
+      "sha256:8d3f8ca1951587fcbd646c3e97590c2daa631be129b867e17e0e8787d66da1cd";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -159,7 +160,7 @@ describe("registry", () => {
     expect(def.pack).toBe("event-runtime");
     expect(Object.keys(def)).not.toContain("pack");
     expect(computeDefHash(def)).toBe(
-      "sha256:93df77f053690c1c2463fea4d497ec9c742fd9200ac369d1682ac575596b4129",
+      "sha256:614eccc3078f9d4d71eb6349d03e45020ff083f54546dbe15d9c1ce3d981d6f2",
     );
   });
 
@@ -478,6 +479,17 @@ describe("registry", () => {
       JSON.stringify({ ...raw, workspace: { type: "ephemeral" } }),
     );
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
+  });
+
+  test("dispatch input exposes the closed per-ticket modelTier vocabulary (WM-694)", () => {
+    const schema = getAgent(loadRegistry(), "dispatch@1").inputSchema;
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties.modelTier).toEqual({
+      type: "string",
+      enum: ["strong", "standard", "light"],
+      description:
+        "Optional per-dispatch model tier override; takes precedence over the ticket tier:* label and agent definition",
+    });
   });
 
   test("agent-declared kernel control fields validate fail-closed (WM-469)", () => {

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -14,6 +14,11 @@
       "pattern": "^[A-Z]+-[0-9]+$",
       "description": "Linear issue identifier to implement; must be Todo + ai:agent-ready + unassigned at plan time (docs/event-runtime-dispatch.md §2)"
     },
+    "modelTier": {
+      "type": "string",
+      "enum": ["strong", "standard", "light"],
+      "description": "Optional per-dispatch model tier override; takes precedence over the ticket tier:* label and agent definition"
+    },
     "humanDecision": {
       "type": "object",
       "required": ["schemaVersion", "inboxItemId", "authorisation"],


### PR DESCRIPTION
## Summary
- accept an optional dispatch `modelTier` payload override and validate the closed ticket `tier:*` label vocabulary
- resolve payload > label > definition precedence at plan time, recording the source in dispatch evidence and pinning the concrete model
- add regression coverage for invalid labels, unchanged default specs, and fail-closed mappings; document the routing contract

## Verification
- `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs && bun test` — pass (81 focused tests; full suite 2,626 passed, 9 skipped, 0 failed)

UX critique: skipped — backend planner/schema/docs change; no user-facing flow.

Fixes WM-694