### PR TITLE
ui: show elapsed duration in Runs table

### DIFF
--- a/event-runtime/web/src/components/RunHoverCard.test.tsx
+++ b/event-runtime/web/src/components/RunHoverCard.test.tsx
@@ -103,6 +103,20 @@ describe("runDurationSeconds", () => {
     expect(runDurationSeconds(stubRun(), undefined, NOW_MS)).toBe(150);
   });
 
+  test("ticks an in-flight list fallback to now instead of updated_at", () => {
+    const run = stubRun({ state: "RUNNING", startedAt: T0, updated_at: T1 });
+    expect(runDurationSeconds(run, undefined, NOW_MS)).toBe(300);
+  });
+
+  test("leaves queued and proposed list fallbacks empty", () => {
+    expect(
+      runDurationSeconds(stubRun({ state: "QUEUED" }), undefined, NOW_MS),
+    ).toBeNull();
+    expect(
+      runDurationSeconds(stubRun({ state: "PROPOSED" }), undefined, NOW_MS),
+    ).toBeNull();
+  });
+
   test("is null when nothing dates the run", () => {
     const detail = stubDetail({ attempts: [] });
     const run = stubRun({ created_at: "", updated_at: "" });

--- a/event-runtime/web/src/components/RunHoverCard.tsx
+++ b/event-runtime/web/src/components/RunHoverCard.tsx
@@ -3,9 +3,9 @@
  * what set it off", without opening the detail pane and losing the list.
  *
  * The list row already knows the agent, state and attempt budget; only the
- * duration and the artifacts a run produced need the detail endpoint, so that
- * query sits behind `enabled: open` with a `staleTime`. Sweeping a pointer
- * down a hundred rows must not fetch a hundred run details.
+ * attempt-level duration and the artifacts a run produced need the detail
+ * endpoint, so that query sits behind `enabled: open` with a `staleTime`.
+ * Sweeping a pointer down a hundred rows must not fetch a hundred run details.
  *
  * The shared pieces — `CausationGlyphs`, `HoverCardAction`, `chainHref` —
  * come from `EventHoverCard`; see the note there on why they live in that file.
@@ -16,7 +16,7 @@ import { api } from "../api";
 import { resolveEntity } from "../entities";
 import { EMPTY, formatDuration } from "../format";
 import { runNodeId } from "../graph/chainModel";
-import type { RunDetail, RunListItem } from "../types";
+import type { RunDetail, RunListItem, RunState } from "../types";
 import {
   HOVER_CARD_STALE_MS,
   HoverCardAction,
@@ -25,6 +25,19 @@ import {
 } from "./EventHoverCard";
 import { HoverCard } from "./HoverCard";
 import { StateBadge, shortId } from "./ui";
+
+const IN_FLIGHT_DURATION_STATES = new Set<RunState>([
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+]);
+const TERMINAL_DURATION_STATES = new Set<RunState>([
+  "COMPLETED",
+  "REFUSED",
+  "FAILED",
+  "TIMED_OUT",
+  "CANCELLED",
+]);
 
 /**
  * Wall-clock time this run has spent executing: first attempt's start to the
@@ -56,10 +69,18 @@ export function runDurationSeconds(
     return Math.max(0, Math.round((end - Math.min(...starts)) / 1000));
   }
 
-  const created = at(run.created_at);
-  const updated = at(run.updated_at);
-  if (created === null || updated === null) return null;
-  return Math.max(0, Math.round((updated - created) / 1000));
+  if (
+    !IN_FLIGHT_DURATION_STATES.has(run.state) &&
+    !TERMINAL_DURATION_STATES.has(run.state)
+  )
+    return null;
+
+  const started = at(run.startedAt ?? run.created_at);
+  const finished = IN_FLIGHT_DURATION_STATES.has(run.state)
+    ? now
+    : at(run.updated_at);
+  if (started === null || finished === null) return null;
+  return Math.max(0, Math.round((finished - started) / 1000));
 }
 
 /** Stored outputs this run produced; the pre-`artifacts[]` shape counts as one. */

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -264,10 +264,11 @@ describe("Runs sortable columns (OPS-492)", () => {
       startedAt: "2026-08-18T12:00:30.000Z",
       updated_at: "2026-08-18T12:00:45.000Z",
     });
+    const missing = stubListItem("run_missing", "QUEUED");
 
     await withApi(
       {
-        runs: async () => ({ runs: [live, long, short] }),
+        runs: async () => ({ runs: [missing, live, long, short] }),
         status: async () => createStatusFixture(),
       },
       async () => {
@@ -278,7 +279,14 @@ describe("Runs sortable columns (OPS-492)", () => {
           Array.from(
             r.container.querySelectorAll("tbody tr td:first-child"),
           ).map((cell) => cell.getAttribute("title")),
-        ).toEqual(["run_short", "run_long", "run_live"]);
+        ).toEqual(["run_short", "run_long", "run_live", "run_missing"]);
+
+        fireEvent.click(r.getByRole("button", { name: /Duration/ }));
+        expect(
+          Array.from(
+            r.container.querySelectorAll("tbody tr td:first-child"),
+          ).map((cell) => cell.getAttribute("title")),
+        ).toEqual(["run_live", "run_long", "run_short", "run_missing"]);
       },
     );
   });
@@ -340,6 +348,9 @@ describe("Runs Duration column (WM-871)", () => {
         );
         expect(headers.indexOf("Duration")).toBe(
           headers.indexOf("Remaining") + 1,
+        );
+        expect(r.container.querySelector("table")?.style.minWidth).toBe(
+          `${headers.length * 112}px`,
         );
         expect(cellFor(r, "run_completed", "Duration").textContent).toBe(
           "2m 30s",

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1,5 +1,12 @@
 import "../test-dom";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { useState } from "react";
 import { Runs, runDrilldownFilters, statesForRunTab } from "./Runs";
@@ -28,6 +35,7 @@ afterEach(() => {
   cleanup();
   restoreApi();
   localStorage.clear();
+  setSystemTime();
 });
 
 const noop = () => {};
@@ -237,6 +245,139 @@ describe("Runs sortable columns (OPS-492)", () => {
             r.container.querySelectorAll("tbody tr td:first-child"),
           ).map((cell) => cell.getAttribute("title")),
         ).toEqual(["run_early", "run_fallback", "run_late"]);
+      },
+    );
+  });
+
+  test("Duration sorts by numeric elapsed seconds", async () => {
+    setSystemTime(new Date("2026-08-18T12:03:00.000Z"));
+    const early = "2026-08-18T12:00:00.000Z";
+    const short = stubListItem("run_short", "COMPLETED", {
+      startedAt: early,
+      updated_at: "2026-08-18T12:01:00.000Z",
+    });
+    const long = stubListItem("run_long", "COMPLETED", {
+      startedAt: early,
+      updated_at: "2026-08-18T12:02:00.000Z",
+    });
+    const live = stubListItem("run_live", "RUNNING", {
+      startedAt: "2026-08-18T12:00:30.000Z",
+      updated_at: "2026-08-18T12:00:45.000Z",
+    });
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [live, long, short] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await r.findByRole("columnheader", { name: /Duration/ });
+        fireEvent.click(r.getByRole("button", { name: /Duration/ }));
+        expect(
+          Array.from(
+            r.container.querySelectorAll("tbody tr td:first-child"),
+          ).map((cell) => cell.getAttribute("title")),
+        ).toEqual(["run_short", "run_long", "run_live"]);
+      },
+    );
+  });
+});
+
+describe("Runs Duration column (WM-871)", () => {
+  function cellFor(
+    r: ReturnType<typeof renderRuns>,
+    runId: string,
+    label: string,
+  ): HTMLTableCellElement {
+    const index = [...r.container.querySelectorAll("thead th")].findIndex(
+      (th) => (th.textContent ?? "").startsWith(label),
+    );
+    expect(index).toBeGreaterThanOrEqual(0);
+    const row = r.container
+      .querySelector(`td[title="${runId}"]`)
+      ?.closest("tr");
+    expect(row).toBeTruthy();
+    return row!.querySelectorAll("td")[index] as HTMLTableCellElement;
+  }
+
+  test("renders terminal elapsed time, ticks in-flight rows, and never fetches row details", async () => {
+    const t0 = Date.parse("2026-08-18T12:00:00.000Z");
+    setSystemTime(new Date(t0 + 150_000));
+    let detailCalls = 0;
+    const completed = stubListItem("run_completed", "COMPLETED", {
+      startedAt: new Date(t0).toISOString(),
+      created_at: new Date(t0 - 60_000).toISOString(),
+      updated_at: new Date(t0 + 150_000).toISOString(),
+    });
+    const running = stubListItem("run_running", "RUNNING", {
+      startedAt: new Date(t0).toISOString(),
+      updated_at: new Date(t0 + 30_000).toISOString(),
+    });
+    const queued = stubListItem("run_queued", "QUEUED", {
+      created_at: new Date(t0).toISOString(),
+      updated_at: new Date(t0 + 30_000).toISOString(),
+    });
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [completed, running, queued] }),
+        run: async () => {
+          detailCalls += 1;
+          return stubDetail("run_running", "RUNNING", []);
+        },
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() =>
+          expect(
+            r.container.querySelector('td[title="run_completed"]'),
+          ).toBeTruthy(),
+        );
+        const headers = [...r.container.querySelectorAll("thead th")].map(
+          (th) => th.textContent?.replace(/[↕↑↓×]/g, "").trim(),
+        );
+        expect(headers.indexOf("Duration")).toBe(
+          headers.indexOf("Remaining") + 1,
+        );
+        expect(cellFor(r, "run_completed", "Duration").textContent).toBe(
+          "2m 30s",
+        );
+        expect(cellFor(r, "run_running", "Duration").textContent).toBe(
+          "2m 30s",
+        );
+        expect(cellFor(r, "run_queued", "Duration").textContent).toBe("—");
+        expect(detailCalls).toBe(0);
+
+        setSystemTime(new Date(t0 + 152_000));
+        await waitFor(
+          () =>
+            expect(cellFor(r, "run_running", "Duration").textContent).toBe(
+              "2m 32s",
+            ),
+          { timeout: 4000 },
+        );
+        expect(detailCalls).toBe(0);
+      },
+    );
+  }, 10_000);
+
+  test("stays visible when saved options only hide another column", async () => {
+    localStorage.setItem(
+      "evrt-display-runs",
+      JSON.stringify({ hiddenColumns: ["model"] }),
+    );
+    await withApi(
+      {
+        runs: async () => ({ runs: [stubListItem("run_saved", "COMPLETED")] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        expect(
+          await r.findByRole("columnheader", { name: /Duration/ }),
+        ).toBeTruthy();
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -36,7 +36,7 @@ import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import { AgentHoverCard } from "../components/AgentHoverCard";
 import { CausationGlyphs, chainHref } from "../components/EventHoverCard";
-import { RunHoverCard } from "../components/RunHoverCard";
+import { RunHoverCard, runDurationSeconds } from "../components/RunHoverCard";
 import { chainKeyOfEvent, runNodeId } from "../graph/chainModel";
 import {
   ApprovalRiskDetails,
@@ -257,6 +257,12 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
       get: remainingDeadline,
       column: "remaining",
     },
+    {
+      key: "duration",
+      label: "Duration",
+      get: (r) => runDurationSeconds(r, undefined, Date.now()) ?? -1,
+      column: "duration",
+    },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
     {
       key: "adapter",
@@ -302,6 +308,7 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
     { key: "run", label: "Run", always: true },
     { key: "state", label: "State" },
     { key: "remaining", label: "Remaining" },
+    { key: "duration", label: "Duration" },
     { key: "agent", label: "Agent" },
     { key: "adapter", label: "Adapter" },
     { key: "model", label: "Model" },
@@ -391,6 +398,11 @@ function RemainingCell({ r, now }: { r: RunListItem; now: number }) {
       )}
     </span>
   );
+}
+
+function DurationCell({ r, now }: { r: RunListItem; now: number }) {
+  const duration = runDurationSeconds(r, undefined, now);
+  return <span>{duration === null ? EMPTY : formatDuration(duration)}</span>;
 }
 
 /**
@@ -638,8 +650,19 @@ export function Runs({
       groups: RUNS_DISPLAY.groups.map((g) =>
         g.key === "state" ? { ...g, order: statesForRunTab(tab) } : g,
       ),
+      // Every row sorts against the same clock it renders against. Calling
+      // Date.now() per getter could straddle a second boundary mid-sort.
+      sorts: RUNS_DISPLAY.sorts.map((s) =>
+        s.key === "duration"
+          ? {
+              ...s,
+              get: (r: RunListItem) =>
+                runDurationSeconds(r, undefined, now) ?? -1,
+            }
+          : s,
+      ),
     }),
-    [tab],
+    [tab, now],
   );
   const [display, setDisplay] = useDisplayOptions(displayConfig);
   const sections = useMemo(
@@ -767,9 +790,15 @@ export function Runs({
   // pane and the unselected list retain every configured column.
   const listCols = sel
     ? cols.filter((c) =>
-        ["run", "state", "remaining", "reason", "origin", "updated"].includes(
-          c.key,
-        ),
+        [
+          "run",
+          "state",
+          "remaining",
+          "duration",
+          "reason",
+          "origin",
+          "updated",
+        ].includes(c.key),
       )
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
@@ -1275,6 +1304,11 @@ export function Runs({
                       ) : (
                         ""
                       )}
+                    </td>
+                  )}
+                  {show.has("duration") && (
+                    <td className="max-w-24 overflow-hidden whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                      <DurationCell r={r} now={now} />
                     </td>
                   )}
                   {show.has("agent") && (

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -405,6 +405,19 @@ function DurationCell({ r, now }: { r: RunListItem; now: number }) {
   return <span>{duration === null ? EMPTY : formatDuration(duration)}</span>;
 }
 
+/** Missing durations are not zero-length runs; keep them behind measured rows. */
+function measuredDurationsFirst(rows: RunListItem[], now: number) {
+  const measured: RunListItem[] = [];
+  const missing: RunListItem[] = [];
+  for (const row of rows) {
+    (runDurationSeconds(row, undefined, now) === null
+      ? missing
+      : measured
+    ).push(row);
+  }
+  return [...measured, ...missing];
+}
+
 /**
  * The sentence the row's `↳` / `→ N` arrows stand for (WM-702). The Run column
  * has room for the glyphs and nothing else; this is where they say what they
@@ -665,10 +678,18 @@ export function Runs({
     [tab, now],
   );
   const [display, setDisplay] = useDisplayOptions(displayConfig);
-  const sections = useMemo(
-    () => buildSections(visible, displayConfig, display),
-    [visible, displayConfig, display],
-  );
+  const sections = useMemo(() => {
+    const built = buildSections(visible, displayConfig, display);
+    if (display.sortBy !== "duration") return built;
+    return built.map((section) => ({
+      ...section,
+      rows: measuredDurationsFirst(section.rows, now),
+      subsections: section.subsections?.map((subsection) => ({
+        ...subsection,
+        rows: measuredDurationsFirst(subsection.rows, now),
+      })),
+    }));
+  }, [visible, displayConfig, display, now]);
   const flat = useMemo(
     () => flattenSections(sections, display.collapsed),
     [sections, display.collapsed],
@@ -1207,7 +1228,10 @@ export function Runs({
           </>
         }
       >
-        <Table className="w-full table-fixed border-separate border-spacing-0">
+        <Table
+          className="w-full table-fixed border-separate border-spacing-0"
+          style={{ minWidth: `${listCols.length * 112}px` }}
+        >
           <thead>
             <tr className="text-left">
               {listCols.map((c) => {


### PR DESCRIPTION
## Summary
- add a default-visible, sortable Duration column beside Remaining
- tick in-flight elapsed time from list timestamps without per-row detail fetches
- preserve readable table columns on narrow viewports and keep missing durations last when sorting

## Verification
- `bun test --timeout 20000 --max-concurrency=4 event-runtime/web/src/views/Runs.test.tsx event-runtime/web/src/components/RunHoverCard.test.tsx` (55 pass)
- `bun test` (3022 pass, 9 skip)
- `cd event-runtime/web && bun run build`
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`

UX critique: required — SHIP after 2 rounds; observed http://127.0.0.1:7707/#/runs; responsive evidence `/tmp/WM-871-round2-780px.png`.

Fixes WM-871