### PR TITLE
feat(runtime): store typed result artifacts (WM-858)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -590,12 +590,19 @@ create unique directory
 ```
 
 The workspace is scratch state. Accepted, content-addressed artifacts and run
-events are durable state: at publish time the worker copies every verified
-artifact file (including the adapter-captured transcript) into
-`<home>/artifacts/<sha256>`, and the control API serves them from there —
-result rows never reference files that died with a workspace. Passing work
-between agents means materializing an accepted artifact into a new workspace,
-not letting two agents share a live directory. The same rule covers memory:
+events are durable state. Two result fields have distinct meanings:
+
+- the **result artifact (typed output)** is `result.artifact`, validated by the
+  agent's output schema and written as canonical JSON under
+  `result.artifactHash`; and
+- **collected artifacts (files)** are `result.artifacts`, such as reports and
+  the adapter-captured transcript, copied from the workspace after validation.
+
+At publish time the worker materializes both kinds into
+`<home>/artifacts/<sha256>`, and the control API serves them from there. Result
+rows never reference bytes that died with a workspace. Passing work between
+agents means materializing an accepted artifact into a new workspace, not
+letting two agents share a live directory. The same rule covers memory:
 agents get no board or shared scratch to read at will — cross-run knowledge is
 a **memo** (`factory.memo/v1`), an artifact of an accepted run or of an inbox
 decision, declared by the consumer, folded by the planner into the spec input

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -3,7 +3,14 @@
 import { COMMANDS } from "./cli/commands.mjs";
 import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { createAdapterRegistry } from "./lib/adapters/index.mjs";
-import { API_HOST, DEFAULT_PORT } from "./lib/config.mjs";
+import { backfillResultArtifacts } from "./lib/artifacts.mjs";
+import {
+  API_HOST,
+  DEFAULT_PORT,
+  artifactsRoot,
+  runtimeHome,
+} from "./lib/config.mjs";
+import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
 import {
   loadExtensions,
@@ -13,10 +20,18 @@ import {
 const USAGE = BASE_USAGE.replace(
   "  inbox                          open items waiting on the human",
   "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API",
-).replace(
-  "  agents                         registered agent definitions and event routing",
-  "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts\n  extensions validate <path>     validate a factory-extension.json without loading it",
-);
+)
+  .replace(
+    "  agents                         registered agent definitions and event routing",
+    "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts\n  extensions validate <path>     validate a factory-extension.json without loading it",
+  )
+  .concat(
+    "\n  artifacts backfill-results [--apply]\n                                 materialize stored typed result output (dry by default)",
+  )
+  .replace(
+    "All commands except serve, work, supervise, and update-pins are clients of the control",
+    "All commands except serve, work, supervise, update-pins, and artifacts are clients of the control",
+  );
 
 // Preserve the small programmatic surface used by runtime tests and tooling.
 export {
@@ -221,12 +236,38 @@ export async function extensionsCommand(args = []) {
   process.exit(1);
 }
 
+/** Backfill accepted typed output into the content store (WM-858). */
+export function artifactsCommand(
+  args = [],
+  { db = null, storeRoot = artifactsRoot(runtimeHome()) } = {},
+) {
+  const [sub, ...rest] = args;
+  if (sub !== "backfill-results" || rest.some((arg) => arg !== "--apply")) {
+    throw new Error("usage: artifacts backfill-results [--apply]");
+  }
+  const apply = rest.includes("--apply");
+  const ownedDb = db ?? openDb();
+  try {
+    const counts = backfillResultArtifacts(ownedDb, storeRoot, { apply });
+    const action = apply
+      ? `${counts.materialized} materialized`
+      : `${counts.wouldMaterialize} would be materialized`;
+    console.log(
+      `result artifacts: ${counts.scanned} rows scanned, ${counts.eligible} eligible, ${counts.alreadyStored} already stored, ${action}, ${counts.invalid} invalid${apply ? "" : " (dry run)"}`,
+    );
+    return counts;
+  } finally {
+    if (!db) ownedDb.close();
+  }
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
   if (command === "adapters") return adaptersCommand(args);
   if (command === "extensions") return extensionsCommand(args);
+  if (command === "artifacts") return artifactsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -5,8 +5,14 @@ import {
   openSync,
   readFileSync,
   readSync,
+  rmSync,
 } from "node:fs";
-import { findArtifact, listArtifacts, pruneArtifacts } from "./artifacts.mjs";
+import {
+  findArtifact,
+  hashFile,
+  listArtifacts,
+  pruneArtifacts,
+} from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
 
 /** Crude but honest content-type: render text in the browser, download the rest. */
@@ -112,6 +118,10 @@ export async function handleArtifactApiRoute({
   if (req.method === "GET" && artifactGet) {
     const found = findArtifact(artifactsRoot(env.home), artifactGet[1]);
     if (!found) return send(404, { error: `no artifact ${artifactGet[1]}` });
+    if (hashFile(found.file) !== artifactGet[1]) {
+      rmSync(found.file, { force: true });
+      return send(404, { error: `no artifact ${artifactGet[1]}` });
+    }
     const rawName = url.searchParams.get("name");
     const safeName = rawName
       ? rawName.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64)

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -3,6 +3,7 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-artifacts-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import {
   GH_SECRET,
   PV,
@@ -249,6 +250,35 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
 
       const view = await client.run(summary.runId);
       const report = view.result.artifacts.find((a) => a.kind === "report");
+      const resultDigest = view.result.artifactHash.slice("sha256:".length);
+      const typedResult = await fetch(
+        `http://127.0.0.1:${port}/artifacts/${resultDigest}`,
+      );
+      expect(typedResult.status).toBe(200);
+      expect(await typedResult.text()).toBe(
+        canonicalJson(view.result.artifact),
+      );
+
+      const inventory = await (
+        await fetch(`http://127.0.0.1:${port}/artifacts`)
+      ).json();
+      expect(
+        inventory.artifacts.find(
+          (artifact) => artifact.sha256 === resultDigest,
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          referenced: true,
+          references: [
+            expect.objectContaining({
+              runId: summary.runId,
+              attempt: 1,
+              kind: "result",
+            }),
+          ],
+        }),
+      );
+
       const res = await fetch(
         `http://127.0.0.1:${port}/artifacts/${report.sha256}`,
       );
