### PR TITLE
fix(extensions): show config namespace and fill array-item defaults (WM-860)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -23,7 +23,7 @@ const USAGE = BASE_USAGE.replace(
 )
   .replace(
     "  agents                         registered agent definitions and event routing",
-    "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts\n  extensions validate <path>     validate a factory-extension.json without loading it",
+    "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts, config namespace\n  extensions validate <path>     validate a factory-extension.json without loading it",
   )
   .concat(
     "\n  artifacts backfill-results [--apply]\n                                 materialize stored typed result output (dry by default)",
@@ -175,9 +175,10 @@ export async function adaptersCommand(args = []) {
 
 /**
  * `extensions list` — the allow-listed extensions the loader accepts (WM-838),
- * with their contribution counts; faults print as anomalies on stderr, exactly
- * as /status would report them, and the command still exits 0 because a
- * broken third-party extension is a configuration anomaly, not a CLI failure.
+ * with their contribution counts and `contributes.config` namespace; faults
+ * print as anomalies on stderr, exactly as /status would report them, and the
+ * command still exits 0 because a broken third-party extension is a
+ * configuration anomaly, not a CLI failure.
  * `extensions validate <path>` — validate one manifest (schema, path
  * existence, adapter names) without loading a pack or importing an adapter;
  * exit 1 when it does not validate. Both are local — no serve needed.
@@ -199,8 +200,14 @@ export async function extensionsCommand(args = []) {
     const contributes = out.manifest.contributes ?? {};
     const packs = (contributes.packs ?? []).length;
     const adapters = Object.keys(contributes.adapters ?? {}).length;
+    const namespace = contributes.config?.namespace;
+    const counts = `${packs} pack${packs === 1 ? "" : "s"}, ${adapters} adapter${adapters === 1 ? "" : "s"}`;
+    const configBit =
+      typeof namespace === "string" && namespace !== ""
+        ? `, config namespace ${namespace}`
+        : "";
     console.log(
-      `${out.manifest.name}@${out.manifest.version}: valid (${packs} pack${packs === 1 ? "" : "s"}, ${adapters} adapter${adapters === 1 ? "" : "s"})`,
+      `${out.manifest.name}@${out.manifest.version}: valid (${counts}${configBit})`,
     );
     return out;
   }
@@ -222,12 +229,19 @@ export async function extensionsCommand(args = []) {
       10,
       ...loaded.extensions.map((ext) => ext.name.length + 2),
     );
+    const nsWidth = Math.max(
+      10,
+      ...loaded.extensions.map(
+        (ext) => (ext.config?.namespace ?? "-").length + 2,
+      ),
+    );
     console.log(
-      `${"EXTENSION".padEnd(width)}${"VERSION".padEnd(10)}${"PACKS".padEnd(7)}${"ADAPTERS".padEnd(10)}PATH`,
+      `${"EXTENSION".padEnd(width)}${"VERSION".padEnd(10)}${"PACKS".padEnd(7)}${"ADAPTERS".padEnd(10)}${"NAMESPACE".padEnd(nsWidth)}PATH`,
     );
     for (const ext of loaded.extensions) {
+      const namespace = ext.config?.namespace ?? "-";
       console.log(
-        `${ext.name.padEnd(width)}${ext.version.padEnd(10)}${String(ext.packs.length).padEnd(7)}${String(ext.adapters.length).padEnd(10)}${ext.path}`,
+        `${ext.name.padEnd(width)}${ext.version.padEnd(10)}${String(ext.packs.length).padEnd(7)}${String(ext.adapters.length).padEnd(10)}${namespace.padEnd(nsWidth)}${ext.path}`,
       );
     }
     return loaded;

--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -57,7 +57,7 @@ function entriesForRepos(repos) {
 function entriesForPolicy(policy) {
   return POLICY_KEYS.filter((key) => Object.hasOwn(policy, key)).map((key) => ({
     key,
-    value: policy[key],
+    value: redactSecrets(policy[key]),
     reload: key === "models" ? "restart" : "hot",
   }));
 }

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -58,6 +58,9 @@ function fixtureRoot() {
       "    standard: pi/model",
       "unknown_private_block:",
       "  token: never-publish-this",
+      "notify:",
+      "  command: echo",
+      "  webhookToken: leaked-notify-token",
       "",
     ].join("\n"),
   );
@@ -205,6 +208,12 @@ describe("GET /config view", () => {
     ).toBe(false);
     expect(wire).not.toContain("never-publish-this");
     expect(wire).not.toContain("super-secret-value");
+    expect(wire).not.toContain("leaked-notify-token");
+    const notify = policy.entries.find((entry) => entry.key === "notify");
+    expect(notify.value).toEqual({
+      command: "echo",
+      webhookToken: "[redacted]",
+    });
     expect(
       nodes.entries.find((entry) => entry.key === "lab.env.keys").value,
     ).toEqual(["API_TOKEN", "FACTORY_EVENT_PORT"]);
@@ -346,6 +355,24 @@ describe("GET /config view", () => {
       "hello",
     );
     expect(JSON.stringify(view)).not.toContain("shh");
+  });
+
+  test("GET /config redacts secret-looking keys in the policy section, not only extension values", () => {
+    const view = configView({
+      root: fixtureRoot(),
+      registry: registry(),
+      repos: () => new Map(),
+      policyVersion: "git:test",
+      now: 0,
+    });
+    const policy = view.sections.find((section) => section.id === "policy");
+    expect(
+      policy.entries.find((entry) => entry.key === "notify").value,
+    ).toEqual({
+      command: "echo",
+      webhookToken: "[redacted]",
+    });
+    expect(JSON.stringify(view)).not.toContain("leaked-notify-token");
   });
 
   test("redactSecrets masks token/secret/key/password keys at any depth and leaves the rest", () => {

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -318,9 +318,11 @@ function isPlainObject(value) {
 
 /**
  * Fill `default`s from a schema into a value, recursively through
- * `properties`. A nested object property with no value is only created when
- * a default inside it produces something — an empty object would trip that
- * property's own `required` where absence would not.
+ * `properties` and `items`. A nested object property with no value is only
+ * created when a default inside it produces something — an empty object would
+ * trip that property's own `required` where absence would not. Array elements
+ * are filled from `schema.items` the same way (the array itself is not
+ * invented unless the schema supplies a `default`).
  */
 export function applyConfigDefaults(schema, value) {
   if (!isPlainObject(schema)) return cloneJson(value);
@@ -342,6 +344,9 @@ export function applyConfigDefaults(schema, value) {
       if (isPlainObject(filled) && Object.keys(filled).length === 0) continue;
       out[key] = filled;
     }
+  }
+  if (Array.isArray(out) && isPlainObject(schema.items)) {
+    out = out.map((item) => applyConfigDefaults(schema.items, item));
   }
   return out;
 }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -17,6 +17,7 @@ import {
   EXTENSION_SCHEMA,
   ExtensionError,
   RESERVED_CONTRIBUTIONS,
+  applyConfigDefaults,
   getExtensionConfig,
   loadExtensionRoots,
   loadExtensions,
@@ -555,6 +556,61 @@ describe("extension config (contributes.config)", () => {
     );
   });
 
+  test("applyConfigDefaults fills schema.items defaults on array values", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        servers: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              host: { type: "string" },
+              port: { type: "integer", default: 443 },
+              retries: { type: "integer", default: 2 },
+            },
+          },
+        },
+        tags: {
+          type: "array",
+          default: [{ label: "x" }],
+          items: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+              weight: { type: "integer", default: 1 },
+            },
+          },
+        },
+      },
+    };
+    expect(
+      applyConfigDefaults(schema, {
+        servers: [{ host: "a.example" }, { host: "b.example", port: 8443 }],
+      }),
+    ).toEqual({
+      servers: [
+        { host: "a.example", port: 443, retries: 2 },
+        { host: "b.example", port: 8443, retries: 2 },
+      ],
+      tags: [{ label: "x", weight: 1 }],
+    });
+    // A missing array is not invented when the schema has no default.
+    expect(
+      applyConfigDefaults({ type: "array", items: { default: 1 } }, undefined),
+    ).toBeUndefined();
+    // Existing arrays still walk items even without an object wrapper.
+    expect(
+      applyConfigDefaults(
+        {
+          type: "array",
+          items: { type: "object", properties: { n: { default: 1 } } },
+        },
+        [{}],
+      ),
+    ).toEqual([{ n: 1 }]);
+  });
+
   test("validate refuses a manifest whose config key is malformed", () => {
     const bad = tempExtension((m) => {
       m.contributes.config = { namespace: "Bad Space" };
@@ -791,8 +847,19 @@ describe("cli extensions", () => {
     const ok = run("validate", SAMPLE_EXTENSION);
     expect(ok.exitCode).toBe(0);
     expect(ok.stdout.toString()).toMatch(
-      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter\)/,
+      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter, config namespace sample\)/,
     );
+
+    const noConfig = tempExtension((m) => {
+      m.name = "factory/plain";
+      delete m.contributes.config;
+    });
+    const plain = run("validate", noConfig);
+    expect(plain.exitCode).toBe(0);
+    expect(plain.stdout.toString()).toMatch(
+      /factory\/plain@1\.0\.0: valid \(1 pack, 1 adapter\)/,
+    );
+    expect(plain.stdout.toString()).not.toMatch(/config namespace/);
 
     const bad = tempExtension((m) => {
       m.version = "one";
@@ -838,10 +905,12 @@ describe("cli extensions", () => {
     });
     expect(out.exitCode).toBe(0);
     const text = out.stdout.toString();
-    expect(text).toMatch(/EXTENSION\s+VERSION\s+PACKS\s+ADAPTERS\s+PATH/);
+    expect(text).toMatch(
+      /EXTENSION\s+VERSION\s+PACKS\s+ADAPTERS\s+NAMESPACE\s+PATH/,
+    );
     expect(text).toMatch(
       new RegExp(
-        `factory/sample\\s+1\\.0\\.0\\s+1\\s+1\\s+${SAMPLE_EXTENSION}`,
+        `factory/sample\\s+1\\.0\\.0\\s+1\\s+1\\s+sample\\s+${SAMPLE_EXTENSION}`,
       ),
     );
     expect(out.stderr.toString()).toMatch(
@@ -863,6 +932,7 @@ describe("cli extensions", () => {
     });
     const parsed = JSON.parse(json.stdout.toString());
     expect(parsed.extensions[0].name).toBe("factory/sample");
+    expect(parsed.extensions[0].config.namespace).toBe("sample");
     expect(parsed.anomalies).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- `extensions validate` / `extensions list` now display `contributes.config` namespace when declared (NAMESPACE column; validate suffix `config namespace <ns>`).
- `applyConfigDefaults` walks `schema.items` so array-element defaults fill the same way nested object defaults already did.
- `GET /config` runs `redactSecrets` on the policy section, matching extension config values.

Fixes WM-860

UX critique: skipped — CLI/API/library change, no user-completable flow

Docs follow-up (outside Owned Paths): WM-904

## Test plan
- [x] `bun test event-runtime/lib/api-config.test.mjs event-runtime/lib/extensions.test.mjs`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `bun test` (full suite)


Made with [Cursor](https://cursor.com)