### PR TITLE
refactor(adapters): adapter registry with contract validation replaces the hardcoded literals in cli/work.mjs and cli/serve.mjs (WM-837)

### DIFF
--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -203,6 +203,58 @@ plane disappears. Manual `serve`, `work`, and `supervise` commands remain the
 development fallback; a sandboxed interactive shell may not carry a usable SSH
 context, which is precisely why that fallback is not the production setup.
 
+## 2c. Adapter registry and contract — **shipped, WM-837**
+
+A worker executes a run through a _harness adapter_ — `claude`, `pi`,
+`cursor`, `agy`, `command`, `actions`, and the test-only `fake`, all in
+`event-runtime/lib/adapters/`. Which adapters a worker carries used to be an
+object literal duplicated in `cli/work.mjs` and `cli/serve.mjs`; both now
+obtain the set from the registry in `event-runtime/lib/adapters/index.mjs`,
+which is also what a future extension loader (packs, out-of-tree adapters)
+registers into.
+
+**The contract.** An adapter is a module (an ES module namespace or any object
+with the same exports) that satisfies all of:
+
+- `execute(options)` — the async run entry point `lib/worker.mjs` invokes;
+  its options object and result shape are specified in
+  `docs/event-runtime-conventions.md` § "Adapter contract";
+- `SANDBOX_SUPPORT` — `"gondolin"` (the adapter runs the agent inside the
+  microVM via `runSandboxed()` when a definition carries `sandbox`) or
+  `"unsupported"` (it must refuse such a definition, WM-313); no third value;
+- a name matching `^[a-z][a-z0-9-]*$` — it appears in run specs, worker
+  labels, and `--adapter-override`.
+
+**The registry.** `builtinAdapters()` returns the seven shipped modules keyed
+by name. `createAdapterRegistry({ builtins = builtinAdapters() })` validates
+and registers them with source `builtin` and returns:
+
+- `register(name, module, { source, replace = false })` — validates the
+  contract; an invalid module throws `AdapterContractError`
+  (`code: "adapter_contract_invalid"`, `missing` naming the failed part:
+  `name`, `module`, `execute`, or `SANDBOX_SUPPORT`); a duplicate name throws
+  `AdapterRegistrationError` (`code: "adapter_duplicate"`) unless
+  `replace: true`; `source` is mandatory so the listing can always say where
+  an adapter came from;
+- `get(name)`, `has(name)`, `list()` (`{ name, source, sandboxSupport }`,
+  sorted by name);
+- `toMap()` — a frozen `name → adapter` snapshot, the shape
+  `runOnce(db, registry, adapters, opts)` / `executeClaimed` consume.
+
+**The sandbox seam is mandatory.** Nothing the registry hands out is the raw
+module: `get()` and `toMap()` return a frozen wrapper whose `execute` consults
+`sandboxed.mjs` first — an `unsupported` adapter is refused with
+`SandboxUnsupportedError` for a sandboxed definition before its own code runs,
+so an adapter that forgets `refuseSandbox()` still cannot execute on the host.
+`gondolin` adapters are delegated to and own the `runSandboxed()` call, and
+`sandboxed.test.mjs` proves each built-in reaches the VM boundary.
+`index.test.mjs` asserts that no unwrapped adapter escapes.
+
+**Inspecting it.** `bun event-runtime/cli.mjs adapters` (`--json` for
+machine-readable output) prints the registered adapters with their source and
+sandbox support — the same registry a worker builds, so it needs no running
+`serve`.
+
 ## 3. Stage 2 — workers on other nodes
 
 A `work` process on another machine talks to the authenticated `/worker/v1`

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -2,12 +2,16 @@
 /** Event-runtime CLI argument routing and command dispatch. */
 import { COMMANDS } from "./cli/commands.mjs";
 import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
+import { createAdapterRegistry } from "./lib/adapters/index.mjs";
 import { API_HOST, DEFAULT_PORT } from "./lib/config.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
 
 const USAGE = BASE_USAGE.replace(
   "  inbox                          open items waiting on the human",
   "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API",
+).replace(
+  "  agents                         registered agent definitions and event routing",
+  "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)",
 );
 
 // Preserve the small programmatic surface used by runtime tests and tooling.
@@ -126,10 +130,33 @@ export async function decideCommand(args) {
   return result;
 }
 
+/**
+ * Read-only listing of the adapter registry (WM-837): the same registry
+ * `work` and `serve` build, so what this prints is what a worker would
+ * execute with. Local — it needs no running serve.
+ */
+export function adaptersCommand(args = []) {
+  const registry = createAdapterRegistry();
+  const rows = registry.list();
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ adapters: rows }, null, 2));
+    return rows;
+  }
+  const width = Math.max(8, ...rows.map((row) => row.name.length + 3));
+  console.log(`${"ADAPTER".padEnd(width)}${"SOURCE".padEnd(12)}SANDBOX`);
+  for (const row of rows) {
+    console.log(
+      `${row.name.padEnd(width)}${row.source.padEnd(12)}${row.sandboxSupport}`,
+    );
+  }
+  return rows;
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
+  if (command === "adapters") return adaptersCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -1,13 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import * as actions from "../lib/adapters/actions.mjs";
-import * as agy from "../lib/adapters/agy.mjs";
-import * as claude from "../lib/adapters/claude.mjs";
-import * as command from "../lib/adapters/command.mjs";
-import * as cursor from "../lib/adapters/cursor.mjs";
-import * as fake from "../lib/adapters/fake.mjs";
-import * as pi from "../lib/adapters/pi.mjs";
+import { createAdapterRegistry } from "../lib/adapters/index.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -310,8 +304,11 @@ export default async function serve(args) {
     fail(`serve: invalid port "${rawPort}" (must be integer 1-65535)`);
   }
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  const adapters = { actions, agy, claude, command, cursor, fake, pi };
-  if (adapterOverride && !adapters[adapterOverride]) {
+  // Built-ins only for now; the registry validates the contract and wraps
+  // every adapter in the sandbox seam (lib/adapters/index.mjs, WM-837).
+  const adapterRegistry = createAdapterRegistry();
+  const adapters = adapterRegistry.toMap();
+  if (adapterOverride && !adapterRegistry.has(adapterOverride)) {
     fail(
       `serve: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`,
     );

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -1,12 +1,6 @@
 import { existsSync } from "node:fs";
 import { hostname } from "node:os";
-import * as actions from "../lib/adapters/actions.mjs";
-import * as agy from "../lib/adapters/agy.mjs";
-import * as claude from "../lib/adapters/claude.mjs";
-import * as command from "../lib/adapters/command.mjs";
-import * as cursor from "../lib/adapters/cursor.mjs";
-import * as fake from "../lib/adapters/fake.mjs";
-import * as pi from "../lib/adapters/pi.mjs";
+import { createAdapterRegistry } from "../lib/adapters/index.mjs";
 import {
   dbPath,
   ensureHome,
@@ -53,8 +47,11 @@ export default async function work(args) {
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
-  const adapters = { actions, agy, claude, command, cursor, fake, pi };
-  if (adapterOverride && !adapters[adapterOverride]) {
+  // Built-ins only for now; the registry validates the contract and wraps
+  // every adapter in the sandbox seam (lib/adapters/index.mjs, WM-837).
+  const adapterRegistry = createAdapterRegistry();
+  const adapters = adapterRegistry.toMap();
+  if (adapterOverride && !adapterRegistry.has(adapterOverride)) {
     fail(
       `work: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`,
     );

--- a/event-runtime/lib/adapters/index.mjs
+++ b/event-runtime/lib/adapters/index.mjs
@@ -1,0 +1,255 @@
+/**
+ * The adapter registry (WM-837).
+ *
+ * Harness adapters share one contract — an exported async `execute()` (the
+ * entry point lib/worker.mjs calls) plus a `SANDBOX_SUPPORT` verdict for the
+ * sandbox seam in sandboxed.mjs — but until this module the set of adapters
+ * was an object literal duplicated in cli/work.mjs and cli/serve.mjs. Adding
+ * one meant editing two CLIs, and nothing outside the repo could contribute
+ * one. The registry gives the follow-up extension loader something to
+ * register into, and it validates the contract at registration time so a
+ * malformed adapter fails at startup, typed and named, rather than as an
+ * `unknown_adapter` or a TypeError mid-run.
+ *
+ * Two properties this module owns:
+ *
+ *   1. **Contract validation.** `register()` (and therefore construction,
+ *      which registers the built-ins) refuses a module that lacks `execute`
+ *      or `SANDBOX_SUPPORT`, carries an unknown support value, or has a name
+ *      outside `^[a-z][a-z0-9-]*$` — with `AdapterContractError` naming the
+ *      missing export. Duplicate names are `AdapterRegistrationError` unless
+ *      `{ replace: true }` says the caller means it.
+ *   2. **The sandbox seam is mandatory.** Everything the registry hands out
+ *      (`get()`, `toMap()`) is a frozen wrapper whose `execute` consults
+ *      sandboxed.mjs first: an adapter that declares `unsupported` is refused
+ *      with `SandboxUnsupportedError` for a sandboxed definition before its own
+ *      code runs, so even an adapter that forgets `refuseSandbox()` cannot
+ *      execute on the host. `gondolin` adapters are delegated to and own the
+ *      `runSandboxed()` call; sandboxed.test.mjs proves each built-in reaches
+ *      the VM boundary. No code path yields the raw module — index.test.mjs
+ *      asserts that.
+ *
+ * The registry is not a class hierarchy (docs/event-runtime-conventions.md):
+ * it is a closure over a Map with a handful of functions, and the worker keeps
+ * consuming the plain `name → adapter` object it always has, obtained via
+ * `toMap()`.
+ */
+import * as actions from "./actions.mjs";
+import * as agy from "./agy.mjs";
+import * as claude from "./claude.mjs";
+import * as command from "./command.mjs";
+import * as cursor from "./cursor.mjs";
+import * as fake from "./fake.mjs";
+import * as pi from "./pi.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
+
+/** Adapter names are lower-case identifiers; they appear in labels, specs, and CLI flags. */
+export const ADAPTER_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/** The only two answers the sandbox seam accepts (sandboxed.mjs, WM-313). */
+export const SANDBOX_SUPPORT_VALUES = Object.freeze([
+  "gondolin",
+  "unsupported",
+]);
+
+/** The export lib/worker.mjs invokes: `adapters[adapterKey].execute({...})`. */
+export const ADAPTER_ENTRY_POINT = "execute";
+
+/** Source label for the adapters shipped in this directory. */
+export const BUILTIN_SOURCE = "builtin";
+
+const SANDBOX_GUARDED = Symbol.for("factory.adapter.sandbox-guarded");
+
+export class AdapterContractError extends Error {
+  /**
+   * @param {string} adapter - the name being registered
+   * @param {string} missing - which part of the contract failed: `name`, `module`, `execute`, or `SANDBOX_SUPPORT`
+   * @param {string} detail
+   */
+  constructor(adapter, missing, detail) {
+    super(
+      `adapter "${adapter}" does not satisfy the adapter contract (${missing}): ${detail}`,
+    );
+    this.name = "AdapterContractError";
+    this.code = "adapter_contract_invalid";
+    this.adapter = adapter;
+    this.missing = missing;
+  }
+}
+
+export class AdapterRegistrationError extends Error {
+  /**
+   * @param {string} adapter
+   * @param {string} code - `adapter_duplicate` or `adapter_source_missing`
+   * @param {string} detail
+   */
+  constructor(adapter, code, detail) {
+    super(`adapter "${adapter}" cannot be registered: ${detail}`);
+    this.name = "AdapterRegistrationError";
+    this.code = code;
+    this.adapter = adapter;
+  }
+}
+
+/**
+ * The adapters shipped with the runtime, keyed by the name a run spec's
+ * `adapter` field carries. A fresh, frozen object each call so no caller can
+ * mutate the built-in set for the next one.
+ */
+export function builtinAdapters() {
+  return Object.freeze({ actions, agy, claude, command, cursor, fake, pi });
+}
+
+/**
+ * Check one module against the adapter contract. Returns the normalized
+ * summary the registry stores; throws `AdapterContractError` naming the
+ * missing piece otherwise. Exported so a loader can validate before it
+ * decides whether to register (e.g. to report every broken adapter in a
+ * pack at once instead of stopping at the first).
+ *
+ * @param {string} name
+ * @param {unknown} module - an ES module namespace or any object with the same exports
+ * @returns {{ name: string, sandboxSupport: "gondolin"|"unsupported" }}
+ */
+export function validateAdapterContract(name, module) {
+  if (typeof name !== "string" || !ADAPTER_NAME_PATTERN.test(name)) {
+    throw new AdapterContractError(
+      String(name),
+      "name",
+      `adapter names must match ${ADAPTER_NAME_PATTERN} (got ${JSON.stringify(name)})`,
+    );
+  }
+  if (
+    module === null ||
+    (typeof module !== "object" && typeof module !== "function")
+  ) {
+    throw new AdapterContractError(
+      name,
+      "module",
+      `expected a module namespace, got ${module === null ? "null" : typeof module}`,
+    );
+  }
+  if (typeof module[ADAPTER_ENTRY_POINT] !== "function") {
+    throw new AdapterContractError(
+      name,
+      ADAPTER_ENTRY_POINT,
+      `missing export "${ADAPTER_ENTRY_POINT}" — the async run entry point lib/worker.mjs invokes`,
+    );
+  }
+  if (!SANDBOX_SUPPORT_VALUES.includes(module.SANDBOX_SUPPORT)) {
+    throw new AdapterContractError(
+      name,
+      "SANDBOX_SUPPORT",
+      `missing or invalid export "SANDBOX_SUPPORT" — must be one of ${SANDBOX_SUPPORT_VALUES.join(" | ")} (got ${JSON.stringify(module.SANDBOX_SUPPORT ?? null)}); see lib/adapters/sandboxed.mjs`,
+    );
+  }
+  return { name, sandboxSupport: module.SANDBOX_SUPPORT };
+}
+
+/** True when `adapter` came out of a registry (i.e. its execute goes through the sandbox seam). */
+export function isSandboxGuarded(adapter) {
+  return adapter?.[SANDBOX_GUARDED] === true;
+}
+
+/**
+ * The wrapper the registry hands out. Spreads the module's exports so callers
+ * that read adapter constants keep working, then replaces `execute` with one
+ * that makes the sandbox decision before delegating. Frozen: nobody can swap
+ * `execute` back afterwards.
+ */
+function guardAdapter(name, module, sandboxSupport) {
+  const reason =
+    `Adapter "${name}" declares SANDBOX_SUPPORT="${sandboxSupport}", so the registry refuses ` +
+    `the run before the adapter is invoked (lib/adapters/index.mjs).`;
+  const execute = async (params) => {
+    if (sandboxSupport !== "gondolin") refuseSandbox(name, params?.def, reason);
+    return module.execute(params);
+  };
+  return Object.freeze({
+    ...module,
+    name,
+    SANDBOX_SUPPORT: sandboxSupport,
+    execute,
+    [SANDBOX_GUARDED]: true,
+  });
+}
+
+/**
+ * Create a registry. The built-ins are registered first with source
+ * `builtin`; anything else arrives through `register()`.
+ *
+ * @param {{ builtins?: Record<string, unknown> }} [options]
+ */
+export function createAdapterRegistry({ builtins = builtinAdapters() } = {}) {
+  /** @type {Map<string, { name: string, source: string, sandboxSupport: string, adapter: object }>} */
+  const entries = new Map();
+
+  const summary = (entry) => ({
+    name: entry.name,
+    source: entry.source,
+    sandboxSupport: entry.sandboxSupport,
+  });
+
+  /**
+   * Validate and add one adapter.
+   *
+   * @param {string} name
+   * @param {unknown} module
+   * @param {{ source: string, replace?: boolean }} options - `source` is
+   *   mandatory so `adapters` can always say where an adapter came from
+   *   (`builtin`, a pack name, an extension path); `replace` permits
+   *   overriding an existing name on purpose.
+   * @returns {{ name: string, source: string, sandboxSupport: string }}
+   */
+  function register(name, module, { source, replace = false } = {}) {
+    const validated = validateAdapterContract(name, module);
+    if (typeof source !== "string" || source === "") {
+      throw new AdapterRegistrationError(
+        name,
+        "adapter_source_missing",
+        "register() needs { source } saying where the adapter came from",
+      );
+    }
+    const existing = entries.get(name);
+    if (existing && !replace) {
+      throw new AdapterRegistrationError(
+        name,
+        "adapter_duplicate",
+        `already registered from ${existing.source}; pass { replace: true } to override it deliberately`,
+      );
+    }
+    const entry = {
+      ...validated,
+      source,
+      adapter: guardAdapter(name, module, validated.sandboxSupport),
+    };
+    entries.set(name, entry);
+    return summary(entry);
+  }
+
+  for (const [name, module] of Object.entries(builtins ?? {})) {
+    register(name, module, { source: BUILTIN_SOURCE });
+  }
+
+  return Object.freeze({
+    register,
+    /** The sandbox-guarded adapter, or undefined. */
+    get: (name) => entries.get(name)?.adapter,
+    has: (name) => entries.has(name),
+    /** Sorted by name; what `bun event-runtime/cli.mjs adapters` prints. */
+    list: () =>
+      [...entries.values()]
+        .map(summary)
+        .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0)),
+    /**
+     * A frozen `name → adapter` snapshot — the shape lib/worker.mjs consumes
+     * (`runOnce(db, registry, adapters, opts)` → `adapters[adapterKey]`).
+     */
+    toMap: () =>
+      Object.freeze(
+        Object.fromEntries(
+          [...entries.values()].map((entry) => [entry.name, entry.adapter]),
+        ),
+      ),
+  });
+}

--- a/event-runtime/lib/adapters/index.test.mjs
+++ b/event-runtime/lib/adapters/index.test.mjs
@@ -1,0 +1,318 @@
+/**
+ * The adapter registry (WM-837): contract validation for every built-in and
+ * for a minimal fixture, plus the property the sandbox seam depends on — no
+ * caller can obtain an adapter from the registry that bypasses the
+ * `def.sandbox` decision in sandboxed.mjs.
+ *
+ * Pure: nothing here spawns a process or touches the filesystem.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  ADAPTER_NAME_PATTERN,
+  AdapterContractError,
+  AdapterRegistrationError,
+  builtinAdapters,
+  createAdapterRegistry,
+  isSandboxGuarded,
+  validateAdapterContract,
+} from "./index.mjs";
+import { SandboxUnsupportedError } from "./sandboxed.mjs";
+
+const BUILTIN_NAMES = [
+  "actions",
+  "agy",
+  "claude",
+  "command",
+  "cursor",
+  "fake",
+  "pi",
+];
+
+/** A minimal adapter that satisfies the contract and records what it was handed. */
+function fixtureAdapter({ sandboxSupport = "unsupported" } = {}) {
+  const calls = [];
+  return {
+    calls,
+    module: {
+      SANDBOX_SUPPORT: sandboxSupport,
+      async execute(params) {
+        calls.push(params);
+        return { exitCode: 0, timedOut: false };
+      },
+    },
+  };
+}
+
+describe("builtinAdapters", () => {
+  test("returns exactly the seven shipped adapters, keyed by name", () => {
+    expect(Object.keys(builtinAdapters()).sort()).toEqual(BUILTIN_NAMES);
+  });
+
+  test("every built-in satisfies the adapter contract", () => {
+    for (const [name, mod] of Object.entries(builtinAdapters())) {
+      const report = validateAdapterContract(name, mod);
+      expect(report.name).toBe(name);
+      expect(["gondolin", "unsupported"]).toContain(report.sandboxSupport);
+    }
+  });
+});
+
+describe("validateAdapterContract", () => {
+  test("accepts a minimal fixture adapter", () => {
+    const { module } = fixtureAdapter({ sandboxSupport: "gondolin" });
+    expect(validateAdapterContract("fixture", module)).toEqual({
+      name: "fixture",
+      sandboxSupport: "gondolin",
+    });
+  });
+
+  test("a module without the run entry point throws a typed error naming it", () => {
+    let caught;
+    try {
+      validateAdapterContract("broken", { SANDBOX_SUPPORT: "unsupported" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AdapterContractError);
+    expect(caught.code).toBe("adapter_contract_invalid");
+    expect(caught.adapter).toBe("broken");
+    expect(caught.missing).toBe("execute");
+    expect(caught.message).toContain("execute");
+  });
+
+  test("a module without SANDBOX_SUPPORT throws a typed error naming it", () => {
+    let caught;
+    try {
+      validateAdapterContract("broken", { execute: async () => ({}) });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AdapterContractError);
+    expect(caught.missing).toBe("SANDBOX_SUPPORT");
+    expect(caught.message).toContain("SANDBOX_SUPPORT");
+  });
+
+  test("an unknown SANDBOX_SUPPORT value is rejected — the sandbox seam only knows two answers", () => {
+    expect(() =>
+      validateAdapterContract("broken", {
+        SANDBOX_SUPPORT: "maybe",
+        execute: async () => ({}),
+      }),
+    ).toThrow(AdapterContractError);
+  });
+
+  test("names must match ^[a-z][a-z0-9-]*$", () => {
+    const { module } = fixtureAdapter();
+    for (const bad of ["", "Claude", "1pi", "my_adapter", "a b", "-x", "é"]) {
+      let caught;
+      try {
+        validateAdapterContract(bad, module);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(AdapterContractError);
+      expect(caught.missing).toBe("name");
+      expect(ADAPTER_NAME_PATTERN.test(bad)).toBe(false);
+    }
+    for (const good of ["a", "pi", "my-adapter", "x9", "claude-code2"]) {
+      expect(validateAdapterContract(good, module).name).toBe(good);
+    }
+  });
+
+  test("a non-object module is rejected", () => {
+    expect(() => validateAdapterContract("x", null)).toThrow(
+      AdapterContractError,
+    );
+    expect(() => validateAdapterContract("x", "claude")).toThrow(
+      AdapterContractError,
+    );
+  });
+});
+
+describe("createAdapterRegistry", () => {
+  test("registers the built-ins with source builtin by default", () => {
+    const registry = createAdapterRegistry();
+    expect(registry.list().map((a) => a.name)).toEqual(BUILTIN_NAMES);
+    for (const entry of registry.list()) {
+      expect(entry.source).toBe("builtin");
+      expect(["gondolin", "unsupported"]).toContain(entry.sandboxSupport);
+      expect(registry.has(entry.name)).toBe(true);
+    }
+    expect(registry.has("nope")).toBe(false);
+    expect(registry.get("nope")).toBeUndefined();
+  });
+
+  test("an empty builtins map yields an empty registry", () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    expect(registry.list()).toEqual([]);
+    expect(registry.toMap()).toEqual({});
+  });
+
+  test("register adds an adapter with its source; list is sorted by name", () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    const { module } = fixtureAdapter();
+    const entry = registry.register("zeta", module, { source: "pack:x" });
+    registry.register("alpha", module, { source: "pack:y" });
+    expect(entry).toEqual({
+      name: "zeta",
+      source: "pack:x",
+      sandboxSupport: "unsupported",
+    });
+    expect(registry.list()).toEqual([
+      { name: "alpha", source: "pack:y", sandboxSupport: "unsupported" },
+      { name: "zeta", source: "pack:x", sandboxSupport: "unsupported" },
+    ]);
+    expect(registry.has("alpha")).toBe(true);
+    expect(typeof registry.get("alpha").execute).toBe("function");
+  });
+
+  test("register requires a source", () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    const { module } = fixtureAdapter();
+    expect(() => registry.register("x", module)).toThrow(
+      AdapterRegistrationError,
+    );
+    expect(() => registry.register("x", module, { source: "" })).toThrow(
+      AdapterRegistrationError,
+    );
+  });
+
+  test("register rejects an invalid module and leaves the registry unchanged", () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    expect(() =>
+      registry.register(
+        "broken",
+        { SANDBOX_SUPPORT: "unsupported" },
+        {
+          source: "test",
+        },
+      ),
+    ).toThrow(AdapterContractError);
+    expect(registry.has("broken")).toBe(false);
+    expect(registry.list()).toEqual([]);
+  });
+
+  test("duplicate names throw unless { replace: true }", () => {
+    const registry = createAdapterRegistry();
+    const { module } = fixtureAdapter();
+    let caught;
+    try {
+      registry.register("claude", module, { source: "test" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AdapterRegistrationError);
+    expect(caught.code).toBe("adapter_duplicate");
+    expect(caught.adapter).toBe("claude");
+    expect(caught.message).toContain("builtin");
+    // The original stays in place after a refused duplicate.
+    expect(registry.list().find((a) => a.name === "claude").source).toBe(
+      "builtin",
+    );
+
+    registry.register("claude", module, { source: "test", replace: true });
+    expect(registry.list().find((a) => a.name === "claude").source).toBe(
+      "test",
+    );
+    expect(registry.list()).toHaveLength(BUILTIN_NAMES.length);
+  });
+
+  test("toMap is the worker's lookup shape: name → adapter with execute", () => {
+    const registry = createAdapterRegistry();
+    const map = registry.toMap();
+    expect(Object.keys(map).sort()).toEqual(BUILTIN_NAMES);
+    for (const name of BUILTIN_NAMES) {
+      expect(map[name]).toBe(registry.get(name));
+      expect(typeof map[name].execute).toBe("function");
+      expect(map[name].name).toBe(name);
+    }
+    expect(Object.isFrozen(map)).toBe(true);
+    // A snapshot: registering afterwards does not mutate a handed-out map.
+    registry.register("later", fixtureAdapter().module, { source: "test" });
+    expect(map.later).toBeUndefined();
+    expect(registry.toMap().later).toBeDefined();
+  });
+
+  test("builtins are validated at construction, so a broken built-in fails fast", () => {
+    expect(() =>
+      createAdapterRegistry({
+        builtins: { bad: { execute: async () => ({}) } },
+      }),
+    ).toThrow(AdapterContractError);
+  });
+});
+
+describe("no unwrapped adapter escapes the registry (sandboxed.mjs is mandatory)", () => {
+  test("every adapter handed out — via get() and toMap() — is the sandbox-guarded wrapper, never the raw module", () => {
+    const registry = createAdapterRegistry();
+    const raw = builtinAdapters();
+    for (const name of BUILTIN_NAMES) {
+      const viaGet = registry.get(name);
+      expect(viaGet).not.toBe(raw[name]);
+      expect(viaGet.execute).not.toBe(raw[name].execute);
+      expect(isSandboxGuarded(viaGet)).toBe(true);
+      expect(isSandboxGuarded(raw[name])).toBe(false);
+      // Other exports still ride along for callers that read adapter constants.
+      expect(viaGet.SANDBOX_SUPPORT).toBe(raw[name].SANDBOX_SUPPORT);
+    }
+    for (const adapter of Object.values(registry.toMap())) {
+      expect(isSandboxGuarded(adapter)).toBe(true);
+    }
+    const { module } = fixtureAdapter();
+    registry.register("fixture", module, { source: "test" });
+    expect(registry.get("fixture")).not.toBe(module);
+    expect(isSandboxGuarded(registry.get("fixture"))).toBe(true);
+    expect(Object.isFrozen(registry.get("fixture"))).toBe(true);
+  });
+
+  test("an unsupported adapter that ignores def.sandbox is refused by the wrapper before its execute runs", async () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    const { module, calls } = fixtureAdapter({ sandboxSupport: "unsupported" });
+    registry.register("careless", module, { source: "test" });
+    const adapter = registry.get("careless");
+    let caught = null;
+    try {
+      await adapter.execute({
+        spec: { agent: "careless@1" },
+        def: { ref: "careless@1", sandbox: { provider: "gondolin" } },
+        workspaceDir: "/nonexistent",
+        timeoutMs: 10,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+    expect(caught.adapter).toBe("careless");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("an ordinary definition passes straight through to the module's execute with the same params", async () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    const { module, calls } = fixtureAdapter({ sandboxSupport: "unsupported" });
+    registry.register("plain", module, { source: "test" });
+    const params = {
+      spec: { agent: "plain@1" },
+      def: { ref: "plain@1" },
+      workspaceDir: "/nonexistent",
+      timeoutMs: 10,
+    };
+    const outcome = await registry.get("plain").execute(params);
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(params);
+  });
+
+  test("a gondolin adapter is delegated to for sandboxed definitions — the module owns the runSandboxed call", async () => {
+    const registry = createAdapterRegistry({ builtins: {} });
+    const { module, calls } = fixtureAdapter({ sandboxSupport: "gondolin" });
+    registry.register("vm", module, { source: "test" });
+    const params = {
+      spec: { agent: "vm@1" },
+      def: { ref: "vm@1", sandbox: { provider: "gondolin" } },
+      workspaceDir: "/nonexistent",
+      timeoutMs: 10,
+    };
+    await registry.get("vm").execute(params);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -12,6 +12,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
+import { builtinAdapters } from "./index.mjs";
 import {
   GUEST_BINARIES,
   GUEST_HOME,
@@ -295,9 +296,10 @@ describe("runSandboxed", () => {
  * means the adapter ignored the block, which is the WM-313 defect.
  */
 describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
-  // This is the adapter registry loaded by cli/work.mjs and cli/serve.mjs.
-  // Keep it explicit: helper modules added beside adapters must not silently
-  // become executable conformance targets merely because of their filename.
+  // These are the built-ins cli/work.mjs and cli/serve.mjs obtain through
+  // createAdapterRegistry(). Keep the list explicit: helper modules added
+  // beside adapters must not silently become executable conformance targets
+  // merely because of their filename.
   const modules = [
     "actions",
     "agy",
@@ -308,19 +310,8 @@ describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
     "pi",
   ];
 
-  test("the explicit sweep registry matches both production worker entry points", () => {
-    const registeredAdapters = (relativePath) => {
-      const source = readFileSync(
-        path.resolve(import.meta.dir, relativePath),
-        "utf8",
-      );
-      const declaration = source.match(/const adapters = \{([^}]+)\};/);
-      expect(declaration).not.toBeNull();
-      return declaration[1].split(",").map((name) => name.trim());
-    };
-
-    expect(registeredAdapters("../../cli/work.mjs")).toEqual(modules);
-    expect(registeredAdapters("../../cli/serve.mjs")).toEqual(modules);
+  test("the explicit sweep list matches the built-in set both worker entry points register (lib/adapters/index.mjs)", () => {
+    expect(Object.keys(builtinAdapters()).sort()).toEqual(modules);
   });
 
   for (const name of modules) {


### PR DESCRIPTION
Introduces `event-runtime/lib/adapters/index.mjs`: `builtinAdapters()` and `createAdapterRegistry({ builtins })` with `register/get/has/list/toMap`. `register` validates the adapter contract (`execute` entry point, `SANDBOX_SUPPORT ∈ {gondolin,unsupported}`, name `^[a-z][a-z0-9-]*$`) and throws typed `AdapterContractError` (naming the missing export) / `AdapterRegistrationError` (duplicates unless `{ replace: true }`).

Every adapter the registry hands out is a frozen wrapper whose `execute` runs `sandboxed.mjs` `refuseSandbox()` first, so no code path can obtain an unwrapped adapter — `index.test.mjs` asserts this against every built-in and a fixture. `toMap()` is the plain `name → adapter` object `worker.mjs` already consumes, so `runOnce`/`executeClaimed` are untouched.

`cli/work.mjs` and `cli/serve.mjs` consume the registry (both literals gone); `cli.mjs` gains a read-only `adapters` subcommand (`--json`). `sandboxed.test.mjs`'s sweep now checks `builtinAdapters()` instead of regexing the removed literals (the one file outside Owned Paths). Docs: `docs/event-runtime-workers.md` §2c.

Verification: `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/adapters && bun run lint && bun run check && ! git grep -n "{ actions, agy, claude" -- event-runtime/cli` — pass (230 tests, 0 fail; lint 0 errors; grep empty). `factory security` pass. No spawn-based tests added.

Fixes WM-837