### PR TITLE
perf(api): paginate collection endpoints

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -252,6 +252,21 @@ idempotency key. In particular it never embeds `spec_json`; callers open
 The Runs view moves through pages with its **Older** control, preserving
 the existing row selection and inspect/detail links.
 
+### List endpoint pagination convention
+
+Live ledger/catalogue collections use the same newest-first page contract:
+`limit` defaults to 100 and is capped at 200; a response returns its collection
+key plus `nextBefore`, an opaque cursor to pass as `before` for the next page.
+A bare request remains valid JSON and returns the newest bounded page. This
+applies to `/runs`, `/events`, `/proposals`, `/inbox`, and `/artifacts`.
+`/chains`, `/journal`, `/outbox`, `/tickets`, metrics series/breakdowns,
+`/memos`, schedules, panels, registries, status, and config are already
+bounded by a fixed time window, sequence limit, explicit/default top-N, exact
+subject cap, or finite declarative configuration; they retain their existing
+response shapes. List rows stay summaries wherever an item detail route exists
+(`/runs/:id`, `/proposals/:id`, `/inbox/:id`, `/artifacts/:sha256`, and
+`/chain/:id`).
+
 Runtime retention is an explicit maintenance sweep, dry by default:
 `bun event-runtime/lib/janitor.mjs retention [--apply] [--trace-days N]
 [--artifact-days N]`. It reports the trace-row and artifact-file counts it

