### PR TITLE
feat(event-runtime-web): harness/model Metrics breakdowns and full-card retry/token charts (WM-883)

### DIFF
--- a/event-runtime/web/src/components/Charts.tsx
+++ b/event-runtime/web/src/components/Charts.tsx
@@ -189,6 +189,78 @@ export function StackedBars({
   );
 }
 
+export interface ShareBarRow {
+  key: string;
+  label: string;
+  value: number;
+  hue: string;
+  link?: ChartLink | null;
+}
+
+/** Ranked full-card distribution; fills the same h-44 slot as StackedBars. */
+export function ShareBars({
+  rows,
+  label,
+  format = (value) => String(value),
+}: {
+  rows: ShareBarRow[];
+  label: string;
+  format?: (value: number) => string;
+}) {
+  const max = Math.max(0, ...rows.map((row) => Math.max(0, row.value)));
+  if (rows.length === 0 || max === 0) {
+    return (
+      <div
+        role="img"
+        aria-label={label}
+        data-empty="true"
+        className="flex h-44 items-center justify-center rounded-md border border-dashed border-(--border) bg-(--surface-0) px-4 text-center text-[12px] text-(--text-faint)"
+      >
+        No values in this window.
+      </div>
+    );
+  }
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className="flex h-44 flex-col justify-start gap-1.5 overflow-y-auto"
+    >
+      {rows.map((row) => {
+        const value = Math.max(0, row.value);
+        return (
+          <LinkedMark key={row.key} link={row.link}>
+            <div
+              data-share-row={row.key}
+              className={
+                row.link ? "cursor-pointer hover:opacity-80" : undefined
+              }
+            >
+              <div className="flex items-baseline justify-between gap-2 text-[11px]">
+                <span className="min-w-0 truncate text-(--text-dim)">
+                  {row.label}
+                </span>
+                <span className="mono shrink-0 tabular-nums text-(--text-dim)">
+                  {format(value)}
+                </span>
+              </div>
+              <div className="mt-0.5 h-2 overflow-hidden rounded-sm bg-(--surface-2)">
+                <div
+                  className="h-full rounded-sm"
+                  style={{
+                    width: `${(value / max) * 100}%`,
+                    background: row.hue,
+                  }}
+                />
+              </div>
+            </div>
+          </LinkedMark>
+        );
+      })}
+    </div>
+  );
+}
+
 export interface BandDatum {
   p50: number | null;
   p95: number | null;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -226,6 +226,7 @@ export interface MetricsView {
 
 export interface MetricsBreakdownView {
   window: MetricsWindow;
+  /** Dimension key: agent, adapter, model, repo, source, reason_code, event_type, edge. */
   by: string;
   metric: string;
   limit: number | null;

--- a/event-runtime/web/src/views/Metrics.test.tsx
+++ b/event-runtime/web/src/views/Metrics.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { Metrics, METRICS_WINDOW_KEY, metricsAreEmpty } from "./Metrics";
-import type { MetricsView } from "../types";
+import type { MetricsBreakdownView, MetricsView } from "../types";
 
 const populated: MetricsView = {
   window: "24h",
@@ -32,6 +32,28 @@ const populated: MetricsView = {
     "events.intake": { admitted: [2, 2] },
     "attempts.retries": { total: [0, 1] },
   },
+};
+
+const adapterBreakdown: MetricsBreakdownView = {
+  window: "24h",
+  by: "adapter",
+  metric: "runs",
+  limit: 8,
+  rows: [
+    { key: "claude", value: 3 },
+    { key: "pi", value: 1 },
+  ],
+};
+
+const modelBreakdown: MetricsBreakdownView = {
+  window: "24h",
+  by: "model",
+  metric: "tokens",
+  limit: 8,
+  rows: [
+    { key: "model-fixture-1", value: 250 },
+    { key: "gpt-4o", value: 50 },
+  ],
 };
 
 function emptyMetrics(): MetricsView {
@@ -85,7 +107,19 @@ beforeEach(() => {
   requests = [];
   response = Response.json(populated);
   globalThis.fetch = (async (input: RequestInfo | URL) => {
-    requests.push(String(input));
+    const url = String(input);
+    requests.push(url);
+    if (url.includes("/metrics/breakdown")) {
+      if (url.includes("by=adapter")) return Response.json(adapterBreakdown);
+      if (url.includes("by=model")) return Response.json(modelBreakdown);
+      return Response.json({
+        window: "24h",
+        by: "unknown",
+        metric: "runs",
+        limit: 8,
+        rows: [],
+      });
+    }
     return response.clone();
   }) as typeof fetch;
 });
@@ -102,6 +136,8 @@ describe("Metrics", () => {
     for (const section of ["Latency", "Spend", "Approval gate"]) {
       expect(view.getByRole("heading", { name: section })).toBeTruthy();
     }
+    expect(view.getByRole("heading", { name: "Harness share" })).toBeTruthy();
+    expect(view.getByRole("heading", { name: "Model share" })).toBeTruthy();
     const failed = view.getByRole("link", { name: /1 failed run in/i });
     expect(failed.getAttribute("href")).toContain("#/runs?");
     expect(failed.getAttribute("href")).toContain("population=terminal");
@@ -113,23 +149,46 @@ describe("Metrics", () => {
     ).toBe(true);
   });
 
-  test("Retry rate and Token volume share Outcome mix card geometry", async () => {
+  test("Retry rate and Token volume share Outcome mix card geometry as stacked bars", async () => {
     const view = renderMetrics();
     const outcome = await view.findByRole("img", { name: /Outcome mix:/ });
     const retry = view.getByRole("img", { name: /Retry rate by/ });
-    const tokens = view.getByRole("img", { name: /recorded tokens/ });
+    const tokens = view.getByRole("img", { name: /Token volume by agent/ });
     for (const chart of [outcome, retry, tokens]) {
       expect(chart.getAttribute("viewBox")).toBe("0 0 600 180");
       expect(chart.getAttribute("preserveAspectRatio")).toBe("none");
+      expect(chart.querySelector("polyline")).toBeNull();
+      expect(
+        chart.querySelectorAll("rect[data-segment]").length,
+      ).toBeGreaterThan(0);
     }
-    const retryLine = retry.querySelector("polyline");
-    expect(retryLine).toBeTruthy();
-    const xs = retryLine!
-      .getAttribute("points")!
-      .split(" ")
-      .map((point) => Number(point.split(",")[0]));
-    expect(xs[0]).toBe(4);
-    expect(xs.at(-1)).toBe(596);
+    const retried = view.getByRole("link", { name: /1 retried run in/i });
+    expect(retried.getAttribute("href")).toContain("population=retried");
+    const retryBar = retry.querySelector(
+      '[data-bar="2026-08-18T09:00:00.000Z"]',
+    );
+    expect(retryBar?.querySelector('[data-segment="retries"]')).toBeTruthy();
+    expect(retryBar?.querySelector('[data-segment="first"]')).toBeTruthy();
+  });
+
+  test("Harness and Model share cards render ranked bars with window drilldown", async () => {
+    const view = renderMetrics();
+    const harness = await view.findByRole("img", {
+      name: /Harness share by adapter/,
+    });
+    const models = await view.findByRole("img", {
+      name: /Model share of recorded tokens/,
+    });
+    expect(harness.querySelector('[data-share-row="claude"]')).toBeTruthy();
+    expect(
+      models.querySelector('[data-share-row="model-fixture-1"]'),
+    ).toBeTruthy();
+    const claude = view.getByRole("link", { name: "claude: 3" });
+    expect(claude.getAttribute("href")).toContain("population=created");
+    expect(claude.getAttribute("href")).toContain("adapter=claude");
+    const sonnet = view.getByRole("link", { name: "model-fixture-1: 250" });
+    expect(sonnet.getAttribute("href")).toContain("population=usage");
+    expect(sonnet.getAttribute("href")).toContain("model=model-fixture-1");
   });
 
   test("switches and persists the selected window", async () => {

--- a/event-runtime/web/src/views/Metrics.tsx
+++ b/event-runtime/web/src/views/Metrics.tsx
@@ -1,16 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import { fetchMetrics } from "../api";
+import { fetchMetrics, fetchMetricsBreakdown } from "../api";
 import {
   Band,
-  Sparkline,
+  ShareBars,
   StackedBars,
   type BandDatum,
   type ChartLink,
+  type ShareBarRow,
   type StackedBarDatum,
 } from "../components/Charts";
-import { SegmentMeter } from "./Overview";
-import type { MetricsView, MetricsWindow } from "../types";
+import type {
+  MetricsBreakdownView,
+  MetricsView,
+  MetricsWindow,
+} from "../types";
 
 export const METRICS_WINDOW_KEY = "evrt-metrics-window";
 const WINDOWS: MetricsWindow[] = ["1h", "24h", "7d", "30d"];
@@ -48,6 +52,12 @@ const DECISION_HUES: Record<string, string> = {
   expired: "var(--hue-warn)",
   superseded: "var(--hue-verify)",
 };
+const SERIES_HUES = [
+  "var(--hue-info)",
+  "var(--hue-verify)",
+  "var(--hue-ok)",
+  "var(--hue-warn)",
+] as const;
 
 function readWindow(): MetricsWindow {
   try {
@@ -103,6 +113,20 @@ function drilldown(
 ): string {
   const range = timeRange(data, index);
   const query = new URLSearchParams({ from: range.from, to: range.to });
+  for (const [key, value] of Object.entries(values))
+    if (value) query.set(key, value);
+  return `#/${view}?${query.toString()}`;
+}
+
+function windowDrilldown(
+  view: "runs",
+  data: MetricsView,
+  values: Record<string, string | undefined>,
+): string {
+  if (data.buckets.length === 0) return `#/${view}`;
+  const from = data.buckets[0]!;
+  const to = timeRange(data, data.buckets.length - 1).to;
+  const query = new URLSearchParams({ from, to });
   for (const [key, value] of Object.entries(values))
     if (value) query.set(key, value);
   return `#/${view}?${query.toString()}`;
@@ -193,6 +217,54 @@ function TimeAxis({ data }: { data: MetricsView }) {
       <span>{bucketLabel(data.buckets[0]!, data.window)}</span>
       <span>{bucketLabel(last, data.window)}</span>
     </div>
+  );
+}
+
+function BreakdownCard({
+  title,
+  value,
+  pending,
+  error,
+  rows,
+  label,
+  format,
+  caption,
+}: {
+  title: string;
+  value?: string;
+  pending: boolean;
+  error: boolean;
+  rows: ShareBarRow[];
+  label: string;
+  format?: (value: number) => string;
+  caption?: string;
+}) {
+  return (
+    <Card title={title} value={value}>
+      {pending ? (
+        <div
+          role="status"
+          className="flex h-44 items-center justify-center text-[12px] text-(--text-faint)"
+        >
+          Loading breakdown…
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex h-44 items-center justify-center px-4 text-center text-[12px]"
+          style={{ color: "var(--hue-err)" }}
+        >
+          Breakdown API unreachable
+        </div>
+      ) : (
+        <>
+          <ShareBars rows={rows} label={label} format={format} />
+          {caption ? (
+            <p className="mt-2 text-[11px] text-(--text-faint)">{caption}</p>
+          ) : null}
+        </>
+      )}
+    </Card>
   );
 }
 
@@ -309,12 +381,6 @@ function spendBars(data: MetricsView): StackedBarDatum[] {
   const agents = Object.keys(series).sort(
     (a, b) => sum(series[b]) - sum(series[a]),
   );
-  const hues = [
-    "var(--hue-info)",
-    "var(--hue-verify)",
-    "var(--hue-ok)",
-    "var(--hue-warn)",
-  ];
   return data.buckets.map((bucket, index) => ({
     key: bucket,
     label: bucketLabel(bucket, data.window),
@@ -324,7 +390,7 @@ function spendBars(data: MetricsView): StackedBarDatum[] {
         key: agent,
         label: agent,
         value,
-        hue: hues[agentIndex % hues.length]!,
+        hue: SERIES_HUES[agentIndex % SERIES_HUES.length]!,
         link:
           value > 0
             ? {
@@ -338,6 +404,106 @@ function spendBars(data: MetricsView): StackedBarDatum[] {
       };
     }),
   }));
+}
+
+function retryBars(data: MetricsView): StackedBarDatum[] {
+  const started = data.series["runs.started"]?.total ?? [];
+  const retries = data.series["attempts.retries"]?.total ?? [];
+  return data.buckets.map((bucket, index) => {
+    const startedCount = started[index] ?? 0;
+    const retryCount = retries[index] ?? 0;
+    const first = Math.max(0, startedCount - retryCount);
+    const label = bucketLabel(bucket, data.window);
+    return {
+      key: bucket,
+      label,
+      segments: [
+        {
+          key: "retries",
+          label: "retries",
+          value: retryCount,
+          hue: "var(--hue-warn)",
+          link:
+            retryCount > 0
+              ? {
+                  href: drilldown("runs", data, index, {
+                    population: "retried",
+                  }),
+                  label: `${retryCount} retried run${retryCount === 1 ? "" : "s"} in ${label}`,
+                }
+              : null,
+        },
+        {
+          key: "first",
+          label: "first attempts",
+          value: first,
+          hue: "var(--hue-ok)",
+          link:
+            first > 0
+              ? {
+                  href: drilldown("runs", data, index, {
+                    population: "started",
+                  }),
+                  label: `${first} first attempt${first === 1 ? "" : "s"} in ${label}`,
+                }
+              : null,
+        },
+      ],
+    };
+  });
+}
+
+function tokenBars(data: MetricsView): StackedBarDatum[] {
+  const series = data.series["spend.tokens"] ?? {};
+  const agents = Object.keys(series).sort(
+    (a, b) => sum(series[b]) - sum(series[a]),
+  );
+  return data.buckets.map((bucket, index) => ({
+    key: bucket,
+    label: bucketLabel(bucket, data.window),
+    segments: agents.map((agent, agentIndex) => {
+      const value = series[agent]?.[index] ?? 0;
+      return {
+        key: agent,
+        label: agent,
+        value,
+        hue: SERIES_HUES[agentIndex % SERIES_HUES.length]!,
+        link:
+          value > 0
+            ? {
+                href: drilldown("runs", data, index, {
+                  population: "usage",
+                  agent,
+                }),
+                label: `${new Intl.NumberFormat().format(value)} tokens by ${agent} in ${bucketLabel(bucket, data.window)}`,
+              }
+            : null,
+      };
+    }),
+  }));
+}
+
+function shareRows(
+  breakdown: MetricsBreakdownView | undefined,
+  data: MetricsView,
+  population: "created" | "usage",
+  dimension: "adapter" | "model",
+): ShareBarRow[] {
+  return (breakdown?.rows ?? [])
+    .filter((row) => row.value > 0)
+    .map((row, index) => ({
+      key: row.key,
+      label: row.key,
+      value: row.value,
+      hue: SERIES_HUES[index % SERIES_HUES.length]!,
+      link: {
+        href: windowDrilldown("runs", data, {
+          population,
+          [dimension]: row.key,
+        }),
+        label: `${row.key}: ${row.value}`,
+      },
+    }));
 }
 
 function bandValues(
@@ -382,6 +548,21 @@ export function Metrics() {
   }, [window]);
 
   const data = query.data;
+  const chartsReady = query.isSuccess && data != null && !metricsAreEmpty(data);
+  const adapterQuery = useQuery({
+    queryKey: ["metrics-breakdown", window, "adapter", "runs"],
+    queryFn: () => fetchMetricsBreakdown(window, "adapter", "runs", 8),
+    enabled: chartsReady,
+    refetchInterval: 30_000,
+    retry: false,
+  });
+  const modelQuery = useQuery({
+    queryKey: ["metrics-breakdown", window, "model", "tokens"],
+    queryFn: () => fetchMetricsBreakdown(window, "model", "tokens", 8),
+    enabled: chartsReady,
+    refetchInterval: 30_000,
+    retry: false,
+  });
   const derived = useMemo(() => {
     if (!data) return null;
     const outcomes = OUTCOMES.map((state) => ({
@@ -396,17 +577,6 @@ export function Metrics() {
     }));
     const started = sum(data.series["runs.started"]?.total);
     const retries = sum(data.series["attempts.retries"]?.total);
-    const retryRate = data.buckets.map((_, index) => {
-      const denominator = data.series["runs.started"]?.total?.[index] ?? 0;
-      const numerator = data.series["attempts.retries"]?.total?.[index] ?? 0;
-      return denominator === 0 ? 0 : (numerator / denominator) * 100;
-    });
-    const tokens = data.buckets.map((_, index) =>
-      Object.values(data.series["spend.tokens"] ?? {}).reduce(
-        (total, values) => total + (values[index] ?? 0),
-        0,
-      ),
-    );
     const agents = Object.entries(data.series["spend.cost"] ?? {})
       .map(([agent, values]) => ({
         label: agent,
@@ -415,14 +585,35 @@ export function Metrics() {
       .sort((a, b) => b.value - a.value)
       .map((item, index) => ({
         ...item,
-        hue: [
-          "var(--hue-info)",
-          "var(--hue-verify)",
-          "var(--hue-ok)",
-          "var(--hue-warn)",
-        ][index % 4]!,
+        hue: SERIES_HUES[index % SERIES_HUES.length]!,
       }));
-    return { outcomes, decisions, started, retries, retryRate, tokens, agents };
+    const tokenAgents = Object.entries(data.series["spend.tokens"] ?? {})
+      .map(([agent, values]) => ({
+        label: agent,
+        value: sum(values),
+      }))
+      .sort((a, b) => b.value - a.value)
+      .map((item, index) => ({
+        ...item,
+        hue: SERIES_HUES[index % SERIES_HUES.length]!,
+      }));
+    const tokens = sum(
+      data.buckets.map((_, index) =>
+        Object.values(data.series["spend.tokens"] ?? {}).reduce(
+          (total, values) => total + (values[index] ?? 0),
+          0,
+        ),
+      ),
+    );
+    return {
+      outcomes,
+      decisions,
+      started,
+      retries,
+      agents,
+      tokenAgents,
+      tokens,
+    };
   }, [data]);
 
   return (
@@ -501,7 +692,7 @@ export function Metrics() {
           <>
             <Section
               title="Reliability"
-              description="Terminal outcome mix and retries per run start. Every mark opens the exact bucket population."
+              description="Terminal outcome mix, retries per run start, and harness share. Every mark opens the matching run population."
             >
               <Card
                 title="Outcome mix"
@@ -522,40 +713,37 @@ export function Metrics() {
                     : "—"
                 }
               >
-                <Sparkline
-                  values={derived.retryRate}
+                <StackedBars
+                  bars={retryBars(data)}
                   label={`Retry rate by ${data.bucket} bucket; ${derived.retries} retries across ${derived.started} starts`}
-                  hue="var(--hue-warn)"
-                  linkForPoint={(index, value) => ({
-                    href: drilldown("runs", data, index, {
-                      population: "retried",
-                    }),
-                    label: `${value.toFixed(1)}% retry rate in ${bucketLabel(data.buckets[index]!, data.window)}`,
-                  })}
                 />
                 <TimeAxis data={data} />
-                <div className="mt-4">
-                  <SegmentMeter
-                    segments={[
-                      {
-                        key: "retry",
-                        label: "Retries",
-                        value: derived.retries,
-                        hue: "var(--hue-warn)",
-                      },
-                      {
-                        key: "first",
-                        label: "First attempts",
-                        value: Math.max(0, derived.started - derived.retries),
-                        hue: "var(--hue-ok)",
-                      },
-                    ]}
-                  />
-                  <p className="mt-2 text-[11px] text-(--text-faint)">
-                    {derived.retries} retries · {derived.started} run starts
-                  </p>
-                </div>
+                {legend([
+                  {
+                    label: "retries",
+                    value: derived.retries,
+                    hue: "var(--hue-warn)",
+                  },
+                  {
+                    label: "first attempts",
+                    value: Math.max(0, derived.started - derived.retries),
+                    hue: "var(--hue-ok)",
+                  },
+                ])}
               </Card>
+              <BreakdownCard
+                title="Harness share"
+                value={`${new Intl.NumberFormat().format(adapterQuery.data?.rows.reduce((total, row) => total + row.value, 0) ?? derived.started)} runs`}
+                pending={adapterQuery.isPending}
+                error={adapterQuery.isError}
+                rows={shareRows(adapterQuery.data, data, "created", "adapter")}
+                label={`Harness share by adapter: ${
+                  (adapterQuery.data?.rows ?? [])
+                    .map((row) => `${row.value} ${row.key}`)
+                    .join(", ") || "none"
+                }`}
+                caption="Runs in this window grouped by adapter (claude, pi, cursor, …)"
+              />
             </Section>
 
             <Section
@@ -596,7 +784,7 @@ export function Metrics() {
 
             <Section
               title="Spend"
-              description="Recorded cost and token volume by agent. Click through to runs with usage recorded in that bucket."
+              description="Recorded cost, token volume, and model share. Click through to runs with usage recorded in that bucket."
             >
               <Card
                 title="Cost by agent"
@@ -613,25 +801,36 @@ export function Metrics() {
               </Card>
               <Card
                 title="Token volume"
-                value={new Intl.NumberFormat().format(sum(derived.tokens))}
+                value={new Intl.NumberFormat().format(derived.tokens)}
               >
-                <Sparkline
-                  values={derived.tokens}
-                  label={`${new Intl.NumberFormat().format(sum(derived.tokens))} recorded tokens across the window`}
-                  hue="var(--hue-info)"
-                  linkForPoint={(index, value) => ({
-                    href: drilldown("runs", data, index, {
-                      population: "usage",
-                    }),
-                    label: `${new Intl.NumberFormat().format(value)} tokens in ${bucketLabel(data.buckets[index]!, data.window)}`,
-                  })}
+                <StackedBars
+                  bars={tokenBars(data)}
+                  label={`Token volume by agent: ${derived.tokenAgents.map((item) => `${item.label} ${new Intl.NumberFormat().format(item.value)}`).join(", ") || "none"}`}
                 />
                 <TimeAxis data={data} />
-                <p className="mt-4 text-[11px] text-(--text-faint)">
-                  Input, output, cache creation, and cache-read tokens recorded
-                  by the runtime
-                </p>
+                {legend(derived.tokenAgents, (value) =>
+                  new Intl.NumberFormat().format(value),
+                )}
               </Card>
+              <BreakdownCard
+                title="Model share"
+                value={new Intl.NumberFormat().format(
+                  modelQuery.data?.rows.reduce(
+                    (total, row) => total + row.value,
+                    0,
+                  ) ?? derived.tokens,
+                )}
+                pending={modelQuery.isPending}
+                error={modelQuery.isError}
+                rows={shareRows(modelQuery.data, data, "usage", "model")}
+                label={`Model share of recorded tokens: ${
+                  (modelQuery.data?.rows ?? [])
+                    .map((row) => `${row.key} ${row.value}`)
+                    .join(", ") || "none"
+                }`}
+                format={(value) => new Intl.NumberFormat().format(value)}
+                caption="Token volume grouped by observed or pinned model"
+              />
             </Section>
 
             <Section


### PR DESCRIPTION
## Summary
- Metrics Reliability now includes **Harness share** (`GET /metrics/breakdown?by=adapter&metric=runs`) and Spend includes **Model share** (`by=model&metric=tokens`).
- Retry Rate and Token Volume no longer use thin sparklines: both are full-card `StackedBars` (retries vs first attempts; tokens by agent) matching Outcome mix geometry, with existing population drilldowns.
- Follow-ups filed: WM-960 (token-kind input/output/cache-read series in `metrics.mjs`) and WM-961 (Runs list should honor `adapter=` / `model=` query params).

Fixes WM-883

UX critique: required — SHIP

## Test plan
- [ ] Open `#/metrics`, confirm Retry Rate and Token Volume fill the card like Outcome mix (no polyline sparkline)
- [ ] Confirm Harness share and Model share cards; click a retry segment and land on `#/runs?population=retried`
- [ ] Switch 1h / 24h / 7d / 30d; empty window still withholds charts; unreachable API still alerts
- [ ] `cd event-runtime/web && bun test src/views/Metrics.test.tsx && bun run build`


Made with [Cursor](https://cursor.com)