### PR TITLE
a11y(web): expose Agents row selection in the accessibility tree (WM-754)

### DIFF
--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -1,6 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 import {
@@ -256,6 +262,39 @@ describe("Agents table columns (WM-211)", () => {
       );
       expect(headers.filter((t) => /claude1/.test(t))).toHaveLength(1);
       expect(headers.filter((t) => /command1/.test(t))).toHaveLength(1);
+    });
+  });
+});
+
+describe("Agents table accessible selection (WM-754)", () => {
+  test("the selected agent row is exposed as selected in the accessibility tree", async () => {
+    const agents = [stubAgent("alpha"), stubAgent("beta")];
+    await withAgents(agents, async () => {
+      const r = renderWithClient(<SelectableAgents />);
+      const grid = await r.findByRole("grid", { name: "Agents registry" });
+      expect(within(grid).getAllByRole("rowgroup")).toHaveLength(2);
+
+      const alpha = r.getByRole("row", { name: "alpha@1" });
+      const beta = r.getByRole("row", { name: "beta@1" });
+      expect(alpha.getAttribute("role")).toBe("row");
+      expect(within(alpha).getAllByRole("gridcell").length).toBeGreaterThan(0);
+      expect(r.queryByRole("row", { selected: true })).toBeNull();
+
+      alpha.focus();
+      fireEvent.keyDown(alpha, { key: "Enter" });
+      expect(r.getByRole("row", { selected: true, name: "alpha@1" })).toBe(
+        alpha,
+      );
+      expect(r.getByRole("row", { selected: false, name: "beta@1" })).toBe(
+        beta,
+      );
+
+      fireEvent.keyDown(alpha, { key: "ArrowDown" });
+      expect(document.activeElement).toBe(beta);
+      expect(r.getByRole("row", { selected: true, name: "beta@1" })).toBe(beta);
+      expect(
+        r.queryByRole("row", { selected: true, name: "alpha@1" }),
+      ).toBeNull();
     });
   });
 });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -420,9 +420,13 @@ export function Agents({
             </>
           }
         >
-          <Table className="w-full border-separate border-spacing-0">
-            <thead>
-              <tr className="text-left">
+          <Table
+            role="grid"
+            aria-label="Agents registry"
+            className="w-full border-separate border-spacing-0"
+          >
+            <thead role="rowgroup">
+              <tr role="row" className="text-left">
                 {cols.map((c) => {
                   const sort = AGENTS_DISPLAY.sorts.find(
                     (s) => s.column === c.key,
@@ -459,11 +463,12 @@ export function Agents({
                 })}
               </tr>
             </thead>
-            <tbody>
+            <tbody role="rowgroup">
               {(() => {
                 const renderRow = (a: AgentDef) => (
                   <tr
                     key={a.ref}
+                    role="row"
                     data-agent-ref={a.ref}
                     tabIndex={0}
                     onClick={() => onSelectAgent(a.ref)}
@@ -508,21 +513,33 @@ export function Agents({
                     aria-selected={a.ref === selectedRef}
                     className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${a.ref === selectedRef ? "row-selected" : ""}`}
                   >
-                    <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                    <td
+                      role="gridcell"
+                      className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                    >
                       {a.ref}
                     </td>
                     {show.has("contract") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap"
+                      >
                         {a.outputContract}
                       </td>
                     )}
                     {show.has("adapter") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
+                      >
                         {adapterText(a)}
                       </td>
                     )}
                     {show.has("tier") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
+                      >
                         {tierText(a)}
                         {a.model && a.modelTier && (
                           <span
@@ -535,7 +552,10 @@ export function Agents({
                       </td>
                     )}
                     {show.has("model") && (
-                      <td className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                      >
                         <ModelCell
                           model={modelText(a)}
                           className={
@@ -547,17 +567,26 @@ export function Agents({
                       </td>
                     )}
                     {show.has("mutating") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                      >
                         <AgentMutationBadge mutating={a.mutating} />
                       </td>
                     )}
                     {show.has("capabilities") && (
-                      <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap"
+                      >
                         {caps(a)}
                       </td>
                     )}
                     {show.has("timeout") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap"
+                      >
                         <span
                           title={
                             a.limits.timeout_seconds != null
@@ -570,7 +599,10 @@ export function Agents({
                       </td>
                     )}
                     {show.has("attempts") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
+                      <td
+                        role="gridcell"
+                        className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap"
+                      >
                         {a.limits.attempts ?? EMPTY}
                       </td>
                     )}


### PR DESCRIPTION
## Summary
- Give the Agents registry table grid/row/rowgroup/gridcell semantics so Chromium's accessibility tree exposes the selected row (`aria-selected`), matching the Artifacts inventory pattern.
- Keyboard Enter / ArrowUp / ArrowDown selection is unchanged; tests now query `getByRole("row", { selected: true })`.

Fixes WM-754

UX critique: required — SHIP (round 1). Evidence: `http://127.0.0.1:7503/#/agents`, `http://127.0.0.1:7503/#/agents/agy-smoke%401`. Follow-ups filed: WM-900 (roving tabindex), WM-899 (unnamed detail-pane landmark).

## Test plan
- [x] `cd event-runtime/web && bun test src/views/Agents.test.tsx`
- [x] `cd event-runtime/web && bun run build`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [ ] Keyboard: Tab to an agent row, Enter opens the pane, ArrowDown/ArrowUp moves `aria-selected` and hash
- [ ] Chromium a11y tree: selected row reports selected on the Agents grid


Made with [Cursor](https://cursor.com)