### PR TITLE
ui(event-runtime-web): group and reorder primary navigation rail into functional blocks with subtle dividers (WM-819)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -248,6 +248,29 @@ describe("sidebar navigation accessibility", () => {
       );
     }
   });
+
+  test("renders navigation rail grouped into functional tiers separated by dividers (WM-819)", async () => {
+    const { sidebar } = renderApp();
+    const separators = sidebar.getAllByRole("separator");
+    expect(separators.length).toBe(3);
+
+    const buttons = sidebar.getAllByRole("button");
+    const labels = buttons.map((b) => b.textContent?.trim()).filter(Boolean);
+    const overviewIdx = labels.findIndex((l) => l?.startsWith("Overview"));
+    const inboxIdx = labels.findIndex((l) => l?.startsWith("Inbox"));
+    const proposalsIdx = labels.findIndex((l) => l?.startsWith("Proposals"));
+    const runsIdx = labels.findIndex((l) => l?.startsWith("Runs"));
+    const eventsIdx = labels.findIndex((l) => l?.startsWith("Events"));
+    const ticketsIdx = labels.findIndex((l) => l?.startsWith("Tickets"));
+    const chainsIdx = labels.findIndex((l) => l?.startsWith("Chains"));
+
+    expect(overviewIdx).toBeLessThan(inboxIdx);
+    expect(inboxIdx).toBeLessThan(proposalsIdx);
+    expect(proposalsIdx).toBeLessThan(runsIdx);
+    expect(runsIdx).toBeLessThan(eventsIdx);
+    expect(eventsIdx).toBeLessThan(ticketsIdx);
+    expect(ticketsIdx).toBeLessThan(chainsIdx);
+  });
 });
 
 describe("Graph proposal navigation (WM-165)", () => {

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -748,38 +749,47 @@ export function App() {
             </div>
           </div>
           <div className="flex-1 px-2">
-            {NAV.map((n) => {
+            {NAV.map((n, index) => {
+              const prev = index > 0 ? NAV[index - 1] : null;
+              const isGroupBoundary = prev && prev.group !== n.group;
               const badge = navBadges[n.key];
               const current = navIsCurrent(n.key, view);
               return (
-                <PrimitiveButton
-                  bare
-                  key={n.key}
-                  type="button"
-                  aria-current={current ? "page" : undefined}
-                  aria-describedby={
-                    badge.count > 0 ? `nav-badge-${n.key}` : undefined
-                  }
-                  onClick={() => {
-                    setMobileNavOpen(false);
-                    navigate(n.key);
-                  }}
-                  className={`flex min-h-11 w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] md:min-h-0 ${
-                    current
-                      ? "bg-(--surface-3) font-medium text-(--text)"
-                      : "text-(--text-dim) hover:bg-(--surface-2)"
-                  }`}
-                >
-                  <span>{n.label}</span>
-                  {badge.count > 0 && (
-                    /* aria-hidden keeps the count out of the accessible name —
-                       "Events" must not announce as "Events 6" — while the
-                       aria-describedby reference above still reads it back as
-                       the button's description (accname spec includes hidden
-                       nodes referenced by labelledby/describedby). */
-                    <NavCount id={`nav-badge-${n.key}`} badge={badge} />
+                <Fragment key={n.key}>
+                  {isGroupBoundary && (
+                    <div
+                      role="separator"
+                      className="my-1.5 mx-2.5 border-t border-(--border)"
+                    />
                   )}
-                </PrimitiveButton>
+                  <PrimitiveButton
+                    bare
+                    type="button"
+                    aria-current={current ? "page" : undefined}
+                    aria-describedby={
+                      badge.count > 0 ? `nav-badge-${n.key}` : undefined
+                    }
+                    onClick={() => {
+                      setMobileNavOpen(false);
+                      navigate(n.key);
+                    }}
+                    className={`flex min-h-11 w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] md:min-h-0 ${
+                      current
+                        ? "bg-(--surface-3) font-medium text-(--text)"
+                        : "text-(--text-dim) hover:bg-(--surface-2)"
+                    }`}
+                  >
+                    <span>{n.label}</span>
+                    {badge.count > 0 && (
+                      /* aria-hidden keeps the count out of the accessible name —
+                         "Events" must not announce as "Events 6" — while the
+                         aria-describedby reference above still reads it back as
+                         the button's description (accname spec includes hidden
+                         nodes referenced by labelledby/describedby). */
+                      <NavCount id={`nav-badge-${n.key}`} badge={badge} />
+                    )}
+                  </PrimitiveButton>
+                </Fragment>
               );
             })}
             <PrimitiveButton

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -8,22 +8,32 @@
 // Inbox's 1–4 status tabs never see them); with no open card the tabs keep
 // their existing binding. Chains rides `g l` ("chain link"): its natural `c`
 // went to Settings (WM-704, config) first (WM-537).
+export type NavGroup = "live" | "work" | "machinery" | "system";
+
 export const NAV = [
-  { key: "overview", label: "Overview", go: "o" },
-  { key: "inbox", label: "Inbox", go: "n" },
-  { key: "events", label: "Events", go: "e" },
-  { key: "chains", label: "Chains", go: "l" },
-  { key: "proposals", label: "Proposals", go: "p" },
-  { key: "runs", label: "Runs", go: "r" },
-  { key: "tickets", label: "Tickets", go: "k" },
-  { key: "projects", label: "Projects", go: "f" },
-  { key: "agents", label: "Agents", go: "t" },
-  { key: "artifacts", label: "Artifacts", go: "y" },
-  { key: "schedules", label: "Schedules", go: "s" },
-  { key: "workers", label: "Workers", go: "w" },
-  { key: "graph", label: "Graph", go: "g" },
-  { key: "settings", label: "Settings", go: "c" },
+  // Attention / Live Actions (badge-carrying / immediate triage)
+  { key: "overview", label: "Overview", go: "o", group: "live" },
+  { key: "inbox", label: "Inbox", go: "n", group: "live" },
+  { key: "proposals", label: "Proposals", go: "p", group: "live" },
+  { key: "runs", label: "Runs", go: "r", group: "live" },
+  { key: "events", label: "Events", go: "e", group: "live" },
+
+  // Work Journey (artifact and execution lifecycle)
+  { key: "tickets", label: "Tickets", go: "k", group: "work" },
+  { key: "chains", label: "Chains", go: "l", group: "work" },
+  { key: "projects", label: "Projects", go: "f", group: "work" },
+  { key: "artifacts", label: "Artifacts", go: "y", group: "work" },
+
+  // Machinery & Topology (configuration, workers, cadence, graph)
+  { key: "agents", label: "Agents", go: "t", group: "machinery" },
+  { key: "workers", label: "Workers", go: "w", group: "machinery" },
+  { key: "schedules", label: "Schedules", go: "s", group: "machinery" },
+  { key: "graph", label: "Graph", go: "g", group: "machinery" },
+
+  // System
+  { key: "settings", label: "Settings", go: "c", group: "system" },
 ] as const;
 
 export type NavItem = (typeof NAV)[number];
 export type NavKey = NavItem["key"];
+

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -36,4 +36,3 @@ export const NAV = [
 
 export type NavItem = (typeof NAV)[number];
 export type NavKey = NavItem["key"];
-


### PR DESCRIPTION
## Summary
Groups and reorders the 14 primary navigation rail items into functional blocks (*Attention / Live* → *Work Journey* → *Machinery & Topology* → *System*) separated by subtle 1px hairline dividers without bulky headings.

- **Attention / Live Actions**: Overview (`g o`), Inbox (`g n`), Proposals (`g p`), Runs (`g r`), Events (`g e`) — clusters all active decision/state badge surfaces at the top for one-glance situational awareness.
- **Work Journey**: Tickets (`g k`), Chains (`g l`), Projects (`g f`), Artifacts (`g y`) — mirrors the execution lifecycle (ticket → chain → repo project → artifacts).
- **Machinery & Topology**: Agents (`g t`), Workers (`g w`), Schedules (`g s`), Graph (`g g`) — infrastructure and execution topology.
- **System**: Settings (`g c`).
- Preserves all existing `g <key>` keyboard chords and navigation contracts.

## Verification
- `cd event-runtime/web && bun test && bun run build` (pass, 1062 tests passed, bundle built cleanly in 7.83s)
- `bun run lint` (pass, 0 errors)
- `./lib/security-check.sh` (pass)

Fixes WM-819