### PR TITLE
fix(work-scan): Owned Paths overlap is advisory in candidate selection (WM-677 parity)

### DIFF
--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:097744fb5ef68feb4cc53d5fab99d57eb0a6e13e9983efac7595e433fe94caef",
+    "agents/work-scan.md": "sha256:650c43e6d15e1fe48fe7521bf831ad2d1f122d7ea154825757cb901332618334",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
     "schemas/work-scan.output.json": "sha256:98a2cb891198b79d8d8d9924a3db1fe2bd11e2983c71ae4a3499bc54a5d43f5f"
   }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -92,12 +92,23 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    still plannable, but only alone, with nothing in flight. Ambiguous overlap
    is overlap — the same biases as `orchestrator/owned-paths.mjs`, always toward
    collision.
-5. **Select the plan**: walk the entire ordered candidate queue. Take each
-   ticket whose Owned Paths are disjoint from every in-flight ticket's paths AND
-   from every ticket already selected while a free slot remains. Selected in
-   order, each item pins `{ticket, ownedPaths, reason}`. Every candidate not
-   selected goes in `deferred` as `{ticket, reason}`, where `reason` is the typed
-   value `owned_paths_overlap` for a collision or `cap_full` when no slot remains.
+5. **Select the plan**: walk the entire ordered candidate queue. Owned Paths
+   overlap is **advisory** (WM-677, `config/policy.yaml`
+   `dispatch.owned_paths_collision: advisory`): a textual overlap with an
+   in-flight ticket or an already-selected ticket does NOT disqualify — select
+   the ticket while a free slot remains and record the overlap in its `reason`
+   (`overlaps WM-123 on event-runtime/web/src/App.tsx`); rebase and merge-fix
+   resolve real conflicts later. Only two collisions are hard and defer a
+   candidate as `owned_paths_overlap`: (a) an in-flight or selected ticket
+   claims `**` (including a ticket with no parseable Owned Paths section — see
+   step 4), or (b) the candidate and an in-flight/selected ticket claim the
+   _identical_ concrete file (no globs on either side). Selected in order, each
+   item pins `{ticket, ownedPaths, reason}`. Every candidate not selected goes
+   in `deferred` as `{ticket, reason}`, where `reason` is the typed value
+   `owned_paths_overlap` for a hard collision or `cap_full` when no slot
+   remains. When a hard collision comes from an in-flight ticket with no
+   parseable Owned Paths, name that ticket in the `summary` so the operator can
+   fix its description (WM-868).
    Do not stop accounting when the slots fill: mark every remaining candidate
    `cap_full`.
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -142,8 +142,9 @@ describe("registry", () => {
     // Regenerated (merge-scan output-shape fix): agent def is a registry input.
     // Regenerated (merge on agy): merge-scan/merge-fix adapter claude→agy; event-types.json is a registry input.
     // Regenerated (triage on agy): triage-scan adapter pi→agy; event-types.json is a registry input.
+    // Regenerated (work-scan advisory overlap, WM-677): agent def is a registry input.
     const expected =
-      "sha256:2384d64a85abe4425d6ed88865467b68606fd9e59ba3e889678bb1c4b52a0bd0";
+      "sha256:402564c111373e2afb9bbfae78cd59e36c709fe34a31f85f6c48309dee5f1c03";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
The planner's dispatch gate has been advisory since #565/#566 (WM-677), but `work-scan@1`'s selection step still required Owned Paths *disjoint* from every in-flight ticket, so the chain-driven supply loop kept returning `NOOP all_overlapping` (21:2xZ: 'all 9 candidates overlap an in-flight ticket's fail-closed Owned Paths') even though direct dispatch of the same tickets succeeded. Selection now mirrors the gate: textual overlap → select and record in `reason`; only `**` (incl. an unparseable Owned Paths section — WM-816 tonight) or an identical concrete file defers, and the summary names the ticket to fix. Re-pinned work-scan.json; registry digest regenerated; work.test + registry.test 48/48; emit --check ok. Related: WM-677, WM-868.