### PR TITLE
feat(event-runtime): operational harness/model overlay + Agents editors (WM-887, WM-884)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1016,13 +1016,17 @@ with Copy prompt),
 hash table, captioned: content-hash pins that fail the registry closed on
 drift — versions are bumped and re-pinned, never edited in place), and
 **Event routing** (which event types select this agent, with adapter,
-idempotency scope, and proposal TTL). The shared envelope contracts
+idempotency scope, and proposal TTL). The adapter on each route and the
+agent's model tier / exact pin are editable: they write a machine-local
+overlay in `runtime.db` (WM-887 / WM-884), not git. An effective value that
+differs from the declared git mapping shows a **this runtime** chip and
+Revert. The shared envelope contracts
 (`factory.event/v1`, `factory.agent-result/v1`) render once at the list
 level, not per agent. The selected ref in the pane title is followed by the
 shared `<CopyActions />` icon controls: copy-ref (`c`) and copy-link (`c l`)
 put their chord in `title` and `aria-label`, while the text-labeled `Close`
-button carries no visible `Esc` badge. Strictly read-only — the registry has
-no mutation surface. ⌘K jumps to an agent ref the same way it jumps to a run
+button carries no visible `Esc` badge. Overlay saves are this box only —
+not `origin/develop`. ⌘K jumps to an agent ref the same way it jumps to a run
 or event.
 
 Chord choice: `g t` ("what is **t**his agent?"). `o/e/p/r` were taken, and

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -401,7 +401,13 @@ resolves tier → model at plan time and pins the result into the RunSpec**
 (`modelTier` + `model`, the same pattern as `repoPin`), so the proposal the
 operator approves, the stored run, and `inspect`/receipt output all name the
 exact model; `GET /agents` and `cli.mjs agents` show the declared tier and the
-per-route resolved value. Resolution order: per-definition `"model"` override
+per-route resolved value. A machine-local **operational overlay** (WM-887) may
+repoint an event type's adapter or an agent's `model_tier` / `model` without
+touching those files: it lives in `runtime.db` (`GET`/`PUT`/`DELETE /overrides`),
+is applied at plan time, and `GET /agents` reports both declared (git) and
+effective (next plan) values. Precedence: envelope/ticket per-run fields →
+overlay → git. Process-wide `--adapter-override` is still execution-only.
+Resolution order: per-definition `"model"` override
 (the one escape hatch for an exact id — both fields may coexist, the override
 wins) > tier map > adapter default (absent fields = no spec fields = today's
 behavior). Repository dispatches can additionally select a per-ticket tier;

--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -73,3 +73,21 @@ an opt-in `run-e2e` label until proven stable on self-hosted runners.
 Decided 2026-08-18. Telegram notifications remain outbound-only deep links to the Web UI
 over Tailscale. No inbound Telegram bot webhook endpoint or long-polling write path will
 be introduced into `serve`, preserving the loopback-only security confinement (OPS-408, WM-61).
+
+## Operational overlay (WM-887)
+
+Decided 2026-08-19. Swift harness / model changes are a **machine-local overlay**
+in `runtime.db`, applied at plan time. They do not write
+`event-types.json`, `agents/*.json`, or `config/policy.yaml`. Packs cannot
+shadow built-ins (WM-470 duplicate keys fail closed); WM-479 apply is a
+different write path (whole resources into an API-managed pack) and stays
+out of this loop.
+
+Precedence, highest first: envelope / ticket per-run fields (WM-694,
+WM-488) → overlay → git. In-flight RunSpecs are immutable. Process-wide
+`--adapter-override` remains execution substitution and does not change
+model resolution; the overlay changes `mapping.adapter` so the model follows
+the effective adapter's `policy.yaml` `models:` map.
+
+The fleet default still moves by PR. Promoting an overlay into git is WM-889.
+The global `models:` map itself is WM-888. Agents UI on this store is WM-884.

