### PR TITLE
fix(event-runtime-web): size Metrics sparklines to the full card

### DIFF
--- a/event-runtime/web/src/components/Charts.test.tsx
+++ b/event-runtime/web/src/components/Charts.test.tsx
@@ -30,6 +30,28 @@ describe("Sparkline", () => {
     ).toContain("population=retried");
     expect(one.container.querySelector("polyline")).toBeNull();
   });
+
+  test("fills a Metrics card like StackedBars instead of a 120×32 tile", () => {
+    const values = Array.from({ length: 24 }, (_, index) =>
+      index === 12 ? 8 : 0,
+    );
+    const view = render(
+      <Sparkline values={values} label="Retry rate by 1h bucket" />,
+    );
+    const svg = view.getByRole("img", { name: "Retry rate by 1h bucket" });
+    expect(svg.getAttribute("viewBox")).toBe("0 0 600 180");
+    expect(svg.getAttribute("preserveAspectRatio")).toBe("none");
+    expect(svg.getAttribute("class")).toContain("h-44");
+    expect(svg.getAttribute("class")).not.toContain("h-8");
+    const polyline = view.container.querySelector("polyline");
+    expect(polyline).toBeTruthy();
+    const xs = polyline!
+      .getAttribute("points")!
+      .split(" ")
+      .map((point) => Number(point.split(",")[0]));
+    expect(xs[0]).toBe(4);
+    expect(xs.at(-1)).toBe(596);
+  });
 });
 
 describe("StackedBars", () => {

--- a/event-runtime/web/src/components/Charts.tsx
+++ b/event-runtime/web/src/components/Charts.tsx
@@ -43,8 +43,8 @@ export function Sparkline({
   values,
   label,
   hue = "var(--hue-info)",
-  width = 120,
-  height = 32,
+  width = 600,
+  height = 180,
   linkForPoint,
 }: {
   values: number[];
@@ -69,7 +69,8 @@ export function Sparkline({
       role="img"
       aria-label={label}
       viewBox={`0 0 ${width} ${height}`}
-      className="h-8 w-full overflow-visible"
+      preserveAspectRatio="none"
+      className="h-44 w-full overflow-visible"
       data-empty={values.length === 0 ? "true" : undefined}
     >
       {values.length > 1 && (

--- a/event-runtime/web/src/views/Metrics.test.tsx
+++ b/event-runtime/web/src/views/Metrics.test.tsx
@@ -113,6 +113,25 @@ describe("Metrics", () => {
     ).toBe(true);
   });
 
+  test("Retry rate and Token volume share Outcome mix card geometry", async () => {
+    const view = renderMetrics();
+    const outcome = await view.findByRole("img", { name: /Outcome mix:/ });
+    const retry = view.getByRole("img", { name: /Retry rate by/ });
+    const tokens = view.getByRole("img", { name: /recorded tokens/ });
+    for (const chart of [outcome, retry, tokens]) {
+      expect(chart.getAttribute("viewBox")).toBe("0 0 600 180");
+      expect(chart.getAttribute("preserveAspectRatio")).toBe("none");
+    }
+    const retryLine = retry.querySelector("polyline");
+    expect(retryLine).toBeTruthy();
+    const xs = retryLine!
+      .getAttribute("points")!
+      .split(" ")
+      .map((point) => Number(point.split(",")[0]));
+    expect(xs[0]).toBe(4);
+    expect(xs.at(-1)).toBe(596);
+  });
+
   test("switches and persists the selected window", async () => {
     const view = renderMetrics();
     await view.findByRole("heading", { name: "Reliability" });


### PR DESCRIPTION
## Summary
- Retry rate and Token volume were drawing as a short stub because `Sparkline` used the 120×32 Overview-tile viewBox with default `preserveAspectRatio` (`meet`).
- Defaults now match `StackedBars` (`600×180`, `preserveAspectRatio="none"`, `h-44`) so the polyline spans the Metrics card.
- Tests assert the card geometry and that Metrics Retry rate / Token volume share Outcome mix's viewBox.

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/web/src/components/Charts.test.tsx event-runtime/web/src/views/Metrics.test.tsx`
- [ ] Reload `#/metrics` at 24h and confirm Retry rate and Token volume span the card like Outcome mix / Cost by agent.

UX critique: skipped — isolated chart geometry; no new user-completable flow.

Fixes WM-853