### PR TITLE
feat(merge): add review ledger and per-PR merge-review fan-out (WM-907)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -15,6 +15,7 @@ chain_auto_approval:
     - factory.dispatch.requested
     # Autonomous merge lifecycle. Mutating stages are independently rechecked.
     - factory.merge.requested
+    - factory.merge-review.requested
     - factory.merge-fix.requested
     - factory.merge-apply.requested
     - factory.merge-landed

--- a/docs/merge-lane.md
+++ b/docs/merge-lane.md
@@ -1,0 +1,49 @@
+# Merge lane
+
+The factory merge lane reviews open base-targeting PRs, applies mechanical
+fixes, and lands at most one PR per base-CI cycle. This document is the v3
+shape (WM-907 / WM-906): a durable review ledger plus per-PR reviews, with
+landing still serialized until part 2.
+
+## Flow
+
+1. **`factory.merge.requested`** → `merge-scan@2` (command enumerator).
+   Lists open, non-draft, base-targeting PRs with live head/base SHAs. Looks
+   each `(github, pr, headSha, baseSha)` up in `merge_reviews`. Emits
+   `reviews[]` for ledger **misses** only. A selected scan (`prNumbers`)
+   forces a review even on a hit. Stub `plan[]` is today's single lowest
+   MERGE candidate already in the ledger, so one PR can still land per cycle.
+2. **`factory.merge-review.requested`** → `merge-review@1` (agy, one PR).
+   The body of the old batch merge-scan: same rubric, same CI proof resolver,
+   same refusal semantics. Writes `factory.merge-review/v1`. On COMPLETED the
+   worker upserts `merge_reviews`. FIX and ESCALATE chain immediately; MERGE
+   is recorded for the enumerator's plan stub.
+3. **`factory.merge-fix.requested`** → `merge-fix@1`. On `UPDATED`, chains to
+   `factory.merge-review.requested` for that PR's new head — not a full scan.
+4. **`factory.merge-apply.requested`** / landed / verify are unchanged.
+
+A second scheduled tick with no SHA movement emits **zero** review runs: every
+open PR is a ledger hit, so `reviews[]` is empty and the command enumerator
+returns in seconds.
+
+## Ledger
+
+Table `merge_reviews` in `runtime.db`, keyed
+`(github, pr, head_sha, base_sha)`. A moved head is a miss. Columns:
+
+| column           | meaning                                        |
+| ---------------- | ---------------------------------------------- |
+| `verdict`        | `MERGE` \| `FIX` \| `ESCALATE`                 |
+| `findings_json`  | reviewer findings                              |
+| `fix_json`       | the `fix[]` item shape merge-scan used to emit |
+| `plan_json`      | the per-PR plan assertions a MERGE needs       |
+| `policy_version` | run policy pin                                 |
+| `run_id`         | the `merge-review@1` run that wrote the row    |
+| `reviewed_at`    | ISO time                                       |
+
+Helpers: `event-runtime/lib/merge-reviews.mjs`.
+
+## Out of scope (part 2)
+
+Batching and parallel landing. Until that lands, the enumerator still emits at
+most one `merge-apply.requested` from the ledger's lowest MERGE candidate.

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -1,0 +1,28 @@
+{
+  "id": "merge-review",
+  "version": 1,
+  "prompt": "agents/merge-review.md",
+  "input_schema": "schemas/merge-review.input.json",
+  "output_schema": "schemas/merge-review.output.json",
+  "output_contract": "factory.merge-review/v1",
+  "model_tier": "standard",
+  "workspace": {
+    "type": "repository",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": ["gh:read", "linear:read", "repo:read"]
+  },
+  "limits": {
+    "timeout_seconds": 300,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/merge-review.md": "sha256:285105f51813a31f81e3dc9af56bb45ad4c97ce91d3f178464d6c79d8362bf89",
+    "schemas/merge-review.input.json": "sha256:e64c8725e8ed715cdfcb261527c67f3424d140faba5d525d9aad20269f5dc0fc",
+    "schemas/merge-review.output.json": "sha256:987433ffbb39d935d42090eb62e63ece917a36b38fc849a6c5bfa27a26c898f8"
+  }
+}

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -20,6 +20,16 @@
     "attempts": 1
   },
   "mutating": false,
+  "memos": [
+    {
+      "subject": {
+        "type": "repo",
+        "id": "$.input.repo"
+      },
+      "kinds": ["decision"],
+      "max": 10
+    }
+  ],
   "pins": {
     "agents/merge-review.md": "sha256:285105f51813a31f81e3dc9af56bb45ad4c97ce91d3f178464d6c79d8362bf89",
     "schemas/merge-review.input.json": "sha256:e64c8725e8ed715cdfcb261527c67f3424d140faba5d525d9aad20269f5dc0fc",

--- a/event-runtime/agents/merge-review.md
+++ b/event-runtime/agents/merge-review.md
@@ -1,0 +1,222 @@
+# merge-review — independent cold review of exactly one PR
+
+You are an independent cold reviewer. You did not write or fix this PR in this
+run. `./input.json` names one `{repo, github, base, pr, headSha, baseSha}`. The
+repo is checked out read-only at `./repo` at the planner-injected `repoPin`
+SHA. Read `./repo/config/repos.yaml` and `./repo/config/policy.yaml` from that
+pinned snapshot. Review exactly the named PR — do not enumerate the open-PR
+set and do not add newer, related, or otherwise open PRs.
+
+Resolve the numbered PR directly, including a number absent from an open-PR
+listing. A PR that is missing, closed, draft, or targets a base other than the
+configured base fails this review closed. Write a schema-valid refusal with
+`terminalState: "refused"` and `reasonCode: "needs_human"`, with evidence
+clearly naming whether it is missing, closed, draft, or wrong-base. Do not
+emit a merge-plan artifact, FIX request, or merge candidate when the target is
+invalid. This whole-run refusal is the explicit human escalation; never
+silently skip an invalid selected PR.
+
+Never modify the checkout, GitHub, or Linear. Write only `./result.json` in the
+workspace root.
+
+If either pinned config file is missing or unreadable, or the named repo's
+configuration is missing or malformed, fail closed with this complete result
+and stop:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "refused",
+  "reasonCode": "needs_human"
+}
+```
+
+Record the live `headRefOid` and the current base ref SHA. Read the complete
+diff, PR body, every review, required checks, and the full Linear ticket plus
+comments. Require a valid structured Handoff, diff containment in Owned Paths,
+mergeability, non-draft state, real required CI, behavior correctness, and
+falsifiable regression tests. Green CI alone is never MERGE.
+
+Resolve the CI gate mechanically for the pinned head SHA with the supported
+PR-level command and the checked-in resolver. Capture status and combined
+output from exactly:
+
+```sh
+required_status=0
+required_output=$(gh pr checks "$pr" --repo "$github" --required --json name,bucket,state 2>&1) || required_status=$?
+required=$(printf '%s' "$required_output" | bun "$FACTORY_ROOT/event-runtime/lib/merge-ci-proof.mjs" resolve-required-contexts "$required_status" "$headRef")
+```
+
+`FACTORY_ROOT` is injected by the Factory adapter and names the running Factory
+runtime checkout, independently of the selected target checkout at `./repo`.
+Never look for this helper inside the target repository. A resolver failure is
+ESCALATE. Do not query
+`repos/{owner}/{repo}/branches/{branch}/protection` or any other
+branch-protection endpoint: an unavailable feature response such as HTTP 403 is
+not required-context evidence and cannot override the supported PR-level
+result. Status 0 with a valid nonempty list of unique contexts whose names are
+nonempty is authoritative. Status 1 with exactly
+`no required checks reported on the '<headRef>' branch` resolves to an explicit
+empty list. Any other nonzero status, unexpected diagnostic, malformed JSON,
+empty list, empty/invalid name, or duplicate name fails closed. These are the
+same status/output rules enforced again by merge-apply.
+
+When the resolver returns a nonempty list, prove every returned check is
+`bucket: pass` and `state: SUCCESS` on `headRefOid`. When it returns an empty
+list, load `merge_ci.workflow` and the unique nonempty
+`merge_ci.required_checks` from this repo's `config/repos.yaml` entry. Missing
+or malformed config is ESCALATE, never an empty green set. For the configured
+fallback, locate the one unambiguous pull-request run of that exact workflow at
+`headRefOid`, inspect its jobs, and prove exactly one job with each configured
+name is `completed` / `success` (the same contract as
+`proveMergeCiFallback` in the checked-in helper). Re-read the head SHA after
+collecting evidence. Empty, missing, duplicate, pending, neutral, skipped,
+cancelled, stale-SHA, wrong-workflow, API-error, or otherwise ambiguous
+evidence fails closed. Never substitute all currently visible checks for
+either authoritative set; that recreates the early auxiliary-check race.
+
+ESCALATE is for conditions a human must decide, and nothing else: auth/authz,
+money movement, credentials/secrets, destructive migrations, production
+infrastructure, CLNT security behavior, any `escalate_paths` match, product
+ambiguity in the diff itself, `main`/`master`, the configured deploy branch,
+and a fix whose next round would exceed `merge.max_fix_rounds`. Existing
+draft/escalated holds stay held and are summarized.
+
+Operational conditions are FIX, never ESCALATE (WM-679). They are mechanical
+and merge-fix already performs them:
+
+- CONFLICTING, or behind base → FIX, finding `rebase_onto_base`.
+- Green only on an old SHA, or no run at `headRefOid` → FIX, finding
+  `rerun_ci_at_head` (rebase first if behind, then a fresh run). The evidence
+  is not uncertain; it is old.
+- A red `Verify` whose only failing step is `Formatting check (prettier)` or
+  `Lint (eslint)`, or whose complete failing-test set consists only of eslint
+  diagnostics → FIX, finding exactly `format_and_lint`. Inspect the failed job
+  steps and logs; an umbrella `Verify` name alone is not enough. This is an
+  auto-format operational condition, never ESCALATE and never a review FIX
+  that parks the PR. Mixed failures use their ordinary finding instead.
+- A red check on a test the PR does not touch, where the same test is also red
+  on the base branch at the merge-base SHA → this is base red, not the PR. Do
+  not escalate the PR. Emit one `CI RED` item for the base (once per base SHA,
+  not per PR) and hold the PR as FIX pending base green, finding
+  `base_red:<test>`.
+- A red test outside the PR's Owned Paths that the PR's own change caused (an
+  expectation its refactor invalidated) → FIX, with the Owned Paths deviation
+  named in the finding so merge-fix updates the expectation and records the
+  deviation on the ticket. Being outside scope alone is not a reason to stop.
+
+A FIX may auto-dispatch only when it is mechanical and its next round is at
+most `merge.max_fix_rounds` (2). Read PR comments for
+`factory-merge-fix round=<n> finding=<hash>` markers. Set the next round and
+SHA-256 hash of the exact finding. Exhausted rounds, security findings, and
+genuine product ambiguity are ESCALATE. `format_and_lint` is the deterministic
+exception: its separate
+`factory-merge-fix mechanical=format_and_lint finding=<hash>` marker does not
+consume or increment `max_fix_rounds`; after its fresh verification/CI, scan
+the PR from scratch. In the fast lane, formatting- or eslint-only red means
+auto-fix then re-evaluate every lane criterion, not disqualification.
+
+Fail closed only on what truly cannot be evidenced — GitHub or Linear API
+errors, malformed config, an unresolvable base SHA — and record those as
+`noopReason` for the next tick, not as a per-PR human escalation.
+
+Populate `escalate`, `fix`, and `plan` for this one PR only. Include an
+eligible mechanical fix in `fix`, and put a MERGE candidate in `plan` so the
+enumerator can pick today's single lowest-PR merge. The `verdict` is exactly
+MERGE, FIX, or ESCALATE. Every plan boolean is a positive assertion from your
+review; the schema rejects anything weaker. Include `base`, `deployBranch`,
+head/base SHA, and exact head branch. A moved SHA requires a new review.
+
+## Result envelope
+
+`./result.json` must always be a `factory.agent-result/v1` wrapper. On a
+completed review, put the complete `factory.merge-review/v1` artifact under
+`artifact`, never at the wrapper root:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "verdict": "ESCALATE",
+    "repo": "factory",
+    "github": "watt-mind/factory",
+    "base": "develop",
+    "deployBranch": "master",
+    "pr": 514,
+    "headSha": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "baseSha": "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b",
+    "headRef": "feat/WM-514",
+    "ticket": "WM-514",
+    "plan": [],
+    "fix": [],
+    "escalate": [
+      {
+        "pr": 514,
+        "headSha": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "ticket": "WM-514",
+        "reason": "Touches credentials handling; needs human."
+      }
+    ],
+    "findings": [],
+    "summary": "PR #514 needs a human."
+  },
+  "evidence": {
+    "commands": []
+  }
+}
+```
+
+Never omit `terminalState`. For any refusal, use the fail-closed wrapper shown
+above rather than writing a partial review. An invalid-target refusal must
+additionally include the evidence required above.
+
+## Output shape (exact)
+
+`plan`, `fix`, `escalate` items use exactly these property names — never
+`title`, `headRefName`, or other GitHub API names.
+
+`plan` item (present only on MERGE):
+<!-- prettier-ignore -->
+```json
+{ "pr": 512, "headSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "baseSha": "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b",
+  "headRef": "fix/wm-512-thing", "ticket": "WM-512", "action": "merge_pr", "reason": "Green CI, in Owned Paths, falsifiable tests.",
+  "checksGreen": true, "mergeable": true, "ownedPathsValid": true, "handoffValid": true, "testsFalsifiable": true,
+  "policySafe": true, "sensitive": false, "ambiguous": false }
+```
+
+`fix` item:
+<!-- prettier-ignore -->
+```json
+{ "pr": 513, "headSha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3", "baseSha": "2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c",
+  "headRef": "fix/wm-513-thing", "ticket": "WM-513", "finding": "rebase_onto_base",
+  "findingHash": "6e27a6319dc7dcc61478b9b5214e7390843aa7210328f7299f0768394922ae62",
+  "round": 1, "mechanical": true, "withinOwnedPaths": true, "ownedPaths": ["event-runtime/lib/worker.mjs"] }
+```
+
+`fix.ownedPaths` is the **ticket's Owned Paths list, verbatim** (or a subset of
+it) — never the list of files the PR touched. The planner refuses a fix whose
+`ownedPaths` contains anything outside the ticket's Owned Paths
+(`merge_fix_owned_paths_moved`), so listing PR-touched files parks the fix. If
+the PR itself changed files outside its ticket's Owned Paths, that is a review
+finding for `fix` (deviation) with `ownedPaths` still equal to the ticket's
+list, or an `escalate` item — not a wider `ownedPaths`. Emit **one** `fix`
+item (merge the findings into one `finding` string, keep the most severe
+first); several fix items for the same PR only race each other
+(`merge_fix_run_active`).
+
+`escalate` item — exactly `pr`, `headSha`, `ticket`, `reason` (no `title`/`headRefName`/`headRef`):
+<!-- prettier-ignore -->
+```json
+{ "pr": 514, "headSha": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "ticket": "WM-514", "reason": "Touches credentials handling; needs human." }
+```
+
+Checklist before writing `./result.json`: `additionalProperties` are
+rejected everywhere; the `plan`/`fix`/`escalate` item needs its own
+40-char hex `headSha`; write the result file even on refusal — the
+fail-closed wrapper above, never an unwritten `./result.json`.
+
+After producing the artifact, do nothing else. In particular, never approve,
+merge, push, mark Done, or delete a branch.

