### PR TITLE
ui-ux(event-runtime-web): hover-only table checkboxes and Excel-style Shift+Click range selection across Inbox and Proposals (WM-885)

### DIFF
--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -756,4 +756,85 @@ describe("Inbox view", () => {
         .disabled,
     ).toBe(true);
   });
+
+  test("table checkboxes have hover-only visibility when none selected and full opacity when selected", async () => {
+    const { view } = renderInbox();
+    await waitFor(() => view.getByLabelText("Select all inbox items"));
+
+    const headerCb = view.getByLabelText(
+      "Select all inbox items",
+    ) as HTMLInputElement;
+    const rowCb1 = view.getByLabelText(
+      "Select inbox item inbox_open_1",
+    ) as HTMLInputElement;
+    const rowCb2 = view.getByLabelText(
+      "Select inbox item inbox_open_2",
+    ) as HTMLInputElement;
+
+    expect(headerCb.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+    expect(rowCb1.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+    expect(rowCb2.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+
+    // Table head and rows have group class
+    expect(headerCb.closest("thead")?.className).toContain("group");
+    expect(rowCb1.closest("tr")?.className).toContain("group");
+    expect(rowCb2.closest("tr")?.className).toContain("group");
+
+    // Select row 1 -> checkboxes become opacity-100
+    fireEvent.click(rowCb1);
+    expect(headerCb.className).toContain("opacity-100");
+    expect(rowCb1.className).toContain("opacity-100");
+    expect(rowCb2.className).toContain("opacity-100");
+  });
+
+  test("Shift+Click selects and deselects contiguous range of items", async () => {
+    ledger = [
+      item({ id: "inbox_1", kind: "BLOCKED", title: "Item 1", createdAt: T0 }),
+      item({ id: "inbox_2", kind: "BLOCKED", title: "Item 2", createdAt: T1 }),
+      item({ id: "inbox_3", kind: "BLOCKED", title: "Item 3", createdAt: T2 }),
+      item({ id: "inbox_4", kind: "BLOCKED", title: "Item 4", createdAt: T2 }),
+    ];
+    const { view } = renderInbox();
+    await waitFor(() => view.getByLabelText("Select inbox item inbox_1"));
+
+    const cb1 = view.getByLabelText(
+      "Select inbox item inbox_1",
+    ) as HTMLInputElement;
+    const cb2 = view.getByLabelText(
+      "Select inbox item inbox_2",
+    ) as HTMLInputElement;
+    const cb3 = view.getByLabelText(
+      "Select inbox item inbox_3",
+    ) as HTMLInputElement;
+    const cb4 = view.getByLabelText(
+      "Select inbox item inbox_4",
+    ) as HTMLInputElement;
+
+    // Click item 1
+    fireEvent.click(cb1);
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(false);
+    expect(cb3.checked).toBe(false);
+    expect(cb4.checked).toBe(false);
+
+    // Shift+Click item 3 -> items 1, 2, 3 selected
+    fireEvent.click(cb3, { shiftKey: true });
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(true);
+    expect(cb3.checked).toBe(true);
+    expect(cb4.checked).toBe(false);
+
+    // Shift+Click checked item 2 -> deselects range between anchor (item 3) and target (item 2), leaving item 1
+    fireEvent.click(cb2, { shiftKey: true });
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(false);
+    expect(cb3.checked).toBe(false);
+    expect(cb4.checked).toBe(false);
+  });
 });

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -772,20 +772,50 @@ export function Inbox({
     });
   }, [actionableVisible]);
 
-  const toggleSelect = (id: string) => {
+  const lastInteractedId = useRef<string | null>(null);
+
+  const toggleSelect = (id: string, shiftKey = false) => {
+    const anchorId = lastInteractedId.current;
+    lastInteractedId.current = id;
+
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
+      const isSelected = next.has(id);
+      const targetIndex = actionableVisible.findIndex((it) => it.id === id);
+      const anchorIndex =
+        anchorId !== null
+          ? actionableVisible.findIndex((it) => it.id === anchorId)
+          : -1;
+
+      if (shiftKey && anchorIndex !== -1 && targetIndex !== -1) {
+        const start = Math.min(anchorIndex, targetIndex);
+        const end = Math.max(anchorIndex, targetIndex);
+        const range = actionableVisible.slice(start, end + 1);
+        if (isSelected) {
+          for (const item of range) {
+            next.delete(item.id);
+          }
+        } else {
+          for (const item of range) {
+            next.add(item.id);
+          }
+        }
       } else {
-        next.add(id);
+        if (isSelected) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
       }
       return next;
     });
   };
-  const selectAllActionable = () =>
+  const selectAllActionable = () => {
+    lastInteractedId.current = null;
     setSelectedIds(new Set(actionableVisible.map((it) => it.id)));
+  };
   const toggleSelectAll = () => {
+    lastInteractedId.current = null;
     if (allActionableSelected) setSelectedIds(new Set());
     else selectAllActionable();
   };
