### PR TITLE
fix(tests): clean tracked temporary directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
     runs-on: [self-hosted, shadow]
     timeout-minutes: 15
     steps:
+      - name: Sweep stale shared-host temp directories
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+
       - name: Checkout (no action download)
         shell: bash
         env:
@@ -149,6 +154,12 @@ jobs:
         # Explicit liveness bounds declared by individual tests still win.
         run: bun test --timeout 20000 --max-concurrency=4 event-runtime/lib
 
+      - name: Sweep stale shared-host temp directories
+        if: always()
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+
   verify:
     name: Full verification
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -164,6 +175,11 @@ jobs:
     # Runaway guard only — queue time is now spent in GitHub's queue, not here.
     timeout-minutes: 45
     steps:
+      - name: Sweep stale shared-host temp directories
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+
       # No `uses:` steps in this job on purpose (WM-573). Every marketplace
       # action is fetched from codeload.github.com at "Set up job", and the
       # shadow fleet (eight runners, one egress IP, no action archive cache)
@@ -373,6 +389,12 @@ jobs:
 
           bun event-runtime/demo/seed.mjs --port "$PORT" --prefix "ci-demo"
           bun event-runtime/demo/verify.mjs --port "$PORT"
+
+      - name: Sweep stale shared-host temp directories
+        if: always()
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
 
   required-verify:
     name: Verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Sweep stale shared-host temp directories
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
       - name: Checkout (no action download)
         shell: bash
@@ -158,7 +158,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
   verify:
     name: Full verification
@@ -178,7 +178,7 @@ jobs:
       - name: Sweep stale shared-host temp directories
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
       # No `uses:` steps in this job on purpose (WM-573). Every marketplace
       # action is fetched from codeload.github.com at "Set up job", and the
@@ -394,7 +394,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
   required-verify:
     name: Verify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sweep stale shared-host temp directories
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
       - name: Checkout (no action download)
         shell: bash
@@ -131,4 +131,4 @@ jobs:
         if: always()
         shell: bash
         run: |
-          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: [self-hosted, verify-lane]
     timeout-minutes: 45
     steps:
+      - name: Sweep stale shared-host temp directories
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +
+
       - name: Checkout (no action download)
         shell: bash
         env:
@@ -121,3 +126,9 @@ jobs:
         env:
           PLAYWRIGHT_CHANNEL: chromium
         run: cd event-runtime/web && bun run test:e2e
+
+      - name: Sweep stale shared-host temp directories
+        if: always()
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} +

