### PR TITLE
ui-ux(web): run header copy icons on the title row (WM-848)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -722,30 +722,29 @@ standard `Esc` close exception remains unbadged. A verb reachable only through
 
 #### DetailPane header actions (WM-209)
 
-The pane header is three rows, and each row holds one kind of thing:
+The pane header is two rows; copy lives with the id so it is not a third
+toolbar:
 
 ```
-Runs / [● STATE]  run_xxxx                          [Close]
+Runs / [● STATE]  run_xxxx  [id] [CLI] [link]          [Close]
 [Cancel x]                            [Expand o]  [Open in tab]
-CopyActions: [id icon] · [CLI icon] · [link icon]
 ```
 
-1. **Title row** — breadcrumb (`view / StateBadge id`) and the single
-   `close` slot (WM-97). `Close` is not badged with `Esc`; dismissal is the
-   standard global exception in the keyboard-hint table above.
+1. **Title row** — breadcrumb (`view / StateBadge shortId`) and the single
+   `close` slot (WM-97). `CopyActions` (WM-302) sits after the id, still a
+   utility control (`title` + `aria-label` for `c` / `c i` / `c l`). `Close`
+   is not badged with `Esc`; dismissal is the standard global exception in
+   the keyboard-hint table above. The full-page run view (`RunFull`) puts
+   navigation verbs (`View chain`, `Open in tab`) on this row’s right and
+   omits the verb row when the run has no lifecycle action.
 2. **Verb row** — bordered `Button`s, **≤ 3**: lifecycle verbs on the left
    (`danger` leftmost, hidden — not disabled — when the state does not admit
-   it), navigation verbs (Expand, Open in tab) on the right. This is where a
-   lifecycle verb lives; it never floats between content sections.
-3. **Utility row** — copy/share controls use the compact icon-only
-   `<CopyActions />` component (WM-302), not text links or bordered buttons.
-   Each icon button conveys its label and chord through `title` and
-   `aria-label` (`c`, `c i`, or `c l`) rather than a visible hint. Anything
-   here is also registered in ⌘K. Do not add a copy action for a value that
-   `KV` already copies on click. A read-only pane may co-locate `CopyActions`
-   with the identifier in the title row instead of rendering an otherwise
-   empty utility row; it remains a utility control and follows the same
-   tooltip/accessibility rule (as in Agents, §10.6).
+   it), navigation verbs (Expand, Open in tab) on the right in the list pane.
+   This is where a lifecycle verb lives; it never floats between content
+   sections. RUNNING deadline changes are one `Extend…` (dialog holds +15m /
+   +30m presets and the custom minutes field), not three header buttons.
+3. **Utility** — not its own row. Do not add a copy action for a value that
+   `KV` already copies on click. Anything here is also registered in ⌘K.
 
 Bordered buttons all carry equal visual weight, so five in a row is five
 things claiming priority; the row split is what expresses hierarchy without

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -691,6 +691,29 @@ describe("DetailPane", () => {
     );
     expect(r.queryByText("Close")).toBeNull();
   });
