### PR TITLE
feat(web): event and run hover cards with causation glyphs (WM-702)

### DIFF
--- a/event-runtime/web/src/components/EventHoverCard.test.tsx
+++ b/event-runtime/web/src/components/EventHoverCard.test.tsx
@@ -1,0 +1,360 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import {
+  CausationGlyphs,
+  EventHoverCard,
+  chainHref,
+  payloadSummary,
+} from "./EventHoverCard";
+import {
+  createEventFixture,
+  createRunListItemFixture,
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
+import type { AdmittedEvent } from "../types";
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+});
+
+const NOW = new Date().toISOString();
+
+function stubEvent(overrides?: Partial<AdmittedEvent>): AdmittedEvent {
+  return createEventFixture({
+    source: "github",
+    eventId: "evt_1001",
+    type: "pull_request.opened",
+    correlationId: "corr_1001",
+    occurredAt: NOW,
+    admittedAt: NOW,
+    envelope: {
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_1001",
+      type: "pull_request.opened",
+      source: "github",
+      occurredAt: NOW,
+      payload: {
+        repo: "watt-mind/factory",
+        number: 608,
+        draft: false,
+        labels: ["ready", "ui"],
+        author: "hdkiller",
+      },
+    },
+    ...overrides,
+  });
+}
+
+/** The wrapper the primitive puts the popup ARIA state on. */
+function triggerOf(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[aria-haspopup='dialog']");
+  if (!el) throw new Error("hover card trigger not found");
+  return el;
+}
+
+describe("payloadSummary", () => {
+  test("takes the leading payload keys and formats each with formatCellValue", () => {
+    const { entries, total } = payloadSummary(stubEvent().envelope, 4);
+
+    expect(total).toBe(5);
+    expect(entries).toHaveLength(4);
+    expect(entries.map((e) => e.key)).toEqual([
+      "repo",
+      "number",
+      "draft",
+      "labels",
+    ]);
+    // formatCellValue's own grammar: numbers bare, booleans spelled, arrays counted.
+    expect(entries.map((e) => e.text)).toEqual([
+      "watt-mind/factory",
+      "608",
+      "false",
+      "[2]",
+    ]);
+  });
+
+  test("falls back to the envelope's own fields when it carries no payload", () => {
+    const { entries } = payloadSummary({
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_1001",
+      type: "clock.tick",
+      source: "schedule",
+      occurredAt: NOW,
+      loop: "merge-scan",
+      slot: "2026-08-18T12:00:00.000Z",
+    });
+
+    // Envelope metadata is already in the card's header; only the rest is news.
+    expect(entries.map((e) => e.key)).toEqual(["loop", "slot"]);
+  });
+
+  test("is empty for an envelope that says nothing beyond its metadata", () => {
+    const { entries, total } = payloadSummary({
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_1001",
+      type: "clock.tick",
+      source: "schedule",
+    });
+    expect(entries).toHaveLength(0);
+    expect(total).toBe(0);
+  });
+});
+
+describe("chainHref", () => {
+  test("addresses the chain, preselecting a node when one is named", () => {
+    expect(chainHref("corr_1001")).toBe("#/chain/corr_1001");
+    expect(chainHref("corr_1001", "event:github:evt_1001")).toBe(
+      "#/chain/corr_1001/event%3Agithub%3Aevt_1001",
+    );
+    expect(chainHref(null)).toBeNull();
+  });
+});
+
+describe("CausationGlyphs", () => {
+  test("renders nothing when an event neither came from nor led to anything", () => {
+    const r = renderWithClient(
+      <CausationGlyphs causedBy={null} fanOut={0} href="#/chain/x" title="x" />,
+    );
+    expect(r.container.textContent).toBe("");
+  });
+
+  test("links both glyphs into the chain and keeps the click off the row", () => {
+    const onRowClick = mock(() => {});
+    const r = renderWithClient(
+      <button type="button" onClick={onRowClick}>
+        <CausationGlyphs
+          causedBy="run_abc"
+          fanOut={2}
+          href="#/chain/corr_1001/run%3Arun_abc"
+          title="Caused by run_abc · 2 derived"
+        />
+      </button>,
+    );
+
+    const link = r.getByRole("link", { name: /Caused by run_abc/ });
+    expect(link.getAttribute("href")).toBe("#/chain/corr_1001/run%3Arun_abc");
+    expect(link.textContent).toContain("↳");
+    expect(link.textContent).toContain("→ 2");
+
+    fireEvent.click(link);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  test("degrades to plain glyphs when the chain id is unknown", () => {
+    const r = renderWithClient(
+      <CausationGlyphs
+        causedBy="run_abc"
+        fanOut={0}
+        href={null}
+        title="Caused by run_abc"
+      />,
+    );
+    expect(r.queryByRole("link")).toBeNull();
+    expect(r.getByTitle("Caused by run_abc").textContent).toContain("↳");
+  });
+});
+
+describe("EventHoverCard", () => {
+  test("opens on hover with the event's type, status, publisher and payload", async () => {
+    await withApi({ runs: async () => ({ runs: [] }) }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent()}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      const card = r.getByRole("dialog");
+      expect(card.getAttribute("aria-label")).toBe("Event evt_1001");
+      expect(card.textContent).toContain("pull_request.opened");
+      expect(card.textContent).toContain("admitted");
+      expect(card.textContent).toContain("github");
+      // Top payload keys, formatted the way the table's custom columns are.
+      expect(card.textContent).toContain("repo");
+      expect(card.textContent).toContain("watt-mind/factory");
+      expect(card.textContent).toContain("608");
+      // A fifth key exists but stays behind a count rather than growing the card.
+      expect(card.textContent).toContain("+1 more");
+      expect(card.textContent).not.toContain("hdkiller");
+    });
+  });
+
+  test("holds the causation query until the card opens, then previews the run that emitted the event", async () => {
+    let calls = 0;
+    const runs = async () => {
+      calls += 1;
+      return {
+        runs: [
+          createRunListItemFixture({
+            runId: "run_cause_1",
+            state: "COMPLETED",
+            agent: "merge-scan",
+          }),
+        ],
+      };
+    };
+
+    await withApi({ runs }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent({ causationId: "run_cause_1" })}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+
+      // A mouse sweep across a table must not fire one request per row.
+      expect(calls).toBe(0);
+
+      fireEvent.mouseEnter(triggerOf(r.container));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      await waitFor(() => {
+        const card = r.getByRole("dialog");
+        expect(card.textContent).toContain("merge-scan");
+        expect(card.textContent).toContain("COMPLETED");
+      });
+      expect(calls).toBe(1);
+    });
+  });
+
+  test("a second open inside the stale window reuses the cached causation", async () => {
+    let calls = 0;
+    const runs = async () => {
+      calls += 1;
+      return {
+        runs: [
+          createRunListItemFixture({ runId: "run_cause_1", agent: "sweep" }),
+        ],
+      };
+    };
+
+    await withApi({ runs }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent({ causationId: "run_cause_1" })}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      const trigger = triggerOf(r.container);
+
+      fireEvent.mouseEnter(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      await waitFor(() => expect(calls).toBe(1));
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+
+      fireEvent.mouseEnter(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(calls).toBe(1);
+    });
+  });
+
+  test("never queries for an origin event, and says it starts the chain", async () => {
+    let calls = 0;
+    const runs = async () => {
+      calls += 1;
+      return { runs: [] };
+    };
+
+    await withApi({ runs }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent({ causationId: null })}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(r.getByRole("dialog").textContent).toContain("starts this chain");
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("offers the chain and the event as real links, preselecting this event", async () => {
+    await withApi({ runs: async () => ({ runs: [] }) }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent()}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(
+        r.getByRole("link", { name: /View chain/i }).getAttribute("href"),
+      ).toBe("#/chain/corr_1001/event%3Agithub%3Aevt_1001");
+      expect(
+        r.getByRole("link", { name: /Open event/i }).getAttribute("href"),
+      ).toBe("#/events/github/evt_1001");
+    });
+  });
+
+  test("routes the quick actions through the view's own navigation when it wires one", async () => {
+    const onJumpChain = mock(() => {});
+    const onJumpEvent = mock(() => {});
+
+    await withApi({ runs: async () => ({ runs: [] }) }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard
+          event={stubEvent()}
+          onJumpChain={onJumpChain}
+          onJumpEvent={onJumpEvent}
+        >
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      fireEvent.click(r.getByRole("link", { name: /View chain/i }));
+      expect(onJumpChain).toHaveBeenCalledWith(
+        "corr_1001",
+        "event:github:evt_1001",
+      );
+
+      fireEvent.mouseEnter(triggerOf(r.container));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      fireEvent.click(r.getByRole("link", { name: /Open event/i }));
+      expect(onJumpEvent).toHaveBeenCalledWith("github", "evt_1001");
+    });
+  });
+
+  test("falls back to the event's own id as the chain key when it carries no correlation", async () => {
+    await withApi({ runs: async () => ({ runs: [] }) }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent({ correlationId: null })}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: /View chain/i }).getAttribute("href"),
+        ).toBe("#/chain/evt_1001/event%3Agithub%3Aevt_1001"),
+      );
+    });
+  });
+
+  test("opens on keyboard focus so the card is not mouse-only", async () => {
+    await withApi({ runs: async () => ({ runs: [] }) }, async () => {
+      const r = renderWithClient(
+        <EventHoverCard event={stubEvent()}>
+          <span>evt_1001</span>
+        </EventHoverCard>,
+      );
+      const trigger = triggerOf(r.container);
+      expect(trigger.getAttribute("tabindex")).toBe("0");
+
+      trigger.focus();
+      fireEvent.focus(trigger);
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+});

--- a/event-runtime/web/src/components/EventHoverCard.tsx
+++ b/event-runtime/web/src/components/EventHoverCard.tsx
@@ -1,0 +1,416 @@
+/**
+ * Event hover card and the causation glyphs that trigger it (WM-702).
+ *
+ * The Events table answers "what arrived"; it took a navigation away to answer
+ * "and why". This card gives the one hop either side of a row — the run that
+ * emitted the event, the runs it went on to plan — without leaving the table,
+ * and hands off to the chain trace when one hop is not enough.
+ *
+ * The query lives behind `enabled: open` on purpose: a pointer crossing a
+ * hundred rows must cost nothing, and a `staleTime` keeps a second look at the
+ * same row off the wire entirely.
+ *
+ * `CausationGlyphs`, `HoverCardAction` and `chainHref` are shared with
+ * `RunHoverCard` and both tables. They live here rather than in a module of
+ * their own because WM-702 owns these two card files and the two views, and a
+ * third shared file would sit outside that set.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { api } from "../api";
+import { resolveEntity } from "../entities";
+import { EMPTY, formatRelative } from "../format";
+import { chainKeyOfEvent, eventNodeId } from "../graph/chainModel";
+import { hashPath } from "../hash";
+import type { AdmittedEvent, RunListItem } from "../types";
+import { formatCellValue } from "./CustomCell";
+import { HoverCard } from "./HoverCard";
+import { EVENT_STATUS_HUES, StateBadge, shortId } from "./ui";
+
+/**
+ * How long a card's answer stays good. Long enough that re-hovering a row, or
+ * sweeping back up a table, never refetches; short enough that a card opened a
+ * minute later is not describing a run that has since finished.
+ */
+export const HOVER_CARD_STALE_MS = 30_000;
+
+/** Payload keys a card shows before it starts costing more than it explains. */
+export const PAYLOAD_KEY_LIMIT = 4;
+
+/** Envelope fields the card's own header already states. */
+const ENVELOPE_METADATA = new Set([
+  "schemaVersion",
+  "eventId",
+  "type",
+  "source",
+  "subject",
+  "occurredAt",
+  "receivedAt",
+  "correlationId",
+  "causationId",
+  "payload",
+]);
+
+const FOOTER_LINK_CLASS =
+  "cursor-pointer text-[11px] font-medium text-(--accent) hover:underline inline-flex items-center gap-1";
+
+const ROW_CLASS = "flex items-baseline justify-between gap-2";
+const ROW_KEY_CLASS = "shrink-0 text-(--text-faint)";
+const ROW_VALUE_CLASS = "mono min-w-0 truncate text-(--text-dim)";
+
+export interface PayloadEntry {
+  key: string;
+  text: string;
+  title?: string;
+}
+
+/**
+ * The leading few payload keys, rendered in the same grammar as the tables'
+ * custom columns (`formatCellValue`) so a value never reads one way in a cell
+ * and another in the card describing it.
+ *
+ * An envelope with no `payload` object still says something — a schedule tick
+ * carries its loop and slot at the top level — so the fields the header does
+ * not already show stand in for it.
+ */
+export function payloadSummary(
+  envelope: Record<string, unknown> | null | undefined,
+  limit: number = PAYLOAD_KEY_LIMIT,
+): { entries: PayloadEntry[]; total: number } {
+  const raw = envelope?.payload;
+  const payload =
+    raw !== null && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : null;
+  const source = payload ?? envelope ?? {};
+  const keys = Object.keys(source).filter(
+    (key) => payload !== null || !ENVELOPE_METADATA.has(key),
+  );
+  const entries = keys.slice(0, Math.max(0, limit)).map((key) => {
+    const { text, title } = formatCellValue(source[key]);
+    return { key, text, title };
+  });
+  return { entries, total: keys.length };
+}
+
+/**
+ * The chain trace route, optionally with the node to preselect. Null when
+ * nothing names the chain — a link to `#/chain/undefined` is a 404 dressed up
+ * as an affordance.
+ */
+export function chainHref(
+  correlationId: string | null | undefined,
+  nodeId?: string | null,
+): string | null {
+  if (!correlationId) return null;
+  return `#/${hashPath("chain", correlationId, nodeId)}`;
+}
+
+export interface CausationGlyphsProps {
+  /** Id of the one thing that caused this row, or null when it is an origin. */
+  causedBy: string | null;
+  /** How many things this row went on to cause. */
+  fanOut: number;
+  /** Chain route to open, or null when no correlation id is known. */
+  href: string | null;
+  /** Tooltip and accessible name — the glyphs themselves say nothing aloud. */
+  title: string;
+  /** In-app navigation, when the view wires one. Falls back to `href`. */
+  onJump?: () => void;
+}
+
+/**
+ * `↳` for "something caused this", `→ N` for "this caused N things" — the two
+ * facts a lineage question starts from, in the width a table cell can spare.
+ * Clicking opens the chain with this row already selected, and never selects
+ * the row underneath: following a link and changing the selection are two
+ * different intents and one click cannot mean both.
+ */
+export function CausationGlyphs({
+  causedBy,
+  fanOut,
+  href,
+  title,
+  onJump,
+}: CausationGlyphsProps) {
+  if (!causedBy && fanOut <= 0) return null;
+
+  const body = (
+    <>
+      {causedBy && <span aria-hidden="true">↳</span>}
+      {fanOut > 0 && (
+        <span aria-hidden="true" className="tabular-nums">
+          → {fanOut}
+        </span>
+      )}
+    </>
+  );
+  const className =
+    "inline-flex shrink-0 items-center gap-1 text-[10px] text-(--text-faint)";
+
+  if (!href) {
+    return (
+      <span className={className} title={title}>
+        {body}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      title={title}
+      aria-label={title}
+      className={`${className} hover:text-(--accent)`}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!onJump) return;
+        e.preventDefault();
+        onJump();
+      }}
+    >
+      {body}
+    </a>
+  );
+}
+
+/**
+ * A card's footer action. Always a real link so middle-click and copy-address
+ * work, and the wired-up navigation only replaces the default when a view has
+ * one — a card that is a dead end for the keyboard is half a card.
+ */
+export function HoverCardAction({
+  href,
+  onJump,
+  close,
+  children,
+}: {
+  href: string | null;
+  onJump?: () => void;
+  close: () => void;
+  children: ReactNode;
+}) {
+  if (!href) return null;
+  return (
+    <a
+      href={href}
+      className={FOOTER_LINK_CLASS}
+      onClick={(e) => {
+        e.stopPropagation();
+        close();
+        if (!onJump) return;
+        e.preventDefault();
+        onJump();
+      }}
+    >
+      {children} <span aria-hidden="true">→</span>
+    </a>
+  );
+}
+
+/** One `key   value` line, the shape every hover card states facts in. */
+export function HoverCardRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={ROW_CLASS}>
+      <span className={ROW_KEY_CLASS}>{label}</span>
+      <span className={ROW_VALUE_CLASS}>{children}</span>
+    </div>
+  );
+}
+
+export interface EventHoverCardProps {
+  event: AdmittedEvent;
+  /** Open the chain trace, preselecting this event. */
+  onJumpChain?: (correlationId: string, nodeId?: string) => void;
+  /** Select this event in the Events view. */
+  onJumpEvent?: (source: string, eventId: string) => void;
+  /** Open the run that emitted this event. */
+  onJumpRun?: (runId: string) => void;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Hover card for one admitted event: what it is, who published it, the run
+ * that caused it, and the head of its payload.
+ */
+export function EventHoverCard({
+  event,
+  onJumpChain,
+  onJumpEvent,
+  onJumpRun,
+  children,
+  className,
+}: EventHoverCardProps) {
+  const [open, setOpen] = useState(false);
+  // Read the clock when the card opens, not on every render: a relative
+  // timestamp per table row would otherwise want a ticking timer per row.
+  const [now, setNow] = useState(() => Date.now());
+  const onOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (next) setNow(Date.now());
+  }, []);
+  const causationId = event.causationId ?? null;
+
+  // Shared cache key with the Events and Runs tables, so an open card usually
+  // reads a list the view already holds and never touches the network.
+  const runsQ = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    enabled: open && causationId !== null,
+    staleTime: HOVER_CARD_STALE_MS,
+  });
+
+  const cause: RunListItem | null = useMemo(() => {
+    if (!causationId) return null;
+    return (
+      (runsQ.data?.runs ?? []).find((r) => r.runId === causationId) ?? null
+    );
+  }, [runsQ.data, causationId]);
+
+  const chainId = chainKeyOfEvent(event);
+  const nodeId = eventNodeId(event.source, event.eventId);
+  const eventEntity = resolveEntity("event", event.eventId, {
+    source: event.source,
+  });
+  const summary = useMemo(
+    () => payloadSummary(event.envelope),
+    [event.envelope],
+  );
+  const hidden = summary.total - summary.entries.length;
+
+  return (
+    <HoverCard
+      label={`Event ${event.eventId}`}
+      className={className}
+      onOpenChange={onOpenChange}
+      estimatedHeight={260}
+      trigger={<span className="min-w-0 truncate">{children}</span>}
+    >
+      {({ close }) => (
+        <>
+          {/* Header: what happened, and what the planner made of it. */}
+          <div className="flex items-start justify-between gap-2 border-b border-(--border) pb-2.5">
+            <div className="min-w-0 flex-1">
+              <div
+                className="truncate font-semibold text-(--text) text-[13px]"
+                title={event.type}
+              >
+                {event.type}
+              </div>
+              <div className="mono mt-0.5 truncate text-[10px] text-(--text-faint)">
+                {event.source} · {event.eventId}
+              </div>
+            </div>
+            <StateBadge state={event.status} hues={EVENT_STATUS_HUES} />
+          </div>
+
+          <div className="my-2.5 space-y-1.5 text-[11px]">
+            <HoverCardRow label="Publisher">
+              {cause ? `${event.source} · ${cause.agent}` : event.source}
+            </HoverCardRow>
+
+            <HoverCardRow label="Occurred">
+              <span title={event.occurredAt}>
+                {formatRelative(event.occurredAt, now)}
+              </span>
+            </HoverCardRow>
+
+            {event.subject && (
+              <HoverCardRow label="Subject">{event.subject}</HoverCardRow>
+            )}
+
+            {/* One hop back: the run that emitted this event, previewed rather
+                than merely named — an id alone is another navigation. */}
+            <div className="mt-2 border-t border-(--border) pt-2">
+              {causationId ? (
+                <HoverCardRow label="Caused by">
+                  {cause ? (
+                    <a
+                      href={`#/${hashPath("run", causationId)}`}
+                      title={causationId}
+                      className="hover:text-(--accent)"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        close();
+                        if (!onJumpRun) return;
+                        e.preventDefault();
+                        onJumpRun(causationId);
+                      }}
+                    >
+                      {shortId(causationId)} · {cause.agent} · {cause.state}
+                    </a>
+                  ) : (
+                    <span title={causationId}>
+                      {runsQ.isLoading
+                        ? "Loading…"
+                        : `${shortId(causationId)} ${EMPTY}`}
+                    </span>
+                  )}
+                </HoverCardRow>
+              ) : (
+                <div className="text-[11px] text-(--text-faint)">
+                  No causation — this event starts this chain.
+                </div>
+              )}
+            </div>
+
+            {summary.entries.length > 0 && (
+              <div className="mt-2 border-t border-(--border) pt-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-(--text-faint)">
+                  Payload
+                </div>
+                <div className="space-y-1">
+                  {summary.entries.map((entry) => (
+                    <div key={entry.key} className={ROW_CLASS}>
+                      <span className={`mono ${ROW_KEY_CLASS}`}>
+                        {entry.key}
+                      </span>
+                      <span className={ROW_VALUE_CLASS} title={entry.title}>
+                        {entry.text}
+                      </span>
+                    </div>
+                  ))}
+                  {hidden > 0 && (
+                    <div className="text-[10px] text-(--text-faint)">
+                      +{hidden} more
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-2.5 flex justify-between gap-2 border-t border-(--border) pt-2">
+            <HoverCardAction
+              href={chainHref(chainId, nodeId)}
+              close={close}
+              onJump={
+                onJumpChain ? () => onJumpChain(chainId, nodeId) : undefined
+              }
+            >
+              View chain
+            </HoverCardAction>
+            <HoverCardAction
+              href={eventEntity?.href ?? null}
+              close={close}
+              onJump={
+                onJumpEvent
+                  ? () => onJumpEvent(event.source, event.eventId)
+                  : undefined
+              }
+            >
+              Open event
+            </HoverCardAction>
+          </div>
+        </>
+      )}
+    </HoverCard>
+  );
+}

--- a/event-runtime/web/src/components/RunHoverCard.test.tsx
+++ b/event-runtime/web/src/components/RunHoverCard.test.tsx
@@ -1,0 +1,302 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import {
+  RunHoverCard,
+  artifactCount,
+  runDurationSeconds,
+  runOrigin,
+} from "./RunHoverCard";
+import {
+  createRunDetailFixture,
+  createRunListItemFixture,
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
+import type { ArtifactRef, Attempt, RunDetail, RunListItem } from "../types";
+
+function artifactRef(uri: string, fill: string): ArtifactRef {
+  return { kind: "report", uri, sha256: fill.repeat(64), sizeBytes: 128 };
+}
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+});
+
+const T0 = "2026-08-18T12:00:00.000Z";
+const T1 = "2026-08-18T12:02:30.000Z";
+const NOW_MS = Date.parse("2026-08-18T12:05:00.000Z");
+
+function attempt(overrides?: Partial<Attempt>): Attempt {
+  return {
+    run_id: "run_test_1001",
+    attempt: 1,
+    lease_owner: "worker_test",
+    lease_expires_at: null,
+    started_at: T0,
+    finished_at: T1,
+    terminal_state: "COMPLETED",
+    reason_code: null,
+    workspace_path: "/tmp/ws",
+    ...overrides,
+  };
+}
+
+function stubRun(overrides?: Partial<RunListItem>): RunListItem {
+  return createRunListItemFixture({
+    runId: "run_test_1001",
+    state: "COMPLETED",
+    attempts: 2,
+    maxAttempts: 3,
+    agent: "merge-scan",
+    adapter: "claude-code",
+    eventSource: "github",
+    eventId: "evt_1001",
+    created_at: T0,
+    updated_at: T1,
+    ...overrides,
+  });
+}
+
+function stubDetail(overrides?: Partial<RunDetail>): RunDetail {
+  return createRunDetailFixture({
+    run: {
+      runId: "run_test_1001",
+      state: "COMPLETED",
+      attempts: 2,
+    } as RunDetail["run"],
+    attempts: [attempt()],
+    result: {
+      terminalState: "COMPLETED",
+      reasonCode: null,
+      artifacts: [
+        artifactRef("report.md", "a"),
+        artifactRef("diff.patch", "b"),
+      ],
+    },
+    ...overrides,
+  });
+}
+
+/** The wrapper the primitive puts the popup ARIA state on. */
+function triggerOf(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[aria-haspopup='dialog']");
+  if (!el) throw new Error("hover card trigger not found");
+  return el;
+}
+
+describe("runDurationSeconds", () => {
+  test("spans the first attempt's start to the last attempt's finish", () => {
+    expect(runDurationSeconds(stubRun(), stubDetail(), NOW_MS)).toBe(150);
+  });
+
+  test("runs the clock to now while an attempt is still open", () => {
+    const detail = stubDetail({
+      attempts: [attempt({ finished_at: null, terminal_state: null })],
+    });
+    expect(runDurationSeconds(stubRun(), detail, NOW_MS)).toBe(300);
+  });
+
+  test("falls back to the list row's own timestamps before the detail arrives", () => {
+    expect(runDurationSeconds(stubRun(), undefined, NOW_MS)).toBe(150);
+  });
+
+  test("is null when nothing dates the run", () => {
+    const detail = stubDetail({ attempts: [] });
+    const run = stubRun({ created_at: "", updated_at: "" });
+    expect(runDurationSeconds(run, detail, NOW_MS)).toBeNull();
+  });
+});
+
+describe("artifactCount", () => {
+  test("counts the stored artifacts a run produced", () => {
+    expect(artifactCount(stubDetail())).toBe(2);
+  });
+
+  test("counts the single legacy artifact hash as one", () => {
+    const detail = stubDetail({
+      result: {
+        terminalState: "COMPLETED",
+        reasonCode: null,
+        artifactHash: "c".repeat(64),
+      },
+    });
+    expect(artifactCount(detail)).toBe(1);
+  });
+
+  test("is zero for a run with no result yet", () => {
+    expect(artifactCount(stubDetail({ result: null }))).toBe(0);
+    expect(artifactCount(undefined)).toBe(0);
+  });
+});
+
+describe("runOrigin", () => {
+  test("names the schedule that ticked, not a webhook that did not", () => {
+    const origin = runOrigin(
+      stubRun({ eventSource: "schedule", eventId: "manual:merge-scan" }),
+    );
+    expect(origin.kind).toBe("schedule");
+  });
+
+  test("names the origin event for an event-triggered run", () => {
+    expect(runOrigin(stubRun())).toEqual({
+      kind: "event",
+      source: "github",
+      eventId: "evt_1001",
+    });
+  });
+
+  test("has no origin when the run names no event", () => {
+    expect(runOrigin(stubRun({ eventSource: null, eventId: null })).kind).toBe(
+      "none",
+    );
+  });
+});
+
+describe("RunHoverCard", () => {
+  test("opens on hover with agent, state, attempts, duration and artifact count", async () => {
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()} chainId="corr_1001">
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      const card = r.getByRole("dialog");
+      expect(card.getAttribute("aria-label")).toBe("Run run_test_1001");
+      expect(card.textContent).toContain("COMPLETED");
+      expect(card.textContent).toContain("merge-scan");
+      expect(card.textContent).toContain("2/3");
+      await waitFor(() => {
+        expect(r.getByRole("dialog").textContent).toContain("2m 30s");
+        expect(r.getByRole("dialog").textContent).toContain("2 artifacts");
+      });
+    });
+  });
+
+  test("holds the detail query until the card opens and reuses it on reopen", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls += 1;
+      return stubDetail();
+    };
+
+    await withApi({ run }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()}>
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+
+      // Sweeping the pointer down a runs table must not fetch one detail per row.
+      expect(calls).toBe(0);
+
+      const trigger = triggerOf(r.container);
+      fireEvent.mouseEnter(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      await waitFor(() => expect(calls).toBe(1));
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      await waitFor(() => expect(r.queryByRole("dialog")).toBeNull());
+
+      fireEvent.mouseEnter(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(calls).toBe(1);
+    });
+  });
+
+  test("links the triggering event and routes it through the view's navigation", async () => {
+    const onJumpEvent = mock(() => {});
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()} onJumpEvent={onJumpEvent}>
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      const link = r.getByRole("link", { name: /evt_1001/ });
+      expect(link.getAttribute("href")).toBe("#/events/github/evt_1001");
+      fireEvent.click(link);
+      expect(onJumpEvent).toHaveBeenCalledWith("github", "evt_1001");
+    });
+  });
+
+  test("says a scheduled run was triggered by its loop, not by a webhook", async () => {
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard
+          run={stubRun({
+            eventSource: "schedule",
+            eventId: "clock.tick.merge-scan",
+          })}
+        >
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() =>
+        expect(r.getByRole("dialog").textContent).toContain("Schedule"),
+      );
+    });
+  });
+
+  test("offers the chain and the full run view as real links", async () => {
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()} chainId="corr_1001">
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(
+        r.getByRole("link", { name: /View chain/i }).getAttribute("href"),
+      ).toBe("#/chain/corr_1001/run%3Arun_test_1001");
+      expect(
+        r.getByRole("link", { name: /Open run/i }).getAttribute("href"),
+      ).toBe("#/run/run_test_1001");
+    });
+  });
+
+  test("omits the chain action when no correlation id reaches the card", async () => {
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()}>
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+      fireEvent.mouseEnter(triggerOf(r.container));
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(r.queryByRole("link", { name: /View chain/i })).toBeNull();
+      expect(r.getByRole("link", { name: /Open run/i })).toBeTruthy();
+    });
+  });
+
+  test("opens on keyboard focus so the card is not mouse-only", async () => {
+    await withApi({ run: async () => stubDetail() }, async () => {
+      const r = renderWithClient(
+        <RunHoverCard run={stubRun()}>
+          <span>run_test_1001</span>
+        </RunHoverCard>,
+      );
+      const trigger = triggerOf(r.container);
+      expect(trigger.getAttribute("tabindex")).toBe("0");
+
+      trigger.focus();
+      fireEvent.focus(trigger);
+
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+      expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+});

--- a/event-runtime/web/src/components/RunHoverCard.tsx
+++ b/event-runtime/web/src/components/RunHoverCard.tsx
@@ -1,0 +1,252 @@
+/**
+ * Run hover card (WM-702) — the Runs table's answer to "what is this run, and
+ * what set it off", without opening the detail pane and losing the list.
+ *
+ * The list row already knows the agent, state and attempt budget; only the
+ * duration and the artifacts a run produced need the detail endpoint, so that
+ * query sits behind `enabled: open` with a `staleTime`. Sweeping a pointer
+ * down a hundred rows must not fetch a hundred run details.
+ *
+ * The shared pieces — `CausationGlyphs`, `HoverCardAction`, `chainHref` —
+ * come from `EventHoverCard`; see the note there on why they live in that file.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { type ReactNode, useCallback, useState } from "react";
+import { api } from "../api";
+import { resolveEntity } from "../entities";
+import { EMPTY, formatDuration } from "../format";
+import { runNodeId } from "../graph/chainModel";
+import type { RunDetail, RunListItem } from "../types";
+import {
+  HOVER_CARD_STALE_MS,
+  HoverCardAction,
+  HoverCardRow,
+  chainHref,
+} from "./EventHoverCard";
+import { HoverCard } from "./HoverCard";
+import { StateBadge, shortId } from "./ui";
+
+/**
+ * Wall-clock time this run has spent executing: first attempt's start to the
+ * last one's finish, still ticking while an attempt is open. Before the detail
+ * arrives — the common case for the first frame of an open card — the list
+ * row's own timestamps carry the same answer to within a poll interval.
+ */
+export function runDurationSeconds(
+  run: RunListItem,
+  detail: RunDetail | null | undefined,
+  now: number,
+): number | null {
+  const attempts = detail?.attempts ?? [];
+  const at = (value: string | null) => {
+    const ms = value ? Date.parse(value) : Number.NaN;
+    return Number.isFinite(ms) ? ms : null;
+  };
+
+  const starts = attempts
+    .map((a) => at(a.started_at))
+    .filter((ms): ms is number => ms !== null);
+  if (starts.length > 0) {
+    const finishes = attempts
+      .map((a) => at(a.finished_at))
+      .filter((ms): ms is number => ms !== null);
+    const stillOpen = attempts.some((a) => a.started_at && !a.finished_at);
+    const end =
+      stillOpen || finishes.length === 0 ? now : Math.max(...finishes);
+    return Math.max(0, Math.round((end - Math.min(...starts)) / 1000));
+  }
+
+  const created = at(run.created_at);
+  const updated = at(run.updated_at);
+  if (created === null || updated === null) return null;
+  return Math.max(0, Math.round((updated - created) / 1000));
+}
+
+/** Stored outputs this run produced; the pre-`artifacts[]` shape counts as one. */
+export function artifactCount(detail: RunDetail | null | undefined): number {
+  const result = detail?.result;
+  if (!result) return 0;
+  if (Array.isArray(result.artifacts)) return result.artifacts.length;
+  return result.artifactHash ? 1 : 0;
+}
+
+export interface RunOrigin {
+  kind: "event" | "schedule" | "none";
+  source: string | null;
+  eventId: string | null;
+}
+
+/**
+ * What set this run off. A schedule tick is an admitted event like any other,
+ * but calling it "event" hides the only thing an operator wants to know about
+ * a run that appeared at 04:00 with nobody at a keyboard.
+ */
+export function runOrigin(run: RunListItem): RunOrigin {
+  const source = run.eventSource ?? null;
+  const eventId = run.eventId ?? null;
+  if (!source || !eventId) return { kind: "none", source, eventId };
+  return {
+    kind: source === "schedule" ? "schedule" : "event",
+    source,
+    eventId,
+  };
+}
+
+export interface RunHoverCardProps {
+  run: RunListItem;
+  /**
+   * Correlation id of the chain this run belongs to. Resolved by the caller:
+   * it lives on the origin event, which the run row does not carry.
+   */
+  chainId?: string | null;
+  /** Open the chain trace, preselecting this run. */
+  onJumpChain?: (correlationId: string, nodeId?: string) => void;
+  /** Open the full-page run view. */
+  onJumpRun?: (runId: string) => void;
+  /** Select the run's origin event. */
+  onJumpEvent?: (source: string, eventId: string) => void;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function RunHoverCard({
+  run,
+  chainId,
+  onJumpChain,
+  onJumpRun,
+  onJumpEvent,
+  children,
+  className,
+}: RunHoverCardProps) {
+  const [open, setOpen] = useState(false);
+  // Read the clock when the card opens, not on every render: an in-flight
+  // duration per table row would otherwise want a ticking timer per row.
+  const [now, setNow] = useState(() => Date.now());
+  const onOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (next) setNow(Date.now());
+  }, []);
+
+  // Same cache key as the Runs detail pane, so opening a card for the selected
+  // run is free and opening the pane afterwards is already warm.
+  const detailQ = useQuery({
+    queryKey: ["run", run.runId],
+    queryFn: () => api.run(run.runId),
+    enabled: open,
+    staleTime: HOVER_CARD_STALE_MS,
+  });
+
+  const detail = detailQ.data;
+  const duration = runDurationSeconds(run, detail, now);
+  const artifacts = artifactCount(detail);
+  const origin = runOrigin(run);
+  const originEntity =
+    origin.kind === "none"
+      ? null
+      : resolveEntity("event", origin.eventId, { source: origin.source });
+  const runEntity = resolveEntity("run", run.runId);
+
+  return (
+    <HoverCard
+      label={`Run ${run.runId}`}
+      className={className}
+      onOpenChange={onOpenChange}
+      estimatedHeight={230}
+      trigger={<span className="min-w-0 truncate">{children}</span>}
+    >
+      {({ close }) => (
+        <>
+          <div className="flex items-start justify-between gap-2 border-b border-(--border) pb-2.5">
+            <div className="min-w-0 flex-1">
+              <div
+                className="mono truncate font-semibold text-(--text) text-[13px]"
+                title={run.runId}
+              >
+                {shortId(run.runId)}
+              </div>
+              <div className="mt-0.5 truncate text-[10px] text-(--text-faint)">
+                <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-(--text-dim)">
+                  {run.agent}
+                </span>{" "}
+                {run.adapter}
+              </div>
+            </div>
+            <StateBadge state={run.state} />
+          </div>
+
+          <div className="my-2.5 space-y-1.5 text-[11px]">
+            <HoverCardRow label="Triggered by">
+              {origin.kind === "none" ? (
+                EMPTY
+              ) : (
+                <>
+                  <span className="font-sans text-(--text-faint)">
+                    {origin.kind === "schedule" ? "Schedule" : "Event"}
+                  </span>{" "}
+                  {origin.source} ·{" "}
+                  {originEntity ? (
+                    <a
+                      href={originEntity.href}
+                      title={origin.eventId ?? undefined}
+                      className="hover:text-(--accent)"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        close();
+                        if (!onJumpEvent) return;
+                        e.preventDefault();
+                        onJumpEvent(origin.source!, origin.eventId!);
+                      }}
+                    >
+                      {shortId(origin.eventId!)}
+                    </a>
+                  ) : (
+                    shortId(origin.eventId!)
+                  )}
+                </>
+              )}
+            </HoverCardRow>
+
+            <HoverCardRow label="Duration">
+              {duration === null ? EMPTY : formatDuration(duration)}
+            </HoverCardRow>
+
+            <HoverCardRow label="Attempts">
+              {run.attempts}/{run.maxAttempts}
+            </HoverCardRow>
+
+            <HoverCardRow label="Output">
+              {detailQ.isLoading
+                ? "Loading…"
+                : `${artifacts} artifact${artifacts === 1 ? "" : "s"}`}
+            </HoverCardRow>
+
+            {run.reasonCode && run.reasonCode.toLowerCase() !== "ok" && (
+              <HoverCardRow label="Reason">{run.reasonCode}</HoverCardRow>
+            )}
+          </div>
+
+          <div className="mt-2.5 flex justify-between gap-2 border-t border-(--border) pt-2">
+            <HoverCardAction
+              href={chainHref(chainId, runNodeId(run.runId))}
+              close={close}
+              onJump={
+                onJumpChain && chainId
+                  ? () => onJumpChain(chainId, runNodeId(run.runId))
+                  : undefined
+              }
+            >
+              View chain
+            </HoverCardAction>
+            <HoverCardAction
+              href={runEntity?.href ?? null}
+              close={close}
+              onJump={onJumpRun ? () => onJumpRun(run.runId) : undefined}
+            >
+              Open run
+            </HoverCardAction>
+          </div>
+        </>
+      )}
+    </HoverCard>
+  );
+}

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -1170,3 +1170,113 @@ describe("Events long-list window (WM-563)", () => {
     );
   });
 });
