### PR TITLE
feat(control-plane): wire github into loadControlPlane (WM-955)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -12,10 +12,10 @@ reference tables and the sections the floor points at** — routing, the
 five-section template, the filing bar, adapter verbs — never instead of the
 floor, and never the whole file when one section answers the question.
 
-Call `loadControlPlane({ root })` for Linear/memory. The GitHub Issues adapter
-is `githubControlPlane()` in `lib/control-plane/github.mjs` (wiring
-`kind: github` into `loadControlPlane()` is a follow-up so WM-798 stayed
-inside its Owned Paths). Selection is `config/policy.yaml`:
+Call `loadControlPlane({ root })` to select Linear, memory, or GitHub Issues.
+`controlPlane.kind: github` is fully wired (WM-955): it constructs
+`githubControlPlane()` with the `controlPlane.github` options (`repo`,
+`teams`, `project`, `statusField`). Selection is `config/policy.yaml`:
 
 ```yaml
 controlPlane:

--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -17,9 +17,12 @@ import {
   IN_PROGRESS_LABEL,
   loadControlPlane,
 } from "../../lib/control-plane/index.mjs";
+import * as controlPlaneIndex from "../../lib/control-plane/index.mjs";
+import { githubControlPlane as githubControlPlaneFromAdapter } from "../../lib/control-plane/github.mjs";
 import { memoryControlPlane } from "../../lib/control-plane/memory.mjs";
 
 const TEAM = "WM";
+const GH_REPO = "acme/widget";
 const RAW_PING = "query { ping }";
 
 function freshSeed() {
@@ -522,4 +525,133 @@ describe("loadControlPlane selection", () => {
   test("the repo's own policy.yaml selects linear", () => {
     expect(loadControlPlane().kind).toBe("linear");
   });
+
+  test("re-exports githubControlPlane from the adapter", () => {
+    expect(controlPlaneIndex.githubControlPlane).toBe(
+      githubControlPlaneFromAdapter,
+    );
+  });
+
+  test("CONTROL_PLANE_KINDS includes github", () => {
+    expect(CONTROL_PLANE_KINDS).toContain("github");
+  });
+
+  test("selects github from an explicit kind and runs getTicket / listDispatchable", async () => {
+    const seed = githubSelectionSeed();
+    const api = fakeGithubApi(seed);
+    const cp = loadControlPlane({
+      kind: "github",
+      api,
+      repo: GH_REPO,
+      teams: { [TEAM]: GH_REPO },
+    });
+    expect(cp.kind).toBe("github");
+    const ticket = await cp.getTicket(`${GH_REPO}#1`);
+    expect(ticket.identifier).toBe(`${GH_REPO}#1`);
+    expect(ticket.title).toBe("ready ticket");
+    expect(ticket.state.name).toBe("Todo");
+    expect(
+      (await cp.listDispatchable({ team: TEAM })).map((t) => t.identifier),
+    ).toEqual([`${GH_REPO}#1`]);
+  });
+
+  test("selects github from policy.yaml and passes root options through", async () => {
+    const root = withPolicy(
+      [
+        "controlPlane:",
+        "  kind: github",
+        "  github:",
+        `    repo: ${GH_REPO}`,
+        "    teams:",
+        `      ${TEAM}: ${GH_REPO}`,
+        "    project: Factory",
+        "",
+      ].join("\n"),
+    );
+    expect(controlPlaneKindFromPolicy(root)).toBe("github");
+    const seed = githubSelectionSeed();
+    const api = fakeGithubApi(seed);
+    const cp = loadControlPlane({ root, api });
+    expect(cp.kind).toBe("github");
+    expect(
+      (await cp.listDispatchable({ team: TEAM })).map((t) => t.identifier),
+    ).toEqual([`${GH_REPO}#1`]);
+  });
 });
+
+function githubSelectionSeed() {
+  return {
+    repo: GH_REPO,
+    issue: {
+      id: 101,
+      node_id: "I_1",
+      number: 1,
+      title: "ready ticket",
+      body: "",
+      html_url: `https://github.com/${GH_REPO}/issues/1`,
+      state: "open",
+      assignee: null,
+      labels: [{ id: 10, name: AGENT_READY_LABEL }],
+      comments: [],
+    },
+    project: {
+      id: "PVT_1",
+      title: "Factory",
+      field: {
+        id: "FIELD_status",
+        name: "Status",
+        options: [{ id: "opt-todo", name: "Todo" }],
+      },
+    },
+    items: [
+      {
+        id: "PVTI_1",
+        content: {
+          id: "I_1",
+          number: 1,
+          repository: { nameWithOwner: GH_REPO },
+        },
+        fieldValueByName: { name: "Todo" },
+      },
+    ],
+  };
+}
+
+function fakeGithubApi(seed) {
+  const api = (method, pathName, { body, query } = {}) => {
+    api.calls.push({ method, pathName, body, query });
+    const pathOnly = String(pathName).replace(/^\//, "").split("?")[0];
+    if (pathOnly === "graphql") {
+      const q = body?.query ?? "";
+      if (q.includes("FindRepoProject") || q.includes("FindViewerProject")) {
+        const node = {
+          id: seed.project.id,
+          title: seed.project.title,
+          field: seed.project.field,
+        };
+        return {
+          data: {
+            repository: { projectsV2: { nodes: [node] } },
+            viewer: { projectsV2: { nodes: [node] } },
+          },
+        };
+      }
+      if (q.includes("ProjectItems")) {
+        return { data: { node: { items: { nodes: seed.items } } } };
+      }
+      throw new ControlPlaneError("raw query not seeded");
+    }
+    const one = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues\/(\d+)$/);
+    if (one && method === "GET") {
+      if (one[1] !== seed.repo || Number(one[2]) !== seed.issue.number) {
+        throw new ControlPlaneError("github api: Not Found", { status: 404 });
+      }
+      return seed.issue;
+    }
+    const list = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues$/);
+    if (list && method === "GET") return [seed.issue];
+    throw new ControlPlaneError(`unknown github api ${method} ${pathName}`);
+  };
+  api.calls = [];
+  return api;
+}

