### PR TITLE
fix(auto-approval): sibling edges declared via also are registered chain edges

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -525,6 +525,15 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     : undefined;
   const declaredEdge =
     rule?.independent === true ? undefined : rule?.edges?.[recommendation];
+  // A declared edge may fan out to sibling edges via `also` (e.g. dispatch@1
+  // PR_OPEN → work.requested also PR_OPEN_MERGE → merge.requested). Those
+  // siblings are registered edges too; without this every dispatch-chained
+  // merge-scan sat as chain_edge_not_registered until an operator approved it.
+  const alsoEdgeTypes = Array.isArray(declaredEdge?.also)
+    ? declaredEdge.also
+        .map((key) => rule?.edges?.[key]?.eventType)
+        .filter((type) => typeof type === "string")
+    : [];
   const independentEdge = independentlySelectedEdge(
     rule,
     spec,
@@ -537,6 +546,7 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
   );
   if (
     declaredEdge?.eventType !== envelope.type &&
+    !alsoEdgeTypes.includes(envelope.type) &&
     !independentEdge &&
     !commandEdge
   )

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1133,6 +1133,28 @@ describe("chain auto approval (WM-357)", () => {
     expect(runState(db, escalation.runId)).toBe("QUEUED");
   });
 
+  test("a sibling edge declared via `also` is a registered edge (dispatch PR_OPEN → merge.requested)", async () => {
+    const db = openDb(":memory:");
+    // dispatch@1 PR_OPEN maps to work.requested and fans out to
+    // merge.requested via `also: ["PR_OPEN_MERGE"]`; the merge-scan proposal
+    // must auto-approve instead of waiting as chain_edge_not_registered.
+    const merge = seed(db, {
+      id: "dispatch-also-merge",
+      type: "factory.merge.requested",
+      input: { repo: "factory", prNumbers: [777] },
+      predecessorAgent: "dispatch@1",
+      predecessorArtifact: {
+        outcome: "PR_OPEN",
+        repo: "factory",
+        prNumber: 777,
+      },
+      predecessorInput: { repo: "factory", ticket: "WM-777" },
+    });
+    const result = await auto(db, { runtimeGuard: () => null });
+    expect(result.approved.map((a) => a.proposalId)).toContain(merge.id);
+    expect(runState(db, merge.runId)).toBe("QUEUED");
+  });
+
   test("a non-independent array sibling remains watched", async () => {
     const db = openDb(":memory:");
     const mergeInput = {


### PR DESCRIPTION
Every dispatch-chained merge-scan proposal sat as `auto_approval_ineligible:chain_edge_not_registered` until the operator approved it: `dispatch@1` PR_OPEN → `factory.work.requested` fans out to `factory.merge.requested` via `also: ["PR_OPEN_MERGE"]`, but the auto-approval edge check only considered the primary declared edge. Now sibling edges' event types count as registered. Regression test (fails without the fix — verified). auto-approval/merge/loop tests green. Part of the operator's 2026-08-19 'broaden approvals' request.