--- a/event-runtime/agents/merge-review.view.json
+++ b/event-runtime/agents/merge-review.view.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "title": "Merge review",
+  "summary": "/summary",
+  "status": {
+    "path": "/verdict",
+    "tone": {
+      "MERGE": "ok",
+      "FIX": "warn",
+      "ESCALATE": "error"
+    }
+  },
+  "sections": [
+    {
+      "path": "/plan",
+      "as": "table",
+      "label": "Merge",
+      "columns": ["pr", "ticket", "headRef", "reason"],
+      "formats": {
+        "pr": "pr",
+        "ticket": "issue",
+        "headSha": "sha",
+        "baseSha": "sha"
+      },
+      "expand": ["headSha", "baseSha", "sensitive", "ambiguous"]
+    },
+    {
+      "path": "/fix",
+      "as": "table",
+      "label": "Fix",
+      "columns": ["pr", "ticket", "round", "mechanical", "finding"],
+      "formats": {
+        "pr": "pr",
+        "ticket": "issue",
+        "round": "count",
+        "headSha": "sha",
+        "baseSha": "sha"
+      },
+      "tone": {
+        "mechanical": { "true": "ok", "false": "warn" },
+        "withinOwnedPaths": { "true": "ok", "false": "error" }
+      },
+      "expand": [
+        "headRef",
+        "headSha",
+        "baseSha",
+        "withinOwnedPaths",
+        "ownedPaths",
+        "findingHash"
+      ]
+    },
+    {
+      "path": "/escalate",
+      "as": "table",
+      "label": "Escalate",
+      "columns": ["pr", "ticket", "reason"],
+      "formats": { "pr": "pr", "ticket": "issue", "headSha": "sha" },
+      "expand": ["headSha"]
+    },
+    {
+      "path": "/findings",
+      "as": "list",
+      "label": "Findings"
+    },
+    {
+      "path": "",
+      "as": "keyvalue",
+      "label": "PR",
+      "keys": [
+        "repo",
+        "github",
+        "base",
+        "deployBranch",
+        "pr",
+        "ticket",
+        "headRef"
+      ],
+      "formats": { "repo": "repo", "pr": "pr", "ticket": "issue" }
+    }
+  ]
+}

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -5,18 +5,22 @@
   "input_schema": "schemas/merge-scan.input.json",
   "output_schema": "schemas/merge-scan.output.json",
   "output_contract": "factory.merge-plan/v2",
-  "model_tier": "standard",
+  "command": [
+    "bun",
+    "{factoryRoot}/event-runtime/lib/merge-reviews.mjs",
+    "scan"
+  ],
+  "writesResult": true,
   "workspace": {
-    "type": "repository",
-    "checkoutDir": "repo",
+    "type": "ephemeral",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["gh:read", "linear:read", "repo:read"]
+    "services": ["gh:read"]
   },
   "limits": {
-    "timeout_seconds": 1500,
+    "timeout_seconds": 120,
     "attempts": 1
   },
   "mutating": false,
@@ -31,8 +35,8 @@
     }
   ],
   "pins": {
-    "agents/merge-scan.md": "sha256:3b2d898c29bd0d95eda7b3c942c66cf1226020933dd9d937fd0e7c07d77d98b4",
+    "agents/merge-scan.md": "sha256:cbedecd2f5c02aa4a81c71ec14b6d57ec358f4a05ecc8df61252acb2204f601b",
     "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
-    "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
+    "schemas/merge-scan.output.json": "sha256:7da0007262077e89f63ebb5a9627137ef64b6e48733593eea0bf08a69c7ce398"
   }
 }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -1,15 +1,24 @@
-# merge-scan — independent cold review and one-PR merge planning
+# merge-scan — ledger enumerator (not a reviewer)
 
