### PR TITLE
ops(event-runtime): route triage-scan to the agy adapter

### DIFF
--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -37,7 +37,7 @@
   },
   "factory.triage.requested": {
     "agent": "triage-scan@1",
-    "adapter": "pi",
+    "adapter": "agy",
     "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -141,8 +141,9 @@ describe("registry", () => {
     // Regenerated (WM-769): merge-scan/merge-fix format_and_lint routing changed agent defs (registry inputs).
     // Regenerated (merge-scan output-shape fix): agent def is a registry input.
     // Regenerated (merge on agy): merge-scan/merge-fix adapter claude→agy; event-types.json is a registry input.
+    // Regenerated (triage on agy): triage-scan adapter pi→agy; event-types.json is a registry input.
     const expected =
-      "sha256:3f92016f63e7fdb97f36c8383a4b7ba5b0e7760d15e72ca06e981b31ed3ef774";
+      "sha256:2384d64a85abe4425d6ed88865467b68606fd9e59ba3e889678bb1c4b52a0bd0";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -125,7 +125,7 @@ function triagePlanScan({ action, detail }) {
   };
 }
 
-function harness({ adapters = { pi: fake, actions: fake } } = {}) {
+function harness({ adapters = { agy: fake, actions: fake } } = {}) {
   const dir = tmpDir("evrt-triage-");
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = tmpDir("evrt-triage-ws-");
@@ -248,7 +248,7 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     ).toBe(true);
 
     const { db, approveNext } = harness({
-      adapters: { pi: fakeCanonicalScan, actions: fake },
+      adapters: { agy: fakeCanonicalScan, actions: fake },
     });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-5"));
 
@@ -274,7 +274,7 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
 
   test("apply outcome SUPPLY_CHANGED chains to work.requested", async () => {
     const { db, approveNext } = harness({
-      adapters: { pi: fake, actions: fake },
+      adapters: { agy: fake, actions: fake },
     });
     admitEvent(db, registry, triageEnvelope("bj29", "triage-6"));
 
@@ -303,7 +303,7 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
     // factory.triage.requested.
     const { db, approveNext } = harness({
       adapters: {
-        pi: triagePlanScan({
+        agy: triagePlanScan({
           action: "write-detail",
           detail: canonicalWriteDetail,
         }),
@@ -331,7 +331,7 @@ describe("triage chain: scan → approved apply (OPS-229)", () => {
   test("apply outcome NO_CHANGE terminates with no follow-up", async () => {
     const { db, approveNext } = harness({
       adapters: {
-        pi: triagePlanScan({ action: "move-to-todo" }),
+        agy: triagePlanScan({ action: "move-to-todo" }),
         actions: fake,
       },
     });

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -465,7 +465,8 @@ describe("work-scan registration (WM-110)", () => {
     // The default harness is pi. The only committed non-pi LLM routes are the
     // merge-scan/merge-fix exceptions (WM-722 put them on claude/sonnet;
     // operator decision 2026-08-18 moved them to agy, gemini-3.7-flash, which
-    // is fast and on a separate subscription). agy-smoke rides agy by
+    // is fast and on a separate subscription; triage-scan followed on 2026-08-18
+    // evening to spare codex quota). agy-smoke rides agy by
     // definition. Any other route leaving pi must be an explicit, reviewed
     // decision. No route rides claude any more.
     expect(byAdapter.claude).toBeUndefined();
@@ -473,8 +474,9 @@ describe("work-scan registration (WM-110)", () => {
       "agy-smoke@1",
       "merge-fix@1",
       "merge-scan@2",
+      "triage-scan@1",
     ]);
-    for (const ref of ["merge-fix@1", "merge-scan@2"]) {
+    for (const ref of ["merge-fix@1", "merge-scan@2", "triage-scan@1"]) {
       const resolved = resolveModel(
         registry.agents.get(ref),
         "agy",


### PR DESCRIPTION
Operator decision 2026-08-18 (codex quota): `factory.triage.requested` → adapter agy (gemini-3.7-flash). Registry digest regenerated; work.test routing assertion and triage.test fake adapters updated. Full `event-runtime/lib` suite green locally. Restart the stack after merge, then inject `factory.triage.requested` to run the first agy triage.