### PR TITLE
feat(web): config-driven Linear ticket auto-linking and TicketHoverCard (WM-701)

### DIFF
--- a/event-runtime/web/src/components/CustomCell.test.tsx
+++ b/event-runtime/web/src/components/CustomCell.test.tsx
@@ -1,0 +1,255 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { CustomCell, formatCellValue, readCellUi } from "./CustomCell";
+import { renderWithClient, restoreApi, withApi } from "../test-render";
+import type { RepoItem } from "../types";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+  globalThis.fetch = realFetch;
+});
+
+function repo(name: string, team: string | null): RepoItem {
+  return {
+    name,
+    path: `/tmp/${name}`,
+    github: `watt-mind/${name}`,
+    team,
+    project: null,
+    base: "develop",
+    deployBranch: null,
+    reportOnly: false,
+    maxInFlight: null,
+    worktreeRoot: null,
+    hasWorktreeUp: false,
+    hasWorktreeDown: false,
+    hasWorktreeWarm: false,
+    verify: null,
+  };
+}
+
+const reposApi = () => ({
+  repos: mock(async () => ({
+    repos: [repo("factory", "WM"), repo("bj29", "CLNT")],
+  })),
+});
+
+/** A cell only renders inside a row; hydration warns otherwise. */
+function renderCell(cell: React.ReactElement) {
+  return renderWithClient(
+    <table>
+      <tbody>
+        <tr>{cell}</tr>
+      </tbody>
+    </table>,
+  );
+}
+
+describe("formatCellValue", () => {
+  test("formats primitives, arrays and objects as before", () => {
+    expect(formatCellValue(undefined)).toMatchObject({
+      text: "—",
+      isComplex: false,
+    });
+    expect(formatCellValue(true)).toMatchObject({
+      text: "true",
+      isComplex: false,
+    });
+    expect(formatCellValue(7)).toMatchObject({ text: "7", isComplex: false });
+    expect(formatCellValue("hi")).toMatchObject({
+      text: "hi",
+      isComplex: false,
+    });
+    expect(formatCellValue([1, 2, 3])).toMatchObject({
+      text: "[3]",
+      isComplex: true,
+    });
+    expect(formatCellValue({ a: 1, b: 2, c: 3 })).toMatchObject({
+      text: "{a, b…}",
+      isComplex: true,
+    });
+  });
+
+  test("x-ui kind ticket marks a scalar cell as a ticket reference", () => {
+    expect(formatCellValue("wm-701", { kind: "ticket" })).toMatchObject({
+      text: "WM-701",
+      kind: "ticket",
+    });
+  });
+
+  test("x-ui kind ticket never claims a complex value", () => {
+    expect(
+      formatCellValue({ id: "WM-701" }, { kind: "ticket" }).kind,
+    ).toBeNull();
+    expect(formatCellValue(null, { kind: "ticket" }).kind).toBeNull();
+  });
+});
+
+describe("readCellUi", () => {
+  test("reads the x-ui annotation off a schema node", () => {
+    expect(readCellUi({ type: "string", "x-ui": { kind: "ticket" } })).toEqual({
+      kind: "ticket",
+    });
+  });
+
+  test("ignores schemas without a usable annotation", () => {
+    expect(readCellUi({ type: "string" })).toBeNull();
+    expect(readCellUi({ "x-ui": "ticket" })).toBeNull();
+    expect(readCellUi(null)).toBeNull();
+  });
+});
+
+describe("CustomCell", () => {
+  test("an x-ui ticket column links the whole cell to the ticket journey", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ payload: { ticket: "WM-701" } }}
+          path="payload.ticket"
+          ui={{ kind: "ticket" }}
+        />,
+      );
+      const link = await waitFor(() => r.getByRole("link", { name: "WM-701" }));
+      expect(link.getAttribute("href")).toBe("#/tickets/WM-701");
+    });
+  });
+
+  test("an x-ui ticket column normalizes the id it links to", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ ticket: " clnt-526 " }}
+          path="ticket"
+          ui={{ kind: "ticket" }}
+        />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "CLNT-526" }).getAttribute("href"),
+        ).toBe("#/tickets/CLNT-526"),
+      );
+    });
+  });
+
+  // The annotation is what the free-text scan cannot do: a column that says it
+  // holds a ticket is believed even when the team is not one this factory runs.
+  test("an x-ui ticket column links a team the free-text scan would skip", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ ticket: "FOO-12" }}
+          path="ticket"
+          ui={{ kind: "ticket" }}
+        />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
+        ).toBe("#/tickets/FOO-12"),
+      );
+    });
+  });
+
+  test("reads the annotation off a raw schema node when given one", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ ticket: "FOO-12" }}
+          path="ticket"
+          schema={{ type: "string", "x-ui": { kind: "ticket" } }}
+        />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
+        ).toBe("#/tickets/FOO-12"),
+      );
+    });
+  });
+
+  test("the same value without the annotation stays plain text", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell row={{ ticket: "FOO-12" }} path="ticket" />,
+      );
+      await waitFor(() => expect(r.container.textContent).toContain("FOO-12"));
+      expect(r.queryByRole("link")).toBeNull();
+    });
+  });
+
+  test("free-text cells linkify embedded ids and leave the rest of the text intact", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ summary: "merged WM-642 after a UTF-8 fix" }}
+          path="summary"
+        />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "WM-642" }).getAttribute("href"),
+        ).toBe("#/tickets/WM-642"),
+      );
+      expect(r.container.textContent).toContain(
+        "merged WM-642 after a UTF-8 fix",
+      );
+      expect(r.queryByRole("link", { name: /UTF-8/ })).toBeNull();
+    });
+  });
+
+  test("a sha-like value is never mistaken for a ticket", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell row={{ digest: "SHA-256:6dbaab46a7f3" }} path="digest" />,
+      );
+      await waitFor(() => expect(r.container.textContent).toContain("SHA-256"));
+      expect(r.queryByRole("link")).toBeNull();
+    });
+  });
+
+  test("complex values keep their JSON preview badge and stay unlinked", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ refs: { ticket: "WM-701", pr: 499 } }}
+          path="refs"
+        />,
+      );
+      await waitFor(() =>
+        expect(r.container.textContent).toContain("{ticket, pr}"),
+      );
+      expect(r.queryByRole("link")).toBeNull();
+    });
+  });
+
+  test("a linkified id routes through the navigation handler when one is wired", async () => {
+    const onNavigateTicket = mock(() => {});
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ ticket: "WM-701" }}
+          path="ticket"
+          ui={{ kind: "ticket" }}
+          onNavigateTicket={onNavigateTicket}
+        />,
+      );
+      const link = await waitFor(() => r.getByRole("link", { name: "WM-701" }));
+      fireEvent.click(link);
+      expect(onNavigateTicket).toHaveBeenCalledWith("WM-701");
+    });
+  });
+
+  test("the cell still renders booleans, numbers and empties without a ticket lookup", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(<CustomCell row={{ ok: false }} path="ok" />);
+      expect(r.container.textContent).toContain("false");
+      cleanup();
+      const empty = renderCell(<CustomCell row={{}} path="missing" />);
+      expect(empty.container.textContent).toContain("—");
+    });
+  });
+});

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -1,47 +1,107 @@
 /**
  * Reusable cell renderer for dynamic / custom payload columns (WM-214).
  * Extracts nested path values safely and formats primitives, code badges, and objects.
+ *
+ * A column can declare what a value *means* with the `x-ui` schema annotation
+ * (WM-701): `x-ui: { kind: "ticket" }` says the whole cell is one ticket id, so
+ * it renders as a hover-card link rather than as a string that happens to look
+ * like one. Everything else is still scanned for embedded ids, because the
+ * useful ticket reference is usually buried in a summary line, not in a column
+ * anybody thought to annotate.
  */
 import { extractRowValue } from "../pathExtractor";