+
+// One-hop causation, read off the row itself (WM-702): `↳` for the run that
+// emitted this event, `→ N` for the runs it went on to plan, both landing on
+// the chain trace with this event already selected.
+describe("Events causation glyphs and hover card (WM-702)", () => {
+  const derived = stubEvent("evt_derived", "planned", {
+    correlationId: "corr_1001",
+    causationId: "run_parent",
+  });
+
+  const plannedRuns = [
+    createRunListItemFixture({
+      runId: "run_child_a",
+      eventSource: "github",
+      eventId: "evt_derived",
+    }),
+    createRunListItemFixture({
+      runId: "run_child_b",
+      eventSource: "github",
+      eventId: "evt_derived",
+    }),
+  ];
+
+  function eventCell(container: HTMLElement, eventId: string): HTMLElement {
+    const cell = container.querySelector<HTMLElement>(`td[title="${eventId}"]`);
+    if (!cell) throw new Error(`no Event cell for ${eventId}`);
+    return cell;
+  }
+
+  test("an emitted event carries a causation link into its chain, preselected", async () => {
+    const onSelectEvent = mock(() => {});
+    await withApi(
+      {
+        events: async () => ({ events: [derived] }),
+        runs: async () => ({ runs: plannedRuns }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents({ onSelectEvent });
+
+        const link = await waitFor(() => {
+          const el = eventCell(r.container, "evt_derived").querySelector("a");
+          if (!el) throw new Error("no causation link in the Event cell");
+          return el;
+        });
+
+        expect(link.getAttribute("href")).toBe(
+          "#/chain/corr_1001/event%3Agithub%3Aevt_derived",
+        );
+        expect(link.textContent).toContain("↳");
+        // Two runs were planned from this event — the fan-out the chain shows.
+        await waitFor(() => expect(link.textContent).toContain("→ 2"));
+
+        // Following the chain must not also select the row underneath it.
+        fireEvent.click(link);
+        expect(onSelectEvent).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  test("an origin event with no fan-out gets no glyph at all", async () => {
+    const origin = stubEvent("evt_origin", "admitted", {
+      correlationId: "corr_2002",
+      causationId: null,
+    });
+    await withApi(
+      {
+        events: async () => ({ events: [origin] }),
+        runs: async () => ({ runs: [] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents();
+        await waitFor(() => eventCell(r.container, "evt_origin"));
+        expect(
+          eventCell(r.container, "evt_origin").querySelector("a"),
+        ).toBeNull();
+        expect(eventCell(r.container, "evt_origin").textContent).not.toContain(
+          "↳",
+        );
+      },
+    );
+  });
+
+  test("hovering the event id opens the event hover card", async () => {
+    await withApi(
+      {
+        events: async () => ({ events: [derived] }),
+        runs: async () => ({ runs: plannedRuns }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents();
+        const cell = await waitFor(() => eventCell(r.container, "evt_derived"));
+
+        const trigger = cell.querySelector<HTMLElement>(
+          "[aria-haspopup='dialog']",
+        );
+        expect(trigger).toBeTruthy();
+        fireEvent.mouseEnter(trigger!);
+
+        await waitFor(() => {
+          const card = r.getByRole("dialog");
+          expect(card.getAttribute("aria-label")).toBe("Event evt_derived");
+          expect(card.textContent).toContain("pull_request.opened");
+        });
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -27,6 +27,12 @@ import {
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
+import {
+  CausationGlyphs,
+  EventHoverCard,
+  chainHref,
+} from "../components/EventHoverCard";
+import { chainKeyOfEvent, eventNodeId } from "../graph/chainModel";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
 import type {
@@ -288,6 +294,22 @@ export function decisionText(d: EventDecision | null): string {
   return `${d.outcome}${status}${reason ? ` · ${reason}` : ""}`;
 }
 
+/**
+ * The sentence the row's `↳` / `→ N` arrows stand for (WM-702). The glyphs are
+ * the only thing narrow enough for the Event column; the tooltip is where they
+ * say what they mean, to a screen reader as much as to a pointer.
+ */
+export function eventCausationTitle(
+  causedBy: string | null,
+  fanOut: number,
+): string {
+  const parts: string[] = [];
+  if (causedBy) parts.push(`Emitted by run ${shortId(causedBy)}`);
+  if (fanOut > 0)
+    parts.push(`${fanOut} run${fanOut === 1 ? "" : "s"} planned from it`);
+  return `${parts.join(" · ")} — open the chain`;
+}
+
 function isStatusTab(value: string | undefined): value is StatusTab {
   return !!value && (STATUS_TABS as readonly string[]).includes(value);
 }
@@ -444,8 +466,16 @@ export function Events({
       if (!prev || prev.created_at < p.created_at) byEvent.set(k, p);
     }
     const runsById = new Map<string, RunListItem>();
-    for (const r of runsQ.data?.runs ?? []) runsById.set(r.runId, r);
-    return { byId, byEvent, runsById };
+    // Causation fan-out (WM-702): the runs an event went on to plan are the
+    // event's children in the chain DAG, one hop down.
+    const runsByEvent = new Map<string, number>();
+    for (const r of runsQ.data?.runs ?? []) {
+      runsById.set(r.runId, r);
+      if (!r.eventSource || !r.eventId) continue;
+      const k = `${r.eventSource}:${r.eventId}`;
+      runsByEvent.set(k, (runsByEvent.get(k) ?? 0) + 1);
+    }
+    return { byId, byEvent, runsById, runsByEvent };
   }, [proposalsQ.data, runsQ.data]);
   const decisionFor = (e: AdmittedEvent) =>
     decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
@@ -1125,6 +1155,10 @@ export function Events({
                 const decision = decisionFor(e);
                 const decisionTitle = decisionText(decision);
                 const isSelected = keyOf(e) === selectedKey;
+                const causedBy = e.causationId ?? null;
+                const fanOut = decisions.runsByEvent.get(keyOf(e)) ?? 0;
+                const chainId = chainKeyOfEvent(e);
+                const nodeId = eventNodeId(e.source, e.eventId);
                 return (
                   <tr
                     key={keyOf(e)}
@@ -1133,10 +1167,31 @@ export function Events({
                     className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${isSelected ? "row-selected" : ""}`}
                   >
                     <td
-                      className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                      className="mono max-w-28 overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
                       title={e.eventId}
                     >
-                      {shortId(e.eventId)}
+                      <span className="flex min-w-0 items-center gap-1">
+                        <EventHoverCard
+                          event={e}
+                          className="min-w-0"
+                          onJumpChain={onJumpChain}
+                          onJumpEvent={onSelectEvent}
+                          onJumpRun={onJumpRun}
+                        >
+                          <span className="truncate">{shortId(e.eventId)}</span>
+                        </EventHoverCard>
+                        <CausationGlyphs
+                          causedBy={causedBy}
+                          fanOut={fanOut}
+                          href={chainHref(chainId, nodeId)}
+                          title={eventCausationTitle(causedBy, fanOut)}
+                          onJump={
+                            onJumpChain
+                              ? () => onJumpChain(chainId, nodeId)
+                              : undefined
+                          }
+                        />
+                      </span>
                     </td>
                     {show.has("source") && (
                       <td

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -6,6 +6,7 @@ import { Runs, statesForRunTab } from "./Runs";
 import {
   changeInput,
   createAgentsFixture,
+  createEventFixture,
   createLifecycleEventFixture,
   createProposalFixture,
   createRunSpecFixture,
@@ -1385,6 +1386,157 @@ describe("Runs in-flight row height (WM-725)", () => {
         expect(calmRemaining.textContent).toMatch(/\b9m\b/);
         expect(calmRemaining.textContent).not.toContain("lease");
         expect(cellFor(r, "run_calm", "State").textContent).toBe("RUNNING");
+      },
+    );
+  });
+});
+
+// One-hop causation on the row (WM-702): `↳` when the run's own origin event
+// was emitted by another run, `→ N` for the events it emitted, both landing on
+// the chain trace with this run already selected. The chain key lives on the
+// origin event, so the view has to read the event list to address the chain.
+describe("Runs causation glyphs and hover card (WM-702)", () => {
+  const triggered = stubListItem("run_chained", "COMPLETED", {
+    eventSource: "github",
+    eventId: "evt_origin",
+  });
+
+  const chainEvents = [
+    createEventFixture({
+      source: "github",
+      eventId: "evt_origin",
+      correlationId: "corr_1001",
+      causationId: "run_parent",
+    }),
+    createEventFixture({
+      source: "factory",
+      eventId: "evt_emitted_a",
+      correlationId: "corr_1001",
+      causationId: "run_chained",
+    }),
+    createEventFixture({
+      source: "factory",
+      eventId: "evt_emitted_b",
+      correlationId: "corr_1001",
+      causationId: "run_chained",
+    }),
+  ];
+
+  function runCell(container: HTMLElement, runId: string): HTMLElement {
+    const cell = container.querySelector<HTMLElement>(`td[title="${runId}"]`);
+    if (!cell) throw new Error(`no Run cell for ${runId}`);
+    return cell;
+  }
+
+  test("a triggered run links into its origin event's chain, preselected", async () => {
+    const onSelectRun = mock(() => {});
+    await withApi(
+      {
+        runs: async () => ({ runs: [triggered] }),
+        events: async () => ({ events: chainEvents }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns({ onSelectRun });
+
+        const link = await waitFor(() => {
+          const el = runCell(r.container, "run_chained").querySelector("a");
+          if (!el) throw new Error("no causation link in the Run cell");
+          return el;
+        });
+
+        // The chain key is the origin event's correlation id, not the run id.
+        expect(link.getAttribute("href")).toBe(
+          "#/chain/corr_1001/run%3Arun_chained",
+        );
+        expect(link.textContent).toContain("↳");
+        expect(link.textContent).toContain("→ 2");
+
+        fireEvent.click(link);
+        expect(onSelectRun).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  // Almost every run names an origin event, so "was triggered by an event"
+  // would put an arrow on every row and tell an operator nothing.
+  test("a run at the head of its chain gets the fan-out arrow but no downstream one", async () => {
+    const rootEvents = [
+      createEventFixture({
+        source: "github",
+        eventId: "evt_root",
+        correlationId: "corr_2002",
+        causationId: null,
+      }),
+      createEventFixture({
+        source: "factory",
+        eventId: "evt_from_root",
+        correlationId: "corr_2002",
+        causationId: "run_root",
+      }),
+    ];
+    await withApi(
+      {
+        runs: async () => ({
+          runs: [
+            stubListItem("run_root", "COMPLETED", {
+              eventSource: "github",
+              eventId: "evt_root",
+            }),
+          ],
+        }),
+        events: async () => ({ events: rootEvents }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        // The fan-out arrow proves the event list reached the row.
+        await waitFor(() =>
+          expect(runCell(r.container, "run_root").textContent).toContain("→ 1"),
+        );
+        expect(runCell(r.container, "run_root").textContent).not.toContain("↳");
+      },
+    );
+  });
+
+  test("a run with no origin event and no emissions gets no glyph", async () => {
+    await withApi(
+      {
+        runs: async () => ({ runs: [stubListItem("run_bare", "COMPLETED")] }),
+        events: async () => ({ events: [] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() => runCell(r.container, "run_bare"));
+        expect(runCell(r.container, "run_bare").querySelector("a")).toBeNull();
+      },
+    );
+  });
+
+  test("hovering the run id opens the run hover card", async () => {
+    await withApi(
+      {
+        runs: async () => ({ runs: [triggered] }),
+        events: async () => ({ events: chainEvents }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        const cell = await waitFor(() => runCell(r.container, "run_chained"));
+
+        const trigger = cell.querySelector<HTMLElement>(
+          "[aria-haspopup='dialog']",
+        );
+        expect(trigger).toBeTruthy();
+        fireEvent.mouseEnter(trigger!);
+
+        await waitFor(() => {
+          const card = r.getByRole("dialog");
+          expect(card.getAttribute("aria-label")).toBe("Run run_chained");
+          expect(card.textContent).toContain("triage-scan");
+          expect(card.textContent).toContain("COMPLETED");
+        });
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -34,6 +34,9 @@ import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import { AgentHoverCard } from "../components/AgentHoverCard";
+import { CausationGlyphs, chainHref } from "../components/EventHoverCard";
+import { RunHoverCard } from "../components/RunHoverCard";
+import { chainKeyOfEvent, runNodeId } from "../graph/chainModel";
 import {
   ApprovalRiskDetails,
   useProposalAgent,
@@ -56,7 +59,7 @@ import {
   parseFilterQuery,
 } from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
-import type { Proposal, RunListItem, RunState } from "../types";
+import type { AdmittedEvent, Proposal, RunListItem, RunState } from "../types";
 import { EMPTY, formatDuration, formatRelative } from "../format";
 import {
   Button,
@@ -360,6 +363,68 @@ function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
   );
 }
 
+/**
+ * The sentence the row's `↳` / `→ N` arrows stand for (WM-702). The Run column
+ * has room for the glyphs and nothing else; this is where they say what they
+ * mean, to a screen reader as much as to a pointer.
+ *
+ * `↳` marks a run whose *origin event was itself emitted by a run* — not
+ * merely one that names an origin event. Almost every run does the latter, and
+ * an arrow on every row is a decoration, not a signal.
+ */
+export function runCausationTitle(
+  parentRunId: string | null,
+  fanOut: number,
+): string {
+  const parts: string[] = [];
+  if (parentRunId) parts.push(`Downstream of run ${shortId(parentRunId)}`);
+  if (fanOut > 0)
+    parts.push(`${fanOut} event${fanOut === 1 ? "" : "s"} emitted`);
+  return `${parts.join(" · ")} — open the chain`;
+}
+
+/**
+ * The Run column: the id, its hover card, and the causation glyphs (WM-702).
+ * Kept a component rather than inline JSX so the row stays a concise arrow —
+ * `causationOf(r)` needs somewhere to land, and a `const` in the row body
+ * would reindent every cell below it for no change in behaviour.
+ */
+function RunIdCell({
+  run,
+  causation,
+  onJumpEvent,
+  onJumpRun,
+}: {
+  run: RunListItem;
+  causation: {
+    chainId: string | null;
+    parentRun: string | null;
+    fanOut: number;
+  };
+  onJumpEvent?: (source: string, eventId: string) => void;
+  onJumpRun?: (runId: string) => void;
+}) {
+  return (
+    <span className="flex min-w-0 items-center gap-1">
+      <RunHoverCard
+        run={run}
+        chainId={causation.chainId}
+        className="min-w-0"
+        onJumpEvent={onJumpEvent}
+        onJumpRun={onJumpRun}
+      >
+        <span className="truncate">{shortId(run.runId)}</span>
+      </RunHoverCard>
+      <CausationGlyphs
+        causedBy={causation.parentRun}
+        fanOut={causation.fanOut}
+        href={chainHref(causation.chainId, runNodeId(run.runId))}
+        title={runCausationTitle(causation.parentRun, causation.fanOut)}
+      />
+    </span>
+  );
+}
+
 const rowWash = (s: string) =>
   s === "FAILED" || s === "TIMED_OUT"
     ? "row-wash-err"
@@ -444,6 +509,50 @@ export function Runs({
     queryFn: api.status,
     ...refetchIntervals.fast,
   });
+  // Causation needs the events on either side of a run (WM-702): the origin
+  // event is the only thing carrying the chain's correlation id, and the
+  // events a run emitted are its fan-out. Same cache key as the Events view.
+  const eventsQ = useQuery({
+    queryKey: ["events", "all"],
+    queryFn: () => api.events(),
+    ...refetchIntervals.secondary,
+  });
+  const causation = useMemo(() => {
+    const originByKey = new Map<string, AdmittedEvent>();
+    const emittedCount = new Map<string, number>();
+    const emittedFirst = new Map<string, AdmittedEvent>();
+    for (const e of eventsQ.data?.events ?? []) {
+      originByKey.set(`${e.source}:${e.eventId}`, e);
+      if (!e.causationId) continue;
+      emittedCount.set(
+        e.causationId,
+        (emittedCount.get(e.causationId) ?? 0) + 1,
+      );
+      if (!emittedFirst.has(e.causationId)) emittedFirst.set(e.causationId, e);
+    }
+    return { originByKey, emittedCount, emittedFirst };
+  }, [eventsQ.data]);
+  /**
+   * Where a run sits in its chain. The chain key comes off the origin event; a
+   * run whose origin is outside the loaded page is still placed by any event
+   * it emitted, because those carry the same correlation id.
+   */
+  const causationOf = (r: RunListItem) => {
+    const origin =
+      r.eventSource && r.eventId
+        ? causation.originByKey.get(`${r.eventSource}:${r.eventId}`)
+        : undefined;
+    const emitted = causation.emittedFirst.get(r.runId);
+    return {
+      chainId: origin
+        ? chainKeyOfEvent(origin)
+        : emitted
+          ? chainKeyOfEvent(emitted)
+          : null,
+      parentRun: origin?.causationId ?? null,
+      fanOut: causation.emittedCount.get(r.runId) ?? 0,
+    };
+  };
   const rows = list.data?.runs ?? [];
   const scoped = useMemo(
     () =>
@@ -1064,10 +1173,15 @@ export function Runs({
                   className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
                 >
                   <td
-                    className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    className="mono max-w-28 overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
                     title={r.runId}
                   >
-                    {shortId(r.runId)}
+                    <RunIdCell
+                      run={r}
+                      causation={causationOf(r)}
+                      onJumpEvent={onJumpEvent}
+                      onJumpRun={onOpenFull}
+                    />
                   </td>
                   {/*
                     State cell carries no `max-w-*`/`truncate` (WM-505): its content is a


### PR DESCRIPTION
## Summary

Reading the Events or Runs table meant leaving it. The id column showed a truncated id and nothing about where that row sat in its chain, so answering "what caused this?" cost a click into the detail pane and a click back.

- **`EventHoverCard`** — type, status, publisher, causation, and a payload key summary under the pointer.
- **`RunHoverCard`** — state, agent, duration, attempts, artifact count, and origin, fetching the full run detail only while open.
- **Causation glyphs** — `↳` / `→ N` in both id cells, deep-linking to `#/chain/:correlationId/:nodeId`.

Both cards use the `HoverCard` primitive from WM-700, so they inherit its focus, Escape, and scroll-dismiss behaviour rather than reimplementing it.

## Notes for the reviewer

**Queries are gated on open.** `enabled: open` with a 30s `staleTime` means sweeping the pointer down a column does not fan out a request per row, and a second open inside that window is served from cache. `EventHoverCard.test.tsx` and `RunHoverCard.test.tsx` both assert the query count directly, so a regression here fails rather than merely getting slower.

**`↳` marks a run whose origin event was itself emitted by a run** — not merely one that names an origin event. Nearly every run does the latter, so the looser reading put an arrow on almost every row, which is decoration rather than signal. `Runs.test.tsx` covers the distinction from both sides: a triggered run gets the glyph, a run at the root of its chain does not.

**The Runs view now queries the events list.** Placing a run needs the events on both sides of it — the origin event carries the correlation id, the emitted events are the fan-out. It reuses the cache key the Events view already uses, so this is not an extra round trip in practice.

**The run id cell is a component (`RunIdCell`) rather than inline JSX.** `causationOf(r)` needs somewhere to land, and a `const` in the row body reindents every cell below it — the first version of this diff was 346 lines, of which ~250 were whitespace. It is 120 now, and `git diff -w` shows no churn. Worth knowing given this file also moves under WM-746.

**Entry chunk: 583.65 kB → 594.92 kB, against a 600 kB budget.** The build gate passes, but that leaves ~5 kB of headroom and the next feature touching an eager view will trip it. Filed as WM-768 rather than re-baselining the budget inside an unrelated PR.

## Verification

```
cd event-runtime/web && bun test src/components/EventHoverCard.test.tsx src/components/RunHoverCard.test.tsx src/views/Events.test.tsx src/views/Runs.test.tsx
```

87 pass, 0 fail. Every new test was observed failing before its implementation existed. Also green: `bunx tsc --noEmit`, `bun run lint` (620 warnings, under the 621 ratchet), `bun run format:check`, `bun run build`, `factory security`.

UX critique skipped — the critic is blocked by WM-726 / WM-730.

## Filed while working on this

- **WM-767** — two `Proposals.test.tsx` selection-safety tests fail on a clean `develop`, confirmed pre-existing at the same base commit and unrelated to these paths.
- **WM-768** — the entry chunk headroom above.

Fixes WM-702
