### PR TITLE
feat(web): FACTORY_EVENT_WEB_ALLOWED_HOSTS — web UI over tailscale serve (WM-973)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1496,3 +1496,27 @@ bounds / `default` drive the control. Search indexes every property's
 `title` and `description` as well as keys and values. Secret properties
 publish `{ set, source }` and never a value. Anomaly replaces the form.
 Built-in sections should migrate onto the same schema shape (WM-924).
+
+## Tailnet access (WM-973)
+
+`tailscale serve` can publish the web UI to your tailnet without changing the
+process bindings — both servers stay on 127.0.0.1 and Tailscale proxies to the
+loopback port, so transport auth is the tailnet's WireGuard identity
+(tailnet-only; never use `tailscale funnel`, which is public):
+
+```sh
+sudo tailscale serve --bg --http=80 http://127.0.0.1:7382
+```
+
+The web server answers only for loopback Hosts by default. Add the tailnet
+name via `FACTORY_EVENT_WEB_ALLOWED_HOSTS` (comma-separated hostnames, no
+scheme or port) in the environment that starts `bin/live-stack.sh`:
+
+```sh
+export FACTORY_EVENT_WEB_ALLOWED_HOSTS=runner.whale-pike.ts.net
+```
+
+The `/api/*` proxy presents itself as loopback upstream (rewrites `Host`,
+drops `Origin`), so the control API's own loopback/rebinding guard
+(`api.mjs`) is unchanged — the web layer enforces the same defense against
+unlisted Hosts and cross-site Origins before anything is served.

--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -82,7 +82,7 @@ Bun.serve({
       });
     const origin = req.headers.get("origin");
     if (origin) {
-      let originHost = null;
+      let originHost;
       try {
         originHost = new URL(origin).hostname;
       } catch {

--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -17,6 +17,34 @@ const WEB_PORT = Number(process.env.FACTORY_EVENT_WEB_PORT || 7382);
 const API_PORT = Number(process.env.FACTORY_EVENT_PORT || 7381);
 const DIST = path.join(path.dirname(fileURLToPath(import.meta.url)), "dist");
 
+// WM-973: extra Host values (beyond loopback) this server will answer for —
+// e.g. a tailnet name published via `tailscale serve`, which proxies to the
+// loopback port so the binding stays 127.0.0.1 and transport auth comes from
+// the tailnet. Hostnames only, comma-separated, compared case-insensitively
+// with any :port stripped. Unset = loopback-only, exactly the old behavior.
+const ALLOWED_HOSTS = new Set(
+  (process.env.FACTORY_EVENT_WEB_ALLOWED_HOSTS || "")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+function hostOf(value) {
+  if (typeof value !== "string" || value === "") return null;
+  // Host header / Origin host: strip :port (IPv6 literals keep brackets).
+  const m = value.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (m) return m[1].toLowerCase();
+  return value.replace(/:\d+$/, "").toLowerCase();
+}
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+function hostAllowed(value) {
+  const host = hostOf(value);
+  if (host === null) return false;
+  return LOOPBACK_HOSTS.has(host) || ALLOWED_HOSTS.has(host);
+}
+
 if (!existsSync(path.join(DIST, "index.html"))) {
   console.error(
     `no build at ${DIST} — build it first:\n  cd event-runtime/web && bun install && bun run build`,
@@ -44,13 +72,43 @@ Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
 
+    // WM-973: answer only for loopback and explicitly allowed Hosts, and
+    // reject cross-site Origins at this layer — the API's own loopback guard
+    // stays untouched because the proxy below rewrites Host/Origin.
+    if (!hostAllowed(req.headers.get("host")))
+      return new Response(JSON.stringify({ error: "invalid_host" }), {
+        status: 403,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      });
+    const origin = req.headers.get("origin");
+    if (origin) {
+      let originHost = null;
+      try {
+        originHost = new URL(origin).hostname;
+      } catch {
+        originHost = null;
+      }
+      if (originHost === null || !hostAllowed(originHost))
+        return new Response(
+          JSON.stringify({ error: "cross_origin_rejected" }),
+          {
+            status: 403,
+            headers: { "content-type": "application/json; charset=utf-8" },
+          },
+        );
+    }
+
     if (url.pathname === "/api" || url.pathname.startsWith("/api/")) {
       const target = `http://127.0.0.1:${API_PORT}${url.pathname.slice(4) || "/"}${url.search}`;
       // Pass-through, nothing added: the proxy exists only for same-origin.
       // WHATWG fetch rejects GET/HEAD when a body option is present, even when
       // the incoming client supplied one, so omit the option for those methods.
       const bodyless = req.method === "GET" || req.method === "HEAD";
-      const headers = bodyless ? new Headers(req.headers) : req.headers;
+      const headers = new Headers(req.headers);
+      // WM-973: the upstream API enforces a loopback Host and Origin; this
+      // proxy IS the same-origin boundary, so present as loopback upstream.
+      headers.set("host", `127.0.0.1:${API_PORT}`);
+      headers.delete("origin");
       const init = { method: req.method, headers };
       try {
         if (bodyless) {

--- a/event-runtime/web/serve.test.mjs
+++ b/event-runtime/web/serve.test.mjs
@@ -207,3 +207,32 @@ describe("event-runtime web API proxy", () => {
     });
   });
 });
+
+// WM-973: FACTORY_EVENT_WEB_ALLOWED_HOSTS — tailnet hosts without weakening
+// the API loopback guard. The env var is read at import time, so these tests
+// exercise the helper behavior through subprocess-free direct requests using
+// the already-running server (loopback) plus Host-header variation.
+describe("allowed hosts (WM-973)", () => {
+  test("unlisted non-loopback Host is rejected at the web layer", async () => {
+    const res = await fetch(`http://127.0.0.1:${webPort}/`, {
+      headers: { host: "attacker.example" },
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("invalid_host");
+  });
+
+  test("cross-site Origin is rejected even on a loopback Host", async () => {
+    const res = await fetch(`http://127.0.0.1:${webPort}/api/health`, {
+      headers: { origin: "https://attacker.example" },
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("cross_origin_rejected");
+  });
+
+  test("loopback Origin still passes", async () => {
+    const res = await fetch(`http://127.0.0.1:${webPort}/api/health`, {
+      headers: { origin: `http://127.0.0.1:${webPort}` },
+    });
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
Operator request: reach the web UI over the tailnet instead of an SSH tunnel. `tailscale serve` proxies to loopback 7382, so bindings stay 127.0.0.1 and transport auth is the tailnet.

- Web server: explicit Host allowlist (`FACTORY_EVENT_WEB_ALLOWED_HOSTS`, unset = loopback-only, behavior-identical) + cross-site Origin rejection at the web layer.
- `/api` proxy rewrites upstream Host to `127.0.0.1:<API_PORT>` and drops Origin — the control API's loopback/rebinding guard (`api.mjs`) is unchanged.
- Docs: tailscale-serve recipe (tailnet-only; funnel explicitly ruled out).

## Handoff
- Verification: `bun test event-runtime/web/serve.test.mjs` — 12 pass (3 new: unlisted-host 403, cross-site-origin 403, loopback origin passes)
- Files within Owned Paths (serve.mjs, serve.test.mjs, docs)
- UX critique: n/a (access path, no UI change)