### PR TITLE
chore(ci): key develop push concurrency by sha, not ref (WM-866)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,14 @@ on:
 permissions:
   contents: read
 
-# One live run per PR, and one per pushed branch: a newer push to develop
-# supersedes the older develop run (WM-773 item 6) — a stale develop SHA green
-# proves nothing and used to cost a full lane hold per merge.
+# One live run per PR: a newer synchronize cancels the superseded PR run.
+# Push events are keyed by SHA so back-to-back develop merges each finish
+# Full verification — canceling the earlier SHA made its aggregate check
+# report RED (WM-866). WM-773 item 6 coalesced by ref; that is no longer
+# the policy.
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   shadow-runner-health:


### PR DESCRIPTION
## Summary
- Key CI `push` concurrency groups by `${{ github.sha }}` so back-to-back develop merges each finish Full verification instead of canceling the earlier SHA (which reported as CI RED).
- Keep `cancel-in-progress` for `pull_request` events so a newer synchronize still supersedes the old PR run.
- Follow-ups (outside this ticket's Owned Paths): WM-916 (`security.yml` still coalesces push by ref), WM-917 (`docs/ci.md` Run coalescing is now stale).

Fixes WM-866

## Test plan
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` — 1191 pass, emit ok
- [ ] Confirm a subsequent develop merge does not cancel the previous SHA's CI run

UX critique: skipped — CI workflow concurrency; no user-facing surface.

Made with [Cursor](https://cursor.com)