-You are an independent cold reviewer. You did not write or fix any PR in this
-run. `./input.json` names a configured repo and contains a planner-injected
-`repoPin` with the exact commit SHA materialized for this run. The repo is
-checked out read-only at `./repo` at that SHA. Read
-`./repo/config/repos.yaml` and `./repo/config/policy.yaml` from that pinned
-snapshot. When `prNumbers` is absent, enumerate **all** open PRs and classify
-every base-targeting, non-draft PR as exactly MERGE, FIX, or ESCALATE. When
-`prNumbers` is present, review exactly those PR numbers in the listed repo — do
-not enumerate the open-PR set and do not add newer, related, or otherwise open
-PRs to the scan. Selected scans must stay O(the number selected), normally O(1).
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+bun {factoryRoot}/event-runtime/lib/merge-reviews.mjs scan
+```
+
+The command reads `./input.json` and writes `./result.json`. It lists open PRs
+via the forge, looks each `(github, pr, headSha, baseSha)` up in the
+`merge_reviews` ledger, and emits `reviews[]` only for misses. A selected scan
+(`prNumbers`) forces a review even on a ledger hit. The stub `plan[]` is today's
+single lowest MERGE candidate already in the ledger so the lane still lands one
+PR per cycle until merge-lane v3 part 2 batches landing.
+
+When `prNumbers` is absent, enumerate **all** open PRs and consider every
+base-targeting, non-draft PR. When `prNumbers` is present, review exactly those
+PR numbers in the listed repo — do not enumerate the open-PR set and do not add
+newer, related, or otherwise open PRs to the scan. Selected scans must stay
+O(the number selected), normally O(1).
 
 Resolve every selected number directly, including numbers absent from an
 open-PR listing. A selected PR that is missing, closed, draft, or targets a
@@ -21,12 +30,14 @@ emit a merge-plan artifact, FIX request, or merge candidate when any selected
 target is invalid. This whole-run refusal is the explicit human escalation;
 never silently skip an invalid selected number.
 
+Transient forge errors (list/view/base SHA) complete as `NOOP` with a summary
+naming the error, not as a per-PR human escalation — the next tick retries.
+
 Never modify the checkout, GitHub, or Linear. Write only `./result.json` in the
 workspace root.
 
-If either pinned config file is missing or unreadable, or the named repo's
-configuration is missing or malformed, fail closed with this complete result
-and stop:
+If the named repo's configuration is missing or malformed, fail closed with
+this complete result and stop:
 
 ```json
 {
@@ -35,114 +46,6 @@ and stop:
   "reasonCode": "needs_human"
 }
 ```
-
-For every PR record the live `headRefOid` and the current base ref SHA. Read the
-complete diff, PR body, every review, required checks, and the full Linear
-ticket plus comments. Require a valid structured Handoff, diff containment in
-Owned Paths, mergeability, non-draft state, real required CI, behavior
-correctness, and falsifiable regression tests. Green CI alone is never MERGE.
-
-Resolve the CI gate mechanically for each pinned head SHA with the supported
-PR-level command and the checked-in resolver. Capture status and combined
-output from exactly:
-
-```sh
-required_status=0
-required_output=$(gh pr checks "$pr" --repo "$github" --required --json name,bucket,state 2>&1) || required_status=$?
-required=$(printf '%s' "$required_output" | bun "$FACTORY_ROOT/event-runtime/lib/merge-ci-proof.mjs" resolve-required-contexts "$required_status" "$headRef")
-```
-
-`FACTORY_ROOT` is injected by the Factory adapter and names the running Factory
-runtime checkout, independently of the selected target checkout at `./repo`.
-Never look for this helper inside the target repository. A resolver failure is
-ESCALATE. Do not query
-`repos/{owner}/{repo}/branches/{branch}/protection` or any other
-branch-protection endpoint: an unavailable feature response such as HTTP 403 is
-not required-context evidence and cannot override the supported PR-level
-result. Status 0 with a valid nonempty list of unique contexts whose names are
-nonempty is authoritative. Status 1 with exactly
-`no required checks reported on the '<headRef>' branch` resolves to an explicit
-empty list. Any other nonzero status, unexpected diagnostic, malformed JSON,
-empty list, empty/invalid name, or duplicate name fails closed. These are the
-same status/output rules enforced again by merge-apply.
-
-When the resolver returns a nonempty list, prove every returned check is
-`bucket: pass` and `state: SUCCESS` on `headRefOid`. When it returns an empty
-list, load `merge_ci.workflow` and the unique nonempty
-`merge_ci.required_checks` from this repo's `config/repos.yaml` entry. Missing
-or malformed config is ESCALATE, never an empty green set. For the configured
-fallback, locate the one unambiguous pull-request run of that exact workflow at
-`headRefOid`, inspect its jobs, and prove exactly one job with each configured
-name is `completed` / `success` (the same contract as
-`proveMergeCiFallback` in the checked-in helper). Re-read the head SHA after
-collecting evidence. Empty, missing, duplicate, pending, neutral, skipped,
-cancelled, stale-SHA, wrong-workflow, API-error, or otherwise ambiguous
-evidence fails closed. Never substitute all currently visible checks for
-either authoritative set; that recreates the early auxiliary-check race.
-
-ESCALATE is for conditions a human must decide, and nothing else: auth/authz,
-money movement, credentials/secrets, destructive migrations, production
-infrastructure, CLNT security behavior, any `escalate_paths` match, product
-ambiguity in the diff itself, `main`/`master`, the configured deploy branch,
-and a fix whose next round would exceed `merge.max_fix_rounds`. Existing
-draft/escalated holds stay held and are summarized.
-
-If `memos.json` holds a `decision` memo on this repo (or a related ticket/PR
-subject), the operator has ruled on a related question before. **Cite it** —
-item id, decided-at, option — in the `reason` / `context` of any new
-decision request or escalate item, so the operator sees the precedent and
-can answer faster. A decision memo never lets you MERGE or otherwise
-proceed: only an explicit human authorisation does that, and a memo is
-precedent, not permission.
-
-Operational conditions are FIX, never ESCALATE (WM-679). They are mechanical
-and merge-fix already performs them:
-
-- CONFLICTING, or behind base → FIX, finding `rebase_onto_base`.
-- Green only on an old SHA, or no run at `headRefOid` → FIX, finding
-  `rerun_ci_at_head` (rebase first if behind, then a fresh run). The evidence
-  is not uncertain; it is old.
-- A red `Verify` whose only failing step is `Formatting check (prettier)` or
-  `Lint (eslint)`, or whose complete failing-test set consists only of eslint
-  diagnostics → FIX, finding exactly `format_and_lint`. Inspect the failed job
-  steps and logs; an umbrella `Verify` name alone is not enough. This is an
-  auto-format operational condition, never ESCALATE and never a review FIX
-  that parks the PR. Mixed failures use their ordinary finding instead.
-- A red check on a test the PR does not touch, where the same test is also red
-  on the base branch at the merge-base SHA → this is base red, not the PR. Do
-  not escalate the PR. Emit one `CI RED` item for the base (once per base SHA,
-  not per PR) and hold the PR as FIX pending base green, finding
-  `base_red:<test>`.
-- A red test outside the PR's Owned Paths that the PR's own change caused (an
-  expectation its refactor invalidated) → FIX, with the Owned Paths deviation
-  named in the finding so merge-fix updates the expectation and records the
-  deviation on the ticket. Being outside scope alone is not a reason to stop.
-
-A FIX may auto-dispatch only when it is mechanical and its next round is at
-most `merge.max_fix_rounds` (2). Read PR comments for
-`factory-merge-fix round=<n> finding=<hash>` markers. Set the next round and
-SHA-256 hash of the exact finding. Exhausted rounds, security findings, and
-genuine product ambiguity are ESCALATE. `format_and_lint` is the deterministic
-exception: its separate
-`factory-merge-fix mechanical=format_and_lint finding=<hash>` marker does not
-consume or increment `max_fix_rounds`; after its fresh verification/CI, scan
-the PR from scratch. In the fast lane, formatting- or eslint-only red means
-auto-fix then re-evaluate every lane criterion, not disqualification.
-
-Fail closed only on what truly cannot be evidenced — GitHub or Linear API
-errors, malformed config, an unresolvable base SHA — and record those as
-`noopReason` for the next tick, not as a per-PR human escalation.
-
-Populate `escalate`, `fix`, and `plan` independently per PR: an
-escalated or held PR appears in `escalate` but suppresses only itself, never an
-eligible fix or safe merge for another PR. Include every eligible mechanical
-fix in `fix`, and put exactly one deterministic safe candidate (lowest PR
-number) in `plan` so only one PR can land per base-CI cycle. The legacy
-`recommendation` remains a batch summary using precedence ESCALATE, then FIX,
-then MERGE, then NOOP; it does not suppress any populated action array. Every
-plan boolean is a positive assertion from your review; the schema rejects
-anything weaker. Include `base`, `deployBranch`, head/base SHA, and exact head
-branch. A moved SHA requires a new scan.
 
 ## Result envelope
 
@@ -163,6 +66,7 @@ review):
     "github": "watt-mind/factory",
     "base": "develop",
     "deployBranch": "master",
+    "reviews": [],
     "plan": [],
     "fix": [],
     "escalate": [],
@@ -176,61 +80,11 @@ review):
 ```
 
 Do not place `recommendation`, `repo`, `github`, `base`, `deployBranch`,
-`plan`, `fix`, `escalate`, `summary`, or `noopReason` beside `schemaVersion`;
-all merge-plan fields belong inside `artifact`. Never omit `terminalState`.
-For any refusal, use the fail-closed wrapper shown above rather than writing a
-partial merge plan. A selected-target refusal must additionally include the
-evidence required above.
-
-## Output shape (exact)
-
-`plan`, `fix`, `escalate` items use exactly these property names — never
-`title`, `headRefName`, or other GitHub API names.
-
-`plan` item (≤1, lowest eligible PR):
-<!-- prettier-ignore -->
-```json
-{ "pr": 512, "headSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "baseSha": "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b",
-  "headRef": "fix/wm-512-thing", "ticket": "WM-512", "action": "merge_pr", "reason": "Green CI, in Owned Paths, falsifiable tests.",
-  "checksGreen": true, "mergeable": true, "ownedPathsValid": true, "handoffValid": true, "testsFalsifiable": true,
-  "policySafe": true, "sensitive": false, "ambiguous": false }
-```
-
-`fix` item:
-<!-- prettier-ignore -->
-```json
-{ "pr": 513, "headSha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3", "baseSha": "2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c",
-  "headRef": "fix/wm-513-thing", "ticket": "WM-513", "finding": "rebase_onto_base",
-  "findingHash": "6e27a6319dc7dcc61478b9b5214e7390843aa7210328f7299f0768394922ae62",
-  "round": 1, "mechanical": true, "withinOwnedPaths": true, "ownedPaths": ["event-runtime/lib/worker.mjs"] }
-```
-
-`fix.ownedPaths` is the **ticket's Owned Paths list, verbatim** (or a subset of
-it) — never the list of files the PR touched. The planner refuses a fix whose
-`ownedPaths` contains anything outside the ticket's Owned Paths
-(`merge_fix_owned_paths_moved`), so listing PR-touched files parks the fix. If
-the PR itself changed files outside its ticket's Owned Paths, that is a review
-finding for `fix` (deviation) with `ownedPaths` still equal to the ticket's
-list, or an `escalate` item — not a wider `ownedPaths`. Emit **one** `fix`
-item per PR per scan (merge the findings into one `finding` string, keep the
-most severe first); several fix items for the same PR only race each other
-(`merge_fix_run_active`).
-
-`escalate` item — exactly `pr`, `headSha`, `ticket`, `reason` (no `title`/`headRefName`/`headRef`):
-<!-- prettier-ignore -->
-```json
-{ "pr": 514, "headSha": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-  "ticket": "WM-514", "reason": "Touches credentials handling; needs human." }
-```
-
-`noopReason` (only when `recommendation` is `NOOP`): `no_open_prs` — no open
-PR targets the configured base branch; `all_prs_held` — open PRs exist but
-all are already held/escalated.
-
-Checklist before writing `./result.json`: `additionalProperties` are
-rejected everywhere; every `plan`/`fix`/`escalate` item needs its own
-40-char hex `headSha`; write the result file even on refusal — the
-fail-closed wrapper above, never an unwritten `./result.json`.
+`reviews`, `plan`, `fix`, `escalate`, `summary`, or `noopReason` beside
+`schemaVersion`; all merge-plan fields belong inside `artifact`. Never omit
+`terminalState`. For any refusal, use the fail-closed wrapper shown above
+rather than writing a partial merge plan. A selected-target refusal must
+additionally include the evidence required above.
 
 After producing the artifact, do nothing else. In particular, never approve,
 merge, push, mark Done, or delete a branch.

