### PR TITLE
fix(planner): accept flat labels shape in dispatch admission — supply pipeline stalled since WM-894 (WM-978)

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1250,7 +1250,9 @@ function linearIssueResolved(row, issue, db) {
   if (row.kind === "BLOCKED") return state !== "Blocked";
   if (row.kind === "ESCALATED") {
     const delivery = parseObject(row.delivery_json);
-    const labels = (issue?.labels?.nodes ?? []).map((label) => label.name);
+    const labels = (
+      Array.isArray(issue?.labels) ? issue.labels : (issue?.labels?.nodes ?? [])
+    ).map((label) => label.name); // WM-978: both label shapes
     const hasEscalatedLabel = labels.includes("ai:escalated");
     if (hasEscalatedLabel && !delivery.seenEscalated) {
       delivery.seenEscalated = true;

--- a/event-runtime/lib/merge-apply.mjs
+++ b/event-runtime/lib/merge-apply.mjs
@@ -69,7 +69,11 @@ function githubHeld(labels) {
 function linearHeld(ticketJson) {
   if (!ticketJson || typeof ticketJson !== "object") return true;
   if (ticketJson.state?.name === "Blocked") return true;
-  const names = (ticketJson.labels?.nodes ?? []).map((n) => n?.name ?? "");
+  const names = (
+    Array.isArray(ticketJson.labels)
+      ? ticketJson.labels
+      : (ticketJson.labels?.nodes ?? [])
+  ).map((n) => n?.name ?? ""); // WM-978: both label shapes
   return names.some((name) =>
     /^(ai:escalated|type:security|.*security.*)$/i.test(name),
   );

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -682,7 +682,11 @@ function linearHeld(ticketState) {
   if (!ticketState || typeof ticketState !== "object") return true;
   const state = ticketState.state?.name;
   if (state === "Blocked") return true;
-  const names = (ticketState.labels?.nodes ?? [])
+  const names = (
+    Array.isArray(ticketState.labels)
+      ? ticketState.labels
+      : (ticketState.labels?.nodes ?? [])
+  ) // WM-978: both label shapes
     .map((node) => (typeof node?.name === "string" ? node.name : ""))
     .filter(Boolean);
   return names.some((name) =>

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -738,7 +738,14 @@ function evidenceTicket(ticket, ticketId) {
     state: ticket?.state?.name ?? null,
     assigneeNull: !ticket?.assignee,
     labels: sortUnique(
-      (ticket?.labels?.nodes ?? []).map((label) => label?.name).filter(Boolean),
+      // WM-978: tolerate both label shapes — the WM-894 control-plane adapter
+      // emits a flat [{id,name}] array; older payloads used GraphQL {nodes}.
+      (Array.isArray(ticket?.labels)
+        ? ticket.labels
+        : (ticket?.labels?.nodes ?? [])
+      )
+        .map((label) => label?.name)
+        .filter(Boolean),
     ),
     ownedPaths: effectiveOwnedPaths(description),
     ownedPathsParsed: parsed.length > 0,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1237,6 +1237,35 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
+  test("flat labels array from the control-plane adapter still admits (WM-978)", () => {
+    withReposRoot(
+      `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
+      () => {
+        // WM-894's adapter emits labels as a flat [{id,name}] array instead of
+        // the GraphQL {nodes:[...]} shape; admission must accept both.
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-978" },
+          {
+            countLeases: () => 0,
+            budgetRefusal: () => null,
+            fetchTicket: () => ({
+              identifier: "WM-978",
+              state: { name: "Todo" },
+              assignee: null,
+              labels: [{ id: "x", name: "ai:agent-ready" }],
+              description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+            }),
+            fetchInFlight: () => [],
+          },
+        );
+        expect(result.refusal?.reason).not.toBe("ticket_not_agent_ready");
+        expect(result.evidence.ticket.labels).toContain("ai:agent-ready");
+      },
+    );
+  });
+
   test("lease-loss retry accepts only the factory viewer's surviving In Progress claim (WM-621)", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1453,7 +1453,10 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
-    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+    if (
+      !(Array.isArray(cur.labels) ? cur.labels : (cur.labels?.nodes ?? [])) // WM-978
+        .some((l) => l.name === "ai:in-progress")
+    )
       return false;
 
     runLinearCli([
@@ -1661,7 +1664,10 @@ function defaultBlockBaselineTicket({
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
-    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+    if (
+      !(Array.isArray(cur.labels) ? cur.labels : (cur.labels?.nodes ?? [])) // WM-978
+        .some((l) => l.name === "ai:in-progress")
+    )
       return false;
 
     const signature = baselineFailureSignature({ why, log, baseline });


### PR DESCRIPTION
WM-894 (#756) changed `linear.mjs get --json` label shape to a flat array; the planner (and 5 other runtime consumers) still read `labels.nodes`, so every ticket normalized to zero labels → every dispatch noop'd `ticket_not_agent_ready` since the 15:1xZ restart. Live evidence: WM-976/977 (Todo+agent-ready+unassigned) refused twice; the 16:06Z chain scan dispatched nothing.

All six `.nodes` consumers now tolerate both shapes; planner regression test admits with the flat shape.

## Handoff
- Verification: bun test event-runtime/lib — full slice green; planner.test.mjs 68 pass incl. new WM-978 test
- Files: planner/merge-apply/merge-reviews/inbox/worker + planner.test.mjs
- UX critique: n/a