### PR TITLE
chore(oss): add CLA.md and contributor-assistant PR gate (WM-792)

### DIFF
--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Write access is required so CLA Assistant can comment on the PR, set a
+# status check, and append signatures to .github/cla-signatures.json on
+# develop. This workflow must never check out pull-request HEAD: it runs
+# as pull_request_target with the base-branch token.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA Assistant
+    # Self-hosted per project-conventions PC-03 / PC-22. The one `uses:`
+    # step is the WM-792 exception to the no-marketplace-action rule
+    # (WM-573): this job is a single infrequent API call, not Verify.
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 5
+    steps:
+      - name: CLA Assistant
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla-signatures.json"
+          path-to-document: "https://github.com/watt-mind/factory/blob/develop/CLA.md"
+          branch: develop
+          allowlist: "hdkiller,dependabot[bot],github-actions[bot],bot*"
+          signed-commit-message: "$contributorName has signed the CLA in $owner/$repo#$pullRequestNo (WM-792)"
+          create-file-commit-message: "chore(oss): create CLA signature record (WM-792)"
+          lock-pullrequest-aftermerge: false

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,147 @@
+# Watt Mind Individual Contributor License Agreement
+
+Thank you for your interest in Factory, an open source project of Watt Mind
+Kft. (the "Company").
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, the Company must have a Contributor
+License Agreement ("CLA") on file that has been signed by each Contributor,
+indicating agreement to the license terms below. This license is for your
+protection as a Contributor as well as the protection of the Company and its
+users; it does not change your rights to use your own Contributions for any
+other purpose.
+
+This agreement follows the structure of the Apache Software Foundation
+Individual Contributor License Agreement ("Agreement") V2.2, adapted for Watt
+Mind Kft. It is a grant of rights, not an assignment: You keep copyright in
+Your Contributions. The phrase "Apache Software Foundation" and ASF-specific
+nonprofit terms do not apply to this document except as this derivation note.
+
+## How to sign
+
+Sign by posting the following comment on your pull request when CLA Assistant
+asks you to:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+The GitHub identity, timestamp, and pull request that recorded the signature
+are stored in [`.github/cla-signatures.json`](.github/cla-signatures.json).
+One signature covers present and future Contributions to this repository. You
+do not need to re-sign for each pull request.
+
+Core maintainers and bot accounts listed in the CLA workflow allowlist are not
+required to sign.
+
+If You are contributing on behalf of an employer or other legal entity that
+owns the Contribution, You must have permission to grant the licenses below
+(see section 4), or that entity must execute a separate Corporate CLA with the
+Company before the Contribution can be merged.
+
+## Agreement
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to the Company. Except for the license
+granted herein to the Company and recipients of software distributed by the
+Company, You reserve all right, title, and interest in and to Your
+Contributions.
+
+### 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is making this Agreement with the Company. For legal
+entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are
+considered to be a single Contributor. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii) ownership
+of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Company for inclusion in, or documentation of, any of
+the products owned or managed by the Company (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal, or written
+communication sent to the Company or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the
+Company for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by
+Your Contribution(s) alone or by combination of Your Contribution(s) with the
+Work to which such Contribution(s) was submitted. If any entity institutes
+patent litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that your Contribution, or the Work to
+which you have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work shall terminate as of the date such
+litigation is filed.
+
+### 4. Entitlement to grant the license
+
+You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission
+to make Contributions on behalf of that employer, that your employer has
+waived such rights for your Contributions to the Company, or that your
+employer has executed a separate Corporate CLA with the Company.
+
+### 5. Original creation
+
+You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license
+or other restriction (including, but not limited to, related patents and
+trademarks) of which you are personally aware and which are associated with
+any part of Your Contributions.
+
+### 6. Support and warranty
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 7. Third-party submissions
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Company separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+### 8. Notice of changed circumstances
+
+You agree to notify the Company of any facts or circumstances of which you
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+Based on the Apache Software Foundation Individual Contributor License
+Agreement V2.2 (<https://www.apache.org/licenses/icla.pdf>), modified for Watt
+Mind Kft. The copyright license in section 2 includes the right to sublicense,
+which permits the Company to distribute the Work (including Your
+Contributions) under Apache License 2.0 and, if desired later, additional
+open-source or commercial terms.


### PR DESCRIPTION
## Summary

- Add `CLA.md`, a Watt Mind Individual Contributor License Agreement in the Apache ICLA v2.2 structure (copyright and patent grants, representations, third-party submissions, AS-IS warranty), signed via the CLA Assistant pull-request comment.
- Add `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1` (pinned SHA) on `[self-hosted, shadow]`, with an allowlist for `hdkiller` and bot accounts.
- Seed `.github/cla-signatures.json` as valid empty JSON so the signature record parses cleanly.

Fixes WM-792

UX critique: skipped — docs and CI gate only; no user-facing application surface.

## Test plan

- [x] `actionlint .github/workflows/cla.yml && bun run check`
- [x] `bun test event-runtime/lib --timeout 20000` (1155 pass, 9 skip)
- [ ] Confirm the CLA check runs on this PR (allowlisted maintainer should not be asked to sign)
- [ ] After merge, confirm an external (non-allowlisted) PR is prompted to sign


Made with [Cursor](https://cursor.com)