--- a/event-runtime/lib/api-http.mjs
+++ b/event-runtime/lib/api-http.mjs
@@ -53,6 +53,7 @@ const COLLECTION_PATHS = new Set([
   "/proposals",
   "/workers",
   "/agents",
+  "/overrides",
   "/status",
   "/repos",
   "/artifacts",

--- a/event-runtime/lib/api-http.test.mjs
+++ b/event-runtime/lib/api-http.test.mjs
@@ -239,6 +239,7 @@ describe("Host and Origin header security confinement (OPS-408)", () => {
       "/proposals",
       "/workers",
       "/agents",
+      "/overrides",
       "/status",
       "/repos",
       "/artifacts",

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -2,60 +2,97 @@
 import { readFileSync } from "node:fs";
 import { getArtifactView, resolveModel } from "./registry.mjs";
 import { RepoError, reposView } from "./repos.mjs";
+import {
+  KIND_AGENT,
+  KIND_EVENT_TYPE,
+  OverlayError,
+  deleteOverride,
+  emptyOverrides,
+  knownAdapters,
+  listOverrideJournal,
+  listOverrides,
+  mergeAgentPatch,
+  overlayForAgent,
+  overlayForEventType,
+  plannedDef,
+  putOverride,
+  validateAgentPatch,
+  validateEventTypePatch,
+} from "./runtime-overrides.mjs";
 
-export function agentsView(registry) {
+export function agentsView(registry, { overrides = emptyOverrides() } = {}) {
+  const adapters = [...knownAdapters(registry)].sort();
   return {
-    agents: [...registry.agents.values()].map((def) => ({
-      ref: def.ref,
-      id: def.id,
-      version: def.version,
-      outputContract: def.output_contract,
-      workspace: def.workspace,
-      capabilities: def.capabilities,
-      limits: def.limits,
-      mutating: def.mutating,
-      promptFile: def.prompt,
-      prompt: readFileSync(def.promptPath, "utf8"),
-      inputSchemaFile: def.input_schema,
-      inputSchema: def.inputSchema,
-      outputSchemaFile: def.output_schema,
-      outputSchema: def.outputSchema,
-      // Artifact-view sidecar (WM-454 / WM-897): null when the agent has
-      // none or its view failed the drift check (then /status names the
-      // anomaly). `view.source` says whether the agent file or the
-      // contract-keyed fallback applied.
-      outputViewFile: getArtifactView(registry, def.ref).file,
-      outputView: getArtifactView(registry, def.ref).view,
-      view: (() => {
-        const source = getArtifactView(registry, def.ref).source;
-        return source ? { source } : null;
-      })(),
-      pins: def.pins,
-      command: def.command ?? null,
-      actionRegistry: def.actionRegistry ?? null,
-      hosts: def.hosts ? Object.keys(def.hosts) : null,
-      repos: def.repos ?? null,
-      modelTier: def.model_tier ?? null,
-      model: def.model ?? null,
-      eventTypes: Object.entries(registry.eventTypes)
-        .filter(([, mapping]) => mapping.agent === def.ref)
-        .map(([type, mapping]) => ({
-          type,
-          adapter: mapping.adapter,
-          idempotencyScope: mapping.idempotencyScope,
-          proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
-          resolvedModel: resolveModel(
-            def,
-            mapping.adapter,
-            registry.modelTiers,
-          ),
-        })),
-    })),
+    adapters,
+    agents: [...registry.agents.values()].map((def) => {
+      const agentPatch = overlayForAgent(overrides, def.ref) ?? {};
+      const modelTierOverride = Object.hasOwn(agentPatch, "modelTier")
+        ? agentPatch.modelTier
+        : undefined;
+      const modelOverride = Object.hasOwn(agentPatch, "model")
+        ? agentPatch.model
+        : undefined;
+      const planned = plannedDef(def, { modelTierOverride, modelOverride });
+      return {
+        ref: def.ref,
+        id: def.id,
+        version: def.version,
+        outputContract: def.output_contract,
+        workspace: def.workspace,
+        capabilities: def.capabilities,
+        limits: def.limits,
+        mutating: def.mutating,
+        promptFile: def.prompt,
+        prompt: readFileSync(def.promptPath, "utf8"),
+        inputSchemaFile: def.input_schema,
+        inputSchema: def.inputSchema,
+        outputSchemaFile: def.output_schema,
+        outputSchema: def.outputSchema,
+        // Artifact-view sidecar (WM-454 / WM-897): null when the agent has
+        // none or its view failed the drift check (then /status names the
+        // anomaly). `view.source` says whether the agent file or the
+        // contract-keyed fallback applied.
+        outputViewFile: getArtifactView(registry, def.ref).file,
+        outputView: getArtifactView(registry, def.ref).view,
+        view: (() => {
+          const source = getArtifactView(registry, def.ref).source;
+          return source ? { source } : null;
+        })(),
+        pins: def.pins,
+        command: def.command ?? null,
+        actionRegistry: def.actionRegistry ?? null,
+        hosts: def.hosts ? Object.keys(def.hosts) : null,
+        repos: def.repos ?? null,
+        declaredModelTier: def.model_tier ?? null,
+        modelTier: planned.model_tier ?? null,
+        declaredModel: def.model ?? null,
+        model: planned.model ?? null,
+        eventTypes: Object.entries(registry.eventTypes)
+          .filter(([, mapping]) => mapping.agent === def.ref)
+          .map(([type, mapping]) => {
+            const adapter =
+              overlayForEventType(overrides, type)?.adapter ?? mapping.adapter;
+            return {
+              type,
+              declaredAdapter: mapping.adapter,
+              adapter,
+              idempotencyScope: mapping.idempotencyScope,
+              proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
+              resolvedModel: resolveModel(
+                planned,
+                adapter,
+                registry.modelTiers,
+              ),
+            };
+          }),
+      };
+    }),
     edges: registry.edges ?? {},
     eventTypes: Object.entries(registry.eventTypes).map(([type, mapping]) => ({
       type,
       agent: mapping.agent,
-      adapter: mapping.adapter,
+      declaredAdapter: mapping.adapter,
+      adapter: overlayForEventType(overrides, type)?.adapter ?? mapping.adapter,
       idempotencyScope: mapping.idempotencyScope,
       proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
     })),
@@ -63,7 +100,14 @@ export function agentsView(registry) {
       "factory.event/v1": registry.schemas.envelope,
       "factory.agent-result/v1": registry.schemas.agentResult,
     },
+    overrides,
   };
+}
+
+function sendOverlayError(send, err) {
+  if (err instanceof OverlayError)
+    return send(err.status, { error: err.message });
+  throw err;
 }
 
 export async function handleRegistryApiRoute({
@@ -77,8 +121,89 @@ export async function handleRegistryApiRoute({
   repos,
   janitor,
   actor,
+  db,
+  nowMs,
 }) {
-  if (route === "GET /agents") return send(200, agentsView(registry));
+  if (route === "GET /agents") {
+    const overrides = db ? listOverrides(db) : emptyOverrides();
+    return send(200, agentsView(registry, { overrides }));
+  }
+
+  if (route === "GET /overrides") {
+    return send(200, {
+      ...listOverrides(db),
+      journal: listOverrideJournal(db),
+    });
+  }
+
+  const eventTypePath = url.pathname.match(/^\/overrides\/event-types\/(.+)$/);
+  if (eventTypePath && (req.method === "PUT" || req.method === "DELETE")) {
+    const type = decodeURIComponent(eventTypePath[1]);
+    try {
+      if (req.method === "DELETE") {
+        return send(
+          200,
+          deleteOverride(db, {
+            kind: KIND_EVENT_TYPE,
+            key: type,
+            actor,
+            now: nowMs,
+          }),
+        );
+      }
+      const parsed = parseJson(await readBody(req));
+      if (parsed.error) return send(422, { error: parsed.error });
+      const patch = validateEventTypePatch(registry, type, parsed.value);
+      return send(
+        200,
+        putOverride(db, {
+          kind: KIND_EVENT_TYPE,
+          key: type,
+          patch,
+          actor,
+          now: nowMs,
+        }),
+      );
+    } catch (err) {
+      return sendOverlayError(send, err);
+    }
+  }
+
+  const agentPath = url.pathname.match(/^\/overrides\/agents\/(.+)$/);
+  if (agentPath && (req.method === "PUT" || req.method === "DELETE")) {
+    const ref = decodeURIComponent(agentPath[1]);
+    try {
+      if (req.method === "DELETE") {
+        return send(
+          200,
+          deleteOverride(db, { kind: KIND_AGENT, key: ref, actor, now: nowMs }),
+        );
+      }
+      const parsed = parseJson(await readBody(req));
+      if (parsed.error) return send(422, { error: parsed.error });
+      const incoming = validateAgentPatch(registry, ref, parsed.value);
+      const existing = overlayForAgent(listOverrides(db), ref);
+      const patch = mergeAgentPatch(existing, incoming);
+      if (!patch) {
+        return send(
+          200,
+          deleteOverride(db, { kind: KIND_AGENT, key: ref, actor, now: nowMs }),
+        );
+      }
+      return send(
+        200,
+        putOverride(db, {
+          kind: KIND_AGENT,
+          key: ref,
+          patch,
+          actor,
+          now: nowMs,
+        }),
+      );
+    } catch (err) {
+      return sendOverlayError(send, err);
+    }
+  }
 
   if (route === "GET /repos") {
     try {

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -65,6 +65,8 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
       const commandDef = defs.find((d) => d.ref === "reconcile@1");
       expect(commandDef.modelTier).toBeNull();
       expect(commandDef.eventTypes[0].resolvedModel).toBeNull();
+      expect(def.declaredModelTier).toBe("standard");
+      expect(def.eventTypes[0].declaredAdapter).toBe("pi");
       expect(
         contracts["factory.agent-result/v1"].properties.terminalState.enum,
       ).toContain("refused");
@@ -373,5 +375,82 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
     expect(apply).toContain("--apply");
     expect(apply).not.toContain("--force");
     expect(apply.filter((a) => a === "--apply")).toHaveLength(1);
+  });
+});
+
+describe("runtime overlay API (WM-887)", () => {
+  const eventTypesFile = path.resolve(import.meta.dir, "../event-types.json");
+
+  test("PUT/GET/DELETE event-type overlay; git file bytes are unchanged", async () => {
+    const before = readFileSync(eventTypesFile);
+    const { server, port, close } = await makeServer();
+    try {
+      const type = encodeURIComponent("factory.status-report.requested");
+      const put = await fetch(
+        `http://127.0.0.1:${port}/overrides/event-types/${type}`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ adapter: "cursor" }),
+        },
+      );
+      expect(put.status).toBe(200);
+      const listed = await fetch(`http://127.0.0.1:${port}/overrides`);
+      const body = await listed.json();
+      expect(body.eventTypes["factory.status-report.requested"]).toEqual({
+        adapter: "cursor",
+      });
+      const agents = await fetch(`http://127.0.0.1:${port}/agents`);
+      const view = await agents.json();
+      const def = view.agents.find((d) => d.ref === "factory-status-report@1");
+      expect(def.eventTypes[0].declaredAdapter).toBe("pi");
+      expect(def.eventTypes[0].adapter).toBe("cursor");
+      expect(def.eventTypes[0].resolvedModel).toBe("cursor-grok-4.6-high");
+      const del = await fetch(
+        `http://127.0.0.1:${port}/overrides/event-types/${type}`,
+        { method: "DELETE" },
+      );
+      expect((await del.json()).deleted).toBe(true);
+      expect(readFileSync(eventTypesFile).equals(before)).toBe(true);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("unknown adapter is 422; agent overlay updates GET /agents effective tier", async () => {
+    const { server, port, close } = await makeServer();
+    try {
+      const type = encodeURIComponent("factory.status-report.requested");
+      const bad = await fetch(
+        `http://127.0.0.1:${port}/overrides/event-types/${type}`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ adapter: "nope" }),
+        },
+      );
+      expect(bad.status).toBe(422);
+      const ref = encodeURIComponent("factory-status-report@1");
+      const put = await fetch(
+        `http://127.0.0.1:${port}/overrides/agents/${ref}`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ modelTier: "light" }),
+        },
+      );
+      expect(put.status).toBe(200);
+      const view = await (
+        await fetch(`http://127.0.0.1:${port}/agents`)
+      ).json();
+      const def = view.agents.find((d) => d.ref === "factory-status-report@1");
+      expect(def.declaredModelTier).toBe("standard");
+      expect(def.modelTier).toBe("light");
+      expect(def.eventTypes[0].resolvedModel).toBe("openai-codex/gpt-5.6-luna");
+    } finally {
+      close();
+      server.close();
+    }
   });
 });

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -323,6 +323,8 @@ export function createApi({
       }
       if (
         url.pathname === "/agents" ||
+        url.pathname === "/overrides" ||
+        url.pathname.startsWith("/overrides/") ||
         url.pathname === "/repos" ||
         url.pathname.startsWith("/repos/")
       ) {

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -352,6 +352,33 @@ export const MIGRATIONS = [
       }
     },
   },
