### PR TITLE
fix(merge): durable fix round = executed rounds + 1; REFUSED runs and lower scan rounds do not block

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -537,14 +537,14 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
 
 function durableFixRoundReason(db, candidate, input, policy) {
   const cap = policy.maxFixRounds ?? 0;
-  // Count only rounds that were actually admitted to run (a proposal decided
-  // "run" that produced a run). Every merge-scan tick re-emits the current
-  // round's fix request for a PR that is still red; counting those refused or
-  // superseded emissions exhausted max_fix_rounds before any fix executed and
-  // parked every PR as fix-round-exhausted (2026-08-18).
+  // A fix round is "spent" only when a merge-fix run for this PR actually
+  // executed (or is executing). Emitted-but-never-run events (merge-scan
+  // re-emits every tick), REFUSED execute-time refusals (pr moved, ticket
+  // state) and CANCELLED stale-pinned runs do not consume the budget
+  // (2026-08-18: counting them exhausted max_fix_rounds before any fix ran).
   const rows = db
     .query(
-      `SELECT e.event_id, e.envelope_json FROM events e
+      `SELECT e.event_id, e.envelope_json, r.state FROM events e
        JOIN proposals p ON p.event_id = e.event_id AND p.event_source = e.source
        JOIN runs r ON r.run_id = p.run_id
        WHERE e.source = 'chain'
@@ -554,7 +554,7 @@ function durableFixRoundReason(db, candidate, input, policy) {
          AND e.event_id != ?`,
     )
     .all(candidate.event_id);
-  const priorRounds = [];
+  let executed = 0;
   for (const row of rows) {
     let payload;
     try {
@@ -569,11 +569,20 @@ function durableFixRoundReason(db, candidate, input, policy) {
     ) {
       if (!Number.isInteger(payload.round) || payload.round < 1)
         return "merge_fix_history_invalid";
-      priorRounds.push(payload.round);
+      executed += 1;
     }
   }
-  const durableRound = (priorRounds.length ? Math.max(...priorRounds) : 0) + 1;
-  if (durableRound > cap || input.round !== durableRound)
+  // The durable round is the count of executed rounds plus one — the runtime,
+  // not the scanning model, is the source of truth. The scan may still say a
+  // lower round (it does not see run history); a higher round than durable is
+  // a replay/skip and is refused.
+  const durableRound = executed + 1;
+  if (durableRound > cap) return "merge_fix_round_not_durable";
+  if (
+    !Number.isInteger(input.round) ||
+    input.round < 1 ||
+    input.round > durableRound
+  )
     return "merge_fix_round_not_durable";
   return null;
 }

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1658,6 +1658,68 @@ describe("policy approval and global merge barrier", () => {
     ).toBe(2);
   });
 
+  test("a scan that re-emits round 1 after round 1 executed is accepted as the next durable round; REFUSED runs do not spend rounds", () => {
+    const db = openDb(":memory:");
+    const payload = (round) => ({
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 90,
+      headSha: SHA,
+      baseSha: BASE_SHA,
+      headRef: "feat/WM-590",
+      ticket: "WM-590",
+      finding: `mechanical round ${round}`,
+      findingHash: FINDING_HASH,
+      round,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: ["event-runtime/merge.test.mjs"],
+    });
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(1), "fix90-1"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    // Round 1 executed; the model does not see run history and emits round 1 again.
+    db.query(
+      `UPDATE runs SET state='COMPLETED' WHERE json_extract(spec_json,'$.agent')='merge-fix@1' AND json_extract(spec_json,'$.input.pr')=90`,
+    ).run();
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(1), "fix90-1-again"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(
+      openProposals(db, {}).find((p) => p.event_id === "fix90-1-again"),
+    ).toBeUndefined();
+    // Mark that second run REFUSED (execute-time refusal): it must not spend the budget.
+    db.query(
+      `UPDATE runs SET state='REFUSED' WHERE json_extract(spec_json,'$.agent')='merge-fix@1' AND json_extract(spec_json,'$.input.pr')=90 AND state='QUEUED'`,
+    ).run();
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(2), "fix90-2"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(
+      openProposals(db, {}).find((p) => p.event_id === "fix90-2"),
+    ).toBeUndefined();
+    // Two executed (COMPLETED + QUEUED) → a further emission is exhausted.
+    admitEvent(
+      db,
+      registry,
+      envelope("factory.merge-fix.requested", payload(2), "fix90-3"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(
+      openProposals(db, {}).find((p) => p.event_id === "fix90-3").reason,
+    ).toContain("merge_fix_round_not_durable");
+  });
+
   test("mechanical fix rounds are bounded and exhausted rounds fail schema/policy closed", () => {
     const schema = registry.agents.get("merge-fix@1").inputSchema;
     expect(schema.properties.round.maximum).toBe(2);


### PR DESCRIPTION
Follow-up to #671 — after the restart 18–20 merge-fix proposals were still `merge_fix_round_not_durable` because (1) REFUSED execute-time refusals and stale-pinned QUEUED runs were counted as spent rounds and (2) the agy/sonnet scan re-emits round 1 after round 1 already executed (it cannot see run history) and the strict `input.round === durableRound` refused it forever. Now: `durableRound = executed rounds + 1` (runs in QUEUED..FAILED; REFUSED/CANCELLED/PROPOSED excluded), a scan round ≤ durable is accepted, > durable or > max_fix_rounds is refused. merge.test 42/42, auto-approval 27/27.