### PR TITLE
fix(merge): key the review ledger on (pr, headSha) (WM-936)

### DIFF
--- a/docs/merge-lane.md
+++ b/docs/merge-lane.md
@@ -2,17 +2,21 @@
 
 The factory merge lane reviews open base-targeting PRs, applies mechanical
 fixes, and lands at most one PR per base-CI cycle. This document is the v3
-shape (WM-907 / WM-906): a durable review ledger plus per-PR reviews, with
-landing still serialized until part 2.
+shape (WM-907 / WM-936 / WM-906): a durable review ledger keyed on head SHA
+plus per-PR reviews, with landing still serialized until part 2.
 
 ## Flow
 
 1. **`factory.merge.requested`** → `merge-scan@2` (command enumerator).
    Lists open, non-draft, base-targeting PRs with live head/base SHAs. Looks
-   each `(github, pr, headSha, baseSha)` up in `merge_reviews`. Emits
-   `reviews[]` for ledger **misses** only. A selected scan (`prNumbers`)
-   forces a review even on a hit. Stub `plan[]` is today's single lowest
-   MERGE candidate already in the ledger, so one PR can still land per cycle.
+   each `(github, pr, headSha)` up in `merge_reviews`. Emits `reviews[]` for
+   ledger **misses** (moved head) only. A moved base with the same head is a
+   hit. Hits that are CONFLICTING/BEHIND emit an operational
+   `rebase_onto_base` `fix[]` item (no review run). A selected scan
+   (`prNumbers`) forces a review even on a hit. In-flight `merge-review@1`
+   proposals/runs at the same head are not re-emitted. Stub `plan[]` is
+   today's single lowest MERGE candidate already in the ledger that is still
+   mergeable, so one PR can still land per cycle.
 2. **`factory.merge-review.requested`** → `merge-review@1` (agy, one PR).
    The body of the old batch merge-scan: same rubric, same CI proof resolver,
    same refusal semantics. Writes `factory.merge-review/v1`. On COMPLETED the
@@ -22,14 +26,17 @@ landing still serialized until part 2.
    `factory.merge-review.requested` for that PR's new head — not a full scan.
 4. **`factory.merge-apply.requested`** / landed / verify are unchanged.
 
-A second scheduled tick with no SHA movement emits **zero** review runs: every
-open PR is a ledger hit, so `reviews[]` is empty and the command enumerator
-returns in seconds.
+A second scheduled tick with no **head** movement emits **zero** review runs:
+every open PR is a ledger hit (a develop merge that only moves `base_sha` is
+not a miss). Behind/conflicting hits emit mechanical rebase fixes instead.
+`reviews[]` stays empty and the command enumerator returns in seconds.
 
 ## Ledger
 
 Table `merge_reviews` in `runtime.db`, keyed
