### PR TITLE
docs(oss): add community health and open-core guides (WM-796)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a reproducible problem in Factory
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Factory. For vulnerabilities, stop here and follow SECURITY.md instead of filing a public issue.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and pull requests for this problem.
+          required: true
+        - label: This report does not contain credentials, personal data, or client data.
+          required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it?
+      description: Provide the smallest deterministic sequence, including commands and inputs with sensitive values removed.
+      placeholder: |
+        1. Run ...
+        2. Configure ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Factory commit or version
+      placeholder: Commit SHA or release version
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, architecture, Bun version, agent harness and version, and relevant configuration with secrets removed.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Logs or additional context
+      description: Paste only the minimum useful, redacted output. Attachments are welcome.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/watt-mind/factory/security/policy
+    about: Report vulnerabilities privately by following the security policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a focused improvement to Factory
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and pull requests for this proposal.
+          required: true
+        - label: I am describing the problem before prescribing an implementation.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Who encounters this problem, in what workflow, and what does it cost today?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable behavior and how a maintainer could verify it.
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: Optional. Include alternatives and trade-offs if you have explored them.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Agent and harness packaging
+        - Orchestration and dispatch
+        - Event runtime
+        - Web control plane
+        - Developer experience and documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Link examples, screenshots, prior art, or related issues. Do not include secrets or private data.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Summary
+
+<!-- What changed, and why is this the smallest useful change? -->
+
+## Related issue
+
+<!-- Use "Fixes #123" for a public issue or "Fixes WM-123" for an internal ticket. -->
+
+Fixes
+
+## Verification
+
+<!-- List the exact commands run and summarize their results. -->
+
+```text
+
+```
+
+## Risk and impact
+
+- [ ] This change is narrowly scoped to the linked issue.
+- [ ] I added or updated tests for behavior changes, or explained why no test is needed.
+- [ ] I updated documentation for user- or operator-visible behavior.
+- [ ] I regenerated emitted files when changing `shared/` and ran `bun run check`.
+- [ ] I considered security and privacy impact and did not include credentials or private data.
+- [ ] I identified compatibility, migration, or rollback concerns below.
+
+<!-- Describe reviewer focus and any unchecked item. Write "None known" when appropriate. -->
+
+## Screenshots
+
+<!-- Required for user-interface changes; remove this section otherwise. -->
+
+## Contributor statement
+
+- [ ] I have read and agree to follow `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+- [ ] I have the right to submit this work under Apache License 2.0.
+- [ ] I have completed a Contributor License Agreement if a maintainer or check requested one.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[laszlo@watt-mind.com](mailto:laszlo@watt-mind.com). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Factory
+
+Thank you for helping improve Factory. Contributions may include bug reports,
+documentation, tests, fixes, and focused feature proposals.
+
+## Before you start
+
+- Search the existing GitHub issues and pull requests before opening a new one.
+- Use the appropriate issue template. Please report vulnerabilities privately
+  as described in [SECURITY.md](SECURITY.md), not in a public issue.
+- For a substantial change, open an issue first so maintainers can confirm the
+  design and whether the work belongs in the Apache-licensed core or at the
+  [`ee/`](ee/README.md) boundary.
+- Keep one pull request focused on one issue. Unrelated discoveries should be
+  reported separately.
+
+All participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development setup
+
+Factory requires Git and [Bun](https://bun.sh/) 1.3 or newer.
+
+```bash
+git clone https://github.com/watt-mind/factory.git
+cd factory
+bun install --frozen-lockfile
+cd event-runtime/web && bun install --frozen-lockfile && cd ../..
+```
+
+See [SETUP.md](SETUP.md) for optional local harness links and instructions for
+running the event runtime. Do not commit credentials, local runtime state,
+worktrees, generated launch-agent files, or agent transcripts.
+
+## Make a change
+
+1. Branch from `develop`.
+2. Add or update tests for behavior changes. A regression test should fail
+   before the fix and pass afterward.
+3. Edit source files rather than generated copies. In particular, `shared/` is
+   the source of truth for content emitted into `plugins/` and `dist/`; run
+   `bun build/emit.mjs` after changing it.
+4. Keep changes narrowly scoped and update user or operator documentation when
+   behavior changes.
+
+## Test and format
+
+Run the checks relevant to your change, then run the complete suite before
+requesting review:
+
+```bash
+bun run format
+bun run lint
+bun run check
+bun test
+```
+
+Changes under `event-runtime/web/` should also pass:
+
+```bash
+cd event-runtime/web
+bun run build
+```
+
+The repository uses Prettier with the checked-in `.prettierrc` and ESLint with
+`eslint.config.mjs`. Do not disable rules, weaken tests, or update generated
+files by hand to make a check pass. If a check appears wrong, describe the
+failure in the pull request instead.
+
+## Commit conventions
+
+Use a Conventional Commit-style subject:
+
+```text
+type(scope): concise imperative summary (WM-123)
+```
+
+Common types include `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`,
+and `build`. Repository work tracked internally must include its assigned
+ticket ID. A maintainer can provide that ID before a larger contribution is
+started; for a small external contribution that has no internal ticket, the
+commit hook documents the deliberate `FACTORY_NO_TICKET=1` escape hatch.
+
+Keep the subject focused, explain motivation and trade-offs in the body when
+needed, and avoid mixing mechanical formatting with unrelated behavior.
+
+## Pull requests
+
+- Target `develop`, not `main`.
+- Complete the pull request template and link the issue the change resolves.
+- Include the exact commands you ran and any relevant output or screenshots.
+- Call out security impact, compatibility concerns, and follow-up work.
+- Expect review feedback. Approval and passing automation are both required;
+  an author does not merge their own pull request.
+
+## Licensing and CLA
+
+By submitting a contribution, you agree that it is licensed under the
+[Apache License 2.0](LICENSE) and that you have the right to provide it under
+those terms.
+
+Watt Mind may require a Contributor License Agreement (CLA) for a contribution.
+When a CLA applies, a maintainer or automated check will provide the exact
+agreement and signing instructions, and the contribution cannot be merged
+until the agreement is complete. Do not submit employer-owned or third-party
+material unless you are authorized to license it.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ bun run link-repos           # symlink plugins/core/commands/ into every repo in
 >
 > So the non-negotiables live in `shared/floor.md` and are committed into each repo's **`AGENTS.md`**, which every harness reads and which travels with the checkout.
 
+## Open-core boundary
+
+Factory's orchestration, event runtime, shared agent workflows, harness
+packaging, and public extension contracts form the open core. The current
+repository is licensed under Apache License 2.0 and is intended to remain
+useful, buildable, and testable without private services or unpublished code.
+
+[`ee/`](ee/README.md) reserves an explicit seam for possible enterprise-only
+extensions. Core code may expose generic contracts that enterprise extensions
+implement, but it must not import or depend on enterprise implementations. The
+directory currently contains documentation only. If separately licensed code
+is added there in the future, it must carry explicit terms; placement under
+`ee/` alone does not override the repository license.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change, especially one
+that may cross this boundary.
+
 **Why `--check` is the important half.** The failure this repo exists to prevent is a rule living in one harness's file and nowhere else — coach-wattz carries "NEVER `prisma db push`" only in `GEMINI.md`, invisible to Claude. Four generated copies are only safer than four hand-written ones if CI proves they still match their source. If the check fails, move the rule into `shared/`; never edit the generated file.
 
 ## Using it from a product repo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not open a public GitHub issue for a suspected vulnerability. Email
+[laszlo@watt-mind.com](mailto:laszlo@watt-mind.com) with the subject
+`[factory security] <short summary>`.
+
+Include, where possible:
+
+- the affected commit, version, component, and configuration;
+- a minimal reproduction or proof of concept;
+- the impact and the trust boundary that is crossed;
+- whether the issue is already public; and
+- a safe way to contact you for follow-up.
+
+Do not include live credentials, personal data, or client data. Use synthetic
+data and the least destructive reproduction possible. If encrypted disclosure
+is necessary, ask for a current public key in an initial message.
+
+We aim to acknowledge reports within three business days and provide an initial
+assessment within seven business days. Remediation timing depends on severity
+and operational risk. We will keep the reporter informed when those targets
+cannot be met.
+
+## Supported versions
+
+Security fixes are made on the repository's active development branch and then
+included in the next release. Older commits and unmaintained forks are not
+supported. If you are unsure whether a deployment is affected, include its
+commit SHA in the report.
+
+## Autonomous-agent threat model
+
+Factory orchestrates coding agents and gives some processes access to source
+trees, command execution, issue trackers, and source-control APIs. Treat model
+output and all text an agent reads—including tickets, repository files, tool
+output, and web content—as untrusted input. An agent's instruction or claim is
+not authorization; authorization comes from the surrounding policy, scoped
+credentials, approval gates, and independently observed checks.
+
+Reports are particularly valuable when untrusted input can:
+
+- execute commands or access files outside the declared worktree or owned
+  paths;
+- read, disclose, or persist credentials or data that the task did not require;
+- cross one agent's, repository's, tenant's, or run's isolation boundary;
+- bypass claim fencing, review, human-approval, or protected-operation gates;
+- forge or tamper with run state, verification evidence, receipts, or audit
+  history;
+- inject shell arguments, paths, webhook data, artifacts, or dependency content
+  in a way that crosses a privilege boundary; or
+- escape an enabled sandbox or obtain capabilities not declared for the run.
+
+The security boundary does **not** assume that an autonomous model is reliable,
+truthful, prompt-injection resistant, or able to judge its own output. The
+system must remain safe when the model is mistaken or adversarial. Reports that
+only demonstrate poor suggestions, hallucinations, or policy-compliant actions
+performed with credentials and approval explicitly granted to the operator are
+normally product-quality issues rather than vulnerabilities. A model failure
+that crosses one of the boundaries above is a security issue.
+
+## Disclosure policy
+
+Please allow us a reasonable opportunity to investigate and remediate before
+publishing details. We prefer coordinated disclosure and will work with you on
+a publication date, credit, and the level of technical detail. As a default,
+we target disclosure within 90 days of a validated report, sooner when a fix is
+available and users have had time to update, or later by mutual agreement when
+disclosure would create disproportionate risk.
+
+We ask researchers to act in good faith: avoid privacy violations, service
+degradation, persistence, lateral movement, and access beyond what is necessary
+to demonstrate the issue. We will not pursue action against good-faith research
+that follows this policy.

--- a/ee/README.md
+++ b/ee/README.md
@@ -1,0 +1,26 @@
+# Enterprise extension boundary
+
+The `ee/` directory is the reserved seam for enterprise-only extensions to
+Factory's Apache-licensed core. It documents an architectural and licensing
+boundary; no enterprise implementation is present today.
+
+## Boundary rules
+
+- The core must remain useful, buildable, and testable without `ee/`.
+- Core code must not import unpublished enterprise code or require private
+  services, credentials, or artifacts to pass its standard checks.
+- Shared contracts and extension points belong in the core. An enterprise
+  implementation may depend on those contracts, not the reverse.
+- A change that affects both sides should keep generic behavior in the core and
+  isolate only enterprise-specific policy or integration in `ee/`.
+- Do not use this directory to hide a generally useful bug fix or to duplicate
+  the core as a long-lived fork.
+
+All files currently in this repository, including this document, are licensed
+under the repository's [Apache License 2.0](../LICENSE). If separately licensed
+enterprise source is added in the future, its files must carry an explicit
+license notice and the applicable terms must be documented here. The directory
+name alone does not change a file's license.
+
+Contributors should open an issue before proposing work for this boundary so
+maintainers can confirm placement and licensing expectations.


### PR DESCRIPTION
## Summary

- add contribution, security, and Contributor Covenant community health documents
- add structured bug/feature issue forms and a pull request checklist
- document the Apache-licensed core and reserved `ee/` enterprise extension seam

## Verification

- `test -s CONTRIBUTING.md && test -s SECURITY.md && test -s CODE_OF_CONDUCT.md && test -s ee/README.md && bun run check` — pass; 90 generated files match
- `bun test` — pass; 3,039 passed, 9 skipped, 0 failed
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` — pass; 1,155 passed, 9 skipped, 0 failed; generated tree matches

UX critique: skipped — documentation and repository community templates have no user-facing application flow.

Fixes WM-796