### PR TITLE
Remaining ISO tooltip and canonical 440px panes (WM-747, WM-685)

### DIFF
--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1777,3 +1777,27 @@ describe("Proposals navigation shortcuts (WM-875)", () => {
     );
   });
 });
+
+describe("Proposals detail pane width (WM-685)", () => {
+  test("detail pane uses the canonical 440px width", async () => {
+    const proposal = stubProposal("prop_pane_width", "open", {
+      reason: "Needs width review",
+    });
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => createStatusFixture(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const view = renderProposals({ focusProposalId: "prop_pane_width" });
+        await waitFor(() => view.getAllByText("prop_pane_width").length > 0);
+        const className =
+          view.container.querySelector("aside")?.className ?? "";
+        expect(className).toContain("w-[440px]");
+        expect(className).not.toContain("w-[460px]");
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1490,7 +1490,7 @@ export function Proposals({
 
       {sel && (
         <DetailPane
-          widthClass="w-full sm:w-[460px]"
+          widthClass="w-full sm:w-[440px]"
           title={
             <nav
               aria-label="Breadcrumb"

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1556,6 +1556,40 @@ describe("Runs in-flight row height (WM-725)", () => {
       },
     );
   });
+
+  test("Remaining title includes the ISO deadline alongside the relative countdown (WM-747)", async () => {
+    const now = Date.now();
+    const deadlineAt = new Date(now + 9 * 60_000).toISOString();
+    const calm = stubListItem("run_iso_deadline", "RUNNING", {
+      startedAt: new Date(now - 2 * 60_000).toISOString(),
+      deadlineAt,
+      leaseExpiresAt: new Date(now + 11 * 60_000).toISOString(),
+      timeoutSeconds: 600,
+    });
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [calm] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() =>
+          expect(
+            r.container.querySelector('td[title="run_iso_deadline"]'),
+          ).toBeTruthy(),
+        );
+
+        const remaining = cellFor(r, "run_iso_deadline", "Remaining");
+        const title =
+          remaining.querySelector("[title]")?.getAttribute("title") ?? "";
+        expect(title).toContain("timeout in");
+        expect(title).toContain(deadlineAt);
+        expect(remaining.textContent).toMatch(/\b9m\b/);
+        expect(remaining.textContent).not.toContain(deadlineAt);
+      },
+    );
+  });
 });
 
 // One-hop causation on the row (WM-702): `↳` when the run's own origin event

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1592,6 +1592,30 @@ describe("Runs in-flight row height (WM-725)", () => {
   });
 });
 
+describe("Runs detail pane width (WM-685)", () => {
+  test("detail pane uses the canonical 440px width", async () => {
+    const run = stubListItem("run_pane_width", "RUNNING");
+    const detail = stubDetail("run_pane_width", "RUNNING", [
+      transition(1, "run_pane_width", null, "RUNNING", null),
+    ]);
+    await withApi(
+      {
+        runs: async () => ({ runs: [run] }),
+        run: async () => detail,
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const view = renderRuns({ focusRunId: "run_pane_width" });
+        await waitFor(() => view.getByText("idempotencyKey"));
+        const className =
+          view.container.querySelector("aside")?.className ?? "";
+        expect(className).toContain("w-[440px]");
+        expect(className).not.toContain("w-[460px]");
+      },
+    );
+  });
+});
+
 // One-hop causation on the row (WM-702): `↳` when the run's own origin event
 // was emitted by another run, `→ N` for the events it emitted, both landing on
 // the chain trace with this run already selected. The chain key lives on the

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -357,10 +357,7 @@ function budgetPart(
       : undefined;
   return {
     text: leftLabel(c.leftMs),
-    title: remainingTitle(
-      `timeout in ${formatDuration(c.leftMs / 1000)}`,
-      iso,
-    ),
+    title: remainingTitle(`timeout in ${formatDuration(c.leftMs / 1000)}`, iso),
     hue,
   };
 }
@@ -385,10 +382,7 @@ function leasePart(
   if (budget?.kind === "live" && c.leftMs >= budget.leftMs) return null;
   return {
     text: `lease ${leftLabel(c.leftMs)}`,
-    title: remainingTitle(
-      `reaped in ${formatDuration(c.leftMs / 1000)}`,
-      iso,
-    ),
+    title: remainingTitle(`reaped in ${formatDuration(c.leftMs / 1000)}`, iso),
     hue: budget?.kind === "spent" ? "var(--hue-warn)" : undefined,
   };
 }
@@ -405,7 +399,8 @@ function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
   const budgetClock = deadline ? clockTo(deadline, 0, now) : null;
   const leaseClock = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
   const budget =
-    budgetClock && budgetPart(budgetClock, timeoutSeconds, r.deadlineAt || deadline);
+    budgetClock &&
+    budgetPart(budgetClock, timeoutSeconds, r.deadlineAt || deadline);
   const lease =
     leaseClock && leasePart(leaseClock, budgetClock, leaseExpiresAt);
   if (!budget && !lease) return <span>{EMPTY}</span>;
@@ -1507,7 +1502,7 @@ export function Runs({
 
       {sel && (
         <DetailPane
-          widthClass="fixed inset-0 z-20 w-full sm:static sm:z-auto sm:w-[460px]"
+          widthClass="fixed inset-0 z-20 w-full sm:static sm:z-auto sm:w-[440px]"
           title={
             <nav
               aria-label="Breadcrumb"

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -329,14 +329,27 @@ const leftLabel = (leftMs: number) => {
 
 type RemainingPart = { text: string; title: string; hue?: string };
 
+/** Relative phrasing plus the wall-clock ISO, matching other time-column titles (WM-747). */
+function remainingTitle(relative: string, iso?: string | null): string {
+  return iso ? `${relative} · ${iso}` : relative;
+}
+
 /**
  * The compact form of the detail pane's `BudgetClock`, on the same thresholds
  * so the two never disagree: the full phrasing moves to the cell's title.
  */
-function budgetPart(c: Clock, timeoutSeconds: number): RemainingPart | null {
+function budgetPart(
+  c: Clock,
+  timeoutSeconds: number,
+  iso?: string | null,
+): RemainingPart | null {
   if (c.kind === "off") return null;
   if (c.kind === "spent")
-    return { text: "spent", title: "budget spent", hue: "var(--hue-err)" };
+    return {
+      text: "spent",
+      title: remainingTitle("budget spent", iso),
+      hue: "var(--hue-err)",
+    };
   // The last tenth of the declared budget — long enough to notice on a long run.
   const hue =
     timeoutSeconds > 0 && c.leftMs <= timeoutSeconds * 100
@@ -344,7 +357,10 @@ function budgetPart(c: Clock, timeoutSeconds: number): RemainingPart | null {
       : undefined;
   return {
     text: leftLabel(c.leftMs),
-    title: `timeout in ${formatDuration(c.leftMs / 1000)}`,
+    title: remainingTitle(
+      `timeout in ${formatDuration(c.leftMs / 1000)}`,
+      iso,
+    ),
     hue,
   };
 }
@@ -354,14 +370,25 @@ function budgetPart(c: Clock, timeoutSeconds: number): RemainingPart | null {
  * expires after the budget and adds nothing to the row. It earns its half of
  * the line only when it is the deadline that will actually fire first.
  */
-function leasePart(c: Clock, budget: Clock | null): RemainingPart | null {
+function leasePart(
+  c: Clock,
+  budget: Clock | null,
+  iso?: string | null,
+): RemainingPart | null {
   if (c.kind === "off") return null;
   if (c.kind === "spent")
-    return { text: "lease due", title: "reap due", hue: "var(--hue-err)" };
+    return {
+      text: "lease due",
+      title: remainingTitle("reap due", iso),
+      hue: "var(--hue-err)",
+    };
   if (budget?.kind === "live" && c.leftMs >= budget.leftMs) return null;
   return {
     text: `lease ${leftLabel(c.leftMs)}`,
-    title: `reaped in ${formatDuration(c.leftMs / 1000)}`,
+    title: remainingTitle(
+      `reaped in ${formatDuration(c.leftMs / 1000)}`,
+      iso,
+    ),
     hue: budget?.kind === "spent" ? "var(--hue-warn)" : undefined,
   };
 }
@@ -377,8 +404,10 @@ function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
   const deadline = remainingDeadline(r);
   const budgetClock = deadline ? clockTo(deadline, 0, now) : null;
   const leaseClock = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
-  const budget = budgetClock && budgetPart(budgetClock, timeoutSeconds);
-  const lease = leaseClock && leasePart(leaseClock, budgetClock);
+  const budget =
+    budgetClock && budgetPart(budgetClock, timeoutSeconds, r.deadlineAt || deadline);
+  const lease =
+    leaseClock && leasePart(leaseClock, budgetClock, leaseExpiresAt);
   if (!budget && !lease) return <span>{EMPTY}</span>;
 
   return (


### PR DESCRIPTION
## Summary
- Remaining in-flight cell `title` now includes the absolute ISO deadline (`deadlineAt` / `leaseExpiresAt`) alongside the relative countdown; cell text stays relative (WM-747).
- Proposals and Runs detail panes use the canonical `sm:w-[440px]` width. Mobile `w-full` / fixed overlay is unchanged. Inbox stays 460px (out of scope) (WM-685).

## Test plan
- [x] `cd event-runtime/web && bun test src/views/Runs.test.tsx` — 34 pass (after WM-747), 35 with WM-685
- [x] `cd event-runtime/web && bun test src/views/Proposals.test.tsx src/views/Runs.test.tsx` — 72 pass
- Negative tests observed failing before each fix.

UX critique: skipped — WM-726/730 blocked.

Fixes WM-747
Fixes WM-685