### PR TITLE
fix(merge-scan): spell out the exact output item shapes and noopReason enum (sonnet contract violations)

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:a68d5a886739be1acfeb392eaaacf5cce844a5c2c3c7c0f7cef1c276b0af6938",
+    "agents/merge-scan.md": "sha256:c2570c4734882240bf921c699238169683f2d40ab907752700e70dcb8f5568f6",
     "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -174,5 +174,44 @@ For any refusal, use the fail-closed wrapper shown above rather than writing a
 partial merge plan. A selected-target refusal must additionally include the
 evidence required above.
 
+## Output shape (exact)
+
+`plan`, `fix`, `escalate` items use exactly these property names — never
+`title`, `headRefName`, or other GitHub API names.
+
+`plan` item (≤1, lowest eligible PR):
+<!-- prettier-ignore -->
+```json
+{ "pr": 512, "headSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "baseSha": "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b",
+  "headRef": "fix/wm-512-thing", "ticket": "WM-512", "action": "merge_pr", "reason": "Green CI, in Owned Paths, falsifiable tests.",
+  "checksGreen": true, "mergeable": true, "ownedPathsValid": true, "handoffValid": true, "testsFalsifiable": true,
+  "policySafe": true, "sensitive": false, "ambiguous": false }
+```
+
+`fix` item:
+<!-- prettier-ignore -->
+```json
+{ "pr": 513, "headSha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3", "baseSha": "2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c",
+  "headRef": "fix/wm-513-thing", "ticket": "WM-513", "finding": "rebase_onto_base",
+  "findingHash": "6e27a6319dc7dcc61478b9b5214e7390843aa7210328f7299f0768394922ae62",
+  "round": 1, "mechanical": true, "withinOwnedPaths": true, "ownedPaths": ["event-runtime/lib/worker.mjs"] }
+```
+
+`escalate` item — exactly `pr`, `headSha`, `ticket`, `reason` (no `title`/`headRefName`/`headRef`):
+<!-- prettier-ignore -->
+```json
+{ "pr": 514, "headSha": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "ticket": "WM-514", "reason": "Touches credentials handling; needs human." }
+```
+
+`noopReason` (only when `recommendation` is `NOOP`): `no_open_prs` — no open
+PR targets the configured base branch; `all_prs_held` — open PRs exist but
+all are already held/escalated.
+
+Checklist before writing `./result.json`: `additionalProperties` are
+rejected everywhere; every `plan`/`fix`/`escalate` item needs its own
+40-char hex `headSha`; write the result file even on refusal — the
+fail-closed wrapper above, never an unwritten `./result.json`.
+
 After producing the artifact, do nothing else. In particular, never approve,
 merge, push, mark Done, or delete a branch.

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -139,8 +139,9 @@ describe("registry", () => {
     // burning the pi/codex adapter's quota on ~30-minute chain-triggered triage
     // scans; triage now runs on a fixed 8h clock plus manual operator injection.
     // Regenerated (WM-769): merge-scan/merge-fix format_and_lint routing changed agent defs (registry inputs).
+    // Regenerated (merge-scan output-shape fix): agent def is a registry input.
     const expected =
-      "sha256:27ff1f911aa62264bb1d689b2e8dc179022928e96c3738398da76de3ee07cda8";
+      "sha256:65f3c11cb87b8173b47701c814b5192258f174d8064de8a60d4f57b9525b359a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
## Problem

Since merge-scan moved to the claude/sonnet adapter, 3 of the last 4 clock-tick `merge-scan@2` runs FAILED with contract violations against `event-runtime/schemas/merge-scan.output.json`:

- run_aa2f907b-cc42-4ae7-8db1-f80d18f95ecb — `$.escalate[0]: missing required property "headSha", unknown property "title", unknown property "headRefName"`
- run_2d7b9365-6718-4480-b22c-ace48b961e68 — `$.noopReason: value not in enum ["no_open_prs","all_prs_held"]`
- run_51923ef5-f344-475b-ba37-18d515d21e94 — `missing_result` (no result file written)

Autonomous merging is broken because merge-scan.md never spelled out the exact `plan`/`fix`/`escalate` item shapes or the `noopReason` enum values, and the sonnet adapter guessed GitHub-API-shaped field names (`title`, `headRefName`) instead of the schema's own names.

## Fix

- Added an "Output shape (exact)" section to `event-runtime/agents/merge-scan.md` with one concrete, schema-valid JSON example each for a `plan`, `fix`, and `escalate` item, using exactly the schema's property names (`escalate` = `pr`, `headSha` (40-hex), `ticket`, `reason` — never `title`/`headRefName`), the full `noopReason` enum with when to use each, and a short checklist (`additionalProperties` rejected, every item needs a real 40-char `headSha`, always write `result.json` even on refusal). All three examples were validated against the real schema with the repo's own `lib/schema.mjs` validator.
- Re-pinned `merge-scan.md` via `bun event-runtime/cli.mjs update-pins` and regenerated the registry digest baseline in `event-runtime/lib/registry.test.mjs`.

## Repair-round investigation (step 2)

Checked whether a retry-once-with-validation-errors-fed-back mechanism already exists for claude-adapter runs that could be enabled for merge-scan. It does not: every agent definition in `event-runtime/agents/*.json` sets `limits.attempts: 1`, and there is no repair/feedback loop in `lib/worker.mjs` or any adapter that re-runs an agent with its own schema violations fed back. Skipped — nothing to enable.

## Test plan

- [x] `bun test event-runtime/lib/registry.test.mjs event-runtime/merge.test.mjs` — 73 pass, 0 fail
- [x] `bunx prettier --check` on all changed files — clean
- [x] `bun build/emit.mjs --check` — 90 generated files match shared/ (unrelated pre-existing AGENTS.md floor-drift warning, out of scope)
- [x] All three new JSON examples validated against `event-runtime/schemas/merge-scan.output.json` via the repo's `lib/schema.mjs` validator