### PR TITLE
fix(auto-approval): merge-review fan-out auto-approves — ignore planner pins, admit memoPin (WM-907 follow-up)

### DIFF
--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,11 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read",
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["gh:read", "linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -30,9 +26,7 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": [
-        "decision"
-      ],
+      "kinds": ["decision"],
       "max": 10
     }
   ],

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,7 +13,11 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["gh:read", "linear:read", "repo:read"]
+    "services": [
+      "gh:read",
+      "linear:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -26,13 +30,15 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": ["decision"],
+      "kinds": [
+        "decision"
+      ],
       "max": 10
     }
   ],
   "pins": {
     "agents/merge-review.md": "sha256:285105f51813a31f81e3dc9af56bb45ad4c97ce91d3f178464d6c79d8362bf89",
-    "schemas/merge-review.input.json": "sha256:e64c8725e8ed715cdfcb261527c67f3424d140faba5d525d9aad20269f5dc0fc",
+    "schemas/merge-review.input.json": "sha256:94bbf3e051bbcb836822cf6038e008806a445473aec4f9f52eec39ba8f768326",
     "schemas/merge-review.output.json": "sha256:987433ffbb39d935d42090eb62e63ece917a36b38fc849a6c5bfa27a26c898f8"
   }
 }

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -224,6 +224,21 @@ function sameJson(left, right) {
   return hashJson(left) === hashJson(right);
 }
 
+// Keys the planner folds into a chain event's payload after the predecessor
+// emitted it: `repoPin` for repository-workspace targets and `memoPin` for
+// agents that declare memos (docs/event-runtime-memos.md §4.2). They are not
+// part of the edge the predecessor declared, so an independent-edge match must
+// compare the payload without them — otherwise every merge-review fan-out
+// (pinned checkout + decision memos) sat as chain_edge_not_registered.
+const PLANNER_INJECTED_PAYLOAD_KEYS = ["repoPin", "memoPin"];
+
+function withoutPlannerPins(payload) {
+  if (!payload || typeof payload !== "object") return payload ?? {};
+  const out = { ...payload };
+  for (const key of PLANNER_INJECTED_PAYLOAD_KEYS) delete out[key];
+  return out;
+}
+
 /** `approve.before` hook point (lib/hooks.mjs); the seam an extension gates on. */
 export const APPROVE_BEFORE_HOOK = "approve.before";
 
@@ -420,6 +435,7 @@ function chainArrayField(field, context) {
 /** Prove an explicitly independent sibling edge from its declared selector and payload. */
 function independentlySelectedEdge(rule, spec, result, envelope) {
   if (rule?.independent !== true) return false;
+  const eventPayload = withoutPlannerPins(envelope.payload);
 
   const artifactHash = {};
   for (const entry of result.artifacts ?? []) {
@@ -464,17 +480,12 @@ function independentlySelectedEdge(rule, spec, result, envelope) {
           }
           if (edge.perItem)
             Object.assign(payload, buildChainInput(edge.perItem, itemContext));
-          if (sameJson(payload, envelope.payload ?? {})) return true;
+          if (sameJson(payload, eventPayload)) return true;
         }
         continue;
       }
 
-      if (
-        sameJson(
-          buildChainInput(edge.input ?? {}, context),
-          envelope.payload ?? {},
-        )
-      ) {
+      if (sameJson(buildChainInput(edge.input ?? {}, context), eventPayload)) {
         return true;
       }
     } catch {

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -522,6 +522,53 @@ describe("chain auto approval (WM-357)", () => {
     ]);
   });
 
