### PR TITLE
feat(event-runtime-web): full-page artifact reader view with 'o' shortcut (WM-828)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -66,7 +66,8 @@ export function navIsCurrent(key: NavKey, view?: string): boolean {
     key === view ||
     (key === "runs" && view === "run") ||
     (key === "tickets" && view === "prs") ||
-    (key === "chains" && view === "chain")
+    (key === "chains" && view === "chain") ||
+    (key === "artifacts" && view === "artifact")
   );
 }
 
@@ -110,6 +111,9 @@ export function listSelectionPath(
 
 const Artifacts = lazy(() =>
   import("./views/Artifacts").then((m) => ({ default: m.Artifacts })),
+);
+const ArtifactFull = lazy(() =>
+  import("./views/ArtifactFull").then((m) => ({ default: m.ArtifactFull })),
 );
 const Metrics = lazy(() =>
   import("./views/Metrics").then((m) => ({ default: m.Metrics })),
@@ -320,6 +324,8 @@ export function App() {
   // `#/run/:id` is the full-page run view — a distinct first segment, so
   // crossing from `#/runs/:id` pushes history and Back restores the panel.
   const fullRunId = view === "run" ? (route[1] ?? null) : null;
+  // `#/artifact/:digest` is the full-page artifact reader view (WM-828).
+  const fullArtifactDigest = view === "artifact" ? (route[1] ?? null) : null;
   const focusProposalId = view === "proposals" ? (route[1] ?? null) : null;
   const focusRepoName = view === "projects" ? (route[1] ?? null) : null;
   const focusAgentRef = view === "agents" ? (route[1] ?? null) : null;
@@ -378,6 +384,8 @@ export function App() {
     navigate(hashPath("runs", runId));
   };
   const openRunFull = (runId: string) => navigate(hashPath("run", runId));
+  const openArtifactFull = (digest: string) =>
+    navigate(hashPath("artifact", digest));
   const jumpToTicket = (ticketId: string) =>
     navigate(hashPath("tickets", ticketId));
   const jumpToPr = (number: number) =>
@@ -557,7 +565,9 @@ export function App() {
         ? "Chain"
         : view === "prs"
           ? "PR"
-          : "Overview");
+          : view === "artifact"
+            ? "Artifact"
+            : "Overview");
 
   useEffect(() => {
     const id = route.length > 1 ? route[route.length - 1] : null;
@@ -1102,7 +1112,21 @@ export function App() {
                   }
                 />
               </Suspense>
-            ) : view === "artifacts" ? (
+            ) : view === "artifact" && fullArtifactDigest ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading artifact…
+                  </div>
+                }
+              >
+                <ArtifactFull
+                  digest={fullArtifactDigest}
+                  onBack={() => navigate("artifacts")}
+                  onJumpRun={jumpToRun}
+                />
+              </Suspense>
+            ) : view === "artifacts" || view === "artifact" ? (
               <Suspense
                 fallback={
                   <div className="p-5 text-(--text-faint)">
@@ -1117,6 +1141,7 @@ export function App() {
                     navigate(artifactsHash(filters))
                   }
                   onJumpRun={jumpToRun}
+                  onOpenFull={openArtifactFull}
                 />
               </Suspense>
             ) : view === "metrics" ? (

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -687,6 +687,7 @@ export function ArtifactPanel({
   raw: rawProp,
   onRawChange,
   rawFallback,
+  onOpenFull,
 }: {
   artifact: unknown;
   schema?: unknown;
@@ -697,6 +698,7 @@ export function ArtifactPanel({
   onRawChange?: (raw: boolean) => void;
   /** What Raw shows; defaults to `JsonBlock` over the artifact. */
   rawFallback?: ReactNode;
+  onOpenFull?: () => void;
 }) {
   const [rawState, setRawState] = useState(loadArtifactRaw);
   const raw = rawProp ?? rawState;
@@ -707,11 +709,41 @@ export function ArtifactPanel({
   };
   const applies = viewApplies(view, artifact);
   const fallback = rawFallback ?? <JsonBlock value={artifact} />;
-  if (!applies) return <>{fallback}</>;
+
+  const openFullAction = onOpenFull && (
+    <PrimitiveButton
+      bare
+      type="button"
+      onClick={onOpenFull}
+      title="Open in full page (o)"
+      className="cursor-pointer rounded px-2 py-0.5 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+    >
+      <span>Open in full page</span>
+      <span
+        aria-hidden="true"
+        className="mono ml-1 text-(--text-faint) text-xs"
+      >
+        o
+      </span>
+    </PrimitiveButton>
+  );
+
+  if (!applies) {
+    if (openFullAction) {
+      return (
+        <div>
+          <div className="mb-2 flex justify-end">{openFullAction}</div>
+          {fallback}
+        </div>
+      );
+    }
+    return <>{fallback}</>;
+  }
   if (raw) {
     return (
       <div>
-        <div className="mb-2 flex justify-end">
+        <div className="mb-2 flex items-center justify-end gap-1.5">
+          {openFullAction}
           <RawToggle raw onChange={setRaw} />
         </div>
         {fallback}
@@ -724,7 +756,12 @@ export function ArtifactPanel({
       schema={schema}
       view={view}
       onJumpRun={onJumpRun}
-      actions={<RawToggle raw={false} onChange={setRaw} />}
+      actions={
+        <div className="flex items-center gap-1.5">
+          {openFullAction}
+          <RawToggle raw={false} onChange={setRaw} />
+        </div>
+      }
     />
   );
 }

--- a/event-runtime/web/src/views/ArtifactFull.test.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.test.tsx
@@ -1,0 +1,226 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { ArtifactInventoryItem } from "../types";
+import { ArtifactFull } from "./ArtifactFull";
+import { ARTIFACT_RAW_KEY } from "../components/ArtifactView";
+
+const originalFetch = globalThis.fetch;
+const originalClipboard = navigator.clipboard;
+const LONG_RUN_ID = "run_12345678-1234-1234-1234-123456789abc";
+const SHA_A = "a".repeat(64);
+
+const ITEMS: ArtifactInventoryItem[] = [
+  {
+    sha256: SHA_A,
+    sizeBytes: 1_024,
+    mtime: "2026-01-02T03:04:05.000Z",
+    referenced: true,
+    references: [
+      {
+        runId: LONG_RUN_ID,
+        kind: "report",
+        agent: "reporter@1",
+        state: "COMPLETED",
+        createdAt: "2026-01-02T03:04:05.000Z",
+      },
+    ],
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  window.location.hash = `#/artifact/${SHA_A}`;
+  globalThis.fetch = originalFetch;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: originalClipboard,
+  });
+  localStorage.removeItem(ARTIFACT_RAW_KEY);
+});
+
+function renderArtifactFull({
+  digest = SHA_A,
+  onBack = mock(() => {}),
+  onJumpRun = mock(() => {}),
+  seed = {},
+}: {
+  digest?: string;
+  onBack?: () => void;
+  onJumpRun?: (runId: string) => void;
+  seed?: { items?: ArtifactInventoryItem[]; agents?: unknown[] };
+} = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchInterval: false, staleTime: Infinity },
+    },
+  });
+  client.setQueryData(["artifacts"], { artifacts: seed.items ?? ITEMS });
+  if (seed.agents) {
+    client.setQueryData(["agents"], {
+      agents: seed.agents,
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+    });
+  }
+
+  function Harness() {
+    return (
+      <QueryClientProvider client={client}>
+        <ArtifactFull digest={digest} onBack={onBack} onJumpRun={onJumpRun} />
+      </QueryClientProvider>
+    );
+  }
+
+  return { ...render(<Harness />), onBack, onJumpRun };
+}
+
+describe("ArtifactFull reader view (WM-828)", () => {
+  test("renders header with back button, kind badges, short digest, size, timestamp, producing run jump link, and copy actions", async () => {
+    const raw = JSON.stringify({ summary: "report content", status: "ok" });
+    globalThis.fetch = mock(
+      async () => new Response(raw, { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const view = renderArtifactFull();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    // Back button
+    const backBtn = view.getByRole("button", { name: /← Artifacts/ });
+    expect(backBtn).toBeTruthy();
+    fireEvent.click(backBtn);
+    expect(view.onBack).toHaveBeenCalled();
+
+    // Kind badge & size & time
+    expect(view.getByText("report")).toBeTruthy();
+    expect(view.getByText("1.0 KB")).toBeTruthy();
+
+    // Producing run link
+    const runLink = view.getByRole("button", { name: "run_12345678" });
+    expect(runLink.getAttribute("title")).toBe(LONG_RUN_ID);
+    fireEvent.click(runLink);
+    expect(view.onJumpRun).toHaveBeenCalledWith(LONG_RUN_ID);
+
+    // Download link
+    const download = view.getByRole("link", { name: "Download" });
+    expect(download.getAttribute("href")).toContain(`/api/artifacts/${SHA_A}`);
+
+    // Copy actions in header
+    expect(view.getByRole("group", { name: "Copy actions" })).toBeTruthy();
+  });
+
+  test("handles Esc shortcut to go back and keyboard shortcuts for copying", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("line 1\nline 2", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const writeText = mock(async () => {});
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const view = renderArtifactFull();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    // Esc triggers onBack
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(view.onBack).toHaveBeenCalled();
+
+    // c copies digest
+    fireEvent.keyDown(document.body, { key: "c" });
+    expect(writeText).toHaveBeenCalledWith(SHA_A);
+  });
+
+  test("renders schema-derived ArtifactView and toggles raw with 'r' key shortcut", async () => {
+    const MERGE_VIEW = JSON.parse(
+      readFileSync(
+        path.resolve(import.meta.dir, "../../../agents/merge-scan.view.json"),
+        "utf8",
+      ),
+    );
+    const MERGE_AGENT = {
+      ref: "merge-scan@2",
+      id: "merge-scan",
+      outputSchema: { title: "merge plan" },
+      outputView: MERGE_VIEW,
+    };
+    const MERGE_SHA = "d".repeat(64);
+    const MERGE_ITEM: ArtifactInventoryItem = {
+      sha256: MERGE_SHA,
+      sizeBytes: 900,
+      mtime: "2026-01-05T03:04:05.000Z",
+      referenced: true,
+      references: [
+        {
+          runId: "run_merge",
+          kind: "report",
+          agent: "merge-scan@2",
+          state: "COMPLETED",
+          createdAt: "2026-01-05T03:04:05.000Z",
+        },
+      ],
+    };
+    const MERGE_PLAN = {
+      recommendation: "ESCALATE",
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      deployBranch: "main",
+      plan: [],
+      fix: [],
+      escalate: [
+        {
+          pr: 471,
+          ticket: "WM-210",
+          headSha: "c".repeat(40),
+          reason: "Draft hold.",
+        },
+      ],
+      summary: "One PR held in full view.",
+    };
+
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify(MERGE_PLAN), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const view = renderArtifactFull({
+      digest: MERGE_SHA,
+      seed: {
+        items: [MERGE_ITEM],
+        agents: [MERGE_AGENT],
+      },
+    });
+
+    expect(await view.findByText("One PR held in full view.")).toBeTruthy();
+    expect(view.getByText("ESCALATE")).toBeTruthy();
+
+    // Toggle to raw via 'r'
+    fireEvent.keyDown(document.body, { key: "r" });
+    const rawPreview = await view.findByRole("region", {
+      name: "Artifact content",
+    });
+    expect(rawPreview.textContent).toContain('"recommendation": "ESCALATE"');
+    expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
+
+    // Toggle back to formatted view via 'r'
+    fireEvent.keyDown(document.body, { key: "r" });
+    expect(await view.findByText("One PR held in full view.")).toBeTruthy();
+  });
+
+  test("binary artifact displays binary information and download action", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("PK\u0003\u0004\u0000\u0000\uFFFD\uFFFD\u0001\u0002", {
+          status: 200,
+        }),
+    ) as unknown as typeof fetch;
+
+    const view = renderArtifactFull();
+    expect(await view.findByText(/cannot be previewed/i)).toBeTruthy();
+    expect(view.getByRole("link", { name: "Download file" })).toBeTruthy();
+  });
+});

--- a/event-runtime/web/src/views/ArtifactFull.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.tsx
@@ -1,0 +1,401 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api, artifactUrl, fetchArtifacts } from "../api";
+import {
+  ArtifactView,
+  loadArtifactRaw,
+  RawToggle,
+  saveArtifactRaw,
+} from "../components/ArtifactView";
+import {
+  Ago,
+  Button,
+  CopyActions,
+  FilterInput,
+  JumpLink,
+  copyLink,
+  copyText,
+  shortId,
+} from "../components/ui";
+import { formatBytes } from "../format";
+import { keyGuard, refetchIntervals, useNow } from "../hooks";
+import { viewApplies } from "../lib/artifactView";
+import { setContextActions } from "../palette";
+import type { AgentDef } from "../types";
+import {
+  downloadName,
+  formattedContent,
+  highlightedLine,
+  KindBadge,
+  kindsOf,
+  looksBinary,
+  parsedObject,
+} from "./Artifacts";
+
+/**
+ * Full-page artifact reader view (`#/artifact/:digest`, WM-828) —
+ * provides a wide, readable measure for long artifacts (reports, scans, plans)
+ * with schema-derived view rendering and raw inspection toggle.
+ */
+export function ArtifactFull({
+  digest,
+  onBack,
+  onJumpRun,
+}: {
+  digest: string;
+  onBack: () => void;
+  onJumpRun?: (runId: string) => void;
+}) {
+  const now = useNow();
+  const [contentSearch, setContentSearch] = useState("");
+  const [artifactRaw, setArtifactRaw] = useState(loadArtifactRaw);
+
+  const artifactsQ = useQuery({
+    queryKey: ["artifacts"],
+    queryFn: () => fetchArtifacts(),
+    ...refetchIntervals.primary,
+  });
+  const artifacts = artifactsQ.data?.artifacts ?? [];
+
+  const selected = useMemo(
+    () => artifacts.find((artifact) => artifact.sha256 === digest) ?? null,
+    [artifacts, digest],
+  );
+
+  const contentQ = useQuery({
+    queryKey: ["artifact-content", digest],
+    queryFn: async () => {
+      const response = await fetch(artifactUrl(digest));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.text();
+    },
+    enabled: Boolean(digest),
+  });
+
+  const agentsQ = useQuery({
+    queryKey: ["agents"],
+    queryFn: () => api.agents(),
+    staleTime: 30_000,
+  });
+
+  const selectedKinds = selected ? kindsOf(selected) : [];
+  const selectedName = digest ? downloadName(digest, selectedKinds) : "";
+  const shortDigest = digest.slice(0, 12);
+
+  const binary = contentQ.data !== undefined && looksBinary(contentQ.data);
+  const preview =
+    contentQ.data === undefined || binary
+      ? null
+      : formattedContent(contentQ.data, selectedKinds);
+
+  const parsedArtifact = useMemo(
+    () => (contentQ.data === undefined ? null : parsedObject(contentQ.data)),
+    [contentQ.data],
+  );
+
+  const producerAgent: AgentDef | undefined = useMemo(() => {
+    const refs =
+      selected?.references
+        ?.map((reference) => reference.agent)
+        .filter(Boolean) ?? [];
+    const defs = agentsQ.data?.agents ?? [];
+    for (const ref of refs) {
+      const def = defs.find((a) => a.ref === ref || a.id === ref);
+      if (def?.outputView) return def;
+    }
+    return undefined;
+  }, [selected, agentsQ.data]);
+
+  const canToggleView =
+    parsedArtifact !== null &&
+    viewApplies(producerAgent?.outputView, parsedArtifact);
+
+  const viewShown = canToggleView && !artifactRaw;
+
+  const previewLines = useMemo(
+    () => (preview ? preview.split("\n") : []),
+    [preview],
+  );
+
+  const matchCount = contentSearch.trim()
+    ? previewLines.filter((line) =>
+        line.toLowerCase().includes(contentSearch.trim().toLowerCase()),
+      ).length
+    : null;
+
+  const toggleRaw = useCallback(() => {
+    setArtifactRaw((prev) => {
+      const next = !prev;
+      saveArtifactRaw(next);
+      return next;
+    });
+  }, []);
+
+  const setRaw = useCallback((raw: boolean) => {
+    saveArtifactRaw(raw);
+    setArtifactRaw(raw);
+  }, []);
+
+  // Keyboard shortcuts: Esc -> onBack, r -> toggle raw, c / c l -> copy
+  useEffect(() => {
+    let pendingC = 0;
+    function onKey(e: KeyboardEvent) {
+      if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey) return;
+      const keyNow = Date.now();
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onBack();
+        return;
+      }
+      if (e.key === "r" && canToggleView) {
+        e.preventDefault();
+        toggleRaw();
+        return;
+      }
+      if (pendingC && keyNow - pendingC < 800) {
+        if (e.key === "l") {
+          e.preventDefault();
+          pendingC = 0;
+          copyLink();
+          return;
+        }
+      }
+      if (e.key === "c") {
+        e.preventDefault();
+        pendingC = keyNow;
+        copyText(digest, "artifact digest");
+      } else {
+        pendingC = 0;
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [digest, onBack, canToggleView, toggleRaw]);
+
+  // Register palette actions
+  useEffect(() => {
+    setContextActions([
+      { label: "Back to Artifacts", hint: "Esc", run: onBack },
+      {
+        label: `Copy digest ${shortDigest}`,
+        hint: "c",
+        run: () => copyText(digest, "artifact digest"),
+      },
+      { label: "Copy link to this artifact", hint: "c l", run: copyLink },
+      ...(canToggleView
+        ? [
+            {
+              label: artifactRaw
+                ? "Switch to formatted view"
+                : "Switch to raw content",
+              hint: "r",
+              run: toggleRaw,
+            },
+          ]
+        : []),
+    ]);
+    return () => setContextActions([]);
+  }, [digest, shortDigest, onBack, canToggleView, artifactRaw, toggleRaw]);
+
+  return (
+    <div className="fixed inset-0 z-20 flex h-full min-w-0 flex-col overflow-hidden bg-(--surface-0) sm:static sm:z-auto">
+      <header className="sticky top-0 z-10 flex shrink-0 flex-col items-stretch gap-2 border-b border-(--border) bg-(--surface-1) px-6 py-3">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-2">
+            <ol className="flex min-w-0 flex-wrap items-center gap-2 list-none p-0 m-0 text-[13px]">
+              <li className="shrink-0">
+                <Button onClick={onBack}>
+                  <span>← Artifacts</span>
+                  <span
+                    aria-hidden="true"
+                    className="mono ml-1 text-(--text-faint) text-xs"
+                  >
+                    Esc
+                  </span>
+                </Button>
+              </li>
+              <li aria-hidden="true" className="text-(--text-faint) shrink-0">
+                /
+              </li>
+              <li
+                className="flex min-w-0 items-center gap-2"
+                aria-current="page"
+              >
+                {selectedKinds.length > 0 && (
+                  <div className="flex flex-nowrap gap-1">
+                    {selectedKinds.map((kind) => (
+                      <KindBadge key={kind} kind={kind} />
+                    ))}
+                  </div>
+                )}
+                <span
+                  className="display mono min-w-0 truncate text-[15px] font-semibold text-(--text)"
+                  title={digest}
+                >
+                  {shortDigest}
+                </span>
+              </li>
+            </ol>
+          </nav>
+
+          <div className="flex items-center gap-2">
+            <a
+              href={artifactUrl(digest, selectedName)}
+              download={selectedName}
+              className="inline-flex rounded-md border border-(--border-strong) px-2.5 py-1 text-[12px] font-medium hover:bg-(--surface-2)"
+            >
+              Download
+            </a>
+            {canToggleView && (
+              <div className="flex items-center gap-1">
+                <RawToggle raw={artifactRaw} onChange={setRaw} />
+                <span
+                  aria-hidden="true"
+                  className="mono text-(--text-faint) text-xs"
+                >
+                  r
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-(--text-faint)">
+          {selected && (
+            <>
+              <span className="mono">{formatBytes(selected.sizeBytes)}</span>
+              <span aria-hidden="true">·</span>
+              <span>
+                <Ago iso={selected.mtime} now={now} />
+              </span>
+              {selected.references && selected.references.length > 0 && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="flex items-center gap-1">
+                    <span>produced by</span>
+                    {selected.references.map((reference) => (
+                      <JumpLink
+                        key={`${reference.runId}:${reference.kind ?? "unknown"}`}
+                        onClick={() => onJumpRun?.(reference.runId)}
+                        title={reference.runId}
+                      >
+                        {shortId(reference.runId)}
+                      </JumpLink>
+                    ))}
+                  </span>
+                </>
+              )}
+              <span aria-hidden="true">·</span>
+            </>
+          )}
+          <CopyActions id={digest} idLabel="artifact digest" variant="quiet" />
+        </div>
+      </header>
+
+      <main className="min-w-0 flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-[1000px]">
+          {contentQ.isPending && (
+            <div className="text-[13px] text-(--text-faint)">
+              Loading artifact content…
+            </div>
+          )}
+          {contentQ.isError && (
+            <div className="text-[13px] text-(--hue-err)">
+              Could not load artifact content:{" "}
+              {(contentQ.error as Error).message}
+            </div>
+          )}
+          {binary && (
+            <div className="rounded-md border border-(--border) bg-(--surface-0) p-6 text-[13px]">
+              <h2 className="display text-[15px] font-semibold text-(--text)">
+                Binary artifact
+              </h2>
+              <p className="mt-1 text-(--text-dim)">
+                These bytes cannot be previewed as text. Download the file to
+                open it in a local viewer.
+              </p>
+              <dl className="mono mt-4 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-sm">
+                <dt className="text-(--text-faint)">File</dt>
+                <dd className="break-all">{selectedName}</dd>
+                <dt className="text-(--text-faint)">Size</dt>
+                <dd>
+                  {selected ? formatBytes(selected.sizeBytes) : "unknown"}
+                </dd>
+                <dt className="text-(--text-faint)">Kinds</dt>
+                <dd>
+                  {selectedKinds.length ? selectedKinds.join(", ") : "unknown"}
+                </dd>
+              </dl>
+              <a
+                href={artifactUrl(digest, selectedName)}
+                download={selectedName}
+                className="mt-4 inline-flex rounded-md bg-(--accent) px-3 py-1.5 text-[12px] font-medium text-(--on-accent) hover:opacity-90"
+              >
+                Download file
+              </a>
+            </div>
+          )}
+          {preview !== null && (
+            <div>
+              {viewShown && producerAgent?.outputView ? (
+                <div className="rounded-md border border-(--border) bg-(--surface-0) p-6">
+                  <ArtifactView
+                    artifact={parsedArtifact}
+                    schema={producerAgent.outputSchema}
+                    view={producerAgent.outputView}
+                    onJumpRun={onJumpRun}
+                  />
+                </div>
+              ) : (
+                <div>
+                  <div className="mb-3 flex items-center justify-between gap-2">
+                    <div className="text-[12px] text-(--text-faint)">
+                      {matchCount === null
+                        ? `${previewLines.length.toLocaleString()} lines`
+                        : `${matchCount.toLocaleString()} matching lines`}
+                    </div>
+                    <FilterInput
+                      value={contentSearch}
+                      onChange={setContentSearch}
+                      placeholder="Find in content…"
+                      label="Search artifact content"
+                    />
+                  </div>
+                  <div
+                    role="region"
+                    aria-label="Artifact content"
+                    className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-3 text-sm leading-relaxed"
+                  >
+                    {previewLines.map((line, index) => (
+                      <div
+                        key={index}
+                        className={`grid grid-cols-[4rem_minmax(0,1fr)] px-3 ${
+                          contentSearch.trim() &&
+                          line
+                            .toLowerCase()
+                            .includes(contentSearch.trim().toLowerCase())
+                            ? "bg-(--surface-2)"
+                            : ""
+                        }`}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="select-none border-r border-(--border) pr-3 text-right text-(--text-faint)"
+                        >
+                          {index + 1}
+                        </span>
+                        <span className="min-w-0 whitespace-pre-wrap break-words pl-3">
+                          {highlightedLine(line, contentSearch)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -77,6 +77,7 @@ function renderArtifacts(
   onJumpRun = mock(() => {}),
   initialFilters: ArtifactFilters = { kind: null, orphan: null, search: "" },
   seed: { items?: ArtifactInventoryItem[]; agents?: unknown[] } = {},
+  onOpenFull = mock(() => {}),
 ) {
   const client = new QueryClient({
     defaultOptions: {
@@ -127,11 +128,12 @@ function renderArtifacts(
           filters={filters}
           onFiltersChange={setFilters}
           onJumpRun={onJumpRun}
+          onOpenFull={onOpenFull}
         />
       </QueryClientProvider>
     );
   }
-  return { ...render(<Harness />), onJumpRun };
+  return { ...render(<Harness />), onJumpRun, onOpenFull };
 }
 
 // happy-dom mutates this controlled input without reaching React's onChange;
@@ -656,5 +658,51 @@ describe("Artifacts inspector renders a view for the producing agent's artifact 
     expect(
       view.queryByRole("group", { name: "Artifact rendering" }),
     ).toBeNull();
+  });
+});
+
+describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", () => {
+  const SHA_A = "a".repeat(64);
+
+  test("pressing 'o' on selected artifact row navigates to full page reader view", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/api/artifacts") || u.includes("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: ITEMS }), {
+          status: 200,
+        });
+      }
+      return new Response("line one\nline two", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+    await view.findByRole("region", { name: "Artifact content" });
+
+    fireEvent.keyDown(document.body, { key: "o" });
+    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A);
+  });
+
+  test("detail pane includes Open in full page action with 'o' shortcut hint", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/api/artifacts") || u.includes("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: ITEMS }), {
+          status: 200,
+        });
+      }
+      return new Response("line one\nline two", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+    await view.findByRole("region", { name: "Artifact content" });
+
+    const openBtns = view.getAllByRole("button", { name: "Open in full page" });
+    expect(openBtns.length).toBeGreaterThanOrEqual(1);
+    expect(openBtns[0].getAttribute("title")).toBe("Open in full page (o)");
+
+    fireEvent.click(openBtns[0]);
+    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A);
   });
 });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,5 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { api, artifactUrl, fetchArtifacts } from "../api";
 import { ArtifactPanel, loadArtifactRaw } from "../components/ArtifactView";
 import { DisplayOptions } from "../components/DisplayOptions";
@@ -27,7 +33,12 @@ import {
 } from "../displayOptions";
 import { EMPTY, formatBytes, formatRelative } from "../format";
 import { hashSearch } from "../hash";
-import { refetchIntervals, useDisplayOptions, useNow } from "../hooks";
+import {
+  refetchIntervals,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+} from "../hooks";
 import { viewApplies } from "../lib/artifactView";
 import type {
   AdmittedEvent,
@@ -47,7 +58,7 @@ export type ArtifactFilters = {
 
 const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
 
-function kindsOf(artifact: ArtifactInventoryItem): string[] {
+export function kindsOf(artifact: ArtifactInventoryItem): string[] {
   return [
     ...new Set(
       (artifact.references ?? []).flatMap((reference) => reference.kind ?? []),
@@ -156,7 +167,7 @@ function openArtifactInspector(sha256: string) {
 }
 
 /** The name a downloaded copy gets: short SHA plus the first kind as extension. */
-function downloadName(sha256: string, kinds: string[]): string {
+export function downloadName(sha256: string, kinds: string[]): string {
   return `${sha256.slice(0, 12)}${kinds[0] ? `.${kinds[0]}` : ""}`;
 }
 
@@ -165,7 +176,7 @@ function downloadName(sha256: string, kinds: string[]): string {
  * UTF-8, so a zip or an image comes back as NULs and U+FFFD replacements —
  * rendering that as numbered lines is noise the operator has to scroll past.
  */
-function looksBinary(raw: string): boolean {
+export function looksBinary(raw: string): boolean {
   const sample = raw.slice(0, 4096);
   if (!sample) return false;
   if (sample.includes("\u0000")) return true;
@@ -190,7 +201,7 @@ function containsArtifactHash(
 }
 
 /** The stored bytes as one JSON object, or null — the only shape a view can describe. */
-function parsedObject(raw: string): Record<string, unknown> | null {
+export function parsedObject(raw: string): Record<string, unknown> | null {
   if (!/^\s*\{/.test(raw)) return null;
   try {
     const value: unknown = JSON.parse(raw);
@@ -202,7 +213,7 @@ function parsedObject(raw: string): Record<string, unknown> | null {
   }
 }
 
-function formattedContent(raw: string, kinds: string[]): string {
+export function formattedContent(raw: string, kinds: string[]): string {
   if (kinds.some((kind) => /json/i.test(kind)) || /^\s*[\[{]/.test(raw)) {
     try {
       return JSON.stringify(JSON.parse(raw), null, 2);
@@ -213,7 +224,7 @@ function formattedContent(raw: string, kinds: string[]): string {
   return raw;
 }
 
-function highlightedLine(line: string, search: string): ReactNode {
+export function highlightedLine(line: string, search: string): ReactNode {
   const term = search.trim();
   if (!term) return line || " ";
   const lower = line.toLowerCase();
@@ -238,7 +249,7 @@ function highlightedLine(line: string, search: string): ReactNode {
   return chunks;
 }
 
-function KindBadge({ kind }: { kind: string }) {
+export function KindBadge({ kind }: { kind: string }) {
   return (
     <span
       className="mono inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium"
@@ -258,11 +269,13 @@ export function Artifacts({
   filters,
   onFiltersChange,
   onJumpRun,
+  onOpenFull,
 }: {
   metrics?: StatusView["artifacts"];
   filters: ArtifactFilters;
   onFiltersChange: (filters: ArtifactFilters) => void;
   onJumpRun: (runId: string) => void;
+  onOpenFull?: (digest: string) => void;
 }) {
   const now = useNow();
   const artifactsQ = useQuery({
@@ -412,6 +425,40 @@ export function Artifacts({
     setContentSearch("");
     window.location.hash = withCurrentArtifactQuery("artifacts");
   };
+
+  const openFull = useCallback(
+    (sha256: string) => {
+      if (onOpenFull) {
+        onOpenFull(sha256);
+      } else {
+        window.location.hash = withCurrentArtifactQuery(
+          `artifact/${encodeURIComponent(sha256)}`,
+        );
+      }
+    },
+    [onOpenFull],
+  );
+
+  const selectedIndex = useMemo(
+    () => ordered.findIndex((artifact) => artifact.sha256 === selectedSha),
+    [ordered, selectedSha],
+  );
+
+  useListKeys({
+    count: ordered.length,
+    selected: selectedIndex,
+    onSelect: (index) => {
+      const target = ordered[index];
+      if (target) selectArtifact(target.sha256);
+    },
+    onOpen: () => {
+      if (selectedSha) openFull(selectedSha);
+    },
+    onClose: () => {
+      if (selectedSha) closeInspector();
+      else if (filters.search) onFiltersChange({ ...filters, search: "" });
+    },
+  });
 
   const fallbackMetrics = useMemo(
     () => ({
@@ -793,6 +840,18 @@ export function Artifacts({
           }
           actions={
             <>
+              <Button
+                onClick={() => openFull(selectedSha)}
+                title="Open in full page (o)"
+              >
+                <span>Open in full page</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-(--text-faint) text-xs"
+                >
+                  o
+                </span>
+              </Button>
               <a
                 href={artifactUrl(selectedSha, selectedName)}
                 download={selectedName}
@@ -1031,6 +1090,7 @@ export function Artifacts({
                   schema={producerAgent?.outputSchema}
                   view={parsedArtifact ? producerAgent?.outputView : null}
                   onJumpRun={onJumpRun}
+                  onOpenFull={() => openFull(selectedSha)}
                   raw={artifactRaw}
                   onRawChange={setArtifactRaw}
                   rawFallback={


### PR DESCRIPTION
## Summary
Implements dedicated full-page artifact reader view at #/artifact/:digest (WM-828).

- Adds ArtifactFull.tsx component rendering wide full-page artifact view with header (back button with Esc shortcut, kind badges, short digest, size, timestamp, producing run jump link, raw/view toggle with 'r' shortcut, and copy verbs 'c'/'c l') and schema-derived ArtifactView or formatted raw line preview with search.
- In Artifacts.tsx: adds 'o' key shortcut when an artifact is selected to open the full page view, and adds 'Open in full page' action with 'o' tooltip to DetailPane and ArtifactPanel.
- In App.tsx: routes #/artifact/:digest (and view === 'artifact') to ArtifactFull and maintains active state for 'artifacts' nav item in navIsCurrent.
- Adds component and regression tests in ArtifactFull.test.tsx and Artifacts.test.tsx.

Fixes WM-828