### PR TITLE
ui-ux(event-runtime-web): add missing keyboard shortcuts and hints across Run, Chain, Event, and Detail views (WM-875)

### DIFF
--- a/event-runtime/web/src/components/ShortcutsDialog.test.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.test.tsx
@@ -180,4 +180,18 @@ describe("ShortcutsDialog", () => {
     expect(content).toContain("⌘↵");
     expect(content).toMatch(/confirm inject/i);
   });
+
+  test("documents chain, run, event, and proposal navigation shortcuts (WM-875)", () => {
+    const r = render(<ShortcutsDialog onClose={() => {}} />);
+    const actionsSection = r.getByRole("region", { name: "Actions" });
+    const content = actionsSection.textContent ?? "";
+
+    expect(content).toContain("o / Enter");
+    expect(content).toContain("open run (Chain)");
+    expect(content).toContain("show in Runs (Chain, Events, Proposals)");
+    expect(content).toContain("open in Events (Chain, Proposals)");
+    expect(content).toContain("c / l");
+    expect(content).toContain("view chain (Run, Events)");
+    expect(content).toContain("open proposal (Run, Events)");
+  });
 });

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -26,8 +26,22 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "[ ]", does: "previous / next status tab" },
   { keys: "1–N", does: "switch status tab" },
   { keys: "Enter", does: "open detail" },
