### PR TITLE
fix(notify): stored inbox item with failed projection is a warning, not exit 12 (WM-825)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -194,7 +194,18 @@ case "$cmd" in
           });
           if (!response.ok) process.exit(10);
           const body = await response.json();
-          process.exit(body?.delivery?.ok === false ? 12 : 0);
+          // The inbox item is the durable record; the external projection
+          // (notify.py) is best-effort. A stored item with a failed projection
+          // is a warning, not a failed run (WM-825): merge-notify was FAILED
+          // on every escalation on hosts without ~/Develop/hdkiller.
+          if (body?.delivery?.ok === false) {
+            if (body?.item?.id) {
+              console.error(`notify: inbox item ${body.item.id} stored; external projection failed: ${body.delivery.error ?? "exit " + body.delivery.exitCode}`);
+              process.exit(0);
+            }
+            process.exit(12);
+          }
+          process.exit(0);
         } catch {
           process.exit(11);
         }


### PR DESCRIPTION
`merge-notify@1` has FAILED with `agent_exit_12` on every escalation (52+ times on 2026-08-18/19) because `factory notify` exits 12 when the runtime's external projection (`~/Develop/hdkiller/scripts/notify.py`) fails — even though the inbox item was created and is queryable. Now: item stored + projection failed → stderr warning, exit 0; exit 12 only when the runtime rejected the item. Verified on the runner host: `factory notify …` now exits 0 with the warning. Item 1 of WM-825 (items 2–3: runtime marks `delivery.skipped: script_missing`, doctor line — follow-up).