### PR TITLE
feat(extensions): make contributes.connectors a real runtime seam (WM-919)

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -26,6 +26,10 @@ Today an extension can contribute:
 - **hooks** — decision-returning modules run at a named point of the runtime,
   today `approve.before` (immediately before each chain auto-approval); a
   fail-closed waterfall whose every decision is persisted (§Hooks below);
+- **connectors** — long-running processes the runtime starts with `serve`
+  and stops on shutdown; they talk to the outside world (Buzz, Telegram, a
+  tracker) through a narrow loopback client and never hold a DB handle
+  (§Connectors below);
 - **panels** — declarative `factory.panel-view/v1` Overview tiles
   ([`event-runtime-artifact-views.md` §2.6](event-runtime-artifact-views.md#26-panels--factorypanel-viewv1-wm-840));
   data only, drawn by the web's existing artifact-view renderer, bound to an
@@ -34,9 +38,9 @@ Today an extension can contribute:
   `build/emit.mjs` packages for Claude Code, Codex, Gemini, Cursor and Pi
   (§Harness below). `shared/` is the built-in `factory/core` pack.
 
-The manifest also **reserves** `connectors` and `views` for the tickets that
-land them. A
-manifest that carries a reserved key loads its packs and adapters and records a
+The manifest also **reserves** `views` for the ticket that lands it. A
+manifest that carries a reserved key loads its packs, adapters, connectors
+and the rest and records a
 "not supported yet" configuration anomaly for the rest — it is accepted, not
 rejected, so an extension written for a later runtime still does what this one
 understands.
@@ -55,6 +59,8 @@ Implementation: `event-runtime/lib/extensions.mjs`, schema
     argent.mjs                # an adapter module (execute + SANDBOX_SUPPORT)
   hooks/
     no-infra-merges.mjs       # an approve.before hook (id + default (ctx) => decision) (§Hooks)
+  connectors/
+    buzz.mjs                  # a connector (id + default start(ctx) => { stop, health }) (§Connectors)
   config.schema.json          # the shape of the extension's operator config (§Config)
   panels/
     blocked-tickets.panel.json  # a factory.panel-view/v1 panel
@@ -82,6 +88,7 @@ directory, and must stay inside it.
     "adapters": { "argent": "./adapters/argent.mjs" },
     "config": { "namespace": "mobile", "schema": "./config.schema.json" },
     "hooks": { "approve.before": "./hooks/no-infra-merges.mjs" },
+    "connectors": { "buzz": "./connectors/buzz.mjs" },
     "panels": ["./panels"],
     "harness": {
       "floor": "./harness/floor.md",
@@ -93,19 +100,20 @@ directory, and must stay inside it.
 }
 ```
 
-| Key                                | Required | Meaning                                                                                                                                                                                                                                                      |
-| :--------------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                             | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                                    |
-| `version`                          | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                                    |
-| `description`                      | no       | Up to 200 characters, for listings.                                                                                                                                                                                                                          |
-| `factory.min`                      | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                                          |
-| `contributes.packs`                | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                               |
-| `contributes.adapters`             | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension).              |
-| `contributes.config`               | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.                        |
-| `contributes.hooks`                | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                                      |
-| `contributes.panels`               | no       | Array of relative directories; every `*.panel.json` directly inside is a `factory.panel-view/v1` panel (§Panels). The manifest check proves the directories exist inside the extension; the registry validates each panel at load and skips a bad one alone. |
-| `contributes.harness`              | no       | Object `{ floor?, commands?, skills?, subagents? }`: relative file/directory of harness-neutral markdown emit packages (§Harness). The built-in pack is `shared/` (`factory/core`).                                                                          |
-| `contributes.connectors`, `.views` | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.<key> is not supported yet`.                                                                                                                   |
+| Key                      | Required | Meaning                                                                                                                                                                                                                                                      |
+| :----------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                   | yes      | `publisher/extension`, matching `^[a-z0-9-]+/[a-z0-9-]+$`. Recorded as the `source` of every adapter the extension registers, so `bun event-runtime/cli.mjs adapters` can say where an adapter came from.                                                    |
+| `version`                | yes      | Semver (`MAJOR.MINOR.PATCH`, optional pre-release/build).                                                                                                                                                                                                    |
+| `description`            | no       | Up to 200 characters, for listings.                                                                                                                                                                                                                          |
+| `factory.min`            | no       | The oldest factory the extension was written for. Informational until the runtime carries a version; the loader records it and does not enforce it.                                                                                                          |
+| `contributes.packs`      | no       | Array of relative directories, each containing a `pack.json`. The pack's `name` and `namespace` come from its own `pack.json` (`docs/kernel-and-packs.md` § Pack format) — the policy entry names the extension, not the pack.                               |
+| `contributes.adapters`   | no       | Object `name → relative .mjs path`. Names must match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export `execute` and `SANDBOX_SUPPORT`. An extension may not replace an existing adapter (built-in or from an earlier extension).              |
+| `contributes.config`     | no       | Object `{ namespace, schema }`: the name the extension's operator values are published under (`^[a-z][a-z0-9-]*$`, unique across loaded extensions) and the relative path of the JSON-schema those values must satisfy. See § Config.                        |
+| `contributes.hooks`      | no       | Object `hook point → relative .mjs path`. The only point today is `approve.before`; an unknown key is a schema violation. The module must export a string `id` and a default `(ctx) => decision` function. See § Hooks.                                      |
+| `contributes.connectors` | no       | Object `name → relative .mjs path`. Names match the adapter pattern `^[a-z][a-z0-9-]*$`; the module must export a string `id` and a default `start(ctx) → { stop, health }`. See § Connectors.                                                               |
+| `contributes.panels`     | no       | Array of relative directories; every `*.panel.json` directly inside is a `factory.panel-view/v1` panel (§Panels). The manifest check proves the directories exist inside the extension; the registry validates each panel at load and skips a bad one alone. |
+| `contributes.harness`    | no       | Object `{ floor?, commands?, skills?, subagents? }`: relative file/directory of harness-neutral markdown emit packages (§Harness). The built-in pack is `shared/` (`factory/core`).                                                                          |
+| `contributes.views`      | no       | **Reserved.** Accepted by the schema, ignored by the loader, reported as a configuration anomaly `contributes.views is not supported yet`.                                                                                                                   |
 
 Unknown top-level keys and unknown `contributes` keys are schema violations.
 Validate a manifest without loading anything:
@@ -116,11 +124,11 @@ bun event-runtime/cli.mjs extensions validate ~/.factory/extensions/wattmind-mob
 ```
 
 `validate` checks the schema, that every contributed path exists and stays
-inside the extension directory, and that adapter names and hook points are
-well-formed. It does not load a pack, import an adapter or hook module, or
-read a panel document — running third-party code is what enabling does, and
-panel documents are validated by the registry at load (an invalid one is a
-`/status` anomaly).
+inside the extension directory, and that adapter names, connector names and
+hook points are well-formed. It does not load a pack, import an adapter,
+hook or connector module, or read a panel document — running third-party
+code is what enabling does, and panel documents are validated by the registry
+at load (an invalid one is a `/status` anomaly).
 
 ## Trust model
 
@@ -140,14 +148,18 @@ There are two kinds of contribution, and the difference is what runs.
   is why the fixture pack is a copy of `test-support/packs/sample`.
 - **Operator-installed code.** An adapter is an ES module the worker imports
   and calls; a hook is an ES module `serve` imports and calls inside the
-  approval pass. Enabling an extension that contributes either is running that
-  code in the runtime process with its credentials. Only the operator
+  approval pass; a connector is an ES module `serve` starts after the
+  registry loads and stops on shutdown. Enabling an extension that contributes
+  any of them is running that code in the runtime process with its credentials.
+  Only the operator
   enables extensions — by editing `config/policy.yaml`, a committed file —
   and nothing an agent does at runtime can add one. The registry still puts
   every adapter behind the sandbox seam (an `unsupported` adapter is refused
   for a sandboxed definition before its code runs, WM-313/WM-837), and it
   refuses a module that does not satisfy the contract at load time rather
-  than mid-run.
+  than mid-run. A connector that fails `start()` is the one exception to
+  all-or-nothing: that connector is disabled with a configuration anomaly and
+  the extension's other contributions stay loaded.
 
 Two rules follow. Discovery is **allow-listed, never scanned**: the loader reads
 only the directories `policy.yaml` names, in that order — dropping a directory
@@ -212,11 +224,14 @@ message naming both packs; fix the pack (or the order) and restart.
 5. If the extension gates unattended work, add an `approve.before` hook
    (§Hooks); the smallest conformant module is
    `event-runtime/test-support/extensions/sample/hooks/approve-before.mjs`.
-6. Add panels as `panels/<slug>.panel.json` (§Panels); the fixture's
+6. If the extension talks to an external system (Buzz, a tracker, a
+   notifier), add a connector (§Connectors); the smallest conformant module
+   is `event-runtime/test-support/extensions/sample/connectors/echo.mjs`.
+7. Add panels as `panels/<slug>.panel.json` (§Panels); the fixture's
    `panels/open-proposals.panel.json` is a complete one.
-7. Add harness content as `contributes.harness` (§Harness) when the
+8. Add harness content as `contributes.harness` (§Harness) when the
    extension ships slash commands, skills, subagents or a floor block.
-8. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
+9. `bun event-runtime/cli.mjs extensions validate <dir>` until it is clean,
    enable it, `extensions list`, restart.
 
 The fixture `event-runtime/test-support/extensions/sample/` is a complete,
@@ -573,6 +588,120 @@ allows unless the extension config says `greeting: "deny"` (proving
 files there (`throws.mjs`, `hangs.mjs`, `async-deny.mjs`, `no-id.mjs`,
 `no-default.mjs`) exercise each failure mode in `hooks.test.mjs` and
 `extensions.test.mjs`.
+
+## Connectors
+
+_Shipped in WM-919. Implementation: `event-runtime/lib/connectors.mjs`
+(`validateConnectorModule`, `createConnectorClient`, `startConnectors`,
+`stopConnectors`, `connectorStatus`), load-time import in
+`event-runtime/lib/extensions.mjs`, start/stop in `event-runtime/cli/serve.mjs`,
+status projection in `event-runtime/lib/api-status.mjs`, fixture
+`event-runtime/test-support/extensions/sample/connectors/echo.mjs`._
+
+A **connector** is how an extension talks to an external system without
+editing the kernel: Buzz, a tracker, a notifier that is not the hard-wired
+Telegram path in `lib/notify.mjs`. It is operator-installed **code** — the
+same trust class as adapters and hooks, allow-listed in `policy.yaml`, never
+scanned. The connector talks to the runtime only through a narrow client;
+it never receives a DB handle and cannot mutate the registry.
+
+```json
+"contributes": {
+  "connectors": { "buzz": "./connectors/buzz.mjs" }
+}
+```
+
+Names match the adapter pattern `^[a-z][a-z0-9-]*$`. Paths are relative to
+the manifest and must stay inside the extension.
+
+### Contract
+
+```js
+// contributes.connectors: { "echo": "./connectors/echo.mjs" }
+export const id = "factory/sample:echo"; // publisher[/extension]:name
+
+export default async function start(ctx) {
+  // ctx: { config, secrets, client, log, signal }
+  const unsubscribe = ctx.client.inbox.subscribe((event) => {
+    ctx.log(`inbox ${event.type} ${event.item?.id ?? ""}`);
+  });
+  ctx.signal.addEventListener("abort", () => unsubscribe(), { once: true });
+  return {
+    async stop() {
+      unsubscribe();
+    },
+    health() {
+      return { ok: true, detail: "subscribed", lastEventAt: undefined };
+    },
+  };
+}
+```
+
+| `ctx` field | What it is                                                                                                                                                                                                                                                            |
+| :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`    | The extension's effective config with secret values stripped. Read settings from here, not from `policy.yaml`. Never contains secret values.                                                                                                                          |
+| `secrets`   | Values the loader resolved from `FACTORY_EXT_<NAMESPACE>_<KEY>` (process env, then `~/.factory/secrets.env`) for every `format: "secret"` property, plus remaining keys matching `/nsec\|token\|secret\|key\|password/i`. Absent keys are missing, not empty strings. |
+| `client`    | The narrow loopback client (below).                                                                                                                                                                                                                                   |
+| `log`       | `(message) => void` — prefixed `connector <ext>/<name>:` on the serve log.                                                                                                                                                                                            |
+| `signal`    | An `AbortSignal`. Aborted when `serve` shuts down, when `start()` overruns 10 s, and when that connector is otherwise stopped.                                                                                                                                        |
+
+`start` may be sync or async. Its return value must be `{ stop, health }`:
+
+| Method     | Contract                                                                                                             |
+| :--------- | :------------------------------------------------------------------------------------------------------------------- |
+| `stop()`   | May be async. Isolated: a throw does not fail shutdown or other connectors.                                          |
+| `health()` | Sync. `{ ok: boolean, detail?: string, lastEventAt?: string }`. A throw is reported as `ok: false` with the message. |
+
+### Client
+
+The connector never holds the database. `client` is the only runtime surface:
+
+| Method                                  | What it does                                                                                                                                                                                                 |
+| :-------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inject(envelope)`                      | Same intake as `cli inject` (`admitExternalEvent`). Overwrites `source` to `connector:<ext>/<name>`. The event follows the normal planner/approval path — a connector cannot approve a proposal it injected. |
+| `inbox.list({ status })`                | Open/acked/resolved/all inbox items.                                                                                                                                                                         |
+| `inbox.get(id)`                         | One inbox item, or `null`.                                                                                                                                                                                   |
+| `inbox.decide(id, response, { actor })` | Records `decidedBy: "connector:<ext>/<name>:<actor>"` (`unknown` when actor is omitted).                                                                                                                     |
+| `inbox.subscribe(cb)`                   | `cb({ type, item, at })` on new-item / changed. Returns an unsubscribe function.                                                                                                                             |
+| `proposals.get(id)`                     | One proposal, or `null`.                                                                                                                                                                                     |
+| `runs.get(id)`                          | One run (`runId`, `state`, `attempts`, `spec`, …), or `null`.                                                                                                                                                |
+
+There is no `approve`, no registry write, no raw SQL.
+
+### Semantics
+
+- **Load is all-or-nothing; start is not.** Each connector module is imported
+  and contract-checked before the extension is accepted. A module that fails
+  the contract (missing `default` function, bad `id`, import error) disables
+  the extension whole — like a bad adapter. After the registry loads, `serve`
+  calls `start()` with an `AbortSignal`. A `start()` that throws, rejects, or
+  does not return `{ stop, health }` within **10 seconds** records
+  `connector <ext>/<name> failed to start: <msg>` under
+  `/status.anomalies.configuration` and **leaves the extension's other
+  contributions loaded**. Connectors are the one contribution that may fail
+  independently. Other connectors of the same extension still start.
+- **Secrets never sit in `policy.yaml`.** Every `format: "secret"` property
+  (WM-920) is read from `FACTORY_EXT_<NAMESPACE>_<KEY>` (upper-snake) and
+  never from the policy entry. A secret present in `policy.yaml` disables the
+  extension. Until a schema declares `format: "secret"`, keys matching
+  `/nsec|token|secret|key|password/i` are treated as secrets for `ctx` (moved
+  out of `config` into `secrets`). `/config` publishes `{ set, source }` for
+  declared secret fields, never the value.
+- **Attribution.** `inject` stamps `source: "connector:<ext>/<name>"`.
+  `inbox.decide` records `decidedBy: "connector:<ext>/<name>:<external actor>"`.
+- **Status.** `connectorStatus()` / `attachConnectorStatus()` project
+  `connectors: [{ extension, name, ok, detail, lastEventAt, startedAt }]`.
+  Start-failure anomalies already appear on `/status.anomalies.configuration`
+  via `registry.anomalies`. Wiring the `connectors` array onto `GET /status`,
+  one doctor line per connector, and a CONNECTORS column on `extensions list`
+  is a follow-up — those files sit outside this ticket's Owned Paths.
+  `extensions list --json` already includes the `connectors` array the loader
+  records.
+
+The fixture `event-runtime/test-support/extensions/sample/connectors/echo.mjs`
+subscribes to inbox writes, logs them, and exposes health so
+`extensions.test.mjs`, `connectors.test.mjs` and `api-status.test.mjs` can
+watch load/start/stop/anomaly/secrets without an external network.
 
 ## Harness
 

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createAdapterRegistry } from "../lib/adapters/index.mjs";
 import { loadExtensions } from "../lib/extensions.mjs";
+import { startConnectors, stopConnectors } from "../lib/connectors.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -332,6 +333,8 @@ export default async function serve(args) {
     panelRoots: extensions.panelRoots,
   });
   registry.anomalies.push(...extensions.anomalies);
+  const startedConnectors = await startConnectors({ db, registry, log });
+  registry.anomalies.push(...startedConnectors.anomalies);
   const pv = policyVersion();
   const owner = newWorkerId();
 
@@ -479,8 +482,13 @@ export default async function serve(args) {
     log(`shutting down (${signal})`);
     if (timer) clearInterval(timer);
     releaseServeLock(home);
-    server.close(() => process.exit(0));
-    setTimeout(() => process.exit(0), 1000).unref?.();
+    const finish = () => {
+      server.close(() => process.exit(0));
+      setTimeout(() => process.exit(0), 1000).unref?.();
+    };
+    Promise.resolve(stopConnectors())
+      .catch((err) => log(`connector stop: ${err.message}`))
+      .finally(finish);
   };
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/event-runtime/lib/api-status.mjs
+++ b/event-runtime/lib/api-status.mjs
@@ -1,0 +1,32 @@
+/**
+ * Connector rows on the status projection (WM-919).
+ *
+ * `GET /status` is composed in lib/status-view.mjs, which is outside this
+ * ticket's Owned Paths. Call `attachConnectorStatus(payload)` from that
+ * handler to publish `connectors: [...]`. Until that follow-up lands,
+ * `serve` still starts connectors and start-failure anomalies already
+ * appear under `/status.anomalies.configuration` via `registry.anomalies`.
+ *
+ * Doctor (`cli/status.mjs`) and `extensions list` similarly sit outside
+ * Owned Paths; `loadExtensions` already records connector counts on each
+ * extension so `--json` shows them.
+ */
+import { connectorStatus } from "./connectors.mjs";
+
+/** Snapshot of every loaded connector for `/status.connectors`. */
+export function connectorsStatus() {
+  return connectorStatus();
+}
+
+/**
+ * Merge the connector snapshot onto a status payload without mutating it.
+ *
+ * @param {object} payload
+ * @returns {object}
+ */
+export function attachConnectorStatus(payload) {
+  return {
+    ...payload,
+    connectors: connectorsStatus(),
+  };
+}

--- a/event-runtime/lib/api-status.test.mjs
+++ b/event-runtime/lib/api-status.test.mjs
@@ -1,0 +1,106 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-status-test-mjs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cpSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { attachConnectorStatus, connectorsStatus } from "./api-status.mjs";
+import { createAdapterRegistry } from "./adapters/index.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  emitInboxChange,
+  startConnectors,
+  stopConnectors,
+} from "./connectors.mjs";
+import { openDb } from "./db.mjs";
+import { EXTENSION_MANIFEST, loadExtensions } from "./extensions.mjs";
+import { createHookRegistry } from "./hooks.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const SAMPLE_EXTENSION = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+);
+
+afterEach(async () => {
+  await stopConnectors();
+});
+
+async function loadSample() {
+  await loadExtensions({
+    policy: { extensions: [{ path: SAMPLE_EXTENSION }] },
+    adapterRegistry: createAdapterRegistry(),
+    hookRegistry: createHookRegistry(),
+    packRoots: [],
+  });
+}
+
+describe("GET /status.connectors projection (WM-919)", () => {
+  test("attachConnectorStatus adds connectors: [{ extension, name, ok, detail, lastEventAt, startedAt }]", async () => {
+    await loadSample();
+    await startConnectors({
+      db: openDb(":memory:"),
+      registry: loadRegistry(),
+    });
+    emitInboxChange({
+      type: "new-item",
+      item: { id: "inbox_status" },
+      at: "2026-08-20T01:00:00.000Z",
+    });
+    const payload = attachConnectorStatus({
+      events: { admitted: 0 },
+      anomalies: { configuration: [] },
+    });
+    expect(payload.connectors).toEqual([
+      {
+        extension: "factory/sample",
+        name: "echo",
+        ok: true,
+        detail: "echo subscribed (1 inbox events)",
+        lastEventAt: "2026-08-20T01:00:00.000Z",
+        startedAt: expect.any(String),
+      },
+    ]);
+    expect(connectorsStatus()).toEqual(payload.connectors);
+  });
+
+  test("a failed start is listed with ok: false and the anomaly detail", async () => {
+    const dir = tmpDir("event-status-conn-");
+    cpSync(SAMPLE_EXTENSION, dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "connectors", "echo.mjs"),
+      `export const id = "factory/sample:echo";
+export default async function start() { throw new Error("down"); }
+`,
+    );
+    const manifestFile = path.join(dir, EXTENSION_MANIFEST);
+    const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
+    manifest.name = "factory/down";
+    writeFileSync(manifestFile, JSON.stringify(manifest, null, 2));
+    await loadExtensions({
+      policy: { extensions: [{ path: dir }] },
+      adapterRegistry: createAdapterRegistry(),
+      hookRegistry: createHookRegistry(),
+      packRoots: [],
+    });
+    const started = await startConnectors({
+      db: openDb(":memory:"),
+      registry: loadRegistry(),
+    });
+    const payload = attachConnectorStatus({
+      anomalies: { configuration: started.anomalies },
+    });
+    expect(payload.anomalies.configuration).toEqual([
+      "connector factory/down/echo failed to start: down",
+    ]);
+    expect(payload.connectors).toEqual([
+      expect.objectContaining({
+        extension: "factory/down",
+        name: "echo",
+        ok: false,
+        detail: "connector factory/down/echo failed to start: down",
+        startedAt: null,
+      }),
+    ]);
+  });
+});

--- a/event-runtime/lib/connectors.mjs
+++ b/event-runtime/lib/connectors.mjs
@@ -1,0 +1,507 @@
+/**
+ * Connectors — long-running extension processes with a narrow loopback
+ * client (WM-919, docs/extensions.md § Connectors).
+ *
+ * An extension declares `contributes.connectors: { name: "./path.mjs" }`.
+ * The loader (lib/extensions.mjs) imports and contract-checks each module
+ * at load, the same way it does hooks/adapters. `serve` then calls
+ * `startConnectors` after the registry is up: a `start()` that throws or
+ * rejects within 10s is a configuration anomaly that disables *that
+ * connector*, not the extension. Other contributions stay loaded.
+ *
+ * Contract of a connector module:
+ *
+ *   export const id = "publisher/extension:name";
+ *   export default async function start(ctx) {
+ *     return {
+ *       stop(): Promise<void>,
+ *       health(): { ok: boolean, detail?: string, lastEventAt?: string },
+ *     };
+ *   }
+ *
+ * `ctx = { config, secrets, client, log, signal }`. `client` is the only
+ * runtime surface: inject (stamped `source: connector:<ext>/<name>`),
+ * inbox list/get/decide/subscribe, proposals.get, runs.get. No DB handle,
+ * no registry mutation. A connector cannot approve a proposal it injected;
+ * the event follows the normal planner/approval path.
+ *
+ * Secrets never arrive through `ctx.config`. The loader resolves
+ * `format: "secret"` (and heuristic `nsec|token|secret|key|password` keys)
+ * from `FACTORY_EXT_<NAMESPACE>_<KEY>` / `~/.factory/secrets.env` into
+ * `ctx.secrets`.
+ */
+import { ADAPTER_NAME_PATTERN } from "./adapters/index.mjs";
+import { decideInboxItem, getInboxItem, listInboxItems } from "./inbox.mjs";
+import { admitExternalEvent } from "./intake.mjs";
+import { getProposal } from "./proposals.mjs";
+
+/** Connector names match adapter names: lower-case identifiers. */
+export const CONNECTOR_NAME_PATTERN = ADAPTER_NAME_PATTERN;
+
+/** `publisher[/extension]:name`, same shape as a hook id. */
+export const CONNECTOR_ID_PATTERN =
+  /^[a-z0-9-]+(\/[a-z0-9-]+)?:[a-z0-9][a-z0-9-]*$/;
+
+/** A `start()` that has not returned by then is a failed start. */
+export const CONNECTOR_START_TIMEOUT_MS = 10_000;
+
+const SECRET_KEY_HEURISTIC = /nsec|token|secret|key|password/i;
+
+/** Typed error for a module that fails the connector contract. */
+export class ConnectorError extends Error {
+  /**
+   * @param {string} code - `connector_module_invalid` | `connector_name_invalid`
+   * @param {string} message
+   */
+  constructor(code, message) {
+    super(message);
+    this.name = "ConnectorError";
+    this.code = code;
+  }
+}
+
+/**
+ * Prove a module satisfies the connector contract without calling it: a
+ * `default` export that is a function and a string `id` shaped
+ * `publisher[/ext]:name`. Throws a ConnectorError naming the fault; the
+ * loader turns that into the anomaly that disables the extension.
+ *
+ * @param {unknown} module
+ * @returns {{ id: string, start: Function }}
+ */
+export function validateConnectorModule(module) {
+  if (typeof module !== "object" || module === null) {
+    throw new ConnectorError(
+      "connector_module_invalid",
+      "connector module must be an ES module namespace or object",
+    );
+  }
+  if (typeof module.default !== "function") {
+    throw new ConnectorError(
+      "connector_module_invalid",
+      "connector module must export a default async function start(ctx) → { stop, health }",
+    );
+  }
+  if (typeof module.id !== "string" || !CONNECTOR_ID_PATTERN.test(module.id)) {
+    throw new ConnectorError(
+      "connector_module_invalid",
+      `connector module must export a string id matching ${CONNECTOR_ID_PATTERN} (got ${JSON.stringify(module.id ?? null)})`,
+    );
+  }
+  return { id: module.id, start: module.default };
+}
+
+/**
+ * Modules the last `loadExtensions` run accepted. `startConnectors` reads
+ * this; a failed start does not remove the descriptor (the extension stays
+ * loaded). Replaced wholesale on every load.
+ *
+ * @typedef {{
+ *   extension: string,
+ *   name: string,
+ *   id: string,
+ *   module: object,
+ *   config: object,
+ *   secrets: object,
+ * }} LoadedConnector
+ */
+let LOADED = [];
+
+/** @type {LoadedConnector[]} */
+export function setLoadedConnectors(list) {
+  LOADED = Array.isArray(list) ? list : [];
+}
+
+export function loadedConnectors() {
+  return LOADED;
+}
+
+const inboxListeners = new Set();
+
+/**
+ * Register a callback for inbox new-item / changed events. The connector
+ * client's `inbox.subscribe` is this bus; tests (and a follow-up that
+ * hooks lib/inbox.mjs's write path) call `emitInboxChange`.
+ *
+ * @param {(event: { type: string, item?: object, at?: string }) => void} cb
+ * @returns {() => void} unsubscribe
+ */
+export function subscribeInboxWrites(cb) {
+  if (typeof cb !== "function") {
+    throw new ConnectorError(
+      "connector_module_invalid",
+      "inbox.subscribe callback must be a function",
+    );
+  }
+  inboxListeners.add(cb);
+  return () => inboxListeners.delete(cb);
+}
+
+/** Fan out an inbox write to every subscriber. Isolates callback throws. */
+export function emitInboxChange(event) {
+  const payload = {
+    type: event?.type ?? "changed",
+    item: event?.item ?? null,
+    at: event?.at ?? new Date().toISOString(),
+  };
+  for (const cb of inboxListeners) {
+    try {
+      cb(payload);
+    } catch {
+      // A connector that throws from subscribe must not take down the others.
+    }
+  }
+}
+
+function clearInboxListeners() {
+  inboxListeners.clear();
+}
+
+/**
+ * Attribution strings a connector client stamps on the events and decisions
+ * it produces. `inject` overwrites envelope.source; `inbox.decide` records
+ * decidedBy. A connector has no approve() — injected events go through the
+ * normal planner / approval path.
+ */
+export function connectorSource(extension, name) {
+  return `connector:${extension}/${name}`;
+}
+
+export function connectorActor(extension, name, actor) {
+  const who =
+    typeof actor === "string" && actor.trim() !== "" ? actor.trim() : "unknown";
+  return `connector:${extension}/${name}:${who}`;
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function getRun(db, id) {
+  const row = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(id);
+  if (!row) return null;
+  return {
+    runId: row.run_id,
+    state: row.state,
+    attempts: row.attempts,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+  };
+}
+
+/**
+ * Narrow loopback client one connector may hold. The db and registry stay
+ * inside this closure; the connector never receives them.
+ *
+ * @param {{ db: object, registry: object, extension: string, name: string }} opts
+ */
+export function createConnectorClient({ db, registry, extension, name }) {
+  const source = connectorSource(extension, name);
+  return Object.freeze({
+    async inject(envelope) {
+      if (
+        !envelope ||
+        typeof envelope !== "object" ||
+        Array.isArray(envelope)
+      ) {
+        throw new Error("inject envelope must be an object");
+      }
+      const stamped = { ...envelope, source };
+      return admitExternalEvent(db, registry, stamped);
+    },
+    inbox: Object.freeze({
+      list(options = {}) {
+        return listInboxItems(db, options);
+      },
+      get(id) {
+        return getInboxItem(db, id);
+      },
+      decide(id, response, { actor } = {}) {
+        const decidedBy = connectorActor(extension, name, actor);
+        const result = decideInboxItem(db, id, response, { decidedBy });
+        emitInboxChange({
+          type: "changed",
+          item: result?.item ?? null,
+        });
+        return result;
+      },
+      subscribe(cb) {
+        return subscribeInboxWrites(cb);
+      },
+    }),
+    proposals: Object.freeze({
+      get(id) {
+        return getProposal(db, id);
+      },
+    }),
+    runs: Object.freeze({
+      get(id) {
+        return getRun(db, id);
+      },
+    }),
+  });
+}
+
+/**
+ * Split an extension's effective config into the public object a connector
+ * may read (`config`) and the secret bag (`secrets`). `format: "secret"`
+ * fields come first; remaining keys matching the heuristic are moved too
+ * so a schema that predates WM-920 still does not leak credentials into
+ * `ctx.config`.
+ *
+ * @param {object|null|undefined} values
+ * @param {Array<{ path: string[] }>} secretFields
+ */
+export function splitConfigSecrets(values, secretFields = []) {
+  const config = cloneJson(values) ?? {};
+  const secrets = {};
+  const move = (keyPath) => {
+    let node = values;
+    for (const key of keyPath) {
+      if (
+        node === null ||
+        typeof node !== "object" ||
+        !Object.hasOwn(node, key)
+      )
+        return;
+      node = node[key];
+    }
+    setAt(secrets, keyPath, node);
+    deleteAt(config, keyPath);
+  };
+  for (const field of secretFields) move(field.path);
+  moveHeuristic(config, secrets, []);
+  return { config, secrets };
+}
+
+function moveHeuristic(from, secrets, path) {
+  if (!from || typeof from !== "object" || Array.isArray(from)) return;
+  for (const [key, inner] of Object.entries(from)) {
+    const next = [...path, key];
+    if (SECRET_KEY_HEURISTIC.test(key) && !isPlainObject(inner)) {
+      setAt(secrets, next, inner);
+      delete from[key];
+      continue;
+    }
+    moveHeuristic(inner, secrets, next);
+  }
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function setAt(obj, keyPath, value) {
+  let node = obj;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const key = keyPath[i];
+    if (!isPlainObject(node[key])) node[key] = {};
+    node = node[key];
+  }
+  node[keyPath[keyPath.length - 1]] = value;
+}
+
+function deleteAt(obj, keyPath) {
+  let node = obj;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const key = keyPath[i];
+    if (!isPlainObject(node[key])) return;
+    node = node[key];
+  }
+  delete node[keyPath[keyPath.length - 1]];
+}
+
+function connectorLog(log, extension, name) {
+  return (message) => {
+    log(`connector ${extension}/${name}: ${message}`);
+  };
+}
+
+function readHealth(handle) {
+  const raw = handle.health();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, detail: "health() did not return an object" };
+  }
+  return {
+    ok: Boolean(raw.ok),
+    ...(typeof raw.detail === "string" ? { detail: raw.detail } : {}),
+    ...(typeof raw.lastEventAt === "string"
+      ? { lastEventAt: raw.lastEventAt }
+      : {}),
+  };
+}
+
+/**
+ * @typedef {{
+ *   extension: string,
+ *   name: string,
+ *   id: string,
+ *   handle: { stop: Function, health: Function }|null,
+ *   controller: AbortController,
+ *   startedAt: string|null,
+ *   startError: string|null,
+ * }} ConnectorInstance
+ */
+
+/** @type {ConnectorInstance[]} */
+let INSTANCES = [];
+
+function formatStartFailure(extension, name, err) {
+  const msg = err?.message ?? String(err);
+  return `connector ${extension}/${name} failed to start: ${msg}`;
+}
+
+function validateHandle(handle) {
+  if (!handle || typeof handle !== "object" || Array.isArray(handle)) {
+    throw new Error("start() must return { stop(), health() }");
+  }
+  if (typeof handle.stop !== "function") {
+    throw new Error("start() must return a stop() function");
+  }
+  if (typeof handle.health !== "function") {
+    throw new Error("start() must return a health() function");
+  }
+  return handle;
+}
+
+async function withTimeout(promise, timeoutMs, onTimeout) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          onTimeout();
+          reject(new Error(`timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Start every connector the last load accepted. Per-connector: a throw,
+ * rejection, bad return, or overrun of `timeoutMs` records an anomaly and
+ * leaves the rest of the extension loaded. Idempotent against a previous
+ * start — running instances are stopped first.
+ *
+ * @returns {Promise<{ instances: ConnectorInstance[], anomalies: string[] }>}
+ */
+export async function startConnectors({
+  db,
+  registry,
+  log = () => {},
+  timeoutMs = CONNECTOR_START_TIMEOUT_MS,
+  now = () => Date.now(),
+} = {}) {
+  await stopConnectors();
+  const anomalies = [];
+  const instances = [];
+  for (const loaded of LOADED) {
+    const { extension, name, id, module, config, secrets } = loaded;
+    const controller = new AbortController();
+    const startedAt = new Date(now()).toISOString();
+    const client = createConnectorClient({ db, registry, extension, name });
+    const ctx = {
+      config: cloneJson(config) ?? {},
+      secrets: cloneJson(secrets) ?? {},
+      client,
+      log: connectorLog(log, extension, name),
+      signal: controller.signal,
+    };
+    const start = module.default;
+    const startPromise = Promise.resolve()
+      .then(() => start(ctx))
+      .then(validateHandle);
+    try {
+      const handle = await withTimeout(startPromise, timeoutMs, () =>
+        controller.abort(),
+      );
+      instances.push({
+        extension,
+        name,
+        id,
+        handle,
+        controller,
+        startedAt,
+        startError: null,
+      });
+    } catch (err) {
+      controller.abort();
+      startPromise.then((handle) => handle?.stop?.()).catch(() => {});
+      const detail = formatStartFailure(extension, name, err);
+      anomalies.push(detail);
+      instances.push({
+        extension,
+        name,
+        id,
+        handle: null,
+        controller,
+        startedAt: null,
+        startError: detail,
+      });
+      log(detail);
+    }
+  }
+  INSTANCES = instances;
+  return { instances, anomalies };
+}
+
+/** Stop every running connector. Isolates per-connector stop errors. */
+export async function stopConnectors() {
+  const running = INSTANCES;
+  INSTANCES = [];
+  clearInboxListeners();
+  for (const inst of running) {
+    inst.controller?.abort();
+    if (typeof inst.handle?.stop !== "function") continue;
+    try {
+      await inst.handle.stop();
+    } catch {
+      // Shutdown must not fail because a connector's stop() threw.
+    }
+  }
+}
+
+/**
+ * `GET /status.connectors` projection: one row per loaded connector,
+ * including those that failed to start (`ok: false`, `detail` is the
+ * anomaly line).
+ */
+export function connectorStatus() {
+  return INSTANCES.map((inst) => {
+    const base = {
+      extension: inst.extension,
+      name: inst.name,
+      startedAt: inst.startedAt,
+    };
+    if (inst.startError || !inst.handle) {
+      return {
+        ...base,
+        ok: false,
+        detail: inst.startError ?? "not started",
+        lastEventAt: undefined,
+      };
+    }
+    try {
+      const health = readHealth(inst.handle);
+      return {
+        ...base,
+        ok: health.ok,
+        ...(health.detail !== undefined ? { detail: health.detail } : {}),
+        ...(health.lastEventAt !== undefined
+          ? { lastEventAt: health.lastEventAt }
+          : {}),
+      };
+    } catch (err) {
+      return {
+        ...base,
+        ok: false,
+        detail: err?.message ?? String(err),
+      };
+    }
+  });
+}

--- a/event-runtime/lib/connectors.test.mjs
+++ b/event-runtime/lib/connectors.test.mjs
@@ -1,0 +1,353 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-connectors-test-mjs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createAdapterRegistry } from "./adapters/index.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  CONNECTOR_START_TIMEOUT_MS,
+  connectorActor,
+  connectorSource,
+  connectorStatus,
+  createConnectorClient,
+  emitInboxChange,
+  loadedConnectors,
+  splitConfigSecrets,
+  startConnectors,
+  stopConnectors,
+  validateConnectorModule,
+} from "./connectors.mjs";
+import { openDb } from "./db.mjs";
+import { decisionRequestHash } from "./decision.mjs";
+import { EXTENSION_MANIFEST, loadExtensions } from "./extensions.mjs";
+import { createHookRegistry } from "./hooks.mjs";
+import { createInboxItem, getInboxItem } from "./inbox.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const SAMPLE_EXTENSION = path.join(
+  RUNTIME_ROOT,
+  "test-support",
+  "extensions",
+  "sample",
+);
+
+function tempExtension(mutate = () => {}) {
+  const dir = tmpDir("event-connector-");
+  cpSync(SAMPLE_EXTENSION, dir, { recursive: true });
+  const manifestFile = path.join(dir, EXTENSION_MANIFEST);
+  const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
+  const next = mutate(manifest, dir) ?? manifest;
+  writeFileSync(manifestFile, JSON.stringify(next, null, 2));
+  return dir;
+}
+
+function policyFor(...dirs) {
+  return { extensions: dirs.map((p) => ({ path: p })) };
+}
+
+async function load(policy) {
+  return loadExtensions({
+    policy,
+    adapterRegistry: createAdapterRegistry(),
+    hookRegistry: createHookRegistry(),
+    packRoots: [],
+  });
+}
+
+afterEach(async () => {
+  await stopConnectors();
+});
+
+describe("validateConnectorModule", () => {
+  test("requires a default start function and a shaped id", () => {
+    expect(() => validateConnectorModule(null)).toThrow(/ES module/);
+    expect(() => validateConnectorModule({ id: "a/b:echo" })).toThrow(
+      /default async function start/,
+    );
+    expect(() =>
+      validateConnectorModule({ default: async () => {}, id: "Nope" }),
+    ).toThrow(/string id matching/);
+    expect(
+      validateConnectorModule({
+        id: "factory/sample:echo",
+        default: async () => {},
+      }).id,
+    ).toBe("factory/sample:echo");
+  });
+});
+
+describe("splitConfigSecrets", () => {
+  test("moves format: secret fields and heuristic keys out of config", () => {
+    const values = {
+      greeting: "hi",
+      apiToken: "sk-live",
+      nsec: "nsec1abc",
+      nested: { signingKey: "k", retries: 1 },
+    };
+    const { config, secrets } = splitConfigSecrets(values, [
+      { path: ["apiToken"] },
+    ]);
+    expect(config).toEqual({ greeting: "hi", nested: { retries: 1 } });
+    expect(secrets).toEqual({
+      apiToken: "sk-live",
+      nsec: "nsec1abc",
+      nested: { signingKey: "k" },
+    });
+    expect(values.apiToken).toBe("sk-live");
+  });
+});
+
+describe("connector attribution", () => {
+  test("inject source and decide actor are connector:<ext>/<name>[:actor]", () => {
+    expect(connectorSource("factory/sample", "echo")).toBe(
+      "connector:factory/sample/echo",
+    );
+    expect(connectorActor("factory/sample", "echo", "alice")).toBe(
+      "connector:factory/sample/echo:alice",
+    );
+    expect(connectorActor("factory/sample", "echo")).toBe(
+      "connector:factory/sample/echo:unknown",
+    );
+  });
+});
+
+describe("startConnectors / stopConnectors", () => {
+  test("loads the echo fixture, starts, reports health, stops", async () => {
+    await load(policyFor(SAMPLE_EXTENSION));
+    expect(loadedConnectors().map((c) => c.name)).toEqual(["echo"]);
+    const db = openDb(":memory:");
+    const registry = loadRegistry();
+    const logs = [];
+    const started = await startConnectors({
+      db,
+      registry,
+      log: (line) => logs.push(line),
+    });
+    expect(started.anomalies).toEqual([]);
+    expect(connectorStatus()).toEqual([
+      expect.objectContaining({
+        extension: "factory/sample",
+        name: "echo",
+        ok: true,
+        detail: "echo subscribed (0 inbox events)",
+        startedAt: expect.any(String),
+      }),
+    ]);
+    emitInboxChange({
+      type: "new-item",
+      item: { id: "inbox_1" },
+      at: "2026-08-20T00:00:00.000Z",
+    });
+    expect(connectorStatus()[0]).toMatchObject({
+      ok: true,
+      detail: "echo subscribed (1 inbox events)",
+      lastEventAt: "2026-08-20T00:00:00.000Z",
+    });
+    expect(logs.some((line) => /inbox new-item inbox_1/.test(line))).toBe(true);
+    await stopConnectors();
+    expect(connectorStatus()).toEqual([]);
+  });
+
+  test("ctx.config never contains secrets; ctx.secrets holds env-resolved values", async () => {
+    const seen = [];
+    const dir = tempExtension((m, dirPath) => {
+      m.name = "factory/secretprobe";
+      m.contributes.config.namespace = "secretprobe";
+      writeFileSync(
+        path.join(dirPath, "connectors", "echo.mjs"),
+        `export const id = "factory/secretprobe:echo";
+export default async function start(ctx) {
+  globalThis.__connectorCtx = { config: ctx.config, secrets: ctx.secrets };
+  return { stop() {}, health() { return { ok: true }; } };
+}
+`,
+      );
+    });
+    process.env.FACTORY_EXT_SECRETPROBE_API_TOKEN = "tok-from-env";
+    try {
+      await load({
+        extensions: [{ path: dir, config: { greeting: "secret-hi" } }],
+      });
+      const db = openDb(":memory:");
+      await startConnectors({ db, registry: loadRegistry() });
+      seen.push(globalThis.__connectorCtx);
+    } finally {
+      delete process.env.FACTORY_EXT_SECRETPROBE_API_TOKEN;
+      delete globalThis.__connectorCtx;
+    }
+    expect(seen[0].config.greeting).toBe("secret-hi");
+    expect(seen[0].config.apiToken).toBeUndefined();
+    expect(seen[0].secrets.apiToken).toBe("tok-from-env");
+  });
+
+  test("a start() that throws is a per-connector anomaly; other contributions stay loaded", async () => {
+    const dir = tempExtension((m, dirPath) => {
+      m.name = "factory/boom";
+      writeFileSync(
+        path.join(dirPath, "connectors", "echo.mjs"),
+        `export const id = "factory/boom:echo";
+export default async function start() {
+  throw new Error("refused to connect");
+}
+`,
+      );
+    });
+    const loaded = await load(policyFor(dir));
+    expect(loaded.extensions).toHaveLength(1);
+    expect(loaded.extensions[0].adapters).toEqual(["echo"]);
+    expect(loaded.extensions[0].hooks).toHaveLength(1);
+    const started = await startConnectors({
+      db: openDb(":memory:"),
+      registry: loadRegistry(),
+    });
+    expect(started.anomalies).toEqual([
+      "connector factory/boom/echo failed to start: refused to connect",
+    ]);
+    expect(connectorStatus()).toEqual([
+      expect.objectContaining({
+        extension: "factory/boom",
+        name: "echo",
+        ok: false,
+        detail:
+          "connector factory/boom/echo failed to start: refused to connect",
+        startedAt: null,
+      }),
+    ]);
+  });
+
+  test("a start() that overruns the timeout is a failed start and aborts the signal", async () => {
+    const dir = tempExtension((m, dirPath) => {
+      m.name = "factory/slow";
+      writeFileSync(
+        path.join(dirPath, "connectors", "echo.mjs"),
+        `export const id = "factory/slow:echo";
+export default async function start(ctx) {
+  await new Promise((resolve) => {
+    ctx.signal.addEventListener("abort", resolve, { once: true });
+  });
+  return { stop() {}, health() { return { ok: true }; } };
+}
+`,
+      );
+    });
+    await load(policyFor(dir));
+    const started = await startConnectors({
+      db: openDb(":memory:"),
+      registry: loadRegistry(),
+      timeoutMs: 30,
+    });
+    expect(started.anomalies[0]).toMatch(
+      /connector factory\/slow\/echo failed to start: timed out after 30ms/,
+    );
+    expect(CONNECTOR_START_TIMEOUT_MS).toBe(10_000);
+  });
+
+  test("one connector failing to start does not prevent another from starting", async () => {
+    const dir = tempExtension((m, dirPath) => {
+      m.name = "factory/pair";
+      mkdirSync(path.join(dirPath, "connectors"), { recursive: true });
+      writeFileSync(
+        path.join(dirPath, "connectors", "ok.mjs"),
+        `export const id = "factory/pair:ok";
+export default async function start() {
+  return { stop() {}, health() { return { ok: true, detail: "ok" }; } };
+}
+`,
+      );
+      writeFileSync(
+        path.join(dirPath, "connectors", "bad.mjs"),
+        `export const id = "factory/pair:bad";
+export default async function start() {
+  throw new Error("nope");
+}
+`,
+      );
+      m.contributes.connectors = {
+        bad: "./connectors/bad.mjs",
+        ok: "./connectors/ok.mjs",
+      };
+    });
+    await load(policyFor(dir));
+    const started = await startConnectors({
+      db: openDb(":memory:"),
+      registry: loadRegistry(),
+    });
+    expect(started.anomalies).toEqual([
+      "connector factory/pair/bad failed to start: nope",
+    ]);
+    const status = connectorStatus();
+    expect(status.find((row) => row.name === "bad").ok).toBe(false);
+    expect(status.find((row) => row.name === "ok")).toMatchObject({
+      ok: true,
+      detail: "ok",
+    });
+  });
+});
+
+describe("narrow loopback client", () => {
+  test("inject stamps source; inbox.decide records connector actor; no approve on the client", async () => {
+    const db = openDb(":memory:");
+    const registry = loadRegistry();
+    const client = createConnectorClient({
+      db,
+      registry,
+      extension: "factory/sample",
+      name: "echo",
+    });
+    expect(client.approve).toBeUndefined();
+    expect(client.inject).toBeTypeOf("function");
+    expect(client.inbox).toBeDefined();
+    expect(client.proposals.get).toBeTypeOf("function");
+    expect(client.runs.get).toBeTypeOf("function");
+
+    const envelope = {
+      schemaVersion: "factory.event/v1",
+      eventId: "conn-1",
+      type: "factory.status-report.requested",
+      source: "forged",
+      subject: "factory",
+      occurredAt: new Date().toISOString(),
+      correlationId: "conn-1",
+      causationId: null,
+      payload: { repos: ["bj29"] },
+    };
+    const admitted = await client.inject(envelope);
+    expect(admitted.admitted).toBe(true);
+    expect(admitted.event.source).toBe("connector:factory/sample/echo");
+
+    const decision = {
+      schemaVersion: "factory.decision-request/v1",
+      question: "Dismiss?",
+      options: [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
+    };
+    const item = createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "from connector test",
+        decision,
+      },
+      { id: "inbox_conn" },
+    );
+    expect(client.inbox.get("inbox_conn").id).toBe(item.id);
+    expect(client.inbox.list({ status: "open" }).map((row) => row.id)).toEqual([
+      "inbox_conn",
+    ]);
+    const decided = client.inbox.decide(
+      "inbox_conn",
+      {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(decision),
+        optionId: "dismiss",
+        fields: {},
+      },
+      { actor: "alice" },
+    );
+    expect(decided.item.decidedBy).toBe("connector:factory/sample/echo:alice");
+    expect(getInboxItem(db, "inbox_conn").decidedBy).toBe(
+      "connector:factory/sample/echo:alice",
+    );
+    expect(client.proposals.get("missing")).toBeNull();
+    expect(client.runs.get("missing")).toBeNull();
+  });
+});

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -21,9 +21,9 @@
  *      registry.mjs) and skips *that* extension whole — nothing of it is
  *      registered — while every other extension still loads. `serve`/`work`
  *      never fail to start because a third-party manifest is broken.
