### PR TITLE
ci: install event-runtime/web deps in the Timing-bound tests job (WM-918 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,13 @@ jobs:
       - name: Install root dependencies
         run: bun install --frozen-lockfile
 
+      # `bun test --test-name-pattern` still loads every test file before
+      # filtering by name, so event-runtime/web/*.test.tsx need their own
+      # node_modules here too (same reason as in Full verification, OPS-384);
+      # without it the job dies on `Cannot find module '@testing-library/react'`.
+      - name: Install event-runtime/web deps
+        run: cd event-runtime/web && bun install --frozen-lockfile
+
       - name: Run timing-group tests
         shell: bash
         run: |


### PR DESCRIPTION
The non-required `Timing-bound tests` job from #735 has failed on every run since it landed (`Cannot find module '@testing-library/react'` across the web component tests): `bun test --test-name-pattern` loads every test file before filtering, so `event-runtime/web/*.test.tsx` need their own node_modules in that job too — same as `Full verification` already does (OPS-384). One install step added; no change to required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz