### PR TITLE
fix(event-runtime-web): parse PR object in Tickets hub table to prevent '[object Object]' rendering (WM-835)

### DIFF
--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -848,9 +848,12 @@ export interface TicketSummary {
   lastActivityDescription?: string | null;
   lastActivityKind?: string | null;
   attempts?: number;
-  pr?: number | null;
+  activeRun?: { runId: string; state: string; agent: string } | null;
+  lastDecision?: string | null;
+  pr?: { number: number; url?: string; ci?: string } | number | null;
   prUrl?: string | null;
   checksGreen?: boolean | null;
   ciStatus?: "green" | "red" | "pending" | string | null;
   url?: string | null;
+  merged?: boolean;
 }

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -543,6 +543,26 @@ describe("PR journey view", () => {
 describe("Tickets hub landing view", () => {
   const ticketsFixture = [
     {
+      id: "WM-772",
+      title: "Auto approval workflow fix",
+      state: "Done",
+      repo: "factory",
+      repos: ["factory"],
+      lastActivityAt: "2026-08-18T19:00:00.000Z",
+      lastActivityDescription: "merged into develop",
+      lastActivityKind: "merge",
+      attempts: 23,
+      pr: {
+        number: 772,
+        url: "https://github.com/watt-mind/factory/pull/772",
+        ci: "green",
+      },
+      prUrl: "https://github.com/watt-mind/factory/pull/772",
+      checksGreen: true,
+      ciStatus: "green",
+      url: "https://linear.app/watt-mind/issue/WM-772",
+    },
+    {
       id: "WM-822",
       title: "Tickets hub landing view",
       state: "In Progress",
@@ -631,12 +651,15 @@ describe("Tickets hub landing view", () => {
     await view.findByPlaceholderText(/WM-542/i);
     // Table should contain ticket entries
     await view.findByText("WM-822");
+    expect(view.getByText("WM-772")).toBeTruthy();
     expect(view.getByText("WM-821")).toBeTruthy();
     expect(view.getByText("OPS-91")).toBeTruthy();
     expect(view.getByText("Tickets hub landing view")).toBeTruthy();
     expect(view.getAllByText("In Progress").length).toBeGreaterThan(0);
     expect(view.getAllByText("factory").length).toBeGreaterThan(0);
-    expect(view.getByText("PR #542")).toBeTruthy();
+    expect(view.getByText("#772")).toBeTruthy();
+    expect(view.getByText("#542")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("[object Object]");
     expect(view.getByText("2", { selector: "td" })).toBeTruthy(); // attempts
   });
 
@@ -771,7 +794,7 @@ describe("Tickets hub landing view", () => {
     expect(navigatedTicket).toBe("WM-822");
 
     // Click PR link
-    fireEvent.click(view.getByText("PR #542"));
+    fireEvent.click(view.getByText("#542"));
     expect(navigatedPr).toBe(542);
   });
 

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -540,39 +540,60 @@ function TicketsHub({
                       {ticket.attempts != null ? ticket.attempts : "—"}
                     </td>
                     <td className="px-3 py-2">
-                      {ticket.pr != null ? (
-                        <span className="inline-flex items-center gap-1.5">
-                          <a
-                            href={ticket.prUrl || `#/prs/${ticket.pr}`}
-                            onClick={(e) => {
-                              if (onNavigatePr) {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onNavigatePr(ticket.pr!);
-                              }
-                            }}
-                            className="mono text-(--accent) hover:underline"
-                          >
-                            {`PR #${ticket.pr}`}
-                          </a>
-                          {(ticket.ciStatus || ticket.checksGreen != null) && (
-                            <span
-                              className={`inline-block size-2 rounded-full ring-2 ring-(--surface-1) ${
-                                ticket.ciStatus === "green" ||
-                                ticket.checksGreen === true
-                                  ? "bg-(--hue-ok)"
-                                  : ticket.ciStatus === "red" ||
-                                      ticket.checksGreen === false
-                                    ? "bg-(--hue-err)"
-                                    : "bg-(--hue-warn)"
-                              }`}
-                              title={`CI: ${ticket.ciStatus ?? (ticket.checksGreen ? "green" : "red")}`}
-                            />
-                          )}
-                        </span>
-                      ) : (
-                        <span className="text-(--text-faint)">—</span>
-                      )}
+                      {(() => {
+                        const prNumber =
+                          typeof ticket.pr === "number"
+                            ? ticket.pr
+                            : ticket.pr && typeof ticket.pr === "object"
+                              ? ticket.pr.number
+                              : null;
+                        const prUrl =
+                          typeof ticket.pr === "object" && ticket.pr?.url
+                            ? ticket.pr.url
+                            : ticket.prUrl ||
+                              (prNumber ? `#/prs/${prNumber}` : undefined);
+                        const ci =
+                          typeof ticket.pr === "object" && ticket.pr?.ci
+                            ? ticket.pr.ci
+                            : (ticket.ciStatus ??
+                              (ticket.checksGreen != null
+                                ? ticket.checksGreen
+                                  ? "green"
+                                  : "red"
+                                : null));
+
+                        return prNumber != null ? (
+                          <span className="inline-flex items-center gap-1.5">
+                            <a
+                              href={prUrl || `#/prs/${prNumber}`}
+                              onClick={(e) => {
+                                if (onNavigatePr) {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  onNavigatePr(prNumber);
+                                }
+                              }}
+                              className="mono text-(--accent) hover:underline"
+                            >
+                              {`#${prNumber}`}
+                            </a>
+                            {ci && (
+                              <span
+                                className={`inline-block size-2 rounded-full ring-2 ring-(--surface-1) ${
+                                  ci === "green"
+                                    ? "bg-(--hue-ok)"
+                                    : ci === "red"
+                                      ? "bg-(--hue-err)"
+                                      : "bg-(--hue-warn)"
+                                }`}
+                                title={`CI: ${ci}`}
+                              />
+                            )}
+                          </span>
+                        ) : (
+                          <span className="text-(--text-faint)">—</span>
+                        );
+                      })()}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Summary
Safely parses PR object / numeric values from `ticket.pr` in the Tickets hub table, correctly rendering `#<number>` instead of literal `PR #[object Object]`.

- Updates `TicketSummary` in `types.ts` to allow `pr` as `{ number: number, url?: string, ci?: string } | number | null`.
- Extracts `prNumber`, `prUrl`, and CI status cleanly in `Ticket.tsx`.
- Adds component assertions in `Ticket.test.tsx` ensuring object and number PR fixtures render `#<number>` without `[object Object]`.

Fixes WM-835