+  {
+    version: 11,
+    name: "runtime_overrides",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS runtime_overrides (
+          kind       TEXT NOT NULL,
+          key        TEXT NOT NULL,
+          patch_json TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          updated_by TEXT NOT NULL,
+          PRIMARY KEY (kind, key)
+        );
+        CREATE TABLE IF NOT EXISTS runtime_override_journal (
+          seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+          kind       TEXT NOT NULL,
+          key        TEXT NOT NULL,
+          before_json TEXT,
+          after_json  TEXT,
+          actor      TEXT NOT NULL,
+          at         TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_override_journal_at
+          ON runtime_override_journal (at, seq);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =
@@ -373,6 +400,8 @@ export const CORE_TABLES = [
   "memos",
   "memo_uses",
   "merge_reviews",
+  "runtime_overrides",
+  "runtime_override_journal",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -262,6 +262,39 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     upgraded.close();
   });
 
+  test("runtime_overrides migrate onto an existing v7 database (WM-887)", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    migrateDb(db, { targetVersion: 7 });
+    expect(getSchemaVersion(db)).toBe(7);
+    expect(
+      db
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'runtime_overrides'",
+        )
+        .get(),
+    ).toBeNull();
+    db.close();
+
+    const upgraded = openDb(file);
+    expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(
+      upgraded
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'runtime_overrides'",
+        )
+        .get()?.name,
+    ).toBe("runtime_overrides");
+    expect(
+      upgraded
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'runtime_override_journal'",
+        )
+        .get()?.name,
+    ).toBe("runtime_override_journal");
+    upgraded.close();
+  });
+
   test("a database at a newer user_version refuses to open loudly with a clear message", () => {
     const file = freshFile();
     const db = openDb(file);

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -48,6 +48,13 @@ import {
   MODEL_TIERS,
   resolveModel,
 } from "./registry.mjs";
+import {
+  knownAdapters,
+  listOverrides,
+  overlayForAgent,
+  overlayForEventType,
+  plannedDef,
+} from "./runtime-overrides.mjs";
 import { pinRepo } from "./repository.mjs";
 import {
   RepoError,
@@ -194,9 +201,11 @@ export function buildRunSpec(
     now = Date.now(),
     approvalPolicy = null,
     modelTierOverride,
+    modelOverride,
   } = {},
 ) {
   const def = getAgent(registry, mapping.agent);
+  const planned = plannedDef(def, { modelTierOverride, modelOverride });
   let payload = envelope.payload;
   if (def.workspace?.type === "repository" && payload?.repo) {
     try {
@@ -241,22 +250,17 @@ export function buildRunSpec(
     // proposal, receipt, and inspect output all name the exact model. Fields
     // appear only when the definition declares intent — an undeclared
     // definition's spec is byte-identical to before (regression contract).
-    // Resolution keys off the REGISTERED adapter (mapping.adapter), not the
-    // override: `--adapter-override fake` substitutes execution, and the fake
-    // ignores the model; the spec still records what was routed. A null model
-    // means the routed adapter takes none (not applicable).
+    // Resolution keys off mapping.adapter. Process-wide `--adapter-override`
+    // substitutes execution only (fake still pins the registered route's
+    // model). A runtime overlay (WM-887) changes mapping.adapter itself so
+    // the model follows the effective harness. A null model means the routed
+    // adapter takes none (not applicable).
     ...(modelTierOverride !== undefined ||
-    def.model_tier !== undefined ||
-    def.model !== undefined
+    planned.model_tier !== undefined ||
+    planned.model !== undefined
       ? {
-          modelTier: modelTierOverride ?? def.model_tier ?? null,
-          model: resolveModel(
-            modelTierOverride === undefined
-              ? def
-              : { ...def, model_tier: modelTierOverride },
-            mapping.adapter,
-            registry.modelTiers,
-          ),
+          modelTier: modelTierOverride ?? planned.model_tier ?? null,
+          model: resolveModel(planned, mapping.adapter, registry.modelTiers),
         }
       : {}),
     timeoutSeconds: def.limits.timeout_seconds,
@@ -1361,8 +1365,8 @@ export function planEvent(
     const envelope = JSON.parse(event.envelope_json);
     const at = new Date(now).toISOString();
 
-    const mapping = getEventType(registry, envelope.type);
-    if (!mapping)
+    const gitMapping = getEventType(registry, envelope.type);
+    if (!gitMapping)
       return humanNeeded(
         db,
         event,
@@ -1370,6 +1374,23 @@ export function planEvent(
         at,
         DEFAULT_PROPOSAL_TTL_SECONDS,
       );
+    const overrides = listOverrides(db);
+    const overlayAdapter = overlayForEventType(
+      overrides,
+      envelope.type,
+    )?.adapter;
+    if (overlayAdapter && !knownAdapters(registry).has(overlayAdapter)) {
+      return humanNeeded(
+        db,
+        event,
+        `overlay_unknown_adapter:${overlayAdapter}`,
+        at,
+        gitMapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS,
+      );
+    }
+    const mapping = overlayAdapter
+      ? { ...gitMapping, adapter: overlayAdapter }
+      : gitMapping;
     const ttlSeconds =
       mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS;
 
@@ -1745,14 +1766,20 @@ export function planEvent(
 
     // Per-ticket routing applies only to factory dispatch. The payload is
     // already schema-validated above; ticket labels were validated by the
-    // dispatch gate. Passing no override preserves every other event's spec,
-    // and dispatches with neither source retain the definition-only behavior.
+    // dispatch gate. Overlay (WM-887) sits below those and above git.
+    const agentPatch = overlayForAgent(overrides, mapping.agent) ?? {};
+    const overlayTier = Object.hasOwn(agentPatch, "modelTier")
+      ? agentPatch.modelTier
+      : undefined;
+    const overlayModel = Object.hasOwn(agentPatch, "model")
+      ? agentPatch.model
+      : undefined;
     const modelTierOverride =
       envelope.type === "factory.dispatch.requested"
         ? (payload.modelTier ??
           dispatchEvidence?.ticket?.modelTier ??
-          undefined)
-        : undefined;
+          overlayTier)
+        : overlayTier;
 
     const spec = {
       ...buildRunSpec(registry, pinnedEnvelope, mapping, {
@@ -1762,6 +1789,7 @@ export function planEvent(
         now,
         approvalPolicy,
         modelTierOverride,
+        modelOverride: overlayModel,
       }),
       idempotencyKey,
     };

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -31,6 +31,12 @@ import {
   withProvenance,
 } from "./memos.mjs";
 import { LinearRateLimitError } from "../../tools/linear.mjs";
+import {
+  KIND_AGENT,
+  KIND_EVENT_TYPE,
+  deleteOverride,
+  putOverride,
+} from "./runtime-overrides.mjs";
 
 const registry = loadRegistry();
 const NOW = Date.parse("2026-08-12T10:30:02Z");
@@ -1620,6 +1626,100 @@ describe("buildRunSpec", () => {
     });
     expect(overridden.adapter).toBe("pi");
     expect(overridden.idempotencyKey).toBe(a.idempotencyKey);
+  });
+});
+
+describe("planEvent runtime overlay (WM-887)", () => {
+  test("an event-type adapter overlay pins that adapter and resolves the model via its policy map", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db);
+    putOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: "factory.status-report.requested",
+      patch: { adapter: "cursor" },
+    });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(outcome.decision).toBe("run");
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.adapter).toBe("cursor");
+    expect(spec.modelTier).toBe("standard");
+    expect(spec.model).toBe("cursor-grok-4.6-high");
+  });
+
+  test("deleting the overlay returns the next plan to the git adapter; the first spec is unchanged", () => {
+    const db = openDb(":memory:");
+    const firstRef = admit(db, {
+      eventId: "overlay-first",
+      correlationId: "c1",
+    });
+    putOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: "factory.status-report.requested",
+      patch: { adapter: "cursor" },
+    });
+    const first = planEvent(db, registry, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const firstSpec = JSON.parse(first.proposal.spec_json);
+    expect(firstSpec.adapter).toBe("cursor");
+    deleteOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: "factory.status-report.requested",
+    });
+    const secondRef = admit(db, {
+      eventId: "overlay-second",
+      correlationId: "c2",
+    });
+    const second = planEvent(db, registry, secondRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(JSON.parse(second.proposal.spec_json).adapter).toBe("pi");
+    expect(
+      JSON.parse(
+        db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(first.runId)
+          .spec_json,
+      ).adapter,
+    ).toBe("cursor");
+  });
+
+  test("an agent model_tier overlay pins the resolved model; payload.modelTier still wins on dispatch", () => {
+    const db = openDb(":memory:");
+    putOverride(db, {
+      kind: KIND_AGENT,
+      key: "factory-status-report@1",
+      patch: { modelTier: "light" },
+    });
+    const ref = admit(db, { eventId: "tier-overlay", correlationId: "tier-c" });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.modelTier).toBe("light");
+    expect(spec.model).toBe("openai-codex/gpt-5.6-luna");
+  });
+
+  test("a stale overlay adapter parks human_needed instead of planning", () => {
+    const db = openDb(":memory:");
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES ('eventType', 'factory.status-report.requested', '{"adapter":"nope"}', 't', 'x')`,
+    ).run();
+    const ref = admit(db, {
+      eventId: "stale-overlay",
+      correlationId: "stale-c",
+    });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toBe("overlay_unknown_adapter:nope");
   });
 });
 

--- a/event-runtime/lib/runtime-overrides.mjs
+++ b/event-runtime/lib/runtime-overrides.mjs
@@ -1,0 +1,266 @@
+/**
+ * Machine-local operational overlay (WM-887).
+ *
+ * Git remains the declared fleet default (`event-types.json` adapter,
+ * `agents/*.json` model_tier / model). This module stores a last-wins patch
+ * in runtime.db and the planner applies it at plan time. Packs cannot shadow
+ * built-ins (WM-470); this is not a pack.
+ */
+import { builtinAdapters } from "./adapters/index.mjs";
+import { txImmediate } from "./db.mjs";
+
+export const KIND_EVENT_TYPE = "eventType";
+export const KIND_AGENT = "agent";
+export const MODEL_TIERS = new Set(["strong", "standard", "light"]);
+
+export class OverlayError extends Error {
+  /**
+   * @param {number} status
+   * @param {string} message
+   */
+  constructor(status, message) {
+    super(message);
+    this.name = "OverlayError";
+    this.status = status;
+  }
+}
+
+export function emptyOverrides() {
+  return { eventTypes: {}, agents: {} };
+}
+
+/** Adapters the overlay may name: builtins plus any currently routed. */
+export function knownAdapters(registry) {
+  const names = new Set(Object.keys(builtinAdapters()));
+  for (const mapping of Object.values(registry?.eventTypes ?? {})) {
+    if (typeof mapping?.adapter === "string" && mapping.adapter !== "") {
+      names.add(mapping.adapter);
+    }
+  }
+  return names;
+}
+
+export function listOverrides(db) {
+  const rows = db
+    .query(
+      `SELECT kind, key, patch_json, updated_at, updated_by FROM runtime_overrides ORDER BY kind, key`,
+    )
+    .all();
+  const out = emptyOverrides();
+  for (const row of rows) {
+    const patch = JSON.parse(row.patch_json);
+    if (row.kind === KIND_EVENT_TYPE) out.eventTypes[row.key] = patch;
+    else if (row.kind === KIND_AGENT) out.agents[row.key] = patch;
+  }
+  return out;
+}
+
+export function listOverrideJournal(db, { limit = 100 } = {}) {
+  return db
+    .query(
+      `SELECT seq, kind, key, before_json, after_json, actor, at
+         FROM runtime_override_journal
+        ORDER BY seq DESC
+        LIMIT ?`,
+    )
+    .all(limit)
+    .map((row) => ({
+      seq: row.seq,
+      kind: row.kind,
+      key: row.key,
+      before: row.before_json ? JSON.parse(row.before_json) : null,
+      after: row.after_json ? JSON.parse(row.after_json) : null,
+      actor: row.actor,
+      at: row.at,
+    }));
+}
+
+function readRow(db, kind, key) {
+  const row = db
+    .query(
+      `SELECT patch_json, updated_at, updated_by FROM runtime_overrides WHERE kind = ? AND key = ?`,
+    )
+    .get(kind, key);
+  if (!row) return null;
+  return {
+    patch: JSON.parse(row.patch_json),
+    updatedAt: row.updated_at,
+    updatedBy: row.updated_by,
+  };
+}
+
+function writeJournal(db, { kind, key, before, after, actor, at }) {
+  db.query(
+    `INSERT INTO runtime_override_journal (kind, key, before_json, after_json, actor, at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    kind,
+    key,
+    before == null ? null : JSON.stringify(before),
+    after == null ? null : JSON.stringify(after),
+    actor,
+    at,
+  );
+}
+
+function isoNow(now) {
+  return new Date(now ?? Date.now()).toISOString();
+}
+
+export function putOverride(
+  db,
+  { kind, key, patch, actor = "operator", now = Date.now() },
+) {
+  const at = isoNow(now);
+  return txImmediate(db, () => {
+    const prev = readRow(db, kind, key);
+    const before = prev?.patch ?? null;
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(kind, key) DO UPDATE SET
+         patch_json = excluded.patch_json,
+         updated_at = excluded.updated_at,
+         updated_by = excluded.updated_by`,
+    ).run(kind, key, JSON.stringify(patch), at, actor);
+    writeJournal(db, { kind, key, before, after: patch, actor, at });
+    return { kind, key, patch, updatedAt: at, updatedBy: actor };
+  });
+}
+
+export function deleteOverride(
+  db,
+  { kind, key, actor = "operator", now = Date.now() },
+) {
+  const at = isoNow(now);
+  return txImmediate(db, () => {
+    const prev = readRow(db, kind, key);
+    if (!prev) return { deleted: false };
+    db.query(`DELETE FROM runtime_overrides WHERE kind = ? AND key = ?`).run(
+      kind,
+      key,
+    );
+    writeJournal(db, {
+      kind,
+      key,
+      before: prev.patch,
+      after: null,
+      actor,
+      at,
+    });
+    return { deleted: true };
+  });
+}
+
+export function validateEventTypePatch(registry, type, patch) {
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+    throw new OverlayError(422, "body must be an object");
+  }
+  const keys = Object.keys(patch);
+  if (keys.length === 0 || keys.some((k) => k !== "adapter")) {
+    throw new OverlayError(422, "event-type overlay accepts only adapter");
+  }
+  if (typeof patch.adapter !== "string" || patch.adapter.trim() === "") {
+    throw new OverlayError(422, "adapter must be a non-empty string");
+  }
+  const mapping = registry.eventTypes?.[type];
+  if (!mapping) {
+    throw new OverlayError(422, `unknown event type ${JSON.stringify(type)}`);
+  }
+  if (mapping.observe === true) {
+    throw new OverlayError(
+      422,
+      `event type ${JSON.stringify(type)} is observe-only and has no adapter`,
+    );
+  }
+  if (!knownAdapters(registry).has(patch.adapter)) {
+    throw new OverlayError(
+      422,
+      `unknown adapter ${JSON.stringify(patch.adapter)}`,
+    );
+  }
+  return { adapter: patch.adapter };
+}
+
+export function validateAgentPatch(registry, ref, patch) {
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+    throw new OverlayError(422, "body must be an object");
+  }
+  const allowed = new Set(["modelTier", "model"]);
+  const keys = Object.keys(patch);
+  if (keys.length === 0) {
+    throw new OverlayError(422, "agent overlay requires modelTier or model");
+  }
+  for (const key of keys) {
+    if (!allowed.has(key)) {
+      throw new OverlayError(422, `unexpected field ${JSON.stringify(key)}`);
+    }
+  }
+  if (!registry.agents?.has(ref)) {
+    throw new OverlayError(422, `unknown agent ${JSON.stringify(ref)}`);
+  }
+  const out = {};
+  if (Object.hasOwn(patch, "modelTier")) {
+    if (patch.modelTier !== null && !MODEL_TIERS.has(patch.modelTier)) {
+      throw new OverlayError(
+        422,
+        `modelTier must be strong, standard, light, or null`,
+      );
+    }
+    out.modelTier = patch.modelTier;
+  }
+  if (Object.hasOwn(patch, "model")) {
+    if (patch.model !== null && typeof patch.model !== "string") {
+      throw new OverlayError(422, "model must be a string or null");
+    }
+    if (typeof patch.model === "string" && patch.model.trim() === "") {
+      throw new OverlayError(422, "model must be a non-empty string or null");
+    }
+    out.model = patch.model;
+  }
+  return out;
+}
+
+/**
+ * Merge a new agent patch onto whatever is already stored for that ref so
+ * tier and exact pin can be saved independently.
+ */
+export function mergeAgentPatch(existing, incoming) {
+  const next = { ...(existing ?? {}) };
+  if (Object.hasOwn(incoming, "modelTier")) {
+    if (incoming.modelTier === null) delete next.modelTier;
+    else next.modelTier = incoming.modelTier;
+  }
+  if (Object.hasOwn(incoming, "model")) {
+    if (incoming.model === null) next.model = null;
+    else next.model = incoming.model;
+  }
+  if (Object.keys(next).length === 0) return null;
+  return next;
+}
+
+/** Def the planner / GET /agents should resolve models against. */
+export function plannedDef(def, { modelTierOverride, modelOverride } = {}) {
+  const planned = { ...def };
+  if (modelTierOverride !== undefined) {
+    if (modelTierOverride === null) delete planned.model_tier;
+    else planned.model_tier = modelTierOverride;
+  }
+  if (modelOverride !== undefined) {
+    if (modelOverride === null) delete planned.model;
+    else planned.model = modelOverride;
+  }
+  return planned;
+}
+
+export function overlayForEventType(overrides, type) {
+  return overrides?.eventTypes?.[type] ?? null;
+}
+
+export function overlayForAgent(overrides, ref) {
+  return overrides?.agents?.[ref] ?? null;
+}
+
+export function effectiveAdapter(mapping, overrides, type) {
+  return overlayForEventType(overrides, type)?.adapter ?? mapping.adapter;
+}