--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -10,7 +10,7 @@ import {
 import {
   findArtifact,
   hashFile,
-  listArtifacts,
+  listArtifactPage,
   pruneArtifacts,
 } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
@@ -68,14 +68,33 @@ export async function handleArtifactApiRoute({
       return send(422, { error: "orphan must be true or false" });
     }
     const limitParam = url.searchParams.get("limit");
-    const limit = limitParam === null ? undefined : Number(limitParam);
+    const limit = limitParam === null ? 100 : Number(limitParam);
     if (
       limit !== undefined &&
       (!Number.isInteger(limit) || limit < 1 || limit > 500)
     ) {
       return send(422, { error: "limit must be an integer between 1 and 500" });
     }
-    const artifacts = listArtifacts(db, artifactsRoot(env.home), {
+    const rawBefore = url.searchParams.get("before");
+    let before = null;
+    if (rawBefore) {
+      try {
+        before = JSON.parse(
+          Buffer.from(rawBefore, "base64url").toString("utf8"),
+        );
+        if (
+          !before ||
+          typeof before.mtime !== "string" ||
+          !Number.isFinite(Date.parse(before.mtime)) ||
+          !/^[0-9a-f]{64}$/.test(before.sha256)
+        ) {
+          throw new Error("invalid cursor");
+        }
+      } catch {
+        return send(422, { error: "invalid before cursor" });
+      }
+    }
+    const page = listArtifactPage(db, artifactsRoot(env.home), {
       orphan: orphanParam === null ? undefined : orphanParam === "true",
       kind: url.searchParams.has("kind")
         ? url.searchParams.get("kind")
@@ -84,8 +103,9 @@ export async function handleArtifactApiRoute({
         ? url.searchParams.get("search")
         : undefined,
       limit,
+      before,
     });
-    return send(200, { artifacts });
+    return send(200, page);
   }
 
   if (route === "POST /artifacts/prune") {

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -138,6 +138,15 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(
         (await (await fetch(`${base}/artifacts?limit=1`)).json()).artifacts,
       ).toHaveLength(1);
+      const firstPage = await (await fetch(`${base}/artifacts?limit=2`)).json();
+      expect(typeof firstPage.nextBefore).toBe("string");
+      const secondPage = await (
+        await fetch(
+          `${base}/artifacts?limit=2&before=${encodeURIComponent(firstPage.nextBefore)}`,
+        )
+      ).json();
+      expect(secondPage.artifacts).toHaveLength(1);
+      expect(secondPage.nextBefore).toBeNull();
       expect((await fetch(`${base}/artifacts?orphan=maybe`)).status).toBe(422);
       expect((await fetch(`${base}/artifacts?limit=0`)).status).toBe(422);
 

--- a/event-runtime/lib/api-inbox.mjs
+++ b/event-runtime/lib/api-inbox.mjs
@@ -3,7 +3,7 @@ import {
   ackInboxItem,
   createInboxItem,
   deliverInboxItem,
-  listInboxItems,
+  listInboxPage,
   resolveInboxItem,
 } from "./inbox.mjs";
 
@@ -62,7 +62,7 @@ export async function handleInboxApiRoute({
   if (route === "GET /inbox") {
     const status = url.searchParams.get("status") ?? "open";
     try {
-      return send(200, { items: listInboxItems(db, { status }) });
+      return send(200, listInboxPage(db, { status, ...listPage(url) }));
     } catch (err) {
       return send(422, { error: err.message });
     }
@@ -114,4 +114,34 @@ export async function handleInboxApiRoute({
   }
 
   return false;
+}
+
+const LIST_DEFAULT_LIMIT = 100;
+const LIST_MAX_LIMIT = 200;
+
+function listPage(url) {
+  const rawLimit = url.searchParams.get("limit");
+  const limit = rawLimit === null ? LIST_DEFAULT_LIMIT : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > LIST_MAX_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${LIST_MAX_LIMIT}`);
+  }
+  const rawBefore = url.searchParams.get("before");
+  if (!rawBefore) return { limit, before: null };
+  try {
+    const before = JSON.parse(
+      Buffer.from(rawBefore, "base64url").toString("utf8"),
+    );
+    if (
+      !before ||
+      typeof before.createdAt !== "string" ||
+      !Number.isFinite(Date.parse(before.createdAt)) ||
+      !Number.isSafeInteger(before.rowid) ||
+      before.rowid < 1
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return { limit, before };
+  } catch {
+    throw new Error("invalid before cursor");
+  }
 }

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -44,6 +44,38 @@ const makeServer = async (...args) => {
 };
 
 describe("human inbox API (WM-285)", () => {
+  test("GET /inbox applies a default keyset page", async () => {
+    const s = await makeServer({ now: () => 1_700_000_000_000 });
+    try {
+      for (const title of ["a", "b", "c"]) {
+        await fetch(s.url("/inbox"), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            kind: "BLOCKED",
+            title,
+            source: "agent:test",
+          }),
+        });
+      }
+      const first = await (await fetch(s.url("/inbox?limit=2"))).json();
+      expect(first.items).toHaveLength(2);
+      expect(typeof first.nextBefore).toBe("string");
+      const second = await (
+        await fetch(
+          s.url(
+            `/inbox?limit=2&before=${encodeURIComponent(first.nextBefore)}`,
+          ),
+        )
+      ).json();
+      expect(second.items).toHaveLength(1);
+      expect(second.nextBefore).toBeNull();
+      expect((await fetch(s.url("/inbox?limit=201"))).status).toBe(422);
+    } finally {
+      s.close();
+    }
+  });
+
   test("POST writes before a failed delivery, rejects unknown kinds, and GET/ack/resolve filter rows", async () => {
     const delivered = [];
     const s = await makeServer({

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -7,11 +7,7 @@ import { runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
-import {
-  approveProposal,
-  openProposals,
-  rejectProposal,
-} from "./proposals.mjs";
+import { approveProposal, rejectProposal } from "./proposals.mjs";
 import { traceOf } from "./trace.mjs";
 import {
   attemptDeadline,
@@ -76,28 +72,48 @@ function proposalView(row, registry) {
   };
 }
 
-function proposalHistory(db, status, filters = {}) {
+function proposalHistory(
+  db,
+  status,
+  filters = {},
+  page = { limit: Number.MAX_SAFE_INTEGER, before: null },
+) {
   const filteredDecision = filters.population === "decision";
-  const rows =
-    status && !filteredDecision
-      ? db
-          .query(
-            `SELECT * FROM proposals WHERE status = ? ORDER BY created_at DESC, rowid DESC`,
-          )
-          .all(status)
-      : db
-          .query(`SELECT * FROM proposals ORDER BY created_at DESC, rowid DESC`)
-          .all();
-  return rows.flatMap((row) => {
+  const clauses = [];
+  const params = [];
+  if (status && !filteredDecision) {
+    clauses.push("status = ?");
+    params.push(status);
+  }
+  if (page.before) {
+    clauses.push("(created_at < ? OR (created_at = ? AND rowid < ?))");
+    params.push(
+      page.before.createdAt,
+      page.before.createdAt,
+      page.before.rowid,
+    );
+  }
+  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  const rows = db
+    .query(
+      `SELECT *, rowid AS list_rowid FROM proposals ${where}
+       ORDER BY created_at DESC, rowid DESC LIMIT ?`,
+    )
+    .all(...params, page.limit + 1);
+  const hasNextPage = rows.length > page.limit;
+  const pageRows = hasNextPage ? rows.slice(0, -1) : rows;
+  const proposals = pageRows.flatMap((row) => {
     let decisionAt = row.decided_at ?? null;
     let effectiveStatus = row.status;
-    if (filteredDecision && row.status === "open") {
-      const expiresAt =
-        Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
-      if (Number.isFinite(expiresAt) && expiresAt < filters.nowMs) {
-        decisionAt = new Date(expiresAt).toISOString();
-        effectiveStatus = "expired";
-      }
+    const expiresAt =
+      Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
+    const expired =
+      row.status === "open" &&
+      Number.isFinite(expiresAt) &&
+      expiresAt < (filters.nowMs ?? Date.now());
+    if (filteredDecision && expired) {
+      decisionAt = new Date(expiresAt).toISOString();
+      effectiveStatus = "expired";
     }
     if (filteredDecision) {
       const at = Date.parse(decisionAt ?? "");
@@ -112,18 +128,27 @@ function proposalHistory(db, status, filters = {}) {
           ...row,
           status: effectiveStatus,
           decided_at: decisionAt,
-          expired: effectiveStatus === "expired",
+          expired,
           spec: row.spec_json ? JSON.parse(row.spec_json) : null,
         },
         filters.registry,
       ),
     ];
   });
+  const last = pageRows.at(-1);
+  return {
+    proposals,
+    nextBefore: hasNextPage ? encodeListCursor(last) : null,
+  };
 }
 
-function eventsView(db, status) {
+function eventsView(
+  db,
+  status,
+  page = { limit: Number.MAX_SAFE_INTEGER, before: null },
+) {
   const sql = `
-    SELECT e.*, p.id AS proposal_id, p.run_id AS run_id
+    SELECT e.*, e.rowid AS list_rowid, p.id AS proposal_id, p.run_id AS run_id
     FROM events e
     LEFT JOIN proposals p ON p.rowid = (
       SELECT p2.rowid FROM proposals p2
@@ -131,10 +156,19 @@ function eventsView(db, status) {
       ORDER BY p2.created_at DESC, p2.rowid DESC
       LIMIT 1
     )
-    ${status ? "WHERE e.status = ?" : ""}
-    ORDER BY e.admitted_at DESC, e.rowid DESC`;
-  const rows = status ? db.query(sql).all(status) : db.query(sql).all();
-  return rows.map((row) => {
+    ${status ? "WHERE e.status = ?" : ""}${page.before ? `${status ? " AND" : " WHERE"} (e.admitted_at < ? OR (e.admitted_at = ? AND e.rowid < ?))` : ""}
+    ORDER BY e.admitted_at DESC, e.rowid DESC LIMIT ?`;
+  const params = status ? [status] : [];
+  if (page.before)
+    params.push(
+      page.before.createdAt,
+      page.before.createdAt,
+      page.before.rowid,
+    );
+  const rows = db.query(sql).all(...params, page.limit + 1);
+  const hasNextPage = rows.length > page.limit;
+  const pageRows = hasNextPage ? rows.slice(0, -1) : rows;
+  const events = pageRows.map((row) => {
     const envelope = JSON.parse(row.envelope_json);
     return {
       source: row.source,
@@ -155,6 +189,12 @@ function eventsView(db, status) {
       repos: repoNamesFromInput(envelope.payload),
     };
   });
+  return {
+    events,
+    nextBefore: hasNextPage
+      ? encodeListCursor(pageRows.at(-1), "admitted_at")
+      : null,
+  };
 }
 
 const TICKET_ID = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
@@ -332,10 +372,10 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     }
   }
 
-  const matchedEvents = eventsView(db).filter((event) =>
+  const matchedEvents = eventsView(db).events.filter((event) =>
     events.has(`${event.source}\0${event.eventId}`),
   );
-  const matchedProposals = proposalHistory(db).filter((proposal) =>
+  const matchedProposals = proposalHistory(db).proposals.filter((proposal) =>
     proposals.has(proposal.id),
   );
   const matchedRuns = [...runs]
@@ -519,6 +559,45 @@ class ListQueryError extends Error {
   constructor(error, details = {}) {
     super(error);
     this.body = { error, ...details };
+  }
+}
+
+function encodeListCursor(row, timestampKey = "created_at") {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: row[timestampKey],
+      rowid: row.list_rowid ?? row.rowid,
+    }),
+  ).toString("base64url");
+}
+
+/** Shared WM-976 cursor convention for newest-first table collections. */
+function collectionPage(url) {
+  const rawLimit = url.searchParams.get("limit");
+  const limit = rawLimit === null ? RUN_LIST_DEFAULT_LIMIT : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > RUN_LIST_MAX_LIMIT) {
+    throw new ListQueryError("invalid_limit", {
+      message: `limit must be an integer between 1 and ${RUN_LIST_MAX_LIMIT}`,
+    });
+  }
+  const rawBefore = url.searchParams.get("before");
+  if (!rawBefore) return { limit, before: null };
+  try {
+    const before = JSON.parse(
+      Buffer.from(rawBefore, "base64url").toString("utf8"),
+    );
+    if (
+      !before ||
+      typeof before.createdAt !== "string" ||
+      !Number.isFinite(Date.parse(before.createdAt)) ||
+      !Number.isSafeInteger(before.rowid) ||
+      before.rowid < 1
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return { limit, before };
+  } catch {
+    throw new ListQueryError("invalid_before");
   }
 }
 
@@ -1212,33 +1291,7 @@ function encodeRunCursor(row) {
 }
 
 function runPage(url) {
-  const rawLimit = url.searchParams.get("limit");
-  const limit = rawLimit === null ? RUN_LIST_DEFAULT_LIMIT : Number(rawLimit);
-  if (!Number.isInteger(limit) || limit < 1 || limit > RUN_LIST_MAX_LIMIT) {
-    throw new ListQueryError("invalid_limit", {
-      message: `limit must be an integer between 1 and ${RUN_LIST_MAX_LIMIT}`,
-    });
-  }
-
-  const before = url.searchParams.get("before");
-  if (!before) return { limit, before: null };
-  try {
-    const cursor = JSON.parse(
-      Buffer.from(before, "base64url").toString("utf8"),
-    );
-    if (
-      !cursor ||
-      typeof cursor.createdAt !== "string" ||
-      !Number.isFinite(Date.parse(cursor.createdAt)) ||
-      !Number.isSafeInteger(cursor.rowid) ||
-      cursor.rowid < 1
-    ) {
-      throw new Error("invalid cursor");
-    }
-    return { limit, before: cursor };
-  } catch {
-    throw new ListQueryError("invalid_before");
-  }
+  return collectionPage(url);
 }
 
 function runsView(db, filters = {}, page = {}) {
@@ -1494,9 +1547,15 @@ export async function handleRunApiRoute({
   repos: loadReposFn,
 }) {
   if (route === "GET /events") {
-    return send(200, {
-      events: eventsView(db, url.searchParams.get("status")),
-    });
+    try {
+      return send(
+        200,
+        eventsView(db, url.searchParams.get("status"), collectionPage(url)),
+      );
+    } catch (err) {
+      if (err instanceof ListQueryError) return send(422, err.body);
+      throw err;
+    }
   }
 
   if (route === "GET /proposals") {
@@ -1507,19 +1566,16 @@ export async function handleRunApiRoute({
         decisionStatus: url.searchParams.get("decisionStatus") ?? undefined,
         registry,
       };
-      if (status || filters.population)
-        return send(200, {
-          proposals: proposalHistory(
-            db,
-            status === "all" ? null : status,
-            filters,
-          ),
-        });
-      return send(200, {
-        proposals: openProposals(db, { now: nowMs }).map((row) =>
-          proposalView(row, registry),
+      const page = collectionPage(url);
+      return send(
+        200,
+        proposalHistory(
+          db,
+          status === "all" ? null : (status ?? "open"),
+          filters,
+          page,
         ),
-      });
+      );
     } catch (err) {
       if (err instanceof ListQueryError) return send(422, err.body);
       throw err;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -489,6 +489,34 @@ describe("list views carry repos[] (OPS-356)", () => {
       s.close();
     }
   });
+
+  test("GET /events defaults to a cursor page and walks tied timestamps", async () => {
+    const s = await makeServer({ now: () => 1_700_000_000_000 });
+    try {
+      for (const eventId of [
+        "events-page-a",
+        "events-page-b",
+        "events-page-c",
+      ]) {
+        await s.client.replay(envelope({ eventId, payload: {} }));
+      }
+      const first = await (await fetch(s.url("/events?limit=2"))).json();
+      expect(first.events).toHaveLength(2);
+      expect(typeof first.nextBefore).toBe("string");
+      const second = await (
+        await fetch(
+          s.url(
+            `/events?limit=2&before=${encodeURIComponent(first.nextBefore)}`,
+          ),
+        )
+      ).json();
+      expect(second.events).toHaveLength(1);
+      expect(second.nextBefore).toBeNull();
+      expect((await fetch(s.url("/events?limit=0"))).status).toBe(422);
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("ticket journey join (WM-595)", () => {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -13,6 +13,7 @@ import {
   TRANSCRIPT_MODEL_SCAN_BYTES,
 } from "./api-artifacts.mjs";
 import { handleInboxApiRoute } from "./api-inbox.mjs";
+import { handleMemosApiRoute } from "./api-memos.mjs";
 import {
   isLoopbackHost,
   isLoopbackOrigin,
@@ -242,6 +243,13 @@ export function createApi({
           now: nowMs,
           registryLoadedAt,
         });
+      }
+      if (route === "GET /memos") {
+        const result = handleMemosApiRoute({
+          ...common,
+          artifactsDir: artifactsRoot(env?.home),
+        });
+        if (result !== false) return result;
       }
       if (
         url.pathname === "/metrics" ||

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -302,7 +302,21 @@ export function listArtifacts(
   storeRoot,
   { orphan, kind, search, limit } = {},
 ) {
-  if (!existsSync(storeRoot)) return [];
+  return listArtifactPage(db, storeRoot, {
+    orphan,
+    kind,
+    search,
+    limit: limit ?? Number.MAX_SAFE_INTEGER,
+  }).artifacts;
+}
+
+/** Newest-first cursor page for the artifact catalogue HTTP projection. */
+export function listArtifactPage(
+  db,
+  storeRoot,
+  { orphan, kind, search, limit = 100, before = null } = {},
+) {
+  if (!existsSync(storeRoot)) return { artifacts: [], nextBefore: null };
 
   const references = new Map();
   const rows = db
@@ -352,9 +366,9 @@ export function listArtifacts(
 
   const term = typeof search === "string" ? search.toLowerCase() : null;
   const inventory = [];
-  for (const sha256 of readdirSync(storeRoot)
-    .filter((name) => HEX64.test(name))
-    .sort()) {
+  for (const sha256 of readdirSync(storeRoot).filter((name) =>
+    HEX64.test(name),
+  )) {
     const stat = statSync(path.join(storeRoot, sha256));
     if (!stat.isFile()) continue;
     const refs = references.get(sha256) ?? [];
@@ -380,9 +394,30 @@ export function listArtifacts(
       referenced,
       references: refs,
     });
-    if (limit !== undefined && inventory.length >= limit) break;
   }
-  return inventory;
+  inventory.sort(
+    (a, b) =>
+      b.mtime.localeCompare(a.mtime) || a.sha256.localeCompare(b.sha256),
+  );
+  const afterCursor = before
+    ? inventory.filter(
+        (item) =>
+          item.mtime < before.mtime ||
+          (item.mtime === before.mtime && item.sha256 > before.sha256),
+      )
+    : inventory;
+  const page = afterCursor.slice(0, limit + 1);
+  const hasNextPage = page.length > limit;
+  const artifacts = hasNextPage ? page.slice(0, -1) : page;
+  const last = artifacts.at(-1);
+  return {
+    artifacts,
+    nextBefore: hasNextPage
+      ? Buffer.from(
+          JSON.stringify({ mtime: last.mtime, sha256: last.sha256 }),
+        ).toString("base64url")
+      : null,
+  };
 }
 
 /**

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -857,6 +857,18 @@ export function retryInboxDecision(db, id, options = {}) {
 }
 
 export function listInboxItems(db, { status = "open" } = {}) {
+  return listInboxPage(db, { status, limit: Number.MAX_SAFE_INTEGER }).items;
+}
+
+/**
+ * Newest-first keyset page for the inbox ledger.  Keep listInboxItems above
+ * for internal callers that intentionally need the complete local ledger;
+ * the HTTP surface always uses this bounded projection.
+ */
+export function listInboxPage(
+  db,
+  { status = "open", limit = 100, before = null } = {},
+) {
   if (!STATUSES.has(status)) throw new Error(`unknown inbox status: ${status}`);
   const where = {
     open: "resolved_at IS NULL AND acked_at IS NULL",
@@ -864,12 +876,34 @@ export function listInboxItems(db, { status = "open" } = {}) {
     resolved: "resolved_at IS NOT NULL",
     all: "1 = 1",
   }[status];
-  return db
+  const cursor = before
+    ? " AND (created_at < ? OR (created_at = ? AND rowid < ?))"
+    : "";
+  const params = before
+    ? [before.createdAt, before.createdAt, before.rowid, limit + 1]
+    : [limit + 1];
+  const rows = db
     .query(
-      `SELECT * FROM inbox_items WHERE ${where} ORDER BY created_at DESC, rowid DESC`,
+      `SELECT *, rowid AS list_rowid FROM inbox_items
+       WHERE ${where}${cursor}
+       ORDER BY created_at DESC, rowid DESC
+       LIMIT ?`,
     )
-    .all()
-    .map(itemView);
+    .all(...params);
+  const hasNextPage = rows.length > limit;
+  const pageRows = hasNextPage ? rows.slice(0, -1) : rows;
+  const last = pageRows.at(-1);
+  return {
+    items: pageRows.map(itemView),
+    nextBefore: hasNextPage
+      ? Buffer.from(
+          JSON.stringify({
+            createdAt: last.created_at,
+            rowid: last.list_rowid,
+          }),
+        ).toString("base64url")
+      : null,
+  };
 }
 
 /**

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -152,11 +152,18 @@ export type RunListResponse = {
   nextBefore?: string | null;
 };
 
+export type CursorPage<T, Key extends string> = Record<Key, T[]> & {
+  /** Opaque cursor returned by the preceding newest-first page. */
+  nextBefore?: string | null;
+};
+
 export type ProposalListFilters = {
   from?: string;
   to?: string;
   population?: "decision";
   decisionStatus?: string;
+  limit?: number;
+  before?: string;
 };
 
 function withQuery(path: string, values: Record<string, string | undefined>) {
@@ -174,7 +181,7 @@ export function fetchProposalHistory(
   status = "all",
   filters: ProposalListFilters = {},
 ) {
-  return call<{ proposals: Proposal[] }>(
+  return call<CursorPage<Proposal, "proposals">>(
     "GET",
     withQuery("/proposals", {
       status,
@@ -182,6 +189,18 @@ export function fetchProposalHistory(
       to: filters.to,
       population: filters.population,
       decisionStatus: filters.decisionStatus,
+      limit: filters.limit == null ? undefined : String(filters.limit),
+      before: filters.before,
+    }),
+  );
+}
+
+export function fetchProposals(page: { limit?: number; before?: string } = {}) {
+  return call<CursorPage<Proposal, "proposals">>(
+    "GET",
+    withQuery("/proposals", {
+      limit: page.limit == null ? undefined : String(page.limit),
+      before: page.before,
     }),
   );
 }
@@ -261,14 +280,18 @@ export function fetchArtifacts(filters?: {
   kind?: string;
   orphan?: boolean;
   search?: string;
+  limit?: number;
+  before?: string;
 }) {
   const query = new URLSearchParams();
   if (filters?.kind) query.set("kind", filters.kind);
   if (filters?.orphan !== undefined)
     query.set("orphan", String(filters.orphan));
   if (filters?.search) query.set("search", filters.search);
+  if (filters?.limit != null) query.set("limit", String(filters.limit));
+  if (filters?.before) query.set("before", filters.before);
   const suffix = query.size > 0 ? `?${query.toString()}` : "";
-  return call<{ artifacts: ArtifactInventoryItem[] }>(
+  return call<CursorPage<ArtifactInventoryItem, "artifacts">>(
     "GET",
     `/artifacts${suffix}`,
   );
@@ -294,12 +317,16 @@ export const api = {
       "/health",
     ),
   status: () => call<StatusView>("GET", "/status"),
-  events: (status?: string) =>
-    call<{ events: AdmittedEvent[] }>(
+  events: (status?: string, page: { limit?: number; before?: string } = {}) =>
+    call<CursorPage<AdmittedEvent, "events">>(
       "GET",
-      `/events${status ? `?status=${encodeURIComponent(status)}` : ""}`,
+      withQuery("/events", {
+        status,
+        limit: page.limit == null ? undefined : String(page.limit),
+        before: page.before,
+      }),
     ),
-  proposals: () => call<{ proposals: Proposal[] }>("GET", "/proposals"),
+  proposals: () => fetchProposals(),
   // Full decision history (?status=all), newest first — read-only audit view.
   proposalHistory: (status = "all", filters: ProposalListFilters = {}) =>
     fetchProposalHistory(status, filters),
@@ -437,10 +464,17 @@ export const api = {
   // The worker registry: which processes are alive, where, and what they run.
   workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
   // Human inbox ledger (WM-285): everything waiting on the operator, by status.
-  inbox: (status: InboxStatus = "open") =>
-    call<{ items: InboxItem[] }>(
+  inbox: (
+    status: InboxStatus = "open",
+    page: { limit?: number; before?: string } = {},
+  ) =>
+    call<CursorPage<InboxItem, "items">>(
       "GET",
-      `/inbox?status=${encodeURIComponent(status)}`,
+      withQuery("/inbox", {
+        status,
+        limit: page.limit == null ? undefined : String(page.limit),
+        before: page.before,
+      }),
     ),
   // Ack = "seen"; 404 unknown item, 409 already resolved.
   ackInbox: (id: string) =>


### PR DESCRIPTION
Fixes WM-977

## Collection audit

| Route | Current behavior after this PR | UI polling |
| --- | --- | --- |
| `/runs` | WM-976 cursor page, default 100/max 200 | yes |
| `/events`, `/proposals`, `/inbox`, `/artifacts` | cursor page, default 100/max 200, newest-first | yes |
| `/journal`, `/outbox`, `/tickets`, `/chains` | already bounded by sequence/default top-N/window | yes |
| `/metrics`, `/metrics/breakdown` | bounded aligned time window/top-N | yes |
| `/memos` | exact-subject, default max 20 | yes; route now mounted |
| `/agents`, `/overrides`, `/repos`, `/schedules`, `/panels`, `/status`, `/workers`, `/config` | finite configuration/status projections or existing bounded journal | yes |

The isolated worktree has no live production DB, so no production payload/latency claim is made. Local HTTP fixtures exercise tied timestamp cursor walks for events/inbox and artifact pages; the full suite and web build pass. Existing UI callers retain bare requests, which now receive a bounded newest page; `web/src/api.ts` exposes `limit`/`before` and `nextBefore` for pagination consumers.

UX critique: skipped — backend/API pagination and documentation only; no user-completable flow or UI interaction changed.