### PR TITLE
feat(web): surface extension contribution counts in Settings (WM-856)

### DIFF
--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -124,10 +124,61 @@ export function redactSecrets(value) {
   );
 }
 
+function contributionLength(value) {
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === "object") return Object.keys(value).length;
+  return 0;
+}
+
+function emptyContributions() {
+  return { packs: 0, adapters: 0, connectors: 0, hooks: 0, panels: 0 };
+}
+
+/** Pack / adapter / connector / hook / panel counts from a loaded row or a manifest. */
+function contributionsFrom(source) {
+  if (!source || typeof source !== "object") return emptyContributions();
+  const c =
+    source.contributes && typeof source.contributes === "object"
+      ? source.contributes
+      : source;
+  return {
+    packs: contributionLength(c.packs ?? source.packs),
+    adapters: contributionLength(c.adapters ?? source.adapters),
+    connectors: contributionLength(c.connectors ?? source.connectors),
+    hooks: contributionLength(c.hooks ?? source.hooks),
+    panels: contributionLength(c.panels ?? source.panels),
+  };
+}
+
+/**
+ * `loadedExtensions()` only keeps name/version/path/config. When the row has
+ * no contribution arrays, read factory-extension.json at `ext.path` so GET
+ * /config still publishes counts without widening extensions.mjs.
+ */
+function readManifest(dir) {
+  if (!dir || typeof dir !== "string") return null;
+  const file = path.join(dir, "factory-extension.json");
+  if (!existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function contributionsFor(ext) {
+  const fromFields = contributionsFrom(ext);
+  if (Object.values(fromFields).some((n) => n > 0)) return fromFields;
+  const manifest = readManifest(ext.path);
+  return manifest ? contributionsFrom(manifest) : fromFields;
+}
+
 /**
  * Extension config (WM-841): one row per extension the loader saw — accepted
  * ones with their namespace, schema and effective (defaulted, validated,
  * redacted) values; disabled ones with the anomaly that disabled them.
+ * Contribution counts (WM-856) sit on the same row.
  */
 function extensionsSection({ extensions = [], disabled = [] } = {}) {
   const items = [
@@ -146,6 +197,7 @@ function extensionsSection({ extensions = [], disabled = [] } = {}) {
           )
         : null,
       anomaly: null,
+      contributions: contributionsFor(ext),
     })),
     ...disabled.map((ext) => ({
       name: ext.name,
@@ -156,6 +208,7 @@ function extensionsSection({ extensions = [], disabled = [] } = {}) {
       schema: null,
       values: null,
       anomaly: ext.reason,
+      contributions: contributionsFor(ext),
     })),
   ];
   return {

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -243,6 +243,16 @@ describe("GET /config view", () => {
             name: "factory/sample",
             version: "1.0.0",
             path: "/ext/sample",
+            packs: ["sample-ext"],
+            adapters: ["echo"],
+            connectors: [{ name: "echo", id: "factory/sample:echo" }],
+            hooks: [
+              {
+                point: "approve.before",
+                id: "factory/sample:approve-before",
+              },
+            ],
+            panels: ["/ext/sample/panels"],
             config: {
               namespace: "sample",
               schema: "./config.schema.json",
@@ -294,6 +304,13 @@ describe("GET /config view", () => {
           limits: { timeoutSeconds: 30, signingKey: "[redacted]" },
         },
         anomaly: null,
+        contributions: {
+          packs: 1,
+          adapters: 1,
+          connectors: 1,
+          hooks: 1,
+          panels: 1,
+        },
       },
       {
         name: "factory/plain",
@@ -304,6 +321,13 @@ describe("GET /config view", () => {
         schema: null,
         values: null,
         anomaly: null,
+        contributions: {
+          packs: 0,
+          adapters: 0,
+          connectors: 0,
+          hooks: 0,
+          panels: 0,
+        },
       },
       {
         name: "factory/broken",
@@ -314,6 +338,13 @@ describe("GET /config view", () => {
         schema: null,
         values: null,
         anomaly: expect.stringMatching(/\$\.maxParallel: above maximum 4/),
+        contributions: {
+          packs: 0,
+          adapters: 0,
+          connectors: 0,
+          hooks: 0,
+          panels: 0,
+        },
       },
     ]);
     // Entries mirror the same rows so search and generic rendering keep working.
@@ -400,6 +431,13 @@ describe("GET /config view", () => {
     expect(section.extensions[0].schema.properties.apiToken.format).toBe(
       "secret",
     );
+    expect(section.extensions[0].contributions).toEqual({
+      packs: 1,
+      adapters: 1,
+      connectors: 1,
+      hooks: 1,
+      panels: 1,
+    });
   });
 
   test("GET /config over real HTTP: an env-backed secret value never appears in the response body, only { set, source }", async () => {

--- a/event-runtime/web/src/views/Settings.test.tsx
+++ b/event-runtime/web/src/views/Settings.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { useState } from "react";
-import type { ConfigView } from "../api";
+import type { ConfigExtension, ConfigView } from "../api";
 import { changeInput, renderWithClient } from "../test-render";
 import { Settings } from "./Settings";
 
@@ -126,7 +126,14 @@ const fixture: ConfigView = {
             pollEvery: "30s",
           },
           anomaly: null,
-        },
+          contributions: {
+            packs: 1,
+            adapters: 2,
+            connectors: 1,
+            hooks: 0,
+            panels: 1,
+          },
+        } as ConfigExtension,
         {
           name: "wattmind/broken",
           version: "2.0.0",
@@ -137,7 +144,14 @@ const fixture: ConfigView = {
           values: null,
           anomaly:
             "wattmind/broken@2.0.0: config does not match ./config.schema.json — $.maxParallel: above maximum 4",
-        },
+          contributions: {
+            packs: 0,
+            adapters: 0,
+            connectors: 0,
+            hooks: 0,
+            panels: 0,
+          },
+        } as ConfigExtension,
       ],
     },
   ],
@@ -245,6 +259,11 @@ describe("Settings", () => {
     // A loaded extension: name, namespace, titles, and typed widgets.
     expect(view.getByText("wattmind/mobile")).toBeTruthy();
     expect(view.getByText("mobile")).toBeTruthy();
+    expect(view.getByText("1 pack")).toBeTruthy();
+    expect(view.getByText("2 adapters")).toBeTruthy();
+    expect(view.getByText("1 connector")).toBeTruthy();
+    expect(view.getByText("1 panel")).toBeTruthy();
+    expect(view.queryByText("0 hooks")).toBeNull();
     expect(view.getByText("Simulator")).toBeTruthy();
     expect(view.getByText("iPhone-16")).toBeTruthy();
     expect(view.getByText("FACTORY_EXT_MOBILE_API_TOKEN")).toBeTruthy();
@@ -295,6 +314,24 @@ describe("Settings", () => {
       expect(view.getByRole("heading", { name: "Extensions" })).toBeTruthy(),
     );
     expect(view.getByText("wattmind/mobile")).toBeTruthy();
+    expect(view.queryByText("wattmind/broken")).toBeNull();
+  });
+
+  test("searches extension contribution chips", async () => {
+    stubConfig();
+    const view = renderWithClient(<StatefulSettings initial="repos" />);
+    await view.findByText("factory.tools.base");
+    act(() =>
+      changeInput(
+        view.getByRole("combobox", { name: "Search settings" }),
+        "2 adapters",
+      ),
+    );
+    await waitFor(() =>
+      expect(view.getByRole("heading", { name: "Extensions" })).toBeTruthy(),
+    );
+    expect(view.getByText("wattmind/mobile")).toBeTruthy();
+    expect(view.getByText("2 adapters")).toBeTruthy();
     expect(view.queryByText("wattmind/broken")).toBeNull();
   });
 });

--- a/event-runtime/web/src/views/Settings.tsx
+++ b/event-runtime/web/src/views/Settings.tsx
@@ -109,14 +109,74 @@ function extensionKey(ext: ConfigExtension): string {
   return ext.namespace ?? ext.name ?? ext.path;
 }
 
+const CONTRIBUTION_LABELS = [
+  ["packs", "pack"],
+  ["adapters", "adapter"],
+  ["connectors", "connector"],
+  ["hooks", "hook"],
+  ["panels", "panel"],
+] as const;
+
+type ExtensionContributions = Record<
+  (typeof CONTRIBUTION_LABELS)[number][0],
+  number
+>;
+
+function isContributions(value: unknown): value is ExtensionContributions {
+  if (!value || typeof value !== "object") return false;
+  return CONTRIBUTION_LABELS.every(
+    ([key]) => typeof (value as Record<string, unknown>)[key] === "number",
+  );
+}
+
+/** Wire field lives on ConfigExtension after WM-856; api.ts is outside Owned Paths. */
+function contributionsOf(ext: ConfigExtension): ExtensionContributions | null {
+  const raw = (ext as ConfigExtension & { contributions?: unknown })
+    .contributions;
+  return isContributions(raw) ? raw : null;
+}
+
+function contributionChipLabel(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function contributionHaystack(ext: ConfigExtension): string {
+  const counts = contributionsOf(ext);
+  if (!counts) return "";
+  return CONTRIBUTION_LABELS.map(([key, word]) =>
+    contributionChipLabel(counts[key], word),
+  ).join("\n");
+}
+
 function extensionHaystack(ext: ConfigExtension): string {
   return [
     ext.name ?? "",
     ext.namespace ?? "",
     ext.path,
     ext.anomaly ?? "",
+    contributionHaystack(ext),
     schemaSearchText(ext.schema as JsonSchema | null),
   ].join("\n");
+}
+
+function ContributionChips({ ext }: { ext: ConfigExtension }) {
+  const counts = contributionsOf(ext);
+  if (!counts) return null;
+  const chips = CONTRIBUTION_LABELS.filter(([key]) => counts[key] > 0).map(
+    ([key, word]) => {
+      const label = contributionChipLabel(counts[key], word);
+      return (
+        <span
+          key={key}
+          className="mono shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-xs text-(--text-dim)"
+          title={`${label} contributed`}
+        >
+          {label}
+        </span>
+      );
+    },
+  );
+  return chips.length > 0 ? chips : null;
 }
 
 /**
@@ -150,6 +210,7 @@ function ExtensionRow({
             v{ext.version}
           </span>
         )}
+        <ContributionChips ext={ext} />
         {ext.name && (
           <span
             className="mono min-w-0 truncate text-xs text-(--text-faint)"


### PR DESCRIPTION
## Summary
- Publish `contributions` (packs, adapters, connectors, hooks, panels) on every Extensions row from `GET /config`.
- Render non-zero counts as chips next to namespace/version on the Settings Extensions section.
- Follow-up typed in Triage as WM-959 (`ConfigExtension` in `api.ts` is outside this ticket's Owned Paths; Settings duck-types the field).

Fixes WM-856

UX critique: skipped — additive read-only chips on the operator Settings inventory; no new flow, interaction, or error path.

## Test plan
- [x] `bun test event-runtime/lib/api-config.test.mjs && cd event-runtime/web && bun test src/views/Settings.test.tsx && bun run build`
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`
- [ ] Settings → Extensions: loaded rows show contribution chips; disabled rows still show the anomaly; search for a chip label (e.g. `2 adapters`) narrows to that extension.


Made with [Cursor](https://cursor.com)