### PR TITLE
ci: release host verify lock when worker crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,63 @@ jobs:
 
           exit "$failed"
 
+      - name: Check host verify lock guardian
+        shell: bash
+        run: |
+          set -euo pipefail
+          lock="/tmp/factory-verify-host.lock"
+          [ -e "$lock" ] || exit 0
+
+          # lslocks distinguishes the process that owns the flock from queued
+          # processes that merely have the file open; lsof confirms that the
+          # reported PID still has this exact lock file open.
+          holder="$(lslocks -n -o PID,MODE,PATH 2>/dev/null | awk -v lock="$lock" '$2 == "WRITE" && $3 == lock { print $1; exit }')"
+          if [ -z "$holder" ] || ! lsof -t "$lock" 2>/dev/null | grep -qx "$holder"; then
+            exit 0
+          fi
+
+          ppid="$(awk '/^PPid:/ { print $2 }' "/proc/$holder/status" 2>/dev/null || true)"
+          holder_start="$(cut -d\  -f22 "/proc/$holder/stat" 2>/dev/null || true)"
+          cmdline="$(tr '\0' ' ' < "/proc/$holder/cmdline" 2>/dev/null || true)"
+          guardian="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_GUARDIAN" { print $2; exit }' || true)"
+          job_pid="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_PID" { print $2; exit }' || true)"
+          job_exe="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_EXE" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+          job_start="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_START" { print $2; exit }' || true)"
+          runner_temp="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "RUNNER_TEMP" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+          legacy=0
+          case "$cmdline" in
+            *"tail -f /dev/null"*) legacy=1 ;;
+          esac
+
+          # A healthy new guardian names its live Runner.Worker explicitly.
+          # Legacy tail guardians have no such metadata and are only considered
+          # orphaned after init has adopted them.
+          worker_live=0
+          if [[ "$job_pid" =~ ^[0-9]+$ ]] && [ -n "$job_exe" ] && [ -n "$job_start" ] && [ "$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)" = "$job_exe" ] && [ "$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)" = "$job_start" ]; then
+            worker_live=1
+          elif [ "$legacy" -eq 1 ] && [ "${runner_temp%/_work/_temp}" != "$runner_temp" ]; then
+            legacy_worker="${runner_temp%/_work/_temp}/bin/Runner.Worker"
+            for worker_exe in /proc/[0-9]*/exe; do
+              worker_pid="${worker_exe#/proc/}"
+              worker_pid="${worker_pid%/exe}"
+              worker_start="$(cut -d\  -f22 "/proc/$worker_pid/stat" 2>/dev/null || true)"
+              if [ "$(readlink "$worker_exe" 2>/dev/null || true)" = "$legacy_worker" ] && [[ "$holder_start" =~ ^[0-9]+$ ]] && [[ "$worker_start" =~ ^[0-9]+$ ]] && [ "$worker_start" -le "$holder_start" ]; then
+                worker_live=1
+                break
+              fi
+            done
+          fi
+          if [ "$ppid" != "1" ] || { [ "$guardian" != "1" ] && [ "$legacy" -ne 1 ]; } || [ "$worker_live" -eq 1 ]; then
+            exit 0
+          fi
+
+          age="$(ps -o etimes= -p "$holder" 2>/dev/null | tr -d ' ' || true)"
+          if [[ "$age" =~ ^[0-9]+$ ]] && [ "$age" -gt 600 ]; then
+            echo "::error::Host Verify lock has been held by orphan guardian PID $holder for ${age}s: $cmdline"
+            exit 1
+          fi
+          echo "::warning::Host Verify lock is held by orphan guardian PID $holder (${age:-unknown}s old); acquisition cleanup will terminate it."
+
   fast-unit-tests:
     name: Fast unit tests
     needs: shadow-runner-health
@@ -128,21 +185,94 @@ jobs:
         run: |
           set -euo pipefail
           lock="/tmp/factory-verify-host.lock"
+          : >> "$lock"
+
+          # Remove only an init-adopted legacy/new guardian whose Runner.Worker
+          # is gone. lslocks excludes queued waiters; lsof guards against PID
+          # reuse between discovering and inspecting the holder.
+          holder="$(lslocks -n -o PID,MODE,PATH 2>/dev/null | awk -v lock="$lock" '$2 == "WRITE" && $3 == lock { print $1; exit }')"
+          if [ -n "$holder" ] && lsof -t "$lock" 2>/dev/null | grep -qx "$holder"; then
+            ppid="$(awk '/^PPid:/ { print $2 }' "/proc/$holder/status" 2>/dev/null || true)"
+            holder_start="$(cut -d\  -f22 "/proc/$holder/stat" 2>/dev/null || true)"
+            cmdline="$(tr '\0' ' ' < "/proc/$holder/cmdline" 2>/dev/null || true)"
+            guardian="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_GUARDIAN" { print $2; exit }' || true)"
+            job_pid="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_PID" { print $2; exit }' || true)"
+            job_exe="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_EXE" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            job_start="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_START" { print $2; exit }' || true)"
+            runner_temp="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "RUNNER_TEMP" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            legacy=0
+            case "$cmdline" in
+              *"tail -f /dev/null"*) legacy=1 ;;
+            esac
+            worker_live=0
+            if [[ "$job_pid" =~ ^[0-9]+$ ]] && [ -n "$job_exe" ] && [ -n "$job_start" ] && [ "$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)" = "$job_exe" ] && [ "$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)" = "$job_start" ]; then
+              worker_live=1
+            elif [ "$legacy" -eq 1 ] && [ "${runner_temp%/_work/_temp}" != "$runner_temp" ]; then
+              legacy_worker="${runner_temp%/_work/_temp}/bin/Runner.Worker"
+              for worker_exe in /proc/[0-9]*/exe; do
+                worker_pid="${worker_exe#/proc/}"
+                worker_pid="${worker_pid%/exe}"
+                worker_start="$(cut -d\  -f22 "/proc/$worker_pid/stat" 2>/dev/null || true)"
+                if [ "$(readlink "$worker_exe" 2>/dev/null || true)" = "$legacy_worker" ] && [[ "$holder_start" =~ ^[0-9]+$ ]] && [[ "$worker_start" =~ ^[0-9]+$ ]] && [ "$worker_start" -le "$holder_start" ]; then
+                  worker_live=1
+                  break
+                fi
+              done
+            fi
+            if [ "$ppid" = "1" ] && { [ "$guardian" = "1" ] || [ "$legacy" -eq 1 ]; } && [ "$worker_live" -eq 0 ]; then
+              echo "::warning::Killing stale host Verify lock guardian PID $holder before acquisition: $cmdline"
+              kill "$holder" 2>/dev/null || true
+            fi
+          fi
+
           state_dir="$(mktemp -d "$RUNNER_TEMP/factory-verify-lock.XXXXXX")"
           ready="$state_dir/ready"
           mkfifo "$ready"
+          job_pid="$PPID"
+          job_exe="$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)"
+          job_start="$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)"
+          case "$job_exe" in
+            */bin/Runner.Worker) ;;
+            *) echo "::error::Cannot identify Runner.Worker parent PID $job_pid ($job_exe); refusing to create an untracked lock guardian."; exit 1 ;;
+          esac
+          # Opening the FIFO read/write before spawning means a guardian can
+          # signal without blocking even if Runner.Worker dies during the wait.
+          exec 8<>"$ready"
+          rm -f "$ready"
 
           # Keep flock alive across subsequent Actions steps. Reading the FIFO
           # waits on the real lock acquisition rather than sleep-polling. The
-          # final always() step and runner cleanup both release the lock.
-          (
-            flock 9
-            printf 'acquired\n' > "$ready"
-            exec tail -f /dev/null >/dev/null 2>&1
-          ) 9>"$lock" &
+          # guardian also releases it within five seconds if Runner.Worker dies.
+          env FACTORY_VERIFY_GUARDIAN=1 FACTORY_VERIFY_JOB_PID="$job_pid" FACTORY_VERIFY_JOB_EXE="$job_exe" FACTORY_VERIFY_JOB_START="$job_start" \
+            bash -c '
+              worker_alive() {
+                kill -0 "$FACTORY_VERIFY_JOB_PID" 2>/dev/null &&
+                  [ "$(readlink "/proc/$FACTORY_VERIFY_JOB_PID/exe" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_EXE" ] &&
+                  [ "$(cut -d\  -f22 "/proc/$FACTORY_VERIFY_JOB_PID/stat" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_START" ]
+              }
+              flock 9 8>&- &
+              waiter=$!
+              while worker_alive && kill -0 "$waiter" 2>/dev/null; do
+                sleep 5 8>&- 9>&-
+              done
+              if ! worker_alive; then
+                kill "$waiter" 2>/dev/null || true
+                wait "$waiter" 2>/dev/null || true
+                exit 0
+              fi
+              if ! wait "$waiter"; then
+                printf "failed\n" >&8
+                exit 1
+              fi
+              printf "acquired\n" >&8
+              while worker_alive; do
+                sleep 5 8>&- 9>&-
+              done
+            ' 8>&8 9>"$lock" &
           guardian=$!
-          read -r _ < "$ready"
-          rm -f "$ready"
+          read -r lock_status <&8
+          exec 8>&-
+          [ "$lock_status" = "acquired" ]
 
           echo "guardian=$guardian" >> "$GITHUB_OUTPUT"
           echo "state_dir=$state_dir" >> "$GITHUB_OUTPUT"
@@ -224,21 +354,93 @@ jobs:
         run: |
           set -euo pipefail
           lock="/tmp/factory-verify-host.lock"
+          : >> "$lock"
+
+          # Remove only an init-adopted legacy/new guardian whose Runner.Worker
+          # is gone. lslocks excludes queued waiters; lsof guards against PID
+          # reuse between discovering and inspecting the holder.
+          holder="$(lslocks -n -o PID,MODE,PATH 2>/dev/null | awk -v lock="$lock" '$2 == "WRITE" && $3 == lock { print $1; exit }')"
+          if [ -n "$holder" ] && lsof -t "$lock" 2>/dev/null | grep -qx "$holder"; then
+            ppid="$(awk '/^PPid:/ { print $2 }' "/proc/$holder/status" 2>/dev/null || true)"
+            holder_start="$(cut -d\  -f22 "/proc/$holder/stat" 2>/dev/null || true)"
+            cmdline="$(tr '\0' ' ' < "/proc/$holder/cmdline" 2>/dev/null || true)"
+            guardian="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_GUARDIAN" { print $2; exit }' || true)"
+            job_pid="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_PID" { print $2; exit }' || true)"
+            job_exe="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_EXE" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            job_start="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_START" { print $2; exit }' || true)"
+            runner_temp="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "RUNNER_TEMP" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            legacy=0
+            case "$cmdline" in
+              *"tail -f /dev/null"*) legacy=1 ;;
+            esac
+            worker_live=0
+            if [[ "$job_pid" =~ ^[0-9]+$ ]] && [ -n "$job_exe" ] && [ -n "$job_start" ] && [ "$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)" = "$job_exe" ] && [ "$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)" = "$job_start" ]; then
+              worker_live=1
+            elif [ "$legacy" -eq 1 ] && [ "${runner_temp%/_work/_temp}" != "$runner_temp" ]; then
+              legacy_worker="${runner_temp%/_work/_temp}/bin/Runner.Worker"
+              for worker_exe in /proc/[0-9]*/exe; do
+                worker_pid="${worker_exe#/proc/}"
+                worker_pid="${worker_pid%/exe}"
+                worker_start="$(cut -d\  -f22 "/proc/$worker_pid/stat" 2>/dev/null || true)"
+                if [ "$(readlink "$worker_exe" 2>/dev/null || true)" = "$legacy_worker" ] && [[ "$holder_start" =~ ^[0-9]+$ ]] && [[ "$worker_start" =~ ^[0-9]+$ ]] && [ "$worker_start" -le "$holder_start" ]; then
+                  worker_live=1
+                  break
+                fi
+              done
+            fi
+            if [ "$ppid" = "1" ] && { [ "$guardian" = "1" ] || [ "$legacy" -eq 1 ]; } && [ "$worker_live" -eq 0 ]; then
+              echo "::warning::Killing stale host Verify lock guardian PID $holder before acquisition: $cmdline"
+              kill "$holder" 2>/dev/null || true
+            fi
+          fi
+
           state_dir="$(mktemp -d "$RUNNER_TEMP/factory-verify-lock.XXXXXX")"
           ready="$state_dir/ready"
           mkfifo "$ready"
