### PR TITLE
ui-ux(event-runtime-web): pin modal footer with action buttons in Dialog (WM-829)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1377,4 +1377,60 @@ describe("Dialog (WM-270)", () => {
     expect(r.getByRole("dialog", { name: "Parent dialog" })).toBeTruthy();
     expect(modal.depth).toBe(1);
   });
+
+  test("renders pinned footer with action buttons and scrollable body (WM-829)", () => {
+    let submitted = false;
+    let closed = false;
+    const r = render(
+      <Dialog
+        title="Pinned Dialog"
+        onClose={() => {
+          closed = true;
+        }}
+        footer={
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                closed = true;
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                submitted = true;
+              }}
+            >
+              Confirm
+            </button>
+          </>
+        }
+      >
+        <div>Long modal body content</div>
+      </Dialog>,
+    );
+
+    const dialog = r.getByRole("dialog", { name: "Pinned Dialog" });
+    expect(dialog.className).toContain("flex flex-col");
+
+    const header = r.getByText("Pinned Dialog");
+    expect(header.className).toContain("shrink-0");
+
+    const bodyContent = r.getByText("Long modal body content");
+    expect(bodyContent.parentElement?.className).toContain(
+      "flex-1 overflow-y-auto",
+    );
+
+    const cancelButton = r.getByRole("button", { name: "Cancel" });
+    const confirmButton = r.getByRole("button", { name: "Confirm" });
+    expect(cancelButton.parentElement?.className).toContain("border-t");
+
+    fireEvent.click(confirmButton);
+    expect(submitted).toBe(true);
+
+    fireEvent.click(cancelButton);
+    expect(closed).toBe(true);
+  });
 });

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -2366,12 +2366,14 @@ export function Dialog({
   children,
   wide,
   extraWide,
+  footer,
 }: {
   title: string;
   onClose: () => void;
   children: ReactNode;
   wide?: boolean;
   extraWide?: boolean;
+  footer?: ReactNode;
 }) {
   useFocusReturn();
   const titleId = useId();
@@ -2406,12 +2408,24 @@ export function Dialog({
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
-        className={`${extraWide ? "w-[920px] max-w-[95vw]" : wide ? "w-[720px]" : "w-[480px]"} max-h-[85vh] overflow-y-auto rounded-lg border border-(--border-strong) bg-(--surface-1) p-4 sm:p-5 shadow-2xl outline-none`}
+        className={`${extraWide ? "w-[920px] max-w-[95vw]" : wide ? "w-[720px]" : "w-[480px]"} max-h-[85vh] ${footer ? "flex flex-col" : "overflow-y-auto"} rounded-lg border border-(--border-strong) bg-(--surface-1) p-4 sm:p-5 shadow-2xl outline-none`}
       >
-        <div id={titleId} className="display mb-3 text-[15px] font-semibold">
+        <div
+          id={titleId}
+          className={`display mb-3 text-[15px] font-semibold ${footer ? "shrink-0" : ""}`}
+        >
           {title}
         </div>
-        {children}
+        {footer ? (
+          <>
+            <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+            <div className="mt-3 flex shrink-0 justify-end gap-2 border-t border-(--border) pt-3">
+              {footer}
+            </div>
+          </>
+        ) : (
+          children
+        )}
       </div>
     </div>
   );

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1617,3 +1617,43 @@ describe("Proposals long-list window (WM-563)", () => {
     );
   });
 });
