### PR TITLE
fix(test): revert exitOf early-return that broke seed.test on develop

### DIFF
--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -301,12 +301,6 @@ export async function waitFor(box, needle, timeoutMs = 15_000) {
 }
 
 export function exitOf(child) {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return Promise.resolve({
-      code: child.exitCode,
-      signal: child.signalCode,
-    });
-  }
   return new Promise((resolve) =>
     child.once("exit", (code, signal) => resolve({ code, signal })),
   );


### PR DESCRIPTION
develop is red on `Integration and spawn tests` since #640 (docs, WM-808) — it also changed `event-runtime/cli/test-helpers.mjs` (`exitOf` early return when the child already exited). `event-runtime/demo/seed.test.mjs` (OPS-464) then fails deterministically (ECONNREFUSED / 'initial seed exited 1'): reproduced locally 3 fails at `5051961`, 0 fails at `a8f54b9`, 0 fails with this hunk reverted (2/2). This PR restores the pre-#640 helper. If WM-808 needs already-exited semantics, add a separate helper with a test in a follow-up. Trunk fix — landers should rerun after this merges.