### PR TITLE
fix(ci): keep required Verify free of timing-bound spawn flakes (WM-918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,113 @@ jobs:
       - name: Test event-runtime library
         # Spawn-heavy suites can exceed Bun's 5s default on the shared host.
         # Explicit liveness bounds declared by individual tests still win.
-        run: bun test --timeout 20000 --max-concurrency=4 event-runtime/lib
+        # WM-918: required lane excludes the named timing group; those tests
+        # run in the non-required Timing-bound tests job.
+        shell: bash
+        run: |
+          set -euo pipefail
+          exclude="$(bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern)"
+          set +e
+          bun test --timeout 20000 --max-concurrency=4 --test-name-pattern "$exclude" event-runtime/lib | tee "$RUNNER_TEMP/bun-test.log"
+          status="${PIPESTATUS[0]}"
+          set -e
+          if [ "$status" -ne 0 ]; then
+            bun event-runtime/lib/test-helpers-timing.mjs classify "$RUNNER_TEMP/bun-test.log"
+          fi
+          exit "$status"
 
       - name: OSS quickstart dry-run
         # WM-799: the 15-minute path must stay green without Linear/GitHub/model
         # credentials. --dry validates the bundled demo repo and prints the plan.
         run: bin/factory demo --dry
+
+      - name: Sweep stale shared-host temp directories
+        if: always()
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
+
+  timing-bound-tests:
+    name: Timing-bound tests
+    # WM-918: spawn-and-wait tests whose wall-clock ceilings flake under
+    # shared-host contention. Not a required check — required Verify and Fast
+    # unit tests exclude this group. A red result here is a flake signal, not
+    # a merge blocker.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: shadow-runner-health
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 20
+    steps:
+      - name: Sweep stale shared-host temp directories
+        shell: bash
+        run: |
+          find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
+
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
+
+      - name: Setup bun (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
+            curl -fsSL https://bun.sh/install | bash
+          fi
+          if [ -x "$HOME/.bun/bin/bun" ]; then
+            echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            "$HOME/.bun/bin/bun" --version
+          else
+            bun --version
+          fi
+
+      - name: Measure shared-host load factor
+        shell: bash
+        run: |
+          set -euo pipefail
+          cpu_count="$(nproc)"
+          runner_jobs="$(pgrep -fc 'Runner\.Worker' || true)"
+          read -r _ _ _ runnable _ < /proc/loadavg
+          runnable="${runnable%%/*}"
+          runner_jobs="${runner_jobs:-1}"
+          pressure="$runner_jobs"
+          if [ "$runnable" -gt "$pressure" ]; then pressure="$runnable"; fi
+          load_factor=$(( (pressure + cpu_count - 1) / cpu_count ))
+          if [ "$load_factor" -lt 1 ]; then load_factor=1; fi
+          if [ "$load_factor" -gt 4 ]; then load_factor=4; fi
+          echo "CI_LOAD_FACTOR=$load_factor" >> "$GITHUB_ENV"
+          echo "Spawn-test load factor: $load_factor ($pressure runnable/jobs across $cpu_count CPUs)."
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run timing-group tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          include="$(bun event-runtime/lib/test-helpers-timing.mjs include-pattern)"
+          set +e
+          bun test --timeout 30000 --max-concurrency=2 --retry 2 --test-name-pattern "$include" | tee "$RUNNER_TEMP/bun-timing.log"
+          status="${PIPESTATUS[0]}"
+          set -e
+          if grep -q 'Ran 0 tests' "$RUNNER_TEMP/bun-timing.log"; then
+            echo "::error::Timing-bound tests job matched 0 tests; TIMING_TEST_SUBSTRINGS is stale."
+            exit 1
+          fi
+          bun event-runtime/lib/test-helpers-timing.mjs classify "$RUNNER_TEMP/bun-timing.log" || true
+          exit "$status"
 
       - name: Sweep stale shared-host temp directories
         if: always()
@@ -311,7 +412,19 @@ jobs:
         # tests; 20s absorbs host scheduling delay while explicit per-test
         # liveness bounds remain unchanged. Concurrency 4 is the measured
         # non-deadlocking floor from WM-300.
-        run: bun test --timeout 20000 --max-concurrency=4 --path-ignore-patterns='event-runtime/lib/**'
+        # WM-918: required lane excludes the named timing group.
+        shell: bash
+        run: |
+          set -euo pipefail
+          exclude="$(bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern)"
+          set +e
+          bun test --timeout 20000 --max-concurrency=4 --path-ignore-patterns='event-runtime/lib/**' --test-name-pattern "$exclude" | tee "$RUNNER_TEMP/bun-test.log"
+          status="${PIPESTATUS[0]}"
+          set -e
+          if [ "$status" -ne 0 ]; then
+            bun event-runtime/lib/test-helpers-timing.mjs classify "$RUNNER_TEMP/bun-test.log"
+          fi
+          exit "$status"
 
       # The sandbox harness must at least be installable and importable
       # (WM-312). Asserts on `sdk`, never on `available`: a self-hosted runner

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,7 +22,7 @@ CI and Security use `concurrency.group` keyed by PR number for pull requests and
 
 ## Draft pull requests
 
-Draft pull requests run `Shadow runner fleet available`, but skip `Fast unit tests`, `Full verification`, and Browser E2E so held work does not consume the verify lane. The required `Verify` check is a lightweight aggregate on the smoke-test runner: it succeeds explicitly for a draft, and for every other event it succeeds only when fleet health and both CI test jobs succeeded. This prevents a failed prerequisite from turning a skipped downstream job into a misleading successful required check.
+Draft pull requests run `Shadow runner fleet available`, but skip `Fast unit tests`, `Full verification`, `Timing-bound tests`, and Browser E2E so held work does not consume the verify lane. The required `Verify` check is a lightweight aggregate on the smoke-test runner: it succeeds explicitly for a draft, and for every other event it succeeds only when fleet health and both CI test jobs succeeded. This prevents a failed prerequisite from turning a skipped downstream job into a misleading successful required check.
 
 GitHub's `ready_for_review` event starts a fresh workflow on the ready head. Both workflows name readiness and draft-conversion events explicitly; converting a ready PR back to draft cancels its in-flight CI run through the PR concurrency group. Keep the job-level draft guards when editing either trigger.
 
@@ -50,10 +50,15 @@ is disabled or downgraded globally to reach green.
 
 CI splits tests into separately rerunnable jobs:
 
-- **Fast unit tests:** `event-runtime/lib`
-- **Full verification:** every other test, including CLI, daemon, web, demo, orchestration, and process-spawning integration suites
+- **Fast unit tests:** `event-runtime/lib`, minus the timing group below
+- **Full verification:** every other test, including CLI, daemon, web, demo, orchestration, and process-spawning integration suites, minus the timing group
+- **Timing-bound tests (WM-918, not required):** spawn-a-real-process-and-wait tests whose names are listed in `event-runtime/lib/test-helpers-timing.mjs` (`TIMING_TEST_SUBSTRINGS`). Required jobs pass `--test-name-pattern` from `bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern`. This job runs the complementary include pattern with `--retry 2`. A red result here does not fail the required `Verify` aggregator.
 
-Both invoke Bun with `--timeout 20000 --max-concurrency=4`. The 20-second default allows for scheduling delays on a busy self-hosted machine instead of failing unrelated tests at Bun's 5-second default. Tests that encode genuine liveness bounds continue to declare explicit, narrower timeouts; the CLI default does not replace those assertions. Only `Full verification` joins the shared host-lock queue; the fast suite's 15-minute job timeout is a runaway guard rather than queue headroom.
+When a required test step fails, `bun event-runtime/lib/test-helpers-timing.mjs classify <log>` prints the failing names and emits a GitHub `::error title=timing-flake::` annotation if every parsed failure is in that group. Merge-scan should treat a required job whose only failures are that group as a flake (`rerun_ci_at_head`), never ESCALATE — the required lane is supposed to have already excluded them, so the annotation is the miss detector.
+
+Both required test invocations use `--timeout 20000 --max-concurrency=4`. The 20-second default allows for scheduling delays on a busy self-hosted machine instead of failing unrelated tests at Bun's 5-second default. Tests that encode genuine liveness bounds continue to declare explicit, narrower timeouts; the CLI default does not replace those assertions. Only `Full verification` joins the verify-lane queue; the fast suite's 15-minute job timeout is a runaway guard rather than queue headroom. Timing-bound tests run on the general `shadow` pool.
+
+Do not add `describe.skipIf(process.env.CI_FAST)` in the unowned spawn suites from this ticket — the name-pattern split is the quarantine. Follow-up work that owns those files can add in-file tags that match the same list.
 
 ## Operational validation
 

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -1,34 +1,16 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-status-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
 import {
   CLI,
   DEAD_PORT,
-  assertHealthyLiveServe,
-  editStampRoot,
-  exitOf,
-  killPool,
   loadAdjustedTimeout,
-  makeStampRoot,
-  poolSize,
   runCli,
-  runNotifierDeliveryCase,
-  seedRun,
   spawnLiveServe,
-  spawnTracked,
-  spawnSupervisor,
-  spawnWorker,
   throwawayRunDir,
-  waitFor,
   registerCliTmpCleanup,
 } from "./test-helpers.mjs";
 

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -17,11 +17,13 @@ import {
   editStampRoot,
   exitOf,
   killPool,
+  loadAdjustedTimeout,
   makeStampRoot,
   poolSize,
   runCli,
   runNotifierDeliveryCase,
   seedRun,
+  spawnLiveServe,
   spawnTracked,
   spawnSupervisor,
   spawnWorker,
@@ -116,105 +118,84 @@ describe("status and doctor commands", () => {
     ).toBe(true);
   });
 
-  test("doctor against a healthy live serve outputs anomalies none and exits 0", async () => {
-    const home = tmpDir("evrt-doc-healthy-");
-    const port = String(59700 + (process.pid % 100));
-    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
-      env: {
-        ...process.env,
-        FACTORY_EVENT_HOME: home,
-        FACTORY_EVENT_SECRET: "test-secret",
-        FACTORY_GITHUB_WEBHOOK_SECRET: "test-gh-secret",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let out = "";
-    child.stdout.on("data", (b) => {
-      out += b;
-    });
-    child.stderr.on("data", (b) => {
-      out += b;
-    });
-    const deadline = Date.now() + 8000;
-    while (Date.now() < deadline && !out.includes("control API on")) {
-      await Bun.sleep(100);
-    }
-    let docRes;
-    try {
-      expect(out).toContain("control API on");
-      docRes = spawnSync("bun", [CLI, "doctor"], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FACTORY_EVENT_HOME: home,
-          FACTORY_EVENT_PORT: port,
-          FACTORY_RUN_DIR: throwawayRunDir(),
+  test(
+    "doctor against a healthy live serve outputs anomalies none and exits 0",
+    async () => {
+      const home = tmpDir("evrt-doc-healthy-");
+      const box = await spawnLiveServe({
+        home,
+        extraEnv: {
+          FACTORY_EVENT_SECRET: "test-secret",
+          FACTORY_GITHUB_WEBHOOK_SECRET: "test-gh-secret",
         },
       });
-    } finally {
-      child.kill("SIGTERM");
-      await new Promise((resolve) => child.once("exit", resolve));
-    }
-    expect(docRes.status).toBe(0);
-    expect(docRes.stdout).toContain("anomalies");
-    expect(docRes.stdout).toContain("none");
-  });
+      let docRes;
+      try {
+        expect(box.out).toContain("control API on");
+        docRes = spawnSync("bun", [CLI, "doctor"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: home,
+            FACTORY_EVENT_PORT: box.port,
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+        });
+      } finally {
+        box.child.kill("SIGTERM");
+        await new Promise((resolve) => box.child.once("exit", resolve));
+      }
+      expect(docRes.status).toBe(0);
+      expect(docRes.stdout).toContain("anomalies");
+      expect(docRes.stdout).toContain("none");
+    },
+    loadAdjustedTimeout(30_000),
+  );
 
-  test("doctor against a live serve with an anomaly exits non-zero and reports anomaly", async () => {
-    const home = tmpDir("evrt-doc-anomaly-");
-    const port = String(59600 + (process.pid % 100));
-    const db = openDb(path.join(home, "runtime.db"));
-    const at = new Date(Date.now() - 200_000).toISOString();
-    db.query(
-      `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
+  test(
+    "doctor against a live serve with an anomaly exits non-zero and reports anomaly",
+    async () => {
+      const home = tmpDir("evrt-doc-anomaly-");
+      const db = openDb(path.join(home, "runtime.db"));
+      const at = new Date(Date.now() - 200_000).toISOString();
+      db.query(
+        `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      "w-stalled-test",
-      "host-1",
-      1234,
-      "{}",
-      "fake",
-      at,
-      at,
-      "busy",
-      "run-stalled-test",
-    );
-    db.close();
+      ).run(
+        "w-stalled-test",
+        "host-1",
+        1234,
+        "{}",
+        "fake",
+        at,
+        at,
+        "busy",
+        "run-stalled-test",
+      );
+      db.close();
 
-    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
-      env: { ...process.env, FACTORY_EVENT_HOME: home },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let out = "";
-    child.stdout.on("data", (b) => {
-      out += b;
-    });
-    child.stderr.on("data", (b) => {
-      out += b;
-    });
-    const deadline = Date.now() + 8000;
-    while (Date.now() < deadline && !out.includes("control API on")) {
-      await Bun.sleep(100);
-    }
-    let docRes;
-    try {
-      expect(out).toContain("control API on");
-      docRes = spawnSync("bun", [CLI, "doctor"], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FACTORY_EVENT_HOME: home,
-          FACTORY_EVENT_PORT: port,
-          FACTORY_RUN_DIR: throwawayRunDir(),
-        },
-      });
-    } finally {
-      child.kill("SIGTERM");
-      await new Promise((resolve) => child.once("exit", resolve));
-    }
-    expect(docRes.status).not.toBe(0);
-    expect(docRes.stdout).toContain("stalled worker w-stalled-test");
-  });
+      const box = await spawnLiveServe({ home });
+      let docRes;
+      try {
+        expect(box.out).toContain("control API on");
+        docRes = spawnSync("bun", [CLI, "doctor"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: home,
+            FACTORY_EVENT_PORT: box.port,
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+        });
+      } finally {
+        box.child.kill("SIGTERM");
+        await new Promise((resolve) => box.child.once("exit", resolve));
+      }
+      expect(docRes.status).not.toBe(0);
+      expect(docRes.stdout).toContain("stalled worker w-stalled-test");
+    },
+    loadAdjustedTimeout(30_000),
+  );
 });
 
 describe("pool visibility in status/doctor (WM-226)", () => {

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -1,12 +1,6 @@
 import { afterAll, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { policyVersion } from "../lib/config.mjs";
@@ -162,7 +156,9 @@ export async function spawnLiveServe({
   } catch (error) {
     const tail = box.out.slice(-800) || "(empty)";
     child.kill("SIGKILL");
-    throw new Error(`${error.message}\n--- serve output tail ---\n${tail}`);
+    throw new Error(`${error.message}\n--- serve output tail ---\n${tail}`, {
+      cause: error,
+    });
   }
   return box;
 }
@@ -336,7 +332,9 @@ export async function waitFor(box, needle, timeoutMs = 15_000) {
     );
   } catch (error) {
     const tail = String(box.out ?? "").slice(-800) || "(empty)";
-    throw new Error(`${error.message}\n--- output tail ---\n${tail}`);
+    throw new Error(`${error.message}\n--- output tail ---\n${tail}`, {
+      cause: error,
+    });
   }
   return true;
 }

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -22,22 +22,19 @@ export {
   trackProcessGroupsMatching,
 } from "../lib/test-helpers-process.mjs";
 import { spawnTracked, trackProcess } from "../lib/test-helpers-process.mjs";
+export {
+  CI_LOAD_FACTOR,
+  freePort,
+  loadAdjustedTimeout,
+  until,
+} from "../lib/test-helpers-timing.mjs";
+import {
+  freePort,
+  loadAdjustedTimeout,
+  until,
+} from "../lib/test-helpers-timing.mjs";
 
 export const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
-
-const parsedLoadFactor = Number.parseFloat(process.env.CI_LOAD_FACTOR ?? "1");
-
-/**
- * Stretch only liveness ceilings when CI reports shared-host contention.
- * Assertions still wait on observable state; this is not a fixed delay.
- */
-export const CI_LOAD_FACTOR =
-  Number.isFinite(parsedLoadFactor) && parsedLoadFactor >= 1
-    ? Math.min(parsedLoadFactor, 4)
-    : 1;
-
-export const loadAdjustedTimeout = (timeoutMs) =>
-  Math.ceil(timeoutMs * CI_LOAD_FACTOR);
 
 /** A loopback port nothing in these tests ever listens on. */
 export const DEAD_PORT = "59987";
@@ -121,44 +118,79 @@ export function writeGatedNotifier(dir, { exitCode = 0 } = {}) {
   return { outFile, pidFile, startedFile, releaseFile, stub };
 }
 
-export async function assertHealthyLiveServe() {
-  const home = tmpDir("evrt-doc-healthy-");
-  const port = String(59700 + (process.pid % 100));
-  const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
+/**
+ * Spawn `serve` on an OS-assigned port and wait until /health answers.
+ * Callers own cleanup (`box.child.kill`).
+ */
+export async function spawnLiveServe({
+  home,
+  extraEnv = {},
+  args = [],
+  timeoutMs = 20_000,
+} = {}) {
+  if (!home) throw new Error("spawnLiveServe requires home");
+  const port = freePort();
+  const child = spawnTracked("bun", [CLI, "serve", "--port", port, ...args], {
     env: {
       ...process.env,
       FACTORY_EVENT_HOME: home,
-      FACTORY_EVENT_SECRET: "test-secret",
-      FACTORY_GITHUB_WEBHOOK_SECRET: "test-gh-secret",
+      ...extraEnv,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  let out = "";
+  const box = { out: "", child, port };
   child.stdout.on("data", (b) => {
-    out += b;
+    box.out += b;
   });
   child.stderr.on("data", (b) => {
-    out += b;
+    box.out += b;
   });
-  const deadline = Date.now() + loadAdjustedTimeout(8000);
-  while (Date.now() < deadline && !out.includes("control API on")) {
-    await Bun.sleep(10);
+  try {
+    await until(
+      `serve control API on :${port}`,
+      async () => {
+        if (!box.out.includes("control API on")) return false;
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/health`);
+          return res.ok;
+        } catch {
+          return false;
+        }
+      },
+      { timeoutMs, everyMs: 20 },
+    );
+  } catch (error) {
+    const tail = box.out.slice(-800) || "(empty)";
+    child.kill("SIGKILL");
+    throw new Error(`${error.message}\n--- serve output tail ---\n${tail}`);
   }
+  return box;
+}
+
+export async function assertHealthyLiveServe() {
+  const home = tmpDir("evrt-doc-healthy-");
+  const box = await spawnLiveServe({
+    home,
+    extraEnv: {
+      FACTORY_EVENT_SECRET: "test-secret",
+      FACTORY_GITHUB_WEBHOOK_SECRET: "test-gh-secret",
+    },
+  });
   let docRes;
   try {
-    expect(out).toContain("control API on");
+    expect(box.out).toContain("control API on");
     docRes = spawnSync("bun", [CLI, "doctor"], {
       encoding: "utf8",
       env: {
         ...process.env,
         FACTORY_EVENT_HOME: home,
-        FACTORY_EVENT_PORT: port,
+        FACTORY_EVENT_PORT: box.port,
         FACTORY_RUN_DIR: throwawayRunDir(),
       },
     });
   } finally {
-    child.kill("SIGTERM");
-    await new Promise((resolve) => child.once("exit", resolve));
+    box.child.kill("SIGTERM");
+    await new Promise((resolve) => box.child.once("exit", resolve));
   }
   expect(docRes.status).toBe(0);
   expect(docRes.stdout).toContain("anomalies");
@@ -296,40 +328,40 @@ export function spawnWorker(args, env) {
 }
 
 export async function waitFor(box, needle, timeoutMs = 15_000) {
-  timeoutMs = loadAdjustedTimeout(timeoutMs);
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline && !box.out.includes(needle))
-    await Bun.sleep(50);
-  return box.out.includes(needle);
+  try {
+    await until(
+      `output to contain ${JSON.stringify(needle)}`,
+      () => box.out.includes(needle),
+      { timeoutMs, everyMs: 10 },
+    );
+  } catch (error) {
+    const tail = String(box.out ?? "").slice(-800) || "(empty)";
+    throw new Error(`${error.message}\n--- output tail ---\n${tail}`);
+  }
+  return true;
 }
 
-export function exitOf(child) {
+export async function exitOf(child, timeoutMs = 30_000) {
   // Resolve immediately if the child already exited (a drain-signalled
   // worker can finish before the test awaits it — WM-689). Use loose
   // null checks: Bun's ChildProcess reports `signalCode` as undefined (not
   // null) while the process is still running, and a strict `!== null` test
   // made this fire on live children, which broke demo/seed.test.mjs.
   if (child.exitCode != null || child.signalCode != null) {
-    return Promise.resolve({
+    return {
       code: child.exitCode,
       signal: child.signalCode ?? null,
-    });
-  }
-  return new Promise((resolve) => {
-    let resolved = false;
-    const done = (code, signal) => {
-      if (resolved) return;
-      resolved = true;
-      resolve({
-        code: code ?? child.exitCode,
-        signal: signal ?? child.signalCode,
-      });
     };
-    child.once("close", (code, signal) => done(code, signal));
-    child.once("exit", (code, signal) => {
-      setTimeout(() => done(code, signal), 50);
-    });
-  });
+  }
+  await until(
+    `pid ${child.pid} to exit`,
+    () => child.exitCode != null || child.signalCode != null,
+    { timeoutMs, everyMs: 20 },
+  );
+  return {
+    code: child.exitCode,
+    signal: child.signalCode ?? null,
+  };
 }
 
 /** A QUEUED run in `home`'s database, straight through the real lifecycle. */

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -32,6 +32,7 @@ import {
   processOwnerWatchdogSource,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+import { loadAdjustedTimeout, until } from "../test-helpers-timing.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed Cursor refusal shapes yet)", () => {
   test("nothing matches — empty until a Cursor-authored shape is observed", () => {
@@ -460,15 +461,13 @@ if (behavior === "emit_error_tool_result") {
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
 
   async function waitForGrandchildPid(pidFile) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) {
-        const pid = Number(readFileSync(pidFile, "utf8"));
-        trackProcessGroupForPid(pid);
-        return pid;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    throw new Error("stub did not report its grandchild PID");
+    await until("stub grandchild PID file", () => existsSync(pidFile), {
+      timeoutMs: 15_000,
+      everyMs: 10,
+    });
+    const pid = Number(readFileSync(pidFile, "utf8"));
+    trackProcessGroupForPid(pid);
+    return pid;
   }
 
   function processExists(pid) {
@@ -481,11 +480,10 @@ if (behavior === "emit_error_tool_result") {
   }
 
   async function expectProcessExit(pid) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (!processExists(pid)) return;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    expect(processExists(pid)).toBe(false);
+    await until(`pid ${pid} to exit`, () => !processExists(pid), {
+      timeoutMs: 15_000,
+      everyMs: 10,
+    });
   }
 
   function killIfRunning(pid) {
@@ -636,7 +634,7 @@ if (behavior === "emit_error_tool_result") {
         killIfRunning(grandchildPid);
       }
     },
-    { timeout: 12_000 },
+    loadAdjustedTimeout(30_000),
   );
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
@@ -687,6 +685,7 @@ if (behavior === "emit_error_tool_result") {
         killIfRunning(grandchildPid);
       }
     },
+    loadAdjustedTimeout(30_000),
   );
 
   test("tool_call stream maps to tool_use / tool_result and a usage event", async () => {

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -11,6 +11,7 @@ import {
   pendingNotifications,
   sendNotification,
 } from "./notify.mjs";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
 const tmp = (p) => tmpDir(p);
 
@@ -342,7 +343,10 @@ describe("notify (WM-65)", () => {
     const before = Date.now();
     const delivery = sendNotification(bin, "msg", { timeoutMs: 250 });
     // The spawn call itself returns immediately — the tick is never blocked.
-    expect(Date.now() - before).toBeLessThan(200);
+    // Load-adjust the ceiling: under shared-host contention, process spawn
+    // can exceed 200ms without the notifier having been awaited.
+    expect(delivery).toBeInstanceOf(Promise);
+    expect(Date.now() - before).toBeLessThan(loadAdjustedTimeout(1000));
     const outcome = await delivery;
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toContain("timed out after 250ms");

--- a/event-runtime/lib/test-helpers-timing.mjs
+++ b/event-runtime/lib/test-helpers-timing.mjs
@@ -1,0 +1,202 @@
+/**
+ * Timing-bound test registry and condition-polling helpers (WM-918).
+ *
+ * Required CI excludes tests whose names contain any TIMING_TEST_SUBSTRINGS
+ * entry. A separate non-required job runs that group with retries. Classify
+ * a bun-test log so merge-scan can treat an all-timing failure as a flake
+ * rather than ESCALATE if exclusion ever misses.
+ *
+ * Each substring still has to fail on the regression it guards — quarantining
+ * is not a skip of the assertion, only of the required lane.
+ */
+import { readFileSync } from "node:fs";
+
+const parsedLoadFactor = Number.parseFloat(process.env.CI_LOAD_FACTOR ?? "1");
+
+/**
+ * Stretch only liveness ceilings when CI reports shared-host contention.
+ * Assertions still wait on observable state; this is not a fixed delay.
+ */
+export const CI_LOAD_FACTOR =
+  Number.isFinite(parsedLoadFactor) && parsedLoadFactor >= 1
+    ? Math.min(parsedLoadFactor, 4)
+    : 1;
+
+export const loadAdjustedTimeout = (timeoutMs) =>
+  Math.ceil(timeoutMs * CI_LOAD_FACTOR);
+
+/**
+ * Known wall-clock spawn tests. Keep the strings as they appear in bun's
+ * test name (describe prefix optional — substring match). Regression notes
+ * document how the assertion still fails when the production bug returns.
+ */
+export const TIMING_TEST_SUBSTRINGS = [
+  // Drain must finish the leased hang-run before exiting 0. A worker that
+  // exits on the drain flag mid-run fails the `run_drain_busy →` vs
+  // `drain requested` order assertion in cli/work.test.mjs.
+  "a drain-signalled worker holding a lease finishes its run first, then exits 0",
+  // Reload is HEAD-and-worktree, not HEAD-only. A stamp that ignores the
+  // working tree never logs `reloading worker (exit 75)` in cli/work.test.mjs.
+  "an idle worker exits 75 within a poll interval of an uncommitted edit",
+  // Scale-down must drain to workers.min and stay there. A supervisor that
+  // respawns past min fails `poolSize === 1` / "no third spawn" in
+  // cli/supervise.test.mjs.
+  "surplus idle workers drain back to workers.min, and the pool is not respawned past target",
+  // Whole describe: beforeAll races ECONNREFUSED on a just-bound ephemeral
+  // port. Duplicate-prefix still fails immediately on intake; re-seed still
+  // requires a new prefix to clear hang runs (demo/seed.test.mjs, OPS-464).
+  "seed & re-seed deduplication (OPS-464)",
+  "re-seeding with a NEW prefix cleans up hang runs and allows verify to pass",
+  // Durable inbox POST against a live stub server. A notify that falls back
+  // to the unreachable-runtime path leaves requestFile unwritten
+  // (bin/factory.test.mjs).
+  "factory notify posts a structured inbox item when serve is reachable",
+  // Adapter timeout must kill the grandchild, not just the wrapper. A leak
+  // fails `expectProcessExit` in lib/adapters/cursor.test.mjs (WM-263).
+  "timeout kills a real long-lived grandchild",
+];
+
+export function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function timingIncludePattern(substrings = TIMING_TEST_SUBSTRINGS) {
+  if (!substrings.length) {
+    throw new Error("timing include pattern requires at least one substring");
+  }
+  return `(${substrings.map(escapeRegex).join("|")})`;
+}
+
+export function timingExcludePattern(substrings = TIMING_TEST_SUBSTRINGS) {
+  return `^(?!.*(?:${substrings.map(escapeRegex).join("|")})).*$`;
+}
+
+export function isTimingTestName(name, substrings = TIMING_TEST_SUBSTRINGS) {
+  const haystack = String(name ?? "");
+  return substrings.some((s) => haystack.includes(s));
+}
+
+/**
+ * Parse failing test names from `bun test` stdout/stderr.
+ * Handles `(fail) file > describe > name` and `✗ name [12.00ms]` forms.
+ */
+export function parseFailingTests(logText) {
+  const names = [];
+  const seen = new Set();
+  const push = (name) => {
+    const trimmed = String(name ?? "").trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    names.push(trimmed);
+  };
+
+  for (const raw of String(logText ?? "").split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    const fail = /^\(fail\)\s+(.+)$/.exec(line);
+    if (fail) {
+      const body = fail[1];
+      const parts = body.split(" > ");
+      push(parts[parts.length - 1].replace(/\s+\[[^\]]+\]\s*$/, ""));
+      continue;
+    }
+    const mark = /^\s*[×x✗✘]\s+(.+?)(?:\s+\[[\d.]+m?s\])?\s*$/.exec(line);
+    if (mark) push(mark[1]);
+  }
+  return names;
+}
+
+export function classifyTimingFailures(
+  logText,
+  substrings = TIMING_TEST_SUBSTRINGS,
+) {
+  const failing = parseFailingTests(logText);
+  const timing = failing.filter((name) => isTimingTestName(name, substrings));
+  const other = failing.filter((name) => !isTimingTestName(name, substrings));
+  return {
+    failing,
+    timing,
+    other,
+    allTiming: failing.length > 0 && other.length === 0,
+  };
+}
+
+/**
+ * Poll `fn` until it returns a truthy value. Ceiling stretches with
+ * CI_LOAD_FACTOR; the predicate is the assertion, not the clock.
+ */
+export async function until(
+  what,
+  fn,
+  { timeoutMs = 15_000, everyMs = 10 } = {},
+) {
+  const ceiling = loadAdjustedTimeout(timeoutMs);
+  const deadline = Date.now() + ceiling;
+  let last;
+  while (Date.now() < deadline) {
+    last = await fn();
+    if (last) return last;
+    await Bun.sleep(everyMs);
+  }
+  throw new Error(
+    `${what} did not become true within ${ceiling}ms (CI_LOAD_FACTOR=${CI_LOAD_FACTOR})`,
+  );
+}
+
+/** Ask the OS for a free loopback port and release the probe. */
+export function freePort() {
+  const probe = Bun.serve({ port: 0, fetch: () => new Response("") });
+  const port = probe.port;
+  probe.stop(true);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`freePort() got invalid port ${port}`);
+  }
+  return String(port);
+}
+
+export function formatTimingClassifyAnnotation(result) {
+  const names = result.failing.join(", ") || "(none parsed)";
+  if (result.failing.length === 0) {
+    return `::warning title=timing-classify::No bun failing-test names parsed from the log.`;
+  }
+  if (result.allTiming) {
+    return `::error title=timing-flake::All failing tests are in the WM-918 timing group: ${names}`;
+  }
+  return `::error title=non-timing-fail::Failures include tests outside the WM-918 timing group: ${result.other.join(", ")}`;
+}
+
+function printClassify(logText) {
+  const result = classifyTimingFailures(logText);
+  for (const name of result.failing) {
+    const kind = isTimingTestName(name) ? "timing" : "other";
+    console.log(`${kind}: ${name}`);
+  }
+  if (result.failing.length === 0) {
+    console.log("timing-classify: no failing test names parsed");
+  } else if (result.allTiming) {
+    console.log("timing-classify: all failures are in the timing group");
+  } else {
+    console.log("timing-classify: mixed or non-timing failures");
+  }
+  console.log(formatTimingClassifyAnnotation(result));
+}
+
+if (import.meta.main) {
+  const verb = process.argv[2] ?? "";
+  if (verb === "exclude-pattern") {
+    process.stdout.write(`${timingExcludePattern()}\n`);
+  } else if (verb === "include-pattern") {
+    process.stdout.write(`${timingIncludePattern()}\n`);
+  } else if (verb === "classify") {
+    const file = process.argv[3];
+    if (!file) {
+      console.error("classify requires a log file path");
+      process.exit(2);
+    }
+    printClassify(readFileSync(file, "utf8"));
+  } else {
+    console.error(
+      "usage: bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern|include-pattern|classify <logfile>",
+    );
+    process.exit(2);
+  }
+}

--- a/event-runtime/lib/test-helpers-timing.test.mjs
+++ b/event-runtime/lib/test-helpers-timing.test.mjs
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-test-helpers-timing-test-mjs";
+import {
+  TIMING_TEST_SUBSTRINGS,
+  classifyTimingFailures,
+  escapeRegex,
+  formatTimingClassifyAnnotation,
+  freePort,
+  isTimingTestName,
+  parseFailingTests,
+  timingExcludePattern,
+  timingIncludePattern,
+  until,
+} from "./test-helpers-timing.mjs";
+
+const HELPER = fileURLToPath(
+  new URL("./test-helpers-timing.mjs", import.meta.url),
+);
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+describe("timing-test registry (WM-918)", () => {
+  test("every timing substring still appears in the tree (rename = update the list)", () => {
+    const files = [
+      "event-runtime/cli/work.test.mjs",
+      "event-runtime/cli/supervise.test.mjs",
+      "event-runtime/demo/seed.test.mjs",
+      "bin/factory.test.mjs",
+      "event-runtime/lib/adapters/cursor.test.mjs",
+    ];
+    const haystack = files
+      .map((rel) => readFileSync(path.join(REPO_ROOT, rel), "utf8"))
+      .join("\n");
+    for (const substring of TIMING_TEST_SUBSTRINGS) {
+      expect(haystack.includes(substring), substring).toBe(true);
+    }
+  });
+
+  test("include pattern matches each substring and exclude pattern matches none of them", () => {
+    const include = new RegExp(timingIncludePattern());
+    const exclude = new RegExp(timingExcludePattern());
+    for (const substring of TIMING_TEST_SUBSTRINGS) {
+      const full = `suite > ${substring}`;
+      expect(include.test(full)).toBe(true);
+      expect(exclude.test(full)).toBe(false);
+    }
+    expect(
+      exclude.test(
+        "doctor against a healthy live serve outputs anomalies none and exits 0",
+      ),
+    ).toBe(true);
+    expect(include.test("a purely deterministic unit test name")).toBe(false);
+  });
+
+  test("escapeRegex keeps literal parentheses from becoming capturing groups", () => {
+    const re = new RegExp(
+      escapeRegex("seed & re-seed deduplication (OPS-464)"),
+    );
+    expect(re.test("seed & re-seed deduplication (OPS-464)")).toBe(true);
+    expect(re.test("seed & re-seed deduplication OPS-464")).toBe(false);
+  });
+
+  test("parseFailingTests reads bun (fail) and ✗ lines", () => {
+    const log = [
+      "(fail) event-runtime/cli/work.test.mjs > work --drain-file (WM-226) > a drain-signalled worker holding a lease finishes its run first, then exits 0",
+      "  ✗ surplus idle workers drain back to workers.min, and the pool is not respawned past target [20000.00ms]",
+      "(fail) event-runtime/lib/notify.test.mjs > notify (WM-65) > a hanging notifier is killed at the timeout and never delays the caller",
+    ].join("\n");
+    expect(parseFailingTests(log)).toEqual([
+      "a drain-signalled worker holding a lease finishes its run first, then exits 0",
+      "surplus idle workers drain back to workers.min, and the pool is not respawned past target",
+      "a hanging notifier is killed at the timeout and never delays the caller",
+    ]);
+  });
+
+  test("classifyTimingFailures flags an all-timing log and mixed failures separately", () => {
+    const allTiming = classifyTimingFailures(
+      "(fail) x > a drain-signalled worker holding a lease finishes its run first, then exits 0\n",
+    );
+    expect(allTiming.allTiming).toBe(true);
+    expect(allTiming.other).toEqual([]);
+    expect(formatTimingClassifyAnnotation(allTiming)).toContain(
+      "title=timing-flake",
+    );
+
+    const mixed = classifyTimingFailures(
+      [
+        "(fail) x > a drain-signalled worker holding a lease finishes its run first, then exits 0",
+        "(fail) y > zero-pack merged-view digest matches the develop baseline",
+      ].join("\n"),
+    );
+    expect(mixed.allTiming).toBe(false);
+    expect(mixed.other).toEqual([
+      "zero-pack merged-view digest matches the develop baseline",
+    ]);
+    expect(formatTimingClassifyAnnotation(mixed)).toContain(
+      "title=non-timing-fail",
+    );
+    expect(isTimingTestName("unrelated")).toBe(false);
+  });
+
+  test("CLI prints exclude/include patterns and classify annotation", () => {
+    const exclude = spawnSync("bun", [HELPER, "exclude-pattern"], {
+      encoding: "utf8",
+    });
+    expect(exclude.status).toBe(0);
+    expect(exclude.stdout.trim()).toBe(timingExcludePattern());
+
+    const include = spawnSync("bun", [HELPER, "include-pattern"], {
+      encoding: "utf8",
+    });
+    expect(include.status).toBe(0);
+    expect(include.stdout.trim()).toBe(timingIncludePattern());
+
+    const dir = tmpDir("evrt-timing-cli-");
+    const logFile = path.join(dir, "bun-test.log");
+    writeFileSync(
+      logFile,
+      "(fail) x > factory notify posts a structured inbox item when serve is reachable\n",
+    );
+    const classified = spawnSync("bun", [HELPER, "classify", logFile], {
+      encoding: "utf8",
+    });
+    expect(classified.status).toBe(0);
+    expect(classified.stdout).toContain("title=timing-flake");
+    expect(classified.stdout).toContain("all failures are in the timing group");
+  });
+});
+
+describe("until and freePort (WM-918)", () => {
+  test("until returns the first truthy value and throws when the ceiling elapses", async () => {
+    let n = 0;
+    expect(
+      await until("counter", () => ++n >= 3, { timeoutMs: 1000, everyMs: 1 }),
+    ).toBe(true);
+    expect(n).toBe(3);
+
+    let caught = null;
+    try {
+      await until("never", () => false, { timeoutMs: 20, everyMs: 5 });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(String(caught.message)).toContain("never did not become true");
+  });
+
+  test("freePort returns a bindable loopback port", async () => {
+    const port = Number(freePort());
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThanOrEqual(65535);
+    const server = Bun.serve({
+      port,
+      fetch: () => new Response("ok"),
+    });
+    try {
+      expect(server.port).toBe(port);
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await res.text()).toBe("ok");
+    } finally {
+      server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Required `Fast unit tests` and `Full verification` exclude the named timing-bound spawn tests (`event-runtime/lib/test-helpers-timing.mjs`); a separate non-required `Timing-bound tests` job runs that group with `--retry 2`. A required-job failure whose parsed names are all in that group is annotated `timing-flake`.
- Owned suites wait on observable state: `until()`, `freePort()` / `/health` for live serve, load-adjusted notify spawn bound, cursor grandchild PID/exit waits. No assertions dropped.
- Follow-up [WM-933](https://linear.app/watt-mind/issue/WM-933) covers rewriting the unowned spawn suites (`cli/work.test.mjs`, `cli/supervise.test.mjs`, `demo/seed.test.mjs`, `bin/factory.test.mjs`) and re-pinning merge-scan after a flake-classification prompt edit.

Fixes WM-918

UX critique: skipped — CI, test helpers, and spawn-test determinism; no user-completable product surface.

## Test plan
- [ ] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [ ] Confirm Fast unit tests / Full verification no longer run the drain/reload/supervise/seed/notify-inbox/grandchild-timeout names
- [ ] Confirm `Timing-bound tests` is not a required check and may go red without failing `Verify`


Made with [Cursor](https://cursor.com)