### PR TITLE
refactor(web): view registry — nav, lazy import and route resolve from one declaration per view (WM-839)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -134,6 +134,58 @@ Projects (§10.14). Eight of them own a nav-rail entry; the full-page run view
 is reached from Runs, not from the rail. All nine are still thin projections
 of existing endpoints.
 
+### 4.0 Adding a view — the view registry (WM-839)
+
+Every page is one declaration in `src/views/registry.ts` (`VIEWS`), and
+that entry is the only thing to add for a new page. From it the shell
+derives the nav rail (`NAV` in `nav.ts` is a projection of `VIEWS` — same
+objects, chorded entries only), the `g` chord, the ⌘K "Go to" action, the
+lazy import and its Suspense fallback, the hash-route resolve (`#/<key>` →
+that view, `route[1..]` → its `params`), the page title and which rail entry
+is `aria-current`.
+
+```ts
+{
+  key: "widgets",            // #/widgets — first hash segment and rail identity
+  label: "Widgets",          // rail label / page title
+  go: "u",                   // `g u` chord; omit for drill-in routes off the rail
+  group: "machinery",        // rail group; omit with `go` for drill-ins
+  params: [":id"],           // documented focus params: #/widgets/:id
+  load: load(                // lazy import + adapter: shell slice → the view's props
+    () => import("./Widgets"),
+    "Widgets",
+    ({ params, navigate, shell }) => ({
+      connected: shell.connected,
+      focusId: params[0] ?? null,
+      onSelect: (id) => navigate(hashPath("widgets", id)),
+    }),
+  ),
+}
+```
+
+That is the whole change: no `lazy()` in `App.tsx`, no render branch, no
+palette or chord edit. The view itself stays a plain component with its own
+explicit props; the adapter in the entry maps `ViewProps` (`params`, `hash`,
+`navigate`, and the shell's cross-view `jump` callbacks and shared state) onto
+them, so nothing outside the entry has to know the view exists. Drill-in
+routes reached from a parent view (`#/run/:id`, `#/prs/:n`, `#/chain/:id`,
+`#/artifact/:digest`) omit `go`/`group` and set `parent` (which rail entry
+stays current) and, where an id-less URL should show the list, `fallback`.
+Unknown first segments render Overview.
+
+Chord suffixes are checked by `views/registry.test.ts`: keys and chords must
+be unique, and a chord may not be a reserved suffix
+(`RESERVED_GO_SUFFIXES`: `a`/`x` list verbs that would double-fire under the
+chord, `i` and `0`–`9` context chords, `h` for Projects' `g h`). The chord
+rationale for the current rail is the header comment of `registry.ts`.
+
+Chunking: `load` is a dynamic `import()`, so each view stays its own Vite
+chunk. Overview, Runs and Events are the first-paint exceptions — they are
+imported statically by the registry and declared with `component` so the
+entry chunk (budgeted in `vite.config.ts`) renders them without a Suspense
+flash. Do not add `component` to a new view unless it is a first-paint
+surface; that is a budget decision, not routine growth.
+
 Layout is Linear's three-zone shape: a narrow left nav rail, a dense list,
 and a right-side detail panel that opens without leaving the list. The panel
 is `DetailPane` in `src/components/ui.tsx` — hand-rolled, not a shadcn

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -292,6 +292,49 @@ describe("sidebar navigation accessibility", () => {
   });
 });
 
