### PR TITLE
fix(web): keep ?project= on run artifact and chain hrefs

### DIFF
--- a/event-runtime/web/src/components/EventHoverCard.test.tsx
+++ b/event-runtime/web/src/components/EventHoverCard.test.tsx
@@ -19,6 +19,7 @@ import type { AdmittedEvent } from "../types";
 afterEach(() => {
   cleanup();
   restoreApi();
+  window.location.hash = "";
 });
 
 const NOW = new Date().toISOString();
@@ -111,6 +112,16 @@ describe("chainHref", () => {
       "#/chain/corr_1001/event%3Agithub%3Aevt_1001",
     );
     expect(chainHref(null)).toBeNull();
+  });
+
+  test("keeps ?project= from the current hash (WM-787)", () => {
+    window.location.hash = "#/runs?project=factory";
+    expect(chainHref("corr_1001")).toBe("#/chain/corr_1001?project=factory");
+    expect(chainHref("corr_1001", "event:github:evt_1001")).toBe(
+      "#/chain/corr_1001/event%3Agithub%3Aevt_1001?project=factory",
+    );
+    window.location.hash = "#/runs";
+    expect(chainHref("corr_1001")).toBe("#/chain/corr_1001");
   });
 });
 

--- a/event-runtime/web/src/components/EventHoverCard.tsx
+++ b/event-runtime/web/src/components/EventHoverCard.tsx
@@ -21,7 +21,7 @@ import { api } from "../api";
 import { resolveEntity } from "../entities";
 import { EMPTY, formatRelative } from "../format";
 import { chainKeyOfEvent, eventNodeId } from "../graph/chainModel";
-import { hashPath } from "../hash";
+import { hashPath, hashProject, withProject } from "../hash";
 import type { AdmittedEvent, RunListItem } from "../types";
 import { formatCellValue } from "./CustomCell";
 import { HoverCard } from "./HoverCard";
@@ -103,7 +103,7 @@ export function chainHref(
   nodeId?: string | null,
 ): string | null {
   if (!correlationId) return null;
-  return `#/${hashPath("chain", correlationId, nodeId)}`;
+  return `#/${withProject(hashPath("chain", correlationId, nodeId), hashProject(window.location.hash))}`;
 }
 
 export interface CausationGlyphsProps {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -319,6 +319,18 @@ describe("Artifacts inventory (WM-207)", () => {
     expect(window.location.hash).toBe(`#/${`artifacts/${"b".repeat(64)}`}`);
   });
 
+  test("run artifact click keeps ?project= on the inspector hash (WM-761)", () => {
+    const sha = "b".repeat(64);
+    window.location.hash = `#/runs/${LONG_RUN_ID}?project=factory`;
+    const runLink = render(
+      <div onClickCapture={handleRunArtifactClick}>
+        <a href={`/api/artifacts/${sha}?name=transcript`}>Open</a>
+      </div>,
+    );
+    fireEvent.click(runLink.getByRole("link", { name: "Open" }));
+    expect(window.location.hash).toBe(`#/artifacts/${sha}?project=factory`);
+  });
+
   test("preserves URL-backed facets when opening and closing the inspector", async () => {
     globalThis.fetch = mock(
       async () => new Response("artifact report", { status: 200 }),

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -9,7 +9,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { api, ApiError, type RunListFilters } from "../api";
-import { hashSearch } from "../hash";
+import { hashPath, hashProject, hashSearch, withProject } from "../hash";
 import {
   keyGuard,
   refetchIntervals,
@@ -529,7 +529,7 @@ export function handleRunArtifactClick(event: ReactMouseEvent<HTMLElement>) {
   if (!match) return;
   event.preventDefault();
   event.stopPropagation();
-  window.location.hash = `#/artifacts/${match[1]}`;
+  window.location.hash = `#/${withProject(hashPath("artifacts", match[1]), hashProject(window.location.hash))}`;
 }
 
 /** Runs (webui spec §4.3): state tabs, lifecycle timeline, guarded verbs. */


### PR DESCRIPTION
## Summary
- Preserve the context-tab `?project=` when a run artifact link opens the inspector (`handleRunArtifactClick`).
- `chainHref` now carries that query too, so Runs glyphs and hover-card chain links no longer dump the operator back to All.

## Test plan
- [x] `cd event-runtime/web && bun test src/views/Artifacts.test.tsx`
- [x] `cd event-runtime/web && bun test src/components/EventHoverCard.test.tsx`
- [ ] Click an artifact from a run while a project tab is selected — inspector hash keeps `?project=`
- [ ] Click a chain glyph on `#/runs?project=…` — chain hash keeps `?project=`

UX critique: skipped — WM-726/730 blocked

Fixes WM-761
Fixes WM-787