### PR TITLE
feat(packs): add authoring kit and reference packs

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -88,6 +88,7 @@ case "$cmd" in
   tick)         run_bun orchestrator/tick.mjs "$@" ;;
   dispatch)     run_bun tools/dispatch.mjs "$@" ;;
   events)       run_bun event-runtime/cli.mjs "$@" ;;
+  pack)         run_bun event-runtime/cli.mjs pack "$@" ;;
   inbox)        run_bun event-runtime/cli.mjs inbox "$@" ;;
   approve)      run_bun event-runtime/cli.mjs approve "$@" ;;
   reject)       run_bun event-runtime/cli.mjs reject "$@" ;;
@@ -287,6 +288,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   tick          orchestrator/tick.mjs
   dispatch      tools/dispatch.mjs (swift event task runner: triage, status, janitor)
   events        event-runtime/cli.mjs (status, ps, runs, proposals, approve, reject, inject, requeue)
+  pack          scaffold or validate a data-only filesystem pack
   inbox         list open human inbox items
   approve       event-runtime/cli.mjs approve <proposal-id>
   reject        event-runtime/cli.mjs reject <proposal-id> "<reason>"

--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -21,3 +21,13 @@ controlPlane:
     # Projects v2 board whose Status single-select is the factory lifecycle.
     project: Factory
     statusField: Status
+
+# First-party data-only reference packs. Copy this allow-list deliberately;
+# packs are never discovered from the filesystem.
+packs:
+  - name: example-hello
+    path: packs/example-hello
+    namespace: example-hello
+  - name: ops-disk
+    path: packs/ops-disk
+    namespace: ops-disk

--- a/docs/packs.md
+++ b/docs/packs.md
@@ -1,0 +1,137 @@
+# Authoring filesystem packs
+
+A **pack** is the data-only unit that adds an agentic loop to Factory. It can
+contain pinned prompts and schemas plus declarative event routing, edges, and
+schedules. A pack is not discovered by the runtime: an operator must
+allow-list its exact path in `config/policy.yaml` before it can load.
+
+This guide is for pack authors. For the kernel's complete admission rules, see
+[kernel and packs](kernel-and-packs.md); an installable extension that also
+contains code, adapters, hooks, or panels is documented in
+[extensions](extensions.md).
+
+## Start a pack
+
+From a Factory checkout, scaffold a minimal, valid pack:
+
+```sh
+factory pack init my-loop
+# creates packs/my-loop
+
+# Or choose an explicit destination:
+factory pack init my-loop ~/src/my-loop
+```
+
+Names use lowercase letters, digits, and hyphens and begin with a letter. The
+scaffold is intentionally complete: it has one read-only `hello` agent, its
+input/output schemas, a routed event type, and a `pins.json` matching all
+pinned content. Validate it before committing:
+
+```sh
+factory pack validate packs/my-loop
+```
+
+`validate` loads the candidate with the same registry loader the runtime uses.
+It checks the manifest, pinned prompt/schema bytes, agent definitions,
+namespaces, routing maps, event references, edges, schedules, and the merged
+registry invariants. It does not edit `policy.yaml`, execute pack code, or scan
+neighbouring directories.
+
+## Layout
+
+```text
+my-loop/
+  pack.json
+  pins.json
+  agents/
+    hello.json
+    hello.md
+  schemas/
+    hello.input.json
+    hello.output.json
+  event-types.json             # optional object map
+  edges.json                   # optional object map
+  schedules.json               # optional object map
+```
+
+`pack.json` is required. Its `name` must match the operator's policy entry;
+`version` is a non-empty release string; and `namespace` is a non-empty value
+that keeps the pack's agent references separate from the kernel and other
+packs.
+
+```json
+{
+  "name": "my-loop",
+  "version": "0.1.0",
+  "namespace": "my-loop"
+}
+```
+
+An agent with `id: "hello"` and `version: 1` in this pack is registered as
+`my-loop/hello@1`. A pack may route an event to a built-in agent or one from an
+earlier allow-listed pack, but may not shadow any existing agent, event type,
+edge source, or schedule loop.
+
+## Pins and schemas
+
+Each agent names a prompt plus input and output JSON Schema files. Every one
+of those files must be listed in `pins.json` with a `sha256:` content hash.
+The registry refuses missing or stale pins, so bump the pack version and
+regenerate the relevant hashes whenever a pinned file changes.
+
+```json
+{
+  "agents/hello.md": "sha256:...",
+  "schemas/hello.input.json": "sha256:...",
+  "schemas/hello.output.json": "sha256:..."
+}
+```
+
+Keep schemas closed where practical (`additionalProperties: false`) and make
+the agent's declared capabilities, workspace, and limits match the work it
+actually needs. The first-party packs under [`../packs`](../packs) are runnable
+reference trees.
+
+## Events, edges, and schedules
+
+`event-types.json` maps external event names to a registered agent and supplies
+a non-empty idempotency scope. An event mapping may also name its adapter and
+proposal TTL. Example:
+
+```json
+{
+  "my-loop.hello.requested": {
+    "agent": "my-loop/hello@1",
+    "adapter": "fake",
+    "idempotencyScope": ["correlationId"]
+  }
+}
+```
+
+`edges.json` is optional declarative follow-up routing. Its keys are registered
+source agent refs; each edge targets an event type that exists in the fully
+merged registry. `schedules.json` is optional declarative recurring input.
+Each loop has a valid cadence, an existing event type, an approval mode, and
+an explicit enabled state. Start new schedules disabled and watched until the
+operator has reviewed their effect.
+
+## Data-only constraints and lifecycle
+
+Packs contain JSON and prose only. They cannot ship executable adapters, hooks,
+connectors, or panels with arbitrary code, and configured packs may never
+declare `mutating: true`. A pack can recommend or describe work; the Factory's
+normal proposal and approval lifecycle decides whether any work runs. Put code
+in an operator-installed extension only when that trust boundary is appropriate.
+
+To publish a loop: author and validate the pack, commit it, request an
+operator allow-list entry, then restart the runtime so it reads the configured
+path. Removal is the inverse: remove the allow-list entry and restart. Dropping
+a directory on disk alone never enables it.
+
+## First-party references
+
+- [`packs/example-hello`](../packs/example-hello) is the smallest complete
+  hello-world pack.
+- [`packs/ops-disk`](../packs/ops-disk) demonstrates a non-destructive
+  operations observation loop; it analyzes supplied disk telemetry and does
+  not execute commands or modify hosts.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -3,6 +3,8 @@
 import { COMMANDS } from "./cli/commands.mjs";
 import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { backfillResultArtifacts } from "./lib/artifacts.mjs";
