### PR TITLE
feat(event-runtime): inbox escalation dedup with waiters (WM-813)

### DIFF
--- a/event-runtime/cli/inbox.mjs
+++ b/event-runtime/cli/inbox.mjs
@@ -15,11 +15,15 @@ export async function inbox(client) {
     return;
   }
   console.log(
-    `${pad("ID", 44)}${pad("KIND", 18)}${pad("SEVERITY", 11)}${pad("CREATED", 26)}TITLE`,
+    `${pad("ID", 44)}${pad("KIND", 18)}${pad("SEVERITY", 11)}${pad("WAITING", 10)}${pad("CREATED", 26)}TITLE`,
   );
   for (const item of body.items) {
+    const waiting =
+      typeof item.waitingCount === "number" && item.waitingCount > 1
+        ? String(item.waitingCount)
+        : "-";
     console.log(
-      `${pad(item.id, 44)}${pad(item.kind, 18)}${pad(item.severity, 11)}${pad(item.createdAt, 26)}${item.title}`,
+      `${pad(item.id, 44)}${pad(item.kind, 18)}${pad(item.severity, 11)}${pad(waiting, 10)}${pad(item.createdAt, 26)}${item.title}`,
     );
   }
 }

--- a/event-runtime/lib/api-inbox.mjs
+++ b/event-runtime/lib/api-inbox.mjs
@@ -26,6 +26,18 @@ export async function handleInboxApiRoute({
     if (parsed.error) return send(422, { error: parsed.error });
     try {
       const item = createInboxItem(db, parsed.value, { now: nowMs });
+      if (item.attached) {
+        const { attached: _attached, ...publicItem } = item;
+        return send(201, {
+          item: publicItem,
+          delivery: {
+            ok: true,
+            skipped: "deduped",
+            exitCode: null,
+            error: null,
+          },
+        });
+      }
       // Item first, projection second: even a failed transport leaves a
       // queryable row and records the delivery error on it.
       const delivery = await deliverInboxItem(db, item.id, {

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -258,4 +258,53 @@ describe("human inbox API (WM-285)", () => {
       s.close();
     }
   });
+
+  test("POST of the same subject attaches a waiter and does not push again", async () => {
+    const delivered = [];
+    const s = await makeServer({
+      now: () => 1000,
+      inboxSend: async (_command, message) => {
+        delivered.push(message);
+        return { ok: true, exitCode: 0, error: null };
+      },
+    });
+    try {
+      const payload = {
+        kind: "BLOCKED",
+        title: "BLOCKED WM-1: choose a policy",
+        refs: { issue: "WM-1", runId: "run_1" },
+        source: "agent:run_1",
+      };
+      const first = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      expect(first.status).toBe(201);
+      const firstBody = await first.json();
+      expect(firstBody.item.waitingCount).toBe(1);
+      expect(delivered).toHaveLength(1);
+
+      const second = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...payload,
+          refs: { issue: "WM-1", runId: "run_2" },
+          source: "agent:run_2",
+        }),
+      });
+      expect(second.status).toBe(201);
+      const secondBody = await second.json();
+      expect(secondBody.item.id).toBe(firstBody.item.id);
+      expect(secondBody.item.waitingCount).toBe(2);
+      expect(secondBody.item.waiters).toEqual([
+        { runId: "run_2", at: expect.any(String) },
+      ]);
+      expect(secondBody.delivery.skipped).toBe("deduped");
+      expect(delivered).toHaveLength(1);
+    } finally {
+      s.close();
+    }
+  });
 });

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -337,6 +337,21 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 10,
+    name: "inbox_waiters",
+    up(db) {
+      const columns = db
+        .query(`PRAGMA table_info(inbox_items)`)
+        .all()
+        .map((row) => row.name);
+      if (!columns.includes("waiters_json")) {
+        db.exec(
+          `ALTER TABLE inbox_items ADD COLUMN waiters_json TEXT NOT NULL DEFAULT '[]';`,
+        );
+      }
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -215,6 +215,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       "decided_by",
       "dedupe_key",
       "resolved_reason",
+      "waiters_json",
     ]);
     upgraded.close();
   });
@@ -237,13 +238,14 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       .query("PRAGMA table_info(inbox_items)")
       .all()
       .map((row) => row.name);
