### PR TITLE
fix(inbox): retry empty replan ids and update retarget titles (WM-783, WM-784)

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -569,16 +569,27 @@ function settleInboxDecision(
   effect,
   { now, recordedEffect = effect, artifactStore },
 ) {
-  const answer = { ...response, effect: recordedEffect };
   const replanned =
     effect.outcome === "applied" && effect.detail === REPLANNED_DETAIL;
-  if (
-    replanned &&
+  const newProposalId =
     typeof effect.newProposalId === "string" &&
     effect.newProposalId.trim() !== ""
-  ) {
+      ? effect.newProposalId
+      : null;
+  // A re-plan with no fresh id is a broken effect — WM-391 throws on it rather
+  // than returning one. Coerce to failed before recording so retry sees a
+  // failed outcome instead of already_applied (WM-783).
+  if (replanned && !newProposalId) {
+    const error =
+      recordedEffect.error ??
+      "replanned_awaiting_approval without newProposalId";
+    effect = { ...effect, outcome: "failed", error };
+    recordedEffect = { ...recordedEffect, outcome: "failed", error };
+  }
+  const answer = { ...response, effect: recordedEffect };
+  if (replanned && newProposalId) {
     return {
-      item: retargetInboxDecision(db, id, answer, effect.newProposalId, {
+      item: retargetInboxDecision(db, id, answer, newProposalId, {
         now,
       }),
       effect,
@@ -588,9 +599,6 @@ function settleInboxDecision(
     JSON.stringify(answer),
     id,
   );
-  // A re-plan with no fresh id is a broken effect — WM-391 throws on it rather
-  // than returning one. Leave the item open and retryable instead of resolving
-  // on a detail the ledger cannot act on.
   if (effect.outcome === "applied" && !replanned) {
     db.query(
       `UPDATE inbox_items

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -320,12 +320,12 @@ export function getInboxItem(db, id) {
   return itemView(db.query("SELECT * FROM inbox_items WHERE id = ?").get(id));
 }
 
-function supersedeInboxDecision(db, row, { body, refs, decision }) {
+function supersedeInboxDecision(db, row, { title, body, refs, decision }) {
   const updated = db
     .query(
       `UPDATE inbox_items
      SET decision_json = ?, response_json = NULL, decided_at = NULL,
-         decided_by = NULL, body = ?,
+         decided_by = NULL, body = ?, title = ?,
          refs_json = CASE WHEN ? IS NULL THEN refs_json ELSE json_set(
            CASE WHEN json_valid(refs_json) THEN refs_json ELSE '{}' END,
            '$.runId', ?
@@ -343,6 +343,7 @@ function supersedeInboxDecision(db, row, { body, refs, decision }) {
     .run(
       decision === null ? null : JSON.stringify(decision),
       body,
+      title,
       refs.runId ?? null,
       refs.runId ?? null,
       row.id,
@@ -398,6 +399,7 @@ export function createInboxItem(
     }
     if (existing.dedupe_key && existing.dedupe_key === callerKey) {
       const superseded = supersedeInboxDecision(db, existing, {
+        title,
         body,
         refs,
         decision,
@@ -448,6 +450,7 @@ export function createInboxItem(
         return attachWaiter(db, winner, { refs, now });
       }
       const superseded = supersedeInboxDecision(db, winner, {
+        title,
         body,
         refs,
         decision,
@@ -498,10 +501,11 @@ function retargetedDedupeKey(db, row, previousProposalId, proposalId) {
 /**
  * Point a decided item at the proposal a re-plan opened, and re-open it.
  *
- * One statement moves refs, the fresh request, the dedupe key, and the
- * archived answer together while clearing `decided_at`/`decided_by`, so no
- * reader sees the item half-retargeted — pointing at the superseded proposal
- * with the new request installed, or decided against a question nobody asked.
+ * One statement moves refs, the fresh request, the dedupe key, the list
+ * title, and the archived answer together while clearing `decided_at`/
+ * `decided_by`, so no reader sees the item half-retargeted — pointing at the
+ * superseded proposal with the new request installed, or decided against a
+ * question nobody asked.
  */
 function retargetInboxDecision(db, id, answer, proposalId, { now }) {
   const row = decisionRow(db, id);
@@ -528,9 +532,14 @@ function retargetInboxDecision(db, id, answer, proposalId, { now }) {
 
   const { responseHistory, ...delivery } = parseObject(row.delivery_json);
   const history = Array.isArray(responseHistory) ? responseHistory : [];
+  const nextTitle =
+    previousProposalId && row.title.includes(previousProposalId)
+      ? row.title.split(previousProposalId).join(proposalId)
+      : row.title;
   db.query(
     `UPDATE inbox_items
      SET refs_json = ?, decision_json = ?, dedupe_key = ?, delivery_json = ?,
+         title = ?,
          response_json = NULL, decided_at = NULL, decided_by = NULL
      WHERE id = ?`,
   ).run(
@@ -549,6 +558,7 @@ function retargetInboxDecision(db, id, answer, proposalId, { now }) {
         },
       ],
     }),
+    nextTitle,
     id,
   );
   return getInboxItem(db, id);

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1024,6 +1024,64 @@ describe("approving an expired proposal retargets its item (WM-714)", () => {
     // Supersession does not lose the retarget the operator already paid for.
     expect(again.responseHistory).toHaveLength(1);
   });
+
+  test("applied replanned with no newProposalId is recorded failed and stays retryable", () => {
+    const db = openDb(":memory:");
+    const { id, approve } = replanned(db);
+    const decided = decideInboxItem(db, id, approve, {
+      now: 2000,
+      applyEffect: () => ({
+        outcome: "applied",
+        detail: "replanned_awaiting_approval",
+      }),
+    });
+    expect(decided.effect.outcome).toBe("failed");
+    expect(decided.item.resolvedAt).toBeNull();
+    expect(decided.item.response.effect.outcome).toBe("failed");
+    expect(decided.item.response.effect.detail).toBe(
+      "replanned_awaiting_approval",
+    );
+
+    let invoked = 0;
+    const retried = retryInboxDecision(db, id, {
+      now: 3000,
+      applyEffect: () => {
+        invoked += 1;
+        return {
+          outcome: "applied",
+          detail: "replanned_awaiting_approval",
+          newProposalId: FRESH,
+        };
+      },
+    });
+    expect(invoked).toBe(1);
+    expect(retried.item.refs.proposalId).toBe(FRESH);
+    expect(retried.item.resolvedAt).toBeNull();
+  });
+
+  test("applied replanned with an empty newProposalId is also failed and retryable", () => {
+    const db = openDb(":memory:");
+    const { id, approve } = replanned(db);
+    const decided = decideInboxItem(db, id, approve, {
+      now: 2000,
+      applyEffect: () => ({
+        outcome: "applied",
+        detail: "replanned_awaiting_approval",
+        newProposalId: "   ",
+      }),
+    });
+    expect(decided.effect.outcome).toBe("failed");
+    expect(decided.item.resolvedAt).toBeNull();
+    expect(decided.item.response.effect.outcome).toBe("failed");
+    let invoked = 0;
+    retryInboxDecision(db, id, {
+      applyEffect: () => {
+        invoked += 1;
+        return { outcome: "applied" };
+      },
+    });
+    expect(invoked).toBe(1);
+  });
 });
 
 describe("inbox decisions register precedent memos (WM-812)", () => {

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -165,6 +165,7 @@ describe("human inbox ledger (WM-285)", () => {
       { id: "second" },
     );
     expect(second.id).toBe(first.id);
+    expect(second.title).toBe("second");
     expect(second.body).toBe("new");
     expect(second.refs).toEqual({ issue: "WM-1", runId: "run_2" });
     expect(second.decision).toEqual(replacement);
@@ -1020,9 +1021,26 @@ describe("approving an expired proposal retargets its item (WM-714)", () => {
       dedupeKey: `proposal_expired:${FRESH}`,
     });
     expect(again.id).toBe(id);
+    expect(again.title).toBe(
+      `DECISION NEEDED proposal ${FRESH}: expired undecided`,
+    );
+    expect(listInboxItems(db).map((item) => item.title)).toEqual([
+      `DECISION NEEDED proposal ${FRESH}: expired undecided`,
+    ]);
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
     // Supersession does not lose the retarget the operator already paid for.
     expect(again.responseHistory).toHaveLength(1);
+  });
+
+  test("retarget updates the list title to the fresh proposal", () => {
+    const db = openDb(":memory:");
+    const { id, approve, applyEffect } = replanned(db);
+    decideInboxItem(db, id, approve, { now: 2000, applyEffect });
+    const listed = listInboxItems(db);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].title).toContain(FRESH);
+    expect(listed[0].title).not.toContain(OLD);
+    expect(getInboxItem(db, id).title).toContain(FRESH);
   });
 
   test("applied replanned with no newProposalId is recorded failed and stays retryable", () => {


### PR DESCRIPTION
## Summary
- Treat `applied` + `replanned_awaiting_approval` with empty/missing `newProposalId` as a failed effect so the inbox item stays retryable and retry invokes the decision effect instead of returning `already_applied` (WM-783).
- When retargeting or superseding an unresolved inbox item, update the list title to the replacement proposal so open-list copy matches the new question (WM-784).

## Test plan
- [x] `bun test event-runtime/lib/inbox.test.mjs` — 21 pass after each commit and at the end
- [x] Negative tests observed failing before each fix
- [x] UX critique skipped — backend/inbox ledger, no user-facing web flow in this diff

Fixes WM-783
Fixes WM-784