+import { initPack } from "./lib/pack-init.mjs";
+import { validatePack } from "./lib/pack-validate.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -27,7 +29,7 @@ const USAGE = BASE_USAGE.replace(
     "  adapters [--json]               registered harness adapters: name, source, sandbox support (local, no serve needed)\n  extensions list [--json]       allow-listed extensions (policy.yaml extensions:): name, version, path, contribution counts, config namespace\n  extensions validate <path>     validate a factory-extension.json without loading it",
   )
   .concat(
-    "\n  artifacts backfill-results [--apply]\n                                 materialize stored typed result output (dry by default)",
+    "\n  pack init <name> [path]          scaffold a pinned, data-only pack (default packs/<name>)\n  pack validate <path>              validate one pack through the registry loader\n  artifacts backfill-results [--apply]\n                                 materialize stored typed result output (dry by default)",
   )
   .replace(
     "All commands except serve, work, supervise, and update-pins are clients of the control",
@@ -291,6 +293,24 @@ export async function extensionsCommand(args = []) {
   process.exit(1);
 }
 
+/** `pack init` and `pack validate` — local authoring commands, no serve needed. */
+export function packCommand(args = []) {
+  const [sub, first, second, ...rest] = args;
+  if (sub === "init" && first && rest.length === 0) {
+    const created = initPack(first, second ? { dir: second } : undefined);
+    console.log(`${created.name}: initialized ${created.root}`);
+    return created;
+  }
+  if (sub === "validate" && first && !second && rest.length === 0) {
+    const checked = validatePack(first);
+    console.log(
+      `${checked.name}: valid (${checked.agents} agent${checked.agents === 1 ? "" : "s"}, namespace ${checked.namespace})`,
+    );
+    return checked;
+  }
+  throw new Error("usage: pack init <name> [path] | pack validate <path>");
+}
+
 /** Backfill accepted typed output into the content store (WM-858). */
 export function artifactsCommand(
   args = [],
@@ -322,6 +342,7 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "inbox") return inboxCommand(args);
   if (command === "memos") return memosCommand(args);
   if (command === "extensions") return extensionsCommand(args);
+  if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);

