### PR TITLE
ui(web): shared ChainStateBar on chain detail header (WM-832)

### DIFF
--- a/event-runtime/web/src/components/ChainStateBar.test.tsx
+++ b/event-runtime/web/src/components/ChainStateBar.test.tsx
@@ -1,0 +1,43 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { STATE_HUES } from "./ui";
+import { ChainStateBar } from "./ChainStateBar";
+
+afterEach(cleanup);
+
+describe("ChainStateBar", () => {
+  test("renders mixed states as a hue bar in STATE_HUES order", () => {
+    const rendered = render(
+      <ChainStateBar states={{ FAILED: 1, COMPLETED: 2 }} runCount={3} />,
+    );
+    const bar = rendered.getByRole("img", { name: "COMPLETED 2, FAILED 1" });
+    expect(bar.getAttribute("title")).toBe("COMPLETED 2, FAILED 1");
+    expect(bar.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["w-24", "h-1.5", "rounded-full"]),
+    );
+
+    const segments = [...bar.querySelectorAll("[data-state]")];
+    expect(segments.map((el) => el.getAttribute("data-state"))).toEqual([
+      "COMPLETED",
+      "FAILED",
+    ]);
+    const canonical = Object.keys(STATE_HUES);
+    expect(canonical.indexOf("COMPLETED")).toBeLessThan(
+      canonical.indexOf("FAILED"),
+    );
+  });
+
+  test("empty / zero runs is an empty track, not an em dash or badges", () => {
+    const rendered = render(<ChainStateBar states={{}} runCount={0} />);
+    const bar = rendered.getByRole("img");
+    expect(bar.className).toContain("bg-(--surface-2)");
+    expect(bar.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["w-24", "h-1.5", "rounded-full"]),
+    );
+    expect(bar.querySelectorAll("[data-state]").length).toBe(0);
+    expect(bar.textContent).toBe("");
+    expect(rendered.queryByText("—")).toBeNull();
+    expect(rendered.queryByText("FAILED ×1")).toBeNull();
+  });
+});

--- a/event-runtime/web/src/components/ChainStateBar.tsx
+++ b/event-runtime/web/src/components/ChainStateBar.tsx
@@ -1,0 +1,49 @@
+import { STATE_HUES } from "./ui";
+
+const STATE_ORDER = Object.keys(STATE_HUES);
+
+function chainStateSegments(
+  states: Record<string, number>,
+): { state: string; count: number }[] {
+  return STATE_ORDER.flatMap((state) => {
+    const count = states[state] ?? 0;
+    return count > 0 ? [{ state, count }] : [];
+  });
+}
+
+export function ChainStateBar({
+  states,
+  runCount,
+}: {
+  states: Record<string, number>;
+  runCount?: number;
+}) {
+  const parts = chainStateSegments(states);
+  const empty =
+    (runCount !== undefined && runCount === 0) || parts.length === 0;
+  const summary = parts
+    .map(({ state, count }) => `${state} ${count}`)
+    .join(", ");
+  return (
+    <div
+      className="flex h-1.5 w-24 overflow-hidden rounded-full bg-(--surface-2)"
+      role="img"
+      aria-label={empty ? "no runs" : summary}
+      title={empty ? "no runs" : summary}
+    >
+      {!empty &&
+        parts.map(({ state, count }) => (
+          <span
+            key={state}
+            data-state={state}
+            className="h-full min-w-[2px]"
+            style={{
+              flexGrow: count,
+              flexBasis: 0,
+              background: STATE_HUES[state] ?? "var(--hue-idle)",
+            }}
+          />
+        ))}
+    </div>
+  );
+}

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -465,3 +465,74 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     expect(view.selected).toEqual([`event:chain:${FIX_EVENT}`]);
   });
 });
