### PR TITLE
ui-ux(web): pin list rows to py-1.5 (WM-843)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -651,7 +651,8 @@ top-right (WM-97). A view that needs a different frame is a spec change
   group headers can pin at exactly `top-7`), optional `GroupHeaderRow` bands
   under it.
 - Cells: `px-3 py-1.5 border-b border-(--border)` — one row height across
-  the app. (`Schedules` uses `py-2` today; that is debt, not a variant.)
+  the app. In-cell 24×24 controls (`Button size="sm"`, Artifacts download)
+  use `-my-1.5` so they sit in that padding instead of growing the row.
   Numeric columns are `tabular-nums` and right-aligned via `Th align="right"`.
 - Ids and machine values are `.mono`; prose columns are body text; secondary
   columns are `--text-dim`, tertiary `--text-faint`. Long values `truncate`
@@ -813,9 +814,10 @@ besides the env chip. Weights: `font-medium` for active/emphasis,
 #### Known debt (filed, not fixed here)
 
 State-icon implementation is OPS-498. Syntax normalization, wash
-normalization, and the Projects team-hue fix are WM-134. Table row-height
-(`Schedules` `py-2`), sub-11px sizes, and bare `animate-pulse` are additional
-WM-134 scope — this section is the standard they normalize _to_.
+normalization, and the Projects team-hue fix are WM-134. Sub-11px sizes
+and bare `animate-pulse` are additional WM-134 scope — this section is the
+standard they normalize _to_. List-row height (in-cell 24px controls vs
+`py-1.5`) is WM-843.
 
 ## 6. Liveness and concurrency honesty
 

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -728,3 +728,19 @@ describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", ()
     expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A);
   });
 });
+
+describe("Artifacts list row height (WM-843)", () => {
+  test("SHA download stays 24×24 and overlaps py-1.5 padding", async () => {
+    const view = renderArtifacts();
+    const download = await view.findByRole("link", {
+      name: "Download aaaaaaaaaaaa.report",
+    });
+    const tokens = download.className.split(/\s+/);
+    expect(tokens).toContain("h-6");
+    expect(tokens).toContain("w-6");
+    expect(tokens).toContain("-my-1.5");
+    const cell = download.closest("td");
+    expect(cell).toBeTruthy();
+    expect(cell!.className.split(/\s+/)).toContain("py-1.5");
+  });
+});

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -710,7 +710,7 @@ export function Artifacts({
                         onClick={(event) => event.stopPropagation()}
                         aria-label={`Download ${name}`}
                         title={`Download ${name}`}
-                        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-(--border) text-(--text-faint) hover:border-(--border-strong) hover:text-(--accent)"
+                        className="inline-flex h-6 w-6 shrink-0 -my-1.5 items-center justify-center rounded border border-(--border) text-(--text-faint) hover:border-(--border-strong) hover:text-(--accent)"
                       >
                         <span aria-hidden="true">↓</span>
                       </a>

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -719,5 +720,26 @@ describe("Schedules manual merge targeting (WM-426)", () => {
     await waitFor(() =>
       expect(calls).toEqual([{ loop: "merge-factory", prNumbers: undefined }]),
     );
+  });
+});
+
+describe("Schedules list row height (WM-843)", () => {
+  test("list Run now uses sm (h-6) and overlaps py-1.5 padding", async () => {
+    const view = renderSchedules();
+    await waitFor(() =>
+      expect(
+        view.getAllByRole("button", { name: "Run now…" }).length,
+      ).toBeGreaterThan(0),
+    );
+    const table = view.container.querySelector("table");
+    expect(table).toBeTruthy();
+    const btn = within(table as HTMLElement).getAllByRole("button", {
+      name: "Run now…",
+    })[0]!;
+    expect(btn.getAttribute("data-control-size")).toBe("sm");
+    const tokens = btn.className.split(/\s+/);
+    expect(tokens).toContain("h-6");
+    expect(tokens).toContain("-my-1.5");
+    expect(tokens).not.toContain("h-7");
   });
 });

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -677,6 +677,8 @@ export function Schedules({
                     <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-right">
                       <span className="pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
                         <Button
+                          size="sm"
+                          className="-my-1.5"
                           disabled={connected === false}
                           onClick={() => setConfirmLoop(s)}
                         >

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -840,4 +840,39 @@ describe("Tickets hub landing view", () => {
     fireEvent.keyDown(document.body, { key: "k" });
     expect(document.activeElement).toBe(jumpInput);
   });
+
+  test("hub rows use py-1.5 and keep id/title and activity/Ago on one line each (WM-843)", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    const id = await view.findByText("WM-822");
+    const row = id.closest("tr");
+    expect(row).toBeTruthy();
+    const cells = [...row!.querySelectorAll("td")];
+    expect(cells.length).toBeGreaterThan(0);
+    for (const td of cells) {
+      const tokens = td.className.split(/\s+/);
+      expect(tokens).toContain("py-1.5");
+      expect(tokens).not.toContain("py-2");
+      expect(tokens).toContain("whitespace-nowrap");
+    }
+
+    const idCell = id.closest("td")!;
+    expect(idCell.querySelector("div")).toBeNull();
+    expect(view.getByText("Tickets hub landing view").closest("td")).toBe(
+      idCell,
+    );
+
+    const activity = view.getByText("dispatch@1 leased");
+    const activityCell = activity.closest("td")!;
+    expect(activityCell.querySelector("div")).toBeNull();
+    expect(activityCell.textContent).toMatch(/ago/i);
+  });
 });

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -497,49 +497,54 @@ function TicketsHub({
                       selected ? "bg-(--surface-1)" : ""
                     }`}
                   >
-                    <td className="mono px-3 py-2 font-medium">
-                      <a
-                        href={`#/tickets/${encodeURIComponent(ticket.id)}`}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          onNavigate(ticket.id);
-                        }}
-                        className="text-(--accent) hover:underline"
-                      >
-                        {ticket.id}
-                      </a>
-                      {ticket.title && (
-                        <div className="max-w-xs truncate font-sans text-[11px] font-normal text-(--text-dim)">
-                          {ticket.title}
-                        </div>
-                      )}
+                    <td className="mono px-3 py-1.5 whitespace-nowrap font-medium">
+                      <span className="inline-flex max-w-xs items-center gap-2">
+                        <a
+                          href={`#/tickets/${encodeURIComponent(ticket.id)}`}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            onNavigate(ticket.id);
+                          }}
+                          className="shrink-0 text-(--accent) hover:underline"
+                        >
+                          {ticket.id}
+                        </a>
+                        {ticket.title && (
+                          <span
+                            className="min-w-0 truncate font-sans text-[11px] font-normal text-(--text-dim)"
+                            title={ticket.title}
+                          >
+                            {ticket.title}
+                          </span>
+                        )}
+                      </span>
                     </td>