--- a/event-runtime/lib/pack-authoring.test.mjs
+++ b/event-runtime/lib/pack-authoring.test.mjs
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-pack-authoring-test-mjs";
+import { packCommand } from "../cli.mjs";
+import { initPack } from "./pack-init.mjs";
+import { validatePack } from "./pack-validate.mjs";
+
+test("pack init creates a pinned pack the registry loader accepts", () => {
+  const root = path.join(tmpDir("pack-init-"), "author-kit");
+  const created = initPack("author-kit", { dir: root });
+
+  expect(created).toEqual({ name: "author-kit", root });
+  expect(existsSync(path.join(root, "pack.json"))).toBe(true);
+  expect(existsSync(path.join(root, "pins.json"))).toBe(true);
+  expect(validatePack(root)).toMatchObject({
+    name: "author-kit",
+    root,
+    namespace: "author-kit",
+    agents: 1,
+  });
+});
+
+test("pack validate uses registry pin checks rather than accepting drift", () => {
+  const root = path.join(tmpDir("pack-validate-"), "pinned-kit");
+  initPack("pinned-kit", { dir: root });
+  const prompt = path.join(root, "agents", "hello.md");
+  writeFileSync(prompt, `${readFileSync(prompt, "utf8")}drift\n`, "utf8");
+
+  expect(() => validatePack(root)).toThrow(/does not match pin/);
+});
+
+test("pack command supports explicit init destinations and validation", () => {
+  const root = path.join(tmpDir("pack-command-"), "cli-kit");
+
+  expect(packCommand(["init", "cli-kit", root])).toEqual({
+    name: "cli-kit",
+    root,
+  });
+  expect(packCommand(["validate", root])).toMatchObject({
+    name: "cli-kit",
+    root,
+    agents: 1,
+  });
+});
+
+test("the first-party reference packs both pass authoring validation", () => {
+  for (const name of ["example-hello", "ops-disk"]) {
+    expect(validatePack(path.resolve("packs", name))).toMatchObject({
+      name,
+      agents: 1,
+    });
+  }
+});

--- a/event-runtime/lib/pack-init.mjs
+++ b/event-runtime/lib/pack-init.mjs
@@ -1,0 +1,82 @@
+/** Create the smallest data-only filesystem pack accepted by the registry. */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { hashBytes } from "./canonical.mjs";
+
+export const PACK_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+export function assertPackName(name) {
+  if (typeof name !== "string" || !PACK_NAME_PATTERN.test(name)) {
+    throw new Error(
+      "pack name must match ^[a-z][a-z0-9-]*$ (lowercase letters, digits, and hyphens)",
+    );
+  }
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+/**
+ * Scaffold a self-contained, pinned, non-mutating pack. The return value is
+ * intentionally useful to both the CLI and tests without parsing stdout.
+ */
+export function initPack(name, { dir = path.resolve("packs", name) } = {}) {
+  assertPackName(name);
+  const root = path.resolve(dir);
+  if (existsSync(root)) throw new Error(`destination already exists: ${root}`);
+
+  const prompt = "Return a friendly greeting using the supplied name.\n";
+  const schema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    required: ["name"],
+    properties: { name: { type: "string", minLength: 1 } },
+    additionalProperties: false,
+  };
+  const schemaBytes = `${JSON.stringify(schema, null, 2)}\n`;
+  const definition = {
+    id: "hello",
+    version: 1,
+    prompt: "agents/hello.md",
+    input_schema: "schemas/hello.input.json",
+    output_schema: "schemas/hello.output.json",
+    workspace: { type: "ephemeral", retainOnFailure: false },
+    capabilities: { filesystem: "read-only", services: [] },
+    limits: { timeout_seconds: 30, attempts: 1 },
+    mutating: false,
+  };
+
+  mkdirSync(path.join(root, "agents"), { recursive: true });
+  mkdirSync(path.join(root, "schemas"), { recursive: true });
+  writeJson(path.join(root, "pack.json"), {
+    name,
+    version: "0.1.0",
+    namespace: name,
+  });
+  writeFileSync(path.join(root, "agents", "hello.md"), prompt, "utf8");
+  writeJson(path.join(root, "agents", "hello.json"), definition);
+  writeFileSync(
+    path.join(root, "schemas", "hello.input.json"),
+    schemaBytes,
+    "utf8",
+  );
+  writeFileSync(
+    path.join(root, "schemas", "hello.output.json"),
+    schemaBytes,
+    "utf8",
+  );
+  writeJson(path.join(root, "event-types.json"), {
+    [`${name}.hello.requested`]: {
+      agent: `${name}/hello@1`,
+      adapter: "fake",
+      idempotencyScope: ["correlationId"],
+    },
+  });
+  writeJson(path.join(root, "pins.json"), {
+    "agents/hello.md": hashBytes(prompt),
+    "schemas/hello.input.json": hashBytes(schemaBytes),
+    "schemas/hello.output.json": hashBytes(schemaBytes),
+  });
+  return { name, root };
+}

