### PR TITLE
feat(analytics): report merged ticket cost by tier

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -114,6 +114,21 @@ invalid ticket label safe. As with definition tiers, a valid label whose tier
 has no mapping for the routed adapter fails closed rather than falling back to
 an adapter default.
 
+### Default-tier decision rule
+
+`GET /metrics/breakdown?by=modelTier&metric=cost` and
+`bun orchestrator/economics.mjs` report the dispatch cohort, merged-ticket
+count, total and median USD per merged ticket, and the standard-tier escalation
+rate. A cohort is keyed only by the dispatch RunSpec's pinned `modelTier`; the
+concrete model string is never used to infer a tier. For a merged ticket, its
+cost includes every RunSpec carrying that ticket, including retries, merge-fix
+rounds, and escalation reruns.
+
+Change the dispatch default from strong to standard only when standard's
+cost-per-merged-ticket is below strong's across at least 20 merged tickets in
+each tier. Treat a high standard-tier escalation rate as a reason to keep the
+strong default even if the raw cost comparison is favorable.
+
 ### Linear API budget (WM-878)
 
 Linear allows 2500 requests per hour. The factory used to treat a 400/429

--- a/event-runtime/lib/api-metrics.test.mjs
+++ b/event-runtime/lib/api-metrics.test.mjs
@@ -95,4 +95,13 @@ describe("metrics query API (WM-281)", () => {
     expect(valid.status).toBe(200);
     expect((await valid.json()).rows).toEqual([]);
   });
+
+  test("GET /metrics/breakdown exposes model-tier economics cohorts", async () => {
+    const response = await fetch(
+      s.url("/metrics/breakdown?window=24h&by=modelTier&metric=cost"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ by: "modelTier", metric: "cost", rows: [] });
+  });
 });

