### PR TITLE
fix(runtime): treat Linear 2500 req/h exhaustion as retry-later (WM-878)

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -109,6 +109,36 @@ invalid ticket label safe. As with definition tiers, a valid label whose tier
 has no mapping for the routed adapter fails closed rather than falling back to
 an adapter default.
 
+### Linear API budget (WM-878)
+
+Linear allows 2500 requests per hour. The factory used to treat a 400/429
+`Rate limit exceeded` as `needs_human` and then _amplify_ the outage: every
+open chain-dispatch proposal re-ran `fetchTicket` + `fetchViewer` +
+`fetchInFlight` on every tick. Rate-limited outcomes are **retry-later**:
+
+- `tools/linear.mjs` records `X-RateLimit-Requests-*` (falling back to the
+  complexity headers), exposes `factory linear budget`, and exits 3 with
+  `{rateLimited:true, resetAt}` instead of a generic failure.
+- One planning pass memoizes in-flight issues by team+project for ≤60s and
+  per-ticket reads for the run, so ten candidates in one repo do not issue
+  ten 250-issue queries.
+- A rate-limited dispatch plan leaves the event `admitted` with
+  `reason: linear_rate_limited`; `plan_failures` is not incremented, the
+  ticket is not labelled `ai:escalated`, and no inbox item is opened. The
+  next tick (or `resetAt`) retries.
+- Auto-approval rechecks that throw a rate-limit error stay open as
+  `dispatch_recheck_deferred` (the thrown message is logged; any other throw
+  is `dispatch_recheck_failed:<message>`). Rechecks in the same pass back off
+  until `resetAt`.
+- `factory doctor` prints `Linear budget: N/2500 remaining, resets HH:MM`
+  and warns when remaining < 300.
+
+The dispatch agent's prompt still names `needs_human` for an unreachable
+Linear API; a follow-up re-pin of `dispatch@1` plus `verify.mjs`
+`REFUSAL_REASONS` is required before the agent result itself can carry
+`linear_rate_limited` without a contract violation. The planner and
+auto-approval path above is what stops the inbox escalation.
+
 ---
 
 ## 3. Capacity: one budget, checked at plan and again at execute

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -307,10 +307,13 @@ the same run.
 
 Allowed terminal states begin small: `completed`, `refused`, `failed`,
 `timed_out`, and `cancelled`. Refusal is not failure: it carries a typed reason
