### PR TITLE
ops(event-runtime): route merge-scan and merge-fix to the agy adapter

### DIFF
--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -115,7 +115,7 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
-    "adapter": "claude",
+    "adapter": "agy",
     "idempotencyScope": ["correlationId", "inputHash"],
     "proposalTtlSeconds": 1800
   },
@@ -133,7 +133,7 @@
   },
   "factory.merge-fix.requested": {
     "agent": "merge-fix@1",
-    "adapter": "claude",
+    "adapter": "agy",
     "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -140,8 +140,9 @@ describe("registry", () => {
     // scans; triage now runs on a fixed 8h clock plus manual operator injection.
     // Regenerated (WM-769): merge-scan/merge-fix format_and_lint routing changed agent defs (registry inputs).
     // Regenerated (merge-scan output-shape fix): agent def is a registry input.
+    // Regenerated (merge on agy): merge-scan/merge-fix adapter claude→agy; event-types.json is a registry input.
     const expected =
-      "sha256:65f3c11cb87b8173b47701c814b5192258f174d8064de8a60d4f57b9525b359a";
+      "sha256:3f92016f63e7fdb97f36c8383a4b7ba5b0e7760d15e72ca06e981b31ed3ef774";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -340,11 +340,11 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {
     expect(registry.eventTypes["factory.merge.requested"]).toMatchObject({
       agent: "merge-scan@2",
-      adapter: "claude",
+      adapter: "agy",
     });
     expect(registry.eventTypes["factory.merge-fix.requested"]).toMatchObject({
       agent: "merge-fix@1",
-      adapter: "claude",
+      adapter: "agy",
     });
     expect(registry.eventTypes["factory.merge-apply.requested"].agent).toBe(
       "merge-apply@2",
@@ -722,7 +722,7 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       const summary = await runOnce(
         db,
         registry,
-        { claude: adapter },
+        { agy: adapter },
         { workspacesRoot: workspaces, owner: "merge-test", policyVersion: PV },
       );
 

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -456,26 +456,31 @@ describe("work-scan registration (WM-110)", () => {
     );
   });
 
-  test("every LLM route is the pi adapter except the WM-722 merge exceptions; command/actions routes are untouched (WM-215)", () => {
+  test("every LLM route is the pi adapter except the merge exceptions (agy since 2026-08-18); command/actions routes are untouched (WM-215)", () => {
     const byAdapter = {};
     for (const mapping of Object.values(registry.eventTypes)) {
       if (!mapping.agent) continue;
       (byAdapter[mapping.adapter] ??= []).push(mapping.agent);
     }
-    // The default harness is pi. The only committed claude routes are the
-    // WM-722 merge-scan/merge-fix exceptions (standard tier → sonnet); any
-    // other route riding claude must be an explicit, reviewed decision.
-    expect([...byAdapter.claude].sort()).toEqual([
+    // The default harness is pi. The only committed non-pi LLM routes are the
+    // merge-scan/merge-fix exceptions (WM-722 put them on claude/sonnet;
+    // operator decision 2026-08-18 moved them to agy, gemini-3.7-flash, which
+    // is fast and on a separate subscription). agy-smoke rides agy by
+    // definition. Any other route leaving pi must be an explicit, reviewed
+    // decision. No route rides claude any more.
+    expect(byAdapter.claude).toBeUndefined();
+    expect([...byAdapter.agy].sort()).toEqual([
+      "agy-smoke@1",
       "merge-fix@1",
       "merge-scan@2",
     ]);
-    for (const ref of byAdapter.claude) {
+    for (const ref of ["merge-fix@1", "merge-scan@2"]) {
       const resolved = resolveModel(
         registry.agents.get(ref),
-        "claude",
+        "agy",
         registry.modelTiers,
       );
-      expect(resolved).toBe(registry.modelTiers.claude.standard);
+      expect(resolved).toBe(registry.modelTiers.agy.standard);
     }
     expect(byAdapter.pi.length).toBeGreaterThan(0);
     // Every pi route resolves a model: loadRegistry fails closed otherwise,


### PR DESCRIPTION
Operator decision 2026-08-18: try Antigravity (agy, subscription, fast) for merging. agy 1.1.14 installed and smoke-verified on the runner host (`run_a12ce195` → `{"echo":"hello agy"}`). Switches `factory.merge.requested` / `factory.merge-fix.requested` adapter claude→agy (model tier standard → gemini-3.7-flash, effort from tier). Registry digest regenerated. Restart the stack after merge; evaluate on the next merge-factory ticks (contract-valid output, wall time, merges landed). Related: #649 (merge-scan output shape), WM-833 (agy usage mapping).