### PR TITLE
feat(adapters): ACP v1 harness adapter spike (WM-937)

### DIFF
--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -206,12 +206,12 @@ context, which is precisely why that fallback is not the production setup.
 ## 2c. Adapter registry and contract — **shipped, WM-837**
 
 A worker executes a run through a _harness adapter_ — `claude`, `pi`,
-`cursor`, `agy`, `command`, `actions`, and the test-only `fake`, all in
-`event-runtime/lib/adapters/`. Which adapters a worker carries used to be an
-object literal duplicated in `cli/work.mjs` and `cli/serve.mjs`; both now
-obtain the set from the registry in `event-runtime/lib/adapters/index.mjs`,
-which is also what a future extension loader (packs, out-of-tree adapters)
-registers into.
+`cursor`, `agy`, `command`, `actions`, the test-only `fake`, and the
+experimental `acp` adapter (WM-937), all in `event-runtime/lib/adapters/`.
+Which adapters a worker carries used to be an object literal duplicated in
+`cli/work.mjs` and `cli/serve.mjs`; both now obtain the set from the registry
+in `event-runtime/lib/adapters/index.mjs`, which is also what a future
+extension loader (packs, out-of-tree adapters) registers into.
 
 **The contract.** An adapter is a module (an ES module namespace or any object
 with the same exports) that satisfies all of:
@@ -255,6 +255,20 @@ machine-readable output) prints the registered adapters with their source and
 sandbox support — the same registry a worker builds, so it needs no running
 `serve`.
 
+**Experimental `acp` (WM-937).** `event-runtime/lib/adapters/acp.mjs` is an
+ACP v1 client (`protocolVersion` pinned to `1`) that spawns any Agent Client
+Protocol agent as JSON-RPC NDJSON over stdio. Config is `{ command, args, env }`
+with shipped default `{ command: "claude-code-acp", args: [], env: {} }`. It
+satisfies the contract (`execute` + `SANDBOX_SUPPORT = "unsupported"`) and
+tests register it with `createAdapterRegistry({ builtins: { acp } })`. It is
+not yet in `builtinAdapters()` — wiring `index.mjs` is a follow-up outside
+this spike's Owned Paths. Permission requests for workspace-scoped edits and
+an allow-listed command set are auto-answered; anything else fail-closes
+(`reject_once`) rather than blocking the turn on an inbox `decision_needed`
+item (a human cannot beat the run timeout). Usage arrives as ACP
+`usage_update` (`used` / `size` / optional USD `cost`), not Claude's
+`input_tokens` / `output_tokens` split.
+
 ## 2d. Harness content as a RunSpec input — **shipped, WM-851**
 
 Runtime LLM runs used to acquire skills, slash commands, and subagents from
@@ -291,6 +305,7 @@ The worker materializes that declaration **after** workspace create and
    | Adapter  | skills                                           | commands                       | subagents                 |
    | -------- | ------------------------------------------------ | ------------------------------ | ------------------------- |
    | `claude` | `.claude/skills/<n>/` from `plugins/core/skills` | `.claude/commands/<n>.md`      | `.claude/agents/<n>.md`   |
+   | `acp`    | same as `claude` (experimental, WM-937)          | same as `claude`               | same as `claude`          |
    | `cursor` | **unsupported** (emit has none)                  | `.cursor/commands/<n>.md`      | `.cursor/agents/<n>.md`   |
    | `pi`     | `.pi/agent/skills/<n>/` from `dist/pi/skills`    | `.pi/agent/prompts/<n>.md`     | `.pi/agent/agents/<n>.md` |
    | `agy`    | `.gemini/skills/<n>/` from `dist/gemini/skills`  | same (commands emit as skills) | `.gemini/agents/<n>.md`   |

--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -1,0 +1,817 @@
+/**
+ * ACP (Agent Client Protocol) harness adapter (WM-937).
+ *
+ * Speaks ACP v1 as newline-delimited JSON-RPC 2.0 over stdio
+ * (https://agentclientprotocol.com/protocol/v1). Config is
+ * `{ command, args, env }` with `claude-code-acp` as the shipped default, so
+ * any ACP agent is a factory harness without a per-CLI stdout parser.
+ *
+ * Spike scope: session lifecycle, `session/update` folding into
+ * factory.trace/v1, a closed permission auto-allow plus fail-closed escalate,
+ * and the same TERM→KILL / subscription-auth conventions as claude.mjs.
+ * Sandbox is refused (`SANDBOX_SUPPORT = "unsupported"`): the first target
+ * wraps Claude Code on host OAuth, and there is no guest translation yet.
+ *
+ * Not yet in `builtinAdapters()` — `index.mjs` is outside this ticket's
+ * Owned Paths. Tests register the module through `createAdapterRegistry`.
+ */
+import { spawn } from "node:child_process";
+import {
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import {
+  HARNESS_LAYOUT as CLAUDE_HARNESS_LAYOUT,
+  KILL_GRACE_MS as CLAUDE_KILL_GRACE_MS,
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV,
+  killProcessGroup,
+  safeChildEnvironment,
+} from "./claude.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
+
+export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV, killProcessGroup };
+
+/** ACP v1 major version. Agents that answer anything else are refused. */
+export const PROTOCOL_VERSION = 1;
+
+export const KILL_GRACE_MS = CLAUDE_KILL_GRACE_MS;
+
+export const SANDBOX_SUPPORT = "unsupported";
+
+export const SANDBOX_DEFERRAL_REASON =
+  "acp wraps host-authenticated coding agents (first target: claude-code-acp) whose binary, subscription OAuth, and permission surface have no Gondolin guest translation yet (WM-313 deferral; see lib/adapters/acp.mjs)";
+
+/**
+ * First target is Claude Code via ACP, so harness packaging matches claude.
+ * Not part of the WM-837 contract.
+ */
+export const HARNESS_LAYOUT = CLAUDE_HARNESS_LAYOUT;
+
+/** Shipped default — the Zed `claude-code-acp` binary on PATH. */
+export const DEFAULT_ACP_CONFIG = Object.freeze({
+  command: "claude-code-acp",
+  args: Object.freeze([]),
+  env: Object.freeze({}),
+});
+
+/**
+ * Commands auto-allowed on mutating runs when `kind === "execute"`.
+ * Basename of the first token must match. Empty on `mutating: false`.
+ */
+export const DEFAULT_ALLOW_COMMANDS = Object.freeze([
+  "bun",
+  "git",
+  "gh",
+  "node",
+  "npm",
+  "npx",
+]);
+
+export const CLIENT_INFO = Object.freeze({
+  name: "factory-acp",
+  title: "Watt Mind Factory",
+  version: "0.0.0",
+});
+
+const TEXT_PREVIEW_CHARS = 4000;
+const STDERR_FILE_CHARS = 16_384;
+
+export class CliNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CliNotFoundError";
+    this.code = "cli_not_found";
+  }
+}
+
+export class AcpProtocolError extends Error {
+  /**
+   * @param {string} code
+   * @param {string} message
+   */
+  constructor(code, message) {
+    super(message);
+    this.name = "AcpProtocolError";
+    this.code = code;
+  }
+}
+
+function clip(text) {
+  const s = String(text ?? "");
+  return s.length > TEXT_PREVIEW_CHARS
+    ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]`
+    : s;
+}
+
+/**
+ * Merge `{ command, args, env }` from execute options, then spec/def, then
+ * the shipped default.
+ */
+export function resolveAcpConfig({ spec, def, config } = {}) {
+  const raw = config ?? spec?.acp ?? def?.acp ?? {};
+  const command =
+    typeof raw.command === "string" && raw.command !== ""
+      ? raw.command
+      : DEFAULT_ACP_CONFIG.command;
+  const args = Array.isArray(raw.args)
+    ? raw.args.map(String)
+    : [...DEFAULT_ACP_CONFIG.args];
+  const env =
+    raw.env && typeof raw.env === "object" && !Array.isArray(raw.env)
+      ? { ...raw.env }
+      : {};
+  return { command, args, env };
+}
+
+/**
+ * Resolve the agent binary. Absolute paths must exist; names go through
+ * `which`. Returns null when missing so execute() can throw CliNotFoundError.
+ */
+export function resolveAcpCommand(
+  config,
+  { which = Bun.which, pathEnv } = {},
+) {
+  const command = config?.command;
+  if (typeof command !== "string" || command === "") return null;
+  const args = Array.isArray(config.args) ? config.args : [];
+  if (path.isAbsolute(command)) {
+    return existsSync(command) ? { command, args } : null;
+  }
+  const found =
+    typeof pathEnv === "string"
+      ? which(command, { PATH: pathEnv })
+      : which(command);
+  if (!found) return null;
+  return { command: found, args };
+}
+
+function writeRpc(stream, obj) {
+  if (!stream || stream.destroyed || stream.writableEnded) return;
+  stream.write(`${JSON.stringify(obj)}\n`);
+}
+
+/**
+ * Newline-delimited JSON-RPC 2.0 over a child stdin/stdout pair
+ * (ACP stdio transport).
+ */
+export function createAcpRpc({ stdin, stdout, onRequest, onNotification }) {
+  let nextId = 1;
+  const pending = new Map();
+  const rl = createInterface({ input: stdout });
+
+  rl.on("line", (line) => {
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+    if (typeof msg.method === "string" && msg.id !== undefined && msg.id !== null) {
+      onRequest?.(msg);
+      return;
+    }
+    if (typeof msg.method === "string") {
+      onNotification?.(msg);
+      return;
+    }
+    if (msg.id === undefined || !pending.has(msg.id)) return;
+    const waiter = pending.get(msg.id);
+    pending.delete(msg.id);
+    if (msg.error) {
+      const err = new AcpProtocolError(
+        "acp_rpc_error",
+        msg.error.message ?? "ACP JSON-RPC error",
+      );
+      err.rpcError = msg.error;
+      waiter.reject(err);
+    } else {
+      waiter.resolve(msg.result);
+    }
+  });
+
+  return {
+    request(method, params) {
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        try {
+          writeRpc(stdin, { jsonrpc: "2.0", id, method, params });
+        } catch (err) {
+          pending.delete(id);
+          reject(err);
+        }
+      });
+    },
+    notify(method, params) {
+      writeRpc(stdin, { jsonrpc: "2.0", method, params });
+    },
+    respond(id, result) {
+      writeRpc(stdin, { jsonrpc: "2.0", id, result });
+    },
+    respondError(id, error) {
+      writeRpc(stdin, { jsonrpc: "2.0", id, error });
+    },
+    rejectAll(err) {
+      for (const waiter of pending.values()) waiter.reject(err);
+      pending.clear();
+    },
+    close() {
+      try {
+        rl.close();
+      } catch {
+        // already closed
+      }
+    },
+  };
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (content && typeof content === "object" && content.type === "text") {
+    return content.text ?? "";
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (block?.type === "text") return block.text ?? "";
+        if (block?.type === "content") return contentText(block.content);
+        if (block?.type === "diff") {
+          return `diff ${block.path ?? ""}`;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function firstDiff(content) {
+  if (!Array.isArray(content)) return null;
+  const diff = content.find((block) => block?.type === "diff");
+  if (!diff) return null;
+  return {
+    path: diff.path ?? null,
+    oldText: clip(diff.oldText ?? ""),
+    newText: clip(diff.newText ?? ""),
+  };
+}
+
+/**
+ * Map one ACP `session/update` payload to factory.trace/v1 events. Pure.
+ * Unknown update kinds yield an empty array — never fatal.
+ *
+ * @param {any} update
+ * @returns {Array<{kind: string, payload: object}>}
+ */
+export function mapSessionUpdate(update) {
+  if (!update || typeof update !== "object") return [];
+  const kind = update.sessionUpdate;
+  if (kind === "agent_message_chunk") {
+    const text = contentText(update.content);
+    return text ? [{ kind: "assistant_text", payload: { text: clip(text) } }] : [];
+  }
+  if (kind === "tool_call") {
+    return [
+      {
+        kind: "tool_use",
+        payload: {
+          id: update.toolCallId ?? null,
+          name: update.kind || update.title || "tool",
+          input: update.rawInput ?? {},
+          title: update.title ?? null,
+        },
+      },
+    ];
+  }
+  if (kind === "tool_call_update") {
+    const status = update.status;
+    if (status !== "completed" && status !== "failed") return [];
+    const content = Array.isArray(update.content) ? update.content : [];
+    const payload = {
+      content: clip(contentText(content) || contentText(update.rawOutput)),
+      toolUseId: update.toolCallId ?? null,
+    };
+    if (status === "failed") payload.isError = true;
+    const diff = firstDiff(content);
+    if (diff) payload.diff = diff;
+    return [{ kind: "tool_result", payload }];
+  }
+  if (kind === "usage_update") {
+    const usage = {};
+    if (typeof update.used === "number") usage.used = update.used;
+    if (typeof update.size === "number") usage.size = update.size;
+    const amount = update.cost?.amount;
+    const currency = update.cost?.currency;
+    return [
+      {
+        kind: "usage",
+        payload: {
+          durationMs: null,
+          numTurns: null,
+          costUSD:
+            typeof amount === "number" && currency === "USD" ? amount : null,
+          usage,
+        },
+      },
+    ];
+  }
+  return [];
+}
+
+export function usageFromUpdate(update) {
+  if (!update || update.sessionUpdate !== "usage_update") return null;
+  const amount = update.cost?.amount;
+  const currency = update.cost?.currency;
+  return {
+    inputTokens: typeof update.used === "number" ? update.used : null,
+    outputTokens: null,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    contextSize: typeof update.size === "number" ? update.size : null,
+    costUSD: typeof amount === "number" && currency === "USD" ? amount : null,
+  };
+}
+
+function collectPaths(toolCall) {
+  const paths = [];
+  if (typeof toolCall?.path === "string") paths.push(toolCall.path);
+  if (Array.isArray(toolCall?.locations)) {
+    for (const loc of toolCall.locations) {
+      if (typeof loc?.path === "string") paths.push(loc.path);
+    }
+  }
+  const raw = toolCall?.rawInput;
+  if (raw && typeof raw === "object") {
+    for (const key of ["path", "file", "file_path", "filePath"]) {
+      if (typeof raw[key] === "string") paths.push(raw[key]);
+    }
+  }
+  return paths;
+}
+
+export function isInsideWorkspace(filePath, workspaceDir) {
+  if (typeof filePath !== "string" || filePath === "") return false;
+  if (typeof workspaceDir !== "string" || workspaceDir === "") return false;
+  const root = path.resolve(workspaceDir);
+  const resolved = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(root, filePath);
+  return resolved === root || resolved.startsWith(`${root}${path.sep}`);
+}
+
+export function commandBasename(command) {
+  if (typeof command !== "string") return "";
+  const token = command.trim().split(/\s+/)[0] ?? "";
+  return token ? path.basename(token) : "";
+}
+
+/**
+ * Closed permission policy for unattended runs.
+ *
+ * @returns {"allow" | "reject" | "escalate"}
+ */
+export function decidePermission(params, policy = {}) {
+  const toolCall = params?.toolCall ?? params ?? {};
+  const kind = typeof toolCall.kind === "string" ? toolCall.kind : "";
+  const workspaceDir = policy.workspaceDir;
+  const allowCommands = Array.isArray(policy.allowCommands)
+    ? policy.allowCommands
+    : [];
+
+  if (kind === "read" || kind === "search" || kind === "think") return "allow";
+
+  if (kind === "edit" || kind === "delete" || kind === "move") {
+    if (policy.allowWorkspaceEdits === false) return "escalate";
+    const paths = collectPaths(toolCall);
+    if (paths.length === 0) return "escalate";
+    return paths.every((p) => isInsideWorkspace(p, workspaceDir))
+      ? "allow"
+      : "escalate";
+  }
+
+  if (kind === "execute") {
+    const command =
+      toolCall.rawInput?.command ??
+      toolCall.rawInput?.cmd ??
+      toolCall.title ??
+      "";
+    const base = commandBasename(command);
+    return base && allowCommands.includes(base) ? "allow" : "escalate";
+  }
+
+  return "escalate";
+}
+
+/**
+ * Pick a JSON-RPC result for `session/request_permission`.
+ * Prefers once-only options so a spike run does not persist always-allow.
+ */
+export function selectPermissionOption(options, intent) {
+  if (intent === "cancel") return { outcome: { outcome: "cancelled" } };
+  const list = Array.isArray(options) ? options : [];
+  const kinds =
+    intent === "allow"
+      ? ["allow_once", "allow_always"]
+      : ["reject_once", "reject_always"];
+  const opt = kinds
+    .map((kind) => list.find((o) => o?.kind === kind))
+    .find(Boolean);
+  if (!opt?.optionId) return { outcome: { outcome: "cancelled" } };
+  return { outcome: { outcome: "selected", optionId: opt.optionId } };
+}
+
+export function permissionPolicyFor(def, { workspaceDir, allowCommands } = {}) {
+  const mutating = def?.mutating !== false;
+  return {
+    workspaceDir,
+    allowWorkspaceEdits: true,
+    allowCommands: Array.isArray(allowCommands)
+      ? allowCommands
+      : mutating
+        ? [...DEFAULT_ALLOW_COMMANDS]
+        : [],
+  };
+}
+
+function stopReasonExit(stopReason) {
+  if (stopReason === "end_turn") return 0;
+  if (stopReason === "cancelled") return null;
+  return 1;
+}
+
+function emitTrace(onTrace, event) {
+  try {
+    onTrace?.(event.kind, event.payload);
+  } catch {
+    // observability must not fail the child
+  }
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean, policyDenials?: object[], usage?: object }>}
+ */
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  killGraceMs = KILL_GRACE_MS,
+  env = {},
+  config,
+  onTrace,
+  onUsage,
+  onPermissionRequest,
+  resume = null,
+  abortSignal,
+  signal,
+}) {
+  refuseSandbox("acp", def, SANDBOX_DEFERRAL_REASON);
+
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const acpConfig = resolveAcpConfig({ spec, def, config });
+  const childEnv = safeChildEnvironment({ ...acpConfig.env, ...env }, def);
+  const resolved = resolveAcpCommand(acpConfig, {
+    which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? process.env.PATH }),
+    pathEnv: childEnv.PATH ?? process.env.PATH,
+  });
+  if (!resolved) {
+    throw new CliNotFoundError(
+      `ACP agent "${acpConfig.command}" is not on PATH — install @zed-industries/claude-code-acp or pass config.command (docs/event-runtime-workers.md §2c)`,
+    );
+  }
+
+  const policy = permissionPolicyFor(def, { workspaceDir });
+  const argv = [...resolved.args];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolved.command, argv, {
+      cwd: workspaceDir,
+      env: childEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
+    });
+
+    child.stdin?.on("error", () => {});
+
+    const transcript = createWriteStream(
+      path.join(workspaceDir, ".transcript.json"),
+    );
+    transcript.on("error", () => {});
+    if (child.stdout) child.stdout.pipe(transcript);
+
+    let stderrBuf = "";
+    if (child.stderr) {
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        stderrBuf = (stderrBuf + chunk).slice(-STDERR_FILE_CHARS);
+      });
+    }
+
+    const policyDenials = [];
+    const pendingPermissionIds = new Set();
+    let lastUsage = null;
+    let sessionId = null;
+    let sessionOutcome = null;
+    let handshakeError = null;
+    let settled = false;
+    let timedOut = false;
+    let aborted = false;
+    let killTimer = null;
+    let cancelledPermissions = false;
+
+    const finishHandshakeError = (err) => {
+      if (handshakeError || sessionOutcome) return;
+      handshakeError = err;
+    };
+
+    const cancelPendingPermissions = () => {
+      if (cancelledPermissions) return;
+      cancelledPermissions = true;
+      for (const id of pendingPermissionIds) {
+        try {
+          rpc.respond(id, selectPermissionOption([], "cancel"));
+        } catch {
+          // child already gone
+        }
+      }
+      pendingPermissionIds.clear();
+    };
+
+    const onAbortOrTimeout = (asTimeout) => {
+      if (asTimeout) timedOut = true;
+      else aborted = true;
+      if (sessionId) {
+        try {
+          rpc.notify("session/cancel", { sessionId });
+        } catch {
+          // ignore
+        }
+      }
+      cancelPendingPermissions();
+      killProcessGroup(child, "SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
+        killTimer.unref?.();
+      }
+    };
+
+    const rpc = createAcpRpc({
+      stdin: child.stdin,
+      stdout: child.stdout,
+      onNotification: (msg) => {
+        if (msg.method !== "session/update") return;
+        const update = msg.params?.update;
+        for (const event of mapSessionUpdate(update)) {
+          emitTrace(onTrace, event);
+        }
+        const usage = usageFromUpdate(update);
+        if (usage) {
+          lastUsage = usage;
+          try {
+            onUsage?.(usage);
+          } catch {
+            // observability
+          }
+        }
+      },
+      onRequest: (msg) => {
+        if (msg.method !== "session/request_permission") {
+          rpc.respondError(msg.id, {
+            code: -32601,
+            message: `method not found: ${msg.method}`,
+          });
+          return;
+        }
+        pendingPermissionIds.add(msg.id);
+        Promise.resolve()
+          .then(async () => {
+            const decision = decidePermission(msg.params, policy);
+            let intent = decision;
+            if (decision === "escalate") {
+              if (typeof onPermissionRequest === "function") {
+                const answer = await onPermissionRequest(msg.params, {
+                  workspaceDir,
+                  def,
+                });
+                intent =
+                  typeof answer === "string"
+                    ? answer
+                    : answer?.intent ?? "reject";
+                if (answer && typeof answer === "object" && answer.outcome) {
+                  pendingPermissionIds.delete(msg.id);
+                  rpc.respond(msg.id, { outcome: answer.outcome });
+                  return;
+                }
+              } else {
+                intent = "reject";
+                const tool =
+                  msg.params?.toolCall?.kind ||
+                  msg.params?.toolCall?.title ||
+                  "unknown";
+                const denial = {
+                  tool,
+                  rule: clip(
+                    `ACP permission escalated and fail-closed: ${tool}`,
+                  ),
+                };
+                policyDenials.push(denial);
+                emitTrace(onTrace, {
+                  kind: "lifecycle",
+                  payload: { note: "policy_denial", ...denial },
+                });
+              }
+            }
+            pendingPermissionIds.delete(msg.id);
+            rpc.respond(
+              msg.id,
+              selectPermissionOption(msg.params?.options, intent),
+            );
+          })
+          .catch((err) => {
+            pendingPermissionIds.delete(msg.id);
+            rpc.respondError(msg.id, {
+              code: -32000,
+              message: err?.message ?? "permission handler failed",
+            });
+          });
+      },
+    });
+
+    const runSession = async () => {
+      const init = await rpc.request("initialize", {
+        protocolVersion: PROTOCOL_VERSION,
+        clientInfo: CLIENT_INFO,
+        clientCapabilities: {},
+      });
+      const answeredVersion = init?.protocolVersion;
+      if (Number(answeredVersion) !== PROTOCOL_VERSION) {
+        throw new AcpProtocolError(
+          "acp_protocol_mismatch",
+          `ACP agent negotiated protocolVersion ${JSON.stringify(answeredVersion)}, factory pins ${PROTOCOL_VERSION}`,
+        );
+      }
+      if (Array.isArray(init?.authMethods) && init.authMethods.length > 0) {
+        throw new AcpProtocolError(
+          "acp_auth_required",
+          "ACP agent requires authenticate(); factory uses host subscription auth and will not send API keys (same rule as the claude adapter)",
+        );
+      }
+
+      const cwd = path.resolve(workspaceDir);
+      const resumeId =
+        typeof resume?.sessionId === "string" && resume.sessionId
+          ? resume.sessionId
+          : null;
+      const canResume = Boolean(
+        init?.agentCapabilities?.sessionCapabilities?.resume,
+      );
+      const canLoad = init?.agentCapabilities?.loadSession === true;
+      if (resumeId && canResume) {
+        await rpc.request("session/resume", {
+          sessionId: resumeId,
+          cwd,
+          mcpServers: [],
+        });
+        sessionId = resumeId;
+      } else if (resumeId && canLoad) {
+        await rpc.request("session/load", {
+          sessionId: resumeId,
+          cwd,
+          mcpServers: [],
+        });
+        sessionId = resumeId;
+      } else {
+        const created = await rpc.request("session/new", {
+          cwd,
+          mcpServers: [],
+        });
+        sessionId = created?.sessionId;
+      }
+      if (typeof sessionId !== "string" || sessionId === "") {
+        throw new AcpProtocolError(
+          "acp_session_failed",
+          "ACP agent did not return a sessionId from session/new",
+        );
+      }
+
+      const promptResult = await rpc.request("session/prompt", {
+        sessionId,
+        prompt: [{ type: "text", text: prompt }],
+      });
+      return {
+        sessionId,
+        stopReason: promptResult?.stopReason ?? "end_turn",
+      };
+    };
+
+    runSession()
+      .then((outcome) => {
+        sessionOutcome = outcome;
+        try {
+          child.stdin?.end();
+        } catch {
+          // already closed
+        }
+        if (!timedOut && !killTimer) {
+          killProcessGroup(child, "SIGTERM");
+          killTimer = setTimeout(
+            () => killProcessGroup(child, "SIGKILL"),
+            killGraceMs,
+          );
+          killTimer.unref?.();
+        }
+      })
+      .catch((err) => {
+        finishHandshakeError(err);
+        cancelPendingPermissions();
+        try {
+          child.stdin?.end();
+        } catch {
+          // ignore
+        }
+        killProcessGroup(child, "SIGTERM");
+        if (!killTimer) {
+          killTimer = setTimeout(
+            () => killProcessGroup(child, "SIGKILL"),
+            killGraceMs,
+          );
+          killTimer.unref?.();
+        }
+      });
+
+    const termTimer = setTimeout(() => onAbortOrTimeout(true), timeoutMs);
+
+    const onAbort = () => onAbortOrTimeout(false);
+    const abortSig = abortSignal ?? signal;
+    if (abortSig) {
+      if (abortSig.aborted) onAbort();
+      else abortSig.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      cancelPendingPermissions();
+      rpc.rejectAll(new Error("ACP child closed"));
+      rpc.close();
+      transcript.destroy();
+      fn(value);
+    };
+
+    child.on("error", (err) => {
+      settle(reject, err);
+    });
+    child.on("close", (exitCode) => {
+      if (handshakeError && !timedOut && !aborted) {
+        settle(reject, handshakeError);
+        return;
+      }
+      if (stderrBuf && exitCode !== 0) {
+        try {
+          writeFileSync(
+            path.join(workspaceDir, ".stderr.txt"),
+            stderrBuf,
+            "utf8",
+          );
+        } catch {
+          // best-effort
+        }
+      }
+      const stopExit = sessionOutcome
+        ? stopReasonExit(sessionOutcome.stopReason)
+        : exitCode;
+      const finalExit =
+        timedOut || aborted
+          ? null
+          : stopExit === null
+            ? exitCode
+            : stopExit;
+      const usage = lastUsage ?? undefined;
+      try {
+        if (usage) onUsage?.(usage);
+      } catch {
+        // observability
+      }
+      settle(resolve, {
+        exitCode: finalExit,
+        timedOut,
+        policyDenials: finalExit === 0 ? [] : policyDenials,
+        ...(usage ? { usage } : {}),
+      });
+    });
+  });
+}

--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -132,10 +132,7 @@ export function resolveAcpConfig({ spec, def, config } = {}) {
  * Resolve the agent binary. Absolute paths must exist; names go through
  * `which`. Returns null when missing so execute() can throw CliNotFoundError.
  */
-export function resolveAcpCommand(
-  config,
-  { which = Bun.which, pathEnv } = {},
-) {
+export function resolveAcpCommand(config, { which = Bun.which, pathEnv } = {}) {
   const command = config?.command;
   if (typeof command !== "string" || command === "") return null;
   const args = Array.isArray(config.args) ? config.args : [];
@@ -172,7 +169,11 @@ export function createAcpRpc({ stdin, stdout, onRequest, onNotification }) {
       return;
     }
     if (!msg || typeof msg !== "object") return;
-    if (typeof msg.method === "string" && msg.id !== undefined && msg.id !== null) {
+    if (
+      typeof msg.method === "string" &&
+      msg.id !== undefined &&
+      msg.id !== null
+    ) {
       onRequest?.(msg);
       return;
     }
@@ -276,7 +277,9 @@ export function mapSessionUpdate(update) {
   const kind = update.sessionUpdate;
   if (kind === "agent_message_chunk") {
     const text = contentText(update.content);
-    return text ? [{ kind: "assistant_text", payload: { text: clip(text) } }] : [];
+    return text
+      ? [{ kind: "assistant_text", payload: { text: clip(text) } }]
+      : [];
   }
   if (kind === "tool_call") {
     return [
@@ -479,7 +482,8 @@ export async function execute({
   const acpConfig = resolveAcpConfig({ spec, def, config });
   const childEnv = safeChildEnvironment({ ...acpConfig.env, ...env }, def);
   const resolved = resolveAcpCommand(acpConfig, {
-    which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? process.env.PATH }),
+    which: (name) =>
+      Bun.which(name, { PATH: childEnv.PATH ?? process.env.PATH }),
     pathEnv: childEnv.PATH ?? process.env.PATH,
   });
   if (!resolved) {
@@ -607,7 +611,7 @@ export async function execute({
                 intent =
                   typeof answer === "string"
                     ? answer
-                    : answer?.intent ?? "reject";
+                    : (answer?.intent ?? "reject");
                 if (answer && typeof answer === "object" && answer.outcome) {
                   pendingPermissionIds.delete(msg.id);
                   rpc.respond(msg.id, { outcome: answer.outcome });
@@ -795,11 +799,7 @@ export async function execute({
         ? stopReasonExit(sessionOutcome.stopReason)
         : exitCode;
       const finalExit =
-        timedOut || aborted
-          ? null
-          : stopExit === null
-            ? exitCode
-            : stopExit;
+        timedOut || aborted ? null : stopExit === null ? exitCode : stopExit;
       const usage = lastUsage ?? undefined;
       try {
         if (usage) onUsage?.(usage);

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -509,7 +509,9 @@ describe("mapSessionUpdate / usageFromUpdate", () => {
       contextSize: 200000,
       costUSD: 0.045,
     });
-    expect(mapSessionUpdate({ sessionUpdate: "plan", entries: [] })).toEqual([]);
+    expect(mapSessionUpdate({ sessionUpdate: "plan", entries: [] })).toEqual(
+      [],
+    );
     expect(mapSessionUpdate(null)).toEqual([]);
   });
 });
@@ -523,9 +525,9 @@ describe("permission policy", () => {
       { mutating: true },
       { workspaceDir: root },
     );
-    expect(
-      decidePermission({ toolCall: { kind: "read" } }, policy),
-    ).toBe("allow");
+    expect(decidePermission({ toolCall: { kind: "read" } }, policy)).toBe(
+      "allow",
+    );
     expect(
       decidePermission(
         { toolCall: { kind: "edit", locations: [{ path: inside }] } },
@@ -616,9 +618,9 @@ describe("execute against a fake ACP agent", () => {
     expect(record.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(record.env.CLAUDECODE).toBeUndefined();
     expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(true);
-    expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain(
-      "session/update",
-    );
+    expect(
+      readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8"),
+    ).toContain("session/update");
     expect(traceEvents.some((e) => e.kind === "assistant_text")).toBe(true);
     expect(traceEvents.some((e) => e.kind === "tool_use")).toBe(true);
     expect(traceEvents.some((e) => e.kind === "tool_result")).toBe(true);

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -1,0 +1,789 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-acp-test-mjs";
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import * as acp from "./acp.mjs";
+import {
+  AcpProtocolError,
+  CliNotFoundError,
+  DEFAULT_ACP_CONFIG,
+  DEFAULT_ALLOW_COMMANDS,
+  KILL_GRACE_MS,
+  PROTOCOL_VERSION,
+  SANDBOX_DEFERRAL_REASON,
+  SANDBOX_SUPPORT,
+  commandBasename,
+  decidePermission,
+  execute,
+  isInsideWorkspace,
+  mapSessionUpdate,
+  permissionPolicyFor,
+  resolveAcpCommand,
+  resolveAcpConfig,
+  selectPermissionOption,
+  usageFromUpdate,
+} from "./acp.mjs";
+import { createAdapterRegistry, validateAdapterContract } from "./index.mjs";
+import { SandboxUnsupportedError } from "./sandboxed.mjs";
+import {
+  processOwnerWatchdogSource,
+  trackProcessGroupForPid,
+} from "../test-helpers-process.mjs";
+
+const tmpBase = tmpDir("evrt-acp-");
+const stubPath = path.join(tmpBase, "fake-acp.mjs");
+const promptPath = path.join(tmpBase, "prompt.md");
+writeFileSync(promptPath, "You are a test agent.", "utf8");
+
+writeFileSync(
+  stubPath,
+  `#!/usr/bin/env bun
+import { createInterface } from "node:readline";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+${processOwnerWatchdogSource()}
+
+const behavior = process.env.ACP_FAKE_BEHAVIOR || "happy";
+if (process.env.ACP_FAKE_RECORD) {
+  writeFileSync(
+    process.env.ACP_FAKE_RECORD,
+    JSON.stringify({ cwd: process.cwd(), env: process.env, argv: process.argv }),
+  );
+}
+
+function send(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\\n");
+}
+
+const pending = new Map();
+let nextId = 9000;
+function request(method, params) {
+  const id = nextId++;
+  send({ jsonrpc: "2.0", id, method, params });
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+  });
+}
+
+const allowOnce = {
+  optionId: "allow-once",
+  name: "Allow once",
+  kind: "allow_once",
+};
+const rejectOnce = {
+  optionId: "reject-once",
+  name: "Reject",
+  kind: "reject_once",
+};
+
+async function handlePrompt(sessionId) {
+  if (behavior === "hang" || behavior === "ignore_sigterm") return;
+  if (behavior === "spawn_grandchild") {
+    const grandchild = Bun.spawn(
+      [process.execPath, "-e", "setInterval(() => {}, 10_000)"],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    writeFileSync(
+      process.env.ACP_FAKE_GRANDCHILD_PID,
+      String(grandchild.pid),
+      "utf8",
+    );
+    return;
+  }
+
+  send({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Working..." },
+      },
+    },
+  });
+  send({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "Read input",
+        kind: "read",
+        status: "pending",
+        rawInput: { path: path.join(process.cwd(), "input.json") },
+      },
+    },
+  });
+
+  if (behavior.startsWith("permission_")) {
+    const kind =
+      behavior === "permission_edit"
+        ? "edit"
+        : behavior === "permission_outside"
+          ? "edit"
+          : "execute";
+    const toolCall =
+      kind === "edit"
+        ? {
+            toolCallId: "call_perm",
+            kind: "edit",
+            title: "Edit file",
+            locations: [
+              {
+                path:
+                  behavior === "permission_outside"
+                    ? "/etc/passwd"
+                    : path.join(process.cwd(), "result.json"),
+              },
+            ],
+          }
+        : {
+            toolCallId: "call_perm",
+            kind: "execute",
+            title: "Run command",
+            rawInput: {
+              command:
+                behavior === "permission_git" ? "git status" : "curl https://evil.example",
+            },
+          };
+    const decided = await request("session/request_permission", {
+      sessionId,
+      toolCall,
+      options: [allowOnce, rejectOnce],
+    });
+    writeFileSync(
+      path.join(process.cwd(), "permission.json"),
+      JSON.stringify(decided),
+    );
+  }
+
+  send({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call_1",
+        status: "completed",
+        content: [
+          {
+            type: "diff",
+            path: path.join(process.cwd(), "result.json"),
+            oldText: null,
+            newText: "{\\"ok\\":true}",
+          },
+        ],
+      },
+    },
+  });
+  send({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1200,
+        size: 200000,
+        cost: { amount: 0.02, currency: "USD" },
+      },
+    },
+  });
+  writeFileSync(
+    path.join(process.cwd(), "result.json"),
+    JSON.stringify({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+    }) + "\\n",
+  );
+  send({
+    jsonrpc: "2.0",
+    id: currentPromptId,
+    result: { stopReason: "end_turn" },
+  });
+}
+
+let currentPromptId = null;
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.id !== undefined && pending.has(msg.id)) {
+    const waiter = pending.get(msg.id);
+    pending.delete(msg.id);
+    if (msg.error) waiter.reject(new Error(msg.error.message));
+    else waiter.resolve(msg.result);
+    return;
+  }
+  if (msg.method === "initialize") {
+    if (behavior === "protocol_v2") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: 2 } });
+      return;
+    }
+    if (behavior === "auth_required") {
+      send({
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: {
+          protocolVersion: 1,
+          authMethods: [{ id: "api-key", name: "API key" }],
+        },
+      });
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      id: msg.id,
+      result: {
+        protocolVersion: 1,
+        agentCapabilities: {},
+        agentInfo: { name: "fake-acp" },
+        authMethods: [],
+      },
+    });
+    return;
+  }
+  if (msg.method === "session/new") {
+    send({ jsonrpc: "2.0", id: msg.id, result: { sessionId: "sess_test" } });
+    return;
+  }
+  if (msg.method === "session/prompt") {
+    currentPromptId = msg.id;
+    handlePrompt(msg.params.sessionId).catch((err) => {
+      send({
+        jsonrpc: "2.0",
+        id: msg.id,
+        error: { code: -32000, message: err.message },
+      });
+    });
+    return;
+  }
+  if (msg.method === "session/cancel") return;
+  if (msg.id !== undefined) {
+    send({
+      jsonrpc: "2.0",
+      id: msg.id,
+      error: { code: -32601, message: "method not found" },
+    });
+  }
+});
+
+if (behavior === "ignore_sigterm") {
+  process.on("SIGTERM", () => {});
+}
+if (
+  behavior === "hang" ||
+  behavior === "ignore_sigterm" ||
+  behavior === "spawn_grandchild"
+) {
+  setInterval(() => {}, 10_000);
+}
+`,
+  { mode: 0o755 },
+);
+
+writeFileSync(promptPath, "You are a test agent.", "utf8");
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+const ws = () => realpathSync(tmpDir("ws-", tmpBase));
+const defaultDef = {
+  ref: "test-acp@1",
+  promptPath,
+  mutating: false,
+};
+const mutatingDef = { ...defaultDef, mutating: true };
+const defaultSpec = { agent: "test-acp@1", input: {} };
+const fakeConfig = {
+  command: process.execPath,
+  args: [stubPath],
+};
+
+function run(workspaceDir, extra = {}) {
+  return execute({
+    spec: defaultSpec,
+    def: extra.def ?? defaultDef,
+    workspaceDir,
+    timeoutMs: extra.timeoutMs ?? 5000,
+    killGraceMs: extra.killGraceMs ?? 200,
+    env: {
+      ACP_FAKE_BEHAVIOR: extra.behavior ?? "happy",
+      ...(extra.env ?? {}),
+    },
+    config: fakeConfig,
+    onTrace: extra.onTrace,
+    onUsage: extra.onUsage,
+    onPermissionRequest: extra.onPermissionRequest,
+    abortSignal: extra.abortSignal,
+  });
+}
+
+describe("adapter contract", () => {
+  test("satisfies WM-837: execute + SANDBOX_SUPPORT unsupported", () => {
+    expect(SANDBOX_SUPPORT).toBe("unsupported");
+    expect(typeof execute).toBe("function");
+    expect(PROTOCOL_VERSION).toBe(1);
+    expect(KILL_GRACE_MS).toBe(30_000);
+    expect(DEFAULT_ACP_CONFIG.command).toBe("claude-code-acp");
+    expect(SANDBOX_DEFERRAL_REASON).toContain("claude-code-acp");
+    expect(validateAdapterContract("acp", acp)).toEqual({
+      name: "acp",
+      sandboxSupport: "unsupported",
+    });
+  });
+
+  test("registers behind createAdapterRegistry and the sandbox wrapper refuses first", async () => {
+    const registry = createAdapterRegistry({ builtins: { acp } });
+    expect(registry.has("acp")).toBe(true);
+    expect(registry.get("acp").SANDBOX_SUPPORT).toBe("unsupported");
+    const workspaceDir = ws();
+    let caught;
+    try {
+      await registry.get("acp").execute({
+        spec: defaultSpec,
+        def: {
+          ref: "sandboxed-acp@1",
+          promptPath,
+          sandbox: { provider: "gondolin", allowedHosts: [] },
+        },
+        workspaceDir,
+        timeoutMs: 1000,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+    expect(caught.adapter).toBe("acp");
+    expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
+  });
+});
+
+describe("sandbox decision: refused, never ignored", () => {
+  test("a sandboxed definition is refused before spawn", async () => {
+    const workspaceDir = ws();
+    let caught;
+    try {
+      await execute({
+        spec: defaultSpec,
+        def: {
+          ref: "sandboxed-acp@1",
+          promptPath,
+          sandbox: { provider: "gondolin" },
+        },
+        workspaceDir,
+        timeoutMs: 1000,
+        config: { command: "/nonexistent/acp-agent" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+    expect(caught.adapter).toBe("acp");
+    expect(caught.message).toContain(SANDBOX_DEFERRAL_REASON);
+    expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
+  });
+});
+
+describe("resolveAcpConfig / resolveAcpCommand", () => {
+  test("defaults to claude-code-acp and overlays spec/def/config", () => {
+    expect(resolveAcpConfig({})).toEqual({
+      command: "claude-code-acp",
+      args: [],
+      env: {},
+    });
+    expect(
+      resolveAcpConfig({
+        spec: { acp: { command: "goose", args: ["--foo"], env: { A: "1" } } },
+      }),
+    ).toEqual({ command: "goose", args: ["--foo"], env: { A: "1" } });
+    expect(
+      resolveAcpConfig({
+        spec: { acp: { command: "goose" } },
+        config: { command: "override" },
+      }).command,
+    ).toBe("override");
+  });
+
+  test("absolute missing command is null; existing path resolves", () => {
+    expect(resolveAcpCommand({ command: "/no/such/acp-agent" })).toBeNull();
+    expect(resolveAcpCommand({ command: stubPath, args: [] })).toEqual({
+      command: stubPath,
+      args: [],
+    });
+  });
+});
+
+describe("mapSessionUpdate / usageFromUpdate", () => {
+  test("agent_message_chunk → assistant_text", () => {
+    expect(
+      mapSessionUpdate({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Looking at the input now." },
+      }),
+    ).toEqual([
+      {
+        kind: "assistant_text",
+        payload: { text: "Looking at the input now." },
+      },
+    ]);
+  });
+
+  test("tool_call → tool_use; completed update with diff → tool_result", () => {
+    expect(
+      mapSessionUpdate({
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "Edit result",
+        kind: "edit",
+        rawInput: { path: "/ws/result.json" },
+      }),
+    ).toEqual([
+      {
+        kind: "tool_use",
+        payload: {
+          id: "call_1",
+          name: "edit",
+          input: { path: "/ws/result.json" },
+          title: "Edit result",
+        },
+      },
+    ]);
+    const done = mapSessionUpdate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call_1",
+      status: "completed",
+      content: [
+        {
+          type: "diff",
+          path: "/ws/result.json",
+          oldText: null,
+          newText: "{}\n",
+        },
+      ],
+    });
+    expect(done[0].kind).toBe("tool_result");
+    expect(done[0].payload.toolUseId).toBe("call_1");
+    expect(done[0].payload.diff.path).toBe("/ws/result.json");
+    expect(done[0].payload.isError).toBeUndefined();
+  });
+
+  test("usage_update maps tokens and USD cost; unknown kinds are empty", () => {
+    const update = {
+      sessionUpdate: "usage_update",
+      used: 53000,
+      size: 200000,
+      cost: { amount: 0.045, currency: "USD" },
+    };
+    expect(mapSessionUpdate(update)[0]).toEqual({
+      kind: "usage",
+      payload: {
+        durationMs: null,
+        numTurns: null,
+        costUSD: 0.045,
+        usage: { used: 53000, size: 200000 },
+      },
+    });
+    expect(usageFromUpdate(update)).toEqual({
+      inputTokens: 53000,
+      outputTokens: null,
+      cacheCreationInputTokens: null,
+      cacheReadInputTokens: null,
+      contextSize: 200000,
+      costUSD: 0.045,
+    });
+    expect(mapSessionUpdate({ sessionUpdate: "plan", entries: [] })).toEqual([]);
+    expect(mapSessionUpdate(null)).toEqual([]);
+  });
+});
+
+describe("permission policy", () => {
+  const root = "/tmp/acp-ws";
+  const inside = `${root}/repo/file.ts`;
+
+  test("read/search/think allow; workspace edits allow; outside and unknown escalate", () => {
+    const policy = permissionPolicyFor(
+      { mutating: true },
+      { workspaceDir: root },
+    );
+    expect(
+      decidePermission({ toolCall: { kind: "read" } }, policy),
+    ).toBe("allow");
+    expect(
+      decidePermission(
+        { toolCall: { kind: "edit", locations: [{ path: inside }] } },
+        policy,
+      ),
+    ).toBe("allow");
+    expect(
+      decidePermission(
+        { toolCall: { kind: "edit", locations: [{ path: "/etc/passwd" }] } },
+        policy,
+      ),
+    ).toBe("escalate");
+    expect(decidePermission({ toolCall: { kind: "fetch" } }, policy)).toBe(
+      "escalate",
+    );
+  });
+
+  test("execute allow-lists command basename; mutating:false has an empty list", () => {
+    expect(commandBasename("/usr/bin/git status")).toBe("git");
+    expect(isInsideWorkspace(inside, root)).toBe(true);
+    expect(isInsideWorkspace("/etc/passwd", root)).toBe(false);
+    const mutating = permissionPolicyFor(
+      { mutating: true },
+      { workspaceDir: root },
+    );
+    expect(mutating.allowCommands).toEqual([...DEFAULT_ALLOW_COMMANDS]);
+    expect(
+      decidePermission(
+        { toolCall: { kind: "execute", rawInput: { command: "git status" } } },
+        mutating,
+      ),
+    ).toBe("allow");
+    expect(
+      decidePermission(
+        {
+          toolCall: {
+            kind: "execute",
+            rawInput: { command: "curl https://evil" },
+          },
+        },
+        mutating,
+      ),
+    ).toBe("escalate");
+    expect(
+      permissionPolicyFor({ mutating: false }, { workspaceDir: root })
+        .allowCommands,
+    ).toEqual([]);
+  });
+
+  test("selectPermissionOption prefers once-only options", () => {
+    const options = [
+      { optionId: "allow-always", kind: "allow_always" },
+      { optionId: "allow-once", kind: "allow_once" },
+      { optionId: "reject-once", kind: "reject_once" },
+    ];
+    expect(selectPermissionOption(options, "allow")).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+    expect(selectPermissionOption(options, "reject")).toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+    expect(selectPermissionOption(options, "cancel")).toEqual({
+      outcome: { outcome: "cancelled" },
+    });
+  });
+});
+
+describe("execute against a fake ACP agent", () => {
+  test("session lifecycle, update folding, usage, result.json, subscription env stripped", async () => {
+    const workspaceDir = ws();
+    const recordFile = path.join(workspaceDir, "record.json");
+    const traceEvents = [];
+    const usageSeen = [];
+    const outcome = await run(workspaceDir, {
+      env: {
+        ACP_FAKE_RECORD: recordFile,
+        ANTHROPIC_API_KEY: "sk-must-strip",
+        CLAUDECODE: "1",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+      onUsage: (usage) => usageSeen.push(usage),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.policyDenials).toEqual([]);
+    const record = JSON.parse(readFileSync(recordFile, "utf8"));
+    expect(record.cwd).toBe(workspaceDir);
+    expect(record.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(record.env.CLAUDECODE).toBeUndefined();
+    expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(true);
+    expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain(
+      "session/update",
+    );
+    expect(traceEvents.some((e) => e.kind === "assistant_text")).toBe(true);
+    expect(traceEvents.some((e) => e.kind === "tool_use")).toBe(true);
+    expect(traceEvents.some((e) => e.kind === "tool_result")).toBe(true);
+    expect(traceEvents.some((e) => e.kind === "usage")).toBe(true);
+    const toolResult = traceEvents.find((e) => e.kind === "tool_result");
+    expect(toolResult.payload.diff).toBeDefined();
+    expect(usageSeen[0].costUSD).toBe(0.02);
+    expect(usageSeen[0].inputTokens).toBe(1200);
+  });
+
+  test("workspace-scoped edit is auto-allowed", async () => {
+    const workspaceDir = ws();
+    await run(workspaceDir, { behavior: "permission_edit", def: mutatingDef });
+    const decided = JSON.parse(
+      readFileSync(path.join(workspaceDir, "permission.json"), "utf8"),
+    );
+    expect(decided.outcome).toEqual({
+      outcome: "selected",
+      optionId: "allow-once",
+    });
+  });
+
+  test("git execute is auto-allowed on mutating runs; curl fail-closes", async () => {
+    const gitDir = ws();
+    await run(gitDir, { behavior: "permission_git", def: mutatingDef });
+    expect(
+      JSON.parse(readFileSync(path.join(gitDir, "permission.json"), "utf8"))
+        .outcome.optionId,
+    ).toBe("allow-once");
+
+    const curlDir = ws();
+    const traces = [];
+    const curl = await run(curlDir, {
+      behavior: "permission_curl",
+      def: mutatingDef,
+      onTrace: (kind, payload) => traces.push({ kind, payload }),
+    });
+    expect(
+      JSON.parse(readFileSync(path.join(curlDir, "permission.json"), "utf8"))
+        .outcome.optionId,
+    ).toBe("reject-once");
+    expect(curl.policyDenials).toEqual([]);
+    expect(
+      traces.some(
+        (e) => e.kind === "lifecycle" && e.payload.note === "policy_denial",
+      ),
+    ).toBe(true);
+  });
+
+  test("onPermissionRequest can allow an escalated request", async () => {
+    const workspaceDir = ws();
+    const seen = [];
+    await run(workspaceDir, {
+      behavior: "permission_outside",
+      def: mutatingDef,
+      onPermissionRequest: async (params) => {
+        seen.push(params.toolCall.kind);
+        return "allow";
+      },
+    });
+    expect(seen).toEqual(["edit"]);
+    expect(
+      JSON.parse(
+        readFileSync(path.join(workspaceDir, "permission.json"), "utf8"),
+      ).outcome.optionId,
+    ).toBe("allow-once");
+  });
+
+  test("missing binary is cli_not_found before spawn", async () => {
+    const workspaceDir = ws();
+    let caught;
+    try {
+      await execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir,
+        timeoutMs: 1000,
+        config: { command: "definitely-not-an-acp-agent-wm937" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CliNotFoundError);
+    expect(caught.code).toBe("cli_not_found");
+  });
+
+  test("protocol version mismatch is a typed refusal", async () => {
+    const workspaceDir = ws();
+    let caught;
+    try {
+      await run(workspaceDir, { behavior: "protocol_v2" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AcpProtocolError);
+    expect(caught.code).toBe("acp_protocol_mismatch");
+  });
+
+  test("authMethods required is a typed refusal — no API key sent", async () => {
+    const workspaceDir = ws();
+    let caught;
+    try {
+      await run(workspaceDir, { behavior: "auth_required" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AcpProtocolError);
+    expect(caught.code).toBe("acp_auth_required");
+  });
+
+  test("timeout sets timedOut and does not throw", async () => {
+    const workspaceDir = ws();
+    const outcome = await run(workspaceDir, {
+      behavior: "hang",
+      timeoutMs: 200,
+      killGraceMs: 50,
+    });
+    expect(outcome.timedOut).toBe(true);
+    expect(outcome.exitCode).toBeNull();
+  });
+
+  test("abort resolves timedOut false, exitCode null", async () => {
+    const workspaceDir = ws();
+    const ac = new AbortController();
+    const pending = run(workspaceDir, {
+      behavior: "hang",
+      timeoutMs: 10_000,
+      killGraceMs: 50,
+      abortSignal: ac.signal,
+    });
+    ac.abort();
+    const outcome = await pending;
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.exitCode).toBeNull();
+  });
+
+  const testProcessGroup = process.platform === "win32" ? test.skip : test;
+  testProcessGroup("timeout kills a long-lived grandchild", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    const pending = run(workspaceDir, {
+      behavior: "spawn_grandchild",
+      timeoutMs: 400,
+      killGraceMs: 200,
+      env: { ACP_FAKE_GRANDCHILD_PID: pidFile },
+    });
+    let pid = null;
+    for (let i = 0; i < 200; i += 1) {
+      if (existsSync(pidFile)) {
+        pid = Number(readFileSync(pidFile, "utf8"));
+        trackProcessGroupForPid(pid);
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(pid).toBeGreaterThan(0);
+    const outcome = await pending;
+    expect(outcome.timedOut).toBe(true);
+    await new Promise((r) => setTimeout(r, 50));
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Spike `acp` adapter speaking ACP v1 as JSON-RPC NDJSON over stdio, default `{ command: "claude-code-acp", args: [], env: {} }`, contract `execute` + `SANDBOX_SUPPORT = "unsupported"`.
- Folds `session/update` into factory.trace/v1 (text, tool calls with diffs, `usage_update`); auto-allows workspace-scoped edits and allow-listed commands, fail-closes the rest instead of blocking the turn on an inbox decision.
- Registry wiring into `builtinAdapters()` is out of this ticket's Owned Paths — filed as WM-941.

Fixes WM-937

UX critique: skipped — backend harness adapter, no user-facing surface.

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/adapters/acp.test.mjs && bun run lint && bun run check`
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib`
- [ ] Reviewer: WM-941 is the follow-up that makes `adapter: "acp"` dispatchable on a worker


Made with [Cursor](https://cursor.com)