### PR TITLE
fix(web): disconnected env chip retries health instead of a no-op (WM-728)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -536,6 +536,94 @@ describe("health connection chrome (WM-724)", () => {
   });
 });
 
+describe("env chip click affordance (WM-728)", () => {
+  const originalClipboard = navigator.clipboard;
+  const stubClipboard = () => {
+    let written = "";
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          written = text;
+          return Promise.resolve();
+        },
+      },
+    });
+    return {
+      get written() {
+        return written;
+      },
+    };
+  };
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  test("a disconnected chip retries health instead of a no-op", async () => {
+    healthMode = "error";
+    Object.assign(refetchIntervals.primary, {
+      refetchInterval: () => false,
+    });
+    const clip = stubClipboard();
+    const utils = renderApp();
+    await waitFor(() => {
+      expect(utils.sidebar.getByText("disconnected")).toBeTruthy();
+    });
+
+    const chip = utils.sidebar.getByText("disconnected");
+    expect(chip.getAttribute("title")).toMatch(/retry|reconnect/i);
+    expect(chip.getAttribute("title")).not.toMatch(/copy/i);
+
+    const before = healthCalls;
+    fireEvent.click(chip);
+    expect(healthCalls).toBe(before + 1);
+    expect(clip.written).toBe("");
+  });
+
+  test("a connecting chip does not copy home", async () => {
+    healthMode = "pending";
+    const clip = stubClipboard();
+    const utils = renderApp();
+    await waitFor(() => {
+      expect(
+        utils.sidebar.getByRole("button", { name: "Proposals" }).textContent,
+      ).toContain("9");
+    });
+
+    const chip = utils.sidebar.getByText("connecting");
+    expect(chip.getAttribute("title")).toMatch(/retry|reconnect/i);
+    expect(chip.getAttribute("title")).not.toMatch(/copy/i);
+
+    // The first /health is still in flight; refetch joins it rather than
+    // minting a second request. The contract here is: pending never copies.
+    const before = healthCalls;
+    fireEvent.click(chip);
+    expect(clip.written).toBe("");
+    expect(healthCalls).toBe(before);
+  });
+
+  test("a connected chip copies env.home and does not refetch", async () => {
+    const clip = stubClipboard();
+    const utils = renderApp();
+    await waitFor(() => {
+      expect(utils.sidebar.getByText("dev")).toBeTruthy();
+    });
+
+    const chip = utils.sidebar.getByText("dev");
+    expect(chip.getAttribute("title")).toMatch(/copy/i);
+    expect(chip.getAttribute("title")).not.toMatch(/retry|reconnect/i);
+
+    const before = healthCalls;
+    fireEvent.click(chip);
+    expect(clip.written).toBe("/tmp/factory");
+    expect(healthCalls).toBe(before);
+  });
+});
+
 describe("Proposals approval tooltip health wiring (WM-738)", () => {
   // The tooltip sits on the wrapper span around the Approve button, because a
   // disabled button does not fire hover events (Proposals.tsx).

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -749,17 +749,21 @@ export function App() {
                 type="button"
                 className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                 title={
-                  env
+                  env?.home
                     ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
                     : healthPending
-                      ? "connecting to the runtime…"
-                      : "runtime unreachable"
+                      ? "connecting to the runtime… — click to retry"
+                      : "runtime unreachable — click to retry"
                 }
                 style={{
                   color: envHue,
                   background: `color-mix(in oklch, ${envHue} 15%, transparent)`,
                 }}
-                onClick={() => env?.home && copyText(env.home, "runtime home")}
+                onClick={() =>
+                  env?.home
+                    ? copyText(env.home, "runtime home")
+                    : health.refetch()
+                }
               >
                 {envLabel}
               </PrimitiveButton>


### PR DESCRIPTION
## Summary
- Sidebar env chip stays a button: with `env.home` it still copies the runtime home; without it (connecting / disconnected) it calls `health.refetch()`, matching the unreachable banner Retry.
- Chip `title` names the actual action (copy vs retry) so the most visible pill is no longer a no-op.
- `App.test.tsx` covers copy when connected, refetch when health has failed, and no copy while connecting.

## Test plan
- [x] `cd event-runtime/web && bun test src/App.test.tsx` — 34 pass, 0 fail
- [x] Negative test observed failing before the fix (disconnected chip title had no retry affordance; click did not refetch)

UX critique: skipped — WM-726/730 blocked.

Fixes WM-728