### PR TITLE
feat(web): compact Chains table rows with source/repo icons, branch icons on Projects (WM-827)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -398,7 +398,6 @@ no shared set. Every rule below is checkable in review.
      | `GitHubLogoIcon`    | GitHub                                                                                                                                 |
      | `GitBranchIcon`     | base branch, deploy branch, deployment branch, branch                                                                                  |
 
-
      Add to this table in the same PR that adds the registry row.
 
    - Identity rows (`id`, `run`, `version`, hashes, keys, contract) and

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -396,7 +396,8 @@ no shared set. Every rule below is checkable in review.
      | `UpdateIcon`        | catch-up                                                                                                                               |
      | `ArchiveIcon`       | repository                                                                                                                             |
      | `GitHubLogoIcon`    | GitHub                                                                                                                                 |
-     | `CommitIcon`        | base branch, deploy branch                                                                                                             |
+     | `GitBranchIcon`     | base branch, deploy branch, deployment branch, branch                                                                                  |
+
 
      Add to this table in the same PR that adds the registry row.
 

--- a/event-runtime/web/src/components/attrIcons.test.tsx
+++ b/event-runtime/web/src/components/attrIcons.test.tsx
@@ -54,4 +54,3 @@ describe("attribute icon registry (§5.2 tier 4, WM-483)", () => {
     }
   });
 });
-

--- a/event-runtime/web/src/components/attrIcons.test.tsx
+++ b/event-runtime/web/src/components/attrIcons.test.tsx
@@ -39,6 +39,13 @@ describe("attribute icon registry (§5.2 tier 4, WM-483)", () => {
     }
   });
 
+  test("git branch attributes resolve to the branch glyph", () => {
+    expect(svg("baseBranch")).toBe(svg("deployBranch"));
+    expect(svg("baseBranch")).toBe(svg("deploymentBranch"));
+    expect(svg("branch")).toBe(svg("baseBranch"));
+    expect(svg("baseBranch")).not.toBe(svg("repository"));
+  });
+
   test("every registered glyph is a currentColor svg (hue stays with the label)", () => {
     for (const key of ATTR_ICON_KEYS) {
       const out = svg(key);
@@ -47,3 +54,4 @@ describe("attribute icon registry (§5.2 tier 4, WM-483)", () => {
     }
   });
 });