--- a/event-runtime/cli/process-cleanup.test.mjs
+++ b/event-runtime/cli/process-cleanup.test.mjs
@@ -1,13 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-process-cleanup-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  writeFileSync,
-} from "node:fs";
-import os from "node:os";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -79,7 +73,7 @@ describe("tracked test processes (WM-654)", () => {
   });
 
   test("detached fixtures self-destruct when their test owner disappears", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-owner-watch-"));
+    const dir = tmpDir("evrt-owner-watch-");
     const script = path.join(dir, "fixture.mjs");
     writeFileSync(
       script,
@@ -94,7 +88,7 @@ describe("tracked test processes (WM-654)", () => {
   });
 
   test("cleanup kills a spawned wrapper and its long-lived grandchild", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tracked-group-"));
+    const dir = tmpDir("evrt-tracked-group-");
     const pidFile = path.join(dir, "grandchild.pid");
     const child = spawnTracked(
       "bash",
@@ -115,7 +109,7 @@ describe("tracked test processes (WM-654)", () => {
   });
 
   test("live-stack down warns and kills old fake-adapter test runtimes", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-stale-fake-"));
+    const dir = tmpDir("evrt-stale-fake-");
     const fakeCli = path.join(dir, "event-runtime", "cli.mjs");
     mkdirSync(path.dirname(fakeCli), { recursive: true });
     writeFileSync(fakeCli, "setInterval(() => {}, 10_000);\n", "utf8");
@@ -144,7 +138,7 @@ describe("tracked test processes (WM-654)", () => {
   });
 
   test("live-stack down leaves unmarked fake-adapter runtimes alone", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-unmarked-fake-"));
+    const dir = tmpDir("evrt-unmarked-fake-");
     const fakeCli = path.join(dir, "event-runtime", "cli.mjs");
     mkdirSync(path.dirname(fakeCli), { recursive: true });
     writeFileSync(fakeCli, "setInterval(() => {}, 10_000);\n", "utf8");

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -1,15 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-serve-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { openDb } from "../lib/db.mjs";
 import {
   CLI,
@@ -27,11 +25,14 @@ import {
   spawnSupervisor,
   spawnWorker,
   waitFor,
+  registerCliTmpCleanup,
 } from "./test-helpers.mjs";
+
+registerCliTmpCleanup();
 
 describe("serve command", () => {
   test("serve --watch re-execs under bun --watch and binds", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-watch-"));
+    const home = tmpDir("evrt-watch-");
     const port = String(59000 + (process.pid % 800));
     const child = spawnTracked(
       "bun",
@@ -64,7 +65,7 @@ describe("serve command", () => {
   });
 
   test("serve binds the control API, starts the loop, and answers /health", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-serve-"));
+    const home = tmpDir("evrt-serve-");
     const port = String(59800 + (process.pid % 100));
     const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
@@ -98,7 +99,7 @@ describe("serve command", () => {
   });
 
   test("serve --adapter-override pi is accepted at the serve call site (OPS-517)", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-serve-pi-"));
+    const home = tmpDir("evrt-serve-pi-");
     const port = String(59800 + (process.pid % 150));
     const child = spawnTracked(
       "bun",

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-status-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
 import {
@@ -28,7 +27,10 @@ import {
   spawnWorker,
   throwawayRunDir,
   waitFor,
+  registerCliTmpCleanup,
 } from "./test-helpers.mjs";
+
+registerCliTmpCleanup();
 
 describe("status and doctor commands", () => {
   test("status against a dead port says serve is not running, non-zero exit", () => {
@@ -115,7 +117,7 @@ describe("status and doctor commands", () => {
   });
 
   test("doctor against a healthy live serve outputs anomalies none and exits 0", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-doc-healthy-"));
+    const home = tmpDir("evrt-doc-healthy-");
     const port = String(59700 + (process.pid % 100));
     const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env: {
@@ -159,7 +161,7 @@ describe("status and doctor commands", () => {
   });
 
   test("doctor against a live serve with an anomaly exits non-zero and reports anomaly", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-doc-anomaly-"));
+    const home = tmpDir("evrt-doc-anomaly-");
     const port = String(59600 + (process.pid % 100));
     const db = openDb(path.join(home, "runtime.db"));
     const at = new Date(Date.now() - 200_000).toISOString();
@@ -218,7 +220,7 @@ describe("status and doctor commands", () => {
 describe("pool visibility in status/doctor (WM-226)", () => {
   test("no pool ever started → no pool line and no anomaly (single-worker stacks look unchanged)", async () => {
     const { getPoolLines, readPool } = await import("../cli.mjs");
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-view-none-"));
+    const dir = tmpDir("evrt-pool-view-none-");
     try {
       const view = getPoolLines(readPool(dir), {
         runs: { byState: { QUEUED: 4 } },
@@ -232,7 +234,7 @@ describe("pool visibility in status/doctor (WM-226)", () => {
 
   test("a live supervisor reports its pool size; a dead one with a queue is an anomaly", async () => {
     const { getPoolLines, readPool } = await import("../cli.mjs");
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-view-"));
+    const dir = tmpDir("evrt-pool-view-");
     try {
       // This process stands in for a live supervisor and a live worker.
       writeFileSync(path.join(dir, "supervisor.pid"), `${process.pid}\n`);

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-supervise-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
 import { workerPassthroughArgs } from "./supervise.mjs";
@@ -27,7 +26,10 @@ import {
   spawnSupervisor,
   spawnWorker,
   waitFor,
+  registerCliTmpCleanup,
 } from "./test-helpers.mjs";
+
+registerCliTmpCleanup();
 
 describe("supervise (WM-226)", () => {
   test("passes reload and worker-shaping flags through to every pool slot (WM-613)", () => {
@@ -74,7 +76,7 @@ describe("supervise (WM-226)", () => {
   });
 
   test("refuses to be the second supervisor on one run dir — two would orphan each other's workers", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-dup-"));
+    const dir = tmpDir("evrt-pool-dup-");
     try {
       // This process stands in for a live incumbent supervisor.
       writeFileSync(
@@ -112,8 +114,8 @@ describe("supervise (WM-226)", () => {
   });
 
   test("a queued run with no idle worker spawns one within a tick, and the pool stops at workers.max", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-up-"));
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-up-run-"));
+    const home = tmpDir("evrt-pool-up-");
+    const dir = tmpDir("evrt-pool-up-run-");
     // "hang" occupies a worker for the whole spec timeout, so the queue stays
     // hot long enough for the ceiling to be the thing that stops the pool.
     for (const runId of ["run_pool_a", "run_pool_b", "run_pool_c"]) {
@@ -159,8 +161,8 @@ describe("supervise (WM-226)", () => {
   }, 60_000);
 
   test("surplus idle workers drain back to workers.min, and the pool is not respawned past target", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-down-"));
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-down-run-"));
+    const home = tmpDir("evrt-pool-down-");
+    const dir = tmpDir("evrt-pool-down-run-");
     // Two short hangs: long enough to force a second worker, short enough that
     // both go idle while the supervisor is still watching.
     for (const runId of ["run_drain_a", "run_drain_b"]) {

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -1,18 +1,17 @@
-import { expect } from "bun:test";
+import { afterAll, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
+import { cleanupTmpDirs, tmpDir } from "../test-support/tmp.mjs";
 export {
   cleanupTrackedProcesses,
   processOwnerWatchdogSource,
@@ -43,16 +42,20 @@ export const loadAdjustedTimeout = (timeoutMs) =>
 /** A loopback port nothing in these tests ever listens on. */
 export const DEAD_PORT = "59987";
 
+/** Register cleanup for this shared helper's cached temp-directory tracker. */
+export function registerCliTmpCleanup() {
+  afterAll(cleanupTmpDirs);
+}
+
 /**
  * A throwaway run dir, so nothing here reads this machine's real
  * ~/.factory/run — `status` reports the local worker pool from pidfiles
  * (WM-226), and a developer's own running stack must not change a test result.
  */
-export const throwawayRunDir = () =>
-  mkdtempSync(path.join(os.tmpdir(), "evrt-cli-run-"));
+export const throwawayRunDir = () => tmpDir("evrt-cli-run-");
 
 export function runCli(args, env = {}) {
-  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-cli-"));
+  const home = tmpDir("evrt-cli-");
   const result = spawnSync("bun", [CLI, ...args], {
     encoding: "utf8",
     env: {
@@ -119,7 +122,7 @@ export function writeGatedNotifier(dir, { exitCode = 0 } = {}) {
 }
 
 export async function assertHealthyLiveServe() {
-  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-doc-healthy-"));
+  const home = tmpDir("evrt-doc-healthy-");
   const port = String(59700 + (process.pid % 100));
   const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
     env: {
@@ -167,7 +170,7 @@ export async function runNotifierDeliveryCase({
 } = {}) {
   const { tick } = await import("../cli.mjs");
   const { loadRegistry } = await import("../lib/registry.mjs");
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tick-notify-"));
+  const dir = tmpDir("evrt-tick-notify-");
   const { outFile, pidFile, startedFile, releaseFile, stub } =
     writeGatedNotifier(dir);
   const db = openDb(path.join(dir, "runtime.db"));
@@ -247,7 +250,7 @@ export async function runNotifierDeliveryCase({
 
 /** A throwaway checkout for the code stamp to watch, so tests never dirty this repo. */
 export function makeStampRoot() {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-src-"));
+  const root = tmpDir("evrt-reload-src-");
   mkdirSync(path.join(root, "event-runtime", "lib"), { recursive: true });
   mkdirSync(path.join(root, "event-runtime", "cli"), { recursive: true });
   writeFileSync(

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-work-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
@@ -29,7 +28,10 @@ import {
   spawnSupervisor,
   spawnWorker,
   waitFor,
+  registerCliTmpCleanup,
 } from "./test-helpers.mjs";
+
+registerCliTmpCleanup();
 
 const WORKER_POLICY_VERSION = policyVersion();
 
@@ -138,7 +140,7 @@ describe("work command", () => {
       },
     };
 
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-override-"));
+    const home = tmpDir("evrt-override-");
     const claim = claimNext(db, { owner: "w1", adapterOverride: "fake" });
     expect(claim).toBeTruthy();
 
@@ -157,7 +159,7 @@ describe("work command", () => {
     const { createRun, transition } = await import("../lib/lifecycle.mjs");
     const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");
 
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-proc-"));
+    const home = tmpDir("evrt-work-proc-");
     const db = openDb(path.join(home, "runtime.db"));
 
     const input = { repos: ["ok"] };
@@ -247,7 +249,7 @@ describe("work command", () => {
   });
 
   test("work --adapter-override pi is accepted at the work call site (OPS-517)", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-pi-"));
+    const home = tmpDir("evrt-work-pi-");
     const child = spawnTracked(
       "bun",
       [CLI, "work", "--adapter-override", "pi"],
@@ -363,7 +365,7 @@ describe("work command", () => {
       },
     };
 
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-pi-smoke-"));
+    const home = tmpDir("evrt-pi-smoke-");
     const claim = claimNext(db, { owner: "w1" });
     expect(claim).toBeTruthy();
 
@@ -458,7 +460,7 @@ describe("work command", () => {
       },
     };
 
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-agy-smoke-"));
+    const home = tmpDir("evrt-agy-smoke-");
     const claim = claimNext(db, { owner: "w1" });
     expect(claim).toBeTruthy();
 
@@ -476,7 +478,7 @@ describe("work command", () => {
   });
 
   test("work --adapter-override cursor is accepted at the work call site (WM-440)", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-cursor-"));
+    const home = tmpDir("evrt-work-cursor-");
     const child = spawnTracked(
       "bun",
       [CLI, "work", "--adapter-override", "cursor"],
@@ -585,7 +587,7 @@ describe("work command", () => {
       },
     };
 
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-cursor-smoke-"));
+    const home = tmpDir("evrt-cursor-smoke-");
     const claim = claimNext(db, { owner: "w1" });
     expect(claim).toBeTruthy();
 
@@ -607,7 +609,7 @@ describe("work --reload-on-change (WM-213)", () => {
   test(
     "plain work never arms the watcher",
     async () => {
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-off-"));
+      const home = tmpDir("evrt-reload-off-");
       const stampRoot = makeStampRoot();
       const box = spawnWorker(
         ["--adapter-override", "fake", "--poll-ms", "50"],
@@ -639,7 +641,7 @@ describe("work --reload-on-change (WM-213)", () => {
   test(
     "an idle worker exits 75 within a poll interval of an uncommitted edit",
     async () => {
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-idle-"));
+      const home = tmpDir("evrt-reload-idle-");
       const stampRoot = makeStampRoot();
       const box = spawnWorker(
         ["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"],
@@ -674,7 +676,7 @@ describe("work --reload-on-change (WM-213)", () => {
   test(
     "an idle worker reloads when a per-command module changes",
     async () => {
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-command-"));
+      const home = tmpDir("evrt-reload-command-");
       const stampRoot = makeStampRoot();
       const box = spawnWorker(
         ["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"],
@@ -710,7 +712,7 @@ describe("work --reload-on-change (WM-213)", () => {
       const { createRun, transition } = await import("../lib/lifecycle.mjs");
       const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");
 
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-busy-"));
+      const home = tmpDir("evrt-reload-busy-");
       const stampRoot = makeStampRoot();
       const db = openDb(path.join(home, "runtime.db"));
 
@@ -812,8 +814,8 @@ describe("work --drain-file (WM-226)", () => {
   test(
     "a drain-signalled worker holding a lease finishes its run first, then exits 0",
     async () => {
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-drain-busy-"));
-      const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-drain-busy-run-"));
+      const home = tmpDir("evrt-drain-busy-");
+      const dir = tmpDir("evrt-drain-busy-run-");
       const drainFile = path.join(dir, "worker-1.drain");
       await seedRun(home, {
         runId: "run_drain_busy",
@@ -856,8 +858,8 @@ describe("work --drain-file (WM-226)", () => {
   test(
     "plain work ignores a drain file it was never given",
     async () => {
-      const home = mkdtempSync(path.join(os.tmpdir(), "evrt-drain-off-"));
-      const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-drain-off-run-"));
+      const home = tmpDir("evrt-drain-off-");
+      const dir = tmpDir("evrt-drain-off-run-");
       writeFileSync(path.join(dir, "worker-1.drain"), "scale-down\n", "utf8");
       const box = spawnWorker(
         ["--adapter-override", "fake", "--poll-ms", "50"],

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -1,8 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-demo-seed-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { loadAdjustedTimeout } from "../cli/test-helpers.mjs";
 import { validate } from "../lib/schema.mjs";
@@ -142,7 +141,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   let initialTriageApplyRun;
 
   beforeAll(async () => {
-    home = mkdtempSync(path.join(os.tmpdir(), "evrt-seed-test-"));
+    home = tmpDir("evrt-seed-test-");
     // Ask the OS for a genuinely free port instead of pid-modulo arithmetic:
     // on a shared self-hosted runner a leftover server from an earlier
     // (aborted) job can squat any precomputed port, and the seed then fails

--- a/event-runtime/lib/adapters/actions.test.mjs
+++ b/event-runtime/lib/adapters/actions.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-actions-test-mjs";
 import { describe, expect, test } from "bun:test";
 import {
   buildArgv,
@@ -7,12 +8,11 @@ import {
   substituteRemote,
   validateRemotePlaceholders,
 } from "./actions.mjs";
-import { mkdtempSync, readFileSync } from "node:fs";
-import os from "node:os";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { appendIssueDetail } from "../../../tools/linear.mjs";
 
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 describe("appendIssueDetail (WM-343)", () => {
   test("appends the same detail only once", () => {

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-agy-test-mjs";
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   PROMPT_SUFFIX,
@@ -439,7 +438,7 @@ describe("execute with fake binary", () => {
   }
 
   test("spawns agy, pipes transcript, records a trace of the real event shapes", async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    tmp = tmpDir("agy-test-");
     const binDir = path.join(tmp, "bin");
     mkdirSync(binDir, { recursive: true });
     writeFakeAgy(binDir, [
@@ -486,7 +485,7 @@ describe("execute with fake binary", () => {
   });
 
   test("a failed run still produces a trace carrying the error (WM-435)", async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    tmp = tmpDir("agy-test-");
     const binDir = path.join(tmp, "bin");
     mkdirSync(binDir, { recursive: true });
     // The exact shape of the 2026-08-16 agy-smoke failures: init, then a
@@ -524,7 +523,7 @@ describe("execute with fake binary", () => {
   });
 
   test("a throwing onTrace observer cannot strand execution (cf. WM-305)", async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    tmp = tmpDir("agy-test-");
     const binDir = path.join(tmp, "bin");
     mkdirSync(binDir, { recursive: true });
     writeFakeAgy(binDir, [

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-claude-test-mjs";
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   BASE_INHERITED_ENV,
@@ -49,9 +48,7 @@ describe("sandbox decision (WM-313): deferred, so refused — never ignored", ()
   });
 
   test("a sandboxed definition is refused with a typed error naming the adapter, before any spawn or workspace write", async () => {
-    const workspaceDir = realpathSync(
-      mkdtempSync(path.join(tmpdir(), "evrt-claude-sandbox-")),
-    );
+    const workspaceDir = realpathSync(tmpDir("evrt-claude-sandbox-"));
     const promptPath = path.join(workspaceDir, "prompt.md");
     writeFileSync(promptPath, "hello", "utf8");
     let caught;
@@ -520,9 +517,7 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
 });
 
 describe("execute conformance (OPS-427, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(
-    mkdtempSync(path.join(tmpdir(), "evrt-claude-test-")),
-  );
+  const tmpBase = realpathSync(tmpDir("evrt-claude-test-"));
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
 
@@ -688,7 +683,7 @@ if (behavior === "emit_denial_then_recovery") {
     rmSync(tmpBase, { recursive: true, force: true });
   });
 
-  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const ws = () => realpathSync(tmpDir("ws-", tmpBase));
   const defaultDef = {
     ref: "test-agent@1",
     promptPath: promptFile,

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-command-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
-import os from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
 import { openDb } from "../db.mjs";
@@ -14,7 +14,7 @@ import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
 
 const def = (command) => ({ ref: "test-cmd@1", command });
 const spec = (input) => ({ input });
-const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-cmd-"));
+const ws = () => tmpDir("evrt-cmd-");
 const REAPER_SCRIPT = path.join(FACTORY_ROOT, "orchestrator", "reaper.mjs");
 
 describe("resolveTemplate", () => {
@@ -287,12 +287,7 @@ describe("command-adapter registry (OPS-404)", () => {
   });
 
   test("a reaper run planned from a clock tick resolves its argv and executes", async () => {
-    const db = openDb(
-      path.join(
-        mkdtempSync(path.join(os.tmpdir(), "evrt-reaper-")),
-        "runtime.db",
-      ),
-    );
+    const db = openDb(path.join(tmpDir("evrt-reaper-"), "runtime.db"));
     // Only the reaper schedule may tick here (WM-629). Spreading the shipped
     // schedules pulled in every enabled one — e.g. merge-factory — whose
     // repository-workspace agent makes planAdmittedEvents run pinRepo(), i.e.

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-cursor-test-mjs";
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
 import {
@@ -337,9 +336,7 @@ describe("safeChildEnvironment", () => {
 });
 
 describe("execute conformance (WM-440, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(
-    mkdtempSync(path.join(tmpdir(), "evrt-cursor-test-")),
-  );
+  const tmpBase = realpathSync(tmpDir("evrt-cursor-test-"));
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
   const emptyBinDir = path.join(tmpBase, "empty-bin");
@@ -450,7 +447,7 @@ if (behavior === "emit_error_tool_result") {
     rmSync(tmpBase, { recursive: true, force: true });
   });
 
-  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const ws = () => realpathSync(tmpDir("ws-", tmpBase));
   const defaultDef = {
     ref: "test-cursor-agent@1",
     promptPath: promptFile,

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-pi-test-mjs";
 import { describe, expect, test, afterAll, afterEach } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
 import {
@@ -514,9 +513,7 @@ describe("safeChildEnvironment", () => {
 });
 
 describe("execute conformance (OPS-296, docs/event-runtime.md §6)", () => {
-  const tmpBase = realpathSync(
-    mkdtempSync(path.join(tmpdir(), "evrt-pi-test-")),
-  );
+  const tmpBase = realpathSync(tmpDir("evrt-pi-test-"));
   const stubBinDir = path.join(tmpBase, "bin");
   mkdirSync(stubBinDir, { recursive: true });
   const emptyBinDir = path.join(tmpBase, "empty-bin");
@@ -634,7 +631,7 @@ process.stdin.on("end", () => {
     rmSync(tmpBase, { recursive: true, force: true });
   });
 
-  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const ws = () => realpathSync(tmpDir("ws-", tmpBase));
   const defaultDef = {
     ref: "test-pi-agent@1",
     promptPath: promptFile,
@@ -1002,11 +999,9 @@ process.stdin.on("end", () => {
  * an actual guest, skipping (not failing) where `preflight()` says no.
  */
 describe("sandboxed execution (WM-313)", () => {
-  const tmpBase = realpathSync(
-    mkdtempSync(path.join(tmpdir(), "evrt-pi-sandbox-")),
-  );
+  const tmpBase = realpathSync(tmpDir("evrt-pi-sandbox-"));
   afterAll(() => rmSync(tmpBase, { recursive: true, force: true }));
-  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const ws = () => realpathSync(tmpDir("ws-", tmpBase));
   const promptFile = path.join(tmpBase, "prompt.md");
   writeFileSync(promptFile, "You are a sandboxed test agent.", "utf8");
 

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-sandboxed-test-mjs";
 /**
  * The sandbox decision seam (WM-313) — and the conformance sweep that makes
  * "no adapter ignores def.sandbox" a property of the suite rather than a
@@ -8,8 +9,7 @@
  * behaviour is proven in pi.test.mjs behind `preflight()`.
  */
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
 import {
@@ -26,7 +26,7 @@ import {
   withStdinFile,
 } from "./sandboxed.mjs";
 
-const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-sandboxed-"));
+const ws = () => tmpDir("evrt-sandboxed-");
 const sandboxDef = (extra = {}) => ({
   ref: "sandboxed@1",
   sandbox: { provider: "gondolin", allowedHosts: [] },

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-artifacts-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -35,9 +37,15 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
+
 describe("artifact store and agent registry surfacing (OPS-212)", () => {
   test("GET /artifacts catalogues and filters metadata; POST /artifacts/prune dry-runs and applies", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-artifacts-api-"));
+    const home = tmpDir("evrt-artifacts-api-");
     const store = path.join(home, "artifacts");
     mkdirSync(store, { recursive: true });
     const reportHash = "a".repeat(64);
@@ -167,7 +175,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
   test("declared artifacts and the transcript survive the workspace and stream from the API", async () => {
     const { db, server, port } = await makeServer();
     const client = apiClient({ port });
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+    const home = tmpDir("evrt-home-");
     try {
       await client.replay(
         envelope({ eventId: "art-1", payload: { repos: ["with-artifact"] } }),
@@ -205,7 +213,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
   });
 
   test("GET /artifacts/:hash streams stored bytes; unknown and malformed hashes 404", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+    const home = tmpDir("evrt-home-");
     const db = openDb(path.join(home, "runtime.db"));
     const server = startApi({
       db,

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -1,7 +1,19 @@
+import path from "node:path";
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-chain-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { chainKeyOf, chainView } from "./api-chain.mjs";
-import { envelope, makeServer, registry } from "./api-test-helpers.mjs";
+import {
+  envelope,
+  makeServer as makeApiServer,
+  registry,
+} from "./api-test-helpers.mjs";
 import { admitChainEvent } from "./chain.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 /**
  * Chain trace endpoint (WM-527). Fixture is a fan-out tree:

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -1,10 +1,19 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-config-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { configView } from "./api-config.mjs";
-import { makeServer } from "./api-test-helpers.mjs";
+import { makeServer as makeApiServer } from "./api-test-helpers.mjs";
 import { reposView } from "./repos.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 function repo(name = "factory") {
   return {
@@ -28,7 +37,7 @@ function repo(name = "factory") {
 }
 
 function fixtureRoot() {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-config-view-"));
+  const root = tmpDir("evrt-config-view-");
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(
     path.join(root, "config", "policy.yaml"),

--- a/event-runtime/lib/api-http.test.mjs
+++ b/event-runtime/lib/api-http.test.mjs
@@ -1,3 +1,4 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-http-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,9 +16,8 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
   os,
@@ -34,6 +34,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("Host and Origin header security confinement (OPS-408)", () => {
   let s;

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -1,3 +1,4 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-inbox-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,9 +16,8 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
   os,
@@ -34,6 +34,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("human inbox API (WM-285)", () => {
   test("POST writes before a failed delivery, rejects unknown kinds, and GET/ack/resolve filter rows", async () => {

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-intake-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { spawnTracked } from "./test-helpers-process.mjs";
@@ -17,12 +21,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -36,6 +38,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("webhook intake (§14)", () => {
   let s;
@@ -459,7 +467,7 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
   });
 
   test("GET /status reports proposalsPilingUp anomaly when open proposals exceed threshold (WM-124)", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-piling-test-"));
+    const dir = tmpDir("evrt-piling-test-");
     const db = openDb(path.join(dir, "runtime.db"));
     const at = new Date().toISOString();
 
@@ -496,7 +504,7 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
   });
 
   test("serve with invalid non-numeric FACTORY_EVENT_PORT fails loudly", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-port-err-"));
+    const home = tmpDir("evrt-port-err-");
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
 
     const child = spawnTracked("bun", [CLI, "serve"], {
@@ -518,7 +526,7 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
   });
 
   test("serve startup banner warns when FACTORY_EVENT_SECRET is unset", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-banner-"));
+    const home = tmpDir("evrt-banner-");
     const port = String(59600 + (process.pid % 200));
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
 

--- a/event-runtime/lib/api-metrics.test.mjs
+++ b/event-runtime/lib/api-metrics.test.mjs
@@ -1,3 +1,4 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-metrics-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,9 +16,8 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
   os,
@@ -34,6 +34,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("metrics query API (WM-281)", () => {
   let s;

--- a/event-runtime/lib/api-observed-model.test.mjs
+++ b/event-runtime/lib/api-observed-model.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-observed-model-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -34,6 +36,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("model surfacing on run views (WM-221)", () => {
   test("reads the claude harness's own init line", () => {
@@ -91,7 +99,7 @@ describe("model surfacing on run views (WM-221)", () => {
   });
 
   test("the run list carries the plan-time pins and the detail carries observedModel", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+    const home = tmpDir("evrt-home-");
     const { db, server, port, close } = await makeServer({
       env: { name: "test", home },
     });

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-registry-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -34,6 +36,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("agent and repository registry surfacing (OPS-212)", () => {
   test("GET /agents exposes definitions, prompt text, schemas, pins, and routing", async () => {
@@ -66,7 +74,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
   });
 
   test("GET /repos serves the repos.yaml registry, dispatch mode included (OPS-299)", async () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-api-repos-"));
+    const root = tmpDir("evrt-api-repos-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     writeFileSync(
       path.join(root, "config", "repos.yaml"),
@@ -118,7 +126,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
   });
 
   test("GET /repos names a missing repos.yaml instead of a bare internal_error", async () => {
-    const empty = mkdtempSync(path.join(os.tmpdir(), "evrt-api-norepos-"));
+    const empty = tmpDir("evrt-api-norepos-");
     const { server, port, close } = await makeServer({
       repos: () => loadRepos({ root: empty }),
     });
@@ -135,7 +143,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
   });
 
   test("GET /repos surfaces malformed repos.yaml as RepoError instead of internal_error (OPS-346)", async () => {
-    const malformed = mkdtempSync(path.join(os.tmpdir(), "evrt-api-badrepos-"));
+    const malformed = tmpDir("evrt-api-badrepos-");
     mkdirSync(path.join(malformed, "config"), { recursive: true });
     writeFileSync(
       path.join(malformed, "config", "repos.yaml"),

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-runs-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -35,13 +37,19 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
+
 describe("run deadline extension (WM-566)", () => {
   const start = Date.parse("2026-08-12T10:00:00Z");
   // The policy cap the extend endpoint enforces, owned by this suite rather
   // than by the live config/policy.yaml (WM-692).
   const MAX_RUN_MINUTES = 60;
   function policyRootWith(maxRunMinutes) {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-policy-"));
+    const root = tmpDir("evrt-policy-");
     mkdirSync(path.join(root, "config"));
     if (maxRunMinutes !== null) {
       writeFileSync(
@@ -441,7 +449,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
   let s;
   let flowProposalId;
   let flowRunId;
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-api-ws-"));
+  const workspaces = tmpDir("evrt-api-ws-");
   // event-types.json maps to the "pi" adapter (WM-215); back it with the fake so
   // no real pi process ever spawns in tests.
   const adapters = { pi: fake };
@@ -709,7 +717,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         registry,
         { pi: fake, fake },
         {
-          workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
+          workspacesRoot: tmpDir("evrt-ws-"),
           owner: "test-worker",
           policyVersion: PV,
         },
@@ -754,7 +762,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         registry,
         { pi: fake, fake },
         {
-          workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
+          workspacesRoot: tmpDir("evrt-ws-"),
           owner: "test-worker",
           policyVersion: PV,
         },
@@ -935,7 +943,7 @@ describe("run trace surfacing (OPS-295)", () => {
         registry,
         { pi: fake, fake },
         {
-          workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
+          workspacesRoot: tmpDir("evrt-ws-"),
           owner: "test-worker",
           policyVersion: PV,
         },

--- a/event-runtime/lib/api-schedules.test.mjs
+++ b/event-runtime/lib/api-schedules.test.mjs
@@ -1,3 +1,4 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-schedules-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,9 +16,8 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
   os,
@@ -34,6 +34,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 function isolatedScheduleRegistry() {
   const agents = new Map(registry.agents);

--- a/event-runtime/lib/api-status-cache.test.mjs
+++ b/event-runtime/lib/api-status-cache.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-status-cache-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -35,10 +37,16 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
+
 describe("status artifact store stats caching (OPS-456)", () => {
   test("GET /status caches storeStats across repeated calls within TTL", async () => {
     let nowMs = 1000000;
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-status-cache-"));
+    const home = tmpDir("evrt-status-cache-");
     const s = await makeServer({
       env: { name: "test-env", home, adapter: null },
       now: () => nowMs,
@@ -79,7 +87,7 @@ describe("status artifact store stats caching (OPS-456)", () => {
   });
 
   test("statusView resolves artifacts root from env.home", async () => {
-    const customHome = mkdtempSync(path.join(os.tmpdir(), "evrt-custom-home-"));
+    const customHome = tmpDir("evrt-custom-home-");
     const storeDir = path.join(customHome, "artifacts");
     mkdirSync(storeDir, { recursive: true });
     const hash = "c".repeat(64);

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-status-view-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -34,6 +36,12 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("StatusView and Worker client types pinned to API response (OPS-284)", () => {
   const typesPath = path.resolve(import.meta.dir, "../web/src/types.ts");
@@ -102,7 +110,7 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
   }
 
   test("GET /status keys and types strictly match StatusView and nested types", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-status-contract-"));
+    const dir = tmpDir("evrt-status-contract-");
     const db = openDb(path.join(dir, "runtime.db"));
     const nowMs = 100000000;
 
@@ -314,7 +322,7 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
   });
 
   test("GET /workers keys and types strictly match Worker verbatim", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-workers-contract-"));
+    const dir = tmpDir("evrt-workers-contract-");
     const db = openDb(path.join(dir, "runtime.db"));
     const nowMs = 100000000;
 
@@ -409,7 +417,7 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
   });
 
   test("noWorkers anomaly transitions to true when QUEUED runs exist and live worker count is 0", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-noworkers-contract-"));
+    const dir = tmpDir("evrt-noworkers-contract-");
     const db = openDb(path.join(dir, "runtime.db"));
     const nowMs = 100000000;
     const atIso = new Date(nowMs).toISOString();
@@ -463,9 +471,7 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
   });
 
   test("GET /status identifies queued runs whose placement matches no active, non-stale worker", async () => {
-    const dir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-unmatched-placement-contract-"),
-    );
+    const dir = tmpDir("evrt-unmatched-placement-contract-");
     const db = openDb(path.join(dir, "runtime.db"));
     const nowMs = 100000000;
     const atIso = new Date(nowMs).toISOString();

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1,3 +1,7 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-api-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   GH_SECRET,
@@ -15,12 +19,10 @@ import {
   janitorArgv,
   loadRegistry,
   loadRepos,
-  makeServer,
+  makeServer as makeApiServer,
   mkdirSync,
-  mkdtempSync,
   observedModelFromTranscript,
   openDb,
-  os,
   path,
   planAdmittedEvents,
   readFileSync,
@@ -40,6 +42,12 @@ import { createInboxItem } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 import { hashJson } from "./canonical.mjs";
 import { spawnTracked } from "./test-helpers-process.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
 
 describe("inbox decision API (WM-390)", () => {
   const request = {
@@ -342,7 +350,7 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
   });
 
   test("a drifted view is served as null and named in /status.anomalies.configuration", async () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-view-"));
+    const root = tmpDir("evrt-view-");
     for (const dir of ["agents", "schemas"]) {
       cpSync(path.join(registry.root, dir), path.join(root, dir), {
         recursive: true,
@@ -378,7 +386,7 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
 
 describe("environment identity (webui chip)", () => {
   test("health and status expose the env the server was started with", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-env-"));
+    const dir = tmpDir("evrt-env-");
     const db = openDb(path.join(dir, "runtime.db"));
     const server = startApi({
       db,
@@ -404,7 +412,7 @@ describe("serve PID lock (OPS-458)", () => {
   test("acquireServeLock acquires lock in empty runtime home and releaseServeLock removes it", async () => {
     const { acquireServeLock, releaseServeLock, serveLockPath } =
       await import("../cli.mjs");
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));
+    const home = tmpDir("evrt-lock-");
     const lock = acquireServeLock(home, 7381);
     expect(lock.pid).toBe(process.pid);
     expect(lock.port).toBe(7381);
@@ -423,7 +431,7 @@ describe("serve PID lock (OPS-458)", () => {
   test("acquireServeLock fails when locked by a live process with clear PID and port", async () => {
     const { acquireServeLock, releaseServeLock, serveLockPath } =
       await import("../cli.mjs");
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));
+    const home = tmpDir("evrt-lock-");
     const lockFile = serveLockPath(home);
     const { writeFileSync } = await import("node:fs");
     const { spawn } = await import("node:child_process");
@@ -451,7 +459,7 @@ describe("serve PID lock (OPS-458)", () => {
   test("acquireServeLock reclaims a stale lock from a dead process", async () => {
     const { acquireServeLock, releaseServeLock, serveLockPath } =
       await import("../cli.mjs");
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));
+    const home = tmpDir("evrt-lock-");
     const lockFile = serveLockPath(home);
     const { writeFileSync, readFileSync } = await import("node:fs");
 
@@ -475,7 +483,7 @@ describe("serve PID lock (OPS-458)", () => {
   });
 
   test("concurrent duplicate serve on same home fails second instance and releasing first allows next", async () => {
-    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-cli-"));
+    const home = tmpDir("evrt-lock-cli-");
     const port1 = String(59500 + (process.pid % 200));
     const port2 = String(59700 + (process.pid % 200));
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");

--- a/event-runtime/lib/artifact-inputs.test.mjs
+++ b/event-runtime/lib/artifact-inputs.test.mjs
@@ -1,12 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-artifact-inputs-test-mjs";
 import { describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
-import os from "node:os";
+import { mkdirSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   materializeArtifact,
@@ -27,7 +21,7 @@ import { createWorkspace, resolveInputRef } from "./workspace.mjs";
 
 const registry = loadRegistry();
 
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 /** Put bytes in a store the way the worker does: keyed by their own hash. */
 function store(bytes, storeRoot = tmp("evrt-store-")) {

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-artifacts-test-mjs";
 import { describe, expect, test } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   artifactPath,
@@ -24,7 +23,7 @@ import {
 import { sha256Hex } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
 
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 function makeStore(bytes, storeRoot = tmp("evrt-store-")) {
   mkdirSync(storeRoot, { recursive: true });

--- a/event-runtime/lib/backup.test.mjs
+++ b/event-runtime/lib/backup.test.mjs
@@ -1,15 +1,14 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-backup-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import {
   copyFileSync,
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   backupArtifacts,
@@ -20,8 +19,7 @@ import {
 } from "./backup.mjs";
 import { openDb } from "./db.mjs";
 
-const freshDir = (prefix = "evrt-backup-") =>
-  mkdtempSync(path.join(os.tmpdir(), prefix));
+const freshDir = (prefix = "evrt-backup-") => tmpDir(prefix);
 
 describe("WAL-safe backup and integrity check (OPS-414)", () => {
   test("checkIntegrity reports ok on a valid database", () => {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-chain-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { cpSync, mkdtempSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { cpSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { admitChainEvent, buildChainInput, resolveChains } from "./chain.mjs";
@@ -32,9 +32,9 @@ function failedRunEnvelope(overrides = {}) {
 }
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-"));
+  const dir = tmpDir("evrt-chain-");
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-ws-"));
+  const workspaces = tmpDir("evrt-chain-ws-");
   // Chain flow under test never spawns real processes: pi AND command
   // both back onto the contract-shaped fake.
   const adapters = { pi: fake, command: fake };
@@ -282,7 +282,7 @@ describe("registry gates (OPS-223)", () => {
   });
 
   test("edges validation fails closed: unregistered targets and stray input roots", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-reg-"));
+    const root = tmpDir("evrt-reg-");
     cpSync(path.join(registry.root, "agents"), path.join(root, "agents"), {
       recursive: true,
     });
@@ -417,7 +417,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   }
 
   test("fans out N planned items into N admitted chain events with chain-<runId>-<itemKey> IDs", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-multi-"));
+    const dir = tmpDir("evrt-chain-multi-");
     const db = openDb(path.join(dir, "runtime.db"));
 
     seedCompletedRun(db, {
@@ -460,7 +460,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("empty plan skips cleanly without error", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-empty-"));
+    const dir = tmpDir("evrt-chain-empty-");
     const db = openDb(path.join(dir, "runtime.db"));
 
     seedCompletedRun(db, {
@@ -482,7 +482,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("custom eventId templating and perItem mapping overlays", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-tmpl-"));
+    const dir = tmpDir("evrt-chain-tmpl-");
     const db = openDb(path.join(dir, "runtime.db"));
 
     const customRegistry = {
@@ -528,7 +528,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("missing itemKey records error cleanly", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-err-"));
+    const dir = tmpDir("evrt-chain-err-");
     const db = openDb(path.join(dir, "runtime.db"));
 
     seedCompletedRun(db, {
@@ -549,9 +549,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("triage-apply outcome edges route to the correct follow-up", () => {
-    const dir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-chain-triage-apply-1"),
-    );
+    const dir = tmpDir("evrt-chain-triage-apply-1");
     const db = openDb(path.join(dir, "runtime.db"));
 
     seedCompletedRun(db, {
@@ -575,9 +573,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
       repo: "wm/triage",
     });
 
-    const dir2 = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-chain-triage-apply-2"),
-    );
+    const dir2 = tmpDir("evrt-chain-triage-apply-2");
     const db2 = openDb(path.join(dir2, "runtime.db"));
     seedCompletedRun(db2, {
       runId: "run-triage-detail",
@@ -600,9 +596,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
       .get("chain-run-triage-detail");
     expect(detailEvent).toBeNull();
 
-    const dir3 = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-chain-triage-apply-3"),
-    );
+    const dir3 = tmpDir("evrt-chain-triage-apply-3");
     const db3 = openDb(path.join(dir3, "runtime.db"));
     seedCompletedRun(db3, {
       runId: "run-triage-nochange",
@@ -669,7 +663,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("non-completed runs do not generate chain candidates", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-triage-fail-"));
+    const dir = tmpDir("evrt-chain-triage-fail-");
     const db = openDb(path.join(dir, "runtime.db"));
     const now = new Date().toISOString();
 

--- a/event-runtime/lib/concurrency.test.mjs
+++ b/event-runtime/lib/concurrency.test.mjs
@@ -1,5 +1,5 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-concurrency-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { openDb } from "./db.mjs";
@@ -48,7 +48,7 @@ function queueRun(
 
 describe("multi-process concurrency (OPS-424, OPS-233)", () => {
   test("multi-process claiming: N concurrent workers claim M runs with zero duplicates and monotonic tokens", async () => {
-    const home = createIsolatedHome("evrt-mp-claim-");
+    const home = trackTmpDir(createIsolatedHome("evrt-mp-claim-"));
     const dbFile = path.join(home, "runtime.db");
     const db = openDb(dbFile);
 
@@ -136,7 +136,7 @@ describe("multi-process concurrency (OPS-424, OPS-233)", () => {
   });
 
   test("multi-process placement: concurrent workers with distinct placement labels claim correct runs", async () => {
-    const home = createIsolatedHome("evrt-mp-placement-");
+    const home = trackTmpDir(createIsolatedHome("evrt-mp-placement-"));
     const dbFile = path.join(home, "runtime.db");
     const db = openDb(dbFile);
 

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -1,14 +1,16 @@
+import {
+  tmpDir,
+  trackTmpDir,
+} from "../test-support/tmp.mjs?file=event-runtime-lib-db-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import {
   appendFileSync,
   mkdirSync,
-  mkdtempSync,
   rmSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   CURRENT_SCHEMA_VERSION,
@@ -25,8 +27,7 @@ import {
 } from "./db.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
-const freshFile = () =>
-  path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-db-")), "runtime.db");
+const freshFile = () => path.join(tmpDir("evrt-db-"), "runtime.db");
 
 describe("cold start (OPS-376, OPS-424)", () => {
   test("a second connection to a brand-new database does not fight for the WAL switch", () => {
@@ -507,7 +508,7 @@ describe("hermetic execution guard (OPS-425)", () => {
 
   test("isolated home directories never mutate the operator's real ~/.factory", () => {
     const before = realFactorySnapshot();
-    const isolated = createIsolatedHome("evrt-guard-test-");
+    const isolated = trackTmpDir(createIsolatedHome("evrt-guard-test-"));
     const testDbPath = path.join(isolated, "runtime.db");
     const db = openDb(testDbPath);
     db.query(`INSERT INTO counters (name, value) VALUES ('guard', 42)`).run();
@@ -520,7 +521,7 @@ describe("hermetic execution guard (OPS-425)", () => {
   });
 
   test("detects a write to runtime.db in a supplied real-home fixture", () => {
-    const factoryHome = mkdtempSync(path.join(os.tmpdir(), "evrt-real-home-"));
+    const factoryHome = tmpDir("evrt-real-home-");
     const eventHome = path.join(factoryHome, "event-runtime");
     const dbPath = path.join(eventHome, "runtime.db");
     try {

--- a/event-runtime/lib/disk.test.mjs
+++ b/event-runtime/lib/disk.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-disk-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
+import { rmSync } from "node:fs";
 import path from "node:path";
 import {
   DEFAULT_MIN_FREE_BYTES,
@@ -13,7 +13,7 @@ import {
   getDiskSpace,
 } from "./disk.mjs";
 
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 describe("DiskSpaceError", () => {
   test("creates error with proper message and properties", () => {

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-dispatch-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { writeWorkerLease } from "../../lib/worker-leases.mjs";
 import { openDb } from "./db.mjs";
@@ -40,14 +39,10 @@ const calls = () =>
   existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : [];
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-factory-"));
+  const root = tmpDir("evrt-dispatch-factory-");
   fixtures.push(root);
-  repoDir = realpathSync(
-    mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-repo-")),
-  );
-  wtRoot = realpathSync(
-    mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-trees-")),
-  );
+  repoDir = realpathSync(tmpDir("evrt-dispatch-repo-"));
+  wtRoot = realpathSync(tmpDir("evrt-dispatch-trees-"));
   fixtures.push(repoDir, wtRoot);
   callsLog = path.join(repoDir, "calls.log");
 
@@ -104,9 +99,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(
-    path.join(os.tmpdir(), "evrt-dispatch-home-"),
-  );
+  process.env.FACTORY_EVENT_HOME = tmpDir("evrt-dispatch-home-");
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -192,9 +185,7 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
   });
 
   test("the cap counts the dispatcher's own live lease ledger (shared budget, §3)", () => {
-    const leaseDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-dispatch-leases-"),
-    );
+    const leaseDir = tmpDir("evrt-dispatch-leases-");
     fixtures.push(leaseDir);
     writeWorkerLease({
       repo: "wt29",
@@ -471,13 +462,8 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
   };
 
   test("an approved dispatch run builds the worktree by delegation, completes, and tears it down", async () => {
-    const db = openDb(
-      path.join(
-        mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-db-")),
-        "runtime.db",
-      ),
-    );
-    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    const db = openDb(path.join(tmpDir("evrt-dispatch-db-"), "runtime.db"));
+    const workspaces = tmpDir("evrt-dispatch-ws-");
     fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
 
     admitEvent(
@@ -539,7 +525,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
 
   test("execution rechecks stale security eligibility before worktree and adapter", async () => {
     const db = openDb(":memory:");
-    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    const workspaces = tmpDir("evrt-dispatch-ws-");
     fixtures.push(workspaces);
     let labels = [{ name: "ai:agent-ready" }];
     let adapterCalls = 0;
@@ -591,7 +577,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
 
   test("a failing run without retain still tears the worktree down (down-on-failure)", async () => {
     const db = openDb(":memory:");
-    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    const workspaces = tmpDir("evrt-dispatch-ws-");
     fixtures.push(workspaces);
 
     admitEvent(

--- a/event-runtime/lib/intake-github.test.mjs
+++ b/event-runtime/lib/intake-github.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-intake-github-test-mjs";
 /**
  * GitHub webhook intake (WM-112): GitHub's raw-body HMAC verified with a
  * dedicated secret, deliveries translated into `factory.event/v1` envelopes
@@ -6,8 +7,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { mkdtempSync } from "node:fs";
-import os from "node:os";
+
 import path from "node:path";
 import { startApi } from "./api.mjs";
 import { openDb } from "./db.mjs";
@@ -370,7 +370,7 @@ describe("translateGitHubEvent (WM-112)", () => {
 describe("POST /github route (WM-112)", () => {
   let s;
   beforeAll(async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-gh-api-"));
+    const dir = tmpDir("evrt-gh-api-");
     const db = openDb(path.join(dir, "runtime.db"));
     const onEvents = [];
     const server = startApi({

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-notify-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { openDb } from "./db.mjs";
 import {
@@ -12,7 +12,7 @@ import {
   sendNotification,
 } from "./notify.mjs";
 
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 /** A stub notifier that appends its message argument to `outFile`. */
 function stubNotifier(dir, { exitCode = 0 } = {}) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1,7 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-planner-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { DEAD_LETTER_AFTER } from "./config.mjs";
@@ -88,7 +88,7 @@ describe("idempotencyKeyFor", () => {
 
 describe("merge concurrency policy", () => {
   test("reads a positive integer max_concurrent_merges and fails safe otherwise", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-policy-"));
+    const root = tmpDir("evrt-merge-policy-");
     mkdirSync(path.join(root, "config"));
     const policy = path.join(root, "config", "policy.yaml");
 
@@ -744,7 +744,7 @@ describe("planEvent worktree gate (WM-108)", () => {
   }
 
   function withReposRoot(yaml, fn) {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-plan-wt-"));
+    const root = tmpDir("evrt-plan-wt-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
     const previous = process.env.FACTORY_REPOS_ROOT;
@@ -1662,7 +1662,7 @@ describe("planAdmittedEvents", () => {
   });
 
   test("holds write transaction from second connection and does not increment plan_failures or dead-letter (OPS-451)", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-planner-"));
+    const dir = tmpDir("evrt-planner-");
     const file = path.join(dir, "test.db");
     const db1 = openDb(file);
     const db2 = openDb(file);
@@ -1690,7 +1690,7 @@ describe("planAdmittedEvents", () => {
   });
 
   test("three consecutive lock collisions leave the event admitted, not dead_lettered (OPS-451)", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-planner-"));
+    const dir = tmpDir("evrt-planner-");
     const file = path.join(dir, "test.db");
     const db1 = openDb(file);
     const db2 = openDb(file);
@@ -1716,9 +1716,9 @@ describe("planAdmittedEvents", () => {
   });
 
   test("TTL re-plan preserves repoPin for repository workspace agent across expiry (OPS-418)", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-plan-factory-"));
+    const root = tmpDir("evrt-plan-factory-");
     mkdirSync(path.join(root, "config"), { recursive: true });
-    const repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-repo-"));
+    const repoDir = tmpDir("evrt-repo-");
     execFileSync("git", ["init", "--quiet", "--initial-branch=develop"], {
       cwd: repoDir,
     });
@@ -1737,9 +1737,7 @@ describe("planAdmittedEvents", () => {
     const oldReposRoot = process.env.FACTORY_REPOS_ROOT;
     const oldHome = process.env.FACTORY_EVENT_HOME;
     process.env.FACTORY_REPOS_ROOT = root;
-    process.env.FACTORY_EVENT_HOME = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-plan-home-"),
-    );
+    process.env.FACTORY_EVENT_HOME = tmpDir("evrt-plan-home-");
 
     try {
       const db = openDb(":memory:");
@@ -1811,7 +1809,7 @@ describe("planAdmittedEvents", () => {
       new Date(NOW).toISOString(),
     );
 
-    const artifactStore = mkdtempSync(path.join(os.tmpdir(), "evrt-pm-store-"));
+    const artifactStore = tmpDir("evrt-pm-store-");
     const transcriptSha =
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     writeFileSync(path.join(artifactStore, transcriptSha), "{}");

--- a/event-runtime/lib/postmortem.test.mjs
+++ b/event-runtime/lib/postmortem.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-postmortem-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync } from "node:fs";
-import os from "node:os";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
@@ -13,7 +13,7 @@ import { runOnce } from "./worker.mjs";
 
 const registry = loadRegistry();
 const PV = "git:test-pv";
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 function harness() {
   const db = openDb(path.join(tmp("evrt-pm-"), "runtime.db"));

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -1,12 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-registry-test-mjs";
 import { describe, expect, test } from "bun:test";
-import {
-  cpSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes } from "./canonical.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
@@ -27,7 +21,7 @@ import { computeDefHash } from "./receipts.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
 function tempRegistry() {
-  const root = mkdtempSync(path.join(tmpdir(), "event-registry-"));
+  const root = tmpDir("event-registry-");
   for (const dir of ["agents", "schemas"]) {
     cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), {
       recursive: true,
@@ -62,7 +56,7 @@ function samplePack(
 }
 
 function tempPack({ name = "sample", namespace = "sample" } = {}) {
-  const root = mkdtempSync(path.join(tmpdir(), "event-pack-"));
+  const root = tmpDir("event-pack-");
   cpSync(SAMPLE_PACK_ROOT, root, { recursive: true });
   writeFileSync(
     path.join(root, "pack.json"),
@@ -395,7 +389,7 @@ describe("registry", () => {
   });
 
   test("loadPackRoots reads only policy-listed roots and validates fail-closed", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "event-policy-packs-"));
+    const root = tmpDir("event-policy-packs-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     const policy = path.join(root, "config", "policy.yaml");
     expect(loadPackRoots({ root })).toEqual([]);
@@ -729,7 +723,7 @@ describe("registry", () => {
   });
 
   test("loadModelTierMap: reads policy.yaml, validates shape fail-closed, tolerates absence (WM-135)", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "event-policy-"));
+    const root = tmpDir("event-policy-");
     expect(loadModelTierMap({ root })).toEqual({}); // no policy.yaml at all
     mkdirSync(path.join(root, "config"), { recursive: true });
     const write = (yaml) =>

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-repos-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   loadRepos,
@@ -21,7 +21,7 @@ afterAll(() => {
  * make these assertions a description of today's registry.
  */
 function factoryRoot(yaml) {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-repos-"));
+  const root = tmpDir("evrt-repos-");
   scratch.push(root);
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
@@ -134,7 +134,7 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
   });
 
   test("a missing config fails closed rather than reporting an empty registry", () => {
-    const empty = mkdtempSync(path.join(os.tmpdir(), "evrt-repos-empty-"));
+    const empty = tmpDir("evrt-repos-empty-");
     scratch.push(empty);
     expect(() => loadRepos({ root: empty })).toThrow(RepoError);
   });

--- a/event-runtime/lib/repository.test.mjs
+++ b/event-runtime/lib/repository.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-repository-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { expandHome, getRepo, loadRepos, RepoError } from "./repos.mjs";
 import {
@@ -22,7 +21,7 @@ import {
 
 const scratch = [];
 const tmp = (prefix) => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = tmpDir(prefix);
   scratch.push(dir);
   return dir;
 };

--- a/event-runtime/lib/sandbox/invariants.test.mjs
+++ b/event-runtime/lib/sandbox/invariants.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-sandbox-invariants-test-mjs";
 /**
  * Real-VM invariant tests (WM-185).
  *
@@ -17,8 +18,7 @@
  * generous; warm boots measured 51-93ms on macOS arm64.
  */
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { KILL_GRACE_MS, preflight, runInSandbox } from "./gondolin.mjs";
 
@@ -29,7 +29,7 @@ if (!report.available) {
 }
 
 const VM_TIMEOUT_MS = 180_000;
-const workspace = () => mkdtempSync(path.join(os.tmpdir(), "evrt-sandbox-"));
+const workspace = () => tmpDir("evrt-sandbox-");
 
 describe("gondolin sandbox invariants", () => {
   itVM(

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-schedules-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import os from "node:os";
+
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { openDb } from "./db.mjs";
@@ -22,10 +22,7 @@ import { runOnce } from "./worker.mjs";
 
 const PV = "git:test-pv";
 const base = loadRegistry();
-const db = () =>
-  openDb(
-    path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-sched-")), "runtime.db"),
-  );
+const db = () => openDb(path.join(tmpDir("evrt-sched-"), "runtime.db"));
 
 /** The real registry with one loop overridden — schedules are just data. */
 const withLoop = (overrides = {}) => ({
@@ -400,8 +397,8 @@ describe("emitDueTicks (§3)", () => {
 describe("planning a tick (§5, §6)", () => {
   const adapters = { command: fake, claude: fake };
   const workerOpts = () => ({
-    workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-ws-")),
-    artifactStore: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-store-")),
+    workspacesRoot: tmpDir("evrt-sched-ws-"),
+    artifactStore: tmpDir("evrt-sched-store-"),
     owner: "w",
     policyVersion: PV,
   });
@@ -615,8 +612,8 @@ describe("planning a tick (§5, §6)", () => {
 describe("scheduleView (§9)", () => {
   const adapters = { command: fake, claude: fake };
   const workerOpts = () => ({
-    workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-ws-")),
-    artifactStore: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-store-")),
+    workspacesRoot: tmpDir("evrt-sched-ws-"),
+    artifactStore: tmpDir("evrt-sched-store-"),
     owner: "w",
     policyVersion: PV,
   });

--- a/event-runtime/lib/slice2.test.mjs
+++ b/event-runtime/lib/slice2.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-slice2-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as actions from "./adapters/actions.mjs";
 import * as fake from "./adapters/fake.mjs";
@@ -37,9 +37,9 @@ function alertEnvelope(overrides = {}) {
 }
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-"));
+  const dir = tmpDir("evrt-s2-");
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-ws-"));
+  const workspaces = tmpDir("evrt-s2-ws-");
   const adapters = { pi: fake, actions: fake };
   const workerOpts = {
     workspacesRoot: workspaces,
@@ -172,9 +172,9 @@ describe("actions adapter (OPS-208)", () => {
   }
 
   test("probes before/after, executes registered actions, artifact matches evidence", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    const dir = tmpDir("evrt-act-");
     writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
-    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+    const workspaceDir = tmpDir("evrt-act-ws-");
 
     const outcome = await actions.execute({
       spec: {
@@ -199,9 +199,9 @@ describe("actions adapter (OPS-208)", () => {
   });
 
   test("unregistered action ID refuses before executing anything", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    const dir = tmpDir("evrt-act-");
     writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
-    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+    const workspaceDir = tmpDir("evrt-act-ws-");
 
     const outcome = await actions.execute({
       spec: {
@@ -224,9 +224,9 @@ describe("actions adapter (OPS-208)", () => {
   });
 
   test("unknown host refuses before executing", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    const dir = tmpDir("evrt-act-");
     writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
-    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+    const workspaceDir = tmpDir("evrt-act-ws-");
     const outcome = await actions.execute({
       spec: {
         input: { host: "prod-db", mount: "/", actions: [{ action: "shrink" }] },

--- a/event-runtime/lib/sweep.test.mjs
+++ b/event-runtime/lib/sweep.test.mjs
@@ -1,7 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-sweep-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { resolveChains } from "./chain.mjs";
@@ -32,7 +32,7 @@ let previousReposRoot;
 let previousHome;
 
 function makeGitRepo(name) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  const dir = tmpDir(`evrt-${name}-`);
   fixtures.push(dir);
   git(["init", "--quiet", "--initial-branch=develop"], dir);
   git(["config", "user.email", "test@example.com"], dir);
@@ -44,7 +44,7 @@ function makeGitRepo(name) {
 }
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  const root = tmpDir("evrt-factory-");
   fixtures.push(root);
   mkdirSync(path.join(root, "config"), { recursive: true });
   const bj29 = makeGitRepo("bj29");
@@ -58,7 +58,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousHome = process.env.FACTORY_EVENT_HOME;
-  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  const home = tmpDir("evrt-home-");
   fixtures.push(home);
   process.env.FACTORY_EVENT_HOME = home;
 });
@@ -72,10 +72,10 @@ afterAll(() => {
 });
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-"));
+  const dir = tmpDir("evrt-sweep-");
   fixtures.push(dir);
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-ws-"));
+  const workspaces = tmpDir("evrt-sweep-ws-");
   fixtures.push(workspaces);
   const adapters = { pi: fake, actions: fake };
   const workerOpts = {

--- a/event-runtime/lib/tick.test.mjs
+++ b/event-runtime/lib/tick.test.mjs
@@ -1,12 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-tick-test-mjs";
 import { describe, expect, test } from "bun:test";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
-import os from "node:os";
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { PRUNE_INTERVAL_MS, TICK_SUBSYSTEMS, tick } from "../cli.mjs";
 import { sha256Hex } from "./canonical.mjs";
@@ -14,7 +8,7 @@ import { openDb } from "./db.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
-const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+const tmp = (p) => tmpDir(p);
 
 function harness() {
   const dir = tmp("evrt-tick-");

--- a/event-runtime/lib/tmp-hygiene.test.mjs
+++ b/event-runtime/lib/tmp-hygiene.test.mjs
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { withTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-tmp-hygiene-test-mjs";
+
+describe("temporary-directory test hygiene", () => {
+  test("event-runtime tests use the tracked tmpDir helper", () => {
+    const root = path.resolve(import.meta.dir, "..");
+    const pending = [root];
+    const offenders = [];
+    const forbiddenCall = ["mkdtemp", "Sync("].join("");
+    const trackedCall = ["tmp", "Dir("].join("");
+
+    while (pending.length) {
+      const dir = pending.pop();
+      for (const entry of readdirSync(dir)) {
+        const candidate = path.join(dir, entry);
+        const stat = statSync(candidate);
+        if (stat.isDirectory()) {
+          if (entry !== "node_modules" && entry !== "dist")
+            pending.push(candidate);
+        } else if (entry.endsWith(".test.mjs")) {
+          const source = readFileSync(candidate, "utf8");
+          if (
+            source.includes(forbiddenCall) ||
+            (source.includes(trackedCall) && !source.includes("tmp.mjs?file="))
+          )
+            offenders.push(path.relative(root, candidate));
+        }
+      }
+    }
+
+    expect(offenders.sort()).toEqual([]);
+  });
+
+  test("withTmpDir removes the directory after synchronous work", () => {
+    let dir;
+    const value = withTmpDir("evrt-scoped-", (candidate) => {
+      dir = candidate;
+      expect(existsSync(candidate)).toBe(true);
+      return "done";
+    });
+
+    expect(value).toBe("done");
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("withTmpDir removes the directory after asynchronous work", async () => {
+    let dir;
+    await withTmpDir("evrt-scoped-", async (candidate) => {
+      dir = candidate;
+      expect(existsSync(candidate)).toBe(true);
+    });
+
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/event-runtime/lib/tmp-hygiene.test.mjs
+++ b/event-runtime/lib/tmp-hygiene.test.mjs
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { withTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-tmp-hygiene-test-mjs";
+import { commandFixture } from "../test-support/command-fixture.mjs";
+import { TMP_PREFIXES } from "../../orchestrator/chrome-sweep.mjs";
 
 describe("temporary-directory test hygiene", () => {
   test("event-runtime tests use the tracked tmpDir helper", () => {
@@ -53,5 +55,23 @@ describe("temporary-directory test hygiene", () => {
     });
 
     expect(existsSync(dir)).toBe(false);
+  });
+
+  test("commandFixture creates directories under a sweep-matched prefix (WM-760)", () => {
+    // commandFixture() is used by merge.test.mjs / merge-apply.test.mjs with
+    // caller-supplied prefixes ("merge-apply-linear-", "branch-guard-", ...)
+    // that don't themselves appear in the CI sweep / chrome-sweep janitor
+    // prefix lists. The helper must force every fixture root under a prefix
+    // those sweeps do match, regardless of what the caller passes, or the
+    // directories leak forever instead of just until the next sweep.
+    const fixture = commandFixture("some-caller-supplied-prefix-");
+    try {
+      const base = path.basename(fixture.root);
+      expect(TMP_PREFIXES.some((prefix) => base.startsWith(prefix))).toBe(
+        true,
+      );
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
   });
 });

--- a/event-runtime/lib/tmp-hygiene.test.mjs
+++ b/event-runtime/lib/tmp-hygiene.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import path from "node:path";
 import { withTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-tmp-hygiene-test-mjs";
 import { commandFixture } from "../test-support/command-fixture.mjs";
@@ -67,9 +73,7 @@ describe("temporary-directory test hygiene", () => {
     const fixture = commandFixture("some-caller-supplied-prefix-");
     try {
       const base = path.basename(fixture.root);
-      expect(TMP_PREFIXES.some((prefix) => base.startsWith(prefix))).toBe(
-        true,
-      );
+      expect(TMP_PREFIXES.some((prefix) => base.startsWith(prefix))).toBe(true);
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/event-runtime/lib/trace.test.mjs
+++ b/event-runtime/lib/trace.test.mjs
@@ -1,7 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-trace-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+
 import * as fake from "./adapters/fake.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
@@ -228,7 +227,7 @@ function queueRun(db, spec, now = T0) {
 function opts(extra = {}) {
   return {
     owner: "w1",
-    workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-trace-")),
+    workspacesRoot: tmpDir("evrt-trace-"),
     now: T0,
     policyVersion: "test",
     ...extra,

--- a/event-runtime/lib/transcripts.test.mjs
+++ b/event-runtime/lib/transcripts.test.mjs
@@ -1,12 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-transcripts-test-mjs";
 import { describe, expect, test } from "bun:test";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import os from "node:os";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Readable, PassThrough } from "node:stream";
 import { sha256Hex } from "./canonical.mjs";
@@ -18,7 +12,7 @@ import {
   waitForStreamFlush,
 } from "./transcripts.mjs";
 
-const tmpWs = () => mkdtempSync(path.join(os.tmpdir(), "evrt-transcript-"));
+const tmpWs = () => tmpDir("evrt-transcript-");
 
 describe("transcripts (OPS-426)", () => {
   test("waitForStreamFlush resolves immediately for null or already finished streams", async () => {

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -1,13 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-triage-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import os from "node:os";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as actions from "./adapters/actions.mjs";
 import * as fake from "./adapters/fake.mjs";
@@ -42,7 +36,7 @@ let previousReposRoot;
 let mirrorsDir;
 
 function makeGitRepo(name) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  const dir = tmpDir(`evrt-${name}-`);
   fixtures.push(dir);
   git(["init", "--quiet", "--initial-branch=develop"], dir);
   git(["config", "user.email", "test@example.com"], dir);
@@ -54,7 +48,7 @@ function makeGitRepo(name) {
 }
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  const root = tmpDir("evrt-factory-");
   fixtures.push(root);
   mkdirSync(path.join(root, "config"), { recursive: true });
   const bj29 = makeGitRepo("bj29");
@@ -68,7 +62,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   // Mirrors land under the runtime home, which these tests also isolate.
-  mirrorsDir = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  mirrorsDir = tmpDir("evrt-home-");
   fixtures.push(mirrorsDir);
   process.env.FACTORY_EVENT_HOME = mirrorsDir;
 });
@@ -132,9 +126,9 @@ function triagePlanScan({ action, detail }) {
 }
 
 function harness({ adapters = { pi: fake, actions: fake } } = {}) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-"));
+  const dir = tmpDir("evrt-triage-");
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-ws-"));
+  const workspaces = tmpDir("evrt-triage-ws-");
   const workerOpts = {
     workspacesRoot: workspaces,
     owner: "w-test",
@@ -412,8 +406,8 @@ describe("triage-apply is closed by construction (OPS-229)", () => {
   }
 
   test("applies one registered action per item and records what landed", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-"));
-    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-ws-"));
+    const dir = tmpDir("evrt-apply-");
+    const workspaceDir = tmpDir("evrt-apply-ws-");
     const outcome = await actions.execute({
       spec: {
         input: {
@@ -441,8 +435,8 @@ describe("triage-apply is closed by construction (OPS-229)", () => {
   });
 
   test("an unregistered action refuses before applying ANY item — including the valid ones", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-"));
-    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-ws-"));
+    const dir = tmpDir("evrt-apply-");
+    const workspaceDir = tmpDir("evrt-apply-ws-");
     const outcome = await actions.execute({
       spec: {
         input: {

--- a/event-runtime/lib/unblock.test.mjs
+++ b/event-runtime/lib/unblock.test.mjs
@@ -1,7 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-unblock-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { resolveChains } from "./chain.mjs";
@@ -32,7 +32,7 @@ let previousReposRoot;
 let previousHome;
 
 function makeGitRepo(name) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  const dir = tmpDir(`evrt-${name}-`);
   fixtures.push(dir);
   git(["init", "--quiet", "--initial-branch=develop"], dir);
   git(["config", "user.email", "test@example.com"], dir);
@@ -44,7 +44,7 @@ function makeGitRepo(name) {
 }
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  const root = tmpDir("evrt-factory-");
   fixtures.push(root);
   mkdirSync(path.join(root, "config"), { recursive: true });
   const bj29 = makeGitRepo("bj29");
@@ -58,7 +58,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousHome = process.env.FACTORY_EVENT_HOME;
-  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  const home = tmpDir("evrt-home-");
   fixtures.push(home);
   process.env.FACTORY_EVENT_HOME = home;
 });
@@ -72,10 +72,10 @@ afterAll(() => {
 });
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-"));
+  const dir = tmpDir("evrt-unblock-");
   fixtures.push(dir);
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-ws-"));
+  const workspaces = tmpDir("evrt-unblock-ws-");
   fixtures.push(workspaces);
   const adapters = { pi: fake, actions: fake };
   const workerOpts = {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -958,7 +958,7 @@ describe("handoff verification helpers (WM-718)", () => {
   });
 
   test("changedFilesSince diffs merge-base(origin/<base>)..HEAD and reports an unusable tree instead of guessing", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-diff-"));
+    const dir = tmpDir("evrt-handoff-diff-");
     const git = (...args) => execFileSync("git", args, { cwd: dir });
     git("init", "-q", "-b", "develop");
     git("config", "user.email", "t@t");
@@ -980,7 +980,7 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(diff.baseRef).toBe("origin/develop");
     expect(diff.files).toEqual(["base.txt", "src/new.mjs"]);
 
-    const notGit = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-nogit-"));
+    const notGit = tmpDir("evrt-handoff-nogit-");
     const none = changedFilesSince({ worktreePath: notGit, base: "develop" });
     expect(none.ok).toBe(false);
     expect(none.files).toBeNull();
@@ -1036,7 +1036,7 @@ describe("handoff verification helpers (WM-718)", () => {
   });
 
   test("policyOwnedPathsConformance defaults to advisory and only 'strict' tightens", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-policy-"));
+    const root = tmpDir("evrt-handoff-policy-");
     expect(policyOwnedPathsConformance(root)).toBe("advisory");
     mkdirSync(path.join(root, "config"));
     const file = path.join(root, "config", "policy.yaml");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-verify-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { hashJson, sha256Hex } from "./canonical.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
@@ -41,7 +41,7 @@ function makeSpec(input = { repos: ["bj29"] }) {
 }
 
 function makeWorkspace(result) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-"));
+  const dir = tmpDir("evrt-verify-");
   if (result !== undefined) {
     writeFileSync(
       path.join(dir, "result.json"),

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4843,9 +4843,9 @@ describe("handoff verification gate (WM-718)", () => {
     `${OWNED}## Verification Command\n\n\`\`\`\n${cmd}\n\`\`\`\n`;
 
   beforeAll(() => {
-    factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-factory-"));
-    repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-repo-"));
-    wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-trees-"));
+    factoryRoot = tmpDir("evrt-handoff-factory-");
+    repoDir = tmpDir("evrt-handoff-repo-");
+    wtRoot = tmpDir("evrt-handoff-trees-");
     mkdirSync(path.join(repoDir, "bin"), { recursive: true });
     // A real git worktree with an `origin/develop` ref, so the gate can diff
     // merge-base..HEAD exactly as it does for a repo-owned worktree_up.
@@ -4989,10 +4989,8 @@ describe("handoff verification gate (WM-718)", () => {
       { fake: adapter },
       opts({
         dispatch: {
-          locksDir: mkdtempSync(path.join(os.tmpdir(), "evrt-handoff-locks-")),
-          leasesDir: mkdtempSync(
-            path.join(os.tmpdir(), "evrt-handoff-leases-"),
-          ),
+          locksDir: tmpDir("evrt-handoff-locks-"),
+          leasesDir: tmpDir("evrt-handoff-leases-"),
           fetchTicket: () => ({
             identifier: spec.input.ticket,
             state: { name: "Todo" },

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-worker-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
@@ -5,14 +6,12 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   buildClaudeArgv,
@@ -154,7 +153,7 @@ function linkEvent(
 }
 
 function freshRoot() {
-  return mkdtempSync(path.join(os.tmpdir(), "evrt-worker-"));
+  return tmpDir("evrt-worker-");
 }
 
 function opts(extra = {}) {
@@ -169,7 +168,7 @@ function opts(extra = {}) {
 
 describe("worker", () => {
   test("repository integrity gate rejects any checkout dirt before output acceptance", () => {
-    const repo = mkdtempSync(path.join(os.tmpdir(), "evrt-clean-repo-"));
+    const repo = tmpDir("evrt-clean-repo-");
     const git = (args) =>
       spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
     expect(git(["init", "--quiet"]).status).toBe(0);
@@ -197,7 +196,7 @@ describe("worker", () => {
   });
 
   test("repository integrity baseline permits pre-existing ignored state but detects later writes", () => {
-    const repo = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-repo-"));
+    const repo = tmpDir("evrt-baseline-repo-");
     const git = (args) =>
       spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
     expect(git(["init", "--quiet"]).status).toBe(0);
@@ -225,7 +224,7 @@ describe("worker", () => {
   });
 
   test("repository status returns null when git exceeds its timeout", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-hanging-git-"));
+    const dir = tmpDir("evrt-hanging-git-");
     const hangingGit = path.join(dir, "git");
     writeFileSync(hangingGit, "#!/bin/bash\nwhile :; do :; done\n", "utf8");
     execFileSync("chmod", ["+x", hangingGit]);
@@ -238,7 +237,7 @@ describe("worker", () => {
   });
 
   test("Linear helper subprocesses honor the configured timeout", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-hanging-linear-"));
+    const dir = tmpDir("evrt-hanging-linear-");
     const hangingCommand = path.join(dir, "bun");
     writeFileSync(hangingCommand, "#!/bin/bash\nwhile :; do :; done\n", "utf8");
     execFileSync("chmod", ["+x", hangingCommand]);
@@ -1454,7 +1453,7 @@ describe("worker", () => {
   });
 
   test("restart survival: results, receipt, and journal readable from a reopened file db", async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-db-"));
+    const dir = tmpDir("evrt-db-");
     const file = path.join(dir, "runtime.db");
     const db = openDb(file);
     const spec = queueRun(db, makeSpec());
@@ -2573,11 +2572,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   let previousReposRoot;
 
   beforeAll(() => {
-    factoryRoot = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-worker-hard-factory-"),
-    );
-    repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-worker-hard-repo-"));
-    wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-worker-hard-trees-"));
+    factoryRoot = tmpDir("evrt-worker-hard-factory-");
+    repoDir = tmpDir("evrt-worker-hard-repo-");
+    wtRoot = tmpDir("evrt-worker-hard-trees-");
     callsLog = path.join(repoDir, "calls.log");
 
     mkdirSync(path.join(repoDir, "bin"), { recursive: true });
@@ -2829,7 +2826,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   };
 
   test("resolves Linear credentials from env first, then the shared env file", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-linear-key-"));
+    const dir = tmpDir("evrt-linear-key-");
     const envFile = path.join(dir, ".env");
     writeFileSync(envFile, "OTHER=value\nLINEAR_API_KEY='file-key'\n", "utf8");
 
@@ -2845,9 +2842,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const previousHome = process.env.FACTORY_EVENT_HOME;
     const previousKey = process.env.LINEAR_API_KEY;
     const previousStub = process.env.FACTORY_DISPATCH_STUB;
-    process.env.FACTORY_EVENT_HOME = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-linear-unconfigured-"),
-    );
+    process.env.FACTORY_EVENT_HOME = tmpDir("evrt-linear-unconfigured-");
     delete process.env.LINEAR_API_KEY;
     delete process.env.FACTORY_DISPATCH_STUB;
 
@@ -2945,7 +2940,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   });
 
   test("acquireClaimLock acquires lock file and prevents concurrent acquire, release unlocks", () => {
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));
+    const lockDir = tmpDir("evrt-lock-");
     const lockFile = dispatchLockPath("wt-worker", lockDir);
     expect(acquireClaimLock(lockFile, { pid: process.pid, now: 1000 })).toBe(
       true,
@@ -2963,7 +2958,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   });
 
   test("acquireClaimLock preserves old locks from live owners and reclaims dead owners", () => {
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-stale-"));
+    const lockDir = tmpDir("evrt-lock-stale-");
     const lockFile = dispatchLockPath("wt-worker", lockDir);
     // Age alone cannot make a live owner's lock safe to steal.
     writeFileSync(lockFile, `${process.pid} 1000\n`, "utf8");
@@ -2990,7 +2985,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("contended claim lock requeues with jittered backoff without consuming an attempt, then runs", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-busy-"));
+    const lockDir = tmpDir("evrt-lock-busy-");
     const lockFile = dispatchLockPath("wt-worker", lockDir);
     acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
 
@@ -3053,7 +3048,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("claim lock starvation refuses with a distinct reason after the requeue ceiling", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-starved-"));
+    const lockDir = tmpDir("evrt-lock-starved-");
     const lockFile = dispatchLockPath("wt-worker", lockDir);
     acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
 
@@ -3095,7 +3090,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("concurrent disjoint dispatches drain through the claim lock with mutually exclusive claims", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-burst-"));
+    const lockDir = tmpDir("evrt-lock-burst-");
     const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) =>
       queueRun(
         db,
@@ -3182,7 +3177,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("merge-fix gate accepts an assigned In Review ticket without invoking the dispatch claim", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-fix-gate-"));
+    const lockDir = tmpDir("evrt-merge-fix-gate-");
     const spec = queueRun(db, makeMergeFixSpec());
     let claimCalled = false;
 
@@ -3246,9 +3241,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         { "merge-fake": mergeFixFakeAdapter },
         opts({
           dispatch: {
-            locksDir: mkdtempSync(
-              path.join(os.tmpdir(), `evrt-merge-fix-${suffix}-`),
-            ),
+            locksDir: tmpDir(`evrt-merge-fix-${suffix}-`),
             fetchTicket: () => ({
               identifier: spec.input.ticket,
               state: { name: "In Review" },
@@ -3270,7 +3263,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("execute-time re-checks refuse on ticket_not_todo, ticket_assigned, capacity_full, owned_paths_overlap, ticket_claim_lost", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-rechecks-"));
+    const lockDir = tmpDir("evrt-rechecks-");
 
     // 1. ticket_not_todo
     const spec1 = queueRun(
@@ -3397,7 +3390,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // every other test here, which is why they still see strict.
   test("advisory owned-paths mode dispatches across overlap and refuses only hard conflicts (WM-677)", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-advisory-"));
+    const lockDir = tmpDir("evrt-advisory-");
     const policyPath = path.join(factoryRoot, "config", "policy.yaml");
     const priorPolicy = readFileSync(policyPath, "utf8");
     writeFileSync(policyPath, "dispatch:\n  owned_paths_collision: advisory\n");
@@ -3494,12 +3487,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-claim-retry-locks-"),
-    );
-    const leaseDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-claim-retry-leases-"),
-    );
+    const lockDir = tmpDir("evrt-claim-retry-locks-");
+    const leaseDir = tmpDir("evrt-claim-retry-leases-");
     const spec = queueRun(
       db,
       makeDispatchSpec({
@@ -3627,9 +3616,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("claim-time Linear read failure contradicting plan evidence requeues with backoff", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-transient-linear-"),
-    );
+    const lockDir = tmpDir("evrt-transient-linear-");
     const description = "## Owned Paths\n- src/feature/**\n";
     const spec = queueRun(
       db,
@@ -3690,9 +3677,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("empty claim-time description retries only when its hash contradicts plan evidence, then explains recovery", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-transient-owned-paths-"),
-    );
+    const lockDir = tmpDir("evrt-transient-owned-paths-");
     const spec = queueRun(
       db,
       makeDispatchSpec({
@@ -3751,8 +3736,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("worker lease is acquired during execution and released on completion", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lease-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lease-dir-"));
+    const lockDir = tmpDir("evrt-lease-locks-");
+    const leaseDir = tmpDir("evrt-lease-dir-");
 
     let sawActiveLease = false;
     const leaseCheckAdapter = {
@@ -3796,8 +3781,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("mutating worktree is exempt from read-only clean check and runs repo verify command", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-locks-"));
-    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-verify-leases-"));
+    const lockDir = tmpDir("evrt-verify-locks-");
+    const leaseDir = tmpDir("evrt-verify-leases-");
 
     const spec = queueRun(
       db,
@@ -3833,10 +3818,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // Todo + ai:agent-ready and the PR is held; still FAILED, still no result row.
   test("failing repo verify command at handoff fails handoff_verification_failed", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-fverify-locks-"));
-    const leaseDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-fverify-leases-"),
-    );
+    const lockDir = tmpDir("evrt-fverify-locks-");
+    const leaseDir = tmpDir("evrt-fverify-leases-");
 
     const spec = queueRun(
       db,
@@ -3868,10 +3851,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-locks-"));
-    const leaseDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-baseline-leases-"),
-    );
+    const lockDir = tmpDir("evrt-baseline-locks-");
+    const leaseDir = tmpDir("evrt-baseline-leases-");
     let executionInput = null;
     const unclaimCalls = [];
     const blockCalls = [];
@@ -3943,7 +3924,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       const ticket = `WM-${732000000 + Math.floor(Math.random() * 1_000_000)}`;
       const apiPort = "7408";
       const apiPortNumber = Number(apiPort);
-      const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "wm334-real-"));
+      const tmpRoot = tmpDir("wm334-real-");
       const stubDir = path.join(tmpRoot, "stub");
       const linearStateDir = path.join(tmpRoot, "linear-state");
       const worktreeRoot = path.join(tmpRoot, "worktrees");
@@ -4189,12 +4170,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         process.env.FACTORY_TEST_TRACKED_PROCESS = testProcessMarker;
 
         const db = openDb(":memory:");
-        const lockDir = mkdtempSync(
-          path.join(os.tmpdir(), "wm334-real-locks-"),
-        );
-        const leaseDir = mkdtempSync(
-          path.join(os.tmpdir(), "wm334-real-leases-"),
-        );
+        const lockDir = tmpDir("wm334-real-locks-");
+        const leaseDir = tmpDir("wm334-real-leases-");
         const executionInputs = [];
         const blockCalls = [];
         const observedAdapter = {
@@ -4274,9 +4251,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
               registry,
               { fake: observedAdapter },
               opts({
-                workspacesRoot: mkdtempSync(
-                  path.join(os.tmpdir(), `${repoName}-run-`),
-                ),
+                workspacesRoot: tmpDir(`${repoName}-run-`),
                 dispatch: {
                   locksDir: lockDir,
                   leasesDir: leaseDir,
@@ -4376,9 +4351,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("worktree provisioning failure is not misclassified as adapter_error and never reaches execution", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-provision-locks-"),
-    );
+    const lockDir = tmpDir("evrt-provision-locks-");
     let executed = false;
     const observingAdapter = {
       async execute() {
@@ -4419,9 +4392,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("sandboxed execution against a worktree workspace is refused typed before the adapter runs", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-sandbox-wt-locks-"),
-    );
+    const lockDir = tmpDir("evrt-sandbox-wt-locks-");
     let executed = false;
     const observingAdapter = {
       async execute() {
@@ -4475,9 +4446,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("filesystem failures after worktree_up remain typed workspace provisioning errors", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-link-collision-locks-"),
-    );
+    const lockDir = tmpDir("evrt-link-collision-locks-");
     let executed = false;
     const observingAdapter = {
       async execute() {
@@ -4523,7 +4492,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("worktree_up daemon startup failure surfaces serve.log in provisioning error message", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-crash-locks-"));
+    const lockDir = tmpDir("evrt-crash-locks-");
     const observingAdapter = {
       async execute() {
         return { exitCode: 0, timedOut: false };
@@ -4563,10 +4532,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test("rollback Linear ticket state to Todo on crash, timeout, and contract violation", async () => {
     const db = openDb(":memory:");
-    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-rollback-locks-"));
-    const leaseDir = mkdtempSync(
-      path.join(os.tmpdir(), "evrt-rollback-leases-"),
-    );
+    const lockDir = tmpDir("evrt-rollback-locks-");
+    const leaseDir = tmpDir("evrt-rollback-leases-");
 
     const rollbacks = [];
     const mockUnclaim = ({ repo, ticket, why }) => {
@@ -4643,7 +4610,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 // ---------------------------------------------------------------------------
 
 function stampRepo() {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-stamp-"));
+  const root = tmpDir("evrt-stamp-");
   mkdirSync(path.join(root, "event-runtime", "lib", "adapters"), {
     recursive: true,
   });

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -1,6 +1,6 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-workers-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { openDb } from "./db.mjs";
 import { createRun } from "./lifecycle.mjs";
@@ -22,13 +22,7 @@ import {
 } from "./workers.mjs";
 
 const PV = "git:test-pv";
-const db = () =>
-  openDb(
-    path.join(
-      mkdtempSync(path.join(os.tmpdir(), "evrt-workers-")),
-      "runtime.db",
-    ),
-  );
+const db = () => openDb(path.join(tmpDir("evrt-workers-"), "runtime.db"));
 
 /** A QUEUED run, straight through the real lifecycle. */
 function queueRun(database, { runId, placement, adapter = "fake" }) {
@@ -242,7 +236,7 @@ describe("worker registry and heartbeats (OPS-233)", () => {
 
 describe("worker pool policy (WM-226)", () => {
   const configRoot = (yaml) => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-pool-cfg-"));
+    const root = tmpDir("evrt-pool-cfg-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     if (yaml !== null)
       writeFileSync(path.join(root, "config", "policy.yaml"), yaml, "utf8");

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-workspace-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   existsSync,
   lstatSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   realpathSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import {
@@ -23,7 +22,7 @@ import {
 } from "./workspace.mjs";
 
 function tmpRoot() {
-  return mkdtempSync(path.join(os.tmpdir(), "evrt-ws-"));
+  return tmpDir("evrt-ws-");
 }
 
 describe("safeJoin", () => {
@@ -195,13 +194,9 @@ describe("worktree workspaces (WM-108)", () => {
       : [];
 
   beforeAll(() => {
-    factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-wt-factory-"));
-    repoDir = realpathSync(
-      mkdtempSync(path.join(os.tmpdir(), "evrt-wt-repo-")),
-    );
-    wtRoot = realpathSync(
-      mkdtempSync(path.join(os.tmpdir(), "evrt-wt-trees-")),
-    );
+    factoryRoot = tmpDir("evrt-wt-factory-");
+    repoDir = realpathSync(tmpDir("evrt-wt-repo-"));
+    wtRoot = realpathSync(tmpDir("evrt-wt-trees-"));
     callsLog = path.join(repoDir, "calls.log");
 
     mkdirSync(path.join(repoDir, "bin"), { recursive: true });

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-loop-test-mjs";
 /**
  * Closing the loop (WM-112): a finished dispatch re-fires the work-scan —
  * dispatch@1 outcomes PR_OPEN and NOT_CLAIMED chain into
@@ -11,8 +12,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { resolveChains } from "./lib/chain.mjs";
 import { openDb } from "./lib/db.mjs";
@@ -47,10 +47,10 @@ let previousReposRoot;
 let previousEventHome;
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-factory-"));
+  const root = tmpDir("evrt-loop-factory-");
   fixtures.push(root);
-  const repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-repo-"));
-  const wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-trees-"));
+  const repoDir = tmpDir("evrt-loop-repo-");
+  const wtRoot = tmpDir("evrt-loop-trees-");
   fixtures.push(repoDir, wtRoot);
 
   git(["init", "--quiet", "--initial-branch=develop"], repoDir);
@@ -87,9 +87,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(
-    path.join(os.tmpdir(), "evrt-loop-home-"),
-  );
+  process.env.FACTORY_EVENT_HOME = tmpDir("evrt-loop-home-");
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -152,13 +150,8 @@ const dispatchFake = (outcome) => ({
 
 /** Admit → plan → approve → execute one dispatch run ending in `outcome`. */
 async function dispatchTo(outcome, eventId, ticket) {
-  const db = openDb(
-    path.join(
-      mkdtempSync(path.join(os.tmpdir(), "evrt-loop-db-")),
-      "runtime.db",
-    ),
-  );
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-ws-"));
+  const db = openDb(path.join(tmpDir("evrt-loop-db-"), "runtime.db"));
+  const workspaces = tmpDir("evrt-loop-ws-");
   fixtures.push(workspaces);
   const planAll = () =>
     planAdmittedEvents(db, registry, {

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1,14 +1,13 @@
+import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-merge-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { substituteArgv } from "./lib/adapters/actions.mjs";
@@ -493,9 +492,7 @@ describe("merge-scan required-context resolution (WM-433)", () => {
   });
 
   test("the resolver executes when the selected non-Factory repo has no event-runtime tree", () => {
-    const fixture = mkdtempSync(
-      path.join(os.tmpdir(), "merge-scan-cross-repo-"),
-    );
+    const fixture = tmpDir("merge-scan-cross-repo-");
     const target = path.join(fixture, "repo");
     mkdirSync(target);
     writeFileSync(path.join(target, "README.md"), "# non-Factory fixture\n");
@@ -549,7 +546,7 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
   });
 
   test("a planned scan reads pinned config and a schema-valid fail-closed result is refused, not contract-invalid", async () => {
-    const fixture = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-scan-"));
+    const fixture = tmpDir("evrt-merge-scan-");
     const source = path.join(fixture, "source");
     const eventHome = path.join(fixture, "event-home");
     const workspaces = path.join(fixture, "workspaces");

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-ship-test-mjs";
 /**
  * Ship chain (WM-111): ship-scan@1 assembles the release candidate — base
  * ahead of the deploy branch, real checks green on the head commit, changelog
@@ -13,11 +14,9 @@ import {
   chmodSync,
   cpSync,
   existsSync,
-  mkdtempSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as fake from "./lib/adapters/fake.mjs";
@@ -95,7 +94,7 @@ describe("ship-scan registration (WM-111)", () => {
  * to $SHIM_LOG.
  */
 async function runApply(plan, env = {}) {
-  const shims = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-shims-"));
+  const shims = tmpDir("evrt-ship-shims-");
   const log = path.join(shims, "shim.log");
   writeFileSync(
     path.join(shims, "gh"),
@@ -140,7 +139,7 @@ fi
       `console.log(JSON.stringify(outcome));\n`,
   );
 
-  const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-ws-"));
+  const workspaceDir = tmpDir("evrt-ship-ws-");
   const input = {
     repo: "bj29",
     github: "watt-mind/bj29",
@@ -330,7 +329,7 @@ describe("ship-apply is closed by construction (WM-111)", () => {
   // The endpoint runs as a child process: runApply's spawnSync blocks this
   // process's event loop, so an in-process Bun.serve could never answer.
   async function withSmokeServer(payload, fn) {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-smoke-"));
+    const dir = tmpDir("evrt-ship-smoke-");
     const script = path.join(dir, "server.mjs");
     writeFileSync(
       script,
@@ -482,7 +481,7 @@ function openShipApplyProposal(db) {
 describe("ship-apply approval is structurally human-only (WM-111)", () => {
   test("schedules.json declaring approval auto on the ship-apply event type cannot load", () => {
     // Copy the real registry into a temp root so the test can corrupt it safely.
-    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-registry-"));
+    const root = tmpDir("evrt-ship-registry-");
     for (const dir of ["agents", "schemas"]) {
       cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), {
         recursive: true,
@@ -513,7 +512,7 @@ describe("ship-apply approval is structurally human-only (WM-111)", () => {
   });
 
   test("a schedule-actor approval attempt is rejected fail-closed with a typed reason — then the human's still works", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-"));
+    const dir = tmpDir("evrt-ship-");
     const db = openDb(path.join(dir, "runtime.db"));
     const proposal = openShipApplyProposal(db);
 
@@ -658,9 +657,9 @@ const shipFake = {
 };
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-"));
+  const dir = tmpDir("evrt-ship-e2e-");
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-ws-"));
+  const workspaces = tmpDir("evrt-ship-e2e-ws-");
   const adapters = { pi: shipFake, actions: shipFake, command: shipFake };
   const workerOpts = {
     workspacesRoot: workspaces,

--- a/event-runtime/test-support/command-fixture.mjs
+++ b/event-runtime/test-support/command-fixture.mjs
@@ -3,8 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+// The `evrt-` prefix is required, not cosmetic: it is one of the patterns the
+// CI/e2e workflow sweeps and orchestrator/chrome-sweep.mjs's janitor reap on
+// the shared shadow host (see WM-760). A caller-supplied prefix without it
+// would create directories no sweep pattern matches, leaking permanently.
 export function commandFixture(prefix = "event-runtime-command-") {
-  const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+  const root = mkdtempSync(path.join(os.tmpdir(), `evrt-${prefix}`));
   const bin = path.join(root, "bin");
   Bun.spawnSync(["mkdir", "-p", bin]);
   return { root, bin, log: path.join(root, "commands.log") };

--- a/event-runtime/test-support/tmp.mjs
+++ b/event-runtime/test-support/tmp.mjs
@@ -1,0 +1,51 @@
+import { afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Bun caches modules across test files, but afterAll is file-scoped. Tests use
+// a stable `?file=...` import query so each file gets its own tracker and hook;
+// otherwise the first file's hook can remove another file's top-level fixture.
+const tracked = new Set();
+
+function removeTmpDir(dir) {
+  tracked.delete(dir);
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Track a temp directory created by a legacy test fixture. */
+export function trackTmpDir(dir) {
+  tracked.add(dir);
+  return dir;
+}
+
+export function cleanupTmpDirs() {
+  for (const dir of [...tracked].reverse()) removeTmpDir(dir);
+}
+
+/** Create a tracked temporary directory beneath the system temp directory. */
+export function tmpDir(prefix, baseDir = os.tmpdir()) {
+  const dir = mkdtempSync(path.join(baseDir, prefix));
+  return trackTmpDir(dir);
+}
+
+/** Run a callback with a temporary directory and remove it when it settles. */
+export function withTmpDir(prefix, fn) {
+  const dir = tmpDir(prefix);
+  let result;
+  try {
+    result = fn(dir);
+  } catch (error) {
+    removeTmpDir(dir);
+    throw error;
+  }
+
+  if (result && typeof result.then === "function") {
+    return Promise.resolve(result).finally(() => removeTmpDir(dir));
+  }
+
+  removeTmpDir(dir);
+  return result;
+}
+
+afterAll(cleanupTmpDirs);

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -1,3 +1,4 @@
+import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-work-test-mjs";
 /**
  * Work chain (WM-110): work-scan@1 reads a repo's agent-ready Linear queue
  * against a pinned tree and emits a typed DISPATCH plan; the chain edge feeds
@@ -9,8 +10,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as fake from "./lib/adapters/fake.mjs";
 import { resolveChains } from "./lib/chain.mjs";
@@ -45,7 +45,7 @@ let previousReposRoot;
 let previousEventHome;
 
 function makeGitRepo(name) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-work-${name}-`));
+  const dir = tmpDir(`evrt-work-${name}-`);
   fixtures.push(dir);
   git(["init", "--quiet", "--initial-branch=develop"], dir);
   git(["config", "user.email", "test@example.com"], dir);
@@ -57,7 +57,7 @@ function makeGitRepo(name) {
 }
 
 beforeAll(() => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-work-factory-"));
+  const root = tmpDir("evrt-work-factory-");
   fixtures.push(root);
   mkdirSync(path.join(root, "config"), { recursive: true });
   const wm29 = makeGitRepo("wm29");
@@ -66,7 +66,7 @@ beforeAll(() => {
   const overlap = low;
   const cap = low;
   const lowBad = low;
-  const wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-work-trees-"));
+  const wtRoot = tmpDir("evrt-work-trees-");
   fixtures.push(wtRoot);
 
   for (const r of [wm29, clean, low]) {
@@ -118,9 +118,7 @@ beforeAll(() => {
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;
   previousEventHome = process.env.FACTORY_EVENT_HOME;
-  process.env.FACTORY_EVENT_HOME = mkdtempSync(
-    path.join(os.tmpdir(), "evrt-work-home-"),
-  );
+  process.env.FACTORY_EVENT_HOME = tmpDir("evrt-work-home-");
   fixtures.push(process.env.FACTORY_EVENT_HOME);
 });
 
@@ -364,9 +362,9 @@ const openWorld = {
 };
 
 function harness() {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-work-"));
+  const dir = tmpDir("evrt-work-");
   const db = openDb(path.join(dir, "runtime.db"));
-  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-work-ws-"));
+  const workspaces = tmpDir("evrt-work-ws-");
   const adapters = { pi: workFake };
   const workerOpts = {
     workspacesRoot: workspaces,

--- a/orchestrator/chrome-sweep.mjs
+++ b/orchestrator/chrome-sweep.mjs
@@ -22,8 +22,14 @@
  *      agent's Chrome still has its MCP server as parent and is left alone.
  */
 import { execSync } from "node:child_process";
-import { existsSync, lstatSync, unlinkSync } from "node:fs";
-import { homedir } from "node:os";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 const APPLY = process.argv.includes("--apply");
@@ -34,7 +40,38 @@ const SHARED_PROFILE = path.join(
 
 /** Does this ps line look like an agent-launched Chrome profile? */
 const AGENT_PROFILE =
-  /--user-data-dir=[^ ]*(chrome-devtools-mcp|puppeteer_dev_(chrome|firefox)_profile)/;
+  /--user-data-dir=[^ ]*(chrome-devtools-mcp|pi-chrome-devtools|puppeteer_dev_(chrome|firefox)_profile)/;
+
+export const TMP_PREFIXES = [
+  "evrt-",
+  "wm334-real-",
+  "pi-chrome-devtools-",
+  "puppeteer_dev_chrome_profile-",
+  "factory-wt-",
+];
+const TMP_MIN_AGE_MS = 30 * 60 * 1000;
+
+/** Find stale factory-owned temp directories without following symlinks. */
+export function staleTmpDirectories({
+  root = tmpdir(),
+  nowMs = Date.now(),
+  inUsePaths = [],
+} = {}) {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) return [];
+    if (!TMP_PREFIXES.some((prefix) => entry.name.startsWith(prefix)))
+      return [];
+    const candidate = path.join(root, entry.name);
+    if (inUsePaths.includes(candidate)) return [];
+    try {
+      return nowMs - lstatSync(candidate).mtimeMs > TMP_MIN_AGE_MS
+        ? [candidate]
+        : [];
+    } catch {
+      return [];
+    }
+  });
+}
 
 /**
  * Pure classifier over `ps -axo pid=,ppid=,command=` rows so the kill logic is
@@ -66,6 +103,10 @@ if (import.meta.main) {
     }),
   );
   const { orphans, live } = classify(rows);
+  const inUsePaths = rows.flatMap((row) => {
+    const profile = row.command.match(/--user-data-dir=([^ ]+)/)?.[1];
+    return profile ? [profile] : [];
+  });
 
   if (live.length)
     console.log(
@@ -118,6 +159,11 @@ if (import.meta.main) {
         /* not present */
       }
     }
+  }
+
+  for (const dir of staleTmpDirectories({ inUsePaths })) {
+    console.log(`  ${APPLY ? "removing" : "would remove"} stale ${dir}`);
+    if (APPLY) rmSync(dir, { recursive: true, force: true });
   }
 
   if (!APPLY && orphans.length)


### PR DESCRIPTION
## Summary
- add a file-scoped tracked temp-directory helper and migrate event-runtime tests away from direct `mkdtempSync` calls
- add a regression guard plus CI/E2E start/end age-gated temp sweeps
- extend the live Chrome sweep to reap stale Factory-owned temp prefixes while preserving active profiles

## Verification
- `bun test event-runtime/lib event-runtime/cli && actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` — 1,071 pass, 9 environment skips, 0 fail
- `/tmp` before/after matching-prefix snapshot — 1 new entry (target ≤5)
- `bun run lint --max-warnings=621` — pass (611 existing warnings)
- `bun test orchestrator/chrome-sweep.test.mjs` — 6 pass

UX critique: skipped — test, CI, and janitor infrastructure only; no user-facing flow

Fixes WM-760