+          job_pid="$PPID"
+          job_exe="$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)"
+          job_start="$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)"
+          case "$job_exe" in
+            */bin/Runner.Worker) ;;
+            *) echo "::error::Cannot identify Runner.Worker parent PID $job_pid ($job_exe); refusing to create an untracked lock guardian."; exit 1 ;;
+          esac
+          exec 8<>"$ready"
+          rm -f "$ready"
 
           # Eight shadow runner services share one physical host. A single flock
           # serializes test jobs across workflow runs so CPU-heavy spawn suites
-          # cannot starve one another. FIFO readiness avoids sleep-polling.
-          (
-            flock 9
-            printf 'acquired\n' > "$ready"
-            exec tail -f /dev/null >/dev/null 2>&1
-          ) 9>"$lock" &
+          # cannot starve one another. FIFO readiness avoids sleep-polling; the
+          # guardian drops the lock within five seconds if Runner.Worker dies.
+          env FACTORY_VERIFY_GUARDIAN=1 FACTORY_VERIFY_JOB_PID="$job_pid" FACTORY_VERIFY_JOB_EXE="$job_exe" FACTORY_VERIFY_JOB_START="$job_start" \
+            bash -c '
+              worker_alive() {
+                kill -0 "$FACTORY_VERIFY_JOB_PID" 2>/dev/null &&
+                  [ "$(readlink "/proc/$FACTORY_VERIFY_JOB_PID/exe" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_EXE" ] &&
+                  [ "$(cut -d\  -f22 "/proc/$FACTORY_VERIFY_JOB_PID/stat" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_START" ]
+              }
+              flock 9 8>&- &
+              waiter=$!
+              while worker_alive && kill -0 "$waiter" 2>/dev/null; do
+                sleep 5 8>&- 9>&-
+              done
+              if ! worker_alive; then
+                kill "$waiter" 2>/dev/null || true
+                wait "$waiter" 2>/dev/null || true
+                exit 0
+              fi
+              if ! wait "$waiter"; then
+                printf "failed\n" >&8
+                exit 1
+              fi
+              printf "acquired\n" >&8
+              while worker_alive; do
+                sleep 5 8>&- 9>&-
+              done
+            ' 8>&8 9>"$lock" &
           guardian=$!
-          read -r _ < "$ready"
-          rm -f "$ready"
+          read -r lock_status <&8
+          exec 8>&-
+          [ "$lock_status" = "acquired" ]
 
           echo "guardian=$guardian" >> "$GITHUB_OUTPUT"
           echo "state_dir=$state_dir" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,17 +58,88 @@ jobs:
           # Reuse their lock: a second lock lane would allow CPU-heavy suites
           # to overlap on the same machine and recreate the flake this protects.
           lock="/tmp/factory-verify-host.lock"
+          : >> "$lock"
+
+          # Remove only an init-adopted legacy/new guardian whose Runner.Worker
+          # is gone. lslocks excludes queued waiters; lsof guards against PID
+          # reuse between discovering and inspecting the holder.
+          holder="$(lslocks -n -o PID,MODE,PATH 2>/dev/null | awk -v lock="$lock" '$2 == "WRITE" && $3 == lock { print $1; exit }')"
+          if [ -n "$holder" ] && lsof -t "$lock" 2>/dev/null | grep -qx "$holder"; then
+            ppid="$(awk '/^PPid:/ { print $2 }' "/proc/$holder/status" 2>/dev/null || true)"
+            holder_start="$(cut -d\  -f22 "/proc/$holder/stat" 2>/dev/null || true)"
+            cmdline="$(tr '\0' ' ' < "/proc/$holder/cmdline" 2>/dev/null || true)"
+            guardian="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_GUARDIAN" { print $2; exit }' || true)"
+            job_pid="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_PID" { print $2; exit }' || true)"
+            job_exe="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_EXE" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            job_start="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "FACTORY_VERIFY_JOB_START" { print $2; exit }' || true)"
+            runner_temp="$(tr '\0' '\n' < "/proc/$holder/environ" 2>/dev/null | awk -F= '$1 == "RUNNER_TEMP" { sub(/^[^=]*=/, ""); print; exit }' || true)"
+            legacy=0
+            case "$cmdline" in
+              *"tail -f /dev/null"*) legacy=1 ;;
+            esac
+            worker_live=0
+            if [[ "$job_pid" =~ ^[0-9]+$ ]] && [ -n "$job_exe" ] && [ -n "$job_start" ] && [ "$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)" = "$job_exe" ] && [ "$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)" = "$job_start" ]; then
+              worker_live=1
+            elif [ "$legacy" -eq 1 ] && [ "${runner_temp%/_work/_temp}" != "$runner_temp" ]; then
+              legacy_worker="${runner_temp%/_work/_temp}/bin/Runner.Worker"
+              for worker_exe in /proc/[0-9]*/exe; do
+                worker_pid="${worker_exe#/proc/}"
+                worker_pid="${worker_pid%/exe}"
+                worker_start="$(cut -d\  -f22 "/proc/$worker_pid/stat" 2>/dev/null || true)"
+                if [ "$(readlink "$worker_exe" 2>/dev/null || true)" = "$legacy_worker" ] && [[ "$holder_start" =~ ^[0-9]+$ ]] && [[ "$worker_start" =~ ^[0-9]+$ ]] && [ "$worker_start" -le "$holder_start" ]; then
+                  worker_live=1
+                  break
+                fi
+              done
+            fi
+            if [ "$ppid" = "1" ] && { [ "$guardian" = "1" ] || [ "$legacy" -eq 1 ]; } && [ "$worker_live" -eq 0 ]; then
+              echo "::warning::Killing stale host Verify lock guardian PID $holder before acquisition: $cmdline"
+              kill "$holder" 2>/dev/null || true
+            fi
+          fi
+
           state_dir="$(mktemp -d "$RUNNER_TEMP/factory-e2e-lock.XXXXXX")"
           ready="$state_dir/ready"
           mkfifo "$ready"
-          (
-            flock 9
-            printf 'acquired\n' > "$ready"
-            exec tail -f /dev/null >/dev/null 2>&1
-          ) 9>"$lock" &
-          guardian=$!
-          read -r _ < "$ready"
+          job_pid="$PPID"
+          job_exe="$(readlink "/proc/$job_pid/exe" 2>/dev/null || true)"
+          job_start="$(awk '{ print $22 }' "/proc/$job_pid/stat" 2>/dev/null || true)"
+          case "$job_exe" in
+            */bin/Runner.Worker) ;;
+            *) echo "::error::Cannot identify Runner.Worker parent PID $job_pid ($job_exe); refusing to create an untracked lock guardian."; exit 1 ;;
+          esac
+          exec 8<>"$ready"
           rm -f "$ready"
