### PR TITLE
feat(event-runtime): register inbox decisions as precedent memos (WM-812)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -24,14 +24,25 @@
   "mutating": true,
   "memos": [
     {
-      "subject": { "type": "ticket", "id": "$.input.ticket" },
-      "kinds": ["postmortem"],
+      "subject": {
+        "type": "ticket",
+        "id": "$.input.ticket"
+      },
+      "kinds": ["postmortem", "decision"],
+      "max": 10
+    },
+    {
+      "subject": {
+        "type": "repo",
+        "id": "$.input.repo"
+      },
+      "kinds": ["decision"],
       "max": 10
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:aac2eb7d47a6d5e27a504c3d24f2a5c5bc07cc730d40780a9db78f970ef12ac3",
-    "schemas/dispatch.input.json": "sha256:2855ba815604953b9b1564cfa8fb6eec14906c46b3373945b28c16c31a093573",
+    "agents/dispatch.md": "sha256:03b4b5aba3d6ae725645a5b7d000938b7948fc608006b6b5fe2bf18212df3757",
+    "schemas/dispatch.input.json": "sha256:7949221631e30ad9c6f8fa8a92d071f6ee88ea03e7fbafcbf3af1dffa432cdee",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }
 }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -159,6 +159,14 @@ ticket's Owned Paths), and quote the authorisation's inbox item id and
 request whose `context` says the ticket changed after approval; never reuse an
 authorisation for a different ticket description.
 
+If `memos.json` holds a `decision` memo on this subject, the operator has
+ruled on a related question before. **Cite it** — item id, decided-at,
+option — in the `context` of any new decision request, so the operator sees
+the precedent and can answer faster. A decision memo never lets you proceed:
+only `humanDecision.authorisation` in your input does that (inbox §5), and
+only for the ticket description it is bound to. Quote a cited memo's `sha256`
+prefix in the Handoff `Risks` line so the reviewer sees what the run knew.
+
 ## 3. When it goes wrong
 
 Do not open a PR on a guess. Comment the ticket with the specific decision,

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -20,9 +20,19 @@
     "attempts": 1
   },
   "mutating": false,
+  "memos": [
+    {
+      "subject": {
+        "type": "repo",
+        "id": "$.input.repo"
+      },
+      "kinds": ["decision"],
+      "max": 10
+    }
+  ],
   "pins": {
-    "agents/merge-scan.md": "sha256:78436422e010c525b185b809e1ae7eb69587c7d7df4f7ca60860653b33655054",
-    "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
+    "agents/merge-scan.md": "sha256:3b2d898c29bd0d95eda7b3c942c66cf1226020933dd9d937fd0e7c07d77d98b4",
+    "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }
 }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -87,6 +87,14 @@ ambiguity in the diff itself, `main`/`master`, the configured deploy branch,
 and a fix whose next round would exceed `merge.max_fix_rounds`. Existing
 draft/escalated holds stay held and are summarized.
 
+If `memos.json` holds a `decision` memo on this repo (or a related ticket/PR
+subject), the operator has ruled on a related question before. **Cite it** —
+item id, decided-at, option — in the `reason` / `context` of any new
+decision request or escalate item, so the operator sees the precedent and
+can answer faster. A decision memo never lets you MERGE or otherwise
+proceed: only an explicit human authorisation does that, and a memo is
+precedent, not permission.
+
 Operational conditions are FIX, never ESCALATE (WM-679). They are mechanical
 and merge-fix already performs them:
 

--- a/event-runtime/lib/decision-effects.mjs
+++ b/event-runtime/lib/decision-effects.mjs
@@ -158,7 +158,10 @@ function authorise(db, item, response, option, { linear, planner, now }) {
       `dispatch admission failed: ${(admitted?.errors ?? ["no outcome"]).join("; ")}`,
     );
   }
