### PR TITLE
ops(event-runtime): route dispatch@1 to the cursor adapter (Grok 4.6)

### DIFF
--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -157,7 +157,7 @@
   },
   "factory.dispatch.requested": {
     "agent": "dispatch@1",
-    "adapter": "pi",
+    "adapter": "cursor",
     "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -496,7 +496,8 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     const summary = await runOnce(
       db,
       registry,
-      { pi: dispatchFake },
+      // dispatch@1 rides cursor (WM-215/WM-694).
+      { cursor: dispatchFake },
       {
         workspacesRoot: workspaces,
         owner: "w-test",
@@ -617,7 +618,8 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     const summary = await runOnce(
       db,
       registry,
-      { pi: crashing },
+      // dispatch@1 rides cursor (WM-215/WM-694).
+      { cursor: crashing },
       {
         workspacesRoot: workspaces,
         owner: "w-test",

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -798,7 +798,7 @@ describe("planEvent worktree gate (WM-108)", () => {
           labels: [],
           source: "definition",
           tier: "strong",
-          model: "openai-codex/gpt-5.6-sol",
+          model: "cursor-grok-4.6-high",
         },
         {
           eventId: "tier-label",
@@ -806,7 +806,7 @@ describe("planEvent worktree gate (WM-108)", () => {
           labels: ["tier:light"],
           source: "label",
           tier: "light",
-          model: "openai-codex/gpt-5.6-luna",
+          model: "cursor-grok-4.6-low-fast",
         },
         {
           eventId: "tier-payload",
@@ -818,7 +818,7 @@ describe("planEvent worktree gate (WM-108)", () => {
           labels: ["tier:light"],
           source: "payload",
           tier: "standard",
-          model: "openai-codex/gpt-5.6-terra",
+          model: "cursor-grok-4.6-high",
         },
       ];
 
@@ -872,9 +872,9 @@ describe("planEvent worktree gate (WM-108)", () => {
         ...registry,
         modelTiers: {
           ...registry.modelTiers,
-          pi: {
-            strong: registry.modelTiers.pi.strong,
-            standard: registry.modelTiers.pi.standard,
+          cursor: {
+            strong: registry.modelTiers.cursor.strong,
+            standard: registry.modelTiers.cursor.standard,
           },
         },
       };
@@ -890,7 +890,7 @@ describe("planEvent worktree gate (WM-108)", () => {
           now: NOW,
           dispatch: tierDispatch(["tier:light"]),
         }),
-      ).toThrow(/model_tier "light" has no mapping for adapter "pi"/);
+      ).toThrow(/model_tier "light" has no mapping for adapter "cursor"/);
       expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
     });
   });
@@ -1591,7 +1591,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"pi","agent":"dispatch@1","capabilities":["linear:write","repo:write","github:write"],"idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"openai-codex/gpt-5.6-sol","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["linear:write","repo:write","github:write"],"idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -144,8 +144,9 @@ describe("registry", () => {
     // Regenerated (triage on agy): triage-scan adapter pi→agy; event-types.json is a registry input.
     // Regenerated (work-scan advisory overlap, WM-677): agent def is a registry input.
     // Regenerated (merge-scan fix.ownedPaths rule): agent def is a registry input.
+    // Regenerated (dispatch on cursor): dispatch@1 adapter pi→cursor; event-types.json is a registry input.
     const expected =
-      "sha256:56652ec7a003bb02b21408f71e7449403ffcefc90cf4145d81cb364d89a30be6";
+      "sha256:e01433ee54ed398681bc34fec0cbf791decc28674f1b9bee612845c584bdbf32";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -182,7 +182,7 @@ async function dispatchTo(outcome, eventId, ticket) {
   const summary = await runOnce(
     db,
     registry,
-    { pi: dispatchFake(outcome) },
+    { cursor: dispatchFake(outcome) },
     {
       workspacesRoot: workspaces,
       owner: "w-test",

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -365,7 +365,10 @@ function harness() {
   const dir = tmpDir("evrt-work-");
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = tmpDir("evrt-work-ws-");
-  const adapters = { pi: workFake };
+  // work-scan@1 rides pi; dispatch@1 rides cursor (WM-215/WM-694) — the fake
+  // dispatches on spec.outputContract, not the adapter key, so both routes
+  // share it.
+  const adapters = { pi: workFake, cursor: workFake };
   const workerOpts = {
     workspacesRoot: workspaces,
     owner: "w-test",
@@ -430,16 +433,16 @@ describe("work-scan registration (WM-110)", () => {
     });
   });
 
-  // WM-215: pi is the default harness, so the one mutating LLM agent in the
-  // registry now rides it. The §14 admission rule that lets a mutating LLM
-  // agent exist at all is the tier-2 worktree carve-out (WM-108, generalized
-  // to any adapter by OPS-296) — assert it holds for dispatch@1 on pi, since
-  // a regression here would refuse the whole registry at load, not just this
-  // route.
-  test("dispatch@1 is admissible as a mutating pi agent over a tier-2 worktree (WM-215)", () => {
+  // WM-215/WM-694: dispatch@1 rides cursor (Grok 4.6) since 2026-08-19
+  // (operator decision to spare codex quota — see WM-215 test above). The
+  // §14 admission rule that lets a mutating LLM agent exist at all is the
+  // tier-2 worktree carve-out (WM-108, generalized to any adapter by
+  // OPS-296) — assert it holds for dispatch@1 on cursor, since a regression
+  // here would refuse the whole registry at load, not just this route.
+  test("dispatch@1 is admissible as a mutating cursor agent over a tier-2 worktree (WM-215)", () => {
     expect(registry.eventTypes["factory.dispatch.requested"]).toEqual({
       agent: "dispatch@1",
-      adapter: "pi",
+      adapter: "cursor",
       idempotencyScope: ["inputHash"],
       proposalTtlSeconds: 1800,
     });
@@ -448,11 +451,11 @@ describe("work-scan registration (WM-110)", () => {
     expect(def.workspace.type).toBe("worktree");
     // The registry loaded at module scope: loadRegistry() already ran the §14
     // admission check and the WM-135 fail-closed model resolution over this
-    // route, so a pi+worktree+mutating definition is admitted and its strong
-    // tier resolves against models.pi.
+    // route, so a cursor+worktree+mutating definition is admitted and its
+    // strong tier resolves against models.cursor.
     expect(def.model_tier).toBe("strong");
-    expect(resolveModel(def, "pi", registry.modelTiers)).toBe(
-      registry.modelTiers.pi.strong,
+    expect(resolveModel(def, "cursor", registry.modelTiers)).toBe(
+      registry.modelTiers.cursor.strong,
     );
   });
 

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -476,6 +476,19 @@ describe("work-scan registration (WM-110)", () => {
       "merge-scan@2",
       "triage-scan@1",
     ]);
+    // dispatch@1 rides cursor (Grok 4.6) since 2026-08-19 — operator decision to
+    // spare codex quota; cursor-smoke rides cursor by definition.
+    expect([...byAdapter.cursor].sort()).toEqual([
+      "cursor-smoke@1",
+      "dispatch@1",
+    ]);
+    expect(
+      resolveModel(
+        registry.agents.get("dispatch@1"),
+        "cursor",
+        registry.modelTiers,
+      ),
+    ).toBe(registry.modelTiers.cursor.standard);
     for (const ref of ["merge-fix@1", "merge-scan@2", "triage-scan@1"]) {
       const resolved = resolveModel(
         registry.agents.get(ref),


### PR DESCRIPTION
Operator decision 2026-08-19 to spare codex quota. cursor-smoke verified on this host today (run_47da4861 → {"echo":"hello cursor"}).

- event-types adapter pi→cursor
- tests updated, registry digest regenerated
- restart the stack after merge; new dispatches will run on cursor