### PR TITLE
feat(event-runtime): add GET /memos, CLI memos, and Notes panel (WM-814)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -19,7 +19,7 @@ import {
 
 const USAGE = BASE_USAGE.replace(
   "  inbox                          open items waiting on the human",
-  "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API",
+  "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API\n  memos <subjectType> <id> [--kind k] [--all]\n                                 live memos for a subject, with provenance and expiry",
 )
   .replace(
     "  agents                         registered agent definitions and event routing",
@@ -73,6 +73,70 @@ async function callControl(method, pathname, body) {
     throw err;
   }
   return payload;
+}
+
+/** Format one memo row for `memos` (docs/event-runtime-memos.md §8). */
+function formatMemoLine(memo) {
+  const subject = `${memo.subject?.type ?? "?"}:${memo.subject?.id ?? "?"}`;
+  const live = memo.live === false ? "expired" : "live";
+  const expires = memo.expiresAt ?? "-";
+  const uses = `${memo.usefulCount ?? 0}u/${memo.wrongCount ?? 0}w`;
+  const agent = memo.provenance?.agent ?? "-";
+  const from =
+    memo.inboxItemId && !memo.runId
+      ? `operator decision ${memo.inboxItemId}`
+      : memo.runId
+        ? `${agent} ${memo.runId}`
+        : agent;
+  return `${memo.kind}\t${subject}\t${live}\t${expires}\t${uses}\t${from}`;
+}
+
+/** Read-only fold of live memos for one subject (WM-814). */
+export async function memosCommand(args = []) {
+  const positional = [];
+  let kind;
+  let all = false;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--kind") {
+      kind = args[++i];
+      continue;
+    }
+    if (args[i] === "--all") {
+      all = true;
+      continue;
+    }
+    positional.push(args[i]);
+  }
+  const [subjectType, subjectId] = positional;
+  if (!subjectType || !subjectId) {
+    throw new Error("usage: memos <subjectType> <id> [--kind k] [--all]");
+  }
+  const query = new URLSearchParams({
+    subjectType,
+    subjectId,
+    live: all ? "false" : "true",
+  });
+  if (kind) query.set("kind", kind);
+  const body = await callControl("GET", `/memos?${query}`);
+  const memos = body.memos ?? [];
+  if (memos.length === 0) {
+    console.log(
+      all
+        ? `no memos for ${subjectType}:${subjectId}`
+        : `no live memos for ${subjectType}:${subjectId}`,
+    );
+    return memos;
+  }
+  console.log("KIND\tSUBJECT\tSTATE\tEXPIRES\tUSES\tFROM");
+  for (const memo of memos) {
+    console.log(formatMemoLine(memo));
+    if (typeof memo.body === "string" && memo.body.trim()) {
+      for (const line of memo.body.trim().split("\n")) {
+        console.log(`  ${line}`);
+      }
+    }
+  }
+  return memos;
 }
 
 /** Owned-path override of the split inbox command, adding decision markers. */
@@ -279,6 +343,7 @@ export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
+  if (command === "memos") return memosCommand(args);
   if (command === "adapters") return adaptersCommand(args);
   if (command === "extensions") return extensionsCommand(args);
   if (command === "artifacts") return artifactsCommand(args);

