### PR TITLE
feat(control-plane): GitHub Issues adapter (WM-798)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -124,6 +124,11 @@ case "$cmd" in
   up)           exec bash "$ROOT/bin/live-stack.sh" up "$@" ;;
   down)         exec bash "$ROOT/bin/live-stack.sh" down "$@" ;;
   tail)         exec bash "$ROOT/bin/live-stack.sh" tail "$@" ;;
+  init)
+    # GitHub Issues control-plane defaults (WM-798). Full config scaffolding
+    # (repos/policy/schedule examples) is WM-794.
+    exec bun "$ROOT/lib/control-plane/github.mjs" "$@"
+    ;;
   demo)
     # Isolated event-runtime env (OPS-217) stays available behind --here /
     # --down so existing worktree-up sessions keep working. Bare `factory demo`
@@ -287,6 +292,8 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   up            start live event-runtime stack (API 7381, live worker, and Web UI 7382)
   down          stop live event-runtime stack
   tail          tail live daemon logs (~/.factory/run/{serve,worker,web}.log)
+  init          scaffold GitHub Issues control-plane defaults
+                (factory init --control-plane github [--root DIR] [--repo owner/name])
   demo          run the bundled starter ticket (WM-799); --dry for CI.
                 Isolated event-runtime env: demo --here / demo --down
   run           runners/run-agent.sh

--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -1,0 +1,23 @@
+# Example ControlPlane selection for a GitHub Issues factory (WM-798).
+#
+# Copy this stanza into config/policy.yaml, or run:
+#   factory init --control-plane github [--root DIR] [--repo owner/name]
+#
+# Requires `gh auth login` — the same credential the forge already uses.
+# No Linear account. Create a GitHub Project named "Factory" whose Status
+# field has options: Triage, Todo, In Progress, In Review, Done, Blocked.
+# Protocol labels keep Linear's spelling (ai:agent-ready, type:*, …).
+
+controlPlane:
+  kind: github
+  github:
+    # Default repository when a team key is not in `teams`.
+    repo: OWNER/REPO
+    # Linear-style team key → GitHub repository. `file` and
+    # `listDispatchable` resolve `team` through this map; a key that already
+    # looks like owner/name is used as-is.
+    teams:
+      DEMO: OWNER/REPO
+    # Projects v2 board whose Status single-select is the factory lifecycle.
+    project: Factory
+    statusField: Status

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,18 +1,37 @@
 # Control plane protocol
 
-Tracker-neutral contract for the factory's ticket adapter (`lib/control-plane/`, WM-797). Implementations exist for Linear (v1) and an in-memory fake (tests / offline demo). GitHub Issues is the next implementation (WM-798).
+Tracker-neutral contract for the factory's ticket adapter (`lib/control-plane/`, WM-797). Implementations exist for Linear (v1), an in-memory fake (tests / offline demo), and GitHub Issues (`lib/control-plane/github.mjs`, WM-798).
 
 This file is the **adapter contract**, not the full agent operating protocol. Dispatchable predicates, Owned Paths, heartbeats, and harness packaging still live in the operator's `linear.md` until WM-795 copies them here. What this document freezes is the vocabulary everything outside `lib/control-plane/` is allowed to speak.
 
-Call `loadControlPlane({ root })`. Selection is `config/policy.yaml`:
+Call `loadControlPlane({ root })` for Linear/memory. The GitHub Issues adapter is `githubControlPlane()` in `lib/control-plane/github.mjs` (wiring `kind: github` into `loadControlPlane()` is a follow-up so this ticket stays inside Owned Paths). Selection is `config/policy.yaml`:
 
 ```yaml
 controlPlane:
   kind: linear # default when the stanza is absent
   # kind: memory   # in-process fake; no network
+  # kind: github   # Issues + Projects; zero Linear account
+  # github:
+  #   repo: owner/name
+  #   teams: { DEMO: owner/name }   # team key → repository
+  #   project: Factory              # Projects v2 title
+  #   statusField: Status
 ```
 
-An unknown kind is a configuration error. A tracker the factory cannot reach must never be silently read as "no tickets".
+`factory init --control-plane github` writes those GitHub defaults (see `config/policy.example.yaml`). An unknown kind is a configuration error. A tracker the factory cannot reach must never be silently read as "no tickets".
+
+## GitHub Issues binding
+
+| Protocol     | GitHub                                                                                        |
+| :----------- | :-------------------------------------------------------------------------------------------- |
+| `identifier` | `owner/repo#42`                                                                               |
+| `team`       | Repository, via `controlPlane.github.teams` (or a key that already looks like `owner/name`)   |
+| `labels`     | Issue labels of the **same spelling**. Writes send the complete resulting set, never a delta. |
+| `assignee`   | Issue assignee. `claim` assigns the `gh` viewer, then **reads the assignee back**.            |
+| `state`      | Projects v2 single-select (`project` / `statusField`). Options must match the names below.    |
+| `raw`        | GraphQL via `gh api graphql`, or a REST path when the query string starts with `/`.           |
+
+Production talks to GitHub through `gh api` — the same CLI the forge already requires. No Octokit, no Linear token. `gh auth login` is the quickstart credential.
 
 ## Ticket shape
 
@@ -69,7 +88,7 @@ These names are part of the protocol, not Linear branding. A GitHub Issues adapt
 | `setLabels(id, { add, remove })`                   | Compute the **complete** resulting label set and write that. Passing only the labels you want added is how every other label on the ticket disappears.                                                                                                                                                                                             |
 | `file({ team, title, body?, labels?, state? })`    | Create a ticket. Default state `Triage`.                                                                                                                                                                                                                                                                                                           |
 | `appendDetail(id, markdown)`                       | Idempotent description append. `{ appended: false }` if the text is already present.                                                                                                                                                                                                                                                               |
