### PR TITLE
docs(oss): launch numbers and community drafts (WM-802)

### DIFF
--- a/docs/oss/launch-drafts/claude-code.md
+++ b/docs/oss/launch-drafts/claude-code.md
@@ -1,0 +1,35 @@
+# Claude Code community post (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Where: Claude Code Discord / forum / HN comment as appropriate. Not a launch
+thread of its own — a "how we run Claude Code unattended" note.
+
+---
+
+Claude Code is the worker. Factory is the floor manager.
+
+We dispatch `claude` against Linear tickets in isolated worktrees (own
+branch, ports, database). The ticket names Owned Paths and a Verification
+Command. A worker re-runs that command after the session; the agent's
+"looks good" is commentary. CI is what merges.
+
+17 days unattended, 3–20 August 2026:
+
+- 1,825 tickets dispatched, 1,620 merged
+- 87% merged without a Blocked stop or `ai:escalated`
+- median claim → merge: 38 minutes
+- the factory repo itself is 529 of those merges — Claude (and the others)
+  ship the orchestrator they run in
+
+We do not wrap Claude in a second agent that "manages" it. The planner is
+deterministic and outside the model. Claim, worktree, verify, PR, merge
+are scripts. Claude does the ticket. The interesting Claude-specific
+lessons so far: keep the Linear MCP off the unattended allowlist (too much
+surface, and it fails in ways that look like "Linear is down"); prefer
+snapshots over screenshots (context burn); never `sleep` for CI.
+
+Apache-2.0: https://github.com/watt-mind/factory
+
+`bin/factory demo --harness claude` records Claude on the demo ticket
+without needing the demo to call out to the API.

--- a/docs/oss/launch-drafts/codex.md
+++ b/docs/oss/launch-drafts/codex.md
@@ -1,0 +1,31 @@
+# Codex community post (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Where: Codex Discord / OpenAI forum / relevant GitHub Discussion.
+
+---
+
+Codex is a first-class harness in the factory, not an afterthought.
+
+The content (skills, floor rules, agent prompts) is portable. Packaging
+is the only per-harness work: Codex reads `AGENTS.md` and
+`~/.agents/skills/`. Same ticket protocol as Claude Code — claim, isolated
+worktree, Owned Paths, verification command, PR, CI.
+
+We spent the first week of dispatch half-blind on Codex. A parser that
+only understood Claude's JSON schema reported Codex runs as "0 turns, $0,
+no result" — indistinguishable from a harness that did nothing. That hid
+109 Codex runs from the budget gate in two days. The fix was one parser
+(`lib/transcript.mjs`) that every consumer imports. Adding a harness now
+means teaching that file, not each dashboard.
+
+17 days unattended (3–20 August): 1,825 tickets dispatched, 1,620 merged,
+median claim → merge 38 minutes, 87% without a human unblocking them.
+Tokens-by-harness, including Codex, come from `bun tools/launch-numbers.mjs`
+on the dispatch host.
+
+We do not compete with Codex. We sit above it. If you already live in
+Codex, the factory is the queue, the worktree, and the merge gate.
+
+https://github.com/watt-mind/factory — Apache-2.0, `bin/factory demo --harness codex`

--- a/docs/oss/launch-drafts/cursor.md
+++ b/docs/oss/launch-drafts/cursor.md
@@ -1,0 +1,33 @@
+# Cursor community post (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Where: Cursor forum / Discord. Tone: practitioners who already live in
+the editor, showing the unattended CLI path.
+
+---
+
+Cursor Agent CLI (`agent -p`) is one of the factory's harnesses.
+
+Interactive Cursor is how humans specify work. Unattended Cursor is how
+the factory runs a ticket overnight: `agent -p --output-format stream-json
+--trust --force`, cwd = the ticket worktree, prompt pointing at
+`./input.json` → `./result.json`. We never pass Cursor's own `--worktree`;
+the factory owns isolation (branch, ports, database) so two tickets cannot
+share a checkout.
+
+Same protocol as the other harnesses. The ticket is the unit. Owned Paths
+are the concurrency key. CI is the reward. The factory does not merge
+because the agent said it was done.
+
+17 days, 3–20 August 2026: 1,825 tickets dispatched, 1,620 merged, 87%
+without a Blocked detour, median 38 minutes from claim to merge. Client
+repos and the factory repo itself (529 merges) go through the same loop.
+
+If you already review PRs in Cursor, the interesting part is everything
+_around_ the agent: a tracker that can be Linear today and GitHub Issues
+next, a worker that re-runs the verification command, a merge lane that
+stops on `ai:escalated`.
+
+https://github.com/watt-mind/factory — Apache-2.0,
+`bin/factory demo --harness cursor`

--- a/docs/oss/launch-drafts/dogfood-badge.md
+++ b/docs/oss/launch-drafts/dogfood-badge.md
@@ -1,0 +1,27 @@
+# Dogfood-in-public badge (draft)
+
+**DRAFT — a human pastes this. Agents do not publish, and they do not
+edit README.md from this ticket (Owned Paths do not include it).**
+
+The updater that refreshes the count lives on a sibling ticket
+(WM-958). This snippet is the static launch version, pinned to the
+window in `docs/oss/launch-post.md`.
+
+## README / social preview
+
+```markdown
+[![Dogfooded in public](https://img.shields.io/badge/dogfooded-17_days_unattended-0f766e)](docs/oss/launch-post.md)
+```
+
+Alt copy if the post is not yet linked from the default branch:
+
+```markdown
+[![Dogfooded in public](https://img.shields.io/badge/dogfooded-in_public-0f766e)](https://github.com/watt-mind/factory)
+```
+
+## What the badge is allowed to claim
+
+The number is the unattended dispatch window from
+`bun tools/launch-numbers.mjs --since 2026-08-03` (`window.days` /
+`window.weeks`). It is not a streak, not uptime, and not "no humans
+work here." Re-run the command when the badge is updated.

--- a/docs/oss/launch-drafts/gemini-cli.md
+++ b/docs/oss/launch-drafts/gemini-cli.md
@@ -1,0 +1,33 @@
+# Gemini CLI community post (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Where: Gemini CLI Discord / Google AI forum.
+
+---
+
+Gemini CLI (and Antigravity, which shares `~/.gemini/`) is a packaging
+target, not a fork of the factory.
+
+Skills and floor rules live in `shared/` and emit into
+`~/.gemini/skills/` and `~/.gemini/agents/`. `GEMINI.md` points at
+`AGENTS.md`. The ticket protocol does not change: claim, worktree, Owned
+Paths, verification, PR, CI.
+
+We ship one floor, several wrappers. Adding Gemini was "put the files
+where Gemini looks," not a second orchestrator. That is the point of the
+project: sit above coding agents instead of competing with them.
+
+Measured across every harness we actually dispatched, 3–20 August 2026:
+
+- 17 days unattended
+- 1,825 tickets dispatched, 1,620 merged
+- 87% merged without Blocked / `ai:escalated`
+- 38 minute median claim → merge
+
+Paste Gemini's row from `bun tools/launch-numbers.mjs` (dispatch host)
+before posting if you want per-harness token counts. A host without
+transcripts will not invent them.
+
+https://github.com/watt-mind/factory — Apache-2.0,
+`bin/factory demo --harness gemini`

--- a/docs/oss/launch-drafts/show-hn.md
+++ b/docs/oss/launch-drafts/show-hn.md
@@ -1,0 +1,31 @@
+# Show HN (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Suggested title:
+
+> Show HN: Factory – unattended agents that turn tickets into merged PRs
+
+Suggested body:
+
+---
+
+We have been running coding agents (Claude Code, Codex, Cursor, Gemini CLI, Pi) against a real ticket queue since 3 August, without sitting in the sessions.
+
+In 17 days: 1,825 tickets dispatched, 1,620 merged. Median time from claim to merge is 38 minutes. 87% of merges never hit Blocked and never needed an escalation label. The other 13% stopped for a human — a decision, a credential, or a security-relevant diff.
+
+The factory does not replace the coding agent. It is the loop around it: Linear (or, soon, GitHub Issues) as the control plane, an isolated worktree per ticket, Owned Paths so two agents cannot collide, a verification command the worker re-runs, CI as the merge gate. Nothing merges because the model said it was done.
+
+It also runs itself. This repo is an ordinary dispatch target. Harness defects become tickets; tickets become PRs; merges change the next run. We keep a friction log of the repeats (agents `sleep` instead of `gh pr checks --watch`, orphaned Chrome locking the next session, a parser that treated a fenced Owned Paths block as empty).
+
+Apache-2.0. No telemetry. 15-minute demo with no third-party accounts:
+
+```
+bun install
+bin/factory demo --dry
+bin/factory demo
+```
+
+Repo: https://github.com/watt-mind/factory
+
+Numbers from `bun tools/launch-numbers.mjs --since 2026-08-03` (2026-08-20). Re-run before posting.

--- a/docs/oss/launch-drafts/x-thread.md
+++ b/docs/oss/launch-drafts/x-thread.md
@@ -1,0 +1,38 @@
+# X thread (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Keep each beat under 280. Numbers from
+`bun tools/launch-numbers.mjs --since 2026-08-03` on 2026-08-20. Re-run
+before posting.
+
+---
+
+1/ We ran coding agents unattended for 17 days. Not a demo. Real tickets,
+real repos, including the factory's own.
+
+2/ 1,825 tickets dispatched. 1,620 merged. Median 38 minutes from claim
+to merge. 87% never sat in Blocked and never needed an escalation label.
+
+3/ The other 13% stopped on purpose: a human decision, a credential, or a
+diff that touches auth/payments/secrets. The protocol is built to refuse
+those, not to wave them through.
+
+4/ Factory does not replace Claude Code, Codex, Cursor, Gemini CLI, or
+Pi. It is the loop around them: tracker → isolated worktree → verify →
+PR → CI. Nothing merges because the model said it was done.
+
+5/ The factory is also the first customer. 529 of those merges are the
+orchestrator itself. A harness bug becomes a ticket, then a PR, then the
+next run. That is the dogfood-in-public badge, not a slogan.
+
+6/ Things that actually bit us: agents `sleep 180` instead of `gh pr
+checks --watch`. Orphaned Chrome locking the next 20 sessions. A parser
+that treated a fenced "Owned Paths" block as empty, so a good ticket
+looked unspecified.
+
+7/ Apache-2.0, no telemetry, 15-minute demo with no third-party accounts:
+
+bun install && bin/factory demo
+
+https://github.com/watt-mind/factory