--- a/event-runtime/lib/api-memos.mjs
+++ b/event-runtime/lib/api-memos.mjs
@@ -1,0 +1,233 @@
+/**
+ * Read-only memo query (docs/event-runtime-memos.md §8, WM-814).
+ *
+ * `GET /memos?subjectType=&subjectId=&kind=&live=` folds the ledger for one
+ * exact subject. There is no write verb — memos enter through accepted runs
+ * and inbox decisions. Mount from `createApi` in `api.mjs`.
+ */
+import { readFileSync } from "node:fs";
+import { findArtifact } from "./artifacts.mjs";
+import { artifactsRoot } from "./config.mjs";
+import {
+  LIST_MEMOS_DEFAULT_MAX,
+  MEMO_KINDS,
+  SUBJECT_TYPES,
+  listMemos,
+} from "./memos.mjs";
+
+const LIVE_TRUE = new Set(["true", "1"]);
+const LIVE_FALSE = new Set(["false", "0"]);
+
+export class MemosQueryError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MemosQueryError";
+  }
+}
+
+function parseLive(raw) {
+  if (raw === null || raw === "") return true;
+  const value = String(raw).trim().toLowerCase();
+  if (LIVE_TRUE.has(value)) return true;
+  if (LIVE_FALSE.has(value)) return false;
+  throw new MemosQueryError("live must be true or false");
+}
+
+function parseMax(raw) {
+  if (raw === null || raw === "") return LIST_MEMOS_DEFAULT_MAX;
+  const max = Number(raw);
+  if (!Number.isInteger(max) || max < 1 || max > 500) {
+    throw new MemosQueryError("max must be an integer between 1 and 500");
+  }
+  return max;
+}
+
+function parseKinds(raw) {
+  if (raw === null || raw === "") return undefined;
+  const kinds = String(raw)
+    .split(",")
+    .map((kind) => kind.trim())
+    .filter(Boolean);
+  if (kinds.length === 0) return undefined;
+  const unknown = kinds.filter((kind) => !MEMO_KINDS.includes(kind));
+  if (unknown.length > 0) {
+    throw new MemosQueryError(
+      `kind must be one of ${MEMO_KINDS.join(", ")} (got ${unknown.join(", ")})`,
+    );
+  }
+  return kinds;
+}
+
+/**
+ * Validate and normalise the query string. Throws MemosQueryError on 422.
+ *
+ * @returns {{ subject: { type: string, id: string }, kinds?: string[], live: boolean, max: number }}
+ */
+export function parseMemosQuery(searchParams) {
+  const subjectType = searchParams.get("subjectType");
+  const subjectId = searchParams.get("subjectId");
+  if (typeof subjectType !== "string" || subjectType.trim() === "") {
+    throw new MemosQueryError("subjectType is required");
+  }
+  if (typeof subjectId !== "string" || subjectId.trim() === "") {
+    throw new MemosQueryError("subjectId is required");
+  }
+  if (!SUBJECT_TYPES.includes(subjectType)) {
+    throw new MemosQueryError(
+      `subjectType must be one of ${SUBJECT_TYPES.join(", ")}`,
+    );
+  }
+  return {
+    subject: { type: subjectType, id: subjectId.trim() },
+    kinds: parseKinds(searchParams.get("kind")),
+    live: parseLive(searchParams.get("live")),
+    max: parseMax(searchParams.get("max")),
+  };
+}
+
+function loadMemoDocument(artifactsDir, sha256) {
+  const found = findArtifact(artifactsDir, sha256);
+  if (!found) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(found.file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function usesByHash(db, hashes) {
+  const grouped = new Map(hashes.map((sha) => [sha, []]));
+  if (hashes.length === 0) return grouped;
+  const placeholders = hashes.map(() => "?").join(", ");
+  const rows = db
+    .query(
+      `SELECT sha256, run_id AS runId, verdict, run_state AS runState, at
+       FROM memo_uses WHERE sha256 IN (${placeholders})
+       ORDER BY at ASC`,
+    )
+    .all(...hashes);
+  for (const row of rows) {
+    const list = grouped.get(row.sha256);
+    if (!list) continue;
+    list.push({
+      runId: row.runId,
+      verdict: row.verdict,
+      runState: row.runState,
+      at: new Date(row.at).toISOString(),
+    });
+  }
+  return grouped;
+}
+
+function isLiveRow(row, nowMs) {
+  if (row.supersededBy) return false;
+  if (row.retiredAt) return false;
+  if (row.expiresAt !== null && Date.parse(row.expiresAt) <= nowMs)
+    return false;
+  return true;
+}
+
+function memoViewEntry(row, document, uses, nowMs) {
+  const provenance = document?.provenance ?? {
+    runId: row.runId,
+    agent: row.inboxItemId ? "runtime:inbox" : null,
+    createdAt: row.createdAt,
+  };
+  return {
+    sha256: row.sha256,
+    subject: row.subject,
+    kind: row.kind,
+    live: isLiveRow(row, nowMs),
+    body: typeof document?.body === "string" ? document.body : null,
+    claim: document?.claim ?? null,
+    evidence: document?.evidence ?? null,
+    precedentOnly: document?.precedentOnly === true,
+    bindings: document?.bindings ?? {
+      ...(row.descriptionHash ? { descriptionHash: row.descriptionHash } : {}),
+      ...(row.headSha ? { headSha: row.headSha } : {}),
+      ...(row.expiresAt ? { expiresAt: row.expiresAt } : {}),
+    },
+    provenance,
+    refs: document?.refs ?? {
+      ...(row.inboxItemId ? { inboxItemId: row.inboxItemId } : {}),
+      ...(row.runId ? { runId: row.runId } : {}),
+    },
+    runId: row.runId,
+    inboxItemId: row.inboxItemId,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    supersededBy: row.supersededBy,
+    retiredAt: row.retiredAt,
+    retiredReason: row.retiredReason,
+    usefulCount: row.usefulCount,
+    wrongCount: row.wrongCount,
+    uses,
+  };
+}
+
+/**
+ * Fold memos for one subject and attach store bodies + use rows.
+ *
+ * @returns {{ memos: object[] }}
+ */
+export function memosView(
+  db,
+  {
+    subject,
+    kinds,
+    live = true,
+    max = LIST_MEMOS_DEFAULT_MAX,
+    now,
+    artifactsDir,
+  },
+) {
+  const nowMs = now ?? Date.now();
+  const rows = listMemos(db, subject, { kinds, live, max, now: nowMs });
+  const uses = usesByHash(
+    db,
+    rows.map((row) => row.sha256),
+  );
+  return {
+    memos: rows.map((row) =>
+      memoViewEntry(
+        row,
+        loadMemoDocument(artifactsDir, row.sha256),
+        uses.get(row.sha256) ?? [],
+        nowMs,
+      ),
+    ),
+  };
+}
+
+export function handleMemosApiRoute({
+  route,
+  url,
+  send,
+  db,
+  env,
+  nowMs,
+  artifactsDir,
+}) {
+  if (route !== "GET /memos") return false;
+  try {
+    const query = parseMemosQuery(url.searchParams);
+    const store = artifactsDir ?? artifactsRoot(env?.home);
+    return send(
+      200,
+      memosView(db, { ...query, now: nowMs, artifactsDir: store }),
+    );
+  } catch (err) {
+    if (err instanceof MemosQueryError)
+      return send(422, { error: err.message });
+    if (
+      err instanceof Error &&
+      /unknown subject type|subject\.id/.test(err.message)
+    ) {
+      return send(422, { error: err.message });
+    }
+    throw err;
+  }
+}

--- a/event-runtime/lib/api-memos.test.mjs
+++ b/event-runtime/lib/api-memos.test.mjs
@@ -1,0 +1,266 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-memos-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  handleMemosApiRoute,
+  memosView,
+  parseMemosQuery,
+} from "./api-memos.mjs";
+import { canonicalJson } from "./canonical.mjs";
+import { openDb } from "./db.mjs";
+import {
+  MEMO_SCHEMA_VERSION,
+  memoDigest,
+  registerMemos,
+  withProvenance,
+} from "./memos.mjs";
+
+function postmortemDoc(overrides = {}) {
+  return {
+    schemaVersion: MEMO_SCHEMA_VERSION,
+    subject: { type: "ticket", id: "WM-809" },
+    kind: "postmortem",
+    body: "Run the scoped command, not the full suite.",
+    ...overrides,
+  };
+}
+
+function accepted(document, { runId = "run_memo_api", now, agent } = {}) {
+  const createdAt = new Date(now).toISOString();
+  const full = withProvenance(document, {
+    runId,
+    agent: agent ?? "run-postmortem@2",
+    createdAt,
+  });
+  const sha256 = memoDigest(full);
+  return {
+    full,
+    sha256,
+    result: { memos: [{ sha256, document: full }] },
+  };
+}
+
+function putStore(storeRoot, sha256, document) {
+  mkdirSync(storeRoot, { recursive: true });
+  writeFileSync(path.join(storeRoot, sha256), canonicalJson(document));
+}
+
+function invoke(db, search, { now, home } = {}) {
+  const url = new URL(`http://127.0.0.1/memos${search}`);
+  let captured = null;
+  const send = (status, body) => {
+    captured = { status, body };
+    return captured;
+  };
+  const result = handleMemosApiRoute({
+    route: "GET /memos",
+    url,
+    send,
+    db,
+    env: { home },
+    nowMs: now,
+    artifactsDir: home ? path.join(home, "artifacts") : undefined,
+  });
+  return result ?? captured;
+}
+
+describe("parseMemosQuery", () => {
+  test("requires subjectType and subjectId and accepts live/kind/max", () => {
+    expect(() => parseMemosQuery(new URLSearchParams(""))).toThrow(
+      /subjectType is required/,
+    );
+    expect(() =>
+      parseMemosQuery(new URLSearchParams("subjectType=ticket")),
+    ).toThrow(/subjectId is required/);
+    expect(() =>
+      parseMemosQuery(new URLSearchParams("subjectType=board&subjectId=x")),
+    ).toThrow(/subjectType must be one of/);
+    expect(() =>
+      parseMemosQuery(
+        new URLSearchParams("subjectType=ticket&subjectId=WM-1&kind=gossip"),
+      ),
+    ).toThrow(/kind must be one of/);
+    expect(() =>
+      parseMemosQuery(
+        new URLSearchParams("subjectType=ticket&subjectId=WM-1&live=maybe"),
+      ),
+    ).toThrow(/live must be true or false/);
+    expect(
+      parseMemosQuery(
+        new URLSearchParams(
+          "subjectType=ticket&subjectId=wm-809&kind=postmortem&live=false&max=5",
+        ),
+      ),
+    ).toEqual({
+      subject: { type: "ticket", id: "wm-809" },
+      kinds: ["postmortem"],
+      live: false,
+      max: 5,
+    });
+  });
+});
+
+describe("GET /memos (WM-814)", () => {
+  test("returns live memos with body, provenance, expiry, and use counts", () => {
+    const db = openDb(":memory:");
+    const home = tmpDir("evrt-api-memos-");
+    const store = path.join(home, "artifacts");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const { sha256, full, result } = accepted(postmortemDoc(), { now });
+    registerMemos(db, "run_memo_api", result, { now });
+    putStore(store, sha256, full);
+    db.query(
+      `INSERT INTO memo_uses (sha256, run_id, verdict, run_state, at)
+       VALUES (?, 'run_consumer', 'useful', 'COMPLETED', ?)`,
+    ).run(sha256, now + 1000);
+
+    const res = invoke(db, "?subjectType=ticket&subjectId=wm-809", {
+      now,
+      home,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.memos).toHaveLength(1);
+    const memo = res.body.memos[0];
+    expect(memo.sha256).toBe(sha256);
+    expect(memo.subject).toEqual({ type: "ticket", id: "WM-809" });
+    expect(memo.kind).toBe("postmortem");
+    expect(memo.live).toBe(true);
+    expect(memo.body).toBe("Run the scoped command, not the full suite.");
+    expect(memo.provenance).toEqual(full.provenance);
+    expect(memo.expiresAt).toBe("2026-09-17T14:02:11.000Z");
+    expect(memo.usefulCount).toBe(1);
+    expect(memo.wrongCount).toBe(0);
+    expect(memo.uses).toEqual([
+      {
+        runId: "run_consumer",
+        verdict: "useful",
+        runState: "COMPLETED",
+        at: new Date(now + 1000).toISOString(),
+      },
+    ]);
+    db.close();
+  });
+
+  test("live=true drops expired and superseded rows; live=false returns them struck", () => {
+    const db = openDb(":memory:");
+    const home = tmpDir("evrt-api-memos-all-");
+    const store = path.join(home, "artifacts");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const first = accepted(postmortemDoc({ body: "attempt 1" }), { now });
+    registerMemos(db, "run_a", first.result, { now });
+    putStore(store, first.sha256, first.full);
+    const second = accepted(
+      postmortemDoc({
+        body: "attempt 2",
+        supersedes: first.sha256,
+      }),
+      { now: now + 1000, runId: "run_b" },
+    );
+    registerMemos(db, "run_b", second.result, { now: now + 1000 });
+    putStore(store, second.sha256, second.full);
+
+    const live = invoke(db, "?subjectType=ticket&subjectId=WM-809", {
+      now: now + 1000,
+      home,
+    });
+    expect(live.body.memos.map((m) => m.sha256)).toEqual([second.sha256]);
+    expect(live.body.memos[0].live).toBe(true);
+
+    const all = invoke(db, "?subjectType=ticket&subjectId=WM-809&live=false", {
+      now: now + 1000,
+      home,
+    });
+    expect(all.body.memos.map((m) => m.sha256).sort()).toEqual(
+      [first.sha256, second.sha256].sort(),
+    );
+    const older = all.body.memos.find((m) => m.sha256 === first.sha256);
+    expect(older.live).toBe(false);
+    expect(older.supersededBy).toBe(second.sha256);
+    db.close();
+  });
+
+  test("kind filters the fold and a missing store still returns the ledger row", () => {
+    const db = openDb(":memory:");
+    const home = tmpDir("evrt-api-memos-kind-");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const note = accepted(
+      {
+        schemaVersion: MEMO_SCHEMA_VERSION,
+        subject: { type: "repo", id: "factory" },
+        kind: "repo-note",
+        claim: { kind: "howto", text: "Use the scoped suite." },
+        evidence: "Root suite: 6m40s. Scoped: 41s.",
+        body: "Use the scoped suite.",
+      },
+      { now, runId: "run_note", agent: "dispatch@1" },
+    );
+    registerMemos(db, "run_note", note.result, { now });
+    const post = accepted(postmortemDoc(), { now, runId: "run_pm" });
+    registerMemos(db, "run_pm", post.result, { now });
+
+    const filtered = invoke(
+      db,
+      "?subjectType=ticket&subjectId=WM-809&kind=postmortem",
+      { now, home },
+    );
+    expect(filtered.body.memos).toHaveLength(1);
+    expect(filtered.body.memos[0].kind).toBe("postmortem");
+    expect(filtered.body.memos[0].body).toBeNull();
+
+    const repo = invoke(db, "?subjectType=repo&subjectId=FACTORY", {
+      now,
+      home,
+    });
+    expect(repo.body.memos).toHaveLength(1);
+    expect(repo.body.memos[0].subject).toEqual({ type: "repo", id: "factory" });
+    db.close();
+  });
+
+  test("rejects unknown query values with 422 and ignores other routes", () => {
+    const db = openDb(":memory:");
+    expect(invoke(db, "").status).toBe(422);
+    expect(invoke(db, "?subjectType=ticket").body.error).toMatch(
+      /subjectId is required/,
+    );
+    expect(
+      handleMemosApiRoute({
+        route: "POST /memos",
+        url: new URL("http://127.0.0.1/memos"),
+        send: () => {
+          throw new Error("must not send");
+        },
+        db,
+      }),
+    ).toBe(false);
+    db.close();
+  });
+
+  test("memosView orders by useful count then newest", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const older = accepted(postmortemDoc({ body: "older" }), {
+      now,
+      runId: "run_old",
+    });
+    registerMemos(db, "run_old", older.result, { now });
+    const newer = accepted(postmortemDoc({ body: "newer" }), {
+      now: now + 5000,
+      runId: "run_new",
+    });
+    registerMemos(db, "run_new", newer.result, { now: now + 5000 });
+    db.query(
+      `INSERT INTO memo_uses (sha256, run_id, verdict, run_state, at)
+       VALUES (?, 'run_u1', 'useful', 'COMPLETED', ?)`,
+    ).run(older.sha256, now + 10);
+
+    const { memos } = memosView(db, {
+      subject: { type: "ticket", id: "WM-809" },
+      live: true,
+      now: now + 5000,
+      artifactsDir: tmpDir("evrt-api-memos-empty-"),
+    });
+    expect(memos.map((m) => m.sha256)).toEqual([older.sha256, newer.sha256]);
+    db.close();
+  });
+});

--- a/event-runtime/web/src/components/NotesPanel.tsx
+++ b/event-runtime/web/src/components/NotesPanel.tsx
@@ -1,0 +1,299 @@
+/**
+ * Read-only Notes panel (docs/event-runtime-memos.md §8, WM-814).
+ *
+ * Live memos for a subject (ticket / repo / PR / run), with provenance,
+ * bindings, use counts, and an expired toggle that reveals retired and
+ * superseded rows struck through. There is no write control here.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { refetchIntervals, useNow } from "../hooks";
+import { Ago, JumpLink, Section, shortId } from "./ui";
+
+export type MemoSubject = { type: string; id: string };
+
+export interface MemoUse {
+  runId: string;
+  verdict: string | null;
+  runState: string;
+  at: string;
+}
+
+export interface MemoEntry {
+  sha256: string;
+  subject: MemoSubject;
+  kind: string;
+  live: boolean;
+  body: string | null;
+  claim?: { kind: string; text: string } | null;
+  evidence?: string | null;
+  precedentOnly?: boolean;
+  bindings?: {
+    descriptionHash?: string;
+    headSha?: string;
+    expiresAt?: string;
+  } | null;
+  provenance?: {
+    runId?: string | null;
+    agent?: string | null;
+    createdAt?: string;
+  } | null;
+  runId?: string | null;
+  inboxItemId?: string | null;
+  createdAt?: string;
+  expiresAt?: string | null;
+  supersededBy?: string | null;
+  retiredAt?: string | null;
+  retiredReason?: string | null;
+  usefulCount?: number;
+  wrongCount?: number;
+  uses?: MemoUse[];
+}
+
+/** Subjects the run detail pane should query: ticket, repo, then the run itself. */
+export function subjectsFromRunInput(
+  input: unknown,
+  runId: string,
+): MemoSubject[] {
+  const subjects: MemoSubject[] = [];
+  const rec =
+    input && typeof input === "object" && !Array.isArray(input)
+      ? (input as Record<string, unknown>)
+      : {};
+  if (typeof rec.ticket === "string" && rec.ticket.trim()) {
+    subjects.push({ type: "ticket", id: rec.ticket.trim() });
+  }
+  if (typeof rec.repo === "string" && rec.repo.trim()) {
+    subjects.push({ type: "repo", id: rec.repo.trim() });
+  }
+  if (typeof rec.pr === "string" && rec.pr.trim()) {
+    subjects.push({ type: "pr", id: rec.pr.trim() });
+  }
+  subjects.push({ type: "run", id: runId });
+  return subjects;
+}
+
+export function memoPinShas(input: unknown): string[] {
+  const rec =
+    input && typeof input === "object" && !Array.isArray(input)
+      ? (input as Record<string, unknown>)
+      : {};
+  const pin = rec.memoPin;
+  if (!pin || typeof pin !== "object" || Array.isArray(pin)) return [];
+  const entries = (pin as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (entry && typeof entry === "object" && "sha256" in entry) {
+        const sha = (entry as { sha256?: unknown }).sha256;
+        return typeof sha === "string" ? sha : "";
+      }
+      return "";
+    })
+    .filter((sha) => sha.length > 0);
+}
+
+async function fetchMemos(
+  subject: MemoSubject,
+  live: boolean,
+): Promise<MemoEntry[]> {
+  const query = new URLSearchParams({
+    subjectType: subject.type,
+    subjectId: subject.id,
+    live: live ? "true" : "false",
+  });
+  try {
+    const res = await fetch(`/api/memos?${query.toString()}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return [];
+    const json: unknown = await res.json();
+    const memos =
+      json && typeof json === "object" && "memos" in json
+        ? (json as { memos?: unknown }).memos
+        : null;
+    return Array.isArray(memos) ? (memos as MemoEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function provenanceLabel(memo: MemoEntry): string {
+  const agent = memo.provenance?.agent;
+  if (memo.inboxItemId && (!memo.runId || agent === "runtime:inbox")) {
+    return `operator decision, inbox item ${memo.inboxItemId}`;
+  }
+  if (agent && memo.runId) return `${agent}`;
+  if (agent) return agent;
+  return "unknown producer";
+}
+
+function bindingState(memo: MemoEntry): string | null {
+  if (memo.retiredReason) return memo.retiredReason.replaceAll("_", " ");
+  if (memo.supersededBy) return "superseded";
+  if (!memo.live && memo.expiresAt) return "expired";
+  return null;
+}
+
+function MemoCard({
+  memo,
+  read,
+  wrote,
+  now,
+}: {
+  memo: MemoEntry;
+  read: boolean;
+  wrote: boolean;
+  now: number;
+}) {
+  const dead = !memo.live;
+  const state = bindingState(memo);
+  const sha = memo.sha256.slice(0, 12);
+  return (
+    <article
+      className={`border-b border-(--border) py-2 last:border-b-0 ${dead ? "opacity-70" : ""}`}
+    >
+      <div
+        className={`flex flex-wrap items-baseline gap-x-2 gap-y-0.5 ${dead ? "line-through" : ""}`}
+      >
+        <span className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+          {memo.kind}
+        </span>
+        <span className="mono text-[11px] text-(--text-dim)">
+          {memo.subject.type}:{memo.subject.id}
+        </span>
+        {read && (
+          <span className="text-[11px] tracking-wide text-(--text-faint) uppercase">
+            read
+          </span>
+        )}
+        {wrote && (
+          <span className="text-[11px] tracking-wide text-(--text-faint) uppercase">
+            wrote
+          </span>
+        )}
+        {memo.precedentOnly && (
+          <span className="text-[11px] tracking-wide text-(--hue-warn) uppercase">
+            precedent only
+          </span>
+        )}
+      </div>
+      <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2 text-[11px] text-(--text-dim)">
+        <span>{provenanceLabel(memo)}</span>
+        {memo.runId && (
+          <JumpLink
+            href={`#/runs/${encodeURIComponent(memo.runId)}`}
+            title={memo.runId}
+          >
+            {shortId(memo.runId)}
+          </JumpLink>
+        )}
+        {memo.createdAt && <Ago iso={memo.createdAt} now={now} />}
+        <span className="mono text-(--text-faint)" title={memo.sha256}>
+          {sha}
+        </span>
+      </div>
+      <div className="mt-0.5 flex flex-wrap gap-x-3 text-[11px] text-(--text-faint)">
+        <span>
+          {memo.usefulCount ?? 0} useful · {memo.wrongCount ?? 0} wrong
+        </span>
+        {memo.expiresAt && (
+          <span title={memo.expiresAt}>
+            expires {memo.expiresAt.slice(0, 10)}
+          </span>
+        )}
+        {state && <span>{state}</span>}
+      </div>
+      {memo.body && (
+        <p
+          className={`mt-1 whitespace-pre-wrap text-[12px] text-(--text) ${dead ? "line-through" : ""}`}
+        >
+          {memo.body}
+        </p>
+      )}
+      {memo.claim?.text && memo.claim.text !== memo.body && (
+        <p className="mt-1 text-[12px] text-(--text-dim)">{memo.claim.text}</p>
+      )}
+    </article>
+  );
+}
+
+export function NotesPanel({
+  subjects,
+  readShas = [],
+  wroteRunId,
+}: {
+  subjects: readonly MemoSubject[];
+  /** Memo hashes this run read (`memoPin`); tagged "read" when present. */
+  readShas?: readonly string[];
+  /** Producer run id; matching memos are tagged "wrote". */
+  wroteRunId?: string | null;
+}) {
+  const now = useNow();
+  const [showExpired, setShowExpired] = useState(false);
+  const key = subjects.map((s) => `${s.type}:${s.id}`).join("|");
+  const query = useQuery({
+    queryKey: ["memos", key, showExpired],
+    queryFn: async () => {
+      const batches = await Promise.all(
+        subjects.map((subject) => fetchMemos(subject, !showExpired)),
+      );
+      const seen = new Set<string>();
+      const merged: MemoEntry[] = [];
+      for (const batch of batches) {
+        for (const memo of batch) {
+          if (!memo?.sha256 || seen.has(memo.sha256)) continue;
+          seen.add(memo.sha256);
+          merged.push(memo);
+        }
+      }
+      merged.sort((a, b) => {
+        const useful = (b.usefulCount ?? 0) - (a.usefulCount ?? 0);
+        if (useful !== 0) return useful;
+        return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+      });
+      return merged;
+    },
+    enabled: subjects.length > 0,
+    ...refetchIntervals.secondary,
+  });
+
+  const read = useMemo(() => new Set(readShas), [readShas]);
+  const memos = query.data ?? [];
+
+  if (subjects.length === 0) return null;
+
+  return (
+    <Section title="Notes" id="notes">
+      <label className="mb-2 flex cursor-pointer items-center gap-2 py-1 text-[12px] text-(--text-dim)">
+        <input
+          type="checkbox"
+          checked={showExpired}
+          onChange={(e) => setShowExpired(e.target.checked)}
+          aria-label="Show expired and superseded notes"
+        />
+        Show expired
+      </label>
+      {query.isPending && memos.length === 0 ? (
+        <div className="py-1 text-[11px] text-(--text-faint)">
+          Loading notes…
+        </div>
+      ) : memos.length === 0 ? (
+        <div className="py-1 text-[11px] text-(--text-faint)">
+          {showExpired ? "No notes for this subject." : "No live notes."}
+        </div>
+      ) : (
+        memos.map((memo) => (
+          <MemoCard
+            key={memo.sha256}
+            memo={memo}
+            read={read.has(memo.sha256)}
+            wrote={Boolean(wroteRunId) && memo.runId === wroteRunId}
+            now={now}
+          />
+        ))
+      )}
+    </Section>
+  );
+}