-such as `missing_input`, `permission_denied`, `needs_human`, or
-`unsupported_capability`. Unknown fields, unknown terminal states, bad hashes,
-and schema violations fail closed. Downstream consumers read only accepted
-results, never free-form final messages or transcripts.
+such as `missing_input`, `permission_denied`, `needs_human`,
+`unsupported_capability`, or `linear_rate_limited` (Linear's 2500 req/h budget
+is exhausted — retry-later, never an inbox escalation; see
+[event-runtime-dispatch.md](event-runtime-dispatch.md) §2). Unknown fields,
+unknown terminal states, bad hashes, and schema violations fail closed.
+Downstream consumers read only accepted results, never free-form final
+messages or transcripts.
 
 ### 5.4 Idempotency key derivation
 

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -15,6 +15,10 @@ import { approveProposal } from "./proposals.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
 import { reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
+import {
+  isLinearRateLimited,
+  isLinearRateLimitMessage,
+} from "../../tools/linear.mjs";
 
 export const CHAIN_APPROVAL_SOURCE = "chain";
 export const CHAIN_APPROVAL_MODE_AUTO = "auto";
@@ -301,6 +305,13 @@ function proposalIntegrity(candidate, mapping, envelope) {
   return null;
 }
 
+function clipReason(message, max = 180) {
+  return String(message ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
 function dispatchSafe(
   envelope,
   approvalPolicy,
@@ -311,11 +322,34 @@ function dispatchSafe(
   if (typeof dispatchEligibility !== "function")
     return "dispatch_recheck_unavailable";
 
+  const nowMs =
+    typeof hookCtx?.now === "number" && Number.isFinite(hookCtx.now)
+      ? hookCtx.now
+      : Date.now();
+  if (
+    dispatch &&
+    Number.isFinite(dispatch.linearRateLimitedUntil) &&
+    nowMs < dispatch.linearRateLimitedUntil
+  ) {
+    return "dispatch_recheck_deferred";
+  }
+
   let result;
   try {
     result = dispatchEligibility(envelope.payload, dispatch);
-  } catch {
-    return "dispatch_recheck_failed";
+  } catch (err) {
+    const message = String(err?.message ?? err);
+    console.error(`dispatch_recheck_failed: ${message}`);
+    if (isLinearRateLimited(err) || isLinearRateLimitMessage(message)) {
+      if (dispatch && typeof dispatch === "object") {
+        const resetMs = Date.parse(err.resetAt);
+        dispatch.linearRateLimitedUntil = Number.isFinite(resetMs)
+          ? resetMs
+          : nowMs + 60_000;
+      }
+      return "dispatch_recheck_deferred";
+    }
+    return `dispatch_recheck_failed:${clipReason(message)}`;
   }
 
   if (!result?.ok)

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -16,6 +16,7 @@ import { planAdmittedEvents } from "./planner.mjs";
 import { lifecycleOf, runState } from "./lifecycle.mjs";
 import { openProposals } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
+import { LinearRateLimitError } from "../../tools/linear.mjs";
 
 const registry = loadRegistry();
 const now = Date.parse("2026-08-19T12:00:00.000Z");
@@ -1721,5 +1722,44 @@ describe("chain auto approval (WM-357)", () => {
     const second = auto(db, { runtimeGuard: () => null });
     expect(runState(db, later.runId)).toBe("QUEUED");
     return Promise.all([pending, second]);
+  });
+
+  test("a Linear rate-limit throw defers the recheck instead of failing it (WM-878)", async () => {
+    const db = openDb(":memory:");
+    const first = dispatchSeed(db, "rl-first", { ticket: "WM-878" });
+    const second = dispatchSeed(db, "rl-second", { ticket: "WM-879" });
+    let calls = 0;
+    const dispatchEligibility = () => {
+      calls += 1;
+      throw new LinearRateLimitError("2026-08-19T13:00:00.000Z");
+    };
+    const result = await auto(db, {
+      dispatchEligibility,
+      runtimeGuard: () => null,
+    });
+    expect(result.approved).toEqual([]);
+    expect(reasonOf(db, first.id)).toBe(
+      "auto_approval_ineligible:dispatch_recheck_deferred",
+    );
+    expect(reasonOf(db, second.id)).toBe(
+      "auto_approval_ineligible:dispatch_recheck_deferred",
+    );
+    expect(runState(db, first.runId)).toBe("PROPOSED");
+    expect(calls).toBe(1);
+  });
+
+  test("any other dispatch recheck throw records dispatch_recheck_failed:<message> (WM-878)", async () => {
+    const db = openDb(":memory:");
+    const row = dispatchSeed(db, "rl-fail", { ticket: "WM-880" });
+    const result = await auto(db, {
+      dispatchEligibility: () => {
+        throw new Error("linear_read_failed: HTTP 503 upstream");
+      },
+      runtimeGuard: () => null,
+    });
+    expect(result.approved).toEqual([]);
+    expect(reasonOf(db, row.id)).toBe(
+      "auto_approval_ineligible:dispatch_recheck_failed:linear_read_failed: HTTP 503 upstream",
+    );
   });
 });

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -63,6 +63,15 @@ import {
   autoApproveChains,
   buildChainApprovalPolicy,
 } from "./auto-approval.mjs";
+import {
+  LINEAR_RATE_LIMIT_EXIT,
+  LinearRateLimitError,
+  isLinearRateLimitMessage,
+  isLinearRateLimited,
+} from "../../tools/linear.mjs";
+
+/** In-flight issues list is stable across one scan; 60s is the ticket cap. */
+export const IN_FLIGHT_CACHE_TTL_MS = 60_000;
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -269,6 +278,114 @@ function linearCli() {
   return path.join(FACTORY_ROOT, "tools", "linear.mjs");
 }
 
+function throwIfLinearCliRateLimited(err) {
+  const stderr = String(err?.stderr ?? "");
+  const stdout = String(err?.stdout ?? "");
+  const combined = `${stderr}\n${stdout}`;
+  if (
+    err?.status === LINEAR_RATE_LIMIT_EXIT ||
+    isLinearRateLimitMessage(combined)
+  ) {
+    let resetAt = null;
+    for (const line of combined.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) continue;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed?.resetAt) resetAt = parsed.resetAt;
+      } catch {
+        // not the rate-limit payload
+      }
+    }
+    throw new LinearRateLimitError(resetAt, err);
+  }
+}
+
+export function createLinearReadCache() {
+  return {
+    tickets: new Map(),
+    inFlight: new Map(),
+    viewer: { value: undefined },
+    rateLimitError: null,
+    rateLimitedUntil: 0,
+    inFlightCalls: 0,
+  };
+}
+
+/**
+ * One planning pass / one scan run: memoize ticket reads for the run and
+ * in-flight lists by team+project for ≤60s. A rate-limit throw is remembered
+ * so later candidates in the same pass do not hit Linear again.
+ */
+export function wrapLinearReads(dispatch = {}, cache, now) {
+  const resolveNow = () => {
+    const clock = now ?? Date.now;
+    return typeof clock === "function" ? clock() : clock;
+  };
+  const throwIfLimited = () => {
+    if (!cache.rateLimitError) return;
+    if (resolveNow() < cache.rateLimitedUntil) throw cache.rateLimitError;
+    cache.rateLimitError = null;
+    cache.rateLimitedUntil = 0;
+  };
+  const remember = (err) => {
+    if (!isLinearRateLimited(err)) return;
+    cache.rateLimitError = err;
+    const resetMs = Date.parse(err.resetAt);
+    cache.rateLimitedUntil = Number.isFinite(resetMs)
+      ? resetMs
+      : resolveNow() + 60_000;
+  };
+
+  const fetchTicket = dispatch.fetchTicket ?? fetchTicketDefault;
+  const fetchViewer = dispatch.fetchViewer ?? fetchViewerDefault;
+  const fetchInFlight = dispatch.fetchInFlight ?? fetchInFlightDefault;
+
+  return {
+    ...dispatch,
+    fetchTicket: (id) => {
+      throwIfLimited();
+      if (cache.tickets.has(id)) return cache.tickets.get(id);
+      try {
+        const value = fetchTicket(id);
+        cache.tickets.set(id, value);
+        return value;
+      } catch (err) {
+        remember(err);
+        throw err;
+      }
+    },
+    fetchViewer: () => {
+      throwIfLimited();
+      if (cache.viewer.value !== undefined) return cache.viewer.value;
+      try {
+        const value = fetchViewer();
+        cache.viewer.value = value;
+        return value;
+      } catch (err) {
+        remember(err);
+        throw err;
+      }
+    },
+    fetchInFlight: (repo) => {
+      throwIfLimited();
+      const key = `${repo?.team ?? ""}::${repo?.project ?? ""}`;
+      const hit = cache.inFlight.get(key);
+      const at = resolveNow();
+      if (hit && at - hit.at < IN_FLIGHT_CACHE_TTL_MS) return hit.value;
+      try {
+        cache.inFlightCalls += 1;
+        const value = fetchInFlight(repo);
+        cache.inFlight.set(key, { value, at });
+        return value;
+      } catch (err) {
+        remember(err);
+        throw err;
+      }
+    },
+  };
+}
+
 function fetchTicketDefault(ticketId) {
   try {
     return JSON.parse(
@@ -278,6 +395,7 @@ function fetchTicketDefault(ticketId) {
       }),
     );
   } catch (err) {
+    throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
     throw new Error(
@@ -299,6 +417,7 @@ function fetchViewerDefault() {
     );
     return JSON.parse(out)?.viewer ?? null;
   } catch (err) {
+    throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");
     throw new Error(
       `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
@@ -367,6 +486,7 @@ function fetchInFlightDefault(repoConfig) {
     );
     return JSON.parse(out)?.issues?.nodes ?? [];
   } catch (err) {
+    throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");
     throw new Error(
       `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
@@ -1195,12 +1315,41 @@ export function planEvent(
         typeof preEnvelope.payload?.ticket === "string" &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
-        worktreeEligibility = worktreeDispatchAutoEligibility(
-          preEnvelope.payload,
-          dispatch,
-        );
+        try {
+          worktreeEligibility = worktreeDispatchAutoEligibility(
+            preEnvelope.payload,
+            dispatch,
+          );
+        } catch (err) {
+          if (!isLinearRateLimited(err)) throw err;
+          worktreeEligibility = {
+            ok: false,
+            rateLimited: true,
+            resetAt: err.resetAt ?? null,
+            refusal: {
+              decision: "retry_later",
+              reason: "linear_rate_limited",
+              detail: err.message,
+            },
+          };
+        }
       }
     }
+  }
+  if (worktreeEligibility?.rateLimited) {
+    const detail = worktreeEligibility.refusal?.detail ?? "linear_rate_limited";
+    try {
+      db.query(
+        `UPDATE events SET last_plan_error = ? WHERE source = ? AND event_id = ?`,
+      ).run(detail, source, eventId);
+    } catch (err) {
+      if (!isBusyError(err)) throw err;
+    }
+    return {
+      decision: "refused",
+      reason: "linear_rate_limited",
+      resetAt: worktreeEligibility.resetAt ?? null,
+    };
   }
   return txImmediate(db, () => {
     const event = db
@@ -1574,10 +1723,9 @@ export function planEvent(
         approvalPolicy?.mode === "auto" &&
         envelope.type === "factory.dispatch.requested"
       ) {
-        const result = worktreeDispatchAutoEligibility(
-          pinnedEnvelope.payload,
-          dispatch,
-        );
+        const result = worktreeEligibility?.ok
+          ? worktreeEligibility
+          : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, dispatch);
         if (!result?.ok) {
           return humanNeeded(
             db,
@@ -1748,15 +1896,29 @@ export function planAdmittedEvents(db, registry, opts = {}) {
       `SELECT source, event_id FROM events WHERE status = 'admitted' ORDER BY admitted_at, rowid`,
     )
     .all();
+  const cache = opts.linearReadCache ?? createLinearReadCache();
+  const dispatch = wrapLinearReads(opts.dispatch ?? {}, cache, opts.now);
+  const planOpts = { ...opts, dispatch };
   let planned = 0;
   let failed = 0;
   let deadLettered = 0;
   for (const { source, event_id: eventId } of rows) {
     try {
-      planEvent(db, registry, { source, eventId }, opts);
+      const outcome = planEvent(db, registry, { source, eventId }, planOpts);
+      if (outcome?.reason === "linear_rate_limited") continue;
       planned += 1;
     } catch (err) {
       if (isBusyError(err)) {
+        continue;
+      }
+      if (isLinearRateLimited(err)) {
+        try {
+          db.query(
+            `UPDATE events SET last_plan_error = ? WHERE source = ? AND event_id = ?`,
+          ).run(String(err.message), source, eventId);
+        } catch (innerErr) {
+          if (!isBusyError(innerErr)) throw innerErr;
+        }
         continue;
       }
       failed += 1;
@@ -1796,7 +1958,7 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     now: opts.now ?? Date.now(),
     policyVersion: opts.policyVersion ?? "unknown",
     dispatchEligibility: worktreeDispatchAutoEligibility,
-    dispatch: opts.dispatch ?? {},
+    dispatch,
   });
   return { planned, failed, deadLettered };
 }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -10,6 +10,7 @@ import { admitEvent } from "./intake.mjs";
 import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
 import {
   buildRunSpec,
+  createLinearReadCache,
   idempotencyKeyFor,
   pinMemos,
   planAdmittedEvents,
@@ -29,6 +30,7 @@ import {
   registerMemos,
   withProvenance,
 } from "./memos.mjs";
+import { LinearRateLimitError } from "../../tools/linear.mjs";
 
 const registry = loadRegistry();
 const NOW = Date.parse("2026-08-12T10:30:02Z");
@@ -2184,5 +2186,116 @@ describe("planEvent memoPin (WM-810)", () => {
     const secondSpec = JSON.parse(second.proposal.spec_json);
     expect(secondSpec.inputHash).not.toBe(firstHash);
     expect(secondSpec.input.memoPin.entries).toHaveLength(1);
+  });
+});
+
+describe("Linear rate limit (WM-878)", () => {
+  function withReposRoot(yaml, fn) {
+    const root = tmpDir("evrt-plan-rl-");
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+    }
+  }
+
+  const gatedYaml =
+    `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
+    `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+    `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`;
+
+  const readyTicket = (id) => ({
+    identifier: id,
+    state: { name: "Todo" },
+    assignee: null,
+    labels: { nodes: [{ name: "ai:agent-ready" }] },
+    description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+  });
+
+  test("a simulated Linear 400 rate-limit refuses linear_rate_limited, leaves the event admitted, and does not dead-letter", () => {
+    withReposRoot(gatedYaml, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "rate-limit-1",
+        correlationId: "rate-limit-1",
+        payload: { repo: "gated", ticket: "WM-878" },
+      });
+      const resetAt = "2026-08-19T13:00:00.000Z";
+      const counts = planAdmittedEvents(db, registry, {
+        now: NOW,
+        policyVersion: "git:test",
+        dispatch: {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: () => {
+            throw new LinearRateLimitError(resetAt);
+          },
+          fetchInFlight: () => {
+            throw new Error("in-flight must not run after a rate-limit");
+          },
+        },
+      });
+      expect(counts).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+      const event = db
+        .query(`SELECT * FROM events WHERE event_id = ?`)
+        .get(ref.eventId);
+      expect(event.status).toBe("admitted");
+      expect(event.plan_failures).toBe(0);
+      expect(event.last_plan_error).toMatch(/^linear_rate_limited:/);
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+      expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(0);
+
+      const direct = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: () => {
+            throw new LinearRateLimitError(resetAt);
+          },
+        },
+      });
+      expect(direct).toMatchObject({
+        decision: "refused",
+        reason: "linear_rate_limited",
+        resetAt,
+      });
+    });
+  });
+
+  test("one planning pass over 10 candidates makes at most 3 in-flight queries", () => {
+    withReposRoot(gatedYaml, () => {
+      const db = openDb(":memory:");
+      for (let i = 1; i <= 10; i++) {
+        admit(db, {
+          type: "factory.dispatch.requested",
+          eventId: `rl-cand-${i}`,
+          correlationId: `rl-cand-${i}`,
+          payload: { repo: "gated", ticket: `WM-${800 + i}` },
+        });
+      }
+      const cache = createLinearReadCache();
+      const counts = planAdmittedEvents(db, registry, {
+        now: NOW,
+        policyVersion: "git:test",
+        linearReadCache: cache,
+        dispatch: {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: (id) => readyTicket(id),
+          fetchInFlight: () => [],
+        },
+      });
+      expect(counts.failed).toBe(0);
+      expect(counts.deadLettered).toBe(0);
+      expect(cache.inFlightCalls).toBeLessThanOrEqual(3);
+      expect(cache.inFlightCalls).toBeGreaterThan(0);
+    });
   });
 });

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -31,8 +31,15 @@ import {
   browserLaunchCheck,
   piChromeDevtoolsCheck,
 } from "./doctor-browser.mjs";
+import {
+  formatLinearBudgetLine,
+  installLinearBudgetCapture,
+  linearBudgetStatus,
+  loadLinearBudget,
+} from "../tools/linear.mjs";
 
 const ROOT = factoryRoot();
+installLinearBudgetCapture();
 const argv = process.argv.slice(2);
 const val = (f) => {
   const i = argv.indexOf(f);
@@ -411,6 +418,19 @@ for (const repo of repos) {
     repo.smoke_workflow
       ? null
       : "without one, Done means merged rather than running",
+  );
+}
+
+{
+  const budget = loadLinearBudget();
+  const status = linearBudgetStatus(budget);
+  check(
+    status === "pass" ? true : "warn",
+    formatLinearBudgetLine(budget),
+    "",
+    status === "warn" && budget?.remaining != null
+      ? "Linear is near its 2500 req/h cap — dispatch retries later instead of escalating"
+      : null,
   );
 }
 

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -362,3 +362,39 @@ describe("piChromeDevtoolsCheck", () => {
     ).toBe("fail");
   });
 });
+
+describe("Linear budget line (WM-878)", () => {
+  test("formats remaining/limit and UTC reset clock, and warns below 300", async () => {
+    const {
+      formatLinearBudgetLine,
+      linearBudgetStatus,
+      parseRateLimitHeaders,
+      LINEAR_BUDGET_WARN_REMAINING,
+    } = await import("../tools/linear.mjs");
+    expect(formatLinearBudgetLine(null)).toBe(
+      "Linear budget: unknown (no recent API call)",
+    );
+    expect(
+      formatLinearBudgetLine({
+        remaining: 1842,
+        limit: 2500,
+        resetAt: "2026-08-19T15:07:00.000Z",
+      }),
+    ).toBe("Linear budget: 1842/2500 remaining, resets 15:07");
+    expect(
+      linearBudgetStatus({ remaining: LINEAR_BUDGET_WARN_REMAINING }),
+    ).toBe("pass");
+    expect(
+      linearBudgetStatus({ remaining: LINEAR_BUDGET_WARN_REMAINING - 1 }),
+    ).toBe("warn");
+    const headers = new Headers({
+      "X-RateLimit-Requests-Remaining": "12",
+      "X-RateLimit-Requests-Limit": "2500",
+      "X-RateLimit-Requests-Reset": "1787150400",
+    });
+    const parsed = parseRateLimitHeaders(headers);
+    expect(parsed.remaining).toBe(12);
+    expect(parsed.limit).toBe(2500);
+    expect(parsed.resetAt).toBe(new Date(1787150400 * 1000).toISOString());
+  });
+});

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -13,6 +13,7 @@
  *   bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
  *   bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
  *   bun tools/linear.mjs queue --repo bj29
+ *   bun tools/linear.mjs budget
  *   bun tools/linear.mjs raw '<graphql>' --var key=value
  *
  * WHY THIS EXISTS, given a perfectly good Linear MCP.
@@ -47,7 +48,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
-import { gql } from "../orchestrator/reaper.mjs";
+import { gql as gqlRaw } from "../orchestrator/reaper.mjs";
 import {
   parseOwnedPaths,
   ownedPathsClosureGaps,
@@ -64,6 +65,198 @@ import {
 // below) does nothing here since no verb calls allLabels() twice in one run.
 const CACHE_DIR = path.join(homedir(), ".factory/cache/linear");
 const CACHE_TTL_MS = 15 * 60 * 1000;
+const BUDGET_FILE = "budget.json";
+const LINEAR_API_HOST = "api.linear.app";
+
+/** Distinct from generic CLI failure (exit 1) so planners can retry-later. */
+export const LINEAR_RATE_LIMIT_EXIT = 3;
+export const LINEAR_REQUESTS_LIMIT = 2500;
+export const LINEAR_BUDGET_WARN_REMAINING = 300;
+
+export class LinearRateLimitError extends Error {
+  constructor(resetAt, cause) {
+    super(`linear_rate_limited: resetAt=${resetAt ?? "unknown"}`);
+    this.name = "LinearRateLimitError";
+    this.rateLimited = true;
+    this.resetAt = resetAt ?? null;
+    if (cause) this.cause = cause;
+  }
+}
+
+export function isLinearRateLimitMessage(text) {
+  const s = String(text ?? "");
+  return (
+    /rate limit exceeded/i.test(s) ||
+    /RATELIMITED/i.test(s) ||
+    /HTTP 429\b/.test(s) ||
+    /"rateLimited"\s*:\s*true/.test(s)
+  );
+}
+
+export function isLinearRateLimited(err) {
+  if (!err) return false;
+  if (err instanceof LinearRateLimitError || err.rateLimited === true)
+    return true;
+  return String(err.message ?? "").startsWith("linear_rate_limited:");
+}
+
+function parseHeaderNumber(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Linear's reset header is a unix timestamp; Retry-After is a small delta.
+ * ISO-8601 strings pass through Date.parse.
+ */
+export function parseRateLimitReset(value, now = Date.now()) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  if (Number.isFinite(n)) {
+    if (n < 1e9) return new Date(now + n * 1000).toISOString();
+    const ms = n < 1e12 ? n * 1000 : n;
+    return new Date(ms).toISOString();
+  }
+  const d = new Date(String(value));
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+export function parseRateLimitHeaders(headers, now = Date.now()) {
+  if (!headers || typeof headers.get !== "function") return null;
+  const remaining = parseHeaderNumber(
+    headers.get("x-ratelimit-requests-remaining"),
+  );
+  const limit = parseHeaderNumber(headers.get("x-ratelimit-requests-limit"));
+  const resetAt = parseRateLimitReset(
+    headers.get("x-ratelimit-requests-reset") ?? headers.get("retry-after"),
+    now,
+  );
+  const complexityRemaining = parseHeaderNumber(
+    headers.get("x-ratelimit-complexity-remaining"),
+  );
+  const complexityLimit = parseHeaderNumber(
+    headers.get("x-ratelimit-complexity-limit"),
+  );
+  const complexityResetAt = parseRateLimitReset(
+    headers.get("x-ratelimit-complexity-reset"),
+    now,
+  );
+  if (
+    remaining == null &&
+    limit == null &&
+    resetAt == null &&
+    complexityRemaining == null &&
+    complexityLimit == null &&
+    complexityResetAt == null
+  ) {
+    return null;
+  }
+  return {
+    remaining: remaining ?? complexityRemaining,
+    limit: limit ?? complexityLimit ?? LINEAR_REQUESTS_LIMIT,
+    resetAt: resetAt ?? complexityResetAt,
+  };
+}
+
+export function linearCacheDir() {
+  return process.env.LINEAR_CACHE_DIR || CACHE_DIR;
+}
+
+export function loadLinearBudget() {
+  try {
+    return JSON.parse(
+      readFileSync(path.join(linearCacheDir(), BUDGET_FILE), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function saveLinearBudget(budget) {
+  try {
+    mkdirSync(linearCacheDir(), { recursive: true });
+    writeFileSync(
+      path.join(linearCacheDir(), BUDGET_FILE),
+      JSON.stringify({ ...budget, capturedAt: new Date().toISOString() }),
+    );
+  } catch {
+    // Budget is an optimization / doctor line, never a dependency.
+  }
+}
+
+function formatResetClock(resetAt) {
+  if (!resetAt) return "unknown";
+  const d = new Date(resetAt);
+  if (Number.isNaN(d.getTime())) return "unknown";
+  return `${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")}`;
+}
+
+export function formatLinearBudgetLine(budget) {
+  if (!budget || budget.remaining == null) {
+    return "Linear budget: unknown (no recent API call)";
+  }
+  const limit = budget.limit ?? LINEAR_REQUESTS_LIMIT;
+  return `Linear budget: ${budget.remaining}/${limit} remaining, resets ${formatResetClock(budget.resetAt)}`;
+}
+
+export function linearBudgetStatus(budget) {
+  if (!budget || budget.remaining == null) return "unknown";
+  if (budget.remaining < LINEAR_BUDGET_WARN_REMAINING) return "warn";
+  return "pass";
+}
+
+function recordLinearBudgetFromResponse(res) {
+  const parsed = parseRateLimitHeaders(res.headers);
+  if (!parsed && res.status !== 400 && res.status !== 429) return;
+  const prior = loadLinearBudget() ?? {};
+  const rateLimited =
+    res.status === 429 ||
+    (res.status === 400 && parsed?.remaining === 0) ||
+    parsed?.remaining === 0;
+  saveLinearBudget({
+    remaining:
+      parsed?.remaining ?? (rateLimited ? 0 : (prior.remaining ?? null)),
+    limit: parsed?.limit ?? prior.limit ?? LINEAR_REQUESTS_LIMIT,
+    resetAt: parsed?.resetAt ?? prior.resetAt ?? null,
+    rateLimited: Boolean(rateLimited || prior.rateLimited),
+    status: res.status,
+  });
+}
+
+let fetchHookInstalled = false;
+
+export function installLinearBudgetCapture() {
+  if (fetchHookInstalled) return;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  fetchHookInstalled = true;
+  globalThis.fetch = async function linearBudgetFetch(input, init) {
+    const url = String(input?.url ?? input);
+    const res = await originalFetch(input, init);
+    if (url.includes(LINEAR_API_HOST)) recordLinearBudgetFromResponse(res);
+    return res;
+  };
+}
+
+async function gql(query, variables = {}, retries) {
+  try {
+    return await gqlRaw(query, variables, retries);
+  } catch (err) {
+    if (isLinearRateLimitMessage(err?.message)) {
+      const budget = loadLinearBudget() ?? {};
+      const resetAt =
+        budget.resetAt ?? new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      saveLinearBudget({
+        remaining: 0,
+        limit: budget.limit ?? LINEAR_REQUESTS_LIMIT,
+        resetAt,
+        rateLimited: true,
+      });
+      throw new LinearRateLimitError(resetAt, err);
+    }
+    throw err;
+  }
+}
 
 function cacheGet(key) {
   if (process.env.LINEAR_NO_CACHE) return null;
@@ -708,6 +901,18 @@ const VERBS = {
     );
   },
 
+  async budget() {
+    const budget = loadLinearBudget();
+    out(
+      budget ?? {
+        remaining: null,
+        limit: LINEAR_REQUESTS_LIMIT,
+        resetAt: null,
+      },
+      formatLinearBudgetLine(budget),
+    );
+  },
+
   async raw() {
     const vars = Object.fromEntries(
       flagAll("var").map((kv) => {
@@ -720,6 +925,7 @@ const VERBS = {
 };
 
 if (import.meta.main) {
+  installLinearBudgetCapture();
   if (!verb || has("help") || !VERBS[verb]) {
     console.log(`verbs: ${Object.keys(VERBS).join(", ")}\n`);
     console.log(
@@ -730,6 +936,13 @@ if (import.meta.main) {
   try {
     await VERBS[verb]();
   } catch (e) {
+    if (isLinearRateLimited(e) || isLinearRateLimitMessage(e.message)) {
+      const budget = loadLinearBudget() ?? {};
+      const resetAt = e.resetAt ?? budget.resetAt ?? null;
+      const payload = { rateLimited: true, resetAt };
+      console.error(JSON.stringify(payload));
+      process.exit(LINEAR_RATE_LIMIT_EXIT);
+    }
     console.error(`linear ${verb}: ${e.message}`);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- Linear CLI now records `X-RateLimit-Requests-*`, exposes `factory linear budget`, and exits 3 with `{rateLimited:true, resetAt}` instead of a generic failure.
- Planner memoizes in-flight queries by team+project (≤60s) and per-ticket reads for the pass; a rate-limit throw leaves the event admitted (`linear_rate_limited`) instead of `human_needed` / dead-letter. Auto-approval rechecks log the error and stay open as `dispatch_recheck_deferred`.
- `factory doctor` prints `Linear budget: N/2500 remaining, resets HH:MM` and warns below 300. Follow-up: WM-903 (dispatch prompt pin, `verify.mjs` REFUSAL_REASONS, worker claim path).

Fixes WM-878

UX critique: skipped — backend Linear client, planner, and doctor; no user-facing surface.

## Test plan
- [x] `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/auto-approval.test.mjs`
- [x] `bun tools/linear.mjs budget`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)