### PR TITLE
chore(cli): fold adapters into COMMANDS and usage (WM-850)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -2,7 +2,6 @@
 /** Event-runtime CLI argument routing and command dispatch. */
 import { COMMANDS } from "./cli/commands.mjs";
 import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
-import { createAdapterRegistry } from "./lib/adapters/index.mjs";
 import { backfillResultArtifacts } from "./lib/artifacts.mjs";
 import {
   API_HOST,
@@ -24,8 +23,8 @@ const USAGE = BASE_USAGE.replace(
   "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API\n  memos <subjectType> <id> [--kind k] [--all]\n                                 live memos for a subject, with provenance and expiry",
 )
   .replace(
-    "  agents                         registered agent definitions and event routing",
-    "  agents                         registered agent definitions and event routing\n  adapters                       registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts, config namespace\n  extensions validate <path>     validate a factory-extension.json without loading it",
+    "  adapters [--json]               registered harness adapters: name, source, sandbox support (local, no serve needed)",
+    "  adapters [--json]               registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts, config namespace\n  extensions validate <path>     validate a factory-extension.json without loading it",
   )
   .concat(
     "\n  artifacts backfill-results [--apply]\n                                 materialize stored typed result output (dry by default)",
@@ -216,30 +215,6 @@ export async function decideCommand(args) {
 }
 
 /**
- * Read-only listing of the adapter registry (WM-837): the same registry
- * `work` and `serve` build, so what this prints is what a worker would
- * execute with. Local — it needs no running serve.
- */
-export async function adaptersCommand(args = []) {
-  const registry = createAdapterRegistry();
-  const loaded = await loadExtensions({ adapterRegistry: registry });
-  for (const anomaly of loaded.anomalies) console.error(`anomaly: ${anomaly}`);
-  const rows = registry.list();
-  if (args.includes("--json")) {
-    console.log(JSON.stringify({ adapters: rows }, null, 2));
-    return rows;
-  }
-  const width = Math.max(8, ...rows.map((row) => row.name.length + 3));
-  console.log(`${"ADAPTER".padEnd(width)}${"SOURCE".padEnd(12)}SANDBOX`);
-  for (const row of rows) {
-    console.log(
-      `${row.name.padEnd(width)}${row.source.padEnd(12)}${row.sandboxSupport}`,
-    );
-  }
-  return rows;
-}
-
-/**
  * `extensions list` — the allow-listed extensions the loader accepts (WM-838),
  * with their contribution counts (packs, adapters, hooks, panels, config)
  * and `contributes.config` namespace; faults print as anomalies on stderr,
@@ -346,7 +321,6 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
   if (command === "memos") return memosCommand(args);
-  if (command === "adapters") return adaptersCommand(args);
   if (command === "extensions") return extensionsCommand(args);
   if (command === "artifacts") return artifactsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -14,6 +14,7 @@ const EXPECTED_COMMANDS = [
   "proposals",
   "inbox",
   "agents",
+  "adapters",
   "workers",
   "schedule",
   "repos",
@@ -41,6 +42,7 @@ describe("cli routing", () => {
       "ps",
       "runs",
       "proposals",
+      "adapters",
       "approve",
       "reject",
       "inject",
@@ -53,9 +55,22 @@ describe("cli routing", () => {
       expect(r.all).toContain(verb);
     }
     expect(r.all).toContain("usage:");
+    expect(r.all).toContain("adapters [--json]");
     expect(r.all).toContain("--watch");
     expect(r.all).toContain("--reload-on-change");
     expect(r.all).toContain("--workers min:max");
+  });
+
+  test("adapters is routed through COMMANDS and lists locally", () => {
+    expect(COMMAND_NAMES).toContain("adapters");
+    const r = runCli(["adapters", "--json"]);
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(Array.isArray(parsed.adapters)).toBe(true);
+    expect(parsed.adapters.length).toBeGreaterThan(0);
+    expect(parsed.adapters[0]).toHaveProperty("name");
+    expect(parsed.adapters[0]).toHaveProperty("source");
+    expect(parsed.adapters[0]).toHaveProperty("sandboxSupport");
   });
 
   test("unknown command → usage text, non-zero exit", () => {

--- a/event-runtime/cli/adapters.mjs
+++ b/event-runtime/cli/adapters.mjs
@@ -1,0 +1,26 @@
+import { createAdapterRegistry } from "../lib/adapters/index.mjs";
+import { loadExtensions } from "../lib/extensions.mjs";
+
+/**
+ * Read-only listing of the adapter registry (WM-837): the same registry
+ * `work` and `serve` build, so what this prints is what a worker would
+ * execute with. Local — it needs no running serve.
+ */
+export default async function adaptersCommand(args = []) {
+  const registry = createAdapterRegistry();
+  const loaded = await loadExtensions({ adapterRegistry: registry });
+  for (const anomaly of loaded.anomalies) console.error(`anomaly: ${anomaly}`);
+  const rows = registry.list();
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ adapters: rows }, null, 2));
+    return rows;
+  }
+  const width = Math.max(8, ...rows.map((row) => row.name.length + 3));
+  console.log(`${"ADAPTER".padEnd(width)}${"SOURCE".padEnd(12)}SANDBOX`);
+  for (const row of rows) {
+    console.log(
+      `${row.name.padEnd(width)}${row.source.padEnd(12)}${row.sandboxSupport}`,
+    );
+  }
+  return rows;
+}

--- a/event-runtime/cli/commands.mjs
+++ b/event-runtime/cli/commands.mjs
@@ -1,3 +1,4 @@
+import adapters from "./adapters.mjs";
 import agents from "./agents.mjs";
 import approve from "./approve.mjs";
 import cancel from "./cancel.mjs";
@@ -36,6 +37,7 @@ export const COMMANDS = Object.freeze({
   proposals,
   inbox,
   agents,
+  adapters,
   workers,
   schedule,
   repos,

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -35,6 +35,7 @@ usage: bun event-runtime/cli.mjs <command>
   proposals                      open proposals with TTL age
   inbox                          open items waiting on the human
   agents                         registered agent definitions and event routing
+  adapters [--json]               registered harness adapters: name, source, sandbox support (local, no serve needed)
   workers                        worker processes: host, labels, state, heartbeat
   schedule                       recurring loops: cadence, approval, last fire, next due
   repos                          factory repos: team, base, dispatch vs report-only


### PR DESCRIPTION
## Summary
- Move the read-only `adapters [--json]` subcommand into `event-runtime/cli/adapters.mjs` and register it on `COMMANDS`.
- Document it in `event-runtime/cli/usage.mjs` and drop the inline dispatch branch from `cli.mjs`.
- Assert routing (and a local `--json` listing) in `event-runtime/cli.test.mjs`.

Fixes WM-850

UX critique: skipped — CLI routing refactor with no behaviour change and no user-facing product surface.

## Test plan
- [x] `bun test event-runtime/cli.test.mjs`
- [ ] `bun event-runtime/cli.mjs adapters` lists adapters without serve
- [ ] `bun event-runtime/cli.mjs adapters --json` prints JSON


Made with [Cursor](https://cursor.com)