### PR TITLE
test(web): cover disabled raw copy fallback (WM-786)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -553,6 +553,11 @@ describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
 
     expect(await view.findByText(/cannot be previewed/i)).toBeTruthy();
     expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
+    expect(
+      view
+        .getByRole("button", { name: "Copy Raw Content" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Assert the long-sample binary fallback disables `Copy Raw Content`
- Keep the existing fallback coverage aligned with the binary-fixture case

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx`
- `bun test`
- `cd event-runtime/web && bun run build`

UX critique: skipped — test-only assertion with no user-facing behavior change

Fixes WM-786