### PR TITLE
fix(test): pick ephemeral ports for serve PID-lock CLI test (WM-740)

### DIFF
--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -521,8 +521,17 @@ describe("serve PID lock (OPS-458)", () => {
 
   test("concurrent duplicate serve on same home fails second instance and releasing first allows next", async () => {
     const home = tmpDir("evrt-lock-cli-");
-    const port1 = String(59500 + (process.pid % 200));
-    const port2 = String(59700 + (process.pid % 200));
+    // Ask the OS for genuinely free ports instead of pid-modulo arithmetic:
+    // 59500/59700 + pid % 200 collides on a busy CI host and fails at listen
+    // before the lock assertion runs (WM-740). Hold both listeners until both
+    // ports are known so the same call never returns duplicates. Serve rejects
+    // --port 0, so the probes are released before spawn.
+    const probes = [
+      Bun.serve({ port: 0, fetch: () => new Response("") }),
+      Bun.serve({ port: 0, fetch: () => new Response("") }),
+    ];
+    const [port1, port2] = probes.map((p) => String(p.port));
+    for (const p of probes) p.stop(true);
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
 
     const serve1 = spawnTracked("bun", [CLI, "serve", "--port", port1], {


### PR DESCRIPTION
## Summary
- The serve PID-lock CLI test derived ports as `59500/59700 + pid % 200`, which collides on a busy CI host and fails at `listen` before the lock assertion.
- Bind two throwaway `Bun.serve({ port: 0 })` probes at once, use the OS-assigned ports, then spawn serve. Lock assertions are unchanged.

Fixes WM-740

UX critique: skipped — test-only change in `event-runtime/lib/api.test.mjs`; no user-facing surface.

## Test plan
- [x] `bun test event-runtime/lib/api.test.mjs` — 11 pass
- [x] `bun test event-runtime/lib --timeout 20000` — 1155 pass
- [x] `bun build/emit.mjs --check` — ok


Made with [Cursor](https://cursor.com)