### PR TITLE
feat(extensions): resolve npm packages as extension roots (WM-922)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,117 @@
+name: Publish extension
+
+# Manual publish of one factory extension as an npm package
+# (`@watt-mind/factory-ext-<name>`, docs/extensions.md §Publishing).
+on:
+  workflow_dispatch:
+    inputs:
+      extension:
+        description: Path to the extension directory (repo-relative)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Validate and publish
+    # Self-hosted, same no-`uses:` checkout as ci.yml (WM-573). Provenance
+    # needs the Actions OIDC token (`id-token: write` above).
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
+
+      - name: Setup bun (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
+            curl -fsSL https://bun.sh/install | bash
+          fi
+          if [ -x "$HOME/.bun/bin/bun" ]; then
+            echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            "$HOME/.bun/bin/bun" --version
+          else
+            bun --version
+          fi
+
+      - name: Require NPM_TOKEN
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret is not set. Add an npm automation token under Settings → Secrets and variables → Actions before publishing."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate extension
+        env:
+          EXTENSION: ${{ inputs.extension }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXTENSION}" ]; then
+            echo "::error::extension input must be a repo-relative path."
+            exit 1
+          fi
+          case "${EXTENSION}" in
+            /*|*..*)
+              echo "::error::extension input must be a repo-relative path without '..'."
+              exit 1
+              ;;
+          esac
+          if [ ! -d "${EXTENSION}" ]; then
+            echo "::error::extension directory ${EXTENSION} does not exist."
+            exit 1
+          fi
+          bun event-runtime/cli.mjs extensions validate "${EXTENSION}"
+          bun event-runtime/cli/extensions.mjs pack "${EXTENSION}"
+
+      - name: Run extension tests
+        env:
+          EXTENSION: ${{ inputs.extension }}
+        run: |
+          set -euo pipefail
+          mapfile -t tests < <(find "${EXTENSION}" -type f \( -name '*.test.mjs' -o -name '*.test.js' -o -name '*.test.ts' \) | sort)
+          if [ "${#tests[@]}" -eq 0 ]; then
+            echo "No tests under ${EXTENSION}; skipping bun test."
+            exit 0
+          fi
+          bun test --timeout 20000 --max-concurrency=4 "${tests[@]}"
+
+      - name: Publish to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          EXTENSION: ${{ inputs.extension }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret is not set."
+            exit 1
+          fi
+          npmrc="$(mktemp)"
+          trap 'rm -f "$npmrc"' EXIT
+          printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$npmrc"
+          export NPM_CONFIG_USERCONFIG="$npmrc"
+          cd "${EXTENSION}"
+          npm publish --provenance --access public

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -120,6 +120,7 @@ Validate a manifest without loading anything:
 
 ```sh
 bun event-runtime/cli.mjs extensions validate ~/.factory/extensions/wattmind-mobile
+bun event-runtime/cli.mjs extensions validate @watt-mind/factory-ext-buzz
 # wattmind/mobile@1.0.0: valid (1 pack, 1 adapter)
 ```
 
@@ -162,8 +163,9 @@ There are two kinds of contribution, and the difference is what runs.
   the extension's other contributions stay loaded.
 
 Two rules follow. Discovery is **allow-listed, never scanned**: the loader reads
-only the directories `policy.yaml` names, in that order — dropping a directory
-into `~/.factory/extensions/` does nothing on its own. And a broken extension is
+only the `path:` directories and `package:` names `policy.yaml` lists, in that
+order — dropping a directory into `~/.factory/extensions/` or installing an
+npm package does nothing on its own. And a broken extension is
 a **configuration anomaly, not a crash**: a missing or malformed manifest, a
 pack the registry would refuse, or an adapter that fails the contract skips
 that extension whole (nothing of it is registered, not even its good parts),
@@ -175,10 +177,14 @@ The one thing that does fail closed is a malformed `extensions:` block itself
 
 ## Enabling an extension
 
-Add its directory to `config/policy.yaml`:
+Add it to `config/policy.yaml` — either a directory (`path:`) or an installed
+npm package (`package:`). Both on one entry, or neither, is a configuration
+anomaly and the entry is skipped. Nothing is auto-discovered from
+`node_modules`.
 
 ```yaml
 extensions:
+  - package: @watt-mind/factory-ext-buzz # resolved from the factory root's node_modules
   - path: ~/.factory/extensions/wattmind-mobile # must contain factory-extension.json
     config: # optional; the shape is the extension's config schema (§Config)
       simulator: iPhone-16
@@ -186,12 +192,22 @@ extensions:
   - path: vendor/another-extension # relative paths resolve from the factory checkout
 ```
 
-Each entry accepts `path` (`~` expands to the home directory) and an optional
-`config` object — anything else is an anomaly and the entry is skipped. Entries
-load after the built-in root and after every `packs:` entry, in policy order:
-`packRoots` handed to the registry is `packs:` first, then each accepted
-extension's packs. Restart `serve` and the workers — extensions are read at
-startup, alongside the registry.
+Each entry accepts **either** `path` (`~` expands to the home directory) **or**
+`package` (`@scope/name` or `name`, resolved with `createRequire` from the
+factory root) and an optional `config` object. `version` on a `package:` entry
+is display-only — the loader records the installed `package.json` version, it
+does not pin or fetch. Anything else is an anomaly and the entry is skipped.
+A `package:` that is not installed is an anomaly naming the `npm i` command,
+never a crash. Entries load after the built-in root and after every `packs:`
+entry, in policy order: `packRoots` handed to the registry is `packs:` first,
+then each accepted extension's packs. Restart `serve` and the workers —
+extensions are read at startup, alongside the registry.
+
+Loaded rows (`extensions list --json`, and the loader snapshot `/config`
+reads) carry `source: "path"` or `source: "package"`, the resolved directory,
+and for packages the installed version. A `node_modules` symlink is realpath'd
+before the inside-the-dir check, so a contributed path cannot escape through
+a linked package.
 
 Inspect what loaded:
 
@@ -757,6 +773,48 @@ nothing until `policy.yaml` names it.
 **Trust.** Harness markdown is the same class as packs — an agent may
 author it — with the operator enablement gate in front. It is not an
 adapter: emit never imports third-party JavaScript.
+
+## Publishing
+
+Distribute an extension as an npm package so another factory install enables
+it with `npm i @watt-mind/factory-ext-<name>` plus one `policy.yaml` line, instead
+of cloning a directory. An extension is already a self-contained directory
+with one manifest, so the package _is_ the extension root — the loader
+resolves `package:` to that directory (§Enabling).
+
+### Package conventions
+
+| Field              | Value                                                                                                                                                                                                                                    |
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`             | `@watt-mind/factory-ext-<name>` (the `@watt-mind` org). Unscoped names resolve too; this is the published convention.                                                                                                                    |
+| `files`            | Whitelist: `factory-extension.json` plus every contributed path the manifest names (`pack/`, `adapters/`, `connectors/`, `hooks/`, `panels/`, `config.schema.json`, harness dirs). Do not ship tests, fixtures, or the factory checkout. |
+| `peerDependencies` | **None.** An extension imports only from the runtime contract via `ctx` (hooks, connectors, adapters). It must not `import` `event-runtime/lib/*` — that is also why connectors receive a client object instead of a DB handle.          |
+| `engines.bun`      | The bun range the extension was tested against (the factory itself is `>=1.3`).                                                                                                                                                          |
+| `keywords`         | Must include `"factory-extension"`.                                                                                                                                                                                                      |
+
+`package.json` may point the loader at a subdirectory with
+`factory.extension: "./ext"` when the package root is not the extension root.
+That path is realpath'd and must stay inside the package.
+
+### Validate and pack
+
+```sh
+bun event-runtime/cli.mjs extensions validate <dir|package>
+bun event-runtime/cli/extensions.mjs pack <dir>
+```
+
+`pack` runs validate, then `npm pack --dry-run`, and lists the files that
+would ship. Use it before the first publish.
+
+### Publish workflow
+
+`.github/workflows/publish-extension.yml` is a manual `workflow_dispatch`
+with an `extension` input (repo-relative directory). It validates, runs
+tests under that directory when they exist, and
+`npm publish --provenance --access public`. The `NPM_TOKEN` repository
+secret must be set — if it is missing the workflow fails loudly rather than
+publishing unauthenticated. The operator adds the token to the `@watt-mind`
+org; the workflow does not create it.
 
 ## Related
 

--- a/event-runtime/cli/extensions.mjs
+++ b/event-runtime/cli/extensions.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * `extensions pack` (WM-922) — validate an extension then run `npm pack
+ * --dry-run` so the operator sees what a publish would ship.
+ *
+ * `extensions list` / `validate` stay in event-runtime/cli.mjs. Validate
+ * already accepts a package name because lib/extensions.mjs resolves it.
+ * Wiring `pack` into cli.mjs is outside this ticket's Owned Paths.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { validateExtensionManifest } from "../lib/extensions.mjs";
+
+/**
+ * Validate `dir` (filesystem path or package name) and list the files
+ * `npm pack --dry-run` would include.
+ *
+ * @param {string} dir
+ * @param {{ spawn?: typeof spawnSync, exit?: (code: number) => never }} [options]
+ */
+export function packExtension(
+  dir,
+  { spawn = spawnSync, exit = (code) => process.exit(code) } = {},
+) {
+  const checked = validateExtensionManifest(dir);
+  for (const warning of checked.warnings) console.error(`warning: ${warning}`);
+  if (!checked.valid) {
+    for (const error of checked.errors) console.error(`error: ${error}`);
+    return exit(1);
+  }
+  const cwd = path.dirname(checked.file);
+  const packed = spawn("npm", ["pack", "--dry-run", "--json"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (packed.status !== 0) {
+    const detail = String(packed.stderr || packed.stdout || "").trim();
+    console.error(detail || "npm pack --dry-run failed");
+    return exit(packed.status === null ? 1 : packed.status);
+  }
+  let report;
+  try {
+    report = JSON.parse(packed.stdout);
+  } catch {
+    console.log(packed.stdout);
+    return checked;
+  }
+  const entries = Array.isArray(report) ? report : [report];
+  for (const item of entries) {
+    const files = item.files ?? [];
+    const name = item.name ?? checked.manifest.name;
+    const version = item.version ?? checked.manifest.version;
+    console.log(`${name}@${version}: would pack ${files.length} files`);
+    for (const file of files) {
+      console.log(`  ${file.path ?? file}`);
+    }
+  }
+  return { ...checked, pack: entries };
+}
+
+export async function extensionsCommand(args = []) {
+  const [sub, ...rest] = args;
+  if (sub === "pack") {
+    const target = rest.find((a) => !a.startsWith("--"));
+    if (!target) {
+      console.error("usage: extensions pack <dir>");
+      process.exit(1);
+    }
+    return packExtension(target);
+  }
+  if (sub === "validate") {
+    const target = rest.find((a) => !a.startsWith("--"));
+    if (!target) {
+      console.error("usage: extensions validate <dir|package>");
+      process.exit(1);
+    }
+    const out = validateExtensionManifest(target);
+    for (const warning of out.warnings) console.error(`warning: ${warning}`);
+    if (!out.valid) {
+      for (const error of out.errors) console.error(`error: ${error}`);
+      process.exit(1);
+    }
+    const contributes = out.manifest.contributes ?? {};
+    const packs = (contributes.packs ?? []).length;
+    const adapters = Object.keys(contributes.adapters ?? {}).length;
+    const namespace = contributes.config?.namespace;
+    const counts = `${packs} pack${packs === 1 ? "" : "s"}, ${adapters} adapter${adapters === 1 ? "" : "s"}`;
+    const configBit =
+      typeof namespace === "string" && namespace !== ""
+        ? `, config namespace ${namespace}`
+        : "";
+    console.log(
+      `${out.manifest.name}@${out.manifest.version}: valid (${counts}${configBit})`,
+    );
+    return out;
+  }
+  console.error(
+    "usage: extensions pack <dir> | extensions validate <dir|package>",
+  );
+  process.exit(1);
+}
+
+export default function extensions(args = []) {
+  return extensionsCommand(args);
+}
+
+if (import.meta.main) {
+  await extensionsCommand(process.argv.slice(2));
+}

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -11,9 +11,11 @@
  *
  * Three properties this module owns:
  *
- *   1. **Discovery is allow-listed, never scanned.** Only the directories in
+ *   1. **Discovery is allow-listed, never scanned.** Only the entries in
  *      `config/policy.yaml extensions:` are read, in policy order, mirroring
- *      `packs:` — an absent block loads nothing.
+ *      `packs:` — an absent block loads nothing. Each entry is either a
+ *      `path:` (directory) or a `package:` (an installed npm package resolved
+ *      from the factory root). Nothing is auto-discovered from `node_modules`.
  *   2. **Failures are configuration anomalies, not crashes.** A missing or
  *      malformed manifest, a schema violation, a pack the registry would
  *      refuse, or an adapter that fails the contract records a
@@ -73,7 +75,8 @@
  * lib/worker.mjs, and `result.packRoots` must be what `loadRegistry` is
  * given.
  */
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -180,8 +183,11 @@ export function formatContributionCounts(counts) {
   ].join(", ");
 }
 
-/** Policy entry fields `extensions[]` accepts besides `path`. */
-const ENTRY_FIELDS = new Set(["path", "config"]);
+/** Policy entry fields `extensions[]` accepts besides the locator. */
+const ENTRY_FIELDS = new Set(["path", "package", "version", "config"]);
+
+/** npm package name: `@scope/name` or `name` (no path separators). */
+const PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/i;
 
 /**
  * The last `loadExtensions` result, kept so `getExtensionConfig` (adapters,
@@ -196,6 +202,114 @@ export class ExtensionError extends Error {
     super(message);
     this.name = "ExtensionError";
   }
+}
+
+/** True for `@scope/name` or unscoped `name`; false for filesystem paths. */
+export function looksLikePackageName(value) {
+  if (typeof value !== "string") return false;
+  const name = value.trim();
+  if (!name) return false;
+  if (
+    name.startsWith(".") ||
+    name.startsWith("/") ||
+    name.startsWith("~") ||
+    name.includes("\\") ||
+    name.includes("..")
+  )
+    return false;
+  return PACKAGE_NAME.test(name);
+}
+
+function existingRealpath(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Resolve an installed npm package from the factory root to the directory
+ * that contains `factory-extension.json`. Follows `node_modules` symlinks
+ * with `realpath` so contributed paths cannot escape via a linked package.
+ *
+ * @param {string} packageName
+ * @param {{ root?: string }} [options]
+ * @returns {{ path: string, package: string, packageVersion: string|null, source: "package" }}
+ */
+export function resolveExtensionPackage(
+  packageName,
+  { root = reposRoot() } = {},
+) {
+  const name = String(packageName ?? "").trim();
+  if (!looksLikePackageName(name)) {
+    throw new ExtensionError(
+      `package must be a package name (@scope/name or name), got "${packageName}"`,
+    );
+  }
+  const require = createRequire(path.join(root, "package.json"));
+  let pkgJsonPath;
+  try {
+    pkgJsonPath = require.resolve(`${name}/package.json`);
+  } catch {
+    throw new ExtensionError(
+      `package "${name}" is not installed — npm i ${name}`,
+    );
+  }
+  const pkgDir = path.dirname(pkgJsonPath);
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+  } catch (err) {
+    throw new ExtensionError(
+      `package "${name}": unreadable package.json — ${err.message}`,
+    );
+  }
+  const rel = pkg.factory?.extension;
+  let extDir = pkgDir;
+  if (rel !== undefined && rel !== null) {
+    if (typeof rel !== "string" || rel.trim() === "") {
+      throw new ExtensionError(
+        `package "${name}": package.json factory.extension must be a relative path`,
+      );
+    }
+    extDir = path.resolve(pkgDir, rel);
+  }
+  const realPkg = existingRealpath(pkgDir);
+  const realExt = existingRealpath(extDir);
+  if (!isInside(realPkg, realExt)) {
+    throw new ExtensionError(
+      `package "${name}": factory.extension "${rel}" escapes the package directory`,
+    );
+  }
+  if (!existsSync(path.join(realExt, EXTENSION_MANIFEST))) {
+    throw new ExtensionError(
+      `package "${name}" has no ${EXTENSION_MANIFEST} in ${realExt}`,
+    );
+  }
+  return {
+    path: realExt,
+    package: name,
+    packageVersion: typeof pkg.version === "string" ? pkg.version : null,
+    source: "package",
+  };
+}
+
+/**
+ * A CLI/`validate` target: an existing filesystem path, or a package name
+ * resolved from the factory root.
+ *
+ * @param {string} spec
+ * @param {{ root?: string }} [options]
+ * @returns {{ path: string, source: "path"|"package", package?: string, packageVersion?: string|null }}
+ */
+export function resolveExtensionTarget(spec, { root = reposRoot() } = {}) {
+  const trimmed = String(spec ?? "").trim();
+  const asPath = path.resolve(expandHome(trimmed));
+  if (trimmed && existsSync(asPath)) return { path: asPath, source: "path" };
+  if (looksLikePackageName(trimmed))
+    return resolveExtensionPackage(trimmed, { root });
+  return { path: asPath, source: "path" };
 }
 
 function policyFile(root) {
@@ -221,9 +335,12 @@ function readPolicy(root) {
  * is reported per entry so one typo does not hide the other extensions.
  *
  * @param {{ root?: string, policy?: object }} [options]
- * @returns {{ roots: Array<{ path: string, index: number, config?: object }>, anomalies: string[] }}
+ * @returns {{ roots: Array<{ path: string, index: number, source: "path"|"package", package?: string, packageVersion?: string|null, config?: object }>, anomalies: string[] }}
  *   `config` is the operator's raw values for the extension (validated by
  *   `loadExtensions` against the schema the manifest declares).
+ *   `source` is `"path"` or `"package"`; package rows also carry the name
+ *   and the installed `package.json` version (`version:` on the entry is
+ *   display-only and is not compared).
  */
 export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
   const parsed = policy ?? readPolicy(root);
@@ -240,7 +357,9 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
   configured.forEach((entry, index) => {
     const at = `${file}: extensions[${index}]`;
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-      anomalies.push(`${at} must be an object with path (entry skipped)`);
+      anomalies.push(
+        `${at} must be an object with path or package (entry skipped)`,
+      );
       return;
     }
     const unknown = Object.keys(entry).filter((key) => !ENTRY_FIELDS.has(key));
@@ -250,8 +369,25 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
       );
       return;
     }
-    if (typeof entry.path !== "string" || entry.path.trim() === "") {
-      anomalies.push(`${at}.path must be a non-empty string (entry skipped)`);
+    const hasPath = Object.hasOwn(entry, "path");
+    const hasPackage = Object.hasOwn(entry, "package");
+    if (hasPath && hasPackage) {
+      anomalies.push(
+        `${at} must have path or package, not both (entry skipped)`,
+      );
+      return;
+    }
+    if (!hasPath && !hasPackage) {
+      anomalies.push(`${at} must have path or package (entry skipped)`);
+      return;
+    }
+    if (
+      Object.hasOwn(entry, "version") &&
+      (typeof entry.version !== "string" || entry.version.trim() === "")
+    ) {
+      anomalies.push(
+        `${at}.version must be a non-empty string (display only; entry skipped)`,
+      );
       return;
     }
     if (
@@ -263,15 +399,49 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
       anomalies.push(`${at}.config must be an object (entry skipped)`);
       return;
     }
-    const resolved = path.resolve(root, expandHome(entry.path));
-    if (seen.has(resolved)) {
-      anomalies.push(`${at}: duplicate extension path ${resolved} (skipped)`);
+
+    let located;
+    if (hasPath) {
+      if (typeof entry.path !== "string" || entry.path.trim() === "") {
+        anomalies.push(`${at}.path must be a non-empty string (entry skipped)`);
+        return;
+      }
+      located = {
+        path: path.resolve(root, expandHome(entry.path)),
+        source: "path",
+      };
+    } else {
+      if (typeof entry.package !== "string" || entry.package.trim() === "") {
+        anomalies.push(
+          `${at}.package must be a non-empty string (entry skipped)`,
+        );
+        return;
+      }
+      try {
+        located = resolveExtensionPackage(entry.package, { root });
+      } catch (err) {
+        anomalies.push(`${at}: ${err.message} (entry skipped)`);
+        return;
+      }
+    }
+
+    if (seen.has(located.path)) {
+      anomalies.push(
+        `${at}: duplicate extension path ${located.path} (skipped)`,
+      );
       return;
     }
-    seen.add(resolved);
+    seen.add(located.path);
     roots.push({
-      path: resolved,
+      path: located.path,
       index,
+      source: located.source,
+      ...(located.package
+        ? {
+            package: located.package,
+            packageVersion: located.packageVersion ?? null,
+          }
+        : {}),
       ...(Object.hasOwn(entry, "config") ? { config: entry.config } : {}),
     });
   });
@@ -285,14 +455,25 @@ export function loadExtensionRoots({ root = reposRoot(), policy } = {}) {
  * and no adapter module is imported — that is what `extensions validate` in
  * the CLI promises.
  *
- * @param {string} dir - the extension directory (the manifest's parent)
+ * @param {string} dir - the extension directory (the manifest's parent), or a package name
+ * @param {{ root?: string }} [options] - factory root used when `dir` is a package name
  * @returns {{ valid: boolean, errors: string[], warnings: string[], manifest: object|null, file: string }}
  */
-export function validateExtensionManifest(dir) {
-  const root = path.resolve(dir);
-  const file = path.join(root, EXTENSION_MANIFEST);
+export function validateExtensionManifest(dir, { root = reposRoot() } = {}) {
   const errors = [];
   const warnings = [];
+  let resolvedDir;
+  try {
+    resolvedDir = resolveExtensionTarget(dir, { root }).path;
+  } catch (err) {
+    const file = String(dir);
+    if (err instanceof ExtensionError) {
+      errors.push(err.message);
+      return { valid: false, errors, warnings, manifest: null, file };
+    }
+    throw err;
+  }
+  const file = path.join(resolvedDir, EXTENSION_MANIFEST);
   const result = (manifest) => ({
     valid: errors.length === 0,
     errors,
@@ -301,7 +482,7 @@ export function validateExtensionManifest(dir) {
     file,
   });
   if (!existsSync(file)) {
-    errors.push(`missing ${EXTENSION_MANIFEST} in ${root}`);
+    errors.push(`missing ${EXTENSION_MANIFEST} in ${resolvedDir}`);
     return result(null);
   }
   let manifest;
@@ -327,8 +508,8 @@ export function validateExtensionManifest(dir) {
   }
   const packs = new Set();
   for (const [i, rel] of (contributes.packs ?? []).entries()) {
-    const abs = path.resolve(root, rel);
-    if (!isInside(root, abs)) {
+    const abs = path.resolve(resolvedDir, rel);
+    if (!isInside(resolvedDir, abs)) {
       errors.push(
         `${file}: contributes.packs[${i}] "${rel}" escapes the extension directory`,
       );
@@ -352,8 +533,8 @@ export function validateExtensionManifest(dir) {
       );
       continue;
     }
-    const abs = path.resolve(root, rel);
-    if (!isInside(root, abs)) {
+    const abs = path.resolve(resolvedDir, rel);
+    if (!isInside(resolvedDir, abs)) {
       errors.push(
         `${file}: contributes.adapters.${name} "${rel}" escapes the extension directory`,
       );
@@ -372,8 +553,8 @@ export function validateExtensionManifest(dir) {
       );
       continue;
     }
-    const abs = path.resolve(root, rel);
-    if (!isInside(root, abs)) {
+    const abs = path.resolve(resolvedDir, rel);
+    if (!isInside(resolvedDir, abs)) {
       errors.push(
         `${file}: contributes.connectors.${name} "${rel}" escapes the extension directory`,
       );
@@ -392,8 +573,8 @@ export function validateExtensionManifest(dir) {
       );
       continue;
     }
-    const abs = path.resolve(root, rel);
-    if (!isInside(root, abs)) {
+    const abs = path.resolve(resolvedDir, rel);
+    if (!isInside(resolvedDir, abs)) {
       errors.push(
         `${file}: contributes.hooks["${point}"] "${rel}" escapes the extension directory`,
       );
@@ -407,8 +588,8 @@ export function validateExtensionManifest(dir) {
   }
   if (contributes.config) {
     const rel = contributes.config.schema;
-    const abs = path.resolve(root, rel);
-    if (!isInside(root, abs)) {
+    const abs = path.resolve(resolvedDir, rel);
+    if (!isInside(resolvedDir, abs)) {
       errors.push(
         `${file}: contributes.config.schema "${rel}" escapes the extension directory`,
       );
@@ -418,8 +599,8 @@ export function validateExtensionManifest(dir) {
       );
     }
   }
-  errors.push(...panelDirErrors(root, file, contributes.panels));
-  errors.push(...harnessPathErrors(root, file, contributes.harness));
+  errors.push(...panelDirErrors(resolvedDir, file, contributes.panels));
+  errors.push(...harnessPathErrors(resolvedDir, file, contributes.harness));
   return result(manifest);
 }
 
@@ -940,7 +1121,7 @@ export function collectHarnessRoots({
 }
 
 function isInside(root, abs) {
-  const rel = path.relative(root, abs);
+  const rel = path.relative(existingRealpath(root), existingRealpath(abs));
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
@@ -1026,7 +1207,13 @@ export async function loadExtensions({
       packRoots: candidates,
     });
 
-  for (const { path: dir, config: values } of roots) {
+  for (const {
+    path: dir,
+    config: values,
+    source = "path",
+    package: packageName,
+    packageVersion,
+  } of roots) {
     const checked = validateExtensionManifest(dir);
     const skip = (reason) => {
       anomalies.push(`extension ${dir}: ${reason} (extension skipped)`);
@@ -1236,6 +1423,10 @@ export async function loadExtensions({
       name: manifest.name,
       version: manifest.version,
       path: dir,
+      source,
+      ...(source === "package"
+        ? { package: packageName, packageVersion: packageVersion ?? null }
+        : {}),
       packs: extPackRoots.map((p) => p.name),
       adapters: modules.map((m) => m.name),
       hooks: hookModules.map(({ point, id }) => ({ point, id })),
@@ -1253,6 +1444,10 @@ export async function loadExtensions({
       name: manifest.name,
       version: manifest.version,
       path: dir,
+      source,
+      ...(source === "package"
+        ? { package: packageName, packageVersion: packageVersion ?? null }
+        : {}),
       config: config ? { ...publicConfig, schemaJson, secretMeta } : null,
     });
   }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -5,7 +5,9 @@ import {
   cpSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -30,7 +32,9 @@ import {
   loadExtensionRoots,
   loadExtensions,
   loadedExtensions,
+  looksLikePackageName,
   resetExtensionSecretsCache,
+  resolveExtensionPackage,
   validateExtensionManifest,
 } from "./extensions.mjs";
 import { createHookRegistry, hookDecisionsFor } from "./hooks.mjs";
@@ -58,6 +62,47 @@ function tempExtension(mutate = () => {}) {
 
 function policyFor(...dirs) {
   return { extensions: dirs.map((p) => ({ path: p })) };
+}
+
+/**
+ * Install the sample fixture as an npm package under a temp factory root
+ * (`node_modules/@test/sample-ext` → realpath of a copy, WM-922).
+ */
+function sampleAsPackage({
+  name = "@test/sample-ext",
+  version = "1.2.3",
+  factoryExtension,
+  mutate,
+} = {}) {
+  const factoryRoot = tmpDir("event-extension-pkgfactory-");
+  const installed = tmpDir("event-extension-pkginstall-");
+  cpSync(SAMPLE_EXTENSION, installed, { recursive: true });
+  const pkg = {
+    name,
+    version,
+    type: "module",
+    engines: { bun: ">=1.3" },
+    keywords: ["factory-extension"],
+    files: [
+      "factory-extension.json",
+      "pack",
+      "adapters",
+      "config.schema.json",
+      "hooks",
+      "connectors",
+      "panels",
+    ],
+  };
+  if (factoryExtension) pkg.factory = { extension: factoryExtension };
+  mutate?.(pkg, installed, factoryRoot);
+  writeFileSync(
+    path.join(installed, "package.json"),
+    JSON.stringify(pkg, null, 2),
+  );
+  const nm = path.join(factoryRoot, "node_modules", ...name.split("/"));
+  mkdirSync(path.dirname(nm), { recursive: true });
+  symlinkSync(installed, nm);
+  return { factoryRoot, installed, nm, name, version };
 }
 
 /** Load with an empty base pack list so the fixture never collides with the checkout's policy. */
@@ -186,7 +231,9 @@ describe("loadExtensionRoots", () => {
       path.join(os.homedir(), "ext"),
     ]);
     expect(out.anomalies).toHaveLength(4);
-    expect(out.anomalies[0]).toMatch(/extensions\[0\] must be an object/);
+    expect(out.anomalies[0]).toMatch(
+      /extensions\[0\] must be an object with path or package/,
+    );
     expect(out.anomalies[1]).toMatch(/extensions\[1\]\.path must be/);
     expect(out.anomalies[2]).toMatch(/unknown field "name"/);
     expect(out.anomalies[3]).toMatch(/duplicate extension path/);
@@ -200,8 +247,36 @@ describe("loadExtensionRoots", () => {
       "extensions:\n  - path: ext/one\n",
     );
     expect(loadExtensionRoots({ root }).roots).toEqual([
-      { path: path.join(root, "ext", "one"), index: 0 },
+      { path: path.join(root, "ext", "one"), index: 0, source: "path" },
     ]);
+  });
+
+  test("path and package together, or neither, are anomalies; version is display-only", () => {
+    const root = tmpDir("event-extension-xor-");
+    const out = loadExtensionRoots({
+      root,
+      policy: {
+        extensions: [
+          { config: { a: 1 } },
+          { path: "vendor/one", package: "@watt-mind/factory-ext-one" },
+          { package: "@watt-mind/factory-ext-missing", version: "9.9.9" },
+          { package: "../not-a-package" },
+          { package: "" },
+        ],
+      },
+    });
+    expect(out.roots).toEqual([]);
+    expect(out.anomalies[0]).toMatch(
+      /extensions\[0\] must have path or package \(entry skipped\)/,
+    );
+    expect(out.anomalies[1]).toMatch(
+      /must have path or package, not both \(entry skipped\)/,
+    );
+    expect(out.anomalies[2]).toMatch(
+      /package "@watt-mind\/factory-ext-missing" is not installed — npm i @watt-mind\/factory-ext-missing/,
+    );
+    expect(out.anomalies[3]).toMatch(/package must be a package name/);
+    expect(out.anomalies[4]).toMatch(/package must be a non-empty string/);
   });
 });
 
@@ -240,6 +315,20 @@ describe("validateExtensionManifest", () => {
     );
   });
 
+  test("a contributed path that is a symlink out of the extension is an escape", () => {
+    const dir = tempExtension();
+    const outside = tmpDir("event-extension-escape-target-");
+    writeFileSync(
+      path.join(outside, "pack.json"),
+      JSON.stringify({ name: "escaped", version: "1.0.0", namespace: "x" }),
+    );
+    rmSync(path.join(dir, "pack"), { recursive: true, force: true });
+    symlinkSync(outside, path.join(dir, "pack"));
+    const out = validateExtensionManifest(dir);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(/packs\[0\] "\.\/pack" escapes/);
+  });
+
   test("connector paths must exist, stay inside, and match the name pattern", () => {
     const dir = tempExtension((m) => {
       m.contributes.connectors["missing"] = "./connectors/nope.mjs";
@@ -265,6 +354,7 @@ describe("loadExtensions", () => {
         name: "factory/sample",
         version: "1.0.0",
         path: SAMPLE_EXTENSION,
+        source: "path",
         packs: ["sample-ext"],
         adapters: ["echo"],
         hooks: [
@@ -1365,5 +1455,182 @@ describe("contributes.harness (WM-849)", () => {
     expect(out.valid).toBe(false);
     expect(out.errors.join("\n")).toMatch(/harness\.floor .* is not a file/);
     expect(out.errors.join("\n")).toMatch(/harness\.commands .* escapes/);
+  });
+});
+
+describe("extension packages (WM-922)", () => {
+  test("looksLikePackageName accepts @scope/name and unscoped names, not paths", () => {
+    expect(looksLikePackageName("@watt-mind/factory-ext-buzz")).toBe(true);
+    expect(looksLikePackageName("@test/sample-ext")).toBe(true);
+    expect(looksLikePackageName("factory-ext-buzz")).toBe(true);
+    expect(looksLikePackageName("./vendor/ext")).toBe(false);
+    expect(looksLikePackageName("vendor/ext")).toBe(false);
+    expect(looksLikePackageName("~/ext")).toBe(false);
+    expect(looksLikePackageName("../escape")).toBe(false);
+  });
+
+  test("the sample fixture loads as a package via a node_modules symlink", async () => {
+    const { factoryRoot, installed, name, version } = sampleAsPackage();
+    const resolved = resolveExtensionPackage(name, { root: factoryRoot });
+    expect(resolved.source).toBe("package");
+    expect(resolved.package).toBe(name);
+    expect(resolved.packageVersion).toBe(version);
+    expect(resolved.path).toBe(realpathSync(installed));
+
+    const adapterRegistry = createAdapterRegistry();
+    const out = await loadExtensions({
+      root: factoryRoot,
+      policy: {
+        extensions: [{ package: name, version: "ignored-display-only" }],
+      },
+      adapterRegistry,
+      hookRegistry: createHookRegistry(),
+      packRoots: [],
+    });
+    expect(out.anomalies).toEqual([]);
+    expect(out.extensions).toHaveLength(1);
+    expect(out.extensions[0]).toMatchObject({
+      name: "factory/sample",
+      version: "1.0.0",
+      path: realpathSync(installed),
+      source: "package",
+      package: name,
+      packageVersion: version,
+      packs: ["sample-ext"],
+      adapters: ["echo"],
+    });
+    expect(adapterRegistry.has("echo")).toBe(true);
+    expect(loadedExtensions().extensions[0]).toMatchObject({
+      source: "package",
+      package: name,
+      packageVersion: version,
+      path: realpathSync(installed),
+    });
+  });
+
+  test("factory.extension points at a subdir; a subdir that escapes is refused", () => {
+    const nestedRoot = tmpDir("event-extension-nested-pkg-");
+    const pkgDir = tmpDir("event-extension-nested-install-");
+    const extDir = path.join(pkgDir, "ext");
+    cpSync(SAMPLE_EXTENSION, extDir, { recursive: true });
+    writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@test/nested-ext",
+        version: "0.4.0",
+        factory: { extension: "./ext" },
+      }),
+    );
+    mkdirSync(path.join(nestedRoot, "node_modules", "@test"), {
+      recursive: true,
+    });
+    symlinkSync(
+      pkgDir,
+      path.join(nestedRoot, "node_modules", "@test", "nested-ext"),
+    );
+    const resolved = resolveExtensionPackage("@test/nested-ext", {
+      root: nestedRoot,
+    });
+    expect(resolved.path).toBe(realpathSync(extDir));
+    expect(resolved.packageVersion).toBe("0.4.0");
+
+    const escapedRoot = tmpDir("event-extension-escaped-pkg-");
+    const escapedPkg = tmpDir("event-extension-escaped-install-");
+    writeFileSync(
+      path.join(escapedPkg, "package.json"),
+      JSON.stringify({
+        name: "@test/escaped-ext",
+        version: "0.0.1",
+        factory: { extension: "../outside" },
+      }),
+    );
+    mkdirSync(path.join(escapedRoot, "node_modules", "@test"), {
+      recursive: true,
+    });
+    symlinkSync(
+      escapedPkg,
+      path.join(escapedRoot, "node_modules", "@test", "escaped-ext"),
+    );
+    expect(() =>
+      resolveExtensionPackage("@test/escaped-ext", { root: escapedRoot }),
+    ).toThrow(/factory\.extension "\.\.\/outside" escapes/);
+  });
+
+  test("a package whose contributed pack is a symlink out of the package is an escape", () => {
+    const { factoryRoot, installed, name } = sampleAsPackage();
+    const outside = tmpDir("event-extension-pkg-escape-");
+    writeFileSync(
+      path.join(outside, "pack.json"),
+      JSON.stringify({ name: "escaped", version: "1.0.0", namespace: "x" }),
+    );
+    rmSync(path.join(installed, "pack"), { recursive: true, force: true });
+    symlinkSync(outside, path.join(installed, "pack"));
+    const resolved = resolveExtensionPackage(name, { root: factoryRoot });
+    const out = validateExtensionManifest(resolved.path);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(/packs\[0\] "\.\/pack" escapes/);
+  });
+
+  test("extensions validate accepts a package name via the existing CLI", () => {
+    const { factoryRoot, name } = sampleAsPackage();
+    const ok = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "event-runtime/cli.mjs",
+        "extensions",
+        "validate",
+        name,
+      ],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_REPOS_ROOT: factoryRoot },
+    });
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout.toString()).toMatch(
+      /factory\/sample@1\.0\.0: valid \(1 pack, 1 adapter, 1 hook, 1 panel, 1 config, config namespace sample\)/,
+    );
+
+    const missing = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "event-runtime/cli.mjs",
+        "extensions",
+        "validate",
+        "@watt-mind/factory-ext-nope",
+      ],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_REPOS_ROOT: factoryRoot },
+    });
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr.toString()).toMatch(
+      /is not installed — npm i @watt-mind\/factory-ext-nope/,
+    );
+  });
+
+  test("extensions pack validates then lists npm pack --dry-run files", () => {
+    const dir = tempExtension();
+    writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "@test/pack-ext",
+        version: "0.1.0",
+        type: "module",
+        files: ["factory-extension.json", "pack", "adapters"],
+      }),
+    );
+    const packed = Bun.spawnSync({
+      cmd: [process.execPath, "event-runtime/cli/extensions.mjs", "pack", dir],
+      cwd: path.dirname(RUNTIME_ROOT),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(packed.exitCode).toBe(0);
+    const text = packed.stdout.toString();
+    expect(text).toMatch(/@test\/pack-ext@0\.1\.0: would pack/);
+    expect(text).toMatch(/factory-extension\.json/);
+    expect(text).toMatch(/package\.json/);
   });
 });


### PR DESCRIPTION
## Summary
- `policy.yaml` `extensions:` entries accept `path:` or `package:` (`@scope/name` or `name`). Both or neither is a configuration anomaly; a missing install names `npm i <name>` and never crashes the loader.
- Loaded rows carry `source: "path"|"package"`, the realpath'd directory, and the installed `package.json` version. Contributed paths are realpath'd so a `node_modules` symlink cannot escape the package.
- `extensions validate` accepts a package name (existing `cli.mjs` path). `extensions pack` (validate + `npm pack --dry-run`) lives in `event-runtime/cli/extensions.mjs`. Manual publish workflow: `.github/workflows/publish-extension.yml`.
- Follow-up [WM-948](https://linear.app/watt-mind/issue/WM-948) (Triage): wire `pack` into `cli.mjs`, surface `source` on `GET /config`, add `package.json` to the sample fixture.

## Test plan
- [x] `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/extensions.test.mjs`
- [x] `bun run lint` (0 errors)
- [x] `bun run check`
- [x] `bun test --timeout 20000 --max-concurrency=4` (full suite, 3408 pass)
- [ ] Manual: `extensions: - package: @watt-mind/factory-ext-buzz` after `npm i` on a factory checkout

Fixes WM-922

UX critique: skipped

Made with [Cursor](https://cursor.com)