@@ -280,6 +310,14 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(
         (await fetch(`http://127.0.0.1:${port}/artifacts/not-a-hash`)).status,
       ).toBe(404);
+
+      const corruptHash = sha256Hex("expected bytes");
+      writeFileSync(path.join(home, "artifacts", corruptHash), "corrupt");
+      expect(
+        (await fetch(`http://127.0.0.1:${port}/artifacts/${corruptHash}`))
+          .status,
+      ).toBe(404);
+      expect(existsSync(path.join(home, "artifacts", corruptHash))).toBe(false);
     } finally {
       server.close();
     }

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -20,11 +20,44 @@ import {
   renameSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { canonicalJson, hashJson } from "./canonical.mjs";
 
 const HEX64 = /^[0-9a-f]{64}$/;
+const SHA256 = /^sha256:([0-9a-f]{64})$/;
+
+function resultDigest(artifactHash) {
+  return SHA256.exec(artifactHash ?? "")?.[1] ?? null;
+}
+
+/** Atomically persist bytes whose digest is already known. */
+function storeBytes({ bytes, sha256hex, storeRoot }) {
+  mkdirSync(storeRoot, { recursive: true });
+  const dest = artifactPath(storeRoot, sha256hex);
+  if (existsSync(dest)) {
+    if (hashFile(dest) === sha256hex) return dest;
+    rmSync(dest, { force: true });
+  }
+
+  const tmpName = `${sha256hex}.tmp.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}`;
+  const tmpPath = path.join(storeRoot, tmpName);
+  try {
+    writeFileSync(tmpPath, bytes);
+    const tmpHash = hashFile(tmpPath);
+    if (tmpHash !== sha256hex) {
+      throw new Error(
+        `artifact store hash mismatch: expected ${sha256hex}, got ${tmpHash}`,
+      );
+    }
+    renameSync(tmpPath, dest);
+  } finally {
+    if (existsSync(tmpPath)) rmSync(tmpPath, { force: true });
+  }
+  return dest;
+}
 
 /** Compute sha256 hex digest of a file on disk. */
 export function hashFile(filePath) {
@@ -100,6 +133,83 @@ export function storeCollected({ entries, storeRoot }) {
   });
 }
 