-  return { detail: admitted.duplicate ? "already_admitted" : "dispatched" };
+  return {
+    detail: admitted.duplicate ? "already_admitted" : "dispatched",
+    descriptionHash: authorisation.descriptionHash,
+  };
 }
 
 /**
@@ -189,14 +192,18 @@ export function applyDecisionEffect(
   try {
     let detail;
     let newProposalId;
+    let descriptionHash;
     switch (kind) {
-      case "authorise":
-        detail = authorise(db, item, response, option, {
+      case "authorise": {
+        const authorised = authorise(db, item, response, option, {
           linear,
           planner,
           now: at,
-        }).detail;
+        });
+        detail = authorised.detail;
+        descriptionHash = authorised.descriptionHash;
         break;
+      }
       case "send_to_triage": {
         const text =
           textFields(item, response) ||
@@ -263,6 +270,7 @@ export function applyDecisionEffect(
       outcome: "applied",
       ...(detail ? { detail } : {}),
       ...(newProposalId ? { newProposalId } : {}),
+      ...(descriptionHash ? { descriptionHash } : {}),
     };
   } catch (err) {
     return {

--- a/event-runtime/lib/decision-effects.test.mjs
+++ b/event-runtime/lib/decision-effects.test.mjs
@@ -197,6 +197,7 @@ describe("runtime decision effects", () => {
       kind: "authorise",
       outcome: "applied",
       detail: "dispatched",
+      descriptionHash: hashBytes("Current Linear body"),
     });
     expect(envelope).toMatchObject({
       schemaVersion: "factory.event/v1",
@@ -310,6 +311,7 @@ describe("runtime decision effects", () => {
     const retried = retryInboxDecision(db, "retry_effect", {
       now: NOW + 1,
       applyEffect,
+      artifactStore: null,
     });
     expect(retried.effect.outcome).toBe("applied");
     expect(retried.item.resolvedBy).toBe("operator:send_to_triage");

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -20,6 +20,7 @@ import {
   templateFor,
 } from "./decision-templates.mjs";
 import { txImmediate } from "./db.mjs";
+import { registerInboxDecisionMemos } from "./memos.mjs";
 
 export const INBOX_KINDS = Object.freeze([
   "BLOCKED",
@@ -377,7 +378,7 @@ function settleInboxDecision(
   id,
   response,
   effect,
-  { now, recordedEffect = effect },
+  { now, recordedEffect = effect, artifactStore },
 ) {
   const answer = { ...response, effect: recordedEffect };
   const replanned =
@@ -409,7 +410,16 @@ function settleInboxDecision(
        WHERE id = ?`,
     ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
   }
-  return { item: getInboxItem(db, id), effect };
+  const item = getInboxItem(db, id);
+  let memos = [];
+  if (effect.outcome === "applied" && !replanned) {
+    memos = registerInboxDecisionMemos(db, item, response, {
+      now,
+      artifactStore,
+      descriptionHash: effect.descriptionHash,
+    });
+  }
+  return { item, effect, memos };
 }
 
 function normalizeEffect(effect, item, response) {
@@ -435,6 +445,7 @@ function decideInboxItemInTransaction(
     now = Date.now(),
     decidedBy = "operator",
     applyEffect = applyDecisionEffect,
+    artifactStore,
   } = {},
 ) {
   const row = decisionRow(db, id);
@@ -521,7 +532,10 @@ function decideInboxItemInTransaction(
       storedResponse,
     );
   }
-  return settleInboxDecision(db, id, storedResponse, effect, { now });
+  return settleInboxDecision(db, id, storedResponse, effect, {
+    now,
+    artifactStore,
+  });
 }
 
 export function decideInboxItem(db, id, response, options = {}) {
@@ -540,6 +554,7 @@ function retryInboxDecisionInTransaction(
     now = Date.now(),
     applyEffect = applyDecisionEffect,
     expectedResponseJson,
+    artifactStore,
   } = {},
 ) {
   const row = decisionRow(db, id);
@@ -582,6 +597,7 @@ function retryInboxDecisionInTransaction(
   return settleInboxDecision(db, id, response, effect, {
     now,
     recordedEffect: { ...effect, retryAttempt },
+    artifactStore,
   });
 }
 

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1,4 +1,7 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-inbox-test-mjs";
 import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { openDb } from "./db.mjs";
 import {
   INBOX_KINDS,
@@ -18,6 +21,7 @@ import {
 } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 import { templateFor } from "./decision-templates.mjs";
+import { listMemos, MEMO_SCHEMA_VERSION, memoDigest } from "./memos.mjs";
 
 function decision(
   options = [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
@@ -228,6 +232,7 @@ describe("human inbox ledger (WM-285)", () => {
     const retried = retryInboxDecision(db, item.id, {
       now: 3000,
       applyEffect: () => ({ kind: "send_to_triage", outcome: "applied" }),
+      artifactStore: null,
     });
     expect(retried.item.resolvedBy).toBe("operator:send_to_triage");
     expect(retried.item.resolvedAt).toBe(new Date(3000).toISOString());
@@ -885,5 +890,241 @@ describe("approving an expired proposal retargets its item (WM-714)", () => {
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
     // Supersession does not lose the retarget the operator already paid for.
     expect(again.responseHistory).toHaveLength(1);
+  });
+});
+
+describe("inbox decisions register precedent memos (WM-812)", () => {
+  const NOW = Date.parse("2026-08-16T12:00:00.000Z");
+
+  function decideDismiss(db, { id, refs, now = NOW, artifactStore, fields }) {
+    const request = decision();
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "decide",
+        refs,
+        decision: request,
+      },
+      { id },
+    );
+    return decideInboxItem(
+      db,
+      id,
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "dismiss",
+        fields: fields ?? {},
+      },
+      { now, artifactStore },
+    );
+  }
+
+  test("applied decisions register a precedentOnly memo per issue/repo/pr subject and store the bytes", () => {
+    const db = openDb(":memory:");
+    const store = tmpDir("evrt-inbox-decision-store-");
+    const decided = decideDismiss(db, {
+      id: "inbox_812",
+      refs: { issue: "wm-313", repo: "factory", pr: "612" },
+      artifactStore: store,
+    });
+    expect(decided.effect.outcome).toBe("applied");
+    expect(decided.memos).toHaveLength(3);
+    expect(decided.memos.every((row) => row.inserted)).toBe(true);
+
+    const ticket = listMemos(
+      db,
+      { type: "ticket", id: "WM-313" },
+      { now: NOW },
+    );
+    const repo = listMemos(db, { type: "repo", id: "factory" }, { now: NOW });
+    const pr = listMemos(db, { type: "pr", id: "factory#612" }, { now: NOW });
+    expect(ticket).toHaveLength(1);
+    expect(repo).toHaveLength(1);
+    expect(pr).toHaveLength(1);
+    expect(ticket[0].kind).toBe("decision");
+    expect(ticket[0].runId).toBeNull();
+    expect(ticket[0].inboxItemId).toBe("inbox_812");
+
+    for (const row of decided.memos) {
+      const file = path.join(store, row.sha256);
+      expect(existsSync(file)).toBe(true);
+      const document = JSON.parse(readFileSync(file, "utf8"));
+      expect(document).toMatchObject({
+        schemaVersion: MEMO_SCHEMA_VERSION,
+        kind: "decision",
+        precedentOnly: true,
+        refs: { inboxItemId: "inbox_812" },
+        provenance: { agent: "runtime:inbox", runId: null },
+      });
+      expect(document.body).toBe("Operator chose `dismiss` on 2026-08-16.");
+      expect(memoDigest(document)).toBe(row.sha256);
+    }
+    db.close();
+  });
+
+  test("failed and unsupported effects do not register; a successful retry does", () => {
+    const db = openDb(":memory:");
+    const store = tmpDir("evrt-inbox-decision-retry-store-");
+    const request = decision([
+      { id: "triage", label: "Triage", effect: "send_to_triage" },
+    ]);
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "retry memo",
+        refs: { issue: "WM-812" },
+        decision: request,
+      },
+      { id: "retry_memo" },
+    );
+    const failed = decideInboxItem(
+      db,
+      "retry_memo",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "triage",
+        fields: {},
+      },
+      {
+        now: NOW,
+        artifactStore: store,
+        applyEffect: () => ({ outcome: "failed", error: "Linear unavailable" }),
+      },
+    );
+    expect(failed.effect.outcome).toBe("failed");
+    expect(failed.memos).toEqual([]);
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-812" }, { now: NOW }),
+    ).toEqual([]);
+
+    const retried = retryInboxDecision(db, "retry_memo", {
+      now: NOW + 1000,
+      artifactStore: store,
+      applyEffect: () => ({ kind: "send_to_triage", outcome: "applied" }),
+    });
+    expect(retried.effect.outcome).toBe("applied");
+    expect(retried.memos).toHaveLength(1);
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-812" }, { now: NOW + 1000 }),
+    ).toHaveLength(1);
+    db.close();
+  });
+
+  test("a proposal re-plan does not register a decision memo", () => {
+    const db = openDb(":memory:");
+    insertProposal(db, { id: "prop-old" });
+    const refs = {
+      proposalId: "prop-old",
+      eventSource: "test",
+      eventId: "evt",
+    };
+    const request = templateFor("proposal_expired", {
+      producer: "proposal",
+      refs,
+    });
+    createInboxItem(
+      db,
+      {
+        kind: "proposal_expired",
+        title: "retarget",
+        refs,
+        source: "serve:notify",
+        decision: request,
+        dedupeKey: "proposal_expired:prop-old",
+      },
+      { id: "no_memo_replan" },
+    );
+    const decided = decideInboxItem(
+      db,
+      "no_memo_replan",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "approve",
+        fields: {},
+      },
+      {
+        now: NOW,
+        artifactStore: tmpDir("evrt-inbox-decision-replan-"),
+        applyEffect: () => ({
+          outcome: "applied",
+          detail: "replanned_awaiting_approval",
+          newProposalId: "prop-fresh",
+        }),
+      },
+    );
+    expect(decided.effect.detail).toBe("replanned_awaiting_approval");
+    expect(decided.memos).toBeUndefined();
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(0);
+    db.close();
+  });
+
+  test("authorise descriptionHash binds only the ticket-subject memo", () => {
+    const db = openDb(":memory:");
+    const store = tmpDir("evrt-inbox-decision-bind-");
+    const request = decision([
+      {
+        id: "authorise",
+        label: "Authorise",
+        effect: "authorise",
+        scope: { paths: ["pi"], summary: "Use the file secret" },
+      },
+    ]);
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "authorise",
+        refs: { issue: "WM-812", repo: "factory", runId: "run_refused" },
+        decision: request,
+      },
+      { id: "bind_hash" },
+    );
+    const descriptionHash = `sha256:${"ab".repeat(32)}`;
+    const decided = decideInboxItem(
+      db,
+      "bind_hash",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "authorise",
+        fields: {},
+      },
+      {
+        now: NOW,
+        artifactStore: store,
+        applyEffect: () => ({
+          kind: "authorise",
+          outcome: "applied",
+          descriptionHash,
+        }),
+      },
+    );
+    expect(decided.memos).toHaveLength(2);
+    const ticketDoc = JSON.parse(
+      readFileSync(
+        path.join(
+          store,
+          decided.memos.find((row) => row.subject.type === "ticket").sha256,
+        ),
+        "utf8",
+      ),
+    );
+    const repoDoc = JSON.parse(
+      readFileSync(
+        path.join(
+          store,
+          decided.memos.find((row) => row.subject.type === "repo").sha256,
+        ),
+        "utf8",
+      ),
+    );
+    expect(ticketDoc.bindings).toEqual({ descriptionHash });
+    expect(repoDoc.bindings).toBeUndefined();
+    db.close();
   });
 });

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -5,10 +5,18 @@
  * decisions) may register one. Reads are by exact subject; liveness is a fold
  * over the ledger, never a directory listing. There is no write API.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { storeCollected } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
-import { RUNTIME_ROOT } from "./config.mjs";
+import { artifactsRoot, RUNTIME_ROOT } from "./config.mjs";
 import { loadRepos } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 
@@ -236,6 +244,143 @@ export function registerMemos(
     registered.push(insertMemoRow(db, entry, { now }));
   }
   recordMemoUses(db, runId, result, { now, runState });
+  return registered;
+}
+
+const DECISION_PRODUCER = "runtime:inbox";
+
+function persistMemoDocument(storeRoot, document) {
+  const bytes = canonicalJson(document);
+  const sha256 = memoDigest(document);
+  const dir = mkdtempSync(path.join(tmpdir(), "factory-memo-"));
+  try {
+    const file = path.join(dir, sha256);
+    writeFileSync(file, bytes);
+    storeCollected({
+      entries: [{ kind: "memo", sha256, uri: `file://${file}` }],
+      storeRoot,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  return sha256;
+}
+
+function insightText(item, response) {
+  const fields = item?.decision?.fields ?? [];
+  return fields
+    .filter((field) => field.kind === "text")
+    .map((field) => response?.fields?.[field.id])
+    .filter((value) => typeof value === "string" && value.trim() !== "")
+    .join("\n\n");
+}
+
+function selectedPaths(item, response) {
+  const option = item?.decision?.options?.find(
+    (candidate) => candidate.id === response?.optionId,
+  );
+  const scoped = option?.scope?.paths;
+  if (!Array.isArray(scoped) || scoped.length === 0) return [];
+  const gated = (item.decision.fields ?? []).filter(
+    (field) =>
+      field.kind === "multi-choice" &&
+      Array.isArray(field.whenOption) &&
+      field.whenOption.includes(option.id),
+  );
+  if (gated.length === 0) return [...scoped];
+  const selected = new Set();
+  for (const field of gated) {
+    const ids = new Set(response.fields?.[field.id] ?? []);
+    for (const choice of field.choices ?? []) {
+      if (ids.has(choice.id)) selected.add(choice.label);
+    }
+  }
+  return scoped.filter((scopedPath) => selected.has(scopedPath));
+}
+
+/** Subjects an inbox item names for a decision memo (docs/event-runtime-memos.md §5.3). */
+export function inboxDecisionSubjects(refs, options) {
+  const subjects = [];
+  const add = (type, id) => {
+    try {
+      subjects.push(normalizeSubject({ type, id }, options));
+    } catch {
+      // A malformed optional ref is not a subject.
+    }
+  };
+  if (typeof refs?.issue === "string" && refs.issue.trim()) {
+    add("ticket", refs.issue);
+  }
+  if (typeof refs?.repo === "string" && refs.repo.trim()) {
+    add("repo", refs.repo);
+  }
+  if (typeof refs?.pr === "string" && refs.pr.trim()) {
+    const raw = refs.pr.trim();
+    if (raw.includes("#")) add("pr", raw);
+    else if (typeof refs?.repo === "string" && refs.repo.trim()) {
+      add("pr", `${refs.repo.trim()}#${raw.replace(/^#/, "")}`);
+    } else add("pr", raw);
+  }
+  return subjects;
+}
+
+/** Operator-facing distillation stored as the decision memo body. */
+export function inboxDecisionMemoBody(
+  item,
+  response,
+  { now = Date.now() } = {},
+) {
+  const optionId =
+    typeof response?.optionId === "string" && response.optionId.trim()
+      ? response.optionId.trim()
+      : "unknown";
+  const decidedAt = response?.decidedAt ?? new Date(now).toISOString();
+  const day = String(decidedAt).slice(0, 10);
+  const insight = insightText(item, response);
+  const paths = selectedPaths(item, response);
+  let body = `Operator chose \`${optionId}\` on ${day}`;
+  if (insight) body += `: "${insight}"`;
+  if (paths.length > 0) body += ` (paths: ${paths.join(", ")})`;
+  return `${body}.`;
+}
+
+/**
+ * Runtime producer for inbox decisions (docs/event-runtime-memos.md §5.3).
+ * Persist bytes before the ledger row so a memo never names a missing object.
+ * `artifactStore: null` skips the store (ledger only); omit to use the runtime home.
+ */
+export function registerInboxDecisionMemos(
+  db,
+  item,
+  response,
+  { now = Date.now(), artifactStore, descriptionHash } = {},
+) {
+  const store = artifactStore === undefined ? artifactsRoot() : artifactStore;
+  const createdAt = new Date(now).toISOString();
+  const body = inboxDecisionMemoBody(item, response, { now });
+  const binding =
+    typeof descriptionHash === "string" && descriptionHash.trim()
+      ? descriptionHash.trim()
+      : null;
+  const registered = [];
+  for (const subject of inboxDecisionSubjects(item?.refs)) {
+    const document = withProvenance(
+      {
+        schemaVersion: MEMO_SCHEMA_VERSION,
+        subject,
+        kind: "decision",
+        precedentOnly: true,
+        body,
+        refs: { inboxItemId: item.id },
+        ...(binding && subject.type === "ticket"
+          ? { bindings: { descriptionHash: binding } }
+          : {}),
+      },
+      { runId: null, agent: DECISION_PRODUCER, createdAt },
+    );
+    if (store) persistMemoDocument(store, document);
+    registered.push(...registerMemos(db, null, document, { now }));
+  }
   return registered;
 }
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -147,8 +147,9 @@ describe("registry", () => {
     // Regenerated (dispatch on cursor): dispatch@1 adapter pi→cursor; event-types.json is a registry input.
     // Regenerated (WM-811): dispatch declares ticket postmortem memos; run-postmortem
     // emits them; dispatch.input admits memoPin; both defs re-pinned.
+    // Regenerated (WM-812): dispatch/merge-scan declare decision memos and re-pin briefs.
     const expected =
-      "sha256:9f9a0f35d31e6284fcf611a16712643f5b1ee822e14c248e829ba05a6248c36f";
+      "sha256:e24e3f3be336136beb62a18ec3fe76d74bef14c2fdd289f6612cc327c32e8c6d";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -168,8 +169,9 @@ describe("registry", () => {
     // WM-718 and WM-391 changed dispatch@1's prompt and input schema, so its
     // pin — and therefore this defHash — legitimately moved, exactly as it did
     // for WM-610. Still not a provenance break: `pack` stays non-enumerable.
+    // WM-812 adds decision-memo declarations and re-pins the dispatch brief.
     expect(computeDefHash(def)).toBe(
-      "sha256:ee4c35754465539959b5dee9831c7c4d42e10ce9153fe79a5a379185335631fa",
+      "sha256:dc4dc32b31daba9bbb70cf570c78145f5125d0454a99ad62c8b28cf037079eb4",
     );
   });
 
@@ -495,13 +497,18 @@ describe("registry", () => {
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
   });
 
-  test("dispatch declares ticket postmortem memos and run-postmortem emits them (WM-811)", () => {
+  test("dispatch declares ticket postmortem/decision and repo decision memos (WM-811, WM-812)", () => {
     const registry = loadRegistry();
     const dispatch = getAgent(registry, "dispatch@1");
     expect(dispatch.memos).toEqual([
       {
         subject: { type: "ticket", id: "$.input.ticket" },
-        kinds: ["postmortem"],
+        kinds: ["postmortem", "decision"],
+        max: 10,
+      },
+      {
+        subject: { type: "repo", id: "$.input.repo" },
+        kinds: ["decision"],
         max: 10,
       },
     ]);
@@ -514,6 +521,14 @@ describe("registry", () => {
     expect(
       postmortem.outputSchema.properties.memos.items.properties.kind,
     ).toEqual({ const: "postmortem" });
+    const mergeScan = getAgent(registry, "merge-scan@2");
+    expect(mergeScan.memos).toEqual([
+      {
+        subject: { type: "repo", id: "$.input.repo" },
+        kinds: ["decision"],
+        max: 10,
+      },
+    ]);
   });
 
   test("dispatch input exposes the closed per-ticket modelTier vocabulary (WM-694)", () => {

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -133,7 +133,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["sha256", "subject", "kind"],
+            "required": ["sha256", "subject", "kind", "createdAt"],
             "additionalProperties": false,
             "properties": {
               "sha256": {
@@ -161,7 +161,7 @@
                   "handoff"
                 ]
               },
-              "runId": { "type": "string", "minLength": 1 },
+              "runId": { "type": ["string", "null"] },
               "createdAt": { "type": "string", "minLength": 1 }
             }
           }

--- a/event-runtime/schemas/merge-scan.input.json
+++ b/event-runtime/schemas/merge-scan.input.json
@@ -41,6 +41,51 @@
       "description": "Optional explicit PR numbers for a manual scan. When omitted, review all open PRs targeting the configured base.",
       "items": { "type": "integer", "minimum": 1 }
     },
+    "memoPin": {
+      "type": "object",
+      "required": ["foldedAt", "entries"],
+      "additionalProperties": false,
+      "description": "Planner-injected fold of declared decision memos at plan time (docs/event-runtime-memos.md §4.2); empty entries is the normal case",
+      "properties": {
+        "foldedAt": { "type": "string", "minLength": 1 },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["sha256", "subject", "kind", "createdAt"],
+            "additionalProperties": false,
+            "properties": {
+              "sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "subject": {
+                "type": "object",
+                "required": ["type", "id"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "enum": ["repo", "ticket", "pr", "workflow", "run"]
+                  },
+                  "id": { "type": "string", "minLength": 1 }
+                }
+              },
+              "kind": {
+                "enum": [
+                  "repo-note",
+                  "postmortem",
+                  "decision",
+                  "flake",
+                  "handoff"
+                ]
+              },
+              "runId": { "type": ["string", "null"] },
+              "createdAt": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
     "loop": { "type": "string", "minLength": 1 },
     "slot": { "type": "string", "minLength": 1 },
     "cadenceSeconds": { "type": "integer", "minimum": 1 },


### PR DESCRIPTION
## Summary
- `decideInboxItem` now registers a content-addressed `factory.memo/v1` of kind `decision` (`precedentOnly: true`) on each named subject after the effect applies.
- Dispatch and merge-scan briefs cite those precedents in new decision requests; they never authorise. Definitions declare `kinds: ["decision"]` so the planner folds them into `memoPin`.
- Registry zero-pack digest and dispatch@1 defHash regenerated because those agent defs/pins changed (WM-812).

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib` — 1213 pass, 0 fail
- [x] `bun build/emit.mjs --check` — ok
- [ ] CI green on this PR

Fixes WM-812

UX critique: skipped — backend/runtime producer and agent briefs; no user-facing surface


Made with [Cursor](https://cursor.com)