### PR TITLE
feat(extensions): config schemas validated at load, defaults applied, surfaced in /config + Settings (WM-841)

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -19,10 +19,13 @@ Today an extension can contribute:
 - **adapters** — harness adapters satisfying the contract in
   [`event-runtime-workers.md` §2c](event-runtime-workers.md#2c-adapter-registry-and-contract--shipped-wm-837);
   they are registered into the adapter registry with the extension's name as
-  their `source`.
+  their `source`;
+- **config** — a JSON-schema for the extension's operator settings, validated
+  at load with defaults applied and shown read-only in `GET /config` and
+  Settings (§Config below).
 
-The manifest also **reserves** `connectors`, `views`, `panels`, `config` and
-`hooks` for the tickets that land them (§Panels, §Config, §Hooks below). A
+The manifest also **reserves** `connectors`, `views`, `panels` and `hooks` for
+the tickets that land them (§Panels, §Hooks below). A
 manifest that carries a reserved key loads its packs and adapters and records a
 "not supported yet" configuration anomaly for the rest — it is accepted, not
 rejected, so an extension written for a later runtime still does what this one
@@ -40,6 +43,7 @@ Implementation: `event-runtime/lib/extensions.mjs`, schema
   pack/                       # a filesystem pack (pack.json, pins.json, agents/, schemas/, …)
   adapters/
     argent.mjs                # an adapter module (execute + SANDBOX_SUPPORT)
+  config.schema.json          # the shape of the extension's operator config (§Config)
 ```
 
 Nothing about the layout is fixed except the manifest's name and place: every
@@ -56,20 +60,22 @@ directory, and must stay inside it.
   "factory": { "min": "0.x" },
   "contributes": {
     "packs": ["./pack"],
-    "adapters": { "argent": "./adapters/argent.mjs" }
+    "adapters": { "argent": "./adapters/argent.mjs" },
+    "config": { "namespace": "mobile", "schema": "./config.schema.json" }
   }
 }
 ```
 
-| Key                                                                | Required | Meaning                                                                                                                                                                                                                                         |
-| :----------------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                                             | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
-| `version`                                                          | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
-| `description`                                                      | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
-| `factory.min`                                                      | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
-| `contributes.packs`                                                | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
-| `contributes.adapters`                                             | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
-| `contributes.connectors`, `.views`, `.panels`, `.config`, `.hooks` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
+| Key                                                     | Required | Meaning                                                                                                                                                                                                                                         |
+| :------------------------------------------------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                                  | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
+| `version`                                               | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
+| `description`                                           | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
+| `factory.min`                                           | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
+| `contributes.packs`                                     | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
+| `contributes.adapters`                                  | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
+| `contributes.config`                                    | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.           |
+| `contributes.connectors`, `.views`, `.panels`, `.hooks` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
 
 Unknown top-level keys and unknown `contributes` keys are schema violations.
 Validate a manifest without loading anything:
@@ -124,10 +130,14 @@ Add its directory to `config/policy.yaml`:
 ```yaml
 extensions:
   - path: ~/.factory/extensions/wattmind-mobile # must contain factory-extension.json
+    config: # optional; the shape is the extension's config schema (§Config)
+      simulator: iPhone-16
+      maxParallel: 2
   - path: vendor/another-extension # relative paths resolve from the factory checkout
 ```
 
-Each entry accepts only `path` (`~` expands to the home directory). Entries
+Each entry accepts `path` (`~` expands to the home directory) and an optional
+`config` object — anything else is an anomaly and the entry is skipped. Entries
 load after the built-in root and after every `packs:` entry, in policy order:
 `packRoots` handed to the registry is `packs:` first, then each accepted
 extension's packs. Restart `serve` and the workers — extensions are read at
@@ -158,7 +168,10 @@ message naming both packs; fix the pack (or the order) and restart.
 3. Add adapters as `.mjs` modules exporting `execute` and `SANDBOX_SUPPORT`;
    the smallest conformant module is
    `event-runtime/test-support/extensions/sample/adapters/echo.mjs`.
-4. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+4. If the extension needs operator settings, write `config.schema.json` and
+   declare `contributes.config` (§Config); give every setting a `default`
+   where one makes sense.
+5. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
    enable it, `extensions list`, restart.
 
 The fixture `event-runtime/test-support/extensions/sample/` is a complete,
@@ -173,9 +186,126 @@ accepts the key and reports it as not supported yet._
 
 ## Config
 
-_Reserved key `contributes.config` — lands in WM-841 (extension config schemas
-validated at load and surfaced in `/config` + Settings). Until then the loader
-accepts the key and reports it as not supported yet._
+_Shipped in WM-841. Implementation: `resolveExtensionConfig`,
+`applyConfigDefaults`, `getExtensionConfig` and `loadedExtensions` in
+`event-runtime/lib/extensions.mjs`; the `extensions` section of
+`event-runtime/lib/api-config.mjs`; the Extensions section of
+`web/src/views/Settings.tsx`; fixture
+`event-runtime/test-support/extensions/sample/config.schema.json`._
+
+An extension that needs operator-provided settings — API hosts, allow-lists,
+thresholds — declares their **shape** in the manifest and the operator writes
+the **values** in `policy.yaml`. Neither side is trusted on its own: the loader
+checks the values against the shape before any of the extension's code runs.
+
+Manifest:
+
+```json
+"contributes": {
+  "config": { "namespace": "mobile", "schema": "./config.schema.json" }
+}
+```
+
+Schema (`config.schema.json`, relative to the manifest and inside its
+directory):
+
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "simulator": {
+      "type": "string",
+      "default": "iPhone-16",
+      "description": "booted before each run"
+    },
+    "maxParallel": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 4,
+      "default": 1
+    },
+    "apiToken": { "type": "string", "description": "masked in /config" }
+  }
+}
+```
+
+Values (`config/policy.yaml`):
+
+```yaml
+extensions:
+  - path: ~/.factory/extensions/wattmind-mobile
+    config:
+      maxParallel: 2
+      apiToken: sk-live-…
+```
+
+What the loader does with them, in order:
+
+1. **Reads the schema.** It must be a file inside the extension directory
+   (`extensions validate` checks this too) and valid JSON. The keyword subset
+   is `event-runtime/lib/schema.mjs`'s — `type`, `enum`, `const`, `required`,
+   `properties`, `additionalProperties`, `items`, `min/max*`, `pattern`,
+   `description` — plus `default`. Anything else (`anyOf`, `$ref`, …) fails
+   closed like every other contract in the runtime.
+2. **Applies defaults.** Every `default` under `properties`, recursively, is
+   filled in where the operator gave nothing; a nested object property is only
+   created when a default inside it produces something. With no `config:` in
+   the policy at all the effective object is _just_ the defaults, so an
+   extension whose every setting has a default needs no operator input.
+3. **Validates the effective object** with `schema.mjs validate`. A violation
+   is a configuration anomaly that **disables the extension whole** — nothing
+   of it is registered, its adapters are not even imported — with a message
+   naming the failing path:
+
+   ```text
+   extension ~/.factory/extensions/wattmind-mobile: wattmind/mobile@1.0.0: config does not match ./config.schema.json — $.maxParallel: above maximum 4 (extension skipped)
+   ```
+
+   Two more faults are treated the same way: policy `config:` values for an
+   extension whose manifest declares no `contributes.config` (the values would
+   silently do nothing otherwise), and a `namespace` another loaded extension
+   already uses.
+
+The extension's own code reads the result by name:
+
+```js
+import { getExtensionConfig } from "../../lib/extensions.mjs";
+const cfg = getExtensionConfig("wattmind/mobile"); // { simulator: "iPhone-16", maxParallel: 2, apiToken: "sk-live-…" }
+```
+
+`getExtensionConfig` returns the effective object — defaults applied,
+validated — or `undefined` when no extension of that name loaded (unknown, or
+disabled by an anomaly). It reads the last `loadExtensions` run in the process,
+which `serve` and `work` do once at start; a config change is a **restart**.
+
+### In `/config` and Settings
+
+`GET /config` gains a section `{ id: "extensions", reload: "restart" }` with
+one item per extension the loader saw:
+
+```json
+{ "name": "wattmind/mobile", "version": "1.0.0", "path": "…", "namespace": "mobile",
+  "reload": "restart", "schema": { … }, "values": { "simulator": "iPhone-16", "maxParallel": 2, "apiToken": "[redacted]" },
+  "anomaly": null }
+```
+
+A disabled extension appears with `values: null` and its `anomaly`; an
+extension that declares no config appears with `namespace: null`. The
+section's `entries` mirror the same rows (key = namespace) so the Settings
+search covers them. Settings renders it as the **Extensions** section — name,
+namespace, version, path, the effective values with the schema's
+`description`s as notes, a collapsed copy of the schema, and the anomaly in
+place of the values when the extension is disabled. Read-only, like every
+other Settings section: values change in `policy.yaml`, then restart.
+
+**Redaction rule.** Before publishing, every value whose key matches
+`/token|secret|key|password/i` — at any depth of the effective object — is
+replaced by `"[redacted]"` (`redactSecrets` in `lib/api-config.mjs`). Empty
+and `null` values are left as they are so "unset" stays visible. The schema is
+published as written; do not put a real secret in a `default`. The masking is
+by key name only: name secret settings so the rule catches them (`apiToken`,
+not `credential`).
 
 ## Hooks
 

--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -2,6 +2,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "./config.mjs";
+import { loadedExtensions } from "./extensions.mjs";
 import { reposView } from "./repos.mjs";
 import { loadNodesConfig, nodesConfigPath } from "./workers-remote.mjs";
 
@@ -99,6 +100,77 @@ function entriesForSchedule(schedule) {
   ];
 }
 
+/** Keys whose values are never published, wherever they sit in a config object. */
+const SECRET_KEY = /token|secret|key|password/i;
+const REDACTED = "[redacted]";
+
+/**
+ * Mask secret-looking keys at any depth. Empty and null values stay as they
+ * are (there is nothing to hide and "unset" is what the operator needs to see).
+ */
+export function redactSecrets(value) {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, inner]) => [
+      key,
+      SECRET_KEY.test(key) &&
+      inner !== null &&
+      inner !== "" &&
+      inner !== undefined
+        ? REDACTED
+        : redactSecrets(inner),
+    ]),
+  );
+}
+
+/**
+ * Extension config (WM-841): one row per extension the loader saw — accepted
+ * ones with their namespace, schema and effective (defaulted, validated,
+ * redacted) values; disabled ones with the anomaly that disabled them.
+ */
+function extensionsSection({ extensions = [], disabled = [] } = {}) {
+  const items = [
+    ...extensions.map((ext) => ({
+      name: ext.name,
+      version: ext.version,
+      path: ext.path,
+      namespace: ext.config?.namespace ?? null,
+      reload: "restart",
+      schema: ext.config?.schemaJson ?? null,
+      values: ext.config ? redactSecrets(ext.config.values) : null,
+      anomaly: null,
+    })),
+    ...disabled.map((ext) => ({
+      name: ext.name,
+      version: ext.version,
+      path: ext.path,
+      namespace: ext.namespace ?? null,
+      reload: "restart",
+      schema: null,
+      values: null,
+      anomaly: ext.reason,
+    })),
+  ];
+  return {
+    id: "extensions",
+    title: "Extensions",
+    source: source("config/policy.yaml", "yaml"),
+    reload: "restart",
+    entries: items.map((item) => ({
+      key: item.namespace ?? item.name ?? item.path,
+      value: item.values,
+      reload: "restart",
+      note: item.anomaly
+        ? `${item.name ?? item.path}: disabled — ${item.anomaly}`
+        : item.namespace
+          ? `${item.name}@${item.version}`
+          : `${item.name}@${item.version} declares no config`,
+    })),
+    extensions: items,
+  };
+}
+
 function edgeSummary(edges) {
   const rules = Object.values(edges ?? {});
   return {
@@ -146,6 +218,8 @@ export function configView({
   root = FACTORY_ROOT,
   now = Date.now(),
   registryLoadedAt,
+  // What loadExtensions() accepted/disabled in this process (tests pass their own).
+  extensions = loadedExtensions(),
 } = {}) {
   const policy = readYaml(path.join(root, "config", "policy.yaml"));
   const schedule = readYaml(path.join(root, "config", "schedule.yaml"));
@@ -199,6 +273,7 @@ export function configView({
         reload: "restart",
         entries: entriesForRegistry(registry),
       },
+      extensionsSection(extensions),
     ],
   };
 }

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -5,9 +5,18 @@ import {
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { configView } from "./api-config.mjs";
+import { configView, redactSecrets } from "./api-config.mjs";
 import { makeServer as makeApiServer } from "./api-test-helpers.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { loadExtensions } from "./extensions.mjs";
 import { reposView } from "./repos.mjs";
+
+const SAMPLE_EXTENSION = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+);
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -139,12 +148,14 @@ describe("GET /config view", () => {
       "nodes",
       "schedule",
       "registry",
+      "extensions",
     ]);
     expect(view.sections.map((section) => section.reload)).toEqual([
       "hot",
       "hot",
       "cli-only",
       "cli-only",
+      "restart",
       "restart",
     ]);
     expect(
@@ -204,5 +215,158 @@ describe("GET /config view", () => {
       harness: "pi",
     });
     expect(wire).not.toContain("do-not-publish");
+  });
+
+  test("publishes extension config: namespace, effective values, schema, and disabled reasons", () => {
+    const view = configView({
+      root: fixtureRoot(),
+      registry: registry(),
+      repos: () => new Map(),
+      policyVersion: "git:test",
+      now: 0,
+      extensions: {
+        extensions: [
+          {
+            name: "factory/sample",
+            version: "1.0.0",
+            path: "/ext/sample",
+            config: {
+              namespace: "sample",
+              schema: "./config.schema.json",
+              schemaJson: { type: "object", properties: {} },
+              values: {
+                greeting: "hello",
+                apiToken: "super-secret-value",
+                limits: { timeoutSeconds: 30, signingKey: "k" },
+              },
+            },
+          },
+          {
+            name: "factory/plain",
+            version: "0.1.0",
+            path: "/ext/plain",
+            config: null,
+          },
+        ],
+        disabled: [
+          {
+            name: "factory/broken",
+            version: "2.0.0",
+            path: "/ext/broken",
+            namespace: "broken",
+            reason:
+              "factory/broken@2.0.0: config does not match ./config.schema.json — $.maxParallel: above maximum 4",
+          },
+        ],
+      },
+    });
+    const section = view.sections.find((s) => s.id === "extensions");
+    expect(section.title).toBe("Extensions");
+    expect(section.source).toEqual({
+      file: "config/policy.yaml",
+      kind: "yaml",
+    });
+    expect(section.reload).toBe("restart");
+    expect(section.extensions).toEqual([
+      {
+        name: "factory/sample",
+        version: "1.0.0",
+        path: "/ext/sample",
+        namespace: "sample",
+        reload: "restart",
+        schema: { type: "object", properties: {} },
+        values: {
+          greeting: "hello",
+          apiToken: "[redacted]",
+          limits: { timeoutSeconds: 30, signingKey: "[redacted]" },
+        },
+        anomaly: null,
+      },
+      {
+        name: "factory/plain",
+        version: "0.1.0",
+        path: "/ext/plain",
+        namespace: null,
+        reload: "restart",
+        schema: null,
+        values: null,
+        anomaly: null,
+      },
+      {
+        name: "factory/broken",
+        version: "2.0.0",
+        path: "/ext/broken",
+        namespace: "broken",
+        reload: "restart",
+        schema: null,
+        values: null,
+        anomaly: expect.stringMatching(/\$\.maxParallel: above maximum 4/),
+      },
+    ]);
+    // Entries mirror the same rows so search and generic rendering keep working.
+    expect(section.entries.map((e) => e.key)).toEqual([
+      "sample",
+      "factory/plain",
+      "broken",
+    ]);
+    expect(section.entries[0].value.apiToken).toBe("[redacted]");
+    expect(section.entries[2].note).toMatch(/disabled/);
+    expect(JSON.stringify(view)).not.toContain("super-secret-value");
+  });
+
+  test("defaults to the extensions the process loaded (lib/extensions.mjs snapshot)", async () => {
+    await loadExtensions({
+      policy: {
+        extensions: [
+          {
+            path: SAMPLE_EXTENSION,
+            config: { apiToken: "shh", greeting: "yo" },
+          },
+        ],
+      },
+      packRoots: [],
+    });
+    const view = configView({
+      root: fixtureRoot(),
+      registry: registry(),
+      repos: () => new Map(),
+      policyVersion: "git:test",
+      now: 0,
+    });
+    const section = view.sections.find((s) => s.id === "extensions");
+    expect(section.extensions).toHaveLength(1);
+    expect(section.extensions[0].namespace).toBe("sample");
+    expect(section.extensions[0].values).toEqual({
+      greeting: "yo",
+      maxParallel: 1,
+      apiToken: "[redacted]",
+      limits: { timeoutSeconds: 30 },
+    });
+    expect(section.extensions[0].schema.properties.greeting.default).toBe(
+      "hello",
+    );
+    expect(JSON.stringify(view)).not.toContain("shh");
+  });
+
+  test("redactSecrets masks token/secret/key/password keys at any depth and leaves the rest", () => {
+    expect(
+      redactSecrets({
+        host: "api.example",
+        API_TOKEN: "a",
+        nested: { password: "b", list: [{ secretThing: "c", ok: 1 }] },
+        privateKey: "",
+        monkey: null,
+      }),
+    ).toEqual({
+      host: "api.example",
+      API_TOKEN: "[redacted]",
+      nested: {
+        password: "[redacted]",
+        list: [{ secretThing: "[redacted]", ok: 1 }],
+      },
+      privateKey: "",
+      monkey: null,
+    });
+    expect(redactSecrets("plain")).toBe("plain");
   });
 });

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -22,9 +22,17 @@
  *      registered — while every other extension still loads. `serve`/`work`
  *      never fail to start because a third-party manifest is broken.
  *   3. **Reserved manifest keys are accepted, not rejected.** `connectors`,
- *      `views`, `panels`, `config` and `hooks` belong to follow-up tickets;
- *      a manifest that carries them loads its packs and adapters here and
- *      records a "not supported yet" anomaly for the rest.
+ *      `views`, `panels` and `hooks` belong to follow-up tickets; a manifest
+ *      that carries them loads its packs and adapters here and records a
+ *      "not supported yet" anomaly for the rest.
+ *   4. **Config is declared, validated, defaulted (WM-841).** An extension
+ *      may declare `contributes.config: { namespace, schema }`; the operator's
+ *      values live on the policy entry (`extensions[].config`). At load the
+ *      schema is read, `default`s are applied, and the effective object is
+ *      validated with lib/schema.mjs — a violation disables the extension
+ *      (misconfigured code must not run). `getExtensionConfig(name)` hands the
+ *      effective object to that extension's adapters/hooks/panels, and
+ *      `loadedExtensions()` is the snapshot `GET /config` publishes.
  *
  * Ordering matters for callers: `adapterRegistry.toMap()` is a snapshot, so
  * `loadExtensions` must run before a CLI takes the map it hands to
@@ -57,9 +65,18 @@ export const RESERVED_CONTRIBUTIONS = Object.freeze([
   "connectors",
   "views",
   "panels",
-  "config",
   "hooks",
 ]);
+
+/** Policy entry fields `extensions[]` accepts besides `path`. */
+const ENTRY_FIELDS = new Set(["path", "config"]);
+
+/**
+ * The last `loadExtensions` result, kept so `getExtensionConfig` (adapters,
+ * hooks, panels) and `GET /config` (lib/api-config.mjs) read the same effective
+ * objects the loader validated. `serve` and `work` each load once at start.
+ */
+let LOADED = { extensions: [], disabled: [] };
 
 /** Thrown only for a malformed `extensions:` policy block; per-extension faults are anomalies. */
 export class ExtensionError extends Error {
@@ -92,7 +109,9 @@ function readPolicy(root) {
  * is reported per entry so one typo does not hide the other extensions.
  *
  * @param {{ root?: string, policy?: object }} [options]
- * @returns {{ roots: Array<{ path: string, index: number }>, anomalies: string[] }}
+ * @returns {{ roots: Array<{ path: string, index: number, config?: object }>, anomalies: string[] }}
+ *   `config` is the operator's raw values for the extension (validated by
+ *   `loadExtensions` against the schema the manifest declares).
  */
 export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
   const parsed = policy ?? readPolicy(root);
@@ -112,7 +131,7 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
       anomalies.push(`${at} must be an object with path (entry skipped)`);
       return;
     }
-    const unknown = Object.keys(entry).filter((key) => key !== "path");
+    const unknown = Object.keys(entry).filter((key) => !ENTRY_FIELDS.has(key));
     if (unknown.length > 0) {
       anomalies.push(
         `${at}: unknown field${unknown.length > 1 ? "s" : ""} ${unknown.map((k) => `"${k}"`).join(", ")} (entry skipped)`,
@@ -123,13 +142,26 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
       anomalies.push(`${at}.path must be a non-empty string (entry skipped)`);
       return;
     }
+    if (
+      Object.hasOwn(entry, "config") &&
+      (typeof entry.config !== "object" ||
+        entry.config === null ||
+        Array.isArray(entry.config))
+    ) {
+      anomalies.push(`${at}.config must be an object (entry skipped)`);
+      return;
+    }
     const resolved = path.resolve(root, expandHome(entry.path));
     if (seen.has(resolved)) {
       anomalies.push(`${at}: duplicate extension path ${resolved} (skipped)`);
       return;
     }
     seen.add(resolved);
-    roots.push({ path: resolved, index });
+    roots.push({
+      path: resolved,
+      index,
+      ...(Object.hasOwn(entry, "config") ? { config: entry.config } : {}),
+    });
   });
   return { roots, anomalies };
 }
@@ -221,7 +253,143 @@ export function validateExtensionManifest(dir) {
       );
     }
   }
+  if (contributes.config) {
+    const rel = contributes.config.schema;
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.config.schema "${rel}" escapes the extension directory`,
+      );
+    } else if (!existsSync(abs) || !statSync(abs).isFile()) {
+      errors.push(
+        `${file}: contributes.config.schema "${rel}" is not a file (${abs})`,
+      );
+    }
+  }
   return result(manifest);
