### PR TITLE
feat(extensions): contribute harness content from the extension manifest (WM-849)

### DIFF
--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * shared/ -> per-harness packaging.
+ * Harness packs -> per-harness packaging (WM-849).
  *
  *   bun build/emit.mjs           # regenerate plugins/ and dist/
  *   bun build/emit.mjs --check   # CI: fail if the tree isn't reproducible
@@ -11,6 +11,11 @@
  *                                 # this whenever a /factory-* command is
  *                                 # added or removed, or product repos keep
  *                                 # running against a stale command set
+ *
+ * `shared/` is the built-in `factory/core` pack (`shared/factory-extension.json`).
+ * Every other loaded extension that `contributes.harness` is emitted under its
+ * publisher-extension namespace. Core output paths are unchanged so
+ * plugins/core/** and dist/** stay byte-identical with the pre-packaging tree.
  *
  * Why a build step at all: the CONTENT is harness-neutral (SKILL.md is a shared
  * format; command bodies are markdown) but the PACKAGING is not. Claude wants a
@@ -30,10 +35,8 @@ import {
   writeFileSync,
   mkdirSync,
   rmSync,
-  cpSync,
   readdirSync,
   existsSync,
-  statSync,
   symlinkSync,
   lstatSync,
   unlinkSync,
@@ -43,6 +46,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FLOOR_BEGIN, spliceFloor, floorIsCurrent } from "../lib/floor.mjs";
 import { ensureHarnessGitignore } from "../lib/factory-gitignore.mjs";
+import {
+  CORE_HARNESS_PLUGIN,
+  collectHarnessRoots,
+} from "../event-runtime/lib/extensions.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SHARED = path.join(ROOT, "shared");
@@ -126,188 +133,266 @@ function cleanGenerated(...directories) {
     rmSync(directory, { recursive: true, force: true });
 }
 
-// ------------------------------------------------------------------ inputs ---
-const floor = read(path.join(SHARED, "floor.md"));
-const commands = listFiles(path.join(SHARED, "commands")).filter((f) =>
-  f.endsWith(".md"),
-);
-const skillDirs = existsSync(path.join(SHARED, "skills"))
-  ? readdirSync(path.join(SHARED, "skills"), { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name)
-  : [];
-const agents = listFiles(path.join(SHARED, "agents")).filter((f) =>
-  f.endsWith(".md"),
-);
-const agentDefinitions = agents.map((file) => {
-  const { fm, body } = splitFrontmatter(read(file));
-  const name = fm.name || path.basename(file, ".md");
-  if (!fm.description)
-    throw new Error(`${rel(file)}: agents require a description`);
-  if (name !== path.basename(file, ".md"))
-    throw new Error(
-      `${rel(file)}: agent name must match its filename (${name})`,
-    );
-  return { file, name, description: fm.description, fm, body };
-});
+/** Nested dest for namespaced packs; core (no prefix) keeps historical paths. */
+function destJoin(pack, base, ...parts) {
+  return pack.prefix
+    ? path.join(base, pack.prefix, ...parts)
+    : path.join(base, ...parts);
+}
 
