### PR TITLE
fix(web): singularize artifact line count (WM-750)

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -349,6 +349,28 @@ describe("Artifacts inventory (WM-207)", () => {
 describe("Artifact rows inspect on click, download on demand (WM-699)", () => {
   const SHA_A = "a".repeat(64);
 
+  test.each([
+    ["single-line", "line one", "1 line"],
+    ["multi-line", "line one\nline two", "2 lines"],
+  ])(
+    "labels a %s preview with the correct line-count grammar",
+    async (_, raw, label) => {
+      globalThis.fetch = mock(
+        async () => new Response(raw, { status: 200 }),
+      ) as unknown as typeof fetch;
+      window.location.hash = `#/artifacts/${SHA_A}`;
+
+      const view = renderArtifacts();
+      await view.findByRole("region", { name: "Artifact content" });
+
+      expect(
+        within(
+          view.getByRole("region", { name: "Artifact preview" }),
+        ).getByText(label),
+      ).toBeTruthy();
+    },
+  );
+
   test("opening and closing the inspector preserves project context (WM-748)", async () => {
     globalThis.fetch = mock(
       async () => new Response("line one", { status: 200 }),

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1035,7 +1035,7 @@ export function Artifacts({
                     : binary
                       ? "not text"
                       : matchCount === null
-                        ? `${previewLines.length.toLocaleString()} lines`
+                        ? `${previewLines.length.toLocaleString()} ${previewLines.length === 1 ? "line" : "lines"}`
                         : `${matchCount.toLocaleString()} matching lines`}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- singularize the artifact preview metadata when exactly one line is shown
- retain plural labels for multi-line previews
- add regression coverage for both one-line and multi-line counts

## Verification
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx`
- `bun test`
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- `cd event-runtime/web && bun run build`
- `factory security`

UX critique: skipped — isolated copy grammar correction with no user flow or interaction change

Fixes WM-750