### PR TITLE
fix(event-runtime-web): add Enter/Cmd+Enter hotkey and shortcut hint to submit decisions in DecisionCard (WM-886)

### DIFF
--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -347,4 +347,126 @@ describe("DecisionCard", () => {
     expect(view.getByText("auto:proposal_closed")).toBeTruthy();
     expect(view.queryByRole("button", { name: "Retry" })).toBeNull();
   });
+
+  test("submits with Enter when valid, ignores plain Enter in textarea, and submits with Cmd+Enter/Ctrl+Enter from anywhere", async () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+
+    // Negative test: Enter with no option selected does nothing
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    expect(apiCalls.decide).not.toHaveBeenCalled();
+
+    // Select option 1 (Authorise, which requires paths + confirm)
+    fireEvent.keyDown(document.body, { key: "1" });
+
+    // Negative test: Enter with invalid form does nothing
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    expect(apiCalls.decide).not.toHaveBeenCalled();
+
+    // Fill required fields
+    fireEvent.click(view.getByLabelText("event-runtime/lib/adapters/pi.mjs"));
+    fireEvent.click(
+      view.getByLabelText(/I understand this changes secret handling/),
+    );
+
+    // Focus textarea and press plain Enter - should NOT submit (multiline entry)
+    const textarea = view.getByLabelText(
+      "Anything I should know before I start",
+    );
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(apiCalls.decide).not.toHaveBeenCalled();
+
+    // Press Cmd+Enter inside textarea - SHOULD submit
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    await waitFor(() => expect(apiCalls.decide).toHaveBeenCalledTimes(1));
+    expect(apiCalls.decide).toHaveBeenCalledWith("inbox_decision", {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "authorise",
+      fields: { paths: ["pi"], confirm: true },
+    });
+  });
+
+  test("submits with plain Enter from anywhere when option has no extra required fields", async () => {
+    render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+
+    // Select option 2 (Send back to Triage, which has no required fields)
+    fireEvent.keyDown(document.body, { key: "2" });
+
+    // Plain Enter submits
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    await waitFor(() => expect(apiCalls.decide).toHaveBeenCalledTimes(1));
+    expect(apiCalls.decide).toHaveBeenCalledWith("inbox_decision", {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "triage",
+      fields: {},
+    });
+  });
+
+  test("Ctrl+Enter submits when connected, and ignores shortcuts when disconnected", async () => {
+    const disconnectedView = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        connected={false}
+        apiCalls={apiCalls}
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "2" });
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+    expect(apiCalls.decide).not.toHaveBeenCalled();
+
+    disconnectedView.unmount();
+
+    render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        connected={true}
+        apiCalls={apiCalls}
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "2" });
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+    await waitFor(() => expect(apiCalls.decide).toHaveBeenCalledTimes(1));
+  });
+
+  test("displays shortcut hint on submit button when an option is selected", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_decision"
+        request={request}
+        apiCalls={apiCalls}
+      />,
+    );
+
+    const submitBtnBefore = view.getByRole("button", {
+      name: "Choose an option",
+    });
+    expect(submitBtnBefore.querySelector(".mono")).toBeNull();
+
+    // Select option 2
+    fireEvent.keyDown(document.body, { key: "2" });
+
+    const submitBtnAfter = view.getByRole("button", {
+      name: "Send back to Triage",
+    });
+    const hint = submitBtnAfter.querySelector(".mono");
+    expect(hint).toBeTruthy();
+    expect(hint?.textContent).toBe("↵");
+  });
 });

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { keyGuard } from "../hooks";
+import { keyGuard, modal } from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
   ApiError,
@@ -192,16 +192,43 @@ export function DecisionCard({
   const update = (id: string, value: unknown) =>
     setValues((previous) => ({ ...previous, [id]: value }));
 
-  // While an undecided card is on screen the number keys 1–6 pick its options
-  // from anywhere in the view — the operator arrives via the list row, not by
-  // focusing the card. Capture phase on window so the Inbox status-tab
-  // binding (bubble phase on window) never sees them; text fields, modifiers
-  // and the `g` prefix still win.
+  // While an undecided card is on screen:
+  // - Number keys 1–6 pick options from anywhere in the view (when not editing an input).
+  // - Enter (outside multiline textarea) or Cmd+Enter / Ctrl+Enter submits the decision when valid.
+  // Capture phase on window so the Inbox status-tab binding (bubble phase on window) never sees them;
+  // text fields, modifiers and the `g` prefix still win for single-key number shortcuts.
   const undecided = !currentResponse;
   useEffect(() => {
     if (!undecided) return;
     function onKey(event: KeyboardEvent) {
-      if (keyGuard(event) || goPrefixActive()) return;
+      if (modal.depth > 0 || goPrefixActive()) return;
+
+      const isModEnter =
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        event.key === "Enter";
+      const isPlainEnter =
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key === "Enter";
+
+      if (isModEnter || isPlainEnter) {
+        const target = event.target as HTMLElement | null;
+        const isTextarea = Boolean(
+          target?.closest("textarea, [contenteditable='true']"),
+        );
+        if (isPlainEnter && isTextarea) return;
+        if (!selected || invalidReason !== null || pending || !connected)
+          return;
+        event.preventDefault();
+        event.stopPropagation();
+        void submit();
+        return;
+      }
+
+      if (keyGuard(event)) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const number = Number(event.key);
       if (number < 1 || number > 6 || !options[number - 1]) return;
@@ -213,7 +240,16 @@ export function DecisionCard({
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [undecided, options]);
+  }, [
+    undecided,
+    options,
+    selected,
+    invalidReason,
+    pending,
+    connected,
+    currentRequest,
+    values,
+  ]);
 
   if (currentResponse) {
     if ("superseded" in currentResponse) {
@@ -409,12 +445,21 @@ export function DecisionCard({
           disabled={!connected || pending || invalidReason !== null}
           onClick={() => void submit()}
         >
-          {pending
-            ? "Submitting…"
-            : selected
-              ? currentRequest.options.find((option) => option.id === selected)
+          {pending ? (
+            "Submitting…"
+          ) : selected ? (
+            <>
+              {
+                currentRequest.options.find((option) => option.id === selected)
                   ?.label
-              : "Choose an option"}
+              }
+              <span className="mono ml-1 text-xs opacity-75" aria-hidden="true">
+                ↵
+              </span>
+            </>
+          ) : (
+            "Choose an option"
+          )}
         </Button>
         {invalidReason && (
           <span className="text-[11px] text-(--text-faint)" role="status">


### PR DESCRIPTION
## Summary
- Adds `Enter` and `Cmd+Enter` / `Ctrl+Enter` keyboard shortcuts in `DecisionCard.tsx` to submit selected decisions when form validation passes and connected.
- In multiline textareas, plain `Enter` inserts newlines as usual while `Cmd+Enter` / `Ctrl+Enter` submits.
- Displays a visual shortcut hint (`↵`) in the submit button when an option is selected.
- Adds comprehensive unit tests covering keyboard submission, invalid state guards, textarea behavior, connection status, and visual shortcut hint rendering in `DecisionCard.test.tsx`.

Fixes WM-886