### PR TITLE
fix(ext/buzz): make #ops-factory interrupt cards actionable (WM-974)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -248,11 +248,19 @@ notify:
     - circuit_breaker_tripped
     - release_candidate_ready
 
-# Buzz connector (WM-921). Enabled 2026-08-20: FACTORY_EXT_BUZZ_AGENT_NSEC and
-# FACTORY_EXT_BUZZ_AUTH_TAG provisioned in ~/.factory/secrets.env (chmod 600);
-# @factory admitted to #general; NIP-OA tag verified against the owner key.
-# Telegram stays the blocker channel until a real BLOCKED push is observed.
+# Buzz connector (WM-921, quieter interrupt cards WM-974). Enabled 2026-08-20:
+# FACTORY_EXT_BUZZ_AGENT_NSEC and FACTORY_EXT_BUZZ_AUTH_TAG in
+# ~/.factory/secrets.env (chmod 600). #ops-factory is the pager; run-start
+# telemetry is WM-975 (#feed-factory). Telegram stays until a real BLOCKED
+# push is observed end-to-end.
 extensions:
   - path: extensions/buzz
     config:
       channel: "ea70b81e-0b0c-4b48-82da-5f78c167a12b" # #ops-factory
+      postKinds:
+        - ESCALATED
+        - BLOCKED
+        - CI RED
+        - SMOKE RED
+        - CIRCUIT BREAKER
+        - RC READY

--- a/extensions/buzz/README.md
+++ b/extensions/buzz/README.md
@@ -1,12 +1,14 @@
 # wattmind/buzz
 
-The factory as a Buzz agent. First `connectors` extension (WM-921): inbox items
-post to `#general`, 👍/👎/💤 (and numbered reactions) plus thread replies map
-onto `inbox.decide`, and a closed command grammar (`@factory dispatch`,
-`@factory status`) injects events.
+The factory as a Buzz agent (WM-921, interrupt-channel contract WM-974). Inbox
+items that **wait on a human** post to `#ops-factory`. 👍/👎/💤/🔁/📤/💬/🔓
+reactions and thread replies map onto `inbox.decide`. A closed command grammar
+(`@factory dispatch`, `@factory status`) injects events.
 
-Telegram stays the blocker channel until a real `BLOCKED` push has been
-observed end-to-end on Buzz. This connector is additive.
+Run starts and other telemetry do **not** go here — that is a later
+`#feed-factory` channel (WM-975). Telegram stays the blocker channel until a
+real `BLOCKED` push has been observed end-to-end on Buzz. This connector is
+additive.
 
 ## Setup
 
@@ -28,33 +30,36 @@ observed end-to-end on Buzz. This connector is additive.
    FACTORY_EXT_BUZZ_AUTH_TAG=["auth","…","kind=9&created_at<…","…"]
    ```
 
-3. Uncomment the `extensions: - path: extensions/buzz` block in
-   `config/policy.yaml` (commented on purpose so test `serve` does not hit
-   the live relay). Restart `serve`. The connector starts even when the
-   secrets are missing (`health().ok === false` until they are set).
+3. Enable `extensions: - path: extensions/buzz` in `config/policy.yaml`. Restart
+   `serve`. The connector starts even when the secrets are missing
+   (`health().ok === false` until they are set).
 
 Optional config (non-secret, in the policy `config:` block):
 
-| Key           | Default                                                | Meaning                                                                |
-| ------------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `relayUrl`    | `https://watt-mind.communities.buzz.xyz`               | HTTP relay                                                             |
-| `channel`     | `#general` uuid `91572011-2505-5288-b6f5-4a7d74abf106` | kind-9 `h` tag                                                         |
-| `dmBlockedTo` | unset                                                  | owner pubkey hex; BLOCKED / CIRCUIT BREAKER / SMOKE RED also NIP-17 DM |
-| `postKinds`   | every Decide + Red + Ready inbox kind                  | which ledger rows to post                                              |
-| `pollSeconds` | 15                                                     | `/query` interval (5–120)                                              |
-| `approvers`   | owner pubkey from the auth tag                         | who may react / command                                                |
+| Key           | Default                                                          | Meaning                                                                        |
+| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `relayUrl`    | `https://watt-mind.communities.buzz.xyz`                         | HTTP relay                                                                     |
+| `channel`     | `#ops-factory` uuid (policy); schema default is `#general`       | kind-9 `h` tag — the pager                                                     |
+| `webUrl`      | unset (`FACTORY_WEB_URL`)                                        | Absolute http(s) origin for inbox deep links. Hash-only links are never posted |
+| `dmBlockedTo` | unset                                                            | owner pubkey hex; BLOCKED / CIRCUIT BREAKER / SMOKE RED also NIP-17 DM         |
+| `postKinds`   | ESCALATED, BLOCKED, CI RED, SMOKE RED, CIRCUIT BREAKER, RC READY | interrupt set only                                                             |
+| `pollSeconds` | 15                                                               | `/query` interval (5–120)                                                      |
+| `approvers`   | owner pubkey from the auth tag                                   | who may react / command                                                        |
 
 ## What it does
 