+  test("merge-review edge match ignores the planner-folded repoPin/memoPin (WM-907 follow-up)", async () => {
+    const db = openDb(":memory:");
+    const headSha = "c".repeat(40);
+    const baseSha = "d".repeat(40);
+    const reviewInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 13,
+      headSha,
+      baseSha,
+      // The planner adds these after merge-scan emitted the event; the live
+      // lane sat on chain_edge_not_registered for every review until the edge
+      // comparison learned to drop them.
+      repoPin: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        ref: "develop",
+        sha: baseSha,
+      },
+      memoPin: { entries: [], foldedAt: "2026-08-19T16:26:32.868Z" },
+    };
+    const candidate = seed(db, {
+      id: "merge-review-with-pins",
+      type: "factory.merge-review.requested",
+      input: reviewInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorInput: { repo: "factory" },
+      predecessorArtifact: {
+        recommendation: "REVIEW",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        reviews: [{ pr: 13, headSha, baseSha }],
+        plan: [],
+        fix: [],
+        escalate: [],
+        summary: "one miss",
+      },
+    });
+
+    expect((await auto(db)).approved).toEqual([
+      { proposalId: candidate.id, runId: candidate.runId },
+    ]);
+  });
+
   test("budget, worker cap, and circuit breaker each stop unattended approvals", async () => {
     const runtimePolicy = {
       budget: { per_day_usd: 1 },

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -153,8 +153,11 @@ describe("registry", () => {
     // Regenerated (WM-907, cold-review fixup): merge-review@1 declares the same
     // decision-memo block WM-812 gave merge-scan, so the per-PR reviewer sees
     // prior repo decisions too; agent def is a registry input.
+    // Regenerated (WM-907 follow-up): merge-review.input.json admits the
+    // planner-folded memoPin (the memos block made every review
+    // input_schema_invalid without it); re-pinned merge-review.json.
     const expected =
-      "sha256:80ee956f8de2e4c0397393a73775717237d5c086af9db9c65cecd0a3d6591267";
+      "sha256:55dff52f524185c364bda22fc39ac4153dbc3e016eed3468249fa6cf12664f1a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/merge-review.input.json
+++ b/event-runtime/schemas/merge-review.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "merge-review input — one PR to cold-review against the pinned repo",
+  "title": "merge-review input \u2014 one PR to cold-review against the pinned repo",
   "type": "object",
   "required": ["repo", "github", "base", "pr", "headSha", "baseSha"],
   "additionalProperties": false,
@@ -17,21 +17,104 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9._/-]+$"
     },
-    "pr": { "type": "integer", "minimum": 1 },
-    "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-    "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-    "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "headSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "baseSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "headRef": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._/-]+$"
+    },
+    "ticket": {
+      "type": "string",
+      "pattern": "^[A-Z]+-[0-9]+$"
+    },
     "repoPin": {
       "type": "object",
       "required": ["repo", "sha"],
       "additionalProperties": false,
-      "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
+      "description": "Filled by the planner (pinRepo) at plan time \u2014 not operator-supplied",
       "properties": {
-        "repo": { "type": "string", "minLength": 1 },
-        "ref": { "type": "string" },
-        "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-        "github": { "type": ["string", "null"] }
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "github": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "memoPin": {
+      "type": "object",
+      "required": ["foldedAt", "entries"],
+      "additionalProperties": false,
+      "description": "Planner-resolved live memos for declared subjects at plan time (docs/event-runtime-memos.md \u00a74.2). Empty entries is the normal case when nothing is known yet; never human_needed.",
+      "properties": {
+        "foldedAt": {
+          "type": "string",
+          "minLength": 1,
+          "description": "ISO timestamp of the fold; part of inputHash so a new memo re-admits work"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["sha256", "subject", "kind", "createdAt"],
+            "additionalProperties": false,
+            "properties": {
+              "sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+                "description": "Content hash of the memo artifact in the store"
+              },
+              "subject": {
+                "type": "object",
+                "required": ["type", "id"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "enum": ["repo", "ticket", "pr", "workflow", "run"]
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "kind": {
+                "enum": [
+                  "repo-note",
+                  "postmortem",
+                  "decision",
+                  "flake",
+                  "handoff"
+                ]
+              },
+              "runId": {
+                "type": ["string", "null"]
+              },
+              "createdAt": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
First live run of the lane v3 enumerator (after #733 went live at 16:21Z): 9 `factory.merge-review.requested` events, all 9 proposals stuck as `chain_edge_not_registered` — the planner folds `repoPin` (repository workspace) and `memoPin` (memos block) into the event payload, so `independentlySelectedEdge`'s reconstruction never matched. Once matched they'd still fail `input_schema_invalid` because `merge-review.input.json` is `additionalProperties:false` without `memoPin`.

- `auto-approval.mjs`: independent-edge match compares the payload minus `repoPin`/`memoPin`; new test seeds a review event with both pins.
- `schemas/merge-review.input.json`: `memoPin` (dispatch shape); `merge-review.json` re-pinned; registry digest regenerated (prettier → update-pins → digest).

Operator-approved the 9 reviews by hand meanwhile; this makes the lane autonomous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz