### PR TITLE
feat(event-runtime): factory.memo/v1 contract + memo ledger (WM-809)

### DIFF
--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -284,6 +284,11 @@ export function referencedHashes(db) {
       if (sha256) hashes.add(sha256);
     }
   }
+  // Ledger rows keep memo bytes alive even when no result references them
+  // (runtime-authored decisions; retired memos still cited in receipts).
+  for (const row of db.query(`SELECT sha256 FROM memos`).all()) {
+    if (HEX64.test(row.sha256 ?? "")) hashes.add(row.sha256);
+  }
   return hashes;
 }
 

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -280,6 +280,39 @@ export const MIGRATIONS = [
       }
     },
   },
+  {
+    version: 8,
+    name: "memo_ledger",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS memos (
+          sha256           TEXT PRIMARY KEY,
+          subject_type     TEXT NOT NULL,
+          subject_id       TEXT NOT NULL,
+          kind             TEXT NOT NULL,
+          run_id           TEXT,
+          inbox_item_id    TEXT,
+          created_at       INTEGER NOT NULL,
+          expires_at       INTEGER,
+          description_hash TEXT,
+          head_sha         TEXT,
+          superseded_by    TEXT,
+          retired_at       INTEGER,
+          retired_reason   TEXT
+        );
+        CREATE INDEX IF NOT EXISTS memos_subject
+          ON memos (subject_type, subject_id, kind, created_at DESC);
+        CREATE TABLE IF NOT EXISTS memo_uses (
+          sha256    TEXT NOT NULL,
+          run_id    TEXT NOT NULL,
+          verdict   TEXT,
+          run_state TEXT NOT NULL,
+          at        INTEGER NOT NULL,
+          PRIMARY KEY (sha256, run_id)
+        );
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =
@@ -298,6 +331,8 @@ export const CORE_TABLES = [
   "attempt_trace",
   "run_usage",
   "inbox_items",
+  "memos",
+  "memo_uses",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -1,0 +1,828 @@
+/**
+ * Memo ledger — verified cross-run memory (docs/event-runtime-memos.md §2, §3).
+ *
+ * Memos are artifacts. Only an accepted result (or the runtime, for inbox
+ * decisions) may register one. Reads are by exact subject; liveness is a fold
+ * over the ledger, never a directory listing. There is no write API.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { canonicalJson, sha256Hex } from "./canonical.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { loadRepos } from "./repos.mjs";
+import { validate } from "./schema.mjs";
+
+export const MEMO_SCHEMA_VERSION = "factory.memo/v1";
+export const MEMO_SCHEMA = JSON.parse(
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory.memo.v1.json"),
+    "utf8",
+  ),
+);
+
+export const MEMO_KINDS = Object.freeze([
+  "repo-note",
+  "postmortem",
+  "decision",
+  "flake",
+  "handoff",
+]);
+export const CLAIM_KINDS = Object.freeze(["howto", "pitfall", "fact"]);
+export const SUBJECT_TYPES = Object.freeze([
+  "repo",
+  "ticket",
+  "pr",
+  "workflow",
+  "run",
+]);
+export const USE_VERDICTS = Object.freeze(["useful", "wrong", "stale"]);
+export const LEARNINGS_MAX = 5;
+export const BODY_MAX_BYTES = 4 * 1024;
+export const EVIDENCE_MAX_BYTES = 1024;
+export const LIST_MEMOS_DEFAULT_MAX = 20;
+
+/** Kind-default expiry; a binding.expiresAt always wins (§6.2). */
+export const KIND_DEFAULT_TTL_MS = Object.freeze({
+  postmortem: 30 * 24 * 60 * 60 * 1000,
+  decision: 90 * 24 * 60 * 60 * 1000,
+  flake: 14 * 24 * 60 * 60 * 1000,
+});
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const SHA256 = /^(?:sha256:)?([0-9a-f]{64})$/;
+
+const hasOwn = (obj, key) =>
+  obj !== null &&
+  typeof obj === "object" &&
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+/** Strip an optional `sha256:` prefix; return 64-hex or null. */
+export function digestHex(value) {
+  if (typeof value !== "string") return null;
+  const match = SHA256.exec(value.trim());
+  return match ? match[1] : null;
+}
+
+function byteLength(value) {
+  return Buffer.byteLength(String(value ?? ""), "utf8");
+}
+
+function loadRepoIndex(repos) {
+  if (repos && typeof repos.get === "function") return repos;
+  return loadRepos();
+}
+
+/**
+ * Collapse equivalent subject ids so `WM-313`/`wm-313` and
+ * `watt-mind/factory`/`factory` index as one key (§3.1).
+ */
+export function normalizeSubjectId(type, id, { repos } = {}) {
+  if (typeof id !== "string" || id.trim() === "") {
+    throw new Error("subject.id must be a non-empty string");
+  }
+  const raw = id.trim();
+  if (type === "ticket") return raw.toUpperCase();
+  if (type === "run") return raw;
+  if (type === "pr") {
+    const hash = raw.lastIndexOf("#");
+    if (hash > 0) {
+      return `${normalizeSubjectId("repo", raw.slice(0, hash), { repos })}#${raw.slice(hash + 1)}`;
+    }
+    return raw;
+  }
+  if (type === "workflow") {
+    const colon = raw.lastIndexOf(":");
+    if (colon > 0) {
+      return `${raw.slice(0, colon).toLowerCase()}:${raw.slice(colon + 1)}`;
+    }
+    return raw.toLowerCase();
+  }
+  if (type === "repo") {
+    const loaded = loadRepoIndex(repos);
+    const lower = raw.toLowerCase();
+    for (const repo of loaded.values()) {
+      if (repo.name.toLowerCase() === lower) return repo.name;
+      const github = typeof repo.github === "string" ? repo.github : "";
+      if (github && github.toLowerCase() === lower) return repo.name;
+      const slug = github.includes("/")
+        ? github.slice(github.lastIndexOf("/") + 1).toLowerCase()
+        : "";
+      if (slug && slug === lower) return repo.name;
+    }
+    return lower;
+  }
+  throw new Error(`unknown subject type ${type}`);
+}
+
+export function normalizeSubject(subject, options) {
+  if (!subject || typeof subject !== "object" || Array.isArray(subject)) {
+    throw new Error("subject must be { type, id }");
+  }
+  if (!SUBJECT_TYPES.includes(subject.type)) {
+    throw new Error(`unknown subject type ${subject.type}`);
+  }
+  return {
+    type: subject.type,
+    id: normalizeSubjectId(subject.type, subject.id, options),
+  };
+}
+
+function emittedKinds(def) {
+  const listed = def?.emits?.memos;
+  if (!Array.isArray(listed)) return [];
+  return listed.filter((kind) => typeof kind === "string" && kind.length > 0);
+}
+
+/**
+ * Shape + kind-specific rules. JSON Schema cannot express the conditionals
+ * (`claim` on repo-note, `precedentOnly` on decision); those live here, the
+ * same way `lib/decision.mjs` owns rules the schema cannot say.
+ *
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateMemo(
+  document,
+  { allowProvenance = false, at = "$" } = {},
+) {
+  const errors = [];
+  if (
+    document === null ||
+    typeof document !== "object" ||
+    Array.isArray(document)
+  ) {
+    return { valid: false, errors: [`${at}: expected object`] };
+  }
+  const shape = validate(MEMO_SCHEMA, document);
+  errors.push(...shape.errors);
+  if (!shape.valid) return { valid: false, errors };
+
+  if (hasOwn(document, "provenance") && !allowProvenance) {
+    errors.push(`${at}.provenance: agent-supplied provenance is rejected`);
+  }
+  const bodyBytes = byteLength(document.body);
+  if (bodyBytes > BODY_MAX_BYTES) {
+    errors.push(`${at}.body: ${bodyBytes} bytes > ${BODY_MAX_BYTES}`);
+  }
+  if (document.kind === "repo-note") {
+    if (!hasOwn(document, "claim")) {
+      errors.push(`${at}: repo-note requires claim`);
+    }
+    if (!hasOwn(document, "evidence")) {
+      errors.push(`${at}: repo-note requires evidence`);
+    } else if (byteLength(document.evidence) > EVIDENCE_MAX_BYTES) {
+      errors.push(
+        `${at}.evidence: ${byteLength(document.evidence)} bytes > ${EVIDENCE_MAX_BYTES}`,
+      );
+    }
+  }
+  if (document.kind === "decision" && document.precedentOnly !== true) {
+    errors.push(`${at}: decision memos require precedentOnly: true`);
+  }
+  if (
+    document.supersedes !== undefined &&
+    document.supersedes !== null &&
+    !digestHex(document.supersedes)
+  ) {
+    errors.push(`${at}.supersedes: not a sha256 digest`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function memoDigest(document) {
+  return sha256Hex(canonicalJson(document));
+}
+
+export function withProvenance(document, { runId, agent, createdAt }) {
+  const provenance = {
+    agent,
+    createdAt,
+    ...(runId === undefined || runId === null ? { runId: null } : { runId }),
+  };
+  return { ...document, provenance };
+}
+
+function expiresAtMs(document, createdAtMs) {
+  const binding = document.bindings?.expiresAt;
+  if (typeof binding === "string" && binding.trim()) {
+    const parsed = Date.parse(binding);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`bindings.expiresAt is not a valid time: ${binding}`);
+    }
+    return parsed;
+  }
+  const ttl = KIND_DEFAULT_TTL_MS[document.kind];
+  return ttl === undefined ? null : createdAtMs + ttl;
+}
+
+function inboxItemIdOf(document) {
+  const id = document.refs?.inboxItemId;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
+}
+
+/**
+ * Register memos from an accepted result (or a runtime-authored document).
+ * Idempotent on `sha256`. `runId` is the producer run; pass `null` for
+ * runtime-authored decision memos.
+ */
+export function registerMemos(
+  db,
+  runId,
+  result,
+  { now = Date.now(), agent, runState = "COMPLETED" } = {},
+) {
+  const entries = collectRegisterEntries(result, { runId, agent, now });
+  const registered = [];
+  for (const entry of entries) {
+    registered.push(insertMemoRow(db, entry, { now }));
+  }
+  recordMemoUses(db, runId, result, { now, runState });
+  return registered;
+}
+
+function collectRegisterEntries(result, { runId, agent, now }) {
+  const listed = [];
+  const seen = new Set();
+  const push = (sha256, document) => {
+    if (!HEX64.test(sha256) || seen.has(sha256)) return;
+    seen.add(sha256);
+    listed.push({ sha256, document });
+  };
+  for (const entry of result?.memos ?? []) {
+    if (typeof entry === "string") continue;
+    if (entry && typeof entry === "object" && entry.document) {
+      const sha = digestHex(entry.sha256) ?? memoDigest(entry.document);
+      push(sha, entry.document);
+      continue;
+    }
+    if (entry && typeof entry === "object" && entry.schemaVersion) {
+      push(memoDigest(entry), entry);
+    }
+  }
+  for (const artifact of result?.artifacts ?? []) {
+    if (artifact?.kind !== "memo") continue;
+    const sha = digestHex(artifact.sha256);
+    if (!sha) continue;
+    if (artifact.document) push(sha, artifact.document);
+  }
+  if (
+    result &&
+    typeof result === "object" &&
+    result.schemaVersion === MEMO_SCHEMA_VERSION
+  ) {
+    const prepared =
+      result.provenance !== undefined
+        ? result
+        : withProvenance(result, {
+            runId,
+            agent: agent ?? "runtime:inbox",
+            createdAt: new Date(now).toISOString(),
+          });
+    push(memoDigest(prepared), prepared);
+  }
+  return listed;
+}
+
+function insertMemoRow(db, { sha256, document }, { now }) {
+  const check = validateMemo(document, { allowProvenance: true });
+  if (!check.valid) {
+    throw new Error(
+      `memo ${sha256} failed contract: ${check.errors.join("; ")}`,
+    );
+  }
+  const subject = normalizeSubject(document.subject);
+  const createdAt = Date.parse(document.provenance?.createdAt ?? "") || now;
+  const expiresAt = expiresAtMs(document, createdAt);
+  const descriptionHash = document.bindings?.descriptionHash ?? null;
+  const headSha = document.bindings?.headSha ?? null;
+  const supersedes = digestHex(document.supersedes);
+  const existing = db
+    .query(`SELECT sha256 FROM memos WHERE sha256 = ?`)
+    .get(sha256);
+  if (existing)
+    return { sha256, inserted: false, subject, kind: document.kind };
+  db.query(
+    `INSERT INTO memos (
+       sha256, subject_type, subject_id, kind, run_id, inbox_item_id,
+       created_at, expires_at, description_hash, head_sha
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sha256,
+    subject.type,
+    subject.id,
+    document.kind,
+    document.provenance?.runId ?? null,
+    inboxItemIdOf(document),
+    createdAt,
+    expiresAt,
+    descriptionHash,
+    headSha,
+  );
+  if (supersedes) {
+    db.query(
+      `UPDATE memos SET superseded_by = ?
+       WHERE sha256 = ? AND superseded_by IS NULL`,
+    ).run(sha256, supersedes);
+  }
+  return { sha256, inserted: true, subject, kind: document.kind };
+}
+
+/**
+ * Write `memo_uses` for every pinned memo (verdict NULL) and overlay the
+ * agent's `usedMemos` verdicts. Two distinct `wrong` verdicts retire the
+ * memo as contradicted.
+ */
+export function recordMemoUses(
+  db,
+  runId,
+  result,
+  { now = Date.now(), runState = "COMPLETED" } = {},
+) {
+  if (!runId) return [];
+  const pinEntries = result?.memoPin?.entries ?? [];
+  const pinned = new Map();
+  for (const entry of pinEntries) {
+    const sha = digestHex(entry?.sha256 ?? entry);
+    if (sha) pinned.set(sha, null);
+  }
+  const used = result?.usedMemos ?? [];
+  if (!Array.isArray(used)) {
+    throw new Error("usedMemos must be an array");
+  }
+  for (const entry of used) {
+    const sha = digestHex(entry?.sha256);
+    if (!sha) throw new Error("usedMemos entry is missing sha256");
+    if (entry.verdict !== undefined && !USE_VERDICTS.includes(entry.verdict)) {
+      throw new Error(`unknown usedMemos verdict ${entry.verdict}`);
+    }
+    pinned.set(sha, entry.verdict ?? null);
+  }
+  const rows = [];
+  for (const [sha256, verdict] of pinned) {
+    db.query(
+      `INSERT INTO memo_uses (sha256, run_id, verdict, run_state, at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(sha256, run_id) DO UPDATE SET
+         verdict = COALESCE(excluded.verdict, memo_uses.verdict),
+         run_state = excluded.run_state,
+         at = excluded.at`,
+    ).run(sha256, runId, verdict, runState, now);
+    rows.push({ sha256, runId, verdict, runState });
+    maybeRetireContradicted(db, sha256, now);
+  }
+  return rows;
+}
+
+function maybeRetireContradicted(db, sha256, now) {
+  const count = db
+    .query(
+      `SELECT COUNT(DISTINCT run_id) AS n FROM memo_uses
+       WHERE sha256 = ? AND verdict = 'wrong'`,
+    )
+    .get(sha256)?.n;
+  if (Number(count) < 2) return;
+  db.query(
+    `UPDATE memos SET retired_at = ?, retired_reason = 'contradicted'
+     WHERE sha256 = ? AND retired_at IS NULL`,
+  ).run(now, sha256);
+}
+
+function usefulCounts(db, hashes) {
+  const counts = new Map(hashes.map((sha) => [sha, { useful: 0, wrong: 0 }]));
+  if (hashes.length === 0) return counts;
+  const placeholders = hashes.map(() => "?").join(", ");
+  const rows = db
+    .query(
+      `SELECT sha256, verdict, COUNT(*) AS n FROM memo_uses
+       WHERE sha256 IN (${placeholders}) AND verdict IS NOT NULL
+       GROUP BY sha256, verdict`,
+    )
+    .all(...hashes);
+  for (const row of rows) {
+    const slot = counts.get(row.sha256);
+    if (!slot) continue;
+    if (row.verdict === "useful") slot.useful = Number(row.n);
+    if (row.verdict === "wrong") slot.wrong = Number(row.n);
+  }
+  return counts;
+}
+
+function bindingHolds(row, { descriptionHash, headSha } = {}) {
+  if (
+    row.description_hash &&
+    descriptionHash !== undefined &&
+    descriptionHash !== null &&
+    row.description_hash !== descriptionHash
+  ) {
+    return { holds: false, reason: "description_hash_mismatch" };
+  }
+  if (
+    row.head_sha &&
+    headSha !== undefined &&
+    headSha !== null &&
+    row.head_sha !== headSha
+  ) {
+    return { holds: false, reason: "head_sha_mismatch" };
+  }
+  return { holds: true, reason: null };
+}
+
+/**
+ * Fold memos on a subject. `live: true` (default) drops superseded, retired,
+ * expired, and binding-broken rows. Bindings are compared only against
+ * values the caller already holds — never a network call (§3.2).
+ */
+export function listMemos(
+  db,
+  subject,
+  {
+    kinds,
+    live = true,
+    max = LIST_MEMOS_DEFAULT_MAX,
+    now = Date.now(),
+    descriptionHash,
+    headSha,
+  } = {},
+) {
+  const normalized = normalizeSubject(subject);
+  const params = [normalized.type, normalized.id];
+  let sql = `SELECT * FROM memos WHERE subject_type = ? AND subject_id = ?`;
+  if (Array.isArray(kinds) && kinds.length > 0) {
+    sql += ` AND kind IN (${kinds.map(() => "?").join(", ")})`;
+    params.push(...kinds);
+  }
+  const rows = db.query(sql).all(...params);
+  const counts = usefulCounts(
+    db,
+    rows.map((row) => row.sha256),
+  );
+  const folded = [];
+  for (const row of rows) {
+    if (live) {
+      if (row.superseded_by) continue;
+      if (row.retired_at) continue;
+      if (row.expires_at !== null && row.expires_at <= now) continue;
+      const binding = bindingHolds(row, { descriptionHash, headSha });
+      if (!binding.holds) {
+        db.query(
+          `UPDATE memos SET retired_at = ?, retired_reason = ?
+           WHERE sha256 = ? AND retired_at IS NULL`,
+        ).run(now, binding.reason, row.sha256);
+        continue;
+      }
+    }
+    const tally = counts.get(row.sha256) ?? { useful: 0, wrong: 0 };
+    folded.push({
+      sha256: row.sha256,
+      subject: { type: row.subject_type, id: row.subject_id },
+      kind: row.kind,
+      runId: row.run_id,
+      inboxItemId: row.inbox_item_id,
+      createdAt: new Date(row.created_at).toISOString(),
+      createdAtMs: row.created_at,
+      expiresAt:
+        row.expires_at === null ? null : new Date(row.expires_at).toISOString(),
+      descriptionHash: row.description_hash,
+      headSha: row.head_sha,
+      supersededBy: row.superseded_by,
+      retiredAt:
+        row.retired_at === null ? null : new Date(row.retired_at).toISOString(),
+      retiredReason: row.retired_reason,
+      usefulCount: tally.useful,
+      wrongCount: tally.wrong,
+    });
+  }
+  folded.sort((a, b) => {
+    if (b.usefulCount !== a.usefulCount) return b.usefulCount - a.usefulCount;
+    return b.createdAtMs - a.createdAtMs;
+  });
+  const limit = Number.isInteger(max) && max > 0 ? max : LIST_MEMOS_DEFAULT_MAX;
+  return folded.slice(0, limit);
+}
+
+function learningErrors(entry, index) {
+  const errors = [];
+  const at = `$.learnings[${index}]`;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return [`${at}: expected object`];
+  }
+  const claim = entry.claim;
+  if (!claim || typeof claim !== "object" || Array.isArray(claim)) {
+    errors.push(`${at}.claim: required`);
+  } else {
+    if (!CLAIM_KINDS.includes(claim.kind)) {
+      errors.push(`${at}.claim.kind: must be howto|pitfall|fact`);
+    }
+    if (typeof claim.text !== "string" || claim.text.trim() === "") {
+      errors.push(`${at}.claim.text: required`);
+    } else if (claim.text.length > 280) {
+      errors.push(`${at}.claim.text: longer than 280`);
+    }
+  }
+  if (typeof entry.evidence !== "string" || entry.evidence.trim() === "") {
+    errors.push(
+      `${at}.evidence: required (a learning without evidence is rejected)`,
+    );
+  } else if (byteLength(entry.evidence) > EVIDENCE_MAX_BYTES) {
+    errors.push(
+      `${at}.evidence: ${byteLength(entry.evidence)} bytes > ${EVIDENCE_MAX_BYTES}`,
+    );
+  }
+  return errors;
+}
+
+/**
+ * Turn result `learnings` into `repo-note` memos on the run's repo subject
+ * (and, when `def.emits.learningsOnTicket` is set, on its ticket).
+ */
+export function learningsToMemos(
+  learnings,
+  { spec, def, now = Date.now(), agent },
+) {
+  const errors = [];
+  if (learnings === undefined || learnings === null) {
+    return { errors, memos: [] };
+  }
+  if (!Array.isArray(learnings)) {
+    return { errors: ["$.learnings: expected array"], memos: [] };
+  }
+  if (learnings.length > LEARNINGS_MAX) {
+    return {
+      errors: [
+        `$.learnings: ${learnings.length} entries > max ${LEARNINGS_MAX}`,
+      ],
+      memos: [],
+    };
+  }
+  const emitted = emittedKinds(def);
+  if (!emitted.includes("repo-note")) {
+    return {
+      errors: [
+        "learnings_not_emitted: definition must declare emits.memos including repo-note",
+      ],
+      memos: [],
+    };
+  }
+  const repo = spec?.input?.repo;
+  if (typeof repo !== "string" || !repo.trim()) {
+    return {
+      errors: ["learnings_repo_missing: run spec input.repo is required"],
+      memos: [],
+    };
+  }
+  for (const [index, entry] of learnings.entries()) {
+    errors.push(...learningErrors(entry, index));
+  }
+  if (errors.length > 0) return { errors, memos: [] };
+
+  const createdAt = new Date(now).toISOString();
+  const headSha = spec?.input?.repoPin?.sha ?? spec?.input?.headSha ?? null;
+  const subjects = [{ type: "repo", id: normalizeSubjectId("repo", repo) }];
+  if (def?.emits?.learningsOnTicket === true && spec?.input?.ticket) {
+    subjects.push({
+      type: "ticket",
+      id: normalizeSubjectId("ticket", spec.input.ticket),
+    });
+  }
+  const memos = [];
+  for (const entry of learnings) {
+    for (const subject of subjects) {
+      const document = withProvenance(
+        {
+          schemaVersion: MEMO_SCHEMA_VERSION,
+          subject,
+          kind: "repo-note",
+          claim: { kind: entry.claim.kind, text: entry.claim.text },
+          evidence: entry.evidence,
+          body: entry.claim.text,
+          ...(headSha ? { bindings: { headSha } } : {}),
+        },
+        {
+          runId: spec.runId ?? null,
+          agent: agent ?? spec.agent ?? "unknown",
+          createdAt,
+        },
+      );
+      memos.push({ sha256: memoDigest(document), document });
+    }
+  }
+  return { errors, memos };
+}
+
+function inputValues(input, keys) {
+  const found = [];
+  if (!input || typeof input !== "object") return found;
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) found.push(value);
+  }
+  return found;
+}
+
+/**
+ * Subjects this run is allowed to write memory about. A ticket memo must
+ * name the spec's ticket; a repo memo its repo; a run memo this run or its
+ * pinned run; a pr/workflow memo a value present in the input.
+ */
+export function allowedMemoSubjects(spec, { repos } = {}) {
+  const input = spec?.input ?? {};
+  const allowed = [];
+  const add = (type, id) => {
+    try {
+      allowed.push(normalizeSubject({ type, id }, { repos }));
+    } catch {
+      // Malformed optional input is not an extra allowed subject.
+    }
+  };
+  if (typeof input.ticket === "string") add("ticket", input.ticket);
+  if (typeof input.repo === "string") add("repo", input.repo);
+  if (typeof spec?.runId === "string") add("run", spec.runId);
+  if (typeof input.runPin?.runId === "string") add("run", input.runPin.runId);
+  for (const pr of inputValues(input, ["pr", "pullRequest"])) add("pr", pr);
+  for (const workflow of inputValues(input, ["workflow"]))
+    add("workflow", workflow);
+  return allowed;
+}
+
+export function subjectIsAllowed(subject, spec, options) {
+  const got = normalizeSubject(subject, options);
+  return allowedMemoSubjects(spec, options).some(
+    (allowed) => allowed.type === got.type && allowed.id === got.id,
+  );
+}
+
+function parseMemoBytes(bytes, origin) {
+  try {
+    return {
+      document: JSON.parse(
+        typeof bytes === "string" ? bytes : bytes.toString("utf8"),
+      ),
+      errors: [],
+    };
+  } catch (err) {
+    return { errors: [`${origin}: invalid JSON — ${err.message}`] };
+  }
+}
+
+function writeMemoFile(workspaceDir, relative, document) {
+  const dest = path.join(workspaceDir, relative);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  const bytes = canonicalJson(document);
+  writeFileSync(dest, bytes);
+  return { relative, sha256: sha256Hex(bytes) };
+}
+
+function fileUriPath(uri) {
+  return typeof uri === "string" && uri.startsWith("file://")
+    ? uri.slice("file://".length)
+    : null;
+}
+
+/**
+ * Verify-time collection: validate `kind: memo` artifacts, reject undeclared
+ * kinds, check the subject against the run spec, convert `learnings`, and
+ * validate `usedMemos` against `memoPin`. Rewrites memo files with runtime
+ * provenance so the stored hash is of the complete document.
+ */
+export function processResultMemos({
+  candidate,
+  spec,
+  def,
+  workspaceDir,
+  collected,
+  now = Date.now(),
+}) {
+  const errors = [];
+  const checks = [];
+  const memos = [];
+  const emitted = emittedKinds(def);
+  const memoArtifacts = (collected ?? []).filter(
+    (entry) => entry.kind === "memo",
+  );
+  const learnings = candidate?.learnings ?? candidate?.artifact?.learnings;
+  const usedMemos = candidate?.usedMemos ?? candidate?.artifact?.usedMemos;
+
+  if (memoArtifacts.length > 0 && emitted.length === 0) {
+    errors.push(
+      "memos_not_emitted: definition must declare emits.memos to produce memo artifacts",
+    );
+  }
+
+  for (const [index, entry] of memoArtifacts.entries()) {
+    const origin =
+      fileUriPath(entry.uri) ??
+      path.join(workspaceDir, entry.path ?? `memo-${index}`);
+    let bytes;
+    try {
+      bytes = readFileSync(origin);
+    } catch {
+      errors.push(`artifact_missing: ${origin}`);
+      continue;
+    }
+    const parsed = parseMemoBytes(bytes, `artifacts[${index}]`);
+    if (parsed.errors.length) {
+      errors.push(...parsed.errors);
+      continue;
+    }
+    const check = validateMemo(parsed.document, { allowProvenance: false });
+    if (!check.valid) {
+      errors.push(...check.errors);
+      continue;
+    }
+    if (!emitted.includes(parsed.document.kind)) {
+      errors.push(
+        `memo_kind_not_emitted: ${parsed.document.kind} is not in emits.memos ${JSON.stringify(emitted)}`,
+      );
+      continue;
+    }
+    if (!subjectIsAllowed(parsed.document.subject, spec)) {
+      errors.push(
+        `memo_subject_mismatch: ${parsed.document.subject.type}:${parsed.document.subject.id} is not a subject of this run`,
+      );
+      continue;
+    }
+    const document = withProvenance(parsed.document, {
+      runId: spec.runId,
+      agent: spec.agent ?? def?.ref ?? def?.id ?? "unknown",
+      createdAt: new Date(now).toISOString(),
+    });
+    const relative =
+      entry.path ??
+      (fileUriPath(entry.uri)
+        ? path.relative(workspaceDir, fileUriPath(entry.uri))
+        : `memos/${index}.json`);
+    const written = writeMemoFile(workspaceDir, relative, document);
+    entry.sha256 = written.sha256;
+    entry.uri = `file://${path.join(workspaceDir, relative)}`;
+    memos.push({ sha256: written.sha256, document, path: relative });
+  }
+
+  if (learnings !== undefined) {
+    const converted = learningsToMemos(learnings, { spec, def, now });
+    if (converted.errors.length) errors.push(...converted.errors);
+    for (const [index, memo] of converted.memos.entries()) {
+      const relative = `memos/learnings/${index}.json`;
+      const written = writeMemoFile(workspaceDir, relative, memo.document);
+      collected.push({
+        kind: "memo",
+        uri: `file://${path.join(workspaceDir, relative)}`,
+        sha256: written.sha256,
+      });
+      memos.push({
+        sha256: written.sha256,
+        document: memo.document,
+        path: relative,
+      });
+    }
+  }
+
+  if (usedMemos !== undefined) {
+    if (!Array.isArray(usedMemos)) {
+      errors.push("$.usedMemos: expected array");
+    } else {
+      const pin = new Set(
+        (spec.input?.memoPin?.entries ?? []).map((entry) =>
+          digestHex(entry.sha256),
+        ),
+      );
+      pin.delete(null);
+      for (const [index, entry] of usedMemos.entries()) {
+        const sha = digestHex(entry?.sha256);
+        if (!sha) {
+          errors.push(`$.usedMemos[${index}]: sha256 required`);
+          continue;
+        }
+        if (!pin.has(sha)) {
+          errors.push(
+            `$.usedMemos[${index}]: ${sha} is not in this run's memoPin`,
+          );
+        }
+        if (
+          entry.verdict !== undefined &&
+          !USE_VERDICTS.includes(entry.verdict)
+        ) {
+          errors.push(
+            `$.usedMemos[${index}]: unknown verdict ${JSON.stringify(entry.verdict)}`,
+          );
+        }
+      }
+    }
+  }
+
+  if (memos.length > 0 && errors.length === 0) {
+    checks.push("memos_valid", "memo_subject_confined");
+  }
+  if (learnings !== undefined && errors.length === 0) {
+    checks.push("learnings_materialized");
+  }
+  if (usedMemos !== undefined && errors.length === 0) {
+    checks.push("used_memos_pinned");
+  }
+
+  return {
+    errors,
+    memos,
+    collected,
+    usedMemos: Array.isArray(usedMemos) ? usedMemos : undefined,
+    checks,
+  };
+}

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -1,0 +1,573 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-memos-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pruneArtifacts, referencedHashes } from "./artifacts.mjs";
+import { hashJson, sha256Hex } from "./canonical.mjs";
+import {
+  CURRENT_SCHEMA_VERSION,
+  getSchemaVersion,
+  migrateDb,
+  openDb,
+} from "./db.mjs";
+import {
+  KIND_DEFAULT_TTL_MS,
+  LEARNINGS_MAX,
+  MEMO_SCHEMA_VERSION,
+  learningsToMemos,
+  listMemos,
+  memoDigest,
+  normalizeSubjectId,
+  registerMemos,
+  validateMemo,
+  withProvenance,
+} from "./memos.mjs";
+import { getAgent, loadRegistry } from "./registry.mjs";
+import { ContractViolation, verifyResult } from "./verify.mjs";
+
+const registry = loadRegistry();
+const statusDef = getAgent(registry, "factory-status-report@1");
+
+const VALID_ARTIFACT = {
+  repos: [
+    { name: "bj29", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 },
+  ],
+  recommendedAction: "dispatch",
+};
+
+function makeSpec(input = { repo: "factory", ticket: "WM-809" }) {
+  return {
+    schemaVersion: "factory.run-spec/v1",
+    runId: "run_memo_test",
+    agent: "factory-status-report@1",
+    input,
+    inputHash: hashJson(input),
+    workspace: { type: "ephemeral", retainOnFailure: true },
+    adapter: "fake",
+    promptVersion: "git:test",
+    policyVersion: "git:test",
+    outputContract: "factory.status-report/v1",
+    capabilities: ["linear:read"],
+    timeoutSeconds: 600,
+    maxAttempts: 1,
+    idempotencyKey: "memo-test",
+  };
+}
+
+function makeWorkspace(result) {
+  const dir = tmpDir("evrt-memos-");
+  writeFileSync(path.join(dir, "result.json"), JSON.stringify(result), "utf8");
+  return dir;
+}
+
+function postmortemDoc(overrides = {}) {
+  return {
+    schemaVersion: MEMO_SCHEMA_VERSION,
+    subject: { type: "ticket", id: "WM-809" },
+    kind: "postmortem",
+    body: "Run the scoped command, not the full suite.",
+    ...overrides,
+  };
+}
+
+function repoNoteDoc(overrides = {}) {
+  return {
+    schemaVersion: MEMO_SCHEMA_VERSION,
+    subject: { type: "repo", id: "factory" },
+    kind: "repo-note",
+    claim: { kind: "howto", text: "Verification is the scoped lib suite." },
+    evidence: "Ran the root suite first: 6m40s. Scoped run: 41s clean.",
+    body: "Verification is the scoped lib suite.",
+    ...overrides,
+  };
+}
+
+describe("factory.memo/v1 contract", () => {
+  test("accepts a conforming postmortem and rejects unknown fields", () => {
+    expect(validateMemo(postmortemDoc()).valid).toBe(true);
+    const { valid, errors } = validateMemo(postmortemDoc({ extra: true }));
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes("extra"))).toBe(true);
+  });
+
+  test("rejects agent-supplied provenance and admits runtime provenance", () => {
+    const withAgent = postmortemDoc({
+      provenance: {
+        runId: "run_x",
+        agent: "dispatch@1",
+        createdAt: "2026-08-18T14:02:11.000Z",
+      },
+    });
+    expect(validateMemo(withAgent).valid).toBe(false);
+    expect(validateMemo(withAgent, { allowProvenance: true }).valid).toBe(true);
+  });
+
+  test("repo-note requires claim and evidence; a learning without evidence is rejected", () => {
+    expect(validateMemo(repoNoteDoc()).valid).toBe(true);
+    const noEvidence = { ...repoNoteDoc() };
+    delete noEvidence.evidence;
+    expect(validateMemo(noEvidence).valid).toBe(false);
+    const noClaim = { ...repoNoteDoc() };
+    delete noClaim.claim;
+    expect(validateMemo(noClaim).valid).toBe(false);
+  });
+
+  test("decision memos require precedentOnly: true", () => {
+    const decision = postmortemDoc({
+      kind: "decision",
+      precedentOnly: true,
+      body: "Operator chose authorise on 2026-08-16.",
+    });
+    expect(validateMemo(decision).valid).toBe(true);
+    expect(validateMemo(postmortemDoc({ kind: "decision" })).valid).toBe(false);
+  });
+});
+
+describe("subject normalization", () => {
+  test("collapses ticket case and github slug to the repo name", () => {
+    expect(normalizeSubjectId("ticket", "wm-809")).toBe("WM-809");
+    expect(normalizeSubjectId("repo", "watt-mind/factory")).toBe("factory");
+    expect(normalizeSubjectId("repo", "FACTORY")).toBe("factory");
+    expect(normalizeSubjectId("pr", "watt-mind/factory#612")).toBe(
+      "factory#612",
+    );
+  });
+});
+
+describe("schema migration (memos, memo_uses)", () => {
+  test("a fresh database has the memo ledger at CURRENT_SCHEMA_VERSION", () => {
+    const db = openDb(":memory:");
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(8);
+    const tables = db
+      .query(`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .all()
+      .map((row) => row.name);
+    expect(tables).toContain("memos");
+    expect(tables).toContain("memo_uses");
+    db.close();
+  });
+
+  test("v7 databases gain memos tables on open", () => {
+    const file = path.join(tmpDir("evrt-memos-db-"), "runtime.db");
+    const raw = new Database(file);
+    migrateDb(raw, { targetVersion: 7 });
+    expect(getSchemaVersion(raw)).toBe(7);
+    expect(
+      raw
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memos'`,
+        )
+        .get(),
+    ).toBeNull();
+    raw.close();
+
+    const upgraded = openDb(file);
+    expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(
+      upgraded
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memos'`,
+        )
+        .get()?.name,
+    ).toBe("memos");
+    upgraded.close();
+  });
+});
+
+function accepted(document, { runId = "run_memo_test", now } = {}) {
+  const createdAt = new Date(now ?? Date.now()).toISOString();
+  const full = withProvenance(document, {
+    runId,
+    agent: "run-postmortem@2",
+    createdAt,
+  });
+  const sha256 = memoDigest(full);
+  return {
+    full,
+    sha256,
+    result: {
+      memos: [{ sha256, document: full }],
+      artifacts: [{ kind: "memo", sha256, document: full }],
+    },
+  };
+}
+
+describe("registerMemos / listMemos", () => {
+  test("registers a memo and lists it live; a second insert of the same sha256 is a no-op", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const { sha256, result } = accepted(postmortemDoc(), { now });
+    const first = registerMemos(db, "run_memo_test", result, { now });
+    const second = registerMemos(db, "run_memo_test", result, { now });
+    expect(first[0].inserted).toBe(true);
+    expect(second[0].inserted).toBe(false);
+    const live = listMemos(db, { type: "ticket", id: "wm-809" }, { now });
+    expect(live).toHaveLength(1);
+    expect(live[0].sha256).toBe(sha256);
+    expect(live[0].kind).toBe("postmortem");
+    db.close();
+  });
+
+  test("supersedes drops the earlier memo from the live fold but keeps the row", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const first = accepted(postmortemDoc({ body: "attempt 1" }), { now });
+    registerMemos(db, "run_a", first.result, { now });
+    const second = accepted(
+      postmortemDoc({
+        body: "attempt 2 — do not rerun the full suite",
+        supersedes: first.sha256,
+      }),
+      { runId: "run_b", now: now + 1000 },
+    );
+    registerMemos(db, "run_b", second.result, { now: now + 1000 });
+    const live = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { now: now + 1000 },
+    );
+    expect(live.map((row) => row.sha256)).toEqual([second.sha256]);
+    const all = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { live: false, now: now + 1000 },
+    );
+    expect(all).toHaveLength(2);
+    expect(all.find((row) => row.sha256 === first.sha256).supersededBy).toBe(
+      second.sha256,
+    );
+    db.close();
+  });
+
+  test("kind-default expiry drops a postmortem after 30 days", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const { result } = accepted(postmortemDoc(), { now });
+    registerMemos(db, "run_memo_test", result, { now });
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-809" }, { now }).length,
+    ).toBe(1);
+    expect(
+      listMemos(
+        db,
+        { type: "ticket", id: "WM-809" },
+        { now: now + KIND_DEFAULT_TTL_MS.postmortem + 1 },
+      ),
+    ).toHaveLength(0);
+    db.close();
+  });
+
+  test("a binding observed broken retires the memo", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const descriptionHash = `sha256:${"a".repeat(64)}`;
+    const { sha256, result } = accepted(
+      postmortemDoc({ bindings: { descriptionHash } }),
+      { now },
+    );
+    registerMemos(db, "run_memo_test", result, { now });
+    const live = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { now, descriptionHash: `sha256:${"b".repeat(64)}` },
+    );
+    expect(live).toHaveLength(0);
+    const stored = db
+      .query(`SELECT retired_reason FROM memos WHERE sha256 = ?`)
+      .get(sha256);
+    expect(stored.retired_reason).toBe("description_hash_mismatch");
+    db.close();
+  });
+
+  test("useful count orders the fold; two distinct wrong verdicts retire contradicted", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const older = accepted(postmortemDoc({ body: "older" }), {
+      runId: "run_old",
+      now,
+    });
+    const newer = accepted(postmortemDoc({ body: "newer" }), {
+      runId: "run_new",
+      now: now + 5000,
+    });
+    registerMemos(db, "run_old", older.result, { now });
+    registerMemos(db, "run_new", newer.result, { now: now + 5000 });
+
+    registerMemos(
+      db,
+      "run_consumer_1",
+      {
+        memoPin: { entries: [{ sha256: older.sha256 }] },
+        usedMemos: [{ sha256: older.sha256, verdict: "useful" }],
+      },
+      { now: now + 6000 },
+    );
+    let live = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { now: now + 6000 },
+    );
+    expect(live[0].sha256).toBe(older.sha256);
+
+    registerMemos(
+      db,
+      "run_consumer_2",
+      { usedMemos: [{ sha256: newer.sha256, verdict: "wrong" }] },
+      { now: now + 7000 },
+    );
+    registerMemos(
+      db,
+      "run_consumer_3",
+      { usedMemos: [{ sha256: newer.sha256, verdict: "wrong" }] },
+      { now: now + 8000 },
+    );
+    live = listMemos(db, { type: "ticket", id: "WM-809" }, { now: now + 8000 });
+    expect(live.map((row) => row.sha256)).toEqual([older.sha256]);
+    const retired = db
+      .query(`SELECT retired_reason FROM memos WHERE sha256 = ?`)
+      .get(newer.sha256);
+    expect(retired.retired_reason).toBe("contradicted");
+    db.close();
+  });
+
+  test("runtime-authored documents register with run_id NULL", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const document = withProvenance(
+      postmortemDoc({
+        kind: "decision",
+        precedentOnly: true,
+        body: "Operator chose authorise.",
+        refs: { inboxItemId: "inbox_1" },
+      }),
+      {
+        runId: null,
+        agent: "runtime:inbox",
+        createdAt: new Date(now).toISOString(),
+      },
+    );
+    registerMemos(db, null, document, { now });
+    const live = listMemos(db, { type: "ticket", id: "WM-809" }, { now });
+    expect(live).toHaveLength(1);
+    expect(live[0].runId).toBeNull();
+    expect(live[0].inboxItemId).toBe("inbox_1");
+    db.close();
+  });
+});
+
+describe("learnings → repo-note", () => {
+  const def = { emits: { memos: ["repo-note"] } };
+  const spec = makeSpec({ repo: "watt-mind/factory", ticket: "wm-809" });
+
+  test("turns each learning into a repo-note on the normalized repo subject", () => {
+    const { errors, memos } = learningsToMemos(
+      [
+        {
+          claim: { kind: "howto", text: "Use the scoped verify command." },
+          evidence: "Root suite took 6m40s; scoped run was 41s clean.",
+        },
+      ],
+      { spec, def, now: Date.parse("2026-08-18T14:02:11.000Z") },
+    );
+    expect(errors).toEqual([]);
+    expect(memos).toHaveLength(1);
+    expect(memos[0].document.kind).toBe("repo-note");
+    expect(memos[0].document.subject).toEqual({ type: "repo", id: "factory" });
+    expect(memos[0].document.provenance.agent).toBe(spec.agent);
+  });
+
+  test("rejects more than five learnings and learnings without evidence", () => {
+    const tooMany = learningsToMemos(
+      Array.from({ length: LEARNINGS_MAX + 1 }, () => ({
+        claim: { kind: "fact", text: "x" },
+        evidence: "y",
+      })),
+      { spec, def },
+    );
+    expect(tooMany.errors[0]).toMatch(/max 5/);
+    const noEvidence = learningsToMemos(
+      [{ claim: { kind: "fact", text: "x" } }],
+      { spec, def },
+    );
+    expect(noEvidence.errors.some((e) => e.includes("evidence"))).toBe(true);
+  });
+
+  test("a definition that does not emit repo-note cannot leave learnings", () => {
+    const { errors } = learningsToMemos(
+      [{ claim: { kind: "fact", text: "x" }, evidence: "y" }],
+      { spec, def: { emits: { memos: ["postmortem"] } } },
+    );
+    expect(errors[0]).toMatch(/learnings_not_emitted/);
+  });
+});
+
+describe("referencedHashes protects ledger memos from GC", () => {
+  test("a memo with no result row is not pruned", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmpDir("evrt-memos-store-");
+    const bytes = "memo-bytes\n";
+    const sha256 = sha256Hex(bytes);
+    mkdirSync(storeRoot, { recursive: true });
+    writeFileSync(path.join(storeRoot, sha256), bytes);
+    db.query(
+      `INSERT INTO memos (sha256, subject_type, subject_id, kind, created_at)
+       VALUES (?, 'ticket', 'WM-809', 'postmortem', ?)`,
+    ).run(sha256, Date.now());
+
+    expect(referencedHashes(db).has(sha256)).toBe(true);
+    const pruned = pruneArtifacts(db, storeRoot, { olderThanMs: -1000 });
+    expect(pruned.deleted).toBe(0);
+    db.close();
+  });
+});
+
+describe("verifyResult memo collection", () => {
+  function writeMemoWorkspace(document) {
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+      artifacts: [{ kind: "memo", path: "memos/note.json" }],
+    });
+    mkdirSync(path.join(dir, "memos"), { recursive: true });
+    writeFileSync(
+      path.join(dir, "memos", "note.json"),
+      JSON.stringify(document),
+      "utf8",
+    );
+    return dir;
+  }
+
+  test("admits a memo artifact whose subject matches the spec and kind is emitted", () => {
+    const def = { ...statusDef, emits: { memos: ["postmortem"] } };
+    const dir = writeMemoWorkspace(postmortemDoc());
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.kind).toBe("completed");
+    expect(out.result.verification.checks).toContain("memos_valid");
+    expect(out.result.memos).toHaveLength(1);
+    expect(out.result.memos[0].document.provenance.runId).toBe("run_memo_test");
+    expect(out.result.artifacts[0].kind).toBe("memo");
+  });
+
+  test("a memo without emits.memos is a contract violation", () => {
+    const dir = writeMemoWorkspace(postmortemDoc());
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def: statusDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
+  });
+
+  test("a memo about another ticket is rejected", () => {
+    const def = { ...statusDef, emits: { memos: ["postmortem"] } };
+    const dir = writeMemoWorkspace(
+      postmortemDoc({ subject: { type: "ticket", id: "WM-1" } }),
+    );
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(/memo_subject_mismatch/);
+  });
+
+  test("agent-supplied provenance is rejected at verification", () => {
+    const def = { ...statusDef, emits: { memos: ["postmortem"] } };
+    const dir = writeMemoWorkspace(
+      postmortemDoc({
+        provenance: {
+          runId: "run_forged",
+          agent: "dispatch@1",
+          createdAt: "2026-08-18T14:02:11.000Z",
+        },
+      }),
+    );
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(/provenance/);
+  });
+
+  test("usedMemos whose sha256 is not in memoPin fail closed", () => {
+    const def = {
+      ...statusDef,
+      emits: { memos: ["postmortem"] },
+      outputSchema: { type: "object" },
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: {
+        ...VALID_ARTIFACT,
+        usedMemos: [{ sha256: "a".repeat(64), verdict: "useful" }],
+      },
+    });
+    expect(() =>
+      verifyResult({
+        spec: makeSpec({
+          repo: "factory",
+          ticket: "WM-809",
+          memoPin: { entries: [{ sha256: "b".repeat(64) }] },
+        }),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(/not in this run's memoPin/);
+  });
+
+  test("learnings on the artifact become repo-note memo artifacts", () => {
+    const def = {
+      ...statusDef,
+      emits: { memos: ["repo-note"] },
+      outputSchema: { type: "object" },
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: {
+        ...VALID_ARTIFACT,
+        learnings: [
+          {
+            claim: { kind: "howto", text: "Use the scoped verify command." },
+            evidence: "Root suite took 6m40s; scoped run was 41s clean.",
+          },
+        ],
+      },
+    });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.result.verification.checks).toContain("learnings_materialized");
+    expect(out.result.memos).toHaveLength(1);
+    expect(out.result.memos[0].document.kind).toBe("repo-note");
+    expect(out.result.artifacts.some((entry) => entry.kind === "memo")).toBe(
+      true,
+    );
+  });
+});

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -16,6 +16,7 @@ import path from "node:path";
 import { globToRegExp } from "../../orchestrator/owned-paths.mjs";
 import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { validateDecisionRequest } from "./decision.mjs";
