### PR TITLE
fix(tests): dispatch e2e expects planner-folded memoPin (WM-810 follow-up)

### DIFF
--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -486,7 +486,13 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
       checkoutDir: "repo",
       retainOnFailure: true,
     });
-    expect(proposal.spec.input).toEqual({ repo: "wt29", ticket: "WM-501" });
+    // WM-810 (#724): the planner folds declared memos into input.memoPin on
+    // every dispatch spec; with no memos declared the pin is empty but present.
+    expect(proposal.spec.input).toEqual({
+      repo: "wt29",
+      ticket: "WM-501",
+      memoPin: { entries: [], foldedAt: expect.any(String) },
+    });
     expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
 
     const approved = approveProposal(db, registry, proposal.id, {


### PR DESCRIPTION
develop is red since #724 landed: `dispatch e2e: propose → approve → execute → receipt (WM-108)` asserts the exact dispatch input and the planner now folds `memoPin` into it (run 32261842548). This updates the expectation to the new shape (empty pin, `foldedAt` any string). Test-only change; trunk-red fix-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz