### PR TITLE
fix(inbox): retarget inbox item when approve replans after expiry (WM-714)

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -213,15 +213,15 @@ Every option carries exactly one `effect` from this closed set. The renderer
 does not know what an effect does; the API does, and applies it in the same
 transaction that stores the response.
 
-| Effect             | What the runtime does                                                                                                                                                                                      | Legal only when the item has            |
-| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
-| `authorise`        | Records the authorisation (§3.1) and emits a `factory.dispatch.requested` envelope for `refs.issue` on `refs.repo` with `humanDecision` in the payload (§5). The item resolves as `operator:authorised`.   | `refs.issue`, `refs.repo`, `refs.runId` |
-| `send_to_triage`   | Moves `refs.issue` to `Triage`, removes `ai:agent-ready`, comments the operator's fields (`tools/linear.mjs`). Resolves as `operator:triaged`.                                                             | `refs.issue`                            |
-| `answer`           | Comments the operator's `text` field(s) on `refs.issue` (at least one applicable field is required), moves it `Blocked → Todo` (WM-287's "Answer" verb, unchanged). Resolves as `operator:answered`.       | `refs.issue`                            |
-| `requeue`          | `POST /events/requeue` for `refs.eventSource`/`refs.eventId` (existing planner path). Resolves as `operator:requeued`.                                                                                     | `refs.eventSource`, `refs.eventId`      |
-| `approve_proposal` | `approveProposal(refs.proposalId)`; an expired proposal takes the existing SpecDiff re-plan path and the item stays open until that second approval — never auto-approve. Resolves as `operator:approved`. | `refs.proposalId`                       |
-| `reject_proposal`  | `rejectProposal(refs.proposalId, reason)` with the operator's applicable required `text` field as the reason. Resolves as `operator:rejected`.                                                             | `refs.proposalId`                       |
-| `dismiss`          | Resolves the item as `operator:dismissed`, records the fields, touches nothing else. Every default template offers it; agents are told to offer it.                                                        | —                                       |
+| Effect             | What the runtime does                                                                                                                                                                                                                                                                | Legal only when the item has            |
+| :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
+| `authorise`        | Records the authorisation (§3.1) and emits a `factory.dispatch.requested` envelope for `refs.issue` on `refs.repo` with `humanDecision` in the payload (§5). The item resolves as `operator:authorised`.                                                                             | `refs.issue`, `refs.repo`, `refs.runId` |
+| `send_to_triage`   | Moves `refs.issue` to `Triage`, removes `ai:agent-ready`, comments the operator's fields (`tools/linear.mjs`). Resolves as `operator:triaged`.                                                                                                                                       | `refs.issue`                            |
+| `answer`           | Comments the operator's `text` field(s) on `refs.issue` (at least one applicable field is required), moves it `Blocked → Todo` (WM-287's "Answer" verb, unchanged). Resolves as `operator:answered`.                                                                                 | `refs.issue`                            |
+| `requeue`          | `POST /events/requeue` for `refs.eventSource`/`refs.eventId` (existing planner path). Resolves as `operator:requeued`.                                                                                                                                                               | `refs.eventSource`, `refs.eventId`      |
+| `approve_proposal` | `approveProposal(refs.proposalId)`; an expired proposal takes the existing SpecDiff re-plan path, and the item is **retargeted** onto the fresh proposal rather than resolved (§3.2) — never auto-approve. Resolves as `operator:approve_proposal` only when a run actually started. | `refs.proposalId`                       |
+| `reject_proposal`  | `rejectProposal(refs.proposalId, reason)` with the operator's applicable required `text` field as the reason. Resolves as `operator:rejected`.                                                                                                                                       | `refs.proposalId`                       |
+| `dismiss`          | Resolves the item as `operator:dismissed`, records the fields, touches nothing else. Every default template offers it; agents are told to offer it.                                                                                                                                  | —                                       |
 
 For both `answer` and `reject_proposal`, the applicable required `text` field
 rule accounts for `whenOption` gating before the effect is offered.
@@ -279,6 +279,42 @@ Two bindings make it safe:
 An authorisation is single-use: it lives in one run's input. A second refusal
 raises a second item; the operator decides again. Blanket approval per ticket
 or per area is deliberately not a thing.
+
+### 3.2 An `applied` outcome is not always a decision (WM-714)
+
+`approve_proposal` is the one effect whose success can leave the question
+unanswered. Approving a proposal that has already expired re-plans it: the old
+proposal goes `superseded`, a fresh `open` one is inserted with the new spec,
+and the effect returns
+
+```json
+{
+  "outcome": "applied",
+  "detail": "replanned_awaiting_approval",
+  "newProposalId": "…"
+}
+```
+
+Resolving on that `applied` is what WM-714 fixes. The operator approved a spec
+that is no longer on offer, so the ledger **retargets** the item in the same
+transaction instead:
+
+- `refs.proposalId` becomes `newProposalId`, and the dedupe key follows it
+  (`<kind>:<newProposalId>`), so the next producer for the fresh proposal
+  supersedes this item rather than stacking a second one. A key another open
+  item already holds is left alone — the partial unique index would abort the
+  transaction and take the operator's answer with it.
+- A fresh proposal request replaces the answered one: the same §4.3 `proposal`
+  template, with a `context` saying the spec was re-planned after expiry and
+  asking for a re-review.
+- `response`, `decided_at`, and `decided_by` clear, so the item is undecided
+  again. The answer is not lost — it moves to `responseHistory` (§6) with
+  `retargetedFrom`/`retargetedTo`.
+
+Because `refs.proposalId` now names the live open proposal, `reconcileInbox`
+leaves the item alone; it auto-resolves only once that proposal is decided.
+`POST /inbox/:id/decide/retry` reports `not_decided` — there is no failed
+effect to replay, there is a new question to answer.
 
 ---
 
@@ -410,17 +446,27 @@ with a key that collides with an open item **updates** that item's `decision`,
 free text) carry no key and are never deduplicated — the human typed them on
 purpose.
 
+An answer the ledger archives instead of keeping — today only the §3.2
+retarget — goes to `responseHistory`, exposed on the item view alongside
+`response` and stored in `delivery_json` next to `supersededDecisions`. It
+needs no column and no migration, and the view lifts it back out so `delivery`
+stays about the projection. Each entry is the full stored response (effect
+included) plus `retargetedFrom`, `retargetedTo`, and `retargetedAt`, which is
+how `GET /inbox/:id` shows an operator why the question in front of them is not
+the one they answered.
+
 `resolved_by` gains the `operator:<effect>` family alongside `operator` and
 `auto:*`.
 
 API:
 
 ```
-GET  /inbox/:id                → the item, with decision and response
+GET  /inbox/:id                → the item, with decision, response, responseHistory
 POST /inbox/:id/decide         → body: factory.decision-response/v1 minus decidedAt
                                   200 { item, effect: { kind, outcome } }
                                   400 invalid response · 404 · 409 stale_request | already_decided
 POST /inbox/:id/decide/retry   → re-run a failed effect with the stored response
+                                  409 not_decided after a §3.2 retarget
 ```
 
 `ack` and `resolve` remain for items without a decision and for the

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -34,6 +34,8 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+import { decisionRequestHash } from "./decision.mjs";
+import { templateFor } from "./decision-templates.mjs";
 
 describe("human inbox API (WM-285)", () => {
   test("POST writes before a failed delivery, rejects unknown kinds, and GET/ack/resolve filter rows", async () => {
@@ -120,6 +122,114 @@ describe("human inbox API (WM-285)", () => {
       expect(s.db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(
         0,
       );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("approving an expired proposal retargets the item onto the re-planned one (WM-714)", async () => {
+    const refs = {
+      proposalId: "prop-old",
+      eventSource: "linear",
+      eventId: "evt-1",
+    };
+    const request = templateFor("proposal_expired", {
+      producer: "proposal",
+      refs,
+    });
+    const s = await makeServer({
+      now: () => 1000,
+      inboxSend: async () => ({ ok: true, exitCode: 0, error: null }),
+      inboxPlanner: {
+        // WM-391's expired-proposal path: no approval, a fresh open proposal.
+        approveProposal: () => ({
+          approved: false,
+          replanned: true,
+          proposal: { id: "prop-fresh" },
+        }),
+        rejectProposal: () => ({ ok: true }),
+        requeue: () => ({ ok: true }),
+        admit: () => ({ admitted: true }),
+      },
+    });
+    try {
+      const created = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "proposal_expired",
+          title: "DECISION NEEDED proposal prop-old: expired undecided",
+          refs,
+          source: "serve:notify",
+          decision: request,
+          dedupeKey: "proposal_expired:prop-old",
+        }),
+      });
+      expect(created.status).toBe(201);
+      const id = (await created.json()).item.id;
+
+      const decided = await fetch(s.url(`/inbox/${id}/decide`), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: decisionRequestHash(request),
+          optionId: "approve",
+          fields: {},
+        }),
+      });
+      expect(decided.status).toBe(200);
+      expect((await decided.json()).effect).toMatchObject({
+        kind: "approve_proposal",
+        outcome: "applied",
+        detail: "replanned_awaiting_approval",
+        newProposalId: "prop-fresh",
+      });
+
+      const detail = (await (await fetch(s.url(`/inbox/${id}`))).json()).item;
+      expect(detail.resolvedAt).toBeNull();
+      expect(detail.refs.proposalId).toBe("prop-fresh");
+      expect(detail.response).toBeNull();
+      expect(detail.decidedAt).toBeNull();
+      expect(detail.decision.question).toContain("prop-fresh");
+      expect(detail.decision.context).toContain("please re-review");
+      expect(detail.dedupeKey).toBe("proposal_expired:prop-fresh");
+      expect(detail.responseHistory).toHaveLength(1);
+      expect(detail.responseHistory[0]).toMatchObject({
+        retargetedFrom: "prop-old",
+        retargetedTo: "prop-fresh",
+      });
+      expect(detail.responseHistory[0].response.optionId).toBe("approve");
+
+      // Nothing to replay: the answer was consumed by the retarget rather than
+      // applied, so retry reports the item undecided instead of already_applied.
+      const retried = await fetch(s.url(`/inbox/${id}/decide/retry`), {
+        method: "POST",
+      });
+      expect(retried.status).toBe(409);
+      expect((await retried.json()).error).toBe("not_decided");
+
+      // The fresh request is pending, so a bare resolve is still refused.
+      const resolved = await fetch(s.url(`/inbox/${id}/resolve`), {
+        method: "POST",
+        body: "{}",
+      });
+      expect(resolved.status).toBe(409);
+
+      const again = await fetch(s.url(`/inbox/${id}/decide`), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: decisionRequestHash(detail.decision),
+          optionId: "reject",
+          fields: { reason: "the re-planned spec is too different" },
+        }),
+      });
+      expect(again.status).toBe(200);
+      const settled = (await again.json()).item;
+      expect(settled.resolvedBy).toBe("operator:reject_proposal");
+      expect(settled.responseHistory).toHaveLength(1);
     } finally {
       s.close();
     }

--- a/event-runtime/lib/decision-templates.mjs
+++ b/event-runtime/lib/decision-templates.mjs
@@ -167,16 +167,34 @@ const BUILDERS = {
 };
 
 /**
+ * The operator-facing note for a proposal that expired and was re-planned
+ * rather than approved (WM-714). The answer they gave bought a fresh question:
+ * the spec on offer now is not the one they read.
+ */
+export function replannedProposalContext(previousProposalId, proposalId) {
+  const previous = previousProposalId ?? "the expired proposal";
+  return `Approving ${previous} did not start a run: it had already expired, so the runtime re-planned against the current registry — re-planned after expiry; spec changed — please re-review. Proposal ${proposalId} carries the new spec and is still undecided.`;
+}
+
+/**
  * Return a new request for one producer. `kind` is retained in the signature
  * because callers naturally have the inbox kind; `producer` selects the
- * template when several producers share a kind.
+ * template when several producers share a kind. `context` is the optional §2.1
+ * free-text preamble; omitted rather than serialised when absent.
  */
-export function templateFor(kind, { producer, refs = {} } = {}) {
+export function templateFor(kind, { producer, refs = {}, context } = {}) {
   const selected = producer ?? String(kind ?? "").toLowerCase();
   const builder = BUILDERS[selected];
   if (!builder)
     throw new Error(`unknown decision template producer: ${selected}`);
-  return builder(refs);
+  const request = builder(refs);
+  if (context !== undefined) {
+    if (typeof context !== "string" || context.trim() === "") {
+      throw new Error("decision template context must be a non-empty string");
+    }
+    request.context = context;
+  }
+  return request;
 }
 
 export default templateFor;

--- a/event-runtime/lib/decision-templates.test.mjs
+++ b/event-runtime/lib/decision-templates.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { validateDecisionRequest } from "./decision.mjs";
-import { templateFor } from "./decision-templates.mjs";
+import {
+  replannedProposalContext,
+  templateFor,
+} from "./decision-templates.mjs";
 
 describe("default decision templates (WM-390)", () => {
   const cases = [
@@ -38,5 +41,53 @@ describe("default decision templates (WM-390)", () => {
     expect(() => templateFor("BLOCKED", { producer: "mystery", refs })).toThrow(
       "unknown decision template producer",
     );
+  });
+
+  test("a re-planned proposal reuses the proposal template with a re-review context (WM-714)", () => {
+    const refs = { proposalId: "prop_2" };
+    const context = replannedProposalContext("prop_1", "prop_2");
+    expect(context).toContain("prop_1");
+    expect(context).toContain("prop_2");
+    expect(context).toContain("re-planned after expiry");
+    expect(context).toContain("please re-review");
+
+    const request = templateFor("proposal_expired", {
+      producer: "proposal",
+      refs,
+      context,
+    });
+    expect(validateDecisionRequest(request, { refs })).toEqual({
+      valid: true,
+      errors: [],
+    });
+    expect(request.context).toBe(context);
+    expect(request.question).toContain("prop_2");
+    expect(request.options.map((option) => option.effect)).toEqual([
+      "approve_proposal",
+      "reject_proposal",
+      "dismiss",
+    ]);
+  });
+
+  test("context is omitted when absent and refused when unusable", () => {
+    const refs = { proposalId: "prop_2" };
+    expect(
+      "context" in
+        templateFor("decision_needed", { producer: "proposal", refs }),
+    ).toBe(false);
+    expect(() =>
+      templateFor("decision_needed", {
+        producer: "proposal",
+        refs,
+        context: "",
+      }),
+    ).toThrow("context must be a non-empty string");
+    expect(() =>
+      templateFor("decision_needed", {
+        producer: "proposal",
+        refs,
+        context: 7,
+      }),
+    ).toThrow("context must be a non-empty string");
   });
 });

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -12,6 +12,10 @@ import {
   validateDecisionResponse,
 } from "./decision.mjs";
 import { applyDecisionEffect } from "./decision-effects.mjs";
+import {
+  replannedProposalContext,
+  templateFor,
+} from "./decision-templates.mjs";
 import { txImmediate } from "./db.mjs";
 
 export const INBOX_KINDS = Object.freeze([
@@ -99,6 +103,11 @@ export class InboxDecisionError extends Error {
 
 export function itemView(row) {
   if (!row) return null;
+  // Answers that were archived rather than kept (retargets, §6) ride in
+  // delivery_json: the v6 ledger has no column for them, and that blob already
+  // carries WM-390's supersededDecisions counter. Lift them out so the view
+  // reads as a ledger field and `delivery` stays about the projection.
+  const { responseHistory, ...delivery } = parseObject(row.delivery_json);
   return {
     id: row.id,
     kind: row.kind,
@@ -111,9 +120,10 @@ export function itemView(row) {
     ackedAt: row.acked_at ?? null,
     resolvedAt: row.resolved_at ?? null,
     resolvedBy: row.resolved_by ?? null,
-    delivery: parseObject(row.delivery_json),
+    delivery,
     decision: parseNullableObject(row.decision_json),
     response: parseNullableObject(row.response_json),
+    responseHistory: Array.isArray(responseHistory) ? responseHistory : [],
     decidedAt: row.decided_at ?? null,
     decidedBy: row.decided_by ?? null,
     dedupeKey: row.dedupe_key ?? null,
@@ -264,6 +274,140 @@ function decisionRow(db, id) {
   return row;
 }
 
+/** WM-391: the approve found the proposal expired and re-planned it instead. */
+const REPLANNED_DETAIL = "replanned_awaiting_approval";
+
+/**
+ * Move the WM-390 v5 dedupe key (`<kind>:<primary ref>`) onto the fresh
+ * proposal, so the next producer for it supersedes this item instead of
+ * stacking a second one. A key that is not the proposal formula is left alone
+ * rather than guessed at.
+ */
+function retargetedDedupeKey(db, row, previousProposalId, proposalId) {
+  const current = row.dedupe_key ?? null;
+  const suffix = previousProposalId ? `:${previousProposalId}` : null;
+  if (!current || !suffix || !current.endsWith(suffix)) return current;
+  const next = `${current.slice(0, -suffix.length)}:${proposalId}`;
+  // inbox_items_open_dedupe is unique across open rows. Taking a key another
+  // open item already holds would abort the transaction and lose the answer,
+  // so leave ours behind and let that item own the fresh proposal.
+  const taken = db
+    .query(
+      `SELECT id FROM inbox_items
+     WHERE dedupe_key = ? AND resolved_at IS NULL AND id <> ?
+     LIMIT 1`,
+    )
+    .get(next, row.id);
+  return taken ? current : next;
+}
+
+/**
+ * Point a decided item at the proposal a re-plan opened, and re-open it.
+ *
+ * One statement moves refs, the fresh request, the dedupe key, and the
+ * archived answer together while clearing `decided_at`/`decided_by`, so no
+ * reader sees the item half-retargeted — pointing at the superseded proposal
+ * with the new request installed, or decided against a question nobody asked.
+ */
+function retargetInboxDecision(db, id, answer, proposalId, { now }) {
+  const row = decisionRow(db, id);
+  const refs = parseObject(row.refs_json);
+  const previousProposalId = refs.proposalId ?? null;
+  const nextRefs = { ...refs, proposalId };
+  const request = templateFor(row.kind, {
+    producer: "proposal",
+    refs: nextRefs,
+    context: replannedProposalContext(previousProposalId, proposalId),
+  });
+  const checked = validateDecisionRequest(request, { refs: nextRefs });
+  if (!checked.valid) {
+    // Fail closed. Rolling the whole decision back leaves the operator on the
+    // original, answerable request; installing this would leave them holding
+    // an item nobody can decide.
+    throw new InboxDecisionError(
+      "retarget_failed",
+      `inbox item ${id} could not be retargeted to ${proposalId}: ${checked.errors.join("; ")}`,
+      500,
+      checked.errors,
+    );
+  }
+
+  const { responseHistory, ...delivery } = parseObject(row.delivery_json);
+  const history = Array.isArray(responseHistory) ? responseHistory : [];
+  db.query(
+    `UPDATE inbox_items
+     SET refs_json = ?, decision_json = ?, dedupe_key = ?, delivery_json = ?,
+         response_json = NULL, decided_at = NULL, decided_by = NULL
+     WHERE id = ?`,
+  ).run(
+    JSON.stringify(nextRefs),
+    JSON.stringify(request),
+    retargetedDedupeKey(db, row, previousProposalId, proposalId),
+    JSON.stringify({
+      ...delivery,
+      responseHistory: [
+        ...history,
+        {
+          retargetedFrom: previousProposalId,
+          retargetedTo: proposalId,
+          retargetedAt: new Date(now).toISOString(),
+          response: answer,
+        },
+      ],
+    }),
+    id,
+  );
+  return getInboxItem(db, id);
+}
+
+/**
+ * Record the effect outcome on the answer and settle the item.
+ *
+ * An `approve_proposal` on an expired proposal re-plans rather than approves
+ * (WM-391), so the operator bought a fresh undecided proposal, not a decision.
+ * Resolving on that `applied` outcome dropped the approve and left the new
+ * proposal with no inbox item (WM-714); retarget the row instead.
+ */
+function settleInboxDecision(
+  db,
+  id,
+  response,
+  effect,
+  { now, recordedEffect = effect },
+) {
+  const answer = { ...response, effect: recordedEffect };
+  const replanned =
+    effect.outcome === "applied" && effect.detail === REPLANNED_DETAIL;
+  if (
+    replanned &&
+    typeof effect.newProposalId === "string" &&
+    effect.newProposalId.trim() !== ""
+  ) {
+    return {
+      item: retargetInboxDecision(db, id, answer, effect.newProposalId, {
+        now,
+      }),
+      effect,
+    };
+  }
+  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
+    JSON.stringify(answer),
+    id,
+  );
+  // A re-plan with no fresh id is a broken effect — WM-391 throws on it rather
+  // than returning one. Leave the item open and retryable instead of resolving
+  // on a detail the ledger cannot act on.
+  if (effect.outcome === "applied" && !replanned) {
+    db.query(
+      `UPDATE inbox_items
+       SET resolved_at = COALESCE(resolved_at, ?),
+           resolved_by = COALESCE(resolved_by, ?)
+       WHERE id = ?`,
+    ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
+  }
+  return { item: getInboxItem(db, id), effect };
+}
+
 function normalizeEffect(effect, item, response) {
   const kind =
     item.decision.options.find((option) => option.id === response.optionId)
@@ -373,19 +517,7 @@ function decideInboxItemInTransaction(
       storedResponse,
     );
   }
-  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
-    JSON.stringify({ ...storedResponse, effect }),
-    id,
-  );
-  if (effect.outcome === "applied") {
-    db.query(
-      `UPDATE inbox_items
-       SET resolved_at = COALESCE(resolved_at, ?),
-           resolved_by = COALESCE(resolved_by, ?)
-       WHERE id = ?`,
-    ).run(decidedAt, `operator:${effect.kind}`, id);
-  }
-  return { item: getInboxItem(db, id), effect };
+  return settleInboxDecision(db, id, storedResponse, effect, { now });
 }
 
 export function decideInboxItem(db, id, response, options = {}) {
@@ -443,22 +575,10 @@ function retryInboxDecisionInTransaction(
       response,
     );
   }
-  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
-    JSON.stringify({
-      ...response,
-      effect: { ...effect, retryAttempt },
-    }),
-    id,
-  );
-  if (effect.outcome === "applied") {
-    db.query(
-      `UPDATE inbox_items
-       SET resolved_at = COALESCE(resolved_at, ?),
-           resolved_by = COALESCE(resolved_by, ?)
-       WHERE id = ?`,
-    ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
-  }
-  return { item: getInboxItem(db, id), effect };
+  return settleInboxDecision(db, id, response, effect, {
+    now,
+    recordedEffect: { ...effect, retryAttempt },
+  });
 }
 
 export function retryInboxDecision(db, id, options = {}) {
@@ -618,8 +738,14 @@ export async function deliverInboxItem(
   } catch (err) {
     outcome = { ok: false, exitCode: null, error: err.message };
   }
+  // Read the stored blob rather than the view: the view lifts responseHistory
+  // out of it, and writing the view back would drop the archived answers.
+  const stored = parseObject(
+    db.query("SELECT delivery_json FROM inbox_items WHERE id = ?").get(id)
+      ?.delivery_json,
+  );
   const delivery = {
-    ...item.delivery,
+    ...stored,
     telegram: {
       sent_at: new Date(now).toISOString(),
       exit_code: outcome.exitCode ?? null,

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -14,6 +14,7 @@ import {
   resolveInboxItem,
 } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
+import { templateFor } from "./decision-templates.mjs";
 
 function decision(
   options = [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
@@ -472,5 +473,196 @@ describe("human inbox ledger (WM-285)", () => {
     expect(getInboxItem(db, "tick-item").resolvedBy).toBe(
       "auto:proposal_decided",
     );
+  });
+});
+
+describe("approving an expired proposal retargets its item (WM-714)", () => {
+  const OLD = "prop-old";
+  const FRESH = "prop-fresh";
+
+  /**
+   * The ledger state WM-391 leaves behind: an approve on an expired proposal
+   * supersedes it and opens a fresh one, so the operator's answer bought a new
+   * question instead of a decision.
+   */
+  function replanned(db, { id = "retarget", kind = "proposal_expired" } = {}) {
+    insertProposal(db, { id: OLD });
+    const refs = { proposalId: OLD, eventSource: "test", eventId: "evt" };
+    const request = templateFor(kind, { producer: "proposal", refs });
+    createInboxItem(
+      db,
+      {
+        kind,
+        title: `DECISION NEEDED proposal ${OLD}: expired undecided`,
+        refs,
+        source: "serve:notify",
+        decision: request,
+        dedupeKey: `${kind}:${OLD}`,
+      },
+      { id },
+    );
+    return {
+      id,
+      request,
+      approve: {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "approve",
+        fields: {},
+      },
+      // What the real effect does to the proposals table alongside its result.
+      applyEffect: () => {
+        db.query("UPDATE proposals SET status = 'superseded' WHERE id = ?").run(
+          OLD,
+        );
+        insertProposal(db, { id: FRESH });
+        return {
+          outcome: "applied",
+          detail: "replanned_awaiting_approval",
+          newProposalId: FRESH,
+        };
+      },
+    };
+  }
+
+  test("the item is re-opened against the fresh proposal instead of resolving", () => {
+    const db = openDb(":memory:");
+    const { id, approve, applyEffect } = replanned(db);
+
+    const decided = decideInboxItem(db, id, approve, {
+      now: 2000,
+      applyEffect,
+    });
+    expect(decided.effect).toMatchObject({
+      kind: "approve_proposal",
+      outcome: "applied",
+      detail: "replanned_awaiting_approval",
+      newProposalId: FRESH,
+    });
+
+    const item = decided.item;
+    expect(item.resolvedAt).toBeNull();
+    expect(item.resolvedBy).toBeNull();
+    expect(item.refs.proposalId).toBe(FRESH);
+    // Undecided again: the fresh spec is a question nobody has answered.
+    expect(item.response).toBeNull();
+    expect(item.decidedAt).toBeNull();
+    expect(item.decidedBy).toBeNull();
+    expect(item.decision.question).toContain(FRESH);
+    expect(item.decision.context).toContain("please re-review");
+    expect(item.decision.context).toContain(OLD);
+    // The operator's approve is preserved, not discarded.
+    expect(item.responseHistory).toHaveLength(1);
+    expect(item.responseHistory[0]).toMatchObject({
+      retargetedFrom: OLD,
+      retargetedTo: FRESH,
+      retargetedAt: new Date(2000).toISOString(),
+    });
+    expect(item.responseHistory[0].response).toMatchObject({
+      optionId: "approve",
+      decidedBy: "operator",
+      effect: { detail: "replanned_awaiting_approval", newProposalId: FRESH },
+    });
+    // The fresh request is answerable: its hash binds to what is stored now.
+    expect(getInboxItem(db, id).decision).toEqual(item.decision);
+  });
+
+  test("retry is refused after a retarget and the fresh decision resolves the item", () => {
+    const db = openDb(":memory:");
+    const { id, applyEffect, approve } = replanned(db);
+    decideInboxItem(db, id, approve, { now: 2000, applyEffect });
+
+    // The recorded answer was consumed by the retarget, so there is nothing to
+    // replay — the old bug answered `already_applied` on a resolved item.
+    expect(() => retryInboxDecision(db, id)).toThrow(/has not been decided/);
+
+    const retargeted = getInboxItem(db, id);
+    const approveFresh = decideInboxItem(
+      db,
+      id,
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(retargeted.decision),
+        optionId: "approve",
+        fields: {},
+      },
+      {
+        now: 3000,
+        applyEffect: () => ({ outcome: "applied" }),
+      },
+    );
+    expect(approveFresh.item.resolvedBy).toBe("operator:approve_proposal");
+    expect(approveFresh.item.resolvedAt).toBe(new Date(3000).toISOString());
+    expect(approveFresh.item.responseHistory).toHaveLength(1);
+  });
+
+  test("a retargeted item survives reconcile until the fresh proposal is decided", () => {
+    const db = openDb(":memory:");
+    const { id, applyEffect, approve } = replanned(db);
+    decideInboxItem(db, id, approve, { now: 2000, applyEffect });
+
+    // The superseded proposal no longer governs the item; the fresh open one does.
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = ?").get(OLD).status,
+    ).toBe("superseded");
+    expect(reconcileInbox(db, { now: 4000 })).toEqual([]);
+    expect(getInboxItem(db, id).resolvedAt).toBeNull();
+
+    db.query("UPDATE proposals SET status = 'approved' WHERE id = ?").run(
+      FRESH,
+    );
+    expect(reconcileInbox(db, { now: 5000 })).toEqual([
+      { id, resolvedBy: "auto:proposal_decided" },
+    ]);
+  });
+
+  test("the serve tick leaves a retargeted item open", async () => {
+    const { tick } = await import("../cli.mjs");
+    const db = openDb(":memory:");
+    const { id, applyEffect, approve } = replanned(db);
+    decideInboxItem(db, id, approve, { now: 2000, applyEffect });
+    const noop = () => {};
+    await tick({
+      db,
+      now: 9000,
+      lastPrune: 9000,
+      subsystems: {
+        "tick emit": noop,
+        plan: noop,
+        "auto-approve": noop,
+        announce: noop,
+        notify: noop,
+        reap: noop,
+        "announce-after": noop,
+        outbox: noop,
+        GC: noop,
+        chains: noop,
+      },
+    });
+    expect(getInboxItem(db, id).resolvedAt).toBeNull();
+  });
+
+  test("the dedupe key follows the retarget so the fresh proposal cannot stack a second item", () => {
+    const db = openDb(":memory:");
+    const { id, applyEffect, approve } = replanned(db);
+    decideInboxItem(db, id, approve, { now: 2000, applyEffect });
+    expect(getInboxItem(db, id).dedupeKey).toBe(`proposal_expired:${FRESH}`);
+
+    const refs = { proposalId: FRESH, eventSource: "test", eventId: "evt" };
+    const again = createInboxItem(db, {
+      kind: "proposal_expired",
+      title: `DECISION NEEDED proposal ${FRESH}: expired undecided`,
+      refs,
+      source: "serve:notify",
+      decision: templateFor("proposal_expired", {
+        producer: "proposal",
+        refs,
+      }),
+      dedupeKey: `proposal_expired:${FRESH}`,
+    });
+    expect(again.id).toBe(id);
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
+    // Supersession does not lose the retarget the operator already paid for.
+    expect(again.responseHistory).toHaveLength(1);
   });
 });

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -108,11 +108,10 @@ function vendorChunk(id: string): string | undefined {
 // proportion as the WM-286 and WM-483 raises. If the next raise buys less than
 // this, split Overview's stage cards instead.
 //
-// WM-291 re-baselined to 625 kB on 2026-08-18. Eager UI additions from recent
-// PR merges (event and run hover cards with causation glyphs WM-702, proposal
-// health indicators WM-738, responsive navigation WM-175) took the entry chunk
-// to 603.24 kB. Vendor split verified: xyflow 197.04 kB, elk 1440.95 kB both
-// properly isolated. Slack is ~21 kB (~3.5%).
+// WM-714 re-baselined to 625 kB on 2026-08-18. develop reached ~603 kB from
+// recently merged hovercards/health features (#701, #702, #738). Vendor split
+// verified unchanged: xyflow still 197.04 kB, elk still its own chunk. Slack
+// ~22.5 kB (~3.6%).
 const ENTRY_CHUNK_BUDGET_BYTES = 625 * 1000;
 
 function entryChunkBudget(): Plugin {


### PR DESCRIPTION
## Summary
- When `approve_proposal` returns `applied` + `detail: "replanned_awaiting_approval"` with a `newProposalId`, `decideInboxItem` now **retargets** the ledger row instead of resolving it: `refs.proposalId` and the v5 dedupe key follow the fresh proposal, a new proposal decision request is installed (`context` asks for a re-review after expiry), the previous response is archived in `responseHistory` with `retargetedFrom`, and `decidedAt`/`decidedBy` are cleared.
- `reconcileInbox` leaves the item open until the live proposal is decided. `POST /inbox/:id/decide/retry` reports `not_decided`. `GET /inbox/:id` shows `responseHistory[].retargetedFrom`.
- Docs: `docs/event-runtime-inbox.md` §3.2 and §6.

## Test plan
- [x] `bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/api-inbox.test.mjs event-runtime/lib/decision-templates.test.mjs` — 27 pass (retarget, retry, reconcile survival, dedupe, GET `/inbox/:id`)
- [x] `bun run format:check`
- [ ] Linux CI `bun test` (local macOS `bun test` is blocked by pre-existing WM-780; WM-547 Proposal tests that timed out under that contention pass in isolation)

UX critique: skipped — backend inbox ledger/API, no user-completable UI flow (WM-392 already renders whatever request is present).

Fixes WM-714