-- **Egress.** New inbox items (subscribe + poll, so a missed `inbox.subscribe`
-  fan-out still lands) become one kind-9 in `channel`: subject, the decision
-  question, `👍 approve · 👎 reject · 💤 not now` (or numbered options), and a
-  `#/inbox/<id>` deep link. `delivery.buzz = { eventId, postedAt }` is written
-  through `client.inbox.markDelivered` when that seam exists; until then the
-  mapping is held in connector memory. Resolved items get a thread reply.
+- **Egress.** New inbox items (subscribe + poll) become one kind-9 in `channel`
+  when they are actually answerable: `ESCALATED` needs a ticket; dismiss-only
+  cards stay on the web inbox. Subject is `kind  repo  ticket`, then the why
+  (`decision.context` / `body` / question), then reaction options, then an
+  absolute `#/inbox/<id>` link when `webUrl` is set. `delivery.buzz = { eventId,
+postedAt }` is written through `client.inbox.markDelivered`. Resolved items
+  get a thread reply.
 - **Ingress.** Poll `/query` for kind-7 reactions and kind-9 replies on posted
-  event ids. 👍 → approve, 👎 → reject (asks for a reason in-thread when the
-  option requires one), 💤 → dismiss. Idempotent on the reaction event id.
+  event ids. Closed-set effects map to unique emojis (👍 approve, 👎 reject,
+  💤 not now, 🔁 requeue, 📤 triage, 💬 answer, 🔓 authorise). A thread reply
+  selects `recommended` or `answer` and uses the reply text as the required
+  field. Idempotent on the reaction event id.
 - **Commands.** In the channel, from an approver:
   - `@factory dispatch WM-123 repo=factory` → `factory.dispatch.requested`
   - `@factory status` → inbox open count + this connector's health

--- a/extensions/buzz/config.schema.json
+++ b/extensions/buzz/config.schema.json
@@ -35,20 +35,23 @@
       "title": "NIP-OA auth tag",
       "description": "JSON array [\"auth\", owner, conditions, sig]. Resolved from FACTORY_EXT_BUZZ_AUTH_TAG."
     },