+import { processResultMemos } from "./memos.mjs";
 import { reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { PathViolation, safeJoin } from "./workspace.mjs";
@@ -1088,6 +1089,17 @@ function verifyCompleted({
   }
   if (violations.length > 0) throw new ContractViolation(violations);
 
+  const memoOutcome = processResultMemos({
+    candidate,
+    spec,
+    def,
+    workspaceDir,
+    collected,
+  });
+  if (memoOutcome.errors.length > 0) {
+    throw new ContractViolation(memoOutcome.errors);
+  }
+
   const artifactHash = hashJson(candidate.artifact);
 
   const { evidence, evidenceSetHash } = retainedEvidence(candidate);
@@ -1115,9 +1127,12 @@ function verifyCompleted({
           ? ["evidence_recomputed"]
           : []),
         ...handoffChecks,
+        ...memoOutcome.checks,
       ],
     },
     artifacts: collected,
+    ...(memoOutcome.memos.length > 0 ? { memos: memoOutcome.memos } : {}),
+    ...(memoOutcome.usedMemos ? { usedMemos: memoOutcome.usedMemos } : {}),
   };
   const receipt = {
     runId: spec.runId,

--- a/event-runtime/schemas/factory.memo.v1.json
+++ b/event-runtime/schemas/factory.memo.v1.json
@@ -1,0 +1,77 @@
+{
+  "title": "factory.memo/v1 — verified cross-run memory (docs/event-runtime-memos.md §2)",
+  "type": "object",
+  "required": ["schemaVersion", "subject", "kind", "body"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.memo/v1" },
+    "subject": {
+      "type": "object",
+      "required": ["type", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": ["repo", "ticket", "pr", "workflow", "run"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "kind": {
+      "enum": ["repo-note", "postmortem", "decision", "flake", "handoff"]
+    },
+    "claim": {
+      "type": "object",
+      "required": ["kind", "text"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "enum": ["howto", "pitfall", "fact"] },
+        "text": { "type": "string", "minLength": 1, "maxLength": 280 }
+      }
+    },
+    "evidence": { "type": "string", "minLength": 1, "maxLength": 1024 },
+    "body": { "type": "string", "minLength": 1, "maxLength": 4096 },
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "descriptionHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "expiresAt": { "type": "string", "minLength": 1 }
+      }
+    },
+    "supersedes": {
+      "type": ["string", "null"],
+      "pattern": "^([0-9a-f]{64}|sha256:[0-9a-f]{64})$"
+    },
+    "refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([0-9a-f]{64}|sha256:[0-9a-f]{64})$"
+          }
+        },
+        "inboxItemId": { "type": "string", "minLength": 1 },
+        "pr": { "type": "string", "minLength": 1 },
+        "runId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["agent", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "runId": { "type": ["string", "null"] },
+        "agent": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "minLength": 1 }
+      }
+    },
+    "precedentOnly": { "type": "boolean" }
+  }
+}


### PR DESCRIPTION
## Summary
- Add the `factory.memo/v1` contract, v8 `memos`/`memo_uses` ledger, and `registerMemos`/`listMemos` with subject normalization, live fold, kind-default TTL, and contradicted retirement.
- Verify-time collection admits `kind: memo` artifacts and `learnings` only when the definition declares `emits.memos`, confines the subject to the run spec, and rejects agent-supplied provenance.
- `referencedHashes` unions ledger sha256s so memo artifacts survive GC even with no result row (runtime-authored decisions). Wiring `registerMemos` into the worker accept transaction is filed as WM-895 (outside this ticket's Owned Paths).

Fixes WM-809

UX critique: skipped — backend/schema/ledger; no user-completable flow.

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib` — 1178 pass, 9 skip
- [x] `bun test --timeout 20000 --max-concurrency=4` — 3082 pass, 9 skip
- [ ] Reviewer: confirm v8 migration is additive and `referencedHashes` query is safe on a freshly migrated db


Made with [Cursor](https://cursor.com)