### PR TITLE
feat(event-runtime-web): Tickets hub landing view with recent activity table and jump bar (WM-822)

### DIFF
--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -22,6 +22,7 @@ import type {
   RunDetail,
   RunListItem,
   StatusView,
+  TicketSummary,
   TraceView,
   Worker,
 } from "./types";
@@ -227,6 +228,19 @@ export function fetchArtifacts(filters?: {
   );
 }
 
+export function fetchTickets(
+  filters: { since?: string | number; limit?: number; repo?: string } = {},
+) {
+  return call<{ tickets: TicketSummary[] }>(
+    "GET",
+    withQuery("/tickets", {
+      since: filters.since != null ? String(filters.since) : undefined,
+      limit: filters.limit != null ? String(filters.limit) : undefined,
+      repo: filters.repo || undefined,
+    }),
+  );
+}
+
 export const api = {
   health: () =>
     call<{ ok: boolean; policyVersion: string; env: EnvIdentity }>(
@@ -372,6 +386,9 @@ export const api = {
       `/schedules/${encodeURIComponent(loop)}/run`,
       prNumbers === undefined ? {} : { prNumbers },
     ),
+  // Recent ticket summaries across factory runs (GET /tickets).
+  tickets: (since?: string | number, limit = 50, repo?: string) =>
+    fetchTickets({ since, limit, repo }),
 };
 
 // Decision detail endpoints are named exports so the generic API test harness

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -380,6 +380,7 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
     workers: mock(async (): Promise<{ workers: Worker[] }> => ({
       workers: [],
     })),
+    tickets: mock(async () => ({ tickets: [] })),
     inbox: mock(async (_status = "open") => ({ items: [] })),
     ackInbox: mock(async (id: string) => ({ item: { id } })),
     resolveInbox: mock(async (id: string, _reason?: string) => ({

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -836,3 +836,21 @@ export interface InboxItem {
   decidedBy?: string | null;
   dedupeKey?: string | null;
 }
+
+/** One recent ticket summary (GET /tickets). */
+export interface TicketSummary {
+  id: string;
+  title?: string | null;
+  state?: string | null;
+  repo?: string | null;
+  repos?: string[];
+  lastActivityAt?: string;
+  lastActivityDescription?: string | null;
+  lastActivityKind?: string | null;
+  attempts?: number;
+  pr?: number | null;
+  prUrl?: string | null;
+  checksGreen?: boolean | null;
+  ciStatus?: "green" | "red" | "pending" | string | null;
+  url?: string | null;
+}

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -1,8 +1,15 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { prCandidateRunIds, PullRequest, Ticket } from "./Ticket";
+import { changeInput } from "../test-render";
 import type { JourneyRun, TicketJourneySource } from "../subjectJourney";
 
 const realFetch = globalThis.fetch;
@@ -530,5 +537,284 @@ describe("PR journey view", () => {
       runs: runs as any,
     });
     expect(ids.sort()).toEqual(["run_dispatch", "run_fix", "run_scan"]);
+  });
+});
+
+describe("Tickets hub landing view", () => {
+  const ticketsFixture = [
+    {
+      id: "WM-822",
+      title: "Tickets hub landing view",
+      state: "In Progress",
+      repo: "factory",
+      repos: ["factory"],
+      lastActivityAt: "2026-08-18T18:00:00.000Z",
+      lastActivityDescription: "dispatch@1 leased",
+      lastActivityKind: "run",
+      attempts: 2,
+      pr: 542,
+      prUrl: "https://github.com/watt-mind/factory/pull/542",
+      checksGreen: true,
+      ciStatus: "green",
+      url: "https://linear.app/watt-mind/issue/WM-822",
+    },
+    {
+      id: "WM-821",
+      title: "Fix broken build",
+      state: "Done",
+      repo: "bj29",
+      repos: ["bj29"],
+      lastActivityAt: "2026-08-18T17:00:00.000Z",
+      lastActivityDescription: "merged into master",
+      lastActivityKind: "merge",
+      attempts: 1,
+      pr: 101,
+      prUrl: "https://github.com/watt-mind/bj29/pull/101",
+      checksGreen: true,
+      ciStatus: "green",
+      url: "https://linear.app/watt-mind/issue/WM-821",
+    },
+    {
+      id: "OPS-91",
+      title: "Uptime monitoring setup",
+      state: "Todo",
+      repo: "hdkiller",
+      repos: ["hdkiller"],
+      lastActivityAt: "2026-08-18T16:00:00.000Z",
+      lastActivityDescription: "triage-scan@1 planned",
+      lastActivityKind: "event",
+      attempts: 0,
+      pr: null,
+      prUrl: null,
+      checksGreen: null,
+      ciStatus: null,
+      url: "https://linear.app/watt-mind/issue/OPS-91",
+    },
+  ];
+
+  function ticketsFetch(data = ticketsFixture) {
+    return (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const json = (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      if (/\/api\/repos/.test(url)) {
+        return json({
+          repos: [
+            { name: "factory", team: "WM" },
+            { name: "bj29", team: "WM" },
+            { name: "hdkiller", team: "OPS" },
+          ],
+        });
+      }
+      if (/\/api\/tickets/.test(url)) {
+        return json({ tickets: data });
+      }
+      return json({ error: `unexpected ${url}` }, 404);
+    }) as unknown as typeof fetch;
+  }
+
+  test("renders tickets hub table with columns, jump bar, and filters when ticketId is null", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} onNavigatePr={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    // Should display ticket hub title / jump bar
+    await view.findByPlaceholderText(/WM-542/i);
+    // Table should contain ticket entries
+    await view.findByText("WM-822");
+    expect(view.getByText("WM-821")).toBeTruthy();
+    expect(view.getByText("OPS-91")).toBeTruthy();
+    expect(view.getByText("Tickets hub landing view")).toBeTruthy();
+    expect(view.getAllByText("In Progress").length).toBeGreaterThan(0);
+    expect(view.getAllByText("factory").length).toBeGreaterThan(0);
+    expect(view.getByText("PR #542")).toBeTruthy();
+    expect(view.getByText("2", { selector: "td" })).toBeTruthy(); // attempts
+  });
+
+  test("jump bar navigates to ticket or PR upon Enter", async () => {
+    globalThis.fetch = ticketsFetch();
+    let navigatedTicket = "";
+    let navigatedPr = 0;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket
+          ticketId={null}
+          onNavigate={(id) => {
+            navigatedTicket = id;
+          }}
+          onNavigatePr={(pr) => {
+            navigatedPr = pr;
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    const input = await view.findByPlaceholderText(/WM-542/i);
+    fireEvent.change(input, { target: { value: "WM-999" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(navigatedTicket).toBe("WM-999");
+
+    fireEvent.change(input, { target: { value: "#541" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(navigatedPr).toBe(541);
+  });
+
+  test("filtering by repo and state works in tickets hub", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await view.findByText("WM-822");
+    expect(view.getByText("WM-821")).toBeTruthy();
+
+    const repoSelect = view.getByLabelText(/filter by repo/i);
+    fireEvent.change(repoSelect, { target: { value: "bj29" } });
+
+    await waitFor(() => {
+      expect(view.queryByText("WM-822")).toBeNull();
+    });
+    expect(view.getByText("WM-821")).toBeTruthy();
+  });
+
+  test("keyboard navigation j/k and opening ticket in linear with 'o'", async () => {
+    globalThis.fetch = ticketsFetch();
+    let openedUrl = "";
+    const origOpen = window.open;
+    Object.defineProperty(window, "open", {
+      writable: true,
+      value: (url: string) => {
+        openedUrl = url;
+        return null;
+      },
+    });
+
+    try {
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, refetchInterval: false } },
+      });
+      const view = render(
+        <QueryClientProvider client={client}>
+          <Ticket ticketId={null} onNavigate={() => {}} />
+        </QueryClientProvider>,
+      );
+
+      await view.findByText("WM-822");
+      // Fire keydown 'j' to move selection down
+      fireEvent.keyDown(document.body, { key: "j" });
+      // Fire keydown 'o' to open in linear
+      fireEvent.keyDown(document.body, { key: "o" });
+      expect(openedUrl).toContain("linear.app");
+    } finally {
+      Object.defineProperty(window, "open", {
+        writable: true,
+        value: origOpen,
+      });
+    }
+  });
+
+  test("displays empty state when no tickets match", async () => {
+    globalThis.fetch = ticketsFetch([]);
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await view.findByText(/No tickets found/i);
+  });
+
+  test("row click navigates to ticket journey and PR link navigates to PR", async () => {
+    globalThis.fetch = ticketsFetch();
+    let navigatedTicket = "";
+    let navigatedPr = 0;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket
+          ticketId={null}
+          onNavigate={(id) => {
+            navigatedTicket = id;
+          }}
+          onNavigatePr={(pr) => {
+            navigatedPr = pr;
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await view.findByText("WM-822");
+    // Click row
+    fireEvent.click(view.getByText("Tickets hub landing view"));
+    expect(navigatedTicket).toBe("WM-822");
+
+    // Click PR link
+    fireEvent.click(view.getByText("PR #542"));
+    expect(navigatedPr).toBe(542);
+  });
+
+  test("search text filter filters tickets by query", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await view.findByText("WM-822");
+    const searchInput = view.getByRole("combobox", { name: "Filter tickets" });
+    changeInput(searchInput, "OPS-91");
+
+    await waitFor(() => {
+      expect(view.queryByText("WM-822")).toBeNull();
+    });
+    expect(view.getByText("OPS-91")).toBeTruthy();
+    expect(view.queryByText("WM-821")).toBeNull();
+  });
+
+  test("g k shortcut focuses the jump bar input", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    const jumpInput = await view.findByPlaceholderText(/WM-542 or #541/i);
+    const openBtn = view.getByRole("button", { name: "Open" });
+    openBtn.focus();
+    expect(document.activeElement).toBe(openBtn);
+
+    fireEvent.keyDown(document.body, { key: "g" });
+    fireEvent.keyDown(document.body, { key: "k" });
+    expect(document.activeElement).toBe(jumpInput);
   });
 });

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { api } from "../api";
-import { refetchIntervals } from "../hooks";
+import { refetchIntervals, useListKeys, useNow } from "../hooks";
 import {
   buildTicketJourney,
   formatDuration,
@@ -25,14 +25,28 @@ import {
   type SubjectJourney,
   type TimelineItem,
 } from "../subjectJourney";
-import { StateBadge, STATE_HUES } from "../components/ui";
+import {
+  Ago,
+  Button as PrimitiveButton,
+  FilterInput,
+  ListEmpty,
+  ListPane,
+  StateBadge,
+  STATE_HUES,
+  Th,
+} from "../components/ui";
 import {
   fetchTicketJourney,
   isUnindexedTicket,
   TicketText,
 } from "../components/TicketHoverCard";
-import type { AdmittedEvent, Proposal, RunDetail, RunListItem } from "../types";
-import { Button as PrimitiveButton } from "../components/ui";
+import type {
+  AdmittedEvent,
+  Proposal,
+  RunDetail,
+  RunListItem,
+  TicketSummary,
+} from "../types";
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
@@ -171,72 +185,403 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
   );
 }
 
-function TicketPicker({
+function TicketsHub({
   onNavigate,
   onNavigatePr,
 }: {
   onNavigate: (ticketId: string) => void;
   onNavigatePr?: (number: number) => void;
 }) {
-  const [value, setValue] = useState("");
-  const [error, setError] = useState(false);
+  const [jumpValue, setJumpValue] = useState("");
+  const [jumpError, setJumpError] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [repoFilter, setRepoFilter] = useState("");
+  const [stateFilter, setStateFilter] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const now = useNow();
+
   useEffect(() => {
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
   }, []);
-  const submit = (event: FormEvent) => {
+
+  const ticketsQuery = useQuery({
+    queryKey: ["tickets", repoFilter],
+    queryFn: () => api.tickets(undefined, 100, repoFilter || undefined),
+    ...refetchIntervals.fast,
+  });
+
+  const reposQuery = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    ...refetchIntervals.secondary,
+  });
+
+  const tickets: TicketSummary[] = useMemo(
+    () => ticketsQuery.data?.tickets ?? [],
+    [ticketsQuery.data],
+  );
+
+  const repoOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of reposQuery.data?.repos ?? []) {
+      if (r.name) set.add(r.name);
+    }
+    for (const t of tickets) {
+      if (t.repo) set.add(t.repo);
+      if (t.repos) t.repos.forEach((r) => set.add(r));
+    }
+    return Array.from(set).sort();
+  }, [reposQuery.data, tickets]);
+
+  const stateOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of tickets) {
+      if (t.state) set.add(t.state);
+    }
+    return Array.from(set).sort();
+  }, [tickets]);
+
+  const filteredTickets = useMemo(() => {
+    return tickets.filter((t) => {
+      if (repoFilter) {
+        const matchesRepo =
+          t.repo === repoFilter || (t.repos && t.repos.includes(repoFilter));
+        if (!matchesRepo) return false;
+      }
+      if (stateFilter) {
+        if (t.state !== stateFilter) return false;
+      }
+      if (searchQuery) {
+        const q = searchQuery.trim().toLowerCase();
+        const matchId = t.id.toLowerCase().includes(q);
+        const matchTitle = t.title?.toLowerCase().includes(q);
+        const matchRepo =
+          t.repo?.toLowerCase().includes(q) ||
+          t.repos?.some((r) => r.toLowerCase().includes(q));
+        const matchState = t.state?.toLowerCase().includes(q);
+        const matchDesc = t.lastActivityDescription?.toLowerCase().includes(q);
+        if (
+          !matchId &&
+          !matchTitle &&
+          !matchRepo &&
+          !matchState &&
+          !matchDesc
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [tickets, repoFilter, stateFilter, searchQuery]);
+
+  const selectedIndex = useMemo(() => {
+    if (!selectedId) return 0;
+    const idx = filteredTickets.findIndex((t) => t.id === selectedId);
+    return idx >= 0 ? idx : 0;
+  }, [filteredTickets, selectedId]);
+
+  const selectedTicket = filteredTickets[selectedIndex] ?? null;
+
+  useListKeys({
+    count: filteredTickets.length,
+    selected: selectedIndex,
+    onSelect: (index) => setSelectedId(filteredTickets[index]?.id ?? null),
+    onClose: () => {
+      if (searchQuery) setSearchQuery("");
+      else setSelectedId(null);
+    },
+    keys: {
+      Enter: () => {
+        if (selectedTicket) {
+          onNavigate(selectedTicket.id);
+        }
+      },
+      o: () => {
+        if (selectedTicket) {
+          const linearUrl =
+            selectedTicket.url ||
+            `https://linear.app/watt-mind/issue/${encodeURIComponent(selectedTicket.id)}`;
+          window.open(linearUrl, "_blank", "noreferrer");
+        }
+      },
+    },
+  });
+
+  useEffect(() => {
+    let lastKey = "";
+    let lastKeyTime = 0;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isInput =
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable);
+      if (isInput) return;
+
+      const currentTime = Date.now();
+      if (e.key === "g" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        lastKey = "g";
+        lastKeyTime = currentTime;
+        return;
+      }
+      if (
+        e.key === "k" &&
+        lastKey === "g" &&
+        currentTime - lastKeyTime < 1000 &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        if (typeof inputRef.current?.select === "function") {
+          inputRef.current.select();
+        }
+        lastKey = "";
+        return;
+      }
+      if (e.key === "/" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        if (typeof inputRef.current?.select === "function") {
+          inputRef.current.select();
+        }
+        return;
+      }
+      lastKey = "";
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const submitJump = (event: FormEvent) => {
     event.preventDefault();
-    const ticket = value.trim().toUpperCase();
-    const pr = parsePrRef(value);
+    const raw = (inputRef.current?.value || jumpValue).trim();
+    const ticket = raw.toUpperCase();
+    const pr = parsePrRef(raw);
     if (pr && onNavigatePr) {
-      setError(false);
+      setJumpError(false);
       onNavigatePr(pr);
       return;
     }
     if (!TICKET_ID_PATTERN.test(ticket)) {
-      setError(true);
+      setJumpError(true);
       return;
     }
-    setError(false);
+    setJumpError(false);
     onNavigate(ticket);
   };
+
   return (
-    <div className="mx-auto max-w-lg p-8">
-      <h1 className="display text-h1 font-semibold">Ticket journey</h1>
-      <p className="mt-2 text-[13px] text-(--text-dim)">
-        Enter a Linear ticket id to see its decisions, attempts, PR, CI, and
-        merge history on one timeline.
-        {onNavigatePr ? " A PR reference (#541) opens that PR's journey." : ""}
-      </p>
-      <form onSubmit={submit} className="mt-5 flex gap-2">
-        <input
-          ref={inputRef}
-          autoFocus
-          value={value}
-          onChange={(event) => setValue(event.target.value)}
-          placeholder="WM-542"
-          aria-label="Ticket id"
-          aria-invalid={error}
-          className="mono min-w-0 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-2 text-[13px] outline-none focus:border-(--accent)"
-        />
-        <PrimitiveButton
-          bare
-          type="submit"
-          className="rounded-md bg-(--accent) px-4 py-2 text-[12px] font-medium text-(--on-accent)"
-        >
-          Open
-        </PrimitiveButton>
-      </form>
-      {error && (
-        <div role="alert" className="mt-2 text-[11px] text-(--hue-err)">
-          Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
-        </div>
-      )}
-      <div className="mt-3 text-[11px] text-(--text-faint)">
-        Shortcut: <span className="mono">g k</span>
+    <ListPane
+      chrome={
+        <>
+          <h1 className="display mb-1 text-lg font-semibold">Tickets</h1>
+          <p className="mb-3 text-[11px] text-(--text-faint)">
+            Recent factory ticket activity, journey timelines, and quick search.
+            {onNavigatePr
+              ? " A PR reference (#541) opens that PR's journey."
+              : ""}
+          </p>
+          <form
+            onSubmit={submitJump}
+            className="mb-3 flex flex-wrap items-center gap-2"
+          >
+            <input
+              ref={inputRef}
+              autoFocus
+              value={jumpValue}
+              onChange={(event) => setJumpValue(event.target.value)}
+              placeholder="WM-542 or #541"
+              aria-label="Ticket id"
+              aria-invalid={jumpError}
+              className="mono min-w-48 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-1.5 text-[13px] outline-none focus:border-(--accent)"
+            />
+            <PrimitiveButton
+              bare
+              type="submit"
+              className="rounded-md bg-(--accent) px-3.5 py-1.5 text-[12px] font-medium text-(--on-accent)"
+            >
+              Open
+            </PrimitiveButton>
+          </form>
+          {jumpError && (
+            <div role="alert" className="mb-3 text-[11px] text-(--hue-err)">
+              Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
+            </div>
+          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placeholder="Filter tickets…"
+              label="Filter tickets"
+            />
+            <select
+              aria-label="Filter by repo"
+              value={repoFilter}
+              onChange={(e) => setRepoFilter(e.target.value)}
+              className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
+            >
+              <option value="">All repos</option>
+              {repoOptions.map((repo) => (
+                <option key={repo} value={repo}>
+                  {repo}
+                </option>
+              ))}
+            </select>
+            <select
+              aria-label="Filter by state"
+              value={stateFilter}
+              onChange={(e) => setStateFilter(e.target.value)}
+              className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
+            >
+              <option value="">All states</option>
+              {stateOptions.map((state) => (
+                <option key={state} value={state}>
+                  {state}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="mt-2 text-[11px] text-(--text-faint)">
+            Shortcut: <span className="mono">g k</span> to focus jump bar,{" "}
+            <span className="mono">j</span>/<span className="mono">k</span> to
+            navigate, <span className="mono">Enter</span> to open,{" "}
+            <span className="mono">o</span> to open in Linear
+          </div>
+        </>
+      }
+    >
+      <div className="table-wrap">
+        <table className="w-full text-left text-[12px]">
+          <thead>
+            <tr className="border-b border-(--border)">
+              <Th label="Ticket ID" />
+              <Th label="Repo" />
+              <Th label="State" />
+              <Th label="Last Activity" />
+              <Th label="Attempts" />
+              <Th label="PR / CI" />
+            </tr>
+          </thead>
+          <tbody>
+            {filteredTickets.length === 0 ? (
+              <ListEmpty
+                colSpan={6}
+                query={ticketsQuery}
+                filtered={Boolean(searchQuery || repoFilter || stateFilter)}
+                noun="tickets"
+                empty="No tickets found."
+                onClear={() => {
+                  setSearchQuery("");
+                  setRepoFilter("");
+                  setStateFilter("");
+                }}
+              />
+            ) : (
+              filteredTickets.map((ticket, index) => {
+                const selected =
+                  index === selectedIndex || ticket.id === selectedId;
+                return (
+                  <tr
+                    key={ticket.id}
+                    data-ticket-id={ticket.id}
+                    aria-selected={selected}
+                    onClick={() => onNavigate(ticket.id)}
+                    className={`cursor-pointer border-b border-(--border) hover:bg-(--surface-1) ${
+                      selected ? "bg-(--surface-1)" : ""
+                    }`}
+                  >
+                    <td className="mono px-3 py-2 font-medium">
+                      <a
+                        href={`#/tickets/${encodeURIComponent(ticket.id)}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          onNavigate(ticket.id);
+                        }}
+                        className="text-(--accent) hover:underline"
+                      >
+                        {ticket.id}
+                      </a>
+                      {ticket.title && (
+                        <div className="max-w-xs truncate font-sans text-[11px] font-normal text-(--text-dim)">
+                          {ticket.title}
+                        </div>
+                      )}
+                    </td>
+                    <td className="mono px-3 py-2 text-(--text-dim)">
+                      {ticket.repo || ticket.repos?.join(", ") || "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {ticket.state ? (
+                        <StateBadge state={ticket.state} hues={STATE_HUES} />
+                      ) : (
+                        <span className="text-(--text-faint)">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-(--text-dim)">
+                      <div>
+                        {ticket.lastActivityDescription ||
+                          ticket.lastActivityKind ||
+                          "—"}
+                      </div>
+                      {ticket.lastActivityAt && (
+                        <div className="text-[11px] text-(--text-faint)">
+                          <Ago iso={ticket.lastActivityAt} now={now} />
+                        </div>
+                      )}
+                    </td>
+                    <td className="mono px-3 py-2 tabular-nums text-(--text-dim)">
+                      {ticket.attempts != null ? ticket.attempts : "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {ticket.pr != null ? (
+                        <span className="inline-flex items-center gap-1.5">
+                          <a
+                            href={ticket.prUrl || `#/prs/${ticket.pr}`}
+                            onClick={(e) => {
+                              if (onNavigatePr) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onNavigatePr(ticket.pr!);
+                              }
+                            }}
+                            className="mono text-(--accent) hover:underline"
+                          >
+                            {`PR #${ticket.pr}`}
+                          </a>
+                          {(ticket.ciStatus || ticket.checksGreen != null) && (
+                            <span
+                              className={`inline-block size-2 rounded-full ring-2 ring-(--surface-1) ${
+                                ticket.ciStatus === "green" ||
+                                ticket.checksGreen === true
+                                  ? "bg-(--hue-ok)"
+                                  : ticket.ciStatus === "red" ||
+                                      ticket.checksGreen === false
+                                    ? "bg-(--hue-err)"
+                                    : "bg-(--hue-warn)"
+                              }`}
+                              title={`CI: ${ticket.ciStatus ?? (ticket.checksGreen ? "green" : "red")}`}
+                            />
+                          )}
+                        </span>
+                      ) : (
+                        <span className="text-(--text-faint)">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
       </div>
-    </div>
+    </ListPane>
   );
 }
 
@@ -482,8 +827,8 @@ export function Ticket({
     ...refetchIntervals.secondary,
   });
 
-  if (!ticketId)
-    return <TicketPicker onNavigate={onNavigate} onNavigatePr={onNavigatePr} />;
+  if (!ticketId || ticketId.trim() === "")
+    return <TicketsHub onNavigate={onNavigate} onNavigatePr={onNavigatePr} />;
   if (!valid) {
     return (
       <div className="p-8">


### PR DESCRIPTION
## Summary
Transforms `#/tickets` into an operational Tickets Hub using `ListPane` when landing on the tickets view without a specific `ticketId`.

- Adds top quick-jump search bar with instant Enter submit (supporting tickets like `WM-542` and PR refs like `#541`) and autofocus
- Implements filters for text search, repo filter, and state filter
- Adds high-density Recent Tickets table displaying Ticket ID (mono, clickable), Repo, State (`StateBadge` with `STATE_HUES`), Last Activity description + `Ago` timestamp, Attempts count, and PR number + CI indicator
- Supports keyboard navigation: `j`/`k` row selection via `useListKeys`, `Enter` to open journey drilldown, `o` key to open ticket in Linear in a new tab, and `g k` shortcut to focus jump input
- Handles empty state when no tickets match filters
- Adds unit and component tests in `Ticket.test.tsx`

Fixes WM-822