### PR TITLE
feat(runtime): materialize declared harness content into the run workspace (WM-851)

### DIFF
--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -255,6 +255,69 @@ machine-readable output) prints the registered adapters with their source and
 sandbox support — the same registry a worker builds, so it needs no running
 `serve`.
 
+## 2d. Harness content as a RunSpec input — **shipped, WM-851**
+
+Runtime LLM runs used to acquire skills, slash commands, and subagents from
+ambient host home-dir symlinks (`~/.claude/agents`, `~/.cursor/commands`,
+`~/.pi/agent/…`) written by `bun build/emit.mjs --link`. A worker on a
+machine that had never been linked, or a run that named a subset of that
+content, had no declared input — the harness just inherited whatever $HOME
+happened to contain.
+
+A definition may now declare:
+
+```json
+"harness": {
+  "skills": ["ticket-spec"],
+  "commands": ["factory-ticket"],
+  "subagents": ["factory-ux-critic"]
+}
+```
+
+`buildRunSpec` (`lib/planner.mjs`) copies a well-formed block onto the
+immutable RunSpec — same omit-when-undeclared rule as `model_tier`, so
+existing definitions stay byte-identical. Shape is checked at plan time
+(object, closed keys, names matching `^[a-z0-9][a-z0-9._-]*$`); catalog
+membership is not, because `buildRunSpec` is pure.
+
+The worker materializes that declaration **after** workspace create and
+**before** adapter spawn (`materializeRunHarness` in `lib/worker.mjs`):
+
+1. Resolve each name against `registry.harnessRoots` when WM-849 has
+   populated it, otherwise `shared/{skills,commands,agents}`.
+2. Copy the **adapter's emitted packaging** (not the shared source) into a
+   workspace-relative tree the CLI reads from cwd:
+
+   | Adapter  | skills                                           | commands                       | subagents                 |
+   | -------- | ------------------------------------------------ | ------------------------------ | ------------------------- |
+   | `claude` | `.claude/skills/<n>/` from `plugins/core/skills` | `.claude/commands/<n>.md`      | `.claude/agents/<n>.md`   |
+   | `cursor` | **unsupported** (emit has none)                  | `.cursor/commands/<n>.md`      | `.cursor/agents/<n>.md`   |
+   | `pi`     | `.pi/agent/skills/<n>/` from `dist/pi/skills`    | `.pi/agent/prompts/<n>.md`     | `.pi/agent/agents/<n>.md` |
+   | `agy`    | `.gemini/skills/<n>/` from `dist/gemini/skills`  | same (commands emit as skills) | `.gemini/agents/<n>.md`   |
+
+3. Refuse with a typed reason, never spawn:
+
+   - `harness_unknown_skill` / `_command` / `_subagent` — name not in the catalog;
+   - `harness_unsupported` — the adapter has no layout for that kind (cursor
+     skills; fake/command/actions when anything is named);
+   - `harness_unmaterializable` — catalog hit but emit output is missing or
+     the dest would escape the workspace.
+
+Those codes are fatal (`classifyFailureCause` treats the `harness_` prefix
+as fatal). An undeclared or empty `harness` is a no-op.
+
+LLM adapters export `HARNESS_LAYOUT` describing source/dest/type; it is
+**not** part of the WM-837 adapter contract (`execute` + `SANDBOX_SUPPORT`
+remain the required pair). There is no runtime `codex` adapter — Codex
+packaging lives under `dist/codex/` for emit/`--link` only.
+
+The orchestrator path (`runners/run-agent.sh`) is unchanged: it still
+launches inside a product checkout and relies on `link-repos` plus the
+operator home-dir install. It has no RunSpec.
+
+Auth stays in the real `$HOME`. Materialization adds the declared set to the
+workspace; it does not hide extra home-dir content the CLI may still load.
+
 ## 3. Stage 2 — workers on other nodes
 
 A `work` process on another machine talks to the authenticated `/worker/v1`

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -29,6 +29,29 @@ export const SANDBOX_SUPPORT = "unsupported";
 const SANDBOX_REFUSAL_REASON =
   "the agy CLI has no guest execution path yet — its binary, Google Cloud/Antigravity auth, and prompt transport have not been translated to the microVM";
 
