### PR TITLE
chore(extensions): count hooks/panels/config; configurable escalation labels (WM-865)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -13,6 +13,8 @@ import {
 import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
 import {
+  contributionCounts,
+  formatContributionCounts,
   loadExtensions,
   validateExtensionManifest,
 } from "./lib/extensions.mjs";
@@ -239,10 +241,11 @@ export async function adaptersCommand(args = []) {
 
 /**
  * `extensions list` — the allow-listed extensions the loader accepts (WM-838),
- * with their contribution counts and `contributes.config` namespace; faults
- * print as anomalies on stderr, exactly as /status would report them, and the
- * command still exits 0 because a broken third-party extension is a
- * configuration anomaly, not a CLI failure.
+ * with their contribution counts (packs, adapters, hooks, panels, config)
+ * and `contributes.config` namespace; faults print as anomalies on stderr,
+ * exactly as /status would report them, and the command still exits 0
+ * because a broken third-party extension is a configuration anomaly, not a
+ * CLI failure.
  * `extensions validate <path>` — validate one manifest (schema, path
  * existence, adapter names) without loading a pack or importing an adapter;
  * exit 1 when it does not validate. Both are local — no serve needed.
@@ -262,10 +265,8 @@ export async function extensionsCommand(args = []) {
       process.exit(1);
     }
     const contributes = out.manifest.contributes ?? {};
-    const packs = (contributes.packs ?? []).length;
-    const adapters = Object.keys(contributes.adapters ?? {}).length;
+    const counts = formatContributionCounts(contributionCounts(out.manifest));
     const namespace = contributes.config?.namespace;
-    const counts = `${packs} pack${packs === 1 ? "" : "s"}, ${adapters} adapter${adapters === 1 ? "" : "s"}`;
     const configBit =
       typeof namespace === "string" && namespace !== ""
         ? `, config namespace ${namespace}`
@@ -300,12 +301,13 @@ export async function extensionsCommand(args = []) {
       ),
     );
     console.log(
-      `${"EXTENSION".padEnd(width)}${"VERSION".padEnd(10)}${"PACKS".padEnd(7)}${"ADAPTERS".padEnd(10)}${"NAMESPACE".padEnd(nsWidth)}PATH`,
+      `${"EXTENSION".padEnd(width)}${"VERSION".padEnd(10)}${"PACKS".padEnd(7)}${"ADAPTERS".padEnd(10)}${"HOOKS".padEnd(7)}${"PANELS".padEnd(8)}${"CONFIG".padEnd(8)}${"NAMESPACE".padEnd(nsWidth)}PATH`,
     );
     for (const ext of loaded.extensions) {
+      const counts = contributionCounts(ext);
       const namespace = ext.config?.namespace ?? "-";
       console.log(
-        `${ext.name.padEnd(width)}${ext.version.padEnd(10)}${String(ext.packs.length).padEnd(7)}${String(ext.adapters.length).padEnd(10)}${namespace.padEnd(nsWidth)}${ext.path}`,
+        `${ext.name.padEnd(width)}${ext.version.padEnd(10)}${String(counts.packs).padEnd(7)}${String(counts.adapters).padEnd(10)}${String(counts.hooks).padEnd(7)}${String(counts.panels).padEnd(8)}${String(counts.config).padEnd(8)}${namespace.padEnd(nsWidth)}${ext.path}`,
       );
     }
     return loaded;

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -123,6 +123,63 @@ export function extensionHookSource(name) {
   return `extension:${name}`;
 }
 
+/**
+ * Pack / adapter / hook / panel / config contribution counts for CLI
+ * `extensions list` and `extensions validate` (WM-865). Accepts either a
+ * manifest (`contributes.*`) or a loaded extension (`packs`/`adapters`/
+ * `hooks`/`panels` arrays plus `config`).
+ *
+ * `config` is 1 when the extension declares `contributes.config` (or a
+ * loaded extension carries a config object), else 0 — one contribution,
+ * not the number of schema properties.
+ *
+ * @param {object|null|undefined} source
+ * @returns {{ packs: number, adapters: number, hooks: number, panels: number, config: number }}
+ */
+export function contributionCounts(source) {
+  const empty = { packs: 0, adapters: 0, hooks: 0, panels: 0, config: 0 };
+  if (!source || typeof source !== "object") return empty;
+  const contributes = source.contributes;
+  if (contributes && typeof contributes === "object") {
+    return {
+      packs: Array.isArray(contributes.packs) ? contributes.packs.length : 0,
+      adapters: countKeysOrLength(contributes.adapters),
+      hooks: countKeysOrLength(contributes.hooks),
+      panels: Array.isArray(contributes.panels) ? contributes.panels.length : 0,
+      config: contributes.config ? 1 : 0,
+    };
+  }
+  return {
+    packs: Array.isArray(source.packs) ? source.packs.length : 0,
+    adapters: countKeysOrLength(source.adapters),
+    hooks: countKeysOrLength(source.hooks),
+    panels: Array.isArray(source.panels) ? source.panels.length : 0,
+    config: source.config ? 1 : 0,
+  };
+}
+
+function countKeysOrLength(value) {
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === "object") return Object.keys(value).length;
+  return 0;
+}
+
+function countBit(n, word) {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/** `1 pack, 2 adapters, 0 hooks, 1 panel, 1 config` — validate summary line. */
+export function formatContributionCounts(counts) {
+  const c = counts ?? contributionCounts(null);
+  return [
+    countBit(c.packs, "pack"),
+    countBit(c.adapters, "adapter"),
+    countBit(c.hooks, "hook"),
+    countBit(c.panels, "panel"),
+    countBit(c.config, "config"),
+  ].join(", ");
+}
+
 /** Policy entry fields `extensions[]` accepts besides `path`. */
 const ENTRY_FIELDS = new Set(["path", "config"]);
 

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -22,7 +22,9 @@ import {
   RESERVED_CONTRIBUTIONS,
   applyConfigDefaults,
   collectHarnessRoots,
+  contributionCounts,
   extensionSecretEnvVar,
+  formatContributionCounts,
   getExtensionConfig,
   harnessPluginName,
   loadExtensionRoots,
@@ -1075,6 +1077,52 @@ describe("extension hooks (contributes.hooks)", () => {
   });
 });
 
+describe("contributionCounts (WM-865)", () => {
+  test("counts hooks, panels and config on a manifest and a loaded extension", () => {
+    expect(contributionCounts(null)).toEqual({
+      packs: 0,
+      adapters: 0,
+      hooks: 0,
+      panels: 0,
+      config: 0,
+    });
+    expect(
+      contributionCounts({
+        contributes: {
+          packs: ["./pack"],
+          adapters: { echo: "./adapters/echo.mjs" },
+          hooks: { "approve.before": "./hooks/x.mjs" },
+          panels: ["./panels"],
+          config: { namespace: "sample", schema: "./config.schema.json" },
+        },
+      }),
+    ).toEqual({ packs: 1, adapters: 1, hooks: 1, panels: 1, config: 1 });
+    expect(
+      contributionCounts({
+        packs: ["sample-ext"],
+        adapters: ["echo"],
+        hooks: [
+          { point: "approve.before", id: "factory/sample:approve-before" },
+        ],
+        panels: ["/tmp/panels"],
+        config: null,
+      }),
+    ).toEqual({ packs: 1, adapters: 1, hooks: 1, panels: 1, config: 0 });
+    expect(formatContributionCounts(contributionCounts({}))).toBe(
+      "0 packs, 0 adapters, 0 hooks, 0 panels, 0 configs",
+    );
+    expect(
+      formatContributionCounts({
+        packs: 1,
+        adapters: 1,
+        hooks: 1,
+        panels: 1,
+        config: 1,
+      }),
+    ).toBe("1 pack, 1 adapter, 1 hook, 1 panel, 1 config");
+  });
+});
+
 describe("cli extensions", () => {
   const run = (...args) =>
     Bun.spawnSync({
@@ -1089,7 +1137,7 @@ describe("cli extensions", () => {
     const ok = run("validate", SAMPLE_EXTENSION);
     expect(ok.exitCode).toBe(0);
     expect(ok.stdout.toString()).toMatch(
-      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter, config namespace sample\)/,
+      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter, 1 hook, 1 panel, 1 config, config namespace sample\)/,
     );
 
     const noConfig = tempExtension((m) => {
@@ -1099,9 +1147,19 @@ describe("cli extensions", () => {
     const plain = run("validate", noConfig);
     expect(plain.exitCode).toBe(0);
     expect(plain.stdout.toString()).toMatch(
-      /factory\/plain@1\.0\.0: valid \(1 pack, 1 adapter\)/,
+      /factory\/plain@1\.0\.0: valid \(1 pack, 1 adapter, 1 hook, 1 panel, 0 configs\)/,
     );
     expect(plain.stdout.toString()).not.toMatch(/config namespace/);
+
+    const stripped = tempExtension((m) => {
+      m.name = "factory/bare";
+      m.contributes = {};
+    });
+    const bare = run("validate", stripped);
+    expect(bare.exitCode).toBe(0);
+    expect(bare.stdout.toString()).toMatch(
+      /factory\/bare@1\.0\.0: valid \(0 packs, 0 adapters, 0 hooks, 0 panels, 0 configs\)/,
+    );
 
     const bad = tempExtension((m) => {
       m.version = "one";
@@ -1148,11 +1206,11 @@ describe("cli extensions", () => {
     expect(out.exitCode).toBe(0);
     const text = out.stdout.toString();
     expect(text).toMatch(
-      /EXTENSION\s+VERSION\s+PACKS\s+ADAPTERS\s+NAMESPACE\s+PATH/,
+      /EXTENSION\s+VERSION\s+PACKS\s+ADAPTERS\s+HOOKS\s+PANELS\s+CONFIG\s+NAMESPACE\s+PATH/,
     );
     expect(text).toMatch(
       new RegExp(
-        `factory/sample\\s+1\\.0\\.0\\s+1\\s+1\\s+sample\\s+${SAMPLE_EXTENSION}`,
+        `factory/sample\\s+1\\.0\\.0\\s+1\\s+1\\s+1\\s+1\\s+1\\s+sample\\s+${SAMPLE_EXTENSION}`,
       ),
     );
     expect(out.stderr.toString()).toMatch(

--- a/event-runtime/lib/hooks.test.mjs
+++ b/event-runtime/lib/hooks.test.mjs
@@ -347,6 +347,76 @@ describe("hook registry (WM-842)", () => {
     expect(escalationLabels.default({})).toEqual({ decision: "allow" });
   });
 
+  test("escalation-labels accepts a configurable label list, falling back to the original checks", () => {
+    expect(escalationLabels.DEFAULT_ESCALATION_LABELS).toEqual([
+      "ai:escalated",
+      "type:security",
+      "/security/i",
+    ]);
+    // Unconfigured / malformed options keep the original three checks.
+    for (const options of [undefined, null, {}, { labels: "ai:escalated" }]) {
+      expect(
+        escalationLabels.hasSecurityOrEscalation(["ai:escalated"], options),
+      ).toBe(true);
+      expect(
+        escalationLabels.hasSecurityOrEscalation(["type:security"], options),
+      ).toBe(true);
+      expect(
+        escalationLabels.hasSecurityOrEscalation(
+          ["area:Security-review"],
+          options,
+        ),
+      ).toBe(true);
+      expect(
+        escalationLabels.hasSecurityOrEscalation(["ai:agent-ready"], options),
+      ).toBe(false);
+    }
+    // An explicit list replaces the defaults; `/security/i` is not implied.
+    expect(
+      escalationLabels.hasSecurityOrEscalation(["ai:blocked"], {
+        labels: ["ai:blocked"],
+      }),
+    ).toBe(true);
+    expect(
+      escalationLabels.hasSecurityOrEscalation(["ai:escalated"], {
+        labels: ["ai:blocked"],
+      }),
+    ).toBe(false);
+    expect(
+      escalationLabels.hasSecurityOrEscalation(["area:Security-review"], {
+        labels: ["ai:blocked"],
+      }),
+    ).toBe(false);
+    // Empty list is an explicit "match nothing", not a fallback.
+    expect(
+      escalationLabels.hasSecurityOrEscalation(["ai:escalated"], {
+        labels: [],
+      }),
+    ).toBe(false);
+    // Regex literals and RegExp objects, plus the escalationLabels alias.
+    expect(
+      escalationLabels.hasSecurityOrEscalation(["hold:urgent"], {
+        escalationLabels: ["/hold:/i", /^nogo$/],
+      }),
+    ).toBe(true);
+    expect(escalationLabels.parseLabelMatcher("/hold:/i")("hold:urgent")).toBe(
+      true,
+    );
+    // The default export reads ctx.config the same way.
+    expect(
+      escalationLabels.default({
+        evidence: { ticket: { labels: ["ops:freeze"] } },
+        config: { labels: ["ops:freeze"] },
+      }),
+    ).toEqual({ decision: "deny", reason: "escalated_or_security" });
+    expect(
+      escalationLabels.default({
+        evidence: { ticket: { labels: ["ai:escalated"] } },
+        config: { labels: ["ops:freeze"] },
+      }),
+    ).toEqual({ decision: "allow" });
+  });
+
   test("hookDecisionCounts aggregates allow/deny per hook over the window", () => {
     const db = openDb(":memory:");
     expect(hookDecisionCounts(db, { now })).toEqual({});

--- a/event-runtime/lib/hooks/builtin/escalation-labels.mjs
+++ b/event-runtime/lib/hooks/builtin/escalation-labels.mjs
@@ -1,15 +1,23 @@
 /**
  * Built-in `approve.before` hook: refuse to auto-approve a dispatch whose
- * ticket carries an escalation or security label (WM-842).
+ * ticket carries an escalation or security label (WM-842, WM-865).
  *
  * This is the check `dispatchSafe` in lib/auto-approval.mjs used to run
- * inline (`hasSecurityOrEscalation`), moved onto the hook seam unchanged: the
- * same labels are refused, with the same reason, at the same point of the
- * guard order — after the dispatch evidence hash is confirmed and before the
- * escalate-path intersection check. It reads only the recheck evidence the
- * chain approval already gathered (`ctx.evidence.ticket.labels`), so a
+ * inline (`hasSecurityOrEscalation`), moved onto the hook seam: the same
+ * labels are refused by default, with the same reason, at the same point of
+ * the guard order — after the dispatch evidence hash is confirmed and before
+ * the escalate-path intersection check. It reads only the recheck evidence
+ * the chain approval already gathered (`ctx.evidence.ticket.labels`), so a
  * proposal without dispatch evidence (a merge, a ship, a triage apply) is
  * simply allowed, as it was before.
+ *
+ * The label list is configurable (WM-865). Pass `{ labels }` as the second
+ * argument to `hasSecurityOrEscalation`, or set `ctx.config.labels` (also
+ * `escalationLabels`). Each entry is an exact name, or a `/pattern/flags`
+ * regex literal (and a `RegExp` is accepted on the options object). When
+ * unconfigured — missing options, missing `labels`, or a non-array — the
+ * defaults below preserve the original three checks. An explicit empty
+ * array means "match nothing".
  */
 
 export const id = "factory:escalation-labels";
@@ -18,25 +26,81 @@ export const id = "factory:escalation-labels";
 export const REASON = "escalated_or_security";
 
 /**
- * @param {string[]} [labels]
- * @returns {boolean}
+ * Default list: the two exact labels the inline check named, plus the
+ * case-insensitive `/security/i` pattern that also caught `type:security`
+ * and labels like `area:Security-review`.
  */
-export function hasSecurityOrEscalation(labels = []) {
-  return labels.some(
-    (label) =>
-      label === "ai:escalated" ||
-      label === "type:security" ||
-      /security/i.test(label),
-  );
+export const DEFAULT_ESCALATION_LABELS = Object.freeze([
+  "ai:escalated",
+  "type:security",
+  "/security/i",
+]);
+
+const REGEXP_LITERAL = /^\/(.+)\/([gimsuy]*)$/;
+
+/**
+ * Turn one list entry into a predicate. Exact strings, `/pattern/flags`
+ * literals, and `RegExp` values; anything else is ignored.
+ *
+ * @param {unknown} entry
+ * @returns {((label: string) => boolean)|null}
+ */
+export function parseLabelMatcher(entry) {
+  if (entry instanceof RegExp) return (label) => entry.test(label);
+  if (typeof entry !== "string" || entry === "") return null;
+  const literal = entry.match(REGEXP_LITERAL);
+  if (literal) {
+    try {
+      const re = new RegExp(literal[1], literal[2]);
+      return (label) => re.test(label);
+    } catch {
+      // Invalid regex: treat the original string as an exact label name.
+    }
+  }
+  return (label) => label === entry;
 }
 
 /**
- * @param {{ evidence?: { ticket?: { labels?: string[] } } | null }} ctx
+ * Resolve the configured list. `undefined`/`null`/non-array → defaults;
+ * an array (including empty) is used as-is.
+ *
+ * @param {{ labels?: unknown, escalationLabels?: unknown }|null|undefined} options
+ * @returns {readonly unknown[]}
+ */
+export function resolveEscalationLabels(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    return DEFAULT_ESCALATION_LABELS;
+  }
+  const raw = Object.hasOwn(options, "labels")
+    ? options.labels
+    : options.escalationLabels;
+  if (raw === undefined || raw === null) return DEFAULT_ESCALATION_LABELS;
+  if (!Array.isArray(raw)) return DEFAULT_ESCALATION_LABELS;
+  return raw;
+}
+
+/**
+ * @param {string[]} [labels]
+ * @param {{ labels?: unknown, escalationLabels?: unknown }|null|undefined} [options]
+ * @returns {boolean}
+ */
+export function hasSecurityOrEscalation(labels = [], options) {
+  const matchers = resolveEscalationLabels(options)
+    .map(parseLabelMatcher)
+    .filter(Boolean);
+  return labels.some((label) => matchers.some((match) => match(label)));
+}
+
+/**
+ * @param {{
+ *   evidence?: { ticket?: { labels?: string[] } } | null,
+ *   config?: { labels?: unknown, escalationLabels?: unknown } | null,
+ * }} ctx
  * @returns {{ decision: "allow" } | { decision: "deny", reason: string }}
  */
 export default function escalationLabels(ctx) {
   const labels = ctx?.evidence?.ticket?.labels ?? [];
-  return hasSecurityOrEscalation(labels)
+  return hasSecurityOrEscalation(labels, ctx?.config)
     ? { decision: "deny", reason: REASON }
     : { decision: "allow" };
 }


### PR DESCRIPTION
## Summary

- `extensions list` and `extensions validate` now count hooks, panels, and config contributions alongside packs and adapters.
- The built-in `factory:escalation-labels` hook accepts a replacement label list via `hasSecurityOrEscalation(labels, options)` / `ctx.config.labels` (`/pattern/flags` literals included); unconfigured behaviour is unchanged.

## Related issue

Fixes WM-865

Follow-up (docs, outside Owned Paths): WM-945

## Verification

```text
bun test event-runtime/lib/extensions.test.mjs event-runtime/lib/hooks.test.mjs
# 52 pass, 0 fail

bun test --timeout 20000 && bun build/emit.mjs --check
# 3402 pass, 9 skip, 0 fail; emit: ok — 90 generated files match shared/
```

UX critique: skipped — CLI and hook internals, no user-facing product surface

## Risk and impact

- [x] This change is narrowly scoped to the linked issue.
- [x] I added or updated tests for behavior changes, or explained why no test is needed.
- [ ] I updated documentation for user- or operator-visible behavior.
- [x] I regenerated emitted files when changing `shared/` and ran `bun run check`.
- [x] I considered security and privacy impact and did not include credentials or private data.
- [x] I identified compatibility, migration, or rollback concerns below.

Docs for the configurable label list are filed as WM-945 (`docs/extensions.md` is outside this ticket's Owned Paths). Default refusal behaviour is unchanged. CLI table/summary gained columns and count fields; JSON `extensions list --json` shape is unchanged.

Reviewer focus: `contributionCounts` treating a loaded extension vs a manifest, and empty `labels: []` meaning "match nothing" rather than falling back to defaults.

## Contributor statement

- [x] I have read and agree to follow `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
- [x] I have the right to submit this work under Apache License 2.0.
- [x] I have completed a Contributor License Agreement if a maintainer or check requested one.


Made with [Cursor](https://cursor.com)