### PR TITLE
feat(views): declarative panels (factory.panel-view/v1) from packs/extensions, rendered on Overview (WM-840)

### DIFF
--- a/docs/event-runtime-artifact-views.md
+++ b/docs/event-runtime-artifact-views.md
@@ -167,6 +167,74 @@ hardest to read as JSON. `dispatch`, `work-scan`, `run-postmortem` follow in
 the Backlog ticket once the first two have shown what the vocabulary is
 missing.
 
+### 2.6 Panels — `factory.panel-view/v1` (WM-840)
+
+The same vocabulary, one level up. An artifact view describes one agent's
+output; a **panel** describes a dashboard tile bound to an existing loopback
+API endpoint, so a pack or extension can put "open needs-me items" or "tickets
+blocked > 24h" on Overview without shipping React. No client-side code is
+loaded — a panel is data, validated at registry load, drawn by the same
+`ArtifactView` renderer.
+
+```json
+{
+  "format": "factory.panel-view/v1",
+  "name": "wattmind/mobile:blocked-tickets",
+  "title": "Blocked > 24h",
+  "source": {
+    "endpoint": "/tickets",
+    "query": { "state": "blocked" },
+    "path": "/tickets"
+  },
+  "refreshSeconds": 60,
+  "view": {
+    "sections": [
+      {
+        "path": "",
+        "as": "table",
+        "columns": ["identifier", "title"],
+        "formats": { "identifier": "issue" }
+      }
+    ]
+  }
+}
+```
+
+| Key              | Rule                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`         | `factory.panel-view/v1`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `name`           | Unique across every contributor; `slug` for built-ins, `<namespace>:<slug>` for pack panels, `<publisher>/<extension>:<slug>` for extension panels. A duplicate is a configuration anomaly for the later contributor (built-in, then packs in policy order, then extensions).                                                                                                                                                                                                                                                          |
+| `title`          | ≤ 60 chars, the tile heading. Optional `description` (≤ 200) is the heading's tooltip.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `source`         | `endpoint` — one of the loopback API's GET routes, **allow-listed** in `lib/api-panels.mjs` (`PANEL_ENDPOINTS`; `/agents /artifacts /chains /config /events /health /inbox /journal /metrics /metrics/breakdown /outbox /proposals /repos /runs /schedules /status /tickets /workers`) — no arbitrary URLs, no detail routes, no `/panels`; optional `query` (string values, appended as `?k=v`); optional `path`, an RFC 6901 pointer into the response selecting the node the view draws (`""`, the default, is the whole response). |
+| `refreshSeconds` | 5–3600, default 60: how often the web refetches the source.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `view`           | An artifact-view body (§2.2) without `schemaVersion`: `sections` (each `path` **relative to the selected node**, `""` for the node itself), optional `summary` and `status`. Same `as`, `formats` and `tone` sets, same per-`as` keys.                                                                                                                                                                                                                                                                                                 |
+
+Validation is `lib/panel-view.mjs`: the panel schema
+(`schemas/panel-view.schema.json`), the endpoint allow-list, and `view` through
+the artifact-view validator's shape check (`validateArtifactViewShape` — the
+schema and per-`as` key rules, minus the pointer-drift check, because an
+endpoint has no published output schema). Pointers are RFC 6901 throughout, as
+everywhere else in this document — not JSONPath. A panel that fails any check
+is recorded under `/status.anomalies.configuration` and skipped; the rest of
+its contributor still loads.
+
+**Where panels come from.** `event-runtime/panels/*.panel.json` (built-in;
+`inbox-open` ships as the proof), `<pack>/panels/*.panel.json` for a configured
+pack (`lib/registry.mjs` loads them next to artifact views, origin
+`pack:<namespace>`), and an extension's `contributes.panels` directories
+([`extensions.md` § Panels](extensions.md#panels), origin `extension:<name>`).
+`GET /panels` lists the accepted panels with `origin` and `file` plus the
+endpoint allow-list; `lib/client.mjs` and `web/src/api.ts` mirror it as
+`panels()`.
+
+**Rendering.** `web/src/components/PanelGrid.tsx` reads `/panels` and mounts
+one tile per panel below Overview's own content — nothing at all when there
+are none. Each tile fetches its `source.endpoint` on its own TanStack Query
+at `refreshSeconds`, applies `source.path`, and draws the node with
+`ArtifactView`; a fetch that fails, a pointer that misses, or a render fault
+shows an inline error tile (with Retry) and never takes the grid down. The
+client also refuses to fetch an endpoint outside the list `/panels` returned.
+
 ---
 
 ## 3. Layer B — `factory.presentation/v1`

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,10 +25,14 @@ Today an extension can contribute:
   Settings (§Config below);
 - **hooks** — decision-returning modules run at a named point of the runtime,
   today `approve.before` (immediately before each chain auto-approval); a
-  fail-closed waterfall whose every decision is persisted (§Hooks below).
+  fail-closed waterfall whose every decision is persisted (§Hooks below);
+- **panels** — declarative `factory.panel-view/v1` Overview tiles
+  ([`event-runtime-artifact-views.md` §2.6](event-runtime-artifact-views.md#26-panels--factorypanel-viewv1-wm-840));
+  data only, drawn by the web's existing artifact-view renderer, bound to an
+  allow-listed loopback API endpoint (§Panels below).
 
-The manifest also **reserves** `connectors`, `views` and `panels` for
-the tickets that land them (§Panels below). A
+The manifest also **reserves** `connectors` and `views` for the tickets that
+land them. A
 manifest that carries a reserved key loads its packs and adapters and records a
 "not supported yet" configuration anomaly for the rest — it is accepted, not
 rejected, so an extension written for a later runtime still does what this one
@@ -49,6 +53,8 @@ Implementation: `event-runtime/lib/extensions.mjs`, schema
   hooks/
     no-infra-merges.mjs       # an approve.before hook (id + default (ctx) => decision) (§Hooks)
   config.schema.json          # the shape of the extension's operator config (§Config)
+  panels/
+    blocked-tickets.panel.json  # a factory.panel-view/v1 panel
 ```
 
 Nothing about the layout is fixed except the manifest's name and place: every
@@ -67,22 +73,24 @@ directory, and must stay inside it.
     "packs": ["./pack"],
     "adapters": { "argent": "./adapters/argent.mjs" },
     "config": { "namespace": "mobile", "schema": "./config.schema.json" },
-    "hooks": { "approve.before": "./hooks/no-infra-merges.mjs" }
+    "hooks": { "approve.before": "./hooks/no-infra-merges.mjs" },
+    "panels": ["./panels"]
   }
 }
 ```
 
-| Key                                           | Required | Meaning                                                                                                                                                                                                                                         |
-| :-------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                        | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
-| `version`                                     | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
-| `description`                                 | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
-| `factory.min`                                 | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
-| `contributes.packs`                           | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
-| `contributes.adapters`                        | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
-| `contributes.config`                          | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.           |
-| `contributes.hooks`                           | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                         |
-| `contributes.connectors`, `.views`, `.panels` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
+| Key                                | Required | Meaning                                                                                                                                                                                                                                                      |
+| :--------------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                             | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                                    |
+| `version`                          | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                                    |
+| `description`                      | no       | Up to 200 characters, for listings.                                                                                                                                                                                                                          |
+| `factory.min`                      | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                                          |
+| `contributes.packs`                | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                               |
+| `contributes.adapters`             | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension).              |
+| `contributes.config`               | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.                        |
+| `contributes.hooks`                | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                                      |
+| `contributes.panels`               | no       | Array of relative directories; every `*.panel.json` directly inside is a `factory.panel-view/v1` panel (§Panels). The manifest check proves the directories exist inside the extension; the registry validates each panel at load and skips a bad one alone. |
+| `contributes.connectors`, `.views` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                                   |
 
 Unknown top-level keys and unknown `contributes` keys are schema violations.
 Validate a manifest without loading anything:
@@ -94,15 +102,20 @@ bun event-runtime/cli.mjs extensions validate ~/.factory/extensions/wattmind-mob
 
 `validate` checks the schema, that every contributed path exists and stays
 inside the extension directory, and that adapter names and hook points are
-well-formed. It does not load a pack or import an adapter or hook module —
-running third-party code is what enabling does.
+well-formed. It does not load a pack, import an adapter or hook module, or
+read a panel document — running third-party code is what enabling does, and
+panel documents are validated by the registry at load (an invalid one is a
+`/status` anomaly).
 
 ## Trust model
 
 There are two kinds of contribution, and the difference is what runs.
 
-- **Data-only packs.** A pack is JSON and prose: definitions, schemas, prompts,
-  routing maps. Loading one executes nothing. The kernel then holds it to the
+- **Data-only packs and panels.** A pack is JSON and prose: definitions,
+  schemas, prompts, routing maps. A panel is JSON too — an endpoint the
+  runtime already serves, a pointer and rendering hints; the web loads no
+  code for it and fetches only endpoints the runtime allow-lists. Loading
+  either executes nothing. The kernel then holds it to the
   configured-pack rules — its own namespace, no shadowing of built-ins, pinned
   prompts and schemas, no `mutating: true` — so a pack can add agents but
   cannot widen what an agent may do. This is the surface an _agent_ may author
@@ -182,7 +195,9 @@ message naming both packs; fix the pack (or the order) and restart.
 5. If the extension gates unattended work, add an `approve.before` hook
    (§Hooks); the smallest conformant module is
    `event-runtime/test-support/extensions/sample/hooks/approve-before.mjs`.
-6. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+6. Add panels as `panels/<slug>.panel.json` (§Panels); the fixture's
+   `panels/open-proposals.panel.json` is a complete one.
+7. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
    enable it, `extensions list`, restart.
 
 The fixture `event-runtime/test-support/extensions/sample/` is a complete,
@@ -191,9 +206,61 @@ failure mode and what the anomaly for it says.
 
 ## Panels
 
-_Reserved key `contributes.panels` — lands in WM-840 (declarative
-`factory.panel-view/v1` panels rendered on Overview). Until then the loader
-accepts the key and reports it as not supported yet._
+`contributes.panels` lists directories, relative to the manifest, whose
+`*.panel.json` files are `factory.panel-view/v1` panels — declarative
+Overview tiles bound to one allow-listed loopback API endpoint and drawn by
+the web's artifact-view renderer. The full format, the endpoint allow-list
+and the rendering rules are in
+[`event-runtime-artifact-views.md` §2.6](event-runtime-artifact-views.md#26-panels--factorypanel-viewv1-wm-840);
+what is specific to extensions:
+
+```json
+{
+  "format": "factory.panel-view/v1",
+  "name": "wattmind/mobile:blocked-tickets",
+  "title": "Blocked > 24h",
+  "source": {
+    "endpoint": "/tickets",
+    "query": { "state": "blocked" },
+    "path": "/tickets"
+  },
+  "refreshSeconds": 60,
+  "view": {
+    "sections": [
+      {
+        "path": "",
+        "as": "table",
+        "columns": ["identifier", "title"],
+        "formats": { "identifier": "issue" }
+      }
+    ]
+  }
+}
+```
+
+- **Names** are `<publisher>/<extension>:<slug>` — the extension's own name
+  as prefix — and must be unique across built-ins, packs and every extension;
+  a clash is a configuration anomaly for the later contributor and the earlier
+  panel stays.
+- **Origin.** `GET /panels` reports each of these with
+  `origin: "extension:<name>"`, and the tile shows that origin under its title.
+- **Order.** Extension panel directories load after every pack (built-in and
+  `packs:`), in policy order, into the same registry list.
+- **Failure.** A panel that does not validate — bad schema, an endpoint that
+  is not allow-listed, a `view` the artifact-view vocabulary rejects,
+  unparseable JSON — is skipped alone with a `/status.anomalies.configuration`
+  line naming the file; the extension's other panels, packs and adapters still
+  load. A directory that is missing or escapes the extension is a manifest
+  error and skips the extension whole, like any other bad path.
+- **Panels inside packs.** A pack an extension contributes may also carry
+  `panels/*.panel.json`; those load with the pack (origin `pack:<namespace>`),
+  no manifest key needed. Use `contributes.panels` for tiles that belong to
+  the extension rather than to one pack.
+
+Implementation: `event-runtime/lib/panel-view.mjs` (validation and
+directory loading), `lib/registry.mjs` (`loadRegistry({ panelRoots })`),
+`lib/api-panels.mjs` (`GET /panels`, `PANEL_ENDPOINTS`),
+`web/src/components/PanelGrid.tsx`.
 
 ## Config
 

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -327,7 +327,10 @@ export default async function serve(args) {
   }
 
   const db = openDb();
-  const registry = loadRegistry({ packRoots: extensions.packRoots });
+  const registry = loadRegistry({
+    packRoots: extensions.packRoots,
+    panelRoots: extensions.panelRoots,
+  });
   registry.anomalies.push(...extensions.anomalies);
   const pv = policyVersion();
   const owner = newWorkerId();

--- a/event-runtime/lib/api-panels.mjs
+++ b/event-runtime/lib/api-panels.mjs
@@ -1,0 +1,69 @@
+/**
+ * Panels endpoint (WM-840, docs/event-runtime-artifact-views.md §2.6).
+ *
+ * `GET /panels` lists the declarative `factory.panel-view/v1` panels the
+ * registry accepted at load — built-in, from packs, from extensions — so the
+ * web can draw a dashboard tile per panel with the artifact-view renderer
+ * and no client-side code loading. Panel *data* is not proxied here: the web
+ * fetches each panel's `source.endpoint` itself, and that endpoint must be on
+ * the allow-list below, which is why the list lives in this module (the
+ * one place that knows which loopback routes a panel may bind to).
+ */
+
+/**
+ * The GET routes a panel's `source.endpoint` may name. Every entry is a real
+ * collection route of the loopback API — the file that answers it is noted
+ * — and `api-panels.test.mjs` proves each one answers something other than
+ * 404 through `createApi`, so an entry cannot outlive its route. Detail
+ * routes (`/runs/<id>`, `/inbox/<id>`, `/chain/<id>`) are deliberately
+ * absent: a panel is a standing tile, not a bookmark, and it takes its
+ * parameters through `source.query`. `/panels` itself is not listed.
+ */
+export const PANEL_ENDPOINTS = Object.freeze([
+  "/agents", // api-registry.mjs
+  "/artifacts", // api-artifacts.mjs
+  "/chains", // api-chain.mjs
+  "/config", // api-config.mjs
+  "/events", // api-runs.mjs
+  "/health", // api-intake.mjs
+  "/inbox", // api-inbox.mjs
+  "/journal", // api-runs.mjs
+  "/metrics", // api-metrics.mjs
+  "/metrics/breakdown", // api-metrics.mjs
+  "/outbox", // api-runs.mjs
+  "/proposals", // api-runs.mjs
+  "/repos", // api-registry.mjs
+  "/runs", // api-runs.mjs
+  "/schedules", // api-schedules.mjs
+  "/status", // status-view.mjs
+  "/tickets", // api-runs.mjs
+  "/workers", // status-view.mjs
+]);
+
+/**
+ * The `/panels` body: every accepted panel with the contributor it came from
+ * (`origin`: `builtin`, `pack:<namespace>` or `extension:<name>`) and the
+ * file it was read from, plus the endpoint allow-list so a client can refuse
+ * to fetch anything else without a second round trip. Invalid panels never
+ * reach the registry's list — they are `/status.anomalies.configuration`.
+ */
+export function panelsView(registry) {
+  return {
+    panels: (registry?.panels ?? []).map((entry) => ({
+      name: entry.name,
+      title: entry.title,
+      description: entry.description ?? null,
+      source: entry.source,
+      refreshSeconds: entry.refreshSeconds,
+      view: entry.view,
+      origin: entry.origin,
+      file: entry.file,
+    })),
+    endpoints: [...PANEL_ENDPOINTS],
+  };
+}
+
+export function handlePanelsApiRoute({ route, send, registry }) {
+  if (route === "GET /panels") return send(200, panelsView(registry));
+  return false;
+}

