### PR TITLE
docs(oss): add ADOPTERS.md template and PACKS.md directory (WM-956)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,68 @@
+# Adopters
+
+There is no telemetry. If you run Factory in production, or ship a product
+that depends on it, add yourself here. The list is the public adoption
+signal, together with GitHub Discussions.
+
+Entries are added by pull request against `develop`. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, commit style, and the CLA.
+
+## Who belongs on this list
+
+- **Organizations** running Factory against one or more product repositories
+  (internal or public).
+- **Open-source projects** whose maintainers use Factory to admit, verify,
+  and merge work.
+
+Do not list a confidential or unreleased use. If you cannot name the
+organization or project in public, do not open a PR. A listing is a public
+claim that you use Factory, not a private reference.
+
+## Required fields
+
+Every row must include:
+
+| Field        | Meaning                                                                 |
+| :----------- | :---------------------------------------------------------------------- |
+| **Name**     | Organization or project name, as you want it shown                      |
+| **Homepage** | Public URL (site, GitHub org, or canonical repository)                  |
+| **Kind**     | `organization` or `open-source project`                                 |
+| **Use**      | One sentence: what Factory does for you (wedge, pack, or control plane) |
+
+Optional: a public pack or extension you ship, linked from [PACKS.md](PACKS.md).
+
+Do not add logos, marketing copy, or more than one sentence of description.
+Do not include personal contact details.
+
+## How to add yourself
+
+1. Fork the repository and branch from `develop`.
+2. Add **one new row** to the table below. Keep the table sorted
+   alphabetically by **Name** (ASCII, case-insensitive).
+3. Use the template. Do not reformat other rows.
+4. Open a pull request titled `docs(adopters): add <Name>`.
+5. Sign the CLA when the check asks; see [CLA.md](CLA.md).
+
+A listing PR should touch only this file. Reviewers check that the homepage
+resolves, the kind is one of the two values above, and the use sentence is
+specific (not "we use Factory").
+
+### Row template
+
+Copy this into the table, then fill the three cells:
+
+```markdown
+| [Name](https://example.com) | organization | One sentence about how you use Factory. |
+```
+
+The table's columns are **Name**, **Kind**, **Use**. Put the homepage on the
+name, not in a fourth column.
+
+## Adopters
+
+| Name                                      | Kind         | Use                                                                              |
+| :---------------------------------------- | :----------- | :------------------------------------------------------------------------------- |
+| [Watt Mind](https://github.com/watt-mind) | organization | Runs Factory against this repository: tickets become isolated worktrees and PRs. |
+
+If you are the first external adopter, replace nothing — insert your row so
+the table stays alphabetical.

--- a/PACKS.md
+++ b/PACKS.md
@@ -1,0 +1,86 @@
+# Packs
+
+A **pack** is the unit an adopter ships a loop in: pinned agents, schemas,
+event types, edges, and schedules. A pack is a directory with `pack.json`.
+It is allow-listed, never discovered by scanning the disk.
+
+This file is the public directory of official first-party packs and of
+community packs that have been listed here by pull request. It is an index,
+not an installer and not a marketplace. Enabling a pack on a running factory
+is still an operator choice in `config/policy.yaml` (or via an
+[extension](docs/extensions.md)).
+
+The format and admission rules live in
+[`docs/kernel-and-packs.md`](docs/kernel-and-packs.md). The install unit that
+can wrap a pack with adapters, config, hooks, and panels is documented in
+[`docs/extensions.md`](docs/extensions.md).
+
+## Official first-party packs
+
+These are Watt Mind packs. They are the launch proof that the runtime is not
+only a software factory. In-tree copies land under `packs/` with the pack
+authoring kit (`factory pack init` / `validate`, and `docs/packs.md`).
+
+| Pack            | Path                  | What it is                                                                                     |
+| :-------------- | :-------------------- | :--------------------------------------------------------------------------------------------- |
+| `example-hello` | `packs/example-hello` | Smallest valid first-party pack. A namespaced hello-world loop for authoring and admission.    |
+| `ops-disk`      | `packs/ops-disk`      | First-party ops loop (disk / host operations). Proof that a shipped loop is not only software. |
+
+First-party packs follow the same loader rules as every other pack: a
+non-empty namespace, content hashes in `pins.json`, no `mutating: true`
+agents, and no override of kernel or earlier-pack content.
+
+Until those directories exist in the tree, treat the rows as the reserved
+names. Do not publish a community pack under either name.
+
+## Community packs
+
+Community packs are listed here so adopters can find them. A row in this
+table is a directory entry, not an endorsement of safety, and not an
+allow-list on anyone else's factory.
+
+| Pack               | Publisher | Source | What it is |
+| :----------------- | :-------- | :----- | :--------- |
+| _None listed yet._ |           |        |            |
+
+### Required fields
+
+Every community row must include:
+
+| Field          | Meaning                                                                  |
+| :------------- | :----------------------------------------------------------------------- |
+| **Pack**       | Pack `name` from `pack.json`, matching `^[a-z0-9-]+$`                    |
+| **Publisher**  | Person or organization that maintains it                                 |
+| **Source**     | Public repository URL (the pack root, or the extension that contains it) |
+| **What it is** | One sentence: the loop it ships                                          |
+
+The pack name must not collide with a first-party name (`example-hello`,
+`ops-disk`) or with another listed community pack.
+
+### How to list a community pack
+
+1. Publish the pack in a public repository. It must load as a filesystem
+   pack (`pack.json`, `pins.json`, agents, schemas) or as a pack contributed
+   by a `factory-extension.json`. See
+   [`docs/kernel-and-packs.md`](docs/kernel-and-packs.md) and
+   [`docs/extensions.md`](docs/extensions.md).
+2. Confirm it admits: non-empty namespace, pins match file bytes, no
+   `mutating: true` agent, no attempt to own the kernel's bare namespace.
+3. Fork this repository, branch from `develop`, and add **one new row** to
+   the community table, sorted alphabetically by **Pack**.
+4. Open a pull request titled `docs(packs): list <pack-name>`. Sign the CLA
+   when asked ([CLA.md](CLA.md)). Follow
+   [CONTRIBUTING.md](CONTRIBUTING.md).
+
+A listing PR should touch only this file. Reviewers check that the source URL
+resolves, that a `pack.json` (or extension manifest that contributes a pack)
+is visible, and that the name does not collide.
+
+Listing a pack here does **not**:
+
+- add it to this repository's `config/policy.yaml`;
+- grant it a mutating tier (that admission model is a later design);
+- place it on a hosted marketplace (`ee/` / hosted, not this file).
+
+If you want a first-party pack, or a pack vendored under `packs/` in this
+repository, open an issue first. Do not send the pack tree in a listing PR.


### PR DESCRIPTION
## Summary

- Add `ADOPTERS.md` as the public adoption signal: add-via-PR rules, required fields, row template, and a seeded Watt Mind row.
- Add `PACKS.md` as the public pack directory: official first-party packs (`example-hello`, `ops-disk`) plus community listing instructions.
- In-tree pack trees remain WM-845; this ticket only owns the two root documents.

## Related issue

Fixes WM-956

Follow-up (out of Owned Paths): WM-964 — link these files from the README Docs table.

## Verification

```text
test -s ADOPTERS.md && test -s PACKS.md && npx prettier --check ADOPTERS.md PACKS.md
# prettier: All matched files use Prettier code style!

bun test
# 3404 pass, 9 skip, 0 fail

bun build/emit.mjs --check
# ok — 90 generated files match shared/
```

## Risk and impact

- [x] This change is narrowly scoped to the linked issue.
- [x] I added or updated tests for behavior changes, or explained why no test is needed.
- [x] I updated documentation for user- or operator-visible behavior.
- [x] I regenerated emitted files when changing `shared/` and ran `bun run check`.
- [x] I considered security and privacy impact and did not include credentials or private data.
- [x] I identified compatibility, migration, or rollback concerns below.

Docs-only. No code, schema, or policy change. First-party pack names are reserved in the index until `packs/` lands.

## UX critique

UX critique: skipped — docs-only; no user-completable flow.

## Contributor statement

- [x] I have read and agree to follow `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
- [x] I have the right to submit this work under Apache License 2.0.
- [x] I have completed a Contributor License Agreement if a maintainer or check requested one.

Made with [Cursor](https://cursor.com)