- *   3. **Reserved manifest keys are accepted, not rejected.** `connectors`,
- *      `views` belong to follow-up tickets; a manifest that carries them
- *      loads its packs, adapters, config, hooks and panels here and
+ *   3. **Reserved manifest keys are accepted, not rejected.** `views`
+ *      belongs to a follow-up ticket; a manifest that carries it loads its
+ *      packs, adapters, config, hooks, panels and connectors here and
  *      records a "not supported yet" anomaly for the rest. `panels` (WM-840)
  *      contributes directories of `*.panel.json`; the manifest check only
  *      proves they exist inside the extension, and lib/registry.mjs loads
@@ -58,6 +58,15 @@
  *      byte-identical. Every other contributing root emits under its
  *      `publisher-extension` slug; a non-core pack may not take plugin name
  *      `core` or reuse another pack's slug (the later extension is skipped).
+ *   7. **Connectors start after the registry, and may fail independently
+ *      (WM-919).** `contributes.connectors` maps a name to a module; each is
+ *      imported and contract-checked (`default` start function + string `id`,
+ *      lib/connectors.mjs) before the extension is accepted — a bad module
+ *      disables the extension, like a bad hook. `serve` then calls
+ *      `startConnectors`: a `start()` that throws or overruns 10s is a
+ *      configuration anomaly for *that connector* and the extension's other
+ *      contributions stay loaded. `ctx.secrets` is resolved here from
+ *      `format: "secret"` / env; `ctx.config` never contains those values.
  *
  * Ordering matters for callers: `adapterRegistry.toMap()` is a snapshot, so
  * `loadExtensions` must run before a CLI takes the map it hands to
@@ -73,6 +82,12 @@ import {
   validateAdapterContract,
 } from "./adapters/index.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  CONNECTOR_NAME_PATTERN,
+  setLoadedConnectors,
+  splitConfigSecrets,
+  validateConnectorModule,
+} from "./connectors.mjs";
 import {
   HOOK_POINTS,
   defaultHookRegistry,
@@ -101,7 +116,7 @@ export const EXTENSION_SCHEMA = JSON.parse(
 );
 
 /** Manifest keys the schema accepts today but no ticket has implemented yet. */
-export const RESERVED_CONTRIBUTIONS = Object.freeze(["connectors", "views"]);
+export const RESERVED_CONTRIBUTIONS = Object.freeze(["views"]);
 
 /** The `source` a hook registered by an extension carries (lib/hooks.mjs). */
 export function extensionHookSource(name) {
@@ -293,6 +308,26 @@ export function validateExtensionManifest(dir) {
       );
     }
   }
+  for (const [name, rel] of Object.entries(contributes.connectors ?? {})) {
+    if (!CONNECTOR_NAME_PATTERN.test(name)) {
+      errors.push(
+        `${file}: contributes.connectors key "${name}" must match ${CONNECTOR_NAME_PATTERN}`,
+      );
+      continue;
+    }
+    const abs = path.resolve(root, rel);
+    if (!isInside(root, abs)) {
+      errors.push(
+        `${file}: contributes.connectors.${name} "${rel}" escapes the extension directory`,
+      );
+      continue;
+    }
+    if (!existsSync(abs) || !statSync(abs).isFile()) {
+      errors.push(
+        `${file}: contributes.connectors.${name} "${rel}" is not a file (${abs})`,
+      );
+    }
+  }
   for (const [point, rel] of Object.entries(contributes.hooks ?? {})) {
     if (!HOOK_POINTS.includes(point)) {
       errors.push(
@@ -447,6 +482,15 @@ function deleteAt(obj, keyPath) {
     node = node[key];
   }
   delete node[keyPath[keyPath.length - 1]];
+}
+
+/** Public config vs secrets bag for a connector's `ctx`. */
+function connectorCtxConfig(config) {
+  if (!config) return { config: {}, secrets: {} };
+  return splitConfigSecrets(
+    config.values,
+    collectSecretFields(config.schemaJson ?? {}),
+  );
 }
 
 function parseDotenv(text) {
@@ -875,7 +919,7 @@ function packRootFor(extensionRoot, rel) {
  * @param {Array<object>} [options.packRoots] - the policy `packs:` roots the extension packs join (default: loadPackRoots({ root }))
  * @param {string} [options.registryRoot] - the built-in registry root the dry load uses (tests point it at a copy)
  * @returns {Promise<{
- *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, panels: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
+ *   extensions: Array<{ name: string, version: string, path: string, packs: string[], adapters: string[], hooks: Array<{ point: string, id: string }>, connectors: Array<{ name: string, id: string }>, panels: string[], reserved: string[], config: { namespace: string, schema: string, values: object }|null }>,
  *   panelRoots: Array<{ dir: string, origin: string, base: string }>,
  *   harnessRoots: Array<object>,
  *   packRoots: Array<object>,
@@ -905,6 +949,7 @@ export async function loadExtensions({
     if (hook.source.startsWith(extensionHookSource("")))
       hookRegistry.unregister(hook.id);
   }
+  setLoadedConnectors([]);
   const { roots, anomalies } = loadExtensionRoots({ root, policy });
   const extensions = [];
   const panelRoots = [];
@@ -917,6 +962,7 @@ export async function loadExtensions({
   const acceptedHarnessNames = new Set();
   const disabled = [];
   const loaded = [];
+  const loadedConnectorModules = [];
   const dryLoad = (candidates) =>
     loadRegistry({
       ...(registryRoot ? { root: registryRoot } : {}),
@@ -1037,6 +1083,34 @@ export async function loadExtensions({
       skip(`${label}: ${hookFault}`);
       continue;
     }
+
+    // Connectors: import and contract-check (default start function + id).
+    // Registered for serve to start only once the extension is accepted; a
+    // later start() failure is a per-connector anomaly, not a skip here.
+    const connectorModules = [];
+    let connectorFault = null;
+    for (const [name, rel] of Object.entries(contributes.connectors ?? {})) {
+      const file = path.resolve(dir, rel);
+      let module;
+      try {
+        module = await import(pathToFileURL(file).href);
+      } catch (err) {
+        connectorFault = `connector "${name}" failed to import from ${file}: ${err.message}`;
+        break;
+      }
+      let contract;
+      try {
+        contract = validateConnectorModule(module);
+      } catch (err) {
+        connectorFault = `connector "${name}" (${rel}): ${err.message}`;
+        break;
+      }
+      connectorModules.push({ name, id: contract.id, module });
+    }
+    if (connectorFault) {
+      skip(`${label}: ${connectorFault}`);
+      continue;
+    }
     if (config && acceptedNamespaces.has(config.namespace)) {
       skip(
         `${label}: config namespace "${config.namespace}" is already used by ${acceptedNamespaces.get(config.namespace)}`,
@@ -1079,6 +1153,18 @@ export async function loadExtensions({
         config: () => getExtensionConfig(manifest.name),
       });
     }
+    const { config: connectorConfig, secrets: connectorSecrets } =
+      connectorCtxConfig(config);
+    for (const { name, id, module } of connectorModules) {
+      loadedConnectorModules.push({
+        extension: manifest.name,
+        name,
+        id,
+        module,
+        config: connectorConfig,
+        secrets: connectorSecrets,
+      });
+    }
     for (const warning of checked.warnings) anomalies.push(warning);
     if (config) acceptedNamespaces.set(config.namespace, manifest.name);
     const { schemaJson, secretMeta, ...publicConfig } = config ?? {};
@@ -1096,6 +1182,7 @@ export async function loadExtensions({
       packs: extPackRoots.map((p) => p.name),
       adapters: modules.map((m) => m.name),
       hooks: hookModules.map(({ point, id }) => ({ point, id })),
+      connectors: connectorModules.map(({ name, id }) => ({ name, id })),
       panels: extPanelRoots.map((p) => p.dir),
       reserved: RESERVED_CONTRIBUTIONS.filter((key) =>
         Object.hasOwn(contributes, key),
@@ -1114,6 +1201,7 @@ export async function loadExtensions({
   }
 
   LOADED = { extensions: loaded, disabled };
+  setLoadedConnectors(loadedConnectorModules);
   return {
     extensions,
     packRoots: accepted,

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -118,6 +118,21 @@ describe("factory-extension.json schema", () => {
     }
   });
 
+  test("contributes.connectors is an object of name → .mjs path", () => {
+    const ok = {
+      name: "a/b",
+      version: "0.0.1",
+      contributes: { connectors: { echo: "./connectors/echo.mjs" } },
+    };
+    expect(validate(EXTENSION_SCHEMA, ok)).toEqual({ valid: true, errors: [] });
+    expect(
+      validate(EXTENSION_SCHEMA, {
+        ...ok,
+        contributes: { connectors: { echo: "./echo.js" } },
+      }).errors.join(),
+    ).toMatch(/connectors\.echo: does not match pattern/);
+  });
+
   test("contributes.harness accepts floor/commands/skills/subagents and rejects extras", () => {
     const ok = {
       name: "factory/core",
@@ -217,9 +232,24 @@ describe("validateExtensionManifest", () => {
       /packs\[1\] ".\/missing" has no pack.json/,
     );
     expect(out.errors.join("\n")).toMatch(/packs\[2\] "..\/escape" escapes/);
+    expect(out.errors.join("\n")).toMatch(/key "Bad Name" must match/);
     expect(out.errors.join("\n")).toMatch(
       /adapters\.bad-path .* is not a file/,
     );
+  });
+
+  test("connector paths must exist, stay inside, and match the name pattern", () => {
+    const dir = tempExtension((m) => {
+      m.contributes.connectors["missing"] = "./connectors/nope.mjs";
+      m.contributes.connectors["escaped"] = "../escape.mjs";
+      m.contributes.connectors["Bad Name"] = "./connectors/echo.mjs";
+    });
+    const out = validateExtensionManifest(dir);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(
+      /connectors\.missing .* is not a file/,
+    );
+    expect(out.errors.join("\n")).toMatch(/connectors\.escaped .* escapes/);
     expect(out.errors.join("\n")).toMatch(/key "Bad Name" must match/);
   });
 });
@@ -238,6 +268,7 @@ describe("loadExtensions", () => {
         hooks: [
           { point: "approve.before", id: "factory/sample:approve-before" },
         ],
+        connectors: [{ name: "echo", id: "factory/sample:echo" }],
         panels: [path.join(SAMPLE_EXTENSION, "panels")],
         reserved: [],
         config: {
@@ -432,6 +463,9 @@ describe("loadExtensions", () => {
     const out = await load(policyFor(dir));
     expect(out.extensions[0].reserved).toEqual(["views"]);
     expect(out.extensions[0].adapters).toEqual(["echo"]);
+    expect(out.extensions[0].connectors).toEqual([
+      { name: "echo", id: "factory/sample:echo" },
+    ]);
     expect(out.packRoots.map((p) => p.name)).toEqual(["sample-ext"]);
     expect(out.anomalies).toEqual([
       expect.stringMatching(/contributes\.views is not supported yet/),
@@ -444,7 +478,38 @@ describe("loadExtensions", () => {
       packRoots: [],
     });
     expect(out.extensions[0].adapters).toEqual(["echo"]);
+    expect(out.extensions[0].connectors).toEqual([
+      { name: "echo", id: "factory/sample:echo" },
+    ]);
     expect(out.anomalies).toEqual([]);
+  });
+
+  test("a bad connector module skips the whole extension; a views key still only warns", async () => {
+    const noDefault = tempExtension((m, dir) => {
+      m.name = "factory/no-start";
+      writeFileSync(
+        path.join(dir, "connectors", "echo.mjs"),
+        'export const id = "factory/no-start:echo";\n',
+      );
+    });
+    const skipped = await load(policyFor(noDefault));
+    expect(skipped.extensions).toEqual([]);
+    expect(skipped.anomalies[0]).toMatch(
+      /connector "echo".*must export a default async function start/,
+    );
+
+    const noId = tempExtension((m, dir) => {
+      m.name = "factory/no-id";
+      writeFileSync(
+        path.join(dir, "connectors", "echo.mjs"),
+        "export default async function start() { return { stop() {}, health() { return { ok: true }; } }; }\n",
+      );
+    });
+    const skippedId = await load(policyFor(noId));
+    expect(skippedId.extensions).toEqual([]);
+    expect(skippedId.anomalies[0]).toMatch(
+      /connector "echo".*must export a string id/,
+    );
   });
 
   test("an unreadable policy.yaml extensions block fails closed", async () => {
@@ -1110,6 +1175,9 @@ describe("cli extensions", () => {
     const parsed = JSON.parse(json.stdout.toString());
     expect(parsed.extensions[0].name).toBe("factory/sample");
     expect(parsed.extensions[0].config.namespace).toBe("sample");
+    expect(parsed.extensions[0].connectors).toEqual([
+      { name: "echo", id: "factory/sample:echo" },
+    ]);
     expect(parsed.anomalies).toHaveLength(1);
   });
 });

--- a/event-runtime/schemas/factory-extension.schema.json
+++ b/event-runtime/schemas/factory-extension.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "factory-extension.json — the manifest of one factory extension (docs/extensions.md)",
-  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `connectors` and `views` are reserved keys: the loader accepts them and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs and adapters here. Adapter names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
+  "description": "One extension declares everything it contributes in a single manifest. Paths under `contributes` are relative to the manifest's directory. `views` is reserved: the loader accepts it and records a \"not supported yet\" configuration anomaly instead of rejecting the manifest, so a manifest written for a later runtime still loads its packs, adapters and connectors here. Adapter and connector names are additionally checked against the adapter registry's name pattern by lib/extensions.mjs, because lib/schema.mjs has no patternProperties.",
   "type": "object",
   "required": ["name", "version"],
   "additionalProperties": false,
@@ -48,7 +48,12 @@
           }
         },
         "connectors": {
-          "description": "reserved — tracker/forge/notifier connectors; not supported yet"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "\\.mjs$",
+            "description": "relative path to an ES module satisfying the connector contract (docs/extensions.md § Connectors): export const id and export default async function start(ctx) → { stop(), health() }"
+          }
         },
         "views": {
           "description": "reserved — web views; not supported yet"

--- a/event-runtime/test-support/extensions/sample/connectors/echo.mjs
+++ b/event-runtime/test-support/extensions/sample/connectors/echo.mjs
@@ -1,0 +1,37 @@
+/**
+ * The smallest connector that satisfies the contract (docs/extensions.md
+ * § Connectors): a string `id` and a default `start(ctx)` that returns
+ * `{ stop, health }`. It subscribes to inbox writes, logs them, and
+ * exposes a health snapshot so loader/start/stop tests can watch the
+ * lifecycle without talking to an external network.
+ */
+export const id = "factory/sample:echo";
+
+export default async function start(ctx) {
+  let events = 0;
+  let lastEventAt;
+  const unsubscribe = ctx.client.inbox.subscribe((event) => {
+    events += 1;
+    lastEventAt =
+      typeof event?.at === "string" ? event.at : new Date().toISOString();
+    const itemId = event?.item?.id ?? "";
+    ctx.log(`inbox ${event?.type ?? "change"}${itemId ? ` ${itemId}` : ""}`);
+  });
+  const onAbort = () => {
+    unsubscribe?.();
+  };
+  ctx.signal?.addEventListener?.("abort", onAbort, { once: true });
+  return {
+    async stop() {
+      ctx.signal?.removeEventListener?.("abort", onAbort);
+      unsubscribe?.();
+    },
+    health() {
+      return {
+        ok: true,
+        detail: `echo subscribed (${events} inbox events)`,
+        lastEventAt,
+      };
+    },
+  };
+}

--- a/event-runtime/test-support/extensions/sample/factory-extension.json
+++ b/event-runtime/test-support/extensions/sample/factory-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "factory/sample",
   "version": "1.0.0",
-  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, a config schema, one approve.before hook and one panel.",
+  "description": "Test fixture: one pack (a copy of test-support/packs/sample under the sample-ext namespace), one trivial adapter, a config schema, one approve.before hook, one echo connector and one panel.",
   "factory": {
     "min": "0.1.0"
   },
@@ -16,6 +16,9 @@
     },
     "hooks": {
       "approve.before": "./hooks/approve-before.mjs"
+    },
+    "connectors": {
+      "echo": "./connectors/echo.mjs"
     },
     "panels": ["./panels"]
   }


### PR DESCRIPTION
## Summary
- `contributes.connectors` is no longer reserved: the loader contract-checks connector modules at load, `serve` starts them after the registry (10s timeout + AbortSignal) and stops them on shutdown, and a failed `start()` is a per-connector configuration anomaly that leaves the rest of the extension loaded.
- Narrow loopback client (`inject`, `inbox.list/get/decide/subscribe`, `proposals.get`, `runs.get`) stamps `source: connector:<ext>/<name>` and `decidedBy: connector:<ext>/<name>:<actor>`; `ctx.secrets` comes from `FACTORY_EXT_*` / `format: "secret"`, never `policy.yaml`.
- Fixture `test-support/extensions/sample/connectors/echo.mjs` plus tests. HTTP/CLI/inbox write-path wiring that sat outside Owned Paths is filed as [WM-942](https://linear.app/watt-mind/issue/WM-942).

Fixes WM-919

UX critique: skipped — no user-facing flow (backend connector lifecycle; `/status.connectors` projection is a helper until WM-942 wires `status-view.mjs`).

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/extensions.test.mjs event-runtime/lib/connectors.test.mjs event-runtime/lib/api-status.test.mjs`
- [x] `bun run check && bun run lint`
- [x] `bun test event-runtime/lib --timeout 20000` (1365 pass)
- [ ] Confirm WM-942 is the follow-up for GET /status, doctor, extensions list column, inbox subscribe write-path, and `docs/event-runtime.md`


Made with [Cursor](https://cursor.com)