### PR TITLE
docs(merge-review): operational fixes are always withinOwnedPaths=true (WM-907 follow-up)

### DIFF
--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/merge-review.md": "sha256:285105f51813a31f81e3dc9af56bb45ad4c97ce91d3f178464d6c79d8362bf89",
+    "agents/merge-review.md": "sha256:77be28101f5e4645a37501bc4aa2dd80dd87519b528eb8b9db0c2ed55ea1d73f",
     "schemas/merge-review.input.json": "sha256:94bbf3e051bbcb836822cf6038e008806a445473aec4f9f52eec39ba8f768326",
     "schemas/merge-review.output.json": "sha256:987433ffbb39d935d42090eb62e63ece917a36b38fc849a6c5bfa27a26c898f8"
   }

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,11 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read",
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["gh:read", "linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -30,9 +26,7 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": [
-        "decision"
-      ],
+      "kinds": ["decision"],
       "max": 10
     }
   ],

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,7 +13,11 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["gh:read", "linear:read", "repo:read"]
+    "services": [
+      "gh:read",
+      "linear:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -26,7 +30,9 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": ["decision"],
+      "kinds": [
+        "decision"
+      ],
       "max": 10
     }
   ],

--- a/event-runtime/agents/merge-review.md
+++ b/event-runtime/agents/merge-review.md
@@ -206,6 +206,18 @@ item (merge the findings into one `finding` string, keep the most severe
 first); several fix items for the same PR only race each other
 (`merge_fix_run_active`).
 
+`fix.withinOwnedPaths` means: merge-fix can perform this fix without editing
+any file outside the ticket's Owned Paths. Operational findings —
+`rebase_onto_base`, `rerun_ci_at_head`, `format_and_lint` — are **always
+`true`**: a rebase or a formatter pass changes no file the PR did not already
+own, and those conditions exist precisely so merge-fix can clear them. The
+merge-fix input schema only admits `withinOwnedPaths: true`; a `false` item
+never reaches merge-fix — it parks as `invalid_input` and the PR sits behind
+base forever (the lane went idle on seven such items on 2026-08-19). So when
+the only viable fix would touch files outside the ticket's Owned Paths, do not
+emit a `fix` item with `false`; emit an `escalate` item naming the files
+instead, and keep any operational fix for the same PR as its own `true` item.
+
 `escalate` item — exactly `pr`, `headSha`, `ticket`, `reason` (no `title`/`headRefName`/`headRef`):
 <!-- prettier-ignore -->
 ```json

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -159,7 +159,7 @@ describe("registry", () => {
     // Regenerated (WM-907 follow-up): merge-review.md defines
     // fix.withinOwnedPaths (operational fixes are always true); re-pinned.
     const expected =
-      "sha256:PLACEHOLDER";
+      "sha256:e25fa469ba29d08dcabf8b3e2288382c10b995a367faf7e11f597bf7da7dde36";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -156,8 +156,10 @@ describe("registry", () => {
     // Regenerated (WM-907 follow-up): merge-review.input.json admits the
     // planner-folded memoPin (the memos block made every review
     // input_schema_invalid without it); re-pinned merge-review.json.
+    // Regenerated (WM-907 follow-up): merge-review.md defines
+    // fix.withinOwnedPaths (operational fixes are always true); re-pinned.
     const expected =
-      "sha256:55dff52f524185c364bda22fc39ac4153dbc3e016eed3468249fa6cf12664f1a";
+      "sha256:PLACEHOLDER";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Second first-contact bug of lane v3: the reviewer set `withinOwnedPaths:false` on every `rebase_onto_base` item (7 PRs), `merge-fix.input.json` requires `const true`, so every rebase parked as `invalid_input` → lane idle. merge-review.md now defines the field (operational findings `rebase_onto_base`/`rerun_ci_at_head`/`format_and_lint` are always `true`; a fix that would need files outside Owned Paths becomes an `escalate` item instead). Prompt + re-pin + registry digest only. Lands after #741 (same files re-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz