### PR TITLE
fix(web): preserve artifact facets during inspection (WM-762)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -316,6 +316,31 @@ describe("Artifacts inventory (WM-207)", () => {
     fireEvent.click(runLink.getByRole("link", { name: "Open" }));
     expect(window.location.hash).toBe(`#/${`artifacts/${"b".repeat(64)}`}`);
   });
+
+  test("preserves URL-backed facets when opening and closing the inspector", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("artifact report", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const query =
+      "kind=report&orphan=false&search=reporter%401&project=factory";
+    window.location.hash = `#/artifacts?${query}`;
+    const view = renderArtifacts(mock(() => {}), {
+      kind: "report",
+      orphan: false,
+      search: "reporter@1",
+    });
+
+    fireEvent.click(await view.findByRole("link", { name: "aaaaaaaaaaaa" }));
+    expect(window.location.hash).toBe(
+      `#/artifacts/${"a".repeat(64)}?${query}`,
+    );
+    expect(
+      await view.findByRole("region", { name: "Artifact content" }),
+    ).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: "Close" }));
+    expect(window.location.hash).toBe(`#/artifacts?${query}`);
+  });
 });
 
 describe("Artifact rows inspect on click, download on demand (WM-699)", () => {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -324,16 +324,17 @@ describe("Artifacts inventory (WM-207)", () => {
     const query =
       "kind=report&orphan=false&search=reporter%401&project=factory";
     window.location.hash = `#/artifacts?${query}`;
-    const view = renderArtifacts(mock(() => {}), {
-      kind: "report",
-      orphan: false,
-      search: "reporter@1",
-    });
+    const view = renderArtifacts(
+      mock(() => {}),
+      {
+        kind: "report",
+        orphan: false,
+        search: "reporter@1",
+      },
+    );
 
     fireEvent.click(await view.findByRole("link", { name: "aaaaaaaaaaaa" }));
-    expect(window.location.hash).toBe(
-      `#/artifacts/${"a".repeat(64)}?${query}`,
-    );
+    expect(window.location.hash).toBe(`#/artifacts/${"a".repeat(64)}?${query}`);
     expect(
       await view.findByRole("region", { name: "Artifact content" }),
     ).toBeTruthy();

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -26,7 +26,7 @@ import {
   type DisplayConfig,
 } from "../displayOptions";
 import { EMPTY, formatBytes, formatRelative } from "../format";
-import { hashPath, hashProject, withProject } from "../hash";
+import { hashSearch } from "../hash";
 import { refetchIntervals, useDisplayOptions, useNow } from "../hooks";
 import { viewApplies } from "../lib/artifactView";
 import type {
@@ -141,11 +141,13 @@ function artifactShaFromHash(hash = window.location.hash): string | null {
   }
 }
 
+function withCurrentArtifactQuery(path: string): string {
+  const query = hashSearch(window.location.hash).toString();
+  return `#/${path}${query ? `?${query}` : ""}`;
+}
+
 function artifactInspectorHash(sha256: string): string {
-  return `#/${withProject(
-    hashPath("artifacts", sha256),
-    hashProject(window.location.hash),
-  )}`;
+  return withCurrentArtifactQuery(`artifacts/${encodeURIComponent(sha256)}`);
 }
 
 function openArtifactInspector(sha256: string) {
@@ -408,10 +410,7 @@ export function Artifacts({
   const closeInspector = () => {
     setSelectedSha(null);
     setContentSearch("");
-    window.location.hash = `#/${withProject(
-      "artifacts",
-      hashProject(window.location.hash),
-    )}`;
+    window.location.hash = withCurrentArtifactQuery("artifacts");
   };
 
   const fallbackMetrics = useMemo(


### PR DESCRIPTION
## Summary
- preserve the current artifact hash query when opening an inspector
- restore the faceted artifact-list hash when closing the inspector
- cover kind, orphan, search, and project retention across both transitions

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx` — 17 pass, 0 fail

UX critique: required — SHIP (round 1)
Evidence: http://127.0.0.1:7729/#/artifacts?kind=report&orphan=false&search=report&project=factory

Fixes WM-762