### PR TITLE
feat(tickets): Linear supply Refresh and hub scroll (WM-824, WM-981)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -2,6 +2,7 @@
 import { ControlPlaneError } from "../../lib/control-plane/types.mjs";
 import { artifactHead } from "./api-artifacts.mjs";
 import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
+import { STALE_SCAN_MS, loadLinearSupply } from "./linear.mjs";
 import { loadRepos, RepoError } from "./repos.mjs";
 import { runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
@@ -1143,7 +1144,7 @@ function deriveRecommendedAction(repos) {
  * Latest work-plan and status-report artifacts per configured repo (WM-823).
  * Counts are null when no scan has produced that figure yet — never invented.
  */
-export function ticketSupplyView(db, options = {}) {
+export function scanTicketSupply(db, options = {}) {
   const repoRegistry = options.repos ?? loadRepos();
   const configured = [...repoRegistry.values()];
   const configuredNames = new Set(configured.map((repo) => repo.name));
@@ -1257,6 +1258,77 @@ export function ticketSupplyView(db, options = {}) {
     : deriveRecommendedAction(repos);
 
   return { repos, recommendedAction };
+}
+
+/**
+ * Overlay a Linear snapshot onto scan figures. Linear counts win when the
+ * fetch succeeded; otherwise the scan remains and stale (>1h) scan age is
+ * flagged so it is not confused with Linear freshness (WM-824).
+ */
+export function mergeTicketSupply(scan, linear, { nowMs = Date.now() } = {}) {
+  if (linear?.ok) {
+    const repos = scan.repos.map((repo) => {
+      const live = linear.byRepo?.[repo.name];
+      if (!live) {
+        return { ...repo, source: repo.asOf ? "scan" : null };
+      }
+      return {
+        ...repo,
+        triage: live.triage,
+        ready: live.ready,
+        inFlight: live.inFlight,
+        blocked: live.blocked,
+        asOf: linear.asOf,
+        sourceRunId: null,
+        source: "linear",
+      };
+    });
+    return {
+      repos,
+      recommendedAction: deriveRecommendedAction(repos),
+      source: "linear",
+      asOf: linear.asOf ?? null,
+      stale: false,
+      linearError: null,
+      budget: linear.budget ?? null,
+      cached: linear.cached === true,
+    };
+  }
+
+  let newest = null;
+  for (const repo of scan.repos ?? []) {
+    if (repo.asOf && (!newest || repo.asOf > newest)) newest = repo.asOf;
+  }
+  const ageMs = newest ? nowMs - Date.parse(newest) : null;
+  const stale = Number.isFinite(ageMs) && ageMs > STALE_SCAN_MS;
+  return {
+    ...scan,
+    repos: (scan.repos ?? []).map((repo) => ({
+      ...repo,
+      source: repo.asOf ? "scan" : null,
+    })),
+    source: "scan",
+    asOf: newest,
+    stale,
+    linearError: linear?.error ?? "linear_unavailable",
+    budget: linear?.budget ?? null,
+    cached: false,
+  };
+}
+
+/**
+ * Operator supply for GET /tickets/supply: Linear on demand, scan fallback.
+ */
+export async function ticketSupplyView(db, options = {}) {
+  const scan = scanTicketSupply(db, options);
+  const linear = await loadLinearSupply(options.repos ?? loadRepos(), {
+    refresh: options.refresh === true,
+    nowMs: options.nowMs,
+    gql: options.gql,
+  });
+  return mergeTicketSupply(scan, linear, {
+    nowMs: options.nowMs ?? Date.now(),
+  });
 }
 
 function listFilters(url, { proposal = false, nowMs = Date.now() } = {}) {
@@ -1738,7 +1810,15 @@ export async function handleRunApiRoute({
     try {
       const repoRegistry =
         typeof loadReposFn === "function" ? loadReposFn() : loadRepos();
-      return send(200, ticketSupplyView(db, { repos: repoRegistry }));
+      const refresh = url.searchParams.get("refresh") === "1";
+      return send(
+        200,
+        await ticketSupplyView(db, {
+          repos: repoRegistry,
+          refresh,
+          nowMs,
+        }),
+      );
     } catch (err) {
       if (err instanceof RepoError) return send(500, { error: err.message });
       throw err;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -14,8 +14,11 @@ import { memoryControlPlane } from "../../lib/control-plane/index.mjs";
 import {
   TICKET_DETAIL_CACHE_TTL_MS,
   clearTicketDetailCache,
+  mergeTicketSupply,
+  scanTicketSupply,
   setTicketDetailControlPlane,
   ticketIndexView,
+  ticketSupplyView,
 } from "./api-runs.mjs";
 import {
   GH_SECRET,
@@ -1631,6 +1634,173 @@ describe("GET /tickets/:id/detail (WM-914)", () => {
       const body = await down.json();
       expect(body.error).toBe("tracker_unavailable");
       expect(body.message).toBe("network down");
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("GET /tickets/supply (WM-824)", () => {
+  afterEach(async () => {
+    const {
+      clearLinearSupplyCache,
+      setLinearSupplyGql,
+      setLinearSupplyBudget,
+    } = await import("./linear.mjs");
+    clearLinearSupplyCache();
+    setLinearSupplyGql(null);
+    setLinearSupplyBudget(undefined);
+  });
+
+  function repoMap(rows) {
+    return new Map(
+      rows.map((row) => [
+        row.name,
+        {
+          maxInFlight: 2,
+          team: "WM",
+          project: "Factory",
+          ...row,
+        },
+      ]),
+    );
+  }
+
+  test("merge overlays Linear counts and keeps scan fallback when Linear fails", () => {
+    const scan = {
+      repos: [
+        {
+          name: "factory",
+          team: "WM",
+          triage: 9,
+          ready: 1,
+          inFlight: 0,
+          cap: 2,
+          blocked: 0,
+          noopReason: null,
+          asOf: "2026-08-20T10:00:00.000Z",
+          sourceRunId: "run_scan",
+        },
+      ],
+      recommendedAction: "triage",
+    };
+    const live = mergeTicketSupply(scan, {
+      ok: true,
+      asOf: "2026-08-20T18:00:00.000Z",
+      byRepo: {
+        factory: {
+          triage: 3,
+          ready: 2,
+          inFlight: 1,
+          blocked: 0,
+          inReview: 0,
+        },
+      },
+      budget: { remaining: 2000, limit: 2500 },
+      cached: false,
+    });
+    expect(live.source).toBe("linear");
+    expect(live.stale).toBe(false);
+    expect(live.repos[0]).toMatchObject({
+      triage: 3,
+      ready: 2,
+      inFlight: 1,
+      asOf: "2026-08-20T18:00:00.000Z",
+      sourceRunId: null,
+      source: "linear",
+    });
+    expect(live.recommendedAction).toBe("dispatch");
+
+    const fallback = mergeTicketSupply(
+      scan,
+      {
+        ok: false,
+        error: "RATELIMITED",
+        budget: { remaining: 0, limit: 2500 },
+      },
+      { nowMs: Date.parse("2026-08-20T10:30:00.000Z") },
+    );
+    expect(fallback.source).toBe("scan");
+    expect(fallback.stale).toBe(false);
+    expect(fallback.linearError).toBe("RATELIMITED");
+    expect(fallback.repos[0].triage).toBe(9);
+    expect(fallback.repos[0].source).toBe("scan");
+
+    const stale = mergeTicketSupply(
+      scan,
+      { ok: false, error: "linear_unavailable" },
+      { nowMs: Date.parse("2026-08-20T12:00:00.000Z") },
+    );
+    expect(stale.stale).toBe(true);
+  });
+
+  test("GET /tickets/supply queries Linear on demand and honors refresh=1", async () => {
+    const { setLinearSupplyGql, clearLinearSupplyCache } =
+      await import("./linear.mjs");
+    clearLinearSupplyCache();
+    let calls = 0;
+    setLinearSupplyGql(async () => {
+      calls += 1;
+      return {
+        issues: {
+          nodes: [
+            {
+              state: { name: "Triage" },
+              assignee: null,
+              labels: { nodes: [] },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+      };
+    });
+    const repos = repoMap([{ name: "factory" }]);
+    const s = await makeServer({ repos: () => repos });
+    try {
+      const first = await fetch(s.url("/tickets/supply"));
+      expect(first.status).toBe(200);
+      const body = await first.json();
+      expect(body.source).toBe("linear");
+      expect(body.repos).toEqual([
+        expect.objectContaining({
+          name: "factory",
+          triage: 1,
+          ready: 0,
+          source: "linear",
+        }),
+      ]);
+      expect(calls).toBe(1);
+
+      await fetch(s.url("/tickets/supply"));
+      expect(calls).toBe(1);
+
+      await fetch(s.url("/tickets/supply?refresh=1"));
+      expect(calls).toBe(2);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("scanTicketSupply still reads work-plan / status-report artifacts", async () => {
+    const s = await makeServer();
+    try {
+      const repos = repoMap([{ name: "factory" }]);
+      const empty = scanTicketSupply(s.db, { repos });
+      expect(empty.repos[0]).toMatchObject({
+        name: "factory",
+        triage: null,
+        ready: null,
+        asOf: null,
+      });
+      const merged = await ticketSupplyView(s.db, {
+        repos,
+        gql: async () => {
+          throw new Error("no linear");
+        },
+        nowMs: Date.parse("2026-08-20T12:00:00.000Z"),
+      });
+      expect(merged.source).toBe("scan");
+      expect(merged.linearError).toBe("no linear");
     } finally {
       s.close();
     }

--- a/event-runtime/lib/linear.mjs
+++ b/event-runtime/lib/linear.mjs
@@ -1,0 +1,230 @@
+/**
+ * On-demand Linear ticket-supply snapshot for GET /tickets/supply (WM-824).
+ *
+ * Counts come from Linear GraphQL, not a background poll. A short in-memory
+ * TTL plus in-flight coalescing keep concurrent tabs and rapid Refresh clicks
+ * from turning into a request storm. `loadLinearBudget()` is the circuit
+ * breaker: remaining 0 skips the network and lets the caller fall back to
+ * scan artifacts.
+ */
+import { gql as defaultGql } from "../../orchestrator/reaper.mjs";
+import {
+  installLinearBudgetCapture,
+  loadLinearBudget,
+} from "../../tools/linear.mjs";
+
+export const TICKET_SUPPLY_CACHE_TTL_MS = 45_000;
+export const STALE_SCAN_MS = 60 * 60 * 1000;
+export const AGENT_READY_LABEL = "ai:agent-ready";
+
+const ISSUE_NODE = `state{ name } assignee{ id } labels{ nodes{ name } }`;
+const TEAM_QUERY = `query($t:String!,$after:String){
+  issues(first:100, after:$after, filter:{
+    team:{ key:{ eq:$t } }
+    state:{ type:{ nin:["completed","canceled"] } }
+  }){
+    pageInfo{ hasNextPage endCursor }
+    nodes{ ${ISSUE_NODE} }
+  }
+}`;
+const PROJECT_QUERY = `query($t:String!,$p:String!,$after:String){
+  issues(first:100, after:$after, filter:{
+    team:{ key:{ eq:$t } }
+    project:{ name:{ eq:$p } }
+    state:{ type:{ nin:["completed","canceled"] } }
+  }){
+    pageInfo{ hasNextPage endCursor }
+    nodes{ ${ISSUE_NODE} }
+  }
+}`;
+
+const MAX_PAGES = 8;
+
+let cacheEntry = null;
+let inFlight = null;
+let injectedGql = null;
+let injectedBudget = undefined;
+
+/** Test seam: inject a GraphQL runner (no network). */
+export function setLinearSupplyGql(gql) {
+  injectedGql = gql ?? null;
+}
+
+/** Test seam: inject a budget snapshot. `undefined` restores disk/file. */
+export function setLinearSupplyBudget(budget) {
+  injectedBudget = budget;
+}
+
+export function clearLinearSupplyCache() {
+  cacheEntry = null;
+  inFlight = null;
+}
+
+export function emptyIssueCounts() {
+  return { triage: 0, ready: 0, inFlight: 0, blocked: 0, inReview: 0 };
+}
+
+function labelNames(issue) {
+  const labels = Array.isArray(issue?.labels)
+    ? issue.labels
+    : (issue?.labels?.nodes ?? []);
+  return labels.map((label) => label?.name).filter(Boolean);
+}
+
+/**
+ * Bucket an open Linear issue into the supply columns the hub shows.
+ * Ready is the dispatch predicate: Todo + unassigned + `ai:agent-ready`.
+ */
+export function countOpenIssues(nodes) {
+  const counts = emptyIssueCounts();
+  for (const issue of Array.isArray(nodes) ? nodes : []) {
+    const state = issue?.state?.name ?? "";
+    const names = labelNames(issue);
+    const assignee = issue?.assignee ?? null;
+    if (state === "Triage") counts.triage += 1;
+    else if (
+      state === "Todo" &&
+      !assignee &&
+      names.includes(AGENT_READY_LABEL)
+    ) {
+      counts.ready += 1;
+    } else if (state === "In Progress") counts.inFlight += 1;
+    else if (state === "Blocked") counts.blocked += 1;
+    else if (state === "In Review") counts.inReview += 1;
+  }
+  return counts;
+}
+
+function repoGroupKey(repo) {
+  const team = typeof repo.team === "string" ? repo.team.trim() : "";
+  if (!team) return null;
+  const project =
+    typeof repo.project === "string" && repo.project.trim()
+      ? repo.project.trim()
+      : "";
+  return `${team}\t${project}`;
+}
+
+async function fetchOpenIssues(gql, { team, project }) {
+  const nodes = [];
+  let after = null;
+  const query = project ? PROJECT_QUERY : TEAM_QUERY;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const variables = project
+      ? { t: team, p: project, after }
+      : { t: team, after };
+    const data = await gql(query, variables);
+    const conn = data?.issues ?? {};
+    nodes.push(...(conn.nodes ?? []));
+    if (!conn.pageInfo?.hasNextPage) break;
+    after = conn.pageInfo.endCursor ?? null;
+    if (!after) break;
+  }
+  return nodes;
+}
+
+function readBudget() {
+  if (injectedBudget !== undefined) return injectedBudget;
+  try {
+    return loadLinearBudget();
+  } catch {
+    return null;
+  }
+}
+
+function budgetPayload(budget) {
+  if (!budget || typeof budget !== "object") return null;
+  return {
+    remaining: Number.isFinite(budget.remaining) ? budget.remaining : null,
+    limit: Number.isFinite(budget.limit) ? budget.limit : null,
+  };
+}
+
+async function fetchLinearSupply(repos, options = {}) {
+  const nowMs = options.nowMs ?? Date.now();
+  const asOf = new Date(nowMs).toISOString();
+  const budget = readBudget();
+  if (budget?.remaining === 0) {
+    return {
+      ok: false,
+      asOf: null,
+      byRepo: {},
+      budget: budgetPayload(budget),
+      error: "linear_budget_exhausted",
+    };
+  }
+
+  const gql = options.gql ?? injectedGql ?? defaultGql;
+  if (!options.gql && !injectedGql) {
+    try {
+      installLinearBudgetCapture();
+    } catch {
+      // Capture is best-effort; a missing hook must not fail the snapshot.
+    }
+  }
+
+  const configured = Array.isArray(repos)
+    ? repos
+    : [...(repos?.values?.() ?? [])];
+  const groups = new Map();
+  for (const repo of configured) {
+    const key = repoGroupKey(repo);
+    if (!key) continue;
+    if (!groups.has(key)) {
+      const [team, project] = key.split("\t");
+      groups.set(key, { team, project: project || null, names: [] });
+    }
+    groups.get(key).names.push(repo.name);
+  }
+
+  const byRepo = {};
+  try {
+    for (const group of groups.values()) {
+      const nodes = await fetchOpenIssues(gql, group);
+      const counts = countOpenIssues(nodes);
+      for (const name of group.names) byRepo[name] = { ...counts };
+    }
+    return {
+      ok: true,
+      asOf,
+      byRepo,
+      budget: budgetPayload(readBudget()),
+      error: null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      asOf: null,
+      byRepo: {},
+      budget: budgetPayload(readBudget()),
+      error: err?.message ? String(err.message) : "linear_unavailable",
+    };
+  }
+}
+
+/**
+ * Cached Linear snapshot. `refresh: true` bypasses TTL but still joins an
+ * in-flight request so a double-click is one GraphQL round-trip.
+ */
+export async function loadLinearSupply(repos, options = {}) {
+  const nowMs = options.nowMs ?? Date.now();
+  const refresh = options.refresh === true;
+  if (
+    !refresh &&
+    cacheEntry &&
+    nowMs - cacheEntry.at < TICKET_SUPPLY_CACHE_TTL_MS
+  ) {
+    return { ...cacheEntry.value, cached: true };
+  }
+  if (inFlight) return inFlight;
+  const pending = fetchLinearSupply(repos, options).then((value) => {
+    cacheEntry = { at: nowMs, value };
+    return { ...value, cached: false };
+  });
+  inFlight = pending;
+  try {
+    return await pending;
+  } finally {
+    if (inFlight === pending) inFlight = null;
+  }
+}

--- a/event-runtime/lib/linear.test.mjs
+++ b/event-runtime/lib/linear.test.mjs
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  TICKET_SUPPLY_CACHE_TTL_MS,
+  clearLinearSupplyCache,
+  countOpenIssues,
+  loadLinearSupply,
+  setLinearSupplyBudget,
+  setLinearSupplyGql,
+} from "./linear.mjs";
+
+afterEach(() => {
+  clearLinearSupplyCache();
+  setLinearSupplyGql(null);
+  setLinearSupplyBudget(undefined);
+});
+
+function issue(state, { assignee = null, labels = [] } = {}) {
+  return {
+    state: { name: state },
+    assignee,
+    labels: { nodes: labels.map((name) => ({ name })) },
+  };
+}
+
+describe("countOpenIssues (WM-824)", () => {
+  test("ready is Todo + unassigned + ai:agent-ready", () => {
+    expect(
+      countOpenIssues([
+        issue("Triage"),
+        issue("Todo", { labels: ["ai:agent-ready"] }),
+        issue("Todo", { assignee: { id: "u1" }, labels: ["ai:agent-ready"] }),
+        issue("Todo", { labels: ["type:bug"] }),
+        issue("In Progress"),
+        issue("Blocked"),
+        issue("In Review"),
+        issue("Done"),
+      ]),
+    ).toEqual({
+      triage: 1,
+      ready: 1,
+      inFlight: 1,
+      blocked: 1,
+      inReview: 1,
+    });
+  });
+
+  test("accepts a flat labels array", () => {
+    expect(
+      countOpenIssues([
+        {
+          state: { name: "Todo" },
+          assignee: null,
+          labels: [{ name: "ai:agent-ready" }],
+        },
+      ]).ready,
+    ).toBe(1);
+  });
+});
+
+describe("loadLinearSupply (WM-824)", () => {
+  const repos = [
+    { name: "factory", team: "WM", project: "Factory" },
+    { name: "bj29", team: "CLNT", project: "BJ29 Coaching" },
+    { name: "no-team", team: null, project: null },
+  ];
+
+  test("queries Linear per team+project and maps counts onto repos", async () => {
+    const calls = [];
+    setLinearSupplyGql(async (query, variables) => {
+      calls.push({ query, variables });
+      const nodes =
+        variables.t === "WM"
+          ? [issue("Triage"), issue("Todo", { labels: ["ai:agent-ready"] })]
+          : [issue("In Progress"), issue("In Progress")];
+      return { issues: { nodes, pageInfo: { hasNextPage: false } } };
+    });
+    const snap = await loadLinearSupply(repos, { nowMs: 1_700_000_000_000 });
+    expect(snap.ok).toBe(true);
+    expect(snap.cached).toBe(false);
+    expect(snap.byRepo.factory).toEqual({
+      triage: 1,
+      ready: 1,
+      inFlight: 0,
+      blocked: 0,
+      inReview: 0,
+    });
+    expect(snap.byRepo.bj29.inFlight).toBe(2);
+    expect(snap.byRepo["no-team"]).toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls[0].variables).toEqual({
+      t: "WM",
+      p: "Factory",
+      after: null,
+    });
+  });
+
+  test("TTL cache avoids a second GraphQL round-trip until refresh", async () => {
+    const oneRepo = [{ name: "factory", team: "WM", project: "Factory" }];
+    let calls = 0;
+    setLinearSupplyGql(async () => {
+      calls += 1;
+      return { issues: { nodes: [], pageInfo: { hasNextPage: false } } };
+    });
+    const first = await loadLinearSupply(oneRepo, { nowMs: 1_000 });
+    const cached = await loadLinearSupply(oneRepo, { nowMs: 1_000 + 10_000 });
+    expect(first.cached).toBe(false);
+    expect(cached.cached).toBe(true);
+    expect(calls).toBe(1);
+    const refreshed = await loadLinearSupply(oneRepo, {
+      nowMs: 1_000 + 10_000,
+      refresh: true,
+    });
+    expect(refreshed.cached).toBe(false);
+    expect(calls).toBe(2);
+    await loadLinearSupply(oneRepo, {
+      nowMs: 1_000 + 10_000 + TICKET_SUPPLY_CACHE_TTL_MS + 1,
+    });
+    expect(calls).toBe(3);
+  });
+
+  test("coalesces concurrent callers onto one GraphQL fetch", async () => {
+    const oneRepo = [{ name: "factory", team: "WM", project: "Factory" }];
+    let calls = 0;
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    setLinearSupplyGql(async () => {
+      calls += 1;
+      await gate;
+      return { issues: { nodes: [], pageInfo: { hasNextPage: false } } };
+    });
+    const a = loadLinearSupply(oneRepo, { nowMs: 1_000 });
+    const b = loadLinearSupply(oneRepo, { nowMs: 1_000, refresh: true });
+    release();
+    const [left, right] = await Promise.all([a, b]);
+    expect(calls).toBe(1);
+    expect(left.ok).toBe(true);
+    expect(right.ok).toBe(true);
+  });
+
+  test("skips Linear when remaining budget is 0", async () => {
+    let calls = 0;
+    setLinearSupplyBudget({ remaining: 0, limit: 2500 });
+    setLinearSupplyGql(async () => {
+      calls += 1;
+      return { issues: { nodes: [] } };
+    });
+    const snap = await loadLinearSupply(repos, { nowMs: 1_000 });
+    expect(snap.ok).toBe(false);
+    expect(snap.error).toBe("linear_budget_exhausted");
+    expect(snap.budget).toEqual({ remaining: 0, limit: 2500 });
+    expect(calls).toBe(0);
+  });
+
+  test("returns a fallback error instead of throwing when GraphQL fails", async () => {
+    setLinearSupplyGql(async () => {
+      throw new Error("RATELIMITED");
+    });
+    const snap = await loadLinearSupply(repos, { nowMs: 1_000 });
+    expect(snap.ok).toBe(false);
+    expect(snap.error).toBe("RATELIMITED");
+    expect(snap.byRepo).toEqual({});
+  });
+});

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -905,6 +905,24 @@ describe("context strip fast jump chords (WM-235)", () => {
     expect(document.activeElement === ticketInput).toBe(true);
   });
 
+  test("view slot is a height-capped flex column so ListPane views scroll inside it (WM-981)", async () => {
+    window.location.hash = "#/tickets";
+    const utils = renderApp();
+    const slot = await utils.findByTestId("view-slot");
+    const tokens = slot.className.split(/\s+/);
+    expect(tokens).toEqual(
+      expect.arrayContaining([
+        "flex",
+        "min-h-0",
+        "flex-1",
+        "flex-col",
+        "overflow-hidden",
+      ]),
+    );
+    const hub = await utils.findByTestId("tickets-hub");
+    expect(slot.contains(hub)).toBe(true);
+  });
+
   test("`g` prefix arms and displays GoPrefixHint legend with context chords", async () => {
     const utils = renderApp();
     await waitFor(() => {

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -798,7 +798,10 @@ export function App() {
               </div>
             </div>
           )}
-          <div className="min-h-0 flex-1">
+          <div
+            data-testid="view-slot"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
             <Suspense
               fallback={
                 <div className="p-5 text-(--text-faint)">

--- a/event-runtime/web/src/components/SupplyStrip.test.tsx
+++ b/event-runtime/web/src/components/SupplyStrip.test.tsx
@@ -1,0 +1,123 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  SupplyStrip,
+  hasSnapshot,
+  recommendedActionForRepo,
+  type TicketSupply,
+  type TicketSupplyRepo,
+} from "./SupplyStrip";
+
+afterEach(cleanup);
+
+function repo(
+  overrides: Partial<TicketSupplyRepo> & Pick<TicketSupplyRepo, "name">,
+): TicketSupplyRepo {
+  return {
+    team: "WM",
+    triage: null,
+    ready: null,
+    inFlight: null,
+    cap: 2,
+    blocked: null,
+    noopReason: null,
+    asOf: null,
+    sourceRunId: null,
+    source: null,
+    ...overrides,
+  };
+}
+
+const scanned: TicketSupplyRepo = repo({
+  name: "factory",
+  triage: 2,
+  ready: 1,
+  inFlight: 0,
+  blocked: 0,
+  asOf: "2026-08-20T18:00:00.000Z",
+  source: "linear",
+});
+
+describe("SupplyStrip (WM-824)", () => {
+  test("recommendedActionForRepo prefers dispatch when a ready slot is free", () => {
+    expect(recommendedActionForRepo(scanned)).toBe("dispatch");
+    expect(
+      recommendedActionForRepo(repo({ name: "x", triage: 4, ready: 0 })),
+    ).toBe("triage");
+  });
+
+  test("hasSnapshot treats zero counts as a real snapshot", () => {
+    expect(hasSnapshot(scanned)).toBe(true);
+    expect(hasSnapshot(repo({ name: "ghost" }))).toBe(false);
+    expect(hasSnapshot(repo({ name: "zeros", triage: 0, asOf: "t" }))).toBe(
+      true,
+    );
+  });
+
+  test("renders a compact matrix, Refresh, and collapsed unscanned repos", () => {
+    const clicks: { repo: string; state: string }[] = [];
+    const supply: TicketSupply = {
+      repos: [scanned, repo({ name: "ghost", team: "OPS" })],
+      recommendedAction: "dispatch",
+      source: "linear",
+      asOf: "2026-08-20T18:00:00.000Z",
+      stale: false,
+    };
+    let refreshed = 0;
+    const view = render(
+      <SupplyStrip
+        supply={supply}
+        now={Date.parse("2026-08-20T18:00:12.000Z")}
+        onFilter={(next) => clicks.push(next)}
+        onRefresh={() => {
+          refreshed += 1;
+        }}
+      />,
+    );
+
+    expect(view.getByRole("table")).toBeTruthy();
+    expect(view.getByRole("button", { name: "Refresh" })).toBeTruthy();
+    expect(view.getByText(/next:/)).toBeTruthy();
+    expect(view.getByRole("table").textContent).not.toContain("ghost");
+    fireEvent.click(view.getByText(/without a snapshot/));
+    expect(view.getByText(/ghost/)).toBeTruthy();
+
+    fireEvent.click(
+      view.getByRole("button", { name: /Filter tickets: Ready 1/ }),
+    );
+    expect(clicks).toEqual([{ repo: "factory", state: "Todo" }]);
+
+    fireEvent.click(view.getByRole("button", { name: "Refresh" }));
+    expect(refreshed).toBe(1);
+  });
+
+  test("stale scan age is warning-colored and Linear errors surface the scan fallback", () => {
+    const supply: TicketSupply = {
+      repos: [
+        repo({
+          name: "factory",
+          triage: 9,
+          asOf: "2026-08-20T10:00:00.000Z",
+          source: "scan",
+        }),
+      ],
+      recommendedAction: "triage",
+      source: "scan",
+      asOf: "2026-08-20T10:00:00.000Z",
+      stale: true,
+      linearError: "RATELIMITED",
+    };
+    const view = render(
+      <SupplyStrip
+        supply={supply}
+        now={Date.parse("2026-08-20T18:00:00.000Z")}
+        onFilter={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(view.getByText(/Linear unavailable/)).toBeTruthy();
+    const age = view.getByTitle("Last scan is older than an hour");
+    expect(age.className).toContain("hue-warn");
+  });
+});

--- a/event-runtime/web/src/components/SupplyStrip.tsx
+++ b/event-runtime/web/src/components/SupplyStrip.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { Ago, shortId } from "./ui";
+import { Ago } from "./ui";
 
 export type TicketSupplyAction =
   "dispatch" | "triage" | "merge" | "unblock" | "wait";
@@ -7,6 +7,8 @@ export type TicketSupplyAction =
 export type RepoRecommendedAction = "dispatch" | "triage" | "idle";
 
 export type SupplyChip = "triage" | "ready" | "inFlight" | "blocked";
+
+export type TicketSupplySource = "linear" | "scan" | null;
 
 export interface TicketSupplyRepo {
   name: string;
@@ -19,11 +21,18 @@ export interface TicketSupplyRepo {
   noopReason: "queue_empty" | "cap_full" | "all_overlapping" | null;
   asOf: string | null;
   sourceRunId: string | null;
+  source?: TicketSupplySource;
 }
 
 export interface TicketSupply {
   repos: TicketSupplyRepo[];
   recommendedAction: TicketSupplyAction | null;
+  source?: TicketSupplySource;
+  asOf?: string | null;
+  stale?: boolean;
+  linearError?: string | null;
+  budget?: { remaining: number | null; limit: number | null } | null;
+  cached?: boolean;
 }
 
 export const CHIP_FILTER_STATE: Record<SupplyChip, string> = {
@@ -62,12 +71,12 @@ function formatCount(value: number | null): string {
 }
 
 function actionLabel(action: RepoRecommendedAction): string {
-  if (action === "dispatch") return "→dispatch";
-  if (action === "triage") return "→triage";
+  if (action === "dispatch") return "dispatch";
+  if (action === "triage") return "triage";
   return "idle";
 }
 
-function hasScan(repo: TicketSupplyRepo): boolean {
+export function hasSnapshot(repo: TicketSupplyRepo): boolean {
   return (
     repo.asOf != null ||
     repo.triage != null ||
@@ -80,21 +89,30 @@ function hasScan(repo: TicketSupplyRepo): boolean {
 export function SupplyStrip({
   supply,
   pending,
+  refreshing,
   error,
   repoFilter,
   stateFilter,
   now,
   onFilter,
+  onRefresh,
 }: {
   supply: TicketSupply | null | undefined;
   pending?: boolean;
+  refreshing?: boolean;
   error?: string | null;
   repoFilter?: string;
   stateFilter?: string;
   now: number;
   onFilter: (next: { repo: string; state: string }) => void;
+  onRefresh?: () => void;
 }) {
   const repos = supply?.repos ?? [];
+  const scanned = repos.filter(hasSnapshot);
+  const unscanned = repos.filter((repo) => !hasSnapshot(repo));
+  const asOf = supply?.asOf ?? scanned.find((repo) => repo.asOf)?.asOf ?? null;
+  const stale = supply?.stale === true;
+  const fromScan = supply?.source === "scan";
 
   return (
     <section
@@ -102,22 +120,58 @@ export function SupplyStrip({
       aria-label="Ticket supply"
       className="mb-3 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2"
     >
-      <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-2">
-        <h2 className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+      <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
+        <h2 className="font-medium tracking-wide text-(--text-faint) uppercase">
           Supply
         </h2>
         {supply?.recommendedAction && (
-          <span className="text-[11px] text-(--text-dim)">
-            next:{" "}
+          <span className="text-(--text-dim)">
+            · next:{" "}
             <span className="font-medium text-(--text)">
               {supply.recommendedAction}
             </span>
           </span>
         )}
+        {asOf && (
+          <span
+            className={stale ? "text-(--hue-warn)" : "text-(--text-faint)"}
+            title={
+              stale
+                ? "Last scan is older than an hour"
+                : fromScan
+                  ? "Figures from the last work-plan / status-report scan"
+                  : "Figures from Linear"
+            }
+          >
+            · {fromScan ? "scan · " : ""}as of <Ago iso={asOf} now={now} />
+          </span>
+        )}
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing || pending}
+            aria-busy={refreshing || undefined}
+            className="ml-auto inline-flex items-center gap-1 rounded-md border border-(--border) bg-(--surface-1) px-1.5 py-0.5 font-medium text-(--text-dim) hover:border-(--border-strong) hover:text-(--text) disabled:cursor-wait disabled:opacity-60"
+          >
+            {refreshing ? (
+              <span
+                aria-hidden="true"
+                className="inline-block size-2.5 animate-spin rounded-full border border-(--text-faint) border-t-transparent"
+              />
+            ) : null}
+            Refresh
+          </button>
+        )}
       </div>
+      {supply?.linearError && fromScan && (
+        <p role="status" className="mb-1.5 text-[11px] text-(--hue-warn)">
+          Linear unavailable — showing last scan. {supply.linearError}
+        </p>
+      )}
       {pending && repos.length === 0 ? (
         <p role="status" className="text-[11px] text-(--text-faint)">
-          Loading latest scan figures…
+          Loading supply…
         </p>
       ) : error ? (
         <p role="status" className="text-[11px] text-(--hue-warn)">
@@ -125,21 +179,78 @@ export function SupplyStrip({
         </p>
       ) : repos.length === 0 ? (
         <p role="status" className="text-[11px] text-(--text-dim)">
-          Queue supply will appear after the next work-plan or status-report
-          scan.
+          Queue supply will appear after Linear refresh or the next scan.
         </p>
       ) : (
-        <ul className="flex flex-col gap-1.5">
-          {repos.map((repo) => (
-            <SupplyRow
-              key={repo.name}
-              repo={repo}
-              now={now}
-              active={repoFilter === repo.name ? (stateFilter ?? "") : ""}
-              onFilter={onFilter}
-            />
-          ))}
-        </ul>
+        <>
+          {scanned.length > 0 && (
+            <table className="w-full border-collapse text-left text-[11px]">
+              <caption className="sr-only">
+                Ticket supply by repo: triage, ready, in flight, blocked, next
+                action
+              </caption>
+              <thead>
+                <tr className="text-(--text-faint)">
+                  <th scope="col" className="pr-2 pb-1 font-medium">
+                    Repo
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-1 pb-1 text-right font-medium tabular-nums"
+                  >
+                    Triage
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-1 pb-1 text-right font-medium tabular-nums"
+                  >
+                    Ready
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-1 pb-1 text-right font-medium tabular-nums"
+                  >
+                    In flight
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-1 pb-1 text-right font-medium tabular-nums"
+                  >
+                    Blocked
+                  </th>
+                  <th scope="col" className="pl-2 pb-1 font-medium">
+                    Next
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {scanned.map((repo) => (
+                  <SupplyRow
+                    key={repo.name}
+                    repo={repo}
+                    active={repoFilter === repo.name ? (stateFilter ?? "") : ""}
+                    onFilter={onFilter}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+          {unscanned.length > 0 && (
+            <details className="mt-1.5 text-[11px] text-(--text-faint)">
+              <summary className="cursor-pointer hover:text-(--text-dim)">
+                {unscanned.length} without a snapshot
+              </summary>
+              <ul className="mt-1 flex flex-col gap-0.5 pl-3">
+                {unscanned.map((repo) => (
+                  <li key={repo.name} className="mono">
+                    {repo.name}
+                    {repo.team ? ` · ${repo.team}` : ""}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </>
       )}
     </section>
   );
@@ -147,17 +258,14 @@ export function SupplyStrip({
 
 function SupplyRow({
   repo,
-  now,
   active,
   onFilter,
 }: {
   repo: TicketSupplyRepo;
-  now: number;
   active: string;
   onFilter: (next: { repo: string; state: string }) => void;
 }) {
   const action = recommendedActionForRepo(repo);
-  const scanned = hasScan(repo);
   const linear = linearTeamUrl(repo.team);
   const inFlightLabel =
     repo.inFlight == null ? "—" : `${repo.inFlight}/${repo.cap}`;
@@ -173,86 +281,67 @@ function SupplyRow({
   };
 
   return (
-    <li className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
-      {linear ? (
-        <a
-          href={linear}
-          target="_blank"
-          rel="noreferrer"
-          className="mono shrink-0 font-medium text-(--accent) hover:underline"
-          title={`Open ${repo.team} on Linear`}
-        >
-          {repo.name}
-        </a>
-      ) : (
-        <span className="mono shrink-0 font-medium text-(--text)">
-          {repo.name}
-        </span>
-      )}
-      {repo.team && (
-        <span className="shrink-0 text-(--text-faint)">{repo.team}</span>
-      )}
-      {!scanned ? (
-        <span className="text-(--text-faint)">no scan yet</span>
-      ) : (
-        <>
-          <SupplyChipButton
-            label="Triage"
-            value={formatCount(repo.triage)}
-            active={active === CHIP_FILTER_STATE.triage}
-            disabled={repo.triage == null}
-            onClick={(event) => clickChip(event, "triage")}
-          />
-          <SupplyChipButton
-            label="Ready"
-            value={formatCount(repo.ready)}
-            active={active === CHIP_FILTER_STATE.ready}
-            disabled={repo.ready == null}
-            onClick={(event) => clickChip(event, "ready")}
-          />
-          <SupplyChipButton
-            label="In flight"
-            value={inFlightLabel}
-            active={active === CHIP_FILTER_STATE.inFlight}
-            disabled={repo.inFlight == null}
-            onClick={(event) => clickChip(event, "inFlight")}
-          />
-          <SupplyChipButton
-            label="Blocked"
-            value={formatCount(repo.blocked)}
-            active={active === CHIP_FILTER_STATE.blocked}
-            disabled={repo.blocked == null}
-            onClick={(event) => clickChip(event, "blocked")}
-          />
-          <span
-            className={`shrink-0 font-medium ${
-              action === "idle" ? "text-(--text-faint)" : "text-(--text)"
-            }`}
-            title={repo.noopReason ? `noop: ${repo.noopReason}` : undefined}
+    <tr className="border-t border-(--border)">
+      <th scope="row" className="py-0.5 pr-2 font-medium">
+        {linear ? (
+          <a
+            href={linear}
+            target="_blank"
+            rel="noreferrer"
+            className="mono text-(--accent) hover:underline"
+            title={`Open ${repo.team} on Linear`}
           >
-            {actionLabel(action)}
-          </span>
-          {repo.asOf && (
-            <span className="ml-auto shrink-0 text-(--text-faint)">
-              {repo.sourceRunId ? (
-                <a
-                  href={`#/run/${encodeURIComponent(repo.sourceRunId)}`}
-                  className="hover:text-(--accent) hover:underline"
-                  title={`Scan ${repo.sourceRunId} at ${repo.asOf}`}
-                >
-                  as of <Ago iso={repo.asOf} now={now} /> ·{" "}
-                  {shortId(repo.sourceRunId)}
-                </a>
-              ) : (
-                <>
-                  as of <Ago iso={repo.asOf} now={now} />
-                </>
-              )}
-            </span>
-          )}
-        </>
-      )}
-    </li>
+            {repo.name}
+          </a>
+        ) : (
+          <span className="mono text-(--text)">{repo.name}</span>
+        )}
+      </th>
+      <td className="px-1 py-0.5 text-right">
+        <SupplyChipButton
+          label="Triage"
+          value={formatCount(repo.triage)}
+          active={active === CHIP_FILTER_STATE.triage}
+          disabled={repo.triage == null}
+          onClick={(event) => clickChip(event, "triage")}
+        />
+      </td>
+      <td className="px-1 py-0.5 text-right">
+        <SupplyChipButton
+          label="Ready"
+          value={formatCount(repo.ready)}
+          active={active === CHIP_FILTER_STATE.ready}
+          disabled={repo.ready == null}
+          onClick={(event) => clickChip(event, "ready")}
+        />
+      </td>
+      <td className="px-1 py-0.5 text-right">
+        <SupplyChipButton
+          label="In flight"
+          value={inFlightLabel}
+          active={active === CHIP_FILTER_STATE.inFlight}
+          disabled={repo.inFlight == null}
+          onClick={(event) => clickChip(event, "inFlight")}
+        />
+      </td>
+      <td className="px-1 py-0.5 text-right">
+        <SupplyChipButton
+          label="Blocked"
+          value={formatCount(repo.blocked)}
+          active={active === CHIP_FILTER_STATE.blocked}
+          disabled={repo.blocked == null}
+          onClick={(event) => clickChip(event, "blocked")}
+        />
+      </td>
+      <td
+        className={`py-0.5 pl-2 font-medium ${
+          action === "idle" ? "text-(--text-faint)" : "text-(--text)"
+        }`}
+        title={repo.noopReason ? `noop: ${repo.noopReason}` : undefined}
+      >
+        {actionLabel(action)}
+      </td>
+    </tr>
   );
 }
 
@@ -277,14 +366,13 @@ function SupplyChipButton({
       aria-label={`Filter tickets: ${label} ${value}. ⌘-click opens Linear.`}
       title={`${label} ${value} — click to filter this hub, ⌘-click for Linear`}
       onClick={onClick}
-      className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 tabular-nums ${
+      className={`inline-flex min-w-6 justify-end rounded-sm px-1 py-0.5 tabular-nums ${
         active
-          ? "border-(--accent) bg-(--surface-2) text-(--text)"
-          : "border-(--border) bg-(--surface-1) text-(--text-dim) hover:border-(--border-strong) hover:text-(--text)"
+          ? "bg-(--surface-2) font-medium text-(--text)"
+          : "text-(--text) hover:bg-(--surface-1)"
       } disabled:cursor-default disabled:opacity-60`}
     >
-      <span className="text-(--text-faint)">{label}</span>
-      <span className="font-medium text-(--text)">{value}</span>
+      {value}
     </button>
   );
 }

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -791,7 +791,7 @@ export function ListPane({
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="shrink-0 px-5 pt-5 pb-3">{chrome}</div>
-      <div className="min-h-0 flex-1 overflow-auto px-5 pb-5">{children}</div>
+      <div className="min-h-0 flex-1 overflow-auto px-5 pb-8">{children}</div>
     </div>
   );
 }

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -1005,4 +1005,26 @@ describe("Tickets hub landing view", () => {
     expect(activityCell.querySelector("div")).toBeNull();
     expect(activityCell.textContent).toMatch(/ago/i);
   });
+
+  test("hub is a height-capped pane so the table scrolls above the status bar (WM-981)", async () => {
+    globalThis.fetch = ticketsFetch();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    const hub = await view.findByTestId("tickets-hub");
+    expect(hub.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["flex", "h-full", "min-w-0"]),
+    );
+    const scroller = hub.querySelector(".overflow-auto");
+    expect(scroller).toBeTruthy();
+    const tokens = scroller!.className.split(/\s+/);
+    expect(tokens).toContain("pb-8");
+    expect(tokens).not.toContain("pb-5");
+  });
 });

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -759,6 +759,43 @@ describe("Tickets hub landing view", () => {
           ],
         });
       }
+      if (/\/api\/tickets\/supply/.test(url)) {
+        return json({
+          repos: [
+            {
+              name: "factory",
+              team: "WM",
+              triage: 2,
+              ready: 1,
+              inFlight: 0,
+              cap: 2,
+              blocked: 0,
+              noopReason: null,
+              asOf: "2026-08-20T18:00:00.000Z",
+              sourceRunId: null,
+              source: "linear",
+            },
+            {
+              name: "ghost",
+              team: "OPS",
+              triage: null,
+              ready: null,
+              inFlight: null,
+              cap: 2,
+              blocked: null,
+              noopReason: null,
+              asOf: null,
+              sourceRunId: null,
+              source: null,
+            },
+          ],
+          recommendedAction: "dispatch",
+          source: "linear",
+          asOf: "2026-08-20T18:00:00.000Z",
+          stale: false,
+          linearError: null,
+        });
+      }
       if (/\/api\/tickets/.test(url)) {
         return json({ tickets: data });
       }
@@ -1026,5 +1063,40 @@ describe("Tickets hub landing view", () => {
     const tokens = scroller!.className.split(/\s+/);
     expect(tokens).toContain("pb-8");
     expect(tokens).not.toContain("pb-5");
+  });
+
+  test("supply matrix refreshes Linear on demand and collapses repos without a snapshot (WM-824)", async () => {
+    const urls: string[] = [];
+    const base = ticketsFetch();
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      urls.push(String(input));
+      return base(input, init);
+    }) as typeof fetch;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Ticket ticketId={null} onNavigate={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    const supply = await view.findByTestId("ticket-supply");
+    expect(within(supply).getByText("Refresh")).toBeTruthy();
+    expect(within(supply).getByText("factory")).toBeTruthy();
+    expect(within(supply).getByText("2")).toBeTruthy();
+    expect(within(supply).getAllByText("dispatch").length).toBeGreaterThan(0);
+    expect(within(supply).getByRole("table").textContent).not.toContain("ghost");
+    expect(within(supply).getByText(/without a snapshot/)).toBeTruthy();
+
+    fireEvent.click(within(supply).getByText("Refresh"));
+    await waitFor(() => {
+      expect(
+        urls.some((url) => url.includes("/api/tickets/supply?refresh=1")),
+      ).toBe(true);
+    });
   });
 });

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -1089,7 +1089,9 @@ describe("Tickets hub landing view", () => {
     expect(within(supply).getByText("factory")).toBeTruthy();
     expect(within(supply).getByText("2")).toBeTruthy();
     expect(within(supply).getAllByText("dispatch").length).toBeGreaterThan(0);
-    expect(within(supply).getByRole("table").textContent).not.toContain("ghost");
+    expect(within(supply).getByRole("table").textContent).not.toContain(
+      "ghost",
+    );
     expect(within(supply).getByText(/without a snapshot/)).toBeTruthy();
 
     fireEvent.click(within(supply).getByText("Refresh"));

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -395,253 +395,256 @@ function TicketsHub({
   };
 
   return (
-    <ListPane
-      chrome={
-        <>
-          <h1 className="display mb-1 text-lg font-semibold">Tickets</h1>
-          <p className="mb-3 text-[11px] text-(--text-faint)">
-            Recent factory ticket activity, journey timelines, and quick search.
-            {onNavigatePr
-              ? " A PR reference (#541) opens that PR's journey."
-              : ""}
-          </p>
-          <form
-            onSubmit={submitJump}
-            className="mb-3 flex flex-wrap items-center gap-2"
-          >
-            <input
-              ref={inputRef}
-              autoFocus
-              value={jumpValue}
-              onChange={(event) => setJumpValue(event.target.value)}
-              placeholder="WM-542 or #541"
-              aria-label="Ticket id"
-              aria-invalid={jumpError}
-              className="mono min-w-48 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-1.5 text-[13px] outline-none focus:border-(--accent)"
-            />
-            <PrimitiveButton
-              bare
-              type="submit"
-              className="rounded-md bg-(--accent) px-3.5 py-1.5 text-[12px] font-medium text-(--on-accent)"
+    <div className="flex h-full min-w-0" data-testid="tickets-hub">
+      <ListPane
+        chrome={
+          <>
+            <h1 className="display mb-1 text-lg font-semibold">Tickets</h1>
+            <p className="mb-3 text-[11px] text-(--text-faint)">
+              Recent factory ticket activity, journey timelines, and quick
+              search.
+              {onNavigatePr
+                ? " A PR reference (#541) opens that PR's journey."
+                : ""}
+            </p>
+            <form
+              onSubmit={submitJump}
+              className="mb-3 flex flex-wrap items-center gap-2"
             >
-              Open
-            </PrimitiveButton>
-          </form>
-          {jumpError && (
-            <div role="alert" className="mb-3 text-[11px] text-(--hue-err)">
-              Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
-            </div>
-          )}
-          <SupplyStrip
-            supply={supplyQuery.data}
-            pending={supplyQuery.isPending}
-            error={
-              supplyQuery.isError
-                ? ((supplyQuery.error as Error)?.message ?? "unavailable")
-                : null
-            }
-            repoFilter={repoFilter}
-            stateFilter={stateFilter}
-            now={now}
-            onFilter={({ repo, state }) => {
-              setRepoFilter(repo);
-              setStateFilter(state);
-            }}
-          />
-          <div className="flex flex-wrap items-center gap-2">
-            <FilterInput
-              value={searchQuery}
-              onChange={setSearchQuery}
-              placeholder="Filter tickets…"
-              label="Filter tickets"
-            />
-            <select
-              aria-label="Filter by repo"
-              value={repoFilter}
-              onChange={(e) => setRepoFilter(e.target.value)}
-              className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
-            >
-              <option value="">All repos</option>
-              {repoOptions.map((repo) => (
-                <option key={repo} value={repo}>
-                  {repo}
-                </option>
-              ))}
-            </select>
-            <select
-              aria-label="Filter by state"
-              value={stateFilter}
-              onChange={(e) => setStateFilter(e.target.value)}
-              className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
-            >
-              <option value="">All states</option>
-              {stateOptions.map((state) => (
-                <option key={state} value={state}>
-                  {state}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="mt-2 text-[11px] text-(--text-faint)">
-            Shortcut: <span className="mono">g k</span> to focus jump bar,{" "}
-            <span className="mono">j</span>/<span className="mono">k</span> to
-            navigate, <span className="mono">Enter</span> to open,{" "}
-            <span className="mono">o</span> to open in Linear
-          </div>
-        </>
-      }
-    >
-      <div className="table-wrap">
-        <table className="w-full text-left text-[12px]">
-          <thead>
-            <tr className="border-b border-(--border)">
-              <Th label="Ticket ID" />
-              <Th label="Repo" />
-              <Th label="State" />
-              <Th label="Last Activity" />
-              <Th label="Attempts" />
-              <Th label="PR / CI" />
-            </tr>
-          </thead>
-          <tbody>
-            {filteredTickets.length === 0 ? (
-              <ListEmpty
-                colSpan={6}
-                query={ticketsQuery}
-                filtered={Boolean(searchQuery || repoFilter || stateFilter)}
-                noun="tickets"
-                empty="No tickets found."
-                onClear={() => {
-                  setSearchQuery("");
-                  setRepoFilter("");
-                  setStateFilter("");
-                }}
+              <input
+                ref={inputRef}
+                autoFocus
+                value={jumpValue}
+                onChange={(event) => setJumpValue(event.target.value)}
+                placeholder="WM-542 or #541"
+                aria-label="Ticket id"
+                aria-invalid={jumpError}
+                className="mono min-w-48 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-1.5 text-[13px] outline-none focus:border-(--accent)"
               />
-            ) : (
-              filteredTickets.map((ticket, index) => {
-                const selected =
-                  index === selectedIndex || ticket.id === selectedId;
-                return (
-                  <tr
-                    key={ticket.id}
-                    data-ticket-id={ticket.id}
-                    aria-selected={selected}
-                    onClick={() => onNavigate(ticket.id)}
-                    className={`cursor-pointer border-b border-(--border) hover:bg-(--surface-1) ${
-                      selected ? "bg-(--surface-1)" : ""
-                    }`}
-                  >
-                    <td className="mono px-3 py-1.5 whitespace-nowrap font-medium">
-                      <span className="inline-flex max-w-xs items-center gap-2">
-                        <a
-                          href={`#/tickets/${encodeURIComponent(ticket.id)}`}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            onNavigate(ticket.id);
-                          }}
-                          className="shrink-0 text-(--accent) hover:underline"
-                        >
-                          {ticket.id}
-                        </a>
-                        {ticket.title && (
-                          <span
-                            className="min-w-0 truncate font-sans text-[11px] font-normal text-(--text-dim)"
-                            title={ticket.title}
+              <PrimitiveButton
+                bare
+                type="submit"
+                className="rounded-md bg-(--accent) px-3.5 py-1.5 text-[12px] font-medium text-(--on-accent)"
+              >
+                Open
+              </PrimitiveButton>
+            </form>
+            {jumpError && (
+              <div role="alert" className="mb-3 text-[11px] text-(--hue-err)">
+                Use an id like WM-542{onNavigatePr ? " or a PR like #541" : ""}.
+              </div>
+            )}
+            <SupplyStrip
+              supply={supplyQuery.data}
+              pending={supplyQuery.isPending}
+              error={
+                supplyQuery.isError
+                  ? ((supplyQuery.error as Error)?.message ?? "unavailable")
+                  : null
+              }
+              repoFilter={repoFilter}
+              stateFilter={stateFilter}
+              now={now}
+              onFilter={({ repo, state }) => {
+                setRepoFilter(repo);
+                setStateFilter(state);
+              }}
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <FilterInput
+                value={searchQuery}
+                onChange={setSearchQuery}
+                placeholder="Filter tickets…"
+                label="Filter tickets"
+              />
+              <select
+                aria-label="Filter by repo"
+                value={repoFilter}
+                onChange={(e) => setRepoFilter(e.target.value)}
+                className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
+              >
+                <option value="">All repos</option>
+                {repoOptions.map((repo) => (
+                  <option key={repo} value={repo}>
+                    {repo}
+                  </option>
+                ))}
+              </select>
+              <select
+                aria-label="Filter by state"
+                value={stateFilter}
+                onChange={(e) => setStateFilter(e.target.value)}
+                className="rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text)"
+              >
+                <option value="">All states</option>
+                {stateOptions.map((state) => (
+                  <option key={state} value={state}>
+                    {state}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-2 text-[11px] text-(--text-faint)">
+              Shortcut: <span className="mono">g k</span> to focus jump bar,{" "}
+              <span className="mono">j</span>/<span className="mono">k</span> to
+              navigate, <span className="mono">Enter</span> to open,{" "}
+              <span className="mono">o</span> to open in Linear
+            </div>
+          </>
+        }
+      >
+        <div className="table-wrap">
+          <table className="w-full text-left text-[12px]">
+            <thead>
+              <tr className="border-b border-(--border)">
+                <Th label="Ticket ID" />
+                <Th label="Repo" />
+                <Th label="State" />
+                <Th label="Last Activity" />
+                <Th label="Attempts" />
+                <Th label="PR / CI" />
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTickets.length === 0 ? (
+                <ListEmpty
+                  colSpan={6}
+                  query={ticketsQuery}
+                  filtered={Boolean(searchQuery || repoFilter || stateFilter)}
+                  noun="tickets"
+                  empty="No tickets found."
+                  onClear={() => {
+                    setSearchQuery("");
+                    setRepoFilter("");
+                    setStateFilter("");
+                  }}
+                />
+              ) : (
+                filteredTickets.map((ticket, index) => {
+                  const selected =
+                    index === selectedIndex || ticket.id === selectedId;
+                  return (
+                    <tr
+                      key={ticket.id}
+                      data-ticket-id={ticket.id}
+                      aria-selected={selected}
+                      onClick={() => onNavigate(ticket.id)}
+                      className={`cursor-pointer border-b border-(--border) hover:bg-(--surface-1) ${
+                        selected ? "bg-(--surface-1)" : ""
+                      }`}
+                    >
+                      <td className="mono px-3 py-1.5 whitespace-nowrap font-medium">
+                        <span className="inline-flex max-w-xs items-center gap-2">
+                          <a
+                            href={`#/tickets/${encodeURIComponent(ticket.id)}`}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              onNavigate(ticket.id);
+                            }}
+                            className="shrink-0 text-(--accent) hover:underline"
                           >
-                            {ticket.title}
-                          </span>
-                        )}
-                      </span>
-                    </td>
-                    <td className="mono px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      {ticket.repo || ticket.repos?.join(", ") || "—"}
-                    </td>
-                    <td className="px-3 py-1.5 whitespace-nowrap">
-                      {ticket.state ? (
-                        <StateBadge state={ticket.state} hues={STATE_HUES} />
-                      ) : (
-                        <span className="text-(--text-faint)">—</span>
-                      )}
-                    </td>
-                    <td className="max-w-xs truncate px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      <span>
-                        {ticket.lastActivityDescription ||
-                          ticket.lastActivityKind ||
-                          "—"}
-                      </span>
-                      {ticket.lastActivityAt && (
-                        <span className="ml-2 text-(--text-faint)">
-                          <Ago iso={ticket.lastActivityAt} now={now} />
-                        </span>
-                      )}
-                    </td>
-                    <td className="mono px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-dim)">
-                      {ticket.attempts != null ? ticket.attempts : "—"}
-                    </td>
-                    <td className="px-3 py-1.5 whitespace-nowrap">
-                      {(() => {
-                        const prNumber =
-                          typeof ticket.pr === "number"
-                            ? ticket.pr
-                            : ticket.pr && typeof ticket.pr === "object"
-                              ? ticket.pr.number
-                              : null;
-                        const prUrl =
-                          typeof ticket.pr === "object" && ticket.pr?.url
-                            ? ticket.pr.url
-                            : ticket.prUrl ||
-                              (prNumber ? `#/prs/${prNumber}` : undefined);
-                        const ci =
-                          typeof ticket.pr === "object" && ticket.pr?.ci
-                            ? ticket.pr.ci
-                            : (ticket.ciStatus ??
-                              (ticket.checksGreen != null
-                                ? ticket.checksGreen
-                                  ? "green"
-                                  : "red"
-                                : null));
-
-                        return prNumber != null ? (
-                          <span className="inline-flex items-center gap-1.5">
-                            <a
-                              href={prUrl || `#/prs/${prNumber}`}
-                              onClick={(e) => {
-                                if (onNavigatePr) {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  onNavigatePr(prNumber);
-                                }
-                              }}
-                              className="mono text-(--accent) hover:underline"
+                            {ticket.id}
+                          </a>
+                          {ticket.title && (
+                            <span
+                              className="min-w-0 truncate font-sans text-[11px] font-normal text-(--text-dim)"
+                              title={ticket.title}
                             >
-                              {`#${prNumber}`}
-                            </a>
-                            {ci && (
-                              <span
-                                className={`inline-block size-2 rounded-full ring-2 ring-(--surface-1) ${
-                                  ci === "green"
-                                    ? "bg-(--hue-ok)"
-                                    : ci === "red"
-                                      ? "bg-(--hue-err)"
-                                      : "bg-(--hue-warn)"
-                                }`}
-                                title={`CI: ${ci}`}
-                              />
-                            )}
-                          </span>
+                              {ticket.title}
+                            </span>
+                          )}
+                        </span>
+                      </td>
+                      <td className="mono px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                        {ticket.repo || ticket.repos?.join(", ") || "—"}
+                      </td>
+                      <td className="px-3 py-1.5 whitespace-nowrap">
+                        {ticket.state ? (
+                          <StateBadge state={ticket.state} hues={STATE_HUES} />
                         ) : (
                           <span className="text-(--text-faint)">—</span>
-                        );
-                      })()}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
-    </ListPane>
+                        )}
+                      </td>
+                      <td className="max-w-xs truncate px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                        <span>
+                          {ticket.lastActivityDescription ||
+                            ticket.lastActivityKind ||
+                            "—"}
+                        </span>
+                        {ticket.lastActivityAt && (
+                          <span className="ml-2 text-(--text-faint)">
+                            <Ago iso={ticket.lastActivityAt} now={now} />
+                          </span>
+                        )}
+                      </td>
+                      <td className="mono px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-dim)">
+                        {ticket.attempts != null ? ticket.attempts : "—"}
+                      </td>
+                      <td className="px-3 py-1.5 whitespace-nowrap">
+                        {(() => {
+                          const prNumber =
+                            typeof ticket.pr === "number"
+                              ? ticket.pr
+                              : ticket.pr && typeof ticket.pr === "object"
+                                ? ticket.pr.number
+                                : null;
+                          const prUrl =
+                            typeof ticket.pr === "object" && ticket.pr?.url
+                              ? ticket.pr.url
+                              : ticket.prUrl ||
+                                (prNumber ? `#/prs/${prNumber}` : undefined);
+                          const ci =
+                            typeof ticket.pr === "object" && ticket.pr?.ci
+                              ? ticket.pr.ci
+                              : (ticket.ciStatus ??
+                                (ticket.checksGreen != null
+                                  ? ticket.checksGreen
+                                    ? "green"
+                                    : "red"
+                                  : null));
+
+                          return prNumber != null ? (
+                            <span className="inline-flex items-center gap-1.5">
+                              <a
+                                href={prUrl || `#/prs/${prNumber}`}
+                                onClick={(e) => {
+                                  if (onNavigatePr) {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    onNavigatePr(prNumber);
+                                  }
+                                }}
+                                className="mono text-(--accent) hover:underline"
+                              >
+                                {`#${prNumber}`}
+                              </a>
+                              {ci && (
+                                <span
+                                  className={`inline-block size-2 rounded-full ring-2 ring-(--surface-1) ${
+                                    ci === "green"
+                                      ? "bg-(--hue-ok)"
+                                      : ci === "red"
+                                        ? "bg-(--hue-err)"
+                                        : "bg-(--hue-warn)"
+                                  }`}
+                                  title={`CI: ${ci}`}
+                                />
+                              )}
+                            </span>
+                          ) : (
+                            <span className="text-(--text-faint)">—</span>
+                          );
+                        })()}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </ListPane>
+    </div>
   );
 }
 

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1,4 +1,4 @@
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   useEffect,
   useMemo,
@@ -209,8 +209,10 @@ function TicketsHub({
   const [repoFilter, setRepoFilter] = useState("");
   const [stateFilter, setStateFilter] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [supplyRefreshing, setSupplyRefreshing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const now = useNow();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
@@ -225,8 +227,7 @@ function TicketsHub({
 
   const supplyQuery = useQuery({
     queryKey: ["tickets-supply"],
-    queryFn: fetchTicketSupply,
-    ...refetchIntervals.secondary,
+    queryFn: () => fetchTicketSupply(false),
   });
 
   const reposQuery = useQuery({
@@ -437,6 +438,7 @@ function TicketsHub({
             <SupplyStrip
               supply={supplyQuery.data}
               pending={supplyQuery.isPending}
+              refreshing={supplyRefreshing}
               error={
                 supplyQuery.isError
                   ? ((supplyQuery.error as Error)?.message ?? "unavailable")
@@ -448,6 +450,17 @@ function TicketsHub({
               onFilter={({ repo, state }) => {
                 setRepoFilter(repo);
                 setStateFilter(state);
+              }}
+              onRefresh={() => {
+                void (async () => {
+                  setSupplyRefreshing(true);
+                  try {
+                    const data = await fetchTicketSupply(true);
+                    queryClient.setQueryData(["tickets-supply"], data);
+                  } finally {
+                    setSupplyRefreshing(false);
+                  }
+                })();
               }}
             />
             <div className="flex flex-wrap items-center gap-2">
@@ -654,8 +667,9 @@ type JourneyTab = (typeof JOURNEY_TABS)[number];
 const EXTERNAL_BUTTON_CLASS =
   "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 text-[12px] font-medium text-(--text) hover:bg-(--surface-3)";
 
-async function fetchTicketSupply(): Promise<TicketSupply> {
-  const response = await fetch("/api/tickets/supply");
+async function fetchTicketSupply(refresh = false): Promise<TicketSupply> {
+  const query = refresh ? "?refresh=1" : "";
+  const response = await fetch(`/api/tickets/supply${query}`);
   if (response.status === 404) {
     return { repos: [], recommendedAction: null };
   }

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -349,6 +349,7 @@ test("closure check blocks ai:agent-ready when Owned Paths closure policy is inc
 // Same shape as lib/forge's "nothing outside lib/forge/ spawns gh" check:
 // new Linear GraphQL call sites must go through the adapter, not gql().
 const GQL_IMPORT_ALLOWED = new Set([
+  "event-runtime/lib/linear.mjs",
   "lib/control-plane/linear.mjs",
   "orchestrator/reaper.mjs",
   // Remaining call sites sit outside this ticket's Owned Paths (WM-962).


### PR DESCRIPTION
## Summary

Tickets hub (`#/tickets`) was listing scan-stale supply twice-over and painting the ticket table under the status bar. This is the smallest pair of changes that makes Supply a live Linear snapshot with a real Refresh control, and keeps the list scrolling inside the pane.

## Related issue

<!-- Use "Fixes #123" for a public issue or "Fixes WM-123" for an internal ticket. -->

Fixes WM-824
Fixes WM-981

## Verification

<!-- List the exact commands run and summarize their results. -->

```text
bun test event-runtime/web/src/views/Ticket.test.tsx event-runtime/web/src/App.test.tsx
# pass — 61 tests (WM-981)

bun test event-runtime/lib/linear.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/web/src/components/SupplyStrip.test.tsx event-runtime/web/src/views/Ticket.test.tsx
# pass — 64 tests (WM-824)
```

## Risk and impact

- [x] This change is narrowly scoped to the linked issue.
- [x] I added or updated tests for behavior changes, or explained why no test is needed.
- [ ] I updated documentation for user- or operator-visible behavior.
- [x] I regenerated emitted files when changing `shared/` and ran `bun run check`.
- [x] I considered security and privacy impact and did not include credentials or private data.
- [x] I identified compatibility, migration, or rollback concerns below.

Review Linear overlay vs scan fallback on `GET /tickets/supply`, the 45s TTL / Refresh=`?refresh=1` path, and that App's view-slot `overflow-hidden` still lets Runs/Events/Chains scroll inside the pane. No `shared/` emit. Docs were not updated. Demo API must be restarted to pick up the new route.

## Screenshots

<!-- Required for user-interface changes; remove this section otherwise. -->

Not captured in this session (UX critic subagent unavailable).

## Contributor statement

- [x] I have read and agree to follow `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
- [x] I have the right to submit this work under Apache License 2.0.
- [x] I have completed a Contributor License Agreement if a maintainer or check requested one.