### PR TITLE
fix(web): reject numeric-zero PR ids after canonicalizing (WM-743)

### DIFF
--- a/event-runtime/web/src/entities.test.ts
+++ b/event-runtime/web/src/entities.test.ts
@@ -60,6 +60,13 @@ describe("resolveEntity pull requests", () => {
   test("rejects a non-numeric or zero pull request", () => {
     expect(resolveEntity("pr", "abc")).toBeNull();
     expect(resolveEntity("pr", "0")).toBeNull();
+    expect(resolveEntity("pr", "00")).toBeNull();
+  });
+
+  test("canonicalises a leading-zero positive number", () => {
+    const pr = resolveEntity("pr", "0541");
+    expect(pr?.id).toBe("541");
+    expect(pr?.href).toBe("#/prs/541");
   });
 });
 

--- a/event-runtime/web/src/entities.ts
+++ b/event-runtime/web/src/entities.ts
@@ -75,8 +75,10 @@ function resolvePr(
   const repo =
     url?.[1] ?? (REPO_RE.test(text(options.repo)) ? text(options.repo) : null);
   const number = url?.[2] ?? raw.replace(/^#/, "");
-  if (!/^\d+$/.test(number) || number === "0") return null;
-  const id = String(Number(number));
+  if (!/^\d+$/.test(number)) return null;
+  const n = Number(number);
+  if (n < 1) return null;
+  const id = String(n);
   return entity(
     "pr",
     id,


### PR DESCRIPTION
## Summary
- `resolvePr` now rejects `Number(number) < 1`, so `"00"` (and other all-zero digit strings) return null instead of `#/prs/0`.
- Valid positive pull-request numbers with leading zeros still canonicalize (`"0541"` → `#/prs/541`).

## Test plan
- [x] `cd event-runtime/web && bun test src/entities.test.ts` — 20 pass, 0 fail
- [x] Negative: `resolveEntity("pr", "00")` failed on origin/develop (received `#/prs/0`) before the fix

UX critique: skipped — isolated routing-guard bug, no user-completable flow change; UX critic blocked (WM-726/WM-730).

Fixes WM-743