--- a/event-runtime/agents/merge-scan.view.json
+++ b/event-runtime/agents/merge-scan.view.json
@@ -8,10 +8,24 @@
       "MERGE": "ok",
       "FIX": "warn",
       "ESCALATE": "error",
+      "REVIEW": "warn",
       "NOOP": "neutral"
     }
   },
   "sections": [
+    {
+      "path": "/reviews",
+      "as": "table",
+      "label": "Review",
+      "columns": ["pr", "ticket", "headRef"],
+      "formats": {
+        "pr": "pr",
+        "ticket": "issue",
+        "headSha": "sha",
+        "baseSha": "sha"
+      },
+      "expand": ["headSha", "baseSha"]
+    },
     {
       "path": "/plan",
       "as": "table",

--- a/event-runtime/contracts/factory.merge-review.v1.json
+++ b/event-runtime/contracts/factory.merge-review.v1.json
@@ -1,0 +1,5 @@
+{
+  "title": "factory.merge-review/v1",
+  "$comment": "Alias of schemas/merge-review.output.json — the per-PR cold-review contract (WM-907).",
+  "$ref": "../schemas/merge-review.output.json"
+}

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -161,6 +161,23 @@
     "recommendationField": "recommendation",
     "independent": true,
     "edges": {
+      "REVIEW": {
+        "eventType": "factory.merge-review.requested",
+        "whenItemsField": "reviews",
+        "mixedEventId": "chain-${runId}-review-${item.pr}",
+        "itemsField": "reviews",
+        "itemKey": "pr",
+        "input": {
+          "repo": "$.artifact.repo",
+          "github": "$.artifact.github",
+          "base": "$.artifact.base"
+        },
+        "perItem": {
+          "pr": "$.item.pr",
+          "headSha": "$.item.headSha",
+          "baseSha": "$.item.baseSha"
+        }
+      },
       "MERGE": {
         "eventType": "factory.merge-apply.requested",
         "whenItemsField": "plan",
@@ -209,13 +226,58 @@
       }
     }
   },
+  "merge-review@1": {
+    "recommendationField": "verdict",
+    "independent": true,
+    "edges": {
+      "FIX": {
+        "eventType": "factory.merge-fix.requested",
+        "whenItemsField": "fix",
+        "mixedEventId": "chain-${runId}-fix-${item.pr}-${item.findingHash}",
+        "itemsField": "fix",
+        "itemKey": "ticket",
+        "input": {
+          "repo": "$.artifact.repo",
+          "github": "$.artifact.github",
+          "base": "$.artifact.base"
+        },
+        "perItem": {
+          "pr": "$.item.pr",
+          "headSha": "$.item.headSha",
+          "baseSha": "$.item.baseSha",
+          "headRef": "$.item.headRef",
+          "ticket": "$.item.ticket",
+          "finding": "$.item.finding",
+          "findingHash": "$.item.findingHash",
+          "round": "$.item.round",
+          "mechanical": "$.item.mechanical",
+          "withinOwnedPaths": "$.item.withinOwnedPaths",
+          "ownedPaths": "$.item.ownedPaths"
+        }
+      },
+      "ESCALATE": {
+        "eventType": "factory.merge-escalate.requested",
+        "whenItemsField": "escalate",
+        "mixedEventId": "chain-${runId}-escalate",
+        "input": {
+          "repo": "$.artifact.repo",
+          "summary": "$.artifact.summary"
+        }
+      }
+    }
+  },
   "merge-fix@1": {
     "recommendationField": "outcome",
     "edges": {
       "UPDATED": {
-        "eventType": "factory.merge.requested",
+        "eventType": "factory.merge-review.requested",
         "input": {
-          "repo": "$.artifact.repo"
+          "repo": "$.artifact.repo",
+          "github": "$.input.github",
+          "base": "$.input.base",
+          "pr": "$.artifact.pr",
+          "headSha": "$.artifact.headSha",
+          "baseSha": "$.input.baseSha"
         }
       }
     }

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -115,8 +115,14 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
-    "adapter": "agy",
+    "adapter": "command",
     "idempotencyScope": ["correlationId", "inputHash"],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.merge-review.requested": {
+    "agent": "merge-review@1",
+    "adapter": "agy",
+    "idempotencyScope": ["inputHash"],
     "proposalTtlSeconds": 1800
   },
   "factory.merge-apply.requested": {

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -9,8 +9,10 @@
  * true` definition into the registry at all (lib/registry.mjs).
  *
  * Exit 0 → writes result.json (factory.agent-result/v1) with the resolved
- * command and captured output as the artifact. Nonzero/timeout → no result;
- * the worker records FAILED with `agent_exit_<code>` as usual.
+ * command and captured output as the artifact, unless the definition sets
+ * `writesResult: true` (WM-907): then the command authors result.json and
+ * this adapter does not overwrite it. Nonzero/timeout → no result; the
+ * worker records FAILED with `agent_exit_<code>` as usual.
  *
  * A definition may add a `sandbox` block (WM-185), which moves execution off
  * the host and into a Gondolin microVM: the workspace is mounted read-write
@@ -81,6 +83,7 @@ function killProcessGroup(child, signal = "SIGTERM") {
  * paths so the two can never drift into producing different artifacts.
  */
 function writeResultJson({ workspaceDir, def, argv, output }) {
+  if (def.writesResult) return;
   const captured = def.captureStdout
     ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }]
     : [];

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -135,6 +135,36 @@ describe("execute", () => {
     expect(result.artifact.command.join(" ")).not.toContain("/tmp/pwn");
   });
 
+  test("writesResult leaves a command-authored result.json in place (WM-907)", async () => {
+    const workspaceDir = ws();
+    const script = `import { writeFileSync } from "node:fs";
+writeFileSync("result.json", JSON.stringify({
+  schemaVersion: "factory.agent-result/v1",
+  terminalState: "completed",
+  reasonCode: "ok",
+  artifact: { recommendation: "NOOP", authored: true }
+}) + "\\n");`;
+    const outcome = await execute({
+      spec: spec({}),
+      def: {
+        ref: "merge-scan@2",
+        writesResult: true,
+        command: ["bun", "-e", script],
+      },
+      workspaceDir,
+      timeoutMs: 5000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
+    expect(result.artifact).toEqual({
+      recommendation: "NOOP",
+      authored: true,
+    });
+    expect(result.artifact.command).toBeUndefined();
+  });
+
   test("timeout kills the whole process group, leaving no orphaned grandchildren (OPS-411)", async () => {
     const workspaceDir = ws();
     const pidFile = path.join(workspaceDir, "grandchild.pid");

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -25,6 +25,7 @@ export const CHAIN_AUTO_APPROVAL_EVENT_TYPES = new Set([
   "factory.triage-apply.requested",
   "factory.dispatch.requested",
   "factory.merge.requested",
+  "factory.merge-review.requested",
   "factory.merge-fix.requested",
   "factory.merge-apply.requested",
   "factory.merge-landed",
@@ -638,6 +639,7 @@ function mergeEligibility(db, registry, candidate, envelope, policy, now) {
 
   if (
     envelope.type === "factory.merge.requested" ||
+    envelope.type === "factory.merge-review.requested" ||
     envelope.type === "factory.merge-escalate.requested"
   ) {
     return null;

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -35,6 +35,7 @@ export const CHAIN_AUTO_APPROVAL_EVENT_TYPES = new Set([
 
 const MERGE_EVENT_TYPES = new Set([
   "factory.merge.requested",
+  "factory.merge-review.requested",
   "factory.merge-fix.requested",
   "factory.merge-apply.requested",
   "factory.merge-landed",

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -228,7 +228,12 @@ const independentMergeRegistry = ({
               ...edge,
               whenItemsField:
                 selectors[name] ??
-                { MERGE: "plan", FIX: "fix", ESCALATE: "escalate" }[name],
+                {
+                  MERGE: "plan",
+                  FIX: "fix",
+                  ESCALATE: "escalate",
+                  REVIEW: "reviews",
+                }[name],
             },
           ]),
         ),
@@ -478,6 +483,43 @@ describe("chain auto approval (WM-357)", () => {
       [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
     );
     expect(loaded.reason).toBeNull();
+  });
+
+  test("merge-scan REVIEW proposals auto-approve factory.merge-review.requested (WM-907)", async () => {
+    const db = openDb(":memory:");
+    const headSha = "a".repeat(40);
+    const baseSha = "b".repeat(40);
+    const reviewInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 12,
+      headSha,
+      baseSha,
+    };
+    const candidate = seed(db, {
+      id: "merge-review-from-scan",
+      type: "factory.merge-review.requested",
+      input: reviewInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorInput: { repo: "factory" },
+      predecessorArtifact: {
+        recommendation: "REVIEW",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        reviews: [{ pr: 12, headSha, baseSha }],
+        plan: [],
+        fix: [],
+        escalate: [],
+        summary: "one miss",
+      },
+    });
+
+    expect((await auto(db)).approved).toEqual([
+      { proposalId: candidate.id, runId: candidate.runId },
+    ]);
   });
 
   test("budget, worker cap, and circuit breaker each stop unattended approvals", async () => {

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -125,6 +125,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
               candidate.whenItemsField,
               selectionContext,
             );
+            if (items == null) return false;
             if (!Array.isArray(items)) {
               throw new Error(
                 `independent chain selector "${candidate.whenItemsField}" is not an array`,

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -662,6 +662,111 @@ describe("multi-emit chain resolution (WM-119)", () => {
     });
   });
 
+  test("merge-scan REVIEW fans out per-PR merge-review.requested (WM-907)", () => {
+    const dir = tmpDir("evrt-chain-merge-review-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const head = "a".repeat(40);
+    const base = "b".repeat(40);
+
+    seedCompletedRun(db, {
+      runId: "run-scan-reviews",
+      agent: "merge-scan@2",
+      input: { repo: "factory" },
+      artifact: {
+        recommendation: "REVIEW",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        reviews: [
+          { pr: 12, headSha: head, baseSha: base },
+          { pr: 13, headSha: head, baseSha: base },
+        ],
+        plan: [],
+        fix: [],
+        escalate: [],
+        summary: "two misses",
+      },
+    });
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 2,
+      skipped: 0,
+      errors: [],
+    });
+    for (const pr of [12, 13]) {
+      const event = db
+        .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+        .get(`chain-run-scan-reviews-${pr}`);
+      expect(event).toBeTruthy();
+      expect(event.type).toBe("factory.merge-review.requested");
+      expect(JSON.parse(event.envelope_json).payload).toEqual({
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        pr,
+        headSha: head,
+        baseSha: base,
+      });
+    }
+  });
+
+  test("merge-fix UPDATED targets merge-review.requested for the new head (WM-907)", () => {
+    const dir = tmpDir("evrt-chain-merge-fix-review-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const oldHead = "a".repeat(40);
+    const newHead = "c".repeat(40);
+    const base = "b".repeat(40);
+
+    seedCompletedRun(db, {
+      runId: "run-fix-updated",
+      agent: "merge-fix@1",
+      input: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        pr: 12,
+        headSha: oldHead,
+        baseSha: base,
+        headRef: "feat/WM-12",
+        ticket: "WM-12",
+        finding: "rebase_onto_base",
+        findingHash: "d".repeat(64),
+        round: 1,
+        mechanical: true,
+        withinOwnedPaths: true,
+        ownedPaths: ["event-runtime/lib/chain.mjs"],
+      },
+      artifact: {
+        outcome: "UPDATED",
+        repo: "factory",
+        ticket: "WM-12",
+        pr: 12,
+        headSha: newHead,
+        round: 1,
+        summary: "rebased",
+      },
+    });
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 1,
+      skipped: 0,
+      errors: [],
+    });
+    const event = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get("chain-run-fix-updated");
+    expect(event.type).toBe("factory.merge-review.requested");
+    expect(JSON.parse(event.envelope_json).payload).toEqual({
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 12,
+      headSha: newHead,
+      baseSha: base,
+    });
+  });
+
   test("non-completed runs do not generate chain candidates", () => {
     const dir = tmpDir("evrt-chain-triage-fail-");
     const db = openDb(path.join(dir, "runtime.db"));

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -313,6 +313,30 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 9,
+    name: "merge_reviews",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS merge_reviews (
+          github         TEXT NOT NULL,
+          pr             INTEGER NOT NULL,
+          head_sha       TEXT NOT NULL,
+          base_sha       TEXT NOT NULL,
+          verdict        TEXT NOT NULL,
+          findings_json  TEXT NOT NULL,
+          fix_json       TEXT,
+          plan_json      TEXT,
+          policy_version TEXT,
+          run_id         TEXT,
+          reviewed_at    TEXT NOT NULL,
+          PRIMARY KEY (github, pr, head_sha, base_sha)
+        );
+        CREATE INDEX IF NOT EXISTS idx_merge_reviews_github_pr
+          ON merge_reviews (github, pr, reviewed_at DESC);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =
@@ -333,6 +357,7 @@ export const CORE_TABLES = [
   "inbox_items",
   "memos",
   "memo_uses",
+  "merge_reviews",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -1,0 +1,523 @@
+/**
+ * Merge-review ledger and scan enumerator (WM-907).
+ *
+ * `merge_reviews` is keyed (github, pr, head_sha, base_sha). A moved head is
+ * a miss: the next enumerator tick emits `factory.merge-review.requested`
+ * for that SHA pair only. Completing `merge-review@1` persists the row from
+ * the accepted result (worker hook). `merge-scan@2` is the deterministic
+ * enumerator that reads this table and fans out reviews for misses.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { loadForge, ForgeError } from "../../lib/forge/index.mjs";
+import { openDb } from "./db.mjs";
+import { getRepo, loadRepos, RepoError } from "./repos.mjs";
+
+export const MERGE_REVIEW_VERDICTS = Object.freeze([
+  "MERGE",
+  "FIX",
+  "ESCALATE",
+]);
+export const MERGE_SCAN_AGENT = "merge-scan@2";
+export const MERGE_REVIEW_AGENT = "merge-review@1";
+
+const SHA40 = /^[0-9a-f]{40}$/;
+const TICKET = /[A-Z]+-[0-9]+/;
+const PR_LIST_FIELDS = [
+  "number",
+  "state",
+  "isDraft",
+  "headRefOid",
+  "headRefName",
+  "baseRefName",
+  "title",
+];
+const PR_VIEW_FIELDS = PR_LIST_FIELDS;
+
+function iso(now = Date.now()) {
+  return new Date(now).toISOString();
+}
+
+function asSha(value) {
+  if (typeof value !== "string") return null;
+  const sha = value.trim().toLowerCase();
+  return SHA40.test(sha) ? sha : null;
+}
+
+function asPr(value) {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : null;
+}
+
+function ticketFromRef(headRef, title) {
+  const fromRef =
+    typeof headRef === "string" ? headRef.toUpperCase().match(TICKET) : null;
+  if (fromRef) return fromRef[0];
+  const fromTitle =
+    typeof title === "string" ? title.toUpperCase().match(TICKET) : null;
+  return fromTitle ? fromTitle[0] : null;
+}
+
+function parseJsonColumn(raw, fallback) {
+  if (raw == null || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+/** Look up a review by the exact SHA pair. A moved head is a miss. */
+export function lookupMergeReview(db, { github, pr, headSha, baseSha }) {
+  const row = db
+    .query(
+      `SELECT github, pr, head_sha AS headSha, base_sha AS baseSha,
+              verdict, findings_json AS findingsJson, fix_json AS fixJson,
+              plan_json AS planJson, policy_version AS policyVersion,
+              run_id AS runId, reviewed_at AS reviewedAt
+         FROM merge_reviews
+        WHERE github = ? AND pr = ? AND head_sha = ? AND base_sha = ?`,
+    )
+    .get(github, pr, headSha, baseSha);
+  if (!row) return null;
+  return {
+    github: row.github,
+    pr: row.pr,
+    headSha: row.headSha,
+    baseSha: row.baseSha,
+    verdict: row.verdict,
+    findings: parseJsonColumn(row.findingsJson, []),
+    fix: parseJsonColumn(row.fixJson, null),
+    plan: parseJsonColumn(row.planJson, null),
+    policyVersion: row.policyVersion,
+    runId: row.runId,
+    reviewedAt: row.reviewedAt,
+  };
+}
+
+export function upsertMergeReview(
+  db,
+  {
+    github,
+    pr,
+    headSha,
+    baseSha,
+    verdict,
+    findings = [],
+    fix = null,
+    plan = null,
+    policyVersion = null,
+    runId = null,
+    reviewedAt,
+  },
+) {
+  if (!MERGE_REVIEW_VERDICTS.includes(verdict)) {
+    throw new Error(
+      `merge_reviews verdict ${JSON.stringify(verdict)} is not MERGE|FIX|ESCALATE`,
+    );
+  }
+  const head = asSha(headSha);
+  const base = asSha(baseSha);
+  const number = asPr(pr);
+  if (!github || !number || !head || !base) {
+    throw new Error("merge_reviews row requires github, pr, headSha, baseSha");
+  }
+  db.query(
+    `INSERT INTO merge_reviews (
+       github, pr, head_sha, base_sha, verdict, findings_json, fix_json,
+       plan_json, policy_version, run_id, reviewed_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (github, pr, head_sha, base_sha) DO UPDATE SET
+       verdict = excluded.verdict,
+       findings_json = excluded.findings_json,
+       fix_json = excluded.fix_json,
+       plan_json = excluded.plan_json,
+       policy_version = excluded.policy_version,
+       run_id = excluded.run_id,
+       reviewed_at = excluded.reviewed_at`,
+  ).run(
+    github,
+    number,
+    head,
+    base,
+    verdict,
+    JSON.stringify(findings ?? []),
+    fix == null ? null : JSON.stringify(fix),
+    plan == null ? null : JSON.stringify(plan),
+    policyVersion,
+    runId,
+    reviewedAt ?? iso(),
+  );
+}
+
+/**
+ * Worker COMPLETED hook. No-op unless this run is merge-review@1 with a
+ * schema-valid completed artifact. Never throws out of a missing optional
+ * field — refuse to persist rather than write a partial key.
+ */
+export function persistMergeReviewFromResult(
+  db,
+  { spec, result, runId, now = Date.now() },
+) {
+  if (spec?.agent !== MERGE_REVIEW_AGENT) return false;
+  if (result?.terminalState && result.terminalState !== "completed")
+    return false;
+  const artifact = result?.artifact;
+  if (!artifact || typeof artifact !== "object") return false;
+  const github = artifact.github ?? spec.input?.github;
+  const pr = asPr(artifact.pr ?? spec.input?.pr);
+  const headSha = asSha(artifact.headSha ?? spec.input?.headSha);
+  const baseSha = asSha(artifact.baseSha ?? spec.input?.baseSha);
+  const verdict = artifact.verdict;
+  if (!github || !pr || !headSha || !baseSha) return false;
+  if (!MERGE_REVIEW_VERDICTS.includes(verdict)) return false;
+  const planItem = Array.isArray(artifact.plan)
+    ? (artifact.plan[0] ?? null)
+    : null;
+  const fixItem = Array.isArray(artifact.fix)
+    ? (artifact.fix[0] ?? null)
+    : null;
+  upsertMergeReview(db, {
+    github,
+    pr,
+    headSha,
+    baseSha,
+    verdict,
+    findings: Array.isArray(artifact.findings) ? artifact.findings : [],
+    fix: fixItem,
+    plan: planItem,
+    policyVersion: spec.policyVersion ?? null,
+    runId,
+    reviewedAt: iso(now),
+  });
+  return true;
+}
+
+function reviewItemFromPr(pr) {
+  const item = {
+    pr: pr.number,
+    headSha: pr.headSha,
+    baseSha: pr.baseSha,
+  };
+  if (pr.headRef) item.headRef = pr.headRef;
+  if (pr.ticket) item.ticket = pr.ticket;
+  return item;
+}
+
+function normalizeListedPr(raw, baseSha) {
+  const number = asPr(raw?.number);
+  const headSha = asSha(raw?.headRefOid);
+  const base = asSha(baseSha);
+  if (!number || !headSha || !base) return null;
+  return {
+    number,
+    isDraft: raw.isDraft === true,
+    state: typeof raw.state === "string" ? raw.state.toUpperCase() : "",
+    headSha,
+    baseSha: base,
+    headRef: typeof raw.headRefName === "string" ? raw.headRefName : null,
+    baseRefName: typeof raw.baseRefName === "string" ? raw.baseRefName : null,
+    ticket: ticketFromRef(raw.headRefName, raw.title),
+  };
+}
+
+function classifySelectedPr(raw, { base, baseSha }) {
+  if (!raw) return { invalid: "missing" };
+  const state = typeof raw.state === "string" ? raw.state.toUpperCase() : "";
+  if (state && state !== "OPEN") return { invalid: "closed" };
+  if (raw.isDraft === true) return { invalid: "draft" };
+  const baseRef = typeof raw.baseRefName === "string" ? raw.baseRefName : "";
+  if (baseRef && baseRef !== base) return { invalid: "wrong-base" };
+  const pr = normalizeListedPr(raw, baseSha);
+  if (!pr) return { invalid: "missing" };
+  return { pr };
+}
+
+function lowestMergePlan(candidates) {
+  const mergeable = candidates
+    .filter(
+      (row) =>
+        row.verdict === "MERGE" && row.plan && typeof row.plan === "object",
+    )
+    .slice()
+    .sort((a, b) => a.pr - b.pr);
+  if (mergeable.length === 0) return [];
+  return [mergeable[0].plan];
+}
+
+function recommendationOf({ reviews, plan, escalate }) {
+  if (escalate.length > 0) return "ESCALATE";
+  if (plan.length > 0) return "MERGE";
+  if (reviews.length > 0) return "REVIEW";
+  return "NOOP";
+}
+
+function noopReasonOf({ reviews, plan, escalate, listedCount }) {
+  if (escalate.length > 0 || plan.length > 0 || reviews.length > 0)
+    return undefined;
+  if (listedCount === 0) return "no_open_prs";
+  return "all_prs_held";
+}
+
+/**
+ * Deterministic enumerator. Does not review diffs — it classifies live PRs
+ * against the ledger and emits reviews for misses (or every selected PR).
+ */
+export function enumerateMergeScan({
+  input,
+  db,
+  forge,
+  repos,
+  now = Date.now(),
+}) {
+  const repoName = input?.repo;
+  if (typeof repoName !== "string" || repoName.length === 0) {
+    return refuse("repo is required");
+  }
+
+  let repo;
+  try {
+    repo = getRepo(repos ?? loadRepos(), repoName);
+  } catch (err) {
+    if (err instanceof RepoError) return refuse(err.message);
+    throw err;
+  }
+  if (!repo.github || !repo.base) {
+    return refuse(`repo ${repoName} is missing github or base`);
+  }
+
+  const github = repo.github;
+  const base = repo.base;
+  const deployBranch = repo.deployBranch ?? null;
+  const selected = Array.isArray(input.prNumbers) ? input.prNumbers : null;
+
+  let baseSha;
+  try {
+    const raw = String(
+      forge.apiRaw(`repos/${github}/git/ref/heads/${base}`, {
+        jq: ".object.sha",
+      }),
+    ).trim();
+    baseSha = asSha(raw);
+    if (!baseSha) {
+      try {
+        const parsed = JSON.parse(raw);
+        baseSha = asSha(parsed?.object?.sha ?? parsed?.sha);
+      } catch {
+        baseSha = null;
+      }
+    }
+  } catch (err) {
+    return transient(github, repoName, base, deployBranch, err);
+  }
+  if (!baseSha) {
+    return refuse(`unresolvable base SHA for ${github}#${base}`);
+  }
+
+  let listed;
+  try {
+    listed = selected
+      ? selected.map((number) => {
+          try {
+            return {
+              number,
+              raw: forge.prView(github, number, { fields: PR_VIEW_FIELDS }),
+            };
+          } catch (err) {
+            if (err instanceof ForgeError)
+              return { number, raw: null, error: err };
+            throw err;
+          }
+        })
+      : forge
+          .prList(github, {
+            state: "open",
+            limit: 100,
+            fields: PR_LIST_FIELDS,
+          })
+          .map((raw) => ({ number: raw.number, raw }));
+  } catch (err) {
+    return transient(github, repoName, base, deployBranch, err);
+  }
+
+  if (selected) {
+    const invalid = [];
+    const targets = [];
+    for (const entry of listed) {
+      if (entry.error && !entry.raw) {
+        invalid.push({ pr: entry.number, reason: "missing" });
+        continue;
+      }
+      const classified = classifySelectedPr(entry.raw, { base, baseSha });
+      if (classified.invalid) {
+        invalid.push({ pr: entry.number, reason: classified.invalid });
+      } else {
+        targets.push(classified.pr);
+      }
+    }
+    if (invalid.length > 0) {
+      return refuse(
+        `invalid selected PR(s): ${invalid
+          .map((row) => `#${row.pr} ${row.reason}`)
+          .join("; ")}`,
+        { invalid },
+      );
+    }
+    return assemble({
+      repo: repoName,
+      github,
+      base,
+      deployBranch,
+      db,
+      targets,
+      forceReview: true,
+      listedCount: targets.length,
+    });
+  }
+
+  const targets = [];
+  for (const entry of listed) {
+    const pr = normalizeListedPr(entry.raw, baseSha);
+    if (!pr) continue;
+    if (pr.isDraft) continue;
+    if (pr.baseRefName && pr.baseRefName !== base) continue;
+    targets.push(pr);
+  }
+  return assemble({
+    repo: repoName,
+    github,
+    base,
+    deployBranch,
+    db,
+    targets,
+    forceReview: false,
+    listedCount: targets.length,
+    now,
+  });
+}
+
+function assemble({
+  repo,
+  github,
+  base,
+  deployBranch,
+  db,
+  targets,
+  forceReview,
+  listedCount,
+}) {
+  const reviews = [];
+  const mergeHits = [];
+  for (const pr of targets) {
+    const hit = lookupMergeReview(db, {
+      github,
+      pr: pr.number,
+      headSha: pr.headSha,
+      baseSha: pr.baseSha,
+    });
+    if (!hit || forceReview) {
+      reviews.push(reviewItemFromPr(pr));
+      continue;
+    }
+    if (hit.verdict === "MERGE") mergeHits.push(hit);
+  }
+  const plan = lowestMergePlan(mergeHits);
+  const escalate = [];
+  const artifact = {
+    recommendation: recommendationOf({ reviews, plan, escalate }),
+    repo,
+    github,
+    base,
+    deployBranch,
+    reviews,
+    plan,
+    fix: [],
+    escalate,
+    summary: summaryFor({
+      reviews,
+      plan,
+      listedCount,
+      forceReview,
+    }),
+  };
+  const noopReason = noopReasonOf({
+    reviews,
+    plan,
+    escalate,
+    listedCount,
+  });
+  if (noopReason) artifact.noopReason = noopReason;
+  return completed(artifact);
+}
+
+function summaryFor({ reviews, plan, listedCount, forceReview }) {
+  const bits = [];
+  if (forceReview) bits.push(`selected scan of ${listedCount} PR(s)`);
+  else bits.push(`${listedCount} open base-targeting PR(s)`);
+  bits.push(`${reviews.length} review(s) to run`);
+  if (plan.length > 0) bits.push(`lowest MERGE candidate is #${plan[0].pr}`);
+  return bits.join("; ") + ".";
+}
+
+function completed(artifact) {
+  return {
+    schemaVersion: "factory.agent-result/v1",
+    terminalState: "completed",
+    reasonCode: "ok",
+    artifact,
+    evidence: { commands: ["merge-reviews.scan"] },
+  };
+}
+
+function refuse(message, extra = {}) {
+  return {
+    schemaVersion: "factory.agent-result/v1",
+    terminalState: "refused",
+    reasonCode: "needs_human",
+    evidence: { message, ...extra },
+  };
+}
+
+function transient(github, repo, base, deployBranch, err) {
+  const summary = `transient forge error listing ${github}: ${err?.message ?? err}`;
+  return completed({
+    recommendation: "NOOP",
+    repo,
+    github,
+    base,
+    deployBranch,
+    reviews: [],
+    plan: [],
+    fix: [],
+    escalate: [],
+    summary,
+  });
+}
+
+export function runScanCli({
+  cwd = process.cwd(),
+  db = openDb(),
+  forge = loadForge(),
+  repos = loadRepos(),
+} = {}) {
+  const input = JSON.parse(readFileSync(path.join(cwd, "input.json"), "utf8"));
+  const result = enumerateMergeScan({ input, db, forge, repos });
+  writeFileSync(
+    path.join(cwd, "result.json"),
+    `${JSON.stringify(result, null, 2)}\n`,
+    "utf8",
+  );
+  return result.terminalState === "completed" ||
+    result.terminalState === "refused"
+    ? 0
+    : 1;
+}
+
+if (import.meta.main) {
+  const verb = process.argv[2];
+  if (verb !== "scan") {
+    console.error("usage: bun event-runtime/lib/merge-reviews.mjs scan");
+    process.exit(2);
+  }
+  process.exit(runScanCli());
+}

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { memoryForge } from "../../lib/forge/memory.mjs";
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-merge-reviews-test-mjs";
+import { openDb } from "./db.mjs";
+import {
+  enumerateMergeScan,
+  lookupMergeReview,
+  persistMergeReviewFromResult,
+  runScanCli,
+  upsertMergeReview,
+} from "./merge-reviews.mjs";
+
+const HEAD = "a".repeat(40);
+const HEAD2 = "c".repeat(40);
+const BASE = "b".repeat(40);
+const GITHUB = "watt-mind/factory";
+
+const repos = new Map([
+  [
+    "factory",
+    {
+      name: "factory",
+      github: GITHUB,
+      base: "develop",
+      deployBranch: "master",
+    },
+  ],
+]);
+
+function pr({
+  number,
+  headRefOid = HEAD,
+  headRefName = `feat/WM-${number}`,
+  baseRefName = "develop",
+  isDraft = false,
+  state = "OPEN",
+  title = `Fixes WM-${number}`,
+} = {}) {
+  return {
+    number,
+    state,
+    isDraft,
+    headRefOid,
+    headRefName,
+    baseRefName,
+    title,
+  };
+}
+
+function forgeWith(prs, { baseSha = BASE } = {}) {
+  return memoryForge({
+    repos: { [GITHUB]: { prs } },
+    api: {
+      [`repos/${GITHUB}/git/ref/heads/develop`]: baseSha,
+    },
+  });
+}
+
+function planItem(prNumber = 12) {
+  return {
+    pr: prNumber,
+    headSha: HEAD,
+    baseSha: BASE,
+    headRef: `feat/WM-${prNumber}`,
+    ticket: `WM-${prNumber}`,
+    action: "merge_pr",
+    reason: "green",
+    checksGreen: true,
+    mergeable: true,
+    ownedPathsValid: true,
+    handoffValid: true,
+    testsFalsifiable: true,
+    policySafe: true,
+    sensitive: false,
+    ambiguous: false,
+  };
+}
+
+describe("merge_reviews ledger keying (WM-907)", () => {
+  test("a fresh database has the merge_reviews table", () => {
+    const db = openDb(":memory:");
+    const tables = db
+      .query(`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .all()
+      .map((row) => row.name);
+    expect(tables).toContain("merge_reviews");
+  });
+
+  test("lookup misses when the head SHA moved", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 12,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(12),
+    });
+    expect(
+      lookupMergeReview(db, {
+        github: GITHUB,
+        pr: 12,
+        headSha: HEAD,
+        baseSha: BASE,
+      })?.verdict,
+    ).toBe("MERGE");
+    expect(
+      lookupMergeReview(db, {
+        github: GITHUB,
+        pr: 12,
+        headSha: HEAD2,
+        baseSha: BASE,
+      }),
+    ).toBeNull();
+  });
+
+  test("persistMergeReviewFromResult writes the COMPLETED merge-review artifact", () => {
+    const db = openDb(":memory:");
+    const persisted = persistMergeReviewFromResult(db, {
+      spec: {
+        agent: "merge-review@1",
+        policyVersion: "git:test",
+        input: { github: GITHUB, pr: 12 },
+      },
+      result: {
+        terminalState: "completed",
+        artifact: {
+          verdict: "FIX",
+          github: GITHUB,
+          pr: 12,
+          headSha: HEAD,
+          baseSha: BASE,
+          findings: ["rebase_onto_base"],
+          fix: [
+            {
+              pr: 12,
+              headSha: HEAD,
+              baseSha: BASE,
+              headRef: "feat/WM-12",
+              ticket: "WM-12",
+              finding: "rebase_onto_base",
+              findingHash: "d".repeat(64),
+              round: 1,
+              mechanical: true,
+              withinOwnedPaths: true,
+              ownedPaths: ["event-runtime/lib/worker.mjs"],
+            },
+          ],
+          plan: [],
+        },
+      },
+      runId: "run_review_1",
+      now: Date.parse("2026-08-19T12:00:00.000Z"),
+    });
+    expect(persisted).toBe(true);
+    const row = lookupMergeReview(db, {
+      github: GITHUB,
+      pr: 12,
+      headSha: HEAD,
+      baseSha: BASE,
+    });
+    expect(row.verdict).toBe("FIX");
+    expect(row.runId).toBe("run_review_1");
+    expect(row.fix.finding).toBe("rebase_onto_base");
+    expect(
+      persistMergeReviewFromResult(db, {
+        spec: { agent: "merge-scan@2" },
+        result: { artifact: { verdict: "MERGE" } },
+        runId: "run_scan",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("merge-scan enumerator (WM-907)", () => {
+  test("emits reviews only for ledger misses", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 10,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "ESCALATE",
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({ number: 10 }),
+        pr({ number: 11, headRefOid: HEAD2, headRefName: "feat/WM-11" }),
+        pr({ number: 12, isDraft: true, headRefName: "feat/WM-12" }),
+        pr({
+          number: 13,
+          baseRefName: "master",
+          headRefName: "feat/WM-13",
+        }),
+      ]),
+      repos,
+    });
+    expect(result.terminalState).toBe("completed");
+    expect(result.artifact.reviews.map((row) => row.pr)).toEqual([11]);
+    expect(result.artifact.plan).toEqual([]);
+    expect(result.artifact.recommendation).toBe("REVIEW");
+  });
+
+  test("selected scan forces a review even on a ledger hit", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 10,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(10),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory", prNumbers: [10] },
+      db,
+      forge: forgeWith([pr({ number: 10 })]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([
+      {
+        pr: 10,
+        headSha: HEAD,
+        baseSha: BASE,
+        headRef: "feat/WM-10",
+        ticket: "WM-10",
+      },
+    ]);
+    expect(result.artifact.plan).toEqual([]);
+  });
+
+  test("open scan stubs the lowest MERGE candidate from the ledger", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 20,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(20),
+    });
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 8,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(8),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({ number: 20, headRefName: "feat/WM-20" }),
+        pr({ number: 8, headRefName: "feat/WM-8" }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.plan[0].pr).toBe(8);
+    expect(result.artifact.recommendation).toBe("MERGE");
+  });
+
+  test("an invalid selected PR refuses the whole scan", () => {
+    const result = enumerateMergeScan({
+      input: { repo: "factory", prNumbers: [99] },
+      db: openDb(":memory:"),
+      forge: forgeWith([]),
+      repos,
+    });
+    expect(result.terminalState).toBe("refused");
+    expect(result.reasonCode).toBe("needs_human");
+    expect(result.evidence.message).toMatch(/#99 missing/);
+  });
+
+  test("runScanCli writes result.json from input.json", () => {
+    const dir = tmpDir("merge-scan-cli-");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "input.json"),
+      JSON.stringify({ repo: "factory" }),
+    );
+    const db = openDb(":memory:");
+    const code = runScanCli({
+      cwd: dir,
+      db,
+      forge: forgeWith([]),
+      repos,
+    });
+    expect(code).toBe(0);
+    const written = JSON.parse(
+      readFileSync(path.join(dir, "result.json"), "utf8"),
+    );
+    expect(written.artifact.noopReason).toBe("no_open_prs");
+    expect(written.artifact.reviews).toEqual([]);
+  });
+});

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -150,8 +150,11 @@ describe("registry", () => {
     // Regenerated (WM-812): dispatch/merge-scan declare decision memos and re-pin briefs.
     // Regenerated (WM-907): merge-scan@2 is the command enumerator; merge-review@1 is the per-PR agy reviewer;
     // factory.merge-review.requested + REVIEW fan-out + merge_reviews ledger.
+    // Regenerated (WM-907, cold-review fixup): merge-review@1 declares the same
+    // decision-memo block WM-812 gave merge-scan, so the per-PR reviewer sees
+    // prior repo decisions too; agent def is a registry input.
     const expected =
-      "sha256:4bfa2303906bea9ccb90fef3443e2ac8a863e19f248dc8ef82d0982174ba132d";
+      "sha256:80ee956f8de2e4c0397393a73775717237d5c086af9db9c65cecd0a3d6591267";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -148,8 +148,10 @@ describe("registry", () => {
     // Regenerated (WM-811): dispatch declares ticket postmortem memos; run-postmortem
     // emits them; dispatch.input admits memoPin; both defs re-pinned.
     // Regenerated (WM-812): dispatch/merge-scan declare decision memos and re-pin briefs.
+    // Regenerated (WM-907): merge-scan@2 is the command enumerator; merge-review@1 is the per-PR agy reviewer;
+    // factory.merge-review.requested + REVIEW fan-out + merge_reviews ledger.
     const expected =
-      "sha256:e24e3f3be336136beb62a18ec3fe76d74bef14c2fdd289f6612cc327c32e8c6d";
+      "sha256:b42aabdc99deade3796d81aaa436ecac8487092290aba7f91794898a7c60b6c5";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -151,7 +151,7 @@ describe("registry", () => {
     // Regenerated (WM-907): merge-scan@2 is the command enumerator; merge-review@1 is the per-PR agy reviewer;
     // factory.merge-review.requested + REVIEW fan-out + merge_reviews ledger.
     const expected =
-      "sha256:b42aabdc99deade3796d81aaa436ecac8487092290aba7f91794898a7c60b6c5";
+      "sha256:4bfa2303906bea9ccb90fef3443e2ac8a863e19f248dc8ef82d0982174ba132d";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -65,6 +65,7 @@ import {
   safeJoin,
 } from "./workspace.mjs";
 import { createInboxItem } from "./inbox.mjs";
+import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { templateFor } from "./decision-templates.mjs";
 
 /**
@@ -2802,6 +2803,12 @@ export async function executeClaimed(
         canonicalJson(receipt),
         iso(currentNow),
       );
+      persistMergeReviewFromResult(db, {
+        spec,
+        result,
+        runId,
+        now: currentNow,
+      });
 
       const origin = originatingEvent(db, runId);
       const envelope = {

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -340,8 +340,22 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {
     expect(registry.eventTypes["factory.merge.requested"]).toMatchObject({
       agent: "merge-scan@2",
-      adapter: "agy",
+      adapter: "command",
     });
+    expect(registry.eventTypes["factory.merge-review.requested"]).toMatchObject(
+      {
+        agent: "merge-review@1",
+        adapter: "agy",
+      },
+    );
+    expect(registry.agents.get("merge-scan@2").workspace.type).toBe(
+      "ephemeral",
+    );
+    expect(registry.agents.get("merge-scan@2").command).toEqual([
+      "bun",
+      "{factoryRoot}/event-runtime/lib/merge-reviews.mjs",
+      "scan",
+    ]);
     expect(registry.eventTypes["factory.merge-fix.requested"]).toMatchObject({
       agent: "merge-fix@1",
       adapter: "agy",
@@ -454,7 +468,7 @@ describe("merge-scan selected PR contract (WM-426)", () => {
       "utf8",
     );
     expect(prompt).toContain("`prNumbers` is absent");
-    expect(prompt).toContain("exactly those PR numbers");
+    expect(prompt).toMatch(/exactly those\s+PR numbers/);
     expect(prompt).toMatch(
       /missing, closed, draft, or targets a\s+base other than/,
     );
@@ -469,7 +483,7 @@ describe("merge-scan selected PR contract (WM-426)", () => {
 describe("merge-scan required-context resolution (WM-433)", () => {
   test("scan uses the supported PR query through the deterministic resolver", () => {
     const prompt = readFileSync(
-      registry.agents.get("merge-scan@2").promptPath,
+      registry.agents.get("merge-review@1").promptPath,
       "utf8",
     );
 
@@ -522,7 +536,7 @@ describe("merge-scan required-context resolution (WM-433)", () => {
 
 describe("format and lint mechanical merge fixes (WM-769)", () => {
   const scanPrompt = readFileSync(
-    registry.agents.get("merge-scan@2").promptPath,
+    registry.agents.get("merge-review@1").promptPath,
     "utf8",
   );
   const fixPrompt = readFileSync(
@@ -590,9 +604,9 @@ describe("format and lint mechanical merge fixes (WM-769)", () => {
   });
 });
 
-describe("merge-scan repository workspace and result contract (WM-425)", () => {
+describe("merge-review repository workspace and result contract (WM-425/WM-907)", () => {
   test("the definition and prompt declare the pinned repository contract", () => {
-    const def = registry.agents.get("merge-scan@2");
+    const def = registry.agents.get("merge-review@1");
     expect(def.workspace).toEqual({
       type: "repository",
       checkoutDir: "repo",
@@ -664,15 +678,22 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
         db,
         registry,
         envelope(
-          "factory.merge.requested",
-          { repo: "mergefixture" },
-          "merge-scan-workspace",
+          "factory.merge-review.requested",
+          {
+            repo: "mergefixture",
+            github: "watt-mind/mergefixture",
+            base: "develop",
+            pr: 42,
+            headSha: SHA,
+            baseSha: BASE_SHA,
+          },
+          "merge-review-workspace",
         ),
       );
       planAdmittedEvents(db, registry, { policyVersion: PV });
       const proposal = openProposals(db, {})[0];
 
-      expect(registry.agents.get("merge-scan@2").workspace).toEqual({
+      expect(registry.agents.get("merge-review@1").workspace).toEqual({
         type: "repository",
         checkoutDir: "repo",
         retainOnFailure: true,
@@ -1294,12 +1315,27 @@ describe("merge transition chains", () => {
     });
   });
 
-  test("a fixer can only request a fresh independent scan, never apply", () => {
+  test("a fixer can only request a fresh independent review, never apply", () => {
     const db = openDb(":memory:");
     seedCompleted(db, {
       runId: "fix-done",
       agent: "merge-fix@1",
-      input: { repo: "factory" },
+      input: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        pr: 50,
+        headSha: SHA,
+        baseSha: BASE_SHA,
+        headRef: "feat/WM-501",
+        ticket: "WM-501",
+        finding: "rebase_onto_base",
+        findingHash: FINDING_HASH,
+        round: 1,
+        mechanical: true,
+        withinOwnedPaths: true,
+        ownedPaths: ["event-runtime/lib/chain.mjs"],
+      },
       artifact: {
         outcome: "UPDATED",
         repo: "factory",
@@ -1314,8 +1350,15 @@ describe("merge transition chains", () => {
     const row = db
       .query(`SELECT type,envelope_json FROM events WHERE source='chain'`)
       .get();
-    expect(row.type).toBe("factory.merge.requested");
-    expect(JSON.parse(row.envelope_json).payload).toEqual({ repo: "factory" });
+    expect(row.type).toBe("factory.merge-review.requested");
+    expect(JSON.parse(row.envelope_json).payload).toEqual({
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 50,
+      headSha: SHA,
+      baseSha: BASE_SHA,
+    });
   });
 });
 

--- a/event-runtime/schemas/merge-review.input.json
+++ b/event-runtime/schemas/merge-review.input.json
@@ -1,0 +1,38 @@
+{
+  "title": "merge-review input — one PR to cold-review against the pinned repo",
+  "type": "object",
+  "required": ["repo", "github", "base", "pr", "headSha", "baseSha"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml"
+    },
+    "github": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "base": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._/-]+$"
+    },
+    "pr": { "type": "integer", "minimum": 1 },
+    "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
+    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+    "repoPin": {
+      "type": "object",
+      "required": ["repo", "sha"],
+      "additionalProperties": false,
+      "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
+      "properties": {
+        "repo": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string" },
+        "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "github": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/merge-review.output.json
+++ b/event-runtime/schemas/merge-review.output.json
@@ -1,23 +1,24 @@
 {
-  "title": "factory.merge-plan/v2 — cold per-PR verdicts pinned to both head and base",
+  "title": "factory.merge-review/v1 — one-PR cold verdict pinned to both head and base",
   "type": "object",
   "required": [
-    "recommendation",
+    "verdict",
     "repo",
     "github",
     "base",
     "deployBranch",
+    "pr",
+    "headSha",
+    "baseSha",
     "plan",
     "fix",
     "escalate",
-    "reviews",
+    "findings",
     "summary"
   ],
   "additionalProperties": false,
   "properties": {
-    "recommendation": {
-      "enum": ["MERGE", "FIX", "ESCALATE", "REVIEW", "NOOP"]
-    },
+    "verdict": { "enum": ["MERGE", "FIX", "ESCALATE"] },
     "repo": { "type": "string", "minLength": 1 },
     "github": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
     "base": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
@@ -25,6 +26,11 @@
       "type": ["string", "null"],
       "pattern": "^[A-Za-z0-9._/-]+$"
     },
+    "pr": { "type": "integer", "minimum": 1 },
+    "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
+    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
     "plan": {
       "type": "array",
       "maxItems": 1,
@@ -69,6 +75,7 @@
     },
     "fix": {
       "type": "array",
+      "maxItems": 1,
       "items": {
         "type": "object",
         "required": [
@@ -106,6 +113,7 @@
     },
     "escalate": {
       "type": "array",
+      "maxItems": 1,
       "items": {
         "type": "object",
         "required": ["pr", "headSha", "ticket", "reason"],
@@ -118,22 +126,10 @@
         }
       }
     },
-    "reviews": {
+    "findings": {
       "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["pr", "headSha", "baseSha"],
-        "additionalProperties": false,
-        "properties": {
-          "pr": { "type": "integer", "minimum": 1 },
-          "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-          "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-          "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" }
-        }
-      }
+      "items": { "type": "string", "minLength": 1 }
     },
-    "summary": { "type": "string", "minLength": 1 },
-    "noopReason": { "enum": ["no_open_prs", "all_prs_held"] }
+    "summary": { "type": "string", "minLength": 1 }
   }
 }

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -476,7 +476,7 @@ describe("work-scan registration (WM-110)", () => {
     expect([...byAdapter.agy].sort()).toEqual([
       "agy-smoke@1",
       "merge-fix@1",
-      "merge-scan@2",
+      "merge-review@1",
       "triage-scan@1",
     ]);
     // dispatch@1 rides cursor (Grok 4.6) since 2026-08-19 — operator decision to
@@ -492,7 +492,7 @@ describe("work-scan registration (WM-110)", () => {
         registry.modelTiers,
       ),
     ).toBe(registry.modelTiers.cursor.standard);
-    for (const ref of ["merge-fix@1", "merge-scan@2", "triage-scan@1"]) {
+    for (const ref of ["merge-fix@1", "merge-review@1", "triage-scan@1"]) {
       const resolved = resolveModel(
         registry.agents.get(ref),
         "agy",


### PR DESCRIPTION
## Summary
- Adds `merge_reviews` (runtime.db v9) keyed `(github, pr, head_sha, base_sha)` and persist-on-COMPLETED for `merge-review@1`.
- New `merge-review@1` (agy) cold-reviews one SHA-pinned PR; `merge-scan@2` is a command enumerator that emits `reviews[]` for ledger misses only (selected `prNumbers` force a review).
- `edges.json` fans REVIEW out to `factory.merge-review.requested`; merge-fix UPDATED retargets that event for the new head. Stub `plan[]` is the lowest MERGE row so the lane still works until part 2.

## Owned Paths
In-scope: merge-scan/merge-review agents, `lib/merge-reviews.*`, db/worker/chain/command adapter/auto-approval, schemas/contracts, edges/event-types, `config/policy.yaml`, `docs/merge-lane.md`.

Exceptions (advisory conformance; mechanical for `bun test event-runtime`):
- `event-runtime/merge.test.mjs` — adapter command, prompt moved to merge-review, UPDATED payload
- `event-runtime/work.test.mjs` — agy agent list no longer includes merge-scan

## Test plan
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `bun test --timeout 20000 event-runtime/merge.test.mjs event-runtime/work.test.mjs`
- [x] `bun event-runtime/cli.mjs update-pins` (pins already current)

UX critique: skipped — backend/infra, no user-facing surface

Fixes WM-907

Made with [Cursor](https://cursor.com)