### PR TITLE
fix(web): mirror answer required-text request validation in decision port (WM-753)

### DIFF
--- a/event-runtime/web/src/lib/decision.test.ts
+++ b/event-runtime/web/src/lib/decision.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { DecisionRequest, DecisionResponse } from "../types";
-import { decisionRequestHash, validateDecisionResponse } from "./decision";
+import {
+  checkRequest,
+  decisionRequestHash,
+  validateDecisionResponse,
+} from "./decision";
 
 interface SharedCase {
   name: string;
   request: DecisionRequest;
   hash: string;
+  requestValid?: boolean;
   responses: { name: string; valid: boolean; value: DecisionResponse }[];
 }
 
@@ -23,6 +28,17 @@ describe("browser decision port", () => {
       expect(decisionRequestHash(fixture.request), fixture.name).toBe(
         fixture.hash,
       );
+      if (fixture.requestValid !== undefined) {
+        expect(
+          checkRequest(fixture.request).valid,
+          `${fixture.name}/request`,
+        ).toBe(fixture.requestValid);
+      }
+      if (fixture.name === "answer-without-required-text") {
+        expect(checkRequest(fixture.request).errors).toContain(
+          "option_requires_text:answer",
+        );
+      }
       for (const response of fixture.responses) {
         expect(
           validateDecisionResponse(response.value, fixture.request).valid,
@@ -67,5 +83,67 @@ describe("browser decision port", () => {
         malformed as unknown as DecisionRequest,
       ).valid,
     ).toBe(false);
+  });
+
+  test("answer and reject_proposal require an applicable required text field", () => {
+    for (const effect of ["answer", "reject_proposal"] as const) {
+      const request: DecisionRequest = {
+        schemaVersion: "factory.decision-request/v1",
+        question: "Need a reason",
+        options: [{ id: "choice", label: "Choice", effect }],
+      };
+      expect(checkRequest(request).errors).toContain(
+        "option_requires_text:choice",
+      );
+
+      const withRequiredText: DecisionRequest = {
+        ...request,
+        fields: [
+          {
+            id: "reason",
+            kind: "text",
+            label: "Reason",
+            required: true,
+          },
+        ],
+      };
+      expect(checkRequest(withRequiredText).valid).toBe(true);
+
+      const optionalOnly: DecisionRequest = {
+        ...request,
+        fields: [
+          {
+            id: "reason",
+            kind: "text",
+            label: "Reason",
+            required: false,
+          },
+        ],
+      };
+      expect(checkRequest(optionalOnly).errors).toContain(
+        "option_requires_text:choice",
+      );
+
+      const gatedElsewhere: DecisionRequest = {
+        schemaVersion: "factory.decision-request/v1",
+        question: "Need a reason",
+        options: [
+          { id: "choice", label: "Choice", effect },
+          { id: "other", label: "Other", effect: "dismiss" },
+        ],
+        fields: [
+          {
+            id: "reason",
+            kind: "text",
+            label: "Reason",
+            required: true,
+            whenOption: ["other"],
+          },
+        ],
+      };
+      expect(checkRequest(gatedElsewhere).errors).toContain(
+        "option_requires_text:choice",
+      );
+    }
   });
 });

--- a/event-runtime/web/src/lib/decision.ts
+++ b/event-runtime/web/src/lib/decision.ts
@@ -181,7 +181,7 @@ function duplicateValues(values: string[]): string[] {
 }
 
 /** The response port re-checks the semantic request rules needed at answer time. */
-function checkRequest(request: DecisionRequest): ValidationResult {
+export function checkRequest(request: DecisionRequest): ValidationResult {
   const shape = validate(DECISION_REQUEST_SCHEMA, request);
   if (!shape.valid) return shape;
   const errors: string[] = [];
@@ -276,19 +276,17 @@ function checkRequest(request: DecisionRequest): ValidationResult {
     )
       errors.push(`${path}: minimum cannot exceed maximum`);
   }
-  for (const [index, option] of request.options.entries()) {
-    if (option.effect !== "reject_proposal") continue;
-    const reasonField = fields.some(
+  for (const option of request.options) {
+    if (option.effect !== "answer" && option.effect !== "reject_proposal")
+      continue;
+    const textField = fields.some(
       (field) =>
         field.kind === "text" &&
         field.required === true &&
         (field.whenOption === undefined ||
           field.whenOption.includes(option.id)),
     );
-    if (!reasonField)
-      errors.push(
-        `$.options[${index}].effect: "reject_proposal" requires an applicable required text field`,
-      );
+    if (!textField) errors.push(`option_requires_text:${option.id}`);
   }
   return result(errors);
 }


### PR DESCRIPTION
## Summary
- Mirror the runtime `answer` required-text rule in the browser `checkRequest` so both `answer` and `reject_proposal` options without an applicable required text field fail with `option_requires_text:<optionId>`.
- Assert shared-fixture `requestValid` verdicts in the browser test, including `answer-without-required-text`.

Fixes WM-753

UX critique: skipped — request-validation port in `event-runtime/web/src/lib`; no user-facing flow, layout, or interaction change.

## Test plan
- [x] `bun test event-runtime/web/src/lib/decision.test.ts` — 4 pass
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `cd event-runtime/web && bun run build`
- [ ] Reviewer: confirm `option_requires_text` matches `event-runtime/lib/decision.mjs`


Made with [Cursor](https://cursor.com)