### PR TITLE
fix(merge-scan): fix.ownedPaths = ticket Owned Paths verbatim; one fix item per PR

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -13,11 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read",
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["gh:read", "linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 1500,

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -13,7 +13,11 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["gh:read", "linear:read", "repo:read"]
+    "services": [
+      "gh:read",
+      "linear:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 1500,
@@ -21,7 +25,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:c2570c4734882240bf921c699238169683f2d40ab907752700e70dcb8f5568f6",
+    "agents/merge-scan.md": "sha256:78436422e010c525b185b809e1ae7eb69587c7d7df4f7ca60860653b33655054",
     "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -197,6 +197,17 @@ evidence required above.
   "round": 1, "mechanical": true, "withinOwnedPaths": true, "ownedPaths": ["event-runtime/lib/worker.mjs"] }
 ```
 
+`fix.ownedPaths` is the **ticket's Owned Paths list, verbatim** (or a subset of
+it) — never the list of files the PR touched. The planner refuses a fix whose
+`ownedPaths` contains anything outside the ticket's Owned Paths
+(`merge_fix_owned_paths_moved`), so listing PR-touched files parks the fix. If
+the PR itself changed files outside its ticket's Owned Paths, that is a review
+finding for `fix` (deviation) with `ownedPaths` still equal to the ticket's
+list, or an `escalate` item — not a wider `ownedPaths`. Emit **one** `fix`
+item per PR per scan (merge the findings into one `finding` string, keep the
+most severe first); several fix items for the same PR only race each other
+(`merge_fix_run_active`).
+
 `escalate` item — exactly `pr`, `headSha`, `ticket`, `reason` (no `title`/`headRefName`/`headRef`):
 <!-- prettier-ignore -->
 ```json

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -143,8 +143,9 @@ describe("registry", () => {
     // Regenerated (merge on agy): merge-scan/merge-fix adapter claude→agy; event-types.json is a registry input.
     // Regenerated (triage on agy): triage-scan adapter pi→agy; event-types.json is a registry input.
     // Regenerated (work-scan advisory overlap, WM-677): agent def is a registry input.
+    // Regenerated (merge-scan fix.ownedPaths rule): agent def is a registry input.
     const expected =
-      "sha256:402564c111373e2afb9bbfae78cd59e36c709fe34a31f85f6c48309dee5f1c03";
+      "sha256:56652ec7a003bb02b21408f71e7449403ffcefc90cf4145d81cb364d89a30be6";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Since the agy routing, merge-scan filled `fix[].ownedPaths` with the PR's touched files, so the planner refused every fix (`merge_fix_owned_paths_moved`: PRs 653/663/677 at 21:18/21:34Z) and emitted several fix items per PR that raced (`merge_fix_run_active`). Adds the rule to the output-shape section: ownedPaths = ticket's Owned Paths verbatim (subset ok); PR files outside it are a finding/escalate, not a wider scope; one fix item per PR per scan. Re-pinned merge-scan.json; registry digest regenerated (registry+merge tests 75/75; emit --check ok).