+
+describe("Proposals approval modal pinned footer (WM-829)", () => {
+  test("renders approve modal with pinned footer containing action buttons", async () => {
+    const proposal = stubProposal("prop_pinned_footer");
+    let approvedId: string | null = null;
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => stubStatus(),
+        approve: async (id: string) => {
+          approvedId = id;
+          return { approved: true, runId: `run_${id}` };
+        },
+      },
+      async () => {
+        const r = renderProposals({
+          focusProposalId: proposal.id,
+        });
+
+        const approveBtn = await r.findByRole("button", { name: /^Approve/ });
+        fireEvent.click(approveBtn);
+
+        const dialog = await r.findByRole("dialog", {
+          name: "Approve and queue this run?",
+        });
+        expect(dialog.className).toContain("flex flex-col");
+
+        const confirmBtn = r.getByRole("button", { name: /Approve and queue/ });
+        const notYetBtn = r.getByRole("button", { name: "Not yet" });
+
+        // Confirm and cancel buttons are inside the pinned footer container with border-t
+        expect(confirmBtn.closest("div")?.className).toContain("border-t");
+        expect(notYetBtn.closest("div")?.className).toContain("border-t");
+
+        fireEvent.click(confirmBtn);
+        await waitFor(() => expect(approvedId).toBe("prop_pinned_footer"));
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1731,6 +1731,27 @@ export function Proposals({
           title="Approve and queue this run?"
           onClose={() => setConfirmApprove(false)}
           wide
+          footer={
+            <>
+              <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
+              <span title={approvalDisabledReason}>
+                <Button
+                  variant="primary"
+                  disabled={!canApprove || !connected || approve.isPending}
+                  onClick={() => {
+                    if (!canApprove || proposalIsExpired(sel)) return;
+                    setConfirmApprove(false);
+                    approve.mutate(sel);
+                  }}
+                >
+                  Approve and queue{" "}
+                  <span className="mono ml-1 opacity-80" aria-hidden="true">
+                    ↵
+                  </span>
+                </Button>
+              </span>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             You are approving this exact immutable spec — the agent below runs
@@ -1738,25 +1759,6 @@ export function Proposals({
           </div>
           {/* Shared with the Runs view's approve dialog (WM-505). */}
           <ApprovalRiskDetails proposal={sel} agent={selAgent} />
-          <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
-            <span title={approvalDisabledReason}>
-              <Button
-                variant="primary"
-                disabled={!canApprove || !connected || approve.isPending}
-                onClick={() => {
-                  if (!canApprove || proposalIsExpired(sel)) return;
-                  setConfirmApprove(false);
-                  approve.mutate(sel);
-                }}
-              >
-                Approve and queue{" "}
-                <span className="mono ml-1 opacity-80" aria-hidden="true">
-                  ↵
-                </span>
-              </Button>
-            </span>
-          </div>
         </Dialog>
       )}
 
@@ -1765,6 +1767,29 @@ export function Proposals({
           title="Proposal expired — re-planned against current state"
           onClose={() => setReplan(null)}
           wide
+          footer={
+            <>
+              <Button onClick={() => setReplan(null)}>Not yet</Button>
+              <span
+                title={
+                  replanExpired
+                    ? "This replacement proposal has expired and can no longer be approved."
+                    : undefined
+                }
+              >
+                <Button
+                  variant="primary"
+                  disabled={!connected || replanExpired || approve.isPending}
+                  onClick={approveReplan}
+                >
+                  Approve new proposal{" "}
+                  <span className="mono ml-1 opacity-80" aria-hidden="true">
+                    ↵
+                  </span>
+                </Button>
+              </span>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             The TTL passed, so the planner re-read authoritative state and
@@ -1773,27 +1798,6 @@ export function Proposals({
           </div>
           <div className="mb-3 max-h-[38vh] overflow-auto">
             <SpecDiff before={replan.before.spec} after={replan.after.spec} />
-          </div>
-          <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setReplan(null)}>Not yet</Button>
-            <span
-              title={
-                replanExpired
-                  ? "This replacement proposal has expired and can no longer be approved."
-                  : undefined
-              }
-            >
-              <Button
-                variant="primary"
-                disabled={!connected || replanExpired || approve.isPending}
-                onClick={approveReplan}
-              >
-                Approve new proposal{" "}
-                <span className="mono ml-1 opacity-80" aria-hidden="true">
-                  ↵
-                </span>
-              </Button>
-            </span>
           </div>
         </Dialog>
       )}
@@ -1846,6 +1850,24 @@ export function Proposals({
           title={`Approve and queue ${approvableSelected.length} run${approvableSelected.length === 1 ? "" : "s"}?`}
           onClose={() => setBulkConfirmOpen(false)}
           wide
+          footer={
+            <>
+              <Button onClick={() => setBulkConfirmOpen(false)}>Not yet</Button>
+              <Button
+                variant="primary"
+                autoFocus
+                disabled={!connected || bulkApproving}
+                onClick={() => {
+                  void handleBulkApprove();
+                }}
+              >
+                Approve and queue{" "}
+                <span className="mono ml-1 opacity-80" aria-hidden="true">
+                  ↵
+                </span>
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             You are approving{" "}
@@ -1889,22 +1911,6 @@ export function Proposals({
               </div>
             ))}
           </div>
-          <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setBulkConfirmOpen(false)}>Not yet</Button>
-            <Button
-              variant="primary"
-              autoFocus
-              disabled={!connected || bulkApproving}
-              onClick={() => {
-                void handleBulkApprove();
-              }}
-            >
-              Approve and queue{" "}
-              <span className="mono ml-1 opacity-80" aria-hidden="true">
-                ↵
-              </span>
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -1912,6 +1918,20 @@ export function Proposals({
         <Dialog
           title={`Reject ${rejectableSelected.length} selected proposal${rejectableSelected.length === 1 ? "" : "s"}`}
           onClose={() => setBulkRejectOpen(false)}
+          footer={
+            <>
+              <Button onClick={() => setBulkRejectOpen(false)}>Cancel</Button>
+              <Button
+                variant="danger"
+                disabled={!bulkReason.trim() || bulkRejecting || !connected}
+                onClick={handleBulkReject}
+              >
+                {bulkRejecting
+                  ? "Rejecting…"
+                  : `Reject ${rejectableSelected.length} proposals`}
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             Provide a rejection reason for all {rejectableSelected.length}{" "}
@@ -1957,18 +1977,6 @@ export function Proposals({
             placeholder="Reason (required — rejections are audit records)"
             className="w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none focus:border-(--accent)"
           />
-          <div className="mt-4 flex justify-end gap-2">
-            <Button onClick={() => setBulkRejectOpen(false)}>Cancel</Button>
-            <Button
-              variant="danger"
-              disabled={!bulkReason.trim() || bulkRejecting || !connected}
-              onClick={handleBulkReject}
-            >
-              {bulkRejecting
-                ? "Rejecting…"
-                : `Reject ${rejectableSelected.length} proposals`}
-            </Button>
-          </div>
         </Dialog>
       )}
     </div>

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -734,6 +734,22 @@ export function RunFull({
           title={`Approve and queue run ${shortId(selProposal.runId ?? d.run.runId)}?`}
           onClose={() => setConfirmApprove(false)}
           wide
+          footer={
+            <>
+              <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
+              <Button
+                disabled={!connected || approve.isPending}
+                onClick={() => {
+                  approve.mutate(selProposal.id);
+                }}
+              >
+                Approve and queue{" "}
+                <span className="mono ml-1 opacity-80" aria-hidden="true">
+                  ↵
+                </span>
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             Approving proposal{" "}
@@ -741,20 +757,6 @@ export function RunFull({
             this run for execution.
           </div>
           <VerbError error={approve.error} />
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
-            <Button
-              disabled={!connected || approve.isPending}
-              onClick={() => {
-                approve.mutate(selProposal.id);
-              }}
-            >
-              Approve and queue{" "}
-              <span className="mono ml-1 opacity-80" aria-hidden="true">
-                ↵
-              </span>
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -762,6 +764,23 @@ export function RunFull({
         <Dialog
           title={`Extend ${d.run.runId}`}
           onClose={() => setCustomExtend(false)}
+          footer={
+            <>
+              <Button onClick={() => setCustomExtend(false)}>Cancel</Button>
+              <Button
+                variant="primary"
+                disabled={!connected || extend.isPending || !customMinutesValid}
+                onClick={() =>
+                  extend.mutate({
+                    id: d.run.runId,
+                    seconds: customMinutesNumber * 60,
+                  })
+                }
+              >
+                Extend run
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             Add up to 60 minutes per request. The policy run limit still
@@ -793,21 +812,6 @@ export function RunFull({
               Enter a whole number from 1 to 60.
             </span>
           </label>
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setCustomExtend(false)}>Cancel</Button>
-            <Button
-              variant="primary"
-              disabled={!connected || extend.isPending || !customMinutesValid}
-              onClick={() =>
-                extend.mutate({
-                  id: d.run.runId,
-                  seconds: customMinutesNumber * 60,
-                })
-              }
-            >
-              Extend run
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -815,6 +819,23 @@ export function RunFull({
         <Dialog
           title={`Cancel ${d.run.runId}?`}
           onClose={() => setConfirm(null)}
+          footer={
+            <>
+              <Button onClick={() => setConfirm(null)}>Keep run</Button>
+              <Button
+                variant="danger"
+                disabled={cancel.isPending}
+                onClick={() =>
+                  cancel.mutate({
+                    id: d.run.runId,
+                    reason: cancelReason.trim() || undefined,
+                  })
+                }
+              >
+                Cancel run
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             {d.run.state === "RUNNING"
@@ -828,21 +849,6 @@ export function RunFull({
             placeholder="Reason (optional)"
             className="mb-3 w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-(--text) outline-none focus:border-(--accent)"
           />
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setConfirm(null)}>Keep run</Button>
-            <Button
-              variant="danger"
-              disabled={cancel.isPending}
-              onClick={() =>
-                cancel.mutate({
-                  id: d.run.runId,
-                  reason: cancelReason.trim() || undefined,
-                })
-              }
-            >
-              Cancel run
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -850,6 +856,18 @@ export function RunFull({
         <Dialog
           title="Retry past the attempt budget?"
           onClose={() => setConfirm(null)}
+          footer={
+            <>
+              <Button onClick={() => setConfirm(null)}>Leave it</Button>
+              <Button
+                variant="primary"
+                disabled={retry.isPending}
+                onClick={() => retry.mutate({ id: d.run.runId, force: true })}
+              >
+                Force retry
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             This run has used {d.run.attempts}/{d.run.spec.maxAttempts}{" "}
@@ -857,16 +875,6 @@ export function RunFull({
             recorded in the audit trail as an explicit operator override.
           </div>
           <VerbError error={retry.error} />
-          <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setConfirm(null)}>Leave it</Button>
-            <Button
-              variant="primary"
-              disabled={retry.isPending}
-              onClick={() => retry.mutate({ id: d.run.runId, force: true })}
-            >
-              Force retry
-            </Button>
-          </div>
         </Dialog>
       )}
     </div>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1622,6 +1622,23 @@ export function Runs({
           title={`Approve and queue run ${shortId(selProposal.runId ?? d.run.runId)}?`}
           onClose={() => setConfirmApprove(false)}
           wide
+          footer={
+            <>
+              <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
+              <Button
+                variant="primary"
+                disabled={!connected || approve.isPending}
+                onClick={() => {
+                  approve.mutate(selProposal.id);
+                }}
+              >
+                Approve and queue{" "}
+                <span className="mono ml-1 opacity-80" aria-hidden="true">
+                  ↵
+                </span>
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             You are approving this exact immutable spec — the agent below runs
@@ -1631,21 +1648,6 @@ export function Runs({
           </div>
           <ApprovalRiskDetails proposal={selProposal} agent={approveAgent} />
           <VerbError error={approve.error} />
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
-            <Button
-              variant="primary"
-              disabled={!connected || approve.isPending}
-              onClick={() => {
-                approve.mutate(selProposal.id);
-              }}
-            >
-              Approve and queue{" "}
-              <span className="mono ml-1 opacity-80" aria-hidden="true">
-                ↵
-              </span>
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -1653,6 +1655,23 @@ export function Runs({
         <Dialog
           title={`Cancel ${d.run.runId}?`}
           onClose={() => setConfirm(null)}
+          footer={
+            <>
+              <Button onClick={() => setConfirm(null)}>Keep run</Button>
+              <Button
+                variant="danger"
+                disabled={cancel.isPending}
+                onClick={() =>
+                  cancel.mutate({
+                    id: d.run.runId,
+                    reason: cancelReason.trim() || undefined,
+                  })
+                }
+              >
+                Cancel run
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             {d.run.state === "RUNNING"
@@ -1666,21 +1685,6 @@ export function Runs({
             placeholder="Reason (optional)"
             className="mb-3 w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-(--text) outline-none focus:border-(--accent)"
           />
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setConfirm(null)}>Keep run</Button>
-            <Button
-              variant="danger"
-              disabled={cancel.isPending}
-              onClick={() =>
-                cancel.mutate({
-                  id: d.run.runId,
-                  reason: cancelReason.trim() || undefined,
-                })
-              }
-            >
-              Cancel run
-            </Button>
-          </div>
         </Dialog>
       )}
 
@@ -1688,22 +1692,24 @@ export function Runs({
         <Dialog
           title="Retry past attempt budget?"
           onClose={() => setConfirm(null)}
+          footer={
+            <>
+              <Button onClick={() => setConfirm(null)}>Leave it</Button>
+              <Button
+                variant="primary"
+                disabled={retry.isPending}
+                onClick={() => retry.mutate({ id: d.run.runId, force: true })}
+              >
+                Force retry
+              </Button>
+            </>
+          }
         >
           <div className="mb-3 text-[12px] text-(--text-dim)">
             Used {d.run.attempts}/{d.run.spec.maxAttempts} attempts. Forcing
             retry is recorded as an operator override.
           </div>
           <VerbError error={retry.error} />
-          <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setConfirm(null)}>Leave it</Button>
-            <Button
-              variant="primary"
-              disabled={retry.isPending}
-              onClick={() => retry.mutate({ id: d.run.runId, force: true })}
-            >
-              Force retry
-            </Button>
-          </div>
         </Dialog>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Update `Dialog` component in `event-runtime/web/src/components/ui.tsx` to accept an optional `footer?: ReactNode` prop.
- Layout `Dialog` with pinned header, middle scrollable container (`flex-1 overflow-y-auto min-h-0`), and pinned bottom footer (`shrink-0 pt-3 mt-3 border-t border-(--border) flex justify-end gap-2`).
- Maintain backward compatibility when `footer` is omitted.
- Update action dialogs in `Proposals.tsx`, `Runs.tsx`, and `RunFull.tsx` to pass action buttons via `footer` prop so actions remain visible regardless of modal content length.
- Add unit tests in `ui.test.tsx` and `Proposals.test.tsx` for pinned footer rendering and button interactions.

Fixes WM-829