+
+  test("places utility on the title row with Close, not a third row (WM-848)", () => {
+    const r = render(
+      <DetailPane
+        widthClass="w-[460px]"
+        title={<span>run_0000</span>}
+        utility={<span>utility-slot</span>}
+        actions={<Button onClick={() => {}}>Expand</Button>}
+        close={<Button onClick={() => {}}>Close</Button>}
+      >
+        <div>body</div>
+      </DetailPane>,
+    );
+    const chrome = r.getByText("run_0000").closest(".border-b");
+    expect(chrome).toBeTruthy();
+    const rows = [...(chrome?.children ?? [])];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain("run_0000");
+    expect(rows[0]?.textContent).toContain("utility-slot");
+    expect(rows[0]?.textContent).toContain("Close");
+    expect(rows[1]?.textContent).toContain("Expand");
+    expect(rows[1]?.textContent).not.toContain("utility-slot");
+  });
 });
 
 describe("getValueHue", () => {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -227,8 +227,8 @@ export function CopyActions({
   idChord?: string;
   cli?: string;
   cliLabel?: string;
-  /** Quiet text links suit the utility row below a detail header; icons remain
-   *  the compact default for inline use on other surfaces. */
+  /** Quiet text links are a denser label style for metadata rows (e.g. artifact
+   *  headers). Detail-pane and run headers use the icon default (WM-848). */
   variant?: "icons" | "quiet";
 }) {
   if (variant === "quiet") {
@@ -797,7 +797,7 @@ export function ListPane({
 }
 
 /**
- * Shared detail-pane chrome: identity and Close, then verbs, then copy/share.
+ * Shared detail-pane chrome: identity + copy/share + Close, then verbs.
  * Keeping these rows here prevents each view from inventing its own spacing or
  * moving a primary action above the selected record's identity (WM-552).
  */
@@ -817,10 +817,18 @@ export function PaneHeader({
 }) {
   return (
     <div className="shrink-0 border-b border-(--border) px-4 py-3">
-      {/* Row 1: Title & Close */}
+      {/* Row 1: Title, copy/share, Close. Utility sits here so an otherwise
+          empty third row does not stack under the verbs (WM-848). */}
       <div className="flex items-center justify-between gap-2">
-        <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">
-          {title}
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">
+            {title}
+          </div>
+          {utility != null && (
+            <div className="shrink-0 text-xs text-(--text-faint)">
+              {utility}
+            </div>
+          )}
         </div>
         {close != null && <div className="shrink-0">{close}</div>}
       </div>
@@ -828,12 +836,6 @@ export function PaneHeader({
       {actions != null && (
         <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">
           {actions}
-        </div>
-      )}
-      {/* Row 3: Utility Row (copy/share quiet text line) */}
-      {utility != null && (
-        <div className="mt-2 flex flex-wrap items-center gap-x-2 text-xs text-(--text-faint)">
-          {utility}
         </div>
       )}
     </div>

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -12,6 +12,7 @@ import {
   restoreApi,
   withApi,
 } from "../test-render";
+import { shortId } from "../components/ui";
 import type { RunDetail } from "../types";
 
 afterEach(() => {
@@ -112,10 +113,15 @@ describe("RunFull header (WM-193)", () => {
 
         const header = container.querySelector("header");
         expect(header?.textContent).toContain("← Runs");
-        expect(header?.textContent).toContain(runId);
+        expect(header?.textContent).toContain(shortId(runId));
         expect(header?.textContent).toContain("RUNNING");
+        expect(header?.textContent).not.toContain("copy:");
+        expect(header?.querySelector(`[title="${runId}"]`)?.textContent).toBe(
+          shortId(runId),
+        );
         expect(getByRole("button", { name: /Open in tab/ })).toBeTruthy();
         expect(getByRole("button", { name: /Cancel/ })).toBeTruthy();
+        expect(getByRole("button", { name: "Copy run id (c)" })).toBeTruthy();
         expect(header?.textContent).not.toContain("header-agent@1");
         expect(header?.textContent).not.toContain("header-adapter");
         expect(header?.textContent).not.toContain("2/5 attempts");
@@ -124,6 +130,31 @@ describe("RunFull header (WM-193)", () => {
         expect(sidebar?.textContent).toContain("header-agent@1");
         expect(sidebar?.textContent).toContain("header-adapter");
         expect(sidebar?.textContent).toContain("2/5");
+      },
+    );
+  });
+
+  test("completed runs keep copy icons on the title row and omit the verb row (WM-848)", async () => {
+    const runId = "run_completed_header";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "COMPLETED" } as RunDetail["run"],
+    });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "COMPLETED" })],
+        }),
+      },
+      async () => {
+        const { container, getByRole, queryByRole } = renderRunFull(runId);
+        await waitFor(() => getByRole("button", { name: /Open in tab/ }));
+        const header = container.querySelector("header");
+        expect(header?.textContent).toContain(shortId(runId));
+        expect(header?.textContent).not.toContain("copy:");
+        expect(queryByRole("button", { name: /^Cancel$/ })).toBeNull();
+        expect(queryByRole("button", { name: "Extend…" })).toBeNull();
+        expect(getByRole("button", { name: "Copy run id (c)" })).toBeTruthy();
       },
     );
   });
@@ -205,11 +236,14 @@ describe("RunFull deadline extension (WM-566)", () => {
           await waitFor(() => getByText(/Remaining/));
           expect(getByText(/Remaining/).textContent).toContain("30m");
 
-          fireEvent.click(getByRole("button", { name: "+15m" }));
+          fireEvent.click(getByRole("button", { name: "Extend…" }));
+          fireEvent.click(
+            within(getByRole("dialog")).getByRole("button", { name: "+15m" }),
+          );
           await waitFor(() => expect(calls).toEqual([900]));
           expect(getByText(/Run extended by 15 minutes/)).toBeTruthy();
 
-          fireEvent.click(getByRole("button", { name: "Custom…" }));
+          fireEvent.click(getByRole("button", { name: "Extend…" }));
           const input = getByLabelText("Extension minutes");
           changeInput(input as HTMLInputElement, "0");
           expect(input.getAttribute("aria-invalid")).toBe("true");
@@ -234,7 +268,7 @@ describe("RunFull deadline extension (WM-566)", () => {
     }
   });
 
-  test("preset refusal is visible without opening the custom dialog", async () => {
+  test("preset refusal stays visible in the extend dialog", async () => {
     const runId = "run_extend_refused";
     const detail = createRunDetailFixture({
       run: { runId, state: "RUNNING" } as RunDetail["run"],
@@ -265,11 +299,14 @@ describe("RunFull deadline extension (WM-566)", () => {
           }),
         },
         async () => {
-          const { getByRole, getByText, queryByRole } = renderRunFull(runId);
-          await waitFor(() => getByRole("button", { name: "+30m" }));
-          fireEvent.click(getByRole("button", { name: "+30m" }));
+          const { getByRole, getByText } = renderRunFull(runId);
+          await waitFor(() => getByRole("button", { name: "Extend…" }));
+          fireEvent.click(getByRole("button", { name: "Extend…" }));
+          fireEvent.click(
+            within(getByRole("dialog")).getByRole("button", { name: "+30m" }),
+          );
           await waitFor(() => getByText("deadline_already_expired"));
-          expect(queryByRole("dialog")).toBeNull();
+          expect(getByRole("dialog")).toBeTruthy();
         },
       );
     } finally {
@@ -298,11 +335,11 @@ describe("RunFull deadline extension (WM-566)", () => {
       },
       async () => {
         const { getByRole } = renderRunFull(runId, false);
-        const custom = await waitFor(() =>
-          getByRole("button", { name: "Custom…" }),
+        const extend = await waitFor(() =>
+          getByRole("button", { name: "Extend…" }),
         );
-        expect(custom.hasAttribute("disabled")).toBe(false);
-        fireEvent.click(custom);
+        expect(extend.hasAttribute("disabled")).toBe(false);
+        fireEvent.click(extend);
         expect(
           within(getByRole("dialog"))
             .getByRole("button", { name: "Extend run" })
@@ -402,27 +439,26 @@ describe("RunFull header copy verbs and hints (WM-218)", () => {
         }),
       },
       async () => {
-        const { getByRole } = renderRunFull(runId);
+        const { getByRole, getAllByRole } = renderRunFull(runId);
         await waitFor(() => getByRole("button", { name: /← Runs/ }));
 
         expect(getByRole("button", { name: /← Runs/ }).textContent).toContain(
           "Esc",
         );
+        expect(getByRole("button", { name: "Copy run id (c)" })).toBeTruthy();
         expect(
-          getByRole("button", { name: "Copy run id (c)" }).getAttribute(
-            "title",
-          ),
-        ).toBe("Copy run id · c");
+          getByRole("button", { name: "Copy CLI inspect command (c i)" }),
+        ).toBeTruthy();
+        expect(getByRole("button", { name: "Copy link (c l)" })).toBeTruthy();
         expect(
-          getByRole("button", {
-            name: "Copy CLI inspect command (c i)",
-          }).getAttribute("title"),
-        ).toBe("Copy CLI inspect command · c i");
-        expect(
-          getByRole("button", { name: "Copy link (c l)" }).getAttribute(
-            "title",
-          ),
-        ).toBe("Copy link · c l");
+          getAllByRole("tooltip").map((tooltip) => tooltip.textContent),
+        ).toEqual(
+          expect.arrayContaining([
+            "Copy run id · c",
+            "Copy CLI inspect command · c i",
+            "Copy link · c l",
+          ]),
+        );
       },
     );
   });

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -362,6 +362,14 @@ export function RunFull({
                   },
             ]
           : []),
+        ...(["RUNNING", "VERIFYING"].includes(d.run.state)
+          ? [
+              {
+                label: `Extend ${d.run.runId}…`,
+                run: () => setCustomExtend(true),
+              },
+            ]
+          : []),
         ...copy,
       ]);
     }