-  { keys: "o", does: "open current run (Workers) · full run view (Runs)" },
-  { keys: "r", does: "run schedule now (Schedules)" },
+  {
+    keys: "o / Enter",
+    does: "open run (Chain) · open current run (Workers) · full run view (Runs)",
+  },
+  {
+    keys: "r",
+    does: "show in Runs (Chain, Events, Proposals) · run schedule now (Schedules)",
+  },
+  {
+    keys: "e",
+    does: "open in Events (Chain, Proposals)",
+  },
+  {
+    keys: "c / l",
+    does: "view chain (Run, Events)",
+  },
   { keys: "a", does: "approve proposal (Proposals) · ack item (Inbox)" },
   {
     keys: "x",
@@ -50,7 +64,10 @@ const ACTIONS: { keys: string; does: string }[] = [
     does: "approve / reject selected proposals · ack / resolve selected inbox items",
   },
   { keys: "q", does: "requeue event (Events)" },
-  { keys: "p", does: "pin / unpin selected run (Runs)" },
+  {
+    keys: "p",
+    does: "open proposal (Run, Events) · pin / unpin selected run (Runs)",
+  },
   { keys: "z / Enter", does: "reveal selected node on canvas (Graph)" },
   { keys: "c", does: "copy selected id / name / ref" },
   { keys: "c i / c c", does: "copy CLI inspect command (Runs)" },

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -258,14 +258,17 @@ const proposal: Proposal = {
 
 function renderChain(props: Partial<React.ComponentProps<typeof Chain>> = {}) {
   const selected: Array<string | null> = [];
+  const openedRuns: string[] = [];
+  const jumpedRuns: string[] = [];
+  const jumpedEvents: string[] = [];
   const view = renderWithClient(
     <Chain
       correlationId={CORR}
       focusNodeId={null}
       onSelectNode={(id) => selected.push(id)}
-      onJumpEvent={() => {}}
-      onJumpRun={() => {}}
-      onOpenRunFull={() => {}}
+      onJumpEvent={(source, id) => jumpedEvents.push(`${source}:${id}`)}
+      onJumpRun={(id) => jumpedRuns.push(id)}
+      onOpenRunFull={(id) => openedRuns.push(id)}
       onJumpProposal={() => {}}
       onJumpAgent={() => {}}
       {...props}
@@ -301,7 +304,7 @@ function renderChain(props: Partial<React.ComponentProps<typeof Chain>> = {}) {
       },
     },
   );
-  return { ...view, selected };
+  return { ...view, selected, openedRuns, jumpedRuns, jumpedEvents };
 }
 
 afterEach(() => {
@@ -446,14 +449,14 @@ describe("Chain view — Timeline mode (WM-639)", () => {
     for (const li of list.querySelectorAll('[aria-current="true"]')) {
       expect(li.getAttribute("data-node-id")).toBe(nodeId);
     }
-    // Enter re-asserts the selection (opens the pane as in graph mode).
+    // Enter triggers Open run on selected run node (WM-875).
     fireEvent.keyDown(document.body, { key: "Enter" });
-    expect(focused.selected).toContain(nodeId);
+    expect(focused.openedRuns).toContain(FIX_RUN);
     // The detail pane shows the run, with the reveal action renamed for the mode.
     expect(
       await focused.findByRole("button", { name: /Show in timeline/ }),
     ).toBeTruthy();
-    expect(focused.getByRole("button", { name: "Open run" })).toBeTruthy();
+    expect(focused.getByRole("button", { name: /Open run/ })).toBeTruthy();
   });
 
   test("j/k in timeline mode walk the narrative order of nodes", async () => {
@@ -534,5 +537,51 @@ describe("Chain header state bar (WM-832)", () => {
       expect(rendered.queryByText("FAILED ×1")).toBeNull();
       expect(rendered.queryByText("COMPLETED ×2")).toBeNull();
     });
+  });
+});
+
+describe("Chain navigation shortcuts (WM-875)", () => {
+  test("when run node is selected, o / Enter triggers onOpenRunFull and r triggers onJumpRun", async () => {
+    const runNodeId = `run:${FIX_RUN}`;
+    const view = renderChain({ focusNodeId: runNodeId });
+
+    const openRunBtn = await waitFor(() =>
+      view.getByRole("button", { name: /Open run/ }),
+    );
+    expect(openRunBtn.querySelector('[aria-hidden="true"]')?.textContent).toBe(
+      "o",
+    );
+    const showInRunsBtn = view.getByRole("button", { name: /Show in Runs/ });
+    expect(
+      showInRunsBtn.querySelector('[aria-hidden="true"]')?.textContent,
+    ).toBe("r");
+
+    // Open run via 'o'
+    fireEvent.keyDown(document.body, { key: "o" });
+    expect(view.openedRuns).toContain(FIX_RUN);
+
+    // Open run via 'Enter'
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    expect(view.openedRuns.filter((id) => id === FIX_RUN).length).toBe(2);
+
+    // Jump to runs via 'r'
+    fireEvent.keyDown(document.body, { key: "r" });
+    expect(view.jumpedRuns).toContain(FIX_RUN);
+  });
+
+  test("when event node is selected, e triggers onJumpEvent", async () => {
+    const evtNodeId = `event:chain:${FIX_EVENT}`;
+    const view = renderChain({ focusNodeId: evtNodeId });
+
+    const openInEventsBtn = await waitFor(() =>
+      view.getByRole("button", { name: /Open in Events/ }),
+    );
+    expect(
+      openInEventsBtn.querySelector('[aria-hidden="true"]')?.textContent,
+    ).toBe("e");
+
+    // Open in Events via 'e'
+    fireEvent.keyDown(document.body, { key: "e" });
+    expect(view.jumpedEvents).toContain(`chain:${FIX_EVENT}`);
   });
 });

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -573,6 +573,26 @@ export function Chain({
         revealSelected();
         return;
       }
+      if (selected) {
+        if (selected.kind === "chainRun") {
+          if (e.key === "o" || e.key === "Enter") {
+            e.preventDefault();
+            onOpenRunFull(selected.run.runId);
+            return;
+          }
+          if (e.key === "r") {
+            e.preventDefault();
+            onJumpRun(selected.run.runId);
+            return;
+          }
+        } else if (selected.kind === "chainEvent") {
+          if (e.key === "e") {
+            e.preventDefault();
+            onJumpEvent(selected.event.source, selected.event.eventId);
+            return;
+          }
+        }
+      }
       if (e.key === "Enter" && timelineOn && focusNodeId) {
         // The pane already follows the selection; Enter re-asserts it for a
         // row reached by deep link, matching graph mode's click-to-open.
@@ -608,7 +628,17 @@ export function Chain({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onSelectNode, focusNodeId, positioned, timelineOn, timeline]);
+  }, [
+    onSelectNode,
+    focusNodeId,
+    positioned,
+    timelineOn,
+    timeline,
+    selected,
+    onOpenRunFull,
+    onJumpRun,
+    onJumpEvent,
+  ]);
 
   const eventCount =
     graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
@@ -881,15 +911,33 @@ export function Chain({
                     onJumpEvent(selected.event.source, selected.event.eventId)
                   }
                 >
-                  Open in Events
+                  <span>Open in Events</span>
+                  <span
+                    aria-hidden="true"
+                    className="mono ml-1 text-(--text-faint) text-xs"
+                  >
+                    e
+                  </span>
                 </Button>
               ) : (
                 <div className="flex items-center gap-1.5">
                   <Button onClick={() => onOpenRunFull(selected.run.runId)}>
-                    Open run
+                    <span>Open run</span>
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-xs"
+                    >
+                      o
+                    </span>
                   </Button>
                   <Button onClick={() => onJumpRun(selected.run.runId)}>
-                    Show in Runs
+                    <span>Show in Runs</span>
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-xs"
+                    >
+                      r
+                    </span>
                   </Button>
                 </div>
               )}

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -1280,3 +1280,57 @@ describe("Events causation glyphs and hover card (WM-702)", () => {
     );
   });
 });
