### PR TITLE
feat(hooks): approve.before hook seam with persisted decisions; escalation-label check migrated onto it (WM-842)

### DIFF
--- a/docs/event-runtime-conventions.md
+++ b/docs/event-runtime-conventions.md
@@ -73,7 +73,12 @@ runtime. Existing seams include:
   worker lifecycle functions' injected clocks;
 - `publishOutbox(db, { sink })` and notification transport options;
 - `resolvePiCommand({ which })` and remote-worker `spawnFn` options;
-- explicit `workspaceDir`, `artifactStore`, `env`, and adapter registries; and
+- explicit `workspaceDir`, `artifactStore`, `env`, and adapter registries;
+- the hook registry — `autoApproveChains(db, registry, { hooks, hookTimeoutMs })`
+  and `loadExtensions({ hookRegistry })` take a `createHookRegistry()`
+  instance (`lib/hooks.mjs`; the process-wide `defaultHookRegistry()` is only
+  the default), so tests decide which `approve.before` hooks run and with what
+  timeout; and
 - temporary directories and PATH-local stub CLIs in adapter conformance tests.
 
 Keep defaults in the options destructuring, not in mutable module globals. Do

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -22,10 +22,13 @@ Today an extension can contribute:
   their `source`;
 - **config** — a JSON-schema for the extension's operator settings, validated
   at load with defaults applied and shown read-only in `GET /config` and
-  Settings (§Config below).
+  Settings (§Config below);
+- **hooks** — decision-returning modules run at a named point of the runtime,
+  today `approve.before` (immediately before each chain auto-approval); a
+  fail-closed waterfall whose every decision is persisted (§Hooks below).
 
-The manifest also **reserves** `connectors`, `views`, `panels` and `hooks` for
-the tickets that land them (§Panels, §Hooks below). A
+The manifest also **reserves** `connectors`, `views` and `panels` for
+the tickets that land them (§Panels below). A
 manifest that carries a reserved key loads its packs and adapters and records a
 "not supported yet" configuration anomaly for the rest — it is accepted, not
 rejected, so an extension written for a later runtime still does what this one
@@ -43,6 +46,8 @@ Implementation: `event-runtime/lib/extensions.mjs`, schema
   pack/                       # a filesystem pack (pack.json, pins.json, agents/, schemas/, …)
   adapters/
     argent.mjs                # an adapter module (execute + SANDBOX_SUPPORT)
+  hooks/
+    no-infra-merges.mjs       # an approve.before hook (id + default (ctx) => decision) (§Hooks)
   config.schema.json          # the shape of the extension's operator config (§Config)
 ```
 
@@ -61,21 +66,23 @@ directory, and must stay inside it.
   "contributes": {
     "packs": ["./pack"],
     "adapters": { "argent": "./adapters/argent.mjs" },
-    "config": { "namespace": "mobile", "schema": "./config.schema.json" }
+    "config": { "namespace": "mobile", "schema": "./config.schema.json" },
+    "hooks": { "approve.before": "./hooks/no-infra-merges.mjs" }
   }
 }
 ```
 
-| Key                                                     | Required | Meaning                                                                                                                                                                                                                                         |
-| :------------------------------------------------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                                  | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
-| `version`                                               | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
-| `description`                                           | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
-| `factory.min`                                           | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
-| `contributes.packs`                                     | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
-| `contributes.adapters`                                  | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
-| `contributes.config`                                    | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.           |
-| `contributes.connectors`, `.views`, `.panels`, `.hooks` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
+| Key                                           | Required | Meaning                                                                                                                                                                                                                                         |
+| :-------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                        | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                       |
+| `version`                                     | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                       |
+| `description`                                 | no       | Up to 200 characters, for listings.                                                                                                                                                                                                             |
+| `factory.min`                                 | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                             |
+| `contributes.packs`                           | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                  |
+| `contributes.adapters`                        | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension). |
+| `contributes.config`                          | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.           |
+| `contributes.hooks`                           | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                         |
+| `contributes.connectors`, `.views`, `.panels` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                      |
 
 Unknown top-level keys and unknown `contributes` keys are schema violations.
 Validate a manifest without loading anything:
@@ -86,9 +93,9 @@ bun event-runtime/cli.mjs extensions validate ~/.factory/extensions/wattmind-mob
 ```
 
 `validate` checks the schema, that every contributed path exists and stays
-inside the extension directory, and that adapter names are well-formed. It
-does not load a pack or import an adapter module — running third-party code
-is what enabling does.
+inside the extension directory, and that adapter names and hook points are
+well-formed. It does not load a pack or import an adapter or hook module —
+running third-party code is what enabling does.
 
 ## Trust model
 
@@ -102,8 +109,9 @@ There are two kinds of contribution, and the difference is what runs.
   (a dispatched ticket producing a pack is ordinary data), and it is why the
   fixture pack is a copy of `test-support/packs/sample`.
 - **Operator-installed code.** An adapter is an ES module the worker imports
-  and calls. Enabling an extension that contributes adapters is running that
-  code in the worker process with the worker's credentials. Only the operator
+  and calls; a hook is an ES module `serve` imports and calls inside the
+  approval pass. Enabling an extension that contributes either is running that
+  code in the runtime process with its credentials. Only the operator
   enables extensions — by editing `config/policy.yaml`, a committed file —
   and nothing an agent does at runtime can add one. The registry still puts
   every adapter behind the sandbox seam (an `unsupported` adapter is refused
@@ -171,7 +179,10 @@ message naming both packs; fix the pack (or the order) and restart.
 4. If the extension needs operator settings, write `config.schema.json` and
    declare `contributes.config` (§Config); give every setting a `default`
    where one makes sense.
-5. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+5. If the extension gates unattended work, add an `approve.before` hook
+   (§Hooks); the smallest conformant module is
+   `event-runtime/test-support/extensions/sample/hooks/approve-before.mjs`.
+6. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
    enable it, `extensions list`, restart.
 
 The fixture `event-runtime/test-support/extensions/sample/` is a complete,
@@ -309,9 +320,124 @@ not `credential`).
 
 ## Hooks
 
-_Reserved key `contributes.hooks` — lands in WM-842 (the `approve.before` hook
-seam with persisted decisions). Until then the loader accepts the key and
-reports it as not supported yet._
+_Shipped in WM-842. Implementation: `event-runtime/lib/hooks.mjs`
+(`createHookRegistry`, `defaultHookRegistry`, `hookDecisionsFor`,
+`hookDecisionCounts`), the built-in
+`event-runtime/lib/hooks/builtin/escalation-labels.mjs`, the call site in
+`event-runtime/lib/auto-approval.mjs` (`autoApproveChains` → `eligible` →
+`dispatchSafe`), fixture `event-runtime/test-support/extensions/sample/hooks/`._
+
+The policy that gates unattended work — budget, worker cap, circuit breaker,
+escalated/security labels, escalate-path intersections — lives in
+`lib/auto-approval.mjs`. A **hook** is how an operator adds a gate of their
+own ("never auto-approve merges touching `infra/`", "cap spend per repo")
+without forking that file: a module the extension declares, imported by the
+loader, asked for a decision at a named point. This is a hook seam in the
+pi/deepseek-harness sense — typed, decision-returning interception — with the
+factory's constraints on top: hooks are **declared in a manifest** (operator-
+installed, in-process, never agent-authored), run as a **waterfall**, and
+**every decision is persisted** so the audit trail stays complete.
+
+One point exists today:
+
+| Point            | Evaluated                                                                                                                                                                                                                                                                                                                                                                                                 | Deny becomes                                                                                                                                                                   |
+| :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `approve.before` | In `autoApproveChains`, immediately before each chain auto-approval, once the proposal has passed every structural check (predecessor, integrity, schema, policy allow-list) — for a dispatch, right after the recheck evidence hash is confirmed and before the escalate-path check; for every other event type, at the end of eligibility. The runtime guard (budget/cap/breaker) runs after the hooks. | The proposal stays open with reason `auto_approval_ineligible:dispatch_ineligible:<reason>` (dispatch events) or `auto_approval_ineligible:hook_denied:<reason>` (all others). |
+
+`plan.before`, `execute.before`, `verify.after` and `outbox.before` are
+roadmap; declaring one is a schema violation until its ticket lands.
+
+### Contract
+
+```js
+// contributes.hooks: { "approve.before": "./hooks/no-infra-merges.mjs" }
+export const id = "wattmind/mobile:no-infra-merges"; // publisher[/extension]:name, unique across loaded hooks
+
+export default async function approveBefore(ctx) {
+  // ctx: { proposal, spec, evidence, policy, repo, now, config }
+  const touched =
+    ctx.spec?.input?.plan?.flatMap((item) => item.paths ?? []) ?? [];
+  if (touched.some((p) => p.startsWith("infra/")))
+    return { decision: "deny", reason: "infra_paths_touched" };
+  return { decision: "allow" };
+}
+```
+
+| `ctx` field | What it is                                                                                                                                                                                                 |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `proposal`  | `{ id, runId, eventSource, eventId, eventType, createdAt, ttlSeconds }` of the proposal about to be approved.                                                                                              |
+| `spec`      | The proposal's immutable RunSpec (`agent`, `input`, `approvalPolicy`, …), parsed.                                                                                                                          |
+| `evidence`  | For `factory.dispatch.requested`: the dispatch recheck evidence (`ticket.labels`, `escalatePathIntersections`, …) — the same object the built-in label check reads. `null` for every other event type.     |
+| `policy`    | `spec.approvalPolicy` — `{ source: "chain", mode: "auto", eventType, … }`.                                                                                                                                 |
+| `repo`      | `spec.input.repo`, or `null`.                                                                                                                                                                              |
+| `now`       | The pass's clock (ms since epoch); use it instead of `Date.now()` so replays stay deterministic.                                                                                                           |
+| `config`    | The extension's effective config — `getExtensionConfig(<manifest name>)`, defaults applied, validated at load (§Config). `undefined` for a built-in hook. Read settings from here, not from `policy.yaml`. |
+
+The hook receives a **deep copy** of the context; mutating it changes nothing
+downstream. The function may be sync or async. Its return value must be
+exactly `{ decision: "allow" }` or `{ decision: "deny", reason }` where
+`reason` is a short token (`[A-Za-z0-9_.:/-]{1,120}`) — it is embedded in the
+proposal's reason string and shown in the UI, so keep it greppable
+(`infra_paths_touched`, not a sentence).
+
+### Semantics
+
+- **Waterfall, built-ins first.** For a point, the runtime's own hooks run
+  first (in the order the runtime registers them), then extension hooks in
+  `policy.yaml extensions:` order. The first `deny` ends the run; the hooks
+  after it are not called. An `allow` from every hook is an allow.
+- **Fail closed.** A hook that throws, rejects, returns anything other than a
+  well-formed decision, or does not answer within **`timeoutMs` (2000 ms)**
+  is a `deny` with reason `hook_error:<id>` — the proposal stays open, never
+  approved. A synchronous hook cannot be interrupted, so one that overruns the
+  budget is still denied once it returns; write long checks async. Nothing a
+  hook does — throw, hang, return garbage — can widen what would have been
+  approved without it.
+- **Registration is all-or-nothing per extension.** Each hook module is
+  imported and contract-checked (`default` function, string `id`) before the
+  extension is accepted; a module that fails, or an `id` another loaded hook
+  (built-in or extension) already uses, is a configuration anomaly that
+  disables the extension whole — like a bad adapter. Hooks are registered
+  only once the whole extension is known good, with `source:
+extension:<name>`. Every `loadExtensions` run replaces the previous run's
+  extension hooks, so a removed extension's hook cannot linger past a restart.
+- **A hook can only refuse.** There is no `allow` that overrides a built-in
+  deny, no reordering, no replacing the built-in hooks. The built-in
+  escalation-label refusal (`factory:escalation-labels`) is the first hook of
+  `approve.before` and behaves exactly as the inline check did before this
+  seam existed: `ai:escalated`, `type:security`, or any label matching
+  `/security/i` on the dispatch ticket → `escalated_or_security`.
+
+### Audit table
+
+Every decision — allow and deny alike, for every hook that ran — is appended
+to `hook_decisions`, a table `lib/hooks.mjs` owns (created on first use, the
+`notify_log` pattern; not core schema):
+
+| Column                  | Meaning                                                                    |
+| :---------------------- | :------------------------------------------------------------------------- |
+| `at`                    | ISO timestamp (the pass's clock)                                           |
+| `point`                 | `approve.before`                                                           |
+| `hook_id`, `source`     | The hook, and `builtin` or `extension:<name>`                              |
+| `proposal_id`, `run_id` | What was being decided (`run_id` nullable for future non-proposal points)  |
+| `decision`, `reason`    | `allow` / `deny`, and the deny reason (`null` on allow)                    |
+| `duration_ms`           | How long the hook took                                                     |
+| `error`                 | The message behind a `hook_error:*` deny (throw, timeout, malformed value) |
+
+Read it back:
+
+- `GET /proposals/:id` → `{ proposal, hookDecisions: [...] }`, oldest first —
+  why this proposal was (not) auto-approved, hook by hook;
+- `GET /status` → `hooks.decisions24h`: `{ "<hook id>": { source, point, allow, deny } }`
+  over the trailing 24 h — a gate that is firing, or a broken extension hook
+  denying everything, is visible from the status page and `doctor`.
+
+The fixture hook `event-runtime/test-support/extensions/sample/hooks/approve-before.mjs`
+allows unless the extension config says `greeting: "deny"` (proving
+`ctx.config`) or the dispatch ticket carries `sample:deny`; the sibling
+files there (`throws.mjs`, `hangs.mjs`, `async-deny.mjs`, `no-id.mjs`,
+`no-default.mjs`) exercise each failure mode in `hooks.test.mjs` and
+`extensions.test.mjs`.
 
 ## Related
 

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -110,8 +110,8 @@ export async function tick({
     for (const err of auto.errors) logLine(`schedule approval error: ${err}`);
   });
 
-  await runStep("auto-approve-chains", () => {
-    const auto = autoApproveChains(db, registry, {
+  await runStep("auto-approve-chains", async () => {
+    const auto = await autoApproveChains(db, registry, {
       now,
       policyVersion: pv,
       dispatchEligibility: worktreeDispatchAutoEligibility,

--- a/event-runtime/lib/api-proposals.test.mjs
+++ b/event-runtime/lib/api-proposals.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { makeServer } from "./api-test-helpers.mjs";
+import { createHookRegistry } from "./hooks.mjs";
 
 describe("metrics proposal drill-down filters (WM-282)", () => {
   const now = Date.parse("2026-08-18T10:00:00.000Z");
@@ -79,6 +80,92 @@ describe("metrics proposal drill-down filters (WM-282)", () => {
       );
       expect(unknown.status).toBe(422);
       expect((await unknown.json()).error).toBe("invalid_population");
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("GET /proposals/:id (WM-842)", () => {
+  const now = Date.parse("2026-08-19T12:00:00.000Z");
+
+  test("returns the proposal with its approve.before hook decisions, oldest first; unknown id is 404", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      s.db
+        .query(
+          `INSERT INTO proposals
+             (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds, spec_json, reason)
+           VALUES ('gated', 'chain', 'event-gated', 'run-gated', 'run', 'open', ?, 1800, ?, ?)`,
+        )
+        .run(
+          new Date(now - 60_000).toISOString(),
+          JSON.stringify({ agent: "dispatch@1", input: { repo: "factory" } }),
+          "auto_approval_ineligible:dispatch_ineligible:repo_gated",
+        );
+      const hooks = createHookRegistry();
+      hooks.register(
+        "approve.before",
+        {
+          id: "acme/x:gate",
+          default: () => ({ decision: "deny", reason: "repo_gated" }),
+        },
+        { source: "extension:acme/x" },
+      );
+      hooks.run(
+        "approve.before",
+        {
+          proposal: { id: "gated", runId: "run-gated" },
+          evidence: { ticket: { labels: [] } },
+        },
+        { db: s.db, now },
+      );
+
+      const res = await fetch(s.url("/proposals/gated"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.proposal).toMatchObject({
+        id: "gated",
+        status: "open",
+        expired: false,
+        runId: "run-gated",
+        agent: "dispatch@1",
+        repos: ["factory"],
+        reason: "auto_approval_ineligible:dispatch_ineligible:repo_gated",
+      });
+      expect(
+        body.hookDecisions.map((d) => [
+          d.hookId,
+          d.source,
+          d.decision,
+          d.reason,
+        ]),
+      ).toEqual([
+        ["factory:escalation-labels", "builtin", "allow", null],
+        ["acme/x:gate", "extension:acme/x", "deny", "repo_gated"],
+      ]);
+      expect(body.hookDecisions[0]).toMatchObject({
+        at: new Date(now).toISOString(),
+        point: "approve.before",
+        proposalId: "gated",
+        runId: "run-gated",
+        error: null,
+      });
+
+      const missing = await fetch(s.url("/proposals/nope"));
+      expect(missing.status).toBe(404);
+      expect((await missing.json()).error).toMatch(/unknown proposal nope/);
+
+      // A proposal with no decisions yet still answers, with an empty list.
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds, spec_json)
+           VALUES ('fresh', 'test', 'event-fresh', 'run', 'open', ?, 60, '{}')`,
+        )
+        .run(new Date(now - 120_000).toISOString());
+      const fresh = await (await fetch(s.url("/proposals/fresh"))).json();
+      expect(fresh.hookDecisions).toEqual([]);
+      expect(fresh.proposal.expired).toBe(true);
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -2,6 +2,7 @@
 import { artifactHead } from "./api-artifacts.mjs";
 import { FACTORY_ROOT } from "./config.mjs";
 import { runUsage } from "./db.mjs";