--- a/event-runtime/lib/runtime-overrides.test.mjs
+++ b/event-runtime/lib/runtime-overrides.test.mjs
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { openDb } from "./db.mjs";
+import { loadRegistry } from "./registry.mjs";
+import {
+  KIND_AGENT,
+  KIND_EVENT_TYPE,
+  OverlayError,
+  deleteOverride,
+  knownAdapters,
+  listOverrideJournal,
+  listOverrides,
+  mergeAgentPatch,
+  plannedDef,
+  putOverride,
+  validateAgentPatch,
+  validateEventTypePatch,
+} from "./runtime-overrides.mjs";
+
+const registry = loadRegistry();
+
+describe("runtime-overrides (WM-887)", () => {
+  test("put, get, delete, and journal an event-type adapter overlay", () => {
+    const db = openDb(":memory:");
+    const type = "factory.status-report.requested";
+    putOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: type,
+      patch: { adapter: "cursor" },
+      actor: "operator",
+      now: Date.parse("2026-08-19T10:00:00Z"),
+    });
+    expect(listOverrides(db).eventTypes[type]).toEqual({ adapter: "cursor" });
+    const gone = deleteOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: type,
+      actor: "operator",
+      now: Date.parse("2026-08-19T10:01:00Z"),
+    });
+    expect(gone.deleted).toBe(true);
+    expect(listOverrides(db).eventTypes[type]).toBeUndefined();
+    const journal = listOverrideJournal(db);
+    expect(journal).toHaveLength(2);
+    expect(journal[0].after).toBeNull();
+    expect(journal[1].after).toEqual({ adapter: "cursor" });
+    db.close();
+  });
+
+  test("validateEventTypePatch refuses unknown type, unknown adapter, extra keys", () => {
+    expect(() =>
+      validateEventTypePatch(registry, "nope.requested", { adapter: "pi" }),
+    ).toThrow(OverlayError);
+    expect(() =>
+      validateEventTypePatch(registry, "factory.status-report.requested", {
+        adapter: "nope",
+      }),
+    ).toThrow(/unknown adapter/);
+    expect(() =>
+      validateEventTypePatch(registry, "factory.status-report.requested", {
+        adapter: "pi",
+        extra: true,
+      }),
+    ).toThrow(/only adapter/);
+    const patch = validateEventTypePatch(
+      registry,
+      "factory.status-report.requested",
+      { adapter: "cursor" },
+    );
+    expect(patch).toEqual({ adapter: "cursor" });
+    expect(knownAdapters(registry).has("pi")).toBe(true);
+  });
+
+  test("validateAgentPatch refuses unknown ref and invalid tier; merge keeps independent fields", () => {
+    expect(() =>
+      validateAgentPatch(registry, "missing@1", { modelTier: "light" }),
+    ).toThrow(/unknown agent/);
+    expect(() =>
+      validateAgentPatch(registry, "factory-status-report@1", {
+        modelTier: "turbo",
+      }),
+    ).toThrow(/modelTier/);
+    const incoming = validateAgentPatch(registry, "factory-status-report@1", {
+      model: "cursor-grok-4.6-high",
+    });
+    expect(mergeAgentPatch({ modelTier: "light" }, incoming)).toEqual({
+      modelTier: "light",
+      model: "cursor-grok-4.6-high",
+    });
+    expect(
+      mergeAgentPatch({ modelTier: "light", model: "x" }, { model: null }),
+    ).toEqual({
+      modelTier: "light",
+      model: null,
+    });
+    expect(
+      mergeAgentPatch({ modelTier: "light" }, { modelTier: null }),
+    ).toBeNull();
+  });
+
+  test("plannedDef: null model overlay drops the git pin so the tier map wins", () => {
+    const planned = plannedDef(
+      { model_tier: "standard", model: "pinned-id" },
+      { modelOverride: null },
+    );
+    expect(planned.model).toBeUndefined();
+    expect(planned.model_tier).toBe("standard");
+  });
+});

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -375,7 +375,33 @@ export const api = {
       { runId },
     ),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
