### PR TITLE
a11y(web): stop HoverCard panel keys from reaching useListKeys (WM-756)

### DIFF
--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -355,8 +355,8 @@ describe("HoverCard", () => {
     const listKeys = mock((_e: KeyboardEvent) => {});
     window.addEventListener("keydown", listKeys);
     try {
-      fireEvent.keyDown(action, { key: "ArrowDown" });
-      fireEvent.keyDown(action, { key: "ArrowUp" });
+      expect(fireEvent.keyDown(action, { key: "ArrowDown" })).toBe(true);
+      expect(fireEvent.keyDown(action, { key: "ArrowUp" })).toBe(true);
       expect(listKeys).not.toHaveBeenCalled();
     } finally {
       window.removeEventListener("keydown", listKeys);

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -322,6 +322,32 @@ describe("HoverCard", () => {
     });
   });
 
+  test("ArrowDown on an already-open trigger re-enters the first tabbable stop", async () => {
+    const r = render(<Fixture secondAction />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(r.getByRole("dialog")).toBeTruthy();
+      expect(document.activeElement).toBe(
+        r.getByRole("button", { name: /Open in Agents/ }),
+      );
+    });
+
+    const last = r.getByRole("button", { name: "Copy id" });
+    last.focus();
+    fireEvent.keyDown(last, { key: "Tab" });
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    expect(document.activeElement).toBe(
+      r.getByRole("button", { name: /Open in Agents/ }),
+    );
+  });
+
   test("ArrowDown on an inner trigger button does not reach a window list-keys listener", async () => {
     const listKeys = mock((_e: KeyboardEvent) => {});
     window.addEventListener("keydown", listKeys);

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -675,6 +675,29 @@ describe("HoverCard", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  test("Shift+Tab from a card with no controls returns focus to the trigger", async () => {
+    const r = render(
+      <HoverCard
+        label="Agent triage-scan"
+        openDelayMs={0}
+        closeDelayMs={0}
+        trigger="triage-scan"
+      >
+        <span>card body</span>
+      </HoverCard>,
+    );
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const panel = await waitFor(() => r.getByRole("dialog"));
+    expect(document.activeElement).toBe(panel);
+
+    fireEvent.keyDown(panel, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
   test("Tab from a nested portal does not return focus to the trigger", async () => {
     const portalHost = document.createElement("div");
     document.body.appendChild(portalHost);

--- a/event-runtime/web/src/components/HoverCard.test.tsx
+++ b/event-runtime/web/src/components/HoverCard.test.tsx
@@ -363,6 +363,44 @@ describe("HoverCard", () => {
     }
   });
 
+  test("j, o and a inside the open panel do not reach a window list-keys listener", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const action = await waitFor(() =>
+      r.getByRole("button", { name: /Open in Agents/ }),
+    );
+    expect(document.activeElement).toBe(action);
+
+    const listKeys = mock((_e: KeyboardEvent) => {});
+    window.addEventListener("keydown", listKeys);
+    try {
+      fireEvent.keyDown(action, { key: "j" });
+      fireEvent.keyDown(action, { key: "o" });
+      fireEvent.keyDown(action, { key: "a" });
+      expect(listKeys).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", listKeys);
+    }
+  });
+
+  test("Enter and Space on an in-panel control keep their default activation", async () => {
+    const r = render(<Fixture />);
+    const trigger = triggerOf(r.container);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const action = await waitFor(() =>
+      r.getByRole("button", { name: /Open in Agents/ }),
+    );
+    expect(document.activeElement).toBe(action);
+
+    expect(fireEvent.keyDown(action, { key: "Enter" })).toBe(true);
+    expect(fireEvent.keyDown(action, { key: " " })).toBe(true);
+  });
+
   test("Escape closes the card and restores focus to the trigger", async () => {
     const r = render(<Fixture />);
     const trigger = triggerOf(r.container);

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -381,15 +381,21 @@ export function HoverCard({
     };
   }, [open, close, reposition, restoreFocus]);
 
+  /** Focus the first tabbable in the mounted panel. False if it is not there yet. */
+  const focusPanel = useCallback(() => {
+    const root = panelRef.current;
+    if (!root) return false;
+    const first = getTabbableElements(root)[0];
+    (first ?? root).focus();
+    return true;
+  }, []);
+
   // ArrowDown means "take me into the card", so land focus there once it exists.
   useEffect(() => {
     if (!open || !focusPanelRef.current) return;
     focusPanelRef.current = false;
-    const root = panelRef.current;
-    if (!root) return;
-    const first = getTabbableElements(root)[0];
-    (first ?? root).focus();
-  }, [open]);
+    focusPanel();
+  }, [open, focusPanel]);
 
   const onTriggerFocus = useCallback(
     (e: ReactFocusEvent<HTMLSpanElement>) => {
@@ -408,10 +414,14 @@ export function HoverCard({
       if (e.key !== "ArrowDown" && !ownEnter) return;
       e.preventDefault();
       e.stopPropagation();
-      if (e.key === "ArrowDown") focusPanelRef.current = true;
+      if (e.key === "ArrowDown") {
+        // Already open after a Tab-edge return: `open` will not change, so the
+        // effect above would not run. Focus now if the panel is mounted.
+        if (!focusPanel()) focusPanelRef.current = true;
+      }
       openNow();
     },
-    [openNow],
+    [openNow, focusPanel],
   );
 
   /**

--- a/event-runtime/web/src/components/HoverCard.tsx
+++ b/event-runtime/web/src/components/HoverCard.tsx
@@ -433,6 +433,15 @@ export function HoverCard({
         e.stopPropagation();
         return;
       }
+      // Single-character keys (j/k/o, view verbs like a, Space) bind on
+      // window via useListKeys. Stop them here so they do not fire under an
+      // open card. Do not preventDefault: Space still activates the focused
+      // control, and arrows stay scrollable. Tab, Escape, and Enter are not
+      // length 1 — Tab is handled below, Escape by the window capture listener.
+      if (e.key.length === 1) {
+        e.stopPropagation();
+        return;
+      }
       if (e.key !== "Tab") return;
       const root = panelRef.current;
       if (!root) return;


### PR DESCRIPTION
## Summary
- Stop single-character keys (`j`/`k`/`o`/`a` and Space) on an open HoverCard panel from reaching `useListKeys` on `window`; Tab, Escape, and arrow-scroll default stay intact.
- Lock that ArrowDown/Up on in-panel controls do not `preventDefault`, so a tall card can still scroll.
- Cover Shift+Tab from a control-less panel restoring focus to the trigger.
- ArrowDown on an already-open trigger (after a Tab-edge return) focuses the first tabbable stop again.

## Test plan
- [x] `cd event-runtime/web && bun test src/components/HoverCard.test.tsx` — 41 pass
- [x] Negative leak test for `j`/`o`/`a` observed failing before the WM-756 fix
- [x] ArrowDown default assertion observed failing with a temporary `preventDefault`
- [x] Already-open ArrowDown re-entry observed failing before the WM-817 fix

UX critique: skipped — WM-726/730 blocked

Fixes WM-756
Fixes WM-766
Fixes WM-789
Fixes WM-817