### PR TITLE
feat(oss): add factory starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ setup (clone, `bun install`, checks) is in [CONTRIBUTING.md](CONTRIBUTING.md).
 First-time harness links and the event-runtime daemon are in
 [SETUP.md](SETUP.md).
 
+## Fork your factory
+
+Fork an instance, not the kernel. The
+[`factory-starter`](templates/starter/) scaffold keeps your repository routing,
+local policy, schedules, and optional packs in a repository that pins Factory
+as a dependency. That lets your organization improve its own factory without
+diverging from the shared runtime.
+
+Read [docs/instances.md](docs/instances.md) for the kernel/instance boundary,
+an intentional upgrade path, and how to send reusable kernel improvements
+upstream as proposals and pull requests.
+
 ## The loop
 
 ```

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -1,0 +1,91 @@
+# Factory instances
+
+Factory is designed to be extended without becoming a long-lived fork. The
+[`watt-mind/factory`](https://github.com/watt-mind/factory) repository is the
+**kernel**: the event runtime, control-plane and forge contracts, verification
+gates, harness packaging, and public extension interfaces. A **Factory
+instance** is a separate repository that pins that kernel as a dependency and
+contains one organization's operational choices.
+
+Use the [`templates/starter/`](../templates/starter/) scaffold to create an
+instance repository. Its `package.json` intentionally pins the kernel to an
+exact commit, while the instance owns the files that should differ between
+organizations:
+
+| Kernel                                 | Instance                                                 |
+| -------------------------------------- | -------------------------------------------------------- |
+| Runtime, dispatch and merge mechanics  | `config/repos.yaml` repository routing                   |
+| Safety floor and verification protocol | `config/policy.yaml` local autonomy policy               |
+| Public pack and extension contracts    | `config/schedule.yaml` local, disabled-by-default clocks |
+| Shared harness commands and skills     | `packs/` namespaced data-only additions                  |
+
+This split is important: customizing an instance must not silently alter the
+kernel that other instances use. Conversely, an instance must not need to
+wait for an upstream release to change its repository list, policies, or
+organization-specific packs.
+
+## Create and configure an instance
+
+1. Create a repository from `templates/starter/` and rename it for your
+   organization (for example, `acme-factory`).
+2. Replace the example repository, team, branch and verification values in
+   `config/repos.yaml`. Leave a repository `report_only: true` until it has
+   proven worktree lifecycle scripts.
+3. Review `config/policy.yaml`; it is configuration, not a secret store.
+   Inject credentials through the environment or the runtime's supported
+   secret mechanism.
+4. Keep `config/schedule.yaml` disabled until an operator has reviewed each
+   loop's command and admission gate.
+5. Run `bun run check`; it validates the template without fetching the kernel,
+   so the starter's CI can check every pull request. When your environment can
+   read the kernel repository, run `bun install`, commit the generated
+   lockfile, and use the installed `factory` command.
+
+Packs remain allow-listed: adding a directory beneath `packs/` does nothing
+until `config/policy.yaml` explicitly enables it. See
+[`kernel-and-packs.md`](kernel-and-packs.md) for pack layout and the admission
+rules that protect the kernel namespace.
+
+## Upgrade the kernel deliberately
+
+The starter pins `@watt-mind/factory` to a Git commit rather than a floating
+branch or range. That makes an upgrade a small, reviewable instance change:
+
+1. Read the kernel release notes and migration guidance for the target commit
+   or release.
+2. Update the pinned dependency in the instance's `package.json` and refresh
+   its lockfile with `bun install`.
+3. Run the instance checks and inspect changes to local configuration or packs.
+4. Merge the dependency update through the instance's normal review policy.
+
+Never edit the installed dependency under `node_modules/`: it is regenerated
+on install and creates an unreviewable fork. If an upgrade needs a local
+configuration change, make that change in the instance in the same reviewed
+pull request.
+
+## Send reusable changes upstream
+
+An instance is the right place for organization-specific routing, policies,
+and packs. A change belongs upstream when it fixes or improves the kernel's
+generic behavior, contracts, docs, harness floor, or reusable templates.
+
+Before carrying a local workaround for a kernel limitation, open a proposal or
+issue in `watt-mind/factory` that states the problem, affected instances, and
+the intended contract. Once the approach is agreed, submit a focused pull
+request against the kernel. After it merges, upgrade the instance's pin in its
+own pull request.
+
+This upstream path keeps improvements available to every instance while each
+instance remains free to evolve its own configuration and packs.
+
+## Validate the starter before publishing it
+
+From the kernel checkout, run:
+
+```sh
+bun tools/publish-starter.mjs --dry-run
+```
+
+The command confirms the required scaffold files, checks that the kernel
+dependency is an exact commit pin, and runs `npm pack --dry-run --json` to
+show the package contents. It never publishes or writes files.

--- a/templates/starter/.github/workflows/ci.yml
+++ b/templates/starter/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Validate instance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: "1.3.0"
+      - run: bun run check

--- a/templates/starter/AGENTS.md
+++ b/templates/starter/AGENTS.md
@@ -1,0 +1,21 @@
+# Factory instance operating guide
+
+This repository is a **Factory instance**. It owns local configuration,
+policies, packs, and the work that adapts Factory to this organization. The
+kernel is the pinned `@watt-mind/factory` dependency; do not copy or edit its
+source here.
+
+## Before changing this instance
+
+1. Keep changes to local configuration, local packs, and instance docs in this
+   repository.
+2. Keep schedules disabled until an operator has reviewed the loop and its
+   admission criteria.
+3. Never put credentials in `config/`; inject secrets through the runtime
+   environment instead.
+4. When the change belongs in the reusable kernel, open a proposal or pull
+   request against `watt-mind/factory` rather than carrying a local kernel fork.
+
+Read [`README.md`](README.md) and the installed kernel's
+[`docs/instances.md`](node_modules/@watt-mind/factory/docs/instances.md) before
+enabling a loop or adding a pack.

--- a/templates/starter/README.md
+++ b/templates/starter/README.md
@@ -1,0 +1,41 @@
+# factory-starter
+
+`factory-starter` is the forkable home for one Factory instance. It keeps your
+organization's repository routing, policies, schedules, and optional packs
+separate from the Factory kernel.
+
+## Start an instance
+
+1. Create a repository from this template and replace the example values in
+   `config/` with your organization and repositories.
+2. Validate the copied scaffold before configuring credentials or schedules:
+
+   ```sh
+   bun run check
+   ```
+
+3. Review the exact kernel commit in `package.json`, then install it when your
+   environment can read the kernel's GitHub repository:
+
+   ```sh
+   bun install
+   ```
+
+4. Keep every schedule disabled while you verify repository credentials,
+   worktree scripts, and the proposed workflow.
+
+The committed kernel reference is deliberately an exact Git commit. Upgrades
+are an explicit dependency change: review the Factory release or commit,
+update `package.json`, run `bun install`, then run this instance's checks
+before merging.
+
+## What belongs here
+
+- `config/repos.yaml` — this instance's repository registry and worktree facts
+- `config/policy.yaml` — this instance's autonomy and safety policy
+- `config/schedule.yaml` — disabled-by-default schedule declarations
+- `packs/` — optional, namespaced data-only extensions for this instance
+
+Do not edit the installed `node_modules/@watt-mind/factory` tree. If a feature
+should benefit every instance, propose it upstream; see the kernel's
+[`docs/instances.md`](node_modules/@watt-mind/factory/docs/instances.md).

--- a/templates/starter/config/policy.yaml
+++ b/templates/starter/config/policy.yaml
@@ -1,0 +1,24 @@
+# Instance policy. Keep this file free of credentials and secrets.
+packs: []
+
+forge:
+  kind: github
+
+controlPlane:
+  kind: linear
+
+concurrency:
+  max_in_flight_per_repo: 1
+  max_concurrent_merges: 1
+
+dispatch:
+  owned_paths_collision: strict
+  owned_paths_conformance: strict
+
+escalation:
+  never_auto_merge:
+    - auth / authz
+    - payments / money movement
+    - credential and secret handling
+    - destructive DB migrations
+    - production infra config

--- a/templates/starter/config/repos.yaml
+++ b/templates/starter/config/repos.yaml
@@ -1,0 +1,15 @@
+# Repository facts for this Factory instance. Replace the example before
+# enabling dispatch. A repository needs its own worktree lifecycle scripts
+# before it can safely run concurrent ticket agents.
+repos:
+  - name: example-app
+    path: ~/Develop/example-app
+    github: your-org/example-app
+    team: ENG
+    base: main
+    deploy_branch: main
+    report_only: true
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    verify: bun test
+    escalate_paths: []

--- a/templates/starter/config/schedule.yaml
+++ b/templates/starter/config/schedule.yaml
@@ -1,0 +1,8 @@
+# Every scheduled loop starts disabled. Enable one only after an operator has
+# reviewed its command, admission gate, and expected effects.
+defaults:
+  repo: example-app
+  harness: pi
+  run_at_load: false
+
+jobs: []

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "factory-starter",
+  "private": true,
+  "version": "0.1.0",
+  "description": "A forkable Factory instance: configuration, packs, and local policy.",
+  "type": "module",
+  "scripts": {
+    "factory": "bun node_modules/@watt-mind/factory/bin/factory",
+    "check": "bun scripts/check.mjs"
+  },
+  "dependencies": {
+    "@watt-mind/factory": "github:watt-mind/factory#4336a1633f432e5473ba237116628b64ceb66537"
+  }
+}

--- a/templates/starter/packs/README.md
+++ b/templates/starter/packs/README.md
@@ -1,0 +1,10 @@
+# Instance packs
+
+Put optional, data-only packs in this directory. Each pack needs its own
+`pack.json`, pinned prompts and schemas, and a non-empty namespace. Enable a
+pack explicitly from `config/policy.yaml`; Factory never discovers packs by
+scanning this directory.
+
+See the installed kernel's
+[`docs/kernel-and-packs.md`](../../node_modules/@watt-mind/factory/docs/kernel-and-packs.md)
+for the required layout and admission rules.

--- a/templates/starter/scripts/check.mjs
+++ b/templates/starter/scripts/check.mjs
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REQUIRED = [
+  "AGENTS.md",
+  "README.md",
+  "config/repos.yaml",
+  "config/policy.yaml",
+  "config/schedule.yaml",
+  "packs/README.md",
+  ".github/workflows/ci.yml",
+];
+
+const missing = REQUIRED.filter((file) => !existsSync(path.join(ROOT, file)));
+if (missing.length) {
+  throw new Error(`factory-starter is missing: ${missing.join(", ")}`);
+}
+
+const manifest = JSON.parse(
+  readFileSync(path.join(ROOT, "package.json"), "utf8"),
+);
+const kernel = manifest.dependencies?.["@watt-mind/factory"];
+if (
+  typeof kernel !== "string" ||
+  !/^github:watt-mind\/factory#[0-9a-f]{40}$/.test(kernel)
+) {
+  throw new Error("@watt-mind/factory must be pinned to an exact Git commit");
+}
+
+console.log(`factory-starter: valid (${REQUIRED.length} required files)`);

--- a/tools/publish-starter.mjs
+++ b/tools/publish-starter.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Validate the forkable Factory instance template, then show what an npm
+ * package dry-run would contain. This command never writes or publishes.
+ *
+ *   bun tools/publish-starter.mjs --dry-run
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const STARTER = path.join(ROOT, "templates", "starter");
+const REQUIRED_FILES = [
+  "package.json",
+  "AGENTS.md",
+  "README.md",
+  "config/repos.yaml",
+  "config/policy.yaml",
+  "config/schedule.yaml",
+  "packs/README.md",
+  "scripts/check.mjs",
+  ".github/workflows/ci.yml",
+];
+
+function usage() {
+  return "usage: bun tools/publish-starter.mjs --dry-run";
+}
+
+export function parseArgs(args) {
+  if (args.length === 1 && args[0] === "--dry-run") return { dryRun: true };
+  throw new Error(usage());
+}
+
+export function validateStarter(dir = STARTER) {
+  const missing = REQUIRED_FILES.filter(
+    (file) => !existsSync(path.join(dir, file)),
+  );
+  if (missing.length) {
+    throw new Error(`starter template is missing: ${missing.join(", ")}`);
+  }
+
+  const manifest = JSON.parse(
+    readFileSync(path.join(dir, "package.json"), "utf8"),
+  );
+  const kernel = manifest.dependencies?.["@watt-mind/factory"];
+  if (
+    typeof kernel !== "string" ||
+    !/^github:watt-mind\/factory#[0-9a-f]{40}$/.test(kernel)
+  ) {
+    throw new Error(
+      "starter package.json must pin @watt-mind/factory to an exact Git commit",
+    );
+  }
+  return { dir, manifest, kernel, requiredFiles: REQUIRED_FILES };
+}
+
+export function dryRunPackage(dir = STARTER, spawn = spawnSync) {
+  const packed = spawn("npm", ["pack", "--dry-run", "--json"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  if (packed.status !== 0) {
+    const detail = String(packed.stderr || packed.stdout || "").trim();
+    throw new Error(detail || "npm pack --dry-run failed");
+  }
+  try {
+    return JSON.parse(packed.stdout);
+  } catch {
+    throw new Error("npm pack --dry-run returned invalid JSON");
+  }
+}
+
+export function run(args = process.argv.slice(2), { log = console.log } = {}) {
+  parseArgs(args);
+  const checked = validateStarter();
+  const report = dryRunPackage(checked.dir);
+  const item = Array.isArray(report) ? report[0] : report;
+  const files = item?.files ?? [];
+  log(
+    `factory-starter: valid (${checked.requiredFiles.length} required files)`,
+  );
+  log(`kernel: ${checked.kernel}`);
+  log(
+    `dry-run package: ${item?.name ?? checked.manifest.name}@${item?.version ?? checked.manifest.version} (${files.length} files)`,
+  );
+  for (const file of files) log(`  ${file.path ?? file}`);
+  return { checked, package: item };
+}
+
+if (import.meta.main) {
+  try {
+    run();
+  } catch (error) {
+    console.error(`publish-starter: ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add the factory-starter instance scaffold with local config, packs, agent guidance, and CI
- document the kernel/instance boundary, upgrade process, and upstream contribution path
- add a validation-only starter packaging dry run and link the flow from README

Fixes WM-877

UX critique: skipped — docs, configuration, and packaging validation only; no user-facing application flow changed.