+
+describe("Events navigation shortcuts (WM-875)", () => {
+  test("c triggers onJumpChain, r triggers onJumpRun, and p triggers onJumpProposal", async () => {
+    let jumpedChain = "";
+    let jumpedRun = "";
+    let jumpedProposal = "";
+
+    const evt = stubEvent("evt_shortcuts_test", "planned", {
+      correlationId: "chain_corr_abc",
+      runId: "run_xyz_123",
+      proposalId: "prop_789",
+    });
+
+    await withApi(
+      {
+        events: async () => ({ events: [evt] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole } = renderEvents({
+          focusEvent: { source: "github", eventId: "evt_shortcuts_test" },
+          onJumpChain: (corr) => {
+            jumpedChain = corr;
+          },
+          onJumpRun: (runId) => {
+            jumpedRun = runId;
+          },
+          onJumpProposal: (propId) => {
+            jumpedProposal = propId;
+          },
+        });
+
+        const viewChainBtn = await waitFor(() =>
+          getByRole("button", { name: /View chain/ }),
+        );
+        expect(
+          viewChainBtn.querySelector('[aria-hidden="true"]')?.textContent,
+        ).toBe("c");
+
+        // Press 'c' to view chain
+        fireEvent.keyDown(document.body, { key: "c" });
+        expect(jumpedChain).toBe("chain_corr_abc");
+
+        // Press 'r' to jump to run
+        fireEvent.keyDown(document.body, { key: "r" });
+        expect(jumpedRun).toBe("run_xyz_123");
+
+        // Press 'p' to jump to proposal
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(jumpedProposal).toBe("prop_789");
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -861,8 +861,25 @@ export function Events({
       q: () => canRequeue && connected && sel && requeue.mutate(sel),
       c: () => {
         if (!sel) return;
-        copyText(sel.eventId, "event id");
-        pendingC.current = Date.now();
+        if (onJumpChain) {
+          onJumpChain(
+            sel.correlationId ?? sel.eventId,
+            `event:${sel.source}:${sel.eventId}`,
+          );
+        } else {
+          copyText(sel.eventId, "event id");
+          pendingC.current = Date.now();
+        }
+      },
+      r: () => {
+        if (sel?.runId && onJumpRun) {
+          onJumpRun(sel.runId);
+        }
+      },
+      p: () => {
+        if (sel?.proposalId && onJumpProposal) {
+          onJumpProposal(sel.proposalId);
+        }
       },
       l: () => {
         if (
@@ -892,6 +909,37 @@ export function Events({
               },
             ]
           : []),
+        ...(onJumpChain
+          ? [
+              {
+                label: "View chain",
+                hint: "c",
+                run: () =>
+                  onJumpChain(
+                    sel.correlationId ?? sel.eventId,
+                    `event:${sel.source}:${sel.eventId}`,
+                  ),
+              },
+            ]
+          : []),
+        ...(sel.proposalId && onJumpProposal
+          ? [
+              {
+                label: `Open proposal ${sel.proposalId}`,
+                hint: "p",
+                run: () => onJumpProposal(sel.proposalId!),
+              },
+            ]
+          : []),
+        ...(sel.runId && onJumpRun
+          ? [
+              {
+                label: `Open run ${sel.runId}`,
+                hint: "r",
+                run: () => onJumpRun(sel.runId!),
+              },
+            ]
+          : []),
         {
           label: `Replay ${sel.eventId} through intake…`,
           run: () => setConfirmReplay(true),
@@ -911,7 +959,14 @@ export function Events({
     }
     return () => setContextActions([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sel ? keyOf(sel) : null, canRequeue, connected]);
+  }, [
+    sel ? keyOf(sel) : null,
+    canRequeue,
+    connected,
+    onJumpChain,
+    onJumpRun,
+    onJumpProposal,
+  ]);
 
   const eventCounts = statusQ.data?.events ?? {};
   const allCount = Object.values(eventCounts).reduce((n, v) => n + v, 0);
@@ -1399,7 +1454,13 @@ export function Events({
                       )
                     }
                   >
-                    View chain
+                    <span>View chain</span>
+                    <span
+                      aria-hidden="true"
+                      className="mono ml-1 text-(--text-faint) text-xs"
+                    >
+                      c
+                    </span>
                   </Button>
                 )}
                 <Button

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1657,3 +1657,46 @@ describe("Proposals approval modal pinned footer (WM-829)", () => {
     );
   });
 });
+
+describe("Proposals navigation shortcuts (WM-875)", () => {
+  test("e triggers onJumpEvent and r triggers onRunQueued", async () => {
+    let jumpedEvent = "";
+    let queuedRun = "";
+    const proposal = stubProposal("prop_nav_test", "open", {
+      eventId: "evt_origin_123",
+      eventSource: "github",
+      runId: "run_target_456",
+    });
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => stubStatus(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({
+          focusProposalId: proposal.id,
+          onJumpEvent: (source, eventId) => {
+            jumpedEvent = `${source}:${eventId}`;
+          },
+          onRunQueued: (runId) => {
+            queuedRun = runId;
+          },
+        });
+
+        await r.findByRole("heading", { name: "Proposals" });
+        await waitFor(() => expect(r.getByText("evt_origin_123")).toBeTruthy());
+
+        // Press 'e' to jump to origin event
+        fireEvent.keyDown(document.body, { key: "e" });
+        expect(jumpedEvent).toBe("github:evt_origin_123");
+
+        // Press 'r' to open run
+        fireEvent.keyDown(document.body, { key: "r" });
+        expect(queuedRun).toBe("run_target_456");
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -840,6 +840,16 @@ export function Proposals({
       // When `*` is armed, the proposal-selection listener owns the same `a` key instead.
       a: () => !starPrefixActive() && canApprove && connected && openApprove(),
       x: () => isOpen && connected && openReject(),
+      e: () => {
+        if (sel?.eventId && sel.eventSource && onJumpEvent) {
+          onJumpEvent(sel.eventSource, sel.eventId);
+        }
+      },
+      r: () => {
+        if (sel?.runId && onRunQueued) {
+          onRunQueued(sel.runId);
+        }
+      },
       c: () => {
         if (!sel) return;
         copyText(sel.id, "proposal id");

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -645,3 +645,133 @@ describe("RunFull causal follow-up events and chained runs (WM-420)", () => {
     );
   });
 });
+
+describe("RunFull navigation shortcuts (WM-875)", () => {
+  test("c and l trigger onJumpChain and render c badge hint", async () => {
+    const runId = "run_chain_jump_test";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "COMPLETED" } as RunDetail["run"],
+    });
+    const event = createEventFixture({
+      source: "factory",
+      eventId: "evt_chain_1",
+      correlationId: "chain_corr_123",
+      causationId: runId,
+    });
+    let jumpedChain = "";
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [
+            createRunListItemFixture({
+              runId,
+              state: "COMPLETED",
+              eventId: "evt_chain_1",
+              eventSource: "factory",
+            }),
+          ],
+        }),
+        events: async () => ({
+          events: [event],
+        }),
+      },
+      async () => {
+        const { getByRole } = renderWithClient(
+          <RunFull
+            runId={runId}
+            connected={true}
+            onBack={noop}
+            onJumpAgent={noop}
+            onJumpEvent={noop}
+            onJumpChain={(corr) => {
+              jumpedChain = corr;
+            }}
+          />,
+        );
+
+        const viewChainBtn = await waitFor(() =>
+          getByRole("button", { name: /View chain/ }),
+        );
+        expect(
+          viewChainBtn.querySelector('[aria-hidden="true"]')?.textContent,
+        ).toBe("c");
+
+        // Press 'c'
+        fireEvent.keyDown(document.body, { key: "c" });
+        expect(jumpedChain).toBe("chain_corr_123");
+
+        jumpedChain = "";
+        // Press 'l'
+        fireEvent.keyDown(document.body, { key: "l" });
+        expect(jumpedChain).toBe("chain_corr_123");
+      },
+    );
+  });
+
+  test("p triggers onJumpProposal and renders p badge hint when proposal exists", async () => {
+    const runId = "run_proposal_jump_test";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "PROPOSED" } as RunDetail["run"],
+    });
+    let jumpedProposal = "";
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "PROPOSED" })],
+        }),
+        proposals: async () => ({
+          proposals: [
+            {
+              id: "prop_jump_999",
+              decision: "run",
+              status: "open",
+              runId,
+              created_at: new Date().toISOString(),
+              ttl_seconds: 3600,
+              expired: false,
+              decided_at: null,
+              decided_by: null,
+              reason: null,
+              eventId: null,
+              eventSource: null,
+              agent: "test-agent",
+              spec: null,
+              repos: [],
+            },
+          ],
+        }),
+      },
+      async () => {
+        const { getAllByRole } = renderWithClient(
+          <RunFull
+            runId={runId}
+            connected={true}
+            onBack={noop}
+            onJumpAgent={noop}
+            onJumpEvent={noop}
+            onJumpProposal={(propId) => {
+              jumpedProposal = propId;
+            }}
+          />,
+        );
+
+        const openProposalBtns = await waitFor(() =>
+          getAllByRole("button", { name: /Open proposal/ }),
+        );
+        expect(openProposalBtns.length).toBeGreaterThan(0);
+        expect(
+          openProposalBtns[0].querySelector('[aria-hidden="true"]')
+            ?.textContent,
+        ).toBe("p");
+
+        // Press 'p'
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(jumpedProposal).toBe("prop_jump_999");
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -213,7 +213,7 @@ export function RunFull({
     d?.run?.state === "PROPOSED",
   );
 
-  // Verbs: Esc back to list, x cancel, c copy id, c i / c c copy CLI inspect command, c l copy link.
+  // Verbs: Esc back to list, x cancel, c / l view chain, p open proposal, a approve.
   useEffect(() => {
     let pendingC = 0;
     function onKey(e: KeyboardEvent) {
@@ -225,7 +225,16 @@ export function RunFull({
       }
       if (e.key === "p") {
         e.preventDefault();
-        toggleRunPin(runId);
+        if (selProposal && onJumpProposal) {
+          onJumpProposal(selProposal.id);
+        } else {
+          toggleRunPin(runId);
+        }
+        return;
+      }
+      if ((e.key === "c" || e.key === "l") && onJumpChain && chainKey) {
+        e.preventDefault();
+        onJumpChain(chainKey, `run:${runId}`);
         return;
       }
       if (e.key === "a" && canApprove && connected && !approve.isPending) {
@@ -265,7 +274,18 @@ export function RunFull({
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [d, connected, onBack, runId, canApprove, approve.isPending]);
+  }, [
+    d,
+    connected,
+    onBack,
+    runId,
+    canApprove,
+    approve.isPending,
+    selProposal,
+    onJumpProposal,
+    onJumpChain,
+    chainKey,
+  ]);
 
   // Offer this run's verbs in the ⌘K palette (§5), same rules as the panel.
   useEffect(() => {
@@ -305,7 +325,17 @@ export function RunFull({
           ? [
               {
                 label: `Open proposal ${selProposal.id}`,
+                hint: "p",
                 run: () => onJumpProposal(selProposal.id),
+              },
+            ]
+          : []),
+        ...(onJumpChain && chainKey
+          ? [
+              {
+                label: "View chain",
+                hint: "c",
+                run: () => onJumpChain(chainKey, `run:${runId}`),
               },
             ]
           : []),
@@ -483,22 +513,36 @@ export function RunFull({
           <div className="flex items-center gap-1.5">
             {selProposal && onJumpProposal && (
               <Button onClick={() => onJumpProposal(selProposal.id)}>
-                Open proposal
+                <span>Open proposal</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-(--text-faint) text-xs"
+                >
+                  p
+                </span>
               </Button>
             )}
             {onJumpChain && chainKey && (
               <Button onClick={() => onJumpChain(chainKey, `run:${runId}`)}>
-                View chain
+                <span>View chain</span>
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-(--text-faint) text-xs"
+                >
+                  c
+                </span>
               </Button>
             )}
             <Button onClick={() => toggleRunPin(runId)}>
               <span>Open in tab</span>
-              <span
-                aria-hidden="true"
-                className="mono ml-1 text-(--text-faint) text-xs"
-              >
-                p
-              </span>
+              {(!selProposal || !onJumpProposal) && (
+                <span
+                  aria-hidden="true"
+                  className="mono ml-1 text-(--text-faint) text-xs"
+                >
+                  p
+                </span>
+              )}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Adds missing keyboard shortcuts and visible badge hints across primary views and detail panes in the event runtime web console:

- **RunFull (`#/run/:id`)**:
  - Pressing `c` or `l` navigates to the associated chain trace (`onJumpChain`).
  - Pressing `p` opens the linked proposal (`onJumpProposal`), falling back to tab pinning if no proposal is associated.
  - Added visual shortcut badge hints (`c`, `p`) on the respective action buttons.
- **Chain (`#/chain/:id`)**:
  - When a run node is selected: pressing `o` or `Enter` triggers "Open run" (`onOpenRunFull`), and pressing `r` triggers "Show in Runs" (`onJumpRun`).
  - When an event node is selected: pressing `e` triggers "Open in Events" (`onJumpEvent`).
  - Added visual shortcut badge hints (`o`, `r`, `e`) to DetailPane action buttons.
- **Events (`#/events`) & Proposals (`#/proposals`)**:
  - Added detail pane navigation shortcuts (`c` for causal chain, `r` for run, `p` for proposal in Events; `e` for origin event, `r` for run in Proposals).
  - Added visual badge hints.
- **ShortcutsDialog (`?`)**:
  - Documented the new navigation chords and verbs (`o / Enter`, `r`, `e`, `c / l`, `p`).
- **Tests**:
  - Added unit test suites verifying shortcut activation and hint badges across `RunFull.test.tsx`, `Chain.test.tsx`, `Events.test.tsx`, `Proposals.test.tsx`, and `ShortcutsDialog.test.tsx`.

Fixes WM-875