### PR TITLE
feat(event-runtime-web): live tracker details and spec panel on Ticket Journey (WM-914)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1,4 +1,5 @@
 /** Event, proposal, run, journal, outbox, and worker-action endpoints. */
+import { ControlPlaneError } from "../../lib/control-plane/types.mjs";
 import { artifactHead } from "./api-artifacts.mjs";
 import { FACTORY_ROOT } from "./config.mjs";
 import { runUsage } from "./db.mjs";
@@ -394,6 +395,107 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     proposals: matchedProposals,
     runs: matchedRuns,
   };
+}
+
+/** Short TTL so Ticket Journey can poll without exhausting Linear. */
+export const TICKET_DETAIL_CACHE_TTL_MS = 30_000;
+const ticketDetailCache = new Map();
+let injectedTicketDetailControlPlane = null;
+
+/** Test seam: inject a ControlPlane (typically `memoryControlPlane`) or clear. */
+export function setTicketDetailControlPlane(plane) {
+  injectedTicketDetailControlPlane = plane ?? null;
+}
+
+export function clearTicketDetailCache() {
+  ticketDetailCache.clear();
+}
+
+function trackerStateName(state) {
+  if (typeof state === "string" && state.trim()) return state.trim();
+  if (state && typeof state === "object" && typeof state.name === "string") {
+    const name = state.name.trim();
+    if (name) return name;
+  }
+  return null;
+}
+
+async function ticketDetailControlPlane(override) {
+  if (override) return override;
+  if (injectedTicketDetailControlPlane) return injectedTicketDetailControlPlane;
+  const { loadControlPlane } =
+    await import("../../lib/control-plane/index.mjs");
+  return loadControlPlane({ root: FACTORY_ROOT });
+}
+
+/**
+ * Live tracker snapshot for Ticket Journey (WM-914): title, state, markdown
+ * description, and comments. Cached briefly so a 5s UI poll does not become a
+ * Linear request storm.
+ */
+export async function ticketDetailView(rawTicket, options = {}) {
+  const ticket = String(rawTicket ?? "")
+    .trim()
+    .toUpperCase();
+  if (!TICKET_ID.test(ticket)) return { error: "invalid_ticket" };
+
+  const nowMs = options.nowMs ?? Date.now();
+  const cacheKey = ticket;
+  if (options.noCache !== true) {
+    const cached = ticketDetailCache.get(cacheKey);
+    if (cached && nowMs - cached.timestamp < TICKET_DETAIL_CACHE_TTL_MS) {
+      return { ...cached.data, cached: true };
+    }
+  }
+
+  try {
+    const plane = await ticketDetailControlPlane(options.controlPlane);
+    const [issue, comments] = await Promise.all([
+      plane.getTicket(ticket),
+      plane.listComments(ticket),
+    ]);
+    const identifier = issue.identifier ?? ticket;
+    const data = {
+      ticket: {
+        id: identifier,
+        identifier,
+        title:
+          typeof issue.title === "string" && issue.title.trim()
+            ? issue.title.trim()
+            : null,
+        state: trackerStateName(issue.state),
+        description:
+          typeof issue.description === "string" ? issue.description : "",
+        url:
+          typeof issue.url === "string" && issue.url.trim()
+            ? issue.url.trim()
+            : `https://linear.app/watt-mind/issue/${encodeURIComponent(ticket)}`,
+        assignee: issue.assignee ? { name: issue.assignee.name ?? null } : null,
+      },
+      comments: (Array.isArray(comments) ? comments : []).map((comment) => ({
+        id: comment?.id ?? null,
+        body: typeof comment?.body === "string" ? comment.body : "",
+        createdAt:
+          typeof comment?.createdAt === "string" ? comment.createdAt : null,
+        user: comment?.user
+          ? {
+              id: comment.user.id ?? null,
+              name: comment.user.name ?? null,
+            }
+          : null,
+      })),
+      fetchedAt: new Date(nowMs).toISOString(),
+      cached: false,
+    };
+    ticketDetailCache.set(cacheKey, { timestamp: nowMs, data });
+    return data;
+  } catch (err) {
+    const message = err?.message ? String(err.message) : "tracker read failed";
+    if (err instanceof ControlPlaneError && /no such issue/i.test(message)) {
+      return { error: "not_found", message };
+    }
+    return { error: "tracker_unavailable", message };
+  }
 }
 
 /** States whose attempt deadline is live and render-relevant on the run list. */
