### PR TITLE
fix(web): expose artifact rows as ARIA grid (WM-749)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -218,9 +218,9 @@ describe("Artifacts inventory (WM-207)", () => {
       },
     );
     await waitFor(() => expect(view.getByText("bbbbbbbbbbbb")).toBeTruthy());
-    const table = view.getByRole("table");
-    expect(within(table).queryByText("aaaaaaaaaaaa")).toBeNull();
-    expect(within(table).queryByText("cccccccccccc")).toBeNull();
+    const grid = view.getByRole("grid");
+    expect(within(grid).queryByText("aaaaaaaaaaaa")).toBeNull();
+    expect(within(grid).queryByText("cccccccccccc")).toBeNull();
   });
 
   test("opens a deep-linked inspector with formatted preview, actions, search, and bidirectional references", async () => {
@@ -371,18 +371,28 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
     ).toBeNull();
   });
 
-  test("rows take Tab focus and select on Enter and Space", async () => {
+  test("grid rows take Tab focus and select on Enter and Space", async () => {
     globalThis.fetch = mock(
       async () => new Response("line one", { status: 200 }),
     ) as unknown as typeof fetch;
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
+    const grid = view.getByRole("grid");
+    expect(within(grid).getAllByRole("rowgroup")).toHaveLength(2);
+    expect(within(grid).getAllByRole("columnheader")).toHaveLength(5);
+
     const row = view.getByText("1.0 KB").closest("tr");
+    expect(row?.getAttribute("role")).toBe("row");
+    expect(within(row!).getAllByRole("gridcell")).toHaveLength(5);
     expect(row?.getAttribute("tabindex")).toBe("0");
+    expect(row?.getAttribute("aria-selected")).toBe("false");
 
     fireEvent.keyDown(row!, { key: "Enter" });
     expect(window.location.hash).toBe(`#/artifacts/${SHA_A}`);
+    await waitFor(() =>
+      expect(row?.getAttribute("aria-selected")).toBe("true"),
+    );
     expect(
       await view.findByRole("region", { name: "Artifact content" }),
     ).toBeTruthy();

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -544,9 +544,16 @@ export function Artifacts({
           </>
         }
       >
-        <table className="w-full border-separate border-spacing-0 text-[12px]">
-          <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+        <table
+          role="grid"
+          aria-label="Artifacts inventory"
+          className="w-full border-separate border-spacing-0 text-[12px]"
+        >
+          <thead role="rowgroup">
+            <tr
+              role="row"
+              className="text-left text-[11px] text-(--text-faint)"
+            >
               {columns.map((column) => {
                 const sort = ARTIFACTS_DISPLAY.sorts.find(
                   (field) => field.column === column.key,
@@ -588,13 +595,14 @@ export function Artifacts({
               })}
             </tr>
           </thead>
-          <tbody>
+          <tbody role="rowgroup">
             {ordered.map((artifact) => {
               const artifactKinds = kindsOf(artifact);
               const name = downloadName(artifact.sha256, artifactKinds);
               return (
                 <tr
                   key={artifact.sha256}
+                  role="row"
                   tabIndex={0}
                   // Link clicks are the browser's to handle. Assigning the
                   // hash here as well as through the SHA anchor's default
@@ -619,6 +627,7 @@ export function Artifacts({
                   className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
                 >
                   <td
+                    role="gridcell"
                     className="mono max-w-48 border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
                     title={artifact.sha256}
                   >
@@ -655,7 +664,10 @@ export function Artifacts({
                     </span>
                   </td>
                   {shown.has("kind") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                    <td
+                      role="gridcell"
+                      className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    >
                       {artifactKinds.length > 0 ? (
                         <div className="flex flex-nowrap gap-1">
                           {artifactKinds.map((kind) => (
@@ -668,12 +680,16 @@ export function Artifacts({
                     </td>
                   )}
                   {shown.has("size") && (
-                    <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                    <td
+                      role="gridcell"
+                      className="mono whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-dim)"
+                    >
                       {formatBytes(artifact.sizeBytes)}
                     </td>
                   )}
                   {shown.has("age") && (
                     <td
+                      role="gridcell"
                       className="whitespace-nowrap border-b border-(--border) px-3 py-1.5"
                       title={new Date(artifact.mtime).toLocaleString()}
                     >
@@ -683,7 +699,10 @@ export function Artifacts({
                     </td>
                   )}
                   {shown.has("references") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                    <td
+                      role="gridcell"
+                      className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    >
                       {(artifact.references?.length ?? 0) > 0 ? (
                         <div className="flex flex-nowrap gap-2">
                           {(artifact.references ?? []).map((reference) => (


### PR DESCRIPTION
## Summary
- expose the artifacts inventory as a named ARIA grid with compatible rowgroup, row, and gridcell semantics
- keep selectable rows keyboard-operable and expose their selection state validly
- add regression coverage for the grid hierarchy, aria-selected updates, Enter, and Space

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — 14 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass
- `factory security` — pass

UX critique: required — SHIP; browser evidence at http://127.0.0.1:7567/#/artifacts and /tmp/WM-749-artifacts-keyboard-row-focus.png. Follow-up traversal polish filed as WM-770.

Fixes WM-749