### PR TITLE
feat(extensions): factory-extension.json manifest + allow-listed loader unifying packs and adapters; docs/extensions.md (WM-838)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,10 @@ Triage is the live judgement call: a bad spec burns a full dispatch run, which a
 
 The plugin is a convenience layer, not the safety floor. It reaches Claude Code only, and a cloud sandbox without GitHub auth for this private repo gets nothing — failing closed without knowing it. So the non-negotiables live in `shared/floor.md` and are committed into each repo's `AGENTS.md`, the one channel every harness reads.
 
+### 2.12 Extensions are one unit, allow-listed, and never fatal
+
+Anything that adds to the running factory from outside its tree — an agent pack, a harness adapter, later a panel, a config schema, a hook — arrives as one **extension**: a directory with a `factory-extension.json` that declares what it contributes, enabled by one `extensions:` entry in `config/policy.yaml` ([`extensions.md`](extensions.md)). Three choices are deliberate. Discovery is allow-listed, never a directory scan, because the file that enables code in the worker process should be a committed one the operator edits. Data-only packs and operator-installed adapters share the manifest but not the trust: packs are held to the kernel's read-only, namespaced, pinned rules and are safe for an agent to author, while an adapter is code the operator has chosen to run and the registry still guards behind the sandbox seam. And a broken extension is a configuration anomaly on `/status`, not a failed `serve` — the factory should keep running when a third party ships a bad manifest, and say so where the operator looks.
+
 ---
 
 ## 3. Failure modes this design accepts

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,192 @@
+# Extensions
+
+_Author guide for the malleable-factory epic (WM-834). This page is the one
+reference for everything an extension can contribute; each follow-up ticket
+appends its section here rather than opening a new document._
+
+An **extension** is one directory with one manifest, `factory-extension.json`,
+that declares everything the directory contributes to a running factory. It
+is the unit an operator installs and enables — "the mobile pack + the argent
+adapter" is one extension, enabled with one line, not two things installed two
+ways.
+
+Today an extension can contribute:
+
+- **packs** — agent definitions, schemas, prompts, event types, edges and
+  schedules, in the filesystem pack format of
+  [`kernel-and-packs.md`](kernel-and-packs.md); they go through the same pack
+  loader with the same namespace, duplicate, pin and `mutating` rules;
+- **adapters** — harness adapters satisfying the contract in
+  [`event-runtime-workers.md` §2c](event-runtime-workers.md#2c-adapter-registry-and-contract--shipped-wm-837);
+  they are registered into the adapter registry with the extension's name as
+  their `source`.
+
+The manifest also **reserves** `connectors`, `views`, `panels`, `config` and
+`hooks` for the tickets that land them (§Panels, §Config, §Hooks below). A
+manifest that carries a reserved key loads its packs and adapters and records a
+"not supported yet" configuration anomaly for the rest — it is accepted, not
+rejected, so an extension written for a later runtime still does what this one
+understands.
+
+Implementation: `event-runtime/lib/extensions.mjs`, schema
+`event-runtime/schemas/factory-extension.schema.json`, fixture
+`event-runtime/test-support/extensions/sample/`.
+
+## Layout
+
+```text
+~/.factory/extensions/wattmind-mobile/
+  factory-extension.json      # the manifest — required
+  pack/                       # a filesystem pack (pack.json, pins.json, agents/, schemas/, …)
+  adapters/
+    argent.mjs                # an adapter module (execute + SANDBOX_SUPPORT)
+```
+
+Nothing about the layout is fixed except the manifest's name and place: every
+contributed path is written in the manifest, relative to the manifest's
+directory, and must stay inside it.
+
+## Manifest reference
+
+```json
+{
+  "name": "wattmind/mobile",
+  "version": "1.0.0",
+  "description": "Mobile packs and the argent adapter",
+  "factory": { "min": "0.x" },
+  "contributes": {
+    "packs": ["./pack"],
+    "adapters": { "argent": "./adapters/argent.mjs" }
+  }
+}
+```
+
+| Key                                                                | Required | Meaning                                                                                                                                                                                                                                         |
+| :----------------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                                             | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
+| `version`                                                          | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
+| `description`                                                      | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
+| `factory.min`                                                      | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
+| `contributes.packs`                                                | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
+| `contributes.adapters`                                             | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
+| `contributes.connectors`, `.views`, `.panels`, `.config`, `.hooks` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
+
+Unknown top-level keys and unknown `contributes` keys are schema violations.
+Validate a manifest without loading anything:
+
+```sh
+bun event-runtime/cli.mjs extensions validate ~/.factory/extensions/wattmind-mobile
+# wattmind/mobile@1.0.0: valid (1 pack, 1 adapter)
+```
+
+`validate` checks the schema, that every contributed path exists and stays
+inside the extension directory, and that adapter names are well-formed. It
+does not load a pack or import an adapter module — running third-party code
+is what enabling does.
+
+## Trust model
+
+There are two kinds of contribution, and the difference is what runs.
+
+- **Data-only packs.** A pack is JSON and prose: definitions, schemas, prompts,
+  routing maps. Loading one executes nothing. The kernel then holds it to the
+  configured-pack rules — its own namespace, no shadowing of built-ins, pinned
+  prompts and schemas, no `mutating: true` — so a pack can add agents but
+  cannot widen what an agent may do. This is the surface an _agent_ may author
+  (a dispatched ticket producing a pack is ordinary data), and it is why the
+  fixture pack is a copy of `test-support/packs/sample`.
+- **Operator-installed code.** An adapter is an ES module the worker imports
+  and calls. Enabling an extension that contributes adapters is running that
+  code in the worker process with the worker's credentials. Only the operator
+  enables extensions — by editing `config/policy.yaml`, a committed file —
+  and nothing an agent does at runtime can add one. The registry still puts
+  every adapter behind the sandbox seam (an `unsupported` adapter is refused
+  for a sandboxed definition before its code runs, WM-313/WM-837), and it
+  refuses a module that does not satisfy the contract at load time rather
+  than mid-run.
+
+Two rules follow. Discovery is **allow-listed, never scanned**: the loader reads
+only the directories `policy.yaml` names, in that order — dropping a directory
+into `~/.factory/extensions/` does nothing on its own. And a broken extension is
+a **configuration anomaly, not a crash**: a missing or malformed manifest, a
+pack the registry would refuse, or an adapter that fails the contract skips
+that extension whole (nothing of it is registered, not even its good parts),
+records why under `/status.anomalies.configuration` (visible in `doctor`, the
+web UI's status, and `extensions list`), and lets every other extension load.
+`serve` and `work` never fail to start because of a third-party manifest.
+The one thing that does fail closed is a malformed `extensions:` block itself
+— an operator typo in the allowlist, exactly like `packs:`.
+
+## Enabling an extension
+
+Add its directory to `config/policy.yaml`:
+
+```yaml
+extensions:
+  - path: ~/.factory/extensions/wattmind-mobile # must contain factory-extension.json
+  - path: vendor/another-extension # relative paths resolve from the factory checkout
+```
+
+Each entry accepts only `path` (`~` expands to the home directory). Entries
+load after the built-in root and after every `packs:` entry, in policy order:
+`packRoots` handed to the registry is `packs:` first, then each accepted
+extension's packs. Restart `serve` and the workers — extensions are read at
+startup, alongside the registry.
+
+Inspect what loaded:
+
+```sh
+bun event-runtime/cli.mjs extensions list          # name, version, pack/adapter counts, path; anomalies on stderr
+bun event-runtime/cli.mjs extensions list --json   # { extensions, anomalies }
+bun event-runtime/cli.mjs adapters                 # extension adapters appear with SOURCE = the extension name
+```
+
+An extension pack that duplicates a configured pack's name, or whose agents
+collide with an already-loaded namespace, is refused with the registry's own
+message naming both packs; fix the pack (or the order) and restart.
+
+## Writing one
+
+1. Create the directory and `factory-extension.json`; pick a `name` under your
+   publisher prefix.
+2. Add packs in the pack format (`kernel-and-packs.md`), each under its own
+   `pack.json` with a non-empty `namespace`, and write its `pins.json`
+   (`sha256:` of each prompt and schema, `kernel-and-packs.md` § Pins).
+   `update-pins --pack <name>` reaches only `policy.yaml packs:` entries
+   today; extension packs are pinned by hand until that command learns
+   about extensions.
+3. Add adapters as `.mjs` modules exporting `execute` and `SANDBOX_SUPPORT`;
+   the smallest conformant module is
+   `event-runtime/test-support/extensions/sample/adapters/echo.mjs`.
+4. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+   enable it, `extensions list`, restart.
+
+The fixture `event-runtime/test-support/extensions/sample/` is a complete,
+loadable example, and `event-runtime/lib/extensions.test.mjs` shows every
+failure mode and what the anomaly for it says.
+
+## Panels
+
+_Reserved key `contributes.panels` — lands in WM-840 (declarative
+`factory.panel-view/v1` panels rendered on Overview). Until then the loader
+accepts the key and reports it as not supported yet._
+
+## Config
+
+_Reserved key `contributes.config` — lands in WM-841 (extension config schemas
+validated at load and surfaced in `/config` + Settings). Until then the loader
+accepts the key and reports it as not supported yet._
+
+## Hooks
+
+_Reserved key `contributes.hooks` — lands in WM-842 (the `approve.before` hook
+seam with persisted decisions). Until then the loader accepts the key and
+reports it as not supported yet._
+
+## Related
+
+- [`kernel-and-packs.md`](kernel-and-packs.md) — the pack format and the
+  kernel's admission rules, which extension packs inherit unchanged
+- [`event-runtime-workers.md` §2c](event-runtime-workers.md#2c-adapter-registry-and-contract--shipped-wm-837) —
+  the adapter contract and registry
+- [`architecture.md`](architecture.md) — where extensions sit in the design

--- a/docs/kernel-and-packs.md
+++ b/docs/kernel-and-packs.md
@@ -22,6 +22,14 @@ loaded after the built-in root and in policy order. Each entry accepts only
 `name`, `path`, and optional `namespace`; malformed entries, duplicate names,
 or unreadable pack content fail registry startup closed.
 
+A pack can also arrive inside an **extension** — one directory whose
+`factory-extension.json` lists its packs (and adapters) and is enabled with a
+single `extensions:` entry instead of one `packs:` entry per pack. Extension
+packs go through this same loader with the same rules below; the pack's name
+and namespace come from its `pack.json`, and a pack the registry would refuse
+skips that extension as a configuration anomaly rather than failing startup.
+See [`extensions.md`](extensions.md).
+
 ## Pack format
 
 A filesystem pack has this layout:

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -5,13 +5,17 @@ import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { createAdapterRegistry } from "./lib/adapters/index.mjs";
 import { API_HOST, DEFAULT_PORT } from "./lib/config.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
+import {
+  loadExtensions,
+  validateExtensionManifest,
+} from "./lib/extensions.mjs";
 
 const USAGE = BASE_USAGE.replace(
   "  inbox                          open items waiting on the human",
   "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API",
 ).replace(
   "  agents                         registered agent definitions and event routing",
-  "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)",
+  "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts\n  extensions validate <path>     validate a factory-extension.json without loading it",
 );
 
 // Preserve the small programmatic surface used by runtime tests and tooling.
@@ -135,8 +139,10 @@ export async function decideCommand(args) {
  * `work` and `serve` build, so what this prints is what a worker would
  * execute with. Local — it needs no running serve.
  */
-export function adaptersCommand(args = []) {
+export async function adaptersCommand(args = []) {
   const registry = createAdapterRegistry();
+  const loaded = await loadExtensions({ adapterRegistry: registry });
+  for (const anomaly of loaded.anomalies) console.error(`anomaly: ${anomaly}`);
   const rows = registry.list();
   if (args.includes("--json")) {
     console.log(JSON.stringify({ adapters: rows }, null, 2));
@@ -152,11 +158,75 @@ export function adaptersCommand(args = []) {
   return rows;
 }
 
+/**
+ * `extensions list` — the allow-listed extensions the loader accepts (WM-838),
+ * with their contribution counts; faults print as anomalies on stderr, exactly
+ * as /status would report them, and the command still exits 0 because a
+ * broken third-party extension is a configuration anomaly, not a CLI failure.
+ * `extensions validate <path>` — validate one manifest (schema, path
+ * existence, adapter names) without loading a pack or importing an adapter;
+ * exit 1 when it does not validate. Both are local — no serve needed.
+ */
+export async function extensionsCommand(args = []) {
+  const [sub, ...rest] = args;
+  if (sub === "validate") {
+    const target = rest.find((a) => !a.startsWith("--"));
+    if (!target) {
+      console.error("usage: extensions validate <path>");
+      process.exit(1);
+    }
+    const out = validateExtensionManifest(target);
+    for (const warning of out.warnings) console.error(`warning: ${warning}`);
+    if (!out.valid) {
+      for (const error of out.errors) console.error(`error: ${error}`);
+      process.exit(1);
+    }
+    const contributes = out.manifest.contributes ?? {};
+    const packs = (contributes.packs ?? []).length;
+    const adapters = Object.keys(contributes.adapters ?? {}).length;
+    console.log(
+      `${out.manifest.name}@${out.manifest.version}: valid (${packs} pack${packs === 1 ? "" : "s"}, ${adapters} adapter${adapters === 1 ? "" : "s"})`,
+    );
+    return out;
+  }
+  if (sub === "list" || sub === undefined) {
+    const loaded = await loadExtensions();
+    if (rest.includes("--json") || args.includes("--json")) {
+      console.log(
+        JSON.stringify(
+          { extensions: loaded.extensions, anomalies: loaded.anomalies },
+          null,
+          2,
+        ),
+      );
+      return loaded;
+    }
+    for (const anomaly of loaded.anomalies)
+      console.error(`anomaly: ${anomaly}`);
+    const width = Math.max(
+      10,
+      ...loaded.extensions.map((ext) => ext.name.length + 2),
+    );
+    console.log(
+      `${"EXTENSION".padEnd(width)}${"VERSION".padEnd(10)}${"PACKS".padEnd(7)}${"ADAPTERS".padEnd(10)}PATH`,
+    );
+    for (const ext of loaded.extensions) {
+      console.log(
+        `${ext.name.padEnd(width)}${ext.version.padEnd(10)}${String(ext.packs.length).padEnd(7)}${String(ext.adapters.length).padEnd(10)}${ext.path}`,
+      );
+    }
+    return loaded;
+  }
+  console.error("usage: extensions list [--json] | extensions validate <path>");
+  process.exit(1);
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
   if (command === "adapters") return adaptersCommand(args);
+  if (command === "extensions") return extensionsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createAdapterRegistry } from "../lib/adapters/index.mjs";
+import { loadExtensions } from "../lib/extensions.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -304,9 +305,12 @@ export default async function serve(args) {
     fail(`serve: invalid port "${rawPort}" (must be integer 1-65535)`);
   }
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  // Built-ins only for now; the registry validates the contract and wraps
-  // every adapter in the sandbox seam (lib/adapters/index.mjs, WM-837).
+  // Built-ins first, then allow-listed extensions (lib/extensions.mjs,
+  // WM-838) — before toMap(), which is a snapshot. The registry validates the
+  // contract and wraps every adapter in the sandbox seam (WM-837); a broken
+  // extension is a configuration anomaly on /status, never a failed start.
   const adapterRegistry = createAdapterRegistry();
+  const extensions = await loadExtensions({ adapterRegistry });
   const adapters = adapterRegistry.toMap();
   if (adapterOverride && !adapterRegistry.has(adapterOverride)) {
     fail(
@@ -323,7 +327,8 @@ export default async function serve(args) {
   }
 
   const db = openDb();
-  const registry = loadRegistry();
+  const registry = loadRegistry({ packRoots: extensions.packRoots });
+  registry.anomalies.push(...extensions.anomalies);
   const pv = policyVersion();
   const owner = newWorkerId();
 

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { hostname } from "node:os";
 import { createAdapterRegistry } from "../lib/adapters/index.mjs";
+import { loadExtensions } from "../lib/extensions.mjs";
 import {
   dbPath,
   ensureHome,
@@ -47,9 +48,12 @@ export default async function work(args) {
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
-  // Built-ins only for now; the registry validates the contract and wraps
-  // every adapter in the sandbox seam (lib/adapters/index.mjs, WM-837).
+  // Built-ins first, then allow-listed extensions (lib/extensions.mjs,
+  // WM-838) — before toMap(), which is a snapshot. The registry validates the
+  // contract and wraps every adapter in the sandbox seam (WM-837); a broken
+  // extension is a configuration anomaly on /status, never a failed start.
   const adapterRegistry = createAdapterRegistry();
+  const extensions = await loadExtensions({ adapterRegistry });
   const adapters = adapterRegistry.toMap();
   if (adapterOverride && !adapterRegistry.has(adapterOverride)) {
     fail(
@@ -86,7 +90,8 @@ export default async function work(args) {
 
   ensureHome();
   const db = openDb();
-  const registry = loadRegistry();
+  const registry = loadRegistry({ packRoots: extensions.packRoots });
+  registry.anomalies.push(...extensions.anomalies);
   const pv = policyVersion();
   const workerId = flagValue(args, "--worker-id") ?? newWorkerId();
   const adapterNames = adapterOverride

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -1,0 +1,373 @@
+/**
+ * Extensions — `factory-extension.json` (WM-838, docs/extensions.md).
+ *
+ * The factory has several extension surfaces but, before this module, no
+ * extension *unit*: packs are allow-listed in `policy.yaml packs:` and loaded
+ * by lib/registry.mjs, adapters are registered into the adapter registry
+ * (lib/adapters/index.mjs), and nothing tied them together. An extension is
+ * one directory with one manifest that declares what it contributes; this
+ * loader feeds its packs into the existing pack machinery and its adapters
+ * into the adapter registry. It builds no parallel path for either.
+ *
+ * Three properties this module owns:
+ *
+ *   1. **Discovery is allow-listed, never scanned.** Only the directories in
+ *      `config/policy.yaml extensions:` are read, in policy order, mirroring
+ *      `packs:` — an absent block loads nothing.
+ *   2. **Failures are configuration anomalies, not crashes.** A missing or
+ *      malformed manifest, a schema violation, a pack the registry would
+ *      refuse, or an adapter that fails the contract records a
+ *      `/status.anomalies.configuration` line (the artifact-view pattern,
+ *      registry.mjs) and skips *that* extension whole — nothing of it is
+ *      registered — while every other extension still loads. `serve`/`work`
+ *      never fail to start because a third-party manifest is broken.
+ *   3. **Reserved manifest keys are accepted, not rejected.** `connectors`,
+ *      `views`, `panels`, `config` and `hooks` belong to follow-up tickets;
+ *      a manifest that carries them loads its packs and adapters here and
+ *      records a "not supported yet" anomaly for the rest.
+ *
+ * Ordering matters for callers: `adapterRegistry.toMap()` is a snapshot, so
+ * `loadExtensions` must run before a CLI takes the map it hands to
+ * lib/worker.mjs, and `result.packRoots` must be what `loadRegistry` is
+ * given.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  ADAPTER_NAME_PATTERN,
+  validateAdapterContract,
+} from "./adapters/index.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { RegistryError, loadPackRoots, loadRegistry } from "./registry.mjs";
+import { expandHome, reposRoot } from "./repos.mjs";
+import { validate } from "./schema.mjs";
+
+export const EXTENSION_MANIFEST = "factory-extension.json";
+
+export const EXTENSION_SCHEMA = JSON.parse(
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory-extension.schema.json"),
+    "utf8",
+  ),
+);
+
+/** Manifest keys the schema accepts today but no ticket has implemented yet. */
+export const RESERVED_CONTRIBUTIONS = Object.freeze([
+  "connectors",
+  "views",
+  "panels",
+  "config",
+  "hooks",
+]);
+
+/** Thrown only for a malformed `extensions:` policy block; per-extension faults are anomalies. */
+export class ExtensionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ExtensionError";
+  }
+}
+
+function policyFile(root) {
+  return path.join(root, "config", "policy.yaml");
+}
+
+function readPolicy(root) {
+  const file = policyFile(root);
+  if (!existsSync(file)) return {};
+  try {
+    return Bun.YAML.parse(readFileSync(file, "utf8")) ?? {};
+  } catch (err) {
+    throw new ExtensionError(
+      `${file}: unparseable policy.yaml — ${err.message}`,
+    );
+  }
+}
+
+/**
+ * Read the explicit extension allowlist from a parsed policy. No directory
+ * discovery is ever performed: an absent block is the empty list. The block
+ * itself must be well-formed (fail closed, like `packs:`); a malformed entry
+ * is reported per entry so one typo does not hide the other extensions.
+ *
+ * @param {{ root?: string, policy?: object }} [options]
+ * @returns {{ roots: Array<{ path: string, index: number }>, anomalies: string[] }}
+ */
+export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
+  const parsed = policy ?? readPolicy(root);
+  const file = policyFile(root);
+  const configured = parsed?.extensions;
+  if (configured === undefined || configured === null)
+    return { roots: [], anomalies: [] };
+  if (!Array.isArray(configured))
+    throw new ExtensionError(`${file}: "extensions" must be an array`);
+
+  const roots = [];
+  const anomalies = [];
+  const seen = new Set();
+  configured.forEach((entry, index) => {
+    const at = `${file}: extensions[${index}]`;
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      anomalies.push(`${at} must be an object with path (entry skipped)`);
+      return;
+    }
+    const unknown = Object.keys(entry).filter((key) => key !== "path");
+    if (unknown.length > 0) {
+      anomalies.push(
+        `${at}: unknown field${unknown.length > 1 ? "s" : ""} ${unknown.map((k) => `"${k}"`).join(", ")} (entry skipped)`,
+      );
+      return;
+    }
+    if (typeof entry.path !== "string" || entry.path.trim() === "") {
+      anomalies.push(`${at}.path must be a non-empty string (entry skipped)`);
+      return;
+    }
+    const resolved = path.resolve(root, expandHome(entry.path));
+    if (seen.has(resolved)) {
+      anomalies.push(`${at}: duplicate extension path ${resolved} (skipped)`);
+      return;
+    }
+    seen.add(resolved);
+    roots.push({ path: resolved, index });
+  });
+  return { roots, anomalies };
+}
+
+/**
+ * Read and validate one manifest without loading anything it points at.
+ * Path existence is checked (a pack directory or adapter file that is not
+ * there is a manifest error, not a runtime surprise), but no pack is loaded
+ * and no adapter module is imported — that is what `extensions validate` in
+ * the CLI promises.
+ *
+ * @param {string} dir - the extension directory (the manifest's parent)
+ * @returns {{ valid: boolean, errors: string[], warnings: string[], manifest: object|null, file: string }}
+ */
+export function validateExtensionManifest(dir) {
+  const root = path.resolve(dir);
+  const file = path.join(root, EXTENSION_MANIFEST);
+  const errors = [];
+  const warnings = [];
+  const result = (manifest) => ({
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    manifest,
+    file,
+  });
+  if (!existsSync(file)) {
+    errors.push(`missing ${EXTENSION_MANIFEST} in ${root}`);
+    return result(null);
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    errors.push(`${file}: invalid JSON — ${err.message}`);
+    return result(null);
+  }
+  const check = validate(EXTENSION_SCHEMA, manifest);
+  if (!check.valid) {
+    errors.push(...check.errors.map((e) => `${file}: ${e}`));
+    return result(manifest);
+  }
+
+  const contributes = manifest.contributes ?? {};
+  for (const key of RESERVED_CONTRIBUTIONS) {
+    if (Object.hasOwn(contributes, key)) {
+      warnings.push(
+        `${file}: contributes.${key} is not supported yet (reserved; ignored)`,
+      );
+    }
+  }
+  const packs = new Set();
+  for (const [i, rel] of (contributes.packs ?? []).entries()) {
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.packs[${i}] "${rel}" escapes the extension directory`,
+      );
+      continue;
+    }
+    if (packs.has(abs)) {
+      errors.push(`${file}: contributes.packs[${i}] "${rel}" listed twice`);
+      continue;
+    }
+    packs.add(abs);
+    if (!existsSync(path.join(abs, "pack.json"))) {
+      errors.push(
+        `${file}: contributes.packs[${i}] "${rel}" has no pack.json (${abs})`,
+      );
+    }
+  }
+  for (const [name, rel] of Object.entries(contributes.adapters ?? {})) {
+    if (!ADAPTER_NAME_PATTERN.test(name)) {
+      errors.push(
+        `${file}: contributes.adapters key "${name}" must match ${ADAPTER_NAME_PATTERN}`,
+      );
+      continue;
+    }
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.adapters.${name} "${rel}" escapes the extension directory`,
+      );
+      continue;
+    }
+    if (!existsSync(abs) || !statSync(abs).isFile()) {
+      errors.push(
+        `${file}: contributes.adapters.${name} "${rel}" is not a file (${abs})`,
+      );
+    }
+  }
+  return result(manifest);
+}
+
+function isInside(root, abs) {
+  const rel = path.relative(root, abs);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/** Read the pack name out of `pack.json`; the registry validates the rest. */
+function packRootFor(extensionRoot, rel) {
+  const packDir = path.resolve(extensionRoot, rel);
+  const manifestFile = path.join(packDir, "pack.json");
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
+  } catch (err) {
+    throw new RegistryError(`${manifestFile}: invalid JSON — ${err.message}`);
+  }
+  if (typeof manifest?.name !== "string" || manifest.name.trim() === "") {
+    throw new RegistryError(`${manifestFile}: name must be a non-empty string`);
+  }
+  return { kind: "fs", name: manifest.name, path: packDir };
+}
+
+/**
+ * Load every allow-listed extension: validate the manifest, prove its packs
+ * load alongside everything accepted so far (a dry `loadRegistry`, so the
+ * namespace/duplicate/pin/mutating rules of docs/kernel-and-packs.md apply
+ * unchanged), import and contract-check its adapters, and only then — once
+ * the whole extension is known good — register the adapters. A fault
+ * anywhere skips the extension whole and records why.
+ *
+ * @param {object} [options]
+ * @param {string} [options.root] - the checkout supplying `config/policy.yaml` (default: reposRoot())
+ * @param {object} [options.policy] - an already-parsed policy object; when given, policy.yaml is not read
+ * @param {ReturnType<import("./adapters/index.mjs").createAdapterRegistry>} [options.adapterRegistry] - where adapters go; when absent, adapters are validated but not registered
+ * @param {Array<object>} [options.packRoots] - the policy `packs:` roots the extension packs join (default: loadPackRoots({ root }))
+ * @param {string} [options.registryRoot] - the built-in registry root the dry load uses (tests point it at a copy)
+ * @returns {Promise<{
+ *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], reserved: string[] }>,
+ *   packRoots: Array<object>,
+ *   anomalies: string[],
+ * }>} `packRoots` is the full list — policy packs first, then every accepted
+ *   extension pack in policy order — ready to hand to `loadRegistry`.
+ */
+export async function loadExtensions({
+  root = reposRoot(),
+  policy,
+  adapterRegistry,
+  packRoots,
+  registryRoot,
+} = {}) {
+  const basePackRoots = packRoots ?? loadPackRoots({ root });
+  const { roots, anomalies } = loadExtensionRoots({ root, policy });
+  const extensions = [];
+  const accepted = [...basePackRoots];
+  const acceptedPackNames = new Set(basePackRoots.map((p) => p.name));
+  const acceptedAdapterNames = new Set();
+  const dryLoad = (candidates) =>
+    loadRegistry({
+      ...(registryRoot ? { root: registryRoot } : {}),
+      packRoots: candidates,
+    });
+
+  for (const { path: dir } of roots) {
+    const skip = (reason) => {
+      anomalies.push(`extension ${dir}: ${reason} (extension skipped)`);
+    };
+    const checked = validateExtensionManifest(dir);
+    if (!checked.valid) {
+      skip(checked.errors.join("; "));
+      continue;
+    }
+    const manifest = checked.manifest;
+    const label = `${manifest.name}@${manifest.version}`;
+    const contributes = manifest.contributes ?? {};
+
+    // Packs: resolve to pack roots and prove they load with everything
+    // accepted so far. The registry's own errors identify both packs on a
+    // collision, which is the message an operator needs.
+    let extPackRoots;
+    try {
+      extPackRoots = (contributes.packs ?? []).map((rel) =>
+        packRootFor(dir, rel),
+      );
+      for (const pack of extPackRoots) {
+        if (acceptedPackNames.has(pack.name)) {
+          throw new RegistryError(
+            `pack name "${pack.name}" is already configured (policy packs: or an earlier extension)`,
+          );
+        }
+      }
+      if (extPackRoots.length > 0) dryLoad([...accepted, ...extPackRoots]);
+    } catch (err) {
+      skip(`${label}: pack rejected — ${err.message}`);
+      continue;
+    }
+
+    // Adapters: import, contract-check, and refuse names already taken.
+    // Nothing is registered until every adapter of the extension passed.
+    const modules = [];
+    let adapterFault = null;
+    for (const [name, rel] of Object.entries(contributes.adapters ?? {})) {
+      if (adapterRegistry?.has(name) || acceptedAdapterNames.has(name)) {
+        adapterFault = `adapter "${name}" is already registered (extensions may not replace an existing adapter)`;
+        break;
+      }
+      const file = path.resolve(dir, rel);
+      let module;
+      try {
+        module = await import(pathToFileURL(file).href);
+      } catch (err) {
+        adapterFault = `adapter "${name}" failed to import from ${file}: ${err.message}`;
+        break;
+      }
+      try {
+        validateAdapterContract(name, module);
+      } catch (err) {
+        adapterFault = err.message;
+        break;
+      }
+      modules.push({ name, module });
+    }
+    if (adapterFault) {
+      skip(`${label}: ${adapterFault}`);
+      continue;
+    }
+
+    // Accept: commit packs, register adapters, record the reserved keys.
+    accepted.push(...extPackRoots);
+    for (const pack of extPackRoots) acceptedPackNames.add(pack.name);
+    for (const { name, module } of modules) {
+      adapterRegistry?.register(name, module, { source: manifest.name });
+      acceptedAdapterNames.add(name);
+    }
+    for (const warning of checked.warnings) anomalies.push(warning);
+    extensions.push({
+      name: manifest.name,
+      version: manifest.version,
+      path: dir,
+      packs: extPackRoots.map((p) => p.name),
+      adapters: modules.map((m) => m.name),
+      reserved: RESERVED_CONTRIBUTIONS.filter((key) =>
+        Object.hasOwn(contributes, key),
+      ),
+    });
+  }
+
+  return { extensions, packRoots: accepted, anomalies };
+}

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -1,0 +1,482 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-extensions-test-mjs";
+import { describe, expect, test } from "bun:test";
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createAdapterRegistry } from "./adapters/index.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  EXTENSION_MANIFEST,
+  EXTENSION_SCHEMA,
+  ExtensionError,
+  RESERVED_CONTRIBUTIONS,
+  loadExtensionRoots,
+  loadExtensions,
+  validateExtensionManifest,
+} from "./extensions.mjs";
+import { getAgent, loadRegistry } from "./registry.mjs";
+import { validate } from "./schema.mjs";
+
+const SAMPLE_EXTENSION = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+);
+const SAMPLE_PACK = path.join(RUNTIME_ROOT, "test-support", "packs", "sample");
+
+/** A writable copy of the fixture, optionally with its manifest rewritten. */
+function tempExtension(mutate = () => {}) {
+  const dir = tmpDir("event-extension-");
+  cpSync(SAMPLE_EXTENSION, dir, { recursive: true });
+  const manifestFile = path.join(dir, EXTENSION_MANIFEST);
+  const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
+  const next = mutate(manifest, dir) ?? manifest;
+  writeFileSync(manifestFile, JSON.stringify(next, null, 2));
+  return dir;
+}
+
+function policyFor(...dirs) {
+  return { extensions: dirs.map((p) => ({ path: p })) };
+}
+
+/** Load with an empty base pack list so the fixture never collides with the checkout's policy. */
+function load(policy, adapterRegistry = createAdapterRegistry()) {
+  return loadExtensions({ policy, adapterRegistry, packRoots: [] }).then(
+    (result) => ({ ...result, adapterRegistry }),
+  );
+}
+
+describe("factory-extension.json schema", () => {
+  test("accepts the decided manifest shape and rejects bad names/versions", () => {
+    const ok = {
+      name: "wattmind/mobile",
+      version: "1.0.0",
+      factory: { min: "0.x" },
+      contributes: {
+        packs: ["./pack"],
+        adapters: { argent: "./adapters/argent.mjs" },
+      },
+    };
+    expect(validate(EXTENSION_SCHEMA, ok)).toEqual({ valid: true, errors: [] });
+    expect(
+      validate(EXTENSION_SCHEMA, { ...ok, name: "Mobile" }).errors.join(),
+    ).toMatch(/\$\.name: does not match pattern/);
+    expect(
+      validate(EXTENSION_SCHEMA, { ...ok, version: "1.0" }).errors.join(),
+    ).toMatch(/\$\.version: does not match pattern/);
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...ok,
+        contributes: { adapters: { argent: "./argent.js" } },
+      }).errors.join(),
+    ).toMatch(/adapters\.argent: does not match pattern/);
+    expect(
+      validate(EXTENSION_SCHEMA, { ...ok, extra: 1 }).errors.join(),
+    ).toMatch(/unknown property "extra"/);
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...ok,
+        contributes: { widgets: [] },
+      }).errors.join(),
+    ).toMatch(/unknown property "widgets"/);
+  });
+
+  test("reserved contribution keys are accepted by the schema", () => {
+    for (const key of RESERVED_CONTRIBUTIONS) {
+      const manifest = {
+        name: "a/b",
+        version: "0.0.1",
+        contributes: { [key]: { anything: true } },
+      };
+      expect(validate(EXTENSION_SCHEMA, manifest).valid).toBe(true);
+    }
+  });
+});
+
+describe("loadExtensionRoots", () => {
+  test("absent block is empty; non-array fails closed; bad entries are anomalies", () => {
+    expect(loadExtensionRoots({ policy: {} })).toEqual({
+      roots: [],
+      anomalies: [],
+    });
+    expect(() =>
+      loadExtensionRoots({ policy: { extensions: { path: "x" } } }),
+    ).toThrow(ExtensionError);
+    const root = tmpDir("event-extension-policy-");
+    const out = loadExtensionRoots({
+      root,
+      policy: {
+        extensions: [
+          "just-a-string",
+          { path: "" },
+          { path: "vendor/one", name: "nope" },
+          { path: "vendor/one" },
+          { path: "vendor/one" },
+          { path: "~/ext" },
+        ],
+      },
+    });
+    expect(out.roots.map((r) => r.path)).toEqual([
+      path.join(root, "vendor", "one"),
+      path.join(os.homedir(), "ext"),
+    ]);
+    expect(out.anomalies).toHaveLength(4);
+    expect(out.anomalies[0]).toMatch(/extensions\[0\] must be an object/);
+    expect(out.anomalies[1]).toMatch(/extensions\[1\]\.path must be/);
+    expect(out.anomalies[2]).toMatch(/unknown field "name"/);
+    expect(out.anomalies[3]).toMatch(/duplicate extension path/);
+  });
+
+  test("reads policy.yaml under root/config when no policy object is given", () => {
+    const root = tmpDir("event-extension-policy-");
+    mkdirSync(path.join(root, "config"));
+    writeFileSync(
+      path.join(root, "config", "policy.yaml"),
+      "extensions:\n  - path: ext/one\n",
+    );
+    expect(loadExtensionRoots({ root }).roots).toEqual([
+      { path: path.join(root, "ext", "one"), index: 0 },
+    ]);
+  });
+});
+
+describe("validateExtensionManifest", () => {
+  test("the fixture is valid and reports no warnings", () => {
+    const out = validateExtensionManifest(SAMPLE_EXTENSION);
+    expect(out.valid).toBe(true);
+    expect(out.warnings).toEqual([]);
+    expect(out.manifest.name).toBe("factory/sample");
+  });
+
+  test("checks that contributed paths exist and stay inside the extension", () => {
+    const dir = tempExtension((m) => {
+      m.contributes.packs.push("./missing", "../escape");
+      m.contributes.adapters["bad-path"] = "./adapters/nope.mjs";
+      m.contributes.adapters["Bad Name"] = "./adapters/echo.mjs";
+    });
+    const out = validateExtensionManifest(dir);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(
+      /packs\[1\] ".\/missing" has no pack.json/,
+    );
+    expect(out.errors.join("\n")).toMatch(/packs\[2\] "..\/escape" escapes/);
+    expect(out.errors.join("\n")).toMatch(
+      /adapters\.bad-path .* is not a file/,
+    );
+    expect(out.errors.join("\n")).toMatch(/key "Bad Name" must match/);
+  });
+});
+
+describe("loadExtensions", () => {
+  test("happy path: packs join the registry, adapters register with the extension as source", async () => {
+    const out = await load(policyFor(SAMPLE_EXTENSION));
+    expect(out.anomalies).toEqual([]);
+    expect(out.extensions).toEqual([
+      {
+        name: "factory/sample",
+        version: "1.0.0",
+        path: SAMPLE_EXTENSION,
+        packs: ["sample-ext"],
+        adapters: ["echo"],
+        reserved: [],
+      },
+    ]);
+    expect(out.packRoots).toEqual([
+      {
+        kind: "fs",
+        name: "sample-ext",
+        path: path.join(SAMPLE_EXTENSION, "pack"),
+      },
+    ]);
+    // Adapters go through the registry: contract-checked, sandbox-guarded, sourced.
+    const entry = out.adapterRegistry.list().find((row) => row.name === "echo");
+    expect(entry).toEqual({
+      name: "echo",
+      source: "factory/sample",
+      sandboxSupport: "unsupported",
+    });
+    const result = await out.adapterRegistry
+      .get("echo")
+      .execute({ spec: { input: { hello: "world" } }, def: {} });
+    expect(result).toEqual({ ok: true, echoed: { hello: "world" } });
+    // Packs go through the existing pack loader, namespaced as pack.json says.
+    const registry = loadRegistry({ packRoots: out.packRoots });
+    expect(getAgent(registry, "sample-ext/echo@1").pack).toBe("sample-ext");
+    expect(registry.eventTypes["sample-ext.echo.requested"].adapter).toBe(
+      "echo",
+    );
+  });
+
+  test("policy packs come first in packRoots and an extension pack may not reuse their name", async () => {
+    const samplePack = {
+      kind: "fs",
+      name: "sample",
+      path: SAMPLE_PACK,
+      namespace: "sample",
+    };
+    const clash = tempExtension((m, dir) => {
+      writeFileSync(
+        path.join(dir, "pack", "pack.json"),
+        JSON.stringify({ name: "sample", version: "1.0.0", namespace: "x" }),
+      );
+    });
+    const out = await loadExtensions({
+      policy: policyFor(clash, SAMPLE_EXTENSION),
+      adapterRegistry: createAdapterRegistry(),
+      packRoots: [samplePack],
+    });
+    expect(out.packRoots.map((p) => p.name)).toEqual(["sample", "sample-ext"]);
+    expect(out.anomalies).toHaveLength(1);
+    expect(out.anomalies[0]).toMatch(
+      /pack name "sample" is already configured.*extension skipped/,
+    );
+  });
+
+  test("a missing or malformed manifest is an anomaly and other extensions still load", async () => {
+    const empty = tmpDir("event-extension-empty-");
+    const badJson = tmpDir("event-extension-badjson-");
+    writeFileSync(path.join(badJson, EXTENSION_MANIFEST), "{ nope");
+    const badSchema = tempExtension((m) => {
+      m.name = "NoSlash";
+    });
+    const out = await load(
+      policyFor(empty, badJson, badSchema, SAMPLE_EXTENSION),
+    );
+    expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(out.anomalies).toHaveLength(3);
+    expect(out.anomalies[0]).toMatch(
+      new RegExp(`extension ${empty}: missing ${EXTENSION_MANIFEST}.*skipped`),
+    );
+    expect(out.anomalies[1]).toMatch(/invalid JSON/);
+    expect(out.anomalies[2]).toMatch(/\$\.name: does not match pattern/);
+    expect(out.adapterRegistry.has("echo")).toBe(true);
+  });
+
+  test("a duplicate pack namespace/agent is refused by the registry rules and skips the extension", async () => {
+    const twin = tempExtension((m) => {
+      m.name = "factory/twin";
+      m.contributes.adapters = { "echo-two": "./adapters/echo.mjs" };
+    });
+    const out = await load(policyFor(SAMPLE_EXTENSION, twin));
+    expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
+    expect(out.anomalies).toHaveLength(1);
+    // The twin's pack.json still says "sample-ext": the pack-name check fires first.
+    expect(out.anomalies[0]).toMatch(
+      /pack name "sample-ext" is already configured/,
+    );
+    // Nothing of a skipped extension is registered — not even its good adapter.
+    expect(out.adapterRegistry.has("echo-two")).toBe(false);
+
+    // Same namespace under a different pack name: the registry's own duplicate
+    // agent ref rule fires and names both packs.
+    const renamed = tempExtension((m, dir) => {
+      m.name = "factory/renamed";
+      m.contributes.adapters = {};
+      writeFileSync(
+        path.join(dir, "pack", "pack.json"),
+        JSON.stringify({
+          name: "sample-renamed",
+          version: "1.0.0",
+          namespace: "sample-ext",
+        }),
+      );
+    });
+    const again = await load(policyFor(SAMPLE_EXTENSION, renamed));
+    expect(again.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(again.anomalies[0]).toMatch(
+      /duplicate agent ref "sample-ext\/echo@1" from packs "sample-ext" and "sample-renamed".*skipped/,
+    );
+  });
+
+  test("a mutating agent in an extension pack is refused like any configured pack", async () => {
+    const mutating = tempExtension((m, dir) => {
+      m.name = "factory/mutating";
+      m.contributes.adapters = {};
+      const defFile = path.join(dir, "pack", "agents", "echo.json");
+      const def = JSON.parse(readFileSync(defFile, "utf8"));
+      def.mutating = true;
+      writeFileSync(defFile, JSON.stringify(def));
+    });
+    const out = await load(policyFor(mutating));
+    expect(out.extensions).toEqual([]);
+    expect(out.anomalies[0]).toMatch(/may not declare mutating: true/);
+  });
+
+  test("a bad adapter skips the whole extension: contract failure, import failure, and name collisions", async () => {
+    const noSandbox = tempExtension((m, dir) => {
+      m.name = "factory/no-sandbox";
+      writeFileSync(
+        path.join(dir, "adapters", "echo.mjs"),
+        "export async function execute() { return {}; }\n",
+      );
+    });
+    const syntaxError = tempExtension((m, dir) => {
+      m.name = "factory/syntax";
+      writeFileSync(
+        path.join(dir, "adapters", "echo.mjs"),
+        "export const = ;\n",
+      );
+    });
+    const shadowsBuiltin = tempExtension((m) => {
+      m.name = "factory/shadow";
+      m.contributes.packs = [];
+      m.contributes.adapters = { fake: "./adapters/echo.mjs" };
+    });
+    const out = await load(
+      policyFor(noSandbox, syntaxError, shadowsBuiltin, SAMPLE_EXTENSION),
+    );
+    expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
+    expect(out.anomalies).toHaveLength(3);
+    expect(out.anomalies[0]).toMatch(
+      /adapter "echo" does not satisfy the adapter contract \(SANDBOX_SUPPORT\).*skipped/,
+    );
+    expect(out.anomalies[1]).toMatch(/adapter "echo" failed to import/);
+    expect(out.anomalies[2]).toMatch(
+      /adapter "fake" is already registered.*may not replace/,
+    );
+    // The built-in survived untouched and the fixture's echo won the name.
+    expect(
+      out.adapterRegistry.list().find((r) => r.name === "fake").source,
+    ).toBe("builtin");
+    expect(
+      out.adapterRegistry.list().find((r) => r.name === "echo").source,
+    ).toBe("factory/sample");
+  });
+
+  test("reserved keys load the rest and record a not-supported-yet anomaly", async () => {
+    const dir = tempExtension((m) => {
+      m.name = "factory/future";
+      m.contributes.panels = [{ id: "x" }];
+      m.contributes.hooks = { "approve.before": "./hooks.mjs" };
+    });
+    const out = await load(policyFor(dir));
+    expect(out.extensions[0].reserved).toEqual(["panels", "hooks"]);
+    expect(out.extensions[0].adapters).toEqual(["echo"]);
+    expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
+    expect(out.anomalies).toEqual([
+      expect.stringMatching(/contributes\.panels is not supported yet/),
+      expect.stringMatching(/contributes\.hooks is not supported yet/),
+    ]);
+  });
+
+  test("without an adapter registry, adapters are validated but nothing is registered", async () => {
+    const out = await loadExtensions({
+      policy: policyFor(SAMPLE_EXTENSION),
+      packRoots: [],
+    });
+    expect(out.extensions[0].adapters).toEqual(["echo"]);
+    expect(out.anomalies).toEqual([]);
+  });
+
+  test("an unreadable policy.yaml extensions block fails closed", async () => {
+    const root = tmpDir("event-extension-policy-");
+    mkdirSync(path.join(root, "config"));
+    writeFileSync(
+      path.join(root, "config", "policy.yaml"),
+      "extensions:\n  path: nope\n",
+    );
+    await expect(loadExtensions({ root, packRoots: [] })).rejects.toThrow(
+      /"extensions" must be an array/,
+    );
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("cli extensions", () => {
+  const run = (...args) =>
+    Bun.spawnSync({
+      cmd: [process.execPath, "event-runtime/cli.mjs", "extensions", ...args],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_REPOS_ROOT: undefined },
+    });
+
+  test("validate <path> checks a manifest without loading it", () => {
+    const ok = run("validate", SAMPLE_EXTENSION);
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout.toString()).toMatch(
+      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter\)/,
+    );
+
+    const bad = tempExtension((m) => {
+      m.version = "one";
+    });
+    const failed = run("validate", bad);
+    expect(failed.exitCode).toBe(1);
+    expect(failed.stderr.toString()).toMatch(
+      /\$\.version: does not match pattern/,
+    );
+
+    const usage = run("validate");
+    expect(usage.exitCode).toBe(1);
+    expect(usage.stderr.toString()).toMatch(
+      /usage: extensions validate <path>/,
+    );
+  });
+
+  test("list prints name, version, path and contribution counts from a policy root", () => {
+    const root = tmpDir("event-extension-cli-");
+    mkdirSync(path.join(root, "config"));
+    const broken = tmpDir("event-extension-cli-broken-");
+    // The dry pack load reads the model-tier map from the same policy, so the
+    // temp policy carries the checkout's `models:` block alongside `extensions:`.
+    const { models } = Bun.YAML.parse(
+      readFileSync(
+        path.join(path.dirname(RUNTIME_ROOT), "config", "policy.yaml"),
+        "utf8",
+      ),
+    );
+    writeFileSync(
+      path.join(root, "config", "policy.yaml"),
+      Bun.YAML.stringify({
+        models,
+        extensions: [{ path: SAMPLE_EXTENSION }, { path: broken }],
+      }),
+    );
+    const out = Bun.spawnSync({
+      cmd: [process.execPath, "event-runtime/cli.mjs", "extensions", "list"],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_REPOS_ROOT: root },
+    });
+    expect(out.exitCode).toBe(0);
+    const text = out.stdout.toString();
+    expect(text).toMatch(/EXTENSION\s+VERSION\s+PACKS\s+ADAPTERS\s+PATH/);
+    expect(text).toMatch(
+      new RegExp(
+        `factory/sample\\s+1\\.0\\.0\\s+1\\s+1\\s+${SAMPLE_EXTENSION}`,
+      ),
+    );
+    expect(out.stderr.toString()).toMatch(
+      new RegExp(`anomaly: extension ${broken}: missing ${EXTENSION_MANIFEST}`),
+    );
+
+    const json = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "event-runtime/cli.mjs",
+        "extensions",
+        "list",
+        "--json",
+      ],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_REPOS_ROOT: root },
+    });
+    const parsed = JSON.parse(json.stdout.toString());
+    expect(parsed.extensions[0].name).toBe("factory/sample");
+    expect(parsed.anomalies).toHaveLength(1);
+  });
+});

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -1,0 +1,68 @@
+{
+  "title": "factory-extension.json — the manifest of one factory extension (docs/extensions.md)",
+  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views`, `panels`, `config` and `hooks` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
+  "type": "object",
+  "required": ["name", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$",
+      "description": "publisher/extension, lower-case; the `source` recorded on every adapter it registers"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$",
+      "description": "semver"
+    },
+    "description": { "type": "string", "maxLength": 200 },
+    "factory": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "min": {
+          "type": "string",
+          "minLength": 1,
+          "description": "minimum factory version the extension was written for; informational until the runtime carries a version"
+        }
+      }
+    },
+    "contributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "packs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "relative directory containing pack.json (docs/kernel-and-packs.md)"
+          }
+        },
+        "adapters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "\\.mjs$",
+            "description": "relative path to an ES module satisfying the adapter contract (docs/event-runtime-workers.md §2c)"
+          }
+        },
+        "connectors": {
+          "description": "reserved — tracker/forge/notifier connectors; not supported yet"
+        },
+        "views": {
+          "description": "reserved — web views; not supported yet"
+        },
+        "panels": {
+          "description": "reserved — declarative Overview panels; lands in WM-840"
+        },
+        "config": {
+          "description": "reserved — extension config schemas; lands in WM-841"
+        },
+        "hooks": {
+          "description": "reserved — lifecycle hooks; lands in WM-842"
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/test-support/extensions/sample/adapters/echo.mjs
+++ b/event-runtime/test-support/extensions/sample/adapters/echo.mjs
@@ -1,0 +1,11 @@
+/**
+ * The smallest adapter that satisfies the contract (docs/event-runtime-workers.md §2c):
+ * an `execute()` entry point and a `SANDBOX_SUPPORT` verdict. It returns the
+ * run's input as its result so extension tests can prove the module the
+ * registry hands out is this one.
+ */
+export const SANDBOX_SUPPORT = "unsupported";
+
+export async function execute({ spec } = {}) {
+  return { ok: true, echoed: spec?.input ?? null };
+}

--- a/event-runtime/test-support/extensions/sample/factory-extension.json
+++ b/event-runtime/test-support/extensions/sample/factory-extension.json
@@ -1,0 +1,10 @@
+{
+  "name": "factory/sample",
+  "version": "1.0.0",
+  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace) and one trivial adapter.",
+  "factory": { "min": "0.1.0" },
+  "contributes": {
+    "packs": ["./pack"],
+    "adapters": { "echo": "./adapters/echo.mjs" }
+  }
+}

--- a/event-runtime/test-support/extensions/sample/pack/agents/echo.json
+++ b/event-runtime/test-support/extensions/sample/pack/agents/echo.json
@@ -1,0 +1,20 @@
+{
+  "id": "echo",
+  "version": 1,
+  "prompt": "agents/echo.md",
+  "input_schema": "schemas/echo.input.json",
+  "output_schema": "schemas/echo.output.json",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": false
+  },
+  "capabilities": {
+    "filesystem": "read-only",
+    "services": []
+  },
+  "limits": {
+    "timeout_seconds": 30,
+    "attempts": 1
+  },
+  "mutating": false
+}

--- a/event-runtime/test-support/extensions/sample/pack/agents/echo.md
+++ b/event-runtime/test-support/extensions/sample/pack/agents/echo.md
@@ -1,0 +1,1 @@
+Return the supplied message unchanged.

--- a/event-runtime/test-support/extensions/sample/pack/edges.json
+++ b/event-runtime/test-support/extensions/sample/pack/edges.json
@@ -1,0 +1,6 @@
+{
+  "sample-ext/echo@1": {
+    "recommendationField": "message",
+    "edges": {}
+  }
+}

--- a/event-runtime/test-support/extensions/sample/pack/event-types.json
+++ b/event-runtime/test-support/extensions/sample/pack/event-types.json
@@ -1,0 +1,8 @@
+{
+  "sample-ext.echo.requested": {
+    "agent": "sample-ext/echo@1",
+    "adapter": "echo",
+    "idempotencyScope": ["correlationId"],
+    "proposalTtlSeconds": 1800
+  }
+}

--- a/event-runtime/test-support/extensions/sample/pack/pack.json
+++ b/event-runtime/test-support/extensions/sample/pack/pack.json
@@ -1,0 +1,5 @@
+{
+  "name": "sample-ext",
+  "version": "1.0.0",
+  "namespace": "sample-ext"
+}

--- a/event-runtime/test-support/extensions/sample/pack/pins.json
+++ b/event-runtime/test-support/extensions/sample/pack/pins.json
@@ -1,0 +1,5 @@
+{
+  "agents/echo.md": "sha256:c39d1884049789a1a435f53ac25ad671f01205e4cdf709e533e6722f8ba6d830",
+  "schemas/echo.input.json": "sha256:0e6470b57f8a1ad10cbc7f427ec860822b5bf5eb62391e9eba95822a0b5dc100",
+  "schemas/echo.output.json": "sha256:0e6470b57f8a1ad10cbc7f427ec860822b5bf5eb62391e9eba95822a0b5dc100"
+}

--- a/event-runtime/test-support/extensions/sample/pack/schedules.json
+++ b/event-runtime/test-support/extensions/sample/pack/schedules.json
@@ -1,0 +1,9 @@
+{
+  "sample-ext-echo": {
+    "every": "60m",
+    "eventType": "sample-ext.echo.requested",
+    "catchUp": "none",
+    "approval": "watched",
+    "enabled": false
+  }
+}

--- a/event-runtime/test-support/extensions/sample/pack/schemas/echo.input.json
+++ b/event-runtime/test-support/extensions/sample/pack/schemas/echo.input.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["message"],
+  "properties": {
+    "message": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/event-runtime/test-support/extensions/sample/pack/schemas/echo.output.json
+++ b/event-runtime/test-support/extensions/sample/pack/schemas/echo.output.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["message"],
+  "properties": {
+    "message": { "type": "string" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Introduces the extension unit for the malleable-factory epic (WM-834): one `factory-extension.json` per directory declaring `contributes.packs` and `contributes.adapters`, enabled via an allow-listed `policy.yaml extensions:` block (never scanned).

- `event-runtime/schemas/factory-extension.schema.json` — manifest schema; reserved keys `connectors|views|panels|config|hooks` accepted, reported as "not supported yet".
- `event-runtime/lib/extensions.mjs` — `loadExtensions({ root, policy, adapterRegistry, packRoots })`: validates the manifest, dry-loads the extension's packs through `loadRegistry` (namespace/duplicate/pin/mutating rules unchanged), imports + contract-checks adapters, then registers adapters with `source: <ext name>`; every fault is a `/status.anomalies.configuration` line that skips that extension whole while others load. Returns the full `packRoots` list for `loadRegistry`.
- `cli.mjs extensions list [--json]` / `extensions validate <path>`; `adapters` listing now includes extension adapters.
- `serve`/`work` call `loadExtensions` before `toMap()` and pass `packRoots` + anomalies to the registry.
- Fixture `event-runtime/test-support/extensions/sample/` (pack copied from `packs/sample` under `sample-ext`, trivial `echo` adapter); 17 tests in `extensions.test.mjs`.
- `docs/extensions.md` author guide (manifest, trust model, enabling, Panels/Config/Hooks stubs for WM-840/841/842); links from `kernel-and-packs.md` and `architecture.md` §2.12.

Verification: `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/extensions.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/adapters && bun run lint && bun run check && bun event-runtime/cli.mjs extensions validate event-runtime/test-support/extensions/sample` — 280 pass, lint 0 errors, check clean, fixture valid. `factory security` passes.

Fixes WM-838