### PR TITLE
feat(settings): schema-driven format hints and env-backed secrets (WM-920)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1486,3 +1486,13 @@ keys but never values, schedule jobs publish only name/cadence/harness, and
 the registry publishes counts, event adapters, and summaries. A newly added
 config key therefore remains private until the API allow-list deliberately
 adds it. Nothing here writes any config file; Settings is visibility only.
+
+The **Extensions** section (WM-841, WM-920) is schema-driven: each extension
+row is a read-only `SchemaForm` (`web/src/components/SchemaForm.tsx`) over
+the published `schema` + `values`. `title` is the label, `description` is
+help, `format` selects the widget (`secret` / `uri` / `channel-id` /
+`ticket` / `duration` / `multiline` / `email`), and `enum` / `type` /
+bounds / `default` drive the control. Search indexes every property's
+`title` and `description` as well as keys and values. Secret properties
+publish `{ set, source }` and never a value. Anomaly replaces the form.
+Built-in sections should migrate onto the same schema shape (WM-924).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -313,28 +313,47 @@ directory):
   "properties": {
     "simulator": {
       "type": "string",
+      "title": "Simulator",
       "default": "iPhone-16",
       "description": "booted before each run"
     },
     "maxParallel": {
       "type": "integer",
+      "title": "Max parallel",
       "minimum": 1,
       "maximum": 4,
       "default": 1
     },
-    "apiToken": { "type": "string", "description": "masked in /config" }
+    "apiToken": {
+      "type": "string",
+      "format": "secret",
+      "title": "API token",
+      "description": "resolved from FACTORY_EXT_MOBILE_API_TOKEN"
+    }
   }
 }
 ```
 
-Values (`config/policy.yaml`):
+Values (`config/policy.yaml`) — non-secret settings only:
 
 ```yaml
 extensions:
   - path: ~/.factory/extensions/wattmind-mobile
     config:
       maxParallel: 2
-      apiToken: sk-live-…
+```
+
+Secrets are **not** written in `policy.yaml`. A property with
+`format: "secret"` is resolved from `process.env.FACTORY_EXT_<NAMESPACE>_<KEY>`
+(upper-snake of the config namespace and property path) or, if that is unset,
+from `~/.factory/secrets.env` (dotenv, mode `0600`, loaded once at start;
+`FACTORY_EVENT_SECRETS_FILE` overrides the path). A secret given in
+`policy.yaml` is a configuration anomaly: the extension is disabled and the
+message names the key and the env var to use.
+
+```bash
+# ~/.factory/secrets.env (chmod 600)
+FACTORY_EXT_MOBILE_API_TOKEN=…
 ```
 
 What the loader does with them, in order:
@@ -343,14 +362,22 @@ What the loader does with them, in order:
    (`extensions validate` checks this too) and valid JSON. The keyword subset
    is `event-runtime/lib/schema.mjs`'s — `type`, `enum`, `const`, `required`,
    `properties`, `additionalProperties`, `items`, `min/max*`, `pattern`,
-   `description` — plus `default`. Anything else (`anyOf`, `$ref`, …) fails
-   closed like every other contract in the runtime.
+   `description`, `title`, `format` — plus `default`. `format` is a closed
+   enum: `secret`, `uri`, `channel-id`, `ticket`, `duration`, `multiline`,
+   `email`. Unknown keywords and unknown `format` values fail closed like
+   every other contract in the runtime. `format` is a UI hint except `uri`
+   (the string must parse as a URI) and `duration` (`^\d+(ms|s|m|h|d)$`).
 2. **Applies defaults.** Every `default` under `properties`, recursively, is
    filled in where the operator gave nothing; a nested object property is only
    created when a default inside it produces something. With no `config:` in
    the policy at all the effective object is _just_ the defaults, so an
    extension whose every setting has a default needs no operator input.
-3. **Validates the effective object** with `schema.mjs validate`. A violation
+   `format: "secret"` properties never take a default from the schema or a
+   value from `policy.yaml`.
+3. **Resolves secrets.** Each `format: "secret"` property is filled from
+   `FACTORY_EXT_<NAMESPACE>_<KEY>` as above. The extension's own code sees
+   the resolved string via `getExtensionConfig()`.
+4. **Validates the effective object** with `schema.mjs validate`. A violation
    is a configuration anomaly that **disables the extension whole** — nothing
    of it is registered, its adapters are not even imported — with a message
    naming the failing path:
@@ -368,7 +395,8 @@ The extension's own code reads the result by name:
 
 ```js
 import { getExtensionConfig } from "../../lib/extensions.mjs";
