### PR TITLE
fix(planner): gate dispatch on open blockers

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -50,6 +50,11 @@ RunSpec — and says nothing about tickets. An event run that finds its target
 ticket already assigned refuses with a typed NOOP (`ticket_assigned`); it
 never steals, and it never queues behind the holder.
 
+At plan time the runtime admits only a `Todo`, unassigned,
+`ai:agent-ready` ticket with no unfinished Linear `blocked by` relation.
+Open blockers refuse with `ticket_blocked_by_open:<ID>` (comma-separated for
+several); blockers in completed or canceled states do not gate dispatch.
+
 **Rejected: a ticket lock in the runtime database.** The runtime's ledger is
 authoritative for event facts only (§10); Linear is the authority for
 business work, and architecture.md §1 is explicit that two agents cannot

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -22,6 +22,7 @@ import {
   readPinManifestRequirements,
   ownedPathsClosureGaps,
 } from "../../orchestrator/owned-paths.mjs";
+import { openBlockers } from "../../orchestrator/blockers.mjs";
 import { loadForge } from "../../lib/forge/index.mjs";
 import { budgetExhausted } from "../../lib/spend.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
@@ -677,6 +678,14 @@ export function worktreeDispatchAutoEligibility(
   if (evidence.ticket.labels.includes("ai:escalated")) {
     return refusal("ticket_escalated", evidence);
   }
+
+  const blockers = openBlockers(ticket);
+  evidence.ticket.openBlockers = blockers;
+  if (blockers.length > 0) {
+    evidence.checks.ticket_unblocked = false;
+    return refusal(`ticket_blocked_by_open:${blockers.join(",")}`, evidence);
+  }
+  evidence.checks.ticket_unblocked = true;
 
   // Never let effectiveOwnedPaths' fail-closed `**` sentinel masquerade as a
   // real path during a sensitive-path check. Unknown ticket scope is its own
@@ -1341,7 +1350,12 @@ export function planEvent(
         ttlSeconds,
       });
       setEventStatus(db, event, "noop");
-      return { decision: "noop", proposal, reason: worktreeRefusal.reason };
+      return {
+        decision: "noop",
+        proposal,
+        reason: worktreeRefusal.reason,
+        evidence: worktreeEligibility.evidence,
+      };
     }
 
     // §7 tier 1 (OPS-228): a repository workspace resolves its ref to an

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -866,6 +866,86 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  test("open Linear blockers refuse dispatch with blocker ids in evidence (WM-709)", () => {
+    withReposRoot(tierRepo, () => {
+      const openRelations = {
+        nodes: [
+          {
+            type: "blocks",
+            issue: { identifier: "WM-703", state: { type: "started" } },
+          },
+          {
+            type: "related",
+            issue: { identifier: "WM-701", state: { type: "started" } },
+          },
+          {
+            type: "blocks",
+            issue: { identifier: "WM-702", state: { type: "unstarted" } },
+          },
+        ],
+      };
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "dispatch-open-blockers",
+        correlationId: "dispatch-open-blockers",
+        payload: { repo: "tiered", ticket: "WM-704" },
+      });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: {
+          ...tierDispatch(),
+          fetchTicket: () => ({
+            ...tierTicket(),
+            identifier: "WM-704",
+            inverseRelations: openRelations,
+          }),
+        },
+      });
+
+      expect(outcome).toMatchObject({
+        decision: "noop",
+        reason: "ticket_blocked_by_open:WM-703,WM-702",
+        evidence: {
+          checks: { ticket_unblocked: false },
+          ticket: { openBlockers: ["WM-703", "WM-702"] },
+        },
+      });
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+
+  test("finished blockers and non-blocking relations remain dispatchable (WM-709)", () => {
+    withReposRoot(tierRepo, () => {
+      const relations = [
+        {
+          type: "blocks",
+          issue: { identifier: "WM-700", state: { type: "completed" } },
+        },
+        {
+          type: "blocks",
+          issue: { identifier: "WM-701", state: { type: "canceled" } },
+        },
+        {
+          type: "duplicate",
+          issue: { identifier: "WM-702", state: { type: "started" } },
+        },
+      ];
+      for (const inverseRelations of [undefined, { nodes: relations }]) {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "WM-704" },
+          {
+            ...tierDispatch(),
+            fetchTicket: () => ({ ...tierTicket(), inverseRelations }),
+          },
+        );
+        expect(result.ok).toBe(true);
+        expect(result.evidence.checks.ticket_unblocked).toBe(true);
+        expect(result.evidence.ticket.openBlockers).toEqual([]);
+      }
+    });
+  });
+
   test("a label tier with no routed-adapter mapping fails closed (WM-694)", () => {
     withReposRoot(tierRepo, () => {
       const missingLight = {

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -54,6 +54,7 @@ import {
   readPinManifestRequirements,
   formatOwnedPathClosureGaps,
 } from "../orchestrator/owned-paths.mjs";
+import { BLOCKING_RELATIONS_GQL } from "../orchestrator/blockers.mjs";
 
 // Every verb here is a fresh `bun` process, so nothing in module scope survives
 // between calls — and the protocol calls this constantly (claim, heartbeat
@@ -260,10 +261,11 @@ export function appendIssueDetail(currentDescription, rawDetail) {
 }
 
 // --------------------------------------------------------------- helpers ---
-const ISSUE_FIELDS = `id identifier title url description
+export const ISSUE_FIELDS = `id identifier title url description
   state{ id name type } assignee{ id name }
   team{ key } project{ name }
-  labels(first:30){ nodes{ id name } }`;
+  labels(first:30){ nodes{ id name } }
+  ${BLOCKING_RELATIONS_GQL}`;
 
 const COMMENTS_FIELDS = `id identifier title
   comments(first:50){ nodes{ id body createdAt user{ id name } } }`;

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -23,7 +23,9 @@ import {
   parsePositionalArgs,
   closureCheckMessages,
   __resetLinearReposCache,
+  ISSUE_FIELDS,
 } from "./linear.mjs";
+import { BLOCKING_RELATIONS_GQL } from "../orchestrator/blockers.mjs";
 
 const LABELS = [
   { id: "l-ready", name: "ai:agent-ready" },
@@ -144,6 +146,10 @@ test("formatTicket shows the fields the protocol acts on", () => {
   expect(text).toContain("Todo");
   expect(text).toContain("(unassigned)");
   expect(text).toContain("ai:agent-ready");
+});
+
+test("issue reads request the shared blocked-by relation fields", () => {
+  expect(ISSUE_FIELDS).toContain(BLOCKING_RELATIONS_GQL);
 });
 
 // ------------------------------------------------------------- comments ---


### PR DESCRIPTION
## Summary
- request Linear inverse blocking relations through the shared GraphQL fragment
- refuse event-runtime dispatch when `openBlockers(ticket)` reports unfinished blockers
- record blocker IDs in planner evidence and document the plan-time gate

## Verification
- `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/planner.test.mjs event-runtime/lib/dispatch.test.mjs tools/linear.test.mjs`
- `bun test`
- `bun tools/linear.mjs get WM-709 --json` includes `inverseRelations`

UX critique: skipped — backend planner/transport and documentation change; no user-facing flow

Fixes WM-709