### PR TITLE
docs(event-runtime): specify Layer C canvas artifacts (WM-847)

### DIFF
--- a/docs/event-runtime-artifact-views.md
+++ b/docs/event-runtime-artifact-views.md
@@ -1,8 +1,10 @@
 # Event runtime: readable agent output — artifact views and presentations
 
-Status: **design — operator-ratified, nothing built**. Tracking: WM-452
-(epic); WM-453 (this document); implementation lands through the ticket map in
-§6. Companion to [event-runtime.md](event-runtime.md) §9 (verification — the
+Status: **design — operator-ratified, nothing built** (Layers A–B, WM-452 /
+WM-453). §4 Layer C (WM-847) is design, awaiting the same ratification before
+its implementation tickets are filed. Tracking: WM-452 (epic); WM-453 (this
+document); WM-847 (Layer C). Implementation lands through the ticket map in
+§7. Companion to [event-runtime.md](event-runtime.md) §9 (verification — the
 artifact this renders is the one that verification accepted) and to
 [event-runtime-inbox.md](event-runtime-inbox.md), whose decision requests use
 the same principle and, later, the same block vocabulary.
@@ -26,7 +28,7 @@ way — a closed vocabulary the agent (or the schema author) fills, a generic
 renderer that owns layout — but with a different split, because here the
 artifact already exists and must remain the only source of truth.
 
-Two layers, built in this order:
+Three layers, built in this order:
 
 - **Layer A — derive the view from the output schema.** No per-run authoring,
   no tokens. A sidecar file annotates paths in the agent's output schema with
@@ -40,6 +42,12 @@ Two layers, built in this order:
   inline text or **pointers into the artifact** — the narrative has to point
   at its evidence. Rendered by one block renderer that never sees the agent's
   name.
+- **Layer C — an optional agent-emitted canvas.** For runs where the finding
+  is a _shape_ (a failure's causal chain, a spend curve), the agent may emit
+  one content-addressed drawing — Markdown, Mermaid, or SVG — stored beside
+  the artifact, never as chain input. Layer A and B stay the evidence layer;
+  the canvas is the picture. Sandboxed HTML is a later contract
+  (`factory.canvas-html/v1`), not this one. §4.
 
 Out of scope, said out loud:
 
@@ -47,12 +55,17 @@ Out of scope, said out loud:
   Malleability comes from _composing_ a few blocks, not from an open schema —
   a renderer that draws whatever it is sent cannot be tested, and "malleable
   enough for anything" is how fifteen slightly different tables happen.
-- **Presentation as chain input.** Downstream agents keep reading the
-  artifact. If a chain edge ever consumed the presentation there would be two
-  sources of truth, and the agent would start optimising the story instead
-  of the data.
+  Layer C does not reopen this: it is three media types with a sanitizer, not
+  a component system.
+- **Presentation or canvas as chain input.** Downstream agents keep reading
+  the typed artifact. If a chain edge ever consumed the presentation or the
+  drawing there would be two sources of truth, and the agent would start
+  optimising the story instead of the data.
 - **Replacing the raw view.** JSON stays one click away on every surface.
 - **`x-ui` inside the output schema.** §2.3 says why.
+- **Interactive canvas controls.** A drawing that _does_ something (approve,
+  requeue, filter that mutates factory state) is a decision request, not a
+  canvas — it lives in the inbox design. §4.6.
 
 ---
 
@@ -469,7 +482,7 @@ Presentation is worth tokens only on **human-facing terminal outputs**: scans
 chain, not by people; they do not emit one. It is optional everywhere and
 opt-in per brief.
 
-The pilot is `triage-scan` alone (§6). After a week of real runs, compare the
+The pilot is `triage-scan` alone (§7). After a week of real runs, compare the
 Layer B summary against the Layer A table on the same runs and decide whether
 to roll the brief section to the other scans. The measure is blunt and
 honest: does the operator open the raw view less.
@@ -485,38 +498,293 @@ already does that.
 
 ---
 
-## 4. Relationship to the inbox design
+## 4. Layer C — canvas artifacts
 
-Same principle, different split:
+The human ask: "Could we create canvas-like artifacts and render them in some
+cases?" — richer, drawn output in the control tower, in the spirit of Claude
+Artifacts / ChatGPT canvas.
 
-|                                       | Inbox (WM-383)               | Artifact views (WM-452)             |
-| :------------------------------------ | :--------------------------- | :---------------------------------- |
-| What the agent authors                | the question and the options | the summary and the pointers        |
-| What the runtime owns                 | the effects (verbs)          | the artifact (truth) and the layout |
-| Fallback when the agent's part is bad | default template per kind    | Layer A schema-derived view         |
-| Fail-closed on                        | the effect                   | the artifact and every `$ref`       |
-| Never                                 | agent-invented effects       | presentation as chain input         |
+Layers A and B are tables, badges, and bounded blocks. They are the right
+shape for a triage plan and a merge verdict. They are the wrong shape for
+"here is the causal chain of this failure" or "here is where the day's
+context burn went." Those findings are pictures. Layer C is the picture:
+one agent-produced document per result, three media types, stored
+content-addressed, never consumed by the next agent, with the typed JSON
+still one click away.
 
-Layer B's `format`/`tone` and, later, its blocks are shared with the inbox's
-`DecisionCard`; the two designs are meant to converge on one renderer per
-surface.
+This section is design (WM-847). It is not operator-ratified with the rest of
+this document. Implementation tickets in §7.2 wait on that ratification.
+
+### 4.1 The contract — `factory.canvas/v1`
+
+An optional `canvas` in `result.json`, beside `artifact`, exactly as
+`presentation` sits beside `artifact` (§3.1) and `decision` sits beside
+`reasonCode`. The envelope is metadata; the body is a **collected file
+artifact** (`kind: "canvas"`) copied into `<home>/artifacts/<sha256>` at
+publish time, the same store transcripts and reports already use
+(event-runtime.md §7). Identical drawings collapse to one object; a result
+row never references bytes that died with the workspace.
+
+```json
+{
+  "schemaVersion": "factory.canvas/v1",
+  "title": "How this run failed",
+  "kind": "markdown",
+  "sha256": "a1b2c3d4e5f6…",
+  "bytes": 2340,
+  "mediaType": "text/markdown"
+}
+```
+
+The agent writes the body as a workspace file and declares it:
+
+```json
+{
+  "artifacts": [{ "kind": "canvas", "path": "canvas.md" }]
+}
+```
+
+Verification hashes the file and checks the envelope: it fills `sha256` /
+`bytes` when omitted, and rejects (via the §4.3 tolerant path, not a failed
+run) when they are present and disagree, when the envelope has no matching
+`kind: "canvas"` file, or when a `kind: "canvas"` file has no envelope.
+
+| Key             | Rule                                                                                                                                             |
+| :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion` | `factory.canvas/v1`.                                                                                                                             |
+| `title`         | Optional, ≤ 80 chars; falls back to the agent's output-schema title.                                                                             |
+| `kind`          | Closed: `markdown` \| `mermaid` \| `svg`. One kind per canvas.                                                                                   |
+| `sha256`        | 64 hex chars, the store key of the body bytes. Verification computes it; an agent-supplied value that does not match the file fails.             |
+| `bytes`         | Byte length of the body. Must equal the file.                                                                                                    |
+| `mediaType`     | Derived from `kind`, not authored: `text/markdown`, `text/vnd.mermaid`, `image/svg+xml`. An authored value that disagrees is a validation error. |
+
+One canvas per result. Composition inside a `markdown` canvas is fences, not
+a parts array: at most **four** mermaid fences and at most **two** svg
+fences (info strings `mermaid` and `svg`); each fenced body is held to the
+same source limits as a standalone canvas of that kind (§4.2). A `mermaid`
+or `svg` canvas is the source itself — no wrapping markdown.
+
+`canvas` is **not** part of `artifactHash`. The typed artifact remains the
+chain's truth. The file is content-addressed on its own, like a transcript.
+`additionalProperties: false` on the envelope.
+
+### 4.2 Renderer constraints
+
+The renderer is generic and never branches on the agent name. It draws three
+media types. Everything else is dropped at verify.
+
+**Markdown** (`kind: "markdown"`). CommonMark + GFM tables and strikethrough.
+Headings, lists, quotes, fenced code, links whose scheme is `http`, `https`,
+or `mailto` (plus the existing issue / pr / run chip matchers the rest of
+the UI already uses). **No raw HTML** — today's `MarkdownView`
+(`web/src/components/RunTrace.tsx`) already tokenizes to React nodes rather
+than interpreting markup, and Layer C extends that parser; it does not add a
+markdown-to-HTML pipeline. No images from URLs. No task lists (they look
+like controls). Body ≤ 64 KiB UTF-8.
+
+**Mermaid** (`kind: "mermaid"`, and mermaid fences inside markdown). Source
+≤ 16 KiB. Allowed diagrams, closed: `flowchart`, `sequence`, `state`,
+`pie`, `xychart`, `gantt`, `timeline` — the set a postmortem and an
+economics chart actually need. Render with `securityLevel: "strict"` and
+`htmlLabels: false`. Source must not contain `click`, `javascript:`, or
+HTML tags; verification rejects the canvas rather than stripping silently,
+so a brief that taught the agent to put a link-on-node is a visible
+contract miss, not a quietly dead click. Mermaid runs in the web client
+only (code-split, same as `@xyflow/react`); `lib/` never needs a DOM.
+The rendered SVG is passed through the SVG sanitizer before it touches
+the DOM, so a future mermaid that emits a `<script>` still does not run.
+
+**SVG** (`kind: "svg"`, and svg fences inside markdown). Source ≤ 64 KiB.
+`viewBox` required; rendered box ≤ 2000×2000. Element allowlist: `svg`,
+`g`, `path`, `circle`, `ellipse`, `rect`, `line`, `polyline`, `polygon`,
+`text`, `tspan`, `title`, `desc`, `defs`, `clipPath`, `linearGradient`,
+`radialGradient`, `stop`, `use` (same-document `#fragment` href only).
+Attribute allowlist: geometric and paint properties (`d`, `cx`, `fill`,
+`stroke`, `viewBox`, `transform`, …) plus `style` whose declarations are
+themselves allow-listed (`fill`, `stroke`, `stroke-width`, `opacity`,
+`font-size`, `font-family` from the UI's own stack, `transform`). Forbidden,
+fail closed: `script`, `foreignObject`, `image`, `iframe`, `animate`,
+`set`, `handler`, `listener`, `style` with `url(` or `expression(`, any
+`on*` event attribute, `href` / `xlink:href` other than a same-document
+fragment. No external fonts, images, or fetches.
+
+**No scripts, no iframe, no network from the canvas.** That is the v1
+security boundary, not a default that HTML later relaxes in place.
+
+### 4.3 Security boundary and verification
+
+Defense in depth, in this order:
+
+1. **Schema and kind allowlist** at verify, before the store. Unknown
+   `kind`, oversize body, mermaid source with `click` / HTML, SVG that
+   fails the allowlist → `result.canvasErrors[]`, `canvas` absent. The
+   run **still completes** — same tolerant path as presentation (§3.3).
+   A run whose typed artifact passed must not fail because its drawing
+   was badly formed. The renderer shows Layers A/B with a one-line notice
+   ("the agent's canvas was dropped: N errors") and the errors in a
+   disclosure.
+2. **Sanitizer in `lib/`** (pure, no DOM) for SVG; mermaid source checks
+   as (1). The bytes that enter the store have already passed.
+3. **Store and `GET /artifacts/:hash`.** Canvas kinds are served with
+   `Content-Type` matching the derived `mediaType`,
+   `X-Content-Type-Options: nosniff`, and
+   `Content-Security-Policy: default-src 'none'`. The web app never
+   navigates to the artifact as a document; it fetches bytes and draws
+   them. A browser that does open the URL gets nothing executable.
+4. **Renderer.** Markdown tokenizes to React nodes. Mermaid output is
+   sanitized SVG. SVG is parsed against the allowlist again, so a store
+   object written before a sanitizer tightening still cannot grow a
+   `<script>`.
+5. **Never chain input.** `kind: "canvas"` is not a legal mapping source
+   for a chain edge (registry refuses it at load, the way edges already
+   refuse anything that is not the source run's `input` or `artifact`).
+   Downstream agents keep reading the typed artifact. The drawing is not
+   a second source of truth.
+
+`canvas` is stored on the run result (`results.result_json`) next to
+`presentation`; the file lives in the artifact store. It is not part of
+the receipt's evidence set.
+
+### 4.4 Rendering surfaces
+
+- **Web** — a `CanvasPanel` above Layer B in run detail and on the
+  Artifacts view when a canvas survived verify. Same **Raw** toggle the
+  other layers have (source markdown / mermaid / SVG). The typed artifact's
+  JSON remains one click away, unchanged — Raw on the canvas is the
+  drawing's source, not a substitute for the artifact. The panel never
+  branches on the agent name.
+- **CLI** — `cli.mjs inspect <runId>` prints `title` and, for markdown /
+  mermaid, the source as text. SVG prints `title` plus
+  `(svg N bytes, open in web)` — a terminal is not a drawing surface.
+- **Not Telegram, not DecisionCard.** Those stay on Layer B's blocks
+  (§3.4). A canvas that cannot linearise honestly is not stuffed into a
+  4 KiB push.
+
+### 4.5 First adoption
+
+Two targets, both already in the runtime's world, both whose useful output
+is a shape rather than a table.
+
+**`run-postmortem`.** The agent exists; Layer A already draws
+`category` / `whatHappened` / `operatorAction` as prose and a badge
+(`agents/run-postmortem.view.json`). The canvas is the causal picture the
+prose is describing: a mermaid `sequence` or `flowchart` of agent → tool →
+error → category, optionally wrapped in markdown whose heading is the
+one-sentence finding. The typed artifact does not grow a diagram field —
+the drawing is the canvas, the claims stay in `whatHappened` /
+`evidenceLines`. A dropped canvas still leaves a readable Layer A view,
+which is the whole point of the tolerant path. Pilot because operators
+already open these runs to understand a graph, and because a bad drawing
+must not fail a postmortem whose artifact passed.
+
+**Economics.** `orchestrator/economics.mjs --json` is the data (totals,
+per-harness, per-stage, context-burn, cache read:write). There is no
+event-runtime agent today; the CLI stays the calculator. The canvas is not
+a second calculator. The adoption path is a thin **command-result** agent
+(`economics-report`) that runs that CLI, puts the JSON object in the typed
+artifact (Layer A tables already know how to draw totals), and emits a
+canvas of the _story_ — mermaid `xychart` or SVG of context-burn by stage,
+markdown one-liner for the cache verdict ("prefix keeps invalidating").
+Teaching `factory-status-report` to draw this is rejected: that agent
+already has a job. A purely deterministic SVG generated from `--json`
+without an agent would be Layer A (a new `as: chart` hint), not Layer C;
+if the numbers-as-a-bar-chart is enough, that is a different ticket and
+Layer C stays unused on economics, which is a fine outcome.
+
+### 4.6 Deferred — `factory.canvas-html/v1`
+
+Sandboxed HTML, later. A separate contract, not an extension of
+`factory.canvas/v1`'s `kind` enum: HTML is a different trust model, and
+mixing it into v1 would silently expand the v1 sanitizer's job.
+
+The sketch, so the follow-up does not relitigate the shape:
+
+- Body is still a collected file artifact, still content-addressed, still
+  never chain input, still JSON one click away.
+- Rendered in an `<iframe>` with `sandbox` **without**
+  `allow-same-origin` (so even `allow-scripts`, if later granted, cannot
+  touch the parent origin or the control API). `srcdoc` or a blob URL
+  from the sanitized bytes — never a `src` to `/artifacts/:hash` that
+  would put the artifact origin in play.
+- CSP on the iframe: `default-src 'none'; img-src data:; style-src 'unsafe-inline'`
+  at most. No network. No `postMessage` protocol that mutates factory
+  state.
+- Size cap in the same order as SVG (64 KiB). No `<script src>`, no
+  inline event handlers; if scripts earn themselves they are a later
+  tightening of _this_ contract, not a hole in v1.
+
+**Why interactive controls are deferred — and stay deferred even when HTML
+ships.** A control that changes factory state (approve, requeue, retry,
+decide) is an inbox verb (event-runtime-inbox.md). Putting it inside a
+drawing would be a second, untyped mutation surface the runtime cannot
+audit. A canvas may _depict_ a decision; it may not _be_ one. The same
+rule already sits in §6 for Layer B blocks. HTML does not punch through
+it. The first HTML canvas that wants a button to approve a proposal is
+the signal to put a `links` block or a decision request next to the
+canvas, not a `postMessage` into `cli.mjs`.
+
+HTML earns itself when an adoption target needs a drawing mermaid and SVG
+cannot express (a filterable, read-only explainer). Until then the
+iframe, the origin isolation, and the script question stay unbuilt.
+
+### 4.7 Who emits it, and the cost
+
+Canvas is worth tokens only when the finding is a shape. The two pilots
+in §4.5 are the test. Scans with tabular plans stay on Layers A and B;
+`*-apply` agents still emit nothing a person reads. Optional everywhere,
+opt-in per brief, same as presentation.
+
+A shared brief clause, when the pilots land: one document, one kind;
+put claims you want trusted in the typed artifact, not in the drawing;
+stay under the bounds; if mermaid is enough do not emit SVG; never
+restate the Layer A table as a picture of the same rows.
 
 ---
 
-## 5. What is deliberately not decided here
+## 5. Relationship to the inbox design
+
+Same principle, different split:
+
+|                                       | Inbox (WM-383)               | Artifact views (WM-452)                              |
+| :------------------------------------ | :--------------------------- | :--------------------------------------------------- |
+| What the agent authors                | the question and the options | the summary, the pointers, and (Layer C) the drawing |
+| What the runtime owns                 | the effects (verbs)          | the artifact (truth), the layout, and the sanitizer  |
+| Fallback when the agent's part is bad | default template per kind    | Layer A schema-derived view                          |
+| Fail-closed on                        | the effect                   | the artifact, every `$ref`, and the canvas sanitizer |
+| Never                                 | agent-invented effects       | presentation or canvas as chain input                |
+
+Layer B's `format`/`tone` and, later, its blocks are shared with the inbox's
+`DecisionCard`; the two designs are meant to converge on one renderer per
+surface. Layer C does not join that vocabulary: a drawing is not a block,
+and a block is not a drawing.
+
+---
+
+## 6. What is deliberately not decided here
 
 - **Whether Layer B earns its keep at all.** The pilot decides. If the Layer A
   table plus the artifact's own `summary` string turns out to be enough, Layer
   B stays available and unused, and that is a fine outcome.
-- **Interactive blocks.** A block that _does_ something (approve, requeue) is
-  a decision request, not a presentation — it lives in the inbox design.
+- **Whether Layer C earns its keep at all.** The two pilots in §4.5 decide.
+  If postmortem prose plus Layer A is enough, and economics is happier as a
+  Layer A `as: chart` (or a CLI the operator already has), Layer C stays
+  available and unused.
+- **Whether `factory.canvas-html/v1` ever earns itself.** §4.6 is a sketch,
+  not a commitment. No HTML canvas is in the first implementation tickets.
+- **Interactive blocks or canvases.** A block or drawing that _does_
+  something (approve, requeue) is a decision request, not a presentation —
+  it lives in the inbox design.
 - **Per-agent renderers.** If a specific artifact needs a bespoke component
   (a graph, a diff), that is a `format` or a block type added to the closed
   vocabulary with a ticket, not a component keyed on the agent's name.
+  Layer C's three media types are the escape hatch for "this is a picture";
+  they are not a per-agent React tree.
 
 ---
 
-## 6. Ticket map
+## 7. Ticket map
+
+### 7.1 Layers A and B
 
 | Ticket | Section              | Owns                                                                                                                                                                                                                                                                  |
 | :----- | :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -529,3 +797,18 @@ surface.
 | WM-897 | §2.1–2.2             | `input` / `subject` on the view contract, contract-keyed fallback `agents/views/<output_contract>.view.json`, `agents/dispatch.view.json` input+subject only                                                                                                          |
 | WM-915 | §2.5                 | `agents/dispatch.view.json` output sections (`summary` `/summary`, `status` on `/outcome`, keyvalue for identity / verification / uxCritique) on the WM-897 input+subject sidecar                                                                                     |
 | WM-898 | §2.1, §2.5           | Layer A sidecars for merge-apply/fix, work-scan, ship/sweep/unblock scan+apply, triage-apply, ci-doctor, run-postmortem, factory-status-report. Dispatch output sections and the shared `factory.command-result/v1` view wait on WM-897                               |
+| WM-847 | §4                   | this Layer C section                                                                                                                                                                                                                                                  |
+
+### 7.2 Layer C follow-ups (unfiled — file after §4 is ratified)
+
+Do not implement from this document alone. File as children of WM-452 once
+the operator ratifies §4; Owned Paths and verification commands belong on
+those tickets, not here.
+
+| Ticket (unfiled)         | Section    | Owns                                                                                                                                                                                                                         |
+| :----------------------- | :--------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Layer C contract         | §4.1–4.3   | `schemas/factory.canvas.v1.json`, `lib/canvas.mjs` (envelope + mermaid source checks + SVG allowlist sanitizer, + test), `factory.agent-result.v1.json` `canvas` / `canvasErrors`, `lib/verify.mjs` tolerant path (+ test)   |
+| Layer C store and API    | §4.1, §4.3 | collected `kind: canvas` in `lib/artifacts.mjs`, `GET /artifacts/:hash` `Content-Type` / `nosniff` / `CSP: default-src 'none'` for canvas media types, registry refusal of `kind: canvas` as a chain-edge input mapping      |
+| Layer C web renderer     | §4.4       | `web/src/components/CanvasPanel.tsx` (+ test), mermaid code-split → sanitized SVG, SVG allowlist, `MarkdownView` mermaid/svg fences, Raw toggle, `RunDetailBlocks.tsx` + `views/Artifacts.tsx`, `cli.mjs inspect` title line |
+| `run-postmortem` pilot   | §4.5       | brief clause, optional canvas (typed artifact unchanged), one-week comparison against Layer A-only recorded on the ticket                                                                                                    |
+| `economics-report` pilot | §4.5       | command-result agent wrapping `orchestrator/economics.mjs --json`, Layer A sidecar on the JSON totals, optional canvas of context-burn / cache verdict                                                                       |


### PR DESCRIPTION
## Summary
- Adds `docs/event-runtime-artifact-views.md` §4 **Layer C — canvas artifacts**: `factory.canvas/v1` envelope beside the typed artifact, body as a content-addressed `kind: canvas` file; Markdown / Mermaid / SVG; no scripts; size and sanitizer bounds; never chain input; JSON one click away.
- Documents deferred `factory.canvas-html/v1` (sandboxed iframe) and why interactive controls stay inbox verbs.
- Names first pilots (`run-postmortem`, economics via `orchestrator/economics.mjs --json`) and outlines unfiled follow-up implementation tickets (§7.2) until this design is ratified.

Fixes WM-847

UX critique: skipped — docs, no user-facing surface.

## Test plan
- [x] `bun build/emit.mjs --check` (ticket Verification Command)
- [x] `bun test event-runtime/lib --timeout 20000` (repo verify)
- [ ] Reviewer: §4 contract, security boundary, and §7.2 follow-ups match what we want to ratify before filing implementation tickets


Made with [Cursor](https://cursor.com)