### PR TITLE
ui(web): Chains States as a stacked bar; shorten Depth/Events/Runs (WM-826)

### DIFF
--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -203,6 +203,51 @@ describe("Chains list (WM-537)", () => {
     });
   });
 
+  test("States is a proportional bar, not wrapping badges (WM-826)", async () => {
+    const mixed = chain({
+      correlationId: "corr-mixed",
+      states: { FAILED: 1, COMPLETED: 2 },
+      runCount: 3,
+    });
+    await withApi(
+      { chains: async () => ({ chains: [...rows, mixed] }) },
+      async () => {
+        const view = renderChains();
+        await waitFor(() => {
+          expect(
+            view.container.querySelector('[data-chain-id="corr-mixed"]'),
+          ).toBeTruthy();
+        });
+        const row = view.container.querySelector(
+          '[data-chain-id="corr-mixed"]',
+        ) as HTMLElement;
+        const bar = row.querySelector('[role="img"]');
+        expect(bar).toBeTruthy();
+        expect(bar?.getAttribute("aria-label")).toBe("COMPLETED 2, FAILED 1");
+        expect(row.textContent).not.toMatch(/COMPLETED 2/);
+        expect(row.textContent).not.toMatch(/FAILED 1/);
+        expect(bar?.querySelectorAll("[data-state]")).toHaveLength(2);
+        expect(
+          (bar?.querySelector('[data-state="COMPLETED"]') as HTMLElement).style
+            .flexGrow,
+        ).toBe("2");
+        expect(
+          (bar?.querySelector('[data-state="FAILED"]') as HTMLElement).style
+            .flexGrow,
+        ).toBe("1");
+        expect(
+          view.container.querySelector('col[data-col="depth"]')?.className,
+        ).toContain("w-12");
+        expect(
+          view.container.querySelector('col[data-col="events"]')?.className,
+        ).toContain("w-12");
+        expect(
+          view.container.querySelector('col[data-col="runs"]')?.className,
+        ).toContain("w-12");
+      },
+    );
+  });
+
   test("renders compact single-line table with source icon and repo badges", async () => {
     await withApi({ chains: async () => ({ chains: rows }) }, async () => {
       const view = renderChains();

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -34,7 +34,6 @@ import {
   RepoBadge,
   STATE_HUES,
   SourceIcon,
-  StateBadge,
   TableWindowFooter,
   Th,
   shortId,
@@ -77,6 +76,56 @@ const STATUS_HUES: Record<ChainStatus, string> = {
   "no runs": "var(--hue-idle)",
   other: "var(--hue-warn)",
 };
+
+const STATE_ORDER = Object.keys(STATE_HUES);
+
+const NARROW_COLS = new Set(["depth", "events", "runs"]);
+
+function chainStateSegments(
+  states: ChainListItem["states"],
+): { state: string; count: number }[] {
+  return STATE_ORDER.flatMap((state) => {
+    const count = states[state as RunState] ?? 0;
+    return count > 0 ? [{ state, count }] : [];
+  });
+}
+
+function ChainStateBar({
+  states,
+  runCount,
+}: {
+  states: ChainListItem["states"];
+  runCount: number;
+}) {
+  const parts = chainStateSegments(states);
+  if (runCount === 0 || parts.length === 0) {
+    return <span className="text-(--text-faint)">—</span>;
+  }
+  const summary = parts
+    .map(({ state, count }) => `${state} ${count}`)
+    .join(", ");
+  return (
+    <div
+      className="flex h-1.5 w-24 overflow-hidden rounded-full bg-(--surface-2)"
+      role="img"
+      aria-label={summary}
+      title={summary}
+    >
+      {parts.map(({ state, count }) => (
+        <span
+          key={state}
+          data-state={state}
+          className="h-full min-w-[2px]"
+          style={{
+            flexGrow: count,
+            flexBasis: 0,
+            background: STATE_HUES[state] ?? "var(--hue-idle)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
 
 const CHAIN_FACETS: FilterFacets<ChainListItem> = {
   fields: {
@@ -328,6 +377,21 @@ export function Chains({
         }
       >
         <table className="w-full table-fixed border-separate border-spacing-0">
+          <colgroup>
+            {cols.map((column) => (
+              <col
+                key={column.key}
+                data-col={column.key}
+                className={
+                  NARROW_COLS.has(column.key)
+                    ? "w-12"
+                    : column.key === "states"
+                      ? "w-28"
+                      : undefined
+                }
+              />
+            ))}
+          </colgroup>
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((column) => {
@@ -434,24 +498,11 @@ export function Chains({
                     </td>
                   )}
                   {show.has("states") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <div className="flex items-center gap-1">
-                        {Object.entries(chain.states).map(([state, count]) =>
-                          count ? (
-                            <StateBadge
-                              key={state}
-                              state={`${state} ${count}`}
-                              hues={{
-                                [`${state} ${count}`]: STATE_HUES[state],
-                              }}
-                              dot={false}
-                            />
-                          ) : null,
-                        )}
-                        {chain.runCount === 0 && (
-                          <span className="text-(--text-faint)">—</span>
-                        )}
-                      </div>
+                    <td className="border-b border-(--border) px-3 py-1.5">
+                      <ChainStateBar
+                        states={chain.states}
+                        runCount={chain.runCount}
+                      />
                     </td>
                   )}
                   {show.has("activity") && (


### PR DESCRIPTION
## Summary
- Replace wrapping States badges on `#/chains` with a fixed-width (`w-24`) horizontal bar of `STATE_HUES` segments, proportional to each run-state count. Hover/`aria-label` still lists `COMPLETED 2, FAILED 7`.
- Pin Depth, Events, and Runs to `w-12` so they stop eating the row.

## Test plan
- [x] `cd event-runtime/web && bun test src/views/Chains.test.tsx` — 5 pass (mixed-state bar observed failing before the fix)
- [x] Worktree UI `http://127.0.0.1:7689/#/chains` — mixed failed rows show green/red segments; Depth/Events/Runs measure 48px

UX critique: skipped — critic blocked (WM-726 / WM-730).

Fixes WM-826