+import { hookDecisionsFor } from "./hooks.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
 import {
@@ -1202,6 +1203,29 @@ export async function handleRunApiRoute({
       if (err instanceof ListQueryError) return send(422, err.body);
       throw err;
     }
+  }
+
+  // One proposal with its `approve.before` audit trail (lib/hooks.mjs,
+  // WM-842): every hook decision recorded for it, oldest first. `expired` is
+  // computed the way the open list computes it.
+  const proposalDetail = url.pathname.match(/^\/proposals\/([^/]+)$/);
+  if (req.method === "GET" && proposalDetail) {
+    const id = decodeURIComponent(proposalDetail[1]);
+    const row = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
+    if (!row) return send(404, { error: `unknown proposal ${id}` });
+    const expiresAt =
+      Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
+    return send(200, {
+      proposal: proposalView({
+        ...row,
+        spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+        expired:
+          row.status === "open" &&
+          Number.isFinite(expiresAt) &&
+          expiresAt < nowMs,
+      }),
+      hookDecisions: hookDecisionsFor(db, id),
+    });
   }
 
   if (route === "GET /journal") {

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -36,6 +36,7 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+import { createHookRegistry } from "./hooks.mjs";
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -568,5 +569,66 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
         extractedRenamedKeys,
       );
     }).toThrow();