@@ -946,6 +976,7 @@ export function Inbox({
   ]);
 
   const selectTab = (t: InboxTab) => {
+    lastInteractedId.current = null;
     setTab(t);
     onSelectItem(null);
     setSelectedIds(new Set());
@@ -1163,7 +1194,7 @@ export function Inbox({
             </div>
           ) : (
             <Table className="w-full border-separate border-spacing-0">
-              <thead>
+              <thead className="group">
                 <tr className="text-left">
                   {selectionEnabled && (
                     <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
@@ -1174,7 +1205,11 @@ export function Inbox({
                         checked={allActionableSelected}
                         disabled={actionableVisible.length === 0}
                         onChange={toggleSelectAll}
-                        className="cursor-pointer"
+                        className={`cursor-pointer transition-opacity ${
+                          selectedIds.size > 0
+                            ? "opacity-100"
+                            : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                        }`}
                       />
                     </th>
                   )}
@@ -1233,7 +1268,7 @@ export function Inbox({
                         key={item.id}
                         onClick={() => onSelectItem(item.id)}
                         aria-selected={item.id === sel?.id}
-                        className={`cursor-pointer hover:bg-(--surface-1) ${item.id === sel?.id ? "row-selected" : ""}`}
+                        className={`group cursor-pointer hover:bg-(--surface-1) ${item.id === sel?.id ? "row-selected" : ""}`}
                       >
                         {selectionEnabled && (
                           <td
@@ -1244,8 +1279,16 @@ export function Inbox({
                               type="checkbox"
                               aria-label={`Select inbox item ${item.id}`}
                               checked={selectedIds.has(item.id)}
-                              onChange={() => toggleSelect(item.id)}
-                              className="cursor-pointer"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleSelect(item.id, e.shiftKey);
+                              }}
+                              onChange={() => {}}
+                              className={`cursor-pointer transition-opacity ${
+                                selectedIds.size > 0 || selectedIds.has(item.id)
+                                  ? "opacity-100"
+                                  : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                              }`}
                             />
                           </td>
                         )}

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1657,3 +1657,80 @@ describe("Proposals approval modal pinned footer (WM-829)", () => {
     );
   });
 });
+
+describe("Proposals hover checkboxes and Shift+Click range selection (WM-885)", () => {
+  test("checkboxes have hover-only visibility when none selected and full opacity when selected", async () => {
+    const p1 = stubProposal("prop_1", "open", { agent: "triage-scan" });
+    const p2 = stubProposal("prop_2", "open", { agent: "security-scan" });
+    api.proposals = async () => ({ proposals: [p1, p2] });
+    api.proposalHistory = async () => ({ proposals: [] });
+
+    const r = renderProposals();
+    const headerCb = (await r.findByLabelText(
+      "Select all proposals",
+    )) as HTMLInputElement;
+    const rowCb1 = r.getByLabelText(
+      "Select proposal prop_1",
+    ) as HTMLInputElement;
+    const rowCb2 = r.getByLabelText(
+      "Select proposal prop_2",
+    ) as HTMLInputElement;
+
+    expect(headerCb.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+    expect(rowCb1.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+    expect(rowCb2.className).toContain(
+      "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+    );
+
+    expect(headerCb.closest("thead")?.className).toContain("group");
+    expect(rowCb1.closest("tr")?.className).toContain("group");
+    expect(rowCb2.closest("tr")?.className).toContain("group");
+
+    fireEvent.click(rowCb1);
+    expect(headerCb.className).toContain("opacity-100");
+    expect(rowCb1.className).toContain("opacity-100");
+    expect(rowCb2.className).toContain("opacity-100");
+  });
+
+  test("Shift+Click selects and deselects contiguous range of proposals", async () => {
+    const p1 = stubProposal("prop_1", "open", { agent: "agent-1" });
+    const p2 = stubProposal("prop_2", "open", { agent: "agent-2" });
+    const p3 = stubProposal("prop_3", "open", { agent: "agent-3" });
+    const p4 = stubProposal("prop_4", "open", { agent: "agent-4" });
+    api.proposals = async () => ({ proposals: [p1, p2, p3, p4] });
+    api.proposalHistory = async () => ({ proposals: [] });
+
+    const r = renderProposals();
+    const cb1 = (await r.findByLabelText(
+      "Select proposal prop_1",
+    )) as HTMLInputElement;
+    const cb2 = r.getByLabelText("Select proposal prop_2") as HTMLInputElement;
+    const cb3 = r.getByLabelText("Select proposal prop_3") as HTMLInputElement;
+    const cb4 = r.getByLabelText("Select proposal prop_4") as HTMLInputElement;
+
+    // Click proposal 1
+    fireEvent.click(cb1);
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(false);
+    expect(cb3.checked).toBe(false);
+    expect(cb4.checked).toBe(false);
+
+    // Shift+Click proposal 3 -> selects prop_1, prop_2, prop_3
+    fireEvent.click(cb3, { shiftKey: true });
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(true);
+    expect(cb3.checked).toBe(true);
+    expect(cb4.checked).toBe(false);
+
+    // Shift+Click checked proposal 2 -> deselects range between anchor (prop_3) and target (prop_2)
+    fireEvent.click(cb2, { shiftKey: true });
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(false);
+    expect(cb3.checked).toBe(false);
+    expect(cb4.checked).toBe(false);
+  });
+});

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -423,16 +423,47 @@ export function Proposals({
     }
   }, [someActionableSelected]);
 
-  const toggleSelect = (id: string) => {
+  const lastInteractedId = useRef<string | null>(null);
+
+  const toggleSelect = (id: string, shiftKey = false) => {
+    const anchorId = lastInteractedId.current;
+    lastInteractedId.current = id;
+
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      const isSelected = next.has(id);
+      const targetIndex = actionableVisible.findIndex((p) => p.id === id);
+      const anchorIndex =
+        anchorId !== null
+          ? actionableVisible.findIndex((p) => p.id === anchorId)
+          : -1;
+
+      if (shiftKey && anchorIndex !== -1 && targetIndex !== -1) {
+        const start = Math.min(anchorIndex, targetIndex);
+        const end = Math.max(anchorIndex, targetIndex);
+        const range = actionableVisible.slice(start, end + 1);
+        if (isSelected) {
+          for (const item of range) {
+            next.delete(item.id);
+          }
+        } else {
+          for (const item of range) {
+            next.add(item.id);
+          }
+        }
+      } else {
+        if (isSelected) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+      }
       return next;
     });
   };
 
   const toggleSelectAll = () => {
+    lastInteractedId.current = null;
     setSelectedIds((prev) => {
       const next = new Set(prev);
       if (allActionableSelected) {
@@ -445,6 +476,7 @@ export function Proposals({
   };
 
   const selectAllActionable = () => {
+    lastInteractedId.current = null;
     setSelectedIds((prev) => {
       const next = new Set(prev);
       actionableVisible.forEach((p) => next.add(p.id));
@@ -979,6 +1011,7 @@ export function Proposals({
   }, [sel?.id, canApprove, isOpen, connected]);
 
   const selectTab = (t: ProposalTab) => {
+    lastInteractedId.current = null;
     setTab(t);
     setExpiredOnly(false);
     onSelectProposal(null);
@@ -1182,7 +1215,7 @@ export function Proposals({
           }
         >
           <Table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
-            <thead>
+            <thead className="group">
               <tr className="text-left">
                 {tab === "open" && (
                   <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
@@ -1193,7 +1226,11 @@ export function Proposals({
                       checked={allActionableSelected}
                       disabled={actionableVisible.length === 0}
                       onChange={toggleSelectAll}
-                      className="cursor-pointer"
+                      className={`cursor-pointer transition-opacity ${
+                        selectedIds.size > 0
+                          ? "opacity-100"
+                          : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                      }`}
                     />
                   </th>
                 )}
@@ -1243,7 +1280,7 @@ export function Proposals({
                     key={p.id}
                     onClick={() => onSelectProposal(p.id)}
                     aria-selected={p.id === selectedId}
-                    className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : proposalIsExpired(p, now) ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
+                    className={`group cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : proposalIsExpired(p, now) ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
                   >
                     {tab === "open" && (
                       <td
@@ -1254,11 +1291,16 @@ export function Proposals({
                           type="checkbox"
                           aria-label={`Select proposal ${p.id}`}
                           checked={selectedIds.has(p.id)}
-                          onChange={(e) => {
+                          onClick={(e) => {
                             e.stopPropagation();
-                            toggleSelect(p.id);
+                            toggleSelect(p.id, e.shiftKey);
                           }}
-                          className="cursor-pointer"
+                          onChange={() => {}}
+                          className={`cursor-pointer transition-opacity ${
+                            selectedIds.size > 0 || selectedIds.has(p.id)
+                              ? "opacity-100"
+                              : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                          }`}
                         />
                       </td>
                     )}


### PR DESCRIPTION
Fixes WM-885

## Summary
- Row checkboxes in `Inbox.tsx` and `Proposals.tsx` have hover-only / subtle visibility (`opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity`) when `selectedIds.size === 0`
- When any row is selected (`selectedIds.size > 0`), checkboxes remain fully visible (`opacity-100`)
- Header checkbox reveals on `<thead>` hover or when rows are selected
- Implemented Excel-style `Shift+Click` range selection / deselection between last interacted row and target row in visible list
- Preserved keyboard Space / Shift+Space toggle shortcuts
- Added component tests covering hover-only classes and Shift+Click contiguous range selection