### PR TITLE
fix(worker): merge-fix competing-run check counts only admitted runs

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2000,10 +2000,15 @@ export async function executeClaimed(
             (() =>
               db
                 .query(
+                  // A competing run is one that is actually admitted to execute.
+                  // PROPOSED rows (unapproved or expired proposals) and FAILED
+                  // runs are not competing: counting them refused every later
+                  // merge-fix for the ticket forever (WM-747/#663 on 2026-08-19:
+                  // two expired PROPOSED rows blocked six rounds of fixes).
                   `SELECT run_id AS runId, state
                FROM runs
               WHERE run_id <> ?
-                AND state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
+                AND state IN ('QUEUED','LEASED','RUNNING','VERIFYING')
                 AND json_extract(spec_json, '$.input.repo') = ?
                 AND json_extract(spec_json, '$.input.ticket') = ?
               ORDER BY created_at, run_id`,


### PR DESCRIPTION
`merge_fix_run_active` refused every merge-fix for PR #663 (WM-747) on every tick this morning: the worker's competing-run query excluded only COMPLETED/REFUSED/TIMED_OUT/CANCELLED, so two **PROPOSED** rows (expired, never-approved proposals from 2026-08-18 20:04/20:33) counted as active forever; FAILED runs would too. Competing now = QUEUED/LEASED/RUNNING/VERIFYING. worker/merge/planner tests 203/203.