+  // Effective adapter/tier include the runtime overlay (WM-887).
   agents: () => call<AgentsView>("GET", "/agents"),
+  putEventTypeOverride: (type: string, body: { adapter: string }) =>
+    call<{ patch: { adapter: string } }>(
+      "PUT",
+      `/overrides/event-types/${encodeURIComponent(type)}`,
+      body,
+    ),
+  deleteEventTypeOverride: (type: string) =>
+    call<{ deleted: boolean }>(
+      "DELETE",
+      `/overrides/event-types/${encodeURIComponent(type)}`,
+    ),
+  putAgentOverride: (
+    ref: string,
+    body: { modelTier?: string | null; model?: string | null },
+  ) =>
+    call<{ patch: Record<string, unknown> }>(
+      "PUT",
+      `/overrides/agents/${encodeURIComponent(ref)}`,
+      body,
+    ),
+  deleteAgentOverride: (ref: string) =>
+    call<{ deleted: boolean }>(
+      "DELETE",
+      `/overrides/agents/${encodeURIComponent(ref)}`,
+    ),
   // Declarative Overview panels (WM-840) and the data behind one of them:
   // `panelSource` only ever GETs an endpoint the runtime already
   // allow-listed for the panel; the query is the panel's own `source.query`.

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -362,6 +362,25 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       runId,
     })),
     agents: mock(async () => createAgentsFixture()),