--- a/docs/oss/launch-post.md
+++ b/docs/oss/launch-post.md
@@ -1,0 +1,151 @@
+# Launch post (draft)
+
+**DRAFT — a human posts this. Agents do not publish.**
+
+Numbers below were generated on 2026-08-20 by:
+
+```bash
+bun tools/launch-numbers.mjs --since 2026-08-03
+```
+
+Re-run that command before publishing. Do not hand-edit the figures; if they
+look wrong, fix the script. Token totals are empty until the command is run
+on the dispatch host that writes `~/.factory/logs/*.jsonl`.
+
+---
+
+# The factory that builds software — and itself
+
+Seventeen days. No one driving the sessions.
+
+Since 3 August 2026 the factory has been dispatching coding agents against
+real tickets in real repos — its own, and client work. A specified,
+disjoint, agent-ready ticket becomes a pull request without a human at the
+keyboard. The PR merges because tests passed and a reviewer approved, not
+because an agent said it was done.
+
+That is the whole pitch. The rest of this post is the evidence, and the
+parts that broke.
+
+## The numbers (3–20 August 2026)
+
+|                                                 |                           |
+| ----------------------------------------------- | ------------------------: |
+| Unattended window                               | **17 days** (2 weeks + 3) |
+| Tickets dispatched                              |                 **1,825** |
+| Tickets merged                                  |                 **1,620** |
+| Escalated to a human (`ai:escalated`)           |                    **88** |
+| Merged without a Blocked detour or escalation   |           **1,409 (87%)** |
+| Median ticket → merge (createdAt → completedAt) |             **5.1 hours** |
+| Median claim → merge (startedAt → completedAt)  |            **38 minutes** |
+
+By team:
+
+| Team                    | Dispatched | Merged | Escalated |
+| ----------------------- | ---------: | -----: | --------: |
+| CLNT (client products)  |        631 |    557 |        31 |
+| WM (the factory itself) |        602 |    529 |        25 |
+| OPS                     |        299 |    283 |         5 |
+| CW                      |        153 |    122 |         7 |
+| LAB                     |        140 |    105 |        20 |
+
+"Without human touch" is a tracker fact, not a vibe. The ticket reached
+Done after an agent claim, never visited Blocked, and never carried
+`ai:escalated`. Humans still wrote the specs. CI still gated the merge.
+The 13% that needed a person needed a decision, a credential, or a
+security-relevant diff — and the protocol is built to stop for those.
+
+Tokens-by-harness live in the same command. This draft was generated on a
+host without JSONL transcripts; paste the `tokens by harness` block from a
+dispatch-host run into the table below before this goes public.
+
+| Harness                                                        | Runs | Input | Output | Cache-read | Fresh tokens |
+| -------------------------------------------------------------- | ---: | ----: | -----: | ---------: | -----------: |
+| _(re-run `bun tools/launch-numbers.mjs` on the dispatch host)_ |      |       |        |            |              |
+
+## What it is
+
+The factory orchestrates coding agents (Claude Code, Codex, Gemini CLI,
+Cursor, Pi). It does not compete with them. The tracker is the control
+plane, GitHub is the source of truth, and CI is the reward signal.
+
+A ticket that is specified, disjoint, and labelled `ai:agent-ready` is
+claimed into an isolated worktree (own branch, ports, database). One
+bounded agent implements exactly that ticket, inside its Owned Paths. A
+worker re-runs the ticket's Verification Command; the agent's report is
+commentary, the exit code is the evidence. Then a PR. Then CI. Merge and
+ship are later loops on the same event runtime.
+
+We do not lead with a general agent platform that happens to also write
+code. We lead with shipping software, unattended, and let generality show
+up as a consequence of the same primitives. Infra-ops and editorial loops
+already run on this runtime. Software is first because the verification
+story is strongest there.
+
+The public repo is Apache-2.0. There is no telemetry. The factory
+maintains itself in public: a harness defect becomes a ticket, a ticket
+becomes a PR, a merge changes the next run.
+
+## What measuring taught us
+
+`docs/friction-log.md` is not a retrospective slide. An entry is an open
+defect in the harness, or a record of one that was fixed so nobody
+re-proposes it.
+
+A few shapes from the first weeks:
+
+- Agents `sleep 180` to wait for CI. A fixed sleep is a guess. The floor
+  now requires `gh pr checks --watch --fail-fast`; the harness blocks
+  `sleep`. (F-8)
+- The same guess against a booting dev server. Documented; a
+  `bin/wait-for-dev.sh` default would beat a rule. (F-9, still open)
+- Killed runs leave Chrome holding a profile lock, so the next twenty
+  sessions fail `list_pages`. `chrome-sweep` now runs before each dispatch
+  pass. (F-11)
+- Agents reach for a third-party `linear` CLI and a bundled MCP, both of
+  which fail in ways that look like "Linear is down." One in-repo client
+  (`tools/linear.mjs`) is the road. (F-12)
+- A correct Owned Paths list inside a fenced code block parsed as empty,
+  so a well-specified ticket was undispatchable. The parser was the bug.
+  (F-7)
+
+Friction that repeats becomes a ticket. The factory is the first customer
+of that loop. That is what "dogfooded in public" means — not a badge on a
+README that never changes.
+
+```markdown
+[![Dogfooded in public](https://img.shields.io/badge/dogfooded-17_days_unattended-0f766e)](docs/oss/launch-post.md)
+```
+
+## Try it
+
+Fifteen minutes, no third-party accounts:
+
+```bash
+bun install
+bin/factory demo --dry    # CI runs this
+bin/factory demo          # claim → implement → verify → PR → merge
+```
+
+The default harness is `fake`: a deterministic patch against a bundled
+ticket. Pass `--harness claude` (or `codex`, `pi`, `gemini`, `cursor`,
+`agy`) to record a different adapter; the 15-minute path still applies the
+bundled patch so missing credentials cannot fail the demo closed.
+
+Read [docs/thesis.md](../thesis.md) for why it is shaped this way,
+[docs/quickstart.md](../quickstart.md) for the walkthrough, and
+[ROADMAP.md](../../ROADMAP.md) for what is next (GitHub Issues as a
+control plane, pack authoring, the `ee/` seam left empty at launch).
+
+## What we are not claiming
+
+- That 87% means no human ever opened the PR. Review and CI still happen.
+  The number is "the agent was not stuck waiting on an operator."
+- That every harness is equally measured. Token totals come from
+  `orchestrator/economics.mjs` reading real transcripts. A host without
+  those logs reports empty, it does not invent a spend figure.
+- That the runtime rewrites its own kernel unattended. Packs extend it;
+  proposals remain admission; CI remains the merge gate.
+
+Real numbers beat feature lists. These are the numbers from the first
+seventeen days. Re-run the command on day thirty-four.

