### PR TITLE
chore(policy): enable the Buzz connector extension (WM-921)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -237,10 +237,11 @@ notify:
     - circuit_breaker_tripped
     - release_candidate_ready
 
-# Buzz connector (WM-921). Uncomment after FACTORY_EXT_BUZZ_AGENT_NSEC and
-# FACTORY_EXT_BUZZ_AUTH_TAG are in ~/.factory/secrets.env (chmod 600).
+# Buzz connector (WM-921). Enabled 2026-08-20: FACTORY_EXT_BUZZ_AGENT_NSEC and
+# FACTORY_EXT_BUZZ_AUTH_TAG provisioned in ~/.factory/secrets.env (chmod 600);
+# @factory admitted to #general; NIP-OA tag verified against the owner key.
 # Telegram stays the blocker channel until a real BLOCKED push is observed.
-# extensions:
-#   - path: extensions/buzz
-#     config:
-#       channel: "91572011-2505-5288-b6f5-4a7d74abf106" # #general
+extensions:
+  - path: extensions/buzz
+    config:
+      channel: "91572011-2505-5288-b6f5-4a7d74abf106" # #general


### PR DESCRIPTION
Uncomments the extensions block: the operator minted the agent keypair + NIP-OA auth tag (verified against the owner key), provisioned both secrets in ~/.factory/secrets.env (0600), and admitted @factory to #general. #751's security fixes (ingress signature verification, option-preserving decide flow) are on develop.

## Handoff
- Files: config/policy.yaml only (comment → active block)
- Verification: bun test event-runtime/lib/extensions.test.mjs + registry.test.mjs — green
- UX critique: n/a (config enablement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22yAWwm7najjia2QPzfRv