--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -29,6 +29,7 @@ export const VALID_BREAKDOWN_DIMENSIONS = Object.freeze([
   "reason_code",
   "event_type",
   "edge",
+  "modelTier",
 ]);
 
 export const VALID_BREAKDOWN_METRICS = Object.freeze([
@@ -482,6 +483,127 @@ function breakdownFacts(db, metric, range) {
     .all(range.startIso, range.endIso);
 }
 
+function parseJson(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Economics cohorts are deliberately keyed by the dispatch RunSpec, rather
+ * than by a model name. A concrete model can be reassigned by configuration;
+ * the RunSpec's modelTier is the immutable routing decision for a ticket.
+ */
+export function modelTierEconomicsView(
+  db,
+  { startMs = 0, endMs = Date.now() } = {},
+) {
+  const runRows = db
+    .query(
+      `SELECT r.run_id, r.created_at, r.spec_json,
+              COALESCE(SUM(u.cost_usd), 0) AS cost_usd
+         FROM runs r
+         LEFT JOIN run_usage u ON u.run_id = r.run_id
+        WHERE json_extract(r.spec_json, '$.input.ticket') IS NOT NULL
+        GROUP BY r.run_id`,
+    )
+    .all();
+
+  const tickets = new Map();
+  for (const row of runRows) {
+    const spec = parseJson(row.spec_json);
+    const ticket = spec.input?.ticket;
+    if (typeof ticket !== "string" || ticket === "") continue;
+    const entry = tickets.get(ticket) ?? {
+      runs: [],
+      dispatch: null,
+      totalCostUSD: 0,
+    };
+    const run = {
+      createdAt: row.created_at,
+      agent: spec.agent,
+      modelTier: spec.modelTier,
+      model: spec.model,
+      costUSD: Number(row.cost_usd ?? 0),
+    };
+    entry.runs.push(run);
+    entry.totalCostUSD += run.costUSD;
+    // A dispatch retry can create another RunSpec. The first pinned dispatch
+    // decision is the ticket's cohort; later runs still contribute all cost.
+    if (
+      typeof run.modelTier === "string" &&
+      typeof run.agent === "string" &&
+      run.agent.startsWith("dispatch@") &&
+      (!entry.dispatch || run.createdAt < entry.dispatch.createdAt)
+    ) {
+      entry.dispatch = run;
+    }
+    tickets.set(ticket, entry);
+  }
+
+  const merged = new Set();
+  for (const row of db
+    .query(
+      `SELECT envelope_json FROM events
+        WHERE type = 'factory.merge-landed'
+          AND admitted_at >= ? AND admitted_at < ?`,
+    )
+    .all(new Date(startMs).toISOString(), new Date(endMs).toISOString())) {
+    for (const landed of parseJson(row.envelope_json).payload?.landed ?? []) {
+      if (typeof landed?.ticket === "string") merged.add(landed.ticket);
+    }
+  }
+
+  const tiers = new Map();
+  const tier = (name) =>
+    tiers.get(name) ??
+    tiers
+      .set(name, {
+        key: name,
+        ticketsDispatched: 0,
+        ticketsMerged: 0,
+        costs: [],
+        standardEscalations: 0,
+      })
+      .get(name);
+  for (const [ticket, entry] of tickets) {
+    const dispatch = entry.dispatch;
+    if (!dispatch) continue;
+    const stats = tier(dispatch.modelTier);
+    const dispatchedAt = Date.parse(dispatch.createdAt);
+    if (dispatchedAt >= startMs && dispatchedAt < endMs)
+      stats.ticketsDispatched += 1;
+    if (!merged.has(ticket)) continue;
+    stats.ticketsMerged += 1;
+    stats.costs.push(entry.totalCostUSD);
+    if (
+      dispatch.modelTier === "standard" &&
+      entry.runs.some((run) => run.modelTier === "strong")
+    ) {
+      stats.standardEscalations += 1;
+    }
+  }
+
+  return [...tiers.values()]
+    .map((stats) => {
+      stats.costs.sort((a, b) => a - b);
+      return {
+        key: stats.key,
+        ticketsDispatched: stats.ticketsDispatched,
+        ticketsMerged: stats.ticketsMerged,
+        medianCostPerMergedTicketUSD: percentile(stats.costs, 0.5),
+        totalCostUSD: stats.costs.reduce((total, cost) => total + cost, 0),
+        standardTierEscalationRate:
+          stats.key === "standard" && stats.ticketsMerged > 0
+            ? stats.standardEscalations / stats.ticketsMerged
+            : null,
+      };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
 /** Top-N operational dimensions used by GET /metrics/breakdown. */
 export function metricsBreakdownView(
   db,
@@ -513,6 +635,18 @@ export function metricsBreakdownView(
     }
   }
   const range = timeRange({ now, window, withBuckets: false });
+  if (by === "modelTier") {
+    return {
+      window,
+      by,
+      metric,
+      limit: null,
+      rows: modelTierEconomicsView(db, {
+        startMs: range.startMs,
+        endMs: range.endMs,
+      }),
+    };
+  }
   const facts = breakdownFacts(db, metric, range);
   const grouped = new Map();
   for (const fact of facts) {

--- a/event-runtime/lib/metrics.test.mjs
+++ b/event-runtime/lib/metrics.test.mjs
@@ -18,6 +18,7 @@ function insertRun(
     agent = "agent-a@1",
     adapter = "pi",
     model = "openai/test",
+    modelTier,
     input = { repo: "factory" },
     state = "COMPLETED",
     attempts = 1,
@@ -32,7 +33,13 @@ function insertRun(
   ).run(
     id,
     `idem-${id}`,
-    JSON.stringify({ agent, adapter, model, input }),
+    JSON.stringify({
+      agent,
+      adapter,
+      model,
+      ...(modelTier ? { modelTier } : {}),
+      input,
+    }),
     state,
     attempts,
     createdAt,
@@ -108,6 +115,23 @@ function insertEvent(
     `hash-${source}-${id}`,
     status,
     admittedAt,
+  );
+}
+
+function insertMergeLandedEvent(db, tickets, admittedAt = at(20 * 60_000)) {
+  insertEvent(db, `merge-landed-${tickets.join("-")}`, {
+    type: "factory.merge-landed",
+    source: "chain",
+    admittedAt,
+  });
+  db.query(
+    `UPDATE events SET envelope_json = ?
+      WHERE source = 'chain' AND event_id = ?`,
+  ).run(
+    JSON.stringify({
+      payload: { landed: tickets.map((ticket) => ({ ticket })) },
+    }),
+    `merge-landed-${tickets.join("-")}`,
   );
 }
 
@@ -436,6 +460,81 @@ describe("metrics breakdowns (WM-281)", () => {
         metric: "p95_execution",
       }).rows[0].value,
     ).toBe(71_000);
+    db.close();
+  });
+
+  test("modelTier cohorts use dispatch pins, merged events, and every ticket run cost", () => {
+    const db = openDb(":memory:");
+    insertRun(db, "standard-dispatch", {
+      agent: "dispatch@1",
+      modelTier: "standard",
+      input: { repo: "factory", ticket: "WM-697" },
+    });
+    insertRun(db, "standard-escalation", {
+      agent: "merge-fix@1",
+      modelTier: "strong",
+      input: { repo: "factory", ticket: "WM-697" },
+    });
+    insertRun(db, "standard-unpinned-retry", {
+      agent: "merge-fix@1",
+      model: "a-model-named-strong",
+      input: { repo: "factory", ticket: "WM-697" },
+    });
+    insertRun(db, "strong-dispatch", {
+      agent: "dispatch@1",
+      modelTier: "strong",
+      input: { repo: "factory", ticket: "WM-698" },
+    });
+    insertRun(db, "unmerged-dispatch", {
+      agent: "dispatch@1",
+      modelTier: "standard",
+      input: { repo: "factory", ticket: "WM-699" },
+    });
+    for (const [runId, costUSD] of [
+      ["standard-dispatch", 1.25],
+      ["standard-escalation", 2.75],
+      ["standard-unpinned-retry", 0.5],
+      ["strong-dispatch", 8],
+      ["unmerged-dispatch", 3],
+    ]) {
+      recordRunUsage(db, {
+        runId,
+        attempt: 1,
+        adapter: "pi",
+        costUSD,
+        recordedAt: at(10 * 60_000),
+      });
+    }
+    insertMergeLandedEvent(db, ["WM-697", "WM-698"]);
+
+    expect(
+      metricsBreakdownView(db, {
+        now: NOW,
+        by: "modelTier",
+        metric: "cost",
+      }),
+    ).toMatchObject({
+      by: "modelTier",
+      limit: null,
+      rows: [
+        {
+          key: "standard",
+          ticketsDispatched: 2,
+          ticketsMerged: 1,
+          medianCostPerMergedTicketUSD: 4.5,
+          totalCostUSD: 4.5,
+          standardTierEscalationRate: 1,
+        },
+        {
+          key: "strong",
+          ticketsDispatched: 1,
+          ticketsMerged: 1,
+          medianCostPerMergedTicketUSD: 8,
+          totalCostUSD: 8,
+          standardTierEscalationRate: null,
+        },
+      ],
+    });
     db.close();
   });
 });

--- a/orchestrator/economics.mjs
+++ b/orchestrator/economics.mjs
@@ -41,6 +41,9 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { Database } from "bun:sqlite";
+import { dbPath } from "../event-runtime/lib/config.mjs";
+import { modelTierEconomicsView } from "../event-runtime/lib/metrics.mjs";
 import {
   LOG_DIR,
   METRICS_DIR,
@@ -219,6 +222,23 @@ const totals = {
     runs.filter((r) => r.wasted).reduce((a, b) => a + b.durMs, 0) / 60000,
 };
 
+// The runtime ledger is the source of truth for immutable RunSpecs and merged
+// tickets. Transcript filenames do identify tickets, but cannot safely recover
+// the tier from a mutable model name or the complete merge/fix history.
+let modelTierEconomics = [];
+const runtimeDb = dbPath();
+if (existsSync(runtimeDb)) {
+  const db = new Database(runtimeDb, { readonly: true });
+  try {
+    modelTierEconomics = modelTierEconomicsView(db, {
+      startMs: sinceMs,
+      endMs: Date.now(),
+    });
+  } finally {
+    db.close();
+  }
+}
+
 if (JSON_OUT) {
   console.log(
     JSON.stringify(
@@ -233,6 +253,7 @@ if (JSON_OUT) {
           calls: toolCalls.get(name) ?? v.calls,
         })),
         errors: [...errorsBySig.entries()].map(([sig, v]) => ({ sig, ...v })),
+        modelTierEconomics,
       },
       null,
       2,
@@ -259,6 +280,30 @@ const M = (n) =>
 const MB = (n) => (n / 1e6).toFixed(1) + "MB";
 const pad = (s, n) => String(s).padStart(n);
 const padR = (s, n) => String(s).padEnd(n);
+
+console.log(c.bold("\nmerged-ticket economics by model tier\n"));
+if (!modelTierEconomics.length) {
+  console.log(
+    c.dim("  no merged, RunSpec-pinned ticket cohorts in this window"),
+  );
+} else {
+  console.log(
+    c.dim(
+      "  tier       dispatched  merged  median $/merged  total $  std escalation",
+    ),
+  );
+  for (const row of modelTierEconomics) {
+    const escalation =
+      row.standardTierEscalationRate == null
+        ? "—"
+        : `${(row.standardTierEscalationRate * 100).toFixed(1)}%`;
+    console.log(
+      `  ${padR(row.key, 11)}${pad(row.ticketsDispatched, 6)}${pad(row.ticketsMerged, 8)}` +
+        `${pad(row.medianCostPerMergedTicketUSD == null ? "—" : "$" + row.medianCostPerMergedTicketUSD.toFixed(2), 17)}` +
+        `${pad("$" + row.totalCostUSD.toFixed(2), 9)}${pad(escalation, 16)}`,
+    );
+  }
+}
 
 console.log(
   c.bold(


### PR DESCRIPTION
Fixes WM-697

Adds RunSpec-pinned model-tier merged-ticket economics to the metrics breakdown and CLI report.

UX critique: skipped — backend analytics and documentation only; no user-facing flow changed.