-`(github, pr, head_sha, base_sha)`. A moved head is a miss. Columns:
+`(github, pr, head_sha)`. `base_sha` is recorded so the enumerator can see
+that the base moved; it is not part of the key. A moved head is a miss.
+Columns:
 
 | column           | meaning                                        |
 | ---------------- | ---------------------------------------------- |

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -35,7 +35,7 @@
     }
   ],
   "pins": {
-    "agents/merge-scan.md": "sha256:cbedecd2f5c02aa4a81c71ec14b6d57ec358f4a05ecc8df61252acb2204f601b",
+    "agents/merge-scan.md": "sha256:300203edbf3cfa4fd36d94094ae9e58bb986526f65233cff70086fdd454fdcb7",
     "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
     "schemas/merge-scan.output.json": "sha256:7da0007262077e89f63ebb5a9627137ef64b6e48733593eea0bf08a69c7ce398"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -8,11 +8,18 @@ bun {factoryRoot}/event-runtime/lib/merge-reviews.mjs scan
 ```
 
 The command reads `./input.json` and writes `./result.json`. It lists open PRs
-via the forge, looks each `(github, pr, headSha, baseSha)` up in the
-`merge_reviews` ledger, and emits `reviews[]` only for misses. A selected scan
-(`prNumbers`) forces a review even on a ledger hit. The stub `plan[]` is today's
-single lowest MERGE candidate already in the ledger so the lane still lands one
-PR per cycle until merge-lane v3 part 2 batches landing.
+via the forge, looks each `(github, pr, headSha)` up in the `merge_reviews`
+ledger (`baseSha` is recorded, not part of the key), and emits `reviews[]` only
+for misses — a moved head. A moved base with the same head is a hit. A selected
+scan (`prNumbers`) forces a review even on a ledger hit. For a hit whose live
+state is CONFLICTING or BEHIND (or whose recorded `baseSha` differs from the
+live base tip), emit an operational `rebase_onto_base` item in `fix[]` with
+`mechanical: true`, `withinOwnedPaths: true`, and `round` from the ledger; do
+not start a review run. Do not emit a review item when an open, queued, or
+running `merge-review@1` proposal or run already exists at the same
+`(pr, headSha)`. The stub `plan[]` is today's single lowest MERGE candidate
+already in the ledger that is still mergeable, so the lane still lands one PR
+per cycle until merge-lane v3 part 2 batches landing.
 
 When `prNumbers` is absent, enumerate **all** open PRs and consider every
 base-targeting, non-draft PR. When `prNumbers` is present, review exactly those

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -379,6 +379,42 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 12,
+    name: "merge_reviews_key_head",
+    up(db) {
+      db.exec(`
+        CREATE TABLE merge_reviews_v12 (
+          github         TEXT NOT NULL,
+          pr             INTEGER NOT NULL,
+          head_sha       TEXT NOT NULL,
+          base_sha       TEXT NOT NULL,
+          verdict        TEXT NOT NULL,
+          findings_json  TEXT NOT NULL,
+          fix_json       TEXT,
+          plan_json      TEXT,
+          policy_version TEXT,
+          run_id         TEXT,
+          reviewed_at    TEXT NOT NULL,
+          PRIMARY KEY (github, pr, head_sha)
+        );
+        INSERT INTO merge_reviews_v12 (
+          github, pr, head_sha, base_sha, verdict, findings_json, fix_json,
+          plan_json, policy_version, run_id, reviewed_at
+        )
+        SELECT github, pr, head_sha, base_sha, verdict, findings_json, fix_json,
+               plan_json, policy_version, run_id, reviewed_at
+          FROM merge_reviews
+         WHERE rowid IN (
+           SELECT MAX(rowid) FROM merge_reviews GROUP BY github, pr, head_sha
+         );
+        DROP TABLE merge_reviews;
+        ALTER TABLE merge_reviews_v12 RENAME TO merge_reviews;
+        CREATE INDEX IF NOT EXISTS idx_merge_reviews_github_pr
+          ON merge_reviews (github, pr, reviewed_at DESC);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -1,15 +1,18 @@
 /**
- * Merge-review ledger and scan enumerator (WM-907).
+ * Merge-review ledger and scan enumerator (WM-907 / WM-936).
  *
- * `merge_reviews` is keyed (github, pr, head_sha, base_sha). A moved head is
- * a miss: the next enumerator tick emits `factory.merge-review.requested`
- * for that SHA pair only. Completing `merge-review@1` persists the row from
- * the accepted result (worker hook). `merge-scan@2` is the deterministic
- * enumerator that reads this table and fans out reviews for misses.
+ * `merge_reviews` is keyed (github, pr, head_sha). `base_sha` is recorded,
+ * not part of the key: a moved base with an unchanged head is a hit. A moved
+ * head is a miss — the next enumerator tick emits `factory.merge-review.requested`
+ * for that head only. Completing `merge-review@1` persists the row from the
+ * accepted result (worker hook). `merge-scan@2` is the deterministic enumerator
+ * that reads this table, fans out reviews for misses, and emits operational
+ * `rebase_onto_base` fix items for hits that are CONFLICTING/BEHIND.
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { loadForge, ForgeError } from "../../lib/forge/index.mjs";
+import { sha256Hex } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
 import { getRepo, loadRepos, RepoError } from "./repos.mjs";
 
@@ -31,8 +34,19 @@ const PR_LIST_FIELDS = [
   "headRefName",
   "baseRefName",
   "title",
+  "mergeable",
+  "mergeStateStatus",
 ];
 const PR_VIEW_FIELDS = PR_LIST_FIELDS;
+const REBASE_FINDING = "rebase_onto_base";
+const IN_FLIGHT_RUN_STATES = [
+  "PROPOSED",
+  "APPROVED",
+  "QUEUED",
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+];
 
 function iso(now = Date.now()) {
   return new Date(now).toISOString();
@@ -67,8 +81,8 @@ function parseJsonColumn(raw, fallback) {
   }
 }
 
-/** Look up a review by the exact SHA pair. A moved head is a miss. */
-export function lookupMergeReview(db, { github, pr, headSha, baseSha }) {
+/** Look up a review by (github, pr, headSha). A moved head is a miss. */
+export function lookupMergeReview(db, { github, pr, headSha }) {
   const row = db
     .query(
       `SELECT github, pr, head_sha AS headSha, base_sha AS baseSha,
@@ -76,9 +90,9 @@ export function lookupMergeReview(db, { github, pr, headSha, baseSha }) {
               plan_json AS planJson, policy_version AS policyVersion,
               run_id AS runId, reviewed_at AS reviewedAt
          FROM merge_reviews
-        WHERE github = ? AND pr = ? AND head_sha = ? AND base_sha = ?`,
+        WHERE github = ? AND pr = ? AND head_sha = ?`,
     )
-    .get(github, pr, headSha, baseSha);
+    .get(github, pr, headSha);
   if (!row) return null;
   return {
     github: row.github,
@@ -126,8 +140,9 @@ export function upsertMergeReview(
     `INSERT INTO merge_reviews (
        github, pr, head_sha, base_sha, verdict, findings_json, fix_json,
        plan_json, policy_version, run_id, reviewed_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT (github, pr, head_sha, base_sha) DO UPDATE SET
+     )      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (github, pr, head_sha) DO UPDATE SET
+       base_sha = excluded.base_sha,
        verdict = excluded.verdict,
        findings_json = excluded.findings_json,
        fix_json = excluded.fix_json,
@@ -153,7 +168,8 @@ export function upsertMergeReview(
 /**
  * Worker COMPLETED hook. No-op unless this run is merge-review@1 with a
  * schema-valid completed artifact. Never throws out of a missing optional
- * field — refuse to persist rather than write a partial key.
+ * field — refuse to persist rather than write a partial key. `baseSha` is
+ * required as a recorded column; it is not part of the lookup key.
  */
 export function persistMergeReviewFromResult(
   db,
@@ -218,6 +234,12 @@ function normalizeListedPr(raw, baseSha) {
     headRef: typeof raw.headRefName === "string" ? raw.headRefName : null,
     baseRefName: typeof raw.baseRefName === "string" ? raw.baseRefName : null,
     ticket: ticketFromRef(raw.headRefName, raw.title),
+    mergeable:
+      typeof raw.mergeable === "string" ? raw.mergeable.toUpperCase() : "",
+    mergeStateStatus:
+      typeof raw.mergeStateStatus === "string"
+        ? raw.mergeStateStatus.toUpperCase()
+        : "",
   };
 }
 
@@ -245,18 +267,97 @@ function lowestMergePlan(candidates) {
   return [mergeable[0].plan];
 }
 
-function recommendationOf({ reviews, plan, escalate }) {
+function recommendationOf({ reviews, plan, fix, escalate }) {
   if (escalate.length > 0) return "ESCALATE";
   if (plan.length > 0) return "MERGE";
   if (reviews.length > 0) return "REVIEW";
+  if (fix.length > 0) return "FIX";
   return "NOOP";
 }
 
-function noopReasonOf({ reviews, plan, escalate, listedCount }) {
-  if (escalate.length > 0 || plan.length > 0 || reviews.length > 0)
+function noopReasonOf({ reviews, plan, fix, escalate, listedCount }) {
+  if (
+    escalate.length > 0 ||
+    plan.length > 0 ||
+    reviews.length > 0 ||
+    fix.length > 0
+  )
     return undefined;
   if (listedCount === 0) return "no_open_prs";
   return "all_prs_held";
+}
+
+function isBehindOrConflicting(pr, hit) {
+  if (pr.mergeable === "CONFLICTING") return true;
+  if (pr.mergeStateStatus === "BEHIND") return true;
+  return Boolean(hit?.baseSha && pr.baseSha && hit.baseSha !== pr.baseSha);
+}
+
+function ownedPathsFrom(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string" && item.length > 0);
+}
+
+function rebaseFixItem(pr, hit, { forge, github }) {
+  const headRef = pr.headRef;
+  const ticket = pr.ticket;
+  if (!headRef || !ticket) return null;
+  const previous = hit.fix && typeof hit.fix === "object" ? hit.fix : null;
+  let ownedPaths = ownedPathsFrom(previous?.ownedPaths);
+  if (ownedPaths.length === 0 && forge) {
+    try {
+      ownedPaths = ownedPathsFrom(forge.prDiffFiles(github, pr.number));
+    } catch {
+      ownedPaths = [];
+    }
+  }
+  if (ownedPaths.length === 0) return null;
+  const round =
+    Number.isInteger(previous?.round) && previous.round >= 1
+      ? previous.round
+      : 1;
+  return {
+    pr: pr.number,
+    headSha: pr.headSha,
+    baseSha: pr.baseSha,
+    headRef,
+    ticket,
+    finding: REBASE_FINDING,
+    findingHash: sha256Hex(REBASE_FINDING),
+    round,
+    mechanical: true,
+    withinOwnedPaths: true,
+    ownedPaths,
+  };
+}
+
+function hasInFlightAgent(db, agent, { github, pr, headSha }) {
+  if (!db) return false;
+  const runPlaceholders = IN_FLIGHT_RUN_STATES.map(() => "?").join(", ");
+  const run = db
+    .query(
+      `SELECT 1 AS ok FROM runs
+        WHERE json_extract(spec_json, '$.agent') = ?
+          AND json_extract(spec_json, '$.input.pr') = ?
+          AND json_extract(spec_json, '$.input.headSha') = ?
+          AND json_extract(spec_json, '$.input.github') = ?
+          AND state IN (${runPlaceholders})
+        LIMIT 1`,
+    )
+    .get(agent, pr, headSha, github, ...IN_FLIGHT_RUN_STATES);
+  if (run) return true;
+  const proposal = db
+    .query(
+      `SELECT 1 AS ok FROM proposals
+        WHERE status = 'open'
+          AND json_extract(spec_json, '$.agent') = ?
+          AND json_extract(spec_json, '$.input.pr') = ?
+          AND json_extract(spec_json, '$.input.headSha') = ?
+          AND json_extract(spec_json, '$.input.github') = ?
+        LIMIT 1`,
+    )
+    .get(agent, pr, headSha, github);
+  return Boolean(proposal);
 }
 
 /**
@@ -369,6 +470,7 @@ export function enumerateMergeScan({
       base,
       deployBranch,
       db,
+      forge,
       targets,
       forceReview: true,
       listedCount: targets.length,
@@ -389,6 +491,7 @@ export function enumerateMergeScan({
     base,
     deployBranch,
     db,
+    forge,
     targets,
     forceReview: false,
     listedCount: targets.length,
@@ -402,21 +505,45 @@ function assemble({
   base,
   deployBranch,
   db,
+  forge,
   targets,
   forceReview,
   listedCount,
 }) {
   const reviews = [];
   const mergeHits = [];
+  const fix = [];
   for (const pr of targets) {
     const hit = lookupMergeReview(db, {
       github,
       pr: pr.number,
       headSha: pr.headSha,
-      baseSha: pr.baseSha,
     });
     if (!hit || forceReview) {
+      if (
+        hasInFlightAgent(db, MERGE_REVIEW_AGENT, {
+          github,
+          pr: pr.number,
+          headSha: pr.headSha,
+        })
+      ) {
+        continue;
+      }
       reviews.push(reviewItemFromPr(pr));
+      continue;
+    }
+    if (isBehindOrConflicting(pr, hit)) {
+      if (
+        hasInFlightAgent(db, "merge-fix@1", {
+          github,
+          pr: pr.number,
+          headSha: pr.headSha,
+        })
+      ) {
+        continue;
+      }
+      const item = rebaseFixItem(pr, hit, { forge, github });
+      if (item) fix.push(item);
       continue;
     }
     if (hit.verdict === "MERGE") mergeHits.push(hit);
@@ -424,18 +551,19 @@ function assemble({
   const plan = lowestMergePlan(mergeHits);
   const escalate = [];
   const artifact = {
-    recommendation: recommendationOf({ reviews, plan, escalate }),
+    recommendation: recommendationOf({ reviews, plan, fix, escalate }),
     repo,
     github,
     base,
     deployBranch,
     reviews,
     plan,
-    fix: [],
+    fix,
     escalate,
     summary: summaryFor({
       reviews,
       plan,
+      fix,
       listedCount,
       forceReview,
     }),
@@ -443,6 +571,7 @@ function assemble({
   const noopReason = noopReasonOf({
     reviews,
     plan,
+    fix,
     escalate,
     listedCount,
   });
@@ -450,11 +579,12 @@ function assemble({
   return completed(artifact);
 }
 
-function summaryFor({ reviews, plan, listedCount, forceReview }) {
+function summaryFor({ reviews, plan, fix, listedCount, forceReview }) {
   const bits = [];
   if (forceReview) bits.push(`selected scan of ${listedCount} PR(s)`);
   else bits.push(`${listedCount} open base-targeting PR(s)`);
   bits.push(`${reviews.length} review(s) to run`);
+  if (fix.length > 0) bits.push(`${fix.length} rebase fix(es)`);
   if (plan.length > 0) bits.push(`lowest MERGE candidate is #${plan[0].pr}`);
   return bits.join("; ") + ".";
 }

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { Database } from "bun:sqlite";
 import { memoryForge } from "../../lib/forge/memory.mjs";
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-merge-reviews-test-mjs";
-import { openDb } from "./db.mjs";
+import { sha256Hex } from "./canonical.mjs";
+import { MIGRATIONS, migrateDb, openDb } from "./db.mjs";
 import {
   enumerateMergeScan,
   lookupMergeReview,
@@ -15,7 +17,10 @@ import {
 const HEAD = "a".repeat(40);
 const HEAD2 = "c".repeat(40);
 const BASE = "b".repeat(40);
+const BASE2 = "d".repeat(40);
 const GITHUB = "watt-mind/factory";
+const REBASE_HASH = sha256Hex("rebase_onto_base");
+const OWNED = ["event-runtime/lib/merge-reviews.mjs"];
 
 const repos = new Map([
   [
@@ -37,6 +42,9 @@ function pr({
   isDraft = false,
   state = "OPEN",
   title = `Fixes WM-${number}`,
+  mergeable = "MERGEABLE",
+  mergeStateStatus = "CLEAN",
+  files = OWNED,
 } = {}) {
   return {
     number,
@@ -46,7 +54,55 @@ function pr({
     headRefName,
     baseRefName,
     title,
+    mergeable,
+    mergeStateStatus,
+    files,
   };
+}
+
+function rebaseItem(
+  prNumber,
+  { headSha = HEAD, baseSha = BASE, round = 1 } = {},
+) {
+  return {
+    pr: prNumber,
+    headSha,
+    baseSha,
+    headRef: `feat/WM-${prNumber}`,
+    ticket: `WM-${prNumber}`,
+    finding: "rebase_onto_base",
+    findingHash: REBASE_HASH,
+    round,
+    mechanical: true,
+    withinOwnedPaths: true,
+    ownedPaths: OWNED,
+  };
+}
+
+function insertRun(db, { runId, agent, pr, headSha, state, github = GITHUB }) {
+  const now = "2026-08-19T16:45:00.000Z";
+  const spec = JSON.stringify({
+    agent,
+    input: { github, pr, headSha, baseSha: BASE },
+  });
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, 'sha256:test', ?, 0, ?, ?)`,
+  ).run(runId, `idem-${runId}`, spec, state, now, now);
+}
+
+function insertOpenProposal(db, { id, agent, pr, headSha, github = GITHUB }) {
+  const now = "2026-08-19T16:45:00.000Z";
+  const spec = JSON.stringify({
+    agent,
+    input: { github, pr, headSha, baseSha: BASE },
+  });
+  db.query(
+    `INSERT INTO proposals (
+       id, event_source, event_id, run_id, decision, spec_json, spec_hash,
+       idempotency_key, status, created_at, ttl_seconds
+     ) VALUES (?, 'chain', ?, NULL, 'run', ?, 'sha256:test', ?, 'open', ?, 3600)`,
+  ).run(id, `evt-${id}`, spec, `idem-${id}`, now);
 }
 
 function forgeWith(prs, { baseSha = BASE } = {}) {
@@ -78,7 +134,7 @@ function planItem(prNumber = 12) {
   };
 }
 
-describe("merge_reviews ledger keying (WM-907)", () => {
+describe("merge_reviews ledger keying (WM-907 / WM-936)", () => {
   test("a fresh database has the merge_reviews table", () => {
     const db = openDb(":memory:");
     const tables = db
@@ -114,6 +170,81 @@ describe("merge_reviews ledger keying (WM-907)", () => {
         baseSha: BASE,
       }),
     ).toBeNull();
+  });
+
+  test("lookup hits when the base SHA moved and the head did not", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 12,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(12),
+    });
+    const hit = lookupMergeReview(db, {
+      github: GITHUB,
+      pr: 12,
+      headSha: HEAD,
+      baseSha: BASE2,
+    });
+    expect(hit?.verdict).toBe("MERGE");
+    expect(hit?.baseSha).toBe(BASE);
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 12,
+      headSha: HEAD,
+      baseSha: BASE2,
+      verdict: "MERGE",
+      plan: { ...planItem(12), baseSha: BASE2 },
+    });
+    expect(
+      lookupMergeReview(db, { github: GITHUB, pr: 12, headSha: HEAD })?.baseSha,
+    ).toBe(BASE2);
+  });
+
+  test("v9 rows keyed on base_sha migrate to a head-only primary key", () => {
+    const file = path.join(tmpDir("merge-reviews-v11-"), "runtime.db");
+    const raw = new Database(file);
+    migrateDb(raw, { migrations: MIGRATIONS, targetVersion: 9 });
+    raw
+      .query(
+        `INSERT INTO merge_reviews (
+           github, pr, head_sha, base_sha, verdict, findings_json, fix_json,
+           plan_json, policy_version, run_id, reviewed_at
+         ) VALUES (?, 12, ?, ?, 'MERGE', '[]', NULL, NULL, NULL, 'old', '2026-08-19T16:00:00.000Z'),
+                 (?, 12, ?, ?, 'FIX', '[]', NULL, NULL, NULL, 'new', '2026-08-19T17:00:00.000Z')`,
+      )
+      .run(GITHUB, HEAD, BASE, GITHUB, HEAD, BASE2);
+    const pk = raw
+      .query(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'merge_reviews'`,
+      )
+      .get().sql;
+    expect(pk).toContain("PRIMARY KEY (github, pr, head_sha, base_sha)");
+    raw.close();
+
+    const db = openDb(file);
+    const schema = db
+      .query(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'merge_reviews'`,
+      )
+      .get().sql;
+    expect(schema).toContain("PRIMARY KEY (github, pr, head_sha)");
+    expect(schema).not.toContain(
+      "PRIMARY KEY (github, pr, head_sha, base_sha)",
+    );
+    const rows = db
+      .query(
+        `SELECT verdict, base_sha AS baseSha, run_id AS runId FROM merge_reviews
+          WHERE github = ? AND pr = 12 AND head_sha = ?`,
+      )
+      .all(GITHUB, HEAD);
+    expect(rows).toEqual([{ verdict: "FIX", baseSha: BASE2, runId: "new" }]);
+    expect(
+      lookupMergeReview(db, { github: GITHUB, pr: 12, headSha: HEAD })?.verdict,
+    ).toBe("FIX");
+    db.close();
   });
 
   test("persistMergeReviewFromResult writes the COMPLETED merge-review artifact", () => {
@@ -297,5 +428,209 @@ describe("merge-scan enumerator (WM-907)", () => {
     );
     expect(written.artifact.noopReason).toBe("no_open_prs");
     expect(written.artifact.reviews).toEqual([]);
+  });
+});
+
+describe("merge-scan enumerator (WM-936)", () => {
+  test("base moved with head unchanged is a hit and emits no review", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 8,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(8),
+    });
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 20,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "ESCALATE",
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({ number: 8, headRefName: "feat/WM-8" }),
+          pr({ number: 20, headRefName: "feat/WM-20" }),
+        ],
+        { baseSha: BASE2 },
+      ),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.plan).toEqual([]);
+    expect(result.artifact.fix).toEqual([
+      rebaseItem(8, { baseSha: BASE2 }),
+      rebaseItem(20, { baseSha: BASE2 }),
+    ]);
+    expect(result.artifact.recommendation).toBe("FIX");
+  });
+
+  test("head moved is a miss", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 11,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(11),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({ number: 11, headRefOid: HEAD2, headRefName: "feat/WM-11" }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([
+      {
+        pr: 11,
+        headSha: HEAD2,
+        baseSha: BASE,
+        headRef: "feat/WM-11",
+        ticket: "WM-11",
+      },
+    ]);
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.recommendation).toBe("REVIEW");
+  });
+
+  test("behind-base hit emits a rebase fix item without a review", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+      fix: rebaseItem(9, { round: 1 }),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({
+          number: 9,
+          headRefName: "feat/WM-9",
+          mergeable: "MERGEABLE",
+          mergeStateStatus: "BEHIND",
+        }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.plan).toEqual([]);
+    expect(result.artifact.fix).toEqual([rebaseItem(9)]);
+    expect(result.artifact.fix[0].mechanical).toBe(true);
+    expect(result.artifact.fix[0].withinOwnedPaths).toBe(true);
+    expect(result.artifact.recommendation).toBe("FIX");
+  });
+
+  test("CONFLICTING hit emits rebase without a review", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "FIX",
+      fix: rebaseItem(9, { round: 2 }),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({
+          number: 9,
+          headRefName: "feat/WM-9",
+          mergeable: "CONFLICTING",
+          mergeStateStatus: "DIRTY",
+        }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.fix[0]).toMatchObject({
+      finding: "rebase_onto_base",
+      round: 2,
+      mechanical: true,
+      withinOwnedPaths: true,
+    });
+  });
+
+  test("in-flight merge-review at the same head emits no duplicate item", () => {
+    const db = openDb(":memory:");
+    insertRun(db, {
+      runId: "run_review_inflight",
+      agent: "merge-review@1",
+      pr: 11,
+      headSha: HEAD2,
+      state: "RUNNING",
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({ number: 11, headRefOid: HEAD2, headRefName: "feat/WM-11" }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.recommendation).toBe("NOOP");
+  });
+
+  test("open merge-review proposal at the same head emits no duplicate item", () => {
+    const db = openDb(":memory:");
+    insertOpenProposal(db, {
+      id: "prop_review_open",
+      agent: "merge-review@1",
+      pr: 11,
+      headSha: HEAD2,
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({ number: 11, headRefOid: HEAD2, headRefName: "feat/WM-11" }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+  });
+
+  test("in-flight merge-fix at the same head does not emit a second rebase", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRun(db, {
+      runId: "run_fix_inflight",
+      agent: "merge-fix@1",
+      pr: 9,
+      headSha: HEAD,
+      state: "QUEUED",
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([pr({ number: 9, headRefName: "feat/WM-9" })], {
+        baseSha: BASE2,
+      }),
+      repos,
+    });
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.reviews).toEqual([]);
   });
 });

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -158,8 +158,11 @@ describe("registry", () => {
     // input_schema_invalid without it); re-pinned merge-review.json.
     // Regenerated (WM-907 follow-up): merge-review.md defines
     // fix.withinOwnedPaths (operational fixes are always true); re-pinned.
+    // Regenerated (WM-936): merge-scan enumerator keys the ledger on head SHA,
+    // emits rebase_onto_base for behind hits, and dedupes in-flight reviews;
+    // re-pinned merge-scan.md.
     const expected =
-      "sha256:e25fa469ba29d08dcabf8b3e2288382c10b995a367faf7e11f597bf7da7dde36";
+      "sha256:daf55446288eb3275153d485a7ba87ddf602c46e6a32f1eeb26c2423422bb6e4";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
## Summary
- Key `merge_reviews` on `(github, pr, head_sha)` so a develop merge that only moves `base_sha` is a ledger hit, not a full review fan-out.
- Enumerator emits operational `rebase_onto_base` fix items for CONFLICTING/BEHIND hits (no model run) and skips a review when an in-flight `merge-review@1` proposal/run already exists at the same head.
- Follow-up: [WM-940](https://linear.app/watt-mind/issue/WM-940) — `merge-review.md` pin lives in `merge-review.json`, which this ticket's Owned Paths omitted.

Fixes WM-936

UX critique: skipped — backend enumerator/ledger; no user-facing surface.

## Test plan
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [x] `bun test` (full suite)
- [ ] After merge, next merge-scan tick with N open PRs whose heads did not move should spawn 0 merge-review runs


Made with [Cursor](https://cursor.com)