+  });
+});
+
+describe("GET /status hook decisions (WM-842)", () => {
+  test("hooks.decisions24h counts allow/deny per hook id, only within the trailing 24h", async () => {
+    const dir = tmpDir("evrt-status-hooks-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const nowMs = Date.parse("2026-08-19T12:00:00.000Z");
+    const hooks = createHookRegistry();
+    hooks.register(
+      "approve.before",
+      {
+        id: "acme/x:gate",
+        default: () => ({ decision: "deny", reason: "no" }),
+      },
+      { source: "extension:acme/x" },
+    );
+    const ctx = (labels) => ({
+      proposal: { id: "p1", runId: "r1" },
+      evidence: { ticket: { labels }, escalatePathIntersections: [] },
+    });
+    hooks.run("approve.before", ctx(["ai:escalated"]), { db, now: nowMs });
+    hooks.run("approve.before", ctx([]), { db, now: nowMs - 3600_000 });
+    hooks.run("approve.before", ctx([]), { db, now: nowMs - 25 * 3600_000 });
+
+    const s = await makeServer({ db, secret: "sec", now: () => nowMs });
+    try {
+      const res = await fetch(s.url("/status"));
+      expect(res.status).toBe(200);
+      const status = await res.json();
+      expect(status.hooks).toEqual({
+        decisions24h: {
+          "factory:escalation-labels": {
+            source: "builtin",
+            point: "approve.before",
+            allow: 1,
+            deny: 1,
+          },
+          "acme/x:gate": {
+            source: "extension:acme/x",
+            point: "approve.before",
+            allow: 0,
+            deny: 1,
+          },
+        },
+      });
+    } finally {
+      s.close();
+    }
+  });
+
+  test("hooks.decisions24h is empty before any hook ever ran (no table yet)", async () => {
+    const dir = tmpDir("evrt-status-hooks-empty-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const s = await makeServer({ db, secret: "sec", now: () => 100000000 });
+    try {
+      const status = await (await fetch(s.url("/status"))).json();
+      expect(status.hooks).toEqual({ decisions24h: {} });
+    } finally {
+      s.close();
+    }
   });
 });

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { budgetExhausted } from "../../lib/spend.mjs";
 import { buildChainInput } from "./chain.mjs";
 import { hashJson } from "./canonical.mjs";
+import { defaultHookRegistry } from "./hooks.mjs";
 import { approveProposal } from "./proposals.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
 import { reposRoot } from "./repos.mjs";
@@ -221,12 +222,44 @@ function sameJson(left, right) {
   return hashJson(left) === hashJson(right);
 }
 
-function hasSecurityOrEscalation(labels = []) {
-  return labels.some(
-    (label) =>
-      label === "ai:escalated" ||
-      label === "type:security" ||
-      /security/i.test(label),
+/** `approve.before` hook point (lib/hooks.mjs); the seam an extension gates on. */
+export const APPROVE_BEFORE_HOOK = "approve.before";
+
+function isThenable(value) {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof value.then === "function"
+  );
+}
+
+/** Continue with `fn` after `value`, synchronously unless `value` is a thenable. */
+function after(value, fn) {
+  return isThenable(value) ? value.then(fn) : fn(value);
+}
+
+/**
+ * Run the `approve.before` waterfall for one proposal. Hooks see a copy of
+ * the proposal, its RunSpec, the dispatch recheck evidence (null for
+ * non-dispatch events), the RunSpec's approvalPolicy, the repo and the clock;
+ * `ctx.config` is added per hook by the registry (docs/extensions.md § Hooks).
+ * A throwing registry (a persistence failure, say) is the caller's problem —
+ * `autoApproveChains` turns it into a typed reason, never an approval.
+ *
+ * @returns {import("./hooks.mjs").HookRun | Promise<import("./hooks.mjs").HookRun>}
+ */
+function approveBeforeHooks(hooks, ctx, { evidence = null } = {}) {
+  return hooks.run(
+    APPROVE_BEFORE_HOOK,
+    {
+      proposal: ctx.proposal,
+      spec: ctx.spec,
+      evidence,
+      policy: ctx.spec?.approvalPolicy ?? null,
+      repo: ctx.spec?.input?.repo ?? null,
+      now: ctx.now,
+    },
+    { db: ctx.db, timeoutMs: ctx.hookTimeoutMs, now: ctx.now },
   );
 }
 
@@ -266,7 +299,13 @@ function proposalIntegrity(candidate, mapping, envelope) {
   return null;
 }
 
-function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
+function dispatchSafe(
+  envelope,
+  approvalPolicy,
+  dispatchEligibility,
+  dispatch,
+  hookCtx,
+) {
   if (typeof dispatchEligibility !== "function")
     return "dispatch_recheck_unavailable";
 
@@ -289,13 +328,19 @@ function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
     return "dispatch_ineligible:evidence_changed_since_plan";
   }
 
-  const labels = result.evidence?.ticket?.labels ?? [];
-  if (hasSecurityOrEscalation(labels))
-    return "dispatch_ineligible:escalated_or_security";
-  if ((result.evidence?.escalatePathIntersections ?? []).length > 0)
-    return "dispatch_ineligible:escalate_paths_intersect";
-
-  return null;
+  // The escalated/security-label refusal ran inline here before WM-842; it is
+  // now the built-in `factory:escalation-labels` hook, first in the waterfall,
+  // and every hook deny keeps the `dispatch_ineligible:<reason>` shape.
+  return after(
+    approveBeforeHooks(hookCtx.hooks, hookCtx, { evidence: result.evidence }),
+    (verdict) => {
+      if (verdict.decision === "deny")
+        return `dispatch_ineligible:${verdict.reason}`;
+      if ((result.evidence?.escalatePathIntersections ?? []).length > 0)
+        return "dispatch_ineligible:escalate_paths_intersect";
+      return null;
+    },
+  );
 }
 
 function mergeBarrierReason(db, registry, candidate, now) {
@@ -655,12 +700,16 @@ function mergeEligibility(db, registry, candidate, envelope, policy, now) {
     : null;
 }
 
+/**
+ * @returns {string|null|Promise<string|null>} an ineligibility reason, or
+ *   null; a Promise only when an `approve.before` hook answered asynchronously.
+ */
 function eligible(
   db,
   candidate,
   registry,
   policy,
-  { dispatchEligibility, dispatch, now },
+  { dispatchEligibility, dispatch, now, hooks, hookTimeoutMs },
 ) {
   if (candidate.event_source !== CHAIN_APPROVAL_SOURCE)
     return "event_source_not_chain";
@@ -723,15 +772,35 @@ function eligible(
   ) {
     return "triage_action_not_closed";
   }
+  const hookCtx = {
+    hooks,
+    db,
+    now,
+    hookTimeoutMs,
+    proposal: {
+      id: candidate.id,
+      runId: candidate.run_id,
+      eventSource: candidate.event_source,
+      eventId: candidate.event_id,
+      eventType: candidate.event_type,
+      createdAt: candidate.created_at,
+      ttlSeconds: candidate.ttl_seconds,
+    },
+    spec: runSpec,
+  };
   if (envelope.type === "factory.dispatch.requested") {
     return dispatchSafe(
       envelope,
       approvalPolicy,
       dispatchEligibility,
       dispatch,
+      hookCtx,
     );
   }
-  return null;
+  // Every other auto-approval runs the same hooks, with no dispatch evidence.
+  return after(approveBeforeHooks(hooks, hookCtx), (verdict) =>
+    verdict.decision === "deny" ? `hook_denied:${verdict.reason}` : null,
+  );
 }
 
 function noteOpenReason(db, id, reason) {
@@ -740,11 +809,47 @@ function noteOpenReason(db, id, reason) {
   ).run(`auto_approval_ineligible:${reason}`, id);
 }
 
+/** One pass at a time per database: a floating pass and an awaited one must not interleave. */
+const PASSES = new WeakMap();
+
 /**
  * Recheck and approve the currently open, eligible chain proposals once.
  * A second pass finds no approved proposal and therefore cannot double-approve.
+ *
+ * Returns a Promise, but does its work eagerly: with only synchronous
+ * `approve.before` hooks (the built-in one) the whole pass completes before
+ * the Promise is handed back, so a caller that ignores it (planAdmittedEvents)
+ * still gets the pre-WM-842 behaviour. An asynchronous extension hook defers
+ * the rest of the pass; `serve` awaits it. The Promise never rejects — every
+ * fault is a typed reason on the proposal or an `errors` entry.
+ *
+ * @returns {Promise<{ approved: Array<{ proposalId: string, runId: string }>, open: Array<{ proposalId: string, reason: string }>, errors: Array<{ proposalId: string|null, reason: string, message: string }> }>}
  */
-export function autoApproveChains(
+export function autoApproveChains(db, registry, options = {}) {
+  const state = PASSES.get(db) ?? { tail: null };
+  PASSES.set(db, state);
+  // `settled` flips inside runPass's own frame, so a pass that never awaited
+  // is known to be complete before this function returns and leaves no tail
+  // for the next call to queue behind.
+  const marker = { settled: false };
+  const pass = state.tail
+    ? state.tail.then(() => runPass(db, registry, options, marker))
+    : runPass(db, registry, options, marker);
+  if (!marker.settled) {
+    state.tail = pass;
+    pass.finally(() => {
+      if (state.tail === pass) state.tail = null;
+    });
+  }
+  return pass;
+}
+
+/**
+ * The pass itself. `marker.settled` is set in a `finally` inside this async
+ * frame: if no `await` was reached (every hook answered synchronously) it is
+ * true before the returned Promise even exists — the eager guarantee above.
+ */
+async function runPass(
   db,
   registry,
   {
@@ -755,68 +860,105 @@ export function autoApproveChains(
     policy = loadChainAutoApprovalPolicy(),
     runtimeGuard = chainRuntimeGuard,
     runtimeGuardOptions = {},
+    hooks = defaultHookRegistry(),
+    hookTimeoutMs,
   } = {},
+  marker = { settled: false },
 ) {
-  const approved = [];
-  const open = [];
-  const errors = [];
-  const rows = db
-    .query(
-      `SELECT p.id, p.run_id, p.event_source, p.event_id, p.spec_json AS proposal_spec_json, p.spec_hash AS proposal_spec_hash,
-            p.created_at, p.ttl_seconds, e.type AS event_type, e.envelope_json,
-            r.spec_json AS run_spec_json, r.spec_hash AS run_spec_hash
-       FROM proposals p
-       JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
-       JOIN runs r ON r.run_id = p.run_id
-      WHERE p.status = 'open' AND p.decision = 'run' AND e.source = 'chain'
-      ORDER BY p.created_at, p.rowid`,
-    )
-    .all();
-
-  for (const row of rows) {
-    const age = now - Date.parse(row.created_at);
-    const reason =
-      age > row.ttl_seconds * 1000
-        ? "proposal_expired"
-        : eligible(db, row, registry, policy, {
-            dispatchEligibility,
-            dispatch,
-            now,
-          });
-    if (reason) {
-      noteOpenReason(db, row.id, reason);
-      open.push({ proposalId: row.id, reason });
-      continue;
-    }
-    let guardReason;
+  try {
+    const approved = [];
+    const open = [];
+    const errors = [];
+    let rows;
     try {
-      guardReason = runtimeGuard(db, runtimeGuardOptions);
-    } catch {
-      guardReason = "runtime_guard_failed";
-    }
-    if (guardReason) {
-      noteOpenReason(db, row.id, guardReason);
-      open.push({ proposalId: row.id, reason: guardReason });
-      continue;
-    }
-    try {
-      const outcome = approveProposal(db, registry, row.id, {
-        actor: CHAIN_AUTO_APPROVAL_ACTOR,
-        reason: CHAIN_AUTO_APPROVAL_REASON,
-        now,
-        policyVersion,
-      });
-      if (outcome.approved)
-        approved.push({ proposalId: row.id, runId: outcome.runId });
-      else {
-        noteOpenReason(db, row.id, "replanned");
-        open.push({ proposalId: row.id, reason: "replanned" });
-      }
+      rows = db
+        .query(
+          `SELECT p.id, p.run_id, p.event_source, p.event_id, p.spec_json AS proposal_spec_json, p.spec_hash AS proposal_spec_hash,
+              p.created_at, p.ttl_seconds, e.type AS event_type, e.envelope_json,
+              r.spec_json AS run_spec_json, r.spec_hash AS run_spec_hash
+         FROM proposals p
+         JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+         JOIN runs r ON r.run_id = p.run_id
+        WHERE p.status = 'open' AND p.decision = 'run' AND e.source = 'chain'
+        ORDER BY p.created_at, p.rowid`,
+        )
+        .all();
     } catch (err) {
-      const message = String(err?.message ?? err);
-      noteOpenReason(db, row.id, "approval_error");
-      errors.push({ proposalId: row.id, reason: "approval_error", message });
+      errors.push({
+        proposalId: null,
+        reason: "pass_failed",
+        message: String(err?.message ?? err),
+      });
+      return { approved, open, errors };
     }
+
+    for (const row of rows) {
+      try {
+        const age = now - Date.parse(row.created_at);
+        let reason;
+        if (age > row.ttl_seconds * 1000) reason = "proposal_expired";
+        else {
+          try {
+            reason = eligible(db, row, registry, policy, {
+              dispatchEligibility,
+              dispatch,
+              now,
+              hooks,
+              hookTimeoutMs,
+            });
+            if (isThenable(reason)) reason = await reason;
+          } catch {
+            reason = "approve_hooks_failed";
+          }
+        }
+        if (reason) {
+          noteOpenReason(db, row.id, reason);
+          open.push({ proposalId: row.id, reason });
+          continue;
+        }
+        let guardReason;
+        try {
+          guardReason = runtimeGuard(db, runtimeGuardOptions);
+        } catch {
+          guardReason = "runtime_guard_failed";
+        }
+        if (guardReason) {
+          noteOpenReason(db, row.id, guardReason);
+          open.push({ proposalId: row.id, reason: guardReason });
+          continue;
+        }
+        try {
+          const outcome = approveProposal(db, registry, row.id, {
+            actor: CHAIN_AUTO_APPROVAL_ACTOR,
+            reason: CHAIN_AUTO_APPROVAL_REASON,
+            now,
+            policyVersion,
+          });
+          if (outcome.approved)
+            approved.push({ proposalId: row.id, runId: outcome.runId });
+          else {
+            noteOpenReason(db, row.id, "replanned");
+            open.push({ proposalId: row.id, reason: "replanned" });
+          }
+        } catch (err) {
+          const message = String(err?.message ?? err);
+          noteOpenReason(db, row.id, "approval_error");
+          errors.push({
+            proposalId: row.id,
+            reason: "approval_error",
+            message,
+          });
+        }
+      } catch (err) {
+        errors.push({
+          proposalId: row.id,
+          reason: "pass_row_failed",
+          message: String(err?.message ?? err),
+        });
+      }
+    }
+    return { approved, open, errors };
+  } finally {
+    marker.settled = true;
   }
-  return { approved, open, errors };
 }

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "./auto-approval.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
+import { createHookRegistry, hookDecisionsFor } from "./hooks.mjs";
 import { admitEvent } from "./intake.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
 import { lifecycleOf, runState } from "./lifecycle.mjs";
@@ -418,7 +419,7 @@ describe("declared chain command edge characterization (WM-469)", () => {
         mergeCommitSha: "c".repeat(40),
       },
     ],
-  ])("merge-apply@2 auto-approves its %s command edge", (type, input) => {
+  ])("merge-apply@2 auto-approves its %s command edge", async (type, input) => {
     const db = openDb(":memory:");
     const predecessorInput = reviewedMergeInput({ pr: 469, ticket: "WM-469" });
     const candidate = seed(db, {
@@ -430,12 +431,12 @@ describe("declared chain command edge characterization (WM-469)", () => {
       predecessorArtifact: { outcome: "applied" },
     });
 
-    expect(autoMerge(db).approved).toEqual([
+    expect((await autoMerge(db)).approved).toEqual([
       { proposalId: candidate.id, runId: candidate.runId },
     ]);
   });
 
-  test("merge-verify@1 auto-approves factory.merge.requested when repo matches input", () => {
+  test("merge-verify@1 auto-approves factory.merge.requested when repo matches input", async () => {
     const db = openDb(":memory:");
     const candidate = seed(db, {
       id: "merge-verify-command-match",
@@ -446,12 +447,12 @@ describe("declared chain command edge characterization (WM-469)", () => {
       predecessorArtifact: { outcome: "verified" },
     });
 
-    expect(autoMerge(db).approved).toEqual([
+    expect((await autoMerge(db)).approved).toEqual([
       { proposalId: candidate.id, runId: candidate.runId },
     ]);
   });
 
-  test("merge-verify@1 repo mismatch remains chain_command_edge_payload_mismatch", () => {
+  test("merge-verify@1 repo mismatch remains chain_command_edge_payload_mismatch", async () => {
     const db = openDb(":memory:");
     const candidate = seed(db, {
       id: "merge-verify-command-mismatch",
@@ -462,7 +463,7 @@ describe("declared chain command edge characterization (WM-469)", () => {
       predecessorArtifact: { outcome: "verified" },
     });
 
-    expect(autoMerge(db).approved).toEqual([]);
+    expect((await autoMerge(db)).approved).toEqual([]);
     expect(runState(db, candidate.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_command_edge_payload_mismatch",
@@ -471,7 +472,7 @@ describe("declared chain command edge characterization (WM-469)", () => {
 });
 
 describe("chain auto approval (WM-357)", () => {
-  test("git-owned policy is an explicit closed allowlist", () => {
+  test("git-owned policy is an explicit closed allowlist", async () => {
     const loaded = loadChainAutoApprovalPolicy();
     expect([...loaded.allowed].sort()).toEqual(
       [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
@@ -479,7 +480,7 @@ describe("chain auto approval (WM-357)", () => {
     expect(loaded.reason).toBeNull();
   });
 
-  test("budget, worker cap, and circuit breaker each stop unattended approvals", () => {
+  test("budget, worker cap, and circuit breaker each stop unattended approvals", async () => {
     const runtimePolicy = {
       budget: { per_day_usd: 1 },
       workers: { max: 1 },
@@ -536,7 +537,7 @@ describe("chain auto approval (WM-357)", () => {
 
     const guardedDb = openDb(":memory:");
     const candidate = seed(guardedDb, { id: "guarded" });
-    const result = auto(guardedDb, {
+    const result = await auto(guardedDb, {
       runtimeGuard: () => "circuit_breaker_tripped",
     });
     expect(result.approved).toEqual([]);
@@ -546,7 +547,7 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
-  test("eligible chain work and triage proposals advance with an auditable actor and reason", () => {
+  test("eligible chain work and triage proposals advance with an auditable actor and reason", async () => {
     const db = openDb(":memory:");
     const work = seed(db, { id: "work", type: "factory.work.requested" });
     const triage = seed(db, {
@@ -558,11 +559,9 @@ describe("chain auto approval (WM-357)", () => {
       },
     });
 
-    expect(
-      auto(db)
-        .approved.map((row) => row.runId)
-        .sort(),
-    ).toEqual([work.runId, triage.runId].sort());
+    expect((await auto(db)).approved.map((row) => row.runId).sort()).toEqual(
+      [work.runId, triage.runId].sort(),
+    );
     for (const runId of [work.runId, triage.runId]) {
       expect(runState(db, runId)).toBe("QUEUED");
       const approved = lifecycleOf(db, runId).find(
@@ -575,7 +574,7 @@ describe("chain auto approval (WM-357)", () => {
     }
   });
 
-  test("the planner's bounded pass leaves a caller-fabricated chain proposal watched", () => {
+  test("the planner's bounded pass leaves a caller-fabricated chain proposal watched", async () => {
     const db = openDb(":memory:");
     const synthetic = {
       ...registry,
@@ -626,7 +625,7 @@ describe("chain auto approval (WM-357)", () => {
     expect(db.query(`SELECT state FROM runs`).get().state).toBe("PROPOSED");
   });
 
-  test("operator proposals and protected or incomplete merge/ship proposals remain watched", () => {
+  test("operator proposals and protected or incomplete merge/ship proposals remain watched", async () => {
     const db = openDb(":memory:");
     const manual = seed(db, { id: "manual", source: "operator" });
     const mergeInput = {
@@ -668,7 +667,7 @@ describe("chain auto approval (WM-357)", () => {
     });
     const ship = seed(db, { id: "ship", type: "factory.ship-apply.requested" });
 
-    const result = auto(db, {
+    const result = await auto(db, {
       policy: {
         allowed: new Set([
           "factory.merge-apply.requested",
@@ -688,7 +687,7 @@ describe("chain auto approval (WM-357)", () => {
     ).toContain("merge_owner_not_allowed");
   });
 
-  test("terminal merge applies never hold the barrier", () => {
+  test("terminal merge applies never hold the barrier", async () => {
     for (const state of [
       "FAILED",
       "CANCELLED",
@@ -715,14 +714,14 @@ describe("chain auto approval (WM-357)", () => {
         },
       });
 
-      expect(autoMerge(db).approved).toEqual([
+      expect((await autoMerge(db)).approved).toEqual([
         { proposalId: candidate.id, runId: candidate.runId },
       ]);
       expect(runState(db, candidate.runId)).toBe("QUEUED");
     }
   });
 
-  test("failed or missing exact verification does not clear the hold", () => {
+  test("failed or missing exact verification does not clear the hold", async () => {
     for (const [id, options] of [
       ["failed", { verifierState: "FAILED" }],
       ["missing", { includeVerifier: false }],
@@ -750,14 +749,14 @@ describe("chain auto approval (WM-357)", () => {
         },
       });
 
-      expect(autoMerge(db).approved).toEqual([]);
+      expect((await autoMerge(db)).approved).toEqual([]);
       expect(openProposals(db, {})[0].reason).toContain(
         "merge_barrier_unverified",
       );
     }
   });
 
-  test("in-flight merge applies hold with state and age until their own timeout", () => {
+  test("in-flight merge applies hold with state and age until their own timeout", async () => {
     for (const state of ["QUEUED", "LEASED", "RUNNING", "VERIFYING"]) {
       const db = openDb(":memory:");
       const active = seedHistoricalApply(db, {
@@ -782,7 +781,7 @@ describe("chain auto approval (WM-357)", () => {
         },
       });
 
-      expect(autoMerge(db).approved).toEqual([]);
+      expect((await autoMerge(db)).approved).toEqual([]);
       expect(openProposals(db, {})[0].reason).toContain(
         `merge_barrier_active:${active.runId}:state=${state}:age=599s`,
       );
@@ -791,13 +790,13 @@ describe("chain auto approval (WM-357)", () => {
         new Date(now - 600_000).toISOString(),
         active.runId,
       );
-      expect(autoMerge(db).approved).toEqual([
+      expect((await autoMerge(db)).approved).toEqual([
         { proposalId: candidate.id, runId: candidate.runId },
       ]);
     }
   });
 
-  test("active apply and unverified-landed barriers remain unchanged", () => {
+  test("active apply and unverified-landed barriers remain unchanged", async () => {
     const activeDb = openDb(":memory:");
     const active = seedHistoricalApply(activeDb, {
       id: "active-apply",
@@ -817,7 +816,7 @@ describe("chain auto approval (WM-357)", () => {
         summary: "active barrier candidate",
       },
     });
-    expect(autoMerge(activeDb).approved).toEqual([]);
+    expect((await autoMerge(activeDb)).approved).toEqual([]);
     expect(openProposals(activeDb, {})[0].reason).toContain(
       `merge_barrier_active:${active.runId}`,
     );
@@ -840,13 +839,13 @@ describe("chain auto approval (WM-357)", () => {
         summary: "unverified barrier candidate",
       },
     });
-    expect(autoMerge(unverifiedDb).approved).toEqual([]);
+    expect((await autoMerge(unverifiedDb)).approved).toEqual([]);
     expect(openProposals(unverifiedDb, {})[0].reason).toContain(
       "merge_barrier_unverified:event-landed-unverified-landing",
     );
   });
 
-  test("closed triage apply is approved, while unknown actions remain visible and watched", () => {
+  test("closed triage apply is approved, while unknown actions remain visible and watched", async () => {
     const db = openDb(":memory:");
     const valid = seed(db, {
       id: "triage-valid",
@@ -865,7 +864,9 @@ describe("chain auto approval (WM-357)", () => {
       },
     });
 
-    expect(auto(db).approved.map((row) => row.runId)).toEqual([valid.runId]);
+    expect((await auto(db)).approved.map((row) => row.runId)).toEqual([
+      valid.runId,
+    ]);
     expect(runState(db, invalid.runId)).toBe("PROPOSED");
     expect(
       openProposals(db, {}).find((proposal) => proposal.id === invalid.id)
@@ -873,7 +874,7 @@ describe("chain auto approval (WM-357)", () => {
     ).toContain("input_schema_invalid");
   });
 
-  test("dispatch rechecks escalated and path-sensitive tickets before approval", () => {
+  test("dispatch rechecks escalated and path-sensitive tickets before approval", async () => {
     const db = openDb(":memory:");
     const escalated = seed(db, {
       id: "escalated",
@@ -920,7 +921,7 @@ describe("chain auto approval (WM-357)", () => {
             },
           };
 
-    expect(auto(db, { dispatchEligibility }).approved).toEqual([]);
+    expect((await auto(db, { dispatchEligibility })).approved).toEqual([]);
     expect(runState(db, escalated.runId)).toBe("PROPOSED");
     expect(runState(db, sensitive.runId)).toBe("PROPOSED");
     const reasons = openProposals(db, {})
@@ -930,7 +931,7 @@ describe("chain auto approval (WM-357)", () => {
     expect(reasons).toContain("escalate_paths_intersect");
   });
 
-  test("a spoofed chain event without a durable registered predecessor remains watched", () => {
+  test("a spoofed chain event without a durable registered predecessor remains watched", async () => {
     const db = openDb(":memory:");
     const spoofed = seed(db, {
       id: "spoofed",
@@ -938,14 +939,14 @@ describe("chain auto approval (WM-357)", () => {
       trustedPredecessor: false,
     });
 
-    expect(auto(db).approved).toEqual([]);
+    expect((await auto(db)).approved).toEqual([]);
     expect(runState(db, spoofed.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_predecessor_or_result_missing",
     );
   });
 
-  test("a mixed merge result approves every selected edge while preserving escalation", () => {
+  test("a mixed merge result approves every selected edge while preserving escalation", async () => {
     const db = openDb(":memory:");
     const mergeInput = {
       repo: "factory",
@@ -1023,7 +1024,7 @@ describe("chain auto approval (WM-357)", () => {
       seedPredecessor: false,
     });
 
-    const result = auto(db, {
+    const result = await auto(db, {
       approvalRegistry: independentMergeRegistry(),
       policy: {
         ...policy,
@@ -1042,7 +1043,7 @@ describe("chain auto approval (WM-357)", () => {
     }
   });
 
-  test("an independent recommendation edge with an empty selector remains watched", () => {
+  test("an independent recommendation edge with an empty selector remains watched", async () => {
     const db = openDb(":memory:");
     const escalation = seed(db, {
       id: "independent-recommendation-empty-selector",
@@ -1061,10 +1062,12 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(
-      auto(db, {
-        approvalRegistry: independentMergeRegistry(),
-        runtimeGuard: () => null,
-      }).approved,
+      (
+        await auto(db, {
+          approvalRegistry: independentMergeRegistry(),
+          runtimeGuard: () => null,
+        })
+      ).approved,
     ).toEqual([]);
     expect(runState(db, escalation.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
@@ -1072,7 +1075,7 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
-  test("an independent recommendation edge with a tampered payload remains watched", () => {
+  test("an independent recommendation edge with a tampered payload remains watched", async () => {
     const db = openDb(":memory:");
     const escalation = seed(db, {
       id: "independent-recommendation-tampered-payload",
@@ -1091,10 +1094,12 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(
-      auto(db, {
-        approvalRegistry: independentMergeRegistry(),
-        runtimeGuard: () => null,
-      }).approved,
+      (
+        await auto(db, {
+          approvalRegistry: independentMergeRegistry(),
+          runtimeGuard: () => null,
+        })
+      ).approved,
     ).toEqual([]);
     expect(runState(db, escalation.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
@@ -1102,7 +1107,7 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
-  test("a non-independent recommendation edge preserves legacy approval", () => {
+  test("a non-independent recommendation edge preserves legacy approval", async () => {
     const db = openDb(":memory:");
     const escalation = seed(db, {
       id: "legacy-recommendation-edge",
@@ -1118,15 +1123,17 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(
-      auto(db, {
-        approvalRegistry: independentMergeRegistry({ independent: false }),
-        runtimeGuard: () => null,
-      }).approved,
+      (
+        await auto(db, {
+          approvalRegistry: independentMergeRegistry({ independent: false }),
+          runtimeGuard: () => null,
+        })
+      ).approved,
     ).toEqual([{ proposalId: escalation.id, runId: escalation.runId }]);
     expect(runState(db, escalation.runId)).toBe("QUEUED");
   });
 
-  test("a non-independent array sibling remains watched", () => {
+  test("a non-independent array sibling remains watched", async () => {
     const db = openDb(":memory:");
     const mergeInput = {
       repo: "factory",
@@ -1169,15 +1176,17 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(
-      auto(db, {
-        approvalRegistry: independentMergeRegistry({ independent: false }),
-        policy: {
-          ...policy,
-          autoMergeBase: new Set(["develop"]),
-          autoMergeOwners: new Set(["watt-mind"]),
-        },
-        runtimeGuard: () => null,
-      }).approved,
+      (
+        await auto(db, {
+          approvalRegistry: independentMergeRegistry({ independent: false }),
+          policy: {
+            ...policy,
+            autoMergeBase: new Set(["develop"]),
+            autoMergeOwners: new Set(["watt-mind"]),
+          },
+          runtimeGuard: () => null,
+        })
+      ).approved,
     ).toEqual([]);
     expect(runState(db, sibling.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
@@ -1185,7 +1194,7 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
-  test("a sibling with a nonempty payload array but empty selector remains watched", () => {
+  test("a sibling with a nonempty payload array but empty selector remains watched", async () => {
     const db = openDb(":memory:");
     const mergeInput = {
       repo: "factory",
@@ -1228,17 +1237,19 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(
-      auto(db, {
-        approvalRegistry: independentMergeRegistry({
-          selectors: { MERGE: "fix" },
-        }),
-        policy: {
-          ...policy,
-          autoMergeBase: new Set(["develop"]),
-          autoMergeOwners: new Set(["watt-mind"]),
-        },
-        runtimeGuard: () => null,
-      }).approved,
+      (
+        await auto(db, {
+          approvalRegistry: independentMergeRegistry({
+            selectors: { MERGE: "fix" },
+          }),
+          policy: {
+            ...policy,
+            autoMergeBase: new Set(["develop"]),
+            autoMergeOwners: new Set(["watt-mind"]),
+          },
+          runtimeGuard: () => null,
+        })
+      ).approved,
     ).toEqual([]);
     expect(runState(db, sibling.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
@@ -1246,7 +1257,7 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
-  test("a declared but unselected sibling edge still fails closed", () => {
+  test("a declared but unselected sibling edge still fails closed", async () => {
     const db = openDb(":memory:");
     const fabricated = seed(db, {
       id: "unselected-merge",
@@ -1291,14 +1302,14 @@ describe("chain auto approval (WM-357)", () => {
       predecessorInput: { repo: "factory" },
     });
 
-    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect((await auto(db, { runtimeGuard: () => null })).approved).toEqual([]);
     expect(runState(db, fabricated.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_edge_not_registered",
     );
   });
 
-  test("a primitive fan-out sibling reconstructs the router's injected item key", () => {
+  test("a primitive fan-out sibling reconstructs the router's injected item key", async () => {
     const db = openDb(":memory:");
     const primitive = seed(db, {
       id: "primitive-independent-item",
@@ -1334,12 +1345,12 @@ describe("chain auto approval (WM-357)", () => {
     };
 
     expect(
-      auto(db, { approvalRegistry, runtimeGuard: () => null }).approved,
+      (await auto(db, { approvalRegistry, runtimeGuard: () => null })).approved,
     ).toEqual([{ proposalId: primitive.id, runId: primitive.runId }]);
     expect(runState(db, primitive.runId)).toBe("QUEUED");
   });
 
-  test("a selected sibling edge with a payload not derived from the artifact fails closed", () => {
+  test("a selected sibling edge with a payload not derived from the artifact fails closed", async () => {
     const db = openDb(":memory:");
     const selectedPlan = {
       pr: 431,
@@ -1383,14 +1394,14 @@ describe("chain auto approval (WM-357)", () => {
       predecessorInput: { repo: "factory" },
     });
 
-    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect((await auto(db, { runtimeGuard: () => null })).approved).toEqual([]);
     expect(runState(db, tampered.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_edge_not_registered",
     );
   });
 
-  test("an event type absent from the predecessor rule still fails closed", () => {
+  test("an event type absent from the predecessor rule still fails closed", async () => {
     const db = openDb(":memory:");
     const undeclared = seed(db, {
       id: "undeclared-edge",
@@ -1399,14 +1410,14 @@ describe("chain auto approval (WM-357)", () => {
       predecessorRecommendation: "ESCALATE",
     });
 
-    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect((await auto(db, { runtimeGuard: () => null })).approved).toEqual([]);
     expect(runState(db, undeclared.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_edge_not_registered",
     );
   });
 
-  test("a tampered proposal fails closed and duplicate passes do not double-approve", () => {
+  test("a tampered proposal fails closed and duplicate passes do not double-approve", async () => {
     const db = openDb(":memory:");
     const safe = seed(db, { id: "safe" });
     const tampered = seed(db, {
@@ -1419,12 +1430,232 @@ describe("chain auto approval (WM-357)", () => {
       },
     });
 
-    expect(auto(db).approved.map((row) => row.runId)).toEqual([safe.runId]);
-    expect(auto(db).approved).toEqual([]);
+    expect((await auto(db)).approved.map((row) => row.runId)).toEqual([
+      safe.runId,
+    ]);
+    expect((await auto(db)).approved).toEqual([]);
     expect(runState(db, tampered.runId)).toBe("PROPOSED");
     expect(
       openProposals(db, {}).find((proposal) => proposal.id === tampered.id)
         .reason,
     ).toContain("proposal_run_spec_mismatch");
+  });
+  const dispatchSeed = (
+    db,
+    id,
+    { labels = [], intersections = [], ticket = "WM-900" } = {},
+  ) =>
+    seed(db, {
+      id,
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket },
+      approvalPolicy: {
+        source: "chain",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: {
+          ticket: { labels },
+          escalatePathIntersections: intersections,
+        },
+      },
+    });
+  const evidenceFor = (labels, intersections) => () => ({
+    ok: true,
+    evidence: {
+      ticket: { labels },
+      escalatePathIntersections: intersections,
+    },
+  });
+  const hookModule = (id, fn) => ({ id, default: fn });
+  const reasonOf = (db, id) =>
+    openProposals(db, {}).find((proposal) => proposal.id === id)?.reason;
+
+  test("approve.before hooks (WM-842): the built-in escalation hook keeps the old reason and order, and every decision is persisted", async () => {
+    const db = openDb(":memory:");
+    // Both an escalation label and a path intersection: the label refusal
+    // still wins, exactly where the inline check used to run.
+    const both = dispatchSeed(db, "both", {
+      ticket: "WM-901",
+      labels: ["ai:escalated"],
+      intersections: ["src/auth/**"],
+    });
+    const clean = dispatchSeed(db, "clean", { ticket: "WM-902" });
+    const dispatchEligibility = (payload) =>
+      payload.ticket === "WM-901"
+        ? evidenceFor(["ai:escalated"], ["src/auth/**"])()
+        : evidenceFor([], [])();
+    const hooks = createHookRegistry();
+    const result = await auto(db, {
+      dispatchEligibility,
+      hooks,
+      runtimeGuard: () => null,
+    });
+    expect(result.approved).toEqual([
+      { proposalId: clean.id, runId: clean.runId },
+    ]);
+    expect(reasonOf(db, both.id)).toBe(
+      "auto_approval_ineligible:dispatch_ineligible:escalated_or_security",
+    );
+    expect(
+      hookDecisionsFor(db, both.id).map((r) => [
+        r.hookId,
+        r.source,
+        r.decision,
+        r.reason,
+        r.runId,
+      ]),
+    ).toEqual([
+      [
+        "factory:escalation-labels",
+        "builtin",
+        "deny",
+        "escalated_or_security",
+        both.runId,
+      ],
+    ]);
+    expect(
+      hookDecisionsFor(db, clean.id).map((r) => [r.hookId, r.decision]),
+    ).toEqual([["factory:escalation-labels", "allow"]]);
+    expect(hookDecisionsFor(db, clean.id)[0].at).toBe(
+      new Date(now).toISOString(),
+    );
+  });
+
+  test("an extension hook deny keeps a dispatch open as dispatch_ineligible:<reason>, other events as hook_denied:<reason>", async () => {
+    const db = openDb(":memory:");
+    const dispatch = dispatchSeed(db, "gated");
+    const work = seed(db, { id: "work" });
+    const seen = [];
+    const hooks = createHookRegistry();
+    hooks.register(
+      "approve.before",
+      hookModule("acme/gate:no-factory", (ctx) => {
+        seen.push(ctx);
+        return ctx.repo === "factory"
+          ? { decision: "deny", reason: "repo_gated" }
+          : { decision: "allow" };
+      }),
+      { source: "extension:acme/gate", config: () => ({ blocked: true }) },
+    );
+    const result = await auto(db, { hooks, runtimeGuard: () => null });
+    expect(result.approved).toEqual([]);
+    expect(reasonOf(db, dispatch.id)).toBe(
+      "auto_approval_ineligible:dispatch_ineligible:repo_gated",
+    );
+    expect(reasonOf(db, work.id)).toBe(
+      "auto_approval_ineligible:hook_denied:repo_gated",
+    );
+    expect(runState(db, dispatch.runId)).toBe("PROPOSED");
+    expect(runState(db, work.runId)).toBe("PROPOSED");
+    // The hook context: proposal, RunSpec, evidence (dispatch only), policy, repo, clock, config.
+    const dispatchCtx = seen.find((c) => c.proposal.id === dispatch.id);
+    expect(dispatchCtx).toMatchObject({
+      proposal: {
+        id: dispatch.id,
+        runId: dispatch.runId,
+        eventType: "factory.dispatch.requested",
+      },
+      spec: { runId: dispatch.runId, input: { repo: "factory" } },
+      evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+      policy: { source: "chain", mode: "auto" },
+      repo: "factory",
+      now,
+      config: { blocked: true },
+    });
+    expect(seen.find((c) => c.proposal.id === work.id).evidence).toBeNull();
+    // Persisted for both, built-in first.
+    expect(
+      hookDecisionsFor(db, dispatch.id).map((r) => [r.hookId, r.decision]),
+    ).toEqual([
+      ["factory:escalation-labels", "allow"],
+      ["acme/gate:no-factory", "deny"],
+    ]);
+  });
+
+  test("a throwing, hanging or malformed hook fails closed as hook_error:<id>", async () => {
+    const db = openDb(":memory:");
+    const throwing = dispatchSeed(db, "throwing");
+    const hooks = createHookRegistry();
+    hooks.register(
+      "approve.before",
+      hookModule("acme/bad:throws", () => {
+        throw new Error("boom");
+      }),
+      { source: "extension:acme/bad" },
+    );
+    expect(
+      (await auto(db, { hooks, runtimeGuard: () => null })).approved,
+    ).toEqual([]);
+    expect(reasonOf(db, throwing.id)).toBe(
+      "auto_approval_ineligible:dispatch_ineligible:hook_error:acme/bad:throws",
+    );
+
+    const hangDb = openDb(":memory:");
+    const hanging = seed(hangDb, { id: "hanging" });
+    const slow = createHookRegistry();
+    slow.register(
+      "approve.before",
+      hookModule("acme/slow:hangs", () => new Promise(() => {})),
+      { source: "extension:acme/slow" },
+    );
+    const started = performance.now();
+    expect(
+      (
+        await auto(hangDb, {
+          hooks: slow,
+          hookTimeoutMs: 20,
+          runtimeGuard: () => null,
+        })
+      ).approved,
+    ).toEqual([]);
+    expect(performance.now() - started).toBeLessThan(1500);
+    expect(reasonOf(hangDb, hanging.id)).toBe(
+      "auto_approval_ineligible:hook_denied:hook_error:acme/slow:hangs",
+    );
+    expect(hookDecisionsFor(hangDb, hanging.id).at(-1)).toMatchObject({
+      decision: "deny",
+      reason: "hook_error:acme/slow:hangs",
+      error: expect.stringMatching(/did not answer within 20ms/),
+    });
+  });
+
+  test("an async hook defers the pass; concurrent passes on one database are serialized, not interleaved", async () => {
+    const db = openDb(":memory:");
+    const safe = seed(db, { id: "safe" });
+    let calls = 0;
+    const hooks = createHookRegistry();
+    hooks.register(
+      "approve.before",
+      hookModule("acme/async:allow", async () => {
+        calls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return { decision: "allow" };
+      }),
+      { source: "extension:acme/async" },
+    );
+    const first = auto(db, { hooks, runtimeGuard: () => null });
+    const second = auto(db, { hooks, runtimeGuard: () => null });
+    // Nothing is decided synchronously once a hook goes async.
+    expect(runState(db, safe.runId)).toBe("PROPOSED");
+    const [a, b] = await Promise.all([first, second]);
+    expect(a.approved).toEqual([{ proposalId: safe.id, runId: safe.runId }]);
+    expect(b.approved).toEqual([]);
+    expect(b.errors).toEqual([]);
+    expect(calls).toBe(1);
+    expect(runState(db, safe.runId)).toBe("QUEUED");
+  });
+
+  test("with only synchronous hooks the pass completes before the promise is returned", () => {
+    const db = openDb(":memory:");
+    const safe = seed(db, { id: "safe" });
+    const pending = auto(db, { runtimeGuard: () => null });
+    expect(typeof pending.then).toBe("function");
+    expect(runState(db, safe.runId)).toBe("QUEUED");
+    // A synchronously completed pass leaves nothing queued: the next call in
+    // the same tick (planAdmittedEvents twice in a row) is eager as well.
+    const later = seed(db, { id: "later" });
+    const second = auto(db, { runtimeGuard: () => null });
+    expect(runState(db, later.runId)).toBe("QUEUED");
+    return Promise.all([pending, second]);
   });
 });

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -22,7 +22,7 @@
  *      registered — while every other extension still loads. `serve`/`work`
  *      never fail to start because a third-party manifest is broken.
  *   3. **Reserved manifest keys are accepted, not rejected.** `connectors`,
- *      `views`, `panels` and `hooks` belong to follow-up tickets; a manifest
+ *      `views` and `panels` belong to follow-up tickets; a manifest
  *      that carries them loads its packs and adapters here and records a
  *      "not supported yet" anomaly for the rest.
  *   4. **Config is declared, validated, defaulted (WM-841).** An extension
@@ -33,6 +33,14 @@
  *      (misconfigured code must not run). `getExtensionConfig(name)` hands the
  *      effective object to that extension's adapters/hooks/panels, and
  *      `loadedExtensions()` is the snapshot `GET /config` publishes.
+ *   5. **Hooks are registered, built-ins first (WM-842).** `contributes.hooks`
+ *      maps a hook point to a module; each is imported and contract-checked
+ *      (`default` function + string `id`, lib/hooks.mjs) before the extension
+ *      is accepted, then registered with source `extension:<name>` and a
+ *      getter for the extension's effective config as the hook's `ctx.config`.
+ *      A module that fails the contract, or an id already registered, disables
+ *      the extension. Each load replaces the extension hooks of the registry
+ *      it is given, so the registry always mirrors the last accepted set.
  *
  * Ordering matters for callers: `adapterRegistry.toMap()` is a snapshot, so
  * `loadExtensions` must run before a CLI takes the map it hands to
@@ -47,6 +55,11 @@ import {
   validateAdapterContract,
 } from "./adapters/index.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  HOOK_POINTS,
+  defaultHookRegistry,
+  validateHookModule,
+} from "./hooks.mjs";
 import { RegistryError, loadPackRoots, loadRegistry } from "./registry.mjs";
 import { expandHome, reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
@@ -65,8 +78,12 @@ export const RESERVED_CONTRIBUTIONS = Object.freeze([
   "connectors",
   "views",
   "panels",
-  "hooks",
 ]);
+
+/** The `source` a hook registered by an extension carries (lib/hooks.mjs). */
+export function extensionHookSource(name) {
+  return `extension:${name}`;
+}
 
 /** Policy entry fields `extensions[]` accepts besides `path`. */
 const ENTRY_FIELDS = new Set(["path", "config"]);
@@ -253,6 +270,26 @@ export function validateExtensionManifest(dir) {
       );
     }
   }
+  for (const [point, rel] of Object.entries(contributes.hooks ?? {})) {
+    if (!HOOK_POINTS.includes(point)) {
+      errors.push(
+        `${file}: contributes.hooks key "${point}" is not a hook point (known: ${HOOK_POINTS.join(", ")})`,
+      );
+      continue;
+    }
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.hooks["${point}"] "${rel}" escapes the extension directory`,
+      );
+      continue;
+    }
+    if (!existsSync(abs) || !statSync(abs).isFile()) {
+      errors.push(
+        `${file}: contributes.hooks["${point}"] "${rel}" is not a file (${abs})`,
+      );
+    }
+  }
   if (contributes.config) {
     const rel = contributes.config.schema;
     const abs = path.resolve(root, rel);
@@ -425,10 +462,11 @@ function packRootFor(extensionRoot, rel) {
  * @param {string} [options.root] - the checkout supplying `config/policy.yaml` (default: reposRoot())
  * @param {object} [options.policy] - an already-parsed policy object; when given, policy.yaml is not read
  * @param {ReturnType<import("./adapters/index.mjs").createAdapterRegistry>} [options.adapterRegistry] - where adapters go; when absent, adapters are validated but not registered
+ * @param {ReturnType<import("./hooks.mjs").createHookRegistry>} [options.hookRegistry] - where hooks go (default: the process-wide `defaultHookRegistry()`); its extension hooks are replaced by this load
  * @param {Array<object>} [options.packRoots] - the policy `packs:` roots the extension packs join (default: loadPackRoots({ root }))
  * @param {string} [options.registryRoot] - the built-in registry root the dry load uses (tests point it at a copy)
  * @returns {Promise<{
- *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
+ *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
  *   packRoots: Array<object>,
  *   anomalies: string[],
  *   disabled: Array<{ name: string|null, version: string|null, path: string, namespace: string|null, reason: string }>,
@@ -440,10 +478,18 @@ export async function loadExtensions({
   root = reposRoot(),
   policy,
   adapterRegistry,
+  hookRegistry = defaultHookRegistry(),
   packRoots,
   registryRoot,
 } = {}) {
   const basePackRoots = packRoots ?? loadPackRoots({ root });
+  // Last load wins for hooks, as it does for `LOADED`: drop what an earlier
+  // load registered from extensions so a removed extension's hook cannot
+  // linger, then re-register the accepted set below in policy order.
+  for (const hook of hookRegistry.list()) {
+    if (hook.source.startsWith(extensionHookSource("")))
+      hookRegistry.unregister(hook.id);
+  }
   const { roots, anomalies } = loadExtensionRoots({ root, policy });
   const extensions = [];
   const accepted = [...basePackRoots];
@@ -538,6 +584,40 @@ export async function loadExtensions({
       skip(`${label}: ${adapterFault}`);
       continue;
     }
+
+    // Hooks: import and contract-check (default function + id); an id the
+    // registry already holds is refused. Registered only once accepted.
+    const hookModules = [];
+    let hookFault = null;
+    for (const [point, rel] of Object.entries(contributes.hooks ?? {})) {
+      const file = path.resolve(dir, rel);
+      let module;
+      try {
+        module = await import(pathToFileURL(file).href);
+      } catch (err) {
+        hookFault = `hook "${point}" failed to import from ${file}: ${err.message}`;
+        break;
+      }
+      let contract;
+      try {
+        contract = validateHookModule(module);
+      } catch (err) {
+        hookFault = `hook "${point}" (${rel}): ${err.message}`;
+        break;
+      }
+      if (
+        hookRegistry.has(contract.id) ||
+        hookModules.some((h) => h.id === contract.id)
+      ) {
+        hookFault = `hook id "${contract.id}" is already registered (extensions may not replace an existing hook)`;
+        break;
+      }
+      hookModules.push({ point, id: contract.id, module });
+    }
+    if (hookFault) {
+      skip(`${label}: ${hookFault}`);
+      continue;
+    }
     if (config && acceptedNamespaces.has(config.namespace)) {
       skip(
         `${label}: config namespace "${config.namespace}" is already used by ${acceptedNamespaces.get(config.namespace)}`,
@@ -552,6 +632,12 @@ export async function loadExtensions({
       adapterRegistry?.register(name, module, { source: manifest.name });
       acceptedAdapterNames.add(name);
     }
+    for (const { point, module } of hookModules) {
+      hookRegistry.register(point, module, {
+        source: extensionHookSource(manifest.name),
+        config: () => getExtensionConfig(manifest.name),
+      });
+    }
     for (const warning of checked.warnings) anomalies.push(warning);
     if (config) acceptedNamespaces.set(config.namespace, manifest.name);
     const { schemaJson, ...publicConfig } = config ?? {};
@@ -561,6 +647,7 @@ export async function loadExtensions({
       path: dir,
       packs: extPackRoots.map((p) => p.name),
       adapters: modules.map((m) => m.name),
+      hooks: hookModules.map(({ point, id }) => ({ point, id })),
       reserved: RESERVED_CONTRIBUTIONS.filter((key) =>
         Object.hasOwn(contributes, key),
       ),

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -11,6 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { createAdapterRegistry } from "./adapters/index.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
+import { openDb } from "./db.mjs";
 import {
   EXTENSION_MANIFEST,
   EXTENSION_SCHEMA,
@@ -22,6 +23,7 @@ import {
   loadedExtensions,
   validateExtensionManifest,
 } from "./extensions.mjs";
+import { createHookRegistry, hookDecisionsFor } from "./hooks.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import { validate } from "./schema.mjs";
 
@@ -49,10 +51,17 @@ function policyFor(...dirs) {
 }
 
 /** Load with an empty base pack list so the fixture never collides with the checkout's policy. */
-function load(policy, adapterRegistry = createAdapterRegistry()) {
-  return loadExtensions({ policy, adapterRegistry, packRoots: [] }).then(
-    (result) => ({ ...result, adapterRegistry }),
-  );
+function load(
+  policy,
+  adapterRegistry = createAdapterRegistry(),
+  hookRegistry = createHookRegistry(),
+) {
+  return loadExtensions({
+    policy,
+    adapterRegistry,
+    hookRegistry,
+    packRoots: [],
+  }).then((result) => ({ ...result, adapterRegistry, hookRegistry }));
 }
 
 describe("factory-extension.json schema", () => {
@@ -187,6 +196,9 @@ describe("loadExtensions", () => {
         path: SAMPLE_EXTENSION,
         packs: ["sample-ext"],
         adapters: ["echo"],
+        hooks: [
+          { point: "approve.before", id: "factory/sample:approve-before" },
+        ],
         reserved: [],
         config: {
           namespace: "sample",
@@ -367,15 +379,13 @@ describe("loadExtensions", () => {
     const dir = tempExtension((m) => {
       m.name = "factory/future";
       m.contributes.panels = [{ id: "x" }];
-      m.contributes.hooks = { "approve.before": "./hooks.mjs" };
     });
     const out = await load(policyFor(dir));
-    expect(out.extensions[0].reserved).toEqual(["panels", "hooks"]);
+    expect(out.extensions[0].reserved).toEqual(["panels"]);
     expect(out.extensions[0].adapters).toEqual(["echo"]);
     expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
     expect(out.anomalies).toEqual([
       expect.stringMatching(/contributes\.panels is not supported yet/),
-      expect.stringMatching(/contributes\.hooks is not supported yet/),
     ]);
   });
 
@@ -517,6 +527,7 @@ describe("extension config (contributes.config)", () => {
       m.name = "factory/twin";
       m.contributes.packs = [];
       m.contributes.adapters = {};
+      delete m.contributes.hooks;
     });
     const out = await load(policyFor(SAMPLE_EXTENSION, twin));
     expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
@@ -536,6 +547,213 @@ describe("extension config (contributes.config)", () => {
     );
     expect(out.errors.join("\n")).toMatch(
       /config: missing required property "schema"/,
+    );
+  });
+});
+
+describe("extension hooks (contributes.hooks)", () => {
+  const now = Date.parse("2026-08-19T12:00:00.000Z");
+  const ctx = (labels = [], extra = {}) => ({
+    proposal: { id: "proposal-1", runId: "run-1" },
+    spec: { agent: "dispatch@1", input: { repo: "factory" } },
+    evidence: { ticket: { labels }, escalatePathIntersections: [] },
+    policy: null,
+    repo: "factory",
+    now,
+    ...extra,
+  });
+
+  test("schema: hooks map a known point to a .mjs module; unknown points and other files are violations", () => {
+    const base = { name: "a/b", version: "0.0.1" };
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...base,
+        contributes: { hooks: { "approve.before": "./hooks/x.mjs" } },
+      }).valid,
+    ).toBe(true);
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...base,
+        contributes: { hooks: { "plan.before": "./hooks/x.mjs" } },
+      }).errors.join(),
+    ).toMatch(/hooks: unknown property "plan.before"/);
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...base,
+        contributes: { hooks: { "approve.before": "./hooks/x.js" } },
+      }).errors.join(),
+    ).toMatch(/approve\.before: does not match pattern/);
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...base,
+        contributes: { hooks: ["./hooks/x.mjs"] },
+      }).valid,
+    ).toBe(false);
+  });
+
+  test("validate checks hook paths exist and stay inside the extension", () => {
+    const dir = tempExtension((m) => {
+      m.contributes.hooks = { "approve.before": "./hooks/missing.mjs" };
+    });
+    expect(validateExtensionManifest(dir).errors.join("\n")).toMatch(
+      /hooks\["approve\.before"\] ".\/hooks\/missing.mjs" is not a file/,
+    );
+    const escaping = tempExtension((m) => {
+      m.contributes.hooks = { "approve.before": "../escape.mjs" };
+    });
+    expect(validateExtensionManifest(escaping).errors.join("\n")).toMatch(
+      /hooks\["approve\.before"\] "..\/escape.mjs" escapes/,
+    );
+    expect(validateExtensionManifest(SAMPLE_EXTENSION).valid).toBe(true);
+  });
+
+  test("the fixture hook registers after the built-in with source extension:<name> and sees the extension config", async () => {
+    const out = await load({
+      extensions: [{ path: SAMPLE_EXTENSION, config: { greeting: "deny" } }],
+    });
+    expect(out.anomalies).toEqual([]);
+    expect(out.extensions[0].hooks).toEqual([
+      { point: "approve.before", id: "factory/sample:approve-before" },
+    ]);
+    expect(out.hookRegistry.list()).toEqual([
+      {
+        point: "approve.before",
+        id: "factory:escalation-labels",
+        source: "builtin",
+      },
+      {
+        point: "approve.before",
+        id: "factory/sample:approve-before",
+        source: "extension:factory/sample",
+      },
+    ]);
+    // ctx.config is getExtensionConfig("factory/sample") — defaults applied
+    // over the policy values — so greeting: "deny" makes the fixture deny.
+    expect(getExtensionConfig("factory/sample").greeting).toBe("deny");
+    const db = openDb(":memory:");
+    const verdict = out.hookRegistry.run("approve.before", ctx(), { db, now });
+    expect(verdict).toMatchObject({
+      decision: "deny",
+      reason: "sample_greeting_deny",
+      hookId: "factory/sample:approve-before",
+      source: "extension:factory/sample",
+    });
+    // The built-in ran first (allow), then the extension hook (deny); both persisted.
+    expect(
+      hookDecisionsFor(db, "proposal-1").map((r) => [r.hookId, r.decision]),
+    ).toEqual([
+      ["factory:escalation-labels", "allow"],
+      ["factory/sample:approve-before", "deny"],
+    ]);
+    // Built-in first means an escalated ticket is refused before any extension hook runs.
+    expect(
+      out.hookRegistry.run("approve.before", ctx(["ai:escalated"])),
+    ).toMatchObject({ reason: "escalated_or_security" });
+
+    // Reloading with the default config: allow, and the label rule of the fixture.
+    const again = await load(policyFor(SAMPLE_EXTENSION));
+    expect(again.hookRegistry.run("approve.before", ctx())).toMatchObject({
+      decision: "allow",
+    });
+    expect(
+      again.hookRegistry.run("approve.before", ctx(["sample:deny"])),
+    ).toMatchObject({ decision: "deny", reason: "sample_label_deny" });
+  });
+
+  test("a hook module missing default or id disables the extension whole", async () => {
+    for (const [file, why] of [
+      ["./hooks/no-default.mjs", /must export a default function/],
+      ["./hooks/no-id.mjs", /must export a string id/],
+    ]) {
+      const dir = tempExtension((m) => {
+        m.name = "factory/broken";
+        m.contributes.hooks = { "approve.before": file };
+      });
+      const out = await load(policyFor(dir));
+      expect(out.extensions).toEqual([]);
+      expect(out.packRoots).toEqual([]);
+      expect(out.adapterRegistry.has("echo")).toBe(false);
+      expect(out.hookRegistry.list().map((h) => h.id)).toEqual([
+        "factory:escalation-labels",
+      ]);
+      expect(out.anomalies).toHaveLength(1);
+      expect(out.anomalies[0]).toMatch(
+        /factory\/broken@1\.0\.0: hook "approve\.before"/,
+      );
+      expect(out.anomalies[0]).toMatch(why);
+      expect(out.anomalies[0]).toMatch(/\(extension skipped\)/);
+      expect(out.disabled[0]).toMatchObject({
+        name: "factory/broken",
+        reason: expect.stringMatching(why),
+      });
+    }
+    const missing = tempExtension((m) => {
+      m.name = "factory/gone";
+      m.contributes.hooks = { "approve.before": "./hooks/nope.mjs" };
+    });
+    const out = await load(policyFor(missing));
+    expect(out.extensions).toEqual([]);
+    expect(out.anomalies[0]).toMatch(
+      /hooks\["approve\.before"\] .* is not a file/,
+    );
+  });
+
+  test("a hook id another extension (or a built-in) already registered disables the newcomer; reloads replace, never duplicate", async () => {
+    const twin = tempExtension((m) => {
+      m.name = "factory/twin";
+      m.contributes.packs = [];
+      m.contributes.adapters = {};
+      delete m.contributes.config;
+    });
+    const out = await load(policyFor(SAMPLE_EXTENSION, twin));
+    expect(out.extensions.map((e) => e.name)).toEqual(["factory/sample"]);
+    expect(out.anomalies).toEqual([
+      expect.stringMatching(
+        /factory\/twin@1\.0\.0: hook id "factory\/sample:approve-before" is already registered/,
+      ),
+    ]);
+    expect(out.hookRegistry.list().map((h) => h.id)).toEqual([
+      "factory:escalation-labels",
+      "factory/sample:approve-before",
+    ]);
+
+    // Same registry, loaded again: the extension hook is replaced, not doubled.
+    const again = await load(
+      policyFor(SAMPLE_EXTENSION),
+      createAdapterRegistry(),
+      out.hookRegistry,
+    );
+    expect(again.anomalies).toEqual([]);
+    expect(again.hookRegistry.list().map((h) => h.id)).toEqual([
+      "factory:escalation-labels",
+      "factory/sample:approve-before",
+    ]);
+    // And with the extension gone from policy, its hook is gone too.
+    const none = await load(
+      { extensions: [] },
+      createAdapterRegistry(),
+      out.hookRegistry,
+    );
+    expect(none.hookRegistry.list().map((h) => h.id)).toEqual([
+      "factory:escalation-labels",
+    ]);
+
+    // A built-in id cannot be shadowed by an extension.
+    const shadow = tempExtension((m, dir) => {
+      m.name = "factory/shadow";
+      m.contributes.packs = [];
+      m.contributes.adapters = {};
+      delete m.contributes.config;
+      writeFileSync(
+        path.join(dir, "hooks", "shadow.mjs"),
+        'export const id = "factory:escalation-labels";\nexport default () => ({ decision: "allow" });\n',
+      );
+      m.contributes.hooks = { "approve.before": "./hooks/shadow.mjs" };
+    });
+    const shadowed = await load(policyFor(shadow));
+    expect(shadowed.extensions).toEqual([]);
+    expect(shadowed.anomalies[0]).toMatch(
+      /hook id "factory:escalation-labels" is already registered/,
     );
   });
 });

--- a/event-runtime/lib/hooks.mjs
+++ b/event-runtime/lib/hooks.mjs
@@ -1,0 +1,494 @@
+/**
+ * Hooks — typed, decision-returning interception points (WM-842,
+ * docs/extensions.md § Hooks).
+ *
+ * The policy that gates unattended work lives in lib/auto-approval.mjs. A
+ * hook is how an operator adds a gate without forking it: a module declared
+ * in an extension manifest (`contributes.hooks`), imported in-process by the
+ * loader, and asked for a decision at a named point. This ticket ships one
+ * point, `approve.before`, evaluated by `autoApproveChains` immediately before
+ * each chain auto-approval; the built-in escalation-label refusal runs on it
+ * as the first hook (lib/hooks/builtin/escalation-labels.mjs).
+ *
+ * Contract of a hook module:
+ *
+ *   export const id = "publisher/extension:hook-name";
+ *   export default function (ctx) {          // may be async
+ *     return { decision: "allow" } | { decision: "deny", reason: "why" };
+ *   }
+ *
+ * Properties this module owns:
+ *
+ *   1. **Waterfall, built-ins first.** `run` calls the hooks of a point in
+ *      order — every `builtin` source in registration order, then extension
+ *      hooks in the order the loader registered them (policy.yaml
+ *      `extensions:` order). The first `deny` ends the run.
+ *   2. **Fail closed.** A hook that throws, rejects, returns anything other
+ *      than a well-formed decision, or does not answer within `timeoutMs`
+ *      (default 2000) is a `deny` with reason `hook_error:<id>`. Nothing a
+ *      hook does can widen what would have been approved without it.
+ *   3. **Every decision is persisted.** Allow and deny alike append a row to
+ *      the module-owned `hook_decisions` table (the `notify_log` pattern of
+ *      lib/notify.mjs; auxiliary tables stay out of db.mjs), read back by
+ *      `GET /proposals/:id` and counted on `GET /status`.
+ *   4. **Synchronous when it can be.** `run` returns the decision directly
+ *      when every hook answered synchronously and a Promise as soon as one
+ *      hook returns a thenable. `autoApproveChains` relies on this so a pass
+ *      with only synchronous hooks (the built-in one) still completes before
+ *      `planAdmittedEvents` returns, exactly as before this seam existed;
+ *      callers that do not need that guarantee simply `await` the result.
+ *
+ * `defaultHookRegistry()` is the process-wide registry the loader fills and
+ * `autoApproveChains` reads by default (mirroring `getExtensionConfig`, which
+ * reads the loader's last run); tests build their own with
+ * `createHookRegistry()` and pass it through the options seams.
+ */
+import escalationLabels, * as escalationLabelsModule from "./hooks/builtin/escalation-labels.mjs";
+
+/** The points a hook may be registered on. Widening is a ticket per point. */
+export const HOOK_POINTS = Object.freeze(["approve.before"]);
+
+/** Source recorded on hooks the runtime ships. Extension hooks use `extension:<name>`. */
+export const BUILTIN_HOOK_SOURCE = "builtin";
+
+/** A hook that has not answered by then is a deny (`hook_error:<id>`). */
+export const DEFAULT_HOOK_TIMEOUT_MS = 2000;
+
+/** Decisions older than this do not count on `/status`. */
+export const HOOK_DECISION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const HOOK_ID_PATTERN = /^[a-z0-9-]+(\/[a-z0-9-]+)?:[a-z0-9][a-z0-9-]*$/;
+const REASON_PATTERN = /^[A-Za-z0-9_.:/-]{1,120}$/;
+
+/** Typed error for registry misuse (unknown point, bad module, duplicate id). */
+export class HookError extends Error {
+  /**
+   * @param {string} code - `hook_point_unknown` | `hook_module_invalid` | `hook_duplicate` | `hook_source_missing`
+   * @param {string} message
+   */
+  constructor(code, message) {
+    super(message);
+    this.name = "HookError";
+    this.code = code;
+  }
+}
+
+/**
+ * Prove a module satisfies the hook contract without calling it: a `default`
+ * export that is a function and a string `id` shaped `publisher[/ext]:name`.
+ * Throws a HookError naming the fault; the loader turns that into the anomaly
+ * that disables the extension.
+ *
+ * @param {unknown} module
+ * @returns {{ id: string, fn: Function }}
+ */
+export function validateHookModule(module) {
+  if (typeof module !== "object" || module === null) {
+    throw new HookError(
+      "hook_module_invalid",
+      "hook module must be an ES module namespace or object",
+    );
+  }
+  if (typeof module.default !== "function") {
+    throw new HookError(
+      "hook_module_invalid",
+      "hook module must export a default function (ctx) => decision",
+    );
+  }
+  if (typeof module.id !== "string" || !HOOK_ID_PATTERN.test(module.id)) {
+    throw new HookError(
+      "hook_module_invalid",
+      `hook module must export a string id matching ${HOOK_ID_PATTERN} (got ${JSON.stringify(module.id ?? null)})`,
+    );
+  }
+  return { id: module.id, fn: module.default };
+}
+
+/**
+ * Module-owned audit table. Idempotent; called before every write and by the
+ * read helpers only when the table exists (status/proposal views stay
+ * read-only SQL).
+ */
+export function ensureHookDecisions(db) {
+  db.exec(`CREATE TABLE IF NOT EXISTS hook_decisions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    at          TEXT NOT NULL,
+    point       TEXT NOT NULL,
+    hook_id     TEXT NOT NULL,
+    source      TEXT NOT NULL,
+    proposal_id TEXT,
+    run_id      TEXT,
+    decision    TEXT NOT NULL,
+    reason      TEXT,
+    duration_ms INTEGER NOT NULL,
+    error       TEXT
+  );`);
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS hook_decisions_proposal ON hook_decisions (proposal_id);`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS hook_decisions_at ON hook_decisions (at);`,
+  );
+}
+
+function hasHookDecisions(db) {
+  return !!db
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'hook_decisions'`,
+    )
+    .get();
+}
+
+function decisionRow(row) {
+  return {
+    id: row.id,
+    at: row.at,
+    point: row.point,
+    hookId: row.hook_id,
+    source: row.source,
+    proposalId: row.proposal_id,
+    runId: row.run_id,
+    decision: row.decision,
+    reason: row.reason,
+    durationMs: row.duration_ms,
+    error: row.error,
+  };
+}
+
+/**
+ * Every persisted decision for one proposal, oldest first — what
+ * `GET /proposals/:id` returns as `hookDecisions`.
+ *
+ * @returns {Array<{ at: string, point: string, hookId: string, source: string, proposalId: string|null, runId: string|null, decision: string, reason: string|null, durationMs: number, error: string|null }>}
+ */
+export function hookDecisionsFor(db, proposalId) {
+  if (!hasHookDecisions(db)) return [];
+  return db
+    .query(`SELECT * FROM hook_decisions WHERE proposal_id = ? ORDER BY id`)
+    .all(proposalId)
+    .map(decisionRow);
+}
+
+/**
+ * Allow/deny counts per hook id over the trailing window (24h by default) —
+ * what `GET /status` publishes under `hooks.decisions24h`.
+ *
+ * @param {import("bun:sqlite").Database} db
+ * @param {{ now?: number, windowMs?: number }} [options]
+ * @returns {Record<string, { source: string, point: string, allow: number, deny: number }>}
+ */
+export function hookDecisionCounts(
+  db,
+  { now = Date.now(), windowMs = HOOK_DECISION_WINDOW_MS } = {},
+) {
+  if (!hasHookDecisions(db)) return {};
+  const since = new Date(now - windowMs).toISOString();
+  const rows = db
+    .query(
+      `SELECT hook_id, source, point, decision, COUNT(*) AS n
+         FROM hook_decisions
+        WHERE at >= ?
+        GROUP BY hook_id, source, point, decision
+        ORDER BY hook_id`,
+    )
+    .all(since);
+  const out = {};
+  for (const row of rows) {
+    const entry = (out[row.hook_id] ??= {
+      source: row.source,
+      point: row.point,
+      allow: 0,
+      deny: 0,
+    });
+    if (row.decision === "allow") entry.allow += row.n;
+    else if (row.decision === "deny") entry.deny += row.n;
+  }
+  return out;
+}
+
+function isThenable(value) {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof value.then === "function"
+  );
+}
+
+/** Deep-copy JSON-ish context so a hook cannot mutate what the guard reads next. */
+function cloneContext(ctx) {
+  const out = {};
+  for (const [key, value] of Object.entries(ctx ?? {})) {
+    out[key] =
+      typeof value === "object" && value !== null
+        ? structuredClone(value)
+        : value;
+  }
+  return out;
+}
+
+class HookTimeout extends Error {
+  constructor(id, ms) {
+    super(`hook ${id} did not answer within ${ms}ms`);
+    this.name = "HookTimeout";
+  }
+}
+
+function withTimeout(promise, id, ms) {
+  let timer;
+  const expiry = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new HookTimeout(id, ms)), ms);
+    timer.unref?.();
+  });
+  return Promise.race([promise, expiry]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Create a registry. Built-ins are registered first with source `builtin`;
+ * the extension loader adds the rest with `register()`.
+ *
+ * @param {{ builtins?: Array<{ point: string, module: object }> }} [options]
+ */
+export function createHookRegistry({ builtins = builtinHooks() } = {}) {
+  /** @type {Array<{ point: string, id: string, source: string, fn: Function, config: Function|undefined }>} */
+  const hooks = [];
+
+  const summary = (hook) => ({
+    point: hook.point,
+    id: hook.id,
+    source: hook.source,
+  });
+
+  const ordered = (point) => {
+    const builtin = [];
+    const rest = [];
+    for (const hook of hooks) {
+      if (hook.point !== point) continue;
+      (hook.source === BUILTIN_HOOK_SOURCE ? builtin : rest).push(hook);
+    }
+    return [...builtin, ...rest];
+  };
+
+  /**
+   * Validate and add one hook.
+   *
+   * @param {string} point - one of HOOK_POINTS
+   * @param {unknown} module - a module with `default(ctx)` and `id`
+   * @param {{ source: string, config?: () => unknown }} options - `source` is
+   *   mandatory (`builtin` or `extension:<name>`) so every persisted decision
+   *   says where its hook came from; `config` is a getter for the `ctx.config`
+   *   the hook receives (the loader passes the extension's effective config).
+   * @returns {{ point: string, id: string, source: string }}
+   */
+  function register(point, module, { source, config } = {}) {
+    if (!HOOK_POINTS.includes(point)) {
+      throw new HookError(
+        "hook_point_unknown",
+        `unknown hook point "${point}" (known: ${HOOK_POINTS.join(", ")})`,
+      );
+    }
+    const { id, fn } = validateHookModule(module);
+    if (typeof source !== "string" || source === "") {
+      throw new HookError(
+        "hook_source_missing",
+        `register() needs { source } saying where hook ${id} came from`,
+      );
+    }
+    if (config !== undefined && typeof config !== "function") {
+      throw new HookError(
+        "hook_module_invalid",
+        `register() option config for hook ${id} must be a function`,
+      );
+    }
+    const existing = hooks.find((hook) => hook.id === id);
+    if (existing) {
+      throw new HookError(
+        "hook_duplicate",
+        `hook id "${id}" is already registered from ${existing.source}`,
+      );
+    }
+    const hook = { point, id, source, fn, config };
+    hooks.push(hook);
+    return summary(hook);
+  }
+
+  /** Remove one hook by id; returns whether it was registered. */
+  function unregister(id) {
+    const index = hooks.findIndex((hook) => hook.id === id);
+    if (index === -1) return false;
+    hooks.splice(index, 1);
+    return true;
+  }
+
+  /**
+   * Run the waterfall for one point.
+   *
+   * @param {string} point
+   * @param {object} ctx - `{ proposal, spec, evidence, policy, repo, now }`;
+   *   `config` is added per hook. Hooks receive a deep copy.
+   * @param {{ timeoutMs?: number, db?: import("bun:sqlite").Database, now?: number }} [options] -
+   *   `db` persists every decision to `hook_decisions`; without it nothing is
+   *   written (pure registry tests). `now` stamps the rows.
+   * @returns {HookRun | Promise<HookRun>} the deciding hook's decision, or an
+   *   `allow` with `hookId: null` when no hook denied. Synchronous unless a
+   *   hook returned a thenable.
+   * @typedef {{ decision: "allow"|"deny", reason: string|null, hookId: string|null, source: string|null, durationMs: number, decisions: Array<{ hookId: string, source: string, decision: string, reason: string|null, durationMs: number, error: string|null }> }} HookRun
+   */
+  function run(point, ctx = {}, options = {}) {
+    if (!HOOK_POINTS.includes(point)) {
+      throw new HookError(
+        "hook_point_unknown",
+        `unknown hook point "${point}" (known: ${HOOK_POINTS.join(", ")})`,
+      );
+    }
+    const {
+      timeoutMs = DEFAULT_HOOK_TIMEOUT_MS,
+      db,
+      now = Date.now(),
+    } = options;
+    const chain = ordered(point);
+    const decisions = [];
+    const startedAll = performance.now();
+    if (db) ensureHookDecisions(db);
+
+    const record = (hook, decision, reason, durationMs, error) => {
+      const entry = {
+        hookId: hook.id,
+        source: hook.source,
+        decision,
+        reason,
+        durationMs,
+        error,
+      };
+      decisions.push(entry);
+      if (db) {
+        db.query(
+          `INSERT INTO hook_decisions
+             (at, point, hook_id, source, proposal_id, run_id, decision, reason, duration_ms, error)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          new Date(now).toISOString(),
+          point,
+          hook.id,
+          hook.source,
+          ctx?.proposal?.id ?? null,
+          ctx?.proposal?.runId ?? null,
+          decision,
+          reason,
+          durationMs,
+          error,
+        );
+      }
+      return entry;
+    };
+
+    // Interpret one hook's answer (value or error) into a recorded decision.
+    const settle = (hook, started, value, error) => {
+      const durationMs = Math.round(performance.now() - started);
+      const failClosed = (why) =>
+        record(hook, "deny", `hook_error:${hook.id}`, durationMs, why);
+      if (error !== undefined) {
+        return failClosed(String(error?.message ?? error));
+      }
+      if (durationMs > timeoutMs) {
+        return failClosed(
+          `hook ${hook.id} took ${durationMs}ms > ${timeoutMs}ms`,
+        );
+      }
+      if (typeof value !== "object" || value === null) {
+        return failClosed(
+          `hook returned ${value === null ? "null" : typeof value}, not a decision`,
+        );
+      }
+      if (value.decision === "allow") {
+        return record(hook, "allow", null, durationMs, null);
+      }
+      if (value.decision === "deny") {
+        if (
+          typeof value.reason !== "string" ||
+          !REASON_PATTERN.test(value.reason)
+        ) {
+          return failClosed(
+            `deny without a well-formed reason (${JSON.stringify(value.reason ?? null)})`,
+          );
+        }
+        return record(hook, "deny", value.reason, durationMs, null);
+      }
+      return failClosed(
+        `unknown decision ${JSON.stringify(value.decision ?? null)}`,
+      );
+    };
+
+    const finish = (last) => ({
+      decision: last?.decision === "deny" ? "deny" : "allow",
+      reason: last?.decision === "deny" ? last.reason : null,
+      hookId: last?.decision === "deny" ? last.hookId : null,
+      source: last?.decision === "deny" ? last.source : null,
+      durationMs: Math.round(performance.now() - startedAll),
+      decisions,
+    });
+
+    const step = (index) => {
+      for (let i = index; i < chain.length; i += 1) {
+        const hook = chain[i];
+        const started = performance.now();
+        let value;
+        try {
+          const hookCtx = cloneContext(ctx);
+          hookCtx.config = hook.config ? hook.config() : undefined;
+          value = hook.fn(hookCtx);
+        } catch (err) {
+          return finish(settle(hook, started, undefined, err ?? "thrown"));
+        }
+        if (isThenable(value)) {
+          return withTimeout(Promise.resolve(value), hook.id, timeoutMs)
+            .then(
+              (resolved) => settle(hook, started, resolved, undefined),
+              (err) => settle(hook, started, undefined, err ?? "rejected"),
+            )
+            .then((entry) =>
+              entry.decision === "deny" ? finish(entry) : step(i + 1),
+            );
+        }
+        const entry = settle(hook, started, value, undefined);
+        if (entry.decision === "deny") return finish(entry);
+      }
+      return finish(null);
+    };
+
+    return step(0);
+  }
+
+  for (const { point, module } of builtins ?? []) {
+    register(point, module, { source: BUILTIN_HOOK_SOURCE });
+  }
+
+  return Object.freeze({
+    register,
+    unregister,
+    run,
+    has: (id) => hooks.some((hook) => hook.id === id),
+    /** Hooks in run order: built-ins first, then extensions as registered. */
+    list: () => HOOK_POINTS.flatMap((point) => ordered(point).map(summary)),
+  });
+}
+
+/** The hooks the runtime ships, in the order they run. */
+export function builtinHooks() {
+  return [
+    {
+      point: "approve.before",
+      module: { id: escalationLabelsModule.id, default: escalationLabels },
+    },
+  ];
+}
+
+let DEFAULT_REGISTRY = null;
+
+/**
+ * The process-wide registry: built-ins plus whatever `loadExtensions`
+ * registered. `autoApproveChains` reads it unless given `{ hooks }`.
+ */
+export function defaultHookRegistry() {
+  DEFAULT_REGISTRY ??= createHookRegistry();
+  return DEFAULT_REGISTRY;
+}

--- a/event-runtime/lib/hooks.test.mjs
+++ b/event-runtime/lib/hooks.test.mjs
@@ -1,0 +1,379 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { openDb } from "./db.mjs";
+import * as escalationLabels from "./hooks/builtin/escalation-labels.mjs";
+import {
+  BUILTIN_HOOK_SOURCE,
+  DEFAULT_HOOK_TIMEOUT_MS,
+  HOOK_POINTS,
+  HookError,
+  createHookRegistry,
+  defaultHookRegistry,
+  ensureHookDecisions,
+  hookDecisionCounts,
+  hookDecisionsFor,
+  validateHookModule,
+} from "./hooks.mjs";
+
+const FIXTURE_HOOKS = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+  "hooks",
+);
+const fixture = (name) => import(path.join(FIXTURE_HOOKS, name));
+
+const now = Date.parse("2026-08-19T12:00:00.000Z");
+const ctxFor = (labels = [], extra = {}) => ({
+  proposal: { id: "proposal-1", runId: "run-1" },
+  spec: { agent: "dispatch@1", input: { repo: "factory" } },
+  evidence: { ticket: { labels }, escalatePathIntersections: [] },
+  policy: { source: "chain", mode: "auto" },
+  repo: "factory",
+  now,
+  ...extra,
+});
+const hook = (id, fn) => ({ id, default: fn });
+const allow = () => ({ decision: "allow" });
+const deny = (reason) => () => ({ decision: "deny", reason });
+
+/** A registry with no built-ins, so ordering and persistence tests read cleanly. */
+const bare = () => createHookRegistry({ builtins: [] });
+
+describe("hook registry (WM-842)", () => {
+  test("only approve.before exists; unknown points and bad modules are typed errors", () => {
+    expect(HOOK_POINTS).toEqual(["approve.before"]);
+    const hooks = bare();
+    expect(() =>
+      hooks.register("plan.before", hook("a:b", allow), { source: "x" }),
+    ).toThrow(HookError);
+    try {
+      hooks.register("plan.before", hook("a:b", allow), { source: "x" });
+    } catch (err) {
+      expect(err.code).toBe("hook_point_unknown");
+    }
+    expect(() => hooks.run("plan.before", {})).toThrow(HookError);
+
+    for (const [module, why] of [
+      [{ id: "a:b" }, /default function/],
+      [{ default: allow }, /string id/],
+      [{ id: "Not Valid", default: allow }, /string id/],
+      [null, /module namespace/],
+    ]) {
+      expect(() => validateHookModule(module)).toThrow(why);
+      expect(() =>
+        hooks.register("approve.before", module, { source: "x" }),
+      ).toThrow(HookError);
+    }
+    expect(() =>
+      hooks.register("approve.before", hook("a:b", allow), {}),
+    ).toThrow(/source/);
+    hooks.register("approve.before", hook("a:b", allow), { source: "x" });
+    expect(() =>
+      hooks.register("approve.before", hook("a:b", allow), { source: "y" }),
+    ).toThrow(/already registered from x/);
+    expect(hooks.list()).toEqual([
+      { point: "approve.before", id: "a:b", source: "x" },
+    ]);
+    expect(hooks.has("a:b")).toBe(true);
+    expect(hooks.unregister("a:b")).toBe(true);
+    expect(hooks.unregister("a:b")).toBe(false);
+    expect(hooks.list()).toEqual([]);
+  });
+
+  test("allow passes through synchronously and every decision is persisted", () => {
+    const db = openDb(":memory:");
+    const hooks = bare();
+    const seen = [];
+    hooks.register(
+      "approve.before",
+      hook("acme/ext:first", (ctx) => {
+        seen.push(ctx);
+        return { decision: "allow" };
+      }),
+      { source: "extension:acme/ext", config: () => ({ limit: 3 }) },
+    );
+    hooks.register("approve.before", hook("acme/ext:second", allow), {
+      source: "extension:acme/ext",
+    });
+
+    const out = hooks.run("approve.before", ctxFor(["ai:agent-ready"]), {
+      db,
+      now,
+    });
+    // Synchronous: no thenable came back, so the decision is a plain object.
+    expect(typeof out.then).toBe("undefined");
+    expect(out).toMatchObject({
+      decision: "allow",
+      reason: null,
+      hookId: null,
+      source: null,
+    });
+    expect(out.decisions.map((d) => [d.hookId, d.decision])).toEqual([
+      ["acme/ext:first", "allow"],
+      ["acme/ext:second", "allow"],
+    ]);
+    // ctx.config is the registered getter's value; the hook saw a copy.
+    expect(seen[0].config).toEqual({ limit: 3 });
+    expect(seen[0].evidence.ticket.labels).toEqual(["ai:agent-ready"]);
+    seen[0].evidence.ticket.labels.push("mutated");
+
+    const rows = hookDecisionsFor(db, "proposal-1");
+    expect(rows.map((r) => [r.hookId, r.source, r.decision, r.reason])).toEqual(
+      [
+        ["acme/ext:first", "extension:acme/ext", "allow", null],
+        ["acme/ext:second", "extension:acme/ext", "allow", null],
+      ],
+    );
+    expect(rows[0]).toMatchObject({
+      at: new Date(now).toISOString(),
+      point: "approve.before",
+      proposalId: "proposal-1",
+      runId: "run-1",
+      error: null,
+    });
+    expect(typeof rows[0].durationMs).toBe("number");
+    expect(hookDecisionsFor(db, "nope")).toEqual([]);
+  });
+
+  test("deny short-circuits the waterfall and is persisted with its reason", () => {
+    const db = openDb(":memory:");
+    const hooks = bare();
+    let third = 0;
+    hooks.register("approve.before", hook("a:one", allow), { source: "s" });
+    hooks.register("approve.before", hook("a:two", deny("infra_paths")), {
+      source: "s",
+    });
+    hooks.register(
+      "approve.before",
+      hook("a:three", () => {
+        third += 1;
+        return { decision: "allow" };
+      }),
+      { source: "s" },
+    );
+
+    const out = hooks.run("approve.before", ctxFor(), { db, now });
+    expect(out).toMatchObject({
+      decision: "deny",
+      reason: "infra_paths",
+      hookId: "a:two",
+      source: "s",
+    });
+    expect(third).toBe(0);
+    expect(
+      hookDecisionsFor(db, "proposal-1").map((r) => [
+        r.hookId,
+        r.decision,
+        r.reason,
+      ]),
+    ).toEqual([
+      ["a:one", "allow", null],
+      ["a:two", "deny", "infra_paths"],
+    ]);
+  });
+
+  test("a throwing hook is a deny hook_error:<id> (fail closed), recorded with the error", async () => {
+    const db = openDb(":memory:");
+    const hooks = bare();
+    hooks.register("approve.before", await fixture("throws.mjs"), {
+      source: "extension:factory/sample",
+    });
+    hooks.register("approve.before", hook("a:after", allow), { source: "s" });
+    const out = hooks.run("approve.before", ctxFor(), { db, now });
+    expect(out).toMatchObject({
+      decision: "deny",
+      reason: "hook_error:factory/sample:throws",
+      hookId: "factory/sample:throws",
+    });
+    const [row] = hookDecisionsFor(db, "proposal-1");
+    expect(row.error).toMatch(/fixture hook exploded/);
+    // The hook after it never ran.
+    expect(hookDecisionsFor(db, "proposal-1")).toHaveLength(1);
+  });
+
+  test("a rejecting async hook and a malformed decision are denies too", async () => {
+    const hooks = bare();
+    hooks.register(
+      "approve.before",
+      hook("a:rejects", async () => {
+        throw new Error("nope");
+      }),
+      { source: "s" },
+    );
+    const rejected = hooks.run("approve.before", ctxFor());
+    expect(typeof rejected.then).toBe("function");
+    expect(await rejected).toMatchObject({
+      decision: "deny",
+      reason: "hook_error:a:rejects",
+    });
+
+    for (const bad of [
+      undefined,
+      null,
+      "allow",
+      { decision: "maybe" },
+      { decision: "deny" },
+      { decision: "deny", reason: "" },
+      { decision: "deny", reason: "has spaces in it" },
+    ]) {
+      const h = bare();
+      h.register(
+        "approve.before",
+        hook("a:bad", () => bad),
+        { source: "s" },
+      );
+      expect(h.run("approve.before", ctxFor())).toMatchObject({
+        decision: "deny",
+        reason: "hook_error:a:bad",
+      });
+    }
+  });
+
+  test("a hook that never answers is denied at timeoutMs; default is 2000ms", async () => {
+    expect(DEFAULT_HOOK_TIMEOUT_MS).toBe(2000);
+    const db = openDb(":memory:");
+    const hooks = bare();
+    hooks.register("approve.before", await fixture("hangs.mjs"), {
+      source: "extension:factory/sample",
+    });
+    const started = performance.now();
+    const out = await hooks.run("approve.before", ctxFor(), {
+      db,
+      now,
+      timeoutMs: 30,
+    });
+    expect(performance.now() - started).toBeLessThan(1500);
+    expect(out).toMatchObject({
+      decision: "deny",
+      reason: "hook_error:factory/sample:hangs",
+    });
+    const [row] = hookDecisionsFor(db, "proposal-1");
+    expect(row.error).toMatch(/did not answer within 30ms/);
+  });
+
+  test("an async hook makes the run a Promise; the waterfall continues after it", async () => {
+    const hooks = bare();
+    const order = [];
+    hooks.register(
+      "approve.before",
+      hook("a:async-allow", async () => {
+        order.push("async");
+        return { decision: "allow" };
+      }),
+      { source: "s" },
+    );
+    hooks.register(
+      "approve.before",
+      hook("a:sync-after", () => {
+        order.push("sync");
+        return { decision: "allow" };
+      }),
+      { source: "s" },
+    );
+    const out = hooks.run("approve.before", ctxFor());
+    expect(typeof out.then).toBe("function");
+    expect(await out).toMatchObject({ decision: "allow", hookId: null });
+    expect(order).toEqual(["async", "sync"]);
+
+    hooks.register("approve.before", await fixture("async-deny.mjs"), {
+      source: "extension:factory/sample",
+    });
+    expect(await hooks.run("approve.before", ctxFor())).toMatchObject({
+      decision: "deny",
+      reason: "async_sample_deny",
+      hookId: "factory/sample:async-deny",
+    });
+  });
+
+  test("built-in hooks run before extension hooks regardless of registration order", () => {
+    const hooks = bare();
+    const order = [];
+    const record = (id) =>
+      hook(id, () => {
+        order.push(id);
+        return { decision: "allow" };
+      });
+    hooks.register("approve.before", record("acme/one:ext"), {
+      source: "extension:acme/one",
+    });
+    hooks.register("approve.before", record("factory:builtin-late"), {
+      source: BUILTIN_HOOK_SOURCE,
+    });
+    hooks.register("approve.before", record("acme/two:ext"), {
+      source: "extension:acme/two",
+    });
+    hooks.run("approve.before", ctxFor());
+    expect(order).toEqual([
+      "factory:builtin-late",
+      "acme/one:ext",
+      "acme/two:ext",
+    ]);
+    expect(hooks.list().map((h) => h.id)).toEqual(order);
+  });
+
+  test("the default registry ships the escalation-labels hook first, and it reproduces the old refusal", () => {
+    const hooks = defaultHookRegistry();
+    expect(hooks.list()[0]).toEqual({
+      point: "approve.before",
+      id: "factory:escalation-labels",
+      source: BUILTIN_HOOK_SOURCE,
+    });
+    expect(createHookRegistry().list()).toEqual([hooks.list()[0]]);
+
+    const fresh = createHookRegistry();
+    // The same fixture labels lib/auto-approval.test.mjs used against the inline check.
+    for (const labels of [
+      ["ai:agent-ready", "ai:escalated"],
+      ["type:security"],
+      ["area:Security-review"],
+    ]) {
+      expect(hooks.run("approve.before", ctxFor(labels))).toMatchObject({
+        decision: "deny",
+        reason: "escalated_or_security",
+        hookId: "factory:escalation-labels",
+      });
+      expect(escalationLabels.hasSecurityOrEscalation(labels)).toBe(true);
+    }
+    expect(
+      fresh.run("approve.before", ctxFor(["ai:agent-ready"])),
+    ).toMatchObject({ decision: "allow" });
+    // No dispatch evidence (a merge, a ship) → nothing to refuse, as before.
+    expect(
+      fresh.run("approve.before", ctxFor([], { evidence: null })),
+    ).toMatchObject({ decision: "allow" });
+    expect(escalationLabels.default({})).toEqual({ decision: "allow" });
+  });
+
+  test("hookDecisionCounts aggregates allow/deny per hook over the window", () => {
+    const db = openDb(":memory:");
+    expect(hookDecisionCounts(db, { now })).toEqual({});
+    const hooks = createHookRegistry();
+    hooks.register("approve.before", hook("acme/x:gate", deny("nope")), {
+      source: "extension:acme/x",
+    });
+    hooks.run("approve.before", ctxFor(["ai:escalated"]), { db, now });
+    hooks.run("approve.before", ctxFor(), { db, now: now - 60_000 });
+    hooks.run("approve.before", ctxFor(), { db, now: now - 25 * 3600_000 });
+    expect(hookDecisionCounts(db, { now })).toEqual({
+      "factory:escalation-labels": {
+        source: "builtin",
+        point: "approve.before",
+        allow: 1,
+        deny: 1,
+      },
+      "acme/x:gate": {
+        source: "extension:acme/x",
+        point: "approve.before",
+        allow: 0,
+        deny: 1,
+      },
+    });
+    ensureHookDecisions(db); // idempotent
+    expect(db.query(`SELECT COUNT(*) AS n FROM hook_decisions`).get().n).toBe(
+      5,
+    );
+  });
+});

--- a/event-runtime/lib/hooks/builtin/escalation-labels.mjs
+++ b/event-runtime/lib/hooks/builtin/escalation-labels.mjs
@@ -1,0 +1,42 @@
+/**
+ * Built-in `approve.before` hook: refuse to auto-approve a dispatch whose
+ * ticket carries an escalation or security label (WM-842).
+ *
+ * This is the check `dispatchSafe` in lib/auto-approval.mjs used to run
+ * inline (`hasSecurityOrEscalation`), moved onto the hook seam unchanged: the
+ * same labels are refused, with the same reason, at the same point of the
+ * guard order — after the dispatch evidence hash is confirmed and before the
+ * escalate-path intersection check. It reads only the recheck evidence the
+ * chain approval already gathered (`ctx.evidence.ticket.labels`), so a
+ * proposal without dispatch evidence (a merge, a ship, a triage apply) is
+ * simply allowed, as it was before.
+ */
+
+export const id = "factory:escalation-labels";
+
+/** The refusal reason, unchanged from the inline check. */
+export const REASON = "escalated_or_security";
+
+/**
+ * @param {string[]} [labels]
+ * @returns {boolean}
+ */
+export function hasSecurityOrEscalation(labels = []) {
+  return labels.some(
+    (label) =>
+      label === "ai:escalated" ||
+      label === "type:security" ||
+      /security/i.test(label),
+  );
+}
+
+/**
+ * @param {{ evidence?: { ticket?: { labels?: string[] } } | null }} ctx
+ * @returns {{ decision: "allow" } | { decision: "deny", reason: string }}
+ */
+export default function escalationLabels(ctx) {
+  const labels = ctx?.evidence?.ticket?.labels ?? [];
+  return hasSecurityOrEscalation(labels)
+    ? { decision: "deny", reason: REASON }
+    : { decision: "allow" };
+}

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { storeStats } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { usageSpend } from "./db.mjs";
+import { hookDecisionCounts } from "./hooks.mjs";
 import { inboxCounts } from "./inbox.mjs";
 import { ambiguousOpenProposalRuns, openProposals } from "./proposals.mjs";
 import { proposalsPilingUp, scheduleView } from "./schedules.mjs";
@@ -277,6 +278,10 @@ export function statusView(
       orphanBytes: store.orphanBytes,
       ...(store.at ? { at: store.at } : {}),
     },
+    // `approve.before` hook decisions in the trailing 24h, by hook id
+    // (lib/hooks.mjs, WM-842) — allow/deny counts, so an operator can see a
+    // gate that is firing (or a broken extension hook denying everything).
+    hooks: { decisions24h: hookDecisionCounts(db, { now: nowMs }) },
     anomalies: {
       configuration: configAnomalies,
       expiredOpenProposals: expiredOpen.map((p) => p.id),

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "factory-extension.json — the manifest of one factory extension (docs/extensions.md)",
-  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views`, `panels` and `hooks` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
+  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors`, `views` and `panels` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
   "type": "object",
   "required": ["name", "version"],
   "additionalProperties": false,
@@ -75,7 +75,16 @@
           }
         },
         "hooks": {
-          "description": "reserved — lifecycle hooks; lands in WM-842"
+          "type": "object",
+          "additionalProperties": false,
+          "description": "lifecycle hooks (docs/extensions.md § Hooks): hook point → relative path to an ES module exporting `id` and a default `(ctx) => { decision, reason? }`; run as a fail-closed waterfall after the built-in hooks, every decision persisted to hook_decisions",
+          "properties": {
+            "approve.before": {
+              "type": "string",
+              "pattern": "\\.mjs$",
+              "description": "evaluated immediately before each chain auto-approval (lib/auto-approval.mjs); a deny keeps the proposal open with reason dispatch_ineligible:<reason> (dispatch) or hook_denied:<reason>"
+            }
+          }
         }
       }
     }

--- a/event-runtime/test-support/extensions/sample/factory-extension.json
+++ b/event-runtime/test-support/extensions/sample/factory-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "factory/sample",
   "version": "1.0.0",
-  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, and a config schema.",
+  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, a config schema, and one approve.before hook.",
   "factory": {
     "min": "0.1.0"
   },
@@ -13,6 +13,9 @@
     "config": {
       "namespace": "sample",
       "schema": "./config.schema.json"
+    },
+    "hooks": {
+      "approve.before": "./hooks/approve-before.mjs"
     }
   }
 }

--- a/event-runtime/test-support/extensions/sample/hooks/approve-before.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/approve-before.mjs
@@ -1,0 +1,18 @@
+/**
+ * The smallest hook that satisfies the contract (docs/extensions.md § Hooks):
+ * a string `id` and a default `(ctx) => decision`. It allows everything
+ * unless the extension's effective config says otherwise — proving that
+ * `ctx.config` is the object `getExtensionConfig` hands out — and denies a
+ * proposal whose ticket carries the `sample:deny` label, so extension tests
+ * can watch a deny short-circuit the waterfall and land in `hook_decisions`.
+ */
+export const id = "factory/sample:approve-before";
+
+export default function approveBefore(ctx) {
+  if (ctx?.config?.greeting === "deny")
+    return { decision: "deny", reason: "sample_greeting_deny" };
+  const labels = ctx?.evidence?.ticket?.labels ?? [];
+  if (labels.includes("sample:deny"))
+    return { decision: "deny", reason: "sample_label_deny" };
+  return { decision: "allow" };
+}

--- a/event-runtime/test-support/extensions/sample/hooks/async-deny.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/async-deny.mjs
@@ -1,0 +1,7 @@
+/** An asynchronous hook that denies: the waterfall must await it and stop. */
+export const id = "factory/sample:async-deny";
+
+export default async function asyncDeny() {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  return { decision: "deny", reason: "async_sample_deny" };
+}

--- a/event-runtime/test-support/extensions/sample/hooks/hangs.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/hangs.mjs
@@ -1,0 +1,6 @@
+/** A hook that never answers: the registry's timeout must deny it. */
+export const id = "factory/sample:hangs";
+
+export default function hangs() {
+  return new Promise(() => {});
+}

--- a/event-runtime/test-support/extensions/sample/hooks/no-default.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/no-default.mjs
@@ -1,0 +1,2 @@
+/** Contract violation on purpose: no default export. */
+export const id = "factory/sample:no-default";

--- a/event-runtime/test-support/extensions/sample/hooks/no-id.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/no-id.mjs
@@ -1,0 +1,4 @@
+/** Contract violation on purpose: no `id` export. */
+export default function noId() {
+  return { decision: "allow" };
+}

--- a/event-runtime/test-support/extensions/sample/hooks/throws.mjs
+++ b/event-runtime/test-support/extensions/sample/hooks/throws.mjs
@@ -1,0 +1,6 @@
+/** A hook that throws: fail closed, `hook_error:<id>`. */
+export const id = "factory/sample:throws";
+
+export default function throws() {
+  throw new Error("fixture hook exploded");
+}

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -606,6 +606,13 @@ export interface StatusView {
     orphanBytes: number;
     at?: string;
   };
+  /** `approve.before` hook decisions in the trailing 24h, by hook id (WM-842); absent on a pre-hooks control API. */
+  hooks?: {
+    decisions24h: Record<
+      string,
+      { source: string; point: string; allow: number; deny: number }
+    >;
+  };
   anomalies: {
     configuration?: string[];
     expiredOpenProposals: string[];


### PR DESCRIPTION
Introduces the first hook seam of the malleable-factory epic: `event-runtime/lib/hooks.mjs` (`createHookRegistry` — `register`/`run`/`list`/`unregister`, only `approve.before`, typed `HookError`), a fail-closed waterfall (built-ins first, then extension hooks in policy order; throw / reject / malformed / timeout 2000ms → `deny hook_error:<id>`), and a module-owned `hook_decisions` audit table (notify_log pattern) that records every allow and deny.

- The inline `hasSecurityOrEscalation` check in `auto-approval.mjs` is removed and lives on as the built-in hook `factory:escalation-labels` (`lib/hooks/builtin/`), evaluated in `dispatchSafe` at exactly the old position; a deny keeps the `dispatch_ineligible:<reason>` shape (byte-identical), non-dispatch events get `hook_denied:<reason>`.
- `autoApproveChains` now returns a Promise but runs eagerly (a pass with only sync hooks completes before it returns, so `planAdmittedEvents` callers keep pre-WM-842 behaviour); passes on one db are serialized; `serve` awaits it.
- `extensions.mjs`: `contributes.hooks` (schema property `approve.before` → .mjs), modules imported + contract-checked before acceptance, registered with `source: extension:<name>` and `ctx.config = getExtensionConfig(name)`; missing `default`/`id` or duplicate id disables the extension; each load replaces extension hooks.
- `GET /proposals/:id` (new) returns `{ proposal, hookDecisions }`; `GET /status` gains `hooks.decisions24h` (allow/deny by hook id); `web/src/types.ts` StatusView updated for the contract test.
- Docs: `docs/extensions.md` § Hooks filled; `docs/event-runtime-conventions.md` seams list.

Verification: `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/hooks.test.mjs event-runtime/lib/auto-approval.test.mjs event-runtime/lib/extensions.test.mjs event-runtime/lib/api-proposals.test.mjs event-runtime/lib/api-status-view.test.mjs && bun run lint && bun run check` — 80 pass / 0 fail, lint 0 errors, check ok; full `bun test event-runtime` 2455 pass.

Fixes WM-842