### PR TITLE
ops(event-runtime): triage on an 8h clock, drop chain-triggered triage scans

### DIFF
--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -67,8 +67,14 @@
   },
   "chainOutcome": {
     "precedence": [
-      { "action": "label-agent-ready", "outcome": "SUPPLY_CHANGED" },
-      { "action": "write-detail", "outcome": "DETAIL_CHANGED" }
+      {
+        "action": "label-agent-ready",
+        "outcome": "SUPPLY_CHANGED"
+      },
+      {
+        "action": "write-detail",
+        "outcome": "DETAIL_CHANGED"
+      }
     ],
     "default": "NO_CHANGE"
   },
@@ -86,7 +92,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/triage-apply.md": "sha256:88872839dbb90b8803b1ba0a64bd5bfdf83033c0f17311ffa2400ad2bae14639",
+    "agents/triage-apply.md": "sha256:bf9ec61ac7bbc39e4fa37123bf64a02fd6f806e392f1d1c747531bd3cfdc4994",
     "schemas/triage-apply.input.json": "sha256:fd2378637f0f8accb317bf71444f5a63c26d741628b726695b7e769f050c0810",
     "schemas/triage-applied.output.json": "sha256:5c52b583f055223367bddbcf48e853ff0af9a8e5bf536942ac15f2dc01f217f9"
   }

--- a/event-runtime/agents/triage-apply.md
+++ b/event-runtime/agents/triage-apply.md
@@ -17,10 +17,14 @@ Registered actions — each resolves to one fixed, non-shell-interpolated argv:
 
 `write-detail` is intentionally separate from `label-agent-ready`. It calls
 `tools/linear.mjs detail`, which preserves the description read immediately
-before the mutation and appends only the approved Markdown suffix. A later
-triage scan must make and justify
-the promotion decision independently; writing detail never changes state or
-labels.
+before the mutation and appends only the approved Markdown suffix. Its
+`DETAIL_CHANGED` outcome no longer chains into an immediate re-scan (WM:
+operator decision 2026-08-18, to stop burning the pi/codex adapter's quota on
+~30-minute chain loops); the next triage scan that sees the appended detail
+and makes and justifies the promotion decision independently runs on the 8h
+`triage-factory` clock (`event-runtime/schedules.json`), or sooner if the
+operator manually injects `factory.triage.requested`. Writing detail never
+changes state or labels.
 
 Every action is additive or a forward state move; nothing here closes,
 deletes, or reassigns an issue. An action ID outside this table refuses

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -22,7 +22,7 @@
   "mutating": false,
   "pins": {
     "agents/triage-scan.md": "sha256:a29b89ed8ecedadd0815a3b772f7996882f700e753847ec55e1fd21ce23a1840",
-    "schemas/triage-scan.input.json": "sha256:739315f3204d6d330a17a62650ca3d72a2dede46739874a128af5faead8db7be",
+    "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:6eb237281746aaaea34e4e5927228e9eb90f2954d9df8d05f8c04b00bad27868"
   }
 }

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:aa73e0702f8715e50176ec5209e80c9554d3498c9c0335f3a626d7c9a9431c12",
+    "agents/work-scan.md": "sha256:097744fb5ef68feb4cc53d5fab99d57eb0a6e13e9983efac7595e433fe94caef",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
     "schemas/work-scan.output.json": "sha256:98a2cb891198b79d8d8d9924a3db1fe2bd11e2983c71ae4a3499bc54a5d43f5f"
   }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -1,4 +1,4 @@
-# work-scan — read a repo's agent-ready queue and refill triage when supply is low
+# work-scan — read a repo's agent-ready queue and flag when triage supply is low
 
 You are a dispatch planner. `./input.json` names one repo and the exact source
 tree to read it against:
@@ -189,7 +189,12 @@ Linear `Triage` issues when that independent read is required, and 0 otherwise.
 
 `LOW_SUPPLY` means zero ready candidates and non-empty Triage backlog with a
 successful complete read for both; emit `readyCandidates` and `triageBacklog` in
