### PR TITLE
feat(web): render schema ticket cells in list tables (WM-782)

### DIFF
--- a/event-runtime/web/src/components/CustomCell.test.tsx
+++ b/event-runtime/web/src/components/CustomCell.test.tsx
@@ -1,7 +1,12 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { CustomCell, formatCellValue } from "./CustomCell";
+import {
+  CustomCell,
+  formatCellValue,
+  readCellUi,
+  schemaForCellPath,
+} from "./CustomCell";
 import { renderWithClient, restoreApi, withApi } from "../test-render";
 import type { RepoItem } from "../types";
 
@@ -87,6 +92,23 @@ describe("formatCellValue", () => {
   });
 });
 
+describe("schema annotations", () => {
+  test("reads a ticket annotation from the matching input-schema path", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        ticket: { type: "string", "x-ui": { kind: "ticket" } },
+      },
+    };
+    expect(readCellUi(schemaForCellPath(schema, "payload.ticket"))).toEqual({
+      kind: "ticket",
+    });
+    expect(readCellUi(schemaForCellPath(schema, "spec.input.ticket"))).toEqual({
+      kind: "ticket",
+    });
+  });
+});
+
 describe("CustomCell", () => {
   test("a view format=issue column links the whole cell to the ticket journey", async () => {
     await withApi(reposApi(), async () => {
@@ -138,6 +160,28 @@ describe("CustomCell", () => {
     await withApi(reposApi(), async () => {
       const r = renderCell(
         <CustomCell row={{ ticket: "FOO-12" }} path="ticket" format="issue" />,
+      );
+      await waitFor(() =>
+        expect(
+          r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
+        ).toBe("#/tickets/FOO-12"),
+      );
+    });
+  });
+
+  test("a schema x-ui ticket column links a team the free-text scan skips", async () => {
+    await withApi(reposApi(), async () => {
+      const r = renderCell(
+        <CustomCell
+          row={{ payload: { ticket: "FOO-12" } }}
+          path="payload.ticket"
+          schema={{
+            type: "object",
+            properties: {
+              ticket: { type: "string", "x-ui": { kind: "ticket" } },
+            },
+          }}
+        />,
       );
       await waitFor(() =>
         expect(

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -36,7 +36,11 @@ export function readCellUi(schema: unknown): CellUi | null {
   if (!schema || typeof schema !== "object" || Array.isArray(schema))
     return null;
   const annotation = (schema as Record<string, unknown>)["x-ui"];
-  if (!annotation || typeof annotation !== "object" || Array.isArray(annotation))
+  if (
+    !annotation ||
+    typeof annotation !== "object" ||
+    Array.isArray(annotation)
+  )
     return null;
   const kind = (annotation as Record<string, unknown>).kind;
   return typeof kind === "string" && kind.length > 0 ? { kind } : null;

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -8,10 +8,10 @@
  * the useful ticket reference is usually buried in a summary line, not in a
  * column anybody thought to annotate.
  *
- * The `x-ui` schema annotation (WM-701) is gone — `lib/schema.mjs` fails
- * closed on unknown keywords, so nothing could legally send it.
+ * Registry schemas from compatible producers can additionally use an `x-ui`
+ * annotation to declare the same semantic intent for dynamic table columns.
  */
-import { extractRowValue } from "../pathExtractor";
+import { extractRowValue, parsePath } from "../pathExtractor";
 import type { ArtifactFormat } from "../types";
 import { TicketHoverCard, TicketText } from "./TicketHoverCard";
 
@@ -21,6 +21,57 @@ export interface CellFormat {
   title?: string;
   /** `ticket` when the view format (or equivalent) says the whole cell is one issue id. */
   kind: string | null;
+}
+
+/** The optional presentation annotation attached to a JSON-schema property. */
+export interface CellUi {
+  kind?: string | null;
+}
+
+/**
+ * Read an `x-ui` annotation defensively. Schemas arrive from the registry, so
+ * an incomplete or third-party schema must leave the ordinary cell intact.
+ */
+export function readCellUi(schema: unknown): CellUi | null {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema))
+    return null;
+  const annotation = (schema as Record<string, unknown>)["x-ui"];
+  if (!annotation || typeof annotation !== "object" || Array.isArray(annotation))
+    return null;
+  const kind = (annotation as Record<string, unknown>).kind;
+  return typeof kind === "string" && kind.length > 0 ? { kind } : null;
+}
+
+/**
+ * Resolve the input-schema node for a dynamic table path. Dynamic columns may
+ * name their value directly or retain the Events/Runs scope discovered by the
+ * display picker (`payload.ticket`, `spec.input.ticket`, etc.).
+ */
+export function schemaForCellPath(schema: unknown, path: string): unknown {
+  const parts = [...parsePath(path.replace(/^custom:/, ""))];
+  if (parts[0] === "envelope" && parts[1] === "payload") parts.splice(0, 2);
+  else if (parts[0] === "spec" && parts[1] === "input") parts.splice(0, 2);
+  else if (parts[0] === "payload" || parts[0] === "input") parts.shift();
+
+  let node = schema;
+  for (const part of parts) {
+    if (!node || typeof node !== "object" || Array.isArray(node)) return null;
+    const record = node as Record<string, unknown>;
+    const properties = record.properties;
+    if (
+      properties &&
+      typeof properties === "object" &&
+      !Array.isArray(properties) &&
+      part in properties
+    ) {
+      node = (properties as Record<string, unknown>)[part];
+    } else if (/^\d+$/.test(part) && record.items) {
+      node = record.items;
+    } else {
+      return null;
+    }
+  }
+  return node;
 }
 
 export function formatCellValue(
@@ -70,17 +121,27 @@ export function CustomCell({
   row,
   path,
   format,
+  schema,
+  ui,
   onNavigateTicket,
 }: {
   row: unknown;
   path: string;
   /** Closed `formats` value from the active view, when the caller has one. */
   format?: ArtifactFormat | null;
+  /** Input schema for this row's agent, when the host has registry metadata. */
+  schema?: unknown;
+  /** Resolved schema UI annotation; takes precedence over a raw schema node. */
+  ui?: CellUi | null;
   onNavigateTicket?: (ticketId: string) => void;
 }) {
   const cleanPath = path.replace(/^custom:/, "");
   const value = extractRowValue(row, cleanPath);
-  const { text, isComplex, title, kind } = formatCellValue(value, format);
+  const schemaUi = ui ?? readCellUi(schemaForCellPath(schema, cleanPath));
+  const { text, isComplex, title, kind } = formatCellValue(
+    value,
+    schemaUi?.kind === "ticket" ? "issue" : format,
+  );
 
   const isMono =
     format === "sha" ||

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { Events } from "./Events";
 import {
   changeInput,
+  createAgentsFixture,
   createEventFixture,
   createProposalFixture,
   createRunListItemFixture,
@@ -13,7 +14,7 @@ import {
   withApi,
 } from "../test-render";
 import { shortId } from "../components/ui";
-import type { AdmittedEvent, EventFocus } from "../types";
+import type { AdmittedEvent, AgentsView, EventFocus } from "../types";
 
 afterEach(() => {
   cleanup();
@@ -61,7 +62,58 @@ function renderEvents(props: Partial<Parameters<typeof Events>[0]> = {}) {
   );
 }
 
+function ticketSchemaRegistry(eventType: string): AgentsView {
+  return createAgentsFixture({
+    agents: [
+      {
+        ref: "ticket-agent@1",
+        inputSchema: {
+          type: "object",
+          properties: {
+            ticket: { type: "string", "x-ui": { kind: "ticket" } },
+          },
+        },
+        eventTypes: [],
+      } as unknown as AgentsView["agents"][number],
+    ],
+    eventTypes: [{ type: eventType, agent: "ticket-agent@1" }],
+  });
+}
+
 describe("Events component harness: selection & detail view", () => {
+  test("renders an x-ui ticket payload column from its route schema", async () => {
+    localStorage.setItem(
+      "evrt-display-events",
+      JSON.stringify({ customColumns: ["payload.ticket"] }),
+    );
+    const event = stubEvent("evt_schema_ticket", "admitted", {
+      type: "ticket.route",
+      envelope: {
+        schemaVersion: "factory.event/v1",
+        eventId: "evt_schema_ticket",
+        type: "ticket.route",
+        source: "github",
+        payload: { ticket: "FOO-12" },
+      },
+    });
+
+    await withApi(
+      {
+        events: async () => ({ events: [event] }),
+        status: async () => createStatusFixture(),
+        agents: async () => ticketSchemaRegistry("ticket.route"),
+      },
+      async () => {
+        const r = renderEvents();
+        await waitFor(() =>
+          expect(
+            r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
+          ).toBe("#/tickets/FOO-12"),
+        );
+      },
+    );
+  });
+
   test("clicking a row selects the event via onSelectEvent", async () => {
     const onSelectEvent = mock(() => {});
     const e1 = stubEvent("evt_click_test", "admitted");

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -480,7 +480,8 @@ export function Events({
     // the top-level eventTypes index.
     for (const agent of registry?.agents ?? []) {
       for (const route of agent.eventTypes) {
-        if (!schemas.has(route.type)) schemas.set(route.type, agent.inputSchema);
+        if (!schemas.has(route.type))
+          schemas.set(route.type, agent.inputSchema);
       }
     }
     return schemas;

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -458,6 +458,33 @@ export function Events({
     queryFn: () => api.runs(),
     ...refetchIntervals.secondary,
   });
+  // Dynamic payload columns can be marked by the producing route's input
+  // schema. Keep this separate from row fetching: a registry refresh must not
+  // make Events wait for a second events response before its cells gain their
+  // semantic rendering.
+  const agentsQ = useQuery({
+    queryKey: ["agents"],
+    queryFn: api.agents,
+    ...refetchIntervals.secondary,
+  });
+  const inputSchemaByEventType = useMemo(() => {
+    const registry = agentsQ.data;
+    const byRef = new Map(registry?.agents.map((agent) => [agent.ref, agent]));
+    const schemas = new Map<string, unknown>();
+    for (const route of registry?.eventTypes ?? []) {
+      const schema = route.agent ? byRef.get(route.agent)?.inputSchema : null;
+      if (schema) schemas.set(route.type, schema);
+    }
+    // The route is also retained with its agent definition. This fallback
+    // keeps the semantic cell useful for older registry responses that predate
+    // the top-level eventTypes index.
+    for (const agent of registry?.agents ?? []) {
+      for (const route of agent.eventTypes) {
+        if (!schemas.has(route.type)) schemas.set(route.type, agent.inputSchema);
+      }
+    }
+    return schemas;
+  }, [agentsQ.data]);
   const decisions = useMemo(() => {
     const byId = new Map<string, Proposal>();
     const byEvent = new Map<string, Proposal>();
@@ -1336,6 +1363,7 @@ export function Events({
                           key={c.key}
                           row={e}
                           path={c.key.replace(/^custom:/, "")}
+                          schema={inputSchemaByEventType.get(e.type)}
                         />
                       ))}
                   </tr>

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -29,6 +29,7 @@ import type {
   RunDetail,
   RunListItem,
   RunState,
+  AgentsView,
 } from "../types";
 
 afterEach(() => {
@@ -143,7 +144,54 @@ function renderRuns(props: Partial<Parameters<typeof Runs>[0]> = {}) {
   );
 }
 
+function ticketSchemaRegistry(): AgentsView {
+  return createAgentsFixture({
+    agents: [
+      {
+        ref: "ticket-agent@1",
+        inputSchema: {
+          type: "object",
+          properties: {
+            ticket: { type: "string", "x-ui": { kind: "ticket" } },
+          },
+        },
+        eventTypes: [],
+      } as unknown as AgentsView["agents"][number],
+    ],
+  });
+}
+
 describe("Runs sortable columns (OPS-492)", () => {
+  test("renders an x-ui ticket input column from its run agent schema", async () => {
+    localStorage.setItem(
+      "evrt-display-runs",
+      JSON.stringify({ customColumns: ["spec.input.ticket"] }),
+    );
+    const run = stubListItem("run_schema_ticket", "COMPLETED", {
+      agent: "ticket-agent@1",
+      spec: createRunSpecFixture("run_schema_ticket", {
+        input: { ticket: "FOO-12" },
+      }),
+    });
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [run] }),
+        events: async () => ({ events: [] }),
+        status: async () => createStatusFixture(),
+        agents: async () => ticketSchemaRegistry(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() =>
+          expect(
+            r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
+          ).toBe("#/tickets/FOO-12"),
+        );
+      },
+    );
+  });
+
   test("every data header cycles ascending, descending, and default order with accessible state", async () => {
     const onSelectRun = mock(() => {});
     const later = stubListItem("run_zulu", "RUNNING", {

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -603,6 +603,18 @@ export function Runs({
     queryFn: () => api.events(),
     ...refetchIntervals.secondary,
   });
+  const agentsQ = useQuery({
+    queryKey: ["agents"],
+    queryFn: api.agents,
+    ...refetchIntervals.secondary,
+  });
+  const inputSchemaByAgent = useMemo(
+    () =>
+      new Map(
+        agentsQ.data?.agents.map((agent) => [agent.ref, agent.inputSchema]),
+      ),
+    [agentsQ.data],
+  );
   const causation = useMemo(() => {
     const originByKey = new Map<string, AdmittedEvent>();
     const emittedCount = new Map<string, number>();
@@ -1442,6 +1454,7 @@ export function Runs({
                         key={c.key}
                         row={r}
                         path={c.key.replace(/^custom:/, "")}
+                        schema={inputSchemaByAgent.get(r.agent)}
                       />
                     ))}
                 </tr>


### PR DESCRIPTION
## Summary
- Pass registry input schemas into Events and Runs custom cells so x-ui ticket columns link to ticket journeys.
- Preserve view-format and configured-team free-text ticket links.

## Verification
- cd event-runtime/web && bun test src/components/CustomCell.test.tsx src/views/Events.test.tsx src/views/Runs.test.tsx
- bun test (3408 pass, 9 environment skips)

UX critique: required — NOT-ASSESSED; the running seeded app was inspected at http://127.0.0.1:7781/#/events and http://127.0.0.1:7781/#/runs, but it has no x-ui ticket-schema fixture to drive the new link path.

Fixes WM-782