+    putEventTypeOverride: mock(
+      async (_type: string, body: { adapter: string }) => ({
+        patch: { adapter: body.adapter },
+      }),
+    ),
+    deleteEventTypeOverride: mock(async (_type: string) => ({
+      deleted: true,
+    })),
+    putAgentOverride: mock(
+      async (
+        _ref: string,
+        body: { modelTier?: string | null; model?: string | null },
+      ) => ({
+        patch: { ...body },
+      }),
+    ),
+    deleteAgentOverride: mock(async (_ref: string) => ({
+      deleted: true,
+    })),
     panels: mock(async () => ({ panels: [], endpoints: [] })),
     panelSource: mock(
       async (_endpoint: string, _query?: Record<string, string>) => ({}),

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -408,6 +408,8 @@ export interface RunDetail {
 export interface AgentEventRoute {
   type: string;
   adapter: string;
+  /** Git mapping, before the runtime overlay (WM-887). */
+  declaredAdapter?: string;
   idempotencyScope: string;
   proposalTtlSeconds: number | null;
   /**
@@ -507,8 +509,12 @@ export interface AgentDef {
   hosts: string[] | null;
   /** Declared intent (WM-135): strong | standard | light, or null for none. */
   modelTier: string | null;
+  /** Git model_tier, before the runtime overlay (WM-887). */
+  declaredModelTier?: string | null;
   /** Exact model id, when a definition overrides its tier outright. */
   model: string | null;
+  /** Git model pin, before the runtime overlay (WM-887). */
+  declaredModel?: string | null;
   eventTypes: AgentEventRoute[];
 }
 
@@ -532,6 +538,8 @@ export interface AgentsView {
   edges: Record<string, RecommendationRule>;
   eventTypes: EventRoute[];
   contracts: Record<string, unknown>;
+  /** Adapters the overlay may name (WM-887). */
+  adapters?: string[];
 }
 
 /** A worker's own report of what it is doing; "stopped" is a clean exit. */

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -76,10 +76,6 @@ function stubAgent(id: string, over: Partial<AgentDef> = {}): AgentDef {
     declaredModel: over.declaredModel ?? model,
     eventTypes: [stubRoute()],
     ...over,
-    modelTier,
-    declaredModelTier: over.declaredModelTier ?? modelTier,
-    model,
-    declaredModel: over.declaredModel ?? model,
   };
 }
 

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -21,7 +21,7 @@ import {
   EMPTY_VALUE,
   formatDurationSeconds,
 } from "../components/AgentHoverCard";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import type { AgentDef, AgentEventRoute, AgentsView } from "../types";
 
 afterEach(() => {
@@ -34,9 +34,11 @@ afterEach(() => {
 });
 
 function stubRoute(over: Partial<AgentEventRoute> = {}): AgentEventRoute {
+  const adapter = over.adapter ?? "claude";
   return {
     type: "factory.demo/v1",
-    adapter: "claude",
+    adapter,
+    declaredAdapter: over.declaredAdapter ?? adapter,
     idempotencyScope: "repo",
     proposalTtlSeconds: null,
     resolvedModel: "sonnet",
@@ -45,6 +47,10 @@ function stubRoute(over: Partial<AgentEventRoute> = {}): AgentEventRoute {
 }
 
 function stubAgent(id: string, over: Partial<AgentDef> = {}): AgentDef {
+  const modelTier = Object.hasOwn(over, "modelTier")
+    ? (over.modelTier ?? null)
+    : "standard";
+  const model = Object.hasOwn(over, "model") ? (over.model ?? null) : null;
   return {
     ref: `${id}@1`,
     id,
@@ -64,10 +70,16 @@ function stubAgent(id: string, over: Partial<AgentDef> = {}): AgentDef {
     command: null,
     actionRegistry: null,
     hosts: null,
-    modelTier: "standard",
-    model: null,
+    modelTier,
+    declaredModelTier: over.declaredModelTier ?? modelTier,
+    model,
+    declaredModel: over.declaredModel ?? model,
     eventTypes: [stubRoute()],
     ...over,
+    modelTier,
+    declaredModelTier: over.declaredModelTier ?? modelTier,
+    model,
+    declaredModel: over.declaredModel ?? model,
   };
 }
 
@@ -103,9 +115,20 @@ function SelectableAgents() {
   );
 }
 
-function withAgents(agents: AgentDef[], fn: () => Promise<void>) {
+function withAgents(
+  agents: AgentDef[],
+  fn: () => Promise<void>,
+  extra: Partial<AgentsView> = {},
+) {
   const orig = api.agents;
-  const view: AgentsView = { agents, edges: {}, eventTypes: [], contracts: {} };
+  const view: AgentsView = {
+    agents,
+    edges: {},
+    eventTypes: [],
+    contracts: {},
+    adapters: ["claude", "pi", "cursor", "agy", "command", "actions", "fake"],
+    ...extra,
+  };
   api.agents = async () => view;
   return fn().finally(() => {
     api.agents = orig;
@@ -363,7 +386,8 @@ describe("Agents detail pane (WM-211)", () => {
       }),
     ];
     await withAgents(agents, async () => {
-      const { getByText, getAllByText } = renderAgents("pi-smoke@1");
+      const { getByText, getAllByText, getByLabelText } =
+        renderAgents("pi-smoke@1");
       await waitFor(() => {
         expect(getByText("model tier")).toBeTruthy();
       });
@@ -373,7 +397,9 @@ describe("Agents detail pane (WM-211)", () => {
       expect(getAllByText("openai-codex/gpt-5.6-luna").length).toBeGreaterThan(
         0,
       );
-      expect(getByText(/adapter pi/)).toBeTruthy();
+      expect(
+        getByLabelText("Adapter overlay for factory.pi-smoke/v1"),
+      ).toBeTruthy();
     });
   });
 
@@ -391,13 +417,119 @@ describe("Agents detail pane (WM-211)", () => {
       }),
     ];
     await withAgents(agents, async () => {
-      const { getByText, getAllByText } = renderAgents("reaper@1");
+      const { getByText, getAllByText, getByLabelText } =
+        renderAgents("reaper@1");
       await waitFor(() => {
         expect(getByText("model tier")).toBeTruthy();
       });
       expect(getAllByText("n/a").length).toBeGreaterThan(0);
-      expect(getByText(/adapter command/)).toBeTruthy();
+      expect(
+        getByLabelText("Adapter overlay for factory.reap/v1"),
+      ).toBeTruthy();
     });
+  });
+});
+
+describe("Agents overlay editors (WM-884)", () => {
+  test("select+save paints the this-runtime chip; revert restores declared", async () => {
+    const agent = stubAgent("demo", {
+      eventTypes: [
+        stubRoute({
+          type: "factory.demo.requested",
+          adapter: "pi",
+          declaredAdapter: "pi",
+        }),
+      ],
+    });
+    let current = [agent];
+    const origAgents = api.agents;
+    const origPut = api.putEventTypeOverride;
+    const origDel = api.deleteEventTypeOverride;
+    api.agents = async () => ({
+      agents: current,
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+      adapters: ["pi", "cursor"],
+    });
+    api.putEventTypeOverride = async (type, body) => {
+      current = current.map((row) => ({
+        ...row,
+        eventTypes: row.eventTypes.map((route) =>
+          route.type === type ? { ...route, adapter: body.adapter } : route,
+        ),
+      }));
+      return { patch: body };
+    };
+    api.deleteEventTypeOverride = async (type) => {
+      current = current.map((row) => ({
+        ...row,
+        eventTypes: row.eventTypes.map((route) =>
+          route.type === type
+            ? { ...route, adapter: route.declaredAdapter ?? route.adapter }
+            : route,
+        ),
+      }));
+      return { deleted: true };
+    };
+    try {
+      const { getByLabelText, getByRole, queryByText } = renderAgents(
+        agent.ref,
+      );
+      const select = await waitFor(() =>
+        getByLabelText("Adapter overlay for factory.demo.requested"),
+      );
+      fireEvent.change(select, { target: { value: "cursor" } });
+      await waitFor(() => {
+        expect(queryByText("this runtime")).toBeTruthy();
+      });
+      fireEvent.click(getByRole("button", { name: "Revert" }));
+      await waitFor(() => {
+        expect(queryByText("this runtime")).toBeNull();
+      });
+    } finally {
+      api.agents = origAgents;
+      api.putEventTypeOverride = origPut;
+      api.deleteEventTypeOverride = origDel;
+    }
+  });
+
+  test("a 422 leaves declared values on screen", async () => {
+    const agent = stubAgent("demo", {
+      eventTypes: [
+        stubRoute({
+          type: "factory.demo.requested",
+          adapter: "pi",
+          declaredAdapter: "pi",
+        }),
+      ],
+    });
+    const origAgents = api.agents;
+    const origPut = api.putEventTypeOverride;
+    api.agents = async () => ({
+      agents: [agent],
+      edges: {},
+      eventTypes: [],
+      contracts: {},
+      adapters: ["pi", "cursor"],
+    });
+    api.putEventTypeOverride = async () => {
+      throw new ApiError('unknown adapter "nope"', 422);
+    };
+    try {
+      const { getByLabelText, queryByText } = renderAgents(agent.ref);
+      const select = await waitFor(() =>
+        getByLabelText("Adapter overlay for factory.demo.requested"),
+      );
+      fireEvent.change(select, { target: { value: "cursor" } });
+      await waitFor(() => {
+        expect((select as HTMLSelectElement).value).toBe("pi");
+      });
+      expect(queryByText("this runtime")).toBeNull();
+    } finally {
+      api.agents = origAgents;
+      api.putEventTypeOverride = origPut;
+    }
   });
 });
 

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import {
   refetchIntervals,
   useDisplayOptions,
@@ -41,6 +41,7 @@ import {
   copyText,
   copyLink,
   shortId,
+  notify,
 } from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
 import { AgentMutationBadge } from "../components/AgentHoverCard";
@@ -63,14 +64,44 @@ const caps = (a: AgentDef) =>
  * and rides the CLI's own default. Collapsing both to a blank cell is exactly
  * the ambiguity this view exists to remove.
  */
-const MODEL_ADAPTERS = new Set(["claude", "pi"]);
+const MODEL_ADAPTERS = new Set(["claude", "pi", "agy", "cursor"]);
 
 /**
  * Tier buckets, strongest first — the group order and the sort order at once,
  * so "sort by tier" and "group by tier" cannot disagree. `override` is not a
  * tier but reads as one here: it is what a definition says instead of a tier.
  */
+const TIER_CHOICES = ["strong", "standard", "light"] as const;
 const TIER_ORDER = ["strong", "standard", "light", "override", EMPTY] as const;
+
+const SELECT_CLASS =
+  "rounded-md border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px] text-(--text)";
+
+const declaredAdapterOf = (r: AgentEventRoute): string =>
+  r.declaredAdapter ?? r.adapter;
+
+const adapterIsOverlaid = (r: AgentEventRoute): boolean =>
+  declaredAdapterOf(r) !== r.adapter;
+
+const declaredTierOf = (a: AgentDef): string | null =>
+  a.declaredModelTier ?? a.modelTier;
+
+const declaredModelOf = (a: AgentDef): string | null =>
+  a.declaredModel ?? a.model ?? null;
+
+const modelIsOverlaid = (a: AgentDef): boolean =>
+  declaredTierOf(a) !== a.modelTier || declaredModelOf(a) !== (a.model ?? null);
+
+function RuntimeChip() {
+  return (
+    <span
+      className="rounded-sm border border-(--border) px-1 py-px text-[10px] text-(--text-faint)"
+      title="This box's runtime.db overlay — not origin/develop."
+    >
+      this runtime
+    </span>
+  );
+}
 
 const AGENT_TABS = ["ALL", "MUTATING", "READ_ONLY"] as const;
 type AgentTab = (typeof AGENT_TABS)[number];
@@ -196,12 +227,38 @@ const AGENTS_DISPLAY: DisplayConfig<AgentDef> = {
  */
 const eventsTypeHref = (type: string) => `#/${eventsHash(null, null, type)}`;
 
+function ModelPinEditor({
+  agent,
+  onSave,
+}: {
+  agent: AgentDef;
+  onSave: (model: string | null) => void;
+}) {
+  const [draft, setDraft] = useState(agent.model ?? "");
+  useEffect(() => {
+    setDraft(agent.model ?? "");
+  }, [agent.ref, agent.model]);
+  return (
+    <span className="flex flex-wrap items-center gap-1.5">
+      <input
+        aria-label="Exact model pin overlay"
+        className={`${SELECT_CLASS} min-w-[12rem]`}
+        value={draft}
+        placeholder="exact model id"
+        title="Exact model id — resolved verbatim, whatever the tier says."
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <Button onClick={() => onSave(draft.trim() === "" ? null : draft.trim())}>
+        Apply
+      </Button>
+    </span>
+  );
+}
+
 /**
- * Agents (webui doc §10.6) — the registry, fully readable. An operator
- * approving "factory-status-report@1" can read exactly what that ref means —
- * prompt, schemas, pins, routing, and (WM-211) which adapter runs it on which
- * model — without opening the repo. Read-only: the registry has no mutation
- * surface, by design.
+ * Agents (webui doc §10.6) — the registry, fully readable, plus a narrow
+ * operational overlay editor (WM-884) for event-type adapter and agent
+ * model_tier / model. Saves write runtime.db on this box, not git.
  */
 export function Agents({
   context,
@@ -212,6 +269,7 @@ export function Agents({
   focusAgentRef: string | null;
   onSelectAgent: (ref: string | null) => void;
 }) {
+  const queryClient = useQueryClient();
   const query = useQuery({
     queryKey: ["agents"],
     queryFn: api.agents,
@@ -219,6 +277,54 @@ export function Agents({
   });
   const rows = query.data?.agents ?? [];
   const contracts = query.data?.contracts ?? {};
+  const adapters = useMemo(() => {
+    const fromApi = query.data?.adapters ?? [];
+    if (fromApi.length > 0) return fromApi;
+    return uniq(rows.flatMap((a) => a.eventTypes.map((r) => r.adapter)));
+  }, [query.data?.adapters, rows]);
+
+  const invalidateAgents = () =>
+    queryClient.invalidateQueries({ queryKey: ["agents"] });
+  const overlayError = (err: unknown) =>
+    notify(err instanceof ApiError ? err.message : "save failed", "err");
+
+  const saveAdapter = useMutation({
+    mutationFn: ({ type, adapter }: { type: string; adapter: string }) =>
+      api.putEventTypeOverride(type, { adapter }),
+    onSuccess: () => {
+      notify("Saved on this runtime — not origin/develop", "ok");
+      invalidateAgents();
+    },
+    onError: overlayError,
+  });
+  const revertAdapter = useMutation({
+    mutationFn: (type: string) => api.deleteEventTypeOverride(type),
+    onSuccess: () => {
+      notify("Reverted to git mapping", "ok");
+      invalidateAgents();
+    },
+    onError: overlayError,
+  });
+  const saveModel = useMutation({
+    mutationFn: (body: {
+      ref: string;
+      modelTier?: string | null;
+      model?: string | null;
+    }) => api.putAgentOverride(body.ref, body),
+    onSuccess: () => {
+      notify("Saved on this runtime — not origin/develop", "ok");
+      invalidateAgents();
+    },
+    onError: overlayError,
+  });
+  const revertModel = useMutation({
+    mutationFn: (ref: string) => api.deleteAgentOverride(ref),
+    onSuccess: () => {
+      notify("Reverted to git definition", "ok");
+      invalidateAgents();
+    },
+    onError: overlayError,
+  });
 
   const tabCounts = agentTabCounts(rows);
   const mutatingCount = tabCounts.MUTATING;
@@ -770,17 +876,49 @@ export function Agents({
                 route actually resolves to is per adapter, and lives on the
                 Event routing lines below — the same split `cli.mjs agents` prints. */}
             <KVGroup title="Model">
-              <KV k="model tier" v={sel.modelTier ?? EMPTY} />
+              <KV
+                k="model tier"
+                v={
+                  <span className="flex flex-wrap items-center gap-1.5">
+                    <select
+                      aria-label="Model tier overlay"
+                      className={SELECT_CLASS}
+                      value={sel.modelTier ?? ""}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        saveModel.mutate({
+                          ref: sel.ref,
+                          modelTier: value === "" ? null : value,
+                        });
+                      }}
+                    >
+                      <option value="">
+                        declared ({declaredTierOf(sel) ?? "none"})
+                      </option>
+                      {TIER_CHOICES.map((tier) => (
+                        <option key={tier} value={tier}>
+                          {tier}
+                        </option>
+                      ))}
+                    </select>
+                    {modelIsOverlaid(sel) ? <RuntimeChip /> : null}
+                    {modelIsOverlaid(sel) ? (
+                      <Button onClick={() => revertModel.mutate(sel.ref)}>
+                        Revert
+                      </Button>
+                    ) : null}
+                  </span>
+                }
+              />
               <KV
                 k="model override"
                 v={
-                  sel.model ? (
-                    <span title="Exact model id — resolved verbatim, whatever the tier says.">
-                      {sel.model}
-                    </span>
-                  ) : (
-                    EMPTY
-                  )
+                  <ModelPinEditor
+                    agent={sel}
+                    onSave={(model) =>
+                      saveModel.mutate({ ref: sel.ref, model })
+                    }
+                  />
                 }
               />
             </KVGroup>
@@ -868,42 +1006,76 @@ export function Agents({
             ) : (
               <div className="rounded-md border border-(--border) px-3 py-1">
                 {sel.eventTypes.map((r) => (
-                  <a
+                  <div
                     key={r.type}
-                    href={eventsTypeHref(r.type)}
-                    title={`Show ${r.type} in Events`}
-                    className="group -mx-3 block border-b border-(--border) px-3 py-1.5 last:border-0 hover:bg-(--surface-1)"
+                    className="-mx-3 border-b border-(--border) px-3 py-1.5 last:border-0"
                   >
-                    <div className="mono text-(--accent) group-hover:underline">
+                    <a
+                      href={eventsTypeHref(r.type)}
+                      title={`Show ${r.type} in Events`}
+                      className="mono text-(--accent) hover:underline"
+                    >
                       {r.type}
+                    </a>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-(--text-faint)">
+                      <label className="flex items-center gap-1">
+                        adapter
+                        <select
+                          aria-label={`Adapter overlay for ${r.type}`}
+                          className={SELECT_CLASS}
+                          value={r.adapter}
+                          onChange={(event) =>
+                            saveAdapter.mutate({
+                              type: r.type,
+                              adapter: event.target.value,
+                            })
+                          }
+                        >
+                          {uniq([
+                            r.adapter,
+                            declaredAdapterOf(r),
+                            ...adapters,
+                          ]).map((name) => (
+                            <option key={name} value={name}>
+                              {name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      {adapterIsOverlaid(r) ? <RuntimeChip /> : null}
+                      {adapterIsOverlaid(r) ? (
+                        <Button onClick={() => revertAdapter.mutate(r.type)}>
+                          Revert
+                        </Button>
+                      ) : null}
+                      <span>
+                        · model{" "}
+                        <span
+                          className="mono"
+                          title={
+                            r.resolvedModel != null
+                              ? "What the planner pins into the RunSpec for this route."
+                              : MODEL_ADAPTERS.has(r.adapter)
+                                ? "This definition pins nothing, so dispatch rides the CLI's own default."
+                                : `The ${r.adapter} adapter runs a fixed argv, not a model.`
+                          }
+                        >
+                          {routeModel(r)}
+                        </span>{" "}
+                        · idempotency {r.idempotencyScope}
+                        {r.proposalTtlSeconds != null ? (
+                          <>
+                            {" · proposal TTL "}
+                            <span title={`${r.proposalTtlSeconds}s`}>
+                              {formatDuration(r.proposalTtlSeconds)}
+                            </span>
+                          </>
+                        ) : (
+                          ""
+                        )}
+                      </span>
                     </div>
-                    <div className="text-[11px] text-(--text-faint)">
-                      adapter {r.adapter} · model{" "}
-                      <span
-                        className="mono"
-                        title={
-                          r.resolvedModel != null
-                            ? "What the planner pins into the RunSpec for this route."
-                            : MODEL_ADAPTERS.has(r.adapter)
-                              ? "This definition pins nothing, so dispatch rides the CLI's own default."
-                              : `The ${r.adapter} adapter runs a fixed argv, not a model.`
-                        }
-                      >
-                        {routeModel(r)}
-                      </span>{" "}
-                      · idempotency {r.idempotencyScope}
-                      {r.proposalTtlSeconds != null ? (
-                        <>
-                          {" · proposal TTL "}
-                          <span title={`${r.proposalTtlSeconds}s`}>
-                            {formatDuration(r.proposalTtlSeconds)}
-                          </span>
-                        </>
-                      ) : (
-                        ""
-                      )}
-                    </div>
-                  </a>
+                  </div>
                 ))}
               </div>
             )}

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -95,7 +95,7 @@ const modelIsOverlaid = (a: AgentDef): boolean =>
 function RuntimeChip() {
   return (
     <span
-      className="rounded-sm border border-(--border) px-1 py-px text-[10px] text-(--text-faint)"
+      className="rounded-sm border border-(--border) px-1 py-px text-[11px] text-(--text-faint)"
       title="This box's runtime.db overlay — not origin/develop."
     >
       this runtime


### PR DESCRIPTION
## Summary
- Persist event-type adapter and agent `model_tier` / `model` as a machine-local overlay in `runtime.db` (not git). The planner applies it on the next plan; in-flight specs stay immutable.
- `GET /agents` reports declared (git) vs effective (next plan) values. Agents detail can edit adapter, tier, and model pin, with a **this runtime** chip and Revert.
- Follow-ups not in this PR: WM-888 (policy `models` map), WM-889 (promote overlay to a git PR).

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/runtime-overrides.test.mjs event-runtime/lib/db.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/api-registry.test.mjs`
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/web/src/views/Agents.test.tsx`
- [ ] On a worktree demo: open `#/agents/dispatch@1`, change a route adapter, confirm the chip, inject/plan, inspect the RunSpec adapter, Revert.

Fixes WM-887
Fixes WM-884