### PR TITLE
chore(web): share list-verb keys across registry and cheatsheet (WM-857)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -143,6 +143,30 @@ beforeEach(() => {
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
     if (url.includes("/api/metrics")) return jsonResponse(EMPTY_METRICS);
+    if (url.includes("/api/config")) {
+      // Object-shaped so Settings can read `.registry` / `.sections`. The
+      // generic `[]` fallback is truthy and then throws on `.registry.loadedAt`.
+      return jsonResponse({
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        policyVersion: "wm857-config",
+        registry: {
+          loadedAt: "2026-01-01T00:00:00.000Z",
+          agentCount: 0,
+          eventTypeCount: 0,
+          edgeCount: 0,
+          scheduleCount: 0,
+        },
+        sections: [
+          {
+            id: "policy",
+            title: "Policy",
+            source: { file: "config/policy.yaml", kind: "yaml" },
+            reload: "hot",
+            entries: [{ key: "workers.max", value: 20 }],
+          },
+        ],
+      });
+    }
     if (url.includes("/api/runs?ticket=")) {
       const ticket =
         new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
@@ -332,6 +356,21 @@ describe("view registry routing (WM-839)", () => {
         .getAttribute("aria-current"),
     ).toBe("page");
     expect(document.title).toBe(`factory · Proposals · ${OPEN_PROPOSAL_ID}`);
+  });
+
+  test("the Settings route renders against the config fixture (WM-857)", async () => {
+    window.location.hash = "#/settings";
+    const utils = renderApp();
+    expect(
+      await utils.findByRole("heading", { name: "Settings" }),
+    ).toBeTruthy();
+    expect(
+      utils.sidebar
+        .getByRole("button", { name: "Settings" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(await utils.findByText("wm857-config")).toBeTruthy();
+    expect(utils.getByText("workers.max")).toBeTruthy();
   });
 });
 

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Dialog } from "./ui";
 import { NAV } from "../nav";
-import { Button as PrimitiveButton } from "./ui";
+import { LIST_VERBS } from "../views/registry";
+import { Button as PrimitiveButton, Dialog } from "./ui";
 
 const CONTEXT_CHORDS: { chord: string; label: string }[] = [
   { chord: "g 0", label: "All context" },
@@ -42,11 +42,7 @@ const ACTIONS: { keys: string; does: string }[] = [
     keys: "c / l",
     does: "view chain (Run, Events)",
   },
-  { keys: "a", does: "approve proposal (Proposals) · ack item (Inbox)" },
-  {
-    keys: "x",
-    does: "reject proposal (Proposals) · cancel run (Runs) · resolve item (Inbox)",
-  },
+  ...LIST_VERBS,
   {
     keys: "Space / Shift+Space",
     does: "toggle highlighted proposal selection · toggle highlighted inbox item selection",

--- a/event-runtime/web/src/views/registry.test.ts
+++ b/event-runtime/web/src/views/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { NAV } from "../nav";
 import {
+  LIST_VERBS,
   NAV as REGISTRY_NAV,
   RESERVED_GO_SUFFIXES,
   VIEWS,
@@ -25,15 +26,19 @@ describe("view registry (WM-839)", () => {
   });
 
   test("no `g` chord collides with a reserved suffix (list verb or context chord)", () => {
-    // The rule from the registry header: `g a` would double-fire the
-    // proposals view's `a` (approve) list verb, `x` is reject/cancel/resolve,
-    // `g i` and `g 0`–`g 9` are the context chords (WM-235), and `g h` is the
-    // Projects "open on GitHub" chord.
+    // The rule from the registry header: list verbs (`LIST_VERBS`) would
+    // double-fire under `g`, `g i` and `g 0`–`g 9` are the context chords
+    // (WM-235), and `g h` is the Projects "open on GitHub" chord.
     for (const n of NAV) {
       expect(RESERVED_GO_SUFFIXES.has(n.go)).toBe(false);
     }
-    expect(RESERVED_GO_SUFFIXES.has("a")).toBe(true);
+    expect(LIST_VERBS.length).toBeGreaterThan(0);
+    for (const verb of LIST_VERBS) {
+      expect(verb.keys).toMatch(/^[a-z]$/);
+      expect(RESERVED_GO_SUFFIXES.has(verb.keys)).toBe(true);
+    }
     expect(RESERVED_GO_SUFFIXES.has("i")).toBe(true);
+    expect(RESERVED_GO_SUFFIXES.has("h")).toBe(true);
     for (let d = 0; d <= 9; d++)
       expect(RESERVED_GO_SUFFIXES.has(String(d))).toBe(true);
   });

--- a/event-runtime/web/src/views/registry.ts
+++ b/event-runtime/web/src/views/registry.ts
@@ -110,13 +110,24 @@ export type ViewDef = {
 };
 
 /**
- * `g` suffixes no view may take: `a` approve/ack, `x` reject/cancel/resolve
- * (single-key list verbs that would double-fire under the chord), `i` and
- * `0`–`9` (context chords, WM-235), and `h` (Projects' `g h` opens GitHub).
+ * Single-key list verbs that would double-fire under a `g` chord. The `?`
+ * cheatsheet and `RESERVED_GO_SUFFIXES` both read this list — do not duplicate
+ * the keys or labels elsewhere (WM-857).
+ */
+export const LIST_VERBS: readonly { keys: string; does: string }[] = [
+  { keys: "a", does: "approve proposal (Proposals) · ack item (Inbox)" },
+  {
+    keys: "x",
+    does: "reject proposal (Proposals) · cancel run (Runs) · resolve item (Inbox)",
+  },
+];
+
+/**
+ * `g` suffixes no view may take: list verbs above, `i` and `0`–`9` (context
+ * chords, WM-235), and `h` (Projects' `g h` opens GitHub).
  */
 export const RESERVED_GO_SUFFIXES: ReadonlySet<string> = new Set([
-  "a",
-  "x",
+  ...LIST_VERBS.map((v) => v.keys),
   "i",
   "h",
   ..."0123456789",


### PR DESCRIPTION
## Summary
- Export `LIST_VERBS` (`a` approve/ack, `x` reject/cancel/resolve) as the single source of truth for list-verb shortcuts.
- `RESERVED_GO_SUFFIXES` and the `?` cheatsheet both consume that list; `registry.test.ts` asserts against the export instead of a hardcoded `"a"`.
- `App.test.tsx` stubs `GET /api/config` with a `ConfigView`-shaped fixture so the Settings route can render without crashing on the generic `[]` fallback.

Fixes WM-857

UX critique: skipped — no user-facing flow change; cheatsheet copy is unchanged and the rest is a test fixture.

## Test plan
- [x] `cd event-runtime/web && bun test src/views/registry.test.ts src/App.test.tsx`
- [x] `cd event-runtime/web && bun test src/components/ShortcutsDialog.test.tsx`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `cd event-runtime/web && bun run build`


Made with [Cursor](https://cursor.com)