+}
+
+/** Deep-clone JSON data (schema defaults are shared with the effective object otherwise). */
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Fill `default`s from a schema into a value, recursively through
+ * `properties`. A nested object property with no value is only created when
+ * a default inside it produces something — an empty object would trip that
+ * property's own `required` where absence would not.
+ */
+export function applyConfigDefaults(schema, value) {
+  if (!isPlainObject(schema)) return cloneJson(value);
+  let out = cloneJson(value);
+  if (out === undefined) {
+    if (Object.hasOwn(schema, "default")) out = cloneJson(schema.default);
+    else if (schema.type === "object" || isPlainObject(schema.properties))
+      out = {};
+    else return undefined;
+  }
+  if (isPlainObject(out) && isPlainObject(schema.properties)) {
+    for (const [key, sub] of Object.entries(schema.properties)) {
+      if (Object.hasOwn(out, key)) {
+        out[key] = applyConfigDefaults(sub, out[key]);
+        continue;
+      }
+      const filled = applyConfigDefaults(sub, undefined);
+      if (filled === undefined) continue;
+      if (isPlainObject(filled) && Object.keys(filled).length === 0) continue;
+      out[key] = filled;
+    }
+  }
+  return out;
+}
+
+/** `default` is an annotation lib/schema.mjs does not know; strip it before validating. */
+function withoutDefaults(schema) {
+  if (Array.isArray(schema)) return schema.map(withoutDefaults);
+  if (!isPlainObject(schema)) return schema;
+  const out = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "default") continue;
+    out[key] = withoutDefaults(value);
+  }
+  return out;
+}
+
+/**
+ * Resolve one extension's effective config: read the declared schema, apply
+ * its defaults over the operator's values, validate the result. Returns
+ * `null` when the manifest declares no config and the policy gives none;
+ * throws an ExtensionError naming the fault (and the failing value path)
+ * otherwise, which `loadExtensions` turns into a disabling anomaly.
+ *
+ * @param {string} dir - the extension directory
+ * @param {object} manifest - a schema-valid manifest
+ * @param {object|undefined} values - the policy entry's `config`
+ * @returns {{ namespace: string, schema: string, schemaJson: object, values: object }|null}
+ */
+export function resolveExtensionConfig(dir, manifest, values) {
+  const declared = manifest.contributes?.config;
+  if (!declared) {
+    if (values !== undefined) {
+      throw new ExtensionError(
+        "policy.yaml gives config values but the manifest declares no contributes.config",
+      );
+    }
+    return null;
+  }
+  const schemaFile = path.resolve(dir, declared.schema);
+  let schemaJson;
+  try {
+    schemaJson = JSON.parse(readFileSync(schemaFile, "utf8"));
+  } catch (err) {
+    throw new ExtensionError(
+      `contributes.config.schema "${declared.schema}" is not valid JSON — ${err.message}`,
+    );
+  }
+  const effective = applyConfigDefaults(schemaJson, values ?? {});
+  const check = validate(withoutDefaults(schemaJson), effective);
+  if (!check.valid) {
+    throw new ExtensionError(
+      `config does not match ${declared.schema} — ${check.errors.join("; ")}`,
+    );
+  }
+  return {
+    namespace: declared.namespace,
+    schema: declared.schema,
+    schemaJson,
+    values: effective,
+  };
+}
+
+/**
+ * The effective config object of a loaded extension — schema defaults applied
+ * over the operator's policy values, validated at load. `undefined` when no
+ * extension of that name loaded (unknown, or disabled by an anomaly).
+ *
+ * @param {string} name - the manifest `name` (`publisher/extension`)
+ * @returns {object|undefined}
+ */
+export function getExtensionConfig(name) {
+  return LOADED.extensions.find((e) => e.name === name)?.config?.values;
+}
+
+/**
+ * Snapshot of the last `loadExtensions` run for read-only surfaces
+ * (`GET /config`, lib/api-config.mjs): every accepted extension with its
+ * config, and every extension a fault disabled with the reason.
+ *
+ * @returns {{
+ *   extensions: Array<{ name: string, version: string, path: string, config: { namespace: string, schema: string, schemaJson: object, values: object }|null }>,
+ *   disabled: Array<{ name: string|null, version: string|null, path: string, namespace: string|null, reason: string }>,
+ * }}
+ */
+export function loadedExtensions() {
+  return LOADED;
 }
 
 function isInside(root, abs) {
@@ -260,11 +428,13 @@ function packRootFor(extensionRoot, rel) {
  * @param {Array<object>} [options.packRoots] - the policy `packs:` roots the extension packs join (default: loadPackRoots({ root }))
  * @param {string} [options.registryRoot] - the built-in registry root the dry load uses (tests point it at a copy)
  * @returns {Promise<{
- *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], reserved: string[] }>,
+ *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
  *   packRoots: Array<object>,
  *   anomalies: string[],
+ *   disabled: Array<{ name: string|null, version: string|null, path: string, namespace: string|null, reason: string }>,
  * }>} `packRoots` is the full list — policy packs first, then every accepted
  *   extension pack in policy order — ready to hand to `loadRegistry`.
+ *   `disabled` lists every extension an anomaly skipped, for `/config`.
  */
 export async function loadExtensions({
   root = reposRoot(),
@@ -279,17 +449,27 @@ export async function loadExtensions({
   const accepted = [...basePackRoots];
   const acceptedPackNames = new Set(basePackRoots.map((p) => p.name));
   const acceptedAdapterNames = new Set();
+  const acceptedNamespaces = new Map();
+  const disabled = [];
+  const loaded = [];
   const dryLoad = (candidates) =>
     loadRegistry({
       ...(registryRoot ? { root: registryRoot } : {}),
       packRoots: candidates,
     });
 
-  for (const { path: dir } of roots) {
+  for (const { path: dir, config: values } of roots) {
+    const checked = validateExtensionManifest(dir);
     const skip = (reason) => {
       anomalies.push(`extension ${dir}: ${reason} (extension skipped)`);
+      disabled.push({
+        name: checked.manifest?.name ?? null,
+        version: checked.manifest?.version ?? null,
+        path: dir,
+        namespace: checked.manifest?.contributes?.config?.namespace ?? null,
+        reason,
+      });
     };
-    const checked = validateExtensionManifest(dir);
     if (!checked.valid) {
       skip(checked.errors.join("; "));
       continue;
@@ -297,6 +477,16 @@ export async function loadExtensions({
     const manifest = checked.manifest;
     const label = `${manifest.name}@${manifest.version}`;
     const contributes = manifest.contributes ?? {};
+
+    // Config: schema + defaults + validation, before any extension code is
+    // imported — misconfigured code must not run (WM-841).
+    let config;
+    try {
+      config = resolveExtensionConfig(dir, manifest, values);
+    } catch (err) {
+      skip(`${label}: ${err.message}`);
+      continue;
+    }
 
     // Packs: resolve to pack roots and prove they load with everything
     // accepted so far. The registry's own errors identify both packs on a
@@ -348,6 +538,12 @@ export async function loadExtensions({
       skip(`${label}: ${adapterFault}`);
       continue;
     }
+    if (config && acceptedNamespaces.has(config.namespace)) {
+      skip(
+        `${label}: config namespace "${config.namespace}" is already used by ${acceptedNamespaces.get(config.namespace)}`,
+      );
+      continue;
+    }
 
     // Accept: commit packs, register adapters, record the reserved keys.
     accepted.push(...extPackRoots);
@@ -357,6 +553,8 @@ export async function loadExtensions({
       acceptedAdapterNames.add(name);
     }
     for (const warning of checked.warnings) anomalies.push(warning);
+    if (config) acceptedNamespaces.set(config.namespace, manifest.name);
+    const { schemaJson, ...publicConfig } = config ?? {};
     extensions.push({
       name: manifest.name,
       version: manifest.version,
@@ -366,8 +564,16 @@ export async function loadExtensions({
       reserved: RESERVED_CONTRIBUTIONS.filter((key) =>
         Object.hasOwn(contributes, key),
       ),
+      config: config ? publicConfig : null,
+    });
+    loaded.push({
+      name: manifest.name,
+      version: manifest.version,
+      path: dir,
+      config: config ? { ...publicConfig, schemaJson } : null,
     });
   }
 
-  return { extensions, packRoots: accepted, anomalies };
+  LOADED = { extensions: loaded, disabled };
+  return { extensions, packRoots: accepted, anomalies, disabled };
 }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -16,8 +16,10 @@ import {
   EXTENSION_SCHEMA,
   ExtensionError,
   RESERVED_CONTRIBUTIONS,
+  getExtensionConfig,
   loadExtensionRoots,
   loadExtensions,
+  loadedExtensions,
   validateExtensionManifest,
 } from "./extensions.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
@@ -186,6 +188,15 @@ describe("loadExtensions", () => {
         packs: ["sample-ext"],
         adapters: ["echo"],
         reserved: [],
+        config: {
+          namespace: "sample",
+          schema: "./config.schema.json",
+          values: {
+            greeting: "hello",
+            maxParallel: 1,
+            limits: { timeoutSeconds: 30 },
+          },
+        },
       },
     ]);
     expect(out.packRoots).toEqual([
@@ -388,6 +399,144 @@ describe("loadExtensions", () => {
       /"extensions" must be an array/,
     );
     rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("extension config (contributes.config)", () => {
+  const withValues = (config) => ({
+    extensions: [{ path: SAMPLE_EXTENSION, config }],
+  });
+
+  test("valid values are validated against the schema and defaults fill the gaps", async () => {
+    const out = await load(
+      withValues({
+        greeting: "hey",
+        apiToken: "t0k3n",
+        limits: { retries: 2 },
+      }),
+    );
+    expect(out.anomalies).toEqual([]);
+    expect(out.extensions[0].config).toEqual({
+      namespace: "sample",
+      schema: "./config.schema.json",
+      values: {
+        greeting: "hey",
+        maxParallel: 1,
+        apiToken: "t0k3n",
+        limits: { retries: 2, timeoutSeconds: 30 },
+      },
+    });
+    // The effective object is what adapters/hooks/panels read, by extension name.
+    expect(getExtensionConfig("factory/sample")).toEqual(
+      out.extensions[0].config.values,
+    );
+    expect(getExtensionConfig("nobody/here")).toBeUndefined();
+    expect(loadedExtensions().extensions[0].name).toBe("factory/sample");
+    expect(loadedExtensions().disabled).toEqual([]);
+  });
+
+  test("an invalid value disables the extension whole and names the failing path", async () => {
+    const out = await load(withValues({ maxParallel: 9, bogus: true }));
+    expect(out.extensions).toEqual([]);
+    expect(out.packRoots).toEqual([]);
+    expect(out.adapterRegistry.has("echo")).toBe(false);
+    expect(out.anomalies).toHaveLength(1);
+    expect(out.anomalies[0]).toMatch(
+      /factory\/sample@1\.0\.0: config does not match \.\/config\.schema\.json — \$\.maxParallel: above maximum 4; \$: unknown property "bogus" \(extension skipped\)/,
+    );
+    expect(getExtensionConfig("factory/sample")).toBeUndefined();
+    expect(loadedExtensions().disabled).toEqual([
+      {
+        name: "factory/sample",
+        version: "1.0.0",
+        path: SAMPLE_EXTENSION,
+        namespace: "sample",
+        reason: expect.stringMatching(/\$\.maxParallel: above maximum 4/),
+      },
+    ]);
+  });
+
+  test("a wrong-typed policy config entry is an entry anomaly, like any other bad field", () => {
+    const out = loadExtensionRoots({
+      policy: { extensions: [{ path: "x", config: "nope" }] },
+    });
+    expect(out.roots).toEqual([]);
+    expect(out.anomalies[0]).toMatch(
+      /config must be an object \(entry skipped\)/,
+    );
+  });
+
+  test("values without a declared schema, and a schema that is missing, escaping or unsupported, disable the extension", async () => {
+    const undeclared = tempExtension((m) => {
+      m.name = "factory/undeclared";
+      delete m.contributes.config;
+    });
+    const missing = tempExtension((m) => {
+      m.name = "factory/missing";
+      m.contributes.config.schema = "./nope.json";
+    });
+    const escaping = tempExtension((m) => {
+      m.name = "factory/escaping";
+      m.contributes.config.schema = "../config.schema.json";
+    });
+    const unsupported = tempExtension((m, dir) => {
+      m.name = "factory/unsupported";
+      writeFileSync(
+        path.join(dir, "config.schema.json"),
+        JSON.stringify({ type: "object", anyOf: [] }),
+      );
+    });
+    const out = await loadExtensions({
+      policy: {
+        extensions: [
+          { path: undeclared, config: { greeting: "x" } },
+          { path: missing },
+          { path: escaping },
+          { path: unsupported },
+        ],
+      },
+      packRoots: [],
+    });
+    expect(out.extensions).toEqual([]);
+    expect(out.anomalies).toEqual([
+      expect.stringMatching(
+        /factory\/undeclared@1\.0\.0: policy.yaml gives config values but the manifest declares no contributes\.config/,
+      ),
+      expect.stringMatching(
+        /contributes\.config\.schema ".\/nope.json" is not a file/,
+      ),
+      expect.stringMatching(
+        /contributes\.config\.schema "..\/config.schema.json" escapes/,
+      ),
+      expect.stringMatching(/unsupported schema keyword "anyOf"/),
+    ]);
+  });
+
+  test("two extensions may not share a config namespace", async () => {
+    const twin = tempExtension((m, dir) => {
+      m.name = "factory/twin";
+      m.contributes.packs = [];
+      m.contributes.adapters = {};
+    });
+    const out = await load(policyFor(SAMPLE_EXTENSION, twin));
+    expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(out.anomalies[0]).toMatch(
+      /config namespace "sample" is already used by factory\/sample/,
+    );
+  });
+
+  test("validate refuses a manifest whose config key is malformed", () => {
+    const bad = tempExtension((m) => {
+      m.contributes.config = { namespace: "Bad Space" };
+    });
+    const out = validateExtensionManifest(bad);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(
+      /config\.namespace: does not match pattern/,
+    );
+    expect(out.errors.join("\n")).toMatch(
+      /config: missing required property "schema"/,
+    );
   });
 });
 

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "factory-extension.json — the manifest of one factory extension (docs/extensions.md)",
-  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views`, `panels`, `config` and `hooks` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
+  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views`, `panels` and `hooks` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
   "type": "object",
   "required": ["name", "version"],
   "additionalProperties": false,
@@ -57,7 +57,22 @@
           "description": "reserved — declarative Overview panels; lands in WM-840"
         },
         "config": {
-          "description": "reserved — extension config schemas; lands in WM-841"
+          "type": "object",
+          "required": ["namespace", "schema"],
+          "additionalProperties": false,
+          "description": "the extension's operator config (docs/extensions.md § Config): a JSON-schema file for the values policy.yaml `extensions[].config` supplies; validated at load, defaults applied, surfaced read-only in GET /config and Settings",
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$",
+              "description": "the name the values are published under; unique across loaded extensions"
+            },
+            "schema": {
+              "type": "string",
+              "pattern": "\\.json$",
+              "description": "relative path to a JSON-schema (the lib/schema.mjs subset plus `default`) describing the config object"
+            }
+          }
         },
         "hooks": {
           "description": "reserved — lifecycle hooks; lands in WM-842"

--- a/event-runtime/test-support/extensions/sample/config.schema.json
+++ b/event-runtime/test-support/extensions/sample/config.schema.json
@@ -1,0 +1,32 @@
+{
+  "title": "factory/sample config — the fixture's operator settings (docs/extensions.md § Config)",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "greeting": {
+      "type": "string",
+      "minLength": 1,
+      "default": "hello",
+      "description": "what the echo adapter says first"
+    },
+    "maxParallel": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 4,
+      "default": 1,
+      "description": "how many echoes may run at once"
+    },
+    "apiToken": {
+      "type": "string",
+      "description": "a secret; masked in /config by the redaction rule"
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timeoutSeconds": { "type": "integer", "minimum": 1, "default": 30 },
+        "retries": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/event-runtime/test-support/extensions/sample/factory-extension.json
+++ b/event-runtime/test-support/extensions/sample/factory-extension.json
@@ -1,10 +1,18 @@
 {
   "name": "factory/sample",
   "version": "1.0.0",
-  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace) and one trivial adapter.",
-  "factory": { "min": "0.1.0" },
+  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, and a config schema.",
+  "factory": {
+    "min": "0.1.0"
+  },
   "contributes": {
     "packs": ["./pack"],
-    "adapters": { "echo": "./adapters/echo.mjs" }
+    "adapters": {
+      "echo": "./adapters/echo.mjs"
+    },
+    "config": {
+      "namespace": "sample",
+      "schema": "./config.schema.json"
+    }
   }
 }

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -45,12 +45,25 @@ export interface ConfigEntry {
   reload?: ConfigReload;
   note?: string;
 }
+/** One extension in the `extensions` config section (WM-841): effective, redacted values or the anomaly that disabled it. */
+export interface ConfigExtension {
+  name: string | null;
+  version: string | null;
+  path: string;
+  namespace: string | null;
+  reload: ConfigReload;
+  schema: Record<string, unknown> | null;
+  values: Record<string, unknown> | null;
+  anomaly: string | null;
+}
 export interface ConfigSection {
   id: string;
   title: string;
   source: { file: string; kind: "yaml" | "json" | "registry" };
   reload: ConfigReload;
   entries: ConfigEntry[];
+  /** Only on the `extensions` section. */
+  extensions?: ConfigExtension[];
 }
 export interface ConfigView {
   generatedAt: string;

--- a/event-runtime/web/src/views/Settings.test.tsx
+++ b/event-runtime/web/src/views/Settings.test.tsx
@@ -69,6 +69,55 @@ const fixture: ConfigView = {
         { key: "schedules", value: 1 },
       ],
     },
+    {
+      id: "extensions",
+      title: "Extensions",
+      source: { file: "config/policy.yaml", kind: "yaml" },
+      reload: "restart",
+      entries: [
+        {
+          key: "mobile",
+          value: { simulator: "iPhone-16", apiToken: "[redacted]" },
+          reload: "restart",
+          note: "wattmind/mobile@1.0.0",
+        },
+        {
+          key: "broken",
+          value: null,
+          reload: "restart",
+          note: "wattmind/broken: disabled — config does not match ./config.schema.json — $.maxParallel: above maximum 4",
+        },
+      ],
+      extensions: [
+        {
+          name: "wattmind/mobile",
+          version: "1.0.0",
+          path: "/ext/mobile",
+          namespace: "mobile",
+          reload: "restart",
+          schema: {
+            type: "object",
+            properties: {
+              simulator: { type: "string", description: "simulator name" },
+              apiToken: { type: "string" },
+            },
+          },
+          values: { simulator: "iPhone-16", apiToken: "[redacted]" },
+          anomaly: null,
+        },
+        {
+          name: "wattmind/broken",
+          version: "2.0.0",
+          path: "/ext/broken",
+          namespace: "broken",
+          reload: "restart",
+          schema: null,
+          values: null,
+          anomaly:
+            "wattmind/broken@2.0.0: config does not match ./config.schema.json — $.maxParallel: above maximum 4",
+        },
+      ],
+    },
   ],
 };
 
@@ -159,5 +208,51 @@ describe("Settings", () => {
     fireEvent.click(view.getByRole("button", { name: /Policy\s*3/ }));
     expect(await view.findByText("notify")).toBeTruthy();
     expect(view.getByText("—")).toBeTruthy();
+  });
+
+  test("renders the Extensions section: namespace, effective values, and the anomaly of a disabled extension", async () => {
+    stubConfig();
+    const view = renderWithClient(<StatefulSettings initial="extensions" />);
+    await view.findByRole("heading", { name: "Extensions" });
+    expect(
+      view
+        .getByRole("button", { name: /Extensions\s*2/ })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+
+    // A loaded extension: name, namespace, and its redacted effective values.
+    expect(view.getByText("wattmind/mobile")).toBeTruthy();
+    expect(view.getByText("mobile")).toBeTruthy();
+    expect(view.getByText("simulator")).toBeTruthy();
+    expect(view.getByText("iPhone-16")).toBeTruthy();
+    expect(view.getByText("[redacted]")).toBeTruthy();
+    expect(view.getByText("simulator name")).toBeTruthy();
+    expect(view.getAllByText("restart").length).toBeGreaterThan(0);
+
+    // A disabled one: its anomaly, and no values table.
+    const disabled = view.getByText(/disabled/);
+    expect(disabled.textContent).toContain("$.maxParallel: above maximum 4");
+    expect(view.queryByText("wattmind/broken")).toBeTruthy();
+    // Nothing is editable: read-only inventory.
+    expect(
+      view.container.querySelectorAll("input, select, textarea").length,
+    ).toBe(1);
+  });
+
+  test("searches extension values like any other section", async () => {
+    stubConfig();
+    const view = renderWithClient(<StatefulSettings initial="repos" />);
+    await view.findByText("factory.tools.base");
+    act(() =>
+      changeInput(
+        view.getByRole("combobox", { name: "Search settings" }),
+        "iphone",
+      ),
+    );
+    await waitFor(() =>
+      expect(view.getByRole("heading", { name: "Extensions" })).toBeTruthy(),
+    );
+    expect(view.getByText("iPhone-16")).toBeTruthy();
+    expect(view.queryByText("wattmind/broken")).toBeNull();
   });
 });

--- a/event-runtime/web/src/views/Settings.tsx
+++ b/event-runtime/web/src/views/Settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   fetchConfig,
   type ConfigEntry,
+  type ConfigExtension,
   type ConfigReload,
   type ConfigSection,
 } from "../api";
@@ -94,6 +95,136 @@ function SettingsRow({
         </span>
         <ReloadChip reload={reload} />
       </div>
+    </div>
+  );
+}
+
+/** The entry key the server publishes for an extension (mirrors lib/api-config.mjs). */
+function extensionKey(ext: ConfigExtension): string {
+  return ext.namespace ?? ext.name ?? ext.path;
+}
+
+function schemaDescriptions(
+  schema: ConfigExtension["schema"],
+): Record<string, string> {
+  const properties = (schema?.properties ?? {}) as Record<
+    string,
+    { description?: unknown }
+  >;
+  return Object.fromEntries(
+    Object.entries(properties).flatMap(([key, prop]) =>
+      typeof prop?.description === "string" ? [[key, prop.description]] : [],
+    ),
+  );
+}
+
+/**
+ * One extension of the Extensions section (WM-841): what loaded, under which
+ * namespace, with its effective (defaulted, validated, redacted) values — or
+ * the anomaly that disabled it. Read-only, like every other section.
+ */
+function ExtensionRow({
+  section,
+  ext,
+}: {
+  section: ConfigSection;
+  ext: ConfigExtension;
+}) {
+  const descriptions = schemaDescriptions(ext.schema);
+  const values = ext.values ? Object.entries(ext.values) : [];
+  return (
+    <div className="border-b border-(--border) last:border-b-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 px-3 py-2.5">
+        <span className="mono min-w-0 break-words text-[12px] font-medium text-(--text)">
+          {ext.name ?? ext.path}
+        </span>
+        {ext.namespace && (
+          <span
+            className="mono shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-xs text-(--text-dim)"
+            title="config namespace"
+          >
+            {ext.namespace}
+          </span>
+        )}
+        {ext.version && (
+          <span className="mono shrink-0 text-xs text-(--text-faint)">
+            v{ext.version}
+          </span>
+        )}
+        {ext.name && (
+          <span
+            className="mono min-w-0 truncate text-xs text-(--text-faint)"
+            title={ext.path}
+          >
+            {ext.path}
+          </span>
+        )}
+        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+          <span
+            className="mono shrink-0 rounded border border-(--border) px-1.5 py-0.5 text-xs text-(--text-faint)"
+            title={section.source.file}
+          >
+            {sourceName(section.source.file)}
+          </span>
+          <ReloadChip reload={ext.reload} />
+        </span>
+      </div>
+      {ext.anomaly ? (
+        <div
+          role="status"
+          className="mx-3 mb-2.5 rounded border border-(--hue-err) px-2.5 py-2 text-[12px] text-(--hue-err)"
+        >
+          disabled — {ext.anomaly}
+        </div>
+      ) : ext.values === null ? (
+        <div className="px-3 pb-2.5 text-xs text-(--text-faint)">
+          Declares no config.
+        </div>
+      ) : (
+        <>
+          <div className="mx-3 mb-2 overflow-hidden rounded border border-(--border) bg-(--surface-1)">
+            {values.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-(--text-faint)">
+                No values set and the schema declares no defaults.
+              </div>
+            ) : (
+              values.map(([key, value]) => {
+                const shown = displayValue(value);
+                return (
+                  <div
+                    key={key}
+                    className="grid min-w-0 gap-2 border-b border-(--border) px-3 py-2 last:border-b-0 md:grid-cols-[minmax(10rem,0.8fr)_minmax(12rem,1.4fr)]"
+                  >
+                    <div className="mono min-w-0 break-words text-[12px] text-(--text)">
+                      {key}
+                    </div>
+                    <div className="min-w-0 overflow-x-auto">
+                      <pre
+                        className={`mono w-max min-w-full whitespace-pre text-[12px] ${shown === EMPTY ? "text-(--text-faint)" : "text-(--text-dim)"}`}
+                      >
+                        {shown}
+                      </pre>
+                      {descriptions[key] && (
+                        <div className="mt-1 text-xs text-(--text-faint)">
+                          {descriptions[key]}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+          {ext.schema && (
+            <details className="mx-3 mb-2.5 text-xs text-(--text-faint)">
+              <summary className="cursor-pointer select-none">schema</summary>
+              <pre className="mono mt-1 overflow-x-auto text-[11px] text-(--text-dim)">
+                {JSON.stringify(ext.schema, null, 2)}
+              </pre>
+            </details>
+          )}
+        </>
+      )}
     </div>
   );
 }
@@ -242,13 +373,34 @@ export function Settings({
                     </span>
                   </div>
                   <div className="min-w-0 overflow-hidden rounded-md border border-(--border) bg-(--surface-0)">
-                    {section.entries.map((entry) => (
-                      <SettingsRow
-                        key={entry.key}
-                        section={section}
-                        entry={entry}
-                      />
-                    ))}
+                    {section.extensions && section.extensions.length === 0 && (
+                      <div className="px-3 py-2.5 text-xs text-(--text-faint)">
+                        No extensions enabled — add them under{" "}
+                        <span className="mono">extensions:</span> in
+                        policy.yaml.
+                      </div>
+                    )}
+                    {section.extensions
+                      ? section.extensions
+                          .filter((ext) =>
+                            section.entries.some(
+                              (entry) => entry.key === extensionKey(ext),
+                            ),
+                          )
+                          .map((ext) => (
+                            <ExtensionRow
+                              key={`${extensionKey(ext)}:${ext.path}`}
+                              section={section}
+                              ext={ext}
+                            />
+                          ))
+                      : section.entries.map((entry) => (
+                          <SettingsRow
+                            key={entry.key}
+                            section={section}
+                            entry={entry}
+                          />
+                        ))}
                   </div>
                 </section>
               ))


### PR DESCRIPTION
Extensions can now declare `contributes.config: { namespace, schema }`; operators supply values under `policy.yaml extensions[].config`. At load the schema is read, `default`s applied, and the effective object validated with `lib/schema.mjs` — a violation is a configuration anomaly that disables the extension before any of its code is imported, naming the failing path. `getExtensionConfig(name)` returns the effective object for adapters/hooks/panels; `loadedExtensions()` is the snapshot `GET /config` publishes.

- `GET /config` gains an `extensions` section (name, namespace, reload: restart, schema, values, anomaly) with `redactSecrets` masking `/token|secret|key|password/i` keys at any depth.
- Settings renders a read-only Extensions section: namespace, effective values (schema descriptions as notes), collapsed schema, and the anomaly for a disabled extension.
- Fixture `test-support/extensions/sample/config.schema.json`; docs/extensions.md § Config filled in.
- Kept additive to WM-840 (panels): own function per key, own schema property, own docs section.

Verification: `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/extensions.test.mjs event-runtime/lib/api-config.test.mjs event-runtime/web/src/views/Settings.test.tsx && cd event-runtime/web && bun run build && cd ../.. && bun run lint --max-warnings=627 && bun run check` — pass (35 tests, build ok, 0 lint errors, check ok).

Fixes WM-841