### PR TITLE
feat(event-runtime-web): ticket supply strip from latest scan artifacts (WM-823)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1,7 +1,8 @@
 /** Event, proposal, run, journal, outbox, and worker-action endpoints. */
 import { ControlPlaneError } from "../../lib/control-plane/types.mjs";
 import { artifactHead } from "./api-artifacts.mjs";
-import { FACTORY_ROOT } from "./config.mjs";
+import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
+import { loadRepos, RepoError } from "./repos.mjs";
 import { runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
@@ -999,6 +1000,183 @@ export function ticketIndexView(db, options = {}) {
   return result;
 }
 
+const WORK_PLAN_RECOMMENDATIONS = new Set(["DISPATCH", "LOW_SUPPLY", "NOOP"]);
+const STATUS_REPORT_ACTIONS = new Set([
+  "dispatch",
+  "triage",
+  "merge",
+  "unblock",
+  "wait",
+]);
+const WORK_PLAN_NOOPS = new Set(["queue_empty", "cap_full", "all_overlapping"]);
+
+function asCount(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function isWorkPlanArtifact(artifact) {
+  return (
+    artifact &&
+    typeof artifact === "object" &&
+    !Array.isArray(artifact) &&
+    WORK_PLAN_RECOMMENDATIONS.has(artifact.recommendation) &&
+    typeof artifact.repo === "string" &&
+    artifact.repo !== ""
+  );
+}
+
+function isStatusReportArtifact(artifact) {
+  return (
+    artifact &&
+    typeof artifact === "object" &&
+    !Array.isArray(artifact) &&
+    Array.isArray(artifact.repos) &&
+    STATUS_REPORT_ACTIONS.has(artifact.recommendedAction)
+  );
+}
+
+function laterScan(current, next) {
+  if (!current) return next;
+  if (!next) return current;
+  return String(next.asOf ?? "") > String(current.asOf ?? "") ? next : current;
+}
+
+function deriveRecommendedAction(repos) {
+  let anyTriage = false;
+  let anyBlocked = false;
+  for (const repo of repos) {
+    const ready = repo.ready ?? 0;
+    const cap = repo.cap ?? 0;
+    const inFlight = repo.inFlight ?? 0;
+    if (ready > 0 && (cap === 0 || inFlight < cap)) return "dispatch";
+    if ((repo.triage ?? 0) > 0) anyTriage = true;
+    if ((repo.blocked ?? 0) > 0) anyBlocked = true;
+  }
+  if (anyTriage) return "triage";
+  if (anyBlocked) return "unblock";
+  return "wait";
+}
+
+/**
+ * Latest work-plan and status-report artifacts per configured repo (WM-823).
+ * Counts are null when no scan has produced that figure yet — never invented.
+ */
+export function ticketSupplyView(db, options = {}) {
+  const repoRegistry = options.repos ?? loadRepos();
+  const configured = [...repoRegistry.values()];
+  const configuredNames = new Set(configured.map((repo) => repo.name));
+  const rows = db
+    .query(
+      `SELECT r.run_id, r.spec_json, res.result_json, res.accepted_at
+       FROM results res
+       JOIN runs r ON r.run_id = res.run_id
+       WHERE r.state = 'COMPLETED'
+         AND json_extract(r.spec_json, '$.outputContract') IN (
+           'factory.work-plan/v1',
+           'factory.status-report/v1'
+         )
+       ORDER BY res.accepted_at DESC, res.rowid DESC`,
+    )
+    .all();
+
+  const latestPlanByRepo = new Map();
+  const latestReportByRepo = new Map();
+  let latestReport = null;
+
+  for (const row of rows) {
+    const spec = parseObject(row.spec_json);
+    const result = parseObject(row.result_json);
+    const artifact =
+      result.artifact &&
+      typeof result.artifact === "object" &&
+      !Array.isArray(result.artifact)
+        ? result.artifact
+        : null;
+    if (!artifact) continue;
+    if (result.terminalState && result.terminalState !== "completed") continue;
+    const scan = {
+      artifact,
+      runId: row.run_id,
+      asOf: row.accepted_at,
+    };
+    const contract = spec.outputContract;
+    if (contract === "factory.work-plan/v1" || isWorkPlanArtifact(artifact)) {
+      const name =
+        (typeof artifact.repo === "string" && artifact.repo) ||
+        (typeof spec.input?.repo === "string" && spec.input.repo) ||
+        null;
+      if (!name || !configuredNames.has(name) || latestPlanByRepo.has(name))
+        continue;
+      latestPlanByRepo.set(name, scan);
+      continue;
+    }
+    if (
+      contract === "factory.status-report/v1" ||
+      isStatusReportArtifact(artifact)
+    ) {
+      let touchesConfigured = false;
+      for (const entry of artifact.repos ?? []) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry))
+          continue;
+        if (typeof entry.name !== "string" || entry.name === "") continue;
+        if (!configuredNames.has(entry.name)) continue;
+        touchesConfigured = true;
+        if (latestReportByRepo.has(entry.name)) continue;
+        latestReportByRepo.set(entry.name, {
+          repo: entry,
+          runId: scan.runId,
+          asOf: scan.asOf,
+        });
+      }
+      if (touchesConfigured && !latestReport) latestReport = scan;
+    }
+  }
+
+  const repos = configured.map((repo) => {
+    const plan = latestPlanByRepo.get(repo.name);
+    const report = latestReportByRepo.get(repo.name);
+    const planReady = asCount(plan?.artifact?.readyCandidates);
+    const reportTriage = asCount(report?.repo?.triage);
+    const reportReady = asCount(report?.repo?.agentReady);
+    const planTriage = asCount(plan?.artifact?.triageBacklog);
+    // work-plan leaves triageBacklog at 0 when it skipped the Triage read.
+    const triage =
+      reportTriage ??
+      (planReady != null && planReady > 0 ? null : planTriage) ??
+      null;
+    const ready = planReady ?? reportReady;
+    const inFlight = asCount(report?.repo?.inProgress);
+    const blocked = asCount(report?.repo?.blocked);
+    const noopReason = WORK_PLAN_NOOPS.has(plan?.artifact?.noopReason)
+      ? plan.artifact.noopReason
+      : null;
+    const newest = laterScan(
+      plan ? { runId: plan.runId, asOf: plan.asOf } : null,
+      report ? { runId: report.runId, asOf: report.asOf } : null,
+    );
+    return {
+      name: repo.name,
+      team: repo.team ?? null,
+      triage,
+      ready,
+      inFlight,
+      cap: repo.maxInFlight ?? DEFAULT_MAX_IN_FLIGHT,
+      blocked,
+      noopReason,
+      asOf: newest?.asOf ?? null,
+      sourceRunId: newest?.runId ?? null,
+    };
+  });
+
+  const recommendedAction = STATUS_REPORT_ACTIONS.has(
+    latestReport?.artifact?.recommendedAction,
+  )
+    ? latestReport.artifact.recommendedAction
+    : deriveRecommendedAction(repos);
+
+  return { repos, recommendedAction };
+}
+
 function listFilters(url, { proposal = false, nowMs = Date.now() } = {}) {
   const from = url.searchParams.get("from");
   const to = url.searchParams.get("to");
@@ -1284,6 +1462,7 @@ export async function handleRunApiRoute({
   onEvent,
   policyRoot = FACTORY_ROOT,
   controlPlane,
+  repos: loadReposFn,
 }) {
   if (route === "GET /events") {
     return send(200, {
@@ -1468,6 +1647,17 @@ export async function handleRunApiRoute({
       });
     }
     return send(200, result);
+  }
+
+  if (route === "GET /tickets/supply") {
+    try {
+      const repoRegistry =
+        typeof loadReposFn === "function" ? loadReposFn() : loadRepos();
+      return send(200, ticketSupplyView(db, { repos: repoRegistry }));
+    } catch (err) {
+      if (err instanceof RepoError) return send(500, { error: err.message });
+      throw err;
+    }
   }
 
   if (route === "GET /tickets") {

--- a/event-runtime/web/src/components/SupplyStrip.tsx
+++ b/event-runtime/web/src/components/SupplyStrip.tsx
@@ -1,0 +1,290 @@
+import type { MouseEvent } from "react";
+import { Ago, shortId } from "./ui";
+
+export type TicketSupplyAction =
+  "dispatch" | "triage" | "merge" | "unblock" | "wait";
+
+export type RepoRecommendedAction = "dispatch" | "triage" | "idle";
+
+export type SupplyChip = "triage" | "ready" | "inFlight" | "blocked";
+
+export interface TicketSupplyRepo {
+  name: string;
+  team: string | null;
+  triage: number | null;
+  ready: number | null;
+  inFlight: number | null;
+  cap: number;
+  blocked: number | null;
+  noopReason: "queue_empty" | "cap_full" | "all_overlapping" | null;
+  asOf: string | null;
+  sourceRunId: string | null;
+}
+
+export interface TicketSupply {
+  repos: TicketSupplyRepo[];
+  recommendedAction: TicketSupplyAction | null;
+}
+
+export const CHIP_FILTER_STATE: Record<SupplyChip, string> = {
+  triage: "Triage",
+  ready: "Todo",
+  inFlight: "In Progress",
+  blocked: "Blocked",
+};
+
+const LINEAR_TEAM = "https://linear.app/watt-mind/team";
+
+export function linearTeamUrl(
+  team: string | null,
+  chip?: SupplyChip,
+): string | null {
+  if (!team) return null;
+  const base = `${LINEAR_TEAM}/${encodeURIComponent(team)}`;
+  if (chip === "triage") return `${base}/triage`;
+  return `${base}/active`;
+}
+
+export function recommendedActionForRepo(
+  repo: TicketSupplyRepo,
+): RepoRecommendedAction {
+  const ready = repo.ready ?? 0;
+  const triage = repo.triage ?? 0;
+  const inFlight = repo.inFlight ?? 0;
+  const cap = repo.cap ?? 0;
+  if (ready > 0 && (cap === 0 || inFlight < cap)) return "dispatch";
+  if (triage > 0 && ready === 0) return "triage";
+  return "idle";
+}
+
+function formatCount(value: number | null): string {
+  return value == null ? "—" : String(value);
+}
+
+function actionLabel(action: RepoRecommendedAction): string {
+  if (action === "dispatch") return "→dispatch";
+  if (action === "triage") return "→triage";
+  return "idle";
+}
+
+function hasScan(repo: TicketSupplyRepo): boolean {
+  return (
+    repo.asOf != null ||
+    repo.triage != null ||
+    repo.ready != null ||
+    repo.inFlight != null ||
+    repo.blocked != null
+  );
+}
+
+export function SupplyStrip({
+  supply,
+  pending,
+  error,
+  repoFilter,
+  stateFilter,
+  now,
+  onFilter,
+}: {
+  supply: TicketSupply | null | undefined;
+  pending?: boolean;
+  error?: string | null;
+  repoFilter?: string;
+  stateFilter?: string;
+  now: number;
+  onFilter: (next: { repo: string; state: string }) => void;
+}) {
+  const repos = supply?.repos ?? [];
+
+  return (
+    <section
+      data-testid="ticket-supply"
+      aria-label="Ticket supply"
+      className="mb-3 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2"
+    >
+      <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+          Supply
+        </h2>
+        {supply?.recommendedAction && (
+          <span className="text-[11px] text-(--text-dim)">
+            next:{" "}
+            <span className="font-medium text-(--text)">
+              {supply.recommendedAction}
+            </span>
+          </span>
+        )}
+      </div>
+      {pending && repos.length === 0 ? (
+        <p role="status" className="text-[11px] text-(--text-faint)">
+          Loading latest scan figures…
+        </p>
+      ) : error ? (
+        <p role="status" className="text-[11px] text-(--hue-warn)">
+          Supply figures unavailable: {error}
+        </p>
+      ) : repos.length === 0 ? (
+        <p role="status" className="text-[11px] text-(--text-dim)">
+          Queue supply will appear after the next work-plan or status-report
+          scan.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {repos.map((repo) => (
+            <SupplyRow
+              key={repo.name}
+              repo={repo}
+              now={now}
+              active={repoFilter === repo.name ? (stateFilter ?? "") : ""}
+              onFilter={onFilter}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SupplyRow({
+  repo,
+  now,
+  active,
+  onFilter,
+}: {
+  repo: TicketSupplyRepo;
+  now: number;
+  active: string;
+  onFilter: (next: { repo: string; state: string }) => void;
+}) {
+  const action = recommendedActionForRepo(repo);
+  const scanned = hasScan(repo);
+  const linear = linearTeamUrl(repo.team);
+  const inFlightLabel =
+    repo.inFlight == null ? "—" : `${repo.inFlight}/${repo.cap}`;
+
+  const clickChip = (event: MouseEvent, chip: SupplyChip) => {
+    const href = linearTeamUrl(repo.team, chip);
+    if ((event.metaKey || event.ctrlKey) && href) {
+      event.preventDefault();
+      window.open(href, "_blank", "noreferrer");
+      return;
+    }
+    onFilter({ repo: repo.name, state: CHIP_FILTER_STATE[chip] });
+  };
+
+  return (
+    <li className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
+      {linear ? (
+        <a
+          href={linear}
+          target="_blank"
+          rel="noreferrer"
+          className="mono shrink-0 font-medium text-(--accent) hover:underline"
+          title={`Open ${repo.team} on Linear`}
+        >
+          {repo.name}
+        </a>
+      ) : (
+        <span className="mono shrink-0 font-medium text-(--text)">
+          {repo.name}
+        </span>
+      )}
+      {repo.team && (
+        <span className="shrink-0 text-(--text-faint)">{repo.team}</span>
+      )}
+      {!scanned ? (
+        <span className="text-(--text-faint)">no scan yet</span>
+      ) : (
+        <>
+          <SupplyChipButton
+            label="Triage"
+            value={formatCount(repo.triage)}
+            active={active === CHIP_FILTER_STATE.triage}
+            disabled={repo.triage == null}
+            onClick={(event) => clickChip(event, "triage")}
+          />
+          <SupplyChipButton
+            label="Ready"
+            value={formatCount(repo.ready)}
+            active={active === CHIP_FILTER_STATE.ready}
+            disabled={repo.ready == null}
+            onClick={(event) => clickChip(event, "ready")}
+          />
+          <SupplyChipButton
+            label="In flight"
+            value={inFlightLabel}
+            active={active === CHIP_FILTER_STATE.inFlight}
+            disabled={repo.inFlight == null}
+            onClick={(event) => clickChip(event, "inFlight")}
+          />
+          <SupplyChipButton
+            label="Blocked"
+            value={formatCount(repo.blocked)}
+            active={active === CHIP_FILTER_STATE.blocked}
+            disabled={repo.blocked == null}
+            onClick={(event) => clickChip(event, "blocked")}
+          />
+          <span
+            className={`shrink-0 font-medium ${
+              action === "idle" ? "text-(--text-faint)" : "text-(--text)"
+            }`}
+            title={repo.noopReason ? `noop: ${repo.noopReason}` : undefined}
+          >
+            {actionLabel(action)}
+          </span>
+          {repo.asOf && (
+            <span className="ml-auto shrink-0 text-(--text-faint)">
+              {repo.sourceRunId ? (
+                <a
+                  href={`#/run/${encodeURIComponent(repo.sourceRunId)}`}
+                  className="hover:text-(--accent) hover:underline"
+                  title={`Scan ${repo.sourceRunId} at ${repo.asOf}`}
+                >
+                  as of <Ago iso={repo.asOf} now={now} /> ·{" "}
+                  {shortId(repo.sourceRunId)}
+                </a>
+              ) : (
+                <>
+                  as of <Ago iso={repo.asOf} now={now} />
+                </>
+              )}
+            </span>
+          )}
+        </>
+      )}
+    </li>
+  );
+}
+
+function SupplyChipButton({
+  label,
+  value,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  value: string;
+  active: boolean;
+  disabled: boolean;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-pressed={active}
+      aria-label={`Filter tickets: ${label} ${value}. ⌘-click opens Linear.`}
+      title={`${label} ${value} — click to filter this hub, ⌘-click for Linear`}
+      onClick={onClick}
+      className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 tabular-nums ${
+        active
+          ? "border-(--accent) bg-(--surface-2) text-(--text)"
+          : "border-(--border) bg-(--surface-1) text-(--text-dim) hover:border-(--border-strong) hover:text-(--text)"
+      } disabled:cursor-default disabled:opacity-60`}
+    >
+      <span className="text-(--text-faint)">{label}</span>
+      <span className="font-medium text-(--text)">{value}</span>
+    </button>
+  );
+}

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -35,6 +35,7 @@ import {
   type TimelineItem,
 } from "../subjectJourney";
 import { MarkdownView } from "../components/RunTrace";
+import { SupplyStrip, type TicketSupply } from "../components/SupplyStrip";
 import {
   Ago,
   Button as PrimitiveButton,
@@ -222,6 +223,12 @@ function TicketsHub({
     ...refetchIntervals.fast,
   });
 
+  const supplyQuery = useQuery({
+    queryKey: ["tickets-supply"],
+    queryFn: fetchTicketSupply,
+    ...refetchIntervals.secondary,
+  });
+
   const reposQuery = useQuery({
     queryKey: ["repos"],
     queryFn: api.repos,
@@ -250,8 +257,9 @@ function TicketsHub({
     for (const t of tickets) {
       if (t.state) set.add(t.state);
     }
+    if (stateFilter) set.add(stateFilter);
     return Array.from(set).sort();
-  }, [tickets]);
+  }, [tickets, stateFilter]);
 
   const filteredTickets = useMemo(() => {
     return tickets.filter((t) => {
@@ -424,6 +432,22 @@ function TicketsHub({
               Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
             </div>
           )}
+          <SupplyStrip
+            supply={supplyQuery.data}
+            pending={supplyQuery.isPending}
+            error={
+              supplyQuery.isError
+                ? ((supplyQuery.error as Error)?.message ?? "unavailable")
+                : null
+            }
+            repoFilter={repoFilter}
+            stateFilter={stateFilter}
+            now={now}
+            onFilter={({ repo, state }) => {
+              setRepoFilter(repo);
+              setStateFilter(state);
+            }}
+          />
           <div className="flex flex-wrap items-center gap-2">
             <FilterInput
               value={searchQuery}
@@ -626,6 +650,28 @@ type JourneyTab = (typeof JOURNEY_TABS)[number];
 
 const EXTERNAL_BUTTON_CLASS =
   "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 text-[12px] font-medium text-(--text) hover:bg-(--surface-3)";
+
+async function fetchTicketSupply(): Promise<TicketSupply> {
+  const response = await fetch("/api/tickets/supply");
+  if (response.status === 404) {
+    return { repos: [], recommendedAction: null };
+  }
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      message = body.message ?? body.error ?? message;
+    } catch {
+      // Keep the HTTP status when the control API did not return JSON.
+    }
+    throw new Error(message);
+  }
+  const body = await response.json();
+  if (!body || !Array.isArray(body.repos)) {
+    return { repos: [], recommendedAction: null };
+  }
+  return body as TicketSupply;
+}
 
 async function fetchTicketDetail(
   ticketId: string,


### PR DESCRIPTION
## Summary
- Add `GET /tickets/supply` that reads the latest `factory.work-plan/v1` and `factory.status-report/v1` artifacts per configured repo (no live Linear polling).
- Render a compact Tickets hub supply strip with Triage / Ready / In flight (used/cap) / Blocked chips, `→dispatch` / `→triage` / `idle`, honest `asOf` links to the scan run, and a no-scan fallback.
- Chip click filters the hub by repo + Linear state; ⌘-click and repo names open Linear.

Fixes WM-823

UX critique: required — SHIP
evidence: http://127.0.0.1:7715/#/tickets ; /tmp/wm-823-ux/01-tickets-hub.png

## Test plan
- [ ] Open `#/tickets` and confirm the supply strip sits above the hub table
- [ ] With scan artifacts present, chips show Triage / Ready / In flight used/cap / Blocked and a next action
- [ ] Clicking a count chip filters repo + state; empty hub copy offers Clear filter
- [ ] `asOf` links to `#/run/<sourceRunId>`
- [ ] Repos without scans show `no scan yet` rather than invented zeros
- [ ] `cd event-runtime/web && bun test && bun run build`


Made with [Cursor](https://cursor.com)