### PR TITLE
feat(oss): automated dogfood-in-public badge updater (WM-958)

### DIFF
--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,0 +1,81 @@
+# Weekly dogfood-in-public badge (WM-958).
+#
+# Rewrites the README marker block from tools/update-dogfood-badge.mjs and
+# commits only when the count changed. Schedule + workflow_dispatch only —
+# never pull_request — so the contents:write token is not exposed to a fork
+# PR. No marketplace `uses:` (WM-573): the shadow fleet 429s on
+# actions/checkout; a plain git fetch of develop is the same checkout.
+name: Update dogfood badge
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-badge
+  cancel-in-progress: true
+
+jobs:
+  update-badge:
+    name: Refresh README dogfood badge
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout develop (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin develop
+          git checkout -q -B develop FETCH_HEAD
+          git log -1 --oneline
+
+      - name: Setup bun (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
+            curl -fsSL https://bun.sh/install | bash
+          fi
+          if [ -x "$HOME/.bun/bin/bun" ]; then
+            echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            "$HOME/.bun/bin/bun" --version
+          else
+            bun --version
+          fi
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Update badge
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun tools/update-dogfood-badge.mjs --repo "${{ github.repository }}"
+
+      - name: Commit README if the badge changed
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "badge unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(oss): refresh dogfood-in-public badge"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git push origin HEAD:develop

--- a/tools/update-dogfood-badge.mjs
+++ b/tools/update-dogfood-badge.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env bun
+/**
+ * Rolling 30-day "dogfood-in-public" badge (WM-958).
+ *
+ *   bun tools/update-dogfood-badge.mjs                 # rewrite README.md
+ *   bun tools/update-dogfood-badge.mjs --dry-run       # print, no writes
+ *   bun tools/update-dogfood-badge.mjs --json          # Shields.io endpoint JSON
+ *
+ * Counts merged PRs via lib/forge (never shells out to `gh` itself). A PR is
+ * autonomous when its body matches the factory protocol (`Fixes <TICKET>`).
+ * The number is a rolling 30-day window on `mergedAt`, not a calendar month.
+ *
+ * `--dry-run` is the local verification path: no README write, no git
+ * mutations. The scheduled workflow commits README only when the badge text
+ * actually changed.
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadForge } from "../lib/forge/index.mjs";
+
+export const WINDOW_DAYS = 30;
+export const DEFAULT_REPO = "watt-mind/factory";
+export const DEFAULT_README = "README.md";
+export const DEFAULT_PR_LIMIT = 1000;
+export const BADGE_START = "<!-- factory-dogfood-badge -->";
+export const BADGE_END = "<!-- /factory-dogfood-badge -->";
+export const BADGE_COLOR = "0B6E4F";
+export const BADGE_LABEL = "Maintained by the factory";
+export const PR_FIELDS = Object.freeze([
+  "number",
+  "title",
+  "body",
+  "mergedAt",
+  "url",
+  "headRefName",
+]);
+
+/** Factory protocol: `Fixes WM-958` / `Fixes CLNT-123` in the PR body. */
+export const FIXES_TICKET_RE = /\bFixes\s+[A-Z]{2,}-\d+\b/;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DEFAULT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+export function isAutonomousPr(pr) {
+  return FIXES_TICKET_RE.test(String(pr?.body ?? ""));
+}
+
+export function mergedAtMs(pr) {
+  const v = pr?.mergedAt;
+  if (v == null || v === "") return null;
+  if (v instanceof Date) {
+    const t = v.getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  const t = Date.parse(v);
+  return Number.isNaN(t) ? null : t;
+}
+
+export function inRollingWindow(
+  pr,
+  now = new Date(),
+  windowDays = WINDOW_DAYS,
+) {
+  const t = mergedAtMs(pr);
+  if (t == null) return false;
+  const end = now instanceof Date ? now.getTime() : Date.parse(now);
+  if (Number.isNaN(end)) return false;
+  const start = end - windowDays * MS_PER_DAY;
+  return t >= start && t <= end;
+}
+
+export function countAutonomousMerges(
+  prs,
+  { now = new Date(), windowDays = WINDOW_DAYS } = {},
+) {
+  return (prs ?? []).filter(
+    (pr) => isAutonomousPr(pr) && inRollingWindow(pr, now, windowDays),
+  ).length;
+}
+
+export function badgeMessage(count) {
+  return `${count} PRs merged autonomously this month`;
+}
+
+export function shieldsEndpointPayload(count, extras = {}) {
+  return {
+    schemaVersion: 1,
+    label: BADGE_LABEL,
+    message: badgeMessage(count),
+    color: BADGE_COLOR,
+    ...extras,
+  };
+}
+
+export function shieldsBadgeUrl(count) {
+  const params = new URLSearchParams({
+    label: BADGE_LABEL,
+    message: badgeMessage(count),
+    color: BADGE_COLOR,
+  });
+  return `https://img.shields.io/static/v1?${params.toString()}`;
+}
+
+export function renderBadgeBlock(count, { repo = DEFAULT_REPO } = {}) {
+  const img = shieldsBadgeUrl(count);
+  const href = `https://github.com/${repo}/pulls?q=is%3Apr+is%3Amerged`;
+  return `${BADGE_START}\n[![${BADGE_LABEL}](${img})](${href})\n${BADGE_END}`;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function applyBadgeToReadme(
+  markdown,
+  count,
+  { repo = DEFAULT_REPO } = {},
+) {
+  const block = renderBadgeBlock(count, { repo });
+  const re = new RegExp(
+    `${escapeRegExp(BADGE_START)}[\\s\\S]*?${escapeRegExp(BADGE_END)}`,
+  );
+  if (re.test(markdown)) return markdown.replace(re, block);
+
+  const lines = String(markdown).split("\n");
+  const h1 = lines.findIndex((l) => /^#\s+/.test(l));
+  if (h1 === -1) {
+    return markdown ? `${block}\n\n${markdown}` : `${block}\n`;
+  }
+  const before = lines.slice(0, h1 + 1);
+  const after = lines.slice(h1 + 1);
+  if (after[0] === "") after.shift();
+  return [...before, "", block, "", ...after].join("\n");
+}
+
+export function collectMetrics(
+  forge,
+  repo,
+  { now = new Date(), windowDays = WINDOW_DAYS, limit = DEFAULT_PR_LIMIT } = {},
+) {
+  const prs = forge.prList(repo, {
+    state: "merged",
+    limit,
+    fields: [...PR_FIELDS],
+  });
+  if (!Array.isArray(prs)) {
+    throw new Error(`forge.prList(${repo}) did not return an array`);
+  }
+  const mergedInWindow = prs.filter((pr) =>
+    inRollingWindow(pr, now, windowDays),
+  );
+  // gh pr list is newest-first and caps at --limit. If every returned PR is
+  // still inside the window we did not finish the scan, and publishing that
+  // count would under-state the trust signal.
+  if (prs.length === limit && mergedInWindow.length === prs.length) {
+    throw new Error(
+      `merged PR scan hit the --limit of ${limit} and every result is inside the ${windowDays}-day window; raise --limit (GitHub caps gh pr list at 1000) or the badge would under-count`,
+    );
+  }
+  return {
+    repo,
+    windowDays,
+    scanned: prs.length,
+    mergedInWindow: mergedInWindow.length,
+    autonomousMerges: mergedInWindow.filter(isAutonomousPr).length,
+    asOf: (now instanceof Date ? now : new Date(now)).toISOString(),
+  };
+}
+
+export function parseCliArgs(argv) {
+  const args = [...argv];
+  const flags = {
+    dryRun: false,
+    json: false,
+    help: false,
+    repo: null,
+    readme: null,
+    limit: null,
+  };
+  while (args.length) {
+    const a = args.shift();
+    if (a === "--dry-run") flags.dryRun = true;
+    else if (a === "--json") flags.json = true;
+    else if (a === "--help" || a === "-h") flags.help = true;
+    else if (a === "--repo") flags.repo = args.shift() ?? null;
+    else if (a === "--readme") flags.readme = args.shift() ?? null;
+    else if (a === "--limit") flags.limit = Number(args.shift());
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (flags.limit != null && !Number.isFinite(flags.limit)) {
+    throw new Error(`--limit must be a number`);
+  }
+  return flags;
+}
+
+const USAGE = `tools/update-dogfood-badge.mjs — rolling 30-day autonomous merge badge
+
+Usage:
+  bun tools/update-dogfood-badge.mjs [options]
+
+Options:
+  --dry-run         Print metrics and the badge block; do not write README
+  --json            Print a Shields.io endpoint payload on stdout
+  --repo owner/name GitHub repo to scan (default: watt-mind/factory)
+  --readme PATH     README to update (default: README.md)
+  --limit N         Max merged PRs to scan (default: 1000)
+  --help, -h        Show this help
+`;
+
+export function runUpdate({
+  argv = [],
+  forge,
+  now = new Date(),
+  cwd = DEFAULT_ROOT,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  env = process.env,
+} = {}) {
+  const flags = parseCliArgs(argv);
+  if (flags.help) {
+    stdout.write(USAGE);
+    return { ok: true, help: true };
+  }
+
+  const repo =
+    flags.repo || env.GITHUB_REPOSITORY || env.DOGFOOD_REPO || DEFAULT_REPO;
+  const readmePath = path.resolve(cwd, flags.readme || DEFAULT_README);
+  const loaded = forge ?? loadForge({ root: cwd });
+  const metrics = collectMetrics(loaded, repo, {
+    now,
+    limit: flags.limit ?? DEFAULT_PR_LIMIT,
+  });
+  const count = metrics.autonomousMerges;
+  const payload = shieldsEndpointPayload(count, {
+    count,
+    repo: metrics.repo,
+    windowDays: metrics.windowDays,
+    scanned: metrics.scanned,
+    mergedInWindow: metrics.mergedInWindow,
+    asOf: metrics.asOf,
+    dryRun: flags.dryRun,
+  });
+
+  let markdown = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : "";
+  const next = applyBadgeToReadme(markdown, count, { repo });
+  const changed = next !== markdown;
+
+  if (flags.json) {
+    stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    stdout.write(
+      [
+        `repo: ${repo}`,
+        `autonomousMerges: ${count}`,
+        `mergedInWindow: ${metrics.mergedInWindow}`,
+        `scanned: ${metrics.scanned}`,
+        `windowDays: ${metrics.windowDays}`,
+        `readme: ${flags.dryRun ? "dry-run" : changed ? "updated" : "unchanged"}`,
+        "",
+        renderBadgeBlock(count, { repo }),
+        "",
+      ].join("\n"),
+    );
+  }
+
+  if (flags.dryRun) {
+    return { ok: true, dryRun: true, changed, count, metrics, payload };
+  }
+
+  if (!changed) {
+    return { ok: true, dryRun: false, changed: false, count, metrics, payload };
+  }
+
+  writeFileSync(readmePath, next);
+  stderr.write(`wrote ${readmePath}\n`);
+  return { ok: true, dryRun: false, changed: true, count, metrics, payload };
+}
+
+if (import.meta.main) {
+  try {
+    const result = runUpdate({ argv: process.argv.slice(2) });
+    process.exit(result.ok ? 0 : 1);
+  } catch (err) {
+    console.error(`update-dogfood-badge: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/tools/update-dogfood-badge.test.mjs
+++ b/tools/update-dogfood-badge.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * bun test — dogfood-in-public badge metrics (WM-958).
+ *
+ * Window math and the Fixes-ticket heuristic are the whole product: a badge
+ * that counts human-only PRs, or that silently includes merges from 31 days
+ * ago, is a trust-signal lie. Tests drive a memory forge; they never talk to
+ * GitHub.
+ */
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { expect, test } from "bun:test";
+import { memoryForge } from "../lib/forge/memory.mjs";
+import {
+  WINDOW_DAYS,
+  BADGE_START,
+  BADGE_END,
+  isAutonomousPr,
+  inRollingWindow,
+  countAutonomousMerges,
+  applyBadgeToReadme,
+  renderBadgeBlock,
+  shieldsEndpointPayload,
+  shieldsBadgeUrl,
+  collectMetrics,
+  parseCliArgs,
+  runUpdate,
+} from "./update-dogfood-badge.mjs";
+
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+const dayAgo = (n) =>
+  new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+
+function pr({ number, body, mergedAt, title = "feat: x" }) {
+  return {
+    number,
+    title,
+    body,
+    mergedAt,
+    state: "MERGED",
+    url: `https://github.com/watt-mind/factory/pull/${number}`,
+    headRefName: `feat/WM-${number}-x`,
+  };
+}
+
+function forgeWith(prs) {
+  return memoryForge({
+    repos: { "watt-mind/factory": { prs } },
+  });
+}
+
+// -------------------------------------------------------- heuristic ---
+test("Fixes <TICKET> in the body is autonomous", () => {
+  expect(isAutonomousPr({ body: "Fixes WM-958\n\nrun:abc" })).toBe(true);
+  expect(isAutonomousPr({ body: "See also Fixes CLNT-12." })).toBe(true);
+});
+
+test("human or protocol-less bodies are not autonomous", () => {
+  expect(isAutonomousPr({ body: "this PR fixes a bug" })).toBe(false);
+  expect(isAutonomousPr({ body: "Fixes wm-958" })).toBe(false);
+  expect(isAutonomousPr({ body: "" })).toBe(false);
+  expect(isAutonomousPr({})).toBe(false);
+  expect(
+    isAutonomousPr({ title: "Fixes WM-958", body: "no ticket line" }),
+  ).toBe(false);
+});
+
+// -------------------------------------------------------- window ---
+test("rolling window includes a merge 29 days ago and excludes 31", () => {
+  expect(inRollingWindow({ mergedAt: dayAgo(0) }, NOW)).toBe(true);
+  expect(inRollingWindow({ mergedAt: dayAgo(29) }, NOW)).toBe(true);
+  expect(inRollingWindow({ mergedAt: dayAgo(30) }, NOW)).toBe(true);
+  expect(inRollingWindow({ mergedAt: dayAgo(31) }, NOW)).toBe(false);
+});
+
+test("missing or future mergedAt is outside the window", () => {
+  expect(inRollingWindow({ mergedAt: null }, NOW)).toBe(false);
+  expect(inRollingWindow({}, NOW)).toBe(false);
+  expect(inRollingWindow({ mergedAt: "2026-09-01T00:00:00.000Z" }, NOW)).toBe(
+    false,
+  );
+  expect(inRollingWindow({ mergedAt: "not-a-date" }, NOW)).toBe(false);
+});
+
+test("countAutonomousMerges applies both filters", () => {
+  const prs = [
+    pr({ number: 1, body: "Fixes WM-1", mergedAt: dayAgo(1) }),
+    pr({ number: 2, body: "human review notes", mergedAt: dayAgo(1) }),
+    pr({ number: 3, body: "Fixes WM-3", mergedAt: dayAgo(40) }),
+    pr({ number: 4, body: "Fixes OPS-9", mergedAt: dayAgo(15) }),
+  ];
+  expect(countAutonomousMerges(prs, { now: NOW })).toBe(2);
+});
+
+// -------------------------------------------------------- README ---
+test("applyBadgeToReadme inserts a marker block after the H1", () => {
+  const next = applyBadgeToReadme("# factory\n\nA runtime.\n", 7);
+  expect(next).toContain(BADGE_START);
+  expect(next).toContain(BADGE_END);
+  expect(next).toContain(shieldsBadgeUrl(7));
+  expect(next.startsWith("# factory\n")).toBe(true);
+  expect(next).toContain("A runtime.");
+});
+
+test("applyBadgeToReadme replaces an existing marker block in place", () => {
+  const first = applyBadgeToReadme("# factory\n\nbody\n", 1);
+  const second = applyBadgeToReadme(first, 9);
+  expect(second.split(BADGE_START).length).toBe(2);
+  expect(second).toContain(shieldsBadgeUrl(9));
+  expect(second).not.toContain(shieldsBadgeUrl(1));
+});
+
+test("applyBadgeToReadme is idempotent for the same count", () => {
+  const once = applyBadgeToReadme("# factory\n\nbody\n", 4);
+  expect(applyBadgeToReadme(once, 4)).toBe(once);
+});
+
+test("shields payload matches the endpoint schema", () => {
+  const payload = shieldsEndpointPayload(12);
+  expect(payload).toEqual({
+    schemaVersion: 1,
+    label: "Maintained by the factory",
+    message: "12 PRs merged autonomously this month",
+    color: "0B6E4F",
+  });
+  expect(shieldsBadgeUrl(12)).toContain("img.shields.io/static/v1");
+  expect(renderBadgeBlock(12)).toContain("watt-mind/factory/pulls");
+});
+
+// -------------------------------------------------------- forge ---
+test("collectMetrics reads merged PRs from the forge and counts the window", () => {
+  const forge = forgeWith([
+    pr({ number: 10, body: "Fixes WM-10", mergedAt: dayAgo(2) }),
+    pr({
+      number: 11,
+      body: "Fixes WM-11",
+      mergedAt: dayAgo(WINDOW_DAYS + 2),
+    }),
+    pr({ number: 12, body: "no protocol", mergedAt: dayAgo(2) }),
+    {
+      number: 13,
+      title: "open",
+      body: "Fixes WM-13",
+      state: "OPEN",
+      mergedAt: null,
+    },
+  ]);
+  const metrics = collectMetrics(forge, "watt-mind/factory", { now: NOW });
+  expect(metrics.autonomousMerges).toBe(1);
+  expect(metrics.mergedInWindow).toBe(2);
+  expect(metrics.scanned).toBe(3); // memory forge drops OPEN when state=merged
+  expect(metrics.windowDays).toBe(30);
+  expect(metrics.repo).toBe("watt-mind/factory");
+});
+
+test("collectMetrics refuses a truncated window rather than under-count", () => {
+  const forge = forgeWith([
+    pr({ number: 1, body: "Fixes WM-1", mergedAt: dayAgo(1) }),
+    pr({ number: 2, body: "Fixes WM-2", mergedAt: dayAgo(1) }),
+  ]);
+  expect(() =>
+    collectMetrics(forge, "watt-mind/factory", { now: NOW, limit: 2 }),
+  ).toThrow(/--limit of 2/);
+});
+
+test("parseCliArgs accepts dry-run, json, repo, readme, limit", () => {
+  expect(
+    parseCliArgs([
+      "--dry-run",
+      "--json",
+      "--repo",
+      "acme/x",
+      "--readme",
+      "docs/README.md",
+      "--limit",
+      "10",
+    ]),
+  ).toEqual({
+    dryRun: true,
+    json: true,
+    help: false,
+    repo: "acme/x",
+    readme: "docs/README.md",
+    limit: 10,
+  });
+});
+
+test("parseCliArgs rejects unknown flags", () => {
+  expect(() => parseCliArgs(["--commit"])).toThrow(/unknown argument/);
+});
+
+// -------------------------------------------------------- runUpdate ---
+test("--dry-run prints metrics and does not write README", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "dogfood-badge-"));
+  const readme = path.join(dir, "README.md");
+  const original = "# factory\n\nhello\n";
+  writeFileSync(readme, original);
+  let out = "";
+  const result = runUpdate({
+    argv: ["--dry-run", "--readme", readme, "--repo", "watt-mind/factory"],
+    forge: forgeWith([
+      pr({ number: 20, body: "Fixes WM-20", mergedAt: dayAgo(3) }),
+      pr({ number: 21, body: "Fixes WM-21", mergedAt: dayAgo(3) }),
+    ]),
+    now: NOW,
+    cwd: dir,
+    stdout: { write: (s) => (out += s) },
+    stderr: { write: () => {} },
+  });
+  expect(result.dryRun).toBe(true);
+  expect(result.count).toBe(2);
+  expect(readFileSync(readme, "utf8")).toBe(original);
+  expect(out).toContain("autonomousMerges: 2");
+  expect(out).toContain(BADGE_START);
+});
+
+test("default path writes the README badge and --json emits the endpoint", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "dogfood-badge-"));
+  const readme = path.join(dir, "README.md");
+  writeFileSync(readme, "# factory\n\nhello\n");
+  let jsonOut = "";
+  const written = runUpdate({
+    argv: ["--readme", readme, "--repo", "watt-mind/factory"],
+    forge: forgeWith([
+      pr({ number: 30, body: "Fixes WM-30", mergedAt: dayAgo(1) }),
+    ]),
+    now: NOW,
+    cwd: dir,
+    stdout: { write: () => {} },
+    stderr: { write: () => {} },
+  });
+  expect(written.changed).toBe(true);
+  expect(existsSync(readme)).toBe(true);
+  const after = readFileSync(readme, "utf8");
+  expect(after).toContain(shieldsBadgeUrl(1));
+
+  const jsonResult = runUpdate({
+    argv: [
+      "--json",
+      "--dry-run",
+      "--readme",
+      readme,
+      "--repo",
+      "watt-mind/factory",
+    ],
+    forge: forgeWith([
+      pr({ number: 30, body: "Fixes WM-30", mergedAt: dayAgo(1) }),
+    ]),
+    now: NOW,
+    cwd: dir,
+    stdout: { write: (s) => (jsonOut += s) },
+    stderr: { write: () => {} },
+  });
+  const parsed = JSON.parse(jsonOut);
+  expect(parsed.schemaVersion).toBe(1);
+  expect(parsed.count).toBe(1);
+  expect(parsed.message).toBe("1 PRs merged autonomously this month");
+  expect(jsonResult.dryRun).toBe(true);
+  // dry-run after a write must not revert the file
+  expect(readFileSync(readme, "utf8")).toBe(after);
+});


### PR DESCRIPTION
## Summary
- Adds `tools/update-dogfood-badge.mjs` to count rolling 30-day autonomous merges via `lib/forge` (`prList` state=merged). A PR counts as autonomous when its body matches the factory protocol (`Fixes <TICKET>`).
- `--dry-run` prints metrics and the README badge block without writing; `--json` emits a Shields.io endpoint payload. The default path rewrites a `<!-- factory-dogfood-badge -->` marker in `README.md` (inserts it after the H1 if missing).
- Adds `.github/workflows/update-badge.yml` on a weekly cron (`0 0 * * 0`) plus `workflow_dispatch`. Self-hosted shadow, no marketplace `uses:` (WM-573). Commits README only when the badge text changed. No `pull_request` trigger, so the `contents: write` token is not exposed to fork PRs.

Fixes WM-958

UX critique: skipped — tooling and a scheduled workflow; no user-completable app flow.

## Test plan
- [x] `bun test tools/update-dogfood-badge.test.mjs` (window math, Fixes heuristic, README insert/replace, dry-run, truncation fail-closed)
- [x] `bun run lint && bun run check`
- [ ] After merge, `workflow_dispatch` the badge workflow once and confirm it commits a README marker or reports unchanged

Made with [Cursor](https://cursor.com)