-    expect(columns.slice(-6)).toEqual([
+    expect(columns.slice(-7)).toEqual([
       "decision_json",
       "response_json",
       "decided_at",
       "decided_by",
       "dedupe_key",
       "resolved_reason",
+      "waiters_json",
     ]);
     expect(
       upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get()

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -9,6 +9,7 @@ import { randomUUID } from "node:crypto";
 import { readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { hashJson } from "./canonical.mjs";
 import {
   decisionRequestHash,
   validateDecisionRequest,
@@ -95,6 +96,184 @@ function parseNullableObject(value) {
   }
 }
 
+function parseWaiters(value) {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (waiter) =>
+        waiter && typeof waiter === "object" && !Array.isArray(waiter),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Option id+effect (+ authorise paths); free text is not part of "same question". */
+function decisionShape(decision) {
+  if (!decision || !Array.isArray(decision.options)) return null;
+  return decision.options.map((option) => ({
+    id: option.id,
+    effect: option.effect,
+    ...(Array.isArray(option.scope?.paths)
+      ? { paths: [...option.scope.paths].sort() }
+      : {}),
+  }));
+}
+
+function hasDedupSubject(refs) {
+  return Boolean(
+    refs.issue || refs.pr || refs.repo || refs.proposalId || refs.eventId,
+  );
+}
+
+/**
+ * Identity of "the same question" (WM-813 / memos §7): kind + subject refs
+ * +, for a decision request, the option/effect shape. proposalId and the
+ * event pair are included when present so two proposals (or two parked
+ * events) in one repo do not share a waiter list.
+ */
+export function inboxDedupKey(kind, refs = {}, decision = null) {
+  const subject = {
+    kind,
+    issue: refs.issue ?? null,
+    pr: refs.pr ?? null,
+    repo: refs.repo ?? null,
+  };
+  if (refs.proposalId) subject.proposalId = refs.proposalId;
+  if (refs.eventSource || refs.eventId) {
+    subject.eventSource = refs.eventSource ?? null;
+    subject.eventId = refs.eventId ?? null;
+  }
+  if (decision) subject.shape = decisionShape(decision);
+  return hashJson(subject);
+}
+
+function computedKeyOfRow(row) {
+  return inboxDedupKey(
+    row.kind,
+    parseObject(row.refs_json),
+    parseNullableObject(row.decision_json),
+  );
+}
+
+function findOpenMatch(db, { callerKey, computedKey }) {
+  if (callerKey) {
+    const keyed = db
+      .query(
+        `SELECT * FROM inbox_items
+       WHERE dedupe_key = ? AND resolved_at IS NULL
+       LIMIT 1`,
+      )
+      .get(callerKey);
+    if (keyed) return keyed;
+  }
+  if (!computedKey) return null;
+  const rows = db
+    .query(`SELECT * FROM inbox_items WHERE resolved_at IS NULL`)
+    .all();
+  return rows.find((row) => computedKeyOfRow(row) === computedKey) ?? null;
+}
+
+function rowIsUndecided(row) {
+  return !row.response_json && !row.decided_at;
+}
+
+function attachWaiter(db, row, { refs, now }) {
+  const runId = refs.runId ?? null;
+  const owner = parseObject(row.refs_json);
+  const waiters = parseWaiters(row.waiters_json);
+  if (
+    runId &&
+    (runId === owner.runId || waiters.some((waiter) => waiter.runId === runId))
+  ) {
+    return { ...getInboxItem(db, row.id), attached: true };
+  }
+  const waiter = { at: new Date(now).toISOString() };
+  if (runId) waiter.runId = runId;
+  const extra = {};
+  for (const key of ["proposalId", "eventSource", "eventId"]) {
+    if (refs[key] && refs[key] !== owner[key]) extra[key] = refs[key];
+  }
+  if (Object.keys(extra).length) waiter.refs = extra;
+  waiters.push(waiter);
+  db.query(`UPDATE inbox_items SET waiters_json = ? WHERE id = ?`).run(
+    JSON.stringify(waiters),
+    row.id,
+  );
+  return { ...getInboxItem(db, row.id), attached: true };
+}
+
+function waiterReferentKey(effectKind, refs) {
+  switch (effectKind) {
+    case "dismiss":
+      return "dismiss";
+    case "authorise":
+    case "send_to_triage":
+    case "answer":
+      return `issue:${refs.issue ?? ""}`;
+    case "requeue":
+      return `event:${refs.eventSource ?? ""}:${refs.eventId ?? ""}`;
+    case "approve_proposal":
+    case "reject_proposal":
+      return `proposal:${refs.proposalId ?? ""}`;
+    default:
+      return `run:${refs.runId ?? ""}`;
+  }
+}
+
+function fanOutWaiterEffects(db, item, response, waiters, applyEffect) {
+  const option = item.decision?.options?.find(
+    (candidate) => candidate.id === response?.optionId,
+  );
+  const effectKind = option?.effect ?? "unknown";
+  const seen = new Set([waiterReferentKey(effectKind, item.refs)]);
+  const outcomes = [];
+  const nextWaiters = waiters.map((waiter) => ({ ...waiter }));
+  for (const waiter of nextWaiters) {
+    const refs = {
+      ...item.refs,
+      ...(waiter.refs ?? {}),
+      ...(waiter.runId ? { runId: waiter.runId } : {}),
+    };
+    const referent = waiterReferentKey(effectKind, refs);
+    if (seen.has(referent)) {
+      const effect = {
+        kind: effectKind,
+        outcome: "applied",
+        detail: "shared_referent",
+      };
+      waiter.effect = effect;
+      outcomes.push({ runId: waiter.runId ?? null, effect });
+      continue;
+    }
+    seen.add(referent);
+    const waiterItem = { ...item, refs };
+    let effect;
+    try {
+      effect = normalizeEffect(
+        applyEffect(db, waiterItem, response),
+        waiterItem,
+        response,
+      );
+    } catch (err) {
+      effect = normalizeEffect(
+        { outcome: "failed", error: err?.message ?? String(err) },
+        waiterItem,
+        response,
+      );
+    }
+    waiter.effect = effect;
+    outcomes.push({ runId: waiter.runId ?? null, effect });
+  }
+  db.query(`UPDATE inbox_items SET waiters_json = ? WHERE id = ?`).run(
+    JSON.stringify(nextWaiters),
+    item.id,
+  );
+  return outcomes;
+}
+
 export class InboxDecisionError extends Error {
   constructor(code, message, status = 400, errors = undefined) {
     super(message);
@@ -132,6 +311,8 @@ export function itemView(row) {
     decidedAt: row.decided_at ?? null,
     decidedBy: row.decided_by ?? null,
     dedupeKey: row.dedupe_key ?? null,
+    waiters: parseWaiters(row.waiters_json),
+    waitingCount: 1 + parseWaiters(row.waiters_json).length,
   };
 }
 
@@ -201,18 +382,21 @@ export function createInboxItem(
       );
     }
   }
-  const dedupeKey = optionalString(input?.dedupeKey, "dedupeKey");
+  const callerKey = optionalString(input?.dedupeKey, "dedupeKey");
+  const computedKey = hasDedupSubject(refs)
+    ? inboxDedupKey(kind, refs, decision)
+    : null;
+  const dedupeKey = callerKey ?? computedKey;
   const createdAt = new Date(now).toISOString();
 
-  if (dedupeKey) {
-    const existing = db
-      .query(
-        `SELECT * FROM inbox_items
-       WHERE dedupe_key = ? AND resolved_at IS NULL
-       LIMIT 1`,
-      )
-      .get(dedupeKey);
-    if (existing) {
+  const existing = findOpenMatch(db, { callerKey, computedKey });
+  if (existing) {
+    const sameQuestion =
+      Boolean(computedKey) && computedKeyOfRow(existing) === computedKey;
+    if (sameQuestion && rowIsUndecided(existing)) {
+      return attachWaiter(db, existing, { refs, now });
+    }
+    if (existing.dedupe_key && existing.dedupe_key === callerKey) {
       const superseded = supersedeInboxDecision(db, existing, {
         body,
         refs,
@@ -228,8 +412,8 @@ export function createInboxItem(
       db.query(
         `INSERT INTO inbox_items
            (id, kind, severity, title, body, refs_json, source, created_at,
-            delivery_json, decision_json, dedupe_key)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)`,
+            delivery_json, decision_json, dedupe_key, waiters_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?, '[]')`,
       ).run(
         id,
         kind,
@@ -258,6 +442,11 @@ export function createInboxItem(
             .get(dedupeKey)
         : null;
       if (!winner) break;
+      const sameQuestion =
+        Boolean(computedKey) && computedKeyOfRow(winner) === computedKey;
+      if (sameQuestion && rowIsUndecided(winner)) {
+        return attachWaiter(db, winner, { refs, now });
+      }
       const superseded = supersedeInboxDecision(db, winner, {
         body,
         refs,
@@ -532,10 +721,26 @@ function decideInboxItemInTransaction(
       storedResponse,
     );
   }
-  return settleInboxDecision(db, id, storedResponse, effect, {
+  const settled = settleInboxDecision(db, id, storedResponse, effect, {
     now,
     artifactStore,
   });
+  const waiters = parseWaiters(row.waiters_json);
+  if (
+    waiters.length > 0 &&
+    settled.effect.outcome === "applied" &&
+    settled.effect.detail !== REPLANNED_DETAIL
+  ) {
+    settled.waiterEffects = fanOutWaiterEffects(
+      db,
+      settled.item,
+      storedResponse,
+      waiters,
+      applyEffect,
+    );
+    settled.item = getInboxItem(db, id);
+  }
+  return settled;
 }
 
 export function decideInboxItem(db, id, response, options = {}) {
@@ -594,11 +799,27 @@ function retryInboxDecisionInTransaction(
       response,
     );
   }
-  return settleInboxDecision(db, id, response, effect, {
+  const settled = settleInboxDecision(db, id, response, effect, {
     now,
     recordedEffect: { ...effect, retryAttempt },
     artifactStore,
   });
+  const waiters = parseWaiters(row.waiters_json);
+  if (
+    waiters.length > 0 &&
+    settled.effect.outcome === "applied" &&
+    settled.effect.detail !== REPLANNED_DETAIL
+  ) {
+    settled.waiterEffects = fanOutWaiterEffects(
+      db,
+      settled.item,
+      response,
+      waiters,
+      applyEffect,
+    );
+    settled.item = getInboxItem(db, id);
+  }
+  return settled;
 }
 
 export function retryInboxDecision(db, id, options = {}) {
@@ -798,6 +1019,20 @@ export async function deliverInboxItem(
   if (!item) throw new Error(`unknown inbox item ${id}`);
   if (typeof send !== "function")
     throw new Error("inbox delivery transport is required");
+  // One Telegram per question (WM-813): waiters attach to the existing
+  // item instead of projecting a second push.
+  if (item.delivery?.telegram) {
+    return {
+      ok:
+        item.delivery.telegram.error == null &&
+        (item.delivery.telegram.exit_code === null ||
+          item.delivery.telegram.exit_code === 0),
+      skipped: true,
+      exitCode: item.delivery.telegram.exit_code,
+      error: item.delivery.telegram.error,
+      item,
+    };
+  }
   let outcome;
   try {
     outcome = await send(command, telegramMessage(item, webUrl));

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -84,7 +84,51 @@ describe("human inbox ledger (WM-285)", () => {
     });
   });
 
-  test("open dedupe supersedes the request without stacking rows", () => {
+  test("same-question open items attach as waiters instead of stacking rows", () => {
+    const db = openDb(":memory:");
+    const first = createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "first",
+        body: "old",
+        refs: { issue: "WM-1", runId: "run_1" },
+        source: "agent:run_1",
+        decision: decision(),
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "first" },
+    );
+    const second = createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "second",
+        body: "new",
+        refs: { issue: "WM-1", runId: "run_2" },
+        source: "agent:run_2",
+        decision: decision(),
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "second" },
+    );
+    expect(second.id).toBe(first.id);
+    expect(second.attached).toBe(true);
+    expect(second.body).toBe("old");
+    expect(second.refs).toEqual({ issue: "WM-1", runId: "run_1" });
+    expect(second.decision).toEqual(decision());
+    expect(second.waiters).toEqual([
+      { runId: "run_2", at: expect.any(String) },
+    ]);
+    expect(second.waitingCount).toBe(2);
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
+
+    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed one" });
+    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed two" });
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
+  });
+
+  test("a different decision shape on the same caller key still supersedes", () => {
     const db = openDb(":memory:");
     const first = createInboxItem(
       db,
@@ -100,7 +144,7 @@ describe("human inbox ledger (WM-285)", () => {
       { id: "first" },
     );
     const replacement = decision([
-      { id: "dismiss", label: "Dismiss this time", effect: "dismiss" },
+      { id: "retry", label: "Retry", effect: "requeue" },
     ]);
     const second = createInboxItem(
       db,
@@ -108,7 +152,12 @@ describe("human inbox ledger (WM-285)", () => {
         kind: "ESCALATED",
         title: "second",
         body: "new",
-        refs: { issue: "WM-1", runId: "run_2" },
+        refs: {
+          issue: "WM-1",
+          runId: "run_2",
+          eventSource: "test",
+          eventId: "e",
+        },
         source: "agent:run_2",
         decision: replacement,
         dedupeKey: "ESCALATED:WM-1",
@@ -120,11 +169,93 @@ describe("human inbox ledger (WM-285)", () => {
     expect(second.refs).toEqual({ issue: "WM-1", runId: "run_2" });
     expect(second.decision).toEqual(replacement);
     expect(second.delivery.supersededDecisions).toBe(1);
-    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
+    expect(second.waiters).toEqual([]);
+  });
 
-    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed one" });
-    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed two" });
-    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
+  test("decideInboxItem fans the effect out across waiters bound to each run", () => {
+    const db = openDb(":memory:");
+    const request = decision();
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "first",
+        refs: { issue: "WM-1", runId: "run_1" },
+        decision: request,
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { id: "first", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "second",
+        refs: { issue: "WM-1", runId: "run_2" },
+        decision: request,
+        dedupeKey: "ESCALATED:WM-1",
+      },
+      { now: 2000 },
+    );
+    const appliedRuns = [];
+    const decided = decideInboxItem(
+      db,
+      "first",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "dismiss",
+        fields: {},
+      },
+      {
+        now: 3000,
+        applyEffect: (_db, item) => {
+          appliedRuns.push(item.refs.runId);
+          return { kind: "dismiss", outcome: "applied" };
+        },
+      },
+    );
+    expect(appliedRuns).toEqual(["run_1"]);
+    expect(decided.waiterEffects).toEqual([
+      {
+        runId: "run_2",
+        effect: {
+          kind: "dismiss",
+          outcome: "applied",
+          detail: "shared_referent",
+        },
+      },
+    ]);
+    expect(decided.item.waitingCount).toBe(2);
+    expect(decided.item.waiters[0].effect.detail).toBe("shared_referent");
+    expect(decided.item.resolvedAt).toBe(new Date(3000).toISOString());
+  });
+
+  test("delivery is not retried once a projection exists", async () => {
+    const db = openDb(":memory:");
+    const item = createInboxItem(
+      db,
+      { kind: "CI RED", title: "CI RED PR-4: tests", source: "cli" },
+      { id: "inbox_delivery_once" },
+    );
+    const sends = [];
+    await deliverInboxItem(db, item.id, {
+      command: "/stub",
+      send: async () => {
+        sends.push(1);
+        return { ok: true, exitCode: 0, error: null };
+      },
+    });
+    const again = await deliverInboxItem(db, item.id, {
+      command: "/stub",
+      send: async () => {
+        sends.push(2);
+        return { ok: true, exitCode: 0, error: null };
+      },
+    });
+    expect(sends).toEqual([1]);
+    expect(again.skipped).toBe(true);
+    expect(again.ok).toBe(true);
   });
 
   test("dedupe supersession clears a stored response to avoid binding it to a new request", () => {
@@ -504,6 +635,9 @@ describe("human inbox ledger (WM-285)", () => {
         { id, now: 1000 },
       );
     }
+    expect(getInboxItem(db, "duplicate")).toBeNull();
+    expect(getInboxItem(db, "blocked").waitingCount).toBe(2);
+
     const calls = [];
     const linearIssues = async (ids) => {
       calls.push(ids);
@@ -523,7 +657,6 @@ describe("human inbox ledger (WM-285)", () => {
 
     expect(await reconcileInbox(db, { now: 60_000, linearIssues })).toEqual([
       { id: "blocked", resolvedBy: "auto:linear_unblocked" },
-      { id: "duplicate", resolvedBy: "auto:linear_unblocked" },
     ]);
     expect(calls).toEqual([["WM-10", "WM-11"]]);
     expect(await reconcileInbox(db, { now: 100_000, linearIssues })).toEqual(

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -21,6 +21,8 @@ import {
   itemStatus,
   matchesTab,
   prHref,
+  waitingCount,
+  waitingLabel,
   sourceRunId,
 } from "./Inbox";
 import { api } from "../api";
@@ -237,6 +239,17 @@ describe("inbox pure helpers", () => {
       ),
     ).toBe("1d 4h ago");
   });
+
+  test("waitingCount is 1 plus attached waiters and hides the label at 1", () => {
+    expect(waitingCount(item({ id: "a", kind: "BLOCKED" }))).toBe(1);
+    expect(waitingLabel(1)).toBeNull();
+    const crowded = {
+      ...item({ id: "b", kind: "BLOCKED" }),
+      waiters: [{ runId: "run_2" }, { runId: "run_3" }],
+    };
+    expect(waitingCount(crowded)).toBe(3);
+    expect(waitingLabel(3)).toBe("3 runs waiting on this answer");
+  });
 });
 
 const origInbox = api.inbox;
@@ -348,6 +361,27 @@ describe("Inbox view", () => {
     // Group headers in triage order.
     expect(view.getByText("Decide")).toBeTruthy();
     expect(view.getByText("Red")).toBeTruthy();
+  });
+
+  test("list and detail show how many runs wait on one answer", async () => {
+    ledger = [
+      {
+        ...item({
+          id: "inbox_wait",
+          kind: "BLOCKED",
+          title: "BLOCKED WM-9: shared question",
+          refs: { issue: "WM-9", runId: "run_a" },
+        }),
+        waiters: [{ runId: "run_b" }, { runId: "run_c" }],
+        waitingCount: 3,
+      } as InboxItem,
+    ];
+    const { view } = renderInbox({
+      focusItemId: "inbox_wait",
+      onSelectItem: () => {},
+    });
+    await waitFor(() => view.getByText("3 waiting"));
+    expect(view.getByText("3 runs waiting on this answer")).toBeTruthy();
   });
 
   test("filters with inbox facets and free text, with an Esc-hinted empty state", async () => {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -215,6 +215,27 @@ export function deliveryText(item: InboxItem): string {
   return `Telegram: sent ${when} · exit ${t.exit_code ?? 0}`;
 }
 
+type InboxWaiter = { runId?: string; at?: string };
+
+function inboxWaiters(item: InboxItem): InboxWaiter[] {
+  const waiters = (item as InboxItem & { waiters?: InboxWaiter[] }).waiters;
+  return Array.isArray(waiters) ? waiters : [];
+}
+
+/** 1 (this item) + attached runs. Hidden in the list when the count is 1. */
+export function waitingCount(item: InboxItem): number {
+  const named = (item as InboxItem & { waitingCount?: number }).waitingCount;
+  if (typeof named === "number" && Number.isFinite(named) && named >= 1) {
+    return named;
+  }
+  return 1 + inboxWaiters(item).length;
+}
+
+export function waitingLabel(count: number): string | null {
+  if (count <= 1) return null;
+  return `${count} runs waiting on this answer`;
+}
+
 const DELIVERY_HUES: Record<DeliveryState, string> = {
   sent: "var(--hue-ok)",
   failed: "var(--hue-err)",
@@ -1316,6 +1337,11 @@ export function Inbox({
                                 </span>
                               )}
                               {displayTitle(item)}
+                              {waitingLabel(waitingCount(item)) && (
+                                <span className="ml-1.5 text-(--text-faint)">
+                                  {waitingCount(item)} waiting
+                                </span>
+                              )}
                             </div>
                           </td>
                         )}
@@ -1507,6 +1533,9 @@ export function Inbox({
               }
             />
             <KV k="status" v={itemStatus(sel)} />
+            {waitingLabel(waitingCount(sel)) && (
+              <KV k="waiting" v={waitingLabel(waitingCount(sel))} />
+            )}
             {sel.severity !== "normal" && <KV k="severity" v={sel.severity} />}
             <KV k="created" v={<Ago iso={sel.createdAt} now={now} />} />
             {sel.ackedAt && (


### PR DESCRIPTION
## Summary
- Same-subject inbox items (`kind` + issue/pr/repo, plus proposal/event when present, plus decision option/effect shape) attach as `waiters` on the existing open/acked row instead of stacking a second question or Telegram.
- `decideInboxItem` fans the chosen effect across waiters, applying once per shared referent (issue/proposal/event) so authorise/triage/answer do not fire N times for one ticket.
- CLI and Inbox web show the waiting-run count when more than one run is attached.

Fixes WM-813

UX critique: skipped — waiter count is a status display on the existing operator inbox, not a new flow or interaction.

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib && cd event-runtime/web && bun test src/views/Inbox.test.tsx`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `cd event-runtime/web && bun run build`
- [ ] Confirm an ESCALATED item for the same Linear issue from two runs shows "2 waiting" and one Telegram


Made with [Cursor](https://cursor.com)