### PR TITLE
fix(web): make agent rows keyboard accessible (WM-732)

### DIFF
--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -2,6 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
 import {
   Agents,
   adapterText,
@@ -82,6 +83,17 @@ function renderAgents(focusAgentRef: string | null = null) {
       focusAgentRef={focusAgentRef}
       onSelectAgent={noop}
     />,
+  );
+}
+
+function SelectableAgents() {
+  const [selectedRef, setSelectedRef] = useState<string | null>(null);
+  return (
+    <Agents
+      context={{ kind: "all" }}
+      focusAgentRef={selectedRef}
+      onSelectAgent={setSelectedRef}
+    />
   );
 }
 
@@ -244,6 +256,38 @@ describe("Agents table columns (WM-211)", () => {
       );
       expect(headers.filter((t) => /claude1/.test(t))).toHaveLength(1);
       expect(headers.filter((t) => /command1/.test(t))).toHaveLength(1);
+    });
+  });
+});
+
+describe("Agents table keyboard navigation (WM-732)", () => {
+  test("rows are named, activate with Enter, and arrow between visible agents", async () => {
+    const agents = [stubAgent("alpha"), stubAgent("beta"), stubAgent("gamma")];
+    await withAgents(agents, async () => {
+      const r = renderWithClient(<SelectableAgents />);
+      const alpha = await r.findByRole("row", { name: /alpha@1/ });
+      const beta = r.getByRole("row", { name: /beta@1/ });
+
+      alpha.focus();
+      fireEvent.keyDown(alpha, { key: "Enter" });
+      expect(
+        r.getByRole("button", { name: "Copy agent ref (c)" }),
+      ).toBeTruthy();
+      expect(alpha.getAttribute("aria-selected")).toBe("true");
+
+      const bubbledKeys: string[] = [];
+      const recordBubbledKey = (event: KeyboardEvent) =>
+        bubbledKeys.push(event.key);
+      window.addEventListener("keydown", recordBubbledKey);
+      fireEvent.keyDown(alpha, { key: "ArrowDown" });
+      window.removeEventListener("keydown", recordBubbledKey);
+      expect(document.activeElement).toBe(beta);
+      expect(beta.getAttribute("aria-selected")).toBe("true");
+      expect(bubbledKeys).toEqual([]);
+
+      fireEvent.keyDown(beta, { key: "ArrowUp" });
+      expect(document.activeElement).toBe(alpha);
+      expect(alpha.getAttribute("aria-selected")).toBe("true");
     });
   });
 });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -455,9 +455,49 @@ export function Agents({
                 const renderRow = (a: AgentDef) => (
                   <tr
                     key={a.ref}
+                    data-agent-ref={a.ref}
+                    tabIndex={0}
                     onClick={() => onSelectAgent(a.ref)}
+                    onKeyDown={(event) => {
+                      if (event.target !== event.currentTarget) return;
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onSelectAgent(a.ref);
+                        return;
+                      }
+                      if (event.key !== "ArrowDown" && event.key !== "ArrowUp")
+                        return;
+
+                      event.preventDefault();
+                      // Agents also supports global j/k + arrow list shortcuts.
+                      // This row owns its arrow event, so do not let the global
+                      // handler advance selection a second time.
+                      event.stopPropagation();
+                      const current = event.currentTarget;
+                      const rows = Array.from(
+                        current.parentElement?.querySelectorAll<HTMLTableRowElement>(
+                          "tr[data-agent-ref]",
+                        ) ?? [],
+                      );
+                      const currentIndex = rows.indexOf(current);
+                      const offset = event.key === "ArrowDown" ? 1 : -1;
+                      const next =
+                        rows[
+                          Math.max(
+                            0,
+                            Math.min(rows.length - 1, currentIndex + offset),
+                          )
+                        ];
+                      if (!next) return;
+                      next.focus();
+                      next.scrollIntoView?.({ block: "nearest" });
+                      const nextRef = next.dataset.agentRef;
+                      if (nextRef) onSelectAgent(nextRef);
+                    }}
+                    aria-label={a.ref}
                     aria-selected={a.ref === selectedRef}
-                    className={`cursor-pointer hover:bg-(--surface-1) ${a.ref === selectedRef ? "row-selected" : ""}`}
+                    className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${a.ref === selectedRef ? "row-selected" : ""}`}
                   >
                     <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                       {a.ref}


### PR DESCRIPTION
## Summary
- expose each Agents table row as a named, keyboard-focusable row
- support Enter/Space activation and one-row ArrowUp/ArrowDown focus + selection movement
- prevent row-owned keys from also firing global list navigation
- cover activation, accessibility naming, arrow navigation, and event propagation

## Verification
- `cd event-runtime/web && bun test src/views/Agents.test.tsx` — 14 pass, 0 fail
- `cd event-runtime/web && bun run build` — typecheck and Vite build pass

UX critique: required — SHIP after round-1 double-navigation finding was fixed; evidence: http://127.0.0.1:7655/#/agents/ci-rerun%401 and /tmp/WM-732-round2-focus.png

Follow-up: WM-754 tracks selected-state exposure in Chromium AX separately.

Fixes WM-732