### PR TITLE
docs(oss): thesis.md + model.md — wedge-first positioning (WM-806)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -1,0 +1,256 @@
+# Model
+
+The factory's public primitives, named as they exist in this repository. The
+positioning that chooses this vocabulary is [`thesis.md`](thesis.md). The
+reasons the loops are shaped this way are [`architecture.md`](architecture.md).
+
+Nothing here is a synonym for another product's objects. A ticket is a Linear
+issue. A run is a row the worker claimed. A pack is a directory with
+`pack.json`. If a word is not in git, it is not a primitive.
+
+---
+
+## Authorities
+
+Three systems hold state. The factory holds none of its own.
+
+| Authority | Holds                                         | In this repo                                                      |
+| :-------- | :-------------------------------------------- | :---------------------------------------------------------------- |
+| Linear    | Work: tickets, states, assignee, labels       | `tools/linear.mjs`; claim read-back is the only ticket lock       |
+| GitHub    | Truth: branches, pull requests, review, merge | `lib/forge/` (`kind: github` in `config/policy.yaml`)             |
+| CI        | Reward: the change earned the next step       | Per-repo checks; nothing merges because an agent said it was done |
+
+`orchestrator/tick.mjs` re-reads Linear on every decision. Restarting it loses
+nothing. The PR is the artifact; the branch is the work.
+
+---
+
+## Ticket
+
+The unit of business work. A ticket is dispatchable when it is `Todo`, labelled
+`ai:agent-ready`, unassigned, and carries machine-readable **Owned Paths** and
+a **Verification Command**.
+
+Lifecycle, as the dispatcher and the event chains implement it:
+
+```
+Triage → Todo + ai:agent-ready → In Progress + ai:in-progress
+       → In Review + ai:needs-review → Done
+```
+
+Holds are `Blocked` + `ai:blocked`. The Linear `assignee` is the distributed
+lock; the claim protocol writes it and reads it back. Lost races stop. They
+never steal and never queue behind the holder.
+
+The ticket body is the spec. Follow-up work discovered outside Owned Paths is
+a new `Triage` issue (`tools/linear.mjs file`), never a widening of the one
+in flight.
+
+---
+
+## Owned Paths
+
+The concurrency key. Two tickets may run together only when their glob sets
+are disjoint. `globsOverlap` errs toward collision: a false positive
+serializes two tickets, a false negative puts two agents in one file.
+
+Owned Paths are a section on the ticket, parsed from bullets, fenced blocks,
+and indented code. An empty parse is undispatchable, not "touches
+everything."
+
+---
+
+## Worktree
+
+The isolation unit for repository work. Git isolates branches; it does not
+isolate ports or databases. Each dispatchable repo owns `worktree_up` /
+`worktree_down` scripts (this repo: `bin/worktree-up.sh`,
+`bin/worktree-down.sh`) that give the ticket its own checkout, branch, ports,
+database, and runtime home.
+
+Order is **claim → worktree → spawn**. A `worktree_up` takes minutes; an
+unclaimed ticket is one another agent may take.
+
+A repo without those scripts is `report_only` in `config/repos.yaml`: the
+janitor can see orphans, dispatch refuses them. This repo is an ordinary
+dispatch target (OPS-463): dispatched tickets never touch the live control
+plane's runtime home.
+
+Not every run is a worktree. The event runtime's workspace types include an
+ephemeral directory for agents that only need their declared inputs. A Git
+repository is one workspace provider, not the runtime's foundation. See
+[`event-runtime.md`](event-runtime.md) §7.
+
+---
+
+## Event, proposal, run
+
+The event runtime turns an admitted event into one bounded agent execution.
+
+- **Event** — authenticated, replay-safe intake; typed in
+  `event-runtime/event-types.json`. Idempotency is declared per type
+  (`idempotencyScope`: `correlationId`, `inputHash`, `subject`, …).
+- **Proposal** — the planner's deterministic plan (`lib/planner.mjs`). Watched
+  approval before execution in the MVP; some types are
+  `humanApprovalOnly` (`factory.ship-apply.requested`).
+- **Run** — a worker claim (`BEGIN IMMEDIATE`, lease, fencing token) of an
+  approved spec. One OS process, one agent, one workspace, one verify, one
+  receipt. Agents never spawn agents.
+
+`serve` (`event-runtime/cli.mjs serve`) is API, planner, scheduler, chain
+resolver, and outbox. It runs no worker. `work` claims and executes.
+`--with-worker` is the demo all-in-one.
+
+Typed outcomes (`PR_OPEN`, `NOT_CLAIMED`, `BLOCKED`, `FAILED`, `REFUSED` with
+`reasonCode: "needs_human"`) are the contract the rest of the factory
+reacts to — not free-text logs.
+
+---
+
+## Agent
+
+A versioned, content-pinned definition, not a session.
+
+The kernel registry root is `event-runtime/`. An agent is `id@version` in the
+bare namespace (`dispatch@1`, `work-scan@1`, `merge-scan@2`, `ship-scan@1`,
+`reaper@1`, …) or `namespace/id@version` from a pack. Each definition names:
+
+- a prompt and input/output schemas, hashed in `pins`;
+- an `output_contract` (for example `factory.dispatch-result/v1`);
+- a `model_tier` (`strong` / `standard` / `light`, mapped per adapter in
+  `config/policy.yaml`);
+- a workspace type and capabilities (`filesystem`, `services`, `tools`);
+- limits (`timeout_seconds`, `attempts`, `budget_usd`);
+- whether it is `mutating`.
+
+The model is stochastic. The wrapper is not: planner, lifecycle, permissions,
+prompt version, input hash, output schema, timeout, and acceptance rules are
+deterministic. That is what "deterministic agent" means in this repo.
+
+---
+
+## Registry, pack, extension
+
+- **Kernel** — the built-in `event-runtime/` tree. It owns `namespace: ""`.
+  Exactly one loaded root may own the bare namespace.
+- **Pack** — a filesystem directory with `pack.json`, `pins.json`, `agents/`,
+  `schemas/`, and optional `event-types.json`, `edges.json`,
+  `schedules.json`. Allow-listed in `config/policy.yaml` under `packs:`;
+  never discovered by scanning. Packs are read-only and may not declare
+  `mutating: true`. See [`kernel-and-packs.md`](kernel-and-packs.md).
+- **Extension** — the install unit: one directory, one
+  `factory-extension.json`, enabled by one `extensions:` entry. It may
+  contribute packs, adapters, config, hooks, and panels.
+  [`extensions.md`](extensions.md) is the author guide.
+
+Duplicate final agent refs, event-type keys, edge sources, or schedule loop
+names are load errors. A pack cannot override earlier content. A broken
+extension is a configuration anomaly on `/status`, not a failed `serve`.
+
+---
+
+## Edge and schedule
+
+- **Edge** — `event-runtime/edges.json`. After a run, the chain resolver
+  reads a recommendation field (`TRIAGE`, `SHIP`, `REMEDIATE`, …) and
+  admits the next event type with mapped input. This is the discovered
+  chain, not a declared `dependsOn` workflow.
+- **Schedule** — `event-runtime/schedules.json`, driven by the in-process
+  scheduler as `clock.tick.<loop>` events. Every loop ships disabled
+  (`enabled: false`) until it has been watched. `config/schedule.yaml` is
+  a separate file for the older launchd path and is likewise disabled.
+
+The standing software-factory chain, as event types:
+
+```
+factory.triage.requested        → triage-scan@1 → factory.triage-apply.requested
+factory.work.requested          → work-scan@1   → factory.dispatch.requested
+factory.dispatch.requested      → dispatch@1    → (PR + result event)
+factory.merge.requested         → merge-scan@2  → factory.merge-apply.requested
+factory.ship.requested          → ship-scan@1   → factory.ship-apply.requested
+clock.tick.reaper               → reaper@1
+```
+
+Janitor, unblock, sweep, CI-doctor, and warm are the same shape: a scan
+agent, an apply agent, an edge between them.
+
+---
+
+## Verify and handoff
+
+Verification is independent of the agent.
+
+The ticket names an exact **Verification Command**. The worker re-runs it on
+the tree the agent pushed, plus the repo's declared verify
+(`config/repos.yaml` / this worktree's `.worktree.json`). A non-zero exit
+fails the run, converts the PR to a draft, and returns the ticket to Todo
+labelled `ai:agent-ready`. The agent's `## Handoff` comment is
+agent-reported commentary. The worker posts `## Handoff verification
+(worker-observed)` with the command, exit code, and Owned Paths diff.
+
+UX critique (`factory-ux-critic`) is a separate gate for user-completable
+flows. Docs, schema, and infra tickets skip it (`status: "skipped"`,
+`verdict: null`).
+
+---
+
+## Inbox
+
+When a loop must stop for a human, it files a typed **decision request** on
+an inbox item (`event-runtime/lib/inbox.mjs`). The operator posts a typed
+**response**; closed **effects** apply it (including `authorise`, bound to
+the ticket description so a re-scope expires the grant). Ack and resolve
+without a decision do not unblock work.
+
+`reasonCode: "needs_human"` (auth, payments, secrets, destructive
+migrations, production infra, or a missing fact) is how a run refuses
+without guessing. See [`event-runtime-inbox.md`](event-runtime-inbox.md).
+
+---
+
+## Adapter and forge
+
+- **Adapter** — how a run invokes a harness or a closed command. Kernel
+  adapters include `cursor`, `agy`, `pi`, `command`, `actions`. Extensions
+  may register more. The adapter is named on the event type and on the
+  agent; the worker does not pick one at runtime.
+- **Forge** — `lib/forge/`, the one chokepoint for the code host
+  (`prView`, `prList`, `prDiffFiles`, `prSetDraft`, `prComment`, `runList`,
+  `apiRaw`). Call sites do not spawn `gh` themselves.
+
+---
+
+## Shared content
+
+`shared/` is the only place to edit harness-neutral commands, skills, floor
+rules, and custom-agent definitions. `build/emit.mjs` produces the Claude
+plugin, `dist/{codex,gemini,cursor,pi}/`, and `dist/AGENTS.floor.md`.
+`--check` fails CI when a generated file drifts from `shared/`. The plugin
+is a convenience layer; the non-negotiables travel in each repo's
+`AGENTS.md`.
+
+---
+
+## Policy and repos
+
+- `config/repos.yaml` — per-repo routing: Linear team, base branch,
+  worktree scripts, verify command, `max_in_flight`, `report_only`.
+- `config/policy.yaml` — budgets, concurrency, model tiers, packs,
+  extensions, forge kind, worker min/max.
+- `config/nodes.yaml` — remote-worker node inventory (protocol in
+  [`event-runtime-worker-protocol.md`](event-runtime-worker-protocol.md)).
+
+Capacity is one per-repo in-flight cap, shared by the ticket dispatcher and
+the event path, counted in `~/.factory/worker-leases/`.
+
+---
+
+## Related
+
+- [`thesis.md`](thesis.md) — wedge-first positioning
+- [`architecture.md`](architecture.md) — decisions and rejected alternatives
+- [`event-runtime.md`](event-runtime.md) — runtime architecture
+- [`kernel-and-packs.md`](kernel-and-packs.md) — registry extension rules
+- [`extensions.md`](extensions.md) — the install unit
+- [`event-runtime-dispatch.md`](event-runtime-dispatch.md) — shared claim,
+  capacity, Owned Paths, workspace, and approval with the dispatcher

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -1,0 +1,115 @@
+# Thesis
+
+**The factory that builds software — and itself.**
+
+A runtime for self-improving agentic loops. Code is the first product line.
+
+This is the public positioning, decided 2026-08-18. The nouns that make it
+true live in [`model.md`](model.md). How the loops are shaped, and why, lives
+in [`architecture.md`](architecture.md).
+
+---
+
+## Wedge first
+
+The factory is an unattended software factory. A ticket that is specified,
+disjoint, and agent-ready becomes a pull request without a human driving each
+turn. The PR merges because tests passed and a reviewer approved — never
+because an agent said it was done.
+
+That is the wedge: the thing a visitor can use tomorrow, against a reward
+signal that already exists (CI), on a control plane that already exists
+(tickets), into an artifact that already exists (a pull request). We do not
+lead with a general agent platform that happens to also write code. We lead
+with shipping software, unattended, and let generality show up as a
+consequence of the same primitives.
+
+Code is the first product line because the loop is closed today:
+
+1. Linear holds the work (`Triage` → `Todo` + `ai:agent-ready` → `In Progress`
+   → `In Review` → `Done`).
+2. A worktree isolates the change (`bin/worktree-up.sh`: own branch, ports,
+   database, runtime home).
+3. One bounded agent implements exactly that ticket, inside its `Owned Paths`.
+4. The worker re-runs the ticket's `Verification Command` and the repo's
+   declared verify. The agent's report is commentary; the exit code is the
+   evidence.
+5. GitHub holds the PR. CI is the reward. Merge and ship are later loops on
+   the same event runtime.
+
+A platform-first story would invert this: sell a runtime for "any loop", then
+mention that software is one workload. That is true of the machinery and
+false as a pitch. Nobody adopts a factory because it might later draft
+articles or reclaim disk. They adopt it because specified work leaves the
+queue as reviewed PRs while they sleep.
+
+## And itself
+
+The same loops that ship product ship the factory. This repository is an
+ordinary dispatch target (`config/repos.yaml`, `max_in_flight`,
+`bin/worktree-up.sh`). A harness defect becomes a ticket; a ticket becomes a
+PR; a merge changes the next run. Friction is not a retrospective slide — it
+is intake.
+
+Self-improvement is not a metaphor for "the model gets smarter." It is the
+factory editing its own skills, adapters, pins, and docs through the same
+claim → worktree → verify → PR path it uses on every other repo. Containment
+is process, not trust: a dispatched change never touches the live control
+plane's runtime home, and it runs only after PR, CI, merge, and an operator
+pull-and-restart.
+
+The operator's job is strategy and typed decisions, not poking the session to
+keep the loops moving. When a run must stop, it files a decision request on
+the inbox. When it can continue, it does.
+
+## Generality beyond code
+
+The event runtime is not a git wrapper. A Git repository and a worktree are
+one workspace provider, not the foundation. A research, classification,
+reporting, operations, or editorial agent may only need an isolated directory
+and a versioned input/output contract. Those loops already exist as named
+event types (`keephq.disk-alert.raised`, `factory.status-report.requested`,
+and the editorial cell design in `docs/editorial-agent-runtime.md`).
+
+They share the same public primitives as software work:
+
+- an admitted, idempotent **event**;
+- a content-pinned **agent** with a schema, a timeout, and a budget;
+- a deterministic **planner** outside the model;
+- an isolated **workspace** with explicit capabilities;
+- independent **verification** of the artifact;
+- a **receipt**, and optionally a **chain** into the next event.
+
+Code is first because CI is already a sharp reward signal and a pull request
+is already a reviewable artifact. Other product lines earn the same machinery
+by naming an event type that needs it — never by borrowing another system's
+vocabulary. The runtime speaks tickets, events, runs, pins, packs, and
+extensions.
+
+## What this is not
+
+- **Not a watched copilot.** The human does not sit in the loop for each
+  ticket. They specify, authorise, and review at the gates the protocol
+  already names.
+- **Not a pitch for an agent operating system.** The runtime is general; the
+  product is the factory. Generality is documented so an extension author
+  knows where to plug in, not so the homepage hedges.
+- **Not harness-native.** Content lives in `shared/` and is emitted into
+  Claude Code, Codex, Cursor, Pi, and Gemini. The plugin is a convenience
+  layer. The floor is `AGENTS.md`.
+- **Not a replacement for Linear, Git, or CI.** Those are the authorities.
+  The factory holds no business state of its own: `tick.mjs` re-reads Linear
+  on every decision; the PR is the artifact; CI is the signal that a change
+  earned the next step.
+
+## How to read the rest
+
+| Document                                     | Job                                         |
+| :------------------------------------------- | :------------------------------------------ |
+| This file                                    | Why it exists, and in what order we say so  |
+| [`model.md`](model.md)                       | The primitives, named as they are in git    |
+| [`architecture.md`](architecture.md)         | Why each loop is shaped this way            |
+| [`event-runtime.md`](event-runtime.md)       | The event-driven sidecar, in running code   |
+| [`kernel-and-packs.md`](kernel-and-packs.md) | How the registry extends without shadowing  |
+| [`extensions.md`](extensions.md)             | The install unit for packs, adapters, hooks |
+| [`README.md`](../README.md)                  | How to run it                               |


### PR DESCRIPTION
## Summary
- Author `docs/thesis.md` with the 2026-08-18 wedge-first positioning: headline "The factory that builds software — and itself.", subline "A runtime for self-improving agentic loops. Code is the first product line." Generality beyond code is a consequence of the primitives, not the pitch.
- Author `docs/model.md` naming the public primitives as they exist in this repository (Linear tickets, Owned Paths, worktrees, events/proposals/runs, pinned agents, packs/extensions, verify/handoff, inbox, forge).
- No Kubernetes vocabulary; only `docs/thesis.md` and `docs/model.md` changed.

Fixes WM-806

UX critique: skipped — docs ticket, no user-facing surface

## Test plan
- [x] `test -s docs/thesis.md && test -s docs/model.md && ! grep -niE "kubernetes|k8s|kubectl" docs/thesis.md docs/model.md`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `bun test` (3059 pass, 9 skip, 0 fail)


Made with [Cursor](https://cursor.com)