### PR TITLE
chore(policy): move the Buzz connector to #ops-factory

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -244,4 +244,4 @@ notify:
 extensions:
   - path: extensions/buzz
     config:
-      channel: "91572011-2505-5288-b6f5-4a7d74abf106" # #general
+      channel: "ea70b81e-0b0c-4b48-82da-5f78c167a12b" # #ops-factory


### PR DESCRIPTION
Operator request: factory inbox posts and commands move from #general to #ops-factory (uuid ea70b81e-0b0c-4b48-82da-5f78c167a12b; @factory already admitted). One-line channel swap in config/policy.yaml.

## Handoff
- Files: config/policy.yaml only
- Verification: config value swap; connector reads it at serve start
- UX critique: n/a