### PR TITLE
test(web): cover zero-padded PR references (WM-785)

### DIFF
--- a/event-runtime/web/src/entities.test.ts
+++ b/event-runtime/web/src/entities.test.ts
@@ -61,6 +61,10 @@ describe("resolveEntity pull requests", () => {
     expect(resolveEntity("pr", "abc")).toBeNull();
     expect(resolveEntity("pr", "0")).toBeNull();
     expect(resolveEntity("pr", "00")).toBeNull();
+    expect(resolveEntity("pr", "000")).toBeNull();
+    expect(
+      resolveEntity("pr", "https://github.com/watt-mind/factory/pull/00"),
+    ).toBeNull();
   });
 
   test("canonicalises a leading-zero positive number", () => {


### PR DESCRIPTION
## Summary
- cover the all-zero `000` pull request reference
- cover GitHub pull URLs ending in `/pull/00`

## Verification
- `cd event-runtime/web && bun test src/entities.test.ts` — 20 pass, 0 fail

UX critique: skipped — test-only coverage with no user-facing behavior change

Fixes WM-785