### PR TITLE
feat(artifact-view): add input view, subject, and contract fallback (WM-897)

### DIFF
--- a/docs/event-runtime-artifact-views.md
+++ b/docs/event-runtime-artifact-views.md
@@ -61,10 +61,14 @@ Out of scope, said out loud:
 ### 2.1 Where it lives
 
 `event-runtime/agents/<name>.view.json`, beside the agent's `.md`/`.json`.
-Optional: an agent without one renders as JSON exactly as today. The registry
-loads it (`lib/registry.mjs`) and `GET /agents` exposes it as `outputView`
-next to the `outputSchema` it already ships, so the web has both without a
-new endpoint.
+Optional: an agent without one renders as JSON exactly as today. When the
+agent sidecar is absent, the registry also looks for a **contract-keyed
+fallback** at `agents/views/<output_contract>.view.json` (slashes in the
+contract id become dots: `factory.command-result/v1` →
+`agents/views/factory.command-result.v1.view.json`). Nine command-result
+agents share that one file. The agent sidecar wins when both exist.
+`GET /agents` exposes the applied view as `outputView` plus
+`view.source: "agent" | "contract"` (or `view: null` when neither applied).
 
 ### 2.2 The contract
 
@@ -112,9 +116,11 @@ new endpoint.
 | Key        | Rule                                                                                                                                                                                                                                                                                                                                                                                                    |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `title`    | Optional, ≤ 60 chars; falls back to the output schema's `title`.                                                                                                                                                                                                                                                                                                                                        |
-| `summary`  | Optional JSON pointer (RFC 6901) to a string rendered first, as prose.                                                                                                                                                                                                                                                                                                                                  |
+| `summary`  | Optional JSON pointer (RFC 6901) to a string rendered first, as prose. Pointers on the output body resolve in the **output** schema.                                                                                                                                                                                                                                                                    |
 | `status`   | Optional `{ path, tone }`: a pointer to an enum/string plus a value → tone map. Rendered as the header badge.                                                                                                                                                                                                                                                                                           |
-| `sections` | 1–12, rendered in order. Each has `path` (pointer; array or object or scalar), `as` from the closed set below, optional `label`, and per-`as` keys. A pointer that resolves to `undefined` in a given artifact renders nothing — optional fields are optional.                                                                                                                                          |
+| `sections` | Optional, 1–12 when present, rendered in order. Each has `path` (pointer; array or object or scalar), `as` from the closed set below, optional `label`, and per-`as` keys. A pointer that resolves to `undefined` in a given artifact renders nothing — optional fields are optional. A sidecar may omit `sections` entirely when it only ships `input` and/or `subject`.                               |
+| `input`    | Optional view body (`title`, `summary`, `status`, `sections`, `formats`, `tone`) whose pointers resolve against the agent's **input** schema. Drawn in place of the hand-coded run-detail glance when present.                                                                                                                                                                                          |
+| `subject`  | Optional template string, one line. Placeholders are `{/pointer}` into the input schema or the fixed RunSpec fields `{agent}`, `{model}`, `{adapter}`, `{repo}`. Rendered by `lib/spec-subject.mjs` and exposed as `subject` on `GET /runs/:id`, `GET /proposals`, and `GET /proposals/:id`. Example: `"Dispatch {/ticket} · {/repo} · {model}"`.                                                       |
 | `as`       | `table` (array of objects: `columns` 1–8, optional `groupBy`, `expand` — columns shown only in the row's expanded state, `formats`, `tone`), `keyvalue` (object or scalar: `keys` optional subset, `formats`, `tone`), `list` (array of scalars/objects: `itemLabel` pointer relative to the item, `formats`, `tone`), `badge` (scalar: `tone`), `code` (string: `language` optional), `prose` (string) |
 | `formats`  | Map of column/key (or `""` for the section value itself) → `format`, from `issue \| pr \| url \| sha \| repo \| run \| duration \| datetime \| state \| bytes \| count`. `issue`/`pr`/`run` render as jump chips using the same link builders the rest of the UI uses; `state` uses the run-state hues.                                                                                                 |
 | `tone`     | Map of column/key → (value → `ok \| warn \| error \| muted \| neutral`), or a value map directly for scalars.                                                                                                                                                                                                                                                                                           |
@@ -126,7 +132,16 @@ decides everything else, once, for every agent.
 
 ### 2.3 Why a sidecar and not `x-ui` in the schema
 
-Three reasons, all structural:
+`x-ui` is gone, not merely discouraged. WM-701 introduced
+`x-ui: { kind: "ticket" }` as a schema annotation; `web/src/components/CustomCell.tsx`
+used to read it, but no schema in the repo ever carried `x-ui`, none of the
+`<CustomCell>` callers passed `ui`/`schema`, and `lib/schema.mjs` fails closed
+on unknown keywords so `x-ui` cannot legally appear in an input/output
+schema. CustomCell now takes the closed `formats` value from the active
+artifact view (`issue` → ticket hover-card); without a view it still scans
+the cell text for ticket ids.
+
+Three reasons the rest of the vocabulary stays in a sidecar, all structural:
 
 - `lib/schema.mjs` **fails closed on any unsupported keyword** — a contract
   with `x-ui` in it is an invalid contract today. Admitting an opaque
@@ -139,10 +154,11 @@ Three reasons, all structural:
 
 The cost is drift: a sidecar can name a path the schema no longer has. That is
 closed by a test, not by discipline — `lib/artifact-view.test.mjs` resolves
-every `path`, `columns`, `keys`, `expand`, `itemLabel`, `summary`, and
-`status.path` against the agent's output schema and fails on any that does not
-exist. The registry runs the same check at load and refuses a view that does
-not fit its schema (a bad view is a configuration anomaly, shown in
+every `path`, `columns`, `keys`, `expand`, `itemLabel`, `summary`,
+`status.path`, `input.*` pointer, and `subject` placeholder against the
+matching schema (output or input) and fails on any that does not exist. The
+registry runs the same check at load and refuses a view that does not fit
+(a bad view is a configuration anomaly, shown in
 `/status.anomalies.configuration`, never a rendering crash).
 
 ### 2.4 Rendering
@@ -161,11 +177,33 @@ Tables in a terminal are not worth it yet.
 
 ### 2.5 First views
 
-`triage-scan` and `merge-scan` ship views in the same ticket as the contract:
-they are the two artifacts the operator reads most and the two that are
-hardest to read as JSON. `dispatch`, `work-scan`, `run-postmortem` follow in
-the Backlog ticket once the first two have shown what the vocabulary is
-missing.
+`triage-scan` and `merge-scan` ship output views with the contract: they are
+the two artifacts the operator reads most and the two that are hardest to
+read as JSON. `dispatch` ships an **input + subject** sidecar (no output
+sections — those come with WM-898):
+
+```json
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "subject": "Dispatch {/ticket} · {/repo} · {model}",
+  "input": {
+    "sections": [
+      {
+        "path": "",
+        "as": "keyvalue",
+        "label": "Input",
+        "keys": ["repo", "ticket"],
+        "formats": { "repo": "repo", "ticket": "issue" }
+      }
+    ]
+  }
+}
+```
+
+The nine `factory.command-result/v1` agents share
+`agents/views/factory.command-result.v1.view.json`. `work-scan` and
+`run-postmortem` follow in the Backlog ticket once the first two have shown
+what the vocabulary is missing.
 
 ### 2.6 Panels — `factory.panel-view/v1` (WM-840)
 

--- a/event-runtime/agents/dispatch.view.json
+++ b/event-runtime/agents/dispatch.view.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "subject": "Dispatch {/ticket} · {/repo} · {model}",
+  "input": {
+    "sections": [
+      {
+        "path": "",
+        "as": "keyvalue",
+        "label": "Input",
+        "keys": ["repo", "ticket"],
+        "formats": {
+          "repo": "repo",
+          "ticket": "issue"
+        }
+      }
+    ]
+  }
+}

--- a/event-runtime/agents/views/factory.command-result.v1.view.json
+++ b/event-runtime/agents/views/factory.command-result.v1.view.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "title": "Command",
+  "status": {
+    "path": "/exitCode",
+    "tone": { "0": "ok" }
+  },
+  "sections": [
+    {
+      "path": "/command",
+      "as": "list",
+      "label": "Command"
+    },
+    {
+      "path": "/outputTail",
+      "as": "code",
+      "label": "Output",
+      "language": "text"
+    }
+  ]
+}

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -20,10 +20,16 @@ export function agentsView(registry) {
       inputSchema: def.inputSchema,
       outputSchemaFile: def.output_schema,
       outputSchema: def.outputSchema,
-      // Artifact-view sidecar (WM-454): null when the agent has none or its
-      // view failed the drift check (then /status names the anomaly).
+      // Artifact-view sidecar (WM-454 / WM-897): null when the agent has
+      // none or its view failed the drift check (then /status names the
+      // anomaly). `view.source` says whether the agent file or the
+      // contract-keyed fallback applied.
       outputViewFile: getArtifactView(registry, def.ref).file,
       outputView: getArtifactView(registry, def.ref).view,
+      view: (() => {
+        const source = getArtifactView(registry, def.ref).source;
+        return source ? { source } : null;
+      })(),
       pins: def.pins,
       command: def.command ?? null,
       actionRegistry: def.actionRegistry ?? null,

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -19,6 +19,7 @@ import {
   releaseStalledWorkerLease,
   retryRun,
 } from "./worker.mjs";
+import { proposalSubject } from "./proposal-subject.mjs";
 
 export const MAX_EXTENSION_SECONDS = 3600;
 
@@ -52,7 +53,7 @@ export function repoNamesFromInput(input) {
   return names;
 }
 
-function proposalView(row) {
+function proposalView(row, registry) {
   return {
     id: row.id,
     decision: row.decision,
@@ -68,6 +69,7 @@ function proposalView(row) {
     eventSource: row.event_source,
     agent: row.spec?.agent ?? null,
     spec: row.spec,
+    subject: registry ? proposalSubject(registry, row.spec) : null,
     repos: repoNamesFromInput(row.spec?.input),
   };
 }
@@ -103,13 +105,16 @@ function proposalHistory(db, status, filters = {}) {
         return [];
     }
     return [
-      proposalView({
-        ...row,
-        status: effectiveStatus,
-        decided_at: decisionAt,
-        expired: effectiveStatus === "expired",
-        spec: row.spec_json ? JSON.parse(row.spec_json) : null,
-      }),
+      proposalView(
+        {
+          ...row,
+          status: effectiveStatus,
+          decided_at: decisionAt,
+          expired: effectiveStatus === "expired",
+          spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+        },
+        filters.registry,
+      ),
     ];
   });
 }