-                    <td className="mono px-3 py-2 text-(--text-dim)">
+                    <td className="mono px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
                       {ticket.repo || ticket.repos?.join(", ") || "—"}
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-1.5 whitespace-nowrap">
                       {ticket.state ? (
                         <StateBadge state={ticket.state} hues={STATE_HUES} />
                       ) : (
                         <span className="text-(--text-faint)">—</span>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-(--text-dim)">
-                      <div>
+                    <td className="max-w-xs truncate px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      <span>
                         {ticket.lastActivityDescription ||
                           ticket.lastActivityKind ||
                           "—"}
-                      </div>
+                      </span>
                       {ticket.lastActivityAt && (
-                        <div className="text-[11px] text-(--text-faint)">
+                        <span className="ml-2 text-(--text-faint)">
                           <Ago iso={ticket.lastActivityAt} now={now} />
-                        </div>
+                        </span>
                       )}
                     </td>
-                    <td className="mono px-3 py-2 tabular-nums text-(--text-dim)">
+                    <td className="mono px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-dim)">
                       {ticket.attempts != null ? ticket.attempts : "—"}
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-1.5 whitespace-nowrap">
                       {(() => {
                         const prNumber =
                           typeof ticket.pr === "number"


### PR DESCRIPTION
## Summary
- Schedules list “Run now…” is `Button size="sm"` (`h-6`) with `-my-1.5` so the control sits in `py-1.5` padding instead of stretching the row to 41px.
- Artifacts SHA download stays `h-6 w-6` (WM-733 24×24) and uses the same `-my-1.5` overlap.
- Tickets hub cells are `py-1.5` with id+title and activity+Ago on one line each (was 52px from `py-2` + stacked divs).
- Chains is unchanged (WM-826 / WM-827).

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/web/src/views/Schedules.test.tsx event-runtime/web/src/views/Artifacts.test.tsx event-runtime/web/src/views/Ticket.test.tsx` — 61 pass
- [ ] Spot-check `#/schedules`, `#/artifacts`, `#/tickets` row height vs `#/agents` (~33px)

Fixes WM-843