+describe("view registry routing (WM-839)", () => {
+  test("an unknown first segment lands on Overview, with no rail entry current", async () => {
+    window.location.hash = "#/no-such-view";
+    const utils = renderApp();
+    expect(
+      await utils.findByRole("heading", { name: "Overview" }),
+    ).toBeTruthy();
+    for (const n of NAV) {
+      expect(
+        utils.sidebar
+          .getByRole("button", { name: n.label })
+          .getAttribute("aria-current"),
+      ).toBe(null);
+    }
+  });
+
+  test("an id-less drill-in route falls back to its list view and keeps the parent current", async () => {
+    window.location.hash = "#/run";
+    const utils = renderApp();
+    expect(await utils.findByRole("heading", { name: "Runs" })).toBeTruthy();
+    expect(
+      utils.sidebar
+        .getByRole("button", { name: "Runs" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(window.location.hash).toBe("#/run");
+  });
+
+  test("a lazily registered view with a focus param resolves through the registry", async () => {
+    window.location.hash = `#/proposals/${OPEN_PROPOSAL_ID}`;
+    const utils = renderApp();
+    expect(
+      await utils.findByRole("heading", { name: "Proposals" }),
+    ).toBeTruthy();
+    expect(
+      utils.sidebar
+        .getByRole("button", { name: "Proposals" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(document.title).toBe(`factory · Proposals · ${OPEN_PROPOSAL_ID}`);
+  });
+});
+
 describe("Graph proposal navigation (WM-165)", () => {
   test("Open in Proposals routes through App to the selected proposal", async () => {
     currentProposals = [

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -48,28 +48,21 @@ import {
   copyLink,
   copyText,
 } from "./components/ui";
-import type { ArtifactFilters } from "./views/Artifacts";
-import { Events } from "./views/Events";
-import { Overview } from "./views/Overview";
-import { Runs } from "./views/Runs";
-import { NAV, type NavKey } from "./nav";
+import {
+  NAV,
+  navIsCurrent,
+  resolveView,
+  viewLabel as viewLabelFor,
+  workerHash,
+  type NavKey,
+  type Shell,
+  type WorkerHealthFilter,
+} from "./views/registry";
 import { Button as PrimitiveButton } from "./components/ui";
 
-type WorkerHealthFilter = "live" | "busy" | "stale";
-const isWorkerHealthFilter = (
-  value: string | null,
-): value is WorkerHealthFilter =>
-  value === "live" || value === "busy" || value === "stale";
-
-export function navIsCurrent(key: NavKey, view?: string): boolean {
-  return (
-    key === view ||
-    (key === "runs" && view === "run") ||
-    (key === "tickets" && view === "prs") ||
-    (key === "chains" && view === "chain") ||
-    (key === "artifacts" && view === "artifact")
-  );
-}
+// Route helpers moved to the view registry (WM-839); re-exported for callers
+// (and tests) that reach them through App.
+export { listSelectionPath, navIsCurrent } from "./views/registry";
 
 type NavBadge = {
   count: number;
@@ -96,68 +89,6 @@ function NavCount({ id, badge }: { id: string; badge: NavBadge }) {
   );
 }
 
-export function listSelectionPath(
-  view: "runs" | "proposals",
-  id: string | null,
-  hash: string,
-) {
-  const path = hashPath(view, id);
-  const query = hashSearch(hash);
-  if (!query.has("population") || !query.has("from") || !query.has("to"))
-    return path;
-  query.delete("project");
-  return `${path}?${query.toString()}`;
-}
-
-const Artifacts = lazy(() =>
-  import("./views/Artifacts").then((m) => ({ default: m.Artifacts })),
-);
-const ArtifactFull = lazy(() =>
-  import("./views/ArtifactFull").then((m) => ({ default: m.ArtifactFull })),
-);
-const Metrics = lazy(() =>
-  import("./views/Metrics").then((m) => ({ default: m.Metrics })),
-);
-const Graph = lazy(() =>
-  import("./views/Graph").then((m) => ({ default: m.Graph })),
-);
-const Chains = lazy(() =>
-  import("./views/Chains").then((m) => ({ default: m.Chains })),
-);
-const Chain = lazy(() =>
-  import("./views/Chain").then((m) => ({ default: m.Chain })),
-);
-const Projects = lazy(() =>
-  import("./views/Projects").then((m) => ({ default: m.Projects })),
-);
-const Schedules = lazy(() =>
-  import("./views/Schedules").then((m) => ({ default: m.Schedules })),
-);
-const Proposals = lazy(() =>
-  import("./views/Proposals").then((m) => ({ default: m.Proposals })),
-);
-const Agents = lazy(() =>
-  import("./views/Agents").then((m) => ({ default: m.Agents })),
-);
-const RunFull = lazy(() =>
-  import("./views/RunFull").then((m) => ({ default: m.RunFull })),
-);
-const Ticket = lazy(() =>
-  import("./views/Ticket").then((m) => ({ default: m.Ticket })),
-);
-// The PR journey (WM-640) shares the ticket journey chunk — same layout, other subject.
-const PullRequest = lazy(() =>
-  import("./views/Ticket").then((m) => ({ default: m.PullRequest })),
-);
-const Workers = lazy(() =>
-  import("./views/Workers").then((m) => ({ default: m.Workers })),
-);
-const Settings = lazy(() =>
-  import("./views/Settings").then((m) => ({ default: m.Settings })),
-);
-const Inbox = lazy(() =>
-  import("./views/Inbox").then((m) => ({ default: m.Inbox })),
-);
 const ShortcutsDialog = lazy(() =>
   import("./components/ShortcutsDialog").then((m) => ({
     default: m.ShortcutsDialog,
@@ -317,66 +248,6 @@ export function App() {
     };
   }, []);
 
-  const focusRunId = view === "runs" ? (route[1] ?? null) : null;
-  const focusTicketId = view === "tickets" ? (route[1] ?? null) : null;
-  // `#/prs/:number` — the PR journey (WM-640); a drill-in like `#/tickets/:id`.
-  const focusPrNumber = view === "prs" ? (route[1] ?? null) : null;
-  // `#/run/:id` is the full-page run view — a distinct first segment, so
-  // crossing from `#/runs/:id` pushes history and Back restores the panel.
-  const fullRunId = view === "run" ? (route[1] ?? null) : null;
-  // `#/artifact/:digest` is the full-page artifact reader view (WM-828).
-  const fullArtifactDigest = view === "artifact" ? (route[1] ?? null) : null;
-  const focusProposalId = view === "proposals" ? (route[1] ?? null) : null;
-  const focusRepoName = view === "projects" ? (route[1] ?? null) : null;
-  const focusAgentRef = view === "agents" ? (route[1] ?? null) : null;
-  const focusScheduleLoop = view === "schedules" ? (route[1] ?? null) : null;
-  const focusWorkerId = view === "workers" ? (route[1] ?? null) : null;
-  // `#/inbox/:id` — the Telegram push deep-links here (lib/inbox.mjs telegramMessage).
-  const focusInboxId = view === "inbox" ? (route[1] ?? null) : null;
-  const workerHealthFromHash =
-    view === "workers" ? hashSearch(window.location.hash).get("health") : null;
-  const focusWorkerHealth = isWorkerHealthFilter(workerHealthFromHash)
-    ? workerHealthFromHash
-    : null;
-  const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
-  const focusSettingsSection = view === "settings" ? (route[1] ?? null) : null;
-  const chainsStateFilter =
-    view === "chains" ? hashSearch(window.location.hash).get("state") : null;
-  // `#/chain/:correlationId[/:nodeId]` — the chain trace (WM-527); node
-  // selection rides the hash so a pasted link lands on the same node.
-  const chainId = view === "chain" ? (route[1] ?? null) : null;
-  const focusChainNode = view === "chain" ? (route[2] ?? null) : null;
-  const artifactQuery = hashSearch(window.location.hash);
-  const artifactFilters: ArtifactFilters = {
-    kind: view === "artifacts" ? artifactQuery.get("kind") : null,
-    orphan:
-      view !== "artifacts" || !artifactQuery.has("orphan")
-        ? null
-        : artifactQuery.get("orphan") === "true",
-    search: view === "artifacts" ? (artifactQuery.get("search") ?? "") : "",
-  };
-  const hashEvent: EventFocus | null =
-    view === "events" && route[1] && route[2]
-      ? { source: route[1], eventId: route[2] }
-      : null;
-  const typeFromHash =
-    view === "events" ? hashSearch(window.location.hash).get("type") : null;
-  const focusEvent =
-    view === "events"
-      ? {
-          ...(ephemeralEvent ?? {}),
-          ...(typeFromHash ? { type: typeFromHash } : {}),
-          ...(hashEvent ?? {}),
-        }
-      : null;
-  const hasEventFocus = !!(
-    focusEvent &&
-    (focusEvent.source ||
-      focusEvent.eventId ||
-      focusEvent.status ||
-      focusEvent.type)
-  );
-
   const [rejumpEpoch, setRejumpEpoch] = useState(0);
 
   const jumpToRun = (runId: string) => {
@@ -424,10 +295,6 @@ export function App() {
     navigate("events");
   };
   const jumpToAgent = (ref: string) => navigate(hashPath("agents", ref));
-  const workerHash = (id: string | null, health: WorkerHealthFilter | null) => {
-    const path = hashPath("workers", id);
-    return health ? `${path}?health=${encodeURIComponent(health)}` : path;
-  };
   const jumpToWorker = (id: string) => navigate(workerHash(id, null));
   const jumpToWorkers = (health: WorkerHealthFilter) =>
     navigate(workerHash(null, health));
@@ -557,17 +424,7 @@ export function App() {
     }, [navigate, selectContext, openRepos]),
   );
 
-  const viewLabel =
-    NAV.find((n) => n.key === view)?.label ??
-    (view === "run"
-      ? "Run"
-      : view === "chain"
-        ? "Chain"
-        : view === "prs"
-          ? "PR"
-          : view === "artifact"
-            ? "Artifact"
-            : "Overview");
+  const viewLabel = viewLabelFor(view);
 
   useEffect(() => {
     const id = route.length > 1 ? route[route.length - 1] : null;
@@ -700,6 +557,46 @@ export function App() {
     { label: "Keyboard shortcuts", hint: "?", run: () => setHelpOpen(true) },
     { label: `Cycle theme (${THEMES.join(" → ")})`, run: cycleTheme },
   ];
+
+  // The registry resolves the first hash segment to a view and hands it the
+  // shell slice it needs (WM-839); unknown keys land on Overview.
+  const {
+    def: viewDef,
+    params: viewParams,
+    component: View,
+  } = resolveView(route);
+  const shell: Shell = {
+    connected,
+    healthPending,
+    context,
+    status: status.data,
+    rejumpEpoch,
+    focusRunState,
+    clearFocusRunState: () => setFocusRunState(null),
+    focusExpired,
+    setFocusExpired,
+    ephemeralEvent,
+    setEphemeralEvent,
+    openInject: (seed) => {
+      if (seed) setInjectSeed(seed);
+      setInjectOpen(true);
+    },
+    jump: {
+      run: jumpToRun,
+      runFull: openRunFull,
+      runs: jumpToRuns,
+      artifactFull: openArtifactFull,
+      ticket: jumpToTicket,
+      pr: jumpToPr,
+      proposal: jumpToProposal,
+      event: jumpToEvent,
+      events: jumpToEvents,
+      agent: jumpToAgent,
+      workers: jumpToWorkers,
+      graph: jumpToGraph,
+      chain: jumpToChain,
+    },
+  };
 
   return (
     <div className="flex h-screen flex-col">
@@ -898,317 +795,20 @@ export function App() {
             </div>
           )}
           <div className="min-h-0 flex-1">
-            {view === "proposals" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading proposals…
-                  </div>
-                }
-              >
-                <Proposals
-                  connected={connected}
-                  healthPending={healthPending}
-                  context={context}
-                  onRunQueued={jumpToRun}
-                  focusProposalId={focusProposalId}
-                  onSelectProposal={(id) =>
-                    navigate(
-                      listSelectionPath("proposals", id, window.location.hash),
-                    )
-                  }
-                  focusExpired={focusExpired}
-                  onFocusExpiredConsumed={() => setFocusExpired(false)}
-                  onJumpAgent={jumpToAgent}
-                  onJumpEvent={jumpToEvent}
-                  rejumpEpoch={rejumpEpoch}
-                />
-              </Suspense>
-            ) : view === "run" && fullRunId ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading run…</div>
-                }
-              >
-                <RunFull
-                  runId={fullRunId}
-                  connected={connected}
-                  onBack={() => navigate(hashPath("runs", fullRunId))}
-                  onJumpAgent={jumpToAgent}
-                  onJumpEvent={jumpToEvent}
-                  onJumpProposal={jumpToProposal}
-                  onJumpChain={jumpToChain}
-                />
-              </Suspense>
-            ) : view === "runs" || view === "run" ? (
-              <Runs
-                connected={connected}
-                context={context}
-                focusRunId={focusRunId}
-                onSelectRun={(id) =>
-                  navigate(listSelectionPath("runs", id, window.location.hash))
-                }
-                onOpenFull={openRunFull}
-                focusState={focusRunState}
-                onFocusStateConsumed={() => setFocusRunState(null)}
-                onJumpAgent={jumpToAgent}
-                onJumpEvent={jumpToEvent}
-                onJumpProposal={jumpToProposal}
-                rejumpEpoch={rejumpEpoch}
+            <Suspense
+              fallback={
+                <div className="p-5 text-(--text-faint)">
+                  Loading {viewDef.loading ?? viewDef.label.toLowerCase()}…
+                </div>
+              }
+            >
+              <View
+                params={viewParams}
+                hash={window.location.hash}
+                navigate={navigate}
+                shell={shell}
               />
-            ) : view === "tickets" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading ticket journey…
-                  </div>
-                }
-              >
-                <Ticket
-                  ticketId={focusTicketId}
-                  onNavigate={jumpToTicket}
-                  onNavigatePr={jumpToPr}
-                />
-              </Suspense>
-            ) : view === "prs" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading PR journey…
-                  </div>
-                }
-              >
-                <PullRequest
-                  number={focusPrNumber}
-                  onNavigateTicket={jumpToTicket}
-                />
-              </Suspense>
-            ) : view === "projects" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading projects…
-                  </div>
-                }
-              >
-                <Projects
-                  connected={connected}
-                  focusRepoName={focusRepoName}
-                  onSelectRepo={(name) => navigate(hashPath("projects", name))}
-                />
-              </Suspense>
-            ) : view === "chains" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading chains…</div>
-                }
-              >
-                <Chains
-                  context={context}
-                  initialStateFilter={chainsStateFilter}
-                  onOpenChain={(correlationId) => jumpToChain(correlationId)}
-                />
-              </Suspense>
-            ) : view === "chain" && chainId ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading chain…</div>
-                }
-              >
-                <Chain
-                  correlationId={chainId}
-                  focusNodeId={focusChainNode}
-                  onSelectNode={(id) =>
-                    navigate(hashPath("chain", chainId, id))
-                  }
-                  onJumpEvent={jumpToEvent}
-                  onJumpRun={jumpToRun}
-                  onOpenRunFull={openRunFull}
-                  onJumpProposal={jumpToProposal}
-                  onJumpAgent={jumpToAgent}
-                />
-              </Suspense>
-            ) : view === "graph" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading graph…</div>
-                }
-              >
-                <Graph
-                  context={context}
-                  focusNodeId={focusGraphNode}
-                  onSelectNode={(id) => navigate(hashPath("graph", id))}
-                  onJumpAgent={jumpToAgent}
-                  onJumpEvents={jumpToEvents}
-                  onJumpProposal={jumpToProposal}
-                />
-              </Suspense>
-            ) : view === "agents" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading agents…</div>
-                }
-              >
-                <Agents
-                  context={context}
-                  focusAgentRef={focusAgentRef}
-                  onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
-                />
-              </Suspense>
-            ) : view === "schedules" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading schedules…
-                  </div>
-                }
-              >
-                <Schedules
-                  connected={connected}
-                  context={context}
-                  focusScheduleLoop={focusScheduleLoop}
-                  onSelectSchedule={(loop) =>
-                    navigate(hashPath("schedules", loop))
-                  }
-                  onJumpProposal={jumpToProposal}
-                  onJumpRun={jumpToRun}
-                  onJumpEvent={jumpToEvent}
-                  onJumpAgent={jumpToAgent}
-                  rejumpEpoch={rejumpEpoch}
-                />
-              </Suspense>
-            ) : view === "inbox" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">Loading inbox…</div>
-                }
-              >
-                <Inbox
-                  connected={connected}
-                  focusItemId={focusInboxId}
-                  onSelectItem={(id) => navigate(hashPath("inbox", id))}
-                  onJumpRun={jumpToRun}
-                  onJumpProposal={jumpToProposal}
-                  onJumpEvent={jumpToEvent}
-                />
-              </Suspense>
-            ) : view === "workers" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading workers…
-                  </div>
-                }
-              >
-                <Workers
-                  context={context}
-                  focusWorkerId={focusWorkerId}
-                  onSelectWorker={(id) =>
-                    navigate(workerHash(id, focusWorkerHealth))
-                  }
-                  focusHealth={focusWorkerHealth}
-                  onFocusHealthChange={(health) =>
-                    navigate(workerHash(null, health))
-                  }
-                />
-              </Suspense>
-            ) : view === "artifact" && fullArtifactDigest ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading artifact…
-                  </div>
-                }
-              >
-                <ArtifactFull
-                  digest={fullArtifactDigest}
-                  onBack={() => navigate("artifacts")}
-                  onJumpRun={jumpToRun}
-                />
-              </Suspense>
-            ) : view === "artifacts" || view === "artifact" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading artifacts…
-                  </div>
-                }
-              >
-                <Artifacts
-                  metrics={status.data?.artifacts}
-                  filters={artifactFilters}
-                  onFiltersChange={(filters) =>
-                    navigate(artifactsHash(filters))
-                  }
-                  onJumpRun={jumpToRun}
-                  onOpenFull={openArtifactFull}
-                />
-              </Suspense>
-            ) : view === "metrics" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading metrics…
-                  </div>
-                }
-              >
-                <Metrics />
-              </Suspense>
-            ) : view === "events" ? (
-              <Events
-                connected={connected}
-                context={context}
-                focusEvent={hasEventFocus ? focusEvent : null}
-                onFocusConsumed={() => setEphemeralEvent(null)}
-                onSelectEvent={(source, eventId) =>
-                  navigate(eventsHash(source, eventId, typeFromHash))
-                }
-                onSelectType={(type) =>
-                  navigate(
-                    eventsHash(hashEvent?.source, hashEvent?.eventId, type),
-                  )
-                }
-                onJumpProposal={jumpToProposal}
-                onJumpRun={jumpToRun}
-                onJumpChain={jumpToChain}
-                onTriggerAgain={(envelope) => {
-                  setInjectSeed(envelope);
-                  setInjectOpen(true);
-                }}
-                onInject={() => setInjectOpen(true)}
-                rejumpEpoch={rejumpEpoch}
-              />
-            ) : view === "settings" ? (
-              <Suspense
-                fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading settings…
-                  </div>
-                }
-              >
-                <Settings
-                  focusSectionId={focusSettingsSection}
-                  onSelectSection={(id) => navigate(hashPath("settings", id))}
-                />
-              </Suspense>
-            ) : (
-              <Overview
-                connected={connected}
-                context={context}
-                onJumpRun={jumpToRun}
-                onJumpProposal={jumpToProposal}
-                onJumpEvents={jumpToEvents}
-                onJumpRuns={jumpToRuns}
-                onJumpWorkers={jumpToWorkers}
-                onNavigate={navigate}
-                onJumpExpired={() => {
-                  setFocusExpired(true);
-                  navigate("proposals");
-                }}
-                onJumpGraph={() => jumpToGraph()}
-                onInject={() => setInjectOpen(true)}
-              />
-            )}
+            </Suspense>
           </div>
         </main>
       </div>

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -1,39 +1,12 @@
-// Agents rides `g t` ("what is this agent?"): o/e/p/r are taken, and `g a`
-// would double-fire the proposals view's `a` (approve) list key. Artifacts uses
-// `g y` (the last sound in "artifact") so it does not compete with list `k`.
-// Workers keeps its natural `g w`: `w` is no view's list verb. Inbox takes
-// `g n` ("needs you"): `n` is no view's list verb either, and `g i` is the
-// In-flight context chord (WM-235). Number keys 1–6 belong to an undecided
-// DecisionCard whenever one is on screen (capture-phase window listener, so
-// Inbox's 1–4 status tabs never see them); with no open card the tabs keep
-// their existing binding. Chains rides `g l` ("chain link"): its natural `c`
-// went to Settings (WM-704, config) first (WM-537).
-export type NavGroup = "live" | "work" | "machinery" | "system";
-
-export const NAV = [
-  // Attention / Live Actions (badge-carrying / immediate triage)
-  { key: "overview", label: "Overview", go: "o", group: "live" },
-  { key: "metrics", label: "Metrics", go: "m", group: "live" },
-  { key: "inbox", label: "Inbox", go: "n", group: "live" },
-  { key: "proposals", label: "Proposals", go: "p", group: "live" },
-  { key: "runs", label: "Runs", go: "r", group: "live" },
-  { key: "events", label: "Events", go: "e", group: "live" },
-
-  // Work Journey (artifact and execution lifecycle)
-  { key: "tickets", label: "Tickets", go: "k", group: "work" },
-  { key: "chains", label: "Chains", go: "l", group: "work" },
-  { key: "projects", label: "Projects", go: "f", group: "work" },
-  { key: "artifacts", label: "Artifacts", go: "y", group: "work" },
-
-  // Machinery & Topology (configuration, workers, cadence, graph)
-  { key: "agents", label: "Agents", go: "t", group: "machinery" },
-  { key: "workers", label: "Workers", go: "w", group: "machinery" },
-  { key: "schedules", label: "Schedules", go: "s", group: "machinery" },
-  { key: "graph", label: "Graph", go: "g", group: "machinery" },
-
-  // System
-  { key: "settings", label: "Settings", go: "c", group: "system" },
-] as const;
-
-export type NavItem = (typeof NAV)[number];
-export type NavKey = NavItem["key"];
+// The nav rail is a projection of the view registry (WM-839): one declaration
+// per view in `views/registry.ts` drives the rail, the `g` chords, the ⌘K
+// "Go to" actions, the lazy import and the route resolve. The chord rationale
+// (which suffixes are taken and why) lives at the top of that file, and
+// `views/registry.test.ts` enforces the collision rule. This module keeps the
+// original import path working.
+export {
+  NAV,
+  type NavGroup,
+  type NavItem,
+  type NavKey,
+} from "./views/registry";

