### PR TITLE
revert(ci): restore develop push cancel-in-progress coalescing (WM-866)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ on:
 permissions:
   contents: read
 
-# One live run per PR: a newer synchronize cancels the superseded PR run.
-# Push events are keyed by SHA so back-to-back develop merges each finish
-# Full verification — canceling the earlier SHA made its aggregate check
-# report RED (WM-866). WM-773 item 6 coalesced by ref; that is no longer
-# the policy.
+# One live run per PR, and one per pushed branch: a newer push to develop
+# supersedes the older develop run (WM-773 item 6) — a stale develop SHA green
+# proves nothing and used to cost a full lane hold per merge.
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   shadow-runner-health:


### PR DESCRIPTION
Reverts #726 (4e9421a3).

## Why
WM-866 carries an explicit operator decision (2026-08-19 10:03Z): **keep develop cancel-in-progress** (push coalescing, #638) and fix the merge-verify side instead (WM-863); *do not re-enable per-SHA develop verification*. #726 implemented the opposite and contradicts `docs/ci.md` §Run coalescing. The merge lane flagged it ESCALATE; it was hand-merged by mistake. This restores the documented policy.

## Handoff
- Files: `.github/workflows/ci.yml` only (pure revert)
- Verification: `actionlint .github/workflows/ci.yml` — clean
- UX critique: n/a (CI config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22yAWwm7najjia2QPzfRv