+/**
+ * Materialize the singular, schema-validated result artifact as canonical
+ * JSON. `hashJson` and these bytes deliberately share `canonicalJson`, so the
+ * hash carried by results and completion events is also a retrievable object.
+ */
+export function storeResultArtifact({ artifact, artifactHash, storeRoot }) {
+  if (artifact === undefined) return null;
+  const sha256 = resultDigest(artifactHash);
+  if (!sha256) throw new Error(`invalid result artifact hash: ${artifactHash}`);
+  const bytes = canonicalJson(artifact);
+  const actualHash = hashJson(artifact);
+  if (actualHash !== artifactHash) {
+    throw new Error(
+      `result artifact hash mismatch: expected ${artifactHash}, got ${actualHash}`,
+    );
+  }
+  const dest = storeBytes({ bytes, sha256hex: sha256, storeRoot });
+  return {
+    kind: "result",
+    sha256,
+    uri: `file://${dest}`,
+    sizeBytes: statSync(dest).size,
+  };
+}
+
+/**
+ * Materialize result artifacts from accepted historical rows. Dry by default;
+ * applying repeatedly is safe because the store is content-addressed.
+ */
+export function backfillResultArtifacts(db, storeRoot, { apply = false } = {}) {
+  const counts = {
+    scanned: 0,
+    eligible: 0,
+    alreadyStored: 0,
+    wouldMaterialize: 0,
+    materialized: 0,
+    invalid: 0,
+  };
+  const rows = db
+    .query(`SELECT result_json, artifact_hash FROM results ORDER BY rowid`)
+    .all();
+  for (const row of rows) {
+    counts.scanned += 1;
+    let result;
+    try {
+      result = JSON.parse(row.result_json);
+    } catch {
+      counts.invalid += 1;
+      continue;
+    }
+    if (result.artifact === undefined) continue;
+    counts.eligible += 1;
+    const artifactHash = result.artifactHash ?? row.artifact_hash;
+    const sha256 = resultDigest(artifactHash);
+    if (!sha256 || hashJson(result.artifact) !== artifactHash) {
+      counts.invalid += 1;
+      continue;
+    }
+    const found = findArtifact(storeRoot, sha256);
+    if (found && hashFile(found.file) === sha256) {
+      counts.alreadyStored += 1;
+      continue;
+    }
+    if (!apply) {
+      counts.wouldMaterialize += 1;
+      continue;
+    }
+    storeResultArtifact({
+      artifact: result.artifact,
+      artifactHash,
+      storeRoot,
+    });
+    counts.materialized += 1;
+  }
+  return counts;
+}
+
 /** Locate a stored artifact for serving; null when absent. */
 export function findArtifact(storeRoot, sha256hex) {
   if (!HEX64.test(sha256hex ?? "")) return null;
@@ -162,9 +272,16 @@ export function materializeArtifact({
 /** Every artifact hash any accepted result still points at. */
 export function referencedHashes(db) {
   const hashes = new Set();
-  for (const row of db.query(`SELECT result_json FROM results`).all()) {
-    for (const entry of JSON.parse(row.result_json).artifacts ?? []) {
+  for (const row of db
+    .query(`SELECT result_json, artifact_hash FROM results`)
+    .all()) {
+    const result = JSON.parse(row.result_json);
+    for (const entry of result.artifacts ?? []) {
       if (entry.sha256) hashes.add(entry.sha256);
+    }
+    if (result.artifact !== undefined) {
+      const sha256 = resultDigest(result.artifactHash ?? row.artifact_hash);
+      if (sha256) hashes.add(sha256);
     }
   }
   return hashes;
@@ -185,7 +302,8 @@ export function listArtifacts(
   const references = new Map();
   const rows = db
     .query(
-      `SELECT results.run_id, results.result_json, runs.spec_json, runs.state, runs.created_at
+      `SELECT results.run_id, results.attempt, results.result_json, results.artifact_hash,
+              runs.spec_json, runs.state, runs.created_at
      FROM results
      LEFT JOIN runs ON runs.run_id = results.run_id`,
     )
@@ -197,7 +315,8 @@ export function listArtifacts(
     } catch {
       // A catalogue read should still expose the bytes if an old spec is bad.
     }
-    for (const entry of JSON.parse(row.result_json).artifacts ?? []) {
+    const result = JSON.parse(row.result_json);
+    for (const entry of result.artifacts ?? []) {
       if (!HEX64.test(entry.sha256 ?? "")) continue;
       const refs = references.get(entry.sha256) ?? [];
       refs.push({
@@ -208,6 +327,21 @@ export function listArtifacts(
         createdAt: row.created_at ?? null,
       });
       references.set(entry.sha256, refs);
+    }
+    if (result.artifact !== undefined) {
+      const sha256 = resultDigest(result.artifactHash ?? row.artifact_hash);
+      if (sha256) {
+        const refs = references.get(sha256) ?? [];
+        refs.push({
+          runId: row.run_id,
+          attempt: row.attempt,
+          kind: "result",
+          agent,
+          state: row.state ?? null,
+          createdAt: row.created_at ?? null,
+        });
+        references.set(sha256, refs);
+      }
     }
   }
 

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -1,5 +1,6 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-artifacts-test-mjs";
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -11,16 +12,19 @@ import {
 import path from "node:path";
 import {
   artifactPath,
+  backfillResultArtifacts,
   findArtifact,
   hashFile,
+  listArtifacts,
   materializeArtifact,
   pinRunArtifact,
   pruneArtifacts,
   referencedHashes,
   storeCollected,
+  storeResultArtifact,
   storeStats,
 } from "./artifacts.mjs";
-import { sha256Hex } from "./canonical.mjs";
+import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
 
 const tmp = (p) => tmpDir(p);
@@ -181,6 +185,165 @@ describe("storeCollected (OPS-406)", () => {
     const remainingFiles = readdirSync(storeRoot);
     expect(remainingFiles).toEqual([]);
     expect(existsSync(path.join(storeRoot, hash))).toBe(false);
+  });
+});
+
+describe("result artifacts (WM-858)", () => {
+  test("stores canonical typed output under the hash already carried by the result", () => {
+    const storeRoot = tmp("evrt-result-store-");
+    const artifact = { zebra: 1, alpha: { two: 2, one: 1 } };
+    const artifactHash = hashJson(artifact);
+
+    const stored = storeResultArtifact({ artifact, artifactHash, storeRoot });
+
+    expect(stored).toEqual({
+      kind: "result",
+      sha256: artifactHash.slice("sha256:".length),
+      uri: `file://${path.join(storeRoot, artifactHash.slice("sha256:".length))}`,
+      sizeBytes: Buffer.byteLength(canonicalJson(artifact)),
+    });
+    expect(readFileSync(stored.uri.slice("file://".length), "utf8")).toBe(
+      canonicalJson(artifact),
+    );
+    expect(hashFile(stored.uri.slice("file://".length))).toBe(stored.sha256);
+
+    // Identical typed output is content-addressed and therefore idempotent.
+    expect(storeResultArtifact({ artifact, artifactHash, storeRoot })).toEqual(
+      stored,
+    );
+  });
+
+  test("inventory and prune treat the singular result artifact as a live result reference", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmp("evrt-result-store-");
+    const artifact = { outcome: "UPDATED", pr: 669 };
+    const artifactHash = hashJson(artifact);
+    const stored = storeResultArtifact({ artifact, artifactHash, storeRoot });
+    const createdAt = "2026-08-18T12:00:00.000Z";
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+       VALUES ('run_result', 'idem_result', ?, 'spec-hash', 'COMPLETED', ?, ?)`,
+    ).run(JSON.stringify({ agent: "merge-fix@1" }), createdAt, createdAt);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run_result', 2, ?, ?, '{}', '{}', ?)`,
+    ).run(
+      JSON.stringify({ artifact, artifactHash, artifacts: [] }),
+      artifactHash,
+      createdAt,
+    );
+
+    expect(referencedHashes(db)).toContain(stored.sha256);
+    expect(listArtifacts(db, storeRoot)).toEqual([
+      expect.objectContaining({
+        sha256: stored.sha256,
+        referenced: true,
+        references: [
+          {
+            runId: "run_result",
+            attempt: 2,
+            kind: "result",
+            agent: "merge-fix@1",
+            state: "COMPLETED",
+            createdAt,
+          },
+        ],
+      }),
+    ]);
+    expect(pruneArtifacts(db, storeRoot, { olderThanMs: -1 }).deleted).toBe(0);
+    expect(findArtifact(storeRoot, stored.sha256)).not.toBeNull();
+  });
+
+  test("backfill dry-runs, applies canonical result bytes, and is idempotent", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmp("evrt-result-store-");
+    const artifact = { summary: "existing accepted output", count: 3 };
+    const artifactHash = hashJson(artifact);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run_old', 1, ?, ?, '{}', '{}', ?)`,
+    ).run(
+      JSON.stringify({ artifact, artifactHash, artifacts: [] }),
+      artifactHash,
+      new Date().toISOString(),
+    );
+
+    expect(backfillResultArtifacts(db, storeRoot)).toEqual({
+      scanned: 1,
+      eligible: 1,
+      alreadyStored: 0,
+      wouldMaterialize: 1,
+      materialized: 0,
+      invalid: 0,
+    });
+    expect(findArtifact(storeRoot, artifactHash.slice(7))).toBeNull();
+
+    expect(backfillResultArtifacts(db, storeRoot, { apply: true })).toEqual({
+      scanned: 1,
+      eligible: 1,
+      alreadyStored: 0,
+      wouldMaterialize: 0,
+      materialized: 1,
+      invalid: 0,
+    });
+    expect(
+      readFileSync(path.join(storeRoot, artifactHash.slice(7)), "utf8"),
+    ).toBe(canonicalJson(artifact));
+
+    expect(backfillResultArtifacts(db, storeRoot, { apply: true })).toEqual({
+      scanned: 1,
+      eligible: 1,
+      alreadyStored: 1,
+      wouldMaterialize: 0,
+      materialized: 0,
+      invalid: 0,
+    });
+  });
+
+  test("artifacts backfill-results is dry by default and applies only with --apply", () => {
+    const home = tmp("evrt-result-home-");
+    const db = openDb(path.join(home, "runtime.db"));
+    const artifact = { summary: "CLI backfill" };
+    const artifactHash = hashJson(artifact);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run_cli', 1, ?, ?, '{}', '{}', ?)`,
+    ).run(
+      JSON.stringify({ artifact, artifactHash, artifacts: [] }),
+      artifactHash,
+      new Date().toISOString(),
+    );
+    db.close();
+    const cli = path.resolve(import.meta.dir, "../cli.mjs");
+    const run = (...args) =>
+      spawnSync(
+        process.execPath,
+        [cli, "artifacts", "backfill-results", ...args],
+        {
+          encoding: "utf8",
+          env: { ...process.env, FACTORY_EVENT_HOME: home },
+        },
+      );
+
+    const dry = run();
+    expect(dry.status).toBe(0);
+    expect(dry.stdout).toContain("1 would be materialized");
+    expect(dry.stdout).toContain("dry run");
+    expect(
+      findArtifact(path.join(home, "artifacts"), artifactHash.slice(7)),
+    ).toBeNull();
+
+    const apply = run("--apply");
+    expect(apply.status).toBe(0);
+    expect(apply.stdout).toContain("1 materialized");
+    expect(
+      readFileSync(path.join(home, "artifacts", artifactHash.slice(7)), "utf8"),
+    ).toBe(canonicalJson(artifact));
+
+    const again = run("--apply");
+    expect(again.status).toBe(0);
+    expect(again.stdout).toContain("1 already stored");
+    expect(again.stdout).toContain("0 materialized");
   });
 });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -32,7 +32,7 @@ import {
   writeWorkerLease,
 } from "../../lib/worker-leases.mjs";
 import { loadForge } from "../../lib/forge/index.mjs";
