### PR TITLE
feat(web): show hook decisions per proposal and 24h hook counts (WM-864)

### DIFF
--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -62,6 +62,30 @@ export interface Proposal {
   repos: string[];
 }
 
+/**
+ * One persisted `approve.before` hook decision — oldest first on
+ * `GET /proposals/:id` as `hookDecisions` (WM-842 / WM-864).
+ */
+export interface HookDecision {
+  id: number;
+  at: string;
+  point: string;
+  hookId: string;
+  source: string;
+  proposalId: string | null;
+  runId: string | null;
+  decision: string;
+  reason: string | null;
+  durationMs: number;
+  error: string | null;
+}
+
+/** `GET /proposals/:id` — the list row plus every hook that voted on it. */
+export interface ProposalDetail {
+  proposal: Proposal;
+  hookDecisions: HookDecision[];
+}
+
 export interface AdmittedEvent {
   source: string;
   eventId: string;

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1819,3 +1819,59 @@ describe("Overview declarative panels (WM-840)", () => {
     );
   });
 });
+
+describe("Overview hook metrics (WM-864)", () => {
+  test("renders /status.hooks.decisions24h allow/deny counts per hook", async () => {
+    await withApi(
+      {
+        status: async () => ({
+          ...baseStatus(),
+          hooks: {
+            decisions24h: {
+              "factory:escalation-labels": {
+                source: "builtin",
+                point: "approve.before",
+                allow: 3,
+                deny: 1,
+              },
+              "acme/x:gate": {
+                source: "extension:acme/x",
+                point: "approve.before",
+                allow: 0,
+                deny: 2,
+              },
+            },
+          },
+        }),
+      },
+      async () => {
+        const r = renderOverview();
+        const list = await waitFor(() =>
+          r.getByLabelText("Hook decisions · 24h"),
+        );
+        expect(
+          within(list).getByText("factory:escalation-labels"),
+        ).toBeTruthy();
+        expect(within(list).getByText("acme/x:gate")).toBeTruthy();
+        expect(within(list).getByText("3 allow")).toBeTruthy();
+        expect(within(list).getByText("1 deny")).toBeTruthy();
+        expect(within(list).getByText("0 allow")).toBeTruthy();
+        expect(within(list).getByText("2 deny")).toBeTruthy();
+        expect(r.getByText("Hook decisions · 24h")).toBeTruthy();
+      },
+    );
+  });
+
+  test("does not render hook metrics against a pre-hooks control API", async () => {
+    await withApi(
+      {
+        status: async () => baseStatus(),
+      },
+      async () => {
+        const r = renderOverview();
+        await waitFor(() => r.getByText("Approval Gate"));
+        expect(r.queryByText(/Hook decisions/i)).toBeNull();
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1748,6 +1748,76 @@ export function Overview({
               )}
             </div>
 
+            {s.hooks &&
+              (() => {
+                const entries = Object.entries(s.hooks.decisions24h);
+                const allowTotal = entries.reduce(
+                  (sum, [, counts]) => sum + counts.allow,
+                  0,
+                );
+                const denyTotal = entries.reduce(
+                  (sum, [, counts]) => sum + counts.deny,
+                  0,
+                );
+                return (
+                  <div className="mt-3.5 border-t border-(--border) pt-2.5">
+                    <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+                      <span className="font-semibold text-(--text)">
+                        Hook decisions · 24h
+                      </span>
+                      <span className="mono text-(--text-dim)">
+                        {entries.length === 0
+                          ? "no hook decisions in 24h"
+                          : `${allowTotal} allow · ${denyTotal} deny`}
+                      </span>
+                    </div>
+                    {entries.length === 0 ? (
+                      <div className="text-[12px] text-(--text-faint)">
+                        no hook decisions in 24h
+                      </div>
+                    ) : (
+                      <ul
+                        className="flex flex-col gap-1"
+                        aria-label="Hook decisions · 24h"
+                      >
+                        {entries.map(([hookId, counts]) => (
+                          <li
+                            key={hookId}
+                            className="flex min-w-0 flex-wrap items-baseline gap-x-2 text-[12px] text-(--text-dim)"
+                            title={`${counts.source} · ${counts.point}`}
+                          >
+                            <span className="mono truncate text-(--text)">
+                              {hookId}
+                            </span>
+                            <span className="tabular-nums">
+                              <span
+                                style={
+                                  counts.allow > 0
+                                    ? { color: "var(--hue-ok)" }
+                                    : undefined
+                                }
+                              >
+                                {counts.allow} allow
+                              </span>
+                              {" · "}
+                              <span
+                                style={
+                                  counts.deny > 0
+                                    ? { color: "var(--hue-err)" }
+                                    : undefined
+                                }
+                              >
+                                {counts.deny} deny
+                              </span>
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                );
+              })()}
+
             {/* Sub-row 3: Waiting on you (inbox ledger, WM-286). Absent on a
                 pre-inbox control API — the row simply does not render. */}
             {s.inbox && (

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -24,6 +24,32 @@ afterEach(() => {
   cleanup();
   restoreApi();
   localStorage.clear();
+  globalThis.fetch = realFetch;
+});
+
+const realFetch = globalThis.fetch;
+
+function stubProposalDetailFetch(
+  hookDecisions: unknown[] = [],
+  proposalId?: string,
+) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (!/\/api\/proposals\/[^/?]+\/?$/.test(url)) {
+      return realFetch(input as RequestInfo);
+    }
+    return new Response(
+      JSON.stringify({
+        proposal: { id: proposalId ?? "prop" },
+        hookDecisions,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  stubProposalDetailFetch();
 });
 
 const noop = () => {};
@@ -1803,6 +1829,80 @@ describe("Proposals detail pane width (WM-685)", () => {
           view.container.querySelector("aside")?.className ?? "";
         expect(className).toContain("w-[440px]");
         expect(className).not.toContain("w-[460px]");
+      },
+    );
+  });
+});
+
+describe("Proposals hook decisions (WM-864)", () => {
+  test("detail pane lists hook id, decision, and reason for each hook", async () => {
+    stubProposalDetailFetch([
+      {
+        id: 1,
+        at: NOW,
+        point: "approve.before",
+        hookId: "factory:escalation-labels",
+        source: "builtin",
+        proposalId: "prop_hooks",
+        runId: "run_hooks",
+        decision: "allow",
+        reason: null,
+        durationMs: 2,
+        error: null,
+      },
+      {
+        id: 2,
+        at: NOW,
+        point: "approve.before",
+        hookId: "acme/x:gate",
+        source: "extension:acme/x",
+        proposalId: "prop_hooks",
+        runId: "run_hooks",
+        decision: "deny",
+        reason: "repo_gated",
+        durationMs: 4,
+        error: null,
+      },
+    ]);
+    const proposal = stubProposal("prop_hooks", "open", {
+      agent: "dispatch@1",
+      reason: "auto_approval_ineligible:dispatch_ineligible:repo_gated",
+    });
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => createStatusFixture(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({ focusProposalId: "prop_hooks" });
+        await waitFor(() => r.getByText("factory:escalation-labels"));
+        expect(r.getByText("acme/x:gate")).toBeTruthy();
+        expect(r.getByText("allow")).toBeTruthy();
+        expect(r.getByText("deny")).toBeTruthy();
+        expect(r.getByText("repo_gated")).toBeTruthy();
+        expect(r.getByText("Hook decisions")).toBeTruthy();
+      },
+    );
+  });
+
+  test("empty hookDecisions still names the section so the operator knows none ran", async () => {
+    stubProposalDetailFetch([]);
+    const proposal = stubProposal("prop_hooks_empty", "open");
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => createStatusFixture(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({ focusProposalId: "prop_hooks_empty" });
+        await waitFor(() => r.getByText("Hook decisions"));
+        expect(r.getByText("No hook ran for this proposal.")).toBeTruthy();
       },
     );
   });

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -26,7 +26,7 @@ import {
 import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
-import type { Proposal } from "../types";
+import type { HookDecision, Proposal, ProposalDetail } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
 import {
@@ -79,6 +79,22 @@ import { Button as PrimitiveButton } from "../components/ui";
 
 const PROPOSAL_TABS = ["open", "history"] as const;
 type ProposalTab = (typeof PROPOSAL_TABS)[number];
+
+const HOOK_DECISION_HUES: Record<string, string> = {
+  allow: "var(--hue-ok)",
+  deny: "var(--hue-err)",
+};
+
+/**
+ * `GET /proposals/:id` — raw fetch because `api.ts` has no proposal-detail
+ * method yet (WM-926). Same pattern as Graph.tsx `/metrics/breakdown`.
+ */
+export async function fetchProposalDetail(id: string): Promise<ProposalDetail> {
+  const response = await fetch(`/api/proposals/${encodeURIComponent(id)}`);
+  if (!response.ok)
+    throw new Error(`/proposals/${id} returned HTTP ${response.status}`);
+  return response.json() as Promise<ProposalDetail>;
+}
 
 export function proposalDrilldownFilters(
   hash: string,
@@ -365,6 +381,14 @@ export function Proposals({
     queryFn: () => api.agents(),
     ...refetchIntervals.secondary,
   });
+  const hookDecisionsQuery = useQuery({
+    queryKey: ["proposals", focusProposalId, "hooks"],
+    queryFn: () => fetchProposalDetail(focusProposalId!),
+    enabled: Boolean(focusProposalId),
+    ...refetchIntervals.secondary,
+  });
+  const hookDecisions: HookDecision[] =
+    hookDecisionsQuery.data?.hookDecisions ?? [];
 
   const [filter, setFilter] = useState("");
   const [rejecting, setRejecting] = useState(false);
@@ -1630,6 +1654,54 @@ export function Proposals({
                   </span>
                 }
               />
+            )}
+          </Section>
+
+          <Section title="Hook decisions" icons>
+            {hookDecisionsQuery.isPending ? (
+              <div className="text-[12px] text-(--text-faint)">
+                Loading hook decisions…
+              </div>
+            ) : hookDecisionsQuery.isError ? (
+              <div className="text-[12px] text-(--hue-err)">
+                Could not load hook decisions.
+              </div>
+            ) : hookDecisions.length === 0 ? (
+              <div className="text-[12px] text-(--text-faint)">
+                No hook ran for this proposal.
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-1.5" aria-label="Hook decisions">
+                {hookDecisions.map((decision) => (
+                  <li
+                    key={decision.id}
+                    className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[12px]"
+                  >
+                    <span
+                      className="mono truncate text-(--text)"
+                      title={`${decision.source} · ${decision.point}`}
+                    >
+                      {decision.hookId}
+                    </span>
+                    <StateBadge
+                      state={decision.decision}
+                      hues={HOOK_DECISION_HUES}
+                    />
+                    {decision.reason ? (
+                      <span
+                        className="min-w-0 break-words text-(--text-dim)"
+                        title={decision.error ?? undefined}
+                      >
+                        {decision.reason}
+                      </span>
+                    ) : decision.error ? (
+                      <span className="min-w-0 break-words text-(--hue-err)">
+                        {decision.error}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
             )}
           </Section>
 


### PR DESCRIPTION
## Summary
- Proposal detail fetches `GET /proposals/:id` and lists each hook's id, decision, and reason. An empty list still names the section ("No hook ran for this proposal.").
- Overview renders `/status.hooks.decisions24h` allow/deny counts per hook on the Intake card. Absent on a pre-hooks control API.
- `api.ts` has no `proposal(id)` yet (out of Owned Paths); the view raw-fetches like Graph.tsx. Follow-up: WM-926.

Fixes WM-864

UX critique: required — SHIP
evidence: http://127.0.0.1:7679/#/proposals/prop_2f1b3283-ae0c-43b8-9d11-b7ebc2c61697
follow-ups: WM-931 (24h counts below Overview fold), WM-932 (hook source/point only in tooltip)

## Test plan
- [ ] `cd event-runtime/web && bun test src/views/Proposals.test.tsx src/views/Overview.test.tsx`
- [ ] Open Overview and find Hook decisions · 24h (scroll on a short viewport)
- [ ] Open a proposal with no hooks → "No hook ran for this proposal."
- [ ] Open a history proposal that ran a hook → hook id + allow/deny, reason when present

Made with [Cursor](https://cursor.com)