@@ -1181,6 +1283,7 @@ export async function handleRunApiRoute({
   artifactsDir,
   onEvent,
   policyRoot = FACTORY_ROOT,
+  controlPlane,
 }) {
   if (route === "GET /events") {
     return send(200, {
@@ -1344,6 +1447,27 @@ export async function handleRunApiRoute({
         : 409;
       return send(status, { error: err.message });
     }
+  }
+
+  const ticketDetail = url.pathname.match(/^\/tickets\/([^/]+)\/detail$/);
+  if (req.method === "GET" && ticketDetail) {
+    const result = await ticketDetailView(decodeURIComponent(ticketDetail[1]), {
+      nowMs,
+      controlPlane,
+    });
+    if (result.error === "invalid_ticket") {
+      return send(422, { error: "ticket must look like WM-123" });
+    }
+    if (result.error === "not_found") {
+      return send(404, { error: result.message });
+    }
+    if (result.error === "tracker_unavailable") {
+      return send(502, {
+        error: "tracker_unavailable",
+        message: result.message,
+      });
+    }
+    return send(200, result);
   }
 
   if (route === "GET /tickets") {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -2,8 +2,21 @@ import {
   tmpDir,
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-runs-test-mjs";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { ticketIndexView } from "./api-runs.mjs";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { memoryControlPlane } from "../../lib/control-plane/index.mjs";
+import {
+  TICKET_DETAIL_CACHE_TTL_MS,
+  clearTicketDetailCache,
+  setTicketDetailControlPlane,
+  ticketIndexView,
+} from "./api-runs.mjs";
 import {
   GH_SECRET,
   PV,
@@ -1404,6 +1417,128 @@ describe("run trace surfacing (OPS-295)", () => {
       expect(await client.trace(queuedRun)).toEqual({ head: 0, entries: [] });
     } finally {
       server.close();
+    }
+  });
+});
+
+describe("GET /tickets/:id/detail (WM-914)", () => {
+  afterEach(() => {
+    setTicketDetailControlPlane(null);
+    clearTicketDetailCache();
+  });
+
+  function seedPlane() {
+    const plane = memoryControlPlane({
+      tickets: [
+        {
+          id: "iss-914",
+          identifier: "WM-914",
+          title: "Live tracker title",
+          description: "## Spec\n\nDo the thing.",
+          url: "https://linear.app/watt-mind/issue/WM-914",
+          state: { id: "s-progress", name: "In Progress" },
+          assignee: { id: "u1", name: "Ada" },
+          comments: [
+            {
+              id: "c1",
+              body: "First comment",
+              createdAt: "2026-08-18T10:00:00.000Z",
+              user: { id: "u1", name: "Ada" },
+            },
+          ],
+        },
+      ],
+    });
+    setTicketDetailControlPlane(plane);
+    return plane;
+  }
+
+  test("returns live title, state, description, and comments", async () => {
+    seedPlane();
+    const s = await makeServer();
+    try {
+      const res = await fetch(s.url("/tickets/WM-914/detail"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ticket).toEqual({
+        id: "WM-914",
+        identifier: "WM-914",
+        title: "Live tracker title",
+        state: "In Progress",
+        description: "## Spec\n\nDo the thing.",
+        url: "https://linear.app/watt-mind/issue/WM-914",
+        assignee: { name: "Ada" },
+      });
+      expect(body.comments).toEqual([
+        {
+          id: "c1",
+          body: "First comment",
+          createdAt: "2026-08-18T10:00:00.000Z",
+          user: { id: "u1", name: "Ada" },
+        },
+      ]);
+      expect(body.cached).toBe(false);
+      expect(typeof body.fetchedAt).toBe("string");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("caches within the TTL and refetches after it expires", async () => {
+    const plane = seedPlane();
+    let nowMs = Date.parse("2026-08-19T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const first = await fetch(s.url("/tickets/WM-914/detail"));
+      expect(first.status).toBe(200);
+      expect((await first.json()).cached).toBe(false);
+      expect(plane.calls.filter((c) => c.op === "getTicket")).toHaveLength(1);
+
+      nowMs += 1_000;
+      const cached = await fetch(s.url("/tickets/WM-914/detail"));
+      expect((await cached.json()).cached).toBe(true);
+      expect(plane.calls.filter((c) => c.op === "getTicket")).toHaveLength(1);
+
+      nowMs += TICKET_DETAIL_CACHE_TTL_MS;
+      const stale = await fetch(s.url("/tickets/WM-914/detail"));
+      expect((await stale.json()).cached).toBe(false);
+      expect(plane.calls.filter((c) => c.op === "getTicket")).toHaveLength(2);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("rejects malformed ids, missing issues, and tracker failures", async () => {
+    seedPlane();
+    const s = await makeServer();
+    try {
+      const bad = await fetch(s.url("/tickets/not-a-ticket/detail"));
+      expect(bad.status).toBe(422);
+      expect(await bad.json()).toEqual({
+        error: "ticket must look like WM-123",
+      });
+
+      const missing = await fetch(s.url("/tickets/WM-999/detail"));
+      expect(missing.status).toBe(404);
+      expect((await missing.json()).error).toMatch(/no such issue/i);
+
+      setTicketDetailControlPlane({
+        kind: "memory",
+        getTicket: async () => {
+          throw new Error("network down");
+        },
+        listComments: async () => {
+          throw new Error("network down");
+        },
+      });
+      clearTicketDetailCache();
+      const down = await fetch(s.url("/tickets/WM-914/detail"));
+      expect(down.status).toBe(502);
+      const body = await down.json();
+      expect(body.error).toBe("tracker_unavailable");
+      expect(body.message).toBe("network down");
+    } finally {
+      s.close();
     }
   });
 });

--- a/event-runtime/web/src/subjectJourney.ts
+++ b/event-runtime/web/src/subjectJourney.ts
@@ -114,6 +114,61 @@ export interface TicketJourneySource {
   runs: JourneyRun[];
 }
 
+/** One comment from `GET /tickets/:id/detail` (WM-914). */
+export interface TicketTrackerComment {
+  id: string | null;
+  body: string;
+  createdAt: string | null;
+  user: { id?: string | null; name?: string | null } | null;
+}
+
+/** Live tracker snapshot from `GET /tickets/:id/detail` (WM-914). */
+export interface TicketTrackerDetail {
+  ticket: {
+    id: string;
+    identifier: string;
+    title: string | null;
+    state: string | null;
+    description: string;
+    url: string;
+    assignee: { name?: string | null } | null;
+  };
+  comments: TicketTrackerComment[];
+  fetchedAt: string;
+  cached: boolean;
+}
+
+/** Overlay live tracker title/state/url onto a runtime-built ticket journey. */
+export function overlayTrackerDetail(
+  journey: SubjectJourney,
+  detail: TicketTrackerDetail | null | undefined,
+): SubjectJourney {
+  if (!detail?.ticket || journey.subject.kind !== "ticket") return journey;
+  const title =
+    typeof detail.ticket.title === "string" && detail.ticket.title.trim()
+      ? detail.ticket.title.trim()
+      : journey.subject.title;
+  const state =
+    typeof detail.ticket.state === "string" && detail.ticket.state.trim()
+      ? detail.ticket.state.trim()
+      : journey.subject.state;
+  const url =
+    typeof detail.ticket.url === "string" && detail.ticket.url.trim()
+      ? detail.ticket.url.trim()
+      : journey.subject.url;
+  if (
+    title === journey.subject.title &&
+    state === journey.subject.state &&
+    url === journey.subject.url
+  ) {
+    return journey;
+  }
+  return {
+    ...journey,
+    subject: { ...journey.subject, title, state, url },
+  };
+}
+
 export interface JourneyEvent {
   source: string;
   eventId: string;

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -10,7 +10,11 @@ import {
 } from "@testing-library/react";
 import { prCandidateRunIds, PullRequest, Ticket } from "./Ticket";
 import { changeInput } from "../test-render";
-import type { JourneyRun, TicketJourneySource } from "../subjectJourney";
+import type {
+  JourneyRun,
+  TicketJourneySource,
+  TicketTrackerDetail,
+} from "../subjectJourney";
 
 const realFetch = globalThis.fetch;
 
@@ -112,11 +116,63 @@ function source(): TicketJourneySource {
   };
 }
 
-function renderTicket(data: TicketJourneySource) {
-  globalThis.fetch = (async () =>
-    new Response(JSON.stringify(data), {
-      status: 200,
-    })) as unknown as typeof fetch;
+function trackerDetail(
+  overrides: Partial<TicketTrackerDetail> = {},
+): TicketTrackerDetail {
+  return {
+    ticket: {
+      id: "WM-542",
+      identifier: "WM-542",
+      title: "Live Linear title",
+      state: "In Progress",
+      description: "## Acceptance Criteria\n\n- ship the overlay",
+      url: "https://linear.app/watt-mind/issue/WM-542",
+      assignee: { name: "Ada" },
+    },
+    comments: [
+      {
+        id: "c1",
+        body: "Looks good from Linear",
+        createdAt: "2026-08-18T12:00:00.000Z",
+        user: { name: "Ada" },
+      },
+    ],
+    fetchedAt: "2026-08-19T12:00:00.000Z",
+    cached: false,
+    ...overrides,
+  };
+}
+
+function journeyFetch(
+  data: TicketJourneySource,
+  detail?: TicketTrackerDetail | null,
+  detailStatus = 200,
+) {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (/\/api\/tickets\/[^/]+\/detail/.test(url)) {
+      if (detail === undefined) {
+        return new Response(JSON.stringify({ error: "no such issue" }), {
+          status: 404,
+        });
+      }
+      return new Response(JSON.stringify(detail), {
+        status: detailStatus,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (/\/api\/schedules/.test(url)) {
+      return new Response(JSON.stringify({ schedules: [] }), { status: 200 });
+    }
+    return new Response(JSON.stringify(data), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+function renderTicket(
+  data: TicketJourneySource,
+  detail?: TicketTrackerDetail | null,
+) {
+  globalThis.fetch = journeyFetch(data, detail);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchInterval: false } },
   });
@@ -149,7 +205,7 @@ describe("Ticket journey view", () => {
         .getByRole("link", { name: "run_dispatch · COMPLETED" })
         .getAttribute("href"),
     ).toBe("#/run/run_dispatch");
-    const timeline = view.getByRole("region", { name: /timeline/i });
+    const timeline = view.getByRole("tabpanel", { name: /timeline/i });
     expect(within(timeline).getAllByText("QUEUED").length).toBeGreaterThan(0);
     expect(view.getByRole("heading", { name: "Where it is now" })).toBeTruthy();
   });
@@ -198,11 +254,12 @@ describe("Ticket journey view", () => {
     };
   }
 
-  function renderId(id: string, data: TicketJourneySource) {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify(data), {
-        status: 200,
-      })) as unknown as typeof fetch;
+  function renderId(
+    id: string,
+    data: TicketJourneySource,
+    detail?: TicketTrackerDetail | null,
+  ) {
+    globalThis.fetch = journeyFetch(data, detail);
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchInterval: false } },
     });
@@ -250,6 +307,79 @@ describe("Ticket journey view", () => {
         "no runtime activity for WM-542",
       ),
     );
+  });
+
+  test("header prefers live tracker title and state over runtime metadata", async () => {
+    const data = source();
+    data.ticket.title = null;
+    data.ticket.state = null;
+    const view = renderTicket(data, trackerDetail());
+    await view.findByRole("heading", { name: "WM-542" });
+    expect(view.getByText("Live Linear title")).toBeTruthy();
+    expect(view.getAllByText("In Progress").length).toBeGreaterThan(0);
+    expect(view.container.textContent).not.toContain("title not recorded");
+    const linear = view.getByRole("link", { name: "Open in Linear ↗" });
+    expect(linear.className).toContain("rounded-md");
+    expect(linear.className).toContain("border");
+  });
+
+  test("Spec & Comments tab renders the issue description and comments", async () => {
+    const view = renderTicket(source(), trackerDetail());
+    await view.findByRole("heading", { name: "WM-542" });
+    fireEvent.click(view.getByRole("tab", { name: "Spec & Comments" }));
+    expect(
+      view.getByRole("tabpanel", { name: /spec and comments/i }),
+    ).toBeTruthy();
+    expect(view.getByText("Acceptance Criteria")).toBeTruthy();
+    expect(view.getByText("Looks good from Linear")).toBeTruthy();
+    expect(view.getByText("Ada")).toBeTruthy();
+  });
+
+  test("o shortcut opens the Linear issue in a new tab", async () => {
+    let openedUrl = "";
+    const origOpen = window.open;
+    Object.defineProperty(window, "open", {
+      writable: true,
+      value: (url: string) => {
+        openedUrl = url;
+        return null;
+      },
+    });
+    try {
+      const view = renderTicket(source(), trackerDetail());
+      await view.findByRole("heading", { name: "WM-542" });
+      fireEvent.keyDown(document.body, { key: "o" });
+      expect(openedUrl).toBe("https://linear.app/watt-mind/issue/WM-542");
+    } finally {
+      Object.defineProperty(window, "open", {
+        writable: true,
+        value: origOpen,
+      });
+    }
+  });
+
+  test("an unindexed id Linear still knows shows the live title and spec tab", async () => {
+    const view = renderId(
+      "WM-999",
+      unindexed("WM-999"),
+      trackerDetail({
+        ticket: {
+          id: "WM-999",
+          identifier: "WM-999",
+          title: "External but real",
+          state: "Todo",
+          description: "Brought in from Linear.",
+          url: "https://linear.app/watt-mind/issue/WM-999",
+          assignee: null,
+        },
+      }),
+    );
+    await view.findByRole("heading", { name: "WM-999" });
+    expect(view.getByText("External but real")).toBeTruthy();
+    expect(view.queryByText("Unknown or external ticket")).toBeNull();
+    expect(view.getByText(/no runtime activity for WM-999/)).toBeTruthy();
+    fireEvent.click(view.getByRole("tab", { name: "Spec & Comments" }));
+    expect(view.getByText("Brought in from Linear.")).toBeTruthy();
   });
 });
 

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -730,10 +730,7 @@ function SpecCommentsPanel({
           id="ticket-comments"
           className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase"
         >
-          Comments
-          <span className="ml-1.5 tabular-nums text-(--text-faint)">
-            {(detail.comments ?? []).length}
-          </span>
+          Comments ({(detail.comments ?? []).length})
         </h3>
         {(detail.comments ?? []).length === 0 ? (
           <p className="mt-3 text-[13px] text-(--text-dim)">No comments yet.</p>
@@ -1135,7 +1132,7 @@ export function Ticket({
   // knows it, show the journey chrome with the live title instead of this
   // empty state.
   const trackerKnown = Boolean(
-    detailQuery.data?.ticket.title || detailQuery.data?.ticket.state,
+    detailQuery.data?.ticket?.title || detailQuery.data?.ticket?.state,
   );
   if (isUnindexedTicket(query.data) && !trackerKnown) {
     if (detailQuery.isPending) {

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -8,7 +8,14 @@ import {
   type ReactNode,
 } from "react";
 import { api } from "../api";
-import { refetchIntervals, useListKeys, useNow } from "../hooks";
+import { goPrefixActive } from "../goSequence";
+import {
+  keyGuard,
+  refetchIntervals,
+  useListKeys,
+  useNow,
+  useTabKeys,
+} from "../hooks";
 import {
   buildTicketJourney,
   formatDuration,
@@ -18,13 +25,16 @@ import {
   selectPrSource,
   subjectJourney,
   TICKET_ID_PATTERN,
+  overlayTrackerDetail,
   ticketIdsIn,
   type JourneyEvent,
   type JourneyProposal,
   type JourneyRun,
   type SubjectJourney,
+  type TicketTrackerDetail,
   type TimelineItem,
 } from "../subjectJourney";
+import { MarkdownView } from "../components/RunTrace";
 import {
   Ago,
   Button as PrimitiveButton,
@@ -606,14 +616,169 @@ function TicketsHub({
   );
 }
 
+const JOURNEY_TABS = ["timeline", "spec"] as const;
+type JourneyTab = (typeof JOURNEY_TABS)[number];
+
+const EXTERNAL_BUTTON_CLASS =
+  "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 text-[12px] font-medium text-(--text) hover:bg-(--surface-3)";
+
+async function fetchTicketDetail(
+  ticketId: string,
+): Promise<TicketTrackerDetail | null> {
+  const response = await fetch(
+    `/api/tickets/${encodeURIComponent(ticketId)}/detail`,
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      message = body.message ?? body.error ?? message;
+    } catch {
+      // Keep the HTTP status when the control API did not return JSON.
+    }
+    throw new Error(message);
+  }
+  return response.json();
+}
+
+function ExternalTicketLink({
+  href,
+  label,
+  shortcut,
+}: {
+  href: string;
+  label: string;
+  shortcut?: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={label}
+      title={shortcut ? `${label} (${shortcut})` : label}
+      className={EXTERNAL_BUTTON_CLASS}
+    >
+      {label}
+      {shortcut && (
+        <kbd
+          aria-hidden="true"
+          className="rounded border border-(--border) px-1 font-sans text-xs text-(--text-faint)"
+        >
+          {shortcut}
+        </kbd>
+      )}
+    </a>
+  );
+}
+
+function SpecCommentsPanel({
+  detail,
+  pending,
+  error,
+}: {
+  detail: TicketTrackerDetail | null;
+  pending: boolean;
+  error: string | null;
+}) {
+  if (pending) {
+    return (
+      <div role="status" className="text-[13px] text-(--text-faint)">
+        Loading spec and comments…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-(--hue-warn) bg-(--surface-0) p-3 text-[13px] text-(--hue-warn)"
+      >
+        Cannot load Linear details: {error}
+      </div>
+    );
+  }
+  if (!detail) {
+    return (
+      <div role="status" className="text-[13px] text-(--text-dim)">
+        No Linear issue found for this id.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      <section aria-labelledby="ticket-spec">
+        <h3
+          id="ticket-spec"
+          className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase"
+        >
+          Spec
+        </h3>
+        <div className="mt-3">
+          {(detail.ticket.description ?? "").trim() ? (
+            <MarkdownView text={detail.ticket.description} />
+          ) : (
+            <p className="text-[13px] text-(--text-dim)">
+              No description recorded.
+            </p>
+          )}
+        </div>
+      </section>
+      <section aria-labelledby="ticket-comments">
+        <h3
+          id="ticket-comments"
+          className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase"
+        >
+          Comments
+          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+            {(detail.comments ?? []).length}
+          </span>
+        </h3>
+        {(detail.comments ?? []).length === 0 ? (
+          <p className="mt-3 text-[13px] text-(--text-dim)">No comments yet.</p>
+        ) : (
+          <ol className="mt-3 space-y-4">
+            {(detail.comments ?? []).map((comment, index) => (
+              <li
+                key={comment.id ?? `comment-${index}`}
+                className="rounded-md border border-(--border) bg-(--surface-0) p-3"
+              >
+                <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2 text-[11px] text-(--text-faint)">
+                  <span className="font-medium text-(--text-dim)">
+                    {comment.user?.name ?? "unknown"}
+                  </span>
+                  {comment.createdAt && (
+                    <time dateTime={comment.createdAt}>
+                      {new Date(comment.createdAt).toLocaleString()}
+                    </time>
+                  )}
+                </div>
+                <MarkdownView text={comment.body} allowToggle={false} />
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
 /** Shared header + timeline + "Where it is now" for either subject kind. */
 function JourneyLayout({
   journey,
   onNavigateTicket,
+  detail = null,
+  detailPending = false,
+  detailError = null,
 }: {
   journey: SubjectJourney;
   onNavigateTicket?: (ticketId: string) => void;
+  detail?: TicketTrackerDetail | null;
+  detailPending?: boolean;
+  detailError?: string | null;
 }) {
+  const [tab, setTab] = useState<JourneyTab>("timeline");
   const cost =
     journey.totalCost == null ? "—" : `$${journey.totalCost.toFixed(2)}`;
   const tokens =
@@ -621,7 +786,11 @@ function JourneyLayout({
   const isPr = journey.subject.kind === "pr";
   const title =
     journey.subject.title ??
-    (isPr ? `PR #${journey.subject.id}` : "title not recorded");
+    (detailPending && !isPr
+      ? "Loading title…"
+      : isPr
+        ? `PR #${journey.subject.id}`
+        : "title not recorded");
   const state = journey.subject.state ?? (isPr ? null : "unknown");
   const heading = isPr ? `#${journey.subject.id}` : journey.subject.id;
   const noActivityLabel = isPr
@@ -629,6 +798,23 @@ function JourneyLayout({
     : `no runtime activity for ${journey.subject.id}`;
   const externalLabel = isPr ? "Open on GitHub ↗" : "Open in Linear ↗";
   const externalUrl = isPr ? (journey.pr?.url ?? null) : journey.subject.url;
+  const ticketTabs: readonly JourneyTab[] = isPr ? ["timeline"] : JOURNEY_TABS;
+
+  useTabKeys(ticketTabs, isPr ? "timeline" : tab, setTab);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (keyGuard(event) || event.metaKey || event.ctrlKey || event.altKey)
+        return;
+      if (goPrefixActive()) return;
+      if (event.key !== "o" && event.key !== "l") return;
+      if (!externalUrl) return;
+      event.preventDefault();
+      window.open(externalUrl, "_blank", "noreferrer");
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [externalUrl]);
 
   return (
     <div className="h-full overflow-auto bg-(--surface-0) p-5 lg:p-7">
@@ -670,16 +856,13 @@ function JourneyLayout({
                 {title}
               </div>
             </div>
-            <div className="flex flex-wrap gap-3 text-[12px]">
+            <div className="flex flex-wrap items-center gap-3 text-[12px]">
               {externalUrl && (
-                <a
+                <ExternalTicketLink
                   href={externalUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-(--accent) hover:underline"
-                >
-                  {externalLabel}
-                </a>
+                  label={externalLabel}
+                  shortcut="O"
+                />
               )}
               {!isPr && journey.prUrls[0] && (
                 <a
@@ -717,7 +900,56 @@ function JourneyLayout({
           </div>
         </header>
 
-        {!journey.activity ? (
+        {!isPr && (
+          <div
+            className="mt-5 flex w-max flex-nowrap gap-1 whitespace-nowrap"
+            role="tablist"
+            aria-label="Ticket journey sections"
+          >
+            <PrimitiveButton
+              bare
+              type="button"
+              role="tab"
+              aria-selected={tab === "timeline"}
+              onClick={() => setTab("timeline")}
+              className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                tab === "timeline"
+                  ? "bg-(--surface-3) text-(--text)"
+                  : "text-(--text-faint) hover:bg-(--surface-1)"
+              }`}
+            >
+              Timeline
+            </PrimitiveButton>
+            <PrimitiveButton
+              bare
+              type="button"
+              role="tab"
+              aria-selected={tab === "spec"}
+              onClick={() => setTab("spec")}
+              className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                tab === "spec"
+                  ? "bg-(--surface-3) text-(--text)"
+                  : "text-(--text-faint) hover:bg-(--surface-1)"
+              }`}
+            >
+              Spec & Comments
+            </PrimitiveButton>
+          </div>
+        )}
+
+        {!isPr && tab === "spec" ? (
+          <section
+            role="tabpanel"
+            aria-label="Spec and comments"
+            className="mt-5 rounded-lg border border-(--border) bg-(--surface-1) p-5"
+          >
+            <SpecCommentsPanel
+              detail={detail}
+              pending={detailPending}
+              error={detailError}
+            />
+          </section>
+        ) : !journey.activity ? (
           <div
             role="status"
             className="mt-5 rounded-lg border border-dashed border-(--border-strong) bg-(--surface-1) p-8 text-center"
@@ -726,19 +958,19 @@ function JourneyLayout({
               {noActivityLabel}
             </div>
             {externalUrl && (
-              <a
-                href={externalUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-2 inline-block text-[12px] text-(--accent) hover:underline"
-              >
-                {externalLabel}
-              </a>
+              <div className="mt-3 flex justify-center">
+                <ExternalTicketLink
+                  href={externalUrl}
+                  label={externalLabel}
+                  shortcut="O"
+                />
+              </div>
             )}
           </div>
         ) : (
           <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
             <section
+              role="tabpanel"
               aria-labelledby="ticket-timeline"
               className="rounded-lg border border-(--border) bg-(--surface-1) p-5"
             >
@@ -847,6 +1079,13 @@ export function Ticket({
     enabled: valid,
     ...refetchIntervals.secondary,
   });
+  const detailQuery = useQuery({
+    queryKey: ["ticket-detail", normalized],
+    queryFn: () => fetchTicketDetail(normalized!),
+    enabled: valid,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
 
   if (!ticketId || ticketId.trim() === "")
     return <TicketsHub onNavigate={onNavigate} onNavigatePr={onNavigatePr} />;
@@ -892,10 +1131,20 @@ export function Ticket({
   }
 
   // An id nothing in the runtime has ever named — a typo, another workspace's
-  // ticket, or a team this factory does not dispatch. The journey chrome would
-  // be a page of dashes, so say what happened and offer the one link that can
-  // still answer the question.
-  if (isUnindexedTicket(query.data)) {
+  // ticket, or a team this factory does not dispatch. If the tracker still
+  // knows it, show the journey chrome with the live title instead of this
+  // empty state.
+  const trackerKnown = Boolean(
+    detailQuery.data?.ticket.title || detailQuery.data?.ticket.state,
+  );
+  if (isUnindexedTicket(query.data) && !trackerKnown) {
+    if (detailQuery.isPending) {
+      return (
+        <div className="p-8 text-[13px] text-(--text-faint)">
+          Loading {normalized} from Linear…
+        </div>
+      );
+    }
     return (
       <div className="p-8">
         <div
@@ -910,14 +1159,11 @@ export function Ticket({
             index: no run, event, or proposal has ever named it.
           </div>
           <div className="mt-4 flex flex-wrap justify-center gap-4 text-[12px]">
-            <a
+            <ExternalTicketLink
               href={query.data.ticket.url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-(--accent) hover:underline"
-            >
-              Open in Linear ↗
-            </a>
+              label="Open in Linear ↗"
+              shortcut="O"
+            />
             <button
               type="button"
               onClick={() => onNavigate("")}
@@ -931,11 +1177,25 @@ export function Ticket({
     );
   }
 
-  const journey = buildTicketJourney({
-    ...query.data,
-    schedules: schedules.data?.schedules,
-  });
-  return <JourneyLayout journey={journey} />;
+  const journey = overlayTrackerDetail(
+    buildTicketJourney({
+      ...query.data,
+      schedules: schedules.data?.schedules,
+    }),
+    detailQuery.data,
+  );
+  return (
+    <JourneyLayout
+      journey={journey}
+      detail={detailQuery.data}
+      detailPending={detailQuery.isPending}
+      detailError={
+        detailQuery.isError
+          ? ((detailQuery.error as Error)?.message ?? "unavailable")
+          : null
+      }
+    />
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Control API `GET /tickets/:id/detail` reads live Linear title, state, description, and comments via the control-plane adapter, with a 30s TTL cache.
- Ticket Journey overlays that title/state (no more `"title not recorded"` when Linear knows the issue), adds a Spec & Comments tab with markdown, and restyles Open in Linear as a button with the `o`/`l` shortcut.

Fixes WM-914

UX critique: required — SHIP (http://127.0.0.1:7643/#/tickets/WM-100)

## Test plan
- [x] `bun test event-runtime/lib/api-runs.test.mjs && cd event-runtime/web && bun test src/views/Ticket.test.tsx`
- [x] `cd event-runtime/web && bun run build`
- [ ] Open `#/tickets/WM-100` (or any ticket without captured metadata) and confirm live title/state, Spec & Comments, and `o` opening Linear

Follow-up filed: WM-928 (pre-existing dispatch e2e `memoPin` assertion on develop).


Made with [Cursor](https://cursor.com)