### PR TITLE
ci: coalesce push runs per ref (WM-773 item 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,12 @@ on:
 permissions:
   contents: read
 
+# One live run per PR, and one per pushed branch: a newer push to develop
+# supersedes the older develop run (WM-773 item 6) — a stale develop SHA green
+# proves nothing and used to cost a full lane hold per merge.
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   shadow-runner-health:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,9 +9,12 @@ on:
 permissions:
   contents: read
 
+# One live run per PR, and one per pushed branch: a newer push to develop
+# supersedes the older develop run (WM-773 item 6) — a stale develop SHA green
+# proves nothing and used to cost a full lane hold per merge.
 concurrency:
-  group: security-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: security-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   gitleaks:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,7 +18,7 @@ Capacity is a runner-config knob, not a workflow change: **lanes = number of run
 
 ## Run coalescing
 
-CI and Security use `concurrency.group` keyed by PR number for pull requests and by ref for pushes, with `cancel-in-progress` for both. A newer push to `develop` cancels the older develop run — only the latest develop head is verified — and a newer PR push cancels that PR's older run. Runs never wait in a concurrency group for a *different* PR, so nothing is dropped across PRs; queueing across PRs happens in GitHub's runner queue for the `verify-lane` label.
+CI and Security use `concurrency.group` keyed by PR number for pull requests and by ref for pushes, with `cancel-in-progress` for both. A newer push to `develop` cancels the older develop run — only the latest develop head is verified — and a newer PR push cancels that PR's older run. Runs never wait in a concurrency group for a _different_ PR, so nothing is dropped across PRs; queueing across PRs happens in GitHub's runner queue for the `verify-lane` label.
 
 ## Draft pull requests
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,6 +16,10 @@ Capacity is a runner-config knob, not a workflow change: **lanes = number of run
 
 `Fast unit tests` deliberately runs on the general `shadow` pool, outside the lane. Five shadow-runner measurements made while another verification job held the lock are recorded in the WM-773 handoff; all five were green and below the three-minute stability threshold. The first ready-head measurement was [job 95742407011](https://github.com/watt-mind/factory/actions/runs/32146787946/job/95742407011): 36 seconds job wall time and 30 seconds for the test step. Keep its command bounded to `event-runtime/lib`, `--timeout 20000`, and `--max-concurrency=4`; broadening that job requires repeating the overlap measurements before assuming it is safe.
 
+## Run coalescing
+
+CI and Security use `concurrency.group` keyed by PR number for pull requests and by ref for pushes, with `cancel-in-progress` for both. A newer push to `develop` cancels the older develop run — only the latest develop head is verified — and a newer PR push cancels that PR's older run. Runs never wait in a concurrency group for a *different* PR, so nothing is dropped across PRs; queueing across PRs happens in GitHub's runner queue for the `verify-lane` label.
+
 ## Draft pull requests
 
 Draft pull requests run `Shadow runner fleet available`, but skip `Fast unit tests`, `Full verification`, and Browser E2E so held work does not consume the verify lane. The required `Verify` check is a lightweight aggregate on the smoke-test runner: it succeeds explicitly for a draft, and for every other event it succeeds only when fleet health and both CI test jobs succeeded. This prevents a failed prerequisite from turning a skipped downstream job into a misleading successful required check.


### PR DESCRIPTION
Operator instruction 2026-08-18: land CI throughput fixes immediately (admin merge, not waiting for CI).

- CI + Security: `concurrency.group` for pushes keyed by `github.ref` with `cancel-in-progress: true` — a newer develop push cancels the older develop run. PR grouping unchanged; nothing waits behind a different PR.
- docs/ci.md: 'Run coalescing' section.

actionlint + prettier clean. Part of WM-773.