-const cfg = getExtensionConfig("wattmind/mobile"); // { simulator: "iPhone-16", maxParallel: 2, apiToken: "sk-live-…" }
+const cfg = getExtensionConfig("wattmind/mobile");
+// { simulator: "iPhone-16", maxParallel: 2, apiToken: "…" }
 ```
 
 `getExtensionConfig` returns the effective object — defaults applied,
@@ -383,7 +411,7 @@ one item per extension the loader saw:
 
 ```json
 { "name": "wattmind/mobile", "version": "1.0.0", "path": "…", "namespace": "mobile",
-  "reload": "restart", "schema": { … }, "values": { "simulator": "iPhone-16", "maxParallel": 2, "apiToken": "[redacted]" },
+  "reload": "restart", "schema": { … }, "values": { "simulator": "iPhone-16", "maxParallel": 2, "apiToken": { "set": true, "source": "env" } },
   "anomaly": null }
 ```
 
@@ -391,18 +419,39 @@ A disabled extension appears with `values: null` and its `anomaly`; an
 extension that declares no config appears with `namespace: null`. The
 section's `entries` mirror the same rows (key = namespace) so the Settings
 search covers them. Settings renders it as the **Extensions** section — name,
-namespace, version, path, the effective values with the schema's
-`description`s as notes, a collapsed copy of the schema, and the anomaly in
-place of the values when the extension is disabled. Read-only, like every
-other Settings section: values change in `policy.yaml`, then restart.
+namespace, version, path, a read-only `SchemaForm` of the effective values
+(`title` = label, `description` = help, `format` = widget, `enum` / `type` /
+`minimum` / `maximum` / `default` drive the control), a collapsed copy of the
+schema, and the anomaly in place of the form when the extension is disabled.
+Search also indexes every property's `title` and `description`. Read-only,
+like every other Settings section: values change in `policy.yaml` or env,
+then restart. Built-in sections (Policy, Nodes, …) should migrate onto the
+same schema shape — [WM-924](https://linear.app/watt-mind/issue/WM-924).
 
-**Redaction rule.** Before publishing, every value whose key matches
+**UI hints.** `title` is the field label (the property name is the fallback),
+`description` is help text, `format` selects the widget:
+
+| `format`     | Widget (read-only)                                      |
+| :----------- | :------------------------------------------------------ |
+| `secret`     | "set via env `FACTORY_EXT_…`" / "unset" — never a value |
+| `uri`        | link                                                    |
+| `channel-id` | mono chip                                               |
+| `ticket`     | mono chip with `TicketHoverCard`                        |
+| `duration`   | humanised (`30s` → "30 seconds")                        |
+| `multiline`  | `<pre>`                                                 |
+| `email`      | text                                                    |
+
+Booleans render as a disabled toggle, enums as a disabled select, integers
+with bounds as the number plus a range hint. A value equal to `default` is
+marked.
+
+**Redaction rule.** `format: "secret"` properties publish
+`{ set: true|false, source: "env"|"secrets.env"|null }` instead of a value.
+For schemas that predate `format`, every remaining value whose key matches
 `/token|secret|key|password/i` — at any depth of the effective object — is
 replaced by `"[redacted]"` (`redactSecrets` in `lib/api-config.mjs`). Empty
-and `null` values are left as they are so "unset" stays visible. The schema is
-published as written; do not put a real secret in a `default`. The masking is
-by key name only: name secret settings so the rule catches them (`apiToken`,
-not `credential`).
+and `null` values are left as they are so "unset" stays visible. The schema
+is published as written; do not put a real secret in a `default`.
 
 ## Hooks
 

--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "./config.mjs";
-import { loadedExtensions } from "./extensions.mjs";
+import { loadedExtensions, maskExtensionSecrets } from "./extensions.mjs";
 import { reposView } from "./repos.mjs";
 import { loadNodesConfig, nodesConfigPath } from "./workers-remote.mjs";
 
@@ -138,7 +138,13 @@ function extensionsSection({ extensions = [], disabled = [] } = {}) {
       namespace: ext.config?.namespace ?? null,
       reload: "restart",
       schema: ext.config?.schemaJson ?? null,
-      values: ext.config ? redactSecrets(ext.config.values) : null,
+      values: ext.config
+        ? maskExtensionSecrets(
+            redactSecrets(ext.config.values),
+            ext.config.schemaJson,
+            ext.config.secretMeta,
+          )
+        : null,
       anomaly: null,
     })),
     ...disabled.map((ext) => ({

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -8,7 +8,11 @@ import path from "node:path";
 import { configView, redactSecrets } from "./api-config.mjs";
 import { makeServer as makeApiServer } from "./api-test-helpers.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
-import { loadExtensions } from "./extensions.mjs";
+import {
+  extensionSecretEnvVar,
+  loadExtensions,
+  resetExtensionSecretsCache,
+} from "./extensions.mjs";
 import { reposView } from "./repos.mjs";
 
 const SAMPLE_EXTENSION = path.join(
@@ -396,6 +400,41 @@ describe("GET /config view", () => {
     expect(section.extensions[0].schema.properties.apiToken.format).toBe(
       "secret",
     );
+  });
+
+  test("GET /config over real HTTP: an env-backed secret value never appears in the response body, only { set, source }", async () => {
+    const SECRET_LITERAL = "raw-secret-should-never-leak-9f31a2";
+    const envVar = extensionSecretEnvVar("sample", "apiToken");
+    expect(envVar).toBe("FACTORY_EXT_SAMPLE_API_TOKEN");
+    const prevEnv = process.env[envVar];
+    process.env[envVar] = SECRET_LITERAL;
+    resetExtensionSecretsCache();
+    let apiServer;
+    try {
+      await loadExtensions({
+        policy: {
+          extensions: [{ path: SAMPLE_EXTENSION, config: { greeting: "hi" } }],
+        },
+        packRoots: [],
+      });
+      apiServer = await makeServer({ configRoot: fixtureRoot() });
+      const response = await fetch(apiServer.url("/config"));
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      // Grep the raw response text, not just the parsed value, for the literal.
+      expect(text).not.toContain(SECRET_LITERAL);
+      const body = JSON.parse(text);
+      const section = body.sections.find((s) => s.id === "extensions");
+      const sample = section.extensions.find(
+        (ext) => ext.name === "factory/sample",
+      );
+      expect(sample.values.apiToken).toEqual({ set: true, source: "env" });
+    } finally {
+      apiServer?.close();
+      if (prevEnv === undefined) delete process.env[envVar];
+      else process.env[envVar] = prevEnv;
+      resetExtensionSecretsCache();
+    }
   });
 
   test("GET /config redacts secret-looking keys in the policy section, not only extension values", () => {

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -323,13 +323,52 @@ describe("GET /config view", () => {
     expect(JSON.stringify(view)).not.toContain("super-secret-value");
   });
 
+  test("publishes format: secret as { set, source } and never the resolved value", () => {
+    const view = configView({
+      root: fixtureRoot(),
+      registry: registry(),
+      repos: () => new Map(),
+      policyVersion: "git:test",
+      now: 0,
+      extensions: {
+        extensions: [
+          {
+            name: "factory/sample",
+            version: "1.0.0",
+            path: "/ext/sample",
+            config: {
+              namespace: "sample",
+              schema: "./config.schema.json",
+              schemaJson: {
+                type: "object",
+                properties: {
+                  greeting: { type: "string" },
+                  apiToken: { type: "string", format: "secret" },
+                },
+              },
+              values: { greeting: "hello", apiToken: "super-secret-value" },
+              secretMeta: { apiToken: { set: true, source: "env" } },
+            },
+          },
+        ],
+        disabled: [],
+      },
+    });
+    const section = view.sections.find((s) => s.id === "extensions");
+    expect(section.extensions[0].values).toEqual({
+      greeting: "hello",
+      apiToken: { set: true, source: "env" },
+    });
+    expect(JSON.stringify(view)).not.toContain("super-secret-value");
+  });
+
   test("defaults to the extensions the process loaded (lib/extensions.mjs snapshot)", async () => {
     await loadExtensions({
       policy: {
         extensions: [
           {
             path: SAMPLE_EXTENSION,
-            config: { apiToken: "shh", greeting: "yo" },
+            config: { greeting: "yo" },
           },
         ],
       },
@@ -348,13 +387,15 @@ describe("GET /config view", () => {
     expect(section.extensions[0].values).toEqual({
       greeting: "yo",
       maxParallel: 1,
-      apiToken: "[redacted]",
+      apiToken: { set: false, source: null },
       limits: { timeoutSeconds: 30 },
     });
     expect(section.extensions[0].schema.properties.greeting.default).toBe(
       "hello",
     );
-    expect(JSON.stringify(view)).not.toContain("shh");
+    expect(section.extensions[0].schema.properties.apiToken.format).toBe(
+      "secret",
+    );
   });
 
   test("GET /config redacts secret-looking keys in the policy section, not only extension values", () => {

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -29,13 +29,16 @@
  *      proves they exist inside the extension, and lib/registry.mjs loads
  *      and validates the panels themselves (a bad panel is skipped alone,
  *      never the extension).
- *   4. **Config is declared, validated, defaulted (WM-841).** An extension
- *      may declare `contributes.config: { namespace, schema }`; the operator's
- *      values live on the policy entry (`extensions[].config`). At load the
- *      schema is read, `default`s are applied, and the effective object is
- *      validated with lib/schema.mjs — a violation disables the extension
- *      (misconfigured code must not run). `getExtensionConfig(name)` hands the
- *      effective object to that extension's adapters/hooks/panels, and
+ *   4. **Config is declared, validated, defaulted (WM-841), with UI-hint
+ *      `format` and env-backed secrets (WM-920).** An extension may declare
+ *      `contributes.config: { namespace, schema }`; the operator's values live
+ *      on the policy entry (`extensions[].config`). At load the schema is
+ *      read, `default`s are applied, `format: "secret"` properties resolve
+ *      from `FACTORY_EXT_<NAMESPACE>_<KEY>` (process env, then
+ *      `~/.factory/secrets.env`) — never from `policy.yaml` — and the
+ *      effective object is validated with lib/schema.mjs. A violation
+ *      disables the extension. `getExtensionConfig(name)` hands the
+ *      effective object (secrets included) to adapters/hooks/panels;
  *      `loadedExtensions()` is the snapshot `GET /config` publishes.
  *   5. **Hooks are registered, built-ins first (WM-842).** `contributes.hooks`
  *      maps a hook point to a module; each is imported and contract-checked
@@ -62,6 +65,7 @@
  * given.
  */
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -383,17 +387,151 @@ function withoutDefaults(schema) {
   return out;
 }
 
+/** camelCase / kebab path segment → UPPER_SNAKE for FACTORY_EXT_* names. */
+export function upperSnake(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
+
+/** `FACTORY_EXT_<NAMESPACE>_<KEY>` for a secret property path. */
+export function extensionSecretEnvVar(namespace, keyPath) {
+  const parts = [namespace, ...(Array.isArray(keyPath) ? keyPath : [keyPath])]
+    .map(upperSnake)
+    .filter(Boolean);
+  return `FACTORY_EXT_${parts.join("_")}`;
+}
+
+/**
+ * Every `format: "secret"` property in a config schema, depth-first, with
+ * the path used for env names and published `{ set, source }` overlays.
+ */
+export function collectSecretFields(schema, path = []) {
+  if (!isPlainObject(schema) || !isPlainObject(schema.properties)) return [];
+  const out = [];
+  for (const [key, sub] of Object.entries(schema.properties)) {
+    const next = [...path, key];
+    if (isPlainObject(sub) && sub.format === "secret")
+      out.push({ path: next, key });
+    else out.push(...collectSecretFields(sub, next));
+  }
+  return out;
+}
+
+function hasAt(obj, keyPath) {
+  let node = obj;
+  for (const key of keyPath) {
+    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return false;
+    node = node[key];
+  }
+  return true;
+}
+
+function setAt(obj, keyPath, value) {
+  let node = obj;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const key = keyPath[i];
+    if (!isPlainObject(node[key])) node[key] = {};
+    node = node[key];
+  }
+  node[keyPath[keyPath.length - 1]] = value;
+}
+
+function deleteAt(obj, keyPath) {
+  let node = obj;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const key = keyPath[i];
+    if (!isPlainObject(node[key])) return;
+    node = node[key];
+  }
+  delete node[keyPath[keyPath.length - 1]];
+}
+
+function parseDotenv(text) {
+  const out = {};
+  for (const raw of text.split(/\r?\n/)) {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const line = trimmed.replace(/^export\s+/, "");
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+let secretsFileCache;
+
+/** Drop the cached `~/.factory/secrets.env` parse so a test can reload. */
+export function resetExtensionSecretsCache() {
+  secretsFileCache = undefined;
+}
+
+function secretsFilePath() {
+  return (
+    process.env.FACTORY_EVENT_SECRETS_FILE ||
+    path.join(homedir(), ".factory", "secrets.env")
+  );
+}
+
+/**
+ * Parse `~/.factory/secrets.env` once (dotenv, owner-only mode). A missing
+ * or group/world-readable file contributes nothing — secrets then come only
+ * from `process.env`.
+ */
+function loadSecretsFile() {
+  if (secretsFileCache !== undefined) return secretsFileCache;
+  const file = secretsFilePath();
+  secretsFileCache = {};
+  if (!existsSync(file)) return secretsFileCache;
+  let stat;
+  try {
+    stat = statSync(file);
+  } catch {
+    return secretsFileCache;
+  }
+  if (!stat.isFile() || (stat.mode & 0o077) !== 0) return secretsFileCache;
+  try {
+    secretsFileCache = parseDotenv(readFileSync(file, "utf8"));
+  } catch {
+    secretsFileCache = {};
+  }
+  return secretsFileCache;
+}
+
+function resolveSecretValue(envVar) {
+  const fromEnv = process.env[envVar];
+  if (typeof fromEnv === "string" && fromEnv.length > 0)
+    return { value: fromEnv, source: "env" };
+  const fromFile = loadSecretsFile()[envVar];
+  if (typeof fromFile === "string" && fromFile.length > 0)
+    return { value: fromFile, source: "secrets.env" };
+  return { value: undefined, source: null };
+}
+
 /**
  * Resolve one extension's effective config: read the declared schema, apply
- * its defaults over the operator's values, validate the result. Returns
- * `null` when the manifest declares no config and the policy gives none;
- * throws an ExtensionError naming the fault (and the failing value path)
- * otherwise, which `loadExtensions` turns into a disabling anomaly.
+ * its defaults over the operator's values, pull `format: "secret"` properties
+ * from env / secrets.env, validate the result. Returns `null` when the
+ * manifest declares no config and the policy gives none; throws an
+ * ExtensionError naming the fault (and the failing value path) otherwise,
+ * which `loadExtensions` turns into a disabling anomaly.
  *
  * @param {string} dir - the extension directory
  * @param {object} manifest - a schema-valid manifest
  * @param {object|undefined} values - the policy entry's `config`
- * @returns {{ namespace: string, schema: string, schemaJson: object, values: object }|null}
+ * @returns {{ namespace: string, schema: string, schemaJson: object, values: object, secretMeta: Record<string, { set: boolean, source: "env"|"secrets.env"|null }> }|null}
  */
 export function resolveExtensionConfig(dir, manifest, values) {
   const declared = manifest.contributes?.config;
@@ -414,7 +552,34 @@ export function resolveExtensionConfig(dir, manifest, values) {
       `contributes.config.schema "${declared.schema}" is not valid JSON — ${err.message}`,
     );
   }
-  const effective = applyConfigDefaults(schemaJson, values ?? {});
+  const secrets = collectSecretFields(schemaJson);
+  const operator = cloneJson(values ?? {});
+  const policySecrets = secrets.filter((field) => hasAt(operator, field.path));
+  if (policySecrets.length > 0) {
+    throw new ExtensionError(
+      policySecrets
+        .map((field) => {
+          const envVar = extensionSecretEnvVar(declared.namespace, field.path);
+          return `config.${field.path.join(".")} must not be set in policy.yaml — use env ${envVar}`;
+        })
+        .join("; "),
+    );
+  }
+  for (const field of secrets) deleteAt(operator, field.path);
+  const effective = applyConfigDefaults(schemaJson, operator);
+  const secretMeta = {};
+  for (const field of secrets) {
+    const envVar = extensionSecretEnvVar(declared.namespace, field.path);
+    const resolved = resolveSecretValue(envVar);
+    const key = field.path.join(".");
+    secretMeta[key] = {
+      set: resolved.value !== undefined,
+      source: resolved.source,
+    };
+    deleteAt(effective, field.path);
+    if (resolved.value !== undefined)
+      setAt(effective, field.path, resolved.value);
+  }
   const check = validate(withoutDefaults(schemaJson), effective);
   if (!check.valid) {
     throw new ExtensionError(
@@ -426,7 +591,25 @@ export function resolveExtensionConfig(dir, manifest, values) {
     schema: declared.schema,
     schemaJson,
     values: effective,
+    secretMeta,
   };
+}
+
+/**
+ * Replace every `format: "secret"` property with `{ set, source }` so a
+ * published `/config` payload never carries the resolved value.
+ */
+export function maskExtensionSecrets(values, schemaJson, secretMeta = {}) {
+  const out = cloneJson(values) ?? {};
+  for (const field of collectSecretFields(schemaJson)) {
+    const key = field.path.join(".");
+    const meta = secretMeta[key] ?? { set: false, source: null };
+    setAt(out, field.path, {
+      set: Boolean(meta.set),
+      source: meta.source ?? null,
+    });
+  }
+  return out;
 }
 
 /**
@@ -890,7 +1073,7 @@ export async function loadExtensions({
     }
     for (const warning of checked.warnings) anomalies.push(warning);
     if (config) acceptedNamespaces.set(config.namespace, manifest.name);
-    const { schemaJson, ...publicConfig } = config ?? {};
+    const { schemaJson, secretMeta, ...publicConfig } = config ?? {};
     const extPanelRoots = panelRootsFor(dir, manifest);
     panelRoots.push(...extPanelRoots);
     if (extHarness) {
@@ -918,7 +1101,7 @@ export async function loadExtensions({
       name: manifest.name,
       version: manifest.version,
       path: dir,
-      config: config ? { ...publicConfig, schemaJson } : null,
+      config: config ? { ...publicConfig, schemaJson, secretMeta } : null,
     });
   }
 

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -487,8 +487,10 @@ function secretsFilePath() {
 
 /**
  * Parse `~/.factory/secrets.env` once (dotenv, owner-only mode). A missing
- * or group/world-readable file contributes nothing — secrets then come only
- * from `process.env`.
+ * file contributes nothing; a group/world-readable file also contributes
+ * nothing — secrets then come only from `process.env` — but is not silent
+ * about it: a one-line warning names the file and its mode so an operator
+ * can `chmod 600` it, without failing the load.
  */
 function loadSecretsFile() {
   if (secretsFileCache !== undefined) return secretsFileCache;
@@ -501,7 +503,13 @@ function loadSecretsFile() {
   } catch {
     return secretsFileCache;
   }
-  if (!stat.isFile() || (stat.mode & 0o077) !== 0) return secretsFileCache;
+  if (!stat.isFile()) return secretsFileCache;
+  if ((stat.mode & 0o077) !== 0) {
+    console.warn(
+      `${file}: mode ${(stat.mode & 0o777).toString(8)} is group/world-readable — ignoring it for secrets (chmod 600 ${file})`,
+    );
+    return secretsFileCache;
+  }
   try {
     secretsFileCache = parseDotenv(readFileSync(file, "utf8"));
   } catch {

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -1,6 +1,7 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-extensions-test-mjs";
 import { describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   cpSync,
   mkdirSync,
   readFileSync,
@@ -21,11 +22,13 @@ import {
   RESERVED_CONTRIBUTIONS,
   applyConfigDefaults,
   collectHarnessRoots,
+  extensionSecretEnvVar,
   getExtensionConfig,
   harnessPluginName,
   loadExtensionRoots,
   loadExtensions,
   loadedExtensions,
+  resetExtensionSecretsCache,
   validateExtensionManifest,
 } from "./extensions.mjs";
 import { createHookRegistry, hookDecisionsFor } from "./hooks.mjs";
@@ -467,7 +470,6 @@ describe("extension config (contributes.config)", () => {
     const out = await load(
       withValues({
         greeting: "hey",
-        apiToken: "t0k3n",
         limits: { retries: 2 },
       }),
     );
@@ -478,7 +480,6 @@ describe("extension config (contributes.config)", () => {
       values: {
         greeting: "hey",
         maxParallel: 1,
-        apiToken: "t0k3n",
         limits: { retries: 2, timeoutSeconds: 30 },
       },
     });
@@ -489,6 +490,63 @@ describe("extension config (contributes.config)", () => {
     expect(getExtensionConfig("nobody/here")).toBeUndefined();
     expect(loadedExtensions().extensions[0].name).toBe("factory/sample");
     expect(loadedExtensions().disabled).toEqual([]);
+  });
+
+  test("format: secret resolves from env, then secrets.env, and never from policy.yaml", async () => {
+    const dir = tempExtension((m) => {
+      m.name = "factory/secretprobe";
+      m.contributes.config.namespace = "secretprobe";
+    });
+    const envVar = extensionSecretEnvVar("secretprobe", "apiToken");
+    expect(envVar).toBe("FACTORY_EXT_SECRETPROBE_API_TOKEN");
+
+    const prevFile = process.env.FACTORY_EVENT_SECRETS_FILE;
+    const prevEnv = process.env[envVar];
+    const file = path.join(tmpDir("ext-secrets-"), "secrets.env");
+    writeFileSync(file, `${envVar}=from-file\n`);
+    chmodSync(file, 0o600);
+
+    try {
+      process.env.FACTORY_EVENT_SECRETS_FILE = file;
+      delete process.env[envVar];
+      resetExtensionSecretsCache();
+      const fromFile = await load({
+        extensions: [{ path: dir, config: { greeting: "hey" } }],
+      });
+      expect(fromFile.anomalies).toEqual([]);
+      expect(getExtensionConfig("factory/secretprobe").apiToken).toBe(
+        "from-file",
+      );
+      expect(
+        loadedExtensions().extensions[0].config.secretMeta.apiToken,
+      ).toEqual({ set: true, source: "secrets.env" });
+
+      process.env[envVar] = "from-env";
+      resetExtensionSecretsCache();
+      const fromEnv = await load({
+        extensions: [{ path: dir, config: { greeting: "hey" } }],
+      });
+      expect(getExtensionConfig("factory/secretprobe").apiToken).toBe(
+        "from-env",
+      );
+      expect(
+        loadedExtensions().extensions[0].config.secretMeta.apiToken,
+      ).toEqual({ set: true, source: "env" });
+    } finally {
+      if (prevEnv === undefined) delete process.env[envVar];
+      else process.env[envVar] = prevEnv;
+      if (prevFile === undefined) delete process.env.FACTORY_EVENT_SECRETS_FILE;
+      else process.env.FACTORY_EVENT_SECRETS_FILE = prevFile;
+      resetExtensionSecretsCache();
+    }
+
+    const denied = await load(
+      withValues({ greeting: "hey", apiToken: "in-policy" }),
+    );
+    expect(denied.extensions).toEqual([]);
+    expect(denied.anomalies[0]).toMatch(
+      /config\.apiToken must not be set in policy\.yaml — use env FACTORY_EXT_SAMPLE_API_TOKEN/,
+    );
   });
 
   test("an invalid value disables the extension whole and names the failing path", async () => {

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -549,6 +549,99 @@ describe("extension config (contributes.config)", () => {
     );
   });
 
+  test("a group/world-readable secrets.env warns once, is ignored (not read), and does not fail the load", () => {
+    // os.homedir() is fixed at process start (Bun does not re-read $HOME at
+    // runtime), so a temp HOME has to be a real subprocess env, not an
+    // in-process process.env write — the same reason the "cli extensions"
+    // tests below spawn the CLI instead of calling loadExtensions() directly.
+    const dir = tempExtension((m) => {
+      m.name = "factory/secretmode";
+      m.contributes.config.namespace = "secretmode";
+    });
+    const envVar = extensionSecretEnvVar("secretmode", "apiToken");
+    const home = tmpDir("ext-secrets-home-");
+    mkdirSync(path.join(home, ".factory"), { recursive: true });
+    const file = path.join(home, ".factory", "secrets.env");
+    writeFileSync(file, `${envVar}=from-permissive-file\n`);
+    chmodSync(file, 0o644);
+
+    const root = tmpDir("ext-secrets-policyroot-");
+    mkdirSync(path.join(root, "config"));
+    const { models } = Bun.YAML.parse(
+      readFileSync(
+        path.join(path.dirname(RUNTIME_ROOT), "config", "policy.yaml"),
+        "utf8",
+      ),
+    );
+    writeFileSync(
+      path.join(root, "config", "policy.yaml"),
+      Bun.YAML.stringify({
+        models,
+        extensions: [{ path: dir, config: { greeting: "hey" } }],
+      }),
+    );
+
+    const out = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "event-runtime/cli.mjs",
+        "extensions",
+        "list",
+        "--json",
+      ],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: home,
+        FACTORY_REPOS_ROOT: root,
+        FACTORY_EVENT_SECRETS_FILE: undefined,
+        [envVar]: undefined,
+      },
+    });
+    expect(out.exitCode).toBe(0);
+    const stderr = out.stderr.toString();
+    // Permissive mode means the file is ignored, not read: the extension
+    // still loads (this is a warning, never a fault) with the secret unset.
+    expect(stderr).toContain(file);
+    expect(stderr).toMatch(/group\/world-readable/);
+    expect(stderr).not.toContain("from-permissive-file");
+    const parsed = JSON.parse(out.stdout.toString());
+    expect(parsed.anomalies).toEqual([]);
+    expect(parsed.extensions[0].config.namespace).toBe("secretmode");
+    expect(parsed.extensions[0].config.values.apiToken).toBeUndefined();
+  });
+
+  test("loading an extension with an env-backed secret never prints the raw value (serve logs loadExtensions() output at start)", async () => {
+    const envVar = extensionSecretEnvVar("sample", "apiToken");
+    const SECRET_LITERAL = "raw-secret-should-never-be-logged-77bb1";
+    const prevEnv = process.env[envVar];
+    const logged = [];
+    const spies = ["log", "warn", "error", "info", "debug"].map((method) => {
+      const original = console[method];
+      console[method] = (...args) => logged.push(args.join(" "));
+      return () => {
+        console[method] = original;
+      };
+    });
+    try {
+      process.env[envVar] = SECRET_LITERAL;
+      resetExtensionSecretsCache();
+      const out = await load(withValues({ greeting: "hey" }));
+      expect(out.extensions).toHaveLength(1);
+      expect(getExtensionConfig("factory/sample").apiToken).toBe(
+        SECRET_LITERAL,
+      );
+      expect(logged.some((line) => line.includes(SECRET_LITERAL))).toBe(false);
+    } finally {
+      for (const restore of spies) restore();
+      if (prevEnv === undefined) delete process.env[envVar];
+      else process.env[envVar] = prevEnv;
+      resetExtensionSecretsCache();
+    }
+  });
+
   test("an invalid value disables the extension whole and names the failing path", async () => {
     const out = await load(withValues({ maxParallel: 9, bogus: true }));
     expect(out.extensions).toEqual([]);

--- a/event-runtime/lib/schema.mjs
+++ b/event-runtime/lib/schema.mjs
@@ -22,8 +22,22 @@ const SUPPORTED = new Set([
   "maximum",
   "description",
   "title",
+  "format",
   "$schema",
 ]);
+
+/** Closed UI/validation hints (WM-920). Unknown values fail closed. */
+export const SCHEMA_FORMATS = Object.freeze([
+  "secret",
+  "uri",
+  "channel-id",
+  "ticket",
+  "duration",
+  "multiline",
+  "email",
+]);
+const FORMAT_SET = new Set(SCHEMA_FORMATS);
+const DURATION_PATTERN = /^\d+(ms|s|m|h|d)$/;
 
 const hasOwn = (obj, key) =>
   obj !== null &&
@@ -64,6 +78,15 @@ function check(schema, value, path, errors) {
     if (!SUPPORTED.has(key)) {
       errors.push(
         `${path}: unsupported schema keyword "${key}" — contracts fail closed`,
+      );
+      return;
+    }
+  }
+
+  if (hasOwn(schema, "format")) {
+    if (typeof schema.format !== "string" || !FORMAT_SET.has(schema.format)) {
+      errors.push(
+        `${path}: unsupported format ${JSON.stringify(schema.format)} — contracts fail closed`,
       );
       return;
     }
@@ -116,6 +139,12 @@ function check(schema, value, path, errors) {
       !new RegExp(schema.pattern).test(value)
     ) {
       errors.push(`${path}: does not match pattern ${schema.pattern}`);
+    }
+    if (schema.format === "uri" && !URL.canParse(value)) {
+      errors.push(`${path}: format "uri" value is not a valid URI`);
+    }
+    if (schema.format === "duration" && !DURATION_PATTERN.test(value)) {
+      errors.push(`${path}: format "duration" must match ${DURATION_PATTERN}`);
     }
   }
 

--- a/event-runtime/lib/schema.test.mjs
+++ b/event-runtime/lib/schema.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { validate } from "./schema.mjs";
+import { SCHEMA_FORMATS, validate } from "./schema.mjs";
 
 describe("validate", () => {
   test("accepts a conforming object", () => {
@@ -58,6 +58,66 @@ describe("validate", () => {
     const { valid, errors } = validate({ anyOf: [{ type: "string" }] }, "x");
     expect(valid).toBe(false);
     expect(errors[0]).toContain("unsupported schema keyword");
+  });
+
+  describe("format (WM-920)", () => {
+    test("the closed enum is accepted as a keyword and unknown values fail closed", () => {
+      expect(SCHEMA_FORMATS).toEqual([
+        "secret",
+        "uri",
+        "channel-id",
+        "ticket",
+        "duration",
+        "multiline",
+        "email",
+      ]);
+      for (const format of SCHEMA_FORMATS) {
+        expect(validate({ type: "string", format }, "ok").valid).toBe(
+          format === "uri" || format === "duration" ? false : true,
+        );
+      }
+      const { valid, errors } = validate(
+        { type: "string", format: "uuid" },
+        "x",
+      );
+      expect(valid).toBe(false);
+      expect(errors[0]).toContain("unsupported format");
+      expect(validate({ type: "string", format: 1 }, "x").errors[0]).toContain(
+        "unsupported format",
+      );
+    });
+
+    test("uri must parse; other formats are hints except duration", () => {
+      expect(
+        validate({ type: "string", format: "uri" }, "https://example.test/x")
+          .valid,
+      ).toBe(true);
+      const badUri = validate({ type: "string", format: "uri" }, "not a url");
+      expect(badUri.valid).toBe(false);
+      expect(badUri.errors[0]).toContain("valid URI");
+      expect(
+        validate({ type: "string", format: "duration" }, "30s").valid,
+      ).toBe(true);
+      expect(validate({ type: "string", format: "duration" }, "2h").valid).toBe(
+        true,
+      );
+      expect(
+        validate({ type: "string", format: "duration" }, "15ms").valid,
+      ).toBe(true);
+      const badDur = validate(
+        { type: "string", format: "duration" },
+        "30 seconds",
+      );
+      expect(badDur.valid).toBe(false);
+      expect(badDur.errors[0]).toContain("duration");
+      expect(
+        validate({ type: "string", format: "email" }, "not-an-email").valid,
+      ).toBe(true);
+      expect(
+        validate({ type: "string", format: "secret" }, "sk-live-anything")
+          .valid,
+      ).toBe(true);
+    });
   });
 
   test("nested errors carry a path", () => {

--- a/event-runtime/test-support/extensions/sample/config.schema.json
+++ b/event-runtime/test-support/extensions/sample/config.schema.json
@@ -7,6 +7,7 @@
       "type": "string",
       "minLength": 1,
       "default": "hello",
+      "title": "Greeting",
       "description": "what the echo adapter says first"
     },
     "maxParallel": {
@@ -14,11 +15,50 @@
       "minimum": 1,
       "maximum": 4,
       "default": 1,
+      "title": "Max parallel",
       "description": "how many echoes may run at once"
     },
     "apiToken": {
       "type": "string",
-      "description": "a secret; masked in /config by the redaction rule"
+      "format": "secret",
+      "title": "API token",
+      "description": "resolved from FACTORY_EXT_SAMPLE_API_TOKEN, never from policy.yaml"
+    },
+    "webhookUrl": {
+      "type": "string",
+      "format": "uri",
+      "title": "Webhook URL",
+      "description": "callback the adapter posts to"
+    },
+    "notifyChannel": {
+      "type": "string",
+      "format": "channel-id",
+      "title": "Notify channel",
+      "description": "channel id for operator alerts"
+    },
+    "relatedTicket": {
+      "type": "string",
+      "format": "ticket",
+      "title": "Related ticket",
+      "description": "ticket this extension is tracking"
+    },
+    "pollEvery": {
+      "type": "string",
+      "format": "duration",
+      "title": "Poll interval",
+      "description": "how often the adapter polls"
+    },
+    "notes": {
+      "type": "string",
+      "format": "multiline",
+      "title": "Notes",
+      "description": "free-form operator notes"
+    },
+    "contact": {
+      "type": "string",
+      "format": "email",
+      "title": "Contact",
+      "description": "who owns this extension"
     },
     "limits": {
       "type": "object",

--- a/event-runtime/web/src/components/SchemaForm.test.tsx
+++ b/event-runtime/web/src/components/SchemaForm.test.tsx
@@ -1,0 +1,184 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup } from "@testing-library/react";
+import { renderWithClient } from "../test-render";
+import {
+  SchemaForm,
+  humanizeDuration,
+  schemaSearchText,
+  secretEnvVar,
+  secretState,
+  type JsonSchema,
+} from "./SchemaForm";
+
+afterEach(cleanup);
+
+const schema: JsonSchema = {
+  type: "object",
+  properties: {
+    enabled: {
+      type: "boolean",
+      title: "Enabled",
+      description: "master switch",
+      default: true,
+    },
+    mode: {
+      type: "string",
+      enum: ["echo", "silent"],
+      title: "Mode",
+      default: "echo",
+    },
+    maxParallel: {
+      type: "integer",
+      title: "Max parallel",
+      minimum: 1,
+      maximum: 4,
+      default: 1,
+    },
+    apiToken: {
+      type: "string",
+      format: "secret",
+      title: "API token",
+      description: "never shown",
+    },
+    webhookUrl: {
+      type: "string",
+      format: "uri",
+      title: "Webhook URL",
+    },
+    notifyChannel: {
+      type: "string",
+      format: "channel-id",
+      title: "Notify channel",
+    },
+    relatedTicket: {
+      type: "string",
+      format: "ticket",
+      title: "Related ticket",
+    },
+    pollEvery: {
+      type: "string",
+      format: "duration",
+      title: "Poll interval",
+    },
+    notes: {
+      type: "string",
+      format: "multiline",
+      title: "Notes",
+    },
+    contact: {
+      type: "string",
+      format: "email",
+      title: "Contact",
+    },
+  },
+};
+
+const values = {
+  enabled: true,
+  mode: "echo",
+  maxParallel: 1,
+  apiToken: { set: true, source: "env" as const },
+  webhookUrl: "https://example.test/hook",
+  notifyChannel: "ops-alerts",
+  relatedTicket: "WM-920",
+  pollEvery: "30s",
+  notes: "line one\nline two",
+  contact: "ops@example.test",
+};
+
+describe("SchemaForm helpers", () => {
+  test("secret env var is FACTORY_EXT_<NAMESPACE>_<KEY> in upper-snake", () => {
+    expect(secretEnvVar("sample", ["apiToken"])).toBe(
+      "FACTORY_EXT_SAMPLE_API_TOKEN",
+    );
+    expect(secretEnvVar("mobile", ["limits", "signingKey"])).toBe(
+      "FACTORY_EXT_MOBILE_LIMITS_SIGNING_KEY",
+    );
+  });
+
+  test("humanizeDuration expands the closed duration grammar", () => {
+    expect(humanizeDuration("1s")).toBe("1 second");
+    expect(humanizeDuration("30s")).toBe("30 seconds");
+    expect(humanizeDuration("2h")).toBe("2 hours");
+    expect(humanizeDuration("nope")).toBe("nope");
+  });
+
+  test("secretState never treats a leaked string as displayable", () => {
+    expect(secretState({ set: false, source: null })).toEqual({
+      set: false,
+      source: null,
+    });
+    expect(secretState({ set: true, source: "secrets.env" }).set).toBe(true);
+    expect(secretState("sk-live-leak")).toEqual({ set: true, source: null });
+  });
+
+  test("schemaSearchText indexes title and description of every property", () => {
+    const haystack = schemaSearchText(schema);
+    expect(haystack).toContain("API token");
+    expect(haystack).toContain("never shown");
+    expect(haystack).toContain("Webhook URL");
+  });
+});
+
+describe("SchemaForm", () => {
+  test("renders a widget per type and format, never the secret value", () => {
+    const view = renderWithClient(
+      <SchemaForm schema={schema} values={values} namespace="sample" />,
+    );
+
+    expect(view.getByText("Enabled")).toBeTruthy();
+    expect(
+      view
+        .getByRole("switch", { name: "Enabled" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      view
+        .getByRole("switch", { name: "Enabled" })
+        .getAttribute("aria-disabled"),
+    ).toBe("true");
+
+    const select = view.getByLabelText("Mode") as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+    expect(select.value).toBe("echo");
+
+    expect(view.getByText("1")).toBeTruthy();
+    expect(view.getByText("1–4")).toBeTruthy();
+    expect(view.getAllByText("default").length).toBeGreaterThan(0);
+
+    expect(view.getByText("FACTORY_EXT_SAMPLE_API_TOKEN")).toBeTruthy();
+    expect(view.queryByText("sk-live")).toBeNull();
+    expect(view.getByText("never shown")).toBeTruthy();
+
+    const link = view.getByRole("link", {
+      name: "https://example.test/hook",
+    });
+    expect(link.getAttribute("href")).toBe("https://example.test/hook");
+
+    expect(view.getByText("ops-alerts")).toBeTruthy();
+    expect(view.getByText("WM-920")).toBeTruthy();
+    expect(view.getByText("30 seconds")).toBeTruthy();
+    expect(view.container.querySelector("pre")?.textContent).toBe(
+      "line one\nline two",
+    );
+    expect(view.getByText("ops@example.test")).toBeTruthy();
+  });
+
+  test("unset secrets render an unset badge, not a value", () => {
+    const view = renderWithClient(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            apiToken: { type: "string", format: "secret", title: "API token" },
+          },
+        }}
+        values={{ apiToken: { set: false, source: null } }}
+        namespace="sample"
+      />,
+    );
+    expect(view.getByText("unset")).toBeTruthy();
+    expect(view.queryByText("FACTORY_EXT_SAMPLE_API_TOKEN")).toBeNull();
+  });
+});

--- a/event-runtime/web/src/components/SchemaForm.tsx
+++ b/event-runtime/web/src/components/SchemaForm.tsx
@@ -311,7 +311,7 @@ function SchemaFields({
                 {prop.title ?? key}
               </div>
               {usingDefault && value !== undefined && (
-                <span className="mt-0.5 inline-block text-[10px] tracking-wide text-(--text-faint) uppercase">
+                <span className="mt-0.5 inline-block text-xs tracking-wide text-(--text-faint) uppercase">
                   default
                 </span>
               )}

--- a/event-runtime/web/src/components/SchemaForm.tsx
+++ b/event-runtime/web/src/components/SchemaForm.tsx
@@ -1,0 +1,384 @@
+/**
+ * Read-only settings form driven by a JSON Schema (WM-920). Widgets follow
+ * `type` / `enum` / bounds and the closed `format` set; nothing here writes.
+ */
+import type { ReactNode } from "react";
+import { TicketHoverCard } from "./TicketHoverCard";
+
+export type JsonSchema = {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  format?: string;
+  enum?: unknown[];
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  properties?: Record<string, JsonSchema>;
+};
+
+export type SecretState = {
+  set: boolean;
+  source: "env" | "secrets.env" | null;
+};
+
+const DURATION_RE = /^(\d+)(ms|s|m|h|d)$/;
+const UNIT_WORD: Record<string, string> = {
+  ms: "millisecond",
+  s: "second",
+  m: "minute",
+  h: "hour",
+  d: "day",
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function upperSnake(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
+
+/** `FACTORY_EXT_<NAMESPACE>_<KEY>` — same rule the loader uses. */
+export function secretEnvVar(
+  namespace: string | null | undefined,
+  keyPath: string[],
+): string {
+  const parts = [namespace ?? "", ...keyPath].map(upperSnake).filter(Boolean);
+  return `FACTORY_EXT_${parts.join("_")}`;
+}
+
+export function humanizeDuration(value: string): string {
+  const match = DURATION_RE.exec(value);
+  if (!match) return value;
+  const count = Number(match[1]);
+  const word = UNIT_WORD[match[2] ?? ""] ?? match[2];
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
+}
+
+export function secretState(value: unknown): SecretState {
+  if (isObject(value) && "set" in value)
+    return {
+      set: Boolean(value.set),
+      source:
+        value.source === "env" || value.source === "secrets.env"
+          ? value.source
+          : null,
+    };
+  if (typeof value === "string" && value.length > 0)
+    return { set: true, source: null };
+  return { set: false, source: null };
+}
+
+function declaredType(schema: JsonSchema): string | undefined {
+  if (Array.isArray(schema.type))
+    return schema.type.find((t) => t !== "null") ?? schema.type[0];
+  return schema.type;
+}
+
+function isDefaultValue(value: unknown, fallback: unknown): boolean {
+  if (fallback === undefined) return false;
+  try {
+    return JSON.stringify(value) === JSON.stringify(fallback);
+  } catch {
+    return value === fallback;
+  }
+}
+
+function rangeHint(schema: JsonSchema): string | null {
+  const hasMin = typeof schema.minimum === "number";
+  const hasMax = typeof schema.maximum === "number";
+  if (hasMin && hasMax) return `${schema.minimum}–${schema.maximum}`;
+  if (hasMin) return `≥ ${schema.minimum}`;
+  if (hasMax) return `≤ ${schema.maximum}`;
+  return null;
+}
+
+function DisabledSwitch({
+  checked,
+  label,
+}: {
+  checked: boolean;
+  label: string;
+}) {
+  return (
+    <span
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      aria-disabled="true"
+      className="relative inline-block h-4 w-7 rounded-full opacity-40"
+      style={{ background: checked ? "var(--accent)" : "var(--surface-3)" }}
+    >
+      <span
+        aria-hidden
+        className={`absolute top-0.5 size-3 rounded-full bg-(--contrast) ${
+          checked ? "translate-x-3.5" : "translate-x-0.5"
+        }`}
+        style={checked ? { background: "var(--on-accent)" } : undefined}
+      />
+    </span>
+  );
+}
+
+function Chip({ children }: { children: ReactNode }) {
+  return (
+    <span className="mono inline-block rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[12px] text-(--text-dim)">
+      {children}
+    </span>
+  );
+}
+
+function FieldValue({
+  schema,
+  value,
+  namespace,
+  keyPath,
+}: {
+  schema: JsonSchema;
+  value: unknown;
+  namespace: string | null;
+  keyPath: string[];
+}) {
+  if (schema.format === "secret") {
+    const state = secretState(value);
+    const envVar = secretEnvVar(namespace, keyPath);
+    if (!state.set) {
+      return (
+        <span className="mono rounded border border-(--border) px-1.5 py-0.5 text-xs text-(--text-faint)">
+          unset
+        </span>
+      );
+    }
+    return (
+      <span className="text-[12px] text-(--text-dim)">
+        set via env <span className="mono">{envVar}</span>
+      </span>
+    );
+  }
+
+  if (value === undefined || value === null || value === "") {
+    return <span className="text-(--text-faint)">—</span>;
+  }
+
+  if (schema.format === "uri" && typeof value === "string") {
+    return (
+      <a
+        href={value}
+        className="text-(--accent) hover:underline"
+        rel="noreferrer"
+      >
+        {value}
+      </a>
+    );
+  }
+
+  if (schema.format === "ticket" && typeof value === "string") {
+    return (
+      <Chip>
+        <TicketHoverCard ticketId={value} />
+      </Chip>
+    );
+  }
+
+  if (schema.format === "channel-id" && typeof value === "string") {
+    return <Chip>{value}</Chip>;
+  }
+
+  if (schema.format === "duration" && typeof value === "string") {
+    return (
+      <span className="text-[12px] text-(--text-dim)" title={value}>
+        {humanizeDuration(value)}
+      </span>
+    );
+  }
+
+  if (schema.format === "multiline" && typeof value === "string") {
+    return (
+      <pre className="mono whitespace-pre-wrap text-[12px] text-(--text-dim)">
+        {value}
+      </pre>
+    );
+  }
+
+  if (declaredType(schema) === "boolean" || typeof value === "boolean") {
+    const checked = Boolean(value);
+    const label = schema.title ?? keyPath[keyPath.length - 1] ?? "flag";
+    return <DisabledSwitch checked={checked} label={label} />;
+  }
+
+  if (Array.isArray(schema.enum)) {
+    return (
+      <select
+        disabled
+        value={String(value)}
+        aria-label={schema.title ?? keyPath.join(".")}
+        className="mono rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[12px] text-(--text-dim) opacity-70"
+      >
+        {schema.enum.map((option) => (
+          <option key={String(option)} value={String(option)}>
+            {String(option)}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  const numeric =
+    declaredType(schema) === "integer" ||
+    declaredType(schema) === "number" ||
+    typeof value === "number";
+  if (numeric) {
+    const hint = rangeHint(schema);
+    return (
+      <span className="text-[12px] text-(--text-dim)">
+        <span className="mono">{String(value)}</span>
+        {hint && (
+          <span className="ml-2 text-xs text-(--text-faint)">{hint}</span>
+        )}
+      </span>
+    );
+  }
+
+  if (typeof value === "string") {
+    return <span className="text-[12px] text-(--text-dim)">{value}</span>;
+  }
+
+  return (
+    <pre className="mono whitespace-pre-wrap text-[12px] text-(--text-dim)">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+function SchemaFields({
+  schema,
+  values,
+  namespace,
+  keyPath,
+}: {
+  schema: JsonSchema;
+  values: Record<string, unknown> | null;
+  namespace: string | null;
+  keyPath: string[];
+}) {
+  const properties = schema.properties ?? {};
+  return (
+    <>
+      {Object.entries(properties).map(([key, prop]) => {
+        const path = [...keyPath, key];
+        const value =
+          values && Object.hasOwn(values, key) ? values[key] : undefined;
+        const nested =
+          declaredType(prop) === "object" || isObject(prop.properties);
+        if (nested) {
+          return (
+            <div
+              key={path.join(".")}
+              className="border-b border-(--border) px-3 py-2 last:border-b-0"
+            >
+              <div className="mono mb-1 text-[12px] text-(--text)">
+                {prop.title ?? key}
+              </div>
+              {prop.description && (
+                <div className="mb-1 text-xs text-(--text-faint)">
+                  {prop.description}
+                </div>
+              )}
+              <div className="overflow-hidden rounded border border-(--border)">
+                <SchemaFields
+                  schema={prop}
+                  values={isObject(value) ? value : null}
+                  namespace={namespace}
+                  keyPath={path}
+                />
+              </div>
+            </div>
+          );
+        }
+        const usingDefault = isDefaultValue(value, prop.default);
+        return (
+          <div
+            key={path.join(".")}
+            className="grid min-w-0 gap-2 border-b border-(--border) px-3 py-2 last:border-b-0 md:grid-cols-[minmax(10rem,0.8fr)_minmax(12rem,1.4fr)]"
+          >
+            <div className="min-w-0">
+              <div className="mono break-words text-[12px] text-(--text)">
+                {prop.title ?? key}
+              </div>
+              {usingDefault && value !== undefined && (
+                <span className="mt-0.5 inline-block text-[10px] tracking-wide text-(--text-faint) uppercase">
+                  default
+                </span>
+              )}
+            </div>
+            <div className="min-w-0 overflow-x-auto">
+              <FieldValue
+                schema={prop}
+                value={value}
+                namespace={namespace}
+                keyPath={path}
+              />
+              {prop.description && (
+                <div className="mt-1 text-xs text-(--text-faint)">
+                  {prop.description}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+/** Collect `title` and `description` of every property, for Settings search. */
+export function schemaSearchText(
+  schema: JsonSchema | null | undefined,
+): string {
+  const acc: string[] = [];
+  const walk = (node: JsonSchema | undefined) => {
+    if (!node?.properties) return;
+    for (const prop of Object.values(node.properties)) {
+      if (typeof prop.title === "string") acc.push(prop.title);
+      if (typeof prop.description === "string") acc.push(prop.description);
+      walk(prop);
+    }
+  };
+  walk(schema ?? undefined);
+  return acc.join("\n");
+}
+
+export function SchemaForm({
+  schema,
+  values,
+  namespace,
+}: {
+  schema: JsonSchema | null;
+  values: Record<string, unknown> | null;
+  namespace?: string | null;
+}) {
+  const properties = schema?.properties ?? {};
+  const keys = Object.keys(properties);
+  if (!schema || keys.length === 0) {
+    return (
+      <div className="px-3 py-2 text-xs text-(--text-faint)">
+        No values set and the schema declares no defaults.
+      </div>
+    );
+  }
+  return (
+    <div data-testid="schema-form">
+      <SchemaFields
+        schema={schema}
+        values={values}
+        namespace={namespace ?? null}
+        keyPath={[]}
+      />
+    </div>
+  );
+}

--- a/event-runtime/web/src/views/Settings.test.tsx
+++ b/event-runtime/web/src/views/Settings.test.tsx
@@ -77,7 +77,11 @@ const fixture: ConfigView = {
       entries: [
         {
           key: "mobile",
-          value: { simulator: "iPhone-16", apiToken: "[redacted]" },
+          value: {
+            simulator: "iPhone-16",
+            apiToken: { set: true, source: "env" },
+            pollEvery: "30s",
+          },
           reload: "restart",
           note: "wattmind/mobile@1.0.0",
         },
@@ -98,11 +102,29 @@ const fixture: ConfigView = {
           schema: {
             type: "object",
             properties: {
-              simulator: { type: "string", description: "simulator name" },
-              apiToken: { type: "string" },
+              simulator: {
+                type: "string",
+                title: "Simulator",
+                description: "simulator name",
+              },
+              apiToken: {
+                type: "string",
+                format: "secret",
+                title: "API token",
+                description: "operator credential",
+              },
+              pollEvery: {
+                type: "string",
+                format: "duration",
+                title: "Poll interval",
+              },
             },
           },
-          values: { simulator: "iPhone-16", apiToken: "[redacted]" },
+          values: {
+            simulator: "iPhone-16",
+            apiToken: { set: true, source: "env" },
+            pollEvery: "30s",
+          },
           anomaly: null,
         },
         {
@@ -220,23 +242,26 @@ describe("Settings", () => {
         .getAttribute("aria-current"),
     ).toBe("page");
 
-    // A loaded extension: name, namespace, and its redacted effective values.
+    // A loaded extension: name, namespace, titles, and typed widgets.
     expect(view.getByText("wattmind/mobile")).toBeTruthy();
     expect(view.getByText("mobile")).toBeTruthy();
-    expect(view.getByText("simulator")).toBeTruthy();
+    expect(view.getByText("Simulator")).toBeTruthy();
     expect(view.getByText("iPhone-16")).toBeTruthy();
-    expect(view.getByText("[redacted]")).toBeTruthy();
+    expect(view.getByText("FACTORY_EXT_MOBILE_API_TOKEN")).toBeTruthy();
+    expect(view.queryByText("[redacted]")).toBeNull();
     expect(view.getByText("simulator name")).toBeTruthy();
+    expect(view.getByText("30 seconds")).toBeTruthy();
     expect(view.getAllByText("restart").length).toBeGreaterThan(0);
 
-    // A disabled one: its anomaly, and no values table.
+    // A disabled one: its anomaly replaces the form.
     const disabled = view.getByText(/disabled/);
     expect(disabled.textContent).toContain("$.maxParallel: above maximum 4");
     expect(view.queryByText("wattmind/broken")).toBeTruthy();
-    // Nothing is editable: read-only inventory.
-    expect(
-      view.container.querySelectorAll("input, select, textarea").length,
-    ).toBe(1);
+    // Nothing is editable: search is the only enabled control.
+    const enabled = [
+      ...view.container.querySelectorAll("input, select, textarea"),
+    ].filter((el) => !(el as HTMLInputElement).disabled);
+    expect(enabled.length).toBe(1);
   });
 
   test("searches extension values like any other section", async () => {
@@ -253,6 +278,23 @@ describe("Settings", () => {
       expect(view.getByRole("heading", { name: "Extensions" })).toBeTruthy(),
     );
     expect(view.getByText("iPhone-16")).toBeTruthy();
+    expect(view.queryByText("wattmind/broken")).toBeNull();
+  });
+
+  test("searches extension property titles and descriptions", async () => {
+    stubConfig();
+    const view = renderWithClient(<StatefulSettings initial="repos" />);
+    await view.findByText("factory.tools.base");
+    act(() =>
+      changeInput(
+        view.getByRole("combobox", { name: "Search settings" }),
+        "operator credential",
+      ),
+    );
+    await waitFor(() =>
+      expect(view.getByRole("heading", { name: "Extensions" })).toBeTruthy(),
+    );
+    expect(view.getByText("wattmind/mobile")).toBeTruthy();
     expect(view.queryByText("wattmind/broken")).toBeNull();
   });
 });

--- a/event-runtime/web/src/views/Settings.tsx
+++ b/event-runtime/web/src/views/Settings.tsx
@@ -8,6 +8,11 @@ import {
   type ConfigSection,
 } from "../api";
 import { FilterInput } from "../components/ui";
+import {
+  SchemaForm,
+  schemaSearchText,
+  type JsonSchema,
+} from "../components/SchemaForm";
 import { EMPTY } from "../format";
 import { refetchIntervals } from "../hooks";
 
@@ -104,18 +109,14 @@ function extensionKey(ext: ConfigExtension): string {
   return ext.namespace ?? ext.name ?? ext.path;
 }
 
-function schemaDescriptions(
-  schema: ConfigExtension["schema"],
-): Record<string, string> {
-  const properties = (schema?.properties ?? {}) as Record<
-    string,
-    { description?: unknown }
-  >;
-  return Object.fromEntries(
-    Object.entries(properties).flatMap(([key, prop]) =>
-      typeof prop?.description === "string" ? [[key, prop.description]] : [],
-    ),
-  );
+function extensionHaystack(ext: ConfigExtension): string {
+  return [
+    ext.name ?? "",
+    ext.namespace ?? "",
+    ext.path,
+    ext.anomaly ?? "",
+    schemaSearchText(ext.schema as JsonSchema | null),
+  ].join("\n");
 }
 
 /**
@@ -130,8 +131,6 @@ function ExtensionRow({
   section: ConfigSection;
   ext: ConfigExtension;
 }) {
-  const descriptions = schemaDescriptions(ext.schema);
-  const values = ext.values ? Object.entries(ext.values) : [];
   return (
     <div className="border-b border-(--border) last:border-b-0">
       <div className="flex min-w-0 flex-wrap items-center gap-2 px-3 py-2.5">
@@ -183,37 +182,11 @@ function ExtensionRow({
       ) : (
         <>
           <div className="mx-3 mb-2 overflow-hidden rounded border border-(--border) bg-(--surface-1)">
-            {values.length === 0 ? (
-              <div className="px-3 py-2 text-xs text-(--text-faint)">
-                No values set and the schema declares no defaults.
-              </div>
-            ) : (
-              values.map(([key, value]) => {
-                const shown = displayValue(value);
-                return (
-                  <div
-                    key={key}
-                    className="grid min-w-0 gap-2 border-b border-(--border) px-3 py-2 last:border-b-0 md:grid-cols-[minmax(10rem,0.8fr)_minmax(12rem,1.4fr)]"
-                  >
-                    <div className="mono min-w-0 break-words text-[12px] text-(--text)">
-                      {key}
-                    </div>
-                    <div className="min-w-0 overflow-x-auto">
-                      <pre
-                        className={`mono w-max min-w-full whitespace-pre text-[12px] ${shown === EMPTY ? "text-(--text-faint)" : "text-(--text-dim)"}`}
-                      >
-                        {shown}
-                      </pre>
-                      {descriptions[key] && (
-                        <div className="mt-1 text-xs text-(--text-faint)">
-                          {descriptions[key]}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              })
-            )}
+            <SchemaForm
+              schema={ext.schema as JsonSchema | null}
+              values={ext.values}
+              namespace={ext.namespace}
+            />
           </div>
           {ext.schema && (
             <details className="mx-3 mb-2.5 text-xs text-(--text-faint)">
@@ -264,11 +237,15 @@ export function Settings({
       .map((section) => ({
         ...section,
         entries: needle
-          ? section.entries.filter((entry) =>
-              `${entry.key}\n${displayValue(entry.value)}`
+          ? section.entries.filter((entry) => {
+              const ext = section.extensions?.find(
+                (item) => extensionKey(item) === entry.key,
+              );
+              const extra = ext ? extensionHaystack(ext) : "";
+              return `${entry.key}\n${displayValue(entry.value)}\n${extra}`
                 .toLowerCase()
-                .includes(needle),
-            )
+                .includes(needle);
+            })
           : section.entries,
       }))
       .filter((section) => !needle || section.entries.length > 0);


### PR DESCRIPTION
## Summary
- Add a closed `format` keyword (`secret`, `uri`, `channel-id`, `ticket`, `duration`, `multiline`, `email`) to the runtime JSON Schema subset; unknown values fail closed, with extra validation only for `uri` and `duration`.
- Resolve `format: secret` from `FACTORY_EXT_<NAMESPACE>_<KEY>` (process env, then `~/.factory/secrets.env`); a secret in `policy.yaml` disables the extension. `/config` publishes `{ set, source }` instead of a value; `getExtensionConfig()` still returns the secret to extension code; `redactSecrets` remains the key-name fallback.
- Render extension settings with a read-only `SchemaForm` (titles, help, typed widgets, search over property title/description). Built-in Settings sections should migrate onto the same shape later: WM-924.

Fixes WM-920

UX critique: required — SHIP
Evidence: http://127.0.0.1:7451/#/settings/extensions (factory/sample SchemaForm driven in-browser; secrets shown as unset, never a value)

## Test plan
- [ ] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/schema.test.mjs event-runtime/lib/extensions.test.mjs event-runtime/lib/api-config.test.mjs && cd event-runtime/web && bun run test -- src/views/Settings.test.tsx src/components/SchemaForm.test.tsx && cd ../.. && bun run lint && bun run check`
- [ ] Open Settings → Extensions with an extension that declares `format` properties; confirm widgets, unset secret badge, and search by title/description
- [ ] Confirm a secret in `policy.yaml` disables the extension and names `FACTORY_EXT_…`


Made with [Cursor](https://cursor.com)