+import { TicketHoverCard, TicketText } from "./TicketHoverCard";
 
-export function formatCellValue(value: unknown): {
+/** The `x-ui` annotation a payload schema can attach to a property. */
+export interface CellUi {
+  kind?: string | null;
+}
+
+/**
+ * Read `x-ui` off a JSON-schema node. Anything that is not an object with a
+ * string `kind` is not an annotation — a schema served mid-migration must not
+ * take a table down.
+ */
+export function readCellUi(schema: unknown): CellUi | null {
+  if (!schema || typeof schema !== "object") return null;
+  const annotation = (schema as Record<string, unknown>)["x-ui"];
+  if (!annotation || typeof annotation !== "object") return null;
+  const kind = (annotation as Record<string, unknown>).kind;
+  return typeof kind === "string" && kind ? { kind } : null;
+}
+
+export interface CellFormat {
   text: string;
   isComplex: boolean;
   title?: string;
-} {
+  /** The `x-ui` kind this cell can honour, null when the value cannot carry it. */
+  kind: string | null;
+}
+
+export function formatCellValue(
+  value: unknown,
+  ui?: CellUi | null,
+): CellFormat {
   if (value === undefined || value === null)
-    return { text: "—", isComplex: false };
+    return { text: "—", isComplex: false, kind: null };
   if (typeof value === "boolean")
-    return { text: value ? "true" : "false", isComplex: false };
+    return { text: value ? "true" : "false", isComplex: false, kind: null };
   if (typeof value === "number")
-    return { text: String(value), isComplex: false };
+    return { text: String(value), isComplex: false, kind: null };
   if (typeof value === "string") {
-    return { text: value, isComplex: false, title: value };
+    // Only a scalar string can be the ticket the schema promised; a column
+    // annotated `ticket` whose value arrived as an object is a payload bug,
+    // and linking it would hide that.
+    if (ui?.kind === "ticket")
+      return {
+        text: value.trim().toUpperCase(),
+        isComplex: false,
+        title: value,
+        kind: "ticket",
+      };
+    return { text: value, isComplex: false, title: value, kind: null };
   }
   if (Array.isArray(value)) {
-    const preview = `[${value.length}]`;
     return {
-      text: preview,
+      text: `[${value.length}]`,
       isComplex: true,
       title: JSON.stringify(value, null, 2),
+      kind: null,
     };
   }
   if (typeof value === "object") {
     const keys = Object.keys(value as object);
-    const preview = `{${keys.slice(0, 2).join(", ")}${keys.length > 2 ? "…" : ""}}`;
     return {
-      text: preview,
+      text: `{${keys.slice(0, 2).join(", ")}${keys.length > 2 ? "…" : ""}}`,
       isComplex: true,
       title: JSON.stringify(value, null, 2),
+      kind: null,
     };
   }
-  return { text: String(value), isComplex: false };
+  return { text: String(value), isComplex: false, kind: null };
 }
 
-export function CustomCell({ row, path }: { row: unknown; path: string }) {
+export function CustomCell({
+  row,
+  path,
+  ui,
+  schema,
+  onNavigateTicket,
+}: {
+  row: unknown;
+  path: string;
+  /** The column's `x-ui` annotation, already resolved. */
+  ui?: CellUi | null;
+  /** The column's schema node, for callers that hold the schema, not the annotation. */
+  schema?: unknown;
+  onNavigateTicket?: (ticketId: string) => void;
+}) {
   const cleanPath = path.replace(/^custom:/, "");
   const value = extractRowValue(row, cleanPath);
-  const { text, isComplex, title } = formatCellValue(value);
+  const { text, isComplex, title, kind } = formatCellValue(
+    value,
+    ui ?? readCellUi(schema),
+  );
 
   const isMono =
     cleanPath.toLowerCase().includes("id") ||
@@ -64,6 +124,12 @@ export function CustomCell({ row, path }: { row: unknown; path: string }) {
         <span className="mono text-[11px] text-(--text-faint)">{text}</span>
       ) : typeof value === "number" ? (
         <span className="mono tabular-nums">{text}</span>
+      ) : kind === "ticket" ? (
+        <TicketHoverCard ticketId={text} onNavigateTicket={onNavigateTicket} />
+      ) : typeof value === "string" ? (
+        <span className={isMono ? "mono" : ""}>
+          <TicketText text={text} onNavigateTicket={onNavigateTicket} />
+        </span>
       ) : (
         <span className={isMono ? "mono" : ""}>{text}</span>
       )}

--- a/event-runtime/web/src/components/TicketHoverCard.test.tsx
+++ b/event-runtime/web/src/components/TicketHoverCard.test.tsx
@@ -1,0 +1,326 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import {
+  buildTicketPattern,
+  FALLBACK_TICKET_TEAMS,
+  splitTicketRefs,
+  TicketHoverCard,
+  TicketText,
+  ticketTeamsFrom,
+} from "./TicketHoverCard";
+import { renderWithClient, restoreApi, withApi } from "../test-render";
+import type { RepoItem } from "../types";
+import type { JourneyRun, TicketJourneySource } from "../subjectJourney";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+  globalThis.fetch = realFetch;
+});
+
+function repo(name: string, team: string | null): RepoItem {
+  return {
+    name,
+    path: `/tmp/${name}`,
+    github: `watt-mind/${name}`,
+    team,
+    project: null,
+    base: "develop",
+    deployBranch: null,
+    reportOnly: false,
+    maxInFlight: null,
+    worktreeRoot: null,
+    hasWorktreeUp: false,
+    hasWorktreeDown: false,
+    hasWorktreeWarm: false,
+    verify: null,
+  };
+}
+
+const configuredRepos = [
+  repo("factory", "WM"),
+  repo("hdkiller", "OPS"),
+  repo("bj29", "CLNT"),
+  repo("legacy", null),
+];
+
+const reposApi = () => ({
+  repos: mock(async () => ({ repos: configuredRepos })),
+});
+
+function journeyRun(id: string, at: string, state = "COMPLETED"): JourneyRun {
+  return {
+    run: {
+      runId: id,
+      state,
+      attempts: 1,
+      created_at: at,
+      updated_at: at,
+      spec: { agent: "dispatch@1", adapter: "pi" },
+    },
+    lifecycle: [],
+    result: {
+      terminalState: "completed",
+      artifact: { prUrl: "https://github.com/watt-mind/factory/pull/499" },
+    },
+  } as unknown as JourneyRun;
+}
+
+function ticketSource(
+  overrides: Partial<TicketJourneySource> = {},
+): TicketJourneySource {
+  return {
+    ticket: {
+      id: "WM-542",
+      title: "Ticket hover card fixture",
+      state: "In Review",
+      createdAt: "2026-01-01T09:00:00.000Z",
+      url: "https://linear.app/watt-mind/issue/WM-542",
+    },
+    activity: true,
+    events: [],
+    proposals: [],
+    runs: [
+      journeyRun("run_old", "2026-01-01T09:02:00.000Z"),
+      journeyRun("run_latest", "2026-01-01T10:30:00.000Z", "RUNNING"),
+    ],
+    ...overrides,
+  };
+}
+
+function stubJourney(source: TicketJourneySource) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(source), {
+      status: 200,
+    })) as unknown as typeof fetch;
+}
+
+describe("ticket pattern", () => {
+  test("derives team prefixes from the configured repos, uppercased and deduped", () => {
+    expect(
+      ticketTeamsFrom([...configuredRepos, repo("factory-2", "wm")]),
+    ).toEqual(["CLNT", "OPS", "WM"]);
+  });
+
+  test("falls back to the known teams when repos have not loaded", () => {
+    expect(ticketTeamsFrom(undefined)).toEqual(FALLBACK_TICKET_TEAMS);
+    expect(ticketTeamsFrom([repo("legacy", null)])).toEqual(
+      FALLBACK_TICKET_TEAMS,
+    );
+  });
+
+  test("matches configured ticket ids anywhere in free text", () => {
+    const pattern = buildTicketPattern(["WM", "OPS", "CLNT"]);
+    const text = "merged WM-642 after OPS-277, blocked on CLNT-526.";
+    expect(text.match(pattern)).toEqual(["WM-642", "OPS-277", "CLNT-526"]);
+  });
+
+  test("word boundaries and configured teams keep UTF-8, SHA-256 and glued ids out", () => {
+    const pattern = buildTicketPattern(["WM", "OPS", "CLNT"]);
+    for (const negative of [
+      "encoded as UTF-8 text",
+      "digest SHA-256 mismatch",
+      "xWM-12 is glued to a word",
+      "WM-1234567 has too many digits",
+      "WM- has no number",
+      "WM-x12 has no number",
+      "FOO-12 is not a configured team",
+    ]) {
+      expect(negative.match(pattern)).toBeNull();
+    }
+  });
+
+  test("a hyphen or slash before the id still counts as a boundary", () => {
+    const pattern = buildTicketPattern(["WM"]);
+    expect("feat/WM-701-ticket-hovercard".match(pattern)).toEqual(["WM-701"]);
+  });
+
+  test("no configured teams matches nothing rather than everything", () => {
+    expect("WM-701 OPS-1".match(buildTicketPattern([]))).toBeNull();
+  });
+});
+
+describe("splitTicketRefs", () => {
+  test("splits free text into plain and ticket segments in order", () => {
+    const pattern = buildTicketPattern(["WM", "OPS"]);
+    expect(splitTicketRefs("fixes WM-642 and OPS-277 today", pattern)).toEqual([
+      { text: "fixes ", ticket: null },
+      { text: "WM-642", ticket: "WM-642" },
+      { text: " and ", ticket: null },
+      { text: "OPS-277", ticket: "OPS-277" },
+      { text: " today", ticket: null },
+    ]);
+  });
+
+  test("text with no ticket stays one plain segment", () => {
+    expect(
+      splitTicketRefs("UTF-8 payload", buildTicketPattern(["WM"])),
+    ).toEqual([{ text: "UTF-8 payload", ticket: null }]);
+  });
+
+  test("is reusable — a global pattern's lastIndex never leaks between calls", () => {
+    const pattern = buildTicketPattern(["WM"]);
+    const once = splitTicketRefs("see WM-1", pattern);
+    expect(splitTicketRefs("see WM-1", pattern)).toEqual(once);
+  });
+});
+
+describe("TicketText", () => {
+  test("linkifies embedded ticket ids to #/tickets/:id and leaves prose alone", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(
+        <TicketText text="merged WM-642 for UTF-8 payloads" />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "WM-642" }).getAttribute("href"),
+        ).toBe("#/tickets/WM-642"),
+      );
+      expect(r.container.textContent).toBe("merged WM-642 for UTF-8 payloads");
+      expect(r.queryByRole("link", { name: /UTF/ })).toBeNull();
+    });
+  });
+
+  test("an id whose team is not configured is left as plain text", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketText text="see FOO-12 for context" />);
+      await waitFor(() => expect(r.container.textContent).toContain("FOO-12"));
+      expect(r.queryByRole("link", { name: "FOO-12" })).toBeNull();
+    });
+  });
+
+  test("clicking a linkified id calls the navigation handler instead of the browser", async () => {
+    const onNavigateTicket = mock(() => {});
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(
+        <TicketText
+          text="blocked on OPS-277"
+          onNavigateTicket={onNavigateTicket}
+        />,
+      );
+      const link = await waitFor(() =>
+        r.getByRole("link", { name: "OPS-277" }),
+      );
+      fireEvent.click(link);
+      expect(onNavigateTicket).toHaveBeenCalledWith("OPS-277");
+    });
+  });
+});
+
+describe("TicketHoverCard", () => {
+  test("shows id, status, title, latest run and latest PR on hover", async () => {
+    stubJourney(ticketSource());
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-542" />);
+      const trigger = r.getByRole("link", { name: "WM-542" });
+      expect(trigger.getAttribute("href")).toBe("#/tickets/WM-542");
+
+      fireEvent.mouseEnter(trigger);
+
+      const dialog = await waitFor(() => r.getByRole("dialog"));
+      await waitFor(() =>
+        expect(dialog.textContent).toContain("Ticket hover card fixture"),
+      );
+      expect(dialog.textContent).toContain("In Review");
+      expect(
+        r.getByRole("link", { name: /run_latest/ }).getAttribute("href"),
+      ).toBe("#/run/run_latest");
+      expect(r.getByRole("link", { name: /#499/ }).getAttribute("href")).toBe(
+        "#/prs/499",
+      );
+    });
+  });
+
+  test("names the card so a screen reader announces which ticket it describes", async () => {
+    stubJourney(ticketSource());
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-542" />);
+      fireEvent.mouseEnter(r.getByRole("link", { name: "WM-542" }));
+      await waitFor(() =>
+        expect(r.getByRole("dialog").getAttribute("aria-label")).toBe(
+          "Ticket WM-542",
+        ),
+      );
+    });
+  });
+
+  test("offers both jumps: the in-app journey and Linear", async () => {
+    stubJourney(ticketSource());
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-542" />);
+      fireEvent.mouseEnter(r.getByRole("link", { name: "WM-542" }));
+      await waitFor(() => r.getByRole("dialog"));
+
+      const journey = await waitFor(() =>
+        r.getByRole("link", { name: /Open journey/ }),
+      );
+      expect(journey.getAttribute("href")).toBe("#/tickets/WM-542");
+      const linear = r.getByRole("link", { name: /Linear/ });
+      expect(linear.getAttribute("href")).toBe(
+        "https://linear.app/watt-mind/issue/WM-542",
+      );
+      expect(linear.getAttribute("target")).toBe("_blank");
+    });
+  });
+
+  test("opens on keyboard focus and closes on Escape", async () => {
+    stubJourney(ticketSource());
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-542" />);
+      const trigger = r.getByRole("link", { name: "WM-542" });
+      trigger.focus();
+      fireEvent.focus(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  test("an unindexed ticket reads as unknown or external, not as an empty card", async () => {
+    stubJourney(
+      ticketSource({
+        ticket: {
+          id: "WM-999",
+          title: null,
+          state: null,
+          createdAt: null,
+          url: "https://linear.app/watt-mind/issue/WM-999",
+        },
+        activity: false,
+        runs: [],
+      }),
+    );
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-999" />);
+      fireEvent.mouseEnter(r.getByRole("link", { name: "WM-999" }));
+      await waitFor(() =>
+        expect(r.getByRole("dialog").textContent).toContain(
+          "Unknown or external ticket",
+        ),
+      );
+      expect(r.getByRole("link", { name: /Linear/ }).getAttribute("href")).toBe(
+        "https://linear.app/watt-mind/issue/WM-999",
+      );
+    });
+  });
+
+  test("does not fetch the journey until the card is actually opened", async () => {
+    const fetchSpy = mock(
+      async () => new Response(JSON.stringify(ticketSource()), { status: 200 }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    await withApi(reposApi(), async () => {
+      const r = renderWithClient(<TicketHoverCard ticketId="WM-542" />);
+      await waitFor(() => r.getByRole("link", { name: "WM-542" }));
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      fireEvent.mouseEnter(r.getByRole("link", { name: "WM-542" }));
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    });
+  });
+});

--- a/event-runtime/web/src/components/TicketHoverCard.tsx
+++ b/event-runtime/web/src/components/TicketHoverCard.tsx
@@ -1,0 +1,443 @@
+/**
+ * Ticket auto-linking and the ticket hover card (WM-701).
+ *
+ * Which prefixes are tickets is a property of *this* factory's configuration,
+ * not of the web app: the team keys come from `config/repos.yaml` by way of
+ * `api.repos()`. A hard-coded list would either miss a team the operator added
+ * this morning or linkify another workspace's ids into dead routes.
+ *
+ * The match is deliberately narrow — word boundaries on both sides and at most
+ * six digits — because the payloads this runs over are full of things that
+ * merely look like ticket ids: `UTF-8`, `SHA-256`, `feat/WM-701-slug`. Guessing
+ * wrong here turns ordinary prose into a field of broken links.
+ */
+import { useQuery } from "@tanstack/react-query";
+import {
+  Fragment,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
+import { api } from "../api";
+import { resolveEntity } from "../entities";
+import type { TicketJourneySource } from "../subjectJourney";
+import type { RepoItem } from "../types";
+import { HoverCard } from "./HoverCard";
+import { StateBadge } from "./ui";
+
+function walkJson(
+  value: unknown,
+  visitor: (key: string, value: unknown) => void,
+  seen = new Set<unknown>(),
+) {
+  if (value === null || typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) walkJson(item, visitor, seen);
+    return;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    visitor(key, entry);
+    walkJson(entry, visitor, seen);
+  }
+}
+
+/** PR numbers a record names structurally: `pr`/`prNumber` fields, `PR#541`, or pull URLs. */
+function prNumbersIn(value: unknown): number[] {
+  const numbers = new Set<number>();
+  const addNumber = (candidate: unknown) => {
+    const number =
+      typeof candidate === "string"
+        ? Number(candidate.replace(/^PR\s*#?/i, "").trim())
+        : Number(candidate);
+    if (Number.isInteger(number) && number > 0) numbers.add(number);
+  };
+  const inspect = (key: string, entry: unknown) => {
+    if (/^(pr|prNumber|prNumbers|pullRequestNumber|prs)$/i.test(key)) {
+      if (Array.isArray(entry)) entry.forEach(addNumber);
+      else if (typeof entry !== "object" || entry === null) addNumber(entry);
+    }
+    if (typeof entry === "string") {
+      const url = entry.match(
+        /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/,
+      );
+      if (url) addNumber(url[1]);
+    }
+  };
+  if (typeof value === "string") inspect("prUrl", value);
+  walkJson(value, inspect);
+  return [...numbers];
+}
+
+/** Longest ticket number Linear realistically issues; also the false-positive guard. */
+export const TICKET_REF_MAX_DIGITS = 6;
+
+/**
+ * Team keys assumed until `api.repos()` answers. Without them the first paint
+ * after a reload would show every ticket id as dead prose and then quietly
+ * relink it, which reads as a rendering bug.
+ */
+export const FALLBACK_TICKET_TEAMS = ["CLNT", "CW", "LAB", "OPS", "WM"];
+
+/** A Linear team key: letters and digits, never regex metacharacters. */
+const TEAM_KEY = /^[A-Z][A-Z0-9]{0,9}$/;
+
+/** An alternation that can never match, for a factory with no configured teams. */
+const NEVER_MATCHES = "(?!)";
+
+/** The team keys this factory actually runs tickets for, sorted and deduped. */
+export function ticketTeamsFrom(
+  repos: readonly Pick<RepoItem, "team">[] | null | undefined,
+): string[] {
+  const teams = new Set<string>();
+  for (const repo of repos ?? []) {
+    const team = repo?.team?.trim().toUpperCase();
+    if (team && TEAM_KEY.test(team)) teams.add(team);
+  }
+  return teams.size > 0 ? [...teams].sort() : [...FALLBACK_TICKET_TEAMS];
+}
+
+/**
+ * `\b(?:CLNT|OPS|WM)-\d{1,6}\b` for the configured teams. Longest key first so
+ * a shorter prefix cannot win a partial match, and global so one pattern can
+ * walk a whole string.
+ */
+export function buildTicketPattern(teams: readonly string[]): RegExp {
+  const keys = [
+    ...new Set(
+      teams
+        .map((team) => team?.trim().toUpperCase())
+        .filter((team): team is string => !!team && TEAM_KEY.test(team)),
+    ),
+  ].sort((a, b) => b.length - a.length || a.localeCompare(b));
+  const body = keys.length
+    ? `\\b(?:${keys.join("|")})-\\d{1,${TICKET_REF_MAX_DIGITS}}\\b`
+    : NEVER_MATCHES;
+  return new RegExp(body, "g");
+}
+
+/**
+ * The configured ticket pattern, rebuilt whenever the repo list changes.
+ *
+ * Every custom cell in a table calls this, so it subscribes narrowly: the repo
+ * list is shared with the rest of the app under one key, and a cell has no use
+ * for fetch status — only for the answer.
+ */
+export function useTicketPattern(): RegExp {
+  const reposQ = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    staleTime: 300_000,
+    notifyOnChangeProps: ["data"],
+  });
+  return useMemo(
+    () => buildTicketPattern(ticketTeamsFrom(reposQ.data?.repos)),
+    [reposQ.data],
+  );
+}
+
+export interface TicketSegment {
+  text: string;
+  /** The ticket id when this segment is a reference, null for plain prose. */
+  ticket: string | null;
+}
+
+/**
+ * Split free text into plain and ticket segments, in order. The caller's
+ * pattern is re-created here rather than used directly: a global regex carries
+ * `lastIndex` between calls, and a shared one would skip matches on its second
+ * use.
+ */
+export function splitTicketRefs(
+  text: string,
+  pattern: RegExp,
+): TicketSegment[] {
+  const scanner = new RegExp(pattern.source, "g");
+  const segments: TicketSegment[] = [];
+  let cursor = 0;
+  for (
+    let match = scanner.exec(text);
+    match !== null;
+    match = scanner.exec(text)
+  ) {
+    if (match.index > cursor)
+      segments.push({ text: text.slice(cursor, match.index), ticket: null });
+    segments.push({ text: match[0], ticket: match[0].toUpperCase() });
+    cursor = match.index + match[0].length;
+    // A zero-width match would spin forever; the pattern cannot produce one,
+    // but the loop should not depend on that.
+    if (match[0].length === 0) scanner.lastIndex += 1;
+  }
+  if (cursor < text.length)
+    segments.push({ text: text.slice(cursor), ticket: null });
+  return segments.length ? segments : [{ text, ticket: null }];
+}
+
+/**
+ * The ticket journey source, shared with `views/Ticket.tsx` under one query key
+ * so hovering a ticket and then opening it costs a single fetch.
+ */
+export async function fetchTicketJourney(
+  ticketId: string,
+): Promise<TicketJourneySource> {
+  const response = await fetch(
+    `/api/runs?ticket=${encodeURIComponent(ticketId)}`,
+  );
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      message = (await response.json()).error ?? message;
+    } catch {
+      // Keep the HTTP status when the control API did not return JSON.
+    }
+    throw new Error(message);
+  }
+  return response.json();
+}
+
+/**
+ * A ticket the runtime has no record of: Linear gave back neither a title nor
+ * a state and nothing has ever run for it. Either it does not exist, or it
+ * belongs to a team this factory does not dispatch.
+ */
+export function isUnindexedTicket(
+  source: TicketJourneySource | undefined,
+): boolean {
+  return (
+    !!source &&
+    !source.activity &&
+    source.ticket.title == null &&
+    source.ticket.state == null
+  );
+}
+
+const EMPTY = "—";
+
+const FOOTER_LINK_CLASS =
+  "cursor-pointer text-[11px] font-medium text-(--accent) hover:underline inline-flex items-center gap-1";
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-(--text-faint)">{label}</span>
+      <span className="mono truncate text-(--text-dim)">{children}</span>
+    </div>
+  );
+}
+
+export interface TicketHoverCardProps {
+  ticketId: string;
+  /** In-app navigation; without it the trigger is an ordinary hash link. */
+  onNavigateTicket?: (ticketId: string) => void;
+  /** Trigger content when the caller wants something other than the bare id. */
+  children?: ReactNode;
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Hover card for a Linear ticket reference: identifier, state, title, the
+ * latest run and PR, and the two jumps an operator wants from a table row —
+ * the in-app journey and the ticket itself.
+ *
+ * The journey is fetched only once the card opens. A table of a hundred rows
+ * naming a dozen tickets must not turn into a dozen requests on paint.
+ */
+export function TicketHoverCard({
+  ticketId,
+  onNavigateTicket,
+  children,
+  className,
+  title,
+}: TicketHoverCardProps) {
+  const entity = resolveEntity("ticket", ticketId);
+  const id = entity?.id ?? ticketId;
+  const [open, setOpen] = useState(false);
+  const journeyQ = useQuery({
+    queryKey: ["ticket-journey", id],
+    queryFn: () => fetchTicketJourney(id),
+    enabled: open && entity != null,
+    staleTime: 15_000,
+  });
+
+  const source = journeyQ.data;
+  const latestRun = useMemo(() => {
+    let latest: TicketJourneySource["runs"][number] | null = null;
+    for (const run of source?.runs ?? []) {
+      if (
+        !latest ||
+        Date.parse(run.run.created_at) >= Date.parse(latest.run.created_at)
+      )
+        latest = run;
+    }
+    return latest;
+  }, [source]);
+  const latestPr = useMemo(
+    () => prNumbersIn(source?.runs ?? []).at(-1) ?? null,
+    [source],
+  );
+
+  // A ticket cell usually sits in a clickable row, so the click never belongs
+  // to the row. Without a navigation handler the anchor's own href still runs.
+  const jump = (close: () => void) => (event?: ReactMouseEvent) => {
+    event?.stopPropagation();
+    if (!onNavigateTicket) return;
+    event?.preventDefault();
+    close();
+    onNavigateTicket(id);
+  };
+
+  // An id that is not addressable (an empty or malformed key) gets no card and
+  // no link — a hover target that leads nowhere is worse than plain text.
+  if (!entity) return <>{children ?? ticketId}</>;
+
+  const unknown = isUnindexedTicket(source);
+  const prEntity = latestPr == null ? null : resolveEntity("pr", latestPr);
+  const runEntity = latestRun
+    ? resolveEntity("run", latestRun.run.runId)
+    : null;
+
+  return (
+    <HoverCard
+      label={`Ticket ${id}`}
+      // The trigger is already a link, so the wrapper must not be a second tab
+      // stop: one ticket id should cost one Tab, not two.
+      focusable={false}
+      onOpenChange={setOpen}
+      trigger={({ close }) => (
+        <a
+          href={entity.href}
+          onClick={jump(close)}
+          title={title ?? `Open ticket journey for ${id}`}
+          className={`mono text-(--accent) hover:underline ${className ?? ""}`}
+        >
+          {children ?? id}
+        </a>
+      )}
+    >
+      {({ close }) => (
+        <>
+          <div className="flex items-start justify-between gap-2 border-b border-(--border) pb-2.5">
+            <span className="mono truncate text-[13px] font-semibold text-(--text)">
+              {id}
+            </span>
+            {source?.ticket.state && <StateBadge state={source.ticket.state} />}
+          </div>
+
+          <div className="my-2.5 space-y-1.5 text-[11px]">
+            {journeyQ.isPending ? (
+              <div className="text-(--text-faint)">Loading {id}…</div>
+            ) : journeyQ.isError ? (
+              <div className="text-(--text-faint)">
+                Cannot reach the control API:{" "}
+                {(journeyQ.error as Error)?.message ?? "unavailable"}
+              </div>
+            ) : unknown ? (
+              <div className="text-(--text-dim)">
+                Unknown or external ticket — nothing in this runtime has ever
+                named it.
+              </div>
+            ) : (
+              <>
+                <div className="break-words text-[12px] text-(--text)">
+                  {source?.ticket.title ?? "title not recorded"}
+                </div>
+                <Row label="Latest run">
+                  {runEntity && latestRun ? (
+                    <a
+                      href={runEntity.href}
+                      onClick={() => close()}
+                      className="hover:text-(--accent) hover:underline"
+                    >
+                      {latestRun.run.runId} · {latestRun.run.state}
+                    </a>
+                  ) : (
+                    EMPTY
+                  )}
+                </Row>
+                <Row label="Latest PR">
+                  {prEntity ? (
+                    <a
+                      href={prEntity.href}
+                      onClick={() => close()}
+                      className="hover:text-(--accent) hover:underline"
+                    >
+                      #{prEntity.id}
+                    </a>
+                  ) : (
+                    EMPTY
+                  )}
+                </Row>
+              </>
+            )}
+          </div>
+
+          <div className="flex justify-between gap-3 border-t border-(--border) pt-2">
+            <a
+              href={entity.href}
+              onClick={jump(close)}
+              className={FOOTER_LINK_CLASS}
+            >
+              Open journey <span aria-hidden="true">→</span>
+            </a>
+            {source?.ticket.url && (
+              <a
+                href={source.ticket.url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => close()}
+                className={FOOTER_LINK_CLASS}
+              >
+                Linear <span aria-hidden="true">↗</span>
+              </a>
+            )}
+          </div>
+        </>
+      )}
+    </HoverCard>
+  );
+}
+
+export interface TicketTextProps {
+  text: string;
+  /** Override the configured pattern; the views never need to. */
+  pattern?: RegExp;
+  onNavigateTicket?: (ticketId: string) => void;
+  className?: string;
+}
+
+/**
+ * Free text with every configured ticket id turned into a hover-card link and
+ * everything else left exactly as written.
+ */
+export function TicketText({
+  text,
+  pattern,
+  onNavigateTicket,
+  className,
+}: TicketTextProps) {
+  const configured = useTicketPattern();
+  const active = pattern ?? configured;
+  const segments = useMemo(() => splitTicketRefs(text, active), [text, active]);
+  if (!segments.some((segment) => segment.ticket)) return <>{text}</>;
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.ticket ? (
+          <TicketHoverCard
+            key={`${index}:${segment.ticket}`}
+            ticketId={segment.ticket}
+            onNavigateTicket={onNavigateTicket}
+            className={className}
+          >
+            {segment.text}
+          </TicketHoverCard>
+        ) : (
+          <Fragment key={`${index}:text`}>{segment.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -162,22 +162,36 @@ describe("Ticket journey view", () => {
     const view = renderTicket(data);
     await view.findByRole("heading", { name: "WM-542" });
     expect(view.getAllByText("—").length).toBeGreaterThan(0);
-    expect(view.getByText("Owned paths overlap — WM-544")).toBeTruthy();
+    // The blocking reason names the ticket in the way; it linkifies inline, so
+    // the text is now split across the anchor rather than one text node.
+    const reason = view.getByText("Blocking reason")
+      .nextElementSibling as HTMLElement;
+    expect(reason.textContent).toBe("Owned paths overlap — WM-544");
+    expect(
+      within(reason).getByRole("link", { name: "WM-544" }).getAttribute("href"),
+    ).toBe("#/tickets/WM-544");
     expect(view.getByText(/Waiting: Owned paths overlap/)).toBeTruthy();
     expect(view.container.textContent).not.toContain("$0.00");
   });
 
-  test("unknown ids render an inline no-activity notice instead of a blank page", async () => {
-    const data = source();
-    data.ticket.id = "WM-999";
-    data.ticket.title = null;
-    data.ticket.state = null;
-    data.ticket.createdAt = null;
-    data.ticket.url = "https://linear.app/watt-mind/issue/WM-999";
-    data.activity = false;
-    data.events = [];
-    data.proposals = [];
-    data.runs = [];
+  /** An id Linear never heard of: no title, no state, no runtime activity. */
+  function unindexed(id: string): TicketJourneySource {
+    return {
+      ticket: {
+        id,
+        title: null,
+        state: null,
+        createdAt: null,
+        url: `https://linear.app/watt-mind/issue/${id}`,
+      },
+      activity: false,
+      events: [],
+      proposals: [],
+      runs: [],
+    };
+  }
+
+  function renderId(id: string, data: TicketJourneySource) {
     globalThis.fetch = (async () =>
       new Response(JSON.stringify(data), {
         status: 200,
@@ -185,14 +199,48 @@ describe("Ticket journey view", () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchInterval: false } },
     });
-    const view = render(
+    return render(
       <QueryClientProvider client={client}>
-        <Ticket ticketId="WM-999" onNavigate={() => {}} />
+        <Ticket ticketId={id} onNavigate={() => {}} />
       </QueryClientProvider>,
     );
+  }
+
+  test("an unindexed id reads as unknown or external, with a direct Linear link", async () => {
+    const view = renderId("WM-999", unindexed("WM-999"));
     await waitFor(() =>
       expect(view.getByRole("status").textContent).toContain(
-        "no runtime activity for WM-999",
+        "Unknown or external ticket",
+      ),
+    );
+    expect(view.getByRole("status").textContent).toContain("WM-999");
+    expect(
+      view.getByRole("link", { name: "Open in Linear ↗" }).getAttribute("href"),
+    ).toBe("https://linear.app/watt-mind/issue/WM-999");
+  });
+
+  test("a ticket from a team this factory does not run reads the same way", async () => {
+    const view = renderId("FOO-12", unindexed("FOO-12"));
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toContain(
+        "Unknown or external ticket",
+      ),
+    );
+    expect(
+      view.getByRole("link", { name: "Open in Linear ↗" }).getAttribute("href"),
+    ).toBe("https://linear.app/watt-mind/issue/FOO-12");
+  });
+
+  test("a ticket Linear knows but nothing has run keeps the no-activity notice", async () => {
+    const data = source();
+    data.activity = false;
+    data.events = [];
+    data.proposals = [];
+    data.runs = [];
+    const view = renderId("WM-542", data);
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toContain(
+        "no runtime activity for WM-542",
       ),
     );
   });

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -23,30 +23,16 @@ import {
   type JourneyProposal,
   type JourneyRun,
   type SubjectJourney,
-  type TicketJourneySource,
   type TimelineItem,
 } from "../subjectJourney";
 import { StateBadge, STATE_HUES } from "../components/ui";
+import {
+  fetchTicketJourney,
+  isUnindexedTicket,
+  TicketText,
+} from "../components/TicketHoverCard";
 import type { AdmittedEvent, Proposal, RunDetail, RunListItem } from "../types";
 import { Button as PrimitiveButton } from "../components/ui";
-
-async function fetchTicketJourney(
-  ticketId: string,
-): Promise<TicketJourneySource> {
-  const response = await fetch(
-    `/api/runs?ticket=${encodeURIComponent(ticketId)}`,
-  );
-  if (!response.ok) {
-    let message = `HTTP ${response.status}`;
-    try {
-      message = (await response.json()).error ?? message;
-    } catch {
-      // Keep the HTTP status when the control API did not return JSON.
-    }
-    throw new Error(message);
-  }
-  return response.json();
-}
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
@@ -123,7 +109,9 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
         </SourceLink>
         {item.detail && (
           <div className="mt-0.5 break-words text-sm text-(--text-faint)">
-            {item.detail}
+            {/* The label above is already a link, so only the detail line can
+                carry ticket links without nesting anchors. */}
+            <TicketText text={item.detail} />
           </div>
         )}
       </div>
@@ -434,7 +422,11 @@ function JourneyLayout({
                 <div>
                   <dt className="text-(--text-faint)">Blocking reason</dt>
                   <dd className="mt-1 break-words text-(--text-dim)">
-                    {journey.blockingReason ?? "—"}
+                    {journey.blockingReason ? (
+                      <TicketText text={journey.blockingReason} />
+                    ) : (
+                      "—"
+                    )}
                   </dd>
                 </div>
                 {journey.nextVisit && (
@@ -453,7 +445,7 @@ function JourneyLayout({
                 <div className="border-t border-(--border) pt-3">
                   <dt className="text-(--text-faint)">Next action</dt>
                   <dd className="mt-1 break-words font-medium text-(--text)">
-                    {journey.nextAction}
+                    <TicketText text={journey.nextAction} />
                   </dd>
                 </div>
               </dl>
@@ -528,6 +520,46 @@ export function Ticket({
         >
           Cannot load {normalized}:{" "}
           {(query.error as Error)?.message ?? "control API unavailable"}
+        </div>
+      </div>
+    );
+  }
+
+  // An id nothing in the runtime has ever named — a typo, another workspace's
+  // ticket, or a team this factory does not dispatch. The journey chrome would
+  // be a page of dashes, so say what happened and offer the one link that can
+  // still answer the question.
+  if (isUnindexedTicket(query.data)) {
+    return (
+      <div className="p-8">
+        <div
+          role="status"
+          className="mx-auto max-w-lg rounded-lg border border-dashed border-(--border-strong) bg-(--surface-1) p-8 text-center"
+        >
+          <div className="text-[13px] font-medium text-(--text)">
+            Unknown or external ticket
+          </div>
+          <div className="mt-1.5 text-[12px] text-(--text-dim)">
+            <span className="mono">{normalized}</span> is not in this factory's
+            index: no run, event, or proposal has ever named it.
+          </div>
+          <div className="mt-4 flex flex-wrap justify-center gap-4 text-[12px]">
+            <a
+              href={query.data.ticket.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-(--accent) hover:underline"
+            >
+              Open in Linear ↗
+            </a>
+            <button
+              type="button"
+              onClick={() => onNavigate("")}
+              className="text-(--accent) hover:underline"
+            >
+              Choose another ticket
+            </button>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## What

Ticket ids that appear in payload columns, event envelopes, and agent summaries were plain strings. They now link to `#/tickets/:id` and carry a hover card, and the vocabulary of what counts as a ticket comes from this factory's own configuration rather than a hard-coded list.

- **`components/TicketHoverCard.tsx`** (new) — `ticketTeamsFrom()` reads the team keys off `api.repos()`; `buildTicketPattern()` turns them into `\b(?:CLNT|OPS|WM)-\d{1,6}\b`; `splitTicketRefs()` cuts free text into plain and ticket segments; `TicketText` renders that with hover-card links; `TicketHoverCard` shows the id, state badge, title, latest run and latest PR, and jumps to both the in-app journey and Linear. Built on the WM-700 `HoverCard` primitive, so it opens on focus as well as hover and answers Escape.
- **`components/CustomCell.tsx`** — supports the `x-ui: { kind: "ticket" }` schema annotation (`readCellUi`, `formatCellValue(value, ui)`), and linkifies embedded ids in free-text cells.
- **`views/Ticket.tsx`** — an unindexed id now renders "Unknown or external ticket" with a direct **Open in Linear ↗** link instead of a journey full of dashes; the blocking reason and next action lines linkify the ticket they name.

## Why these two mechanisms and not one

The word-boundary scan is deliberately narrow, because it runs over prose: `UTF-8`, `SHA-256`, and `feat/WM-701-slug` must not become links, and a seven-digit number is not a ticket. That narrowness means it will skip a real ticket from a team this factory does not dispatch — which is exactly what the `x-ui` annotation is for. A column that declares it holds a ticket is believed regardless of team. The tests pin that distinction: removing the annotation branch fails only the test that uses an unconfigured team, which is how I know the branch earns its place.

## Verification

`cd event-runtime/web && bun test src/components/CustomCell.test.tsx src/components/TicketHoverCard.test.tsx src/views/Ticket.test.tsx` — **41 pass, 0 fail**.

Also: full web suite 980 pass / 2 fail, `bunx tsc --noEmit` clean, `bun run lint` 0 errors (620 warnings, under the 621 ratchet), `factory security` pass, prettier clean.

The two full-suite failures are in `Proposals.test.tsx` and are **pre-existing on develop** — I reverted this branch's files to `HEAD` and reproduced the identical two failures without any of these changes. Filed as WM-763.

## Negative testing

Each new behaviour was observed failing before it existed, and then re-checked by breaking it deliberately:

- Dropping `\b` and the digit cap from the pattern → the `UTF-8` / `SHA-256` / `xWM-12` / seven-digit test fails.
- Removing `enabled: open` from the hover card's query → the "does not fetch until opened" test fails.
- Removing the `x-ui` branch from `CustomCell` → the unconfigured-team test fails. The first version of that test used a configured team and passed with the branch deleted; it was rewritten rather than kept.

## Risks

The pattern hook subscribes every custom cell to the shared `["repos"]` query (`notifyOnChangeProps: ["data"]`, `staleTime` 5m, one cache entry app-wide) — worth a look if a wide table feels slower. The hover card and the ticket view now share one `fetchTicketJourney` and one query key, so the fetcher living in a component file is intentional: views import components, not the reverse.

UX critique: blocked — WM-726 / WM-730.

Fixes WM-701