### PR TITLE
fix(overview): stop listing expired-open proposals twice (WM-979)

### DIFF
--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -91,3 +91,19 @@ the effective adapter's `policy.yaml` `models:` map.
 
 The fleet default still moves by PR. Promoting an overlay into git is WM-889.
 The global `models:` map itself is WM-888. Agents UI on this store is WM-884.
+
+## Overview expired-open proposals (WM-979)
+
+Decided 2026-08-20. TTL-expired open proposals are not a Needs-you decision.
+Approve is disabled once TTL has elapsed; reject and bulk reject live on
+Proposals with the Expired chip (`onJumpExpired`).
+
+Overview therefore:
+
+- Does not list `expiredOpenProposals` in Needs you Runtime (no per-id "View
+  proposal" jumps for a spec that cannot be approved).
+- Collapses them to one Anomalies row whose action is **Review expired**.
+- Wires the Approval Gate expired tile to the same jump.
+
+Inbox `proposal_expired` items remain Needs-you Decide rows when they exist.
+Auto-expiry of leftover chain proposals is WM-445, not this.

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -21,7 +21,7 @@ import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
-import { changeInput, withApi } from "../test-render";
+import { withApi } from "../test-render";
 import type {
   AdmittedEvent,
   EventFocus,
@@ -176,6 +176,7 @@ type OverviewCallbacks = Partial<
     | "onJumpEvents"
     | "onJumpRuns"
     | "onNavigate"
+    | "onJumpExpired"
   >
 >;
 
@@ -192,7 +193,7 @@ function renderOverview(
       onJumpEvents={callbacks.onJumpEvents ?? noop}
       onJumpRuns={callbacks.onJumpRuns ?? noop}
       onNavigate={callbacks.onNavigate ?? noop}
-      onJumpExpired={noop}
+      onJumpExpired={callbacks.onJumpExpired ?? noop}
       onJumpGraph={noop}
       onInject={noop}
     />,
@@ -496,7 +497,7 @@ describe("Overview keyboard navigation (WM-292)", () => {
       await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
 
       const first = deck(view)
-        .getByRole("button", { name: "expired open" })
+        .getByRole("button", { name: "1 expired open proposal" })
         .closest('[tabindex="-1"]');
       const second = deck(view)
         .getByRole("button", { name: /github.*planner failed/ })
@@ -524,36 +525,30 @@ describe("Overview keyboard navigation (WM-292)", () => {
   });
 });
 
-describe("Overview anomaly deck (WM-95)", () => {
-  test("enriches an expired-proposal row with agent, decision/reason, origin, and age; demotes the raw id", async () => {
+describe("Overview anomaly deck (WM-95, WM-979)", () => {
+  test("collapses expired-open proposals to one Review-expired row (WM-979)", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
     const origJournal = api.journal;
     api.status = async () =>
-      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+      baseStatus({
+        expiredOpenProposals: [stubProposal.id, "prop_second"],
+      });
     api.proposals = async () => ({ proposals: [stubProposal] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
+    const onJumpExpired = mock(() => {});
 
     try {
-      const { getByText, queryByTitle } = renderOverview();
-
-      await waitFor(() => getByText(/agent: triage-scan/));
-
-      expect(getByText(/agent: triage-scan/)).toBeTruthy();
-      expect(getByText(/human_needed/)).toBeTruthy();
-      expect(getByText(/ambiguous repo pin/)).toBeTruthy();
-      const originId = queryByTitle("evt-789");
-      expect(originId).toBeTruthy();
-      expect(originId?.parentElement?.textContent).toBe(
-        "origin github/evt-789",
+      const view = renderOverview({ kind: "all" }, { onJumpExpired });
+      const row = await waitFor(() =>
+        deck(view).getByRole("button", { name: "2 expired open proposals" }),
       );
-
-      // Raw id is demoted to secondary, copyable text rather than the primary label.
-      const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
-      expect(idNode).toBeTruthy();
-      expect(idNode?.textContent).toBe(shortId(stubProposal.id));
+      expect(view.queryByText(/agent: triage-scan/)).toBeNull();
+      expect(view.queryByRole("button", { name: "Reject…" })).toBeNull();
+      fireEvent.click(row);
+      expect(onJumpExpired).toHaveBeenCalledTimes(1);
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
@@ -562,81 +557,94 @@ describe("Overview anomaly deck (WM-95)", () => {
     }
   });
 
-  test("rejects an expired proposal only after collecting a non-empty reason", async () => {
+  test("does not list expired-open proposals under Needs you Runtime", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
     const origJournal = api.journal;
-    const origReject = api.reject;
     api.status = async () =>
-      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+      baseStatus({
+        expiredOpenProposals: [stubProposal.id],
+        staleLeases: 1,
+      });
     api.proposals = async () => ({ proposals: [stubProposal] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
-
-    const rejectedCalls: { id: string; why?: string }[] = [];
-    api.reject = async (id: string, why?: string) => {
-      rejectedCalls.push({ id, why });
-      return { rejected: true };
-    };
 
     try {
       const view = renderOverview();
-      const reject = await waitFor(() =>
-        view.getByRole("button", { name: "Reject…" }),
-      );
-
-      expect(view.queryByRole("button", { name: "Dismiss" })).toBeNull();
-      fireEvent.click(reject);
-
-      const confirm = view.getByRole("button", {
-        name: "Reject proposal",
-      }) as HTMLButtonElement;
-      const reasonInput = view.getByLabelText(
-        "Rejection reason",
-      ) as HTMLInputElement;
-      expect(reasonInput.placeholder).toMatch(/Reason \(required/i);
-      expect(confirm.disabled).toBe(true);
-
-      await act(async () => changeInput(reasonInput, "   "));
-      fireEvent.click(confirm);
-      expect(rejectedCalls).toEqual([]);
-
-      await act(async () => changeInput(reasonInput, " No longer actionable "));
-      await waitFor(() => expect(confirm.disabled).toBe(false));
-      await act(async () => fireEvent.click(confirm));
-      await waitFor(() =>
-        expect(rejectedCalls).toEqual([
-          { id: stubProposal.id, why: "No longer actionable" },
-        ]),
-      );
+      const needsYou = await waitFor(() => view.getByLabelText("Needs you"));
+      expect(within(needsYou).queryByText(/expired open proposal/)).toBeNull();
+      expect(
+        within(needsYou).getByRole("button", { name: "View leased runs" }),
+      ).toBeTruthy();
+      expect(view.getByText(/Anomalies · 2 active issues/)).toBeTruthy();
+      expect(
+        deck(view).getByRole("button", { name: "1 expired open proposal" }),
+      ).toBeTruthy();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
       api.outbox = origOutbox;
       api.journal = origJournal;
-      api.reject = origReject;
     }
   });
 
-  test("shows a fallback for a proposal id with no match in the proposals list", async () => {
+  test("Approval Gate expired tile jumps via onJumpExpired", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () => ({
+      ...baseStatus({ expiredOpenProposals: [stubProposal.id] }),
+      proposals: { open: 1, expired: 1 },
+    });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    const onJumpExpired = mock(() => {});
+    const onNavigate = mock((_path: string) => {});
+
+    try {
+      const view = renderOverview(
+        { kind: "all" },
+        { onJumpExpired, onNavigate },
+      );
+      const tile = await waitFor(() =>
+        view.getByRole("button", { name: "proposals · expired: 1" }),
+      );
+      fireEvent.click(tile);
+      expect(onJumpExpired).toHaveBeenCalledTimes(1);
+      expect(onNavigate).not.toHaveBeenCalled();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("Needs you is calm when expired-open proposals are the only doctor anomalies", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
     const origJournal = api.journal;
     api.status = async () =>
-      baseStatus({ expiredOpenProposals: ["prop_missing"] });
-    api.proposals = async () => ({ proposals: [] });
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
 
     try {
-      const { getByText, queryByTitle } = renderOverview();
-
-      await waitFor(() => queryByTitle("prop_missing — click to copy"));
-
-      expect(getByText(/agent: —/)).toBeTruthy();
-      expect(getByText(/origin —\/—/)).toBeTruthy();
+      const view = renderOverview();
+      await waitFor(() =>
+        expect(
+          view.getByText(/Nothing needs you · last decision/),
+        ).toBeTruthy(),
+      );
+      expect(
+        deck(view).getByRole("button", { name: "1 expired open proposal" }),
+      ).toBeTruthy();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
@@ -1473,8 +1481,10 @@ describe("buildAnomalyRows (WM-205)", () => {
       "ambiguous",
       "capacity",
     ]);
-    expect(rows[0]!.proposalId).toBe("prop_1");
-    expect(rows[0]!.proposal?.agent).toBe("triage-scan");
+    expect(rows[0]!.text).toBe("1 expired open proposal");
+    expect(rows[0]!.surfaceInNeedsYou).toBe(false);
+    expect(rows[0]!.proposalId).toBeUndefined();
+    expect(rows[0]!.links[0]!.label).toBe("Review expired");
     expect(rows[1]!.text).toMatch(/stale leases: 2/);
     expect(rows[2]!.text).toMatch(/unpublished outbox rows: 1/);
     expect(rows[3]!.requeue).toEqual({ source: "github", eventId: "e99" });
@@ -1483,6 +1493,24 @@ describe("buildAnomalyRows (WM-205)", () => {
     expect(rows[4]!.releaseWorker).toEqual({ workerId: "w1", runId: "r1" });
     expect(rows[5]!.text).toMatch(/ambiguous open proposals: 3/);
     expect(rows[6]!.text).toMatch(/4 queued runs and no live worker/);
+  });
+
+  test("collapses many expired-open ids to one Review-expired row (WM-979)", () => {
+    const onJumpExpired = mock(() => {});
+    const rows = buildAnomalyRows(
+      {
+        ...baseStatus().anomalies,
+        expiredOpenProposals: ["prop_a", "prop_b", "prop_c"],
+      },
+      new Map(),
+      { ...callbacks, onJumpExpired },
+    );
+    const expired = rows.filter((row) => row.kind === "proposal");
+    expect(expired).toHaveLength(1);
+    expect(expired[0]!.text).toBe("3 expired open proposals");
+    expect(expired[0]!.surfaceInNeedsYou).toBe(false);
+    expired[0]!.links[0]!.go();
+    expect(onJumpExpired).toHaveBeenCalledTimes(1);
   });
 
   test("maps stopped and late schedules, piling proposals, and configuration warnings", () => {

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   lazy,
   Suspense,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -423,6 +424,8 @@ export interface AnomalyRow {
   dismissProposalId?: string;
   proposalId?: string;
   proposal?: Proposal;
+  /** False for housekeeping the Approval Gate / Proposals expired chip already cover (WM-979). */
+  surfaceInNeedsYou?: boolean;
 }
 
 /** Collapse dead letters that represent the same operator problem. */
@@ -464,19 +467,24 @@ export function stripAnomalyKindPrefix(
  */
 export function buildAnomalyRows(
   anomalies: StatusView["anomalies"] | undefined,
-  proposalsById: Map<string, Proposal>,
+  _proposalsById: Map<string, Proposal>,
   callbacks: {
     onJumpProposal: (id: string) => void;
     onJumpRuns: (state?: string) => void;
     onJumpEvents: (focus: EventFocus) => void;
     onJumpRun: (runId: string) => void;
     onNavigate: (path: string) => void;
+    onJumpExpired?: () => void;
   },
   s?: StatusView,
   now?: number,
 ): AnomalyRow[] {
   const rows: AnomalyRow[] = [];
   if (!anomalies) return rows;
+  const reviewExpired = () =>
+    callbacks.onJumpExpired
+      ? callbacks.onJumpExpired()
+      : callbacks.onNavigate("proposals");
 
   for (const schedule of anomalies.stoppedSchedules ?? []) {
     rows.push({
@@ -513,16 +521,14 @@ export function buildAnomalyRows(
     });
   }
 
-  for (const id of anomalies.expiredOpenProposals) {
+  const expiredOpen = anomalies.expiredOpenProposals ?? [];
+  if (expiredOpen.length > 0) {
+    const n = expiredOpen.length;
     rows.push({
       kind: "proposal",
-      text: `expired open proposal ${id}`,
-      proposalId: id,
-      proposal: proposalsById.get(id),
-      links: [
-        { label: "View proposal", go: () => callbacks.onJumpProposal(id) },
-      ],
-      dismissProposalId: id,
+      text: n === 1 ? "1 expired open proposal" : `${n} expired open proposals`,
+      links: [{ label: "Review expired", go: reviewExpired }],
+      surfaceInNeedsYou: false,
     });
   }
   if (anomalies.staleLeases > 0) {
@@ -844,7 +850,7 @@ export function Overview({
   onJumpRuns,
   onJumpWorkers,
   onNavigate,
-  onJumpExpired: _onJumpExpired,
+  onJumpExpired,
   onJumpGraph: _onJumpGraph,
   onInject: _onInject,
 }: {
@@ -1038,36 +1044,35 @@ export function Overview({
       notify(`Ack failed: ${(error as Error).message}`, "err"),
   });
 
+  const jumpExpired = useCallback(
+    () => (onJumpExpired ? onJumpExpired() : onNavigate("proposals")),
+    [onJumpExpired, onNavigate],
+  );
   const s = useMemo(() => normalizeStatus(status.data), [status.data]);
   const anomalies = s?.anomalies;
-  const proposalsById = useMemo(() => {
-    return new Map<string, Proposal>(
-      (proposalsForDeck.data?.proposals ?? []).map((p) => [p.id, p]),
-    );
-  }, [proposalsForDeck.data?.proposals]);
-
   const anomalyRows = useMemo(() => {
     return buildAnomalyRows(
       anomalies,
-      proposalsById,
+      new Map(),
       {
         onJumpProposal,
         onJumpRuns,
         onJumpEvents,
         onJumpRun,
         onNavigate,
+        onJumpExpired: jumpExpired,
       },
       s,
       now,
     );
   }, [
     anomalies,
-    proposalsById,
     onJumpProposal,
     onJumpRuns,
     onJumpEvents,
     onJumpRun,
     onNavigate,
+    jumpExpired,
     s,
     now,
   ]);
@@ -1091,13 +1096,15 @@ export function Overview({
   }, [inbox.data?.items]);
   const runtimeNeeds = useMemo(
     () =>
-      anomalyRows.map((row, index) => ({
-        id: `runtime-${index}`,
-        title: row.text,
-        primaryAction: row.links[0]
-          ? { label: row.links[0].label, onClick: row.links[0].go }
-          : undefined,
-      })),
+      anomalyRows
+        .filter((row) => row.surfaceInNeedsYou !== false)
+        .map((row, index) => ({
+          id: `runtime-${index}`,
+          title: row.text,
+          primaryAction: row.links[0]
+            ? { label: row.links[0].label, onClick: row.links[0].go }
+            : undefined,
+        })),
     [anomalyRows],
   );
 
@@ -1330,9 +1337,9 @@ export function Overview({
 
       {/*
         Band A: the anomaly remediation deck (WM-205). Needs-you above surfaces
-        these same anomalies as one-click jumps, but every remediation verb
-        (archive, requeue, release lease, reject) still lives only here. It stays
-        until those actions move onto the Runtime rows.
+        remediatable anomalies as one-click jumps; verbs (archive, requeue,
+        release lease) still live here. Expired-open proposals are not Needs-you
+        (WM-979): they collapse to one Review-expired row that opens Proposals.
       */}
       {hasAnomalies ? (
         <section
@@ -1736,7 +1743,7 @@ export function Overview({
                       value={proposalExpired}
                       hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
                       attention={proposalExpired > 0}
-                      onClick={() => onNavigate("proposals")}
+                      onClick={jumpExpired}
                       total={proposalTotal}
                     />
                   </div>


### PR DESCRIPTION
## Summary
- Needs you no longer lists TTL-expired open proposals as Runtime "View proposal" rows — those specs cannot be approved, so they are not a decision.
- The Anomalies deck collapses `expiredOpenProposals` to one summary row whose action is Review expired (`onJumpExpired` → Proposals Open + Expired chip, where reject / bulk reject work).
- The Approval Gate expired tile uses the same jump. Recorded in `docs/product-decisions.md`. Auto-expiry of leftover chain proposals remains WM-445.

## Test plan
- [x] `bun test event-runtime/web/src/views/Overview.test.tsx` — 48 pass
- [ ] On Overview with several expired-open proposals: Needs you does not show per-id View proposal rows; Anomalies shows one "N expired open proposals" row
- [ ] Clicking that row (and the Approval Gate expired count) lands on Proposals with the Expired chip on
- [ ] Dead letters / stale leases still appear under Needs you Runtime and Anomalies

Fixes WM-979