### PR TITLE
fix(a11y): preserve focus for nested hover card portals (WM-764)

### DIFF
--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -8,6 +8,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
+import { createPortal } from "react-dom";
 import {
   CLOSE_MS,
   computeHoverCardPosition,
@@ -634,6 +635,40 @@ describe("HoverCard", () => {
     fireEvent.keyDown(panel, { key: "Tab" });
 
     expect(document.activeElement).toBe(trigger);
+  });
+
+  test("Tab from a nested portal does not return focus to the trigger", async () => {
+    const portalHost = document.createElement("div");
+    document.body.appendChild(portalHost);
+    try {
+      const r = render(
+        <HoverCard
+          label="Agent triage-scan"
+          openDelayMs={0}
+          closeDelayMs={0}
+          trigger="triage-scan"
+        >
+          {createPortal(
+            <button type="button">Portal action</button>,
+            portalHost,
+          )}
+        </HoverCard>,
+      );
+      const trigger = triggerOf(r.container);
+      trigger.focus();
+      fireEvent.focus(trigger);
+      await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+      const portalAction = r.getByRole("button", { name: "Portal action" });
+      portalAction.focus();
+      const event = createEvent.keyDown(portalAction, { key: "Tab" });
+      fireEvent(portalAction, event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.activeElement).toBe(portalAction);
+    } finally {
+      portalHost.remove();
+    }
   });
 
   test("drops the entry animation when reduced motion is preferred", async () => {

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -436,8 +436,11 @@ export function HoverCard({
       if (e.key !== "Tab") return;
       const root = panelRef.current;
       if (!root) return;
-      const stops = getTabbableElements(root);
       const active = document.activeElement;
+      // React events from a nested portal still bubble through this panel's
+      // component tree, but its focused element is not one of the panel edges.
+      if (!active || !root.contains(active)) return;
+      const stops = getTabbableElements(root);
       // A card with nothing focusable holds focus on the panel itself, so
       // either direction is an edge. Otherwise only the far end is: forward
       // from the panel root still walks into the card, as the DOM order says.


### PR DESCRIPTION
## Summary
- ignore HoverCard Tab-edge handling when focus is outside the panel root
- cover React nested-portal key bubbling without focus restoration or preventDefault

## Verification
- `cd event-runtime/web && bun test src/components/HoverCard.test.tsx` — 33 pass, 0 fail
- `factory security` — pass

UX critique: required — NOT-ASSESSED; the running app has no current HoverCard consumer with a nested portal, so the exact changed scenario could not be driven. Closest keyboard flows were exercised at http://127.0.0.1:7629/#/runs and http://127.0.0.1:7629/#/proposals.

Fixes WM-764