### PR TITLE
fix(web): ignore hidden HoverCard tab stops (WM-765)

### DIFF
--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -48,6 +48,7 @@ function Fixture(props: {
   interactiveTrigger?: boolean;
   /** Two in-card controls, so the first and last tab stops are distinct. */
   secondAction?: boolean;
+  hiddenSecondAction?: boolean;
 }) {
   return (
     <HoverCard
@@ -70,7 +71,11 @@ function Fixture(props: {
           <button type="button" onClick={close}>
             Open in Agents
           </button>
-          {props.secondAction ? <button type="button">Copy id</button> : null}
+          {props.secondAction ? (
+            <button type="button" hidden={props.hiddenSecondAction}>
+              Copy id
+            </button>
+          ) : null}
         </>
       )}
     </HoverCard>
@@ -505,6 +510,77 @@ describe("HoverCard", () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
     });
     expect(r.queryByRole("dialog")).toBeTruthy();
+  });
+
+  test("a hidden last control is not treated as the Tab edge", async () => {
+    const r = render(<Fixture secondAction hiddenSecondAction />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const visibleLast = r.getByRole("button", { name: /Open in Agents/ });
+    visibleLast.focus();
+    fireEvent.keyDown(visibleLast, { key: "Tab" });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test("an inert last control is not treated as the Tab edge", async () => {
+    const r = render(
+      <HoverCard
+        label="Agent triage-scan"
+        openDelayMs={0}
+        closeDelayMs={0}
+        trigger="triage-scan"
+      >
+        <button type="button">Visible action</button>
+        <span inert>
+          <button type="button">Inert action</button>
+        </span>
+      </HoverCard>,
+    );
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.focus(trigger);
+    await waitFor(() => expect(r.getByRole("dialog")).toBeTruthy());
+
+    const visibleLast = r.getByRole("button", { name: "Visible action" });
+    visibleLast.focus();
+    fireEvent.keyDown(visibleLast, { key: "Tab" });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test("ArrowDown skips hidden controls and follows positive tabindex order", async () => {
+    const r = render(
+      <HoverCard
+        label="Agent triage-scan"
+        openDelayMs={0}
+        closeDelayMs={0}
+        trigger="triage-scan"
+      >
+        <button type="button" hidden tabIndex={1}>
+          Hidden first
+        </button>
+        <button type="button" tabIndex={2}>
+          DOM first
+        </button>
+        <button type="button" tabIndex={1}>
+          Tab first
+        </button>
+      </HoverCard>,
+    );
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        r.getByRole("button", { name: "Tab first" }),
+      ),
+    );
   });
 
   test("Shift+Tab from the first in-card control returns focus to the trigger", async () => {

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -38,8 +38,58 @@ export const VIEWPORT_MARGIN = 12;
 /** Gap between the trigger and the panel. */
 export const TRIGGER_GAP = 8;
 
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+const FOCUSABLE = "a[href],button,input,select,textarea,[tabindex]";
+
+/**
+ * Return the controls the browser can actually reach with Tab, in tab order.
+ * querySelectorAll alone also returns controls hidden by an ancestor, controls
+ * under `inert`, and descendants of closed details elements. It also keeps DOM
+ * order even though positive tabindex values are visited first.
+ */
+function getTabbableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE))
+    .filter((candidate) => {
+      if (candidate.tabIndex < 0 || candidate.matches(":disabled")) {
+        return false;
+      }
+
+      for (
+        let current: HTMLElement | null = candidate;
+        current && root.contains(current);
+        current = current.parentElement
+      ) {
+        if (current.hidden || current.hasAttribute("inert")) return false;
+        const style = window.getComputedStyle(current);
+        if (
+          style.display === "none" ||
+          style.visibility === "hidden" ||
+          style.visibility === "collapse" ||
+          style.contentVisibility === "hidden"
+        ) {
+          return false;
+        }
+
+        if (current instanceof HTMLDetailsElement && !current.open) {
+          const summary = Array.from(current.children).find(
+            (child): child is HTMLElement =>
+              child instanceof HTMLElement && child.tagName === "SUMMARY",
+          );
+          if (!summary?.contains(candidate)) return false;
+        }
+      }
+      return true;
+    })
+    .map((element, domOrder) => ({ element, domOrder }))
+    .sort((a, b) => {
+      const aTabIndex = a.element.tabIndex;
+      const bTabIndex = b.element.tabIndex;
+      if (aTabIndex === bTabIndex) return a.domOrder - b.domOrder;
+      if (aTabIndex === 0) return 1;
+      if (bTabIndex === 0) return -1;
+      return aTabIndex - bTabIndex;
+    })
+    .map(({ element }) => element);
+}
 
 interface OpenHoverCard {
   owner: object;
@@ -337,7 +387,7 @@ export function HoverCard({
     focusPanelRef.current = false;
     const root = panelRef.current;
     if (!root) return;
-    const first = root.querySelector<HTMLElement>(FOCUSABLE);
+    const first = getTabbableElements(root)[0];
     (first ?? root).focus();
   }, [open]);
 
@@ -386,7 +436,7 @@ export function HoverCard({
       if (e.key !== "Tab") return;
       const root = panelRef.current;
       if (!root) return;
-      const stops = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+      const stops = getTabbableElements(root);
       const active = document.activeElement;
       // A card with nothing focusable holds focus on the panel itself, so
       // either direction is an edge. Otherwise only the far end is: forward


### PR DESCRIPTION
## Summary
- compute HoverCard tab stops with a shared browser-like tabbable filter
- ignore hidden, inert, and collapsed-details controls for edge detection and ArrowDown focus
- respect positive tabindex order and add regression coverage

## Verification
- `cd event-runtime/web && bun test src/components/HoverCard.test.tsx` — 35 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass

UX critique: required — SHIP; evidence: http://127.0.0.1:7621/#/runs

Follow-up: WM-817 tracks ArrowDown re-entry when a card is already expanded.

Fixes WM-765