### PR TITLE
fix(merge): count only admitted merge-fix rounds toward max_fix_rounds

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -537,12 +537,21 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
 
 function durableFixRoundReason(db, candidate, input, policy) {
   const cap = policy.maxFixRounds ?? 0;
+  // Count only rounds that were actually admitted to run (a proposal decided
+  // "run" that produced a run). Every merge-scan tick re-emits the current
+  // round's fix request for a PR that is still red; counting those refused or
+  // superseded emissions exhausted max_fix_rounds before any fix executed and
+  // parked every PR as fix-round-exhausted (2026-08-18).
   const rows = db
     .query(
-      `SELECT event_id, envelope_json FROM events
-       WHERE source = 'chain'
-         AND type = 'factory.merge-fix.requested'
-         AND event_id != ?`,
+      `SELECT e.event_id, e.envelope_json FROM events e
+       JOIN proposals p ON p.event_id = e.event_id AND p.event_source = e.source
+       JOIN runs r ON r.run_id = p.run_id
+       WHERE e.source = 'chain'
+         AND e.type = 'factory.merge-fix.requested'
+         AND p.decision = 'run'
+         AND r.state IN ('QUEUED','LEASED','RUNNING','VERIFYING','COMPLETED','FAILED')
+         AND e.event_id != ?`,
     )
     .all(candidate.event_id);
   const priorRounds = [];

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1603,6 +1603,61 @@ describe("policy approval and global merge barrier", () => {
     ).toBe(2);
   });
 
+  test("fix rounds that were emitted but never admitted to run do not consume max_fix_rounds", () => {
+    const db = openDb(":memory:");
+    const payload = (round, base = "develop") => ({
+      repo: "factory",
+      github: "watt-mind/factory",
+      base,
+      pr: 89,
+      headSha: SHA,
+      baseSha: BASE_SHA,
+      headRef: "feat/WM-589",
+      ticket: "WM-589",
+      finding: `mechanical round ${round}`,
+      findingHash: FINDING_HASH,
+      round,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: ["event-runtime/merge.test.mjs"],
+    });
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(1), "fix89-1"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    // A round-2 emission that is refused (base not auto-mergeable) leaves an
+    // open proposal with no run — every merge-scan tick re-emits these.
+    admitEvent(
+      db,
+      registry,
+      envelope(
+        "factory.merge-fix.requested",
+        payload(2, "main"),
+        "fix89-2-refused",
+      ),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(2), "fix89-2"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const second = openProposals(db, {}).find(
+      (proposal) => proposal.event_id === "fix89-2",
+    );
+    expect(second).toBeUndefined();
+    expect(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-fix@1' AND json_extract(spec_json,'$.input.pr')=89`,
+        )
+        .get().n,
+    ).toBe(2);
+  });
+
   test("mechanical fix rounds are bounded and exhausted rounds fail schema/policy closed", () => {
     const schema = registry.agents.get("merge-fix@1").inputSchema;
     expect(schema.properties.round.maximum).toBe(2);


### PR DESCRIPTION
At 20:04Z all 13 open merge-fix proposals were `merge_fix_round_not_durable`: `durableFixRoundReason` counted every emitted `factory.merge-fix.requested` chain event for the PR, and merge-scan re-emits the current round every 15-min tick while the PR stays red — so two ticks exhausted `max_fix_rounds=2` before any fix ran, and merge-scan then escalated PRs as fix-round-exhausted (#650/#658/#659). Count only rounds whose proposal was decided `run` and produced a run. Regression test in merge.test.mjs. Related: WM-777, WM-769.