### PR TITLE
feat(forge): add prChecks verb for PR check-run snapshots (WM-862)

### DIFF
--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -35,6 +35,15 @@ function freshSeed() {
             body: "Fixes WM-1",
             url: `https://github.com/${REPO}/pull/1`,
             files: ["src/a.js", "src/b.js"],
+            checks: [
+              {
+                name: "Verify",
+                bucket: "pass",
+                state: "SUCCESS",
+                required: true,
+              },
+              { name: "docs", bucket: "pass", state: "SUCCESS" },
+            ],
           },
           {
             number: 2,
@@ -47,6 +56,15 @@ function freshSeed() {
             body: "",
             url: `https://github.com/${REPO}/pull/2`,
             files: [],
+            checks: [
+              {
+                name: "Lint",
+                bucket: "fail",
+                state: "FAILURE",
+                required: true,
+              },
+              { name: "Verify", bucket: "pending", state: "PENDING" },
+            ],
           },
           {
             number: 3,
@@ -114,7 +132,8 @@ function fakeGhExec(seed) {
       const a = args[i];
       if (a.startsWith("--") || a === "-q") {
         const key = a.replace(/^-+/, "");
-        if (key === "undo" || key === "name-only") flags[key] = true;
+        if (key === "undo" || key === "name-only" || key === "required")
+          flags[key] = true;
         else flags[key] = args[++i];
       } else positional.push(a);
     }
@@ -168,6 +187,24 @@ function fakeGhExec(seed) {
         return ok(
           `https://github.com/${repo}/pull/${pr.number}#issuecomment-1\n`,
         );
+      }
+      case "pr checks": {
+        const pr = findPr(positional[2]);
+        if (!pr)
+          return fail(
+            `GraphQL: Could not resolve to a PullRequest with the number of ${positional[2]}. (repository.pullRequest)`,
+          );
+        let checks = [...(pr.checks ?? [])];
+        if (flags.required) {
+          checks = checks.filter((c) => c.required);
+          if (checks.length === 0)
+            return fail(
+              `no required checks reported on the '${pr.headRefName}' branch`,
+            );
+        } else if (checks.length === 0) {
+          return fail(`no checks reported on the '${pr.headRefName}' branch`);
+        }
+        return ok(JSON.stringify(checks.map(pick)));
       }
       case "run list": {
         let runs = data.runs;
@@ -298,6 +335,29 @@ for (const [name, make] of IMPLEMENTATIONS) {
         { body: "held: red handoff" },
       ]);
       expect(() => forge.prComment(REPO, 999, "x")).toThrow(ForgeError);
+    });
+
+    test("prChecks returns the neutral name/bucket/state snapshot", () => {
+      const { forge } = make();
+      expect(forge.prChecks(REPO, 1)).toEqual([
+        { name: "Verify", bucket: "pass", state: "SUCCESS" },
+        { name: "docs", bucket: "pass", state: "SUCCESS" },
+      ]);
+      expect(forge.prChecks(REPO, 2, { fields: ["name", "bucket"] })).toEqual([
+        { name: "Lint", bucket: "fail" },
+        { name: "Verify", bucket: "pending" },
+      ]);
+      expect(forge.prChecks(REPO, 3)).toEqual([]);
+      expect(() => forge.prChecks(REPO, 999)).toThrow(ForgeError);
+      expect(() => forge.prChecks("nope/none", 1)).toThrow(ForgeError);
+    });
+
+    test("prChecks required:true returns only required checks, or []", () => {
+      const { forge } = make();
+      expect(forge.prChecks(REPO, 1, { required: true })).toEqual([
+        { name: "Verify", bucket: "pass", state: "SUCCESS" },
+      ]);
+      expect(forge.prChecks(REPO, 3, { required: true })).toEqual([]);
     });
 
     test("runList filters by branch, created and limit; returns requested fields", () => {
@@ -522,6 +582,72 @@ describe("github forge: gh argv shapes (byte-identical to the pre-forge call sit
     });
     expect(() => notArray.prList("o/r", {})).toThrow(ForgeError);
     expect(() => notArray.runList("o/r", {})).toThrow(ForgeError);
+    expect(() => notArray.prChecks("o/r", 1)).toThrow(ForgeError);
+  });
+
+  test("prChecks argv, empty snapshots, and JSON-on-nonzero-exit", () => {
+    const exec = recorder({
+      status: 0,
+      stdout: JSON.stringify([
+        { name: "Verify", bucket: "pass", state: "SUCCESS" },
+      ]),
+      stderr: "",
+    });
+    const forge = githubForge({ exec });
+    expect(forge.prChecks("o/r", 42)).toEqual([
+      { name: "Verify", bucket: "pass", state: "SUCCESS" },
+    ]);
+    forge.prChecks(null, "7", {
+      required: true,
+      fields: ["name", "state"],
+      cwd: "/repo",
+    });
+    expect(exec.calls.map((c) => c.args)).toEqual([
+      ["pr", "checks", "42", "--repo", "o/r", "--json", "name,bucket,state"],
+      ["pr", "checks", "7", "--required", "--json", "name,state"],
+    ]);
+    expect(exec.calls[1].opts.cwd).toBe("/repo");
+
+    const empty = githubForge({
+      exec: recorder({
+        status: 1,
+        stdout: "",
+        stderr: "no checks reported on the 'feat/a' branch\n",
+      }),
+    });
+    expect(empty.prChecks("o/r", 1)).toEqual([]);
+
+    const noRequired = githubForge({
+      exec: recorder({
+        status: 1,
+        stdout: "",
+        stderr: "no required checks reported on the 'feat/a' branch\n",
+      }),
+    });
+    expect(noRequired.prChecks("o/r", 1, { required: true })).toEqual([]);
+
+    const red = githubForge({
+      exec: recorder({
+        status: 1,
+        stdout: JSON.stringify([
+          { name: "Lint", bucket: "fail", state: "FAILURE" },
+        ]),
+        stderr: "",
+      }),
+    });
+    expect(red.prChecks("o/r", 1)).toEqual([
+      { name: "Lint", bucket: "fail", state: "FAILURE" },
+    ]);
+
+    const missing = githubForge({
+      exec: recorder({
+        status: 1,
+        stdout: "",
+        stderr:
+          "GraphQL: Could not resolve to a PullRequest with the number of 999. (repository.pullRequest)",
+      }),
+    });
+    expect(() => missing.prChecks("o/r", 999)).toThrow(ForgeError);
   });
 
   test("accepts Bun.spawnSync-shaped results (exitCode + Buffer stdout)", () => {

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -12,10 +12,13 @@
  * suite can drive the implementation with a fake `gh` and no network.
  */
 import { spawnSync } from "node:child_process";
-import { ForgeError } from "./types.mjs";
+import { ForgeError, PR_CHECK_FIELDS } from "./types.mjs";
 
 const text = (v) =>
   v == null ? "" : Buffer.isBuffer(v) ? v.toString() : String(v);
+
+/** GitHub CLI stderr when a PR has no check-runs / no required checks. */
+const NO_CHECKS_RE = /^no (required )?checks reported on the '.+' branch$/;
 
 /**
  * @param {{ exec?: (cmd: string, args: string[], opts: object) => { status?: number|null, exitCode?: number|null, stdout?: string|Buffer, stderr?: string|Buffer, error?: Error } }} [options]
@@ -126,6 +129,44 @@ export function githubForge({ exec = spawnSync } = {}) {
         ["pr", "comment", String(number), ...repoFlag(repo), "--body", body],
         opts,
       );
+    },
+
+    prChecks(repo, number, { required, fields, ...opts } = {}) {
+      const jsonFields = fields?.length ? fields : [...PR_CHECK_FIELDS];
+      const args = [
+        "pr",
+        "checks",
+        String(number),
+        ...repoFlag(repo),
+        ...(required ? ["--required"] : []),
+        "--json",
+        jsonFields.join(","),
+      ];
+      try {
+        const parsed = ghJson(args, opts);
+        if (!Array.isArray(parsed)) {
+          throw new ForgeError("gh pr checks did not return an array", {
+            status: 0,
+            stdout: JSON.stringify(parsed),
+          });
+        }
+        return parsed;
+      } catch (err) {
+        if (!(err instanceof ForgeError)) throw err;
+        // `gh pr checks --json` still prints the array when checks are red or
+        // pending on some CLI versions (exit 1 / 8). Prefer the snapshot.
+        if (err.stdout) {
+          try {
+            const parsed = JSON.parse(err.stdout);
+            if (Array.isArray(parsed)) return parsed;
+          } catch {
+            // not JSON — fall through to the empty-snapshot diagnostics
+          }
+        }
+        const diagnostic = (err.stderr || "").trim();
+        if (err.status === 1 && NO_CHECKS_RE.test(diagnostic)) return [];
+        throw err;
+      }
     },
 
     runList(repo, { branch, created, limit, fields, ...opts } = {}) {

--- a/lib/forge/memory.mjs
+++ b/lib/forge/memory.mjs
@@ -7,7 +7,8 @@
  *     repos: {
  *       "owner/name": {
  *         prs:  [{ number, state, isDraft, labels:[{name}], headRefName,
- *                  headRefOid, title, body, url, files:[...], comments:[...] }],
+ *                  headRefOid, title, body, url, files:[...], comments:[...],
+ *                  checks:[{ name, bucket, state, required }] }],
  *         runs: [{ databaseId, name, workflowName, status, conclusion,
  *                  headBranch, createdAt, startedAt, updatedAt }],
  *       },
@@ -19,7 +20,7 @@
  * at" case). Every mutation is recorded on `forge.calls` so a test can assert
  * what would have been done.
  */
-import { ForgeError } from "./types.mjs";
+import { ForgeError, PR_CHECK_FIELDS } from "./types.mjs";
 
 const pick = (obj, fields) =>
   fields?.length
@@ -98,6 +99,15 @@ export function memoryForge({ repos = {}, api = {}, defaultRepo = null } = {}) {
       calls.push({ op: "prComment", repo, number, body });
       const pr = findPr(repo, number);
       (pr.comments ??= []).push({ body });
+    },
+
+    prChecks(repo, number, { required, fields } = {}) {
+      calls.push({ op: "prChecks", repo, number, required, fields });
+      let checks = [...(findPr(repo, number).checks ?? [])];
+      if (required) checks = checks.filter((c) => c.required);
+      return checks.map((c) =>
+        pick(c, fields?.length ? fields : [...PR_CHECK_FIELDS]),
+      );
     },
 
     runList(repo, { branch, created, limit, fields } = {}) {

--- a/lib/forge/types.mjs
+++ b/lib/forge/types.mjs
@@ -60,6 +60,32 @@
  */
 
 /**
+ * @typedef {ForgeCallOpts & {
+ *   required?: boolean,  // only checks branch protection requires
+ *   fields?: string[],
+ * }} PrChecksOpts
+ */
+
+/**
+ * One CI check on a pull request. Neutral across forges: GitHub's
+ * `gh pr checks --json` vocabulary (`name` / `bucket` / `state`), so
+ * merge-ci-proof can consume the array without knowing which implementation
+ * produced it.
+ *
+ * `bucket` categorises `state` as `pass` | `fail` | `pending` | `skipping` |
+ * `cancel`. `state` is the uppercase conclusion (`SUCCESS`, `FAILURE`,
+ * `PENDING`, `SKIPPED`, …).
+ *
+ * @typedef {object} PrCheck
+ * @property {string} name
+ * @property {string} bucket
+ * @property {string} state
+ */
+
+/** Default JSON fields for {@link Forge.prChecks}. */
+export const PR_CHECK_FIELDS = Object.freeze(["name", "bucket", "state"]);
+
+/**
  * @typedef {object} ForgeCli
  * @property {string|null} bin      executable the implementation shells out to
  *                                  (`gh`), or null when it needs none
@@ -80,6 +106,11 @@
  *   Convert the pull request to draft (`true`) or mark it ready (`false`).
  * @property {(repo: RepoRef, number: number|string, body: string, opts?: ForgeCallOpts) => void} prComment
  *   Post a comment on the pull request.
+ * @property {(repo: RepoRef, number: number|string, opts?: PrChecksOpts) => PrCheck[]} prChecks
+ *   Snapshot of check-runs and commit statuses on the pull request. Empty
+ *   when the PR exists but has no checks (or no required checks, when
+ *   `required` is set). Does not watch; callers that need to wait stay on
+ *   `gh pr checks --watch`.
  * @property {(repo: RepoRef, opts?: RunListOpts) => object[]} runList
  *   Workflow runs matching the filter, each with the requested `fields`.
  * @property {(path: string, opts?: ApiRawOpts) => string} apiRaw


### PR DESCRIPTION
## Summary
- Add `prChecks(repo, n, opts?)` to the Forge contract, returning a neutral `{ name, bucket, state }[]` snapshot of PR check-runs and commit statuses.
- GitHub implementation wraps `gh pr checks --json`; empty-check CLI diagnostics map to `[]`, red/pending JSON on a non-zero exit still returns the array, unknown PRs still throw `ForgeError`.
- Memory fake seeds `pr.checks` and honours `opts.required`; contract tests cover both implementations.

Fixes WM-862

UX critique: skipped — library/backend forge connector, no user-facing surface.

## Test plan
- [x] `bun test lib/forge/contract.test.mjs` (35 pass)
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `bun test` (3064 pass, 0 fail)

Made with [Cursor](https://cursor.com)