+          env FACTORY_VERIFY_GUARDIAN=1 FACTORY_VERIFY_JOB_PID="$job_pid" FACTORY_VERIFY_JOB_EXE="$job_exe" FACTORY_VERIFY_JOB_START="$job_start" \
+            bash -c '
+              worker_alive() {
+                kill -0 "$FACTORY_VERIFY_JOB_PID" 2>/dev/null &&
+                  [ "$(readlink "/proc/$FACTORY_VERIFY_JOB_PID/exe" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_EXE" ] &&
+                  [ "$(cut -d\  -f22 "/proc/$FACTORY_VERIFY_JOB_PID/stat" 2>/dev/null || true)" = "$FACTORY_VERIFY_JOB_START" ]
+              }
+              flock 9 8>&- &
+              waiter=$!
+              while worker_alive && kill -0 "$waiter" 2>/dev/null; do
+                sleep 5 8>&- 9>&-
+              done
+              if ! worker_alive; then
+                kill "$waiter" 2>/dev/null || true
+                wait "$waiter" 2>/dev/null || true
+                exit 0
+              fi
+              if ! wait "$waiter"; then
+                printf "failed\n" >&8
+                exit 1
+              fi
+              printf "acquired\n" >&8
+              while worker_alive; do
+                sleep 5 8>&- 9>&-
+              done
+            ' 8>&8 9>"$lock" &
+          guardian=$!
+          read -r lock_status <&8
+          exec 8>&-
+          [ "$lock_status" = "acquired" ]
           echo "guardian=$guardian" >> "$GITHUB_OUTPUT"
           echo "state_dir=$state_dir" >> "$GITHUB_OUTPUT"
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,9 @@ Treat runner names as parallel executors, not independent machines. CPU, memory,
 
 ## Verify serialization
 
-Both test jobs acquire `/tmp/factory-verify-host.lock` with `flock` before installing dependencies or running tests. A guardian process holds the descriptor across GitHub Actions steps; the final `always()` step releases it, and runner process cleanup releases it after cancellation or failure.
+Both test jobs acquire `/tmp/factory-verify-host.lock` with `flock` before installing dependencies or running tests. A guardian process holds the descriptor across GitHub Actions steps. The guardian records the job's `Runner.Worker` PID, executable, and process start time and checks that identity every five seconds, both while queued and after acquisition. If the worker disappears (including a crash that prevents `always()` cleanup), the guardian cancels its pending `flock` or exits and releases an acquired lock within about ten seconds. The final `always()` step still terminates the guardian on normal completion.
+
+Before blocking, each acquisition checks the current holder with `lslocks` and `lsof`. It kills only a recognized legacy `tail -f /dev/null` or current Factory guardian that has been adopted by PID 1 and has no live recorded `Runner.Worker`, logging the stale PID and command. The `shadow-runner-health` job independently fails when such an orphan has held the lock for more than ten minutes, so a broken liveness rule becomes an explicit check rather than a host-wide silent queue.
 
 The lock is intentionally host-local rather than a GitHub Actions `concurrency` group. A concurrency group keeps only one pending job and replaces older pending jobs when more runs arrive. The host lock lets every started workflow wait its turn while ensuring that no two Factory test critical sections execute on the shared host at once. Job timeouts include lock wait, so they include generous multi-PR queue headroom.
 


### PR DESCRIPTION
## Summary
- tie every host-lock guardian to the exact Runner.Worker PID, executable, and start time
- cancel queued guardians and release acquired locks when their worker disappears
- clean recognized stale legacy/current holders and surface >10 minute orphans in shadow-runner-health
- document the Verify serialization liveness rule

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml`
- `bun test event-runtime/lib --timeout 20000` — 1,027 pass, 9 skip, 0 fail
- `bun build/emit.mjs --check` — generated files match
- local acquired-lock, cancelled-waiter, and manual stale-orphan simulations pass

UX critique: skipped — CI infrastructure has no user-facing surface

Fixes WM-776