@@ -1111,7 +1116,7 @@ export function observedModelFromTranscript(head) {
   return null;
 }
 
-function runView(db, runId, { artifactsDir } = {}) {
+function runView(db, runId, { artifactsDir, registry } = {}) {
   const row = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(runId);
   if (!row) return null;
   const attempts = db
@@ -1127,8 +1132,9 @@ function runView(db, runId, { artifactsDir } = {}) {
     (a) => a.kind === "transcript",
   );
   const latest = attempts[attempts.length - 1];
+  const spec = JSON.parse(row.spec_json);
   const deadline = latest
-    ? attemptDeadline(db, runId, latest.attempt, JSON.parse(row.spec_json))
+    ? attemptDeadline(db, runId, latest.attempt, spec)
     : null;
   return {
     run: {
@@ -1139,8 +1145,9 @@ function runView(db, runId, { artifactsDir } = {}) {
       specHash: row.spec_hash,
       created_at: row.created_at,
       updated_at: row.updated_at,
-      spec: JSON.parse(row.spec_json),
+      spec,
     },
+    subject: registry ? proposalSubject(registry, spec) : null,
     lifecycle: lifecycleOf(db, runId),
     attempts,
     result,
@@ -1187,6 +1194,7 @@ export async function handleRunApiRoute({
       const filters = {
         ...listFilters(url, { proposal: true, nowMs }),
         decisionStatus: url.searchParams.get("decisionStatus") ?? undefined,
+        registry,
       };
       if (status || filters.population)
         return send(200, {
@@ -1197,7 +1205,9 @@ export async function handleRunApiRoute({
           ),
         });
       return send(200, {
-        proposals: openProposals(db, { now: nowMs }).map(proposalView),
+        proposals: openProposals(db, { now: nowMs }).map((row) =>
+          proposalView(row, registry),
+        ),
       });
     } catch (err) {
       if (err instanceof ListQueryError) return send(422, err.body);
@@ -1216,14 +1226,17 @@ export async function handleRunApiRoute({
     const expiresAt =
       Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
     return send(200, {
-      proposal: proposalView({
-        ...row,
-        spec: row.spec_json ? JSON.parse(row.spec_json) : null,
-        expired:
-          row.status === "open" &&
-          Number.isFinite(expiresAt) &&
-          expiresAt < nowMs,
-      }),
+      proposal: proposalView(
+        {
+          ...row,
+          spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+          expired:
+            row.status === "open" &&
+            Number.isFinite(expiresAt) &&
+            expiresAt < nowMs,
+        },
+        registry,
+      ),
       hookDecisions: hookDecisionsFor(db, id),
     });
   }
@@ -1312,7 +1325,10 @@ export async function handleRunApiRoute({
         return send(200, {
           approved: false,
           replanned: true,
-          proposal: proposalView({ ...outcome.proposal, expired: false }),
+          proposal: proposalView(
+            { ...outcome.proposal, expired: false },
+            registry,
+          ),
         });
       }
       const outcome = rejectProposal(db, id, {
@@ -1492,7 +1508,7 @@ export async function handleRunApiRoute({
 
   const runGet = url.pathname.match(/^\/runs\/([^/]+)$/);
   if (req.method === "GET" && runGet) {
-    const view = runView(db, runGet[1], { artifactsDir });
+    const view = runView(db, runGet[1], { artifactsDir, registry });
     if (!view) return send(404, { error: `unknown run ${runGet[1]}` });
     return send(200, view);
   }

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -361,11 +361,27 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
       expect(merge.outputViewFile).toBe("agents/merge-scan.view.json");
       expect(merge.outputView.schemaVersion).toBe("factory.artifact-view/v1");
       expect(merge.outputView.status.path).toBe("/recommendation");
+      expect(merge.view).toEqual({ source: "agent" });
       const triage = defs.find((d) => d.ref === "triage-scan@1");
       expect(triage.outputView.summary).toBe("/summary");
-      const bare = defs.find((d) => d.ref === "reconcile@1");
+      const dispatch = defs.find((d) => d.ref === "dispatch@1");
+      expect(dispatch.view).toEqual({ source: "agent" });
+      expect(dispatch.outputView.subject).toBe(
+        "Dispatch {/ticket} · {/repo} · {model}",
+      );
+      expect(dispatch.outputView.input.sections[0].formats.ticket).toBe(
+        "issue",
+      );
+      const command = defs.find((d) => d.ref === "reconcile@1");
+      expect(command.view).toEqual({ source: "contract" });
+      expect(command.outputViewFile).toBe(
+        "agents/views/factory.command-result.v1.view.json",
+      );
+      expect(command.outputView.title).toBe("Command");
+      const bare = defs.find((d) => d.ref === "ship-scan@1");
       expect(bare.outputView).toBeNull();
       expect(bare.outputViewFile).toBeNull();
+      expect(bare.view).toBeNull();
       // Not part of the pinned identity.
       expect(Object.keys(merge.pins)).not.toContain(
         "agents/merge-scan.view.json",
@@ -381,6 +397,7 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
       );
       expect(agentDef).toContain("outputViewFile?");
       expect(agentDef).toContain("outputView?");
+      expect(agentDef).toContain('source: "agent" | "contract"');
     } finally {
       server.close();
     }
@@ -417,6 +434,81 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
       expect(anomaly).toMatch(/"\/tldr" does not resolve/);
     } finally {
       server.close();
+    }
+  });
+});
+
+describe("spec subject on GET /runs/:id and /proposals (WM-897)", () => {
+  const spec = {
+    schemaVersion: "factory.run-spec/v1",
+    runId: "run_subject",
+    agent: "dispatch@1",
+    input: { repo: "factory", ticket: "WM-862" },
+    inputHash: "sha256:input",
+    workspace: { type: "none" },
+    adapter: "cursor",
+    promptVersion: "test",
+    policyVersion: PV,
+    outputContract: "factory.dispatch-result/v1",
+    capabilities: [],
+    timeoutSeconds: 60,
+    maxAttempts: 1,
+    idempotencyKey: "idem-subject",
+    model: "cursor-grok-4.6-high",
+  };
+
+  test("GET /runs/:id exposes the rendered subject", async () => {
+    const s = await makeServer();
+    try {
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'COMPLETED', 1, ?, ?)`,
+        )
+        .run(
+          "run_subject",
+          "idem-subject",
+          JSON.stringify(spec),
+          "sha256:spec",
+          "2026-08-19T12:00:00.000Z",
+          "2026-08-19T12:00:00.000Z",
+        );
+      const res = await fetch(s.url("/runs/run_subject"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.subject).toBe(
+        "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+      );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("GET /proposals and GET /proposals/:id expose the rendered subject", async () => {
+    const s = await makeServer();
+    try {
+      s.db
+        .query(
+          `INSERT INTO proposals
+             (id, event_source, event_id, decision, status, created_at, ttl_seconds, spec_json)
+           VALUES (?, 'test', 'ev-subject', 'run', 'open', ?, 3600, ?)`,
+        )
+        .run("prop_subject", "2026-08-19T12:00:00.000Z", JSON.stringify(spec));
+      const list = await fetch(s.url("/proposals?status=all"));
+      expect(list.status).toBe(200);
+      const listed = (await list.json()).proposals.find(
+        (p) => p.id === "prop_subject",
+      );
+      expect(listed.subject).toBe(
+        "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+      );
+      const detail = await fetch(s.url("/proposals/prop_subject"));
+      expect(detail.status).toBe(200);
+      expect((await detail.json()).proposal.subject).toBe(
+        "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+      );
+    } finally {
+      s.close();
     }
   });
 });

--- a/event-runtime/lib/artifact-view.mjs
+++ b/event-runtime/lib/artifact-view.mjs
@@ -1,15 +1,19 @@
 /**
  * Artifact views — `factory.artifact-view/v1` (docs/event-runtime-artifact-views.md §2).
  *
- * A sidecar `agents/<name>.view.json` annotates JSON pointers into an agent's
- * output schema with a closed hint vocabulary so a generic renderer can draw
- * the artifact. Two checks, both fail closed and both here rather than in the
- * renderer: the document must match the v1 schema (lib/schema.mjs, the same
- * validator every contract goes through), and every pointer it names must
- * resolve to a property of the agent's output schema — a view cannot drift
- * from the contract it describes (§2.3). Pointer resolution against a
- * concrete document (`resolvePointer`) is shared with the presentation layer
- * (WM-456).
+ * A sidecar `agents/<name>.view.json` (or a contract-keyed fallback under
+ * `agents/views/`) annotates JSON pointers into an agent's output — and
+ * optionally input — schema with a closed hint vocabulary so a generic
+ * renderer can draw the document. Two checks, both fail closed and both here
+ * rather than in the renderer: the document must match the v1 schema
+ * (lib/schema.mjs, the same validator every contract goes through), and every
+ * pointer it names must resolve to a property of the matching schema — a view
+ * cannot drift from the contract it describes (§2.3). Pointer resolution
+ * against a concrete document (`resolvePointer`) is shared with the
+ * presentation layer (WM-456).
+ *
+ * `subject` is a one-line template over input-schema pointers (`{/ticket}`)
+ * plus the fixed RunSpec fields `agent`, `model`, `adapter`, `repo`.
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -46,6 +50,28 @@ export const FORMATS = [
   "count",
 ];
 export const TONES = ["ok", "warn", "error", "muted", "neutral"];
+
+/** Fixed RunSpec fields a `subject` template may name without a leading `/`. */
+export const SUBJECT_FIELDS = ["agent", "model", "adapter", "repo"];
+
+/**
+ * `factory.command-result/v1` → `agents/views/factory.command-result.v1.view.json`.
+ * Slashes become dots so the contract id is a single path segment.
+ */
+export function contractViewRel(outputContract) {
+  if (typeof outputContract !== "string" || !outputContract) return null;
+  return `agents/views/${outputContract.replaceAll("/", ".")}.view.json`;
+}
+
+/** `{/ticket}` and `{model}` tokens, in template order. Empty / nested braces are not tokens. */
+export function subjectPlaceholders(template) {
+  if (typeof template !== "string") return [];
+  const out = [];
+  const re = /\{([^{}]+)\}/g;
+  let m;
+  while ((m = re.exec(template)) !== null) out.push(m[1]);
+  return out;
+}
 
 /** Keys every section may carry, plus the per-`as` keys (design §2.2 `as` row). */
 const COMMON_SECTION_KEYS = new Set(["path", "as", "label"]);
@@ -144,6 +170,57 @@ function relativeNode(base, key) {
   return walkSchema(base, tokens);
 }
 
+function hasOutputBody(view) {
+  return (
+    hasOwn(view, "summary") ||
+    hasOwn(view, "status") ||
+    (Array.isArray(view.sections) && view.sections.length > 0)
+  );
+}
+
+function hasInputBody(body) {
+  return (
+    isObject(body) &&
+    (hasOwn(body, "summary") ||
+      hasOwn(body, "status") ||
+      (Array.isArray(body.sections) && body.sections.length > 0) ||
+      hasOwn(body, "formats") ||
+      hasOwn(body, "tone") ||
+      hasOwn(body, "title"))
+  );
+}
+
+function subjectErrors(template, inputSchema, at) {
+  const errors = [];
+  if (typeof template !== "string" || !template.trim()) {
+    errors.push(`${at}: must be a non-empty template string`);
+    return errors;
+  }
+  const tokens = subjectPlaceholders(template);
+  if (tokens.length === 0) return errors;
+  const needsInput = tokens.some((t) => t.startsWith("/"));
+  if (needsInput && !isObject(inputSchema)) {
+    errors.push(
+      `${at}: input schema is missing — nothing to resolve placeholders against`,
+    );
+    return errors;
+  }
+  for (const token of tokens) {
+    if (token.startsWith("/")) {
+      if (resolveSchemaPointer(inputSchema, token) === undefined) {
+        errors.push(
+          `${at}: placeholder "{${token}}" does not resolve in the input schema`,
+        );
+      }
+    } else if (!SUBJECT_FIELDS.includes(token)) {
+      errors.push(
+        `${at}: unknown placeholder "{${token}}" (input pointer or ${SUBJECT_FIELDS.join("|")})`,
+      );
+    }
+  }
+  return errors;
+}
+
 /** The per-`as` key checks the schema cannot express (design §2.2 `as` row). */
 function sectionKeyErrors(section, at) {
   const errors = [];
@@ -171,67 +248,51 @@ function sectionKeyErrors(section, at) {
 }
 
 /**
- * Validate a view document's *shape* only: the v1 schema plus the per-`as`
- * key rules, with no output schema to resolve pointers against. This is the
- * check a panel (`factory.panel-view/v1`, lib/panel-view.mjs) gets — its data
- * comes from an API endpoint that has no published schema — and the first
- * half of `validateArtifactView`. Never throws.
- * @returns {{ valid: boolean, errors: string[] }}
+ * Pointer and per-`as` checks for one view body (the output side, or
+ * `view.input`) against one schema. `at` prefixes every error (`view` /
+ * `view.input`). A pointer that does not resolve names `schemaLabel`
+ * ("output schema" / "input schema").
  */
-export function validateArtifactViewShape(view) {
-  const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
-  if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
+function validateViewBody(body, schema, at, schemaLabel) {
   const errors = [];
-  view.sections.forEach((section, i) => {
-    errors.push(...sectionKeyErrors(section, `view.sections[${i}]`));
-  });
-  return { valid: errors.length === 0, errors };
-}
-
-/**
- * Validate a view document against the v1 schema AND against the agent's
- * output schema (pointer drift). Never throws.
- * @returns {{ valid: boolean, errors: string[] }}
- */
-export function validateArtifactView(view, outputSchema) {
-  const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
-  if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
-  if (!isObject(outputSchema)) {
-    return {
-      valid: false,
-      errors: [
-        "view: output schema is missing — nothing to resolve pointers against",
-      ],
-    };
+  if (!isObject(body)) {
+    errors.push(`${at}: must be an object`);
+    return errors;
   }
-  const errors = [];
+  if (!isObject(schema)) {
+    errors.push(
+      `${at}: ${schemaLabel} is missing — nothing to resolve pointers against`,
+    );
+    return errors;
+  }
 
   if (
-    hasOwn(view, "summary") &&
-    resolveSchemaPointer(outputSchema, view.summary) === undefined
+    hasOwn(body, "summary") &&
+    resolveSchemaPointer(schema, body.summary) === undefined
   ) {
     errors.push(
-      `view.summary: pointer "${view.summary}" does not resolve in the output schema`,
+      `${at}.summary: pointer "${body.summary}" does not resolve in the ${schemaLabel}`,
     );
   }
   if (
-    hasOwn(view, "status") &&
-    resolveSchemaPointer(outputSchema, view.status.path) === undefined
+    hasOwn(body, "status") &&
+    resolveSchemaPointer(schema, body.status.path) === undefined
   ) {
     errors.push(
-      `view.status.path: pointer "${view.status.path}" does not resolve in the output schema`,
+      `${at}.status.path: pointer "${body.status.path}" does not resolve in the ${schemaLabel}`,
     );
   }
 
-  view.sections.forEach((section, i) => {
-    const at = `view.sections[${i}]`;
+  const sections = Array.isArray(body.sections) ? body.sections : [];
+  sections.forEach((section, i) => {
+    const secAt = `${at}.sections[${i}]`;
     const kind = section.as;
-    errors.push(...sectionKeyErrors(section, at));
+    errors.push(...sectionKeyErrors(section, secAt));
 
-    const node = resolveSchemaPointer(outputSchema, section.path);
+    const node = resolveSchemaPointer(schema, section.path);
     if (node === undefined) {
       errors.push(
-        `${at}.path: pointer "${section.path}" does not resolve in the output schema`,
+        `${secAt}.path: pointer "${section.path}" does not resolve in the ${schemaLabel}`,
       );
       return;
     }
@@ -240,7 +301,7 @@ export function validateArtifactView(view, outputSchema) {
       !(hasOwn(node, "items") && isObject(node.items))
     ) {
       errors.push(
-        `${at}.path: as=${kind} needs an array schema at "${section.path}"`,
+        `${secAt}.path: as=${kind} needs an array schema at "${section.path}"`,
       );
     }
     const base = itemNode(node);
@@ -248,7 +309,7 @@ export function validateArtifactView(view, outputSchema) {
       if (key === "") return;
       if (relativeNode(base, key) === undefined) {
         errors.push(
-          `${at}.${field}: "${key}" does not resolve under "${section.path}" in the output schema`,
+          `${secAt}.${field}: "${key}" does not resolve under "${section.path}" in the ${schemaLabel}`,
         );
       }
     };
@@ -269,20 +330,89 @@ export function validateArtifactView(view, outputSchema) {
         checkKey("tone", key);
         if (!isObject(value)) {
           errors.push(
-            `${at}.tone.${key}: as=${kind} tone maps a column/key to a (value → tone) object`,
+            `${secAt}.tone.${key}: as=${kind} tone maps a column/key to a (value → tone) object`,
           );
           continue;
         }
         for (const [v, tone] of Object.entries(value)) {
           if (!TONES.includes(tone)) {
             errors.push(
-              `${at}.tone.${key}.${v}: tone must be one of ${TONES.join("|")}`,
+              `${secAt}.tone.${key}.${v}: tone must be one of ${TONES.join("|")}`,
             );
           }
         }
       }
     }
   });
+  return errors;
+}
+
+/**
+ * Validate a view document's *shape* only: the v1 schema plus the per-`as`
+ * key rules, with no output schema to resolve pointers against. This is the
+ * check a panel (`factory.panel-view/v1`, lib/panel-view.mjs) gets — its data
+ * comes from an API endpoint that has no published schema — and the first
+ * half of `validateArtifactView`. Never throws.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateArtifactViewShape(view) {
+  const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
+  if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
+  const errors = [];
+  if (
+    !hasOutputBody(view) &&
+    !hasOwn(view, "subject") &&
+    !hasInputBody(view.input)
+  ) {
+    errors.push(
+      "view: needs sections, input, or subject — an empty sidecar is not a view",
+    );
+  }
+  (view.sections ?? []).forEach((section, i) => {
+    errors.push(...sectionKeyErrors(section, `view.sections[${i}]`));
+  });
+  (view.input?.sections ?? []).forEach((section, i) => {
+    errors.push(...sectionKeyErrors(section, `view.input.sections[${i}]`));
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a view document against the v1 schema AND against the agent's
+ * schemas (pointer drift). Output pointers (`summary`, `status`, `sections`)
+ * resolve in `outputSchema`; `input.*` and `subject` placeholders resolve in
+ * `inputSchema` (plus the fixed spec field list). Never throws.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateArtifactView(view, outputSchema, inputSchema) {
+  const shape = validateArtifactViewShape(view);
+  if (!shape.valid) return shape;
+  const errors = [];
+
+  if (hasOutputBody(view)) {
+    errors.push(
+      ...validateViewBody(view, outputSchema, "view", "output schema"),
+    );
+  }
+  if (hasOwn(view, "input")) {
+    if (!hasInputBody(view.input)) {
+      errors.push(
+        "view.input: needs summary, status, or sections — an empty input body is not a view",
+      );
+    } else {
+      errors.push(
+        ...validateViewBody(
+          view.input,
+          inputSchema,
+          "view.input",
+          "input schema",
+        ),
+      );
+    }
+  }
+  if (hasOwn(view, "subject")) {
+    errors.push(...subjectErrors(view.subject, inputSchema, "view.subject"));
+  }
 
   return { valid: errors.length === 0, errors };
 }

--- a/event-runtime/lib/artifact-view.test.mjs
+++ b/event-runtime/lib/artifact-view.test.mjs
@@ -8,6 +8,7 @@ import {
   FORMATS,
   SECTION_KINDS,
   TONES,
+  contractViewRel,
   inspectHeader,
   parsePointer,
   resolvePointer,
@@ -128,6 +129,12 @@ describe("factory.artifact-view/v1 schema (WM-454)", () => {
     expect(TONES).toEqual(["ok", "warn", "error", "muted", "neutral"]);
     // additionalProperties: false throughout the object shapes.
     expect(ARTIFACT_VIEW_SCHEMA.additionalProperties).toBe(false);
+    expect(ARTIFACT_VIEW_SCHEMA.required).toEqual(["schemaVersion"]);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.input).toBeDefined();
+    expect(ARTIFACT_VIEW_SCHEMA.properties.subject).toBeDefined();
+    expect(ARTIFACT_VIEW_SCHEMA.properties.input.additionalProperties).toBe(
+      false,
+    );
     expect(ARTIFACT_VIEW_SCHEMA.properties.status.additionalProperties).toBe(
       false,
     );
@@ -387,7 +394,7 @@ describe("committed views fit their agents' output schemas (drift gate, design �
   });
 
   for (const name of viewFiles) {
-    test(`agents/${name} resolves every pointer against its output schema`, () => {
+    test(`agents/${name} resolves every pointer against its schemas`, () => {
       const defFile = path.join(
         agentsDir,
         name.replace(/\.view\.json$/, ".json"),
@@ -396,8 +403,11 @@ describe("committed views fit their agents' output schemas (drift gate, design �
       const outputSchema = JSON.parse(
         readFileSync(path.join(RUNTIME_ROOT, def.output_schema), "utf8"),
       );
+      const inputSchema = JSON.parse(
+        readFileSync(path.join(RUNTIME_ROOT, def.input_schema), "utf8"),
+      );
       const view = JSON.parse(readFileSync(path.join(agentsDir, name), "utf8"));
-      expect(validateArtifactView(view, outputSchema)).toEqual({
+      expect(validateArtifactView(view, outputSchema, inputSchema)).toEqual({
         valid: true,
         errors: [],
       });
@@ -443,6 +453,122 @@ describe("committed views fit their agents' output schemas (drift gate, design �
   });
 });
 
+const INPUT_SCHEMA = {
+  type: "object",
+  required: ["repo", "ticket"],
+  additionalProperties: false,
+  properties: {
+    repo: { type: "string" },
+    ticket: { type: "string" },
+    modelTier: { type: "string" },
+  },
+};
+
+const INPUT_ONLY = {
+  schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION,
+  subject: "Dispatch {/ticket} · {/repo} · {model}",
+  input: {
+    sections: [
+      {
+        path: "",
+        as: "keyvalue",
+        label: "Input",
+        keys: ["repo", "ticket"],
+        formats: { ticket: "issue", repo: "repo" },
+      },
+    ],
+  },
+};
+
+describe("input view + subject (WM-897)", () => {
+  test("an input-only sidecar (no output sections) is schema-valid and drift-clean", () => {
+    expect(
+      validateArtifactView(INPUT_ONLY, OUTPUT_SCHEMA, INPUT_SCHEMA),
+    ).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  test("a bad input path or placeholder fails at validation (registry load, never a crash)", () => {
+    const badPath = clone(INPUT_ONLY);
+    badPath.input.sections[0].keys = ["nope"];
+    const pathResult = validateArtifactView(
+      badPath,
+      OUTPUT_SCHEMA,
+      INPUT_SCHEMA,
+    );
+    expect(pathResult.valid).toBe(false);
+    expect(pathResult.errors.join("\n")).toMatch(
+      /view.input.sections\[0\].keys: "nope" does not resolve/,
+    );
+
+    const badPlaceholder = clone(INPUT_ONLY);
+    badPlaceholder.subject = "Dispatch {/missing} · {model}";
+    const phResult = validateArtifactView(
+      badPlaceholder,
+      OUTPUT_SCHEMA,
+      INPUT_SCHEMA,
+    );
+    expect(phResult.valid).toBe(false);
+    expect(phResult.errors.join("\n")).toMatch(
+      /placeholder "\{\/missing\}" does not resolve in the input schema/,
+    );
+
+    const unknownField = clone(INPUT_ONLY);
+    unknownField.subject = "Hello {flavour}";
+    const fieldResult = validateArtifactView(
+      unknownField,
+      OUTPUT_SCHEMA,
+      INPUT_SCHEMA,
+    );
+    expect(fieldResult.valid).toBe(false);
+    expect(fieldResult.errors.join("\n")).toMatch(
+      /unknown placeholder "\{flavour\}"/,
+    );
+  });
+
+  test("unknown keys on input still fail closed; empty sidecar is not a view", () => {
+    const extra = clone(INPUT_ONLY);
+    extra.input.layout = "wide";
+    expect(validateArtifactView(extra, OUTPUT_SCHEMA, INPUT_SCHEMA).valid).toBe(
+      false,
+    );
+    expect(
+      validateArtifactView(
+        { schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION },
+        OUTPUT_SCHEMA,
+        INPUT_SCHEMA,
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("dispatch.view.json is the worked example: input + subject only", () => {
+    const view = JSON.parse(
+      readFileSync(
+        path.join(RUNTIME_ROOT, "agents", "dispatch.view.json"),
+        "utf8",
+      ),
+    );
+    expect(view.sections).toBeUndefined();
+    expect(view.subject).toBe("Dispatch {/ticket} · {/repo} · {model}");
+    expect(view.input.sections[0].formats.ticket).toBe("issue");
+    const def = JSON.parse(
+      readFileSync(path.join(RUNTIME_ROOT, "agents", "dispatch.json"), "utf8"),
+    );
+    const outputSchema = JSON.parse(
+      readFileSync(path.join(RUNTIME_ROOT, def.output_schema), "utf8"),
+    );
+    const inputSchema = JSON.parse(
+      readFileSync(path.join(RUNTIME_ROOT, def.input_schema), "utf8"),
+    );
+    expect(validateArtifactView(view, outputSchema, inputSchema)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+});
+
 describe("inspectHeader — the first lines of `inspect`'s result section (WM-455)", () => {
   const view = JSON.parse(
     readFileSync(
@@ -480,5 +606,34 @@ describe("inspectHeader — the first lines of `inspect`'s result section (WM-45
         { summary: "x" },
       ),
     ).toEqual([]);
+  });
+});
+
+describe("contract-keyed view path (WM-897)", () => {
+  test("factory.command-result/v1 maps onto agents/views/<contract>.view.json", () => {
+    expect(contractViewRel("factory.command-result/v1")).toBe(
+      "agents/views/factory.command-result.v1.view.json",
+    );
+    expect(contractViewRel("")).toBeNull();
+    expect(contractViewRel(null)).toBeNull();
+  });
+
+  test("committed contract views resolve against the contract's output schema", () => {
+    const viewsDir = path.join(RUNTIME_ROOT, "agents", "views");
+    const files = readdirSync(viewsDir).filter((n) => n.endsWith(".view.json"));
+    expect(files).toContain("factory.command-result.v1.view.json");
+    const commandSchema = JSON.parse(
+      readFileSync(
+        path.join(RUNTIME_ROOT, "schemas", "command-result.output.json"),
+        "utf8",
+      ),
+    );
+    for (const name of files) {
+      const view = JSON.parse(readFileSync(path.join(viewsDir, name), "utf8"));
+      expect(validateArtifactView(view, commandSchema)).toEqual({
+        valid: true,
+        errors: [],
+      });
+    }
   });
 });

--- a/event-runtime/lib/proposal-subject.mjs
+++ b/event-runtime/lib/proposal-subject.mjs
@@ -1,0 +1,36 @@
+/**
+ * One-line subject for a proposal / run spec (WM-896 / WM-897).
+ *
+ * Prefers the agent's `factory.artifact-view/v1` `subject` template when the
+ * view defines one (`specSubject`). Dispatch keeps a hard-coded fallback so
+ * a missing sidecar still reads as "Dispatch TICKET · repo · model" on the
+ * inbox card and Telegram — the same line WM-896 shipped before the view
+ * existed.
+ */
+import { specSubject } from "./spec-subject.mjs";
+
+function isDispatch(agent) {
+  return typeof agent === "string" && agent.split("@")[0] === "dispatch";
+}
+
+function dispatchFallback(spec) {
+  const input = spec?.input && typeof spec.input === "object" ? spec.input : {};
+  const ticket = typeof input.ticket === "string" ? input.ticket : "?";
+  const repo = typeof input.repo === "string" ? input.repo : "?";
+  const model =
+    typeof spec?.model === "string" && spec.model ? spec.model : "default";
+  return `Dispatch ${ticket} · ${repo} · ${model}`;
+}
+
+/**
+ * `proposalSubject(registry, spec) → string | null`
+ *
+ * View `subject` wins. Dispatch without a subject still gets the fallback.
+ * Every other agent without a subject returns null. Never throws.
+ */
+export function proposalSubject(registry, spec) {
+  const fromView = specSubject(registry, spec);
+  if (fromView) return fromView;
+  if (isDispatch(spec?.agent)) return dispatchFallback(spec);
+  return null;
+}

--- a/event-runtime/lib/proposal-subject.test.mjs
+++ b/event-runtime/lib/proposal-subject.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { proposalSubject } from "./proposal-subject.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const registry = loadRegistry();
+const emptyRegistry = { views: new Map() };
+
+describe("proposalSubject (WM-897)", () => {
+  test("delegates to the view subject when the agent's sidecar defines one", () => {
+    expect(
+      proposalSubject(registry, {
+        agent: "dispatch@1",
+        model: "cursor-grok-4.6-high",
+        adapter: "cursor",
+        input: { repo: "factory", ticket: "WM-862" },
+      }),
+    ).toBe("Dispatch WM-862 · factory · cursor-grok-4.6-high");
+  });
+
+  test("keeps the dispatch fallback when the view does not define subject", () => {
+    expect(
+      proposalSubject(emptyRegistry, {
+        agent: "dispatch@1",
+        model: "sonnet",
+        input: { repo: "bj29", ticket: "CLNT-1" },
+      }),
+    ).toBe("Dispatch CLNT-1 · bj29 · sonnet");
+    expect(
+      proposalSubject(emptyRegistry, {
+        agent: "dispatch@1",
+        input: {},
+      }),
+    ).toBe("Dispatch ? · ? · default");
+  });
+
+  test("returns null for a non-dispatch agent without a subject", () => {
+    expect(
+      proposalSubject(registry, {
+        agent: "merge-scan@2",
+        input: { repo: "factory" },
+      }),
+    ).toBeNull();
+    expect(proposalSubject(registry, null)).toBeNull();
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -14,7 +14,7 @@ import { hashBytes } from "./canonical.mjs";
 import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import { reposRoot } from "./repos.mjs";
-import { validateArtifactView } from "./artifact-view.mjs";
+import { contractViewRel, validateArtifactView } from "./artifact-view.mjs";
 import { PANELS_DIR, loadPanelDir, mergePanels } from "./panel-view.mjs";
 
 export class RegistryError extends Error {
@@ -285,19 +285,22 @@ const isDefinitionFile = (name) =>
   name.endsWith(".json") && !name.endsWith(VIEW_SUFFIX);
 
 /**
- * Artifact-view sidecar (WM-454, docs/event-runtime-artifact-views.md §2):
- * `agents/<name>.view.json` beside `agents/<name>.json`, optional. Loaded
- * and validated against the definition's output schema; a view that does
- * not parse or does not fit its schema is a configuration anomaly (surfaced
- * in /status.anomalies.configuration) and the agent is served WITHOUT a
- * view — never a load failure, never a rendering crash. Views are not part
- * of the definition pin (§2.3): a rendering tweak is not a contract change.
- * @returns {{ file: string|null, view: object|null, anomaly: string|null }}
+ * Artifact-view sidecar (WM-454 / WM-897, docs/event-runtime-artifact-views.md §2):
+ * `agents/<name>.view.json` beside `agents/<name>.json`, optional. When that
+ * file is absent, `agents/views/<output_contract>.view.json` is the
+ * contract-keyed fallback so nine command-result agents share one sidecar.
+ * The agent file wins when both exist, including when it is invalid — a
+ * broken agent sidecar is an anomaly, not a silent fall-through.
+ *
+ * Loaded and validated against the definition's output *and* input schemas;
+ * a view that does not parse or does not fit is a configuration anomaly
+ * (surfaced in /status.anomalies.configuration) and the agent is served
+ * WITHOUT a view — never a load failure, never a rendering crash. Views are
+ * not part of the definition pin (§2.3): a rendering tweak is not a
+ * contract change.
+ * @returns {{ file: string|null, view: object|null, source: "agent"|"contract"|null, anomaly: string|null }}
  */
-function loadArtifactView(root, defFile, def) {
-  const rel = path.relative(root, defFile).replace(/\.json$/, VIEW_SUFFIX);
-  const abs = path.join(root, rel);
-  if (!existsSync(abs)) return { file: null, view: null, anomaly: null };
+function readViewFile(abs, rel, def, source) {
   let view;
   try {
     view = JSON.parse(readFileSync(abs, "utf8"));
@@ -305,18 +308,34 @@ function loadArtifactView(root, defFile, def) {
     return {
       file: rel,
       view: null,
+      source: null,
       anomaly: `artifact view ${rel} for ${def.ref} is unparseable: ${err.message}`,
     };
   }
-  const check = validateArtifactView(view, def.outputSchema);
+  const check = validateArtifactView(view, def.outputSchema, def.inputSchema);
   if (!check.valid) {
     return {
       file: rel,
       view: null,
-      anomaly: `artifact view ${rel} for ${def.ref} does not fit ${def.output_schema} (served without a view): ${check.errors.join("; ")}`,
+      source: null,
+      anomaly: `artifact view ${rel} for ${def.ref} does not fit its schemas (served without a view): ${check.errors.join("; ")}`,
     };
   }
-  return { file: rel, view, anomaly: null };
+  return { file: rel, view, source, anomaly: null };
+}
+
+function loadArtifactView(root, defFile, def) {
+  const agentRel = path.relative(root, defFile).replace(/\.json$/, VIEW_SUFFIX);
+  const agentAbs = path.join(root, agentRel);
+  if (existsSync(agentAbs))
+    return readViewFile(agentAbs, agentRel, def, "agent");
+  const contractRel = contractViewRel(def.output_contract);
+  if (contractRel) {
+    const contractAbs = path.join(root, contractRel);
+    if (existsSync(contractAbs))
+      return readViewFile(contractAbs, contractRel, def, "contract");
+  }
+  return { file: null, view: null, source: null, anomaly: null };
 }
 
 // ---------------------------------------------------------------------------
@@ -691,13 +710,17 @@ export function loadRegistry({
       // Kept off the definition object so receipts' defHash and the pinned
       // identity never see the view (§2.3). Loaders that expose no sidecars
       // (non-fs packs) simply contribute no view.
-      const { file, view, anomaly } = loader.readArtifactView?.(entry, def) ?? {
+      const { file, view, source, anomaly } = loader.readArtifactView?.(
+        entry,
+        def,
+      ) ?? {
         file: null,
         view: null,
+        source: null,
         anomaly: null,
       };
       if (anomaly) anomalies.push(anomaly);
-      views.set(def.ref, { file, view });
+      views.set(def.ref, { file, view, source: source ?? null });
     }
     if (typeof loader.listPanels === "function") {
       panelBatches.push(
@@ -1004,9 +1027,9 @@ export function loadRegistry({
   };
 }
 
-/** The artifact view for a registered agent: `{ file, view }`, both null when the agent has none. */
+/** The artifact view for a registered agent: `{ file, view, source }`, all null when the agent has none. */
 export function getArtifactView(registry, ref) {
-  return registry.views?.get(ref) ?? { file: null, view: null };
+  return registry.views?.get(ref) ?? { file: null, view: null, source: null };
 }
 
 export function getAgent(registry, ref) {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -770,17 +770,31 @@ describe("registry", () => {
     // The committed views: present, validated, keyed by ref, not on the def.
     const merge = getArtifactView(registry, "merge-scan@2");
     expect(merge.file).toBe("agents/merge-scan.view.json");
+    expect(merge.source).toBe("agent");
     expect(merge.view.schemaVersion).toBe("factory.artifact-view/v1");
     expect(getArtifactView(registry, "triage-scan@1").view.status.path).toBe(
       "/recommendation",
     );
-    expect(getArtifactView(registry, "reconcile@1")).toEqual({
+    const dispatch = getArtifactView(registry, "dispatch@1");
+    expect(dispatch.source).toBe("agent");
+    expect(dispatch.view.subject).toBe(
+      "Dispatch {/ticket} · {/repo} · {model}",
+    );
+    const reconcile = getArtifactView(registry, "reconcile@1");
+    expect(reconcile.source).toBe("contract");
+    expect(reconcile.file).toBe(
+      "agents/views/factory.command-result.v1.view.json",
+    );
+    expect(reconcile.view.title).toBe("Command");
+    expect(getArtifactView(registry, "ship-scan@1")).toEqual({
       file: null,
       view: null,
+      source: null,
     });
     expect(getArtifactView(registry, "ghost@9")).toEqual({
       file: null,
       view: null,
+      source: null,
     });
     expect(registry.anomalies).toEqual([]);
     // Views are not part of the definition pin nor of the receipt defHash:
@@ -818,6 +832,7 @@ describe("registry", () => {
     expect(getArtifactView(registry, "merge-scan@2")).toEqual({
       file: "agents/merge-scan.view.json",
       view: null,
+      source: null,
     });
     expect(registry.anomalies).toHaveLength(1);
     expect(registry.anomalies[0]).toContain("merge-scan@2");
@@ -838,6 +853,65 @@ describe("registry", () => {
     );
     expect(loadRegistry({ root, modelTiers: PI_TIERS }).anomalies[0]).toMatch(
       /not in enum/,
+    );
+  });
+
+  test("contract-keyed fallback applies when the agent sidecar is absent; agent sidecar wins when both exist (WM-897)", () => {
+    const root = tempRegistry();
+    const registry = loadRegistry({ root, modelTiers: PI_TIERS });
+    const shared = getArtifactView(registry, "reconcile@1");
+    expect(shared.source).toBe("contract");
+    expect(getArtifactView(registry, "warm@1").file).toBe(shared.file);
+    expect(getArtifactView(registry, "ci-rerun@1").source).toBe("contract");
+    // Agent sidecar wins even when a contract view exists.
+    writeFileSync(
+      path.join(root, "agents", "reconcile.view.json"),
+      JSON.stringify({
+        schemaVersion: "factory.artifact-view/v1",
+        title: "Reconcile (agent)",
+        sections: [{ path: "/command", as: "list", label: "Command" }],
+      }),
+    );
+    const again = loadRegistry({ root, modelTiers: PI_TIERS });
+    const won = getArtifactView(again, "reconcile@1");
+    expect(won.source).toBe("agent");
+    expect(won.file).toBe("agents/reconcile.view.json");
+    expect(won.view.title).toBe("Reconcile (agent)");
+    // A broken agent sidecar does not fall through to the contract view.
+    writeFileSync(
+      path.join(root, "agents", "reconcile.view.json"),
+      JSON.stringify({
+        schemaVersion: "factory.artifact-view/v1",
+        sections: [{ path: "/nope", as: "prose" }],
+      }),
+    );
+    const broken = loadRegistry({ root, modelTiers: PI_TIERS });
+    expect(getArtifactView(broken, "reconcile@1")).toEqual({
+      file: "agents/reconcile.view.json",
+      view: null,
+      source: null,
+    });
+    expect(broken.anomalies[0]).toMatch(/"\/nope" does not resolve/);
+  });
+
+  test("a sidecar with a bad input path / placeholder is a configuration anomaly (WM-897)", () => {
+    const root = tempRegistry();
+    writeFileSync(
+      path.join(root, "agents", "dispatch.view.json"),
+      JSON.stringify({
+        schemaVersion: "factory.artifact-view/v1",
+        subject: "Dispatch {/missing} · {model}",
+        input: {
+          sections: [{ path: "", as: "keyvalue", keys: ["nope"] }],
+        },
+      }),
+    );
+    const registry = loadRegistry({ root, modelTiers: PI_TIERS });
+    expect(getArtifactView(registry, "dispatch@1").view).toBeNull();
+    expect(registry.anomalies.join("\n")).toMatch(/dispatch@1/);
+    expect(registry.anomalies.join("\n")).toMatch(/"nope" does not resolve/);
+    expect(registry.anomalies.join("\n")).toMatch(
+      /placeholder "\{\/missing\}"/,
     );
   });
 });

--- a/event-runtime/lib/spec-subject.mjs
+++ b/event-runtime/lib/spec-subject.mjs
@@ -1,0 +1,65 @@
+/**
+ * Render an agent's `subject` template over a RunSpec (WM-897).
+ *
+ * Pure: looks the view up on the registry, substitutes `{/pointer}` from
+ * `spec.input` and `{agent|model|adapter|repo}` from the spec itself, and
+ * returns null when the agent has no `subject`. A placeholder that does not
+ * resolve in this spec becomes `""` — the template is a hint, not a
+ * validator; drift was already closed at registry load.
+ */
+import {
+  SUBJECT_FIELDS,
+  resolvePointer,
+  subjectPlaceholders,
+} from "./artifact-view.mjs";
+import { getArtifactView } from "./registry.mjs";
+
+const isObject = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+
+function fieldValue(spec, token) {
+  if (token === "repo" && (spec.repo === undefined || spec.repo === null)) {
+    const input = spec.input;
+    if (isObject(input) && typeof input.repo === "string") return input.repo;
+  }
+  const value = spec[token];
+  return value === undefined || value === null ? "" : String(value);
+}
+
+/**
+ * Substitute one `subject` template against a spec. Exported for tests;
+ * production callers go through `specSubject` so a missing view is null.
+ */
+export function renderSubject(template, spec) {
+  if (typeof template !== "string" || !spec || typeof spec !== "object")
+    return null;
+  return template.replace(/\{([^{}]+)\}/g, (_, token) => {
+    if (token.startsWith("/")) {
+      const value = resolvePointer(spec.input, token);
+      return value === undefined || value === null ? "" : String(value);
+    }
+    if (SUBJECT_FIELDS.includes(token)) return fieldValue(spec, token);
+    return `{${token}}`;
+  });
+}
+
+/**
+ * `specSubject(registry, spec) → string | null`
+ *
+ * Looks up the agent's view by `spec.agent` (the `@version` ref). No view,
+ * no `subject`, or a non-object spec → null. Never throws.
+ */
+export function specSubject(registry, spec) {
+  if (!spec || typeof spec !== "object" || typeof spec.agent !== "string")
+    return null;
+  const view = getArtifactView(registry, spec.agent).view;
+  if (typeof view?.subject !== "string") return null;
+  // Defensive: a view that passed registry load has only legal placeholders,
+  // but a hand-built registry in a test might not. Unknown tokens stay
+  // unsubstituted rather than crashing the API.
+  const unknown = subjectPlaceholders(view.subject).filter(
+    (t) => !t.startsWith("/") && !SUBJECT_FIELDS.includes(t),
+  );
+  if (unknown.length) return null;
+  return renderSubject(view.subject, spec);
+}

--- a/event-runtime/lib/spec-subject.test.mjs
+++ b/event-runtime/lib/spec-subject.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { loadRegistry } from "./registry.mjs";
+import { renderSubject, specSubject } from "./spec-subject.mjs";
+
+const registry = loadRegistry();
+
+const dispatchSpec = {
+  agent: "dispatch@1",
+  model: "cursor-grok-4.6-high",
+  adapter: "cursor",
+  input: { repo: "factory", ticket: "WM-862" },
+};
+
+describe("specSubject (WM-897)", () => {
+  test("renders the dispatch sidecar template over input pointers and {model}", () => {
+    expect(specSubject(registry, dispatchSpec)).toBe(
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+    );
+  });
+
+  test("returns null when the agent has no subject (merge-scan) or the spec is junk", () => {
+    expect(
+      specSubject(registry, {
+        agent: "merge-scan@2",
+        input: { repo: "factory" },
+      }),
+    ).toBeNull();
+    expect(specSubject(registry, null)).toBeNull();
+    expect(specSubject(registry, { agent: "ghost@9" })).toBeNull();
+    expect(specSubject(registry, { input: { ticket: "WM-1" } })).toBeNull();
+  });
+
+  test("a missing input pointer renders as empty rather than crashing", () => {
+    expect(
+      specSubject(registry, {
+        agent: "dispatch@1",
+        model: "x",
+        input: { repo: "factory" },
+      }),
+    ).toBe("Dispatch  · factory · x");
+  });
+
+  test("renderSubject substitutes fixed fields and leaves unknown tokens alone", () => {
+    expect(
+      renderSubject("Run {agent} on {adapter}", {
+        agent: "dispatch@1",
+        adapter: "cursor",
+      }),
+    ).toBe("Run dispatch@1 on cursor");
+    expect(renderSubject("Hi {flavour}", { agent: "x" })).toBe("Hi {flavour}");
+    expect(renderSubject("static", {})).toBe("static");
+  });
+});

--- a/event-runtime/schemas/factory.artifact-view.v1.json
+++ b/event-runtime/schemas/factory.artifact-view.v1.json
@@ -1,8 +1,8 @@
 {
-  "title": "factory.artifact-view/v1 — sidecar rendering hints over an agent's output schema (docs/event-runtime-artifact-views.md §2.2)",
-  "description": "A closed hint vocabulary, not a layout language. Per-`as` key applicability (table→columns/groupBy/expand, keyvalue→keys, list→itemLabel, code→language) and the pointer→schema drift check are enforced by lib/artifact-view.mjs, because lib/schema.mjs has no conditional keywords.",
+  "title": "factory.artifact-view/v1 — sidecar rendering hints over an agent's output (and optional input) schema (docs/event-runtime-artifact-views.md §2.2)",
+  "description": "A closed hint vocabulary, not a layout language. Per-`as` key applicability (table→columns/groupBy/expand, keyvalue→keys, list→itemLabel, code→language) and the pointer→schema drift check are enforced by lib/artifact-view.mjs, because lib/schema.mjs has no conditional keywords. `sections` is the output view; optional `input` is the same body resolved against the input schema; optional `subject` is a template over input pointers and the fixed spec fields agent|model|adapter|repo. A sidecar may ship input+subject only (no output sections).",
   "type": "object",
-  "required": ["schemaVersion", "sections"],
+  "required": ["schemaVersion"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": { "const": "factory.artifact-view/v1" },
@@ -10,7 +10,7 @@
     "summary": {
       "type": "string",
       "pattern": "^(/|$)",
-      "description": "RFC 6901 pointer into the artifact to a string rendered first, as prose"
+      "description": "RFC 6901 pointer into the output artifact to a string rendered first, as prose"
     },
     "status": {
       "type": "object",
@@ -99,6 +99,139 @@
             "description": "table/keyvalue/list: column/key → (value → tone); badge: value → tone",
             "additionalProperties": { "type": ["string", "object"] }
           }
+        }
+      }
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "One-line spec heading. Placeholders are `{/pointer}` into the input schema or `{agent}` `{model}` `{adapter}` `{repo}` from the RunSpec. Example: \"Dispatch {/ticket} · {/repo} · {model}\"."
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The same view body as the output side (title, summary, status, sections, formats, tone), with every pointer resolved against the agent's input schema rather than the output schema.",
+      "properties": {
+        "title": { "type": "string", "minLength": 1, "maxLength": 60 },
+        "summary": {
+          "type": "string",
+          "pattern": "^(/|$)",
+          "description": "RFC 6901 pointer into the input to a string rendered first, as prose"
+        },
+        "status": {
+          "type": "object",
+          "required": ["path", "tone"],
+          "additionalProperties": false,
+          "properties": {
+            "path": { "type": "string", "pattern": "^/" },
+            "tone": {
+              "type": "object",
+              "description": "input value → tone",
+              "additionalProperties": {
+                "enum": ["ok", "warn", "error", "muted", "neutral"]
+              }
+            }
+          }
+        },
+        "sections": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 12,
+          "items": {
+            "type": "object",
+            "required": ["path", "as"],
+            "additionalProperties": false,
+            "properties": {
+              "path": { "type": "string", "pattern": "^(/|$)" },
+              "as": {
+                "enum": ["table", "keyvalue", "list", "badge", "code", "prose"]
+              },
+              "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+              "columns": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 8,
+                "items": { "type": "string", "minLength": 1 },
+                "description": "table only: item properties shown as columns, in order"
+              },
+              "groupBy": {
+                "type": "string",
+                "minLength": 1,
+                "description": "table only: item property whose value groups the rows"
+              },
+              "expand": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 },
+                "description": "table only: item properties shown only in the row's expanded state"
+              },
+              "keys": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 },
+                "description": "keyvalue only: subset of the object's properties, in order"
+              },
+              "itemLabel": {
+                "type": "string",
+                "minLength": 1,
+                "description": "list only: pointer relative to each item naming the text shown"
+              },
+              "language": {
+                "type": "string",
+                "minLength": 1,
+                "description": "code only: syntax hint"
+              },
+              "formats": {
+                "type": "object",
+                "description": "column/key (or \"\" for the section value itself) → format",
+                "additionalProperties": {
+                  "enum": [
+                    "issue",
+                    "pr",
+                    "url",
+                    "sha",
+                    "repo",
+                    "run",
+                    "duration",
+                    "datetime",
+                    "state",
+                    "bytes",
+                    "count"
+                  ]
+                }
+              },
+              "tone": {
+                "type": "object",
+                "description": "table/keyvalue/list: column/key → (value → tone); badge: value → tone",
+                "additionalProperties": { "type": ["string", "object"] }
+              }
+            }
+          }
+        },
+        "formats": {
+          "type": "object",
+          "description": "optional body-level formats (same closed set as a section); column/key → format",
+          "additionalProperties": {
+            "enum": [
+              "issue",
+              "pr",
+              "url",
+              "sha",
+              "repo",
+              "run",
+              "duration",
+              "datetime",
+              "state",
+              "bytes",
+              "count"
+            ]
+          }
+        },
+        "tone": {
+          "type": "object",
+          "description": "optional body-level tone (same closed set as a section)",
+          "additionalProperties": { "type": ["string", "object"] }
         }
       }
     }

--- a/event-runtime/web/package.json
+++ b/event-runtime/web/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "build:fast": "vite build",
+    "test": "bun test",
     "test:e2e": "bun add --no-save --exact \"@playwright/test@$(bun e2e/playwright-version.mjs)\" && bun playwright test --config playwright.config.ts"
   },
   "dependencies": {

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { ArtifactView as ArtifactViewDoc } from "../types";
 import { ARTIFACT_RAW_KEY, ArtifactPanel, ArtifactView } from "./ArtifactView";
+import { inputViewOf } from "../lib/artifactView";
 
 const AGENTS = path.resolve(import.meta.dir, "../../../agents");
 const readView = (name: string): ArtifactViewDoc =>
@@ -258,5 +259,25 @@ describe("ArtifactView with the shipped merge-scan view", () => {
         r2.getByRole("link", { name: "run_44fa5716" }) as HTMLAnchorElement
       ).getAttribute("href"),
     ).toBe("#/runs/run_44fa5716-0304-49b1-8b65-a45500d0d784");
+  });
+});
+
+describe("input view (WM-897)", () => {
+  test("dispatch input view renders repo + ticket with an issue chip", () => {
+    const dispatchView = readView("dispatch");
+    const inputView = inputViewOf(dispatchView);
+    expect(inputView).not.toBeNull();
+    const r = render(
+      <ArtifactView
+        artifact={{ repo: "factory", ticket: "WM-862" }}
+        view={inputView!}
+      />,
+    );
+    expect(r.getByText("Input")).toBeTruthy();
+    expect(r.getByText("factory")).toBeTruthy();
+    const link = r.getByRole("link", { name: "WM-862" });
+    expect(link.getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-862",
+    );
   });
 });

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -280,4 +280,29 @@ describe("input view (WM-897)", () => {
       "https://linear.app/watt-mind/issue/WM-862",
     );
   });
+
+  test("omitting schema keeps the dispatch input-schema title out of the glance", () => {
+    const inputView = inputViewOf(readView("dispatch"));
+    const r = render(
+      <ArtifactView
+        artifact={{ repo: "bj29", ticket: "WM-100" }}
+        schema={{
+          title:
+            "dispatch input — one repo, one already-queued ticket (WM-108)",
+        }}
+        view={inputView!}
+      />,
+    );
+    expect(r.getByText(/WM-108/)).toBeTruthy();
+    cleanup();
+    const r2 = render(
+      <ArtifactView
+        artifact={{ repo: "bj29", ticket: "WM-100" }}
+        view={inputView!}
+      />,
+    );
+    expect(r2.queryByText(/WM-108/)).toBeNull();
+    expect(r2.queryByText(/already-queued/)).toBeNull();
+    expect(r2.getByText("Input")).toBeTruthy();
+  });
 });

--- a/event-runtime/web/src/components/CustomCell.test.tsx
+++ b/event-runtime/web/src/components/CustomCell.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { CustomCell, formatCellValue, readCellUi } from "./CustomCell";
+import { CustomCell, formatCellValue } from "./CustomCell";
 import { renderWithClient, restoreApi, withApi } from "../test-render";
 import type { RepoItem } from "../types";
 
@@ -74,43 +74,27 @@ describe("formatCellValue", () => {
     });
   });
 
-  test("x-ui kind ticket marks a scalar cell as a ticket reference", () => {
-    expect(formatCellValue("wm-701", { kind: "ticket" })).toMatchObject({
+  test("view format issue marks a scalar cell as a ticket reference", () => {
+    expect(formatCellValue("wm-701", "issue")).toMatchObject({
       text: "WM-701",
       kind: "ticket",
     });
   });
 
-  test("x-ui kind ticket never claims a complex value", () => {
-    expect(
-      formatCellValue({ id: "WM-701" }, { kind: "ticket" }).kind,
-    ).toBeNull();
-    expect(formatCellValue(null, { kind: "ticket" }).kind).toBeNull();
-  });
-});
-
-describe("readCellUi", () => {
-  test("reads the x-ui annotation off a schema node", () => {
-    expect(readCellUi({ type: "string", "x-ui": { kind: "ticket" } })).toEqual({
-      kind: "ticket",
-    });
-  });
-
-  test("ignores schemas without a usable annotation", () => {
-    expect(readCellUi({ type: "string" })).toBeNull();
-    expect(readCellUi({ "x-ui": "ticket" })).toBeNull();
-    expect(readCellUi(null)).toBeNull();
+  test("view format issue never claims a complex value", () => {
+    expect(formatCellValue({ id: "WM-701" }, "issue").kind).toBeNull();
+    expect(formatCellValue(null, "issue").kind).toBeNull();
   });
 });
 
 describe("CustomCell", () => {
-  test("an x-ui ticket column links the whole cell to the ticket journey", async () => {
+  test("a view format=issue column links the whole cell to the ticket journey", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
         <CustomCell
           row={{ payload: { ticket: "WM-701" } }}
           path="payload.ticket"
-          ui={{ kind: "ticket" }}
+          format="issue"
         />,
       );
       const link = await waitFor(() => r.getByRole("link", { name: "WM-701" }));
@@ -118,13 +102,13 @@ describe("CustomCell", () => {
     });
   });
 
-  test("an x-ui ticket column normalizes the id it links to", async () => {
+  test("a view format=issue column normalizes the id it links to", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
         <CustomCell
           row={{ ticket: " clnt-526 " }}
           path="ticket"
-          ui={{ kind: "ticket" }}
+          format="issue"
         />,
       );
       await waitFor(() =>
@@ -137,14 +121,10 @@ describe("CustomCell", () => {
 
   // The annotation is what the free-text scan cannot do: a column that says it
   // holds a ticket is believed even when the team is not one this factory runs.
-  test("an x-ui ticket column links a team the free-text scan would skip", async () => {
+  test("a view format=issue column links a team the free-text scan would skip", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
-        <CustomCell
-          row={{ ticket: "FOO-12" }}
-          path="ticket"
-          ui={{ kind: "ticket" }}
-        />,
+        <CustomCell row={{ ticket: "FOO-12" }} path="ticket" format="issue" />,
       );
       await waitFor(() =>
         expect(
@@ -154,14 +134,10 @@ describe("CustomCell", () => {
     });
   });
 
-  test("reads the annotation off a raw schema node when given one", async () => {
+  test("the caller passes the view format, not a schema annotation", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
-        <CustomCell
-          row={{ ticket: "FOO-12" }}
-          path="ticket"
-          schema={{ type: "string", "x-ui": { kind: "ticket" } }}
-        />,
+        <CustomCell row={{ ticket: "FOO-12" }} path="ticket" format="issue" />,
       );
       await waitFor(() =>
         expect(
@@ -171,7 +147,7 @@ describe("CustomCell", () => {
     });
   });
 
-  test("the same value without the annotation stays plain text", async () => {
+  test("the same value without a view format stays plain text", async () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
         <CustomCell row={{ ticket: "FOO-12" }} path="ticket" />,
@@ -233,7 +209,7 @@ describe("CustomCell", () => {
         <CustomCell
           row={{ ticket: "WM-701" }}
           path="ticket"
-          ui={{ kind: "ticket" }}
+          format="issue"
           onNavigateTicket={onNavigateTicket}
         />,
       );

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -1,46 +1,31 @@
 /**
  * Reusable cell renderer for dynamic / custom payload columns (WM-214).
- * Extracts nested path values safely and formats primitives, code badges, and objects.
  *
- * A column can declare what a value *means* with the `x-ui` schema annotation
- * (WM-701): `x-ui: { kind: "ticket" }` says the whole cell is one ticket id, so
- * it renders as a hover-card link rather than as a string that happens to look
- * like one. Everything else is still scanned for embedded ids, because the
- * useful ticket reference is usually buried in a summary line, not in a column
- * anybody thought to annotate.
+ * A column can declare what a value *means* with the active artifact-view
+ * `formats` map (WM-897): `issue` says the whole cell is one ticket id, so
+ * it renders as a hover-card link rather than as a string that happens to
+ * look like one. Everything else is still scanned for embedded ids, because
+ * the useful ticket reference is usually buried in a summary line, not in a
+ * column anybody thought to annotate.
+ *
+ * The `x-ui` schema annotation (WM-701) is gone — `lib/schema.mjs` fails
+ * closed on unknown keywords, so nothing could legally send it.
  */
 import { extractRowValue } from "../pathExtractor";
+import type { ArtifactFormat } from "../types";
 import { TicketHoverCard, TicketText } from "./TicketHoverCard";
-
-/** The `x-ui` annotation a payload schema can attach to a property. */
-export interface CellUi {
-  kind?: string | null;
-}
-
-/**
- * Read `x-ui` off a JSON-schema node. Anything that is not an object with a
- * string `kind` is not an annotation — a schema served mid-migration must not
- * take a table down.
- */
-export function readCellUi(schema: unknown): CellUi | null {
-  if (!schema || typeof schema !== "object") return null;
-  const annotation = (schema as Record<string, unknown>)["x-ui"];
-  if (!annotation || typeof annotation !== "object") return null;
-  const kind = (annotation as Record<string, unknown>).kind;
-  return typeof kind === "string" && kind ? { kind } : null;
-}
 
 export interface CellFormat {
   text: string;
   isComplex: boolean;
   title?: string;
-  /** The `x-ui` kind this cell can honour, null when the value cannot carry it. */
+  /** `ticket` when the view format (or equivalent) says the whole cell is one issue id. */
   kind: string | null;
 }
 
 export function formatCellValue(
   value: unknown,
-  ui?: CellUi | null,
+  format?: ArtifactFormat | null,
 ): CellFormat {
   if (value === undefined || value === null)
     return { text: "—", isComplex: false, kind: null };
@@ -49,10 +34,10 @@ export function formatCellValue(
   if (typeof value === "number")
     return { text: String(value), isComplex: false, kind: null };
   if (typeof value === "string") {
-    // Only a scalar string can be the ticket the schema promised; a column
-    // annotated `ticket` whose value arrived as an object is a payload bug,
+    // Only a scalar string can be the ticket the format promised; a column
+    // annotated `issue` whose value arrived as an object is a payload bug,
     // and linking it would hide that.
-    if (ui?.kind === "ticket")
+    if (format === "issue")
       return {
         text: value.trim().toUpperCase(),
         isComplex: false,
@@ -84,26 +69,22 @@ export function formatCellValue(
 export function CustomCell({
   row,
   path,
-  ui,
-  schema,
+  format,
   onNavigateTicket,
 }: {
   row: unknown;
   path: string;
-  /** The column's `x-ui` annotation, already resolved. */
-  ui?: CellUi | null;
-  /** The column's schema node, for callers that hold the schema, not the annotation. */
-  schema?: unknown;
+  /** Closed `formats` value from the active view, when the caller has one. */
+  format?: ArtifactFormat | null;
   onNavigateTicket?: (ticketId: string) => void;
 }) {
   const cleanPath = path.replace(/^custom:/, "");
   const value = extractRowValue(row, cleanPath);
-  const { text, isComplex, title, kind } = formatCellValue(
-    value,
-    ui ?? readCellUi(schema),
-  );
+  const { text, isComplex, title, kind } = formatCellValue(value, format);
 
   const isMono =
+    format === "sha" ||
+    format === "repo" ||
     cleanPath.toLowerCase().includes("id") ||
     cleanPath.toLowerCase().includes("sha") ||
     cleanPath.toLowerCase().includes("hash") ||

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -814,9 +814,10 @@ export function RunDetailBlocks({
             : null;
           return inputView ? (
             <Suspense fallback={<InputRows input={d.run.spec.input} />}>
+              {/* Omit inputSchema so its design-ticket title (e.g. WM-108) is
+                  not the glance caption; the section label is. */}
               <ArtifactPanel
                 artifact={d.run.spec.input}
-                schema={agentDef?.inputSchema}
                 view={inputView}
                 rawFallback={<InputRows input={d.run.spec.input} />}
               />

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -803,7 +803,28 @@ export function RunDetailBlocks({
           v={`${d.run.attempts}/${d.run.spec.maxAttempts}`}
           mono={false}
         />
-        <InputRows input={d.run.spec.input} />
+        {(() => {
+          const inputBody = agentDef?.outputView?.input;
+          const inputView = inputBody
+            ? {
+                schemaVersion: agentDef.outputView!.schemaVersion,
+                ...inputBody,
+                sections: inputBody.sections ?? [],
+              }
+            : null;
+          return inputView ? (
+            <Suspense fallback={<InputRows input={d.run.spec.input} />}>
+              <ArtifactPanel
+                artifact={d.run.spec.input}
+                schema={agentDef?.inputSchema}
+                view={inputView}
+                rawFallback={<InputRows input={d.run.spec.input} />}
+              />
+            </Suspense>
+          ) : (
+            <InputRows input={d.run.spec.input} />
+          );
+        })()}
         {origin?.eventId && (
           <KV
             k="origin event"

--- a/event-runtime/web/src/lib/artifactView.test.ts
+++ b/event-runtime/web/src/lib/artifactView.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import type { ArtifactView } from "../types";
 import {
   formatBytes,
+  formatForColumn,
   formatValue,
   githubOf,
   groupRows,
   headerFor,
+  inputViewOf,
   parsePointer,
   resolvePointer,
   resolveRelative,
@@ -477,5 +479,39 @@ describe("the other section kinds", () => {
         language: "json",
       },
     ]);
+  });
+});
+
+describe("inputViewOf + formatForColumn (WM-897)", () => {
+  const dispatchView = readView("dispatch");
+
+  test("inputViewOf lifts the input body so the same renderer can draw spec.input", () => {
+    const inputView = inputViewOf(dispatchView);
+    expect(inputView).not.toBeNull();
+    expect(inputView?.sections?.[0].formats?.ticket).toBe("issue");
+    const input = { repo: "factory", ticket: "WM-862" };
+    expect(viewApplies(inputView, input)).toBe(true);
+    const sections = sectionsFor(inputView!, input);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].as).toBe("keyvalue");
+    if (sections[0].as === "keyvalue") {
+      expect(sections[0].entries.map((e) => e.key)).toEqual(["repo", "ticket"]);
+      expect(sections[0].entries[1].value).toMatchObject({
+        kind: "chip",
+        chip: "issue",
+        id: "WM-862",
+      });
+    }
+    expect(inputViewOf(triageView)).toBeNull();
+    expect(inputViewOf(null)).toBeNull();
+  });
+
+  test("formatForColumn reads the closed format from the active view", () => {
+    expect(formatForColumn(mergeView, "ticket")).toBe("issue");
+    expect(formatForColumn(mergeView, "pr")).toBe("pr");
+    expect(formatForColumn(dispatchView, "ticket")).toBe("issue");
+    expect(formatForColumn(dispatchView, "repo")).toBe("repo");
+    expect(formatForColumn(triageView, "nope")).toBeUndefined();
+    expect(formatForColumn(null, "ticket")).toBeUndefined();
   });
 });

--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -523,6 +523,57 @@ export function sectionsFor(
   return out;
 }
 
+/**
+ * Lift `view.input` into a stand-alone `factory.artifact-view/v1` document
+ * so the same renderer draws the input glance. Null when the sidecar has
+ * no input body.
+ */
+export function inputViewOf(
+  view: ArtifactView | null | undefined,
+): ArtifactView | null {
+  if (!view?.input) return null;
+  const input = view.input;
+  if (
+    !input.sections?.length &&
+    input.summary === undefined &&
+    input.status === undefined
+  )
+    return null;
+  return {
+    schemaVersion: view.schemaVersion,
+    title: input.title,
+    summary: input.summary,
+    status: input.status,
+    sections: input.sections ?? [],
+  };
+}
+
+/**
+ * The closed format a view assigns to a column/key, first section that
+ * names it. Callers that have a view (Artifacts custom columns) pass this
+ * into CustomCell; without a view the cell falls back to the id-scan.
+ */
+export function formatForColumn(
+  view: ArtifactView | null | undefined,
+  column: string,
+): ArtifactFormat | undefined {
+  if (!view) return undefined;
+  for (const section of view.sections ?? []) {
+    const format = section.formats?.[column];
+    if (format) return format;
+  }
+  if (view.formats && column in view.formats) return view.formats[column];
+  if (view.input) {
+    for (const section of view.input.sections ?? []) {
+      const format = section.formats?.[column];
+      if (format) return format;
+    }
+    if (view.input.formats && column in view.input.formats)
+      return view.input.formats[column];
+  }
+  return undefined;
+}
+
 /** The artifact's own `owner/repo` when it reports one — the only place a PR link can come from. */
 export function githubOf(artifact: unknown): string | null {
   const g = isObject(artifact) ? artifact.github : undefined;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -56,6 +56,8 @@ export interface Proposal {
   eventSource: string | null;
   agent: string | null;
   spec: RunSpec | null;
+  /** One-line spec heading from the agent's view `subject` (WM-897). */
+  subject?: string | null;
   /** Repos the spec input names. Empty if unscoped. */
   repos: string[];
 }
@@ -374,6 +376,8 @@ export interface RunDetail {
    * takes no model, or the harness named none.
    */
   observedModel: string | null;
+  /** One-line spec heading from the agent's view `subject` (WM-897). */
+  subject?: string | null;
 }
 
 /** Which event types route to an agent, and how (GET /agents). */
@@ -434,12 +438,21 @@ export interface ArtifactViewSection {
   /** table/keyvalue/list: column/key → (value → tone); badge: value → tone */
   tone?: Record<string, ArtifactTone | Record<string, ArtifactTone>>;
 }
-export interface ArtifactView {
-  schemaVersion: "factory.artifact-view/v1";
+/** Output or input view body — `input` reuses this shape (WM-897). */
+export interface ArtifactViewBody {
   title?: string;
   summary?: string;
   status?: { path: string; tone: Record<string, ArtifactTone> };
-  sections: ArtifactViewSection[];
+  sections?: ArtifactViewSection[];
+  formats?: Record<string, ArtifactFormat>;
+  tone?: Record<string, ArtifactTone | Record<string, ArtifactTone>>;
+}
+export interface ArtifactView extends ArtifactViewBody {
+  schemaVersion: "factory.artifact-view/v1";
+  /** One-line spec heading template, rendered server-side onto GET /runs/:id and /proposals. */
+  subject?: string;
+  /** View body whose pointers resolve against the agent's input schema. */
+  input?: ArtifactViewBody;
 }
 
 /** One registered agent, fully readable: definition, prompt, schemas, pins. */
@@ -461,6 +474,8 @@ export interface AgentDef {
   /** Artifact-view sidecar (WM-454), null when the agent ships none. */
   outputViewFile?: string | null;
   outputView?: ArtifactView | null;
+  /** Which sidecar applied: the agent file, or the contract-keyed fallback (WM-897). */
+  view?: { source: "agent" | "contract" } | null;
   pins: Record<string, string>;
   /** Closed-execution shape: fixed argv (command adapter) or action registry. */
   command: string[] | null;

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -38,6 +38,7 @@ import {
 import { ScopeCaption } from "../components/ContextTabs";
 import { SpecDiff } from "../components/SpecDiff";
 import { AgentHoverCard } from "../components/AgentHoverCard";
+import { TicketText } from "../components/TicketHoverCard";
 import {
   ApprovalRiskDetails,
   ApprovalSafetyCard,
@@ -1518,8 +1519,15 @@ export function Proposals({
                     sel.status === "open" ? DECISION_HUES : PROPOSAL_STATUS_HUES
                   }
                 />
-                <span className="truncate mono" title={sel.id}>
-                  {shortId(sel.id)}
+                <span
+                  className={`truncate ${sel.subject ? "" : "mono"}`}
+                  title={sel.subject ? `${sel.subject} · ${sel.id}` : sel.id}
+                >
+                  {sel.subject ? (
+                    <TicketText text={sel.subject} />
+                  ) : (
+                    shortId(sel.id)
+                  )}
                 </span>
               </span>
             </nav>

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -25,6 +25,7 @@ import {
 } from "../components/RunDetailBlocks";
 import { handleRunArtifactClick, toggleRunPin } from "./Runs";
 import { AgentHoverCard } from "../components/AgentHoverCard";
+import { TicketText } from "../components/TicketHoverCard";
 import type { RunListItem } from "../types";
 
 /**
@@ -403,10 +404,14 @@ export function RunFull({
                   <StateBadge state={d?.run.state ?? listRow!.state} />
                 )}
                 <span
-                  className="display mono min-w-0 truncate text-[15px] font-semibold text-(--text)"
-                  title={runId}
+                  className="display min-w-0 truncate text-[15px] font-semibold text-(--text)"
+                  title={d?.subject ? `${d.subject} · ${runId}` : runId}
                 >
-                  {runId}
+                  {d?.subject ? (
+                    <TicketText text={d.subject} />
+                  ) : (
+                    <span className="mono">{runId}</span>
+                  )}
                 </span>
               </li>
             </ol>


### PR DESCRIPTION
## Summary
- Extend `factory.artifact-view/v1` with optional `input` and `subject`, make `sections` optional, and fall back to `agents/views/<output_contract>.view.json` when the agent sidecar is absent (agent sidecar still wins, including when invalid).
- Expose `view.source` on GET `/agents` and rendered `subject` on GET `/proposals`, `/proposals/:id`, and `/runs/:id`. Dispatch ships an input+subject sidecar; command-result agents share one contract view.
- Web: dispatch input glance via ArtifactPanel (no schema title), subject headings in RunFull/Proposals, `x-ui` retired from CustomCell in favour of view `formats`.

Fixes WM-897

UX critique: required — SHIP (round 2; round 1 FIX-FIRST was the dispatch schema title citing WM-108 as the glance caption). Evidence: http://127.0.0.1:7459/#/run/run_demo_dispatch_wm100, http://127.0.0.1:7459/#/proposals/prop_demo_dispatch_wm100, `/tmp/wm-897-ux-r2/dispatch-desktop.png`. Follow-ups: WM-910, WM-911, WM-912.

## Test plan
- [ ] Ticket verification command (lib artifact-view/registry/spec-subject/api tests + named web tests + lint + check)
- [ ] Dispatch run heading shows `Dispatch WM-100 · bj29 ·` with a ticket chip; glance caption is **Input**, not WM-108
- [ ] Proposal `prop_demo_dispatch_wm100` aside uses the same subject
- [ ] A factory-status-report run still uses the old input glance
- [ ] `GET /agents` `view.source` is `"agent"` for dispatch and `"contract"` for ci-rerun/reconcile/warm


Made with [Cursor](https://cursor.com)