### PR TITLE
fix(test): exitOf resolves for already-exited children without firing on live ones

### DIFF
--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -304,10 +304,15 @@ export async function waitFor(box, needle, timeoutMs = 15_000) {
 }
 
 export function exitOf(child) {
-  if (child.exitCode !== null || child.signalCode !== null) {
+  // Resolve immediately if the child already exited (a drain-signalled
+  // worker can finish before the test awaits it — WM-689). Use loose
+  // null checks: Bun's ChildProcess reports `signalCode` as undefined (not
+  // null) while the process is still running, and a strict `!== null` test
+  // made this fire on live children, which broke demo/seed.test.mjs.
+  if (child.exitCode != null || child.signalCode != null) {
     return Promise.resolve({
       code: child.exitCode,
-      signal: child.signalCode,
+      signal: child.signalCode ?? null,
     });
   }
   return new Promise((resolve) => {


### PR DESCRIPTION
Redo of `35085ae` (direct push): keep the early return that fixes the drain-signalled worker test (WM-689), but with loose null checks — Bun's ChildProcess reports `signalCode` as `undefined` while running, so `!== null` resolved immediately for live children and broke `event-runtime/demo/seed.test.mjs` (OPS-464): 5/5 lane runs red since 15:57Z. Locally: seed.test 5/5 (x3), work.test 15/15. Supersedes #642. Trunk fix — merged on operator instruction to unblock develop.