### PR TITLE
fix(adapters): inject FACTORY_ROOT for claude and agy like pi does

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -16,6 +16,7 @@ import { createWriteStream, readFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import { FACTORY_ROOT } from "../config.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
 export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
@@ -149,6 +150,9 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
     ),
   );
   Object.assign(childEnv, env);
+  // Same contract as pi/claude (WM-433): pinned procedures call Factory
+  // helpers through $FACTORY_ROOT even when the workspace is a target repo.
+  childEnv.FACTORY_ROOT = FACTORY_ROOT;
 
   for (const key of [
     "ANTHROPIC_API_KEY",

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
 import {
   PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV,
@@ -559,5 +560,15 @@ describe("execute with fake binary", () => {
     // Each event is guarded on its own: throwing on the tool_use must not
     // swallow the terminal result's events too.
     expect(attempted).toEqual(["tool_use", "assistant_text", "usage"]);
+  });
+});
+
+describe("FACTORY_ROOT injection (WM-433 parity with pi)", () => {
+  test("injects the stable Factory runtime path and refuses caller overrides", () => {
+    expect(safeChildEnvironment({}).FACTORY_ROOT).toBe(FACTORY_ROOT);
+    expect(
+      safeChildEnvironment({ FACTORY_ROOT: "/tmp/untrusted-target" })
+        .FACTORY_ROOT,
+    ).toBe(FACTORY_ROOT);
   });
 });

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -198,6 +198,14 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
     ),
   );
   Object.assign(childEnv, env);
+  // Read-only repository workspaces contain the selected target checkout, not
+  // Factory's runtime support code. Expose the running Factory checkout the
+  // same way the pi adapter does (WM-433) so pinned procedures such as
+  // merge-scan's `bun "$FACTORY_ROOT/event-runtime/lib/merge-ci-proof.mjs"`
+  // resolve regardless of adapter. Without it merge-scan on claude/agy
+  // escalated every PR ("FACTORY_ROOT is unset") and, trying to compensate,
+  // dirtied its read-only checkout (workspace_integrity_violation).
+  childEnv.FACTORY_ROOT = FACTORY_ROOT;
   delete childEnv.ANTHROPIC_API_KEY;
   delete childEnv.CLAUDECODE;
   delete childEnv.CLAUDE_CODE_ENTRYPOINT;

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
 import {
   BASE_INHERITED_ENV,
   buildClaudeArgv,
@@ -1186,5 +1187,15 @@ if (behavior === "emit_denial_then_recovery") {
         env: { PATH: "/nonexistent-bin-dir" },
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe("FACTORY_ROOT injection (WM-433 parity with pi)", () => {
+  test("injects the stable Factory runtime path and refuses caller overrides", () => {
+    expect(safeChildEnvironment({}).FACTORY_ROOT).toBe(FACTORY_ROOT);
+    expect(
+      safeChildEnvironment({ FACTORY_ROOT: "/tmp/untrusted-target" })
+        .FACTORY_ROOT,
+    ).toBe(FACTORY_ROOT);
   });
 });


### PR DESCRIPTION
Root cause of today's merge-scan escalations and `workspace_integrity_violation` (e.g. `run_98e9529e`): only the pi adapter injected `FACTORY_ROOT` (WM-433); merge-scan on claude (since #600) — and agy (#660) — could not run `bun "$FACTORY_ROOT/event-runtime/lib/merge-ci-proof.mjs"`, escalated every PR as 'CI gate cannot be mechanically resolved', and while compensating dirtied its read-only checkout. This injects `FACTORY_ROOT` (non-overridable) in `claude.mjs` and `agy.mjs` `safeChildEnvironment` with pi's tests mirrored. adapters suites 111/111. Should land before #660 (agy merge routing) is evaluated.