--- a/event-runtime/web/src/components/NotesPanel.tsx
+++ b/event-runtime/web/src/components/NotesPanel.tsx
@@ -220,18 +220,40 @@ function MemoCard({
 }
 
 export function NotesPanel({
-  subjects,
-  readShas = [],
+  subjects: explicitSubjects,
+  readShas: explicitReadShas,
   wroteRunId,
+  runInput,
+  runId,
 }: {
-  subjects: readonly MemoSubject[];
+  subjects?: readonly MemoSubject[];
   /** Memo hashes this run read (`memoPin`); tagged "read" when present. */
   readShas?: readonly string[];
   /** Producer run id; matching memos are tagged "wrote". */
   wroteRunId?: string | null;
+  /** Run spec input — used to derive subjects and readShas when subjects are not passed. */
+  runInput?: unknown;
+  /** Run id — used to derive subjects when runInput is passed. */
+  runId?: string;
 }) {
   const now = useNow();
   const [showExpired, setShowExpired] = useState(false);
+  const subjects = useMemo(() => {
+    if (explicitSubjects) return explicitSubjects;
+    if (runInput !== undefined && runId !== undefined) {
+      return subjectsFromRunInput(runInput, runId);
+    }
+    return [];
+  }, [explicitSubjects, runInput, runId]);
+
+  const readShas = useMemo(() => {
+    if (explicitReadShas) return explicitReadShas;
+    if (runInput !== undefined) {
+      return memoPinShas(runInput);
+    }
+    return [];
+  }, [explicitReadShas, runInput]);
+
   const key = subjects.map((s) => `${s.type}:${s.id}`).join("|");
   const query = useQuery({
     queryKey: ["memos", key, showExpired],

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -34,6 +34,11 @@ import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
+import {
+  NotesPanel,
+  memoPinShas,
+  subjectsFromRunInput,
+} from "../components/NotesPanel";
 import { AgentHoverCard } from "../components/AgentHoverCard";
 import { CausationGlyphs, chainHref } from "../components/EventHoverCard";
 import { RunHoverCard, runDurationSeconds } from "../components/RunHoverCard";
@@ -1692,6 +1697,11 @@ export function Runs({
                       onExpand={() => onOpenFull(d.run.runId)}
                     />
                   }
+                />
+                <NotesPanel
+                  subjects={subjectsFromRunInput(d.run.spec.input, d.run.runId)}
+                  readShas={memoPinShas(d.run.spec.input)}
+                  wroteRunId={d.run.runId}
                 />
               </div>
             </>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  lazy,
+  Suspense,
   useEffect,
   useMemo,
   useRef,
@@ -34,11 +36,9 @@ import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
-import {
-  NotesPanel,
-  memoPinShas,
-  subjectsFromRunInput,
-} from "../components/NotesPanel";
+const NotesPanelLazy = lazy(() =>
+  import("../components/NotesPanel").then((m) => ({ default: m.NotesPanel })),
+);
 import { AgentHoverCard } from "../components/AgentHoverCard";
 import { CausationGlyphs, chainHref } from "../components/EventHoverCard";
 import { RunHoverCard, runDurationSeconds } from "../components/RunHoverCard";
@@ -1698,11 +1698,13 @@ export function Runs({
                     />
                   }
                 />
-                <NotesPanel
-                  subjects={subjectsFromRunInput(d.run.spec.input, d.run.runId)}
-                  readShas={memoPinShas(d.run.spec.input)}
-                  wroteRunId={d.run.runId}
-                />
+                <Suspense fallback={null}>
+                  <NotesPanelLazy
+                    runInput={d.run.spec.input}
+                    runId={d.run.runId}
+                    wroteRunId={d.run.runId}
+                  />
+                </Suspense>
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary
- Read-only `GET /memos?subjectType=&subjectId=&kind=&live=` in `lib/api-memos.mjs`: folds the memo ledger, attaches store body, provenance, expiry, and `memo_uses` counts.
- `cli.mjs memos <subjectType> <id> [--kind k] [--all]` prints the same fold.
- Notes panel on the Runs detail pane (ticket/repo/pr/run subjects) with an expired toggle, strike-through for retired/superseded rows, and read/wrote tags from `memoPin` / producer run id.

The handler is not yet mounted in `createApi` (`lib/api.mjs` is outside this ticket's Owned Paths). Remainder is [WM-923](https://linear.app/watt-mind/issue/WM-923).

## Test plan
- [x] `bun test event-runtime/lib/api-memos.test.mjs && cd event-runtime/web && bun run build`
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib`
- [x] `cd event-runtime/web && bun test`
- [ ] After WM-923: `GET /memos` through a live serve returns 200; `cli.mjs memos ticket WM-814` prints live notes.

Fixes WM-814

UX critique: skipped — operator control-plane read-only Notes panel; no auth, payment, onboarding, or destructive action.

Made with [Cursor](https://cursor.com)