+
+describe("Chain header state bar (WM-832)", () => {
+  test("mixed-state chain shows ChainStateBar, not header StateBadges", async () => {
+    const view: ChainView = {
+      correlationId: "operator:dispatch:WM-518",
+      events: [chainEvent("chain-run_5b20cfd4")],
+      runs: [
+        {
+          runId: "run_completed_a",
+          state: "COMPLETED",
+          attempts: 1,
+          agent: "agent-a",
+          adapter: "pi",
+          reasonCode: null,
+          eventId: "chain-run_5b20cfd4",
+          eventSource: "factory",
+          created_at: NOW,
+          updated_at: NOW,
+          startedAt: NOW,
+          finishedAt: NOW,
+          repos: [],
+        },
+        {
+          runId: "run_completed_b",
+          state: "COMPLETED",
+          attempts: 1,
+          agent: "agent-b",
+          adapter: "pi",
+          reasonCode: null,
+          eventId: "chain-run_5b20cfd4",
+          eventSource: "factory",
+          created_at: NOW,
+          updated_at: NOW,
+          startedAt: NOW,
+          finishedAt: NOW,
+          repos: [],
+        },
+        {
+          runId: "run_failed_a",
+          state: "FAILED",
+          attempts: 1,
+          agent: "agent-c",
+          adapter: "pi",
+          reasonCode: null,
+          eventId: "chain-run_5b20cfd4",
+          eventSource: "factory",
+          created_at: NOW,
+          updated_at: NOW,
+          startedAt: NOW,
+          finishedAt: NOW,
+          repos: [],
+        },
+      ],
+    };
+
+    await withApi({ chain: async () => view }, async () => {
+      const rendered = renderChainGraph();
+      await waitFor(() =>
+        expect(rendered.getByText(/1 event · 3 runs/)).toBeTruthy(),
+      );
+
+      const bar = rendered.getByRole("img", {
+        name: /COMPLETED 2.*FAILED 1/,
+      });
+      expect(bar.getAttribute("aria-label")).toContain("COMPLETED");
+      expect(bar.getAttribute("aria-label")).toContain("FAILED");
+      expect(rendered.queryByText("FAILED ×1")).toBeNull();
+      expect(rendered.queryByText("COMPLETED ×2")).toBeNull();
+    });
+  });
+});

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -41,6 +41,7 @@ import {
   type ChainViewMode,
   type TimelineRef,
 } from "../chainTimeline";
+import { ChainStateBar } from "../components/ChainStateBar";
 import {
   Ago,
   Button,
@@ -613,13 +614,13 @@ export function Chain({
     graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
   const runCount =
     graph?.nodes.filter((n) => n.kind === "chainRun").length ?? 0;
-  const runStates = useMemo(() => {
-    const counts = new Map<string, number>();
+  const runStateCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
     for (const n of graph?.nodes ?? []) {
       if (n.kind === "chainRun")
-        counts.set(n.run.state, (counts.get(n.run.state) ?? 0) + 1);
+        counts[n.run.state] = (counts[n.run.state] ?? 0) + 1;
     }
-    return [...counts.entries()];
+    return counts;
   }, [graph]);
 
   const emptyCopy = notFound
@@ -665,18 +666,7 @@ export function Chain({
                   run{runCount === 1 ? "" : "s"} · {graph.maxDepth} hop
                   {graph.maxDepth === 1 ? "" : "s"}
                 </span>
-                {runStates.length > 0 && (
-                  <span className="flex shrink-0 items-center gap-1">
-                    {runStates.map(([state, count]) => (
-                      <StateBadge
-                        key={state}
-                        state={count > 1 ? `${state} ×${count}` : state}
-                        hues={badgeHues(state, count)}
-                        dot={false}
-                      />
-                    ))}
-                  </span>
-                )}
+                <ChainStateBar states={runStateCounts} runCount={runCount} />
               </div>
             )}
           </div>
@@ -1076,11 +1066,6 @@ export function Chain({
       )}
     </div>
   );
-}
-
-function badgeHues(state: string, count: number): Record<string, string> {
-  const hue = STATE_HUES[state] ?? "var(--hue-idle)";
-  return { ...STATE_HUES, [`${state} ×${count}`]: hue };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract a shared `ChainStateBar` (`w-24 h-1.5 rounded-full` stacked hues in canonical `STATE_HUES` order) so chain detail can grow the same glyph the list uses, without touching `Chains.tsx`.
- `#/chain/:id` header replaces the run-state `StateBadge` row with that bar. Event/run counts and hops copy stay. Zero runs render an empty track, not `—` or badges.

## Test plan
- [x] `cd event-runtime/web && bun test src/views/Chain.test.tsx`
- [x] `cd event-runtime/web && bun test src/components/ChainStateBar.test.tsx`
- Mixed-state chain: bar present, `aria-label` contains both states, no header badge text like `FAILED ×1`.

UX critique: skipped — WM-726/730 blocked

Fixes WM-832