+/**
+ * Workspace-relative packaging of RunSpec.harness (WM-851). agy/gemini emit
+ * packages commands as skills (`dist/gemini/skills/<name>/`), so both
+ * `skills` and `commands` copy that directory into `.gemini/skills`.
+ */
+export const HARNESS_LAYOUT = Object.freeze({
+  skills: Object.freeze({
+    source: (name) => ["dist", "gemini", "skills", name],
+    dest: (name) => [".gemini", "skills", name],
+    type: "dir",
+  }),
+  commands: Object.freeze({
+    source: (name) => ["dist", "gemini", "skills", name],
+    dest: (name) => [".gemini", "skills", name],
+    type: "dir",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["dist", "gemini", "agents", `${name}.md`],
+    dest: (name) => [".gemini", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
 export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
 

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -63,6 +63,29 @@ export const SANDBOX_DEFERRAL_REASON =
 /** This adapter refuses sandboxed definitions (fail closed) until the deferral above is resolved. */
 export const SANDBOX_SUPPORT = "unsupported";
 
+/**
+ * Workspace-relative packaging of RunSpec.harness (WM-851). Sources are emit
+ * output under FACTORY_ROOT (`plugins/core`) so the bytes match the Claude
+ * plugin; dest is the project `.claude/` tree the CLI reads from cwd.
+ */
+export const HARNESS_LAYOUT = Object.freeze({
+  skills: Object.freeze({
+    source: (name) => ["plugins", "core", "skills", name],
+    dest: (name) => [".claude", "skills", name],
+    type: "dir",
+  }),
+  commands: Object.freeze({
+    source: (name) => ["plugins", "core", "commands", `${name}.md`],
+    dest: (name) => [".claude", "commands", `${name}.md`],
+    type: "file",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["plugins", "core", "agents", `${name}.md`],
+    dest: (name) => [".claude", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -44,6 +44,24 @@ export const SANDBOX_SUPPORT = "unsupported";
 const SANDBOX_REFUSAL_REASON =
   "the Cursor Agent CLI has no guest execution path yet — its binary and CURSOR_API_KEY transport have not been translated to the microVM";
 
+/**
+ * Workspace-relative packaging of RunSpec.harness (WM-851). Cursor emit has
+ * commands and agents, not skills — a spec that names skills is refused
+ * `harness_unsupported` by the worker rather than silently dropped.
+ */
+export const HARNESS_LAYOUT = Object.freeze({
+  commands: Object.freeze({
+    source: (name) => ["dist", "cursor", "commands", `${name}.md`],
+    dest: (name) => [".cursor", "commands", `${name}.md`],
+    type: "file",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["dist", "cursor", "agents", `${name}.md`],
+    dest: (name) => [".cursor", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -71,6 +71,29 @@ export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
 export const SANDBOX_SUPPORT = "gondolin";
 
 /**
+ * Workspace-relative packaging of RunSpec.harness (WM-851). Commands emit as
+ * `dist/pi/prompts`; dest mirrors `~/.pi/agent/{skills,prompts,agents}` so a
+ * run does not depend on `bun build/emit.mjs --link` having populated $HOME.
+ */
+export const HARNESS_LAYOUT = Object.freeze({
+  skills: Object.freeze({
+    source: (name) => ["dist", "pi", "skills", name],
+    dest: (name) => [".pi", "agent", "skills", name],
+    type: "dir",
+  }),
+  commands: Object.freeze({
+    source: (name) => ["dist", "pi", "prompts", `${name}.md`],
+    dest: (name) => [".pi", "agent", "prompts", `${name}.md`],
+    type: "file",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["dist", "pi", "agents", `${name}.md`],
+    dest: (name) => [".pi", "agent", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
+/**
  * Workspace file the prompt is written to for a sandboxed run, then redirected
  * onto pi's stdin inside the guest. Not an artifact: it is the same text the
  * host path pipes, and it lives beside input.json under the workspace mount.

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -180,6 +180,54 @@ export function pinMemos(
 }
 
 /**
+ * Closed identifiers for `def.harness.{skills,commands,subagents}` (WM-851).
+ * No slashes: namespaced third-party pack names wait on WM-849's catalog.
+ */
+export const HARNESS_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+export const HARNESS_KINDS = Object.freeze(["skills", "commands", "subagents"]);
+
+/**
+ * Shape-check an agent definition's `harness` block. Pure: no catalog I/O —
+ * unknown names are a worker refusal, not a plan-time fetch.
+ * Absent field → undefined so undeclared specs stay byte-identical.
+ */
+export function harnessFromDef(def) {
+  if (def?.harness === undefined) return undefined;
+  return normalizeHarness(def.harness, def.ref ?? def.id ?? "harness");
+}
+
+export function normalizeHarness(raw, source = "harness") {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(
+      `${source}: "harness" must be an object { skills?, commands?, subagents? }`,
+    );
+  }
+  const allowed = new Set(HARNESS_KINDS);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${source}: "harness" unknown key "${key}" (allowed: ${HARNESS_KINDS.join(", ")})`,
+      );
+    }
+  }
+  const out = {};
+  for (const kind of HARNESS_KINDS) {
+    if (raw[kind] === undefined) continue;
+    const names = raw[kind];
+    const wellFormed =
+      Array.isArray(names) &&
+      names.every((n) => typeof n === "string" && HARNESS_NAME_PATTERN.test(n));
+    if (!wellFormed) {
+      throw new Error(
+        `${source}: "harness.${kind}" must be an array of names matching ${HARNESS_NAME_PATTERN}`,
+      );
+    }
+    out[kind] = [...names];
+  }
+  return out;
+}
+
+/**
  * Pure assembly of the §5.2 RunSpec from a registered mapping. No I/O, no
  * clock reads beyond the injected `now` — same inputs, same spec, always.
  */
@@ -236,6 +284,11 @@ export function buildRunSpec(
     // Declared repo scope (WM-64) rides in the spec so the proposal the
     // operator approves names it, same as capabilities.
     ...(def.repos ? { repos: def.repos } : {}),
+    // Declared harness content (WM-851): skills/commands/subagents the
+    // worker materializes into the run workspace. Omitted when the
+    // definition does not declare the field, so undeclared specs stay
+    // byte-identical to before.
+    ...(def.harness !== undefined ? { harness: harnessFromDef(def) } : {}),
     // Model-tier routing (WM-135), the house repoPin pattern: the tier is
     // resolved HERE, at plan time, and the concrete value is pinned so the
     // proposal, receipt, and inspect output all name the exact model. Fields

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -13,6 +13,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  cpSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -39,6 +40,8 @@ import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
 import {
+  HARNESS_KINDS,
+  HARNESS_NAME_PATTERN,
   worktreeDispatchAutoEligibility,
   worktreeMergeFixEligibility,
 } from "./planner.mjs";
@@ -67,6 +70,165 @@ import {
 import { createInboxItem } from "./inbox.mjs";
 import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { templateFor } from "./decision-templates.mjs";
+
+const HARNESS_UNKNOWN_CODES = Object.freeze({
+  skills: "harness_unknown_skill",
+  commands: "harness_unknown_command",
+  subagents: "harness_unknown_subagent",
+});
+
+export class HarnessMaterializeError extends Error {
+  /**
+   * @param {string} code - typed reason: `harness_unknown_*` / `harness_unsupported` / `harness_unmaterializable`
+   * @param {string} detail
+   */
+  constructor(code, detail) {
+    super(detail);
+    this.name = "HarnessMaterializeError";
+    this.code = code;
+  }
+}
+
+/**
+ * Catalog roots for resolving declared harness names (WM-851). Prefers
+ * WM-849's `registry.harnessRoots` when present; otherwise `shared/`.
+ */
+export function harnessCatalogRoots(registry, factoryRoot = FACTORY_ROOT) {
+  if (Array.isArray(registry?.harnessRoots) && registry.harnessRoots.length > 0)
+    return registry.harnessRoots;
+  return [
+    {
+      name: "factory/core",
+      builtin: true,
+      prefix: null,
+      skills: path.join(factoryRoot, "shared", "skills"),
+      commands: path.join(factoryRoot, "shared", "commands"),
+      subagents: path.join(factoryRoot, "shared", "agents"),
+    },
+  ];
+}
+
+function catalogHas(roots, kind, name) {
+  for (const root of roots) {
+    const dir = root[kind];
+    if (typeof dir !== "string" || dir === "") continue;
+    const candidate =
+      kind === "skills" ? path.join(dir, name) : path.join(dir, `${name}.md`);
+    if (existsSync(candidate)) return true;
+  }
+  return false;
+}
+
+function harnessRelDest(layout, name) {
+  const parts = layout.dest(name);
+  if (!Array.isArray(parts) || parts.some((p) => typeof p !== "string")) {
+    throw new HarnessMaterializeError(
+      "harness_unmaterializable",
+      `adapter dest() for ${JSON.stringify(name)} did not return a path-segment array`,
+    );
+  }
+  return parts.join("/");
+}
+
+/**
+ * Copy declared RunSpec.harness content into the attempt workspace using the
+ * target adapter's `HARNESS_LAYOUT`. No-op when the spec omits harness or
+ * names nothing. Throws `HarnessMaterializeError` with a typed `code`.
+ */
+export function materializeRunHarness({
+  spec,
+  adapter,
+  adapterKey,
+  workspaceDir,
+  registry,
+  factoryRoot = FACTORY_ROOT,
+} = {}) {
+  const harness = spec?.harness;
+  if (!harness || typeof harness !== "object") return [];
+  const declaredCount = HARNESS_KINDS.reduce(
+    (n, kind) => n + (Array.isArray(harness[kind]) ? harness[kind].length : 0),
+    0,
+  );
+  if (declaredCount === 0) return [];
+
+  const layout = adapter?.HARNESS_LAYOUT;
+  const roots = harnessCatalogRoots(registry, factoryRoot);
+  const written = [];
+
+  for (const kind of HARNESS_KINDS) {
+    const names = Array.isArray(harness[kind]) ? harness[kind] : [];
+    for (const name of names) {
+      if (typeof name !== "string" || !HARNESS_NAME_PATTERN.test(name)) {
+        throw new HarnessMaterializeError(
+          HARNESS_UNKNOWN_CODES[kind],
+          `${kind} name ${JSON.stringify(name)} is not a legal harness identifier`,
+        );
+      }
+      if (!catalogHas(roots, kind, name)) {
+        throw new HarnessMaterializeError(
+          HARNESS_UNKNOWN_CODES[kind],
+          `${kind.slice(0, -1)} "${name}" is not in the harness catalog`,
+        );
+      }
+      const kindLayout = layout?.[kind];
+      if (!kindLayout) {
+        throw new HarnessMaterializeError(
+          "harness_unsupported",
+          `adapter "${adapterKey}" cannot materialize ${kind}`,
+        );
+      }
+      const srcParts = kindLayout.source(name);
+      if (
+        !Array.isArray(srcParts) ||
+        srcParts.some((p) => typeof p !== "string")
+      ) {
+        throw new HarnessMaterializeError(
+          "harness_unmaterializable",
+          `adapter "${adapterKey}" source() for ${kind}/${name} did not return a path-segment array`,
+        );
+      }
+      const src = path.join(factoryRoot, ...srcParts);
+      let dest;
+      try {
+        dest = safeJoin(workspaceDir, harnessRelDest(kindLayout, name));
+      } catch (err) {
+        throw new HarnessMaterializeError(
+          "harness_unmaterializable",
+          err instanceof PathViolation
+            ? `${kind}/${name} dest escapes the workspace`
+            : (err?.message ?? String(err)),
+        );
+      }
+      if (!existsSync(src)) {
+        throw new HarnessMaterializeError(
+          "harness_unmaterializable",
+          `${kind}/${name} has no emitted packaging for adapter "${adapterKey}"`,
+        );
+      }
+      const st = statSync(src);
+      if (kindLayout.type === "dir" && !st.isDirectory()) {
+        throw new HarnessMaterializeError(
+          "harness_unmaterializable",
+          `${kind}/${name} emit path is not a directory for adapter "${adapterKey}"`,
+        );
+      }
+      if (kindLayout.type === "file" && !st.isFile()) {
+        throw new HarnessMaterializeError(
+          "harness_unmaterializable",
+          `${kind}/${name} emit path is not a file for adapter "${adapterKey}"`,
+        );
+      }
+      mkdirSync(path.dirname(dest), { recursive: true });
+      cpSync(src, dest, { recursive: kindLayout.type === "dir" });
+      written.push({
+        kind,
+        name,
+        dest: path.relative(workspaceDir, dest),
+      });
+    }
+  }
+  return written;
+}
 
 /**
  * Runtime-injected artifacts: adapters that capture the agent's output write
@@ -460,7 +622,8 @@ export function classifyFailureCause(reasonCode) {
   }
   if (
     FATAL_FAILURES.has(reasonCode) ||
-    String(reasonCode).startsWith("policy_denied:")
+    String(reasonCode).startsWith("policy_denied:") ||
+    String(reasonCode).startsWith("harness_")
   ) {
     return "fatal";
   }
@@ -2184,6 +2347,33 @@ export async function executeClaimed(
         reasonCode: "agent_definition_mismatch",
         receipt: refusedRes.receipt,
       };
+    }
+
+    try {
+      materializeRunHarness({
+        spec,
+        adapter,
+        adapterKey,
+        workspaceDir,
+        registry,
+      });
+    } catch (err) {
+      if (err instanceof HarnessMaterializeError) {
+        const refusedRes = refuseTerminal(err.code, ["harness_materialize"], {
+          causeTyped: true,
+          detail: err.message,
+        });
+        cleanupWorkspace();
+        if (refusedRes?.fenced) return { fenced: true };
+        return {
+          runId,
+          attempt,
+          terminalState: "REFUSED",
+          reasonCode: err.code,
+          receipt: refusedRes.receipt,
+        };
+      }
+      throw err;
     }
 
     // Live trace (factory.trace/v1): the recorder is already defensive, but

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -154,6 +154,15 @@ if [[ -z "${FACTORY_NOTIFY_CMD:-}" && -z "${FACTORY_NOTIFY_SCRIPT:-}" ]]; then
   eval "$(cd "$ROOT" && bun "$ROOT/lib/notify.mjs" --export-env 2>/dev/null || true)"
 fi
 
+# Runtime workers materialize declared RunSpec.harness content into the run
+# workspace (WM-851, lib/worker.mjs materializeRunHarness) so a headless run
+# does not depend on ~/.claude/agents and ~/.cursor/commands having been
+# populated by `bun build/emit.mjs --link`. This orchestrator path still
+# launches inside a product checkout and reads slash commands from that
+# checkout's `.claude/commands/` (link-repos) plus the operator's home-dir
+# install — it has no RunSpec. Do not treat this script as the runtime
+# materialization path.
+
 if [[ "$USE_API" == "1" ]]; then
   [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "--use-api given but ANTHROPIC_API_KEY is not set" >&2; exit 2; }
   AUTH_NOTE="ANTHROPIC_API_KEY (billed per token; connectors disabled)"


### PR DESCRIPTION
## Summary
- Agent definitions may declare `harness: { skills, commands, subagents }`; `buildRunSpec` pins a well-formed block on the RunSpec (omit-when-undeclared, same as `model_tier`).
- The worker copies each adapter's emit packaging into the attempt workspace before spawn (`claude` → `.claude/`, `cursor` → `.cursor/`, `pi` → `.pi/agent/`, `agy` → `.gemini/`) and refuses with typed `harness_unknown_*` / `harness_unsupported` / `harness_unmaterializable` when a name cannot be materialized.
- Catalog is `shared/` today and `registry.harnessRoots` when WM-849 lands. No Codex runtime adapter (that owned-path pointer was stale).

Fixes WM-851

UX critique: skipped — no user-facing surface (runtime planner/worker/adapters)

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib && bun run lint && bun run check`
- [ ] Approve a dispatch (or smoke) run whose definition declares `harness:` and confirm workspace contains the copied files before the CLI starts
- [ ] A spec naming an unknown skill / cursor skills / missing emit output is `REFUSED` with the matching `harness_*` reason, no spawn


Made with [Cursor](https://cursor.com)