### PR TITLE
fix(web): linkify lowercase ticket references

### DIFF
--- a/event-runtime/web/src/components/CustomCell.test.tsx
+++ b/event-runtime/web/src/components/CustomCell.test.tsx
@@ -181,21 +181,21 @@ describe("CustomCell", () => {
     });
   });
 
-  test("free-text cells linkify embedded ids and leave the rest of the text intact", async () => {
+  test("free-text cells linkify lowercase ids and leave the rest of the text intact", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
         <CustomCell
-          row={{ summary: "merged WM-642 after a UTF-8 fix" }}
+          row={{ summary: "merged wm-642 after a UTF-8 fix" }}
           path="summary"
         />,
       );
       await waitFor(() =>
         expect(
-          r.getByRole("link", { name: "WM-642" }).getAttribute("href"),
+          r.getByRole("link", { name: "wm-642" }).getAttribute("href"),
         ).toBe("#/tickets/WM-642"),
       );
       expect(r.container.textContent).toContain(
-        "merged WM-642 after a UTF-8 fix",
+        "merged wm-642 after a UTF-8 fix",
       );
       expect(r.queryByRole("link", { name: /UTF-8/ })).toBeNull();
     });

--- a/event-runtime/web/src/components/TicketHoverCard.test.tsx
+++ b/event-runtime/web/src/components/TicketHoverCard.test.tsx
@@ -155,6 +155,15 @@ describe("splitTicketRefs", () => {
     ]);
   });
 
+  test("preserves lowercase display text while canonicalising the ticket id", () => {
+    expect(splitTicketRefs("fixes wm-701", buildTicketPattern(["WM"]))).toEqual(
+      [
+        { text: "fixes ", ticket: null },
+        { text: "wm-701", ticket: "WM-701" },
+      ],
+    );
+  });
+
   test("text with no ticket stays one plain segment", () => {
     expect(
       splitTicketRefs("UTF-8 payload", buildTicketPattern(["WM"])),

--- a/event-runtime/web/src/components/TicketHoverCard.tsx
+++ b/event-runtime/web/src/components/TicketHoverCard.tsx
@@ -102,7 +102,8 @@ export function ticketTeamsFrom(
 /**
  * `\b(?:CLNT|OPS|WM)-\d{1,6}\b` for the configured teams. Longest key first so
  * a shorter prefix cannot win a partial match, and global so one pattern can
- * walk a whole string.
+ * walk a whole string. Matching is case-insensitive because ticket ids are
+ * canonicalised only after a free-text match is found.
  */
 export function buildTicketPattern(teams: readonly string[]): RegExp {
   const keys = [
@@ -115,7 +116,7 @@ export function buildTicketPattern(teams: readonly string[]): RegExp {
   const body = keys.length
     ? `\\b(?:${keys.join("|")})-\\d{1,${TICKET_REF_MAX_DIGITS}}\\b`
     : NEVER_MATCHES;
-  return new RegExp(body, "g");
+  return new RegExp(body, "gi");
 }
 
 /**
@@ -154,7 +155,10 @@ export function splitTicketRefs(
   text: string,
   pattern: RegExp,
 ): TicketSegment[] {
-  const scanner = new RegExp(pattern.source, "g");
+  const scanner = new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+  );
   const segments: TicketSegment[] = [];
   let cursor = 0;
   for (


### PR DESCRIPTION
## Summary
- match configured ticket prefixes case-insensitively in free-text cells
- preserve source casing in rendered text while canonicalising journey/hash ids to uppercase
- cover lowercase free-text linkification and canonicalisation regressions

## Verification
- `cd event-runtime/web && bun test src/components/TicketHoverCard.test.tsx src/components/CustomCell.test.tsx` — 34 pass
- `bun test` — 3018 pass, 9 skip, 0 fail
- `cd event-runtime/web && bun run build` — pass

UX critique: required — NOT-ASSESSED; the seeded UI exposed no lowercase/mixed-case free-text fixture. Browser evidence: http://127.0.0.1:7731/#/tickets/WM-100 and /tmp/wm-781-sha256-false-positive.png. The critic also found an artifact SHA-256 dead-link outside this ticket's Owned Paths; follow-up WM-873 filed.

Fixes WM-781