+    "webUrl": {
+      "type": "string",
+      "format": "uri",
+      "title": "Factory web URL",
+      "description": "Absolute http(s) origin for inbox deep links. Hash-only #/inbox/… links are never posted."
+    },
     "postKinds": {
       "type": "array",
       "title": "Post kinds",
-      "description": "Inbox kinds posted to the channel. Default is every Decide + Red + Ready kind.",
+      "description": "Inbox kinds posted to the interrupt channel. Default is the pager set only; run-start telemetry is a later #feed-factory channel (WM-975).",
       "default": [
-        "BLOCKED",
         "ESCALATED",
+        "BLOCKED",
         "CI RED",
         "SMOKE RED",
         "CIRCUIT BREAKER",
-        "RC READY",
-        "human_needed",
-        "decision_needed",
-        "proposal_expired"
+        "RC READY"
       ],
       "items": {
         "type": "string",

--- a/extensions/buzz/lib/format.mjs
+++ b/extensions/buzz/lib/format.mjs
@@ -13,7 +13,15 @@ export const INBOX_KINDS = Object.freeze([
   "proposal_expired",
 ]);
 
-export const DEFAULT_POST_KINDS = INBOX_KINDS;
+/** Interrupt kinds only. Telemetry (run starts, ticket-less FYIs) is WM-975. */
+export const DEFAULT_POST_KINDS = Object.freeze([
+  "ESCALATED",
+  "BLOCKED",
+  "CI RED",
+  "SMOKE RED",
+  "CIRCUIT BREAKER",
+  "RC READY",
+]);
 
 export const DM_KINDS = new Set(["BLOCKED", "CIRCUIT BREAKER", "SMOKE RED"]);
 
@@ -21,13 +29,29 @@ const EMOJI_BY_ID = {
   approve: "👍",
   reject: "👎",
   dismiss: "💤",
+  requeue: "🔁",
+  triage: "📤",
+  answer: "💬",
+  authorise: "🔓",
 };
 const EMOJI_BY_EFFECT = {
   approve_proposal: "👍",
   reject_proposal: "👎",
   dismiss: "💤",
+  requeue: "🔁",
+  send_to_triage: "📤",
+  answer: "💬",
+  authorise: "🔓",
 };
-const SHORT = { "👍": "approve", "👎": "reject", "💤": "not now" };
+const SHORT = {
+  "👍": "approve",
+  "👎": "reject",
+  "💤": "not now",
+  "🔁": "requeue",
+  "📤": "triage",
+  "💬": "answer",
+  "🔓": "authorise",
+};
 
 export function optionEmoji(option) {
   if (!option || typeof option !== "object") return null;
@@ -44,29 +68,42 @@ export function formatOptions(decision) {
   const unique = new Set(emojis.filter(Boolean));
   if (
     options.length > 0 &&
-    options.length <= 3 &&
     unique.size === options.length &&
     emojis.every(Boolean)
   ) {
+    const map = Object.fromEntries(mapped.map((o) => [o.emoji, o.id]));
     return {
       style: "emoji",
-      line: mapped.map((o) => `${o.emoji} ${SHORT[o.emoji]}`).join(" · "),
-      map: Object.fromEntries(mapped.map((o) => [o.emoji, o.id])),
+      line: mapped
+        .map((o) => `${o.emoji} ${SHORT[o.emoji] ?? o.label ?? o.id}`)
+        .join(" · "),
+      map,
     };
   }
-  return {
-    style: "numbered",
-    line: mapped.map((o, i) => `${i + 1}. ${o.label ?? o.id}`).join("\n"),
-    map: Object.fromEntries(mapped.map((o, i) => [String(i + 1), o.id])),
-  };
+  const map = {};
+  const line = mapped
+    .map((o, i) => {
+      const n = String(i + 1);
+      map[n] = o.id;
+      if (o.emoji) map[o.emoji] = o.id;
+      const label = o.label ?? o.id;
+      return o.emoji ? `${n}. ${o.emoji} ${label}` : `${n}. ${label}`;
+    })
+    .join("\n");
+  return { style: "numbered", line, map };
+}
+
+export function absoluteWebUrl(webUrl) {
+  if (typeof webUrl !== "string") return "";
+  const trimmed = webUrl.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return "";
+  return trimmed.replace(/\/$/, "");
 }
 
 export function inboxDeepLink(itemId, webUrl) {
-  const hash = `#/inbox/${encodeURIComponent(itemId)}`;
-  if (typeof webUrl === "string" && webUrl.trim() !== "") {
-    return `${webUrl.replace(/\/$/, "")}/${hash}`;
-  }
-  return hash;
+  const base = absoluteWebUrl(webUrl);
+  if (!base || itemId == null || String(itemId) === "") return "";
+  return `${base}/#/inbox/${encodeURIComponent(itemId)}`;
 }
 
 const MESSAGE_BODY_LIMIT = 300;
@@ -77,20 +114,82 @@ export function truncateBody(text, limit = MESSAGE_BODY_LIMIT) {
   return `${value.slice(0, limit).trimEnd()}…`;
 }
 
-export function formatInboxMessage(item, { webUrl } = {}) {
-  const title = String(item?.title ?? "").trim() || "(untitled)";
+function refText(item, key) {
+  const value = item?.refs?.[key];
+  if (value === undefined || value === null) return "";
+  const text = String(value).trim();
+  return text;
+}
+
+export function formatSubject(item) {
+  const kind = String(item?.kind ?? "").trim();
+  const repo = refText(item, "repo");
+  const ticket = refText(item, "issue");
+  const parts = [kind, repo, ticket].filter(Boolean);
+  if (ticket) return parts.join("  ");
+  const title = String(item?.title ?? "").trim();
+  return title || kind || "(untitled)";
+}
+
+export function formatWhy(item) {
+  const context =
+    typeof item?.decision?.context === "string"
+      ? item.decision.context.trim()
+      : "";
+  if (context) return context;
+  const body = typeof item?.body === "string" ? item.body.trim() : "";
+  if (body) return body;
   const question =
-    typeof item?.decision?.question === "string" &&
-    item.decision.question.trim()
+    typeof item?.decision?.question === "string"
       ? item.decision.question.trim()
-      : typeof item?.body === "string"
-        ? item.body.trim()
-        : "";
+      : "";
+  return question;
+}
+
+export function isDismissOnly(item) {
+  const options = Array.isArray(item?.decision?.options)
+    ? item.decision.options
+    : [];
+  if (options.length === 0) return false;
+  return options.every(
+    (option) => option?.effect === "dismiss" || option?.id === "dismiss",
+  );
+}
+
+export function shouldPost(item, postKinds) {
+  if (!item?.id) return false;
+  const kinds = postKinds instanceof Set ? postKinds : new Set(postKinds ?? []);
+  if (!kinds.has(item.kind)) return false;
+  if (item.kind === "ESCALATED" && !refText(item, "issue")) return false;
+  if (isDismissOnly(item)) return false;
+  return true;
+}
+
+/**
+ * A thread reply selects the recommended option, else `answer`. Never dismiss.
+ */
+export function replyOptionId(decision) {
+  const options = Array.isArray(decision?.options) ? decision.options : [];
+  const byId = (id) => options.find((option) => option.id === id);
+  const recommended = decision?.recommended;
+  if (recommended && byId(recommended)?.effect !== "dismiss")
+    return recommended;
+  const answer = options.find(
+    (option) => option.effect === "answer" || option.id === "answer",
+  );
+  return answer?.id ?? null;
+}
+
+export function formatInboxMessage(item, { webUrl } = {}) {
+  const subject = formatSubject(item);
+  const why = truncateBody(formatWhy(item));
   const options = formatOptions(item?.decision);
   const link = inboxDeepLink(item?.id ?? "", webUrl);
-  return [title, truncateBody(question), options.line, link]
-    .filter((line) => line !== "")
-    .join("\n");
+  const lines = [subject];
+  if (why && why !== subject) lines.push(why);
+  if (options.line) lines.push(options.line);
+  if (link) lines.push(link);
+  return lines.join("\n");
 }
 
 export function formatResolvedReply(item) {

--- a/extensions/buzz/lib/format.mjs
+++ b/extensions/buzz/lib/format.mjs
@@ -80,12 +80,17 @@ export function formatOptions(decision) {
       map,
     };
   }
+  const emojiCounts = new Map();
+  for (const emoji of emojis) {
+    if (!emoji) continue;
+    emojiCounts.set(emoji, (emojiCounts.get(emoji) ?? 0) + 1);
+  }
   const map = {};
   const line = mapped
     .map((o, i) => {
       const n = String(i + 1);
       map[n] = o.id;
-      if (o.emoji) map[o.emoji] = o.id;
+      if (o.emoji && emojiCounts.get(o.emoji) === 1) map[o.emoji] = o.id;
       const label = o.label ?? o.id;
       return o.emoji ? `${n}. ${o.emoji} ${label}` : `${n}. ${label}`;
     })
@@ -166,18 +171,20 @@ export function shouldPost(item, postKinds) {
 }
 
 /**
- * A thread reply selects the recommended option, else `answer`. Never dismiss.
+ * A thread reply selects `answer` when present, else the recommended option.
+ * Never dismiss.
  */
 export function replyOptionId(decision) {
   const options = Array.isArray(decision?.options) ? decision.options : [];
   const byId = (id) => options.find((option) => option.id === id);
-  const recommended = decision?.recommended;
-  if (recommended && byId(recommended)?.effect !== "dismiss")
-    return recommended;
   const answer = options.find(
     (option) => option.effect === "answer" || option.id === "answer",
   );
-  return answer?.id ?? null;
+  if (answer) return answer.id;
+  const recommended = decision?.recommended;
+  const rec = byId(recommended);
+  if (rec && rec.effect !== "dismiss") return rec.id;
+  return null;
 }
 
 export function formatInboxMessage(item, { webUrl } = {}) {

--- a/extensions/buzz/lib/runtime.mjs
+++ b/extensions/buzz/lib/runtime.mjs
@@ -213,7 +213,6 @@ export function createBuzzRuntime({
       });
       return;
     }
-    if (!postKinds.has(item.kind)) return;
     if (!shouldPost(item, postKinds)) return;
     const content = formatInboxMessage(item, { webUrl: resolvedWebUrl });
     const event = channelMessage({

--- a/extensions/buzz/lib/runtime.mjs
+++ b/extensions/buzz/lib/runtime.mjs
@@ -5,8 +5,9 @@
  * fake relay and a fake loopback client.
  */
 import {
-  DM_KINDS,
+  absoluteWebUrl,
   DEFAULT_POST_KINDS,
+  DM_KINDS,
   fieldsForOption,
   formatInboxMessage,
   formatOptions,
@@ -16,6 +17,8 @@ import {
   optionNeedsReason,
   parseCommand,
   reactionToOptionId,
+  replyOptionId,
+  shouldPost,
 } from "./format.mjs";
 import { hashJson } from "./hash.mjs";
 import { giftWrapDm } from "./nip17.mjs";
@@ -105,6 +108,7 @@ export function createBuzzRuntime({
       : null;
 
   const identity = resolveIdentity({ secrets, config });
+  const resolvedWebUrl = absoluteWebUrl(config.webUrl ?? webUrl);
   const posted = new Map(); // itemId -> { eventId, postedAt, optionMap, kind }
   const seenIngress = new Set();
   const pendingReject = new Map(); // rootEventId -> { itemId, optionId }
@@ -210,7 +214,8 @@ export function createBuzzRuntime({
       return;
     }
     if (!postKinds.has(item.kind)) return;
-    const content = formatInboxMessage(item, { webUrl });
+    if (!shouldPost(item, postKinds)) return;
+    const content = formatInboxMessage(item, { webUrl: resolvedWebUrl });
     const event = channelMessage({
       secretHex: identity.secretHex,
       auth: identity.auth,
@@ -231,7 +236,7 @@ export function createBuzzRuntime({
       const wrap = giftWrapDm(
         identity.secretHex,
         dmBlockedTo,
-        `${item.kind}: ${item.title}\n${inboxDeepLink(item.id, webUrl)}`,
+        `${item.kind}: ${item.title}\n${inboxDeepLink(item.id, resolvedWebUrl)}`.trim(),
       );
       await publish(wrap);
     }
@@ -399,6 +404,26 @@ export function createBuzzRuntime({
       if (decided.error) {
         await replyInThread(rootId, `decide failed: ${decided.error}`);
       }
+      return;
+    }
+
+    const found = itemForEventId(rootId);
+    if (!found?.item) return;
+    const optionId = replyOptionId(found.item.decision);
+    if (!optionId) return;
+    const decided = await decideItem(
+      found.item,
+      optionId,
+      identity.npub,
+      event.content,
+    );
+    if (decided.needReason) {
+      pendingReject.set(rootId, { itemId: found.id, optionId });
+      await replyInThread(rootId, reasonPrompt(found.item, optionId));
+      return;
+    }
+    if (decided.error) {
+      await replyInThread(rootId, `decide failed: ${decided.error}`);
     }
   }
 

--- a/extensions/buzz/test/connector.test.mjs
+++ b/extensions/buzz/test/connector.test.mjs
@@ -40,8 +40,9 @@ const proposal = {
 function inboxItem(overrides = {}) {
   return {
     id: "inbox_1",
-    kind: "decision_needed",
+    kind: "ESCALATED",
     title: "Decide proposal prop_1",
+    refs: { issue: "WM-1", repo: "factory" },
     decision: proposal,
     ...overrides,
   };
@@ -155,6 +156,7 @@ describe("egress", () => {
       secrets,
       client,
       fetchImpl: relay.fetchImpl,
+      webUrl: "http://127.0.0.1:7382",
     });
     await runtime.onInboxEvent({ type: "new-item", item: inboxItem() });
     expect(relay.posted).toHaveLength(1);
@@ -166,9 +168,10 @@ describe("egress", () => {
         expect.arrayContaining(["auth", OWNER_PUB]),
       ]),
     );
-    expect(event.content).toContain("Decide proposal prop_1");
+    expect(event.content).toContain("ESCALATED  factory  WM-1");
     expect(event.content).toContain("👍 approve · 👎 reject · 💤 not now");
-    expect(event.content).toContain("#/inbox/inbox_1");
+    expect(event.content).toContain("http://127.0.0.1:7382/#/inbox/inbox_1");
+    expect(event.content).not.toContain("\n#/inbox/");
     expect(marked[0].delivery.buzz.eventId).toBe(event.id);
     expect(runtime.posted.get("inbox_1").eventId).toBe(event.id);
   });
@@ -218,6 +221,35 @@ describe("egress", () => {
     expect(relay.posted[1].tags).toEqual(
       expect.arrayContaining([["e", relay.posted[0].id, "", "reply"]]),
     );
+  });
+
+  test("does not post dismiss-only or ticket-less ESCALATED items", async () => {
+    const relay = startRelay();
+    const runtime = createBuzzRuntime({
+      config: { relayUrl: relay.url, channel: CHANNEL },
+      secrets,
+      client: fakeClient({ items: [] }),
+      fetchImpl: relay.fetchImpl,
+    });
+    await runtime.onInboxEvent({
+      type: "new-item",
+      item: inboxItem({
+        id: "inbox_dismiss",
+        decision: {
+          question: "How should the factory handle this refused run?",
+          options: [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
+        },
+      }),
+    });
+    await runtime.onInboxEvent({
+      type: "new-item",
+      item: inboxItem({
+        id: "inbox_run",
+        title: "ESCALATED run_abc: needs_human",
+        refs: { runId: "run_abc" },
+      }),
+    });
+    expect(relay.posted).toHaveLength(0);
   });
 });
 
@@ -528,6 +560,68 @@ describe("ingress", () => {
           e.content.includes("inbox locked"),
       ),
     ).toBe(true);
+  });
+
+  test("a thread reply selects the recommended option and uses the reply as the field", async () => {
+    const decisions = [];
+    const item = inboxItem({
+      id: "inbox_answer",
+      decision: {
+        schemaVersion: "factory.decision-request/v1",
+        question: "How should the factory proceed with WM-1?",
+        recommended: "answer",
+        options: [
+          {
+            id: "triage",
+            label: "Send back to Triage",
+            effect: "send_to_triage",
+          },
+          { id: "answer", label: "Answer the agent", effect: "answer" },
+          { id: "dismiss", label: "Not now", effect: "dismiss" },
+        ],
+        fields: [
+          {
+            id: "answer",
+            kind: "text",
+            required: true,
+            whenOption: ["answer"],
+          },
+        ],
+      },
+    });
+    const client = fakeClient({
+      items: [item],
+      onDecide: (row) => decisions.push(row),
+    });
+    const postedId = "c".repeat(64);
+    const reply = signEvent(
+      {
+        kind: KIND_CHAT,
+        tags: [["e", postedId, "", "root"]],
+        content: "use the staging Stripe key",
+      },
+      OWNER_SECRET,
+      { createdAt: 1_700_000_020 },
+    );
+    const relay = startRelay({ extraEvents: [reply] });
+    const runtime = createBuzzRuntime({
+      config: { relayUrl: relay.url, channel: CHANNEL },
+      secrets,
+      client,
+      fetchImpl: relay.fetchImpl,
+    });
+    runtime.posted.set("inbox_answer", {
+      eventId: postedId,
+      postedAt: "2026-08-20T00:00:00.000Z",
+      optionMap: { "📤": "triage", "💬": "answer", "💤": "dismiss" },
+      kind: "ESCALATED",
+    });
+    await runtime.poll();
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].response.optionId).toBe("answer");
+    expect(decisions[0].response.fields).toEqual({
+      answer: "use the staging Stripe key",
+    });
   });
 });
 

--- a/extensions/buzz/test/format.test.mjs
+++ b/extensions/buzz/test/format.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_POST_KINDS,
   fieldsForOption,
   formatInboxMessage,
   formatOptions,
@@ -9,6 +10,8 @@ import {
   optionNeedsReason,
   parseCommand,
   reactionToOptionId,
+  replyOptionId,
+  shouldPost,
   truncateBody,
 } from "../lib/format.mjs";
 
@@ -40,7 +43,7 @@ describe("option formatting", () => {
     expect(reactionToOptionId("+", formatted.map)).toBe("approve");
   });
 
-  test("more than three options are numbered", () => {
+  test("more than three options without effects are numbered", () => {
     const formatted = formatOptions({
       options: [
         { id: "a", label: "One" },
@@ -53,6 +56,32 @@ describe("option formatting", () => {
     expect(formatted.line).toBe("1. One\n2. Two\n3. Three\n4. Four");
     expect(reactionToOptionId("2", formatted.map)).toBe("b");
   });
+
+  test("closed-set effects each have a unique reaction emoji", () => {
+    const formatted = formatOptions({
+      options: [
+        { id: "requeue", label: "Requeue the event", effect: "requeue" },
+        {
+          id: "triage",
+          label: "Send back to Triage",
+          effect: "send_to_triage",
+        },
+        { id: "answer", label: "Answer the agent", effect: "answer" },
+        { id: "authorise", label: "Authorise", effect: "authorise" },
+        { id: "dismiss", label: "Not now", effect: "dismiss" },
+      ],
+    });
+    expect(formatted.style).toBe("emoji");
+    expect(formatted.line).toContain("🔁 requeue");
+    expect(formatted.line).toContain("📤 triage");
+    expect(formatted.line).toContain("💬 answer");
+    expect(formatted.line).toContain("🔓 authorise");
+    expect(formatted.line).toContain("💤 not now");
+    expect(reactionToOptionId("🔁", formatted.map)).toBe("requeue");
+    expect(reactionToOptionId("📤", formatted.map)).toBe("triage");
+    expect(reactionToOptionId("💬", formatted.map)).toBe("answer");
+    expect(reactionToOptionId("🔓", formatted.map)).toBe("authorise");
+  });
 });
 
 describe("inbox message", () => {
@@ -60,16 +89,32 @@ describe("inbox message", () => {
     const body = formatInboxMessage(
       {
         id: "inbox_1",
-        title: "Decide proposal prop_1",
-        decision: proposal,
+        kind: "ESCALATED",
+        title: "ESCALATED run_abc: needs_human",
+        refs: { issue: "WM-1", repo: "factory" },
+        decision: {
+          ...proposal,
+          context: "Missing Stripe key on the runner.",
+        },
       },
       { webUrl: "http://127.0.0.1:7382" },
     );
-    expect(body).toStartWith("Decide proposal prop_1\n");
-    expect(body).toContain("Approve dispatch of WM-1?");
+    expect(body).toStartWith("ESCALATED  factory  WM-1\n");
+    expect(body).toContain("Missing Stripe key on the runner.");
     expect(body).toContain("👍 approve · 👎 reject · 💤 not now");
     expect(body).toContain("http://127.0.0.1:7382/#/inbox/inbox_1");
-    expect(inboxDeepLink("x", null)).toBe("#/inbox/x");
+    expect(body).not.toContain("ESCALATED run_abc");
+  });
+
+  test("omits a hash-only inbox link when webUrl is missing", () => {
+    const body = formatInboxMessage({
+      id: "inbox_1",
+      title: "Decide proposal prop_1",
+      decision: proposal,
+    });
+    expect(body).not.toContain("#/inbox/");
+    expect(inboxDeepLink("x", null)).toBe("");
+    expect(inboxDeepLink("x", "#")).toBe("");
   });
 
   test("resolved reply names the actor", () => {
@@ -131,5 +176,92 @@ describe("approvers", () => {
   test("allow-list is case-insensitive hex", () => {
     expect(isApprover("AA", ["aa"])).toBe(true);
     expect(isApprover("bb", ["aa"])).toBe(false);
+  });
+});
+
+describe("shouldPost", () => {
+  const kinds = new Set(DEFAULT_POST_KINDS);
+
+  test("skips dismiss-only cards and ticket-less ESCALATED", () => {
+    expect(
+      shouldPost(
+        {
+          id: "inbox_1",
+          kind: "ESCALATED",
+          refs: { issue: "WM-1" },
+          decision: {
+            options: [{ id: "dismiss", label: "Not now", effect: "dismiss" }],
+          },
+        },
+        kinds,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPost(
+        {
+          id: "inbox_1",
+          kind: "ESCALATED",
+          refs: { runId: "run_1" },
+          decision: proposal,
+        },
+        kinds,
+      ),
+    ).toBe(false);
+  });
+
+  test("posts ESCALATED with a ticket and a real verb", () => {
+    expect(
+      shouldPost(
+        {
+          id: "inbox_1",
+          kind: "ESCALATED",
+          refs: { issue: "WM-1" },
+          decision: proposal,
+        },
+        kinds,
+      ),
+    ).toBe(true);
+  });
+
+  test("posts CI RED even without a decision", () => {
+    expect(shouldPost({ id: "inbox_1", kind: "CI RED" }, kinds)).toBe(true);
+  });
+
+  test("drops kinds outside the interrupt set", () => {
+    expect(
+      shouldPost(
+        { id: "inbox_1", kind: "decision_needed", decision: proposal },
+        kinds,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("replyOptionId", () => {
+  test("selects recommended, else answer, never dismiss", () => {
+    expect(
+      replyOptionId({
+        recommended: "requeue",
+        options: [
+          { id: "requeue", effect: "requeue" },
+          { id: "dismiss", effect: "dismiss" },
+        ],
+      }),
+    ).toBe("requeue");
+    expect(
+      replyOptionId({
+        options: [
+          { id: "triage", effect: "send_to_triage" },
+          { id: "answer", effect: "answer" },
+          { id: "dismiss", effect: "dismiss" },
+        ],
+      }),
+    ).toBe("answer");
+    expect(
+      replyOptionId({
+        recommended: "dismiss",
+        options: [{ id: "dismiss", effect: "dismiss" }],
+      }),
+    ).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary

`#ops-factory` was dumping ticket-less `needs_human` cards whose only action was "not now". The Buzz connector now posts only answerable interrupt items: skip dismiss-only cards and `ESCALATED` with no ticket; subject is `kind  repo  ticket` plus the agent's why; every closed-set effect has a unique reaction; thread replies select `recommended` or `answer`; hash-only `#/inbox/…` links are omitted unless `webUrl` / `FACTORY_WEB_URL` is an absolute URL. Run-start telemetry stays out of this PR (WM-975).

## Related issue

Fixes WM-974

## Verification

```text
bun test --timeout 20000 --max-concurrency=4 extensions/buzz/test
# 45 pass

bun event-runtime/cli.mjs extensions validate extensions/buzz
# wattmind/buzz@1.0.0: valid
```

After merge and a serve restart: ticket-less `needs_human` dumps should stop appearing in `#ops-factory`, and a real ESCALATED with a ticket should be reactable / replyable.

## Risk and impact

- [x] This change is narrowly scoped to the linked issue.
- [x] I added or updated tests for behavior changes, or explained why no test is needed.
- [x] I updated documentation for user- or operator-visible behavior.
- [x] I regenerated emitted files when changing `shared/` and ran `bun run check`.
- [x] I considered security and privacy impact and did not include credentials or private data.
- [x] I identified compatibility, migration, or rollback concerns below.

Serve must restart to pick up the new `postKinds` in `config/policy.yaml`. `#ops-factory` will go quiet for ticket-less dumps — that is intended. No `shared/` changes. Rollback is revert of this commit.

## Contributor statement

- [x] I have read and agree to follow `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
- [x] I have the right to submit this work under Apache License 2.0.
- [x] I have completed a Contributor License Agreement if a maintainer or check requested one.