--- a/orchestrator/economics.mjs
+++ b/orchestrator/economics.mjs
@@ -39,7 +39,6 @@ import {
   mkdirSync,
   appendFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import { dbPath } from "../event-runtime/lib/config.mjs";
@@ -53,421 +52,507 @@ import {
   parseDuration,
 } from "../lib/transcript.mjs";
 
-const argv = process.argv.slice(2);
-const val = (f) => {
-  const i = argv.indexOf(f);
-  return i === -1 ? null : argv[i + 1];
-};
-const JSON_OUT = argv.includes("--json");
-const ROLL = argv.includes("--roll");
-const TOP = Number(val("--top") ?? 15);
-
-if (!existsSync(LOG_DIR)) {
-  console.error(`no transcripts at ${LOG_DIR}`);
-  process.exit(1);
-}
-
-// --gate: is there enough un-rolled material to justify a retro run? Filename
-// comparison only — the rollup keys on the transcript basename, so this never
-// parses a transcript (the gate must stay cheap enough to poll). Exit 0 when
-// >= --gate-min (default 5) completed runs are not yet in the rollup; runs
-// younger than 5 minutes are skipped as possibly still streaming, mirroring
-// the in-flight rule in the rollup writer below.
-if (argv.includes("--gate")) {
-  const min = Number(val("--gate-min") ?? 5);
-  const seen = new Set();
-  if (existsSync(ROLLUP)) {
-    for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
-      if (!line.startsWith("{")) continue;
-      try {
-        seen.add(JSON.parse(line).file);
-      } catch {
-        /* intentionally ignored */
-      }
-    }
-  }
-  const unrolled = readdirSync(LOG_DIR)
-    .filter((f) => f.endsWith(".jsonl") && !seen.has(f))
-    .filter(
-      (f) => Date.now() - statSync(path.join(LOG_DIR, f)).mtimeMs > 5 * 60_000,
-    );
-  console.error(`gate: ${unrolled.length} un-rolled run(s), threshold ${min}`);
-  process.exit(unrolled.length >= min ? 0 : 1);
-}
-
-const sinceArg = val("--since");
-const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
-
-const files = readdirSync(LOG_DIR)
-  .filter((f) => f.endsWith(".jsonl"))
-  .map((f) => ({
-    f,
-    p: path.join(LOG_DIR, f),
-    t: statSync(path.join(LOG_DIR, f)).mtimeMs,
-  }))
-  .filter((x) => x.t >= sinceMs)
-  .sort((a, b) => a.t - b.t);
-
-if (!files.length) {
-  console.error("no transcripts match");
-  process.exit(1);
-}
-
-const runs = files.map(({ f, p, t }) =>
-  parseRun(f, readFileSync(p, "utf8"), t),
-);
-
-// ---------------------------------------------------------------- rollup ---
-// Transcripts are big (350MB for two days) and will eventually be pruned. The
-// rollup is the small, permanent record: one line per run, append-only, keyed
-// by log filename so re-running is idempotent. This is what a dashboard reads.
-if (ROLL) {
-  mkdirSync(METRICS_DIR, { recursive: true });
-  const seen = new Set();
-  if (existsSync(ROLLUP)) {
-    for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
-      if (!line.startsWith("{")) continue;
-      try {
-        seen.add(JSON.parse(line).file);
-      } catch {
-        /* intentionally ignored */
-      }
-    }
-  }
-  let added = 0,
-    inFlight = 0;
-  for (const r of runs) {
-    if (seen.has(r.file)) continue;
-    // A run still streaming has no verdict yet, and the append-only key would
-    // then refuse to replace the half-finished row. Judge that by RECENCY, not
-    // by the missing verdict: a truncated transcript is a permanent record of a
-    // killed run, and that is precisely the waste worth keeping.
-    if (r.truncated && Date.now() - r.mtime < 5 * 60_000) {
-      inFlight++;
-      continue;
-    }
-    const { commands, toolResultBytes, toolCalls, errorSigs, ...rest } = r;
-    // Maps stringify to {}. Flatten the two worth keeping — per-run tool mix and
-    // failure shapes are what makes the rollup answer questions on its own,
-    // after the 350MB of transcripts behind it have been pruned.
-    appendFileSync(
-      ROLLUP,
-      JSON.stringify({
-        ...rest,
-        toolCalls: Object.fromEntries(toolCalls),
-        errorSigs: Object.fromEntries(
-          [...errorSigs].map(([k, v]) => [k, v.count]),
-        ),
-      }) + "\n",
-    );
-    added++;
-  }
-  console.error(
-    `rollup: +${added} run(s)${inFlight ? `, ${inFlight} still in flight` : ""} -> ${ROLLUP}`,
-  );
-}
-
-// ----------------------------------------------------------- aggregation ---
-const sum = (xs, k) => xs.reduce((a, b) => a + (b[k] ?? 0), 0);
-const groupBy = (xs, key) => {
-  const m = new Map();
-  for (const x of xs) {
-    const k = key(x);
-    (m.get(k) ?? m.set(k, []).get(k)).push(x);
-  }
-  return m;
-};
-
-const toolBytes = new Map(); // tool -> {bytes, calls, weighted}
-const toolCalls = new Map();
-const errorsBySig = new Map();
-for (const r of runs) {
-  for (const [name, v] of r.toolResultBytes) {
-    const t = toolBytes.get(name) ?? { bytes: 0, calls: 0, weighted: 0 };
-    t.bytes += v.bytes;
-    t.calls += v.calls;
-    t.weighted += v.weighted;
-    toolBytes.set(name, t);
-  }
-  for (const [name, n] of r.toolCalls)
-    toolCalls.set(name, (toolCalls.get(name) ?? 0) + n);
-  for (const [sig, v] of r.errorSigs) {
-    const e = errorsBySig.get(sig) ?? {
-      count: 0,
-      runs: 0,
-      sample: v.sample,
-      tool: v.tool,
+/**
+ * Load normalised run records from orchestrator transcripts.
+ *
+ * Exported so launch metrics (and tests) can reuse the same parser and
+ * directory contract as this CLI, without importing a file that used to
+ * exit as a side effect of being loaded.
+ */
+export function loadTranscriptRuns({ logDir = LOG_DIR, sinceMs = 0 } = {}) {
+  if (!existsSync(logDir)) {
+    return {
+      ok: false,
+      code: "no-dir",
+      message: `no transcripts at ${logDir}`,
+      runs: [],
+      files: [],
     };
-    e.count += v.count;
-    e.runs++;
-    errorsBySig.set(sig, e);
   }
+  const files = readdirSync(logDir)
+    .filter((f) => f.endsWith(".jsonl"))
+    .map((f) => ({
+      f,
+      p: path.join(logDir, f),
+      t: statSync(path.join(logDir, f)).mtimeMs,
+    }))
+    .filter((x) => x.t >= sinceMs)
+    .sort((a, b) => a.t - b.t);
+  if (!files.length) {
+    return {
+      ok: false,
+      code: "no-match",
+      message: "no transcripts match",
+      runs: [],
+      files: [],
+    };
+  }
+  return {
+    ok: true,
+    code: "ok",
+    message: null,
+    files,
+    runs: files.map(({ f, p, t }) => parseRun(f, readFileSync(p, "utf8"), t)),
+  };
 }
 
-const totals = {
-  runs: runs.length,
-  cost: sum(runs, "cost"),
-  freshIn: sum(runs, "in"),
-  cacheRead: sum(runs, "cacheRead"),
-  cacheWrite: sum(runs, "cacheWrite"),
-  out: sum(runs, "out"),
-  turns: sum(runs, "turns"),
-  tools: sum(runs, "tools"),
-  errors: sum(runs, "errors"),
-  wallMin: sum(runs, "durMs") / 60000,
-  resultBytes: sum(runs, "resultBytes"),
-  weightedBytes: sum(runs, "weightedBytes"),
-  wasted: runs.filter((r) => r.wasted).length,
-  wastedMin:
-    runs.filter((r) => r.wasted).reduce((a, b) => a + b.durMs, 0) / 60000,
-};
-
-// The runtime ledger is the source of truth for immutable RunSpecs and merged
-// tickets. Transcript filenames do identify tickets, but cannot safely recover
-// the tier from a mutable model name or the complete merge/fix history.
-let modelTierEconomics = [];
-const runtimeDb = dbPath();
-if (existsSync(runtimeDb)) {
-  const db = new Database(runtimeDb, { readonly: true });
-  try {
-    modelTierEconomics = modelTierEconomicsView(db, {
-      startMs: sinceMs,
-      endMs: Date.now(),
-    });
-  } finally {
-    db.close();
+/** Per-harness token and run totals. Pure; takes already-parsed Run records. */
+export function harnessTokenTotals(runs) {
+  const m = new Map();
+  for (const r of runs) {
+    const key = r.harness || "unknown";
+    const row = m.get(key) ?? {
+      harness: key,
+      runs: 0,
+      ok: 0,
+      fail: 0,
+      none: 0,
+      in: 0,
+      out: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      tokens: 0,
+      cost: 0,
+      estCost: 0,
+    };
+    row.runs++;
+    if (r.ok === true) row.ok++;
+    else if (r.ok === false) row.fail++;
+    else row.none++;
+    row.in += r.in ?? 0;
+    row.out += r.out ?? 0;
+    row.cacheRead += r.cacheRead ?? 0;
+    row.cacheWrite += r.cacheWrite ?? 0;
+    row.cost += r.cost ?? 0;
+    row.estCost += r.estCost ?? 0;
+    row.tokens = row.in + row.out;
+    m.set(key, row);
   }
+  return [...m.values()].sort((a, b) => b.runs - a.runs);
 }
 
-if (JSON_OUT) {
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const JSON_OUT = argv.includes("--json");
+  const ROLL = argv.includes("--roll");
+  const TOP = Number(val("--top") ?? 15);
+
+  if (!existsSync(LOG_DIR)) {
+    console.error(`no transcripts at ${LOG_DIR}`);
+    process.exit(1);
+  }
+
+  // --gate: is there enough un-rolled material to justify a retro run? Filename
+  // comparison only — the rollup keys on the transcript basename, so this never
+  // parses a transcript (the gate must stay cheap enough to poll). Exit 0 when
+  // >= --gate-min (default 5) completed runs are not yet in the rollup; runs
+  // younger than 5 minutes are skipped as possibly still streaming, mirroring
+  // the in-flight rule in the rollup writer below.
+  if (argv.includes("--gate")) {
+    const min = Number(val("--gate-min") ?? 5);
+    const seen = new Set();
+    if (existsSync(ROLLUP)) {
+      for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
+        if (!line.startsWith("{")) continue;
+        try {
+          seen.add(JSON.parse(line).file);
+        } catch {
+          /* intentionally ignored */
+        }
+      }
+    }
+    const unrolled = readdirSync(LOG_DIR)
+      .filter((f) => f.endsWith(".jsonl") && !seen.has(f))
+      .filter(
+        (f) =>
+          Date.now() - statSync(path.join(LOG_DIR, f)).mtimeMs > 5 * 60_000,
+      );
+    console.error(
+      `gate: ${unrolled.length} un-rolled run(s), threshold ${min}`,
+    );
+    process.exit(unrolled.length >= min ? 0 : 1);
+  }
+
+  const sinceArg = val("--since");
+  const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
+
+  const files = readdirSync(LOG_DIR)
+    .filter((f) => f.endsWith(".jsonl"))
+    .map((f) => ({
+      f,
+      p: path.join(LOG_DIR, f),
+      t: statSync(path.join(LOG_DIR, f)).mtimeMs,
+    }))
+    .filter((x) => x.t >= sinceMs)
+    .sort((a, b) => a.t - b.t);
+
+  if (!files.length) {
+    console.error("no transcripts match");
+    process.exit(1);
+  }
+
+  const runs = files.map(({ f, p, t }) =>
+    parseRun(f, readFileSync(p, "utf8"), t),
+  );
+
+  // ---------------------------------------------------------------- rollup ---
+  // Transcripts are big (350MB for two days) and will eventually be pruned. The
+  // rollup is the small, permanent record: one line per run, append-only, keyed
+  // by log filename so re-running is idempotent. This is what a dashboard reads.
+  if (ROLL) {
+    mkdirSync(METRICS_DIR, { recursive: true });
+    const seen = new Set();
+    if (existsSync(ROLLUP)) {
+      for (const line of readFileSync(ROLLUP, "utf8").split("\n")) {
+        if (!line.startsWith("{")) continue;
+        try {
+          seen.add(JSON.parse(line).file);
+        } catch {
+          /* intentionally ignored */
+        }
+      }
+    }
+    let added = 0,
+      inFlight = 0;
+    for (const r of runs) {
+      if (seen.has(r.file)) continue;
+      // A run still streaming has no verdict yet, and the append-only key would
+      // then refuse to replace the half-finished row. Judge that by RECENCY, not
+      // by the missing verdict: a truncated transcript is a permanent record of a
+      // killed run, and that is precisely the waste worth keeping.
+      if (r.truncated && Date.now() - r.mtime < 5 * 60_000) {
+        inFlight++;
+        continue;
+      }
+      const { commands, toolResultBytes, toolCalls, errorSigs, ...rest } = r;
+      // Maps stringify to {}. Flatten the two worth keeping — per-run tool mix and
+      // failure shapes are what makes the rollup answer questions on its own,
+      // after the 350MB of transcripts behind it have been pruned.
+      appendFileSync(
+        ROLLUP,
+        JSON.stringify({
+          ...rest,
+          toolCalls: Object.fromEntries(toolCalls),
+          errorSigs: Object.fromEntries(
+            [...errorSigs].map(([k, v]) => [k, v.count]),
+          ),
+        }) + "\n",
+      );
+      added++;
+    }
+    console.error(
+      `rollup: +${added} run(s)${inFlight ? `, ${inFlight} still in flight` : ""} -> ${ROLLUP}`,
+    );
+  }
+
+  // ----------------------------------------------------------- aggregation ---
+  const sum = (xs, k) => xs.reduce((a, b) => a + (b[k] ?? 0), 0);
+  const groupBy = (xs, key) => {
+    const m = new Map();
+    for (const x of xs) {
+      const k = key(x);
+      (m.get(k) ?? m.set(k, []).get(k)).push(x);
+    }
+    return m;
+  };
+
+  const toolBytes = new Map(); // tool -> {bytes, calls, weighted}
+  const toolCalls = new Map();
+  const errorsBySig = new Map();
+  for (const r of runs) {
+    for (const [name, v] of r.toolResultBytes) {
+      const t = toolBytes.get(name) ?? { bytes: 0, calls: 0, weighted: 0 };
+      t.bytes += v.bytes;
+      t.calls += v.calls;
+      t.weighted += v.weighted;
+      toolBytes.set(name, t);
+    }
+    for (const [name, n] of r.toolCalls)
+      toolCalls.set(name, (toolCalls.get(name) ?? 0) + n);
+    for (const [sig, v] of r.errorSigs) {
+      const e = errorsBySig.get(sig) ?? {
+        count: 0,
+        runs: 0,
+        sample: v.sample,
+        tool: v.tool,
+      };
+      e.count += v.count;
+      e.runs++;
+      errorsBySig.set(sig, e);
+    }
+  }
+
+  const totals = {
+    runs: runs.length,
+    cost: sum(runs, "cost"),
+    freshIn: sum(runs, "in"),
+    cacheRead: sum(runs, "cacheRead"),
+    cacheWrite: sum(runs, "cacheWrite"),
+    out: sum(runs, "out"),
+    turns: sum(runs, "turns"),
+    tools: sum(runs, "tools"),
+    errors: sum(runs, "errors"),
+    wallMin: sum(runs, "durMs") / 60000,
+    resultBytes: sum(runs, "resultBytes"),
+    weightedBytes: sum(runs, "weightedBytes"),
+    wasted: runs.filter((r) => r.wasted).length,
+    wastedMin:
+      runs.filter((r) => r.wasted).reduce((a, b) => a + b.durMs, 0) / 60000,
+  };
+
+  // The runtime ledger is the source of truth for immutable RunSpecs and merged
+  // tickets. Transcript filenames do identify tickets, but cannot safely recover
+  // the tier from a mutable model name or the complete merge/fix history.
+  let modelTierEconomics = [];
+  const runtimeDb = dbPath();
+  if (existsSync(runtimeDb)) {
+    const db = new Database(runtimeDb, { readonly: true });
+    try {
+      modelTierEconomics = modelTierEconomicsView(db, {
+        startMs: sinceMs,
+        endMs: Date.now(),
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  if (JSON_OUT) {
+    console.log(
+      JSON.stringify(
+        {
+          totals,
+          runs: runs.map(
+            ({ commands, toolResultBytes, errorSigs, toolCalls, ...r }) => r,
+          ),
+          tools: [...toolBytes.entries()].map(([name, v]) => ({
+            name,
+            ...v,
+            calls: toolCalls.get(name) ?? v.calls,
+          })),
+          errors: [...errorsBySig.entries()].map(([sig, v]) => ({ sig, ...v })),
+          modelTierEconomics,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(0);
+  }
+
+  // --------------------------------------------------------------- render ---
+  const c = {
+    dim: (s) => `\x1b[2m${s}\x1b[0m`,
+    bold: (s) => `\x1b[1m${s}\x1b[0m`,
+    red: (s) => `\x1b[31m${s}\x1b[0m`,
+    yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+    green: (s) => `\x1b[32m${s}\x1b[0m`,
+    cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  };
+  const M = (n) =>
+    n >= 1e6
+      ? (n / 1e6).toFixed(1) + "M"
+      : n >= 1e3
+        ? (n / 1e3).toFixed(0) + "k"
+        : String(Math.round(n));
+  const MB = (n) => (n / 1e6).toFixed(1) + "MB";
+  const pad = (s, n) => String(s).padStart(n);
+  const padR = (s, n) => String(s).padEnd(n);
+
+  console.log(c.bold("\nmerged-ticket economics by model tier\n"));
+  if (!modelTierEconomics.length) {
+    console.log(
+      c.dim("  no merged, RunSpec-pinned ticket cohorts in this window"),
+    );
+  } else {
+    console.log(
+      c.dim(
+        "  tier       dispatched  merged  median $/merged  total $  std escalation",
+      ),
+    );
+    for (const row of modelTierEconomics) {
+      const escalation =
+        row.standardTierEscalationRate == null
+          ? "—"
+          : `${(row.standardTierEscalationRate * 100).toFixed(1)}%`;
+      console.log(
+        `  ${padR(row.key, 11)}${pad(row.ticketsDispatched, 6)}${pad(row.ticketsMerged, 8)}` +
+          `${pad(row.medianCostPerMergedTicketUSD == null ? "—" : "$" + row.medianCostPerMergedTicketUSD.toFixed(2), 17)}` +
+          `${pad("$" + row.totalCostUSD.toFixed(2), 9)}${pad(escalation, 16)}`,
+      );
+    }
+  }
+
   console.log(
-    JSON.stringify(
-      {
-        totals,
-        runs: runs.map(
-          ({ commands, toolResultBytes, errorSigs, toolCalls, ...r }) => r,
-        ),
-        tools: [...toolBytes.entries()].map(([name, v]) => ({
-          name,
-          ...v,
-          calls: toolCalls.get(name) ?? v.calls,
-        })),
-        errors: [...errorsBySig.entries()].map(([sig, v]) => ({ sig, ...v })),
-        modelTierEconomics,
-      },
-      null,
-      2,
+    c.bold(
+      `\neconomics across ${totals.runs} run(s)${sinceArg ? ` (last ${sinceArg})` : ""}\n`,
     ),
   );
-  process.exit(0);
-}
 
-// --------------------------------------------------------------- render ---
-const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`,
-  bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`,
-  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
-};
-const M = (n) =>
-  n >= 1e6
-    ? (n / 1e6).toFixed(1) + "M"
-    : n >= 1e3
-      ? (n / 1e3).toFixed(0) + "k"
-      : String(Math.round(n));
-const MB = (n) => (n / 1e6).toFixed(1) + "MB";
-const pad = (s, n) => String(s).padStart(n);
-const padR = (s, n) => String(s).padEnd(n);
-
-console.log(c.bold("\nmerged-ticket economics by model tier\n"));
-if (!modelTierEconomics.length) {
+  const allIn = totals.freshIn + totals.cacheRead + totals.cacheWrite;
   console.log(
-    c.dim("  no merged, RunSpec-pinned ticket cohorts in this window"),
+    `  input   fresh ${pad(M(totals.freshIn), 7)}   cache-write ${pad(M(totals.cacheWrite), 7)}   cache-read ${pad(M(totals.cacheRead), 7)}`,
   );
-} else {
+  console.log(
+    `  output  ${pad(M(totals.out), 7)}        wall ${pad(totals.wallMin.toFixed(0) + "min", 8)}    turns ${pad(totals.turns, 6)}   tools ${pad(totals.tools, 6)}`,
+  );
+  if (allIn) {
+    const hit = (100 * totals.cacheRead) / allIn;
+    const ratio = totals.cacheWrite ? totals.cacheRead / totals.cacheWrite : 0;
+    const verdict =
+      ratio >= 20
+        ? c.green("healthy")
+        : ratio >= 8
+          ? c.yellow("mediocre")
+          : c.red("POOR — prefix keeps invalidating");
+    console.log(
+      `  cache   ${hit.toFixed(1)}% of input served from cache · read:write 1:${ratio.toFixed(1)}  ${verdict}`,
+    );
+  }
+  console.log(
+    `  cost    $${totals.cost.toFixed(2)} notional  ${c.dim(`(subscription auth — a runaway gauge, not a bill)`)}`,
+  );
+
+  // Context burn is the number that actually explains the bill: bytes of tool
+  // output multiplied by the turns that output was still in the window for.
+  console.log(
+    `  context ${MB(totals.resultBytes)} of tool output, re-sent ${MB(totals.weightedBytes)} across turns ` +
+      c.dim(`(~${M(totals.weightedBytes / 4)} tok of cache traffic)`),
+  );
+  if (totals.wasted) {
+    console.log(
+      c.red(
+        `  wasted  ${totals.wasted} run(s) produced nothing — ${totals.wastedMin.toFixed(0)}min of wall clock`,
+      ),
+    );
+  }
+
+  // ---- by harness: the blind spot that motivated this file -------------------
+  console.log(
+    c.bold(`\nby harness`) +
+      c.dim(
+        `   a harness that only ever errors still consumes dispatch slots\n`,
+      ),
+  );
   console.log(
     c.dim(
-      "  tier       dispatched  merged  median $/merged  total $  std escalation",
+      "  harness   runs    ok   fail  none   cost$   wall   avg turns   note",
     ),
   );
-  for (const row of modelTierEconomics) {
-    const escalation =
-      row.standardTierEscalationRate == null
-        ? "—"
-        : `${(row.standardTierEscalationRate * 100).toFixed(1)}%`;
+  for (const [h, rs] of [...groupBy(runs, (r) => r.harness)].sort(
+    (a, b) => b[1].length - a[1].length,
+  )) {
+    const ok = rs.filter((r) => r.ok === true).length;
+    const fail = rs.filter((r) => r.ok === false).length;
+    const none = rs.filter((r) => r.ok === null).length;
+    const cost = sum(rs, "cost");
+    const wall = sum(rs, "durMs") / 60000;
+    // Only Claude and agy report a duration. Printing "0m" for the others reads
+    // as "instant" when it means "not measured" — say which it is.
+    const wallCell =
+      wall > 0 ? pad(wall.toFixed(0) + "m", 7) : c.dim(pad("n/a", 7));
+    const note =
+      cost === 0 && rs.length > 3
+        ? c.yellow(
+            `priced from tokens (~$${sum(rs, "estCost").toFixed(0)}) — this harness reports no cost`,
+          )
+        : "";
     console.log(
-      `  ${padR(row.key, 11)}${pad(row.ticketsDispatched, 6)}${pad(row.ticketsMerged, 8)}` +
-        `${pad(row.medianCostPerMergedTicketUSD == null ? "—" : "$" + row.medianCostPerMergedTicketUSD.toFixed(2), 17)}` +
-        `${pad("$" + row.totalCostUSD.toFixed(2), 9)}${pad(escalation, 16)}`,
+      `  ${padR(h, 9)}${pad(rs.length, 5)}${pad(ok, 6)}${pad(fail, 7)}${pad(none, 6)}${pad("$" + cost.toFixed(0), 8)}${wallCell}${pad((sum(rs, "turns") / rs.length).toFixed(0), 12)}   ${note}`,
     );
   }
-}
 
-console.log(
-  c.bold(
-    `\neconomics across ${totals.runs} run(s)${sinceArg ? ` (last ${sinceArg})` : ""}\n`,
-  ),
-);
-
-const allIn = totals.freshIn + totals.cacheRead + totals.cacheWrite;
-console.log(
-  `  input   fresh ${pad(M(totals.freshIn), 7)}   cache-write ${pad(M(totals.cacheWrite), 7)}   cache-read ${pad(M(totals.cacheRead), 7)}`,
-);
-console.log(
-  `  output  ${pad(M(totals.out), 7)}        wall ${pad(totals.wallMin.toFixed(0) + "min", 8)}    turns ${pad(totals.turns, 6)}   tools ${pad(totals.tools, 6)}`,
-);
-if (allIn) {
-  const hit = (100 * totals.cacheRead) / allIn;
-  const ratio = totals.cacheWrite ? totals.cacheRead / totals.cacheWrite : 0;
-  const verdict =
-    ratio >= 20
-      ? c.green("healthy")
-      : ratio >= 8
-        ? c.yellow("mediocre")
-        : c.red("POOR — prefix keeps invalidating");
+  // ---- by stage --------------------------------------------------------------
+  console.log(c.bold(`\nby stage\n`));
   console.log(
-    `  cache   ${hit.toFixed(1)}% of input served from cache · read:write 1:${ratio.toFixed(1)}  ${verdict}`,
-  );
-}
-console.log(
-  `  cost    $${totals.cost.toFixed(2)} notional  ${c.dim(`(subscription auth — a runaway gauge, not a bill)`)}`,
-);
-
-// Context burn is the number that actually explains the bill: bytes of tool
-// output multiplied by the turns that output was still in the window for.
-console.log(
-  `  context ${MB(totals.resultBytes)} of tool output, re-sent ${MB(totals.weightedBytes)} across turns ` +
-    c.dim(`(~${M(totals.weightedBytes / 4)} tok of cache traffic)`),
-);
-if (totals.wasted) {
-  console.log(
-    c.red(
-      `  wasted  ${totals.wasted} run(s) produced nothing — ${totals.wastedMin.toFixed(0)}min of wall clock`,
+    c.dim(
+      "  stage            runs   cost$  $/run  turns/run  tools/run  err  wasted  ctx re-sent",
     ),
   );
-}
+  for (const [s, rs] of [...groupBy(runs, (r) => r.stage)].sort(
+    (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
+  )) {
+    const cost = sum(rs, "cost");
+    console.log(
+      `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}` +
+        `${pad((sum(rs, "turns") / rs.length).toFixed(0), 11)}${pad((sum(rs, "tools") / rs.length).toFixed(0), 11)}` +
+        `${pad(sum(rs, "errors"), 5)}${pad(rs.filter((r) => r.wasted).length, 8)}${pad(MB(sum(rs, "weightedBytes")), 13)}`,
+    );
+  }
 
-// ---- by harness: the blind spot that motivated this file -------------------
-console.log(
-  c.bold(`\nby harness`) +
-    c.dim(`   a harness that only ever errors still consumes dispatch slots\n`),
-);
-console.log(
-  c.dim(
-    "  harness   runs    ok   fail  none   cost$   wall   avg turns   note",
-  ),
-);
-for (const [h, rs] of [...groupBy(runs, (r) => r.harness)].sort(
-  (a, b) => b[1].length - a[1].length,
-)) {
-  const ok = rs.filter((r) => r.ok === true).length;
-  const fail = rs.filter((r) => r.ok === false).length;
-  const none = rs.filter((r) => r.ok === null).length;
-  const cost = sum(rs, "cost");
-  const wall = sum(rs, "durMs") / 60000;
-  // Only Claude and agy report a duration. Printing "0m" for the others reads
-  // as "instant" when it means "not measured" — say which it is.
-  const wallCell =
-    wall > 0 ? pad(wall.toFixed(0) + "m", 7) : c.dim(pad("n/a", 7));
-  const note =
-    cost === 0 && rs.length > 3
-      ? c.yellow(
-          `priced from tokens (~$${sum(rs, "estCost").toFixed(0)}) — this harness reports no cost`,
-        )
-      : "";
-  console.log(
-    `  ${padR(h, 9)}${pad(rs.length, 5)}${pad(ok, 6)}${pad(fail, 7)}${pad(none, 6)}${pad("$" + cost.toFixed(0), 8)}${wallCell}${pad((sum(rs, "turns") / rs.length).toFixed(0), 12)}   ${note}`,
-  );
-}
+  // ---- by repo ---------------------------------------------------------------
+  console.log(c.bold(`\nby repo\n`));
+  console.log(c.dim("  repo             runs   cost$  $/run   err  wasted"));
+  for (const [s, rs] of [...groupBy(runs, (r) => r.repo)].sort(
+    (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
+  )) {
+    const cost = sum(rs, "cost");
+    console.log(
+      `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}${pad(sum(rs, "errors"), 6)}${pad(rs.filter((r) => r.wasted).length, 8)}`,
+    );
+  }
 
-// ---- by stage --------------------------------------------------------------
-console.log(c.bold(`\nby stage\n`));
-console.log(
-  c.dim(
-    "  stage            runs   cost$  $/run  turns/run  tools/run  err  wasted  ctx re-sent",
-  ),
-);
-for (const [s, rs] of [...groupBy(runs, (r) => r.stage)].sort(
-  (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
-)) {
-  const cost = sum(rs, "cost");
+  // ---- context burn ----------------------------------------------------------
   console.log(
-    `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}` +
-      `${pad((sum(rs, "turns") / rs.length).toFixed(0), 11)}${pad((sum(rs, "tools") / rs.length).toFixed(0), 11)}` +
-      `${pad(sum(rs, "errors"), 5)}${pad(rs.filter((r) => r.wasted).length, 8)}${pad(MB(sum(rs, "weightedBytes")), 13)}`,
+    c.bold(`\ncontext burn by tool`) +
+      c.dim(`   "re-sent" = payload x turns it stayed in the window\n`),
   );
-}
-
-// ---- by repo ---------------------------------------------------------------
-console.log(c.bold(`\nby repo\n`));
-console.log(c.dim("  repo             runs   cost$  $/run   err  wasted"));
-for (const [s, rs] of [...groupBy(runs, (r) => r.repo)].sort(
-  (a, b) => sum(b[1], "cost") - sum(a[1], "cost"),
-)) {
-  const cost = sum(rs, "cost");
-  console.log(
-    `  ${padR(s, 16)}${pad(rs.length, 5)}${pad("$" + cost.toFixed(0), 8)}${pad("$" + (cost / rs.length).toFixed(2), 7)}${pad(sum(rs, "errors"), 6)}${pad(rs.filter((r) => r.wasted).length, 8)}`,
-  );
-}
-
-// ---- context burn ----------------------------------------------------------
-console.log(
-  c.bold(`\ncontext burn by tool`) +
-    c.dim(`   "re-sent" = payload x turns it stayed in the window\n`),
-);
-console.log(c.dim("     calls    payload    re-sent   avg/call   tool"));
-for (const [name, v] of [...toolBytes.entries()]
-  .sort((a, b) => b[1].weighted - a[1].weighted)
-  .slice(0, TOP)) {
-  const avg = v.bytes / Math.max(1, v.calls);
-  const flag = avg > 50000 ? c.red("  <- huge payload per call") : "";
-  console.log(
-    `  ${pad(toolCalls.get(name) ?? v.calls, 6)}${pad(MB(v.bytes), 11)}${pad(MB(v.weighted), 11)}${pad(M(avg) + "B", 11)}   ${name}${flag}`,
-  );
-}
-
-// ---- worst individual runs -------------------------------------------------
-console.log(c.bold(`\nmost expensive runs\n`));
-for (const r of [...runs].sort((a, b) => b.cost - a.cost).slice(0, TOP)) {
-  const ratio = r.cacheWrite ? (r.cacheRead / r.cacheWrite).toFixed(0) : "-";
-  console.log(
-    `  ${pad("$" + r.cost.toFixed(2), 8)}  ${pad(r.turns + "t", 6)} ${pad(r.tools + "tc", 7)}  cache 1:${pad(ratio, 3)}  ${pad((r.durMs / 60000).toFixed(0) + "m", 5)}  ${c.dim(r.file.replace(/\.+jsonl$/, ""))}`,
-  );
-}
-
-// ---- waste -----------------------------------------------------------------
-const wasted = runs.filter((r) => r.wasted);
-if (wasted.length) {
-  console.log(
-    c.bold(`\nruns that produced nothing`) +
-      c.dim(`   these still held a dispatch slot\n`),
-  );
-  // Group by failure SHAPE, not exact text: "quota reached, resets in 44h1m15s"
-  // and "...44h21m16s" are one problem, and listing them separately buries it.
-  const byReason = groupBy(wasted, (r) =>
-    r.error
-      ? messageSignature(r.error)
-      : r.truncated
-        ? "killed mid-run — no final envelope (wall-clock cap, crash, or kill)"
-        : r.ok === false
-          ? "harness reported failure"
-          : "no verdict recorded",
-  );
-  for (const [reason, rs] of [...byReason]
-    .sort((a, b) => b[1].length - a[1].length)
+  console.log(c.dim("     calls    payload    re-sent   avg/call   tool"));
+  for (const [name, v] of [...toolBytes.entries()]
+    .sort((a, b) => b[1].weighted - a[1].weighted)
     .slice(0, TOP)) {
-    const mins = sum(rs, "durMs") / 60000;
-    const where = [...new Set(rs.map((r) => r.harness))].join("/");
+    const avg = v.bytes / Math.max(1, v.calls);
+    const flag = avg > 50000 ? c.red("  <- huge payload per call") : "";
     console.log(
-      `  ${c.red("x" + pad(rs.length, 3))}  ${padR(reason.slice(0, 66), 66)} ${c.dim(padR(where, 8))} ${c.dim(mins ? mins.toFixed(0) + "min" : "")}`,
+      `  ${pad(toolCalls.get(name) ?? v.calls, 6)}${pad(MB(v.bytes), 11)}${pad(MB(v.weighted), 11)}${pad(M(avg) + "B", 11)}   ${name}${flag}`,
     );
   }
-}
 
-console.log(
-  c.dim(
-    `\nNext: friction.mjs for what wasted time; --roll to persist these rows for a dashboard.\n`,
-  ),
-);
+  // ---- worst individual runs -------------------------------------------------
+  console.log(c.bold(`\nmost expensive runs\n`));
+  for (const r of [...runs].sort((a, b) => b.cost - a.cost).slice(0, TOP)) {
+    const ratio = r.cacheWrite ? (r.cacheRead / r.cacheWrite).toFixed(0) : "-";
+    console.log(
+      `  ${pad("$" + r.cost.toFixed(2), 8)}  ${pad(r.turns + "t", 6)} ${pad(r.tools + "tc", 7)}  cache 1:${pad(ratio, 3)}  ${pad((r.durMs / 60000).toFixed(0) + "m", 5)}  ${c.dim(r.file.replace(/\.+jsonl$/, ""))}`,
+    );
+  }
+
+  // ---- waste -----------------------------------------------------------------
+  const wasted = runs.filter((r) => r.wasted);
+  if (wasted.length) {
+    console.log(
+      c.bold(`\nruns that produced nothing`) +
+        c.dim(`   these still held a dispatch slot\n`),
+    );
+    // Group by failure SHAPE, not exact text: "quota reached, resets in 44h1m15s"
+    // and "...44h21m16s" are one problem, and listing them separately buries it.
+    const byReason = groupBy(wasted, (r) =>
+      r.error
+        ? messageSignature(r.error)
+        : r.truncated
+          ? "killed mid-run — no final envelope (wall-clock cap, crash, or kill)"
+          : r.ok === false
+            ? "harness reported failure"
+            : "no verdict recorded",
+    );
+    for (const [reason, rs] of [...byReason]
+      .sort((a, b) => b[1].length - a[1].length)
+      .slice(0, TOP)) {
+      const mins = sum(rs, "durMs") / 60000;
+      const where = [...new Set(rs.map((r) => r.harness))].join("/");
+      console.log(
+        `  ${c.red("x" + pad(rs.length, 3))}  ${padR(reason.slice(0, 66), 66)} ${c.dim(padR(where, 8))} ${c.dim(mins ? mins.toFixed(0) + "min" : "")}`,
+      );
+    }
+  }
+
+  console.log(
+    c.dim(
+      `\nNext: friction.mjs for what wasted time; --roll to persist these rows for a dashboard.\n`,
+    ),
+  );
+}

--- a/tools/launch-numbers.mjs
+++ b/tools/launch-numbers.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env bun
+/**
+ * Reproducible launch metrics for OSS posts.
+ *
+ *   bun tools/launch-numbers.mjs
+ *   bun tools/launch-numbers.mjs --json
+ *   bun tools/launch-numbers.mjs --since 2026-08-03
+ *
+ * Two sources, both pinned to `--since` (default 2026-08-03, the first
+ * dispatch day named in WM-802):
+ *
+ *   Linear              tickets dispatched / merged / escalated, human-touch,
+ *                       median createdAt → completedAt
+ *   ~/.factory/logs     tokens by harness, via orchestrator/economics.mjs
+ *
+ * Humans post the drafts this feeds. This script never publishes.
+ *
+ * "Merged without human touch" means the ticket reached Done after an agent
+ * claim (`agent:*` or `ai:in-progress` / `ai:needs-review` in current labels
+ * or history) and never visited Blocked and never carried `ai:escalated`.
+ * Filing (`source:human`) still counts — humans specify work; agents ship it.
+ * A Blocked detour is human touch even if the operator later unblocked it.
+ */
+import {
+  harnessTokenTotals,
+  loadTranscriptRuns,
+} from "../orchestrator/economics.mjs";
+import { LOG_DIR } from "../lib/transcript.mjs";
+import { loadControlPlane } from "../lib/control-plane/index.mjs";
+
+export const DEFAULT_SINCE = "2026-08-03T00:00:00.000Z";
+
+export const DISPATCH_LABELS = new Set([
+  "ai:in-progress",
+  "ai:needs-review",
+  "ai:blocked",
+  "ai:escalated",
+]);
+
+export const ISSUE_PAGE_SIZE = 50;
+
+export function parseSince(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) throw new TypeError("since date is empty");
+  const iso = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? `${raw}T00:00:00.000Z` : raw;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) throw new TypeError(`invalid since date: ${value}`);
+  return { iso: new Date(ms).toISOString(), ms };
+}
+
+export function labelNames(issue) {
+  return (issue?.labels?.nodes ?? []).map((l) => l.name).filter(Boolean);
+}
+
+export function historyNodes(issue) {
+  return issue?.history?.nodes ?? [];
+}
+
+/** Every label the ticket currently has or ever had added in history. */
+export function everLabels(issue) {
+  const names = new Set(labelNames(issue));
+  for (const h of historyNodes(issue)) {
+    for (const l of h.addedLabels ?? []) {
+      if (l?.name) names.add(l.name);
+    }
+    for (const l of h.removedLabels ?? []) {
+      if (l?.name) names.add(l.name);
+    }
+  }
+  return names;
+}
+
+export function visitedState(issue, name) {
+  const want = String(name).toLowerCase();
+  if (issue?.state?.name?.toLowerCase() === want) return true;
+  return historyNodes(issue).some(
+    (h) =>
+      h.fromState?.name?.toLowerCase() === want ||
+      h.toState?.name?.toLowerCase() === want,
+  );
+}
+
+export function isCompleted(issue) {
+  return Boolean(issue?.completedAt) || issue?.state?.type === "completed";
+}
+
+export function isDispatched(issue) {
+  for (const name of everLabels(issue)) {
+    if (name.startsWith("agent:") || DISPATCH_LABELS.has(name)) return true;
+  }
+  return false;
+}
+
+export function isEscalated(issue) {
+  return everLabels(issue).has("ai:escalated");
+}
+
+export function mergedWithoutHumanTouch(issue) {
+  return (
+    isCompleted(issue) &&
+    isDispatched(issue) &&
+    !isEscalated(issue) &&
+    !visitedState(issue, "Blocked")
+  );
+}
+
+export function median(nums) {
+  if (!nums.length) return null;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+export function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+export function formatDuration(ms) {
+  if (ms == null || !Number.isFinite(ms)) return "n/a";
+  const h = ms / 3_600_000;
+  if (h < 1) return `${Math.round(ms / 60_000)} min`;
+  if (h < 48) return `${round1(h)} h`;
+  return `${round1(h / 24)} d`;
+}
+
+export function formatCompact(n) {
+  if (!Number.isFinite(n)) return "0";
+  if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (Math.abs(n) >= 1e3) return (n / 1e3).toFixed(0) + "k";
+  return String(Math.round(n));
+}
+
+export function weeksUnattended(sinceIso, nowMs = Date.now()) {
+  const elapsed = Math.max(0, nowMs - Date.parse(sinceIso));
+  const days = Math.floor(elapsed / 86_400_000);
+  const weeks = Math.floor(days / 7);
+  return {
+    days,
+    weeks,
+    remainderDays: days % 7,
+  };
+}
+
+export function inWindow(iso, sinceMs) {
+  const t = Date.parse(iso || "");
+  return Number.isFinite(t) && t >= sinceMs;
+}
+
+/** Claimed during the window, or created/completed in-window when startedAt is missing. */
+export function dispatchedInWindow(issue, sinceMs = 0) {
+  if (!isDispatched(issue)) return false;
+  if (sinceMs <= 0) return true;
+  if (issue.startedAt) return inWindow(issue.startedAt, sinceMs);
+  return (
+    inWindow(issue.createdAt, sinceMs) || inWindow(issue.completedAt, sinceMs)
+  );
+}
+
+export function mergedInWindow(issue, sinceMs = 0) {
+  if (!isCompleted(issue) || !isDispatched(issue)) return false;
+  if (sinceMs <= 0) return true;
+  return inWindow(issue.completedAt, sinceMs);
+}
+
+export function classifyIssues(issues, { sinceMs = 0 } = {}) {
+  const dispatched = issues.filter((i) => dispatchedInWindow(i, sinceMs));
+  const merged = issues.filter((i) => mergedInWindow(i, sinceMs));
+  const escalated = dispatched.filter(isEscalated);
+  const blocked = dispatched.filter((i) => visitedState(i, "Blocked"));
+  const untouched = merged.filter(mergedWithoutHumanTouch);
+  const createdToMerge = merged
+    .map((i) => Date.parse(i.completedAt) - Date.parse(i.createdAt))
+    .filter((n) => Number.isFinite(n) && n >= 0);
+  const claimToMerge = merged
+    .filter((i) => i.startedAt)
+    .map((i) => Date.parse(i.completedAt) - Date.parse(i.startedAt))
+    .filter((n) => Number.isFinite(n) && n >= 0);
+  const byTeam = new Map();
+  for (const i of dispatched) {
+    const team = i.team?.key ?? "(none)";
+    const row = byTeam.get(team) ?? {
+      team,
+      dispatched: 0,
+      merged: 0,
+      escalated: 0,
+    };
+    row.dispatched++;
+    if (mergedInWindow(i, sinceMs)) row.merged++;
+    if (isEscalated(i)) row.escalated++;
+    byTeam.set(team, row);
+  }
+  return {
+    dispatched: dispatched.length,
+    merged: merged.length,
+    escalated: escalated.length,
+    blocked: blocked.length,
+    mergedWithoutHumanTouch: untouched.length,
+    mergedWithoutHumanTouchPct: merged.length
+      ? round1((100 * untouched.length) / merged.length)
+      : null,
+    medianTicketToMergeMs: median(createdToMerge),
+    medianClaimToMergeMs: median(claimToMerge),
+    byTeam: [...byTeam.values()].sort((a, b) => b.dispatched - a.dispatched),
+  };
+}
+
+export const FACTORY_ISSUES_QUERY = `query($after: String) {
+  issues(
+    first: ${ISSUE_PAGE_SIZE}
+    after: $after
+    filter: {
+      updatedAt: { gte: "__SINCE__" }
+      or: [
+        { labels: { name: { startsWith: "agent:" } } }
+        { labels: { name: { in: ["ai:in-progress", "ai:needs-review", "ai:blocked", "ai:escalated"] } } }
+      ]
+    }
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      identifier
+      title
+      url
+      createdAt
+      startedAt
+      completedAt
+      updatedAt
+      state { name type }
+      team { key }
+      labels { nodes { name } }
+      history(first: 50) {
+        nodes {
+          createdAt
+          fromState { name }
+          toState { name }
+          addedLabels { name }
+          removedLabels { name }
+        }
+      }
+    }
+  }
+}`;
+
+export function issuesQueryFor(sinceIso) {
+  return FACTORY_ISSUES_QUERY.replace("__SINCE__", sinceIso);
+}
+
+export async function fetchFactoryIssues({
+  gqlFn,
+  sinceIso = DEFAULT_SINCE,
+} = {}) {
+  if (typeof gqlFn !== "function") {
+    throw new TypeError("fetchFactoryIssues requires gqlFn");
+  }
+  const query = issuesQueryFor(sinceIso);
+  const nodes = [];
+  let after = null;
+  for (;;) {
+    const data = await gqlFn(query, { after });
+    const page = data?.issues;
+    nodes.push(...(page?.nodes ?? []));
+    if (!page?.pageInfo?.hasNextPage) break;
+    after = page.pageInfo.endCursor;
+    if (!after) break;
+  }
+  return nodes;
+}
+
+export function collectLaunchNumbers({
+  issues,
+  runs,
+  sinceIso = DEFAULT_SINCE,
+  nowMs = Date.now(),
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const tickets = classifyIssues(issues ?? [], {
+    sinceMs: Date.parse(sinceIso) || 0,
+  });
+  const window = weeksUnattended(sinceIso, nowMs);
+  const byHarness = harnessTokenTotals(runs ?? []);
+  const tokenTotals = byHarness.reduce(
+    (a, h) => ({
+      runs: a.runs + h.runs,
+      in: a.in + h.in,
+      out: a.out + h.out,
+      cacheRead: a.cacheRead + h.cacheRead,
+      cacheWrite: a.cacheWrite + h.cacheWrite,
+      tokens: a.tokens + h.tokens,
+      cost: a.cost + h.cost,
+      estCost: a.estCost + h.estCost,
+    }),
+    {
+      runs: 0,
+      in: 0,
+      out: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      tokens: 0,
+      cost: 0,
+      estCost: 0,
+    },
+  );
+  return {
+    generatedAt,
+    since: sinceIso,
+    window,
+    tickets,
+    tokens: { totals: tokenTotals, byHarness },
+  };
+}
+
+export function formatReport(metrics) {
+  const t = metrics.tickets;
+  const w = metrics.window;
+  const weekLabel =
+    w.weeks === 0
+      ? `${w.days} day${w.days === 1 ? "" : "s"}`
+      : `${w.weeks} week${w.weeks === 1 ? "" : "s"}${
+          w.remainderDays ? ` + ${w.remainderDays}d` : ""
+        } (${w.days} days)`;
+  const pct =
+    t.mergedWithoutHumanTouchPct == null
+      ? "n/a"
+      : `${t.mergedWithoutHumanTouchPct}%`;
+  const lines = [
+    `factory launch numbers`,
+    `  generated  ${metrics.generatedAt}`,
+    `  window     ${metrics.since.slice(0, 10)} → ${metrics.generatedAt.slice(0, 10)}  ${weekLabel} unattended`,
+    ``,
+    `  tickets    dispatched ${t.dispatched}   merged ${t.merged}   escalated ${t.escalated}   blocked ${t.blocked}`,
+    `             merged without human touch ${t.mergedWithoutHumanTouch} (${pct} of merged)`,
+    `             median ticket→merge ${formatDuration(t.medianTicketToMergeMs)}   median claim→merge ${formatDuration(t.medianClaimToMergeMs)}`,
+  ];
+  if (t.byTeam.length) {
+    lines.push(``, `  by team`);
+    for (const row of t.byTeam) {
+      lines.push(
+        `    ${row.team.padEnd(6)}  dispatched ${String(row.dispatched).padStart(4)}  merged ${String(row.merged).padStart(4)}  escalated ${String(row.escalated).padStart(3)}`,
+      );
+    }
+  }
+  lines.push(``, `  tokens by harness`);
+  if (!metrics.tokens.byHarness.length) {
+    lines.push(
+      `    (no ~/.factory/logs/*.jsonl on this host — re-run on the dispatch machine)`,
+    );
+  } else {
+    lines.push(
+      `    ${"harness".padEnd(10)} ${"runs".padStart(6)} ${"input".padStart(8)} ${"output".padStart(8)} ${"cache-rd".padStart(9)} ${"fresh".padStart(8)}`,
+    );
+    for (const h of metrics.tokens.byHarness) {
+      lines.push(
+        `    ${h.harness.padEnd(10)} ${String(h.runs).padStart(6)} ${formatCompact(h.in).padStart(8)} ${formatCompact(h.out).padStart(8)} ${formatCompact(h.cacheRead).padStart(9)} ${formatCompact(h.tokens).padStart(8)}`,
+      );
+    }
+    const tot = metrics.tokens.totals;
+    lines.push(
+      `    ${"total".padEnd(10)} ${String(tot.runs).padStart(6)} ${formatCompact(tot.in).padStart(8)} ${formatCompact(tot.out).padStart(8)} ${formatCompact(tot.cacheRead).padStart(9)} ${formatCompact(tot.tokens).padStart(8)}`,
+    );
+  }
+  lines.push(
+    ``,
+    `Re-run: bun tools/launch-numbers.mjs --since ${metrics.since.slice(0, 10)}`,
+    `Humans post the drafts. This command does not publish.`,
+  );
+  return lines.join("\n");
+}
+
+export async function buildLaunchNumbers({
+  gqlFn = (query, variables) => loadControlPlane().raw(query, variables),
+  logDir = LOG_DIR,
+  since = DEFAULT_SINCE,
+  nowMs = Date.now(),
+} = {}) {
+  const { iso, ms } = parseSince(since);
+  const issues = await fetchFactoryIssues({ gqlFn, sinceIso: iso });
+  const loaded = loadTranscriptRuns({ logDir, sinceMs: ms });
+  const runs = loaded.ok ? loaded.runs : [];
+  return {
+    metrics: collectLaunchNumbers({
+      issues,
+      runs,
+      sinceIso: iso,
+      nowMs,
+    }),
+    transcripts: loaded.ok
+      ? { ok: true, files: loaded.files.length }
+      : { ok: false, code: loaded.code, message: loaded.message },
+  };
+}
+
+function parseArgv(argv) {
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  return {
+    json: argv.includes("--json"),
+    since: val("--since") ?? DEFAULT_SINCE,
+  };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const flags = parseArgv(argv);
+  const { metrics, transcripts } = await buildLaunchNumbers({
+    since: flags.since,
+  });
+  if (!transcripts.ok) {
+    console.error(`transcripts: ${transcripts.message}`);
+  }
+  if (flags.json) {
+    console.log(JSON.stringify({ ...metrics, transcripts }, null, 2));
+    return 0;
+  }
+  console.log(formatReport(metrics));
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exitCode = await main();
+}

--- a/tools/launch-numbers.test.mjs
+++ b/tools/launch-numbers.test.mjs
@@ -1,0 +1,242 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+import {
+  harnessTokenTotals,
+  loadTranscriptRuns,
+} from "../orchestrator/economics.mjs";
+import {
+  classifyIssues,
+  collectLaunchNumbers,
+  dispatchedInWindow,
+  formatDuration,
+  formatReport,
+  isDispatched,
+  isEscalated,
+  median,
+  mergedWithoutHumanTouch,
+  parseSince,
+  visitedState,
+  weeksUnattended,
+} from "./launch-numbers.mjs";
+
+const issue = (over = {}) => ({
+  identifier: "WM-1",
+  createdAt: "2026-08-04T10:00:00.000Z",
+  startedAt: "2026-08-04T11:00:00.000Z",
+  completedAt: "2026-08-04T13:00:00.000Z",
+  updatedAt: "2026-08-04T13:00:00.000Z",
+  state: { name: "Done", type: "completed" },
+  team: { key: "WM" },
+  labels: { nodes: [{ name: "agent:claude-code" }] },
+  history: { nodes: [] },
+  ...over,
+});
+
+test("parseSince accepts a calendar day and an ISO timestamp", () => {
+  expect(parseSince("2026-08-03").iso).toBe("2026-08-03T00:00:00.000Z");
+  expect(parseSince("2026-08-03T12:00:00.000Z").ms).toBe(
+    Date.parse("2026-08-03T12:00:00.000Z"),
+  );
+  expect(() => parseSince("last-week")).toThrow(/invalid since/);
+});
+
+test("median is the middle value, averaging the pair on even length", () => {
+  expect(median([])).toBeNull();
+  expect(median([3])).toBe(3);
+  expect(median([1, 3, 2])).toBe(2);
+  expect(median([2, 8])).toBe(5);
+});
+
+test("weeksUnattended floors whole weeks and keeps remainder days", () => {
+  const since = "2026-08-03T00:00:00.000Z";
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+  expect(weeksUnattended(since, now)).toEqual({
+    days: 17,
+    weeks: 2,
+    remainderDays: 3,
+  });
+});
+
+test("a Done ticket with agent:* is dispatched, merged, and untouched", () => {
+  const i = issue();
+  expect(isDispatched(i)).toBe(true);
+  expect(isEscalated(i)).toBe(false);
+  expect(mergedWithoutHumanTouch(i)).toBe(true);
+});
+
+test("ai:escalated in history is human touch even after the label is gone", () => {
+  const i = issue({
+    labels: { nodes: [{ name: "agent:claude-code" }] },
+    history: {
+      nodes: [
+        {
+          addedLabels: [{ name: "ai:escalated" }],
+          removedLabels: [{ name: "ai:escalated" }],
+        },
+      ],
+    },
+  });
+  expect(isEscalated(i)).toBe(true);
+  expect(mergedWithoutHumanTouch(i)).toBe(false);
+});
+
+test("a Blocked detour is human touch", () => {
+  const i = issue({
+    history: {
+      nodes: [
+        {
+          fromState: { name: "In Progress" },
+          toState: { name: "Blocked" },
+          addedLabels: [{ name: "ai:blocked" }],
+          removedLabels: [],
+        },
+        {
+          fromState: { name: "Blocked" },
+          toState: { name: "In Progress" },
+          addedLabels: [],
+          removedLabels: [{ name: "ai:blocked" }],
+        },
+      ],
+    },
+  });
+  expect(visitedState(i, "Blocked")).toBe(true);
+  expect(mergedWithoutHumanTouch(i)).toBe(false);
+});
+
+test("ai:agent-ready alone is not dispatched", () => {
+  const i = issue({
+    completedAt: null,
+    state: { name: "Todo", type: "unstarted" },
+    labels: { nodes: [{ name: "ai:agent-ready" }, { name: "type:docs" }] },
+  });
+  expect(isDispatched(i)).toBe(false);
+});
+
+test("pre-window tickets are ignored when sinceMs is set", () => {
+  const old = issue({
+    identifier: "WM-OLD",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    startedAt: "2026-07-01T01:00:00.000Z",
+    completedAt: "2026-07-02T00:00:00.000Z",
+  });
+  const fresh = issue({ identifier: "WM-NEW" });
+  const sinceMs = Date.parse("2026-08-03T00:00:00.000Z");
+  expect(dispatchedInWindow(old, sinceMs)).toBe(false);
+  expect(dispatchedInWindow(fresh, sinceMs)).toBe(true);
+  const stats = classifyIssues([old, fresh], { sinceMs });
+  expect(stats.dispatched).toBe(1);
+  expect(stats.merged).toBe(1);
+});
+
+test("classifyIssues rolls dispatched/merged/escalated and the human-touch rate", () => {
+  const stats = classifyIssues([
+    issue({ identifier: "WM-1" }),
+    issue({
+      identifier: "WM-2",
+      team: { key: "CLNT" },
+      labels: {
+        nodes: [{ name: "agent:codex" }, { name: "ai:escalated" }],
+      },
+    }),
+    issue({
+      identifier: "WM-3",
+      completedAt: null,
+      startedAt: "2026-08-10T00:00:00.000Z",
+      state: { name: "In Progress", type: "started" },
+      labels: { nodes: [{ name: "ai:in-progress" }, { name: "agent:pi" }] },
+    }),
+    issue({
+      identifier: "HUMAN-1",
+      completedAt: "2026-08-05T00:00:00.000Z",
+      labels: { nodes: [{ name: "type:docs" }] },
+    }),
+  ]);
+  expect(stats.dispatched).toBe(3);
+  expect(stats.merged).toBe(2);
+  expect(stats.escalated).toBe(1);
+  expect(stats.mergedWithoutHumanTouch).toBe(1);
+  expect(stats.mergedWithoutHumanTouchPct).toBe(50);
+  expect(stats.medianTicketToMergeMs).toBe(3 * 3_600_000);
+  expect(stats.byTeam.map((r) => r.team).sort()).toEqual(["CLNT", "WM"]);
+});
+
+test("formatDuration picks minutes, hours, then days", () => {
+  expect(formatDuration(30_000)).toBe("1 min");
+  expect(formatDuration(90 * 60_000)).toBe("1.5 h");
+  expect(formatDuration(72 * 3_600_000)).toBe("3 d");
+  expect(formatDuration(null)).toBe("n/a");
+});
+
+test("collectLaunchNumbers joins Linear classification with harness tokens", () => {
+  const metrics = collectLaunchNumbers({
+    issues: [issue()],
+    runs: [
+      {
+        harness: "claude",
+        ok: true,
+        in: 100,
+        out: 20,
+        cacheRead: 800,
+        cacheWrite: 10,
+        cost: 0.01,
+        estCost: 0.01,
+      },
+      {
+        harness: "codex",
+        ok: false,
+        in: 50,
+        out: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        estCost: 0.002,
+      },
+    ],
+    sinceIso: "2026-08-03T00:00:00.000Z",
+    nowMs: Date.parse("2026-08-20T00:00:00.000Z"),
+    generatedAt: "2026-08-20T00:00:00.000Z",
+  });
+  expect(metrics.window.days).toBe(17);
+  expect(metrics.tickets.merged).toBe(1);
+  expect(metrics.tokens.totals.runs).toBe(2);
+  expect(metrics.tokens.totals.tokens).toBe(175);
+  expect(metrics.tokens.byHarness[0].harness).toBe("claude");
+  const text = formatReport(metrics);
+  expect(text).toContain("merged without human touch 1");
+  expect(text).toContain("does not publish");
+});
+
+test("loadTranscriptRuns and harnessTokenTotals share economics' parser", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "launch-numbers-"));
+  writeFileSync(
+    path.join(dir, "factory-WM-1-20260804.jsonl"),
+    JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      num_turns: 2,
+      duration_ms: 1000,
+      total_cost_usd: 0.02,
+    }) + "\n",
+  );
+  try {
+    const loaded = loadTranscriptRuns({ logDir: dir, sinceMs: 0 });
+    expect(loaded.ok).toBe(true);
+    expect(loaded.runs).toHaveLength(1);
+    const totals = harnessTokenTotals(loaded.runs);
+    expect(totals[0].harness).toBe("claude");
+    expect(totals[0].runs).toBe(1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTranscriptRuns reports a missing directory instead of throwing", () => {
+  const loaded = loadTranscriptRuns({
+    logDir: path.join(os.tmpdir(), "no-such-factory-logs-wm-802"),
+  });
+  expect(loaded.ok).toBe(false);
+  expect(loaded.code).toBe("no-dir");
+});


### PR DESCRIPTION
## Summary
- Add `tools/launch-numbers.mjs` so launch metrics (dispatched/merged/escalated, % without human touch, median ticket-to-merge, tokens by harness) are generated from Linear + `orchestrator/economics.mjs`, not typed by hand.
- Draft `docs/oss/launch-post.md` and community posts (Show HN, Claude Code, Codex, Cursor, Gemini CLI, X thread) plus a dogfood-in-public badge snippet. Humans post; the script does not publish.
- Wrap `economics.mjs` so importers can reuse transcript loading without the CLI exiting as a side effect.

Fixes WM-802

UX critique: skipped — docs and an operator CLI; no user-completable product flow.

## Test plan
- [x] `bun test tools/launch-numbers.test.mjs`
- [x] `bun run lint && bun run check`
- [x] `bun test` (full suite)
- [ ] Human: re-run `bun tools/launch-numbers.mjs --since 2026-08-03` on the dispatch host (JSONL transcripts) and paste the tokens-by-harness block into the launch post before publishing.
- [ ] Human: post drafts; do not publish from an agent session.


Made with [Cursor](https://cursor.com)