### PR TITLE
test(web): pin pending chrome to text-dim (WM-745)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -289,13 +289,11 @@ describe("health connection chrome (WM-724)", () => {
     });
 
     const chip = utils.sidebar.getByText("connecting");
-    expect(chip.getAttribute("style")).not.toContain("--hue-err");
+    expect(chip.getAttribute("style")).toContain("--text-dim");
     expect(utils.sidebar.queryByText("disconnected")).toBeNull();
     expect(chip.getAttribute("title")).not.toContain("runtime unreachable");
 
-    expect(statusDot(statusBar).getAttribute("style")).not.toContain(
-      "--hue-err",
-    );
+    expect(statusDot(statusBar).getAttribute("style")).toContain("--text-dim");
     expect(statusBar.textContent).not.toContain("runtime unreachable");
     expect(statusBar.textContent).toContain("connecting");
 


### PR DESCRIPTION
## Summary
- positively assert the pending environment chip uses `--text-dim`
- positively assert the pending status dot uses `--text-dim`

## Verification
- `cd event-runtime/web && bun test src/App.test.tsx` — 20 pass, 0 fail

UX critique: skipped — test-only assertion change with no user-facing behavior change

Fixes WM-745