--- a/lib/control-plane/index.mjs
+++ b/lib/control-plane/index.mjs
@@ -9,18 +9,22 @@
  *
  *   controlPlane:
  *     kind: linear     # default when the stanza is absent
+ *     # kind: github   # Issues + Projects (WM-798 / WM-955)
  *
- * `memory` is the in-process fake for tests and the demo. Anything else is a
- * configuration error and throws — a tracker the factory cannot reach must
- * never be silently downgraded to "no tickets". GitHub Issues is WM-798.
+ * `memory` is the in-process fake for tests and the demo. `github` is the
+ * Issues + Projects adapter (WM-798), selected here (WM-955). Anything else
+ * is a configuration error and throws — a tracker the factory cannot reach
+ * must never be silently downgraded to "no tickets".
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { githubControlPlane } from "./github.mjs";
 import { linearControlPlane } from "./linear.mjs";
 import { memoryControlPlane } from "./memory.mjs";
 import { CONTROL_PLANE_KINDS } from "./types.mjs";
 
+export { githubControlPlane } from "./github.mjs";
 export { linearControlPlane } from "./linear.mjs";
 export { memoryControlPlane } from "./memory.mjs";
 export { ControlPlaneError, CONTROL_PLANE_KINDS } from "./types.mjs";
@@ -66,9 +70,15 @@ export function controlPlaneKindFromPolicy(root = DEFAULT_ROOT) {
 /**
  * @param {{
  *   root?: string,
- *   kind?: "linear"|"memory",
+ *   kind?: "linear"|"memory"|"github",
  *   gql?: Function,     // linear: GraphQL runner (tests)
  *   seed?: object,      // memory: initial workspace fixture
+ *   api?: Function,     // github: gh api seam (tests)
+ *   exec?: Function,    // github: spawnSync-shaped runner (tests)
+ *   repo?: string,      // github: default owner/name
+ *   teams?: Record<string, string>, // github: team key → repository
+ *   project?: string,   // github: Projects v2 title
+ *   statusField?: string, // github: status single-select name
  * }} [options]
  * @returns {import("./types.mjs").ControlPlane}
  */
@@ -77,6 +87,12 @@ export function loadControlPlane({
   kind,
   gql,
   seed,
+  api,
+  exec,
+  repo,
+  teams,
+  project,
+  statusField,
 } = {}) {
   const selected = kind ?? controlPlaneKindFromPolicy(root);
   switch (selected) {
@@ -84,6 +100,16 @@ export function loadControlPlane({
       return linearControlPlane(gql ? { gql } : {});
     case "memory":
       return memoryControlPlane(seed);
+    case "github":
+      return githubControlPlane({
+        root,
+        api,
+        exec,
+        repo,
+        teams,
+        project,
+        statusField,
+      });
     default:
       throw new Error(`unknown control-plane kind ${JSON.stringify(selected)}`);
   }

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -7,7 +7,7 @@
  * (`ticket`, `claim`, `transition`) and never names Linear GraphQL;
  * `linear.mjs` owns the Linear specifics, `memory.mjs` is the in-process fake
  * the contract suite and the offline demo run against, and GitHub Issues
- * lands as a third implementation (WM-798).
+ * (`github.mjs`, WM-798) is selected by `loadControlPlane()` (WM-955).
  *
  * The interface is trimmed to the verbs `tools/linear.mjs` and the factory
  * loops actually use today. It grows when a call site needs a verb, not
@@ -80,7 +80,7 @@
 
 /**
  * @typedef {object} ControlPlane
- * @property {"linear"|"memory"} kind
+ * @property {"linear"|"memory"|"github"} kind
  * @property {(identifier: string) => Promise<Ticket>} getTicket
  * @property {(identifier: string) => Promise<TicketComment[]>} listComments
  * @property {(opts: { team: string, project?: string }) => Promise<Ticket[]>} listDispatchable
@@ -117,4 +117,8 @@ export class ControlPlaneError extends Error {
 }
 
 /** Implementations `loadControlPlane()` knows how to select. */
-export const CONTROL_PLANE_KINDS = Object.freeze(["linear", "memory"]);
+export const CONTROL_PLANE_KINDS = Object.freeze([
+  "linear",
+  "memory",
+  "github",
+]);


### PR DESCRIPTION
## Summary
- `loadControlPlane()` now selects `githubControlPlane` for `kind: "github"` (explicit or `controlPlane.kind` in `config/policy.yaml`), passing `root` plus policy options and the `api`/`exec` test seams.
- `githubControlPlane` is re-exported from `lib/control-plane/index.mjs`; `CONTROL_PLANE_KINDS` includes `github`.
- `docs/protocol.md` records that GitHub Issues is fully wired (WM-955). Follow-ups outside Owned Paths: WM-967 (architecture/quickstart docs), WM-968 (demo seed test ConnectionRefused flake).

Fixes WM-955

## Test plan
- [x] `bun test event-runtime/lib/control-plane.test.mjs lib/control-plane/github.test.mjs` — 57 pass
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` — 1396 pass, emit ok
- [ ] Confirm `loadControlPlane({ kind: "github" })` still throws only for unknown kinds, not for github

UX critique: skipped — backend control-plane wiring, no user-facing surface

Made with [Cursor](https://cursor.com)