-import { storeCollected } from "./artifacts.mjs";
+import { storeCollected, storeResultArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
@@ -2750,6 +2750,11 @@ export async function executeClaimed(
     // commits. Orphans from a failed commit are harmless; dead links are not.
     verified.result.artifacts = storeCollected({
       entries: verified.result.artifacts,
+      storeRoot: artifactStore,
+    });
+    storeResultArtifact({
+      artifact: verified.result.artifact,
+      artifactHash: verified.result.artifactHash,
       storeRoot: artifactStore,
     });
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -327,7 +327,7 @@ describe("worker", () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec());
     linkEvent(db, spec.runId);
-    const o = opts();
+    const o = opts({ artifactStore: freshRoot() });
 
     const summary = await runOnce(db, registry, adapters, o);
     expect(summary.terminalState).toBe("COMPLETED");
@@ -344,6 +344,16 @@ describe("worker", () => {
     expect(receipt.runSpecHash).toBe(hashJson(spec));
     expect(receipt.artifactHash).toBe(result.artifact_hash);
     expect(summary.receipt).toEqual(receipt);
+
+    const parsedResult = JSON.parse(result.result_json);
+    const resultDigest = result.artifact_hash.slice("sha256:".length);
+    const storedResult = path.join(o.artifactStore, resultDigest);
+    expect(readFileSync(storedResult, "utf8")).toBe(
+      canonicalJson(parsedResult.artifact),
+    );
+    expect(
+      createHash("sha256").update(readFileSync(storedResult)).digest("hex"),
+    ).toBe(resultDigest);
 
     const outbox = db.query(`SELECT * FROM outbox`).all();
     expect(outbox).toHaveLength(1);

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -11,6 +11,7 @@ import {
   isCancellable,
   modelTierText,
   pinnedModelText,
+  resultArtifactHref,
 } from "./RunDetailBlocks";
 import {
   TicketDecisions,
@@ -412,7 +413,12 @@ describe("artifact position renders the agent's view (WM-455)", () => {
         state: "COMPLETED",
         spec: { agent: "triage-scan@1" },
       } as RunDetail["run"],
-      result: { terminalState: "COMPLETED", reasonCode: null, artifact },
+      result: {
+        terminalState: "COMPLETED",
+        reasonCode: null,
+        artifact,
+        artifactHash: `sha256:${"a".repeat(64)}`,
+      },
     });
 
   afterEach(() => localStorage.removeItem(ARTIFACT_RAW_KEY));
@@ -440,6 +446,23 @@ describe("artifact position renders the agent's view (WM-455)", () => {
     expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
   });
 
+  test("opens the typed result artifact in the full-page artifact view", async () => {
+    stubApi({
+      agents: mock(async () =>
+        createAgentsFixture({ agents: [triageAgent] as never }),
+      ),
+    });
+    const detail = withArtifact();
+
+    const r = renderBlocks(detail);
+    expect(
+      await r.findByRole("button", { name: /Open in full page/ }),
+    ).toBeTruthy();
+    expect(
+      resultArtifactHref(detail.result!.artifactHash, "#/runs/run_result"),
+    ).toBe(`#\/artifact\/${"a".repeat(64)}`);
+  });
+
   test("no view for the agent → the JSON block, unchanged, and no toggle", async () => {
     stubApi({
       agents: mock(async () =>
@@ -451,6 +474,9 @@ describe("artifact position renders the agent's view (WM-455)", () => {
     const r = renderBlocks(withArtifact());
     await waitFor(() => expect(api.agents).toHaveBeenCalled());
     expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
+    expect(
+      await r.findByRole("button", { name: /Open in full page/ }),
+    ).toBeTruthy();
     expect(r.queryByRole("table")).toBeNull();
     const pre = Array.from(r.container.querySelectorAll("pre")).find((el) =>
       el.textContent?.includes('"issueId": "WM-7"'),

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -74,6 +74,20 @@ export const TERMINAL: RunState[] = [
 export const isCancellable = (state: RunState) =>
   !TERMINAL.includes(state) && state !== "VERIFYING";
 
+/** Full-page route for a typed result hash; null for legacy/malformed hashes. */
+export function resultArtifactHref(
+  artifactHash: string | null | undefined,
+  currentHash: string,
+): string | null {
+  const digest = /^sha256:([0-9a-f]{64})$/.exec(artifactHash ?? "")?.[1];
+  return digest
+    ? `#/${withProject(
+        `artifact/${encodeURIComponent(digest)}`,
+        hashProject(currentHash),
+      )}`
+    : null;
+}
+
 /**
  * The states `reapExpiredLeases` sweeps (lib/worker.mjs) — exactly the states
  * where the current attempt is still racing its attempt and lease deadlines.
@@ -756,6 +770,15 @@ export function RunDetailBlocks({
   const agentDef = (agentsQ.data?.agents ?? []).find(
     (a) => a.ref === d.run.spec.agent || a.id === d.run.spec.agent,
   );
+  const resultArtifactLink = resultArtifactHref(
+    d.result?.artifactHash,
+    window.location.hash,
+  );
+  const openResultArtifact = resultArtifactLink
+    ? () => {
+        window.location.hash = resultArtifactLink;
+      }
+    : undefined;
 
   return (
     <>
@@ -1076,17 +1099,14 @@ export function RunDetailBlocks({
         >
           {d.result.artifact !== undefined ? (
             <Disclosure label="artifact" defaultOpen>
-              {agentDef?.outputView ? (
-                <Suspense fallback={<JsonBlock value={d.result.artifact} />}>
-                  <ArtifactPanel
-                    artifact={d.result.artifact}
-                    schema={agentDef.outputSchema}
-                    view={agentDef.outputView}
-                  />
-                </Suspense>
-              ) : (
-                <JsonBlock value={d.result.artifact} />
-              )}
+              <Suspense fallback={<JsonBlock value={d.result.artifact} />}>
+                <ArtifactPanel
+                  artifact={d.result.artifact}
+                  schema={agentDef?.outputSchema}
+                  view={agentDef?.outputView}
+                  onOpenFull={openResultArtifact}
+                />
+              </Suspense>
             </Disclosure>
           ) : (
             <Disclosure label="result" defaultOpen>

--- a/event-runtime/web/src/views/ArtifactFull.test.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.test.tsx
@@ -135,7 +135,7 @@ describe("ArtifactFull reader view (WM-828)", () => {
     expect(writeText).toHaveBeenCalledWith(SHA_A);
   });
 
-  test("renders schema-derived ArtifactView and toggles raw with 'r' key shortcut", async () => {
+  test("renders a result artifact with its agent ArtifactView and toggles raw with 'r' key shortcut", async () => {
     const MERGE_VIEW = JSON.parse(
       readFileSync(
         path.resolve(import.meta.dir, "../../../agents/merge-scan.view.json"),
@@ -156,8 +156,15 @@ describe("ArtifactFull reader view (WM-828)", () => {
       referenced: true,
       references: [
         {
-          runId: "run_merge",
+          runId: "run_collected",
           kind: "report",
+          agent: "unrelated@1",
+          state: "COMPLETED",
+          createdAt: "2026-01-04T03:04:05.000Z",
+        },
+        {
+          runId: "run_merge",
+          kind: "result",
           agent: "merge-scan@2",
           state: "COMPLETED",
           createdAt: "2026-01-05T03:04:05.000Z",
@@ -191,7 +198,19 @@ describe("ArtifactFull reader view (WM-828)", () => {
       digest: MERGE_SHA,
       seed: {
         items: [MERGE_ITEM],
-        agents: [MERGE_AGENT],
+        agents: [
+          {
+            ref: "unrelated@1",
+            id: "unrelated",
+            outputSchema: {},
+            outputView: {
+              schemaVersion: "factory.artifact-view/v1",
+              summary: "/not-present",
+              sections: [],
+            },
+          },
+          MERGE_AGENT,
+        ],
       },
     });
 

--- a/event-runtime/web/src/views/ArtifactFull.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.tsx
@@ -94,17 +94,23 @@ export function ArtifactFull({
   );
 
   const producerAgent: AgentDef | undefined = useMemo(() => {
-    const refs =
-      selected?.references
-        ?.map((reference) => reference.agent)
-        .filter(Boolean) ?? [];
+    const references = [...(selected?.references ?? [])].sort(
+      (a, b) => Number(b.kind === "result") - Number(a.kind === "result"),
+    );
     const defs = agentsQ.data?.agents ?? [];
-    for (const ref of refs) {
-      const def = defs.find((a) => a.ref === ref || a.id === ref);
-      if (def?.outputView) return def;
+    for (const reference of references) {
+      const def = defs.find(
+        (agent) =>
+          agent.ref === reference.agent || agent.id === reference.agent,
+      );
+      if (
+        parsedArtifact !== null &&
+        viewApplies(def?.outputView, parsedArtifact)
+      )
+        return def;
     }
     return undefined;
-  }, [selected, agentsQ.data]);
+  }, [selected, agentsQ.data, parsedArtifact]);
 
   const canToggleView =
     parsedArtifact !== null &&

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -56,7 +56,7 @@ export type ArtifactFilters = {
   search: string;
 };
 
-const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
+const COMMON_KINDS = ["result", "report", "log", "transcript", "ci-log"];
 
 export function kindsOf(artifact: ArtifactInventoryItem): string[] {
   return [
@@ -393,17 +393,23 @@ export function Artifacts({
     [contentQ.data],
   );
   const producerAgent: AgentDef | undefined = useMemo(() => {
-    const refs =
-      selected?.references
-        ?.map((reference) => reference.agent)
-        .filter(Boolean) ?? [];
+    const references = [...(selected?.references ?? [])].sort(
+      (a, b) => Number(b.kind === "result") - Number(a.kind === "result"),
+    );
     const defs = agentsQ.data?.agents ?? [];
-    for (const ref of refs) {
-      const def = defs.find((a) => a.ref === ref || a.id === ref);
-      if (def?.outputView) return def;
+    for (const reference of references) {
+      const def = defs.find(
+        (agent) =>
+          agent.ref === reference.agent || agent.id === reference.agent,
+      );
+      if (
+        parsedArtifact !== null &&
+        viewApplies(def?.outputView, parsedArtifact)
+      )
+        return def;
     }
     return undefined;
-  }, [selected, agentsQ.data]);
+  }, [selected, agentsQ.data, parsedArtifact]);
   const viewShown =
     parsedArtifact !== null &&
     viewApplies(producerAgent?.outputView, parsedArtifact) &&


### PR DESCRIPTION
## Summary
- materialize canonical `result.artifact` JSON in the content store under its existing hash
- inventory typed outputs as `result` references, preserve them during prune, and add idempotent historical backfill
- open typed results from run detail in the full-page agent View/Raw renderer

## Verification
- `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib event-runtime/web/src && bun run lint && bun run check`
- `bun test`
- `cd event-runtime/web && bun run build`
- `factory security`

UX critique: required — SHIP (round 2); observed http://127.0.0.1:7467/#/artifact/e2cde8342ba74a2506b86c5d0bd8bfe6212a70aa0dc724748800beb3b0dd69b8 with View/Raw and producing-run navigation.

Fixes WM-858
