### PR TITLE
refactor(event-runtime): move DEFAULT_MAX_IN_FLIGHT to a dependency-neutral module (WM-755)

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -36,6 +36,7 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -130,7 +131,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         reportOnly: true,
         maxInFlight: null,
         effective: {
-          maxInFlight: 3,
+          maxInFlight: DEFAULT_MAX_IN_FLIGHT,
           maxInFlightSource: "default",
         },
         mergeCi: null,

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -79,6 +79,9 @@ export const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
 /** Events that fail planning this many times are dead-lettered (§13). */
 export const DEAD_LETTER_AFTER = 3;
 
+/** Default cap when neither repo nor policy config supplies one. */
+export const DEFAULT_MAX_IN_FLIGHT = 3;
+
 export const DEFAULT_PROPOSAL_TTL_SECONDS = 30 * 60;
 
 let cachedPolicyVersion;

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -32,6 +32,7 @@ import { listMemos } from "./memos.mjs";
 import {
   artifactsRoot,
   DEAD_LETTER_AFTER,
+  DEFAULT_MAX_IN_FLIGHT,
   DEFAULT_PROPOSAL_TTL_SECONDS,
   FACTORY_ROOT,
 } from "./config.mjs";
@@ -80,6 +81,7 @@ import {
 
 /** In-flight issues list is stable across one scan; 60s is the ticket cap. */
 export const IN_FLIGHT_CACHE_TTL_MS = 60_000;
+export { DEFAULT_MAX_IN_FLIGHT };
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -324,9 +326,6 @@ export function buildRunSpec(
     ...(placement ? { placement } : {}),
   };
 }
-
-/** Default cap when neither repo nor policy config supplies one. */
-export const DEFAULT_MAX_IN_FLIGHT = 3;
 
 function resolveNow(now) {
   return typeof now === "function" ? now() : now;

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4,13 +4,14 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashJson } from "./canonical.mjs";
-import { DEAD_LETTER_AFTER } from "./config.mjs";
+import { DEAD_LETTER_AFTER, DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
 import {
   buildRunSpec,
   createLinearReadCache,
+  DEFAULT_MAX_IN_FLIGHT as PLANNER_DEFAULT_MAX_IN_FLIGHT,
   idempotencyKeyFor,
   pinMemos,
   planAdmittedEvents,
@@ -103,6 +104,13 @@ describe("idempotencyKeyFor", () => {
         "sha256:x",
       ),
     ).toThrow(/unknown idempotency scope/);
+  });
+});
+
+describe("DEFAULT_MAX_IN_FLIGHT (WM-755)", () => {
+  test("planner re-exports the config binding so callers keep working", () => {
+    expect(PLANNER_DEFAULT_MAX_IN_FLIGHT).toBe(DEFAULT_MAX_IN_FLIGHT);
+    expect(DEFAULT_MAX_IN_FLIGHT).toBe(3);
   });
 });
 

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -14,8 +14,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { FACTORY_ROOT } from "./config.mjs";
-import { DEFAULT_MAX_IN_FLIGHT } from "./planner.mjs";
+import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 
 export class RepoError extends Error {
   constructor(message) {

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -1,7 +1,8 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-repos-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import {
   loadRepos,
   proveMergeChecks,
@@ -454,9 +455,14 @@ describe("reposView is what the control API serves", () => {
       maxInFlightSource: "repo",
     });
     expect(rows[1].effective).toEqual({
-      maxInFlight: 3,
+      maxInFlight: DEFAULT_MAX_IN_FLIGHT,
       maxInFlightSource: "default",
     });
+  });
+
+  test("repos.mjs does not import planner.mjs (WM-755)", () => {
+    const source = readFileSync(new URL("./repos.mjs", import.meta.url), "utf8");
+    expect(source).not.toMatch(/from ["']\.\/planner\.mjs["']/);
   });
 
   test("the dispatch/report-only distinction survives the wire", () => {

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -461,7 +461,10 @@ describe("reposView is what the control API serves", () => {
   });
 
   test("repos.mjs does not import planner.mjs (WM-755)", () => {
-    const source = readFileSync(new URL("./repos.mjs", import.meta.url), "utf8");
+    const source = readFileSync(
+      new URL("./repos.mjs", import.meta.url),
+      "utf8",
+    );
     expect(source).not.toMatch(/from ["']\.\/planner\.mjs["']/);
   });
 


### PR DESCRIPTION
## Summary
- Move `DEFAULT_MAX_IN_FLIGHT` from `planner.mjs` into `config.mjs` so `reposView()` can publish the planner default without importing the planner graph.
- `planner.mjs` re-exports the same binding; `repos.mjs` imports it from config, ending the `repos ↔ planner` cycle.

Fixes WM-755

UX critique: skipped — backend module-cycle refactor, no user-facing surface.

## Test plan
- [x] `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/repos.test.mjs event-runtime/lib/api-registry.test.mjs event-runtime/lib/api-config.test.mjs`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`


Made with [Cursor](https://cursor.com)