@@ -376,52 +384,104 @@ export function RunFull({
     selProposal,
   ]);
 
+  const inflight = Boolean(d && ["RUNNING", "VERIFYING"].includes(d.run.state));
+  const showVerbRow =
+    Boolean(canApprove && selProposal) ||
+    Boolean(d && isCancellable(d.run.state)) ||
+    inflight ||
+    Boolean(d && d.run.state === "FAILED");
+
   return (
     <div className="fixed inset-0 z-20 flex h-full min-w-0 flex-col overflow-hidden bg-(--surface-0) sm:static sm:z-auto">
       <header className="sticky top-0 z-10 flex shrink-0 flex-col items-stretch gap-2 border-b border-(--border) bg-(--surface-1) px-6 py-3">
-        <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-2">
-            <ol className="flex min-w-0 flex-wrap items-center gap-2 list-none p-0 m-0 text-[13px]">
-              <li className="shrink-0">
-                <Button onClick={onBack}>
-                  <span>← Runs</span>
-                  <span
-                    aria-hidden="true"
-                    className="mono ml-1 text-(--text-faint) text-xs"
-                  >
-                    Esc
-                  </span>
-                </Button>
-              </li>
-              <li aria-hidden="true" className="text-(--text-faint) shrink-0">
-                /
-              </li>
-              <li
-                className="flex min-w-0 items-center gap-2"
-                aria-current="page"
-              >
-                {(d?.run.state || listRow?.state) && (
-                  <StateBadge state={d?.run.state ?? listRow!.state} />
-                )}
-                <span
-                  className="display min-w-0 truncate text-[15px] font-semibold text-(--text)"
-                  title={d?.subject ? `${d.subject} · ${runId}` : runId}
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-2"
+            >
+              <ol className="m-0 flex min-w-0 list-none flex-wrap items-center gap-2 p-0 text-[13px]">
+                <li className="shrink-0">
+                  <Button onClick={onBack}>
+                    <span>← Runs</span>
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-xs text-(--text-faint)"
+                    >
+                      Esc
+                    </span>
+                  </Button>
+                </li>
+                <li aria-hidden="true" className="shrink-0 text-(--text-faint)">
+                  /
+                </li>
+                <li
+                  className="flex min-w-0 items-center gap-2"
+                  aria-current="page"
                 >
-                  {d?.subject ? (
-                    <TicketText text={d.subject} />
-                  ) : (
-                    <span className="mono">{runId}</span>
+                  {(d?.run.state || listRow?.state) && (
+                    <StateBadge state={d?.run.state ?? listRow!.state} />
                   )}
+                  <span
+                    className="display min-w-0 truncate text-[15px] font-semibold text-(--text)"
+                    title={d?.subject ? `${d.subject} · ${runId}` : runId}
+                  >
+                    {d?.subject ? (
+                      <TicketText text={d.subject} />
+                    ) : (
+                      <span className="mono">{shortId(runId)}</span>
+                    )}
+                  </span>
+                </li>
+              </ol>
+            </nav>
+            <div className="shrink-0 text-(--text-faint)">
+              <CopyActions
+                id={runId}
+                idLabel="run id"
+                cli={`bun event-runtime/cli.mjs inspect ${runId}`}
+                cliLabel="CLI inspect command"
+              />
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+            {selProposal && onJumpProposal && (
+              <Button onClick={() => onJumpProposal(selProposal.id)}>
+                <span>Open proposal</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-xs text-(--text-faint)"
+                >
+                  p
                 </span>
-              </li>
-            </ol>
-          </nav>
+              </Button>
+            )}
+            {onJumpChain && chainKey && (
+              <Button onClick={() => onJumpChain(chainKey, `run:${runId}`)}>
+                <span>View chain</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-xs text-(--text-faint)"
+                >
+                  c
+                </span>
+              </Button>
+            )}
+            <Button onClick={() => toggleRunPin(runId)}>
+              <span>Open in tab</span>
+              {(!selProposal || !onJumpProposal) && (
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-xs text-(--text-faint)"
+                >
+                  p
+                </span>
+              )}
+            </Button>
+          </div>
         </div>
-        {/* Lifecycle verbs stay left; navigation stays right. This keeps the
-            destructive action visually distinct and limits the row to the
-            actions that change or leave the current run. */}
-        <div className="flex min-h-7 flex-wrap items-center justify-between gap-1.5">
-          <div className="flex items-center gap-1.5">
+        {showVerbRow && (
+          <div className="flex min-h-7 flex-wrap items-center gap-1.5">
             {canApprove && selProposal && (
               <Button
                 disabled={!connected || approve.isPending}
@@ -451,10 +511,10 @@ export function RunFull({
                 </span>
               </Button>
             )}
-            {d && ["RUNNING", "VERIFYING"].includes(d.run.state) && (
-              <div className="flex flex-wrap items-center gap-1.5 text-[12px] text-(--text-dim)">
+            {inflight && d && (
+              <>
                 <span
-                  className="mr-1 tabular-nums"
+                  className="mr-1 text-[12px] text-(--text-dim) tabular-nums"
                   title="Current execution deadline. The sidebar budget meter preserves the original approved RunSpec; its lease clock reflects extensions."
                 >
                   Remaining{" "}
@@ -472,28 +532,12 @@ export function RunFull({
                     : "—"}
                 </span>
                 <Button
-                  disabled={!connected || extend.isPending}
-                  onClick={() =>
-                    extend.mutate({ id: d.run.runId, seconds: 15 * 60 })
-                  }
-                >
-                  +15m
-                </Button>
-                <Button
-                  disabled={!connected || extend.isPending}
-                  onClick={() =>
-                    extend.mutate({ id: d.run.runId, seconds: 30 * 60 })
-                  }
-                >
-                  +30m
-                </Button>
-                <Button
                   disabled={extend.isPending}
                   onClick={() => setCustomExtend(true)}
                 >
-                  Custom…
+                  Extend…
                 </Button>
-              </div>
+              </>
             )}
             {d &&
               d.run.state === "FAILED" &&
@@ -515,42 +559,7 @@ export function RunFull({
                 </Button>
               ))}
           </div>
-          <div className="flex items-center gap-1.5">
-            {selProposal && onJumpProposal && (
-              <Button onClick={() => onJumpProposal(selProposal.id)}>
-                <span>Open proposal</span>
-                <span
-                  aria-hidden="true"
-                  className="mono ml-1 text-(--text-faint) text-xs"
-                >
-                  p
-                </span>
-              </Button>
-            )}
-            {onJumpChain && chainKey && (
-              <Button onClick={() => onJumpChain(chainKey, `run:${runId}`)}>
-                <span>View chain</span>
-                <span
-                  aria-hidden="true"
-                  className="mono ml-1 text-(--text-faint) text-xs"
-                >
-                  c
-                </span>
-              </Button>
-            )}
-            <Button onClick={() => toggleRunPin(runId)}>
-              <span>Open in tab</span>
-              {(!selProposal || !onJumpProposal) && (
-                <span
-                  aria-hidden="true"
-                  className="mono ml-1 text-(--text-faint) text-xs"
-                >
-                  p
-                </span>
-              )}
-            </Button>
-          </div>
-        </div>
+        )}
         {extend.error && !customExtend && <VerbError error={extend.error} />}
         {extendNotice && (
           <div className="mt-1 text-[12px] text-(--hue-ok)" role="status">
@@ -559,15 +568,6 @@ export function RunFull({
             RunSpec.
           </div>
         )}
-        <div className="flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
-          <CopyActions
-            id={runId}
-            idLabel="run id"
-            cli={`bun event-runtime/cli.mjs inspect ${runId}`}
-            cliLabel="CLI inspect command"
-            variant="quiet"
-          />
-        </div>
       </header>
 
       {unknownRun ? (
@@ -836,6 +836,24 @@ export function RunFull({
             applies.
           </div>
           <VerbError error={extend.error} />
+          <div className="mb-3 flex flex-wrap items-center gap-1.5">
+            <Button
+              disabled={!connected || extend.isPending}
+              onClick={() =>
+                extend.mutate({ id: d.run.runId, seconds: 15 * 60 })
+              }
+            >
+              +15m
+            </Button>
+            <Button
+              disabled={!connected || extend.isPending}
+              onClick={() =>
+                extend.mutate({ id: d.run.runId, seconds: 30 * 60 })
+              }
+            >
+              +30m
+            </Button>
+          </div>
           <label className="mb-3 block text-[12px] text-(--text-dim)">
             Minutes
             <input


### PR DESCRIPTION
## Summary
- `PaneHeader` puts `CopyActions` on the title row (next to the id, before Close) so every list pane drops the third utility row.
- Full-page `RunFull` matches the pane: `shortId`, icon copy (no `copy: id · CLI · link`), View chain / Open in tab on the title row.
- Completed runs omit the verb row. RUNNING keeps Cancel + Remaining + one **Extend…** (presets + custom minutes live in the dialog).

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/web/src/components/ui.test.tsx event-runtime/web/src/views/RunFull.test.tsx event-runtime/web/src/views/Runs.test.tsx` — 111 pass
- [ ] Spot-check `#/run/:id` COMPLETED vs RUNNING vs `#/runs/:id` pane header

Fixes WM-848