-// ------------------------------------------------- Claude Code (plugin) ------
-// Shared frontmatter uses Claude's expressive keys by default. Pi-only fields
-// are stripped so one harness's tool names cannot alter Claude's allowlist.
-const CLAUDE = path.join(ROOT, "plugins", "core");
+/** Flat-file dest: prefix the filename so ~/.cursor/commands stays collision-free. */
+function destFile(pack, dir, filename) {
+  return pack.prefix
+    ? path.join(dir, `${pack.prefix}-${filename}`)
+    : path.join(dir, filename);
+}
+
+function commandSkillName(pack, file) {
+  const stem = path.basename(file, ".md");
+  return pack.prefix ? `${pack.prefix}-${stem}` : stem;
+}
+
+// ------------------------------------------------------------------ inputs ---
+const { roots: harnessPacks, anomalies: harnessAnomalies } =
+  collectHarnessRoots({
+    root: ROOT,
+    builtin: SHARED,
+  });
+for (const anomaly of harnessAnomalies) console.error(`harness: ${anomaly}`);
+if (harnessPacks.length === 0) {
+  console.error("no harness packs to emit — built-in shared/ pack is missing");
+  process.exit(2);
+}
+
+function loadPackContent(pack) {
+  const commands = pack.commands
+    ? listFiles(pack.commands).filter((f) => f.endsWith(".md"))
+    : [];
+  const skillDirs = pack.skills
+    ? readdirSync(pack.skills, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+    : [];
+  const agents = pack.subagents
+    ? listFiles(pack.subagents).filter((f) => f.endsWith(".md"))
+    : [];
+  const agentDefinitions = agents.map((file) => {
+    const { fm, body } = splitFrontmatter(read(file));
+    const name = fm.name || path.basename(file, ".md");
+    if (!fm.description)
+      throw new Error(`${rel(file)}: agents require a description`);
+    if (name !== path.basename(file, ".md"))
+      throw new Error(
+        `${rel(file)}: agent name must match its filename (${name})`,
+      );
+    return { file, name, description: fm.description, fm, body };
+  });
+  return {
+    pack,
+    floor: pack.floor ? read(pack.floor) : null,
+    commands,
+    skillDirs,
+    skillsRoot: pack.skills,
+    agents,
+    agentDefinitions,
+  };
+}
+
+const loadedPacks = harnessPacks.map(loadPackContent);
+const corePack = loadedPacks.find((p) => p.pack.builtin) ?? loadedPacks[0];
+const floor = corePack.floor;
+if (typeof floor !== "string") {
+  throw new Error("built-in harness pack must contribute a floor");
+}
+
+const CLAUDE = path.join(ROOT, "plugins", CORE_HARNESS_PLUGIN);
+const CODEX = path.join(ROOT, "dist", "codex");
+const GEMINI = path.join(ROOT, "dist", "gemini");
+const CURSOR = path.join(ROOT, "dist", "cursor");
+const PI = path.join(ROOT, "dist", "pi");
+const PI_DEFAULT_AGENT_TOOLS = "read, grep, find, ls, bash";
+
+if (!CHECK) {
+  const extraPlugins = new Set(
+    harnessPacks.filter((p) => !p.builtin).map((p) => p.plugin),
+  );
+  const pluginsRoot = path.join(ROOT, "plugins");
+  if (existsSync(pluginsRoot)) {
+    for (const name of readdirSync(pluginsRoot)) {
+      if (name === CORE_HARNESS_PLUGIN) continue;
+      if (!extraPlugins.has(name))
+        rmSync(path.join(pluginsRoot, name), { recursive: true, force: true });
+    }
+  }
+  const distRoot = path.join(ROOT, "dist");
+  if (existsSync(distRoot)) {
+    for (const name of readdirSync(distRoot)) {
+      if (/^AGENTS\.floor\..+\.md$/.test(name))
+        rmSync(path.join(distRoot, name), { force: true });
+    }
+  }
+}
+
 cleanGenerated(
   path.join(CLAUDE, "commands"),
   path.join(CLAUDE, "skills"),
   path.join(CLAUDE, "agents"),
-);
-for (const f of commands)
-  emit(path.join(CLAUDE, "commands", path.basename(f)), read(f));
-for (const s of skillDirs)
-  for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(
-      path.join(
-        CLAUDE,
-        "skills",
-        s,
-        path.relative(path.join(SHARED, "skills", s), f),
-      ),
-      read(f),
-    );
-for (const agent of agentDefinitions)
-  emit(
-    path.join(CLAUDE, "agents", `${agent.name}.md`),
-    withoutFrontmatterFields(read(agent.file), ["pi-tools", "pi-extensions"]),
-  );
-
-// ------------------------------------------------------------- Codex ---------
-// Codex uses skills for reusable workflows. Factory's shared command bodies
-// become skills so they work in the desktop app too; custom prompts are a
-// deprecated CLI/IDE-only surface.
-const CODEX = path.join(ROOT, "dist", "codex");
-cleanGenerated(
   path.join(CODEX, "agents"),
   path.join(CODEX, "skills"),
   path.join(CODEX, "prompts"),
-);
-for (const agent of agentDefinitions)
-  emit(path.join(CODEX, "agents", `${agent.name}.toml`), codexAgent(agent));
-for (const s of skillDirs)
-  for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(
-      path.join(
-        CODEX,
-        "skills",
-        s,
-        path.relative(path.join(SHARED, "skills", s), f),
-      ),
-      read(f),
-    );
-
-const codexCommandSkills = commands.map((f) => path.basename(f, ".md"));
-for (const f of commands) {
-  const { fm, body } = splitFrontmatter(read(f));
-  const name = path.basename(f, ".md");
-  emit(
-    path.join(CODEX, "skills", name, "SKILL.md"),
-    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
-  );
-}
-// ------------------------------------------------- Gemini CLI / Antigravity ---
-// Antigravity shares ~/.gemini, so one emit covers both.
-const GEMINI = path.join(ROOT, "dist", "gemini");
-cleanGenerated(path.join(GEMINI, "agents"), path.join(GEMINI, "skills"));
-for (const agent of agentDefinitions)
-  emit(
-    path.join(GEMINI, "agents", `${agent.name}.md`),
-    markdownAgent(agent, { kind: "local" }),
-  );
-for (const s of skillDirs)
-  for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(
-      path.join(
-        GEMINI,
-        "skills",
-        s,
-        path.relative(path.join(SHARED, "skills", s), f),
-      ),
-      read(f),
-    );
-
-for (const f of commands) {
-  const { fm, body } = splitFrontmatter(read(f));
-  const name = path.basename(f, ".md");
-  emit(
-    path.join(GEMINI, "skills", name, "SKILL.md"),
-    `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
-  );
-}
-
-// ------------------------------------------------------------- Cursor --------
-// ~/.cursor/commands/*.md — plain markdown, no frontmatter.
-const CURSOR = path.join(ROOT, "dist", "cursor");
-cleanGenerated(path.join(CURSOR, "agents"), path.join(CURSOR, "commands"));
-for (const agent of agentDefinitions)
-  emit(
-    path.join(CURSOR, "agents", `${agent.name}.md`),
-    markdownAgent(agent, { readonly: true }),
-  );
-for (const f of commands) {
-  const { body } = splitFrontmatter(read(f));
-  emit(path.join(CURSOR, "commands", path.basename(f)), body.trimStart());
-}
-
-// ------------------------------------------------------------- Pi ------------
-// dist/pi/ — skills and prompts for the Pi coding agent.
-const PI = path.join(ROOT, "dist", "pi");
-const PI_DEFAULT_AGENT_TOOLS = "read, grep, find, ls, bash";
-cleanGenerated(
+  path.join(GEMINI, "agents"),
+  path.join(GEMINI, "skills"),
+  path.join(CURSOR, "agents"),
+  path.join(CURSOR, "commands"),
   path.join(PI, "agents"),
   path.join(PI, "skills"),
   path.join(PI, "prompts"),
 );
-for (const agent of agentDefinitions) {
-  // Pi-specific declarations live in shared frontmatter so an exceptional
-  // agent's surface is reviewable at the source. Prefixing them avoids passing
-  // Pi tool names through to Claude Code, whose `tools` field has different
-  // names and semantics. Agents without a declaration retain the byte-identical
-  // historical allowlist.
-  const piFields = {
-    tools: agent.fm["pi-tools"] || PI_DEFAULT_AGENT_TOOLS,
-    systemPromptMode: "replace",
-    inheritProjectContext: true,
-    inheritSkills: true,
-  };
-  if (agent.fm["pi-extensions"])
-    piFields.extensions = agent.fm["pi-extensions"];
-  emit(
-    path.join(PI, "agents", `${agent.name}.md`),
-    markdownAgent(agent, piFields),
-  );
-}
-for (const s of skillDirs)
-  for (const f of listFiles(path.join(SHARED, "skills", s)))
-    emit(
-      path.join(
-        PI,
-        "skills",
-        s,
-        path.relative(path.join(SHARED, "skills", s), f),
-      ),
-      read(f),
-    );
-for (const f of commands) {
-  const { fm, body } = splitFrontmatter(read(f));
-  emit(
-    path.join(PI, "prompts", path.basename(f)),
-    `# ${path.basename(f, ".md")}\n\n${fm.description ? `> ${fm.description}\n\n` : ""}${body.trimStart()}`,
+for (const pack of harnessPacks) {
+  if (pack.builtin) continue;
+  const plugin = path.join(ROOT, "plugins", pack.plugin);
+  cleanGenerated(
+    path.join(plugin, "commands"),
+    path.join(plugin, "skills"),
+    path.join(plugin, "agents"),
   );
 }
 
-// ------------------------------------------------- universal floor block ------
-// Every harness reads AGENTS.md or can be pointed at it, and unlike a plugin it
-// travels with the checkout — so this is the only layer a cloud sandbox is
-// guaranteed to get.
-emit(path.join(ROOT, "dist", "AGENTS.floor.md"), floor);
+function emitPack({
+  pack,
+  commands,
+  skillDirs,
+  skillsRoot,
+  agentDefinitions,
+  floor: packFloor,
+}) {
+  const plugin = path.join(ROOT, "plugins", pack.plugin);
+  for (const f of commands)
+    emit(path.join(plugin, "commands", path.basename(f)), read(f));
+  for (const s of skillDirs)
+    for (const f of listFiles(path.join(skillsRoot, s)))
+      emit(
+        path.join(
+          plugin,
+          "skills",
+          s,
+          path.relative(path.join(skillsRoot, s), f),
+        ),
+        read(f),
+      );
+  for (const agent of agentDefinitions)
+    emit(
+      path.join(plugin, "agents", `${agent.name}.md`),
+      withoutFrontmatterFields(read(agent.file), ["pi-tools", "pi-extensions"]),
+    );
+
+  for (const agent of agentDefinitions)
+    emit(
+      destJoin(pack, path.join(CODEX, "agents"), `${agent.name}.toml`),
+      codexAgent(agent),
+    );
+  for (const s of skillDirs)
+    for (const f of listFiles(path.join(skillsRoot, s)))
+      emit(
+        destJoin(
+          pack,
+          path.join(CODEX, "skills"),
+          s,
+          path.relative(path.join(skillsRoot, s), f),
+        ),
+        read(f),
+      );
+  for (const f of commands) {
+    const { fm, body } = splitFrontmatter(read(f));
+    const name = commandSkillName(pack, f);
+    emit(
+      destJoin(pack, path.join(CODEX, "skills"), name, "SKILL.md"),
+      `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
+    );
+  }
+
+  for (const agent of agentDefinitions)
+    emit(
+      destJoin(pack, path.join(GEMINI, "agents"), `${agent.name}.md`),
+      markdownAgent(agent, { kind: "local" }),
+    );
+  for (const s of skillDirs)
+    for (const f of listFiles(path.join(skillsRoot, s)))
+      emit(
+        destJoin(
+          pack,
+          path.join(GEMINI, "skills"),
+          s,
+          path.relative(path.join(skillsRoot, s), f),
+        ),
+        read(f),
+      );
+  for (const f of commands) {
+    const { fm, body } = splitFrontmatter(read(f));
+    const name = commandSkillName(pack, f);
+    emit(
+      destJoin(pack, path.join(GEMINI, "skills"), name, "SKILL.md"),
+      `---\nname: ${name}\ndescription: ${fm.description || `Run the ${name} Factory workflow.`}\n---\n\n# ${name}\n\nThe user's accompanying request is this workflow's argument string. Wherever these instructions refer to \`$ARGUMENTS\`, interpret it as that request.\n\n${body.trimStart()}`,
+    );
+  }
+
+  for (const agent of agentDefinitions)
+    emit(
+      destJoin(pack, path.join(CURSOR, "agents"), `${agent.name}.md`),
+      markdownAgent(agent, { readonly: true }),
+    );
+  for (const f of commands) {
+    const { body } = splitFrontmatter(read(f));
+    emit(
+      destFile(pack, path.join(CURSOR, "commands"), path.basename(f)),
+      body.trimStart(),
+    );
+  }
+
+  for (const agent of agentDefinitions) {
+    const piFields = {
+      tools: agent.fm["pi-tools"] || PI_DEFAULT_AGENT_TOOLS,
+      systemPromptMode: "replace",
+      inheritProjectContext: true,
+      inheritSkills: true,
+    };
+    if (agent.fm["pi-extensions"])
+      piFields.extensions = agent.fm["pi-extensions"];
+    emit(
+      destJoin(pack, path.join(PI, "agents"), `${agent.name}.md`),
+      markdownAgent(agent, piFields),
+    );
+  }
+  for (const s of skillDirs)
+    for (const f of listFiles(path.join(skillsRoot, s)))
+      emit(
+        destJoin(
+          pack,
+          path.join(PI, "skills"),
+          s,
+          path.relative(path.join(skillsRoot, s), f),
+        ),
+        read(f),
+      );
+  for (const f of commands) {
+    const { fm, body } = splitFrontmatter(read(f));
+    emit(
+      destFile(pack, path.join(PI, "prompts"), path.basename(f)),
+      `# ${path.basename(f, ".md")}\n\n${fm.description ? `> ${fm.description}\n\n` : ""}${body.trimStart()}`,
+    );
+  }
+
+  if (packFloor && pack.builtin)
+    emit(path.join(ROOT, "dist", "AGENTS.floor.md"), packFloor);
+  else if (packFloor && pack.plugin)
+    emit(path.join(ROOT, "dist", `AGENTS.floor.${pack.plugin}.md`), packFloor);
+}
+
+for (const loaded of loadedPacks) emitPack(loaded);
+
+const commands = corePack.commands;
+const skillDirs = corePack.skillDirs;
+const agents = corePack.agents;
 
 // ---------------------------------------------------------- floor in repos ---
 // Emitting dist/AGENTS.floor.md is not delivery. Until 2026-08-04 that was the
@@ -327,15 +412,17 @@ function floorStatus() {
   );
   return (cfg.repos ?? []).map((repo) => {
     const repoPath = String(repo.path).replace(/^~/, homedir());
-    const agents = path.join(repoPath, "AGENTS.md");
-    if (!existsSync(repoPath)) return { ...repo, agents, state: "no-checkout" };
-    if (!existsSync(agents)) return { ...repo, agents, state: "missing" };
-    const body = read(agents);
+    const agentsFile = path.join(repoPath, "AGENTS.md");
+    if (!existsSync(repoPath))
+      return { ...repo, agents: agentsFile, state: "no-checkout" };
+    if (!existsSync(agentsFile))
+      return { ...repo, agents: agentsFile, state: "missing" };
+    const body = read(agentsFile);
     if (!body.includes(FLOOR_BEGIN))
-      return { ...repo, agents, state: "missing" };
+      return { ...repo, agents: agentsFile, state: "missing" };
     return {
       ...repo,
-      agents,
+      agents: agentsFile,
       state: floorIsCurrent(body, floor) ? "ok" : "stale",
     };
   });
@@ -389,7 +476,7 @@ if (CHECK) {
     if (!expected.includes(file)) problems.push(`orphaned:  ${rel(file)}`);
 
   if (problems.length) {
-    console.error("Generated tree does not match shared/:\n");
+    console.error("Generated tree does not match harness sources:\n");
     for (const p of problems) console.error("  " + p);
     console.error(`\nRun \`bun build/emit.mjs\` and commit the result.`);
     console.error(
@@ -431,7 +518,9 @@ if (CHECK) {
   process.exit(0);
 }
 
-console.log(`emitted ${written.size} files from shared/`);
+console.log(
+  `emitted ${written.size} files from ${harnessPacks.length} harness pack(s)`,
+);
 console.log(
   `  claude  plugins/core/  (${commands.length} commands, ${skillDirs.length} skills, ${agents.length} agents)`,
 );
@@ -448,6 +537,11 @@ console.log(
   `  pi      dist/pi/       (${skillDirs.length} skills, ${commands.length} prompts, ${agents.length} agents)`,
 );
 console.log(`  floor   dist/AGENTS.floor.md`);
+for (const extra of loadedPacks.filter((p) => !p.pack.builtin)) {
+  console.log(
+    `  extra   plugins/${extra.pack.plugin}/  (${extra.commands.length} commands, ${extra.skillDirs.length} skills, ${extra.agents.length} agents)`,
+  );
+}
 
 // -------------------------------------------------------------- link repos ---
 // Claude Code reads project commands from <repo>/.claude/commands/. Symlinking
@@ -470,23 +564,31 @@ if (process.argv.includes("--link-repos")) {
     }
     const dst = path.join(repoPath, ".claude", "commands");
     mkdirSync(dst, { recursive: true });
-    for (const f of commands) {
-      const target = path.join(dst, path.basename(f));
-      let st = null;
-      try {
-        st = lstatSync(target);
-      } catch {
-        /* intentionally ignored */
+    let linked = 0;
+    for (const loaded of loadedPacks) {
+      const plugin = path.join(ROOT, "plugins", loaded.pack.plugin);
+      for (const f of loaded.commands) {
+        const filename = loaded.pack.prefix
+          ? `${loaded.pack.prefix}-${path.basename(f)}`
+          : path.basename(f);
+        const target = path.join(dst, filename);
+        let st = null;
+        try {
+          st = lstatSync(target);
+        } catch {
+          /* intentionally ignored */
+        }
+        if (st && !st.isSymbolicLink()) {
+          console.log(`  skip     ${repo.name}/${filename} (real file)`);
+          continue;
+        }
+        if (st) unlinkSync(target);
+        symlinkSync(path.join(plugin, "commands", path.basename(f)), target);
+        linked += 1;
       }
-      if (st && !st.isSymbolicLink()) {
-        console.log(`  skip     ${repo.name}/${path.basename(f)} (real file)`);
-        continue;
-      }
-      if (st) unlinkSync(target);
-      symlinkSync(path.join(CLAUDE, "commands", path.basename(f)), target);
     }
     console.log(
-      `  linked   ${repo.name}  ${commands.length} command(s) -> ${repo.path}/.claude/commands/`,
+      `  linked   ${repo.name}  ${linked} command(s) -> ${repo.path}/.claude/commands/`,
     );
     const gi = ensureHarnessGitignore(repoPath);
     if (gi === "ok")
@@ -529,56 +631,92 @@ function linkFactoryBin() {
 
 if (LINK_BIN || LINK) linkFactoryBin();
 
+function packLinks(loaded) {
+  const { pack, commands, skillDirs, agentDefinitions } = loaded;
+  const plugin = path.join(ROOT, "plugins", pack.plugin);
+  const skillNames = [
+    ...skillDirs,
+    ...commands.map((f) => commandSkillName(pack, f)),
+  ];
+  return [
+    ...skillNames.map((s) => [
+      destJoin(pack, path.join(CODEX, "skills"), s),
+      destJoin(pack, path.join(homedir(), ".agents/skills"), s),
+    ]),
+    ...skillNames.map((s) => [
+      destJoin(pack, path.join(GEMINI, "skills"), s),
+      destJoin(pack, path.join(homedir(), ".gemini/skills"), s),
+    ]),
+    ...commands.map((f) => [
+      destFile(pack, path.join(CURSOR, "commands"), path.basename(f)),
+      destFile(
+        pack,
+        path.join(homedir(), ".cursor/commands"),
+        path.basename(f),
+      ),
+    ]),
+    ...commands.map((f) => [
+      destFile(pack, path.join(PI, "prompts"), path.basename(f)),
+      destFile(
+        pack,
+        path.join(homedir(), ".pi/agent/prompts"),
+        path.basename(f),
+      ),
+    ]),
+    ...skillDirs.map((s) => [
+      destJoin(pack, path.join(PI, "skills"), s),
+      destJoin(pack, path.join(homedir(), ".pi/agent/skills"), s),
+    ]),
+    ...agentDefinitions.flatMap((agent) => {
+      const file = pack.prefix ? `${pack.prefix}-${agent.name}` : agent.name;
+      return [
+        [
+          path.join(plugin, "agents", `${agent.name}.md`),
+          path.join(homedir(), ".claude/agents", `${file}.md`),
+        ],
+        [
+          destJoin(pack, path.join(CODEX, "agents"), `${agent.name}.toml`),
+          destFile(
+            pack,
+            path.join(homedir(), ".codex/agents"),
+            `${agent.name}.toml`,
+          ),
+        ],
+        [
+          destJoin(pack, path.join(GEMINI, "agents"), `${agent.name}.md`),
+          destFile(
+            pack,
+            path.join(homedir(), ".gemini/agents"),
+            `${agent.name}.md`,
+          ),
+        ],
+        [
+          destJoin(pack, path.join(CURSOR, "agents"), `${agent.name}.md`),
+          destFile(
+            pack,
+            path.join(homedir(), ".cursor/agents"),
+            `${agent.name}.md`,
+          ),
+        ],
+        [
+          destJoin(pack, path.join(PI, "agents"), `${agent.name}.md`),
+          destFile(
+            pack,
+            path.join(homedir(), ".pi/agent/agents"),
+            `${agent.name}.md`,
+          ),
+        ],
+      ];
+    }),
+  ];
+}
+
 // ------------------------------------------------------------------- link ----
 if (LINK) {
   console.log(
     "\nlinking this machine's harnesses to shared/ (source of truth, no copy to go stale):",
   );
-  const geminiCommandSkills = [...skillDirs, ...codexCommandSkills];
-  const links = [
-    ...[...skillDirs, ...codexCommandSkills].map((s) => [
-      path.join(CODEX, "skills", s),
-      path.join(homedir(), ".agents/skills", s),
-    ]),
-    ...geminiCommandSkills.map((s) => [
-      path.join(GEMINI, "skills", s),
-      path.join(homedir(), ".gemini/skills", s),
-    ]),
-    ...commands.map((f) => [
-      path.join(CURSOR, "commands", path.basename(f)),
-      path.join(homedir(), ".cursor/commands", path.basename(f)),
-    ]),
-    ...commands.map((f) => [
-      path.join(PI, "prompts", path.basename(f)),
-      path.join(homedir(), ".pi/agent/prompts", path.basename(f)),
-    ]),
-    ...skillDirs.map((s) => [
-      path.join(PI, "skills", s),
-      path.join(homedir(), ".pi/agent/skills", s),
-    ]),
-    ...agentDefinitions.flatMap((agent) => [
-      [
-        path.join(CLAUDE, "agents", `${agent.name}.md`),
-        path.join(homedir(), ".claude/agents", `${agent.name}.md`),
-      ],
-      [
-        path.join(CODEX, "agents", `${agent.name}.toml`),
-        path.join(homedir(), ".codex/agents", `${agent.name}.toml`),
-      ],
-      [
-        path.join(GEMINI, "agents", `${agent.name}.md`),
-        path.join(homedir(), ".gemini/agents", `${agent.name}.md`),
-      ],
-      [
-        path.join(CURSOR, "agents", `${agent.name}.md`),
-        path.join(homedir(), ".cursor/agents", `${agent.name}.md`),
-      ],
-      [
-        path.join(PI, "agents", `${agent.name}.md`),
-        path.join(homedir(), ".pi/agent/agents", `${agent.name}.md`),
-      ],
-    ]),
-  ];
+  const links = loadedPacks.flatMap(packLinks);
   for (const [src, dst] of links) {
     mkdirSync(path.dirname(dst), { recursive: true });
     let existing = null;

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,7 +29,10 @@ Today an extension can contribute:
 - **panels** — declarative `factory.panel-view/v1` Overview tiles
   ([`event-runtime-artifact-views.md` §2.6](event-runtime-artifact-views.md#26-panels--factorypanel-viewv1-wm-840));
   data only, drawn by the web's existing artifact-view renderer, bound to an
-  allow-listed loopback API endpoint (§Panels below).
+  allow-listed loopback API endpoint (§Panels below);
+- **harness** — floor markdown, slash commands, skills and subagents that
+  `build/emit.mjs` packages for Claude Code, Codex, Gemini, Cursor and Pi
+  (§Harness below). `shared/` is the built-in `factory/core` pack.
 
 The manifest also **reserves** `connectors` and `views` for the tickets that
 land them. A
@@ -55,6 +58,11 @@ Implementation: `event-runtime/lib/extensions.mjs`, schema
   config.schema.json          # the shape of the extension's operator config (§Config)
   panels/
     blocked-tickets.panel.json  # a factory.panel-view/v1 panel
+  harness/
+    floor.md                    # optional AGENTS.md floor block
+    commands/                   # slash-command markdown
+    skills/                     # skill folders (SKILL.md)
+    agents/                     # custom-agent markdown (manifest key: subagents)
 ```
 
 Nothing about the layout is fixed except the manifest's name and place: every
@@ -74,7 +82,13 @@ directory, and must stay inside it.
     "adapters": { "argent": "./adapters/argent.mjs" },
     "config": { "namespace": "mobile", "schema": "./config.schema.json" },
     "hooks": { "approve.before": "./hooks/no-infra-merges.mjs" },
-    "panels": ["./panels"]
+    "panels": ["./panels"],
+    "harness": {
+      "floor": "./harness/floor.md",
+      "commands": "./harness/commands",
+      "skills": "./harness/skills",
+      "subagents": "./harness/agents"
+    }
   }
 }
 ```
@@ -90,6 +104,7 @@ directory, and must stay inside it.
 | `contributes.config`               | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.                        |
 | `contributes.hooks`                | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                                      |
 | `contributes.panels`               | no       | Array of relative directories; every `*.panel.json` directly inside is a `factory.panel-view/v1` panel (§Panels). The manifest check proves the directories exist inside the extension; the registry validates each panel at load and skips a bad one alone. |
+| `contributes.harness`              | no       | Object `{ floor?, commands?, skills?, subagents? }`: relative file/directory of harness-neutral markdown emit packages (§Harness). The built-in pack is `shared/` (`factory/core`).                                                                          |
 | `contributes.connectors`, `.views` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                                   |
 
 Unknown top-level keys and unknown `contributes` keys are schema violations.
@@ -111,16 +126,18 @@ panel documents are validated by the registry at load (an invalid one is a
 
 There are two kinds of contribution, and the difference is what runs.
 
-- **Data-only packs and panels.** A pack is JSON and prose: definitions,
-  schemas, prompts, routing maps. A panel is JSON too — an endpoint the
-  runtime already serves, a pointer and rendering hints; the web loads no
-  code for it and fetches only endpoints the runtime allow-lists. Loading
-  either executes nothing. The kernel then holds it to the
-  configured-pack rules — its own namespace, no shadowing of built-ins, pinned
-  prompts and schemas, no `mutating: true` — so a pack can add agents but
-  cannot widen what an agent may do. This is the surface an _agent_ may author
-  (a dispatched ticket producing a pack is ordinary data), and it is why the
-  fixture pack is a copy of `test-support/packs/sample`.
+- **Data-only packs, panels and harness markdown.** A pack is JSON and prose:
+  definitions, schemas, prompts, routing maps. A panel is JSON too — an
+  endpoint the runtime already serves, a pointer and rendering hints; the
+  web loads no code for it and fetches only endpoints the runtime
+  allow-lists. Harness content is markdown (floor, commands, skills,
+  subagents) that `build/emit.mjs` packages; loading it executes nothing.
+  The kernel then holds packs to the configured-pack rules — its own
+  namespace, no shadowing of built-ins, pinned prompts and schemas, no
+  `mutating: true` — so a pack can add agents but cannot widen what an
+  agent may do. This is the surface an _agent_ may author (a dispatched
+  ticket producing a pack or a harness command is ordinary data), and it
+  is why the fixture pack is a copy of `test-support/packs/sample`.
 - **Operator-installed code.** An adapter is an ES module the worker imports
   and calls; a hook is an ES module `serve` imports and calls inside the
   approval pass. Enabling an extension that contributes either is running that
@@ -197,7 +214,9 @@ message naming both packs; fix the pack (or the order) and restart.
    `event-runtime/test-support/extensions/sample/hooks/approve-before.mjs`.
 6. Add panels as `panels/<slug>.panel.json` (§Panels); the fixture's
    `panels/open-proposals.panel.json` is a complete one.
-7. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+7. Add harness content as `contributes.harness` (§Harness) when the
+   extension ships slash commands, skills, subagents or a floor block.
+8. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
    enable it, `extensions list`, restart.
 
 The fixture `event-runtime/test-support/extensions/sample/` is a complete,
@@ -505,6 +524,61 @@ allows unless the extension config says `greeting: "deny"` (proving
 files there (`throws.mjs`, `hangs.mjs`, `async-deny.mjs`, `no-id.mjs`,
 `no-default.mjs`) exercise each failure mode in `hooks.test.mjs` and
 `extensions.test.mjs`.
+
+## Harness
+
+_Shipped in WM-849. Implementation: `contributes.harness` on
+`factory-extension.json`; `collectHarnessRoots`, `harnessRootFor` in
+`event-runtime/lib/extensions.mjs`; `build/emit.mjs` emits every loaded
+root; the built-in pack is `shared/factory-extension.json`._
+
+Harness content is markdown the emit pipeline packages for every coding
+agent the factory supports — the AGENTS.md floor, `/factory-*` slash
+commands, skills, and custom subagents. It is **data**, not in-process
+code: loading a harness contribution executes nothing. Enabling it is
+the same allow-list as every other contribution (`policy.yaml
+extensions:`); `shared/` is the exception, the built-in `factory/core`
+pack that emit always includes first so `plugins/core/**` and `dist/**` stay
+byte-identical with the historical layout.
+
+```json
+"contributes": {
+  "harness": {
+    "floor": "./floor.md",
+    "commands": "./commands",
+    "skills": "./skills",
+    "subagents": "./agents"
+  }
+}
+```
+
+Every key is optional. Paths are relative to the manifest and must stay
+inside the extension; `floor` must be a file, the others directories. A
+missing or escaping path is a manifest error and skips the extension
+whole, like any other bad path.
+
+**Emit.** `bun build/emit.mjs` calls `collectHarnessRoots({ builtin: shared/ })`
+then writes each pack:
+
+| Pack                                     | Claude plugin                    | dist/ (Codex, Gemini, Cursor, Pi)                                                                          |
+| :--------------------------------------- | :------------------------------- | :--------------------------------------------------------------------------------------------------------- |
+| `factory/core` (`shared/`, always first) | `plugins/core/`                  | historical paths (`dist/codex/skills/ticket-spec/`, …)                                                     |
+| any other contributing extension         | `plugins/<publisher-extension>/` | nested under the same slug (`dist/codex/skills/<slug>/…`); flat Cursor/Pi filenames are prefixed `<slug>-` |
+
+`--sync-floor` still splices only the core floor into configured repos'
+`AGENTS.md`. A third-party floor is emitted as `dist/AGENTS.floor.<slug>.md`
+and is not auto-spliced.
+
+**Collision.** A non-core pack may not take plugin name `core` or reuse
+another pack's slug or `name`. The later contributor's harness is skipped
+(emit records an anomaly and still writes every other pack; `loadExtensions`
+skips that extension whole, same as an adapter name clash). Discovery stays
+allow-listed: dropping a directory into `~/.factory/extensions/` does
+nothing until `policy.yaml` names it.
+
+**Trust.** Harness markdown is the same class as packs — an agent may
+author it — with the operator enablement gate in front. It is not an
+adapter: emit never imports third-party JavaScript.
 
 ## Related
 

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -45,6 +45,16 @@
  *      A module that fails the contract, or an id already registered, disables
  *      the extension. Each load replaces the extension hooks of the registry
  *      it is given, so the registry always mirrors the last accepted set.
+ *   6. **Harness content is pack data, namespaced at emit (WM-849).**
+ *      `contributes.harness = { floor?, commands?, skills?, subagents? }`
+ *      lists markdown the emit pipeline packages for Claude/Codex/Gemini/
+ *      Cursor/Pi. Paths are checked here (exist, stay inside the extension);
+ *      `build/emit.mjs` is the consumer. `shared/` is the built-in
+ *      `factory/core` pack and is not policy-listed — `collectHarnessRoots`
+ *      always puts it first so `plugins/core/**` and `dist/**` stay
+ *      byte-identical. Every other contributing root emits under its
+ *      `publisher-extension` slug; a non-core pack may not take plugin name
+ *      `core` or reuse another pack's slug (the later extension is skipped).
  *
  * Ordering matters for callers: `adapterRegistry.toMap()` is a snapshot, so
  * `loadExtensions` must run before a CLI takes the map it hands to
@@ -69,6 +79,15 @@ import { expandHome, reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 
 export const EXTENSION_MANIFEST = "factory-extension.json";
+
+/** Plugin directory of the built-in core harness pack (`plugins/core`). */
+export const CORE_HARNESS_PLUGIN = "core";
+
+/** Manifest `name` of `shared/factory-extension.json`. */
+export const CORE_HARNESS_NAME = "factory/core";
+
+const HARNESS_FILE_KEYS = ["floor"];
+const HARNESS_DIR_KEYS = ["commands", "skills", "subagents"];
 
 export const EXTENSION_SCHEMA = JSON.parse(
   readFileSync(
@@ -304,6 +323,7 @@ export function validateExtensionManifest(dir) {
     }
   }
   errors.push(...panelDirErrors(root, file, contributes.panels));
+  errors.push(...harnessPathErrors(root, file, contributes.harness));
   return result(manifest);
 }
 
@@ -475,6 +495,158 @@ function panelRootsFor(dir, manifest) {
   }));
 }
 
+function harnessPathErrors(root, file, harness) {
+  if (!harness) return [];
+  const errors = [];
+  for (const key of HARNESS_FILE_KEYS) {
+    if (!Object.hasOwn(harness, key)) continue;
+    errors.push(
+      ...harnessEntryError(root, file, key, harness[key], { file: true }),
+    );
+  }
+  for (const key of HARNESS_DIR_KEYS) {
+    if (!Object.hasOwn(harness, key)) continue;
+    errors.push(
+      ...harnessEntryError(root, file, key, harness[key], { file: false }),
+    );
+  }
+  return errors;
+}
+
+function harnessEntryError(root, file, key, rel, { file: wantFile }) {
+  const abs = path.resolve(root, rel);
+  if (!isInside(root, abs)) {
+    return [
+      `${file}: contributes.harness.${key} "${rel}" escapes the extension directory`,
+    ];
+  }
+  if (
+    !existsSync(abs) ||
+    (wantFile ? !statSync(abs).isFile() : !statSync(abs).isDirectory())
+  ) {
+    return [
+      `${file}: contributes.harness.${key} "${rel}" is not a ${wantFile ? "file" : "directory"} (${abs})`,
+    ];
+  }
+  return [];
+}
+
+/** Plugin directory name a harness pack emits into (`plugins/<plugin>/`). */
+export function harnessPluginName(manifestName, { builtin = false } = {}) {
+  if (builtin) return CORE_HARNESS_PLUGIN;
+  return String(manifestName).replaceAll("/", "-");
+}
+
+/**
+ * Resolve `contributes.harness` to absolute paths. `null` when the manifest
+ * declares none (or an empty object).
+ */
+export function harnessRootFor(dir, manifest, { builtin = false } = {}) {
+  const declared = manifest?.contributes?.harness;
+  if (!declared) return null;
+  if (
+    !declared.floor &&
+    !declared.commands &&
+    !declared.skills &&
+    !declared.subagents
+  )
+    return null;
+  return {
+    dir: path.resolve(dir),
+    name: manifest.name,
+    version: manifest.version,
+    builtin,
+    origin: builtin ? "builtin" : `extension:${manifest.name}`,
+    plugin: harnessPluginName(manifest.name, { builtin }),
+    prefix: builtin ? null : harnessPluginName(manifest.name),
+    floor: declared.floor ? path.resolve(dir, declared.floor) : null,
+    commands: declared.commands ? path.resolve(dir, declared.commands) : null,
+    skills: declared.skills ? path.resolve(dir, declared.skills) : null,
+    subagents: declared.subagents
+      ? path.resolve(dir, declared.subagents)
+      : null,
+  };
+}
+
+/**
+ * Built-in `shared/` first, then every policy-listed extension that
+ * contributes harness content. A broken third-party manifest is an anomaly
+ * (emit still writes the core pack); a broken builtin throws — that is our
+ * own pack and emit must not invent it.
+ *
+ * @param {object} [options]
+ * @param {string} [options.root] - checkout supplying `config/policy.yaml`
+ * @param {string} [options.builtin] - absolute path of `shared/` (required for emit)
+ * @param {object} [options.policy] - already-parsed policy; when given, policy.yaml is not read
+ * @returns {{ roots: Array<object>, anomalies: string[] }}
+ */
+export function collectHarnessRoots({
+  root = reposRoot(),
+  builtin,
+  policy,
+} = {}) {
+  const roots = [];
+  const anomalies = [];
+  const seenPaths = new Set();
+  const seenNames = new Set();
+  const seenPlugins = new Set();
+
+  const add = (dir, { builtin: isBuiltin = false } = {}) => {
+    const resolved = path.resolve(dir);
+    if (seenPaths.has(resolved)) return;
+    const checked = validateExtensionManifest(resolved);
+    if (!checked.valid) {
+      const reason = checked.errors.join("; ");
+      if (isBuiltin) {
+        throw new ExtensionError(
+          `built-in harness pack ${resolved}: ${reason}`,
+        );
+      }
+      anomalies.push(`extension ${resolved}: ${reason} (harness skipped)`);
+      return;
+    }
+    const pack = harnessRootFor(resolved, checked.manifest, {
+      builtin: isBuiltin,
+    });
+    if (!pack) {
+      if (isBuiltin) {
+        throw new ExtensionError(
+          `built-in harness pack ${resolved}: ${EXTENSION_MANIFEST} declares no contributes.harness`,
+        );
+      }
+      return;
+    }
+    if (!isBuiltin && pack.plugin === CORE_HARNESS_PLUGIN) {
+      anomalies.push(
+        `extension ${resolved}: harness plugin name "${pack.plugin}" is reserved for the built-in core pack (harness skipped)`,
+      );
+      return;
+    }
+    if (seenNames.has(pack.name)) {
+      anomalies.push(
+        `extension ${resolved}: harness name "${pack.name}" is already contributed (harness skipped)`,
+      );
+      return;
+    }
+    if (seenPlugins.has(pack.plugin)) {
+      anomalies.push(
+        `extension ${resolved}: harness plugin "${pack.plugin}" is already contributed (harness skipped)`,
+      );
+      return;
+    }
+    seenPaths.add(resolved);
+    seenNames.add(pack.name);
+    seenPlugins.add(pack.plugin);
+    roots.push(pack);
+  };
+
+  if (builtin) add(builtin, { builtin: true });
+  const loaded = loadExtensionRoots({ root, policy });
+  anomalies.push(...loaded.anomalies);
+  for (const { path: dir } of loaded.roots) add(dir);
+  return { roots, anomalies };
+}
+
 function isInside(root, abs) {
   const rel = path.relative(root, abs);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
@@ -514,14 +686,16 @@ function packRootFor(extensionRoot, rel) {
  * @returns {Promise<{
  *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, panels: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
  *   panelRoots: Array<{ dir: string, origin: string, base: string }>,
+ *   harnessRoots: Array<object>,
  *   packRoots: Array<object>,
- *   panelRoots: Array<{ dir: string, origin: string, base: string }>,
  *   anomalies: string[],
  *   disabled: Array<{ name: string|null, version: string|null, path: string, namespace: string|null, reason: string }>,
  * }>} `packRoots` is the full list — policy packs first, then every accepted
  *   extension pack in policy order — ready to hand to `loadRegistry`;
  *   `panelRoots` is every accepted extension's `contributes.panels`
  *   directories, in the same order, for `loadRegistry({ panelRoots })`.
+ *   `harnessRoots` is every accepted extension's `contributes.harness`
+ *   (WM-849), for `loadRegistry({ harnessRoots })` and `build/emit.mjs`.
  *   `disabled` lists every extension an anomaly skipped, for `/config`.
  */
 export async function loadExtensions({
@@ -543,10 +717,13 @@ export async function loadExtensions({
   const { roots, anomalies } = loadExtensionRoots({ root, policy });
   const extensions = [];
   const panelRoots = [];
+  const harnessRoots = [];
   const accepted = [...basePackRoots];
   const acceptedPackNames = new Set(basePackRoots.map((p) => p.name));
   const acceptedAdapterNames = new Set();
   const acceptedNamespaces = new Map();
+  const acceptedHarnessPlugins = new Set();
+  const acceptedHarnessNames = new Set();
   const disabled = [];
   const loaded = [];
   const dryLoad = (candidates) =>
@@ -676,6 +853,28 @@ export async function loadExtensions({
       continue;
     }
 
+    const extHarness = harnessRootFor(dir, manifest);
+    if (extHarness) {
+      if (extHarness.plugin === CORE_HARNESS_PLUGIN) {
+        skip(
+          `${label}: harness plugin name "${extHarness.plugin}" is reserved for the built-in core pack`,
+        );
+        continue;
+      }
+      if (acceptedHarnessNames.has(extHarness.name)) {
+        skip(
+          `${label}: harness name "${extHarness.name}" is already contributed`,
+        );
+        continue;
+      }
+      if (acceptedHarnessPlugins.has(extHarness.plugin)) {
+        skip(
+          `${label}: harness plugin "${extHarness.plugin}" is already contributed`,
+        );
+        continue;
+      }
+    }
+
     // Accept: commit packs, register adapters, record the reserved keys.
     accepted.push(...extPackRoots);
     for (const pack of extPackRoots) acceptedPackNames.add(pack.name);
@@ -694,6 +893,11 @@ export async function loadExtensions({
     const { schemaJson, ...publicConfig } = config ?? {};
     const extPanelRoots = panelRootsFor(dir, manifest);
     panelRoots.push(...extPanelRoots);
+    if (extHarness) {
+      harnessRoots.push(extHarness);
+      acceptedHarnessPlugins.add(extHarness.plugin);
+      acceptedHarnessNames.add(extHarness.name);
+    }
     extensions.push({
       name: manifest.name,
       version: manifest.version,
@@ -706,6 +910,9 @@ export async function loadExtensions({
         Object.hasOwn(contributes, key),
       ),
       config: config ? publicConfig : null,
+      ...(extHarness
+        ? { harness: { plugin: extHarness.plugin, prefix: extHarness.prefix } }
+        : {}),
     });
     loaded.push({
       name: manifest.name,
@@ -716,5 +923,12 @@ export async function loadExtensions({
   }
 
   LOADED = { extensions: loaded, disabled };
-  return { extensions, packRoots: accepted, panelRoots, anomalies, disabled };
+  return {
+    extensions,
+    packRoots: accepted,
+    panelRoots,
+    harnessRoots,
+    anomalies,
+    disabled,
+  };
 }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -15,10 +15,14 @@ import { openDb } from "./db.mjs";
 import {
   EXTENSION_MANIFEST,
   EXTENSION_SCHEMA,
+  CORE_HARNESS_NAME,
+  CORE_HARNESS_PLUGIN,
   ExtensionError,
   RESERVED_CONTRIBUTIONS,
   applyConfigDefaults,
+  collectHarnessRoots,
   getExtensionConfig,
+  harnessPluginName,
   loadExtensionRoots,
   loadExtensions,
   loadedExtensions,
@@ -109,6 +113,28 @@ describe("factory-extension.json schema", () => {
       };
       expect(validate(EXTENSION_SCHEMA, manifest).valid).toBe(true);
     }
+  });
+
+  test("contributes.harness accepts floor/commands/skills/subagents and rejects extras", () => {
+    const ok = {
+      name: "factory/core",
+      version: "0.1.0",
+      contributes: {
+        harness: {
+          floor: "./floor.md",
+          commands: "./commands",
+          skills: "./skills",
+          subagents: "./agents",
+        },
+      },
+    };
+    expect(validate(EXTENSION_SCHEMA, ok)).toEqual({ valid: true, errors: [] });
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...ok,
+        contributes: { harness: { widgets: [] } },
+      }).errors.join(),
+    ).toMatch(/unknown property "widgets"/);
   });
 });
 
@@ -934,5 +960,133 @@ describe("cli extensions", () => {
     expect(parsed.extensions[0].name).toBe("factory/sample");
     expect(parsed.extensions[0].config.namespace).toBe("sample");
     expect(parsed.anomalies).toHaveLength(1);
+  });
+});
+
+function harnessExtension(mutate = () => {}) {
+  const dir = tmpDir("event-harness-");
+  mkdirSync(path.join(dir, "commands"));
+  mkdirSync(path.join(dir, "skills", "demo"), { recursive: true });
+  mkdirSync(path.join(dir, "agents"));
+  writeFileSync(path.join(dir, "floor.md"), "# floor\n");
+  writeFileSync(path.join(dir, "commands", "demo.md"), "# demo\n");
+  writeFileSync(
+    path.join(dir, "skills", "demo", "SKILL.md"),
+    "---\nname: demo\ndescription: demo skill\n---\n",
+  );
+  writeFileSync(
+    path.join(dir, "agents", "demo-agent.md"),
+    "---\nname: demo-agent\ndescription: A demo subagent.\n---\n\nbody\n",
+  );
+  const manifest = {
+    name: "acme/tools",
+    version: "1.0.0",
+    contributes: {
+      harness: {
+        floor: "./floor.md",
+        commands: "./commands",
+        skills: "./skills",
+        subagents: "./agents",
+      },
+    },
+  };
+  const next = mutate(manifest, dir) ?? manifest;
+  writeFileSync(
+    path.join(dir, EXTENSION_MANIFEST),
+    JSON.stringify(next, null, 2),
+  );
+  return dir;
+}
+
+describe("contributes.harness (WM-849)", () => {
+  const SHARED = path.join(path.dirname(RUNTIME_ROOT), "shared");
+
+  test("the built-in shared/ pack is factory/core and validates", () => {
+    const out = validateExtensionManifest(SHARED);
+    expect(out.valid).toBe(true);
+    expect(out.errors).toEqual([]);
+    expect(out.manifest.name).toBe(CORE_HARNESS_NAME);
+    expect(out.manifest.contributes.harness).toEqual({
+      floor: "./floor.md",
+      commands: "./commands",
+      skills: "./skills",
+      subagents: "./agents",
+    });
+    expect(harnessPluginName(CORE_HARNESS_NAME, { builtin: true })).toBe(
+      CORE_HARNESS_PLUGIN,
+    );
+  });
+
+  test("collectHarnessRoots puts shared/ first and skips policy extensions without harness", () => {
+    const { roots, anomalies } = collectHarnessRoots({
+      builtin: SHARED,
+      policy: { extensions: [{ path: SAMPLE_EXTENSION }] },
+    });
+    expect(anomalies).toEqual([]);
+    expect(roots[0].builtin).toBe(true);
+    expect(roots[0].name).toBe(CORE_HARNESS_NAME);
+    expect(roots[0].plugin).toBe(CORE_HARNESS_PLUGIN);
+    expect(roots[0].prefix).toBeNull();
+    expect(roots).toHaveLength(1);
+  });
+
+  test("a third-party harness pack is namespaced; plugin name core is reserved", async () => {
+    const extra = harnessExtension();
+    const collected = collectHarnessRoots({
+      builtin: SHARED,
+      policy: { extensions: [{ path: extra }] },
+    });
+    expect(collected.anomalies).toEqual([]);
+    expect(collected.roots.map((r) => r.plugin)).toEqual([
+      CORE_HARNESS_PLUGIN,
+      "acme-tools",
+    ]);
+    expect(collected.roots[1].prefix).toBe("acme-tools");
+
+    const stolen = harnessExtension((m) => {
+      m.name = "factory/core";
+    });
+    const clash = collectHarnessRoots({
+      builtin: SHARED,
+      policy: { extensions: [{ path: stolen }] },
+    });
+    expect(clash.roots.map((r) => r.plugin)).toEqual([CORE_HARNESS_PLUGIN]);
+    expect(clash.anomalies.join("\n")).toMatch(
+      /harness name "factory\/core" is already contributed/,
+    );
+
+    const slugA = harnessExtension((m) => {
+      m.name = "foo/bar-baz";
+    });
+    const slugB = harnessExtension((m) => {
+      m.name = "foo-bar/baz";
+    });
+    const slugs = collectHarnessRoots({
+      policy: { extensions: [{ path: slugA }, { path: slugB }] },
+    });
+    expect(slugs.roots.map((r) => r.plugin)).toEqual(["foo-bar-baz"]);
+    expect(slugs.anomalies.join("\n")).toMatch(
+      /harness plugin "foo-bar-baz" is already contributed/,
+    );
+
+    const loaded = await load(policyFor(extra));
+    expect(loaded.anomalies).toEqual([]);
+    expect(loaded.harnessRoots).toHaveLength(1);
+    expect(loaded.harnessRoots[0].plugin).toBe("acme-tools");
+    expect(loaded.extensions[0].harness).toEqual({
+      plugin: "acme-tools",
+      prefix: "acme-tools",
+    });
+  });
+
+  test("harness paths must exist and stay inside the extension", () => {
+    const dir = harnessExtension((m) => {
+      m.contributes.harness.floor = "./missing.md";
+      m.contributes.harness.commands = "../escape";
+    });
+    const out = validateExtensionManifest(dir);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(/harness\.floor .* is not a file/);
+    expect(out.errors.join("\n")).toMatch(/harness\.commands .* escapes/);
   });
 });

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -762,6 +762,7 @@ export function loadRegistry({
   root = RUNTIME_ROOT,
   packRoots,
   panelRoots = [],
+  harnessRoots = [],
   modelTiers = loadModelTierMap(),
   loaderFor = defaultLoaderFor,
 } = {}) {
@@ -774,6 +775,8 @@ export function loadRegistry({
     throw new RegistryError("loaderFor must be a function");
   if (!Array.isArray(panelRoots))
     throw new RegistryError("panelRoots must be an array");
+  if (!Array.isArray(harnessRoots))
+    throw new RegistryError("harnessRoots must be an array");
 
   const builtIn = {
     kind: "fs",
@@ -864,6 +867,9 @@ export function loadRegistry({
   // Extension-contributed panel directories (`contributes.panels`,
   // lib/extensions.mjs) load after every pack, so a pack panel outranks an
   // extension panel of the same name exactly as policy order says.
+  // Harness roots (`contributes.harness`, WM-849) are stored for emit /
+  // introspection and are not registry content — markdown skills and
+  // commands are packaged by build/emit.mjs, not loaded as agents.
   for (const { dir, origin, base } of panelRoots) {
     if (typeof dir !== "string" || typeof origin !== "string") {
       throw new RegistryError("panelRoots entries must be { dir, origin }");
@@ -1141,6 +1147,7 @@ export function loadRegistry({
     edges,
     schedules,
     modelTiers,
+    harnessRoots,
   };
 }
 

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -90,6 +90,33 @@
               "description": "evaluated immediately before each chain auto-approval (lib/auto-approval.mjs); a deny keeps the proposal open with reason dispatch_ineligible:<reason> (dispatch) or hook_denied:<reason>"
             }
           }
+        },
+        "harness": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "harness pack content (docs/extensions.md § Harness): floor markdown, slash-command directory, skill directory, subagent directory; relative to the manifest. `shared/` is the built-in `factory/core` pack; emit writes it to plugins/core and dist/ and every other contributing root under its publisher-extension namespace (WM-849)",
+          "properties": {
+            "floor": {
+              "type": "string",
+              "minLength": 1,
+              "description": "relative path to the AGENTS.md floor markdown file"
+            },
+            "commands": {
+              "type": "string",
+              "minLength": 1,
+              "description": "relative directory of slash-command markdown files"
+            },
+            "skills": {
+              "type": "string",
+              "minLength": 1,
+              "description": "relative directory of skill folders (each containing SKILL.md)"
+            },
+            "subagents": {
+              "type": "string",
+              "minLength": 1,
+              "description": "relative directory of custom-agent markdown files"
+            }
+          }
         }
       }
     }

--- a/shared/factory-extension.json
+++ b/shared/factory-extension.json
@@ -1,0 +1,14 @@
+{
+  "name": "factory/core",
+  "version": "0.1.0",
+  "description": "Built-in core harness pack: AGENTS.md floor, /factory-* commands, ticket-spec skill, factory-* subagents.",
+  "factory": { "min": "0.1.0" },
+  "contributes": {
+    "harness": {
+      "floor": "./floor.md",
+      "commands": "./commands",
+      "skills": "./skills",
+      "subagents": "./agents"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `contributes.harness = { floor?, commands?, skills?, subagents? }` to the extension manifest so skills, slash commands, subagents, and the AGENTS.md floor are pack content rather than a `shared/`-only emit pipeline.
- Make `shared/` the built-in `factory/core` harness pack (`shared/factory-extension.json`); `build/emit.mjs` emits it first so `plugins/core/**` and `dist/**` stay byte-identical, then emits every other loaded harness root under its `publisher-extension` namespace.
- Collision: a later pack may not reuse `factory/core`'s name or another pack's plugin slug; emit records an anomaly and still writes the rest.

Fixes WM-849

UX critique: skipped — backend/schema/docs; no user-completable flow.

## Test plan
- [x] `bun build/emit.mjs && bun run check` — 90 generated files match; `git diff --quiet -- plugins dist`
- [x] `bun test event-runtime/lib/extensions.test.mjs` — 33 pass, including WM-849 harness cases
- [x] `bun run lint` — 0 errors
- [ ] Reviewer: glance at `collectHarnessRoots` collision rules and that core dest paths are unchanged


Made with [Cursor](https://cursor.com)