### PR TITLE
fix(web): keep proposal link visible in run state (WM-731)

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -350,7 +350,7 @@ describe("Runs Duration column (WM-871)", () => {
           headers.indexOf("Remaining") + 1,
         );
         expect(r.container.querySelector("table")?.style.minWidth).toBe(
-          `${headers.length * 112}px`,
+          `${(headers.length - 1) * 112 + 176}px`,
         );
         expect(cellFor(r, "run_completed", "Duration").textContent).toBe(
           "2m 30s",
@@ -1268,6 +1268,12 @@ describe("Runs copy chords and hints (WM-233)", () => {
         // A capped width plus `truncate` is exactly what clipped the link.
         expect(cls).not.toContain("truncate");
         expect(cls).not.toMatch(/\bmax-w-/);
+        expect(cls).not.toContain("overflow-hidden");
+        // The fixed table layout must reserve room for the badge and link.
+        expect(cls).toMatch(/\bmin-w-/);
+        expect(
+          cell!.closest("table")?.querySelectorAll("col")[1]?.className,
+        ).toContain("w-44");
         // The row must still not wrap — that is the point of this PR.
         expect(cls).toContain("whitespace-nowrap");
 

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1259,8 +1259,21 @@ export function Runs({
       >
         <Table
           className="w-full table-fixed border-separate border-spacing-0"
-          style={{ minWidth: `${listCols.length * 112}px` }}
+          style={{
+            minWidth: `${listCols.reduce(
+              (width, c) => width + (c.key === "state" ? 176 : 112),
+              0,
+            )}px`,
+          }}
         >
+          <colgroup>
+            {listCols.map((c) => (
+              <col
+                key={c.key}
+                className={c.key === "state" ? "w-44" : "w-28"}
+              />
+            ))}
+          </colgroup>
           <thead>
             <tr className="text-left">
               {listCols.map((c) => {
@@ -1325,8 +1338,8 @@ export function Runs({
                     to its content instead, which keeps the link fully rendered.
                   */}
                   {show.has("state") && (
-                    <td className="overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
+                    <td className="min-w-44 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <div className="flex items-center gap-1.5 whitespace-nowrap">
                         <StateBadge state={r.state} />
                         {r.state === "PROPOSED" &&
                           (() => {


### PR DESCRIPTION
Fixes WM-731

UX critique: required — SHIP; evidence: http://127.0.0.1:7457/#/runs, /tmp/WM-731-r2-runs-constrained.png