--- a/event-runtime/lib/api-panels.test.mjs
+++ b/event-runtime/lib/api-panels.test.mjs
@@ -1,0 +1,114 @@
+import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-panels-test-mjs";
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { PANEL_ENDPOINTS, panelsView } from "./api-panels.mjs";
+import {
+  apiClient,
+  loadRegistry,
+  makeServer as makeApiServer,
+} from "./api-test-helpers.mjs";
+
+const makeServer = async (...args) => {
+  const result = await makeApiServer(...args);
+  trackTmpDir(path.dirname(result.db.filename));
+  return result;
+};
+
+describe("GET /panels (WM-840)", () => {
+  test("lists the accepted panels with their origin and file, plus the endpoint allow-list", async () => {
+    const { server } = await makeServer();
+    try {
+      const client = apiClient({ port: server.address().port });
+      const body = await client.panels();
+      expect(body.endpoints).toEqual([...PANEL_ENDPOINTS]);
+      expect(body.panels).toHaveLength(1);
+      const [panel] = body.panels;
+      expect(panel).toEqual({
+        name: "inbox-open",
+        title: "Open inbox items",
+        description: expect.stringContaining("Built-in proof panel"),
+        source: {
+          endpoint: "/inbox",
+          query: { status: "open" },
+          path: "/items",
+        },
+        refreshSeconds: 30,
+        view: {
+          sections: [expect.objectContaining({ as: "table", path: "" })],
+        },
+        origin: "builtin",
+        file: "panels/inbox-open.panel.json",
+      });
+      // The panel's own source resolves through the same API, with its query.
+      const res = await fetch(
+        `http://127.0.0.1:${server.address().port}/inbox?status=open`,
+      );
+      expect(res.status).toBe(200);
+      expect(Array.isArray((await res.json()).items)).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("origins are carried through from packs and extensions; invalid panels are absent (they are /status anomalies)", async () => {
+    const registry = loadRegistry();
+    registry.panels = [
+      ...registry.panels,
+      {
+        name: "wattmind/mobile:blocked",
+        title: "Blocked",
+        source: { endpoint: "/tickets", query: {}, path: "/tickets" },
+        refreshSeconds: 60,
+        view: { sections: [{ path: "", as: "list" }] },
+        origin: "extension:wattmind/mobile",
+        file: "panels/blocked.panel.json",
+      },
+    ];
+    registry.anomalies = ["panel x is invalid (skipped): boom"];
+    const { server } = await makeServer({ registry });
+    try {
+      const port = server.address().port;
+      const client = apiClient({ port });
+      const body = await client.panels();
+      expect(body.panels.map((p) => [p.name, p.origin])).toEqual([
+        ["inbox-open", "builtin"],
+        ["wattmind/mobile:blocked", "extension:wattmind/mobile"],
+      ]);
+      expect(body.panels[1].description).toBeNull();
+      const status = await client.status();
+      expect(status.anomalies.configuration).toContain(
+        "panel x is invalid (skipped): boom",
+      );
+      // Only GET; nothing under /panels/.
+      const post = await fetch(`http://127.0.0.1:${port}/panels`, {
+        method: "POST",
+        body: "{}",
+      });
+      expect(post.status).toBe(404);
+      const sub = await fetch(`http://127.0.0.1:${port}/panels/inbox-open`);
+      expect(sub.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("every allow-listed endpoint is a real GET route of the loopback API (never 404)", async () => {
+    const { server } = await makeServer();
+    try {
+      const port = server.address().port;
+      for (const endpoint of PANEL_ENDPOINTS) {
+        const res = await fetch(`http://127.0.0.1:${port}${endpoint}`);
+        expect([endpoint, res.status === 404]).toEqual([endpoint, false]);
+        expect([endpoint, res.status < 500]).toEqual([endpoint, true]);
+      }
+      // And the list is what a panel is validated against — no drift between
+      // what the API answers and what a panel may bind to.
+      expect(panelsView({ panels: [] }).endpoints).toEqual([
+        ...PANEL_ENDPOINTS,
+      ]);
+      expect(PANEL_ENDPOINTS).not.toContain("/panels");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -24,6 +24,7 @@ import { handleIntakeApiRoute } from "./api-intake.mjs";
 import { handleChainApiRoute } from "./api-chain.mjs";
 import { handleConfigApiRoute } from "./api-config.mjs";
 import { handleMetricsApiRoute } from "./api-metrics.mjs";
+import { handlePanelsApiRoute } from "./api-panels.mjs";
 import { handleRegistryApiRoute } from "./api-registry.mjs";
 import {
   handleRunApiRoute,
@@ -314,6 +315,10 @@ export function createApi({
           ...common,
           send: scheduleSend,
         });
+        if (result !== false) return result;
+      }
+      if (url.pathname === "/panels") {
+        const result = handlePanelsApiRoute(common);
         if (result !== false) return result;
       }
       if (

--- a/event-runtime/lib/artifact-view.mjs
+++ b/event-runtime/lib/artifact-view.mjs
@@ -144,6 +144,50 @@ function relativeNode(base, key) {
   return walkSchema(base, tokens);
 }
 
+/** The per-`as` key checks the schema cannot express (design §2.2 `as` row). */
+function sectionKeyErrors(section, at) {
+  const errors = [];
+  const kind = section.as;
+  const allowed = KEYS_BY_KIND[kind];
+  for (const key of Object.keys(section)) {
+    if (!COMMON_SECTION_KEYS.has(key) && !allowed.has(key)) {
+      errors.push(`${at}: "${key}" is not a key of as=${kind}`);
+    }
+  }
+  for (const key of REQUIRED_BY_KIND[kind] ?? []) {
+    if (!hasOwn(section, key))
+      errors.push(`${at}: as=${kind} requires "${key}"`);
+  }
+  if (kind === "badge" && isObject(section.tone)) {
+    for (const [key, value] of Object.entries(section.tone)) {
+      if (!TONES.includes(value)) {
+        errors.push(
+          `${at}.tone.${key}: badge tone must be one of ${TONES.join("|")}`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ * Validate a view document's *shape* only: the v1 schema plus the per-`as`
+ * key rules, with no output schema to resolve pointers against. This is the
+ * check a panel (`factory.panel-view/v1`, lib/panel-view.mjs) gets — its data
+ * comes from an API endpoint that has no published schema — and the first
+ * half of `validateArtifactView`. Never throws.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateArtifactViewShape(view) {
+  const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
+  if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
+  const errors = [];
+  view.sections.forEach((section, i) => {
+    errors.push(...sectionKeyErrors(section, `view.sections[${i}]`));
+  });
+  return { valid: errors.length === 0, errors };
+}
+
 /**
  * Validate a view document against the v1 schema AND against the agent's
  * output schema (pointer drift). Never throws.
@@ -182,16 +226,7 @@ export function validateArtifactView(view, outputSchema) {
   view.sections.forEach((section, i) => {
     const at = `view.sections[${i}]`;
     const kind = section.as;
-    const allowed = KEYS_BY_KIND[kind];
-    for (const key of Object.keys(section)) {
-      if (!COMMON_SECTION_KEYS.has(key) && !allowed.has(key)) {
-        errors.push(`${at}: "${key}" is not a key of as=${kind}`);
-      }
-    }
-    for (const key of REQUIRED_BY_KIND[kind] ?? []) {
-      if (!hasOwn(section, key))
-        errors.push(`${at}: as=${kind} requires "${key}"`);
-    }
+    errors.push(...sectionKeyErrors(section, at));
 
     const node = resolveSchemaPointer(outputSchema, section.path);
     if (node === undefined) {
@@ -230,14 +265,7 @@ export function validateArtifactView(view, outputSchema) {
 
     if (isObject(section.tone)) {
       for (const [key, value] of Object.entries(section.tone)) {
-        if (kind === "badge") {
-          if (!TONES.includes(value)) {
-            errors.push(
-              `${at}.tone.${key}: badge tone must be one of ${TONES.join("|")}`,
-            );
-          }
-          continue;
-        }
+        if (kind === "badge") continue; // checked by sectionKeyErrors
         checkKey("tone", key);
         if (!isObject(value)) {
           errors.push(

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -81,6 +81,8 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
         body: JSON.stringify({ runId }),
       }),
     agents: () => call("GET", "/agents"),
+    /** Declarative Overview panels (WM-840): `{ panels, endpoints }`, panel data is fetched from each `source.endpoint`. */
+    panels: () => call("GET", "/panels"),
     workers: () => call("GET", "/workers"),
     schedules: () => call("GET", "/schedules"),
     /** Factory repo registry from config/repos.yaml (OPS-299). */

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -22,9 +22,13 @@
  *      registered — while every other extension still loads. `serve`/`work`
  *      never fail to start because a third-party manifest is broken.
  *   3. **Reserved manifest keys are accepted, not rejected.** `connectors`,
- *      `views` and `panels` belong to follow-up tickets; a manifest
- *      that carries them loads its packs and adapters here and records a
- *      "not supported yet" anomaly for the rest.
+ *      `views` belong to follow-up tickets; a manifest that carries them
+ *      loads its packs, adapters, config, hooks and panels here and
+ *      records a "not supported yet" anomaly for the rest. `panels` (WM-840)
+ *      contributes directories of `*.panel.json`; the manifest check only
+ *      proves they exist inside the extension, and lib/registry.mjs loads
+ *      and validates the panels themselves (a bad panel is skipped alone,
+ *      never the extension).
  *   4. **Config is declared, validated, defaulted (WM-841).** An extension
  *      may declare `contributes.config: { namespace, schema }`; the operator's
  *      values live on the policy entry (`extensions[].config`). At load the
@@ -74,11 +78,7 @@ export const EXTENSION_SCHEMA = JSON.parse(
 );
 
 /** Manifest keys the schema accepts today but no ticket has implemented yet. */
-export const RESERVED_CONTRIBUTIONS = Object.freeze([
-  "connectors",
-  "views",
-  "panels",
-]);
+export const RESERVED_CONTRIBUTIONS = Object.freeze(["connectors", "views"]);
 
 /** The `source` a hook registered by an extension carries (lib/hooks.mjs). */
 export function extensionHookSource(name) {
@@ -303,6 +303,7 @@ export function validateExtensionManifest(dir) {
       );
     }
   }
+  errors.push(...panelDirErrors(root, file, contributes.panels));
   return result(manifest);
 }
 
@@ -429,6 +430,46 @@ export function loadedExtensions() {
   return LOADED;
 }
 
+/**
+ * `contributes.panels` (WM-840): relative directories of `*.panel.json`,
+ * each inside the extension and existing. Only the directories are checked
+ * here — panel documents are validated when the registry loads them, one
+ * anomaly per bad panel, so `extensions validate` stays a manifest check.
+ */
+function panelDirErrors(root, file, panels) {
+  const errors = [];
+  const seen = new Set();
+  for (const [i, rel] of (panels ?? []).entries()) {
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.panels[${i}] "${rel}" escapes the extension directory`,
+      );
+      continue;
+    }
+    if (seen.has(abs)) {
+      errors.push(`${file}: contributes.panels[${i}] "${rel}" listed twice`);
+      continue;
+    }
+    seen.add(abs);
+    if (!existsSync(abs) || !statSync(abs).isDirectory()) {
+      errors.push(
+        `${file}: contributes.panels[${i}] "${rel}" is not a directory (${abs})`,
+      );
+    }
+  }
+  return errors;
+}
+
+/** The registry `panelRoots` entries for one accepted extension (lib/registry.mjs loadRegistry). */
+function panelRootsFor(dir, manifest) {
+  return (manifest.contributes?.panels ?? []).map((rel) => ({
+    dir: path.resolve(dir, rel),
+    origin: `extension:${manifest.name}`,
+    base: dir,
+  }));
+}
+
 function isInside(root, abs) {
   const rel = path.relative(root, abs);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
@@ -466,12 +507,16 @@ function packRootFor(extensionRoot, rel) {
  * @param {Array<object>} [options.packRoots] - the policy `packs:` roots the extension packs join (default: loadPackRoots({ root }))
  * @param {string} [options.registryRoot] - the built-in registry root the dry load uses (tests point it at a copy)
  * @returns {Promise<{
- *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
+ *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, panels: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
+ *   panelRoots: Array<{ dir: string, origin: string, base: string }>,
  *   packRoots: Array<object>,
+ *   panelRoots: Array<{ dir: string, origin: string, base: string }>,
  *   anomalies: string[],
  *   disabled: Array<{ name: string|null, version: string|null, path: string, namespace: string|null, reason: string }>,
  * }>} `packRoots` is the full list — policy packs first, then every accepted
- *   extension pack in policy order — ready to hand to `loadRegistry`.
+ *   extension pack in policy order — ready to hand to `loadRegistry`;
+ *   `panelRoots` is every accepted extension's `contributes.panels`
+ *   directories, in the same order, for `loadRegistry({ panelRoots })`.
  *   `disabled` lists every extension an anomaly skipped, for `/config`.
  */
 export async function loadExtensions({
@@ -492,6 +537,7 @@ export async function loadExtensions({
   }
   const { roots, anomalies } = loadExtensionRoots({ root, policy });
   const extensions = [];
+  const panelRoots = [];
   const accepted = [...basePackRoots];
   const acceptedPackNames = new Set(basePackRoots.map((p) => p.name));
   const acceptedAdapterNames = new Set();
@@ -641,6 +687,8 @@ export async function loadExtensions({
     for (const warning of checked.warnings) anomalies.push(warning);
     if (config) acceptedNamespaces.set(config.namespace, manifest.name);
     const { schemaJson, ...publicConfig } = config ?? {};
+    const extPanelRoots = panelRootsFor(dir, manifest);
+    panelRoots.push(...extPanelRoots);
     extensions.push({
       name: manifest.name,
       version: manifest.version,
@@ -648,6 +696,7 @@ export async function loadExtensions({
       packs: extPackRoots.map((p) => p.name),
       adapters: modules.map((m) => m.name),
       hooks: hookModules.map(({ point, id }) => ({ point, id })),
+      panels: extPanelRoots.map((p) => p.dir),
       reserved: RESERVED_CONTRIBUTIONS.filter((key) =>
         Object.hasOwn(contributes, key),
       ),
@@ -662,5 +711,5 @@ export async function loadExtensions({
   }
 
   LOADED = { extensions: loaded, disabled };
-  return { extensions, packRoots: accepted, anomalies, disabled };
+  return { extensions, packRoots: accepted, panelRoots, anomalies, disabled };
 }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -171,9 +171,18 @@ describe("validateExtensionManifest", () => {
       m.contributes.packs.push("./missing", "../escape");
       m.contributes.adapters["bad-path"] = "./adapters/nope.mjs";
       m.contributes.adapters["Bad Name"] = "./adapters/echo.mjs";
+      m.contributes.panels.push("./nope", "../escape", "./panels");
     });
     const out = validateExtensionManifest(dir);
     expect(out.valid).toBe(false);
+    // Panels (WM-840): directories only — documents are validated at load.
+    expect(out.errors.join("\n")).toMatch(
+      /panels\[1\] ".\/nope" is not a directory/,
+    );
+    expect(out.errors.join("\n")).toMatch(/panels\[2\] "..\/escape" escapes/);
+    expect(out.errors.join("\n")).toMatch(
+      /panels\[3\] ".\/panels" listed twice/,
+    );
     expect(out.errors.join("\n")).toMatch(
       /packs\[1\] ".\/missing" has no pack.json/,
     );
@@ -199,6 +208,7 @@ describe("loadExtensions", () => {
         hooks: [
           { point: "approve.before", id: "factory/sample:approve-before" },
         ],
+        panels: [path.join(SAMPLE_EXTENSION, "panels")],
         reserved: [],
         config: {
           namespace: "sample",
@@ -216,6 +226,15 @@ describe("loadExtensions", () => {
         kind: "fs",
         name: "sample-ext",
         path: path.join(SAMPLE_EXTENSION, "pack"),
+      },
+    ]);
+    // Panels (WM-840): the directories are handed to the registry, which
+    // loads and validates the documents (lib/panel-view.test.mjs covers that).
+    expect(out.panelRoots).toEqual([
+      {
+        dir: path.join(SAMPLE_EXTENSION, "panels"),
+        origin: "extension:factory/sample",
+        base: SAMPLE_EXTENSION,
       },
     ]);
     // Adapters go through the registry: contract-checked, sandbox-guarded, sourced.
@@ -378,14 +397,14 @@ describe("loadExtensions", () => {
   test("reserved keys load the rest and record a not-supported-yet anomaly", async () => {
     const dir = tempExtension((m) => {
       m.name = "factory/future";
-      m.contributes.panels = [{ id: "x" }];
+      m.contributes.views = [{ id: "x" }];
     });
     const out = await load(policyFor(dir));
-    expect(out.extensions[0].reserved).toEqual(["panels"]);
+    expect(out.extensions[0].reserved).toEqual(["views"]);
     expect(out.extensions[0].adapters).toEqual(["echo"]);
     expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
     expect(out.anomalies).toEqual([
-      expect.stringMatching(/contributes\.panels is not supported yet/),
+      expect.stringMatching(/contributes\.views is not supported yet/),
     ]);
   });
 

--- a/event-runtime/lib/panel-view.mjs
+++ b/event-runtime/lib/panel-view.mjs
@@ -1,0 +1,189 @@
+/**
+ * Panels — `factory.panel-view/v1` (WM-840, docs/event-runtime-artifact-views.md §2.6).
+ *
+ * A panel is the artifact-view idea generalised past one agent's artifact:
+ * a declarative tile that names an existing loopback GET endpoint, selects a
+ * node of its response with an RFC 6901 pointer, and describes how to draw
+ * that node with the same closed hint vocabulary the artifact-view renderer
+ * already speaks (`table|keyvalue|list|badge|code|prose`). Packs contribute
+ * them as `panels/*.panel.json`, extensions through `contributes.panels`,
+ * and one ships built in; the web draws them on Overview with
+ * `components/ArtifactView.tsx`, so a pack gets a dashboard tile without
+ * shipping React.
+ *
+ * Three checks, all fail closed, all here rather than in the renderer:
+ *   1. the document matches schemas/panel-view.schema.json (lib/schema.mjs);
+ *   2. `source.endpoint` is on the allow-list in lib/api-panels.mjs — the
+ *      web will fetch whatever a panel names, so this is what keeps a
+ *      third-party panel from pointing the browser at an arbitrary route;
+ *   3. `view` is a valid artifact-view body (`validateArtifactViewShape`),
+ *      minus the pointer-drift check, because an endpoint has no schema.
+ * A panel that fails is a configuration anomaly (`/status.anomalies.configuration`)
+ * and is skipped; the rest of its contributor still loads.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { PANEL_ENDPOINTS } from "./api-panels.mjs";
+import {
+  ARTIFACT_VIEW_SCHEMA_VERSION,
+  validateArtifactViewShape,
+} from "./artifact-view.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { validate } from "./schema.mjs";
+
+export const PANEL_VIEW_FORMAT = "factory.panel-view/v1";
+export const PANEL_VIEW_SCHEMA = JSON.parse(
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "panel-view.schema.json"),
+    "utf8",
+  ),
+);
+/** Where a pack (or the built-in root) keeps its panels, and how a panel file is named. */
+export const PANELS_DIR = "panels";
+export const PANEL_SUFFIX = ".panel.json";
+export const DEFAULT_REFRESH_SECONDS = 60;
+
+const isObject = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+
+/**
+ * Validate one panel document. Never throws.
+ * @param {unknown} doc - the parsed panel
+ * @param {{ endpoints?: readonly string[] }} [options] - the endpoint allow-list (default: PANEL_ENDPOINTS)
+ * @returns {{ panel: object|null, anomaly: string|null }} `panel` is the
+ *   normalised document (`source.query` and `source.path` present,
+ *   `refreshSeconds` defaulted) or null with `anomaly` naming every error.
+ */
+export function validatePanelView(doc, { endpoints = PANEL_ENDPOINTS } = {}) {
+  const schemaCheck = validate(PANEL_VIEW_SCHEMA, doc, "panel");
+  if (!schemaCheck.valid) {
+    return { panel: null, anomaly: schemaCheck.errors.join("; ") };
+  }
+  const errors = [];
+  const endpoint = doc.source.endpoint;
+  if (!endpoints.includes(endpoint)) {
+    errors.push(
+      `panel.source.endpoint: "${endpoint}" is not an allow-listed GET route (allowed: ${endpoints.join(", ")})`,
+    );
+  }
+  // `view` is an artifact-view body; the format implies the schemaVersion,
+  // but a document that spells one out must spell the right one.
+  const viewDoc = Object.hasOwn(doc.view, "schemaVersion")
+    ? doc.view
+    : { schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION, ...doc.view };
+  const viewCheck = validateArtifactViewShape(viewDoc);
+  if (!viewCheck.valid) {
+    errors.push(...viewCheck.errors.map((e) => `panel.${e}`));
+  }
+  if (errors.length > 0) return { panel: null, anomaly: errors.join("; ") };
+  const { schemaVersion: _ignored, ...view } = viewDoc;
+  return {
+    panel: {
+      format: doc.format,
+      name: doc.name,
+      title: doc.title,
+      ...(doc.description !== undefined
+        ? { description: doc.description }
+        : {}),
+      source: {
+        endpoint,
+        query: isObject(doc.source.query) ? { ...doc.source.query } : {},
+        path: typeof doc.source.path === "string" ? doc.source.path : "",
+      },
+      refreshSeconds: doc.refreshSeconds ?? DEFAULT_REFRESH_SECONDS,
+      view,
+    },
+    anomaly: null,
+  };
+}
+
+/**
+ * Read and validate one `*.panel.json`. Unparseable JSON is the same class
+ * of anomaly as an invalid document.
+ * @returns {{ panel: object|null, anomaly: string|null }}
+ */
+export function readPanelFile(file, options) {
+  let doc;
+  try {
+    doc = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    return {
+      panel: null,
+      anomaly: `panel ${file} is unparseable: ${err.message}`,
+    };
+  }
+  const { panel, anomaly } = validatePanelView(doc, options);
+  if (anomaly)
+    return {
+      panel: null,
+      anomaly: `panel ${file} is invalid (skipped): ${anomaly}`,
+    };
+  return { panel, anomaly: null };
+}
+
+/**
+ * Load every `*.panel.json` directly under `dir` (sorted, not recursive),
+ * tagging each accepted panel with the contributor it came from and the file
+ * it was read from. A missing directory is simply no panels; a file that
+ * fails is an anomaly and the others still load. Name uniqueness across
+ * contributors is the registry's job (lib/registry.mjs), not this loader's.
+ *
+ * @param {string} dir
+ * @param {{ origin: string, base?: string, endpoints?: readonly string[] }} options -
+ *   `origin` is `builtin`, `pack:<namespace>` or `extension:<name>`; `base`
+ *   is the contributor root the served `file` is made relative to (default:
+ *   the panel directory's parent — anomalies always name the absolute path)
+ * @returns {{ panels: Array<object>, anomalies: string[] }}
+ */
+export function loadPanelDir(dir, { origin, base, endpoints } = {}) {
+  const panels = [];
+  const anomalies = [];
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+    return { panels, anomalies };
+  }
+  for (const name of readdirSync(dir).sort()) {
+    if (!name.endsWith(PANEL_SUFFIX)) continue;
+    const file = path.join(dir, name);
+    const { panel, anomaly } = readPanelFile(file, { endpoints });
+    if (anomaly) {
+      anomalies.push(`${anomaly}${origin ? ` [${origin}]` : ""}`);
+      continue;
+    }
+    panels.push({
+      ...panel,
+      origin: origin ?? "builtin",
+      file: path.relative(base ?? path.dirname(dir), file),
+    });
+  }
+  return { panels, anomalies };
+}
+
+/**
+ * Merge panels from several contributors into one list with unique names —
+ * first contributor wins, in load order (built-in, then packs in policy
+ * order, then extensions in policy order), and the loser is an anomaly, not
+ * a silent override: a pack may not shadow a built-in tile any more than it
+ * may shadow a built-in agent.
+ * @param {Array<{ panels: object[], anomalies: string[] }>} batches
+ * @returns {{ panels: object[], anomalies: string[] }}
+ */
+export function mergePanels(batches) {
+  const panels = [];
+  const anomalies = [];
+  const byName = new Map();
+  for (const batch of batches) {
+    anomalies.push(...(batch.anomalies ?? []));
+    for (const panel of batch.panels ?? []) {
+      const seen = byName.get(panel.name);
+      if (seen) {
+        anomalies.push(
+          `panel ${panel.file} [${panel.origin}] duplicates panel name "${panel.name}" already contributed by ${seen.file} [${seen.origin}] (skipped)`,
+        );
+        continue;
+      }
+      byName.set(panel.name, panel);
+      panels.push(panel);
+    }
+  }
+  return { panels, anomalies };
+}

--- a/event-runtime/lib/panel-view.test.mjs
+++ b/event-runtime/lib/panel-view.test.mjs
@@ -1,0 +1,402 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-panel-view-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { PANEL_ENDPOINTS } from "./api-panels.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { loadExtensions } from "./extensions.mjs";
+import {
+  DEFAULT_REFRESH_SECONDS,
+  PANEL_SUFFIX,
+  PANEL_VIEW_FORMAT,
+  loadPanelDir,
+  mergePanels,
+  readPanelFile,
+  validatePanelView,
+} from "./panel-view.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const BUILTIN_PANEL = path.join(
+  RUNTIME_ROOT,
+  "panels",
+  "inbox-open.panel.json",
+);
+const SAMPLE_EXTENSION = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+);
+const SAMPLE_PACK = path.join(RUNTIME_ROOT, "test-support", "packs", "sample");
+
+/** The decided panel shape from the ticket, over the artifact-view vocabulary. */
+function samplePanel(overrides = {}) {
+  const doc = {
+    format: PANEL_VIEW_FORMAT,
+    name: "wattmind/mobile:blocked-tickets",
+    title: "Blocked > 24h",
+    source: {
+      endpoint: "/tickets",
+      query: { state: "blocked" },
+      path: "/items",
+    },
+    refreshSeconds: 60,
+    view: {
+      sections: [
+        {
+          path: "",
+          as: "table",
+          columns: ["identifier", "title"],
+          formats: { identifier: "issue" },
+        },
+      ],
+    },
+    ...overrides,
+  };
+  // `key: undefined` means "leave the key out" — a schema sees presence.
+  for (const key of Object.keys(doc))
+    if (doc[key] === undefined) delete doc[key];
+  return doc;
+}
+
+function writePanel(dir, name, doc) {
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${name}${PANEL_SUFFIX}`);
+  writeFileSync(file, typeof doc === "string" ? doc : JSON.stringify(doc));
+  return file;
+}
+
+describe("validatePanelView (factory.panel-view/v1, WM-840)", () => {
+  test("accepts the decided shape, normalises defaults and strips nothing the renderer needs", () => {
+    const { panel, anomaly } = validatePanelView(samplePanel());
+    expect(anomaly).toBeNull();
+    expect(panel).toEqual({
+      format: PANEL_VIEW_FORMAT,
+      name: "wattmind/mobile:blocked-tickets",
+      title: "Blocked > 24h",
+      source: {
+        endpoint: "/tickets",
+        query: { state: "blocked" },
+        path: "/items",
+      },
+      refreshSeconds: 60,
+      view: {
+        sections: [
+          {
+            path: "",
+            as: "table",
+            columns: ["identifier", "title"],
+            formats: { identifier: "issue" },
+          },
+        ],
+      },
+    });
+    // Optional bits default: no query, whole response, 60 s.
+    const minimal = validatePanelView(
+      samplePanel({
+        source: { endpoint: "/status" },
+        refreshSeconds: undefined,
+        view: { sections: [{ path: "/workers", as: "keyvalue" }] },
+      }),
+    );
+    expect(minimal.anomaly).toBeNull();
+    expect(minimal.panel.source).toEqual({
+      endpoint: "/status",
+      query: {},
+      path: "",
+    });
+    expect(minimal.panel.refreshSeconds).toBe(DEFAULT_REFRESH_SECONDS);
+    // A view that spells out the artifact-view schemaVersion is fine; it is
+    // implied by the format and not served back.
+    const explicit = validatePanelView(
+      samplePanel({
+        view: {
+          schemaVersion: "factory.artifact-view/v1",
+          sections: [{ path: "", as: "badge" }],
+        },
+      }),
+    );
+    expect(explicit.anomaly).toBeNull();
+    expect(explicit.panel.view).toEqual({
+      sections: [{ path: "", as: "badge" }],
+    });
+  });
+
+  test("rejects schema violations: format, name, missing keys, bad refresh, unknown keys", () => {
+    const cases = [
+      [samplePanel({ format: "factory.panel-view/v2" }), /panel\.format/],
+      [samplePanel({ name: "Bad Name" }), /panel\.name/],
+      [
+        samplePanel({ title: undefined }),
+        /panel: missing required property "title"/,
+      ],
+      [
+        samplePanel({ source: undefined }),
+        /panel: missing required property "source"/,
+      ],
+      [
+        samplePanel({ view: undefined }),
+        /panel: missing required property "view"/,
+      ],
+      [samplePanel({ refreshSeconds: 1 }), /panel\.refreshSeconds/],
+      [samplePanel({ refreshSeconds: 2.5 }), /panel\.refreshSeconds/],
+      [samplePanel({ extra: true }), /panel: unknown property "extra"/],
+      [
+        samplePanel({ source: { endpoint: "/tickets", query: { limit: 5 } } }),
+        /panel\.source\.query\.limit/,
+      ],
+      [
+        samplePanel({ source: { endpoint: "/tickets", path: "items" } }),
+        /panel\.source\.path/,
+      ],
+      ["not an object", /panel: expected type object/],
+    ];
+    for (const [doc, pattern] of cases) {
+      const { panel, anomaly } = validatePanelView(doc);
+      expect(panel).toBeNull();
+      expect(anomaly).toMatch(pattern);
+    }
+  });
+
+  test("refuses an endpoint that is not an allow-listed GET route — no arbitrary URLs", () => {
+    for (const endpoint of [
+      "/panels",
+      "/runs/abc",
+      "/inbox?status=open",
+      "/tickets/",
+      "/nope",
+      "http://evil.example/x",
+      "/events/archive",
+    ]) {
+      const { panel, anomaly } = validatePanelView(
+        samplePanel({ source: { endpoint } }),
+      );
+      expect(panel).toBeNull();
+      expect(anomaly).toMatch(/panel\.source\.endpoint/);
+    }
+    // Every allow-listed route is accepted as written.
+    for (const endpoint of PANEL_ENDPOINTS) {
+      expect(
+        validatePanelView(samplePanel({ source: { endpoint } })).anomaly,
+      ).toBeNull();
+    }
+    // A caller-supplied allow-list is honoured (narrower or wider).
+    expect(
+      validatePanelView(samplePanel(), { endpoints: ["/status"] }).anomaly,
+    ).toMatch(
+      /"\/tickets" is not an allow-listed GET route \(allowed: \/status\)/,
+    );
+    expect(
+      validatePanelView(samplePanel({ source: { endpoint: "/custom" } }), {
+        endpoints: ["/custom"],
+      }).anomaly,
+    ).toBeNull();
+  });
+
+  test("validates `view` with the artifact-view vocabulary — the existing validator, not a copy", () => {
+    const bad = [
+      [
+        { sections: [{ path: "", as: "chart" }] },
+        /panel\.view\.sections\[0\]\.as: .*not in enum/,
+      ],
+      [
+        { sections: [{ path: "", as: "table" }] },
+        /as=table requires "columns"/,
+      ],
+      [
+        { sections: [{ path: "", as: "badge", columns: ["x"] }] },
+        /"columns" is not a key of as=badge/,
+      ],
+      [
+        { sections: [{ path: "", as: "badge", tone: { open: "loud" } }] },
+        /badge tone must be one of/,
+      ],
+      [
+        { sections: [{ path: "", as: "list", formats: { "": "emoji" } }] },
+        /panel\.view\.sections\[0\]\.formats\./,
+      ],
+      [{ sections: [] }, /panel\.view\.sections: fewer than minItems 1/],
+      [
+        { sections: [{ path: "items", as: "list" }] },
+        /panel\.view\.sections\[0\]\.path/,
+      ],
+      [
+        {
+          schemaVersion: "factory.artifact-view/v0",
+          sections: [{ path: "", as: "prose" }],
+        },
+        /panel\.view\.schemaVersion/,
+      ],
+      [
+        { sections: [{ path: "", as: "prose" }], nested: true },
+        /panel\.view: unknown property "nested"/,
+      ],
+    ];
+    for (const [view, pattern] of bad) {
+      const { panel, anomaly } = validatePanelView(samplePanel({ view }));
+      expect(panel).toBeNull();
+      expect(anomaly).toMatch(pattern);
+    }
+    // Endpoint and view errors are both reported, not first-wins.
+    const both = validatePanelView(
+      samplePanel({
+        source: { endpoint: "/nope" },
+        view: { sections: [{ path: "", as: "chart" }] },
+      }),
+    );
+    expect(both.anomaly).toMatch(/not an allow-listed GET route/);
+    expect(both.anomaly).toMatch(/not in enum/);
+  });
+
+  test("the built-in panel is valid and reads back what its file says", () => {
+    const doc = JSON.parse(readFileSync(BUILTIN_PANEL, "utf8"));
+    const { panel, anomaly } = readPanelFile(BUILTIN_PANEL);
+    expect(anomaly).toBeNull();
+    expect(panel.name).toBe("inbox-open");
+    expect(panel.source).toEqual({
+      endpoint: "/inbox",
+      query: { status: "open" },
+      path: "/items",
+    });
+    expect(panel.refreshSeconds).toBe(doc.refreshSeconds);
+    expect(panel.view.sections[0].as).toBe("table");
+  });
+});
+
+describe("loadPanelDir / mergePanels", () => {
+  test("loads every *.panel.json in name order, skips bad ones with an anomaly, ignores other files", () => {
+    const root = tmpDir("evrt-panels-");
+    const dir = path.join(root, "panels");
+    writePanel(dir, "b-second", samplePanel({ name: "b-second" }));
+    writePanel(dir, "a-first", samplePanel({ name: "a-first" }));
+    writePanel(dir, "broken", "{ not json");
+    writePanel(
+      dir,
+      "wrong-endpoint",
+      samplePanel({ name: "wrong-endpoint", source: { endpoint: "/nope" } }),
+    );
+    mkdirSync(path.join(dir, "not-a-panel.panel.json"));
+    writeFileSync(path.join(dir, "README.json"), JSON.stringify(samplePanel()));
+
+    const { panels, anomalies } = loadPanelDir(dir, { origin: "pack:x" });
+    expect(panels.map((p) => p.name)).toEqual(["a-first", "b-second"]);
+    expect(panels[0]).toMatchObject({
+      origin: "pack:x",
+      file: "panels/a-first.panel.json",
+      refreshSeconds: 60,
+    });
+    expect(anomalies).toHaveLength(3);
+    expect(anomalies[0]).toMatch(
+      /broken\.panel\.json is unparseable.*\[pack:x\]/,
+    );
+    expect(anomalies[1]).toMatch(/not-a-panel\.panel\.json is unparseable/);
+    expect(anomalies[2]).toMatch(
+      /wrong-endpoint\.panel\.json is invalid \(skipped\): panel\.source\.endpoint: "\/nope" is not an allow-listed GET route/,
+    );
+    // `base` controls what the served file is relative to.
+    expect(
+      loadPanelDir(dir, { origin: "extension:e", base: root }).panels[0].file,
+    ).toBe("panels/a-first.panel.json");
+    // A missing directory is no panels, not an error.
+    expect(
+      loadPanelDir(path.join(root, "absent"), { origin: "pack:x" }),
+    ).toEqual({
+      panels: [],
+      anomalies: [],
+    });
+  });
+
+  test("merges contributors first-wins on name and reports the loser", () => {
+    const a = { name: "dup", origin: "builtin", file: "panels/dup.panel.json" };
+    const b = { name: "dup", origin: "pack:p", file: "panels/dup.panel.json" };
+    const c = {
+      name: "other",
+      origin: "pack:p",
+      file: "panels/other.panel.json",
+    };
+    const merged = mergePanels([
+      { panels: [a], anomalies: ["earlier"] },
+      { panels: [b, c], anomalies: [] },
+    ]);
+    expect(merged.panels).toEqual([a, c]);
+    expect(merged.anomalies).toEqual([
+      "earlier",
+      'panel panels/dup.panel.json [pack:p] duplicates panel name "dup" already contributed by panels/dup.panel.json [builtin] (skipped)',
+    ]);
+  });
+});
+
+describe("registry + extension panel loading (WM-840)", () => {
+  test("the committed registry ships the built-in panel and no anomalies", () => {
+    const registry = loadRegistry();
+    expect(registry.panels.map((p) => [p.name, p.origin, p.file])).toEqual([
+      ["inbox-open", "builtin", "panels/inbox-open.panel.json"],
+    ]);
+    expect(registry.anomalies).toEqual([]);
+  });
+
+  test("packs contribute panels/*.panel.json as pack:<namespace>; extensions via contributes.panels as extension:<name>", async () => {
+    // A configured pack: copy the sample pack and give it a panels/ dir.
+    const packDir = tmpDir("evrt-panel-pack-");
+    const { cpSync } = await import("node:fs");
+    cpSync(SAMPLE_PACK, packDir, { recursive: true });
+    writePanel(
+      path.join(packDir, "panels"),
+      "spend",
+      samplePanel({ name: "sample:spend", source: { endpoint: "/metrics" } }),
+    );
+    writePanel(
+      path.join(packDir, "panels"),
+      "shadow",
+      samplePanel({ name: "inbox-open" }),
+    );
+    writePanel(
+      path.join(packDir, "panels"),
+      "bad",
+      samplePanel({ name: "sample:bad", view: { sections: [] } }),
+    );
+    const packManifest = JSON.parse(
+      readFileSync(path.join(packDir, "pack.json"), "utf8"),
+    );
+
+    // The fixture extension contributes ./panels.
+    const extensions = await loadExtensions({
+      policy: { extensions: [{ path: SAMPLE_EXTENSION }] },
+      packRoots: [{ kind: "fs", name: packManifest.name, path: packDir }],
+    });
+    expect(extensions.anomalies).toEqual([]);
+
+    const registry = loadRegistry({
+      packRoots: extensions.packRoots,
+      panelRoots: extensions.panelRoots,
+    });
+    expect(registry.panels.map((p) => [p.name, p.origin, p.file])).toEqual([
+      ["inbox-open", "builtin", "panels/inbox-open.panel.json"],
+      [
+        "sample:spend",
+        `pack:${packManifest.namespace}`,
+        "panels/spend.panel.json",
+      ],
+      [
+        "factory/sample:open-proposals",
+        "extension:factory/sample",
+        "panels/open-proposals.panel.json",
+      ],
+    ]);
+    // Bad and shadowing panels are configuration anomalies, everything else loads.
+    expect(registry.anomalies).toHaveLength(2);
+    expect(registry.anomalies[0]).toMatch(
+      /bad\.panel\.json is invalid \(skipped\).*sections: fewer than minItems 1/,
+    );
+    expect(registry.anomalies[1]).toMatch(
+      /shadow\.panel\.json \[pack:sample\] duplicates panel name "inbox-open" already contributed by panels\/inbox-open\.panel\.json \[builtin\]/,
+    );
+    // Malformed panelRoots fail closed like every other loader input.
+    expect(() => loadRegistry({ panelRoots: "nope" })).toThrow(
+      /panelRoots must be an array/,
+    );
+    expect(() => loadRegistry({ panelRoots: [{ dir: 1 }] })).toThrow(
+      /panelRoots entries/,
+    );
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -15,6 +15,7 @@ import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import { reposRoot } from "./repos.mjs";
 import { validateArtifactView } from "./artifact-view.mjs";
+import { PANELS_DIR, loadPanelDir, mergePanels } from "./panel-view.mjs";
 
 export class RegistryError extends Error {
   constructor(message) {
@@ -132,6 +133,13 @@ export function createFsPackLoader(
     // absent method as "this pack has no views".
     readArtifactView(entry, def) {
       return loadArtifactView(root, entry.source, def);
+    },
+    // Optional seam member (WM-840): `panels/*.panel.json` under the pack
+    // root, validated by lib/panel-view.mjs; a pack without the directory
+    // contributes no panels, and loadRegistry treats an absent method the
+    // same way.
+    listPanels(origin) {
+      return loadPanelDir(path.join(root, PANELS_DIR), { origin });
     },
     readPinned(relative, def) {
       if (pins === undefined && !builtIn && !ignorePins) {
@@ -617,6 +625,7 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
 export function loadRegistry({
   root = RUNTIME_ROOT,
   packRoots,
+  panelRoots = [],
   modelTiers = loadModelTierMap(),
   loaderFor = defaultLoaderFor,
 } = {}) {
@@ -627,6 +636,8 @@ export function loadRegistry({
     throw new RegistryError("packRoots must be an array");
   if (typeof loaderFor !== "function")
     throw new RegistryError("loaderFor must be a function");
+  if (!Array.isArray(panelRoots))
+    throw new RegistryError("panelRoots must be an array");
 
   const builtIn = {
     kind: "fs",
@@ -652,6 +663,9 @@ export function loadRegistry({
   const agentSources = new Map();
   const views = new Map();
   const anomalies = [];
+  // Panels (WM-840): one batch per contributor, merged after the loop so a
+  // duplicate name is reported against the contributor that got there first.
+  const panelBatches = [];
   const eventTypes = nullDict();
   const edges = nullDict();
   const schedules = nullDict();
@@ -685,6 +699,11 @@ export function loadRegistry({
       if (anomaly) anomalies.push(anomaly);
       views.set(def.ref, { file, view });
     }
+    if (typeof loader.listPanels === "function") {
+      panelBatches.push(
+        loader.listPanels(builtInPack ? "builtin" : `pack:${pack.namespace}`),
+      );
+    }
     mergeMap(
       eventTypes,
       eventSources,
@@ -701,6 +720,19 @@ export function loadRegistry({
       "schedule loop",
     );
   }
+
+  // Extension-contributed panel directories (`contributes.panels`,
+  // lib/extensions.mjs) load after every pack, so a pack panel outranks an
+  // extension panel of the same name exactly as policy order says.
+  for (const { dir, origin, base } of panelRoots) {
+    if (typeof dir !== "string" || typeof origin !== "string") {
+      throw new RegistryError("panelRoots entries must be { dir, origin }");
+    }
+    panelBatches.push(loadPanelDir(dir, { origin, base }));
+  }
+  const merged = mergePanels(panelBatches);
+  anomalies.push(...merged.anomalies);
+  const panels = merged.panels;
 
   for (const [type, mapping] of Object.entries(eventTypes)) {
     if (
@@ -962,6 +994,7 @@ export function loadRegistry({
     })),
     agents,
     views,
+    panels,
     anomalies,
     eventTypes,
     schemas,

--- a/event-runtime/panels/inbox-open.panel.json
+++ b/event-runtime/panels/inbox-open.panel.json
@@ -1,0 +1,34 @@
+{
+  "format": "factory.panel-view/v1",
+  "name": "inbox-open",
+  "title": "Open inbox items",
+  "description": "Built-in proof panel (WM-840): the open ledger of /inbox, newest first, drawn with the artifact-view vocabulary.",
+  "source": {
+    "endpoint": "/inbox",
+    "query": {
+      "status": "open"
+    },
+    "path": "/items"
+  },
+  "refreshSeconds": 30,
+  "view": {
+    "sections": [
+      {
+        "path": "",
+        "as": "table",
+        "columns": ["kind", "severity", "title", "createdAt"],
+        "formats": {
+          "createdAt": "datetime"
+        },
+        "tone": {
+          "severity": {
+            "high": "error",
+            "urgent": "error",
+            "normal": "muted",
+            "low": "muted"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "factory-extension.json — the manifest of one factory extension (docs/extensions.md)",
-  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views` and `panels` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
+  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors` and `views` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
   "type": "object",
   "required": ["name", "version"],
   "additionalProperties": false,
@@ -54,7 +54,12 @@
           "description": "reserved — web views; not supported yet"
         },
         "panels": {
-          "description": "reserved — declarative Overview panels; lands in WM-840"
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "relative directory of factory.panel-view/v1 `*.panel.json` files (docs/extensions.md § Panels)"
+          }
         },
         "config": {
           "type": "object",

--- a/event-runtime/schemas/panel-view.schema.json
+++ b/event-runtime/schemas/panel-view.schema.json
@@ -1,0 +1,51 @@
+{
+  "title": "factory.panel-view/v1 — a declarative Overview tile bound to one loopback API endpoint (docs/event-runtime-artifact-views.md §2.6)",
+  "description": "A panel names a GET endpoint of the loopback API, an optional query and an RFC 6901 pointer into the response, and describes how to draw the selected node with the artifact-view vocabulary. `view` is a `factory.artifact-view/v1` body without `schemaVersion` (`sections`, optional `summary`/`status`); it is validated by lib/artifact-view.mjs against the artifact-view schema, and `source.endpoint` is checked against the allow-list in lib/api-panels.mjs — both by lib/panel-view.mjs, because lib/schema.mjs has no $ref and knows no routes.",
+  "type": "object",
+  "required": ["format", "name", "title", "source", "view"],
+  "additionalProperties": false,
+  "properties": {
+    "format": { "const": "factory.panel-view/v1" },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?(:[a-z0-9][a-z0-9-]*)?$",
+      "description": "unique across every contributor: `slug` for built-ins, `<namespace>:<slug>` for pack panels, `<publisher>/<extension>:<slug>` for extension panels"
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 60 },
+    "description": { "type": "string", "maxLength": 200 },
+    "source": {
+      "type": "object",
+      "required": ["endpoint"],
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "pattern": "^/[a-z][a-z0-9/-]*$",
+          "description": "one of the allow-listed GET routes (lib/api-panels.mjs PANEL_ENDPOINTS); no query string here"
+        },
+        "query": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "maxLength": 200 },
+          "description": "query parameters appended to the endpoint, string values only"
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^(/|$)",
+          "description": "RFC 6901 pointer into the response selecting the node the view renders; `\"\"` (the default) is the whole response"
+        }
+      }
+    },
+    "refreshSeconds": {
+      "type": "integer",
+      "minimum": 5,
+      "maximum": 3600,
+      "description": "how often the web refetches the source; default 60"
+    },
+    "view": {
+      "type": "object",
+      "description": "artifact-view body over the selected node: `sections` (each `path` relative to the node, `\"\"` for the node itself), optional `summary` and `status`; per-`as` keys and vocabulary as in schemas/factory.artifact-view.v1.json"
+    }
+  }
+}

--- a/event-runtime/test-support/extensions/sample/factory-extension.json
+++ b/event-runtime/test-support/extensions/sample/factory-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "factory/sample",
   "version": "1.0.0",
-  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, a config schema, and one approve.before hook.",
+  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, a config schema, one approve.before hook and one panel.",
   "factory": {
     "min": "0.1.0"
   },
@@ -16,6 +16,7 @@
     },
     "hooks": {
       "approve.before": "./hooks/approve-before.mjs"
-    }
+    },
+    "panels": ["./panels"]
   }
 }

--- a/event-runtime/test-support/extensions/sample/panels/open-proposals.panel.json
+++ b/event-runtime/test-support/extensions/sample/panels/open-proposals.panel.json
@@ -1,0 +1,17 @@
+{
+  "format": "factory.panel-view/v1",
+  "name": "factory/sample:open-proposals",
+  "title": "Open proposals (sample)",
+  "description": "Test fixture: an extension-contributed panel bound to /proposals.",
+  "source": { "endpoint": "/proposals", "path": "/proposals" },
+  "view": {
+    "sections": [
+      {
+        "path": "",
+        "as": "table",
+        "columns": ["id", "status", "createdAt"],
+        "formats": { "createdAt": "datetime" }
+      }
+    ]
+  }
+}

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -2,6 +2,7 @@ import type {
   AdmittedEvent,
   AgentsView,
   ArtifactInventoryItem,
+  ArtifactView,
   ChainListItem,
   ChainView,
   ApproveOutcome,
@@ -76,6 +77,30 @@ export interface ConfigView {
     scheduleCount: number;
   };
   sections: ConfigSection[];
+}
+
+/**
+ * A declarative Overview panel (`factory.panel-view/v1`, WM-840) as `GET
+ * /panels` serves it: already validated by the runtime, bound to one
+ * allow-listed loopback GET route, drawn with the artifact-view vocabulary
+ * over the node `source.path` selects in that route's response.
+ */
+export interface PanelView {
+  name: string;
+  title: string;
+  description: string | null;
+  source: { endpoint: string; query: Record<string, string>; path: string };
+  refreshSeconds: number;
+  /** An artifact-view body without `schemaVersion`; sections' `path` is relative to the selected node. */
+  view: Omit<ArtifactView, "schemaVersion">;
+  /** `builtin`, `pack:<namespace>` or `extension:<name>`. */
+  origin: string;
+  file: string;
+}
+export interface PanelsView {
+  panels: PanelView[];
+  /** The `source.endpoint` allow-list — a client refuses to fetch anything else. */
+  endpoints: string[];
 }
 
 /** Deliberately allow-listed repository settings returned by GET /repos. */
@@ -351,6 +376,14 @@ export const api = {
     ),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
+  // Declarative Overview panels (WM-840) and the data behind one of them:
+  // `panelSource` only ever GETs an endpoint the runtime already
+  // allow-listed for the panel; the query is the panel's own `source.query`.
+  panels: () => call<PanelsView>("GET", "/panels"),
+  panelSource: (endpoint: string, query: Record<string, string> = {}) => {
+    const qs = new URLSearchParams(query).toString();
+    return call<unknown>("GET", qs ? `${endpoint}?${qs}` : endpoint);
+  },
   // Every event + run under one correlation id (WM-527); 404 when unknown.
   chain: (correlationId: string) =>
     call<ChainView>("GET", `/chain/${encodeURIComponent(correlationId)}`),

--- a/event-runtime/web/src/components/PanelGrid.test.tsx
+++ b/event-runtime/web/src/components/PanelGrid.test.tsx
@@ -102,9 +102,7 @@ describe("PanelGrid (WM-840)", () => {
         const grid = await findByLabelText("Panels");
         expect(within(grid).getByText("Open inbox items")).toBeTruthy();
         expect(within(grid).getByText("builtin")).toBeTruthy();
-        expect(
-          within(grid).getByText("1 · from packs and extensions"),
-        ).toBeTruthy();
+        expect(within(grid).getByText("1 panel")).toBeTruthy();
         // The table over /items, with the panel's columns and tones.
         await findByText("WM-1 needs a decision");
         const tile = container.querySelector('[data-panel="inbox-open"]')!;

--- a/event-runtime/web/src/components/PanelGrid.test.tsx
+++ b/event-runtime/web/src/components/PanelGrid.test.tsx
@@ -1,0 +1,237 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { api, type PanelView } from "../api";
+import { renderWithClient, withApi } from "../test-render";
+import { PanelGrid } from "./PanelGrid";
+
+afterEach(() => {
+  cleanup();
+});
+
+const ENDPOINTS = ["/inbox", "/proposals", "/status", "/tickets"];
+
+/** The built-in panel, exactly as the runtime serves it (minus origin/file which /panels adds). */
+const BUILTIN = JSON.parse(
+  readFileSync(
+    path.resolve(import.meta.dir, "../../../panels/inbox-open.panel.json"),
+    "utf8",
+  ),
+);
+
+function panel(overrides: Partial<PanelView> = {}): PanelView {
+  return {
+    name: BUILTIN.name,
+    title: BUILTIN.title,
+    description: BUILTIN.description,
+    source: BUILTIN.source,
+    refreshSeconds: BUILTIN.refreshSeconds,
+    view: BUILTIN.view,
+    origin: "builtin",
+    file: "panels/inbox-open.panel.json",
+    ...overrides,
+  };
+}
+
+const inboxItems = [
+  {
+    id: "inbox_1",
+    kind: "BLOCKED",
+    severity: "high",
+    title: "WM-1 needs a decision",
+    createdAt: "2026-08-18T09:00:00.000Z",
+  },
+  {
+    id: "inbox_2",
+    kind: "RC READY",
+    severity: "normal",
+    title: "factory develop → main",
+    createdAt: "2026-08-18T08:00:00.000Z",
+  },
+];
+
+describe("PanelGrid (WM-840)", () => {
+  test("renders nothing when the catalogue has no panels — no empty section", async () => {
+    await withApi(
+      { panels: async () => ({ panels: [], endpoints: ENDPOINTS }) },
+      async () => {
+        const { container } = renderWithClient(<PanelGrid />);
+        await waitFor(() => expect(api.panels).toHaveBeenCalled());
+        expect(container.querySelector('[aria-label="Panels"]')).toBeNull();
+        expect(container.textContent).toBe("");
+        expect(api.panelSource).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  test("renders nothing when the catalogue itself cannot be read", async () => {
+    await withApi(
+      {
+        panels: async () => {
+          throw new Error("HTTP 500");
+        },
+      },
+      async () => {
+        const { container } = renderWithClient(<PanelGrid />);
+        await waitFor(() => expect(api.panels).toHaveBeenCalled());
+        await new Promise((r) => setTimeout(r, 20));
+        expect(container.querySelector('[aria-label="Panels"]')).toBeNull();
+      },
+    );
+  });
+
+  test("fetches each panel's source with its query, applies source.path and draws the node with ArtifactView", async () => {
+    await withApi(
+      {
+        panels: async () => ({ panels: [panel()], endpoints: ENDPOINTS }),
+        panelSource: async (
+          endpoint: string,
+          query?: Record<string, string>,
+        ) => {
+          expect(endpoint).toBe("/inbox");
+          expect(query).toEqual({ status: "open" });
+          return { items: inboxItems };
+        },
+      },
+      async () => {
+        const { container, findByLabelText, findByText } = renderWithClient(
+          <PanelGrid />,
+        );
+        const grid = await findByLabelText("Panels");
+        expect(within(grid).getByText("Open inbox items")).toBeTruthy();
+        expect(within(grid).getByText("builtin")).toBeTruthy();
+        expect(
+          within(grid).getByText("1 · from packs and extensions"),
+        ).toBeTruthy();
+        // The table over /items, with the panel's columns and tones.
+        await findByText("WM-1 needs a decision");
+        const tile = container.querySelector('[data-panel="inbox-open"]')!;
+        expect(tile.querySelector("[data-artifact-view]")).not.toBeNull();
+        expect(within(tile as HTMLElement).getByText("BLOCKED")).toBeTruthy();
+        expect(within(tile as HTMLElement).getByText("RC READY")).toBeTruthy();
+        expect(tile.textContent).toContain("as of ");
+        expect(api.panelSource).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  test("a panel whose fetch fails shows an inline error tile with Retry and never breaks the grid", async () => {
+    let attempts = 0;
+    await withApi(
+      {
+        panels: async () => ({
+          panels: [
+            panel(),
+            panel({
+              name: "wattmind/mobile:blocked",
+              title: "Blocked > 24h",
+              origin: "extension:wattmind/mobile",
+              file: "panels/blocked.panel.json",
+              source: {
+                endpoint: "/tickets",
+                query: { state: "blocked" },
+                path: "/tickets",
+              },
+              view: {
+                sections: [
+                  {
+                    path: "",
+                    as: "table",
+                    columns: ["identifier", "title"],
+                    formats: { identifier: "issue" },
+                  },
+                ],
+              },
+            }),
+          ],
+          endpoints: ENDPOINTS,
+        }),
+        panelSource: async (endpoint: string) => {
+          if (endpoint === "/tickets") {
+            attempts += 1;
+            if (attempts === 1) throw new Error("HTTP 503");
+            return { tickets: [{ identifier: "WM-9", title: "Stuck ticket" }] };
+          }
+          return { items: inboxItems };
+        },
+      },
+      async () => {
+        const { container, findByRole, findByText } = renderWithClient(
+          <PanelGrid />,
+        );
+        // The healthy tile draws; the failing tile reports inline.
+        await findByText("WM-1 needs a decision");
+        const alert = await findByRole("alert");
+        expect(alert.textContent).toContain("Panel failed:");
+        expect(alert.textContent).toContain("HTTP 503");
+        expect(alert.textContent).toContain("/tickets");
+        const failed = container.querySelector(
+          '[data-panel="wattmind/mobile:blocked"]',
+        )!;
+        expect(
+          within(failed as HTMLElement).getByText("Blocked > 24h"),
+        ).toBeTruthy();
+        expect(
+          within(failed as HTMLElement).getByText("extension:wattmind/mobile"),
+        ).toBeTruthy();
+        expect(container.querySelectorAll("[data-panel]")).toHaveLength(2);
+        // Retry refetches just that panel and the tile recovers.
+        fireEvent.click(within(failed as HTMLElement).getByText("Retry"));
+        await findByText("Stuck ticket");
+        expect(container.querySelector('[role="alert"]')).toBeNull();
+        expect(attempts).toBe(2);
+      },
+    );
+  });
+
+  test("a panel whose pointer misses, or whose data is empty, says so instead of drawing nothing", async () => {
+    await withApi(
+      {
+        panels: async () => ({
+          panels: [
+            panel(),
+            panel({
+              name: "other",
+              title: "Other",
+              source: { endpoint: "/status", query: {}, path: "/nope/deeper" },
+            }),
+          ],
+          endpoints: ENDPOINTS,
+        }),
+        panelSource: async (endpoint: string) =>
+          endpoint === "/inbox" ? { items: [] } : { workers: {} },
+      },
+      async () => {
+        const { findByText } = renderWithClient(<PanelGrid />);
+        await findByText("Nothing to show — empty.");
+        const miss = await findByText(/Nothing at/);
+        expect(miss.textContent).toContain("/nope/deeper");
+        expect(miss.textContent).toContain("/status");
+      },
+    );
+  });
+
+  test("refuses client-side to fetch an endpoint the runtime did not allow-list", async () => {
+    await withApi(
+      {
+        panels: async () => ({
+          panels: [
+            panel({
+              source: { endpoint: "/inbox", query: {}, path: "/items" },
+            }),
+          ],
+          endpoints: ["/status"],
+        }),
+        panelSource: mock(async () => ({ items: inboxItems })),
+      },
+      async () => {
+        const { findByRole } = renderWithClient(<PanelGrid />);
+        const alert = await findByRole("alert");
+        expect(alert.textContent).toContain("not allow-listed");
+        expect(api.panelSource).not.toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/components/PanelGrid.tsx
+++ b/event-runtime/web/src/components/PanelGrid.tsx
@@ -1,0 +1,289 @@
+/**
+ * PanelGrid — declarative Overview panels (`factory.panel-view/v1`, WM-840,
+ * docs/event-runtime-artifact-views.md §2.6).
+ *
+ * The runtime serves the catalogue at `GET /panels`: each panel names an
+ * allow-listed loopback GET route, a query, an RFC 6901 pointer into the
+ * response and an artifact-view body. This component fetches the catalogue,
+ * then each panel's source on its own TanStack Query at the panel's
+ * `refreshSeconds`, selects the node and draws it with `ArtifactView` — the
+ * same renderer agents' artifacts use, so a pack or extension gets a
+ * dashboard tile without shipping React.
+ *
+ * Isolation is the whole point of the grid: every tile has its own query and
+ * its own error boundary, so one panel whose endpoint fails, whose pointer
+ * misses, or whose data trips the renderer shows an inline error tile and
+ * never takes the grid — or Overview — with it. Zero panels renders nothing
+ * (no empty section), so a stock install without panels looks as it did.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { Component, useMemo, type ErrorInfo, type ReactNode } from "react";
+import { api, type PanelView } from "../api";
+import { resolvePointer, sectionsFor, viewApplies } from "../lib/artifactView";
+import type { ArtifactView as ArtifactViewDoc } from "../types";
+import { ArtifactView } from "./ArtifactView";
+import { Button } from "./ui";
+
+/** How often the catalogue itself is re-read; panels change at serve start, not per tick. */
+const CATALOGUE_REFRESH_MS = 60_000;
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error && error.message
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : "request failed";
+
+/**
+ * The tile frame every state shares: title, origin, a right-aligned slot,
+ * then the body. `data-panel` carries the panel name for tests and styling.
+ */
+function PanelTile({
+  panel,
+  aside,
+  children,
+}: {
+  panel: PanelView;
+  aside?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      data-panel={panel.name}
+      className="flex min-w-0 flex-col rounded-lg border border-(--border) bg-(--surface-1) p-3.5"
+    >
+      <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span
+          className="text-[12px] font-medium text-(--text)"
+          title={panel.description ?? undefined}
+        >
+          {panel.title}
+        </span>
+        <span
+          className="text-[10.5px] text-(--text-faint)"
+          title={`${panel.file} · ${panel.source.endpoint}`}
+        >
+          {panel.origin}
+        </span>
+        {aside && <span className="ml-auto">{aside}</span>}
+      </div>
+      <div className="min-w-0 overflow-x-auto">{children}</div>
+    </div>
+  );
+}
+
+function TileNote({ children }: { children: ReactNode }) {
+  return <p className="m-0 text-[12px] text-(--text-faint)">{children}</p>;
+}
+
+/** The inline error tile: what went wrong and a way to try again, nothing more. */
+function TileError({
+  panel,
+  message,
+  onRetry,
+}: {
+  panel: PanelView;
+  message: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <PanelTile
+      panel={panel}
+      aside={
+        onRetry && (
+          <Button size="sm" variant="ghost" onClick={onRetry}>
+            Retry
+          </Button>
+        )
+      }
+    >
+      <div
+        role="alert"
+        className="rounded-md px-2.5 py-1.5 text-[12px]"
+        style={{
+          color: "var(--hue-err)",
+          background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
+        }}
+      >
+        <span className="font-medium">Panel failed:</span> {message}
+        <span className="ml-1 text-(--text-faint)">
+          ({panel.source.endpoint})
+        </span>
+      </div>
+    </PanelTile>
+  );
+}
+
+/**
+ * A render fault inside one tile stays inside that tile. The artifact-view
+ * renderer degrades rather than throws, so this is a belt over braces — but
+ * a third-party panel is exactly the input a belt is for.
+ */
+class TileBoundary extends Component<
+  { panel: PanelView; children: ReactNode },
+  { error: string | null }
+> {
+  state = { error: null as string | null };
+  static getDerivedStateFromError(error: unknown) {
+    return { error: errorMessage(error) };
+  }
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    console.error(
+      `panel ${this.props.panel.name} failed to render`,
+      error,
+      info,
+    );
+  }
+  render() {
+    if (this.state.error !== null) {
+      return (
+        <TileError
+          panel={this.props.panel}
+          message={`render error — ${this.state.error}`}
+          onRetry={() => this.setState({ error: null })}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/** One panel: its own query at its own cadence, the selected node drawn with ArtifactView. */
+export function PanelBody({
+  panel,
+  allowed,
+  onJumpRun,
+}: {
+  panel: PanelView;
+  /** The runtime's endpoint allow-list; a panel outside it is refused client-side too. */
+  allowed: string[];
+  onJumpRun?: (runId: string) => void;
+}) {
+  const { endpoint, query, path } = panel.source;
+  const permitted = allowed.includes(endpoint);
+  const source = useQuery({
+    queryKey: ["panel", panel.name, endpoint, query],
+    queryFn: () => api.panelSource(endpoint, query),
+    enabled: permitted,
+    refetchInterval: Math.max(5, panel.refreshSeconds) * 1000,
+    refetchIntervalInBackground: false,
+    retry: false,
+  });
+  const view = useMemo<ArtifactViewDoc>(
+    () => ({ schemaVersion: "factory.artifact-view/v1", ...panel.view }),
+    [panel.view],
+  );
+
+  if (!permitted) {
+    return (
+      <TileError
+        panel={panel}
+        message={`endpoint ${endpoint} is not allow-listed`}
+      />
+    );
+  }
+  if (source.isError) {
+    return (
+      <TileError
+        panel={panel}
+        message={errorMessage(source.error)}
+        onRetry={() => void source.refetch()}
+      />
+    );
+  }
+  if (source.data === undefined) {
+    return (
+      <PanelTile panel={panel}>
+        <TileNote>Loading…</TileNote>
+      </PanelTile>
+    );
+  }
+  const node = resolvePointer(source.data, path);
+  const refreshed = source.dataUpdatedAt
+    ? new Date(source.dataUpdatedAt).toLocaleTimeString()
+    : null;
+  const aside = (
+    <span
+      className={`text-[10.5px] text-(--text-faint) ${source.isFetching ? "opacity-60" : ""}`}
+      title={`refreshes every ${panel.refreshSeconds}s`}
+    >
+      {refreshed ? `as of ${refreshed}` : null}
+    </span>
+  );
+  if (node === undefined) {
+    return (
+      <PanelTile panel={panel} aside={aside}>
+        <TileNote>
+          Nothing at <code>{path || '""'}</code> in {endpoint}.
+        </TileNote>
+      </PanelTile>
+    );
+  }
+  if (Array.isArray(node) && node.length === 0) {
+    return (
+      <PanelTile panel={panel} aside={aside}>
+        <TileNote>Nothing to show — empty.</TileNote>
+      </PanelTile>
+    );
+  }
+  // `viewApplies` gates on an object artifact (that is what agents emit); a
+  // panel's node is often the array itself, so ask the sections directly then.
+  const applies = Array.isArray(node)
+    ? sectionsFor(view, node).length > 0
+    : viewApplies(view, node);
+  if (!applies) {
+    return (
+      <PanelTile panel={panel} aside={aside}>
+        <TileNote>Nothing to show — the view matches no field here.</TileNote>
+      </PanelTile>
+    );
+  }
+  return (
+    <PanelTile panel={panel} aside={aside}>
+      <ArtifactView view={view} artifact={node} onJumpRun={onJumpRun} />
+    </PanelTile>
+  );
+}
+
+/**
+ * The grid: reads `/panels`, renders one isolated tile per panel below the
+ * host's own content, and renders nothing at all when there is no panel
+ * (or the catalogue itself cannot be read — the host page is not the place
+ * to report a missing optional feature; `/status` anomalies are).
+ */
+export function PanelGrid({
+  onJumpRun,
+}: {
+  onJumpRun?: (runId: string) => void;
+}) {
+  const catalogue = useQuery({
+    queryKey: ["panels"],
+    queryFn: api.panels,
+    staleTime: CATALOGUE_REFRESH_MS,
+    refetchInterval: CATALOGUE_REFRESH_MS,
+    refetchIntervalInBackground: false,
+    retry: false,
+  });
+  const panels = catalogue.data?.panels ?? [];
+  const allowed = catalogue.data?.endpoints ?? [];
+  if (panels.length === 0) return null;
+  return (
+    <section aria-label="Panels" className="mb-5">
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">
+          Panels
+        </span>
+        <span className="ml-auto text-right text-[11px] text-(--text-faint)">
+          {panels.length} · from packs and extensions
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
+        {panels.map((panel) => (
+          <TileBoundary key={panel.name} panel={panel}>
+            <PanelBody panel={panel} allowed={allowed} onJumpRun={onJumpRun} />
+          </TileBoundary>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/event-runtime/web/src/components/PanelGrid.tsx
+++ b/event-runtime/web/src/components/PanelGrid.tsx
@@ -60,7 +60,7 @@ function PanelTile({
           {panel.title}
         </span>
         <span
-          className="text-[10.5px] text-(--text-faint)"
+          className="text-xs text-(--text-faint)"
           title={`${panel.file} · ${panel.source.endpoint}`}
         >
           {panel.origin}
@@ -205,7 +205,7 @@ export function PanelBody({
     : null;
   const aside = (
     <span
-      className={`text-[10.5px] text-(--text-faint) ${source.isFetching ? "opacity-60" : ""}`}
+      className={`text-xs text-(--text-faint) ${source.isFetching ? "opacity-60" : ""}`}
       title={`refreshes every ${panel.refreshSeconds}s`}
     >
       {refreshed ? `as of ${refreshed}` : null}

--- a/event-runtime/web/src/components/PanelGrid.tsx
+++ b/event-runtime/web/src/components/PanelGrid.tsx
@@ -67,7 +67,8 @@ function PanelTile({
         </span>
         {aside && <span className="ml-auto">{aside}</span>}
       </div>
-      <div className="min-w-0 overflow-x-auto">{children}</div>
+      {/* Long tables scroll inside the tile so one busy panel cannot stretch the whole grid row. */}
+      <div className="max-h-[24rem] min-w-0 overflow-auto">{children}</div>
     </div>
   );
 }
@@ -274,10 +275,21 @@ export function PanelGrid({
           Panels
         </span>
         <span className="ml-auto text-right text-[11px] text-(--text-faint)">
-          {panels.length} · from packs and extensions
+          {panels.length === 1 ? "1 panel" : `${panels.length} panels`}
         </span>
       </div>
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
+      {/*
+        Columns size to content, not to a breakpoint: one panel takes the full
+        width, three share it, and no tile is ever squeezed under ~22rem while
+        an empty column sits beside it (UX critique, WM-840).
+      */}
+      <div
+        className="grid gap-3"
+        style={{
+          gridTemplateColumns:
+            "repeat(auto-fit, minmax(min(100%, 22rem), 1fr))",
+        }}
+      >
         {panels.map((panel) => (
           <TileBoundary key={panel.name} panel={panel}>
             <PanelBody panel={panel} allowed={allowed} onJumpRun={onJumpRun} />

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -362,6 +362,10 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       runId,
     })),
     agents: mock(async () => createAgentsFixture()),
+    panels: mock(async () => ({ panels: [], endpoints: [] })),
+    panelSource: mock(
+      async (_endpoint: string, _query?: Record<string, string>) => ({}),
+    ),
     repos: mock(async (): Promise<{ repos: RepoItem[] }> => ({ repos: [] })),
     janitor: mock(
       async (name: string, apply = false): Promise<JanitorResult> => ({

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1814,9 +1814,7 @@ describe("Overview declarative panels (WM-840)", () => {
         await waitFor(() => expect(api.panels).toHaveBeenCalled());
         await r.findByText("Worker Fleet Capacity");
         expect(r.queryByLabelText("Panels")).toBeNull();
-        expect(r.container.textContent).not.toContain(
-          "from packs and extensions",
-        );
+        expect(r.container.textContent).not.toContain("1 panel");
       },
     );
   });

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1758,3 +1758,66 @@ describe("Overview waiting-on-you tile (WM-286)", () => {
     }
   });
 });
+
+describe("Overview declarative panels (WM-840)", () => {
+  const inboxPanel = {
+    name: "inbox-open",
+    title: "Open inbox items",
+    description: null,
+    source: { endpoint: "/inbox", query: { status: "open" }, path: "/items" },
+    refreshSeconds: 30,
+    view: {
+      sections: [
+        { path: "", as: "table" as const, columns: ["kind", "title"] },
+      ],
+    },
+    origin: "builtin",
+    file: "panels/inbox-open.panel.json",
+  };
+
+  test("shows the panel grid below the existing content when at least one panel exists", async () => {
+    await withApi(
+      {
+        status: async () => baseStatus(),
+        panels: async () => ({ panels: [inboxPanel], endpoints: ["/inbox"] }),
+        panelSource: async () => ({
+          items: [{ id: "i1", kind: "BLOCKED", title: "WM-7 waits on you" }],
+        }),
+      },
+      async () => {
+        const r = renderOverview();
+        const grid = await r.findByLabelText("Panels");
+        await waitFor(() =>
+          expect(within(grid).getByText("WM-7 waits on you")).toBeTruthy(),
+        );
+        // Below the content Overview already draws (the housekeeping band is its last).
+        const housekeeping = r.getByText("Worker Fleet Capacity");
+        expect(
+          Boolean(
+            housekeeping.compareDocumentPosition(grid) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+          ),
+        ).toBe(true);
+        expect(within(grid).getByText("Open inbox items")).toBeTruthy();
+      },
+    );
+  });
+
+  test("renders no panel section at all when there are zero panels", async () => {
+    await withApi(
+      {
+        status: async () => baseStatus(),
+        panels: async () => ({ panels: [], endpoints: ["/inbox"] }),
+      },
+      async () => {
+        const r = renderOverview();
+        await waitFor(() => expect(api.panels).toHaveBeenCalled());
+        await r.findByText("Worker Fleet Capacity");
+        expect(r.queryByLabelText("Panels")).toBeNull();
+        expect(r.container.textContent).not.toContain(
+          "from packs and extensions",
+        );
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -46,6 +46,13 @@ const OverviewNeedsYou = lazy(() =>
     default: OverviewNeedsYou,
   })),
 );
+// Lazy like Needs-you: the artifact-view renderer behind the panels is not
+// entry-chunk material, and a stock install without panels never draws it.
+const PanelGrid = lazy(() =>
+  import("../components/PanelGrid").then(({ PanelGrid }) => ({
+    default: PanelGrid,
+  })),
+);
 
 export function SectionTitle({
   title,
@@ -2177,6 +2184,15 @@ export function Overview({
           </div>
         </OverviewSection>
       </div>
+
+      {/*
+        Declarative panels (WM-840): tiles contributed by packs and extensions,
+        drawn with the artifact-view renderer. Renders nothing when there are
+        none, so the page above is unchanged on a stock install without them.
+      */}
+      <Suspense fallback={null}>
+        <PanelGrid onJumpRun={onJumpRun} />
+      </Suspense>
 
       {bulkDeadLetterAction && (
         <Dialog


### PR DESCRIPTION
Declarative Overview panels: a pack or extension ships a `*.panel.json` (`factory.panel-view/v1`) naming an allow-listed loopback GET route, a query, an RFC 6901 pointer into the response and an artifact-view body; the runtime validates it at load (schema, `PANEL_ENDPOINTS` allow-list in `lib/api-panels.mjs`, `view` through the artifact-view validator's new `validateArtifactViewShape`), skips invalid ones as `/status.anomalies.configuration`, and serves the catalogue at `GET /panels` (mirrored in `client.mjs` / `web/src/api.ts`).

- Sources: built-in `event-runtime/panels/inbox-open.panel.json` (proof, bound to `/inbox?status=open`), `<pack>/panels/*.panel.json` (`registry.mjs`, origin `pack:<ns>`), extension `contributes.panels` dirs (`extensions.mjs` → `loadRegistry({ panelRoots })`, origin `extension:<name>`); duplicate names are first-wins + anomaly.
- Web: `PanelGrid.tsx` (lazy on Overview, below existing content, nothing when zero panels) fetches each panel's source on its own TanStack Query at `refreshSeconds`, applies `source.path`, draws with `ArtifactView`; per-tile error boundary + inline error tile with Retry.
- Docs: `event-runtime-artifact-views.md` §2.6 Panels, `extensions.md` § Panels. Pointers are RFC 6901 (`/items`), matching the artifact-view vocabulary, rather than the JSONPath spelling in the ticket sketch.
- UX critique (factory-ux-critic, operator persona, 2 rounds): SHIP after grid sizing/tile cap/meta copy fixes.

Verification: `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/panel-view.test.mjs event-runtime/lib/api-panels.test.mjs event-runtime/lib/artifact-view.test.mjs event-runtime/lib/registry.test.mjs event-runtime/web/src/components/PanelGrid.test.tsx event-runtime/web/src/views/Overview.test.tsx && cd event-runtime/web && bun run build && cd ../.. && bun run lint --max-warnings=627 && bun run check` — pass (112 tests, build 617 kB entry, lint 0 errors, check ok). `factory security` passed.

Fixes WM-840