-| `raw(query, variables?)`                           | Escape hatch. Linear GraphQL today; GitHub REST later. Grows only when a call site cannot be expressed with the verbs above.                                                                                                                                                                                                                       |
+| `raw(query, variables?)`                           | Escape hatch. Linear GraphQL; GitHub GraphQL via `gh api graphql` (REST when `query` starts with `/`). Grows only when a call site cannot be expressed with the verbs above.                                                                                                                                                                       |
 
 Every method returns the parsed answer or throws `ControlPlaneError`. `claim` returning `{ ok: false }` is the one protocol outcome that is not an error.
 

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1,0 +1,824 @@
+/**
+ * GitHub Issues ControlPlane (WM-798).
+ *
+ * The same verbs as `linear.mjs` / `memory.mjs`, bound onto GitHub:
+ *   - protocol labels → issue labels of the same spelling (complete set)
+ *   - assignee → issue assignee; claim read-back is the concurrency control
+ *   - factory states → a Projects v2 single-select (default title `Factory`,
+ *     field `Status`)
+ *
+ * Production talks to GitHub through `gh api` / `gh api graphql` (the same
+ * CLI the forge already requires). No Octokit — a Linear-account-free
+ * quickstart is `gh auth login` plus `factory init --control-plane github`.
+ *
+ * `api` is the seam: `(method, path, { body, query }) => json`, so the
+ * contract suite can drive the implementation with a fake tracker and no
+ * network. When omitted, `exec` (spawnSync-shaped) wraps `gh`.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { ControlPlaneError } from "./types.mjs";
+import {
+  AGENT_READY_LABEL,
+  appendIssueDetail,
+  claimLabels,
+  stampRun,
+  validateLabels,
+} from "./labels.mjs";
+
+export const GITHUB_FACTORY_STATES = Object.freeze([
+  "Triage",
+  "Todo",
+  "In Progress",
+  "In Review",
+  "Done",
+  "Blocked",
+]);
+
+const DEFAULT_PROJECT = "Factory";
+const DEFAULT_STATUS_FIELD = "Status";
+
+const FIND_REPO_PROJECT = `query FindRepoProject($owner: String!, $name: String!, $title: String!, $statusField: String!) {
+  repository(owner: $owner, name: $name) {
+    projectsV2(first: 20, query: $title) {
+      nodes {
+        id
+        title
+        field(name: $statusField) {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const FIND_VIEWER_PROJECT = `query FindViewerProject($title: String!, $statusField: String!) {
+  viewer {
+    projectsV2(first: 20, query: $title) {
+      nodes {
+        id
+        title
+        field(name: $statusField) {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const PROJECT_ITEMS = `query ProjectItems($projectId: ID!, $statusField: String!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content {
+            ... on Issue {
+              id
+              number
+              repository { nameWithOwner }
+            }
+          }
+          fieldValueByName(name: $statusField) {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const ADD_PROJECT_ITEM = `mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+    item { id }
+  }
+}`;
+
+const SET_PROJECT_STATUS = `mutation SetProjectStatus($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $optionId }
+    }
+  ) { projectV2Item { id } }
+}`;
+
+const text = (v) =>
+  v == null ? "" : Buffer.isBuffer(v) ? v.toString() : String(v);
+
+/**
+ * Default `api` implementation: `gh api` / `gh api graphql` via `exec`.
+ *
+ * @param {(cmd: string, args: string[], opts: object) => object} exec
+ */
+export function makeGhApi(exec = spawnSync) {
+  return function ghApi(method, pathName, { body, query } = {}) {
+    const args = ["api"];
+    const isGraphql =
+      pathName === "graphql" || pathName === "/graphql" || method === "GRAPHQL";
+    if (isGraphql) {
+      args.push("graphql", "--input", "-");
+      return ghJson(
+        exec,
+        args,
+        JSON.stringify({
+          query: body?.query ?? body,
+          variables: body?.variables ?? query ?? {},
+        }),
+      );
+    }
+    if (method && method !== "GET") args.push("-X", method);
+    let url = String(pathName).replace(/^\//, "");
+    if (query && Object.keys(query).length) {
+      const qs = new URLSearchParams(
+        Object.fromEntries(
+          Object.entries(query).filter(([, v]) => v != null && v !== ""),
+        ),
+      ).toString();
+      if (qs) url += (url.includes("?") ? "&" : "?") + qs;
+    }
+    args.push(url);
+    if (body !== undefined) {
+      args.push("--input", "-");
+      return ghJson(exec, args, JSON.stringify(body));
+    }
+    return ghJson(exec, args);
+  };
+}
+
+function ghJson(exec, args, input) {
+  const r =
+    exec("gh", args, {
+      encoding: "utf8",
+      stdio:
+        input != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+      input: input != null ? input : undefined,
+    }) ?? {};
+  const status = r.status ?? r.exitCode ?? null;
+  const stdout = text(r.stdout);
+  const stderr =
+    text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
+  if (status !== 0) {
+    let message = `gh ${args.slice(0, 2).join(" ")} failed (status ${status})`;
+    try {
+      const parsed = JSON.parse(stdout);
+      if (parsed?.message) message = `github api: ${parsed.message}`;
+    } catch {
+      if (stderr) message = `${message}: ${stderr.trim()}`;
+    }
+    throw new ControlPlaneError(message, {
+      status,
+      cause: r.error,
+    });
+  }
+  if (!stdout.trim()) return {};
+  try {
+    return JSON.parse(stdout);
+  } catch (cause) {
+    throw new ControlPlaneError(
+      `gh ${args.slice(0, 2).join(" ")} returned invalid JSON`,
+      { status: 0, cause },
+    );
+  }
+}
+
+/** Parse `owner/repo#42`, `#42`, or `42` (the last two need a default repo). */
+export function parseIssueIdentifier(identifier, defaultRepo) {
+  const raw = String(identifier ?? "").trim();
+  const full = raw.match(/^([^/#\s]+\/[^/#\s]+)#(\d+)$/);
+  if (full) return { repo: full[1], number: Number(full[2]) };
+  const num = raw.match(/^#?(\d+)$/);
+  if (num && defaultRepo) return { repo: defaultRepo, number: Number(num[1]) };
+  throw new ControlPlaneError(
+    `not a GitHub issue identifier: ${identifier} (want owner/repo#N)`,
+  );
+}
+
+export function issueIdentifier(repo, number) {
+  return `${repo}#${number}`;
+}
+
+function resolveLabelNames(currentNames, { add = [], remove = [] } = {}) {
+  const dropped = new Set(remove);
+  const kept = currentNames.filter((n) => !dropped.has(n));
+  return [...new Set([...kept, ...add])];
+}
+
+function stateType(name) {
+  const n = String(name ?? "").toLowerCase();
+  if (n === "done") return "completed";
+  if (n === "triage" || n === "todo") return "unstarted";
+  return "started";
+}
+
+export function githubPolicyStanza({
+  repo = "OWNER/REPO",
+  teams,
+  project = DEFAULT_PROJECT,
+  statusField = DEFAULT_STATUS_FIELD,
+} = {}) {
+  return {
+    kind: "github",
+    github: {
+      repo,
+      teams: teams ?? { DEMO: repo },
+      project,
+      statusField,
+    },
+  };
+}
+
+/** `controlPlane.github` from `<root>/config/policy.yaml`, or `{}`. */
+export function readGithubPolicy(root) {
+  try {
+    const policy = Bun.YAML.parse(
+      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
+    );
+    const gh = policy?.controlPlane?.github ?? {};
+    return {
+      kind: policy?.controlPlane?.kind,
+      repo: gh.repo ?? null,
+      teams: gh.teams ?? {},
+      project: gh.project ?? DEFAULT_PROJECT,
+      statusField: gh.statusField ?? DEFAULT_STATUS_FIELD,
+    };
+  } catch (err) {
+    if (err?.code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+/**
+ * Write / merge GitHub Issues control-plane defaults into
+ * `<root>/config/policy.yaml`. Idempotent: existing keys besides
+ * `controlPlane` are preserved.
+ */
+export function writeGithubControlPlanePolicy(root, opts = {}) {
+  const configDir = path.join(root, "config");
+  mkdirSync(configDir, { recursive: true });
+  const policyPath = path.join(configDir, "policy.yaml");
+  let existing = {};
+  try {
+    existing = Bun.YAML.parse(readFileSync(policyPath, "utf8")) ?? {};
+  } catch (err) {
+    if (err?.code !== "ENOENT") throw err;
+  }
+  const stanza = githubPolicyStanza(opts);
+  const next = { ...existing, controlPlane: stanza };
+  const yaml = Bun.YAML.stringify(next);
+  writeFileSync(
+    policyPath,
+    `# Generated by factory init --control-plane github (WM-798).\n${yaml.endsWith("\n") ? yaml : `${yaml}\n`}`,
+  );
+  return { path: policyPath, controlPlane: stanza };
+}
+
+/**
+ * @param {{
+ *   exec?: Function,
+ *   api?: Function,
+ *   root?: string,
+ *   repo?: string,
+ *   teams?: Record<string, string>,
+ *   project?: string,
+ *   statusField?: string,
+ * }} [options]
+ * @returns {import("./types.mjs").ControlPlane}
+ */
+export function githubControlPlane(options = {}) {
+  const {
+    exec = spawnSync,
+    api: apiOpt,
+    root,
+    repo: repoOpt,
+    teams: teamsOpt,
+    project: projectOpt,
+    statusField: statusFieldOpt,
+  } = options;
+
+  const fromPolicy = root ? readGithubPolicy(root) : {};
+  const teams = { ...(fromPolicy.teams ?? {}), ...(teamsOpt ?? {}) };
+  const defaultRepo =
+    repoOpt ?? fromPolicy.repo ?? Object.values(teams)[0] ?? null;
+  const projectTitle = projectOpt ?? fromPolicy.project ?? DEFAULT_PROJECT;
+  const statusFieldName =
+    statusFieldOpt ?? fromPolicy.statusField ?? DEFAULT_STATUS_FIELD;
+  const api = apiOpt ?? makeGhApi(exec);
+
+  let projectCache = null;
+
+  async function call(method, pathName, opts) {
+    try {
+      const result = await Promise.resolve(api(method, pathName, opts));
+      const isGraphql =
+        pathName === "graphql" ||
+        pathName === "/graphql" ||
+        method === "GRAPHQL";
+      if (isGraphql) {
+        if (result?.errors?.length)
+          throw new ControlPlaneError(
+            result.errors[0]?.message ?? "github graphql error",
+          );
+        return result?.data ?? result;
+      }
+      return result;
+    } catch (cause) {
+      if (cause instanceof ControlPlaneError) throw cause;
+      throw new ControlPlaneError(
+        cause?.message ? String(cause.message) : "github api failed",
+        { cause, status: cause?.status ?? null },
+      );
+    }
+  }
+
+  function repoForTeam(team) {
+    if (!team) throw new ControlPlaneError("listDispatchable requires team");
+    if (teams[team]) return teams[team];
+    if (String(team).includes("/")) return team;
+    if (defaultRepo) return defaultRepo;
+    throw new ControlPlaneError(`no GitHub repo bound to team ${team}`);
+  }
+
+  function teamKeyForRepo(repoName) {
+    const hit = Object.entries(teams).find(([, r]) => r === repoName);
+    return { key: hit ? hit[0] : repoName };
+  }
+
+  function locate(identifier) {
+    return parseIssueIdentifier(identifier, defaultRepo);
+  }
+
+  async function repoLabels(repo) {
+    const rows = await call("GET", `repos/${repo}/labels`, {
+      query: { per_page: "100" },
+    });
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  async function requireLabelsExist(repo, names) {
+    const bad = validateLabels(names);
+    if (bad.length)
+      throw new ControlPlaneError("invalid label(s):\n  " + bad.join("\n  "));
+    if (!names.length) return;
+    const all = await repoLabels(repo);
+    const missing = names.filter((n) => !all.some((l) => l.name === n));
+    if (missing.length)
+      throw new ControlPlaneError(
+        `label(s) do not exist in this workspace: ${missing.join(", ")}`,
+      );
+  }
+
+  async function loadProject() {
+    if (projectCache) return projectCache;
+    const pick = (nodes) =>
+      (nodes ?? []).find((p) => p.title === projectTitle) ?? (nodes ?? [])[0];
+
+    let node = null;
+    if (defaultRepo && defaultRepo.includes("/")) {
+      const [owner, name] = defaultRepo.split("/");
+      const d = await call("POST", "graphql", {
+        body: {
+          query: FIND_REPO_PROJECT,
+          variables: {
+            owner,
+            name,
+            title: projectTitle,
+            statusField: statusFieldName,
+          },
+        },
+      });
+      node = pick(d?.repository?.projectsV2?.nodes);
+    }
+    if (!node) {
+      const d = await call("POST", "graphql", {
+        body: {
+          query: FIND_VIEWER_PROJECT,
+          variables: { title: projectTitle, statusField: statusFieldName },
+        },
+      });
+      node = pick(d?.viewer?.projectsV2?.nodes);
+    }
+    if (!node)
+      throw new ControlPlaneError(`no GitHub Project titled "${projectTitle}"`);
+    const field = node.field;
+    if (!field?.id || !Array.isArray(field.options))
+      throw new ControlPlaneError(
+        `project "${projectTitle}" has no "${statusFieldName}" single-select field`,
+      );
+    projectCache = {
+      id: node.id,
+      title: node.title,
+      fieldId: field.id,
+      options: field.options,
+    };
+    return projectCache;
+  }
+
+  function optionFor(project, stateName) {
+    const target = project.options.find(
+      (o) => o.name.toLowerCase() === String(stateName).toLowerCase(),
+    );
+    if (!target)
+      throw new ControlPlaneError(
+        `no state "${stateName}" on team ${defaultRepo ?? project.title} — have: ${project.options.map((o) => o.name).join(", ")}`,
+      );
+    return target;
+  }
+
+  async function projectItems() {
+    const project = await loadProject();
+    const d = await call("POST", "graphql", {
+      body: {
+        query: PROJECT_ITEMS,
+        variables: { projectId: project.id, statusField: statusFieldName },
+      },
+    });
+    return {
+      project,
+      items: d?.node?.items?.nodes ?? [],
+    };
+  }
+
+  async function statusOf(repo, number) {
+    const { project, items } = await projectItems();
+    const item = items.find(
+      (it) =>
+        it.content?.number === number &&
+        (it.content?.repository?.nameWithOwner ?? repo) === repo,
+    );
+    const name = item?.fieldValueByName?.name ?? null;
+    const opt = name ? project.options.find((o) => o.name === name) : null;
+    return { project, item, name, opt };
+  }
+
+  async function ensureProjectItem(repo, number, contentId) {
+    const { project, items } = await projectItems();
+    const existing = items.find(
+      (it) =>
+        it.content?.number === number &&
+        (it.content?.repository?.nameWithOwner ?? repo) === repo,
+    );
+    if (existing) return { project, item: existing };
+    const added = await call("POST", "graphql", {
+      body: {
+        query: ADD_PROJECT_ITEM,
+        variables: { projectId: project.id, contentId },
+      },
+    });
+    const item = added?.addProjectV2ItemById?.item;
+    if (!item?.id)
+      throw new ControlPlaneError(
+        `failed to add ${issueIdentifier(repo, number)} to project ${project.title}`,
+      );
+    projectCache = null;
+    return { project, item };
+  }
+
+  async function setStatus(repo, number, contentId, stateName) {
+    const { project, item } = await ensureProjectItem(repo, number, contentId);
+    const opt = optionFor(project, stateName);
+    await call("POST", "graphql", {
+      body: {
+        query: SET_PROJECT_STATUS,
+        variables: {
+          projectId: project.id,
+          itemId: item.id,
+          fieldId: project.fieldId,
+          optionId: opt.id,
+        },
+      },
+    });
+    projectCache = null;
+    return opt;
+  }
+
+  function normalizeIssue(issue, repo, status) {
+    const labels = (issue.labels ?? []).map((l) => ({
+      id: l.id != null ? String(l.id) : undefined,
+      name: l.name,
+    }));
+    const assignee = issue.assignee
+      ? {
+          id: String(issue.assignee.id),
+          name: issue.assignee.login ?? issue.assignee.name,
+        }
+      : null;
+    const statusName =
+      status?.name ?? (issue.state === "closed" ? "Done" : "Triage");
+    const opt = status?.opt;
+    return {
+      id: issue.node_id ?? String(issue.id),
+      identifier: issueIdentifier(repo, issue.number),
+      title: issue.title,
+      description: issue.body ?? "",
+      url: issue.html_url ?? "",
+      state: {
+        id: opt?.id,
+        name: statusName,
+        type: stateType(statusName),
+      },
+      assignee,
+      team: teamKeyForRepo(repo),
+      project: { name: projectTitle },
+      labels,
+    };
+  }
+
+  async function fetchIssue(repo, number) {
+    let issue;
+    try {
+      issue = await call("GET", `repos/${repo}/issues/${number}`);
+    } catch (err) {
+      if (
+        err instanceof ControlPlaneError &&
+        (err.status === 404 || /not found/i.test(err.message))
+      )
+        throw new ControlPlaneError(
+          `no such issue: ${issueIdentifier(repo, number)}`,
+        );
+      throw err;
+    }
+    if (!issue || issue.message === "Not Found" || issue.pull_request)
+      throw new ControlPlaneError(
+        `no such issue: ${issueIdentifier(repo, number)}`,
+      );
+    const status = await statusOf(repo, number);
+    return { issue, status, ticket: normalizeIssue(issue, repo, status) };
+  }
+
+  return {
+    kind: "github",
+
+    async getTicket(identifier) {
+      const { repo, number } = locate(identifier);
+      return (await fetchIssue(repo, number)).ticket;
+    },
+
+    async listComments(identifier) {
+      const { repo, number } = locate(identifier);
+      await fetchIssue(repo, number);
+      const rows = await call("GET", `repos/${repo}/issues/${number}/comments`);
+      return (Array.isArray(rows) ? rows : []).map((c) => ({
+        id: c.id != null ? String(c.id) : undefined,
+        body: c.body,
+        createdAt: c.created_at ?? c.createdAt,
+        user: c.user
+          ? {
+              id: c.user.id != null ? String(c.user.id) : undefined,
+              name: c.user.login ?? c.user.name,
+            }
+          : null,
+      }));
+    },
+
+    async listDispatchable({ team, project } = {}) {
+      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+      if (project && project !== projectTitle) return [];
+      const repo = repoForTeam(team);
+      const rows = await call("GET", `repos/${repo}/issues`, {
+        query: {
+          state: "open",
+          assignee: "none",
+          labels: AGENT_READY_LABEL,
+          per_page: "100",
+        },
+      });
+      const issues = (Array.isArray(rows) ? rows : []).filter(
+        (i) => !i.pull_request,
+      );
+      const { items } = await projectItems();
+      const todo = new Set(
+        items
+          .filter((it) => it.fieldValueByName?.name?.toLowerCase() === "todo")
+          .filter(
+            (it) => (it.content?.repository?.nameWithOwner ?? repo) === repo,
+          )
+          .map((it) => it.content?.number),
+      );
+      const out = [];
+      for (const issue of issues) {
+        if (!todo.has(issue.number)) continue;
+        if (issue.assignee) continue;
+        const names = (issue.labels ?? []).map((l) => l.name);
+        if (!names.includes(AGENT_READY_LABEL)) continue;
+        const status = await statusOf(repo, issue.number);
+        out.push(normalizeIssue(issue, repo, status));
+      }
+      return out;
+    },
+
+    async claim(identifier, { harness = "claude" } = {}) {
+      const { repo, number } = locate(identifier);
+      const { issue, ticket } = await fetchIssue(repo, number);
+      const me = await call("GET", "user");
+      if (!me?.id)
+        throw new ControlPlaneError("github viewer is not available");
+      const { add, remove } = claimLabels(
+        (ticket.labels ?? []).map((l) => l.name),
+        harness,
+      );
+      await requireLabelsExist(repo, add);
+      const nextLabels = resolveLabelNames(
+        (ticket.labels ?? []).map((l) => l.name),
+        { add, remove },
+      );
+      await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+        body: { labels: nextLabels },
+      });
+      await call("PATCH", `repos/${repo}/issues/${number}`, {
+        body: { assignees: [me.login], state: "open" },
+      });
+      await setStatus(repo, number, issue.node_id ?? ticket.id, "In Progress");
+
+      const back = await call("GET", `repos/${repo}/issues/${number}`);
+      const assigneeId =
+        back?.assignee?.id != null ? String(back.assignee.id) : null;
+      return {
+        ok: assigneeId === String(me.id),
+        identifier: issueIdentifier(repo, number),
+        assignee: back?.assignee?.login ?? back?.assignee?.name ?? null,
+      };
+    },
+
+    async comment(identifier, body) {
+      if (!body) throw new ControlPlaneError(`comment requires a body`);
+      const { repo, number } = locate(identifier);
+      await fetchIssue(repo, number);
+      await call("POST", `repos/${repo}/issues/${number}/comments`, {
+        body: { body: stampRun(body) },
+      });
+    },
+
+    async transition(
+      identifier,
+      state,
+      { add = [], remove = [], unassign } = {},
+    ) {
+      if (!state && !add.length && !remove.length && !unassign)
+        throw new ControlPlaneError(
+          `transition requires a state name or a label change`,
+        );
+      const { repo, number } = locate(identifier);
+      const { issue, ticket } = await fetchIssue(repo, number);
+      if (state)
+        await setStatus(repo, number, issue.node_id ?? ticket.id, state);
+      if (add.length || remove.length) {
+        await requireLabelsExist(repo, add);
+        const nextLabels = resolveLabelNames(
+          (ticket.labels ?? []).map((l) => l.name),
+          { add, remove },
+        );
+        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+          body: { labels: nextLabels },
+        });
+      }
+      const patch = {};
+      if (unassign) patch.assignees = [];
+      if (state)
+        patch.state = state.toLowerCase() === "done" ? "closed" : "open";
+      if (Object.keys(patch).length)
+        await call("PATCH", `repos/${repo}/issues/${number}`, { body: patch });
+    },
+
+    async setLabels(identifier, { add = [], remove = [] } = {}) {
+      const { repo, number } = locate(identifier);
+      const { ticket } = await fetchIssue(repo, number);
+      if (!add.length && !remove.length) return;
+      await requireLabelsExist(repo, add);
+      const nextLabels = resolveLabelNames(
+        (ticket.labels ?? []).map((l) => l.name),
+        { add, remove },
+      );
+      await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+        body: { labels: nextLabels },
+      });
+    },
+
+    async file({
+      team,
+      title,
+      body = "",
+      labels = [],
+      state = "Triage",
+      projectId: _projectId,
+    } = {}) {
+      if (!team || !title)
+        throw new ControlPlaneError("file requires team and title");
+      const repo = repoForTeam(team);
+      await requireLabelsExist(repo, labels);
+      const created = await call("POST", `repos/${repo}/issues`, {
+        body: {
+          title,
+          body: stampRun(body),
+          labels,
+        },
+      });
+      if (!created?.number)
+        throw new ControlPlaneError("issueCreate returned no issue");
+      await setStatus(
+        repo,
+        created.number,
+        created.node_id ?? String(created.id),
+        state,
+      );
+      if (state.toLowerCase() === "done")
+        await call("PATCH", `repos/${repo}/issues/${created.number}`, {
+          body: { state: "closed" },
+        });
+      return {
+        identifier: issueIdentifier(repo, created.number),
+        url: created.html_url ?? "",
+      };
+    },
+
+    async appendDetail(identifier, markdown) {
+      const { repo, number } = locate(identifier);
+      const { issue } = await fetchIssue(repo, number);
+      const { description, appended } = appendIssueDetail(
+        issue.body ?? "",
+        markdown,
+      );
+      if (!appended) return { appended: false };
+      await call("PATCH", `repos/${repo}/issues/${number}`, {
+        body: { body: description },
+      });
+      return { appended: true };
+    },
+
+    async raw(query, variables = {}) {
+      if (typeof query === "string" && query.trim().startsWith("/")) {
+        return call("GET", query.trim().replace(/^\//, ""), {
+          query: variables,
+        });
+      }
+      return call("POST", "graphql", {
+        body: { query, variables },
+      });
+    },
+  };
+}
+
+function print(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+function fail(msg, code = 2) {
+  process.stderr.write(`${msg}\n`);
+  process.exit(code);
+}
+
+/** CLI: `factory init --control-plane github [--root DIR] [--repo owner/name]`. */
+export function runGithubInit(argv, { cwd = process.cwd() } = {}) {
+  const args = argv[0] === "init" ? argv.slice(1) : argv;
+  const flag = (name, fallback) => {
+    const i = args.indexOf(`--${name}`);
+    if (i === -1 || i === args.length - 1) return fallback;
+    return args[i + 1];
+  };
+  const controlPlane = flag("control-plane");
+  if (!controlPlane) {
+    fail(
+      "factory init: specify --control-plane github\n" +
+        "(Linear remains the default tracker; this command scaffolds GitHub Issues defaults.)",
+    );
+  }
+  if (controlPlane !== "github") {
+    fail(
+      `factory init: unknown control plane ${JSON.stringify(controlPlane)} — only github is scaffolded (WM-798)`,
+    );
+  }
+  const root = flag("root", cwd);
+  const repo = flag("repo", "OWNER/REPO");
+  const project = flag("project", DEFAULT_PROJECT);
+  const statusField = flag("status-field", DEFAULT_STATUS_FIELD);
+  const team = flag("team", "DEMO");
+  const written = writeGithubControlPlanePolicy(root, {
+    repo,
+    teams: { [team]: repo },
+    project,
+    statusField,
+  });
+  print(`Wrote ${written.path} (controlPlane.kind=github, repo=${repo}).`);
+  print(
+    `Next: gh auth login, then create a GitHub Project named ${JSON.stringify(project)} with Status options:\n  ${GITHUB_FACTORY_STATES.join(", ")}`,
+  );
+  print(
+    "Protocol labels (same spelling as Linear): ai:agent-ready, ai:in-progress, ai:needs-review, ai:blocked, agent:claude-code, type:*, source:*.",
+  );
+  return written;
+}
+
+if (import.meta.main) {
+  runGithubInit(process.argv.slice(2));
+}

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1,0 +1,686 @@
+/**
+ * GitHub Issues ControlPlane contract suite (WM-798).
+ *
+ * Same assertions as `event-runtime/lib/control-plane.test.mjs`, driven by a
+ * fake `gh api` that serves a GitHub-shaped seed. A verb that would pass on
+ * Linear/memory and fail here is an adapter bug.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ControlPlaneError } from "./types.mjs";
+import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
+import {
+  githubControlPlane,
+  githubPolicyStanza,
+  parseIssueIdentifier,
+  writeGithubControlPlanePolicy,
+} from "./github.mjs";
+
+const TEAM = "WM";
+const REPO = "acme/widget";
+const OTHER_REPO = "acme/other";
+const PROJECT = "Factory";
+const RAW_PING = "query { ping }";
+const FACTORY = path.resolve(import.meta.dir, "../../bin/factory");
+
+const tmpDirs = [];
+function tmp(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+const STATUS_OPTIONS = [
+  { id: "opt-triage", name: "Triage" },
+  { id: "opt-todo", name: "Todo" },
+  { id: "opt-progress", name: "In Progress" },
+  { id: "opt-review", name: "In Review" },
+  { id: "opt-done", name: "Done" },
+  { id: "opt-blocked", name: "Blocked" },
+];
+
+function freshSeed() {
+  return {
+    viewer: { id: 1, login: "Ada", name: "Ada" },
+    labels: [
+      { id: 10, name: AGENT_READY_LABEL },
+      { id: 11, name: IN_PROGRESS_LABEL },
+      { id: 12, name: "agent:claude-code" },
+      { id: 13, name: "agent:codex" },
+      { id: 14, name: "type:bug" },
+      { id: 15, name: "type:feature" },
+      { id: 16, name: "ai:needs-review" },
+      { id: 17, name: "source:agent" },
+    ],
+    repos: {
+      [REPO]: { issues: [] },
+      [OTHER_REPO]: { issues: [] },
+    },
+    project: {
+      id: "PVT_1",
+      title: PROJECT,
+      field: {
+        id: "FIELD_status",
+        name: "Status",
+        options: STATUS_OPTIONS,
+      },
+      items: [],
+    },
+    raw: { [RAW_PING]: { ping: true } },
+    loseNextClaim: null,
+  };
+}
+
+function addIssue(seed, repo, spec) {
+  const bucket = seed.repos[repo] ?? (seed.repos[repo] = { issues: [] });
+  const issue = {
+    id: spec.id,
+    node_id: spec.node_id,
+    number: spec.number,
+    title: spec.title,
+    body: spec.body ?? "",
+    html_url: `https://github.com/${repo}/issues/${spec.number}`,
+    state: spec.state ?? "open",
+    assignee: spec.assignee ?? null,
+    labels: spec.labels ?? [],
+    comments: spec.comments ?? [],
+    pull_request: spec.pull_request,
+  };
+  bucket.issues.push(issue);
+  if (spec.status) {
+    seed.project.items.push({
+      id: `PVTI_${spec.number}`,
+      number: spec.number,
+      repo,
+      node_id: spec.node_id,
+      status: spec.status,
+    });
+  }
+  return issue;
+}
+
+function contractSeed() {
+  const seed = freshSeed();
+  addIssue(seed, REPO, {
+    id: 101,
+    node_id: "I_1",
+    number: 1,
+    title: "ready ticket",
+    body: "## Owned Paths\n* lib/control-plane/**\n",
+    labels: [{ id: 10, name: AGENT_READY_LABEL }],
+    comments: [],
+    status: "Todo",
+  });
+  addIssue(seed, REPO, {
+    id: 102,
+    node_id: "I_2",
+    number: 2,
+    title: "in progress ticket",
+    assignee: { id: 99, login: "Other", name: "Other" },
+    labels: [
+      { id: 11, name: IN_PROGRESS_LABEL },
+      { id: 12, name: "agent:claude-code" },
+    ],
+    comments: [
+      {
+        id: 201,
+        body: "hello",
+        created_at: "2026-08-19T10:00:00Z",
+        user: { id: 99, login: "Other" },
+      },
+    ],
+    status: "In Progress",
+  });
+  addIssue(seed, REPO, {
+    id: 103,
+    node_id: "I_3",
+    number: 3,
+    title: "todo but not agent-ready",
+    labels: [{ id: 14, name: "type:bug" }],
+    comments: [],
+    status: "Todo",
+  });
+  addIssue(seed, OTHER_REPO, {
+    id: 104,
+    node_id: "I_4",
+    number: 4,
+    title: "other team ready",
+    labels: [{ id: 10, name: AGENT_READY_LABEL }],
+    comments: [],
+    status: "Todo",
+  });
+  return seed;
+}
+
+function labelByName(seed, name) {
+  return seed.labels.find((l) => l.name === name) ?? { name };
+}
+
+function projectNode(seed) {
+  return {
+    id: seed.project.id,
+    title: seed.project.title,
+    field: seed.project.field,
+  };
+}
+
+function requireIssue(seed, repo, number) {
+  const issue = seed.repos[repo]?.issues.find((i) => i.number === number);
+  if (!issue)
+    throw new ControlPlaneError("github api: Not Found", { status: 404 });
+  return issue;
+}
+
+function fakeApi(seed) {
+  const api = (method, pathName, { body, query } = {}) => {
+    api.calls.push({ method, pathName, body, query });
+    const [pathOnly, qs] = String(pathName).replace(/^\//, "").split("?");
+    const q = {
+      ...Object.fromEntries(new URLSearchParams(qs ?? "")),
+      ...(query ?? {}),
+    };
+
+    const fail = (message, status = 400) => {
+      throw new ControlPlaneError(message, { status });
+    };
+
+    if (pathOnly === "graphql") {
+      const gqlQuery = body?.query ?? "";
+      const variables = body?.variables ?? {};
+      if (seed.raw?.[gqlQuery]) {
+        const hit = seed.raw[gqlQuery];
+        const data = typeof hit === "function" ? hit(variables) : hit;
+        return { data };
+      }
+      if (gqlQuery.includes("FindRepoProject")) {
+        return {
+          data: {
+            repository: {
+              projectsV2: { nodes: [projectNode(seed)] },
+            },
+          },
+        };
+      }
+      if (gqlQuery.includes("FindViewerProject")) {
+        return {
+          data: {
+            viewer: { projectsV2: { nodes: [projectNode(seed)] } },
+          },
+        };
+      }
+      if (gqlQuery.includes("ProjectItems")) {
+        return {
+          data: {
+            node: {
+              items: {
+                nodes: seed.project.items.map((it) => ({
+                  id: it.id,
+                  content: {
+                    id: it.node_id,
+                    number: it.number,
+                    repository: { nameWithOwner: it.repo },
+                  },
+                  fieldValueByName: { name: it.status },
+                })),
+              },
+            },
+          },
+        };
+      }
+      if (gqlQuery.includes("AddProjectItem")) {
+        const contentId = variables.contentId;
+        let found = null;
+        for (const [repo, bucket] of Object.entries(seed.repos)) {
+          const issue = bucket.issues.find((i) => i.node_id === contentId);
+          if (issue) {
+            found = { repo, issue };
+            break;
+          }
+        }
+        if (!found) fail(`no issue with node_id ${contentId}`);
+        const item = {
+          id: `PVTI_${found.issue.number}_${seed.project.items.length + 1}`,
+          number: found.issue.number,
+          repo: found.repo,
+          node_id: found.issue.node_id,
+          status: "Triage",
+        };
+        seed.project.items.push(item);
+        return { data: { addProjectV2ItemById: { item: { id: item.id } } } };
+      }
+      if (gqlQuery.includes("SetProjectStatus")) {
+        const item = seed.project.items.find(
+          (it) => it.id === variables.itemId,
+        );
+        if (!item) fail(`no project item ${variables.itemId}`);
+        const opt = seed.project.field.options.find(
+          (o) => o.id === variables.optionId,
+        );
+        if (!opt) fail(`no status option ${variables.optionId}`);
+        item.status = opt.name;
+        return {
+          data: {
+            updateProjectV2ItemFieldValue: { projectV2Item: { id: item.id } },
+          },
+        };
+      }
+      fail("raw query not seeded");
+    }
+
+    if (pathOnly === "user" && method === "GET") return seed.viewer;
+
+    const labelsMatch = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/labels$/);
+    if (labelsMatch && method === "GET") return seed.labels;
+
+    const commentsMatch = pathOnly.match(
+      /^repos\/([^/]+\/[^/]+)\/issues\/(\d+)\/comments$/,
+    );
+    if (commentsMatch) {
+      const issue = requireIssue(
+        seed,
+        commentsMatch[1],
+        Number(commentsMatch[2]),
+      );
+      if (method === "GET") return issue.comments ?? [];
+      if (method === "POST") {
+        const comment = {
+          id: 300 + (issue.comments?.length ?? 0),
+          body: body.body,
+          created_at: "2026-08-19T12:00:00Z",
+          user: seed.viewer,
+        };
+        (issue.comments ??= []).push(comment);
+        return comment;
+      }
+    }
+
+    const labelsPut = pathOnly.match(
+      /^repos\/([^/]+\/[^/]+)\/issues\/(\d+)\/labels$/,
+    );
+    if (labelsPut && method === "PUT") {
+      const issue = requireIssue(seed, labelsPut[1], Number(labelsPut[2]));
+      const names = body.labels ?? body ?? [];
+      issue.labels = names.map((n) => labelByName(seed, n));
+      return issue.labels;
+    }
+
+    const oneIssue = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues\/(\d+)$/);
+    if (oneIssue) {
+      const repo = oneIssue[1];
+      const number = Number(oneIssue[2]);
+      if (method === "GET") return requireIssue(seed, repo, number);
+      if (method === "PATCH") {
+        const issue = requireIssue(seed, repo, number);
+        if (body.body !== undefined) issue.body = body.body;
+        if (body.state) issue.state = body.state;
+        if (body.assignees) {
+          if (body.assignees.length === 0) issue.assignee = null;
+          else {
+            const login = body.assignees[0];
+            issue.assignee =
+              login === seed.viewer.login
+                ? { ...seed.viewer }
+                : { id: 99, login, name: login };
+          }
+        }
+        if (seed.loseNextClaim) {
+          issue.assignee = { ...seed.loseNextClaim };
+          seed.loseNextClaim = null;
+        }
+        return issue;
+      }
+    }
+
+    const listOrCreate = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues$/);
+    if (listOrCreate) {
+      const repo = listOrCreate[1];
+      const bucket = seed.repos[repo] ?? (seed.repos[repo] = { issues: [] });
+      if (method === "POST") {
+        const number =
+          Math.max(0, ...bucket.issues.map((i) => i.number), 0) + 1;
+        const issue = {
+          id: 1000 + number,
+          node_id: `I_new_${number}`,
+          number,
+          title: body.title,
+          body: body.body ?? "",
+          html_url: `https://github.com/${repo}/issues/${number}`,
+          state: "open",
+          assignee: null,
+          labels: (body.labels ?? []).map((n) => labelByName(seed, n)),
+          comments: [],
+        };
+        bucket.issues.push(issue);
+        return issue;
+      }
+      if (method === "GET") {
+        let rows = bucket.issues.filter((i) => !i.pull_request);
+        if (q.state === "open") rows = rows.filter((i) => i.state !== "closed");
+        if (q.assignee === "none") rows = rows.filter((i) => !i.assignee);
+        if (q.labels) {
+          const needed = String(q.labels).split(",");
+          rows = rows.filter((i) =>
+            needed.every((n) => (i.labels ?? []).some((l) => l.name === n)),
+          );
+        }
+        return rows;
+      }
+    }
+
+    fail(`unknown github api ${method} ${pathName}`);
+  };
+  api.calls = [];
+  return api;
+}
+
+function makePlane() {
+  const seed = contractSeed();
+  const cp = githubControlPlane({
+    api: fakeApi(seed),
+    repo: REPO,
+    teams: { WM: REPO, CLNT: OTHER_REPO },
+    project: PROJECT,
+  });
+  return { cp, seed };
+}
+
+describe("control-plane contract: github", () => {
+  test("kind is github", () => {
+    const { cp } = makePlane();
+    expect(cp.kind).toBe("github");
+  });
+
+  test("getTicket returns the normalized ticket (flat labels, owner/repo#N)", async () => {
+    const { cp } = makePlane();
+    const t = await cp.getTicket(`${REPO}#1`);
+    expect(t.identifier).toBe(`${REPO}#1`);
+    expect(t.title).toBe("ready ticket");
+    expect(t.labels).toEqual([{ id: "10", name: AGENT_READY_LABEL }]);
+    expect(t.labels.nodes).toBeUndefined();
+    expect(t.assignee).toBeNull();
+    expect(t.state.name).toBe("Todo");
+    expect(t.team.key).toBe(TEAM);
+    expect(t.project.name).toBe(PROJECT);
+  });
+
+  test("getTicket on an unknown id throws ControlPlaneError", async () => {
+    const { cp } = makePlane();
+    let err;
+    try {
+      await cp.getTicket(`${REPO}#999`);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ControlPlaneError);
+    expect(err.message).toMatch(/no such issue/i);
+  });
+
+  test("listComments returns the comment bodies", async () => {
+    const { cp } = makePlane();
+    expect(await cp.listComments(`${REPO}#2`)).toEqual([
+      {
+        id: "201",
+        body: "hello",
+        createdAt: "2026-08-19T10:00:00Z",
+        user: { id: "99", name: "Other" },
+      },
+    ]);
+    expect(await cp.listComments(`${REPO}#1`)).toEqual([]);
+    await expect(cp.listComments(`${REPO}#999`)).rejects.toThrow(
+      ControlPlaneError,
+    );
+  });
+
+  test("listDispatchable is Todo + ai:agent-ready + unassigned, scoped to team", async () => {
+    const { cp } = makePlane();
+    const ready = await cp.listDispatchable({ team: TEAM });
+    expect(ready.map((t) => t.identifier)).toEqual([`${REPO}#1`]);
+    const factory = await cp.listDispatchable({
+      team: TEAM,
+      project: PROJECT,
+    });
+    expect(factory.map((t) => t.identifier)).toEqual([`${REPO}#1`]);
+    const none = await cp.listDispatchable({
+      team: TEAM,
+      project: "Nope",
+    });
+    expect(none).toEqual([]);
+    await expect(cp.listDispatchable({})).rejects.toThrow(ControlPlaneError);
+  });
+
+  test("claim moves to In Progress, assigns the viewer, swaps claim labels", async () => {
+    const { cp } = makePlane();
+    const result = await cp.claim(`${REPO}#1`);
+    expect(result).toEqual({
+      ok: true,
+      identifier: `${REPO}#1`,
+      assignee: "Ada",
+    });
+    const t = await cp.getTicket(`${REPO}#1`);
+    expect(t.state.name).toBe("In Progress");
+    expect(t.assignee).toEqual({ id: "1", name: "Ada" });
+    const names = t.labels.map((l) => l.name).sort();
+    expect(names).toContain(IN_PROGRESS_LABEL);
+    expect(names).toContain("agent:claude-code");
+    expect(names).not.toContain(AGENT_READY_LABEL);
+  });
+
+  test("claim reports a lost race instead of throwing", async () => {
+    const { cp, seed } = makePlane();
+    seed.loseNextClaim = { id: 99, login: "Other", name: "Other" };
+    const result = await cp.claim(`${REPO}#1`);
+    expect(result.ok).toBe(false);
+    expect(result.assignee).toBe("Other");
+  });
+
+  test("comment lands on the ticket and is readable back", async () => {
+    const { cp } = makePlane();
+    await cp.comment(`${REPO}#1`, "working");
+    const comments = await cp.listComments(`${REPO}#1`);
+    expect(comments.map((c) => c.body)).toEqual(["working"]);
+    await expect(cp.comment(`${REPO}#999`, "x")).rejects.toThrow(
+      ControlPlaneError,
+    );
+    await expect(cp.comment(`${REPO}#1`, "")).rejects.toThrow(
+      ControlPlaneError,
+    );
+  });
+
+  test("setLabels keeps existing labels (complete-set, not a delta)", async () => {
+    const { cp } = makePlane();
+    await cp.setLabels(`${REPO}#1`, { add: ["type:bug"] });
+    const names = (await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name);
+    expect(names).toContain(AGENT_READY_LABEL);
+    expect(names).toContain("type:bug");
+    await cp.setLabels(`${REPO}#1`, { remove: [AGENT_READY_LABEL] });
+    expect((await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name)).toEqual(
+      ["type:bug"],
+    );
+  });
+
+  test("setLabels rejects unknown type:* values before mutating", async () => {
+    const { cp } = makePlane();
+    await expect(
+      cp.setLabels(`${REPO}#1`, { add: ["type:chore"] }),
+    ).rejects.toThrow(/type:chore/);
+    expect((await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name)).toEqual(
+      [AGENT_READY_LABEL],
+    );
+  });
+
+  test("transition moves Projects Status, can unassign, and rejects unknown states", async () => {
+    const { cp } = makePlane();
+    await cp.transition(`${REPO}#2`, "In Review", {
+      add: ["ai:needs-review"],
+      remove: [IN_PROGRESS_LABEL],
+      unassign: true,
+    });
+    const t = await cp.getTicket(`${REPO}#2`);
+    expect(t.state.name).toBe("In Review");
+    expect(t.assignee).toBeNull();
+    const names = t.labels.map((l) => l.name);
+    expect(names).toContain("ai:needs-review");
+    expect(names).not.toContain(IN_PROGRESS_LABEL);
+    await expect(cp.transition(`${REPO}#2`, "DoesNotExist")).rejects.toThrow(
+      ControlPlaneError,
+    );
+  });
+
+  test("file creates a ticket in Triage with the requested labels", async () => {
+    const { cp } = makePlane();
+    const created = await cp.file({
+      team: TEAM,
+      title: "new finding",
+      body: "saw this while doing WM-798",
+      labels: ["type:feature", "source:agent"],
+    });
+    expect(created.identifier).toBe(`${REPO}#4`);
+    expect(created.url).toBeTruthy();
+    const t = await cp.getTicket(created.identifier);
+    expect(t.title).toBe("new finding");
+    expect(t.state.name).toBe("Triage");
+    expect(t.labels.map((l) => l.name).sort()).toEqual([
+      "source:agent",
+      "type:feature",
+    ]);
+    await expect(cp.file({ team: TEAM })).rejects.toThrow(ControlPlaneError);
+  });
+
+  test("appendDetail is idempotent", async () => {
+    const { cp } = makePlane();
+    const first = await cp.appendDetail(
+      `${REPO}#1`,
+      "## Verification\n`bun test`",
+    );
+    expect(first.appended).toBe(true);
+    const again = await cp.appendDetail(
+      `${REPO}#1`,
+      "## Verification\n`bun test`",
+    );
+    expect(again.appended).toBe(false);
+    const t = await cp.getTicket(`${REPO}#1`);
+    expect(t.description).toContain("## Owned Paths");
+    expect(t.description).toContain("## Verification");
+    expect(t.description.match(/## Verification/g)).toHaveLength(1);
+  });
+
+  test("raw is the escape hatch; unknown queries throw", async () => {
+    const { cp } = makePlane();
+    expect(await cp.raw(RAW_PING)).toEqual({ ping: true });
+    await expect(cp.raw("query { nope }")).rejects.toThrow(ControlPlaneError);
+  });
+});
+
+describe("github identifier and policy defaults", () => {
+  test("parseIssueIdentifier accepts owner/repo#N and #N with a default repo", () => {
+    expect(parseIssueIdentifier("acme/widget#42")).toEqual({
+      repo: "acme/widget",
+      number: 42,
+    });
+    expect(parseIssueIdentifier("#7", "acme/widget")).toEqual({
+      repo: "acme/widget",
+      number: 7,
+    });
+    expect(() => parseIssueIdentifier("WM-1")).toThrow(ControlPlaneError);
+  });
+
+  test("writeGithubControlPlanePolicy creates and merges policy.yaml", () => {
+    const root = tmp("github-policy-");
+    const created = writeGithubControlPlanePolicy(root, {
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+    expect(created.controlPlane).toEqual(
+      githubPolicyStanza({ repo: REPO, teams: { WM: REPO }, project: PROJECT }),
+    );
+    const parsed = Bun.YAML.parse(readFileSync(created.path, "utf8"));
+    expect(parsed.controlPlane.kind).toBe("github");
+    expect(parsed.controlPlane.github.repo).toBe(REPO);
+    expect(parsed.controlPlane.github.project).toBe(PROJECT);
+
+    writeFileSync(
+      created.path,
+      "merge:\n  max_fix_rounds: 2\ncontrolPlane:\n  kind: linear\n",
+    );
+    writeGithubControlPlanePolicy(root, { repo: REPO });
+    const merged = Bun.YAML.parse(readFileSync(created.path, "utf8"));
+    expect(merged.merge.max_fix_rounds).toBe(2);
+    expect(merged.controlPlane.kind).toBe("github");
+    expect(merged.controlPlane.github.repo).toBe(REPO);
+  });
+
+  test("githubControlPlane reads teams from policy.yaml", async () => {
+    const root = tmp("github-root-");
+    writeGithubControlPlanePolicy(root, {
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    const seed = contractSeed();
+    const cp = githubControlPlane({ root, api: fakeApi(seed) });
+    const ready = await cp.listDispatchable({ team: "WM" });
+    expect(ready.map((t) => t.identifier)).toEqual([`${REPO}#1`]);
+  });
+
+  test("factory init --control-plane github writes policy defaults", () => {
+    const root = tmp("github-init-");
+    const result = Bun.spawnSync({
+      cmd: [
+        "bash",
+        FACTORY,
+        "init",
+        "--control-plane",
+        "github",
+        "--root",
+        root,
+        "--repo",
+        REPO,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("controlPlane.kind=github");
+    const policy = Bun.YAML.parse(
+      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
+    );
+    expect(policy.controlPlane.kind).toBe("github");
+    expect(policy.controlPlane.github.repo).toBe(REPO);
+    expect(policy.controlPlane.github.project).toBe("Factory");
+    expect(policy.controlPlane.github.teams.DEMO).toBe(REPO);
+  });
+
+  test("factory init without --control-plane github exits 2", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bash", FACTORY, "init"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toMatch(/--control-plane github/);
+  });
+});
+
+describe("github label write is a complete set", () => {
+  test("setLabels PUT sends every remaining label, not just the add", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    await cp.setLabels(`${REPO}#1`, { add: ["type:bug"] });
+    const put = api.calls.find(
+      (c) => c.method === "PUT" && String(c.pathName).includes("/labels"),
+    );
+    expect(put.body.labels.sort()).toEqual(
+      [AGENT_READY_LABEL, "type:bug"].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `githubControlPlane()` — GitHub Issues binding of the ControlPlane verbs: protocol labels as a complete set, assignee with claim read-back, factory states on a Projects v2 Status field.
- `factory init --control-plane github` writes those policy defaults; `config/policy.example.yaml` is the copy-paste stanza. `gh auth login` is the only credential (no Linear account).
- Contract suite in `lib/control-plane/github.test.mjs`. `loadControlPlane()` wiring is [WM-929](https://linear.app/watt-mind/issue/WM-929) (outside this ticket's Owned Paths).

## Test plan
- [x] `bun test lib/control-plane/github.test.mjs && bun run lint && bun run check`
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib`
- [ ] Confirm `factory init --control-plane github --root /tmp/x --repo owner/name` writes `config/policy.yaml`

Fixes WM-798

UX critique: skipped — backend adapter, policy example, and protocol docs; no user-facing surface

Made with [Cursor](https://cursor.com)