-that artifact.
+that artifact. `LOW_SUPPLY` no longer chains into an immediate
+`factory.triage.requested` (WM: operator decision 2026-08-18, to stop burning
+the pi/codex adapter's quota on ~30-minute chain loops); it is now advisory
+evidence only. The triage floor is the 8h `triage-factory` schedule
+(`event-runtime/schedules.json`) plus the operator manually injecting
+`factory.triage.requested` when supply needs to be refilled sooner.
 
 `NOOP` still means no ready work (`queue_empty`), zero free slots
 (`cap_full`), or ownership overlap (`all_overlapping`) with an empty `plan`,

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -89,12 +89,6 @@
         "input": {
           "repo": "$.artifact.repo"
         }
-      },
-      "LOW_SUPPLY": {
-        "eventType": "factory.triage.requested",
-        "input": {
-          "repo": "$.artifact.repo"
-        }
       }
     }
   },
@@ -103,12 +97,6 @@
     "edges": {
       "SUPPLY_CHANGED": {
         "eventType": "factory.work.requested",
-        "input": {
-          "repo": "$.artifact.repo"
-        }
-      },
-      "DETAIL_CHANGED": {
-        "eventType": "factory.triage.requested",
         "input": {
           "repo": "$.artifact.repo"
         }

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -589,15 +589,16 @@ describe("multi-emit chain resolution (WM-119)", () => {
         applied: [{ issueId: "WM-2", action: "write-detail" }],
       },
     });
+    // DETAIL_CHANGED no longer chains into factory.triage.requested (WM:
+    // operator decision 2026-08-18, to stop burning the pi/codex adapter's
+    // quota on ~30-minute chain loops). The triage floor is now the 8h
+    // triage-factory schedule plus manual operator injection.
     const detailOutcome = resolveChains(db2, registry);
-    expect(detailOutcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    expect(detailOutcome).toEqual({ emitted: 0, skipped: 1, errors: [] });
     const detailEvent = db2
       .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
       .get("chain-run-triage-detail");
-    expect(detailEvent.type).toBe("factory.triage.requested");
-    expect(JSON.parse(detailEvent.envelope_json).payload).toEqual({
-      repo: "wm/triage",
-    });
+    expect(detailEvent).toBeNull();
 
     const dir3 = mkdtempSync(
       path.join(os.tmpdir(), "evrt-chain-triage-apply-3"),

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -141,8 +141,13 @@ describe("registry", () => {
     // Regenerated (WM-722): merge-scan/merge-fix adapter pi→claude; event-types.json is a registry input.
     // Regenerated (WM-391): dispatch admits and documents bounded humanDecision authorisations.
     // Regenerated (WM-694): dispatch input admits a pinned per-ticket modelTier override.
+    // Regenerated 2026-08-18 (ops/triage-8h-clock): dropped work-scan@1 LOW_SUPPLY
+    // and triage-apply@1 DETAIL_CHANGED chain edges to factory.triage.requested,
+    // added the triage-factory 8h schedule. Operator decision 2026-08-18: stop
+    // burning the pi/codex adapter's quota on ~30-minute chain-triggered triage
+    // scans; triage now runs on a fixed 8h clock plus manual operator injection.
     const expected =
-      "sha256:8d3f8ca1951587fcbd646c3e97590c2daa631be129b867e17e0e8787d66da1cd";
+      "sha256:1e6e9eb418c087aaf0bfcdc74b55c79a3a0a22bf84f81b7e1eab5fc4fb9a17f4";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -301,7 +301,12 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "bj29" });
   });
 
-  test("apply outcome DETAIL_CHANGED chains to triage.requested", async () => {
+  test("apply outcome DETAIL_CHANGED no longer chains to triage.requested", async () => {
+    // DETAIL_CHANGED no longer fires a chained triage-scan run (WM:
+    // operator decision 2026-08-18, to stop burning the pi/codex adapter's
+    // quota on ~30-minute chain loops). The triage floor is now the 8h
+    // triage-factory schedule plus manual operator injection of
+    // factory.triage.requested.
     const { db, approveNext } = harness({
       adapters: {
         pi: triagePlanScan({
@@ -322,12 +327,11 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     expect(applied.summary.terminalState).toBe("COMPLETED");
 
     const chain = resolveChains(db, registry);
-    expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    expect(chain).toEqual({ emitted: 0, skipped: 1, errors: [] });
     const event = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`)
       .get(applied.runId);
-    expect(event.type).toBe("factory.triage.requested");
-    expect(JSON.parse(event.envelope_json).payload).toEqual({ repo: "bj29" });
+    expect(event).toBeNull();
   });
 
   test("apply outcome NO_CHANGE terminates with no follow-up", async () => {

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -363,9 +363,19 @@ describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
         enabled: true,
       }),
     );
+    // Operator decision 2026-08-18 (WM): triage now runs on a fixed 8h
+    // clock instead of chain-triggered ~30-minute re-scans, to stop
+    // burning the pi/codex adapter's quota. The operator injects
+    // factory.triage.requested manually when triage is needed sooner.
+    expect(registry.schedules["triage-factory"]).toEqual(
+      loopEntry("factory.triage.requested", "factory", "8h", {
+        approval: "auto",
+        enabled: true,
+      }),
+    );
   });
 
-  test("the exact enabled autonomous merge set is merge-factory", () => {
+  test("the exact enabled autonomous set is merge-factory and triage-factory", () => {
     for (const repo of [
       "coach-wattz",
       "watts-mobile",
@@ -385,10 +395,12 @@ describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
         ([, schedule]) => schedule.enabled && schedule.approval === "auto",
       )
       .map(([loop]) => loop);
-    expect(enabledAutonomous).toEqual(["merge-factory"]);
+    expect(enabledAutonomous.sort()).toEqual(
+      ["merge-factory", "triage-factory"].sort(),
+    );
 
     for (const [loop, schedule] of Object.entries(registry.schedules)) {
-      if (loop !== "merge-factory") {
+      if (loop !== "merge-factory" && loop !== "triage-factory") {
         expect({
           approval: schedule.approval,
           enabled: schedule.enabled,
@@ -429,11 +441,16 @@ describe("loop schedule autonomy scope (WM-112/WM-417)", () => {
     // below proves each tick now plans a real run.
   });
 
-  test("the shipped clock fires only Factory merge discovery", () => {
+  test("the shipped clock fires only Factory merge discovery and triage discovery", () => {
+    // triage-factory's 8h cadence and merge-factory's 15m cadence both have
+    // a due slot at their first tick (no prior admitted slot yet), so a
+    // clock started fresh fires both once.
     const db = openDb(":memory:");
     const emitted = emitDueTicks(db, registry, { now: Date.now() }).emitted;
-    expect(emitted.map((row) => row.loop)).toEqual(["merge-factory"]);
-    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
+    expect(emitted.map((row) => row.loop).sort()).toEqual(
+      ["merge-factory", "triage-factory"].sort(),
+    );
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(2);
     db.close();
   });
 });

--- a/event-runtime/schedules.json
+++ b/event-runtime/schedules.json
@@ -151,6 +151,15 @@
     "approval": "auto",
     "enabled": true
   },
+  "triage-factory": {
+    "every": "8h",
+    "eventType": "factory.triage.requested",
+    "payload": { "repo": "factory" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "auto",
+    "enabled": true
+  },
   "ship-cashsaas": {
     "every": "7d",
     "eventType": "factory.ship.requested",

--- a/event-runtime/schemas/triage-scan.input.json
+++ b/event-runtime/schemas/triage-scan.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "triage-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
+  "title": "triage-scan input — one repo; repoPin is resolved by the planner (OPS-228). A clock tick adds {loop, slot, cadenceSeconds, skippedSlots} bookkeeping to the schedule's static {repo} payload — whitelisted here as in repo-loop.input.json (WM-123)",
   "type": "object",
   "required": ["repo"],
   "additionalProperties": false,
@@ -38,6 +38,10 @@
           "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }
-    }
+    },
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
   }
 }

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -517,9 +517,13 @@ describe("work-scan registration (WM-110)", () => {
     ]);
   });
 
-  test("DISPATCH remains multi-emit and LOW_SUPPLY chains to triage", () => {
+  test("DISPATCH remains multi-emit; LOW_SUPPLY no longer chains to triage", () => {
     // chain.mjs derives eventId chain-<runId>-<ticket> — multi-emit fan-out
     // edge feeds every planned ticket into factory.dispatch.requested.
+    // LOW_SUPPLY no longer has a chain edge (WM: operator decision
+    // 2026-08-18, to stop burning the pi/codex adapter's quota on
+    // ~30-minute chain loops). The triage floor is now the 8h
+    // triage-factory schedule plus manual operator injection.
     expect(registry.edges["work-scan@1"]).toEqual({
       recommendationField: "recommendation",
       edges: {
@@ -527,10 +531,6 @@ describe("work-scan registration (WM-110)", () => {
           eventType: "factory.dispatch.requested",
           itemsField: "plan",
           itemKey: "ticket",
-          input: { repo: "$.artifact.repo" },
-        },
-        LOW_SUPPLY: {
-          eventType: "factory.triage.requested",
           input: { repo: "$.artifact.repo" },
         },
       },
@@ -612,7 +612,12 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     });
   });
 
-  test("a LOW_SUPPLY scan chains to one triage scan", async () => {
+  test("a LOW_SUPPLY scan no longer chains to a triage scan", async () => {
+    // LOW_SUPPLY is still computed as advisory evidence, but it no longer
+    // fires a chained triage-scan run (WM: operator decision 2026-08-18,
+    // to stop burning the pi/codex adapter's quota on ~30-minute chain
+    // loops). The triage floor is now the 8h triage-factory schedule plus
+    // manual operator injection of factory.triage.requested.
     const { db, planAll, approveNext } = harness();
     admitEvent(db, registry, workEnvelope("low", "work-low-1"));
     const scan = await approveNext("work-scan@1");
@@ -626,20 +631,17 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
     expect(scanResult.artifact.triageBacklog).toBe(3);
 
     const chain = resolveChains(db, registry);
-    expect(chain).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    expect(chain).toEqual({ emitted: 0, skipped: 1, errors: [] });
 
     const chainEvent = db
       .query(`SELECT * FROM events WHERE source = 'chain' AND causation_id = ?`)
       .get(scan.runId);
-    expect(chainEvent.type).toBe("factory.triage.requested");
-    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({
-      repo: "low",
-    });
+    expect(chainEvent).toBeNull();
 
     planAll();
     expect(
       openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1"),
-    ).toBeTruthy();
+    ).toBeUndefined();
   });
 
   test("cap-overlap NOOP outcomes still do not fallback to triage", async () => {


### PR DESCRIPTION
## What

- Remove `work-scan@1`'s `LOW_SUPPLY` edge and `triage-apply@1`'s `DETAIL_CHANGED` edge in `event-runtime/edges.json` — both routed into `factory.triage.requested`, causing triage-scan to re-fire roughly every 30 minutes. `SUPPLY_CHANGED -> factory.work.requested` and every other edge is untouched.
- Add a `triage-factory` schedule to `event-runtime/schedules.json`: `every: "8h"`, `factory.triage.requested {repo: "factory"}`, `approval: "auto"`, `enabled: true` — mirrors `merge-factory`'s shape.
- Whitelist the clock-tick bookkeeping fields (`loop`/`slot`/`cadenceSeconds`/`skippedSlots`) in `event-runtime/schemas/triage-scan.input.json`, matching the pattern already used by `work-scan`/`merge-scan`/`ship-scan` input schemas — `triage-scan@1` can now be invoked directly by a schedule tick, not just a chain/manual event.
- Update `work-scan.md` and `triage-apply.md` prose describing `LOW_SUPPLY`/`DETAIL_CHANGED`: they no longer chain immediately; the triage floor is now the 8h `triage-factory` clock plus the operator manually injecting `factory.triage.requested`.
- Re-pinned agent digests via `update-pins`.
- `triage-apply@1`'s `chainOutcome.precedence` (in `triage-apply.json`) is left untouched — `DETAIL_CHANGED` is still recorded as an outcome, it just no longer has a chain edge.

## Why

`triage-scan` runs on the pi/codex adapter. The chain-triggered ~30-minute re-scan loop was burning the operator's codex quota. Operator decision 2026-08-18: put triage on a fixed 8h clock instead, with the operator injecting `factory.triage.requested` manually when triage is needed sooner.

## Test plan

- [x] `bun test event-runtime/lib/chain.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/triage.test.mjs event-runtime/lib/schedule*.test.mjs event-runtime/work.test.mjs` — 104 pass
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib` (CI job 1 scope) — 1027 pass, 9 skip, 0 fail
- [x] `bun test --timeout 20000 --max-concurrency=4 --path-ignore-patterns='event-runtime/lib/**' --path-ignore-patterns='event-runtime/web/**'` — 651/652 pass; the one failure (`supervise` pool-drain timing test) is a pre-existing flake under concurrent load, confirmed passing in isolation and unaffected by this diff
- [x] `bunx prettier --check` on all changed files — clean
- [x] `bun build/emit.mjs --check` — ok, 90 generated files match `shared/`

Operator decision 2026-08-18.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz