### PR TITLE
fix(notify): fall back to direct transport when serve push fails (WM-759)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -143,9 +143,11 @@ case "$cmd" in
     ;;
   run)          run_sh runners/run-agent.sh "$@" ;;
   notify)
-    # Durable first, push second (WM-285). A runtime connection failure falls
-    # back to the original direct transport so an offline serve process cannot
-    # swallow the interrupt. HTTP/delivery failures do not double-send.
+    # Durable first, push second (WM-285). Connection failure (11) or a failed
+    # serve-side push after a successful durable record (12) fall back to the
+    # original direct transport so the human is reached on at least one leg
+    # (WM-759). A successful durable+push does not fall through (no double-send).
+    # HTTP rejection (10) is still terminal.
     _notify_stdin=0
     if [[ "${1:-}" == "-" ]]; then
       _notify_stdin=1
@@ -198,26 +200,26 @@ case "$cmd" in
           });
           if (!response.ok) process.exit(10);
           const body = await response.json();
-          // The inbox item is the durable record; the external projection
-          // (notify.py) is best-effort. A stored item with a failed projection
-          // is a warning, not a failed run (WM-825): merge-notify was FAILED
-          // on every escalation on hosts without ~/Develop/hdkiller.
+          // Durable record succeeded; the serve-side notify.py projection did
+          // not. Exit 12 so the shell falls through to the CLI transport
+          // rather than treating this as delivered (WM-759). WM-825 exited 0
+          // once an item id existed, which left the human unreached when
+          // serve could not push. Stderr must stay visible; it used to be discarded.
           if (body?.delivery?.ok === false) {
-            if (body?.item?.id) {
-              console.error(`notify: inbox item ${body.item.id} stored; external projection failed: ${body.delivery.error ?? "exit " + body.delivery.exitCode}`);
-              process.exit(0);
-            }
+            const why = body.delivery.error ?? ("exit " + body.delivery.exitCode);
+            const stored = body?.item?.id ? `inbox item ${body.item.id} stored; ` : "";
+            console.error(`notify: ${stored}external projection failed: ${why}; falling back to direct transport`);
             process.exit(12);
           }
           process.exit(0);
         } catch {
           process.exit(11);
         }
-      ' >/dev/null 2>&1
+      ' >/dev/null
       _notify_status=$?
       set -e
       if [[ "$_notify_status" -eq 0 ]]; then exit 0; fi
-      if [[ "$_notify_status" -ne 11 ]]; then exit "$_notify_status"; fi
+      if [[ "$_notify_status" -ne 11 && "$_notify_status" -ne 12 ]]; then exit "$_notify_status"; fi
     fi
 
     # Unreachable runtime (or an unstructured legacy message): preserve the
@@ -288,7 +290,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   demo          run the bundled starter ticket (WM-799); --dry for CI.
                 Isolated event-runtime env: demo --here / demo --down
   run           runners/run-agent.sh
-  notify        durable human inbox + notify.py projection (direct fallback when serve is offline)
+  notify        durable human inbox + notify.py projection (direct fallback when serve is offline or its push fails)
   security      lib/security-check.sh (gitleaks + semgrep + actionlint on cwd repo)
   emit          build/emit.mjs (--link --link-bin --link-repos when called bare)
 

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -53,8 +53,52 @@ function runNotify({ args, stdin = "", exitCode = "0", env = {} }) {
     status: result.exitCode,
     args: existsSync(argsFile) ? readFileSync(argsFile, "utf8") : null,
     stdin: existsSync(stdinFile) ? readFileSync(stdinFile, "utf8") : null,
+    stderr: result.stderr.toString(),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
+}
+
+async function withInboxStub(response, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), "factory-inbox-server-"));
+  const requestFile = path.join(dir, "request.json");
+  const serverScript = path.join(dir, "server.py");
+  writeFileSync(
+    serverScript,
+    `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        with open(${JSON.stringify(requestFile)}, "w") as f:
+            f.write(self.rfile.read(length).decode())
+        body = json.dumps(json.loads(${JSON.stringify(JSON.stringify(response))})).encode()
+        self.send_response(201)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *_): pass
+server = HTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.handle_request()
+`,
+  );
+  const server = Bun.spawn({
+    cmd: ["python3", serverScript],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const reader = server.stdout.getReader();
+  const { value } = await reader.read();
+  const port = Number(new TextDecoder().decode(value).trim());
+  try {
+    return await fn({ port, requestFile });
+  } finally {
+    server.kill();
+    await server.exited;
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 test("factory notify delegates argv to the notifier from any cwd", () => {
@@ -84,60 +128,77 @@ test("factory notify preserves stdin mode and the notifier exit code", () => {
 });
 
 test("factory notify posts a structured inbox item when serve is reachable", async () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "factory-inbox-server-"));
-  const requestFile = path.join(dir, "request.json");
-  const serverScript = path.join(dir, "server.py");
-  const port = 31000 + (process.pid % 10000);
-  writeFileSync(
-    serverScript,
-    `
-import json
-from http.server import BaseHTTPRequestHandler, HTTPServer
-class Handler(BaseHTTPRequestHandler):
-    def do_POST(self):
-        length = int(self.headers.get("content-length", "0"))
-        with open(${JSON.stringify(requestFile)}, "w") as f:
-            f.write(self.rfile.read(length).decode())
-        body = json.dumps({"delivery": {"ok": True}}).encode()
-        self.send_response(201)
-        self.send_header("content-type", "application/json")
-        self.send_header("content-length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-    def log_message(self, *_): pass
-server = HTTPServer(("127.0.0.1", ${port}), Handler)
-print("ready", flush=True)
-server.handle_request()
-`,
+  await withInboxStub(
+    { delivery: { ok: true } },
+    async ({ port, requestFile }) => {
+      const result = runNotify({
+        args: ["BLOCKED", "WM-1:", "choose policy"],
+        env: { FACTORY_EVENT_PORT: String(port), FACTORY_RUN_ID: "run_test" },
+      });
+      try {
+        expect(result.status).toBe(0);
+        expect(result.args).toBeNull();
+        const body = JSON.parse(readFileSync(requestFile, "utf8"));
+        expect(body).toEqual({
+          kind: "BLOCKED",
+          title: "BLOCKED WM-1: choose policy",
+          refs: { issue: "WM-1" },
+          source: "agent:run_test",
+        });
+      } finally {
+        result.cleanup();
+      }
+    },
   );
-  const server = Bun.spawn({
-    cmd: ["python3", serverScript],
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const reader = server.stdout.getReader();
-  await reader.read();
+});
 
-  const result = runNotify({
-    args: ["BLOCKED", "WM-1:", "choose policy"],
-    env: { FACTORY_EVENT_PORT: String(port), FACTORY_RUN_ID: "run_test" },
-  });
-  try {
-    expect(result.status).toBe(0);
-    expect(result.args).toBeNull();
-    const body = JSON.parse(readFileSync(requestFile, "utf8"));
-    expect(body).toEqual({
-      kind: "BLOCKED",
-      title: "BLOCKED WM-1: choose policy",
-      refs: { issue: "WM-1" },
-      source: "agent:run_test",
-    });
-  } finally {
-    server.kill();
-    await server.exited;
-    result.cleanup();
-    rmSync(dir, { recursive: true, force: true });
-  }
+test("factory notify falls back to direct transport when durable record succeeds but serve push fails", async () => {
+  await withInboxStub(
+    {
+      item: { id: "inbox_wm759" },
+      delivery: { ok: false, exitCode: 9, error: "telegram unavailable" },
+    },
+    async ({ port, requestFile }) => {
+      const result = runNotify({
+        args: ["BLOCKED", "WM-1:", "choose policy"],
+        env: { FACTORY_EVENT_PORT: String(port) },
+      });
+      try {
+        expect(result.status).toBe(0);
+        expect(result.args).toBe("BLOCKED\nWM-1:\nchoose policy\n");
+        expect(result.stderr).toContain("inbox item inbox_wm759 stored");
+        expect(result.stderr).toContain("telegram unavailable");
+        expect(result.stderr).toContain("falling back to direct transport");
+        const body = JSON.parse(readFileSync(requestFile, "utf8"));
+        expect(body.kind).toBe("BLOCKED");
+      } finally {
+        result.cleanup();
+      }
+    },
+  );
+});
+
+test("factory notify prints why when durable-ok push-failed and the fallback also fails", async () => {
+  await withInboxStub(
+    {
+      item: { id: "inbox_undeliverable" },
+      delivery: { ok: false, exitCode: 9, error: "telegram unavailable" },
+    },
+    async ({ port }) => {
+      const result = runNotify({
+        args: ["ESCALATED", "WM-1:", "need a human"],
+        exitCode: "7",
+        env: { FACTORY_EVENT_PORT: String(port) },
+      });
+      try {
+        expect(result.status).toBe(7);
+        expect(result.args).toBe("ESCALATED\nWM-1:\nneed a human\n");
+        expect(result.stderr).toContain("telegram unavailable");
+      } finally {
+        result.cleanup();
+      }
+    },
+  );
 });
 
 test("factory ps executes orchestrator/ps.mjs via CLI", () => {


### PR DESCRIPTION
## Summary
- `factory notify` for a recognized event now falls through to the direct `notify.py` transport when serve records the interrupt but its Telegram projection fails (`delivery.ok === false`), instead of exiting 12 or 0 with the human unreached.
- Stderr from the bun probe is no longer discarded, so a genuinely undeliverable notify prints why.
- Covered in `bin/factory.test.mjs`: durable-ok + push-failed delivers via the fallback.

Fixes WM-759

UX critique: skipped — CLI notify transport; no user-facing surface.

## Test plan
- [x] `bun test bin/factory.test.mjs`
- [x] `bun test event-runtime/lib --timeout 20000`
- [x] `bun build/emit.mjs --check`
- [x] remainder of `bun test --timeout 20000 --max-concurrency=4`


Made with [Cursor](https://cursor.com)