--- a/event-runtime/web/src/views/registry.test.ts
+++ b/event-runtime/web/src/views/registry.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { NAV } from "../nav";
+import {
+  NAV as REGISTRY_NAV,
+  RESERVED_GO_SUFFIXES,
+  VIEWS,
+  findView,
+  navIsCurrent,
+  resolveView,
+  viewLabel,
+} from "./registry";
+
+describe("view registry (WM-839)", () => {
+  test("every view has a unique key", () => {
+    const keys = VIEWS.map((v) => v.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    // Every key is a usable first hash segment.
+    for (const key of keys) expect(key).toMatch(/^[a-z]+$/);
+  });
+
+  test("every `g` chord suffix is unique and a single lowercase letter", () => {
+    const chords = NAV.map((n) => n.go);
+    expect(new Set(chords).size).toBe(chords.length);
+    for (const go of chords) expect(go).toMatch(/^[a-z]$/);
+  });
+
+  test("no `g` chord collides with a reserved suffix (list verb or context chord)", () => {
+    // The rule from the registry header: `g a` would double-fire the
+    // proposals view's `a` (approve) list verb, `x` is reject/cancel/resolve,
+    // `g i` and `g 0`–`g 9` are the context chords (WM-235), and `g h` is the
+    // Projects "open on GitHub" chord.
+    for (const n of NAV) {
+      expect(RESERVED_GO_SUFFIXES.has(n.go)).toBe(false);
+    }
+    expect(RESERVED_GO_SUFFIXES.has("a")).toBe(true);
+    expect(RESERVED_GO_SUFFIXES.has("i")).toBe(true);
+    for (let d = 0; d <= 9; d++)
+      expect(RESERVED_GO_SUFFIXES.has(String(d))).toBe(true);
+  });
+
+  test("NAV is a projection of VIEWS: same objects, rail order, only chorded views", () => {
+    expect(NAV).toBe(REGISTRY_NAV);
+    const chorded = VIEWS.filter((v) => v.go !== undefined);
+    expect(NAV.length).toBe(chorded.length);
+    NAV.forEach((n, i) => {
+      // Same object reference: mutating a NAV entry (goSequence.test does) is
+      // seen by everything that derives from VIEWS.
+      expect(n === chorded[i]).toBe(true);
+      expect(n.group).toBeDefined();
+    });
+    expect(NAV.map((n) => n.key)).toEqual([
+      "overview",
+      "metrics",
+      "inbox",
+      "proposals",
+      "runs",
+      "events",
+      "tickets",
+      "chains",
+      "projects",
+      "artifacts",
+      "agents",
+      "workers",
+      "schedules",
+      "graph",
+      "settings",
+    ]);
+  });
+
+  test("every view declares a loader and its focus params", () => {
+    for (const v of VIEWS) {
+      expect(typeof v.load).toBe("function");
+      expect(v.label.length).toBeGreaterThan(0);
+    }
+    expect(findView("runs")?.params).toEqual([":id"]);
+    expect(findView("chain")?.params).toEqual([":correlationId", ":nodeId"]);
+    expect(findView("settings")?.params).toEqual([":section"]);
+    expect(findView("events")?.params).toEqual([":source", ":eventId"]);
+  });
+
+  test("drill-in routes keep their parent nav entry current", () => {
+    expect(findView("run")?.parent).toBe("runs");
+    expect(findView("prs")?.parent).toBe("tickets");
+    expect(findView("chain")?.parent).toBe("chains");
+    expect(findView("artifact")?.parent).toBe("artifacts");
+    expect(navIsCurrent("runs", "run")).toBe(true);
+    expect(navIsCurrent("tickets", "prs")).toBe(true);
+    expect(navIsCurrent("chains", "chain")).toBe(true);
+    expect(navIsCurrent("events", "chain")).toBe(false);
+    expect(navIsCurrent("overview", undefined)).toBe(false);
+  });
+
+  test("resolveView maps a hash route to a view and its params", () => {
+    expect(resolveView([]).def.key).toBe("overview");
+    expect(resolveView(["overview"]).def.key).toBe("overview");
+    expect(resolveView(["runs", "run_1"])).toMatchObject({
+      def: { key: "runs" },
+      params: ["run_1"],
+    });
+    expect(resolveView(["chain", "corr_1", "node_2"])).toMatchObject({
+      def: { key: "chain" },
+      params: ["corr_1", "node_2"],
+    });
+    expect(resolveView(["settings", "storage"])).toMatchObject({
+      def: { key: "settings" },
+      params: ["storage"],
+    });
+    // Unknown first segment: the existing not-found behaviour is Overview.
+    expect(resolveView(["nope"]).def.key).toBe("overview");
+    expect(resolveView(["nope", "x"]).params).toEqual([]);
+  });
+
+  test("id-less drill-in routes fall back to their list view", () => {
+    // `#/run` without an id showed Runs before the registry; keep that.
+    expect(resolveView(["run"]).def.key).toBe("runs");
+    expect(resolveView(["run", "run_9"]).def.key).toBe("run");
+    expect(resolveView(["artifact"]).def.key).toBe("artifacts");
+    expect(resolveView(["artifact", "sha256:1"]).def.key).toBe("artifact");
+    // `#/chain` without a correlation id fell through to Overview.
+    expect(resolveView(["chain"]).def.key).toBe("overview");
+    // `#/prs` without a number is the PR picker, not a fallback.
+    expect(resolveView(["prs"]).def.key).toBe("prs");
+  });
+
+  test("viewLabel names drill-in views and defaults to Overview", () => {
+    expect(viewLabel("runs")).toBe("Runs");
+    expect(viewLabel("run")).toBe("Run");
+    expect(viewLabel("prs")).toBe("PR");
+    expect(viewLabel("chain")).toBe("Chain");
+    expect(viewLabel("artifact")).toBe("Artifact");
+    expect(viewLabel("nope")).toBe("Overview");
+    expect(viewLabel(undefined)).toBe("Overview");
+  });
+});

--- a/event-runtime/web/src/views/registry.ts
+++ b/event-runtime/web/src/views/registry.ts
@@ -1,0 +1,658 @@
+/**
+ * The view registry (WM-839): one declaration per view drives the nav rail,
+ * the `g` chords, the ⌘K "Go to" actions, the lazy import and the hash-route
+ * resolve. Adding a page is one entry here — see docs/event-runtime-webui.md
+ * "Adding a view".
+ *
+ * Chord rationale. Agents rides `g t` ("what is this agent?"): o/e/p/r are
+ * taken, and `g a` would double-fire the proposals view's `a` (approve) list
+ * key. Artifacts uses `g y` (the last sound in "artifact") so it does not
+ * compete with list `k`. Workers keeps its natural `g w`: `w` is no view's
+ * list verb. Inbox takes `g n` ("needs you"): `n` is no view's list verb
+ * either, and `g i` is the In-flight context chord (WM-235). Number keys 1–6
+ * belong to an undecided DecisionCard whenever one is on screen
+ * (capture-phase window listener, so Inbox's 1–4 status tabs never see them);
+ * with no open card the tabs keep their existing binding. Chains rides `g l`
+ * ("chain link"): its natural `c` went to Settings (WM-704, config) first
+ * (WM-537). `RESERVED_GO_SUFFIXES` below encodes the collision rule and
+ * `registry.test.ts` enforces it.
+ */
+import { createElement, lazy, type ComponentType } from "react";
+import type { OperatorContext } from "../context";
+import { artifactsHash, eventsHash, hashPath, hashSearch } from "../hash";
+import type { EventFocus, StatusView } from "../types";
+import type { ArtifactFilters } from "./Artifacts";
+import { Events } from "./Events";
+import { Overview } from "./Overview";
+import { Runs } from "./Runs";
+
+export type NavGroup = "live" | "work" | "machinery" | "system";
+
+export type WorkerHealthFilter = "live" | "busy" | "stale";
+export const isWorkerHealthFilter = (
+  value: string | null,
+): value is WorkerHealthFilter =>
+  value === "live" || value === "busy" || value === "stale";
+
+/**
+ * Cross-view navigation and shared state the shell (App.tsx) owns. Views
+ * never see this directly — each registry entry's adapter projects the slice
+ * a view needs onto that view's own props, so a view stays a plain component
+ * with an explicit contract and the shell stays the one owner of state.
+ */
+export type Shell = {
+  connected: boolean;
+  healthPending: boolean;
+  context: OperatorContext;
+  status: StatusView | undefined;
+  /** Bumped when a jump re-targets the same route so the view re-focuses. */
+  rejumpEpoch: number;
+  focusRunState: string | null;
+  clearFocusRunState: () => void;
+  focusExpired: boolean;
+  setFocusExpired: (next: boolean) => void;
+  ephemeralEvent: EventFocus | null;
+  setEphemeralEvent: (next: EventFocus | null) => void;
+  openInject: (seed?: Record<string, unknown>) => void;
+  jump: {
+    run: (runId: string) => void;
+    runFull: (runId: string) => void;
+    runs: (state?: string) => void;
+    artifactFull: (digest: string) => void;
+    ticket: (ticketId: string) => void;
+    pr: (number: number) => void;
+    proposal: (id: string) => void;
+    event: (source: string, eventId: string, status?: string) => void;
+    events: (focus: EventFocus) => void;
+    agent: (ref: string) => void;
+    workers: (health: WorkerHealthFilter) => void;
+    graph: (nodeId?: string) => void;
+    chain: (correlationId: string, nodeId?: string) => void;
+  };
+};
+
+/** What every registered view component receives. */
+export type ViewProps = {
+  /** Hash segments after the view key: `#/chain/:id/:node` → `[id, node]`. */
+  params: readonly string[];
+  /** `window.location.hash` at render time — query filters live there. */
+  hash: string;
+  /** Navigate to a hash path (project context is carried over by the shell). */
+  navigate: (path: string) => void;
+  shell: Shell;
+};
+
+export type ViewDef = {
+  /** First hash segment (`#/<key>`); also the nav-rail identity. */
+  key: string;
+  /** Rail / page-title label. */
+  label: string;
+  /** `g <go>` chord suffix. Absent for drill-in routes reached from a parent view. */
+  go?: string;
+  /** Rail group; absent for routes that are not on the rail. */
+  group?: NavGroup;
+  /** Lazy loader — the view chunk is fetched the first time the route renders. */
+  load: () => Promise<{ default: ComponentType<ViewProps> }>;
+  /** Documented focus params after the key, e.g. `[":id"]` for `#/runs/:id`. */
+  params?: readonly string[];
+  /** Nav key that stays `aria-current` while this drill-in route is shown. */
+  parent?: string;
+  /** View to render instead when the first param is missing (`#/run` → runs). */
+  fallback?: string;
+  /** Suspense fallback noun; defaults to the lowercased label. */
+  loading?: string;
+  /**
+   * First-paint views ship in the entry chunk (vite.config.ts budget: Overview,
+   * Runs and Events stay eager). Set, the shell renders it directly and `load`
+   * resolves to the same component.
+   */
+  component?: ComponentType<ViewProps>;
+};
+
+/**
+ * `g` suffixes no view may take: `a` approve/ack, `x` reject/cancel/resolve
+ * (single-key list verbs that would double-fire under the chord), `i` and
+ * `0`–`9` (context chords, WM-235), and `h` (Projects' `g h` opens GitHub).
+ */
+export const RESERVED_GO_SUFFIXES: ReadonlySet<string> = new Set([
+  "a",
+  "x",
+  "i",
+  "h",
+  ..."0123456789",
+]);
+
+/** Adapt a view's own props to the registry contract without touching the view. */
+function adapt<P extends object>(
+  Component: ComponentType<P>,
+  map: (v: ViewProps) => P,
+): ComponentType<ViewProps> {
+  const Adapted = (v: ViewProps) => createElement(Component, map(v));
+  Adapted.displayName = `View(${Component.displayName ?? Component.name})`;
+  return Adapted;
+}
+
+/** Lazy-import a named export and adapt it. */
+function load<M, K extends keyof M>(
+  importer: () => Promise<M>,
+  name: K,
+  map: M[K] extends ComponentType<infer P> ? (v: ViewProps) => P : never,
+): () => Promise<{ default: ComponentType<ViewProps> }> {
+  return () =>
+    importer().then((m) => ({
+      default: adapt(
+        m[name] as ComponentType<object>,
+        map as (v: ViewProps) => object,
+      ),
+    }));
+}
+
+const at = (params: readonly string[], i: number) => params[i] ?? null;
+
+export function listSelectionPath(
+  view: "runs" | "proposals",
+  id: string | null,
+  hash: string,
+) {
+  const path = hashPath(view, id);
+  const query = hashSearch(hash);
+  if (!query.has("population") || !query.has("from") || !query.has("to"))
+    return path;
+  query.delete("project");
+  return `${path}?${query.toString()}`;
+}
+
+export const workerHash = (
+  id: string | null,
+  health: WorkerHealthFilter | null,
+) => {
+  const path = hashPath("workers", id);
+  return health ? `${path}?health=${encodeURIComponent(health)}` : path;
+};
+
+// First-paint views (entry chunk, no Suspense flash on the operator's landing).
+const OverviewView = adapt(Overview, ({ navigate, shell }) => ({
+  connected: shell.connected,
+  context: shell.context,
+  onJumpRun: shell.jump.run,
+  onJumpProposal: shell.jump.proposal,
+  onJumpEvents: shell.jump.events,
+  onJumpRuns: shell.jump.runs,
+  onJumpWorkers: shell.jump.workers,
+  onNavigate: navigate,
+  onJumpExpired: () => {
+    shell.setFocusExpired(true);
+    navigate("proposals");
+  },
+  onJumpGraph: () => shell.jump.graph(),
+  onInject: () => shell.openInject(),
+}));
+
+const RunsView = adapt(Runs, ({ params, navigate, shell }) => ({
+  connected: shell.connected,
+  context: shell.context,
+  focusRunId: at(params, 0),
+  onSelectRun: (id: string | null) =>
+    navigate(listSelectionPath("runs", id, window.location.hash)),
+  onOpenFull: shell.jump.runFull,
+  focusState: shell.focusRunState,
+  onFocusStateConsumed: shell.clearFocusRunState,
+  onJumpAgent: shell.jump.agent,
+  onJumpEvent: shell.jump.event,
+  onJumpProposal: shell.jump.proposal,
+  rejumpEpoch: shell.rejumpEpoch,
+}));
+
+const EventsView = adapt(Events, ({ params, hash, navigate, shell }) => {
+  const source = at(params, 0);
+  const eventId = at(params, 1);
+  const hashEvent: EventFocus | null =
+    source && eventId ? { source, eventId } : null;
+  const typeFromHash = hashSearch(hash).get("type");
+  const focusEvent: EventFocus = {
+    ...(shell.ephemeralEvent ?? {}),
+    ...(typeFromHash ? { type: typeFromHash } : {}),
+    ...(hashEvent ?? {}),
+  };
+  const hasEventFocus = !!(
+    focusEvent.source ||
+    focusEvent.eventId ||
+    focusEvent.status ||
+    focusEvent.type
+  );
+  return {
+    connected: shell.connected,
+    context: shell.context,
+    focusEvent: hasEventFocus ? focusEvent : null,
+    onFocusConsumed: () => shell.setEphemeralEvent(null),
+    onSelectEvent: (s: string | null, e?: string) =>
+      navigate(eventsHash(s, e, typeFromHash)),
+    onSelectType: (type: string | null) =>
+      navigate(eventsHash(hashEvent?.source, hashEvent?.eventId, type)),
+    onJumpProposal: shell.jump.proposal,
+    onJumpRun: shell.jump.run,
+    onJumpChain: shell.jump.chain,
+    onTriggerAgain: (envelope: Record<string, unknown>) =>
+      shell.openInject(envelope),
+    onInject: () => shell.openInject(),
+    rejumpEpoch: shell.rejumpEpoch,
+  };
+});
+
+const eager = (component: ComponentType<ViewProps>) => ({
+  component,
+  load: () => Promise.resolve({ default: component }),
+});
+
+const DEFS = [
+  // Attention / Live Actions (badge-carrying / immediate triage)
+  {
+    key: "overview",
+    label: "Overview",
+    go: "o",
+    group: "live",
+    params: [],
+    ...eager(OverviewView),
+  },
+  {
+    key: "metrics",
+    label: "Metrics",
+    go: "m",
+    group: "live",
+    params: [],
+    load: load(
+      () => import("./Metrics"),
+      "Metrics",
+      () => ({}),
+    ),
+  },
+  {
+    key: "inbox",
+    label: "Inbox",
+    go: "n",
+    group: "live",
+    // `#/inbox/:id` — the Telegram push deep-links here (lib/inbox.mjs telegramMessage).
+    params: [":id"],
+    load: load(
+      () => import("./Inbox"),
+      "Inbox",
+      ({ params, navigate, shell }) => ({
+        connected: shell.connected,
+        focusItemId: at(params, 0),
+        onSelectItem: (id) => navigate(hashPath("inbox", id)),
+        onJumpRun: shell.jump.run,
+        onJumpProposal: shell.jump.proposal,
+        onJumpEvent: shell.jump.event,
+      }),
+    ),
+  },
+  {
+    key: "proposals",
+    label: "Proposals",
+    go: "p",
+    group: "live",
+    params: [":id"],
+    load: load(
+      () => import("./Proposals"),
+      "Proposals",
+      ({ params, navigate, shell }) => ({
+        connected: shell.connected,
+        healthPending: shell.healthPending,
+        context: shell.context,
+        onRunQueued: shell.jump.run,
+        focusProposalId: at(params, 0),
+        onSelectProposal: (id) =>
+          navigate(listSelectionPath("proposals", id, window.location.hash)),
+        focusExpired: shell.focusExpired,
+        onFocusExpiredConsumed: () => shell.setFocusExpired(false),
+        onJumpAgent: shell.jump.agent,
+        onJumpEvent: shell.jump.event,
+        rejumpEpoch: shell.rejumpEpoch,
+      }),
+    ),
+  },
+  {
+    key: "runs",
+    label: "Runs",
+    go: "r",
+    group: "live",
+    params: [":id"],
+    ...eager(RunsView),
+  },
+  {
+    key: "events",
+    label: "Events",
+    go: "e",
+    group: "live",
+    params: [":source", ":eventId"],
+    ...eager(EventsView),
+  },
+
+  // Work Journey (artifact and execution lifecycle)
+  {
+    key: "tickets",
+    label: "Tickets",
+    go: "k",
+    group: "work",
+    // An id-less route presents the ticket picker.
+    params: [":id"],
+    loading: "ticket journey",
+    load: load(
+      () => import("./Ticket"),
+      "Ticket",
+      ({ params, shell }) => ({
+        ticketId: at(params, 0),
+        onNavigate: shell.jump.ticket,
+        onNavigatePr: shell.jump.pr,
+      }),
+    ),
+  },
+  {
+    key: "chains",
+    label: "Chains",
+    go: "l",
+    group: "work",
+    params: [],
+    load: load(
+      () => import("./Chains"),
+      "Chains",
+      ({ hash, shell }) => ({
+        context: shell.context,
+        initialStateFilter: hashSearch(hash).get("state"),
+        onOpenChain: (correlationId) => shell.jump.chain(correlationId),
+      }),
+    ),
+  },
+  {
+    key: "projects",
+    label: "Projects",
+    go: "f",
+    group: "work",
+    params: [":name"],
+    load: load(
+      () => import("./Projects"),
+      "Projects",
+      ({ params, navigate, shell }) => ({
+        connected: shell.connected,
+        focusRepoName: at(params, 0),
+        onSelectRepo: (name) => navigate(hashPath("projects", name)),
+      }),
+    ),
+  },
+  {
+    key: "artifacts",
+    label: "Artifacts",
+    go: "y",
+    group: "work",
+    params: [],
+    load: load(
+      () => import("./Artifacts"),
+      "Artifacts",
+      ({ hash, navigate, shell }) => {
+        const query = hashSearch(hash);
+        const filters: ArtifactFilters = {
+          kind: query.get("kind"),
+          orphan: query.has("orphan") ? query.get("orphan") === "true" : null,
+          search: query.get("search") ?? "",
+        };
+        return {
+          metrics: shell.status?.artifacts,
+          filters,
+          onFiltersChange: (next) => navigate(artifactsHash(next)),
+          onJumpRun: shell.jump.run,
+          onOpenFull: shell.jump.artifactFull,
+        };
+      },
+    ),
+  },
+
+  // Machinery & Topology (configuration, workers, cadence, graph)
+  {
+    key: "agents",
+    label: "Agents",
+    go: "t",
+    group: "machinery",
+    params: [":ref"],
+    load: load(
+      () => import("./Agents"),
+      "Agents",
+      ({ params, navigate, shell }) => ({
+        context: shell.context,
+        focusAgentRef: at(params, 0),
+        onSelectAgent: (ref) => navigate(hashPath("agents", ref)),
+      }),
+    ),
+  },
+  {
+    key: "workers",
+    label: "Workers",
+    go: "w",
+    group: "machinery",
+    params: [":id"],
+    load: load(
+      () => import("./Workers"),
+      "Workers",
+      ({ params, hash, navigate, shell }) => {
+        const healthFromHash = hashSearch(hash).get("health");
+        const focusHealth = isWorkerHealthFilter(healthFromHash)
+          ? healthFromHash
+          : null;
+        return {
+          context: shell.context,
+          focusWorkerId: at(params, 0),
+          onSelectWorker: (id) => navigate(workerHash(id, focusHealth)),
+          focusHealth,
+          onFocusHealthChange: (health) => navigate(workerHash(null, health)),
+        };
+      },
+    ),
+  },
+  {
+    key: "schedules",
+    label: "Schedules",
+    go: "s",
+    group: "machinery",
+    params: [":loop"],
+    load: load(
+      () => import("./Schedules"),
+      "Schedules",
+      ({ params, navigate, shell }) => ({
+        connected: shell.connected,
+        context: shell.context,
+        focusScheduleLoop: at(params, 0),
+        onSelectSchedule: (loop) => navigate(hashPath("schedules", loop)),
+        onJumpProposal: shell.jump.proposal,
+        onJumpRun: shell.jump.run,
+        onJumpEvent: shell.jump.event,
+        onJumpAgent: shell.jump.agent,
+        rejumpEpoch: shell.rejumpEpoch,
+      }),
+    ),
+  },
+  {
+    key: "graph",
+    label: "Graph",
+    go: "g",
+    group: "machinery",
+    params: [":nodeId"],
+    load: load(
+      () => import("./Graph"),
+      "Graph",
+      ({ params, navigate, shell }) => ({
+        context: shell.context,
+        focusNodeId: at(params, 0),
+        onSelectNode: (id) => navigate(hashPath("graph", id)),
+        onJumpAgent: shell.jump.agent,
+        onJumpEvents: shell.jump.events,
+        onJumpProposal: shell.jump.proposal,
+      }),
+    ),
+  },
+
+  // System
+  {
+    key: "settings",
+    label: "Settings",
+    go: "c",
+    group: "system",
+    params: [":section"],
+    load: load(
+      () => import("./Settings"),
+      "Settings",
+      ({ params, navigate }) => ({
+        focusSectionId: at(params, 0),
+        onSelectSection: (id) => navigate(hashPath("settings", id)),
+      }),
+    ),
+  },
+
+  // Drill-in routes: reached from a parent view (or ⌘K), not from the rail.
+  // Distinct first segments so crossing from the list pushes history and Back
+  // restores the panel.
+  {
+    key: "run",
+    label: "Run",
+    parent: "runs",
+    fallback: "runs",
+    params: [":id"],
+    load: load(
+      () => import("./RunFull"),
+      "RunFull",
+      ({ params, navigate, shell }) => {
+        const runId = params[0]!;
+        return {
+          runId,
+          connected: shell.connected,
+          onBack: () => navigate(hashPath("runs", runId)),
+          onJumpAgent: shell.jump.agent,
+          onJumpEvent: shell.jump.event,
+          onJumpProposal: shell.jump.proposal,
+          onJumpChain: shell.jump.chain,
+        };
+      },
+    ),
+  },
+  {
+    // The PR journey (WM-640) shares the ticket journey chunk — same layout,
+    // other subject.
+    key: "prs",
+    label: "PR",
+    parent: "tickets",
+    params: [":number"],
+    loading: "PR journey",
+    load: load(
+      () => import("./Ticket"),
+      "PullRequest",
+      ({ params, shell }) => ({
+        number: at(params, 0),
+        onNavigateTicket: shell.jump.ticket,
+      }),
+    ),
+  },
+  {
+    // `#/chain/:correlationId[/:nodeId]` — the chain trace (WM-527); node
+    // selection rides the hash so a pasted link lands on the same node.
+    key: "chain",
+    label: "Chain",
+    parent: "chains",
+    fallback: "overview",
+    params: [":correlationId", ":nodeId"],
+    load: load(
+      () => import("./Chain"),
+      "Chain",
+      ({ params, navigate, shell }) => {
+        const correlationId = params[0]!;
+        return {
+          correlationId,
+          focusNodeId: at(params, 1),
+          onSelectNode: (id) => navigate(hashPath("chain", correlationId, id)),
+          onJumpEvent: shell.jump.event,
+          onJumpRun: shell.jump.run,
+          onOpenRunFull: shell.jump.runFull,
+          onJumpProposal: shell.jump.proposal,
+          onJumpAgent: shell.jump.agent,
+        };
+      },
+    ),
+  },
+  {
+    // `#/artifact/:digest` is the full-page artifact reader view (WM-828).
+    key: "artifact",
+    label: "Artifact",
+    parent: "artifacts",
+    fallback: "artifacts",
+    params: [":digest"],
+    load: load(
+      () => import("./ArtifactFull"),
+      "ArtifactFull",
+      ({ params, navigate, shell }) => ({
+        digest: params[0]!,
+        onBack: () => navigate("artifacts"),
+        onJumpRun: shell.jump.run,
+      }),
+    ),
+  },
+] as const satisfies readonly ViewDef[];
+
+/** Every view, rail order first, then the drill-in routes. */
+export const VIEWS: readonly ViewDef[] = DEFS;
+
+export type ViewKey = (typeof DEFS)[number]["key"];
+export type NavItem = ViewDef & { key: NavKey; go: string; group: NavGroup };
+export type NavKey = Extract<(typeof DEFS)[number], { go: string }>["key"];
+
+/**
+ * The nav rail: the chorded, grouped subset of VIEWS — same objects, so a
+ * consumer that reads NAV sees exactly what the shell derives from VIEWS.
+ */
+export const NAV: readonly NavItem[] = VIEWS.filter(
+  (v): v is NavItem => v.go !== undefined && v.group !== undefined,
+);
+
+const byKey = new Map<string, ViewDef>(VIEWS.map((v) => [v.key, v]));
+const DEFAULT_VIEW = byKey.get("overview")!;
+
+export function findView(key: string | undefined): ViewDef | undefined {
+  return key === undefined ? undefined : byKey.get(key);
+}
+
+/** Rail entry `key` stays current on its own route and on its drill-ins. */
+export function navIsCurrent(key: string, view?: string): boolean {
+  return key === view || (view !== undefined && findView(view)?.parent === key);
+}
+
+/** Page-title / rail label for the current first segment. */
+export function viewLabel(view: string | undefined): string {
+  return findView(view)?.label ?? DEFAULT_VIEW.label;
+}
+
+/**
+ * Hash segments → the view to render and its params. Unknown keys land on
+ * Overview (the pre-registry not-found behaviour); an id-less drill-in falls
+ * back to its list view.
+ */
+export function resolveView(route: readonly string[]): ResolvedView {
+  const def = findView(route[0] ?? DEFAULT_VIEW.key);
+  if (!def) return resolved(DEFAULT_VIEW, []);
+  if (def.fallback && !route[1]) {
+    return resolved(byKey.get(def.fallback) ?? DEFAULT_VIEW, []);
+  }
+  return resolved(def, route.slice(1));
+}
+
+export type ResolvedView = {
+  def: ViewDef;
+  params: string[];
+  /** Stable per view: the eager component, or the one `lazy(def.load)` made at module load. */
+  component: ComponentType<ViewProps>;
+};
+
+// One lazy() per view, created once — a fresh lazy() per render would remount
+// the view (and refetch its chunk's module state) on every shell re-render.
+const components = new Map<string, ComponentType<ViewProps>>(
+  VIEWS.map((v) => [v.key, v.component ?? lazy(v.load)]),
+);
+
+function resolved(def: ViewDef, params: string[]): ResolvedView {
+  return { def, params, component: components.get(def.key)! };
+}


### PR DESCRIPTION
Adds \`event-runtime/web/src/views/registry.ts\`: one \`ViewDef\` per view (key, label, \`g\` chord, rail group, focus params, lazy \`load\` + adapter from the shell slice to the view's own props). \`NAV\` in \`nav.ts\` is now a projection of \`VIEWS\` (same objects, same exported shape), so \`ShortcutsDialog\`, the palette and the chords all derive from the registry.

\`App.tsx\` drops the 16 hand-written \`lazy()\` view imports, the per-view focus-param derivations and the 18-branch render switch: it calls \`resolveView(route)\` and renders the resolved component inside one Suspense boundary. Unknown keys still land on Overview; id-less \`#/run\` / \`#/artifact\` still fall back to their list views; drill-ins (\`run\`, \`prs\`, \`chain\`, \`artifact\`) declare their \`parent\` so \`aria-current\` behaviour is unchanged. Overview, Runs and Events stay eager (entry chunk) via \`component\`.

\`registry.test.ts\` encodes the chord rule from the old \`nav.ts\` header (unique keys, unique single-letter chords, no reserved suffix: \`a\`/\`x\`/\`i\`/\`h\`/\`0-9\`), the NAV-is-a-projection invariant, and route resolve/fallback/label lookups. \`App.test.tsx\` gains three registry-routing cases. Docs: new "4.0 Adding a view" section.

Behaviour-preserving refactor, no user-visible change. Build: entry chunk 616.62 kB (develop: 616.80 kB), all view chunks still separate, budget check green.

Verification: \`cd event-runtime/web && bun install --frozen-lockfile && bun run build && cd ../.. && bun test --timeout 20000 event-runtime/web/src/App.test.tsx event-runtime/web/src/hooks.test.tsx event-runtime/web/src/goSequence.test.ts event-runtime/web/src/views/registry.test.ts && bun run lint --max-warnings=627\` — pass (57 tests, 0 lint errors); full \`bun test event-runtime/web/src\` 1152 pass.

Fixes WM-839