### PR TITLE
ui(inbox): make proposal decision items say what is being approved (WM-896)

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -365,8 +365,16 @@ configuration faults that show as anomalies, not questions for a person.
   `dismiss` — never `authorise` (§1, out of scope: nothing merges from here).
 - **Proposals.** `decision_needed` / `proposal_expired` items get the
   `proposal` default (`approve_proposal` / `reject_proposal` + required
-  `text` gated on reject). This replaces WM-287's hardcoded approve/reject
-  buttons with the same behaviour expressed as a template.
+  `text` gated on reject). The inbox title is action-first from
+  `proposalSubject(spec)` (dispatch: `Dispatch <ticket> · <repo> · <model>`;
+  other agents: `<Agent verb> <primary input>`). Expiry is a live countdown
+  on the row, never baked into the title. Telegram still uses
+  `DECISION NEEDED proposal <id> (<agent>): …`. The decision card question
+  names the run (`Run dispatch@1 for WM-862 (factory) on <model>?`), a
+  **Why you're being asked** line renders `proposals.reason` in plain
+  English, and the Linear ticket + proposal links sit on the card. This
+  replaces WM-287's hardcoded approve/reject buttons with the same
+  behaviour expressed as a template.
 
 ### 4.3 Default templates
 

--- a/event-runtime/lib/decision-templates.mjs
+++ b/event-runtime/lib/decision-templates.mjs
@@ -1,4 +1,8 @@
 /** Default, schema-valid decision requests for runtime inbox producers. */
+import {
+  proposalDecisionContext,
+  proposalQuestion,
+} from "./proposal-subject.mjs";
 
 const dismiss = () => ({
   id: "dismiss",
@@ -122,7 +126,7 @@ function mergeEscalation(refs) {
   };
 }
 
-function proposal(refs) {
+function proposal(refs, { spec, reason } = {}) {
   const options = [];
   if (refs.proposalId) {
     options.push({
@@ -139,11 +143,11 @@ function proposal(refs) {
     });
   }
   options.push(dismiss());
+  const context = proposalDecisionContext(reason);
   return {
     schemaVersion: "factory.decision-request/v1",
-    question: refs.proposalId
-      ? `Decide proposal ${refs.proposalId}`
-      : "Should this proposal notification be dismissed?",
+    question: proposalQuestion(spec, { proposalId: refs.proposalId }),
+    ...(context ? { context } : {}),
     options,
     fields: refs.proposalId
       ? [
@@ -182,12 +186,16 @@ export function replannedProposalContext(previousProposalId, proposalId) {
  * template when several producers share a kind. `context` is the optional §2.1
  * free-text preamble; omitted rather than serialised when absent.
  */
-export function templateFor(kind, { producer, refs = {}, context } = {}) {
+export function templateFor(
+  kind,
+  { producer, refs = {}, context, spec, reason } = {},
+) {
   const selected = producer ?? String(kind ?? "").toLowerCase();
   const builder = BUILDERS[selected];
   if (!builder)
     throw new Error(`unknown decision template producer: ${selected}`);
-  const request = builder(refs);
+  const request =
+    selected === "proposal" ? proposal(refs, { spec, reason }) : builder(refs);
   if (context !== undefined) {
     if (typeof context !== "string" || context.trim() === "") {
       throw new Error("decision template context must be a non-empty string");

--- a/event-runtime/lib/decision-templates.test.mjs
+++ b/event-runtime/lib/decision-templates.test.mjs
@@ -43,6 +43,35 @@ describe("default decision templates (WM-390)", () => {
     );
   });
 
+  test("a dispatch proposal names the ticket, repo, model, and why-line (WM-896)", () => {
+    const refs = {
+      proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+      issue: "WM-862",
+      repo: "factory",
+    };
+    const spec = {
+      agent: "dispatch@1",
+      model: "cursor-grok-4.6-high",
+      input: { ticket: "WM-862", repo: "factory" },
+    };
+    const request = templateFor("decision_needed", {
+      producer: "proposal",
+      refs,
+      spec,
+      reason: "auto_approval_ineligible:dispatch_recheck_failed",
+    });
+    expect(validateDecisionRequest(request, { refs })).toEqual({
+      valid: true,
+      errors: [],
+    });
+    expect(request.question).toBe(
+      "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+    );
+    expect(request.context).toBe(
+      "**Why you're being asked.** Auto-approval re-check failed (see proposal)",
+    );
+  });
+
   test("a re-planned proposal reuses the proposal template with a re-review context (WM-714)", () => {
     const refs = { proposalId: "prop_2" };
     const context = replannedProposalContext("prop_1", "prop_2");

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -128,6 +128,51 @@ describe("human inbox ledger (WM-285)", () => {
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
   });
 
+  test("a dispatch proposal item stores the action-first title and why-line (WM-896)", () => {
+    const db = openDb(":memory:");
+    const refs = {
+      proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+      issue: "WM-862",
+      repo: "factory",
+      eventSource: "test",
+      eventId: "evt",
+    };
+    const spec = {
+      agent: "dispatch@1",
+      model: "cursor-grok-4.6-high",
+      input: { ticket: "WM-862", repo: "factory" },
+    };
+    const created = createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+        refs,
+        source: "serve:notify",
+        decision: templateFor("decision_needed", {
+          producer: "proposal",
+          refs,
+          spec,
+          reason: "auto_approval_ineligible:dispatch_recheck_failed",
+        }),
+        dedupeKey: "decision_needed:prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+      },
+      { id: "inbox_dispatch" },
+    );
+    expect(created.title).toBe(
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+    );
+    expect(created.decision.question).toBe(
+      "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+    );
+    expect(created.decision.context).toContain("Why you're being asked");
+    expect(created.refs).toMatchObject({
+      issue: "WM-862",
+      repo: "factory",
+      proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+    });
+  });
+
   test("a different decision shape on the same caller key still supersedes", () => {
     const db = openDb(":memory:");
     const first = createInboxItem(

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -32,6 +32,7 @@ import path from "node:path";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
 import { txImmediate } from "./db.mjs";
 import { templateFor } from "./decision-templates.mjs";
+import { proposalSubject } from "./proposal-subject.mjs";
 
 export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hdkiller", "scripts", "notify.py")}`;
 
@@ -97,15 +98,16 @@ function alreadyNotified(db, kind, target) {
  *   - every `human_needed` event not yet notified —
  *     `BLOCKED <event-type> <eventId>: <reason>`
  *   - every open watched 'run' proposal past 50% of its TTL —
+ *     inbox title from `proposalSubject(spec)`; Telegram
  *     `DECISION NEEDED proposal <id> (<agent>): expires in <n>m`
  *   - every open watched 'run' proposal past its full TTL, once more —
- *     `DECISION NEEDED proposal <id> (<agent>): expired undecided`
+ *     same inbox title; Telegram `… expired undecided`
  *
  * A proposal decided before the 50% threshold is no longer `status = 'open'`
  * and never appears here. Scheduled auto-approved proposals are decided
  * within a tick of creation, so they never age into either threshold.
  *
- * @returns {Array<{ kind: string, dedupKind?: string, target: string, title: string, refs: object, source: string }>}
+ * @returns {Array<{ kind: string, dedupKind?: string, target: string, title: string, message?: string, refs: object, source: string }>}
  */
 export function pendingNotifications(db, { now = Date.now() } = {}) {
   ensureNotifyLog(db);
@@ -131,6 +133,7 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
       dedupKind: KIND_HUMAN_NEEDED,
       target,
       title: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
+      message: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
       refs: { eventSource: e.source, eventId: e.eventId },
       source: "serve:notify",
       decision: templateFor("BLOCKED", {
@@ -152,26 +155,36 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
     if (ageMs < ttlMs / 2) continue;
     const spec = p.spec_json ? JSON.parse(p.spec_json) : null;
     const agent = spec?.agent ?? "?";
+    const title = proposalSubject(spec);
+    const issue =
+      typeof spec?.input?.ticket === "string" ? spec.input.ticket : null;
+    const repo = typeof spec?.input?.repo === "string" ? spec.input.repo : null;
+    const refs = {
+      proposalId: p.id,
+      eventSource: p.event_source,
+      eventId: p.event_id,
+      ...(issue ? { issue } : {}),
+      ...(repo ? { repo } : {}),
+    };
+    const decision = templateFor(
+      ageMs > ttlMs ? KIND_PROPOSAL_EXPIRED : KIND_DECISION_NEEDED,
+      {
+        producer: "proposal",
+        refs,
+        spec,
+        reason: p.reason,
+      },
+    );
     if (ageMs > ttlMs) {
       if (!alreadyNotified(db, KIND_PROPOSAL_EXPIRED, p.id)) {
         pending.push({
           kind: KIND_PROPOSAL_EXPIRED,
           target: p.id,
-          title: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
-          refs: {
-            proposalId: p.id,
-            eventSource: p.event_source,
-            eventId: p.event_id,
-          },
+          title,
+          message: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
+          refs,
           source: "serve:notify",
-          decision: templateFor(KIND_PROPOSAL_EXPIRED, {
-            producer: "proposal",
-            refs: {
-              proposalId: p.id,
-              eventSource: p.event_source,
-              eventId: p.event_id,
-            },
-          }),
+          decision,
           dedupeKey: `${KIND_PROPOSAL_EXPIRED}:${p.id}`,
         });
       }
@@ -181,21 +194,11 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
         kind: KIND_DECISION_NEEDED,
         dedupKind: DEDUP_PROPOSAL_TTL,
         target: p.id,
-        title: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
-        refs: {
-          proposalId: p.id,
-          eventSource: p.event_source,
-          eventId: p.event_id,
-        },
+        title,
+        message: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
+        refs,
         source: "serve:notify",
-        decision: templateFor(KIND_DECISION_NEEDED, {
-          producer: "proposal",
-          refs: {
-            proposalId: p.id,
-            eventSource: p.event_source,
-            eventId: p.event_id,
-          },
-        }),
+        decision,
         dedupeKey: `${KIND_DECISION_NEEDED}:${p.id}`,
       });
     }
@@ -296,33 +299,48 @@ export function notifyPending(
       // create a row for one referent.
       if (alreadyNotified(db, dedupKind, n.target)) return null;
       const item = createInboxItem(db, n, { now });
+      const pushMessage = n.message ?? n.title;
       db.query(
         `INSERT INTO notify_log (kind, target, message, sent_at, inbox_item_id)
          VALUES (?, ?, ?, ?, ?)`,
-      ).run(dedupKind, n.target, n.title, at, item.id);
+      ).run(dedupKind, n.target, pushMessage, at, item.id);
       return item;
     });
     if (!created) continue;
-    const notification = { ...n, message: n.title, inboxItemId: created.id };
+    const pushMessage = n.message ?? n.title;
+    const notification = {
+      ...n,
+      message: pushMessage,
+      inboxItemId: created.id,
+    };
     log(`inbox ${n.kind} ${n.target}: ${n.title}`);
     if (!enabled) continue;
     sent.push(notification);
-    log(`notify ${n.kind} ${n.target}: ${n.title}`);
+    log(`notify ${n.kind} ${n.target}: ${pushMessage}`);
     deliveries.push(
-      deliverInboxItem(db, created.id, { command, send, webUrl, now }).then(
-        (outcome) => {
-          try {
-            db.query(
-              `UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`,
-            ).run(outcome.exitCode, outcome.error, dedupKind, n.target);
-          } catch {
-            // db already closed (shutdown mid-delivery) — the log line below is the record
+      deliverInboxItem(db, created.id, {
+        command,
+        send: (cmd, content) => {
+          const lines = String(content).split("\n");
+          if (lines[0] === created.title && pushMessage !== created.title) {
+            lines[0] = pushMessage;
           }
-          if (!outcome.ok)
-            log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
-          return { ...notification, ...outcome };
+          return send(cmd, lines.join("\n"));
         },
-      ),
+        webUrl,
+        now,
+      }).then((outcome) => {
+        try {
+          db.query(
+            `UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`,
+          ).run(outcome.exitCode, outcome.error, dedupKind, n.target);
+        } catch {
+          // db already closed (shutdown mid-delivery) — the log line below is the record
+        }
+        if (!outcome.ok)
+          log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
+        return { ...notification, ...outcome };
+      }),
     );
   }
   return { sent, deliveries: Promise.all(deliveries) };

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -71,10 +71,20 @@ function insertProposal(
     status = "open",
     reason = null,
     agent = "worktree-ticket@1",
+    input,
+    model,
     createdAt,
     ttlSeconds = 1800,
   },
 ) {
+  const spec =
+    decision === "run"
+      ? {
+          agent,
+          ...(input ? { input } : {}),
+          ...(model ? { model } : {}),
+        }
+      : null;
   db.query(
     `INSERT INTO proposals (id, event_source, event_id, run_id, decision, spec_json, spec_hash, status, reason, created_at, ttl_seconds)
      VALUES (?, 'test', ?, ?, ?, ?, 'sha256:x', ?, ?, ?, ?)`,
@@ -83,7 +93,7 @@ function insertProposal(
     eventId,
     decision === "run" ? `run_${id}` : null,
     decision,
-    decision === "run" ? JSON.stringify({ agent }) : null,
+    spec ? JSON.stringify(spec) : null,
     status,
     reason,
     createdAt ?? new Date().toISOString(),
@@ -237,14 +247,16 @@ describe("notify (WM-65)", () => {
 
     const first = sent(now);
     expect(first).toHaveLength(1);
+    expect(first[0].title).toBe("Ci-Doctor");
     expect(first[0].message).toBe(
       "DECISION NEEDED proposal prop-aging (ci-doctor@2): expires in 14m",
     );
     const proposalItem = db
       .query(
-        "SELECT decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
+        "SELECT title, decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
       )
       .get();
+    expect(proposalItem.title).toBe("Ci-Doctor");
     expect(
       JSON.parse(proposalItem.decision_json).options.map(
         (option) => option.effect,
@@ -263,11 +275,70 @@ describe("notify (WM-65)", () => {
     // Past TTL: one final push, then silence.
     const expired = sent(now + 15 * 60_000);
     expect(expired).toHaveLength(1);
+    expect(expired[0].title).toBe("Ci-Doctor");
     expect(expired[0].message).toBe(
       "DECISION NEEDED proposal prop-aging (ci-doctor@2): expired undecided",
     );
     expect(sent(now + 16 * 60_000)).toEqual([]);
     expect(sent(now + 60 * 60_000)).toEqual([]);
+  });
+
+  test("a dispatch proposal inbox title is action-first; Telegram keeps DECISION NEEDED (WM-896)", async () => {
+    const dir = tmp("evrt-notify-dispatch-");
+    const stub = stubNotifier(dir);
+    const db = openDb(":memory:");
+    const now = Date.now();
+    insertEvent(db, { eventId: "evt-dispatch" });
+    insertProposal(db, {
+      id: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+      eventId: "evt-dispatch",
+      agent: "dispatch@1",
+      model: "cursor-grok-4.6-high",
+      input: { ticket: "WM-862", repo: "factory" },
+      reason: "auto_approval_ineligible:dispatch_recheck_failed",
+      createdAt: new Date(now - 16 * 60_000).toISOString(),
+      ttlSeconds: 1800,
+    });
+
+    const out = notifyPending(db, {
+      now,
+      enabled: true,
+      command: stub.bin,
+      webUrl: "http://127.0.0.1:7382",
+    });
+    expect(out.sent).toHaveLength(1);
+    expect(out.sent[0].title).toBe(
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+    );
+    expect(out.sent[0].message).toBe(
+      "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 14m",
+    );
+    const item = db
+      .query(
+        "SELECT title, refs_json, decision_json FROM inbox_items WHERE kind = 'decision_needed'",
+      )
+      .get();
+    expect(item.title).toBe("Dispatch WM-862 · factory · cursor-grok-4.6-high");
+    expect(JSON.parse(item.refs_json)).toMatchObject({
+      proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+      issue: "WM-862",
+      repo: "factory",
+    });
+    const decision = JSON.parse(item.decision_json);
+    expect(decision.question).toBe(
+      "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+    );
+    expect(decision.context).toContain("Why you're being asked");
+    expect(decision.context).toContain(
+      "Auto-approval re-check failed (see proposal)",
+    );
+    await out.deliveries;
+    expect(stub.pushes()[0]).toBe(
+      "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 14m",
+    );
+    expect(stub.pushes()[1]).toBe(
+      "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+    );
   });
 
   test("a proposal approved or rejected before the threshold never notifies", () => {

--- a/event-runtime/lib/proposal-subject.mjs
+++ b/event-runtime/lib/proposal-subject.mjs
@@ -75,8 +75,7 @@ function dispatchTicketTitle(spec) {
 }
 
 function dispatchFallback(spec) {
-  const input =
-    spec?.input && typeof spec.input === "object" ? spec.input : {};
+  const input = spec?.input && typeof spec.input === "object" ? spec.input : {};
   const ticket = typeof input.ticket === "string" ? input.ticket : "?";
   const repo = typeof input.repo === "string" ? input.repo : "?";
   const model =

--- a/event-runtime/lib/proposal-subject.mjs
+++ b/event-runtime/lib/proposal-subject.mjs
@@ -1,36 +1,156 @@
 /**
- * One-line subject for a proposal / run spec (WM-896 / WM-897).
+ * Human-facing subject / question for a proposal / run spec (WM-896 / WM-897).
  *
- * Prefers the agent's `factory.artifact-view/v1` `subject` template when the
- * view defines one (`specSubject`). Dispatch keeps a hard-coded fallback so
- * a missing sidecar still reads as "Dispatch TICKET · repo · model" on the
- * inbox card and Telegram — the same line WM-896 shipped before the view
- * existed.
+ * `proposalSubject` prefers the agent's `factory.artifact-view/v1` `subject`
+ * template when the view defines one (`specSubject`, WM-897) — callers that
+ * pass a registry get that priority. Dispatch keeps a hard-coded fallback
+ * (ticket · repo · model, with a cached Linear ticket title appended after
+ * an em dash when evidence has one) so a missing sidecar still reads as
+ * "Dispatch TICKET · repo · model" on the inbox card and Telegram — the
+ * same line WM-896 shipped before the view existed. Every other agent
+ * without a subject falls through to an action-first `<Agent verb> <primary
+ * input>` line instead of a bare null, so inbox items and Telegram pushes
+ * always say what is being approved (WM-896).
+ *
+ * Callable either as `proposalSubject(spec)` — registry-less call sites
+ * (notify.mjs, decision-templates.mjs) skip the view-template step — or as
+ * `proposalSubject(registry, spec)` (api-runs.mjs), which tries the view
+ * first.
  */
 import { specSubject } from "./spec-subject.mjs";
 
-function isDispatch(agent) {
-  return typeof agent === "string" && agent.split("@")[0] === "dispatch";
+const REASON_PLAIN = Object.freeze({
+  "auto_approval_ineligible:dispatch_recheck_failed":
+    "Auto-approval re-check failed (see proposal)",
+  "auto_approval_ineligible:capacity_full": "Repo at in-flight cap",
+  "auto_approval_ineligible:evidence_changed_since_plan":
+    "Ticket changed since planning",
+});
+
+const PRIMARY_INPUT_KEYS = Object.freeze([
+  "ticket",
+  "issue",
+  "pr",
+  "prNumber",
+  "runId",
+  "repo",
+]);
+
+/** Agent id without the `@version` suffix (`dispatch@1` → `dispatch`). */
+export function agentFamily(agent) {
+  if (typeof agent !== "string" || agent.trim() === "") return "";
+  return agent.trim().replace(/@\d+$/, "");
+}
+
+/** Title-case the agent family so it reads as a verb (`ci-doctor` → `Ci-doctor`). */
+export function agentVerb(agent) {
+  const family = agentFamily(agent);
+  if (!family) return "Run";
+  return family
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("-");
+}
+
+function stringField(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/** The first operator-meaningful field on `spec.input`. */
+export function primaryInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  for (const key of PRIMARY_INPUT_KEYS) {
+    const value = stringField(input[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function dispatchTicketTitle(spec) {
+  const title = spec?.approvalPolicy?.dispatchEvidence?.ticket?.title;
+  return stringField(title);
 }
 
 function dispatchFallback(spec) {
-  const input = spec?.input && typeof spec.input === "object" ? spec.input : {};
+  const input =
+    spec?.input && typeof spec.input === "object" ? spec.input : {};
   const ticket = typeof input.ticket === "string" ? input.ticket : "?";
   const repo = typeof input.repo === "string" ? input.repo : "?";
   const model =
     typeof spec?.model === "string" && spec.model ? spec.model : "default";
-  return `Dispatch ${ticket} · ${repo} · ${model}`;
+  const subject = `Dispatch ${ticket} · ${repo} · ${model}`;
+  const ticketTitle = dispatchTicketTitle(spec);
+  return ticketTitle ? `${subject} — ${ticketTitle}` : subject;
 }
 
 /**
- * `proposalSubject(registry, spec) → string | null`
+ * `proposalSubject(spec) → string` or `proposalSubject(registry, spec) → string | null`
  *
- * View `subject` wins. Dispatch without a subject still gets the fallback.
- * Every other agent without a subject returns null. Never throws.
+ * View `subject` wins when a registry is passed. Dispatch without a subject
+ * still gets the ticket/repo/model fallback. Every other agent without a
+ * subject gets an action-first `<Verb> <primary input>` line. Only a
+ * non-object spec (with a registry supplied) returns null. Never throws.
  */
-export function proposalSubject(registry, spec) {
-  const fromView = specSubject(registry, spec);
+export function proposalSubject(a, b) {
+  const hasRegistry = b !== undefined;
+  const registry = hasRegistry ? a : null;
+  const spec = hasRegistry ? b : a;
+
+  const fromView = registry ? specSubject(registry, spec) : null;
   if (fromView) return fromView;
-  if (isDispatch(spec?.agent)) return dispatchFallback(spec);
-  return null;
+
+  const agent = spec?.agent;
+  if (agentFamily(agent) === "dispatch") return dispatchFallback(spec);
+
+  if (hasRegistry && (!spec || typeof spec !== "object")) return null;
+  if (hasRegistry && typeof agent !== "string") return null;
+
+  const verb = agentVerb(agent);
+  const primary = primaryInput(spec?.input);
+  return primary ? `${verb} ${primary}` : verb;
 }
+
+/** Decision-card question: what the operator is about to run. */
+export function proposalQuestion(spec, { proposalId } = {}) {
+  const agent = stringField(spec?.agent);
+  if (!agent) {
+    return proposalId
+      ? `Decide proposal ${proposalId}`
+      : "Should this proposal notification be dismissed?";
+  }
+  const input = spec?.input ?? {};
+  if (agentFamily(agent) === "dispatch") {
+    const ticket = stringField(input.ticket) ?? "?";
+    const repo = stringField(input.repo) ?? "?";
+    const model = stringField(spec?.model) ?? "?";
+    return `Run ${agent} for ${ticket} (${repo}) on ${model}?`;
+  }
+  const primary = primaryInput(input);
+  return primary ? `Run ${agent} for ${primary}?` : `Run ${agent}?`;
+}
+
+/** Operator-facing sentence for `proposals.reason`; unknown codes pass through. */
+export function proposalReasonPlain(reason) {
+  const code = stringField(reason);
+  if (!code) return null;
+  if (REASON_PLAIN[code]) return REASON_PLAIN[code];
+  const prefixed = code.startsWith("auto_approval_ineligible:")
+    ? code
+    : `auto_approval_ineligible:${code}`;
+  return REASON_PLAIN[prefixed] ?? code;
+}
+
+/**
+ * Markdown context for the proposal decision card. Only the why-line lives
+ * here; ticket and proposal links are rendered from `refs` on the card.
+ */
+export function proposalDecisionContext(reason) {
+  const why = proposalReasonPlain(reason);
+  if (!why) return undefined;
+  return `**Why you're being asked.** ${why}`;
+}
+
+export default proposalSubject;

--- a/event-runtime/lib/proposal-subject.test.mjs
+++ b/event-runtime/lib/proposal-subject.test.mjs
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { proposalSubject } from "./proposal-subject.mjs";
+import {
+  agentFamily,
+  agentVerb,
+  primaryInput,
+  proposalDecisionContext,
+  proposalQuestion,
+  proposalReasonPlain,
+  proposalSubject,
+} from "./proposal-subject.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
 const emptyRegistry = { views: new Map() };
+
+const dispatchSpec = {
+  agent: "dispatch@1",
+  model: "cursor-grok-4.6-high",
+  input: { ticket: "WM-862", repo: "factory" },
+};
 
 describe("proposalSubject (WM-897)", () => {
   test("delegates to the view subject when the agent's sidecar defines one", () => {
@@ -33,13 +47,110 @@ describe("proposalSubject (WM-897)", () => {
     ).toBe("Dispatch ? · ? · default");
   });
 
-  test("returns null for a non-dispatch agent without a subject", () => {
+  test("a non-dispatch agent without a view subject falls through to <verb> <primary input> (WM-896)", () => {
     expect(
       proposalSubject(registry, {
         agent: "merge-scan@2",
         input: { repo: "factory" },
       }),
-    ).toBeNull();
+    ).toBe("Merge-Scan factory");
     expect(proposalSubject(registry, null)).toBeNull();
+  });
+});
+
+describe("proposalSubject (WM-896)", () => {
+  test("dispatch is ticket · repo · model, with an em-dash title when evidence has one", () => {
+    expect(proposalSubject(dispatchSpec)).toBe(
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+    );
+    expect(
+      proposalSubject({
+        ...dispatchSpec,
+        approvalPolicy: {
+          dispatchEvidence: { ticket: { title: "feat(forge): add prChecks" } },
+        },
+      }),
+    ).toBe(
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high — feat(forge): add prChecks",
+    );
+    expect(
+      proposalSubject({
+        ...dispatchSpec,
+        approvalPolicy: { dispatchEvidence: { ticket: {} } },
+      }),
+    ).toBe("Dispatch WM-862 · factory · cursor-grok-4.6-high");
+  });
+
+  test("other agents use <verb> <primary input>", () => {
+    expect(agentFamily("triage-scan@1")).toBe("triage-scan");
+    expect(agentVerb("triage-scan@1")).toBe("Triage-Scan");
+    expect(agentVerb("ci-doctor@2")).toBe("Ci-Doctor");
+    expect(primaryInput({ repo: "factory" })).toBe("factory");
+    expect(
+      proposalSubject({
+        agent: "triage-scan@1",
+        input: { repo: "factory" },
+      }),
+    ).toBe("Triage-Scan factory");
+    expect(
+      proposalSubject({
+        agent: "merge-scan@2",
+        input: { repo: "bj29", prNumbers: [12] },
+      }),
+    ).toBe("Merge-Scan bj29");
+    expect(proposalSubject({ agent: "ci-doctor@2" })).toBe("Ci-Doctor");
+    expect(proposalSubject(null)).toBe("Run");
+  });
+});
+
+describe("proposalQuestion", () => {
+  test("dispatch names the agent, ticket, repo, and model", () => {
+    expect(proposalQuestion(dispatchSpec)).toBe(
+      "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+    );
+  });
+
+  test("falls back to the proposal id when the spec is missing", () => {
+    expect(proposalQuestion(null, { proposalId: "prop_1" })).toBe(
+      "Decide proposal prop_1",
+    );
+    expect(proposalQuestion({})).toBe(
+      "Should this proposal notification be dismissed?",
+    );
+    expect(
+      proposalQuestion({ agent: "ci-doctor@2", input: { repo: "acme/app" } }),
+    ).toBe("Run ci-doctor@2 for acme/app?");
+  });
+});
+
+describe("proposalReasonPlain", () => {
+  test("maps known auto-approval codes and passes unknown through", () => {
+    expect(
+      proposalReasonPlain("auto_approval_ineligible:dispatch_recheck_failed"),
+    ).toBe("Auto-approval re-check failed (see proposal)");
+    expect(proposalReasonPlain("auto_approval_ineligible:capacity_full")).toBe(
+      "Repo at in-flight cap",
+    );
+    expect(
+      proposalReasonPlain(
+        "auto_approval_ineligible:evidence_changed_since_plan",
+      ),
+    ).toBe("Ticket changed since planning");
+    expect(proposalReasonPlain("capacity_full")).toBe("Repo at in-flight cap");
+    expect(proposalReasonPlain("auto_approval_ineligible:hook_denied")).toBe(
+      "auto_approval_ineligible:hook_denied",
+    );
+    expect(proposalReasonPlain(null)).toBeNull();
+  });
+
+  test("decision context is omitted when there is no reason", () => {
+    expect(proposalDecisionContext(null)).toBeUndefined();
+    expect(
+      proposalDecisionContext(
+        "auto_approval_ineligible:dispatch_recheck_failed",
+      ),
+    ).toBe(
+      "**Why you're being asked.** Auto-approval re-check failed (see proposal)",
+    );
   });
 });

--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -158,6 +158,55 @@ describe("DecisionCard", () => {
     ).toBeTruthy();
   });
 
+  test("proposal cards show ticket and proposal links on the card (WM-896)", () => {
+    const onJumpProposal = mock(() => {});
+    const view = render(
+      <DecisionCard
+        itemId="inbox_dispatch"
+        request={{
+          schemaVersion: "factory.decision-request/v1",
+          question:
+            "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+          context:
+            "**Why you're being asked.** Auto-approval re-check failed (see proposal)",
+          options: [
+            {
+              id: "approve",
+              label: "Approve proposal",
+              effect: "approve_proposal",
+              tone: "primary",
+            },
+            { id: "dismiss", label: "Not now", effect: "dismiss" },
+          ],
+        }}
+        refs={{
+          issue: "WM-862",
+          repo: "factory",
+          proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+        }}
+        onJumpProposal={onJumpProposal}
+        apiCalls={apiCalls}
+      />,
+    );
+    expect(
+      view.getByText(
+        "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+      ),
+    ).toBeTruthy();
+    expect(view.getByText(/Why you're being asked/)).toBeTruthy();
+    expect(
+      view.getByText(/Auto-approval re-check failed \(see proposal\)/),
+    ).toBeTruthy();
+    const ticket = view.getByRole("link", { name: "WM-862" });
+    expect(ticket.getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-862",
+    );
+    fireEvent.click(view.getByText(/prop_2dda/));
+    expect(onJumpProposal).toHaveBeenCalledWith(
+      "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
+    );
+  });
+
   test("keeps submit disabled until confirmation and at least one path are chosen", () => {
     const view = render(
       <DecisionCard

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -13,6 +13,7 @@ import type {
   DecisionResponseInput,
   InboxDecisionResponse,
   InboxItem,
+  InboxRefs,
 } from "../types";
 import {
   applicableFields,
@@ -22,12 +23,16 @@ import {
 } from "../lib/decisionForm";
 import { decisionRequestHash } from "../lib/decision";
 import { MarkdownView } from "./RunTrace";
-import { Button } from "./ui";
+import { Button, JumpLink, shortId } from "./ui";
+
+const LINEAR_ISSUE_URL = "https://linear.app/watt-mind/issue/";
 
 export interface DecisionCardProps {
   itemId: string;
   request: DecisionRequest;
   response?: InboxDecisionResponse | null;
+  refs?: InboxRefs;
+  onJumpProposal?: (id: string) => void;
   connected?: boolean;
   onItemChange?: (item: InboxItem) => void;
   apiCalls?: {
@@ -39,6 +44,41 @@ export interface DecisionCardProps {
 
 const controlClass =
   "w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)";
+
+function DecisionCardRefs({
+  refs,
+  onJumpProposal,
+}: {
+  refs: InboxRefs;
+  onJumpProposal?: (id: string) => void;
+}) {
+  if (!refs.issue && !refs.proposalId) return null;
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px]">
+      {refs.issue && (
+        <JumpLink
+          href={`${LINEAR_ISSUE_URL}${encodeURIComponent(refs.issue)}`}
+          title="Open in Linear"
+        >
+          {refs.issue}
+        </JumpLink>
+      )}
+      {refs.proposalId &&
+        (onJumpProposal ? (
+          <JumpLink
+            onClick={() => onJumpProposal(refs.proposalId!)}
+            title={`Open proposal ${refs.proposalId}`}
+          >
+            {shortId(refs.proposalId)}
+          </JumpLink>
+        ) : (
+          <span className="mono text-(--text-dim)" title={refs.proposalId}>
+            {shortId(refs.proposalId)}
+          </span>
+        ))}
+    </div>
+  );
+}
 
 function responseFields(
   request: DecisionRequest,
@@ -83,6 +123,8 @@ export function DecisionCard({
   itemId,
   request,
   response = null,
+  refs = {},
+  onJumpProposal,
   connected = true,
   onItemChange,
   apiCalls = {
@@ -261,6 +303,7 @@ export function DecisionCard({
           <h2 className="text-[14px] font-semibold text-(--text)">
             {currentRequest.question}
           </h2>
+          <DecisionCardRefs refs={refs} onJumpProposal={onJumpProposal} />
           <div className="mt-3 rounded-md bg-(--surface-1) p-3 text-[12px]">
             <div className="font-semibold text-(--text)">
               This question no longer needs an answer.
@@ -298,6 +341,7 @@ export function DecisionCard({
         <h2 className="text-[14px] font-semibold text-(--text)">
           {currentRequest.question}
         </h2>
+        <DecisionCardRefs refs={refs} onJumpProposal={onJumpProposal} />
         <div className="mt-3 rounded-md bg-(--surface-1) p-3 text-[12px]">
           <div className="font-semibold text-(--text)">
             {option?.label ?? currentResponse.optionId}
@@ -359,6 +403,7 @@ export function DecisionCard({
       <h2 className="text-[14px] font-semibold text-(--text)">
         {currentRequest.question}
       </h2>
+      <DecisionCardRefs refs={refs} onJumpProposal={onJumpProposal} />
       {currentRequest.context && (
         <MarkdownView
           text={currentRequest.context}

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -19,15 +19,17 @@ import {
   inboxActionPrHref,
   inboxAge,
   itemStatus,
+  kindBadgeInRow,
   matchesTab,
   prHref,
+  proposalTtlLabel,
+  sourceRunId,
   waitingCount,
   waitingLabel,
-  sourceRunId,
 } from "./Inbox";
 import { api } from "../api";
 import { clearToasts, ToastContainer } from "../components/ui";
-import type { InboxItem } from "../types";
+import type { InboxItem, Proposal } from "../types";
 import { changeInput } from "../test-render";
 
 afterEach(() => {
@@ -189,6 +191,49 @@ describe("inbox pure helpers", () => {
     expect(row.title).toBe("BLOCKED WM-303: expand paths");
   });
 
+  test("displayTitle strips a legacy DECISION NEEDED prefix (WM-896)", () => {
+    expect(
+      displayTitle(
+        item({
+          id: "legacy",
+          kind: "decision_needed",
+          title:
+            "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 15m",
+        }),
+      ),
+    ).toBe(
+      "proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 15m",
+    );
+    expect(
+      displayTitle(
+        item({
+          id: "dispatch",
+          kind: "decision_needed",
+          title: "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+        }),
+      ),
+    ).toBe("Dispatch WM-862 · factory · cursor-grok-4.6-high");
+  });
+
+  test("kindBadgeInRow hides the badge when the group header already names the group", () => {
+    const decide = item({ id: "d", kind: "decision_needed" });
+    const other = { ...decide, id: "o", kind: "mystery-kind" } as InboxItem;
+    expect(kindBadgeInRow(decide, { groupBy: "attention" })).toBe(false);
+    expect(kindBadgeInRow(decide, { groupBy: "kind" })).toBe(false);
+    expect(kindBadgeInRow(decide, { groupBy: "none" })).toBe(true);
+    expect(kindBadgeInRow(decide, { groupBy: "repo" })).toBe(true);
+    expect(kindBadgeInRow(other, { groupBy: "attention" })).toBe(true);
+  });
+
+  test("proposalTtlLabel is a live countdown and omitted without a TTL", () => {
+    const created = "2026-08-19T12:00:00.000Z";
+    const now = Date.parse("2026-08-19T12:15:00.000Z");
+    expect(proposalTtlLabel(created, 1800, now)).toBe("15m left");
+    expect(proposalTtlLabel(created, 1800, now + 16 * 60_000)).toBe("expired");
+    expect(proposalTtlLabel(undefined, 1800, now)).toBeNull();
+    expect(proposalTtlLabel(created, undefined, now)).toBeNull();
+  });
+
   test("PR refs resolve only with an absolute URL or a known repository", () => {
     expect(
       prHref(
@@ -255,6 +300,7 @@ describe("inbox pure helpers", () => {
 const origInbox = api.inbox;
 const origAck = api.ackInbox;
 const origResolve = api.resolveInbox;
+const origProposals = api.proposals;
 
 let ledger: InboxItem[] = [];
 
@@ -295,6 +341,7 @@ beforeEach(() => {
     }),
   ];
   api.inbox = mock(async () => ({ items: ledger }));
+  api.proposals = mock(async () => ({ proposals: [] }));
   api.ackInbox = mock(async (id: string) => {
     ledger = ledger.map((it) => (it.id === id ? { ...it, ackedAt: T2 } : it));
     return { item: ledger.find((it) => it.id === id)! };
@@ -318,6 +365,7 @@ afterEach(() => {
   api.inbox = origInbox;
   api.ackInbox = origAck;
   api.resolveInbox = origResolve;
+  api.proposals = origProposals;
 });
 
 function renderInbox(props: Partial<React.ComponentProps<typeof Inbox>> = {}) {
@@ -361,6 +409,48 @@ describe("Inbox view", () => {
     // Group headers in triage order.
     expect(view.getByText("Decide")).toBeTruthy();
     expect(view.getByText("Red")).toBeTruthy();
+    // Group headers already identify Decide/Red — the kind badge stays off.
+    expect(view.queryByText("BLOCKED")).toBeNull();
+    expect(view.queryByText("CI RED")).toBeNull();
+  });
+
+  test("proposal rows show a live right-aligned TTL and hide it without one", async () => {
+    ledger = [
+      item({
+        id: "inbox_dispatch",
+        kind: "decision_needed",
+        title: "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+        refs: { proposalId: "prop_aging", issue: "WM-862", repo: "factory" },
+        decision: {
+          schemaVersion: "factory.decision-request/v1",
+          question:
+            "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
+          context:
+            "**Why you're being asked.** Auto-approval re-check failed (see proposal)",
+          options: [
+            { id: "approve", label: "Approve proposal", effect: "dismiss" },
+            { id: "dismiss", label: "Not now", effect: "dismiss" },
+          ],
+        },
+      }),
+    ];
+    api.proposals = mock(async () => ({
+      proposals: [
+        {
+          id: "prop_aging",
+          created_at: new Date(Date.now() - 16 * 60_000).toISOString(),
+          ttl_seconds: 1800,
+        } as Proposal,
+      ],
+    }));
+    const { view } = renderInbox();
+    await waitFor(() =>
+      view.getByText("Dispatch WM-862 · factory · cursor-grok-4.6-high"),
+    );
+    expect(view.getByLabelText(/Time left/).textContent).toMatch(
+      /(?:\d+m left|expired)/,
+    );
+    expect(view.queryByText("decision_needed")).toBeNull();
   });
 
   test("list and detail show how many runs wait on one answer", async () => {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -346,6 +346,9 @@ function refPrefixIsVisible(prefix: string, item: InboxItem): boolean {
 /** Keep the row focused on the action by removing labels already shown beside it. */
 export function displayTitle(item: InboxItem): string {
   let title = item.title.trimStart();
+  if (/^DECISION NEEDED\s+/i.test(title)) {
+    title = title.replace(/^DECISION NEEDED\s+/i, "");
+  }
   const knownKinds = [
     ...new Set([item.kind, ...INBOX_GROUPS.flatMap((group) => group.kinds)]),
   ].sort((a, b) => b.length - a.length);
@@ -371,6 +374,37 @@ export function displayTitle(item: InboxItem): string {
   if (refPrefix && refPrefixIsVisible(refPrefix[1], item))
     title = title.slice(refPrefix[0].length);
   return title || item.title;
+}
+
+/**
+ * Kind badge in the list row is redundant when a group header already names
+ * the group. Other (unknown kinds) still needs the badge; so does an
+ * ungrouped table, or grouping by a field that is not kind/attention.
+ */
+export function kindBadgeInRow(
+  item: InboxItem,
+  display: { groupBy: string },
+): boolean {
+  if (groupOf(item.kind).id === "other") return true;
+  if (display.groupBy === "attention" || display.groupBy === "kind")
+    return false;
+  return true;
+}
+
+/** Live TTL remaining from proposal `created_at + ttl_seconds`. */
+export function proposalTtlLabel(
+  createdAt: string | undefined,
+  ttlSeconds: number | undefined,
+  now: number,
+): string | null {
+  if (!createdAt || ttlSeconds == null || ttlSeconds <= 0) return null;
+  const expiry = new Date(createdAt).getTime() + ttlSeconds * 1000;
+  if (!Number.isFinite(expiry)) return null;
+  const leftMs = expiry - now;
+  if (leftMs <= 0) return "expired";
+  const minutes = Math.max(1, Math.ceil(leftMs / 60_000));
+  if (minutes >= 60) return `${Math.ceil(minutes / 60)}h left`;
+  return `${minutes}m left`;
 }
 
 /** WM-559 will move this precision into shared `Ago`; keep the Inbox local until then. */
@@ -425,6 +459,7 @@ export function NeedsYouRow({
   children,
 }: NeedsYouRowProps) {
   const hues = hue ? { ...INBOX_KIND_HUES, [kind]: hue } : INBOX_KIND_HUES;
+  const showKind = groupOf(kind).id === "other";
   const open = () => onOpen?.();
   return (
     <div
@@ -443,7 +478,7 @@ export function NeedsYouRow({
           : ""
       } ${selected ? "row-selected" : ""}`}
     >
-      <StateBadge state={kind} hues={hues} dot={false} />
+      {showKind && <StateBadge state={kind} hues={hues} dot={false} />}
       <span
         className="min-w-0 flex-1 truncate text-[12px] text-(--text)"
         title={tooltip ?? title}
@@ -694,6 +729,18 @@ export function Inbox({
     ...refetchIntervals.primary,
   });
   const items = query.data?.items ?? [];
+  const proposalsQuery = useQuery({
+    queryKey: ["proposals"],
+    queryFn: api.proposals,
+    ...refetchIntervals.primary,
+  });
+  const proposalsById = useMemo(() => {
+    const map = new Map<string, { created_at: string; ttl_seconds: number }>();
+    for (const proposal of proposalsQuery.data?.proposals ?? []) {
+      map.set(proposal.id, proposal);
+    }
+    return map;
+  }, [proposalsQuery.data]);
 
   const [tab, setTab] = useState<InboxTab>("open");
   const [filter, setFilter] = useState("");
@@ -1284,6 +1331,16 @@ export function Inbox({
                 {(() => {
                   const renderRow = (item: InboxItem) => {
                     const delivery = deliveryState(item);
+                    const proposal = item.refs.proposalId
+                      ? proposalsById.get(item.refs.proposalId)
+                      : undefined;
+                    const ttl = proposalTtlLabel(
+                      proposal?.created_at,
+                      proposal?.ttl_seconds,
+                      now,
+                    );
+                    const showKind =
+                      show.has("kind") && kindBadgeInRow(item, display);
                     return (
                       <tr
                         key={item.id}
@@ -1315,30 +1372,42 @@ export function Inbox({
                         )}
                         {show.has("kind") && (
                           <td className={`${tdCls} w-32`}>
-                            <StateBadge
-                              state={item.kind}
-                              hues={INBOX_KIND_HUES}
-                              dot={false}
-                            />
+                            {showKind && (
+                              <StateBadge
+                                state={item.kind}
+                                hues={INBOX_KIND_HUES}
+                                dot={false}
+                              />
+                            )}
                           </td>
                         )}
                         {show.has("title") && (
                           <td className={`${tdCls} min-w-40 max-w-0`}>
-                            <div
-                              className="truncate text-(--text)"
-                              title={item.title}
-                            >
-                              {item.decision && !item.response && (
+                            <div className="flex min-w-0 items-center gap-2">
+                              <div
+                                className="min-w-0 flex-1 truncate text-(--text)"
+                                title={item.title}
+                              >
+                                {item.decision && !item.response && (
+                                  <span
+                                    className="mono mr-1.5 text-(--hue-warn)"
+                                    aria-label="Decision required"
+                                  >
+                                    ?
+                                  </span>
+                                )}
+                                {displayTitle(item)}
+                              </div>
+                              {ttl && (
                                 <span
-                                  className="mono mr-1.5 text-(--hue-warn)"
-                                  aria-label="Decision required"
+                                  className="mono shrink-0 text-[11px] text-(--text-faint)"
+                                  aria-label={`Time left ${ttl}`}
                                 >
-                                  ?
+                                  {ttl}
                                 </span>
                               )}
-                              {displayTitle(item)}
                               {waitingLabel(waitingCount(item)) && (
-                                <span className="ml-1.5 text-(--text-faint)">
+                                <span className="ml-1.5 shrink-0 text-(--text-faint)">
                                   {waitingCount(item)} waiting
                                 </span>
                               )}
@@ -1463,11 +1532,13 @@ export function Inbox({
                 className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
                 aria-current="page"
               >
-                <StateBadge
-                  state={sel.kind}
-                  hues={INBOX_KIND_HUES}
-                  dot={false}
-                />
+                {groupOf(sel.kind).id === "other" && (
+                  <StateBadge
+                    state={sel.kind}
+                    hues={INBOX_KIND_HUES}
+                    dot={false}
+                  />
+                )}
                 <span className="mono truncate" title={sel.id}>
                   {shortId(sel.id)}
                 </span>
@@ -1587,6 +1658,8 @@ export function Inbox({
                 itemId={sel.id}
                 request={sel.decision}
                 response={sel.response}
+                refs={sel.refs}
+                onJumpProposal={onJumpProposal}
                 connected={connected}
                 onItemChange={invalidate}
               />


### PR DESCRIPTION
## Summary
- Inbox titles for watched proposals are action-first (`Dispatch WM-862 · factory · <model>`), with Telegram still using `DECISION NEEDED proposal <id> (<agent>): …`.
- Decision cards ask `Run dispatch@1 for <ticket> (<repo>) on <model>?`, show a **Why you're being asked** line from `proposals.reason`, and put Linear ticket + proposal links on the card.
- Kind `StateBadge` is hidden when the group header already names the group; expiry is a live `Nm left` / `expired` countdown, never baked into the title. `displayTitle()` strips a legacy `DECISION NEEDED ` prefix.

Fixes WM-896

UX critique: required — SHIP (list http://127.0.0.1:7467/#/inbox and detail http://127.0.0.1:7467/#/inbox/inbox_f20ed9c4-2653-4438-922d-fcf114b780fd; screenshots under `/tmp/factory-ux-wm896/`)

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/notify.test.mjs event-runtime/lib/decision-templates.test.mjs event-runtime/lib/inbox.test.mjs`
- [x] `cd event-runtime/web && bun test src/views/Inbox.test.tsx src/components/DecisionCard.test.tsx`
- [x] `bun run lint` (0 errors)
- [x] `bun test event-runtime/lib --timeout 20000`
- [x] `cd event-runtime/web && bun run build`
- [x] UX critic SHIP against the running worktree UI (web :7467)

Note: the ticket's fenced Verification Command uses `cd event-runtime/web && bun run test -- …`. `event-runtime/web/package.json` has no `test` script, so that fragment invokes `/usr/bin/test` and exits 2. The equivalent that actually runs the web tests is `cd event-runtime/web && bun test src/views/Inbox.test.tsx src/components/DecisionCard.test.tsx`.


Made with [Cursor](https://cursor.com)