--- a/event-runtime/lib/pack-validate.mjs
+++ b/event-runtime/lib/pack-validate.mjs
@@ -1,0 +1,64 @@
+/** Validate one data-only filesystem pack through the production registry loader. */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { loadRegistry } from "./registry.mjs";
+import { assertPackName } from "./pack-init.mjs";
+
+function readManifest(root) {
+  const file = path.join(root, "pack.json");
+  if (!existsSync(file)) throw new Error(`missing ${file}`);
+  try {
+    const manifest = JSON.parse(readFileSync(file, "utf8"));
+    if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+      throw new Error("top level must be an object");
+    }
+    return manifest;
+  } catch (err) {
+    throw new Error(`${file}: invalid JSON — ${err.message}`, { cause: err });
+  }
+}
+
+/**
+ * Run the same loader that admits an allow-listed pack. The direct descriptor
+ * makes this a safe authoring check: it does not edit policy.yaml or discover
+ * neighbouring directories.
+ */
+export function validatePack(target) {
+  if (typeof target !== "string" || target.trim() === "") {
+    throw new Error("pack path must be a non-empty string");
+  }
+  const root = path.resolve(target);
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new Error(`pack directory does not exist: ${root}`);
+  }
+  const manifest = readManifest(root);
+  assertPackName(manifest.name);
+  if (
+    typeof manifest.namespace !== "string" ||
+    manifest.namespace.trim() === ""
+  ) {
+    throw new Error(
+      `${path.join(root, "pack.json")}: namespace must be a non-empty string`,
+    );
+  }
+  const registry = loadRegistry({
+    packRoots: [
+      {
+        kind: "fs",
+        name: manifest.name,
+        path: root,
+        namespace: manifest.namespace,
+      },
+    ],
+  });
+  const pack = registry.packs.find((entry) => entry.name === manifest.name);
+  return {
+    name: manifest.name,
+    root,
+    namespace: manifest.namespace,
+    agents: [...registry.agents.values()].filter(
+      (agent) => agent.pack === manifest.name,
+    ).length,
+    pack,
+  };
+}

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,0 +1,12 @@
+# First-party packs
+
+These reference packs are data-only, pinned examples for adopters. They are
+allow-listed in `config/policy.example.yaml`; copy those entries deliberately
+when enabling them in another Factory checkout.
+
+| Pack            | Path                  | Purpose                                                                |
+| --------------- | --------------------- | ---------------------------------------------------------------------- |
+| `example-hello` | `packs/example-hello` | Smallest valid namespaced hello-world loop.                            |
+| `ops-disk`      | `packs/ops-disk`      | Read-only disk-observation analysis loop; it never runs host commands. |
+
+Validate either tree with `factory pack validate <path>` before adapting it.

--- a/packs/example-hello/agents/hello.json
+++ b/packs/example-hello/agents/hello.json
@@ -1,0 +1,20 @@
+{
+  "id": "hello",
+  "version": 1,
+  "prompt": "agents/hello.md",
+  "input_schema": "schemas/hello.input.json",
+  "output_schema": "schemas/hello.output.json",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": false
+  },
+  "capabilities": {
+    "filesystem": "read-only",
+    "services": []
+  },
+  "limits": {
+    "timeout_seconds": 30,
+    "attempts": 1
+  },
+  "mutating": false
+}

--- a/packs/example-hello/agents/hello.md
+++ b/packs/example-hello/agents/hello.md
@@ -1,0 +1,1 @@
+Return a friendly greeting using the supplied name.

--- a/packs/example-hello/event-types.json
+++ b/packs/example-hello/event-types.json
@@ -1,0 +1,7 @@
+{
+  "example-hello.hello.requested": {
+    "agent": "example-hello/hello@1",
+    "adapter": "fake",
+    "idempotencyScope": ["correlationId"]
+  }
+}

--- a/packs/example-hello/pack.json
+++ b/packs/example-hello/pack.json
@@ -1,0 +1,5 @@
+{
+  "name": "example-hello",
+  "version": "0.1.0",
+  "namespace": "example-hello"
+}

--- a/packs/example-hello/pins.json
+++ b/packs/example-hello/pins.json
@@ -1,0 +1,5 @@
+{
+  "agents/hello.md": "sha256:cec63fed3a63d19cd73b0aec47bca62ff3a772cd6fdae1bcbf61b7be32222aea",
+  "schemas/hello.input.json": "sha256:26046e580a933b6ed8065c344dc221f119ecb6668bc5478af6b376c69300d2ea",
+  "schemas/hello.output.json": "sha256:26046e580a933b6ed8065c344dc221f119ecb6668bc5478af6b376c69300d2ea"
+}

--- a/packs/example-hello/schemas/hello.input.json
+++ b/packs/example-hello/schemas/hello.input.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/packs/example-hello/schemas/hello.output.json
+++ b/packs/example-hello/schemas/hello.output.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/packs/ops-disk/agents/disk-report.json
+++ b/packs/ops-disk/agents/disk-report.json
@@ -1,0 +1,11 @@
+{
+  "id": "disk-report",
+  "version": 1,
+  "prompt": "agents/disk-report.md",
+  "input_schema": "schemas/disk-report.input.json",
+  "output_schema": "schemas/disk-report.output.json",
+  "workspace": { "type": "ephemeral", "retainOnFailure": false },
+  "capabilities": { "filesystem": "read-only", "services": [] },
+  "limits": { "timeout_seconds": 30, "attempts": 1 },
+  "mutating": false
+}

--- a/packs/ops-disk/agents/disk-report.md
+++ b/packs/ops-disk/agents/disk-report.md
@@ -1,0 +1,3 @@
+Assess the supplied disk observation. Explain the current capacity, identify the
+most urgent non-destructive follow-up, and never execute a command or modify a
+host.

--- a/packs/ops-disk/event-types.json
+++ b/packs/ops-disk/event-types.json
@@ -1,0 +1,7 @@
+{
+  "ops.disk.observed": {
+    "agent": "ops-disk/disk-report@1",
+    "adapter": "fake",
+    "idempotencyScope": ["correlationId"]
+  }
+}

--- a/packs/ops-disk/pack.json
+++ b/packs/ops-disk/pack.json
@@ -1,0 +1,5 @@
+{
+  "name": "ops-disk",
+  "version": "0.1.0",
+  "namespace": "ops-disk"
+}

--- a/packs/ops-disk/pins.json
+++ b/packs/ops-disk/pins.json
@@ -1,0 +1,5 @@
+{
+  "agents/disk-report.md": "sha256:a123e17d6c91fea92e9f33adcfeb8c8572cacdf9c984e6f7105fcba113b743ae",
+  "schemas/disk-report.input.json": "sha256:452403034c704f07d297856584b0d4f004d98c6e1251781db3c10248c235c038",
+  "schemas/disk-report.output.json": "sha256:d59313e28b05f58358228cfb746d9cf62d54062780db6875b8077c91962ee940"
+}

--- a/packs/ops-disk/schedules.json
+++ b/packs/ops-disk/schedules.json
@@ -1,0 +1,9 @@
+{
+  "ops-disk-observation": {
+    "every": "1h",
+    "eventType": "ops.disk.observed",
+    "catchUp": "none",
+    "approval": "watched",
+    "enabled": false
+  }
+}

--- a/packs/ops-disk/schemas/disk-report.input.json
+++ b/packs/ops-disk/schemas/disk-report.input.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["host", "usedPercent", "freeBytes"],
+  "properties": {
+    "host": { "type": "string", "minLength": 1 },
+    "usedPercent": { "type": "number", "minimum": 0, "maximum": 100 },
+    "freeBytes": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/packs/ops-disk/schemas/disk-report.output.json
+++ b/packs/ops-disk/schemas/disk-report.output.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["summary", "recommendedAction"],
+  "properties": {
+    "summary": { "type": "string" },
+    "recommendedAction": { "type": "string" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add `factory pack init|validate`, backed by the registry loader and workflow tests
- document public data-only pack authoring and ship `example-hello` and read-only `ops-disk` references
- allow-list the reference packs in `config/policy.example.yaml`

## Verification
- `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib && bun run check && bun run lint`
- `bun test` (3516 pass, 9 skipped)

UX critique: skipped — CLI, docs, policy example, and data-only reference-pack change with no user-facing flow.

Fixes WM-845