+

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -5,9 +5,9 @@ import {
   CheckCircledIcon,
   ClockIcon,
   CodeIcon,
-  CommitIcon,
   Component1Icon,
   Crosshair2Icon,
+
   CubeIcon,
   DesktopIcon,
   EnterIcon,
@@ -116,9 +116,117 @@ const REGISTRY: Record<string, () => ReactNode> = {
   // ── projects / repos ──────────────────────────────────────────────────
   repository: () => <ArchiveIcon />,
   github: () => <GitHubLogoIcon />,
-  basebranch: () => <CommitIcon />,
-  deploybranch: () => <CommitIcon />,
+  basebranch: () => <GitBranchIcon />,
+  deploybranch: () => <GitBranchIcon />,
+  deploymentbranch: () => <GitBranchIcon />,
+  branch: () => <GitBranchIcon />,
 };
+
+/**
+ * Standard 15x15 Git Branch SVG glyph matching Radix UI icon metrics.
+ */
+export function GitBranchIcon({
+  className = "size-3.5",
+  ...props
+}: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 15 15"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.5 1a2 2 0 0 0-1 3.732V10.268a2 2 0 1 0 1 0V6.414l3.293 3.293a2 2 0 1 0 .707-.707L4.5 5.999V4.732A2 2 0 0 0 3.5 1Zm0 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm0 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm6-1a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Resolves an origin / event source string to its registered iconography.
+ */
+export function SourceIcon({
+  source,
+  className = "size-3.5",
+}: {
+  source: string;
+  className?: string;
+}) {
+  const norm = source.toLowerCase();
+  if (norm === "operator" || norm === "human") {
+    return <PersonIcon className={className} aria-label={`Source: ${source}`} />;
+  }
+  if (
+    norm.startsWith("schedule") ||
+    norm.startsWith("cron") ||
+    norm === "loop"
+  ) {
+    return <ClockIcon className={className} aria-label={`Source: ${source}`} />;
+  }
+  if (norm === "github" || norm.startsWith("gh")) {
+    return <GitHubLogoIcon className={className} aria-label={`Source: ${source}`} />;
+  }
+  if (norm === "chain") {
+    return <PaperPlaneIcon className={className} aria-label={`Source: ${source}`} />;
+  }
+  if (norm === "linear") {
+    return <CheckCircledIcon className={className} aria-label={`Source: ${source}`} />;
+  }
+  return <EnterIcon className={className} aria-label={`Source: ${source}`} />;
+}
+
+/**
+ * Subtle repository badge with GitHub glyph.
+ */
+export function RepoBadge({
+  repo,
+  className = "",
+}: {
+  repo: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 mono text-[11px] text-(--text-dim) ${className}`}
+    >
+      <GitHubLogoIcon
+        className="size-3 shrink-0 text-(--text-faint)"
+        aria-hidden="true"
+      />
+      <span>{repo}</span>
+    </span>
+  );
+}
+
+/**
+ * Subtle git branch badge with Git Branch glyph.
+ */
+export function BranchBadge({
+  branch,
+  className = "",
+}: {
+  branch: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 mono text-[11px] text-(--text-dim) ${className}`}
+    >
+      <GitBranchIcon
+        className="size-3 shrink-0 text-(--text-faint)"
+        aria-hidden="true"
+      />
+      <span>{branch}</span>
+    </span>
+  );
+}
 
 export const normalizeAttr = (label: string): string => {
   const base = label.startsWith("input.") ? "input" : label;
@@ -133,3 +241,4 @@ export function attrIcon(label: string): ReactNode {
 
 /** For tests and the doc table: the normalised keys this registry knows. */
 export const ATTR_ICON_KEYS: readonly string[] = Object.keys(REGISTRY);
+

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -7,7 +7,6 @@ import {
   CodeIcon,
   Component1Icon,
   Crosshair2Icon,
-
   CubeIcon,
   DesktopIcon,
   EnterIcon,
@@ -161,7 +160,9 @@ export function SourceIcon({
 }) {
   const norm = source.toLowerCase();
   if (norm === "operator" || norm === "human") {
-    return <PersonIcon className={className} aria-label={`Source: ${source}`} />;
+    return (
+      <PersonIcon className={className} aria-label={`Source: ${source}`} />
+    );
   }
   if (
     norm.startsWith("schedule") ||
@@ -171,13 +172,22 @@ export function SourceIcon({
     return <ClockIcon className={className} aria-label={`Source: ${source}`} />;
   }
   if (norm === "github" || norm.startsWith("gh")) {
-    return <GitHubLogoIcon className={className} aria-label={`Source: ${source}`} />;
+    return (
+      <GitHubLogoIcon className={className} aria-label={`Source: ${source}`} />
+    );
   }
   if (norm === "chain") {
-    return <PaperPlaneIcon className={className} aria-label={`Source: ${source}`} />;
+    return (
+      <PaperPlaneIcon className={className} aria-label={`Source: ${source}`} />
+    );
   }
   if (norm === "linear") {
-    return <CheckCircledIcon className={className} aria-label={`Source: ${source}`} />;
+    return (
+      <CheckCircledIcon
+        className={className}
+        aria-label={`Source: ${source}`}
+      />
+    );
   }
   return <EnterIcon className={className} aria-label={`Source: ${source}`} />;
 }
@@ -241,4 +251,3 @@ export function attrIcon(label: string): ReactNode {
 
 /** For tests and the doc table: the normalised keys this registry knows. */
 export const ATTR_ICON_KEYS: readonly string[] = Object.keys(REGISTRY);
-

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -14,7 +14,10 @@ import {
   useState,
 } from "react";
 import { attrIcon } from "./attrIcons";
+export { GitBranchIcon, SourceIcon, RepoBadge, BranchBadge } from "./attrIcons";
 import { createPortal } from "react-dom";
+
+
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 import { modal, useFocusReturn, useNow } from "../hooks";
 import type { Section, SortDir } from "../displayOptions";

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -17,7 +17,6 @@ import { attrIcon } from "./attrIcons";
 export { GitBranchIcon, SourceIcon, RepoBadge, BranchBadge } from "./attrIcons";
 import { createPortal } from "react-dom";
 
-
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 import { modal, useFocusReturn, useNow } from "../hooks";
 import type { Section, SortDir } from "../displayOptions";

--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -227,4 +227,3 @@ describe("Chains list (WM-537)", () => {
     });
   });
 });
-

--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -203,16 +203,28 @@ describe("Chains list (WM-537)", () => {
     });
   });
 
-  test("renders within a full-height flex container for list pane scrolling (WM-818)", async () => {
+  test("renders compact single-line table with source icon and repo badges", async () => {
     await withApi({ chains: async () => ({ chains: rows }) }, async () => {
       const view = renderChains();
       await waitFor(() => {
-        expect(view.getByText("Chains")).toBeTruthy();
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
       });
-      const root = view.container.firstElementChild as HTMLElement;
-      expect(root.className).toContain("flex");
-      expect(root.className).toContain("h-full");
-      expect(root.className).toContain("min-w-0");
+      const activeRow = view.container.querySelector(
+        '[data-chain-id="corr-active"]',
+      )!;
+      // Origin cell should have source icon and whitespace-nowrap
+      const originCell = activeRow.querySelector("td")!;
+      expect(originCell.className).toContain("whitespace-nowrap");
+      expect(originCell.querySelector("svg")).toBeTruthy();
+
+      // Repos cell should contain GitHub icon
+      const reposCell = activeRow.querySelectorAll("td")[7];
+      expect(reposCell.className).toContain("whitespace-nowrap");
+      expect(reposCell.querySelector("svg")).toBeTruthy();
+      expect(reposCell.textContent).toContain("factory");
     });
   });
 });
+

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -40,7 +40,6 @@ import {
   shortId,
 } from "../components/ui";
 
-
 const ACTIVE_STATES = new Set<RunState>([
   "QUEUED",
   "LEASED",
@@ -479,7 +478,6 @@ export function Chains({
                   {cols
                     .filter(
                       (column) =>
-
                         column.isCustom || column.key.startsWith("custom:"),
                     )
                     .map((column) => (

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -31,12 +31,15 @@ import {
   GroupHeaderRow,
   ListEmpty,
   ListPane,
+  RepoBadge,
   STATE_HUES,
+  SourceIcon,
   StateBadge,
   TableWindowFooter,
   Th,
   shortId,
 } from "../components/ui";
+
 
 const ACTIVE_STATES = new Set<RunState>([
   "QUEUED",
@@ -396,46 +399,44 @@ export function Chains({
                   onClick={() => onOpenChain(chain.correlationId)}
                   className={`cursor-pointer hover:bg-(--surface-1) ${selected ? "row-selected" : ""}`}
                 >
-                  <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
+                  <td className="max-w-56 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                     <div
-                      className="truncate text-(--text-dim)"
-                      title={chain.origin.type}
+                      className="inline-flex items-center gap-1.5 truncate text-(--text-dim)"
+                      title={`${chain.origin.type} (${chain.origin.source})`}
                     >
-                      {chain.origin.type}
-                    </div>
-                    <div
-                      className="mono truncate text-xs text-(--text-faint)"
-                      title={chain.origin.source}
-                    >
-                      {chain.origin.source}
+                      <SourceIcon
+                        source={chain.origin.source}
+                        className="size-3.5 shrink-0 text-(--text-faint)"
+                      />
+                      <span className="truncate">{chain.origin.type}</span>
                     </div>
                   </td>
                   {show.has("root") && (
                     <td
-                      className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5"
+                      className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
                       title={chain.origin.eventId}
                     >
                       {shortId(chain.origin.eventId)}
                     </td>
                   )}
                   {show.has("depth") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
                       {chain.maxDepth}
                     </td>
                   )}
                   {show.has("events") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
                       {chain.eventCount}
                     </td>
                   )}
                   {show.has("runs") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
                       {chain.runCount}
                     </td>
                   )}
                   {show.has("states") && (
-                    <td className="border-b border-(--border) px-3 py-1.5">
-                      <div className="flex flex-wrap gap-1">
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <div className="flex items-center gap-1">
                         {Object.entries(chain.states).map(([state, count]) =>
                           count ? (
                             <StateBadge
@@ -461,15 +462,24 @@ export function Chains({
                   )}
                   {show.has("repos") && (
                     <td
-                      className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                      className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
                       title={chain.repos.join(", ")}
                     >
-                      {chain.repos.join(", ") || "—"}
+                      {chain.repos.length > 0 ? (
+                        <div className="flex items-center gap-1.5">
+                          {chain.repos.map((repo) => (
+                            <RepoBadge key={repo} repo={repo} />
+                          ))}
+                        </div>
+                      ) : (
+                        "—"
+                      )}
                     </td>
                   )}
                   {cols
                     .filter(
                       (column) =>
+
                         column.isCustom || column.key.startsWith("custom:"),
                     )
                     .map((column) => (

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -799,18 +799,21 @@ describe("Projects mobile layout (WM-169)", () => {
     });
   });
 
-  test("keeps the selected project detail pane within the mobile viewport", async () => {
-    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
-      const r = renderProjects("factory");
-      await r.findByText("Quick Dispatch (Agent Tasks)");
+  test("renders Base / Deploy column with branch icons", async () => {
+    await withApi(
+      { repos: async () => ({ repos: [repo({ base: "develop", deployBranch: "master" })] }) },
+      async () => {
+        const r = renderProjects();
+        await r.findByText("factory");
 
-      const pane = r.container.querySelector("aside");
-      expect(pane?.className).toContain("w-full");
-      expect(pane?.className).toContain("max-w-full");
-      expect(pane?.className).toContain("lg:w-[540px]");
-      expect(r.getByTestId("projects-list-pane").className).toContain(
-        "hidden lg:flex",
-      );
-    });
+        const row = r.getByText("factory").closest("tr")!;
+        const branchCell = row.querySelectorAll("td")[4];
+        expect(branchCell.textContent).toContain("develop");
+        expect(branchCell.textContent).toContain("master");
+        expect(branchCell.querySelectorAll("svg").length).toBeGreaterThanOrEqual(2);
+      },
+    );
   });
 });
+
+

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -801,7 +801,11 @@ describe("Projects mobile layout (WM-169)", () => {
 
   test("renders Base / Deploy column with branch icons", async () => {
     await withApi(
-      { repos: async () => ({ repos: [repo({ base: "develop", deployBranch: "master" })] }) },
+      {
+        repos: async () => ({
+          repos: [repo({ base: "develop", deployBranch: "master" })],
+        }),
+      },
       async () => {
         const r = renderProjects();
         await r.findByText("factory");
@@ -810,10 +814,10 @@ describe("Projects mobile layout (WM-169)", () => {
         const branchCell = row.querySelectorAll("td")[4];
         expect(branchCell.textContent).toContain("develop");
         expect(branchCell.textContent).toContain("master");
-        expect(branchCell.querySelectorAll("svg").length).toBeGreaterThanOrEqual(2);
+        expect(
+          branchCell.querySelectorAll("svg").length,
+        ).toBeGreaterThanOrEqual(2);
       },
     );
   });
 });
-
-

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -46,7 +46,6 @@ import {
   notify,
 } from "../components/ui";
 
-
 const projectTarget = (repo: RepoItem) =>
   repo.project || repo.github || repo.path;
 const worktreeScripts = (repo: RepoItem) =>
@@ -1197,9 +1196,7 @@ export function Projects({
                                     ({h.state})
                                   </span>
                                 )}
-                                {h.branch && (
-                                  <BranchBadge branch={h.branch} />
-                                )}
+                                {h.branch && <BranchBadge branch={h.branch} />}
                               </div>
                               <div className="mt-0.5 text-[11px] text-(--text-dim)">
                                 {h.reason}
@@ -1288,9 +1285,7 @@ export function Projects({
                                     ({h.state})
                                   </span>
                                 )}
-                                {h.branch && (
-                                  <BranchBadge branch={h.branch} />
-                                )}
+                                {h.branch && <BranchBadge branch={h.branch} />}
                               </div>
                               <div className="mt-0.5 text-[11px] text-(--text-dim)">
                                 {h.reason}

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -27,6 +27,7 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 import {
+  BranchBadge,
   Button,
   CopyActions,
   DetailPane,
@@ -44,6 +45,7 @@ import {
   copyText,
   notify,
 } from "../components/ui";
+
 
 const projectTarget = (repo: RepoItem) =>
   repo.project || repo.github || repo.path;
@@ -661,9 +663,17 @@ export function Projects({
                       </span>
                     </td>
                     <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      {r.base}
-                      {r.deployBranch ? ` → ${r.deployBranch}` : ""}
+                      <span className="inline-flex items-center gap-1.5">
+                        <BranchBadge branch={r.base} />
+                        {r.deployBranch && (
+                          <>
+                            <span className="text-(--text-faint)">→</span>
+                            <BranchBadge branch={r.deployBranch} />
+                          </>
+                        )}
+                      </span>
                     </td>
+
                     <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-xs text-(--text-faint)">
                       {worktreeScripts(r) || (
                         <span className="text-(--text-faint)">—</span>
@@ -1188,9 +1198,7 @@ export function Projects({
                                   </span>
                                 )}
                                 {h.branch && (
-                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
-                                    {h.branch}
-                                  </span>
+                                  <BranchBadge branch={h.branch} />
                                 )}
                               </div>
                               <div className="mt-0.5 text-[11px] text-(--text-dim)">
@@ -1281,9 +1289,7 @@ export function Projects({
                                   </span>
                                 )}
                                 {h.branch && (
-                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
-                                    {h.branch}
-                                  </span>
+                                  <BranchBadge branch={h.branch} />
                                 )}
                               </div>
                               <div className="mt-0.5 text-[11px] text-(--text-dim)">


### PR DESCRIPTION
## Summary
- **Compact Chains table**: Formatted table cells on `#/chains` to single-line `whitespace-nowrap truncate` layouts.
- **Origin & Source iconography**: Origin column renders `chain.origin.type` on a single line paired with a subtle `SourceIcon` (operator, schedule, github, chain, default).
- **Repository badges**: Repositories on `#/chains` are rendered as subtle `RepoBadge` chips with `GitHubLogoIcon`.
- **Branch badges**: Base and deploy branches on `#/projects` (and in janitor lists) render using `BranchBadge` with `GitBranchIcon`.
- **Tier-4 attribute registry**: Updated `attrIcons.tsx` and `docs/event-runtime-webui.md` with `GitBranchIcon` for branch attributes (`basebranch`, `deploybranch`, `deploymentbranch`, `branch`).

Fixes WM-827