### PR TITLE
sec(ci): sandbox fork PR CI on GitHub-hosted runners for public release (WM-950)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,14 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   push:
     branches: ["develop", "main"]
+  schedule:
+    - cron: "0 4 * * *" # Nightly continuous exercise of the cloud runner lane (WM-950)
   workflow_dispatch:
+    inputs:
+      force_hosted:
+        description: "Force execution on GitHub-hosted runner (ubuntu-latest)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -18,8 +25,45 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
+  route:
+    name: Route CI lane
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      self_hosted: ${{ steps.detect.outputs.self_hosted }}
+      shadow_labels: ${{ steps.detect.outputs.shadow_labels }}
+      verify_labels: ${{ steps.detect.outputs.verify_labels }}
+    steps:
+      - id: detect
+        name: Determine runner lane
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request' }}
+          IS_BOT: ${{ github.actor == 'dependabot[bot]' }}
+          FORCE_HOSTED: ${{ inputs.force_hosted || github.event_name == 'schedule' }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_FORK" = "true" ] || [ "$IS_BOT" = "true" ] || [ "$FORCE_HOSTED" = "true" ]; then
+            echo "Routing to GitHub-hosted runner (ubuntu-latest)"
+            {
+              echo "self_hosted=false"
+              echo 'shadow_labels=["ubuntu-latest"]'
+              echo 'verify_labels=["ubuntu-latest"]'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "Routing to self-hosted runner fleet"
+            {
+              echo "self_hosted=true"
+              echo 'shadow_labels=["self-hosted", "shadow"]'
+              echo 'verify_labels=["self-hosted", "verify-lane"]'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
   shadow-runner-health:
     name: Shadow runner fleet available
+    # Gated on self-hosted lane (WM-950). Cloud runners (ubuntu-latest) do not
+    # have or require the local shadow fleet.
+    needs: route
+    if: needs.route.outputs.self_hosted == 'true'
     # This check must not use the shadow pool: when that pool is dead, the
     # dedicated light runners are what turn a silent queue into an explicit
     # failing check. Both pools live on the same host.
@@ -87,14 +131,19 @@ jobs:
 
   fast-unit-tests:
     name: Fast unit tests
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    needs: shadow-runner-health
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
+      }}
+    needs: [route, shadow-runner-health]
     # Measurements recorded in docs/ci.md show this bounded suite can run
     # safely without joining the integration/E2E host-lock queue.
-    runs-on: [self-hosted, shadow]
+    runs-on: ${{ fromJSON(needs.route.outputs.shadow_labels) }}
     timeout-minutes: 15
     steps:
       - name: Sweep stale shared-host temp directories
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -120,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -173,7 +222,7 @@ jobs:
         run: bin/factory demo --dry
 
       - name: Sweep stale shared-host temp directories
-        if: always()
+        if: always() && runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -184,12 +233,17 @@ jobs:
     # shared-host contention. Not a required check — required Verify and Fast
     # unit tests exclude this group. A red result here is a flake signal, not
     # a merge blocker.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    needs: shadow-runner-health
-    runs-on: [self-hosted, shadow]
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
+      }}
+    needs: [route, shadow-runner-health]
+    runs-on: ${{ fromJSON(needs.route.outputs.shadow_labels) }}
     timeout-minutes: 20
     steps:
       - name: Sweep stale shared-host temp directories
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -215,7 +269,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -268,27 +322,26 @@ jobs:
           exit "$status"
 
       - name: Sweep stale shared-host temp directories
-        if: always()
+        if: always() && runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
   verify:
     name: Full verification
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    needs: [shadow-runner-health, fast-unit-tests]
-    # Self-hosted per project-conventions PC-03 / PC-22 — cloud runners are
-    # forbidden. `verify-lane` is carried by a small, fixed number of shadow
-    # runner services (WM-773): GitHub queues these jobs FIFO for a free lane
-    # runner instead of parking every shadow runner in a host flock, so the
-    # rest of the fleet stays free for lint, security and other repos. Lanes
-    # = number of runners with the label; change capacity by relabelling
-    # runners, not by editing this file.
-    runs-on: [self-hosted, verify-lane]
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success') &&
+        needs.fast-unit-tests.result == 'success'
+      }}
+    needs: [route, shadow-runner-health, fast-unit-tests]
+    runs-on: ${{ fromJSON(needs.route.outputs.verify_labels) }}
     # Runaway guard only — queue time is now spent in GitHub's queue, not here.
     timeout-minutes: 45
     steps:
       - name: Sweep stale shared-host temp directories
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -325,7 +378,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -519,7 +572,7 @@ jobs:
           bun event-runtime/demo/verify.mjs --port "$PORT"
 
       - name: Sweep stale shared-host temp directories
-        if: always()
+        if: always() && runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -527,14 +580,15 @@ jobs:
   required-verify:
     name: Verify
     if: always()
-    needs: [shadow-runner-health, fast-unit-tests, verify]
-    # Keep the required check responsive even when the shadow pool is busy or
-    # unhealthy. It aggregates the expensive jobs without running test code.
-    runs-on: [self-hosted, smoke-test]
+    needs: [route, shadow-runner-health, fast-unit-tests, verify]
+    # Runs on cloud runner so required verification is decoupled from host fleet
+    # health when executing cloud PR runs (WM-950).
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     env:
       EVENT_NAME: ${{ github.event_name }}
       IS_DRAFT: ${{ github.event.pull_request.draft }}
+      SELF_HOSTED: ${{ needs.route.outputs.self_hosted }}
       HEALTH_RESULT: ${{ needs.shadow-runner-health.result }}
       FAST_RESULT: ${{ needs.fast-unit-tests.result }}
       FULL_RESULT: ${{ needs.verify.result }}
@@ -550,8 +604,16 @@ jobs:
           fi
 
           failed=0
+          if [ "$SELF_HOSTED" = "true" ]; then
+            echo "Shadow runner fleet available=$HEALTH_RESULT"
+            if [ "$HEALTH_RESULT" != "success" ]; then
+              failed=1
+            fi
+          else
+            echo "Cloud runner lane active: shadow runner fleet health check skipped."
+          fi
+
           for result in \
-            "Shadow runner fleet available=$HEALTH_RESULT" \
             "Fast unit tests=$FAST_RESULT" \
             "Full verification=$FULL_RESULT"
           do

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,17 +19,16 @@ permissions:
 jobs:
   cla:
     name: CLA Assistant
-    # Self-hosted per project-conventions PC-03 / PC-22. The one `uses:`
-    # step is the WM-792 exception to the no-marketplace-action rule
-    # (WM-573): this job is a single infrequent API call, not Verify.
-    runs-on: [self-hosted, shadow]
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      github.event.comment.body == 'recheck' ||
+      github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+    # Cloud runner per OSS security policy (WM-950). pull_request_target with
+    # write tokens must never run on multi-tenant self-hosted infrastructure.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: CLA Assistant
-        if: >-
-          github.event_name == 'pull_request_target' ||
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,8 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.pull_request.draft == false &&
-          contains(github.event.pull_request.labels.*.name, 'run-e2e')
+          contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+          github.event.pull_request.head.repo.full_name == github.repository
         )
       }}
     # Same dedicated lane as CI's Verify (WM-773): queue in GitHub, not flock.
@@ -36,6 +37,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Sweep stale shared-host temp directories
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
@@ -61,7 +63,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -128,7 +130,7 @@ jobs:
         run: cd event-runtime/web && bun run test:e2e
 
       - name: Sweep stale shared-host temp directories
-        if: always()
+        if: always() && runner.environment == 'self-hosted'
         shell: bash
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -17,9 +17,9 @@ permissions:
 jobs:
   publish:
     name: Validate and publish
-    # Self-hosted, same no-`uses:` checkout as ci.yml (WM-573). Provenance
-    # needs the Actions OIDC token (`id-token: write` above).
-    runs-on: [self-hosted, shadow]
+    # Cloud runner per OSS security policy (WM-950). Gets publish credentials
+    # and OIDC tokens off the shared host.
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout (no action download)
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,22 +19,10 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks
-    # Self-hosted per project-conventions PC-03 / PC-22.
-    runs-on: [self-hosted, shadow]
+    # Cloud runner per OSS security policy (WM-950).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # No `uses:` steps in this workflow on purpose (WM-573, mirrors ci.yml):
-      # every marketplace action is fetched from codeload.github.com at "Set
-      # up job", and the shadow fleet (eight runners, one egress IP, no action
-      # archive cache) has hit 429 Too Many Requests on actions/checkout.
-      # PR runs need connected history between base and head so `git log
-      # base..head` (gitleaks --log-opts) can walk it — start shallow and
-      # deepen only as far as needed to connect the two endpoints.
-      # Push runs (WM-620) do the same against `github.event.before`: in a
-      # depth-1 clone `git log -1` emits the whole tree as added, so gitleaks
-      # scanned ~6 MB per develop push and tripped on pre-existing text.
-      # `before` is all zeros on branch creation and empty on
-      # workflow_dispatch — those fall back to a depth-1 checkout.
       - name: Checkout (no action download)
         shell: bash
         env:
@@ -98,17 +86,8 @@ jobs:
           elif [ -x "$HOME/.local/bin/gitleaks" ]; then
             echo "bin=$HOME/.local/bin/gitleaks" >> "$GITHUB_OUTPUT"
           else
-            # Releases download, not codeload — resolve the current tag via the
-            # GitHub API (versioned asset name, so a hardcoded URL goes stale)
-            # then fetch the linux_x64 tarball straight from
-            # objects.githubusercontent.com, no actions/* download involved.
-            # Capture the full response before grepping it: piping curl
-            # straight into `grep -m1` lets grep exit after the first match
-            # while curl is still writing, which curl reports as exit 23
-            # ("Failure writing output to destination").
-            resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-              https://api.github.com/repos/gitleaks/gitleaks/releases/latest)"
-            tag="$(printf '%s' "$resp" | grep -m1 '"tag_name"' | cut -d '"' -f4)"
+            # Pinned release download (WM-950)
+            tag="v8.24.0"
             ver="${tag#v}"
             mkdir -p "$HOME/.local/bin"
             curl -fsSL -o "$RUNNER_TEMP/gitleaks.tar.gz" \
@@ -144,7 +123,7 @@ jobs:
 
   semgrep:
     name: Semgrep
-    runs-on: [self-hosted, shadow]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout (no action download)
@@ -183,11 +162,11 @@ jobs:
           "$uvx_bin" --version
 
       - name: Semgrep scan
-        run: uvx semgrep scan --config p/security-audit --error --metrics=off .
+        run: uvx --from semgrep==1.111.0 semgrep scan --config p/security-audit --error --metrics=off .
 
   actionlint:
     name: Actionlint
-    runs-on: [self-hosted, shadow]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout (no action download)
@@ -211,7 +190,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v actionlint >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/actionlint" ]; then
-            bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/.local/bin"
+            bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7 "$HOME/.local/bin"
           fi
           # $GITHUB_PATH only takes effect starting the *next* step, not this
           # one — resolve the binary directly here rather than relying on PATH.
@@ -237,7 +216,7 @@ jobs:
     # `CODEQL_ENABLED` repo variable to `true` and replace this placeholder
     # with the real init/analyze steps at that point.
     if: ${{ vars.CODEQL_ENABLED == 'true' }}
-    runs-on: [self-hosted, shadow]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: CodeQL gated placeholder

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -22,7 +22,8 @@ concurrency:
 jobs:
   update-badge:
     name: Refresh README dogfood badge
-    runs-on: [self-hosted, shadow]
+    # Cloud runner per OSS security policy (WM-950).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout develop (no action download)
@@ -45,7 +46,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash
+            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ needed, and avoid mixing mechanical formatting with unrelated behavior.
 - Complete the pull request template and link the issue the change resolves.
 - Include the exact commands you ran and any relevant output or screenshots.
 - Call out security impact, compatibility concerns, and follow-up work.
+- Automated checks run on GitHub-hosted cloud runners; first-time outside contributors may require maintainer approval before CI executes.
 - Expect review feedback. Approval and passing automation are both required;
   an author does not merge their own pull request.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,10 @@ performed with credentials and approval explicitly granted to the operator are
 normally product-quality issues rather than vulnerabilities. A model failure
 that crosses one of the boundaries above is a security issue.
 
+## CI runner and public contribution isolation
+
+Workflows triggered by external pull requests from forks execute strictly in isolated, ephemeral GitHub-hosted environments (`ubuntu-latest`) with read-only repository permissions and withheld Actions secrets. Internal self-hosted runner infrastructure is reserved exclusively for trusted repository branches and maintainer workflows.
+
 ## Disclosure policy
 
 Please allow us a reasonable opportunity to investigate and remediate before

--- a/dist/codex/skills/factory-audit/SKILL.md
+++ b/dist/codex/skills/factory-audit/SKILL.md
@@ -21,7 +21,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -35,7 +35,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 

--- a/dist/cursor/commands/factory-audit.md
+++ b/dist/cursor/commands/factory-audit.md
@@ -12,7 +12,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -26,7 +26,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 

--- a/dist/gemini/skills/factory-audit/SKILL.md
+++ b/dist/gemini/skills/factory-audit/SKILL.md
@@ -21,7 +21,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -35,7 +35,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 

--- a/dist/pi/prompts/factory-audit.md
+++ b/dist/pi/prompts/factory-audit.md
@@ -16,7 +16,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -30,7 +30,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,9 +2,21 @@
 
 ## Runner topology
 
-Factory CI uses self-hosted runners only. The `shadow` label currently maps to eight runner services (`watt-mind-runner-1` through `watt-mind-runner-8`) on one physical host. The lightweight `smoke-test` runner is on that host too, but it only checks fleet health and host capacity.
+Factory CI uses a hybrid runner strategy designed for public open-source operation (WM-950):
 
-Treat runner names as parallel executors, not independent machines. CPU, memory, `/tmp`, and process scheduling are shared across all eight shadow services.
+- **Internal trusted lanes**: Branches originating within `watt-mind/factory` (pushes to `develop`/`main` and internal pull requests) run on high-performance self-hosted runners. The `shadow` label maps to eight runner services (`watt-mind-runner-1` through `watt-mind-runner-8`) on one physical host, and the `smoke-test` runner checks fleet health.
+- **External untrusted fork PRs**: Pull requests from external repository forks run in isolated, ephemeral GitHub-hosted runners (`ubuntu-latest`). Untrusted contributor code has zero access to the host machine, filesystem, `/tmp`, or internal network.
+- **Security & utility workflows**: Workflows handling credentials or isolated scans (`security.yml`, `cla.yml`, `update-badge.yml`, `publish-extension.yml`) run unconditionally on `ubuntu-latest`.
+
+Treat self-hosted runner names as parallel executors, not independent machines. CPU, memory, `/tmp`, and process scheduling are shared across all eight shadow services.
+
+## Fork PR sandboxing & dual routing
+
+In `ci.yml`, a lightweight initial `route` job runs on `ubuntu-latest` to determine the execution lane based on the event context:
+- Untrusted fork PRs (`github.event.pull_request.head.repo.full_name != github.repository`), Dependabot PRs, and nightly exercises route dynamically to `ubuntu-latest`.
+- Trusted internal PRs and branch pushes route to `[self-hosted, shadow]` and `[self-hosted, verify-lane]`.
+- Host-specific steps (`shadow-runner-health`, host `/tmp` sweep) execute only when `runner.environment == 'self-hosted'`.
+- Continuous exercise: A nightly schedule (`0 4 * * *`) and `workflow_dispatch` input `force_hosted` run the full CI suite on `ubuntu-latest` to prevent cloud lane regressions.
 
 ## Verify lane
 
@@ -89,7 +101,7 @@ A failed or cancelled test job breaks the streak. Record the five develop run UR
 
 ## Security scans
 
-`.github/workflows/security.yml` runs on `pull_request`, `push` to `develop`/`main`, and `workflow_dispatch`, on `[self-hosted, shadow]` with the same no-`uses:` git-fetch checkout pattern as `ci.yml` (WM-573). Four jobs:
+`.github/workflows/security.yml` runs on `pull_request`, `push` to `develop`/`main`, and `workflow_dispatch`, on `ubuntu-latest` with the same no-`uses:` git-fetch checkout pattern as `ci.yml` (WM-573). Four jobs:
 
 - **Gitleaks** — `gitleaks git --no-banner --redact` over the PR's base..head range (or the last commit on a branch push). Honours a repo-root `.gitleaks.toml` if one is added. Binary resolves from PATH, then `~/.local/bin/gitleaks`, then a GitHub Releases download (not a marketplace action) on first use per runner host.
 - **Semgrep** — `uvx semgrep scan --config p/security-audit --error --metrics=off .`, scoped by `.semgrepignore` (generated output, vendor trees, fixtures, lockfiles). `uv`/`uvx` installs from astral.sh if missing on the host.

--- a/plugins/core/commands/factory-audit.md
+++ b/plugins/core/commands/factory-audit.md
@@ -18,7 +18,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -32,7 +32,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 

--- a/shared/commands/factory-audit.md
+++ b/shared/commands/factory-audit.md
@@ -18,7 +18,7 @@ Rules that keep the grade honest:
 
 - **Verify against the live repo and the live GitHub settings**, not against what `AGENTS.md` or this guide claims. `PC-20` exists precisely because docs drift; when a doc and reality disagree, the doc is the finding. "Live" means `origin/<base>`, so `git fetch --quiet` first and follow the floor's **Checkout freshness** rule — a FAIL graded against a checkout that predates the fix is a fabricated finding, and it gets filed as a ticket for work already done.
 - **N/A requires a stated reason** grounded in the repo ("no auto-deploy branch", "free private plan blocks branch protection"). Never N/A a check because it's inconvenient or because fixing it is out of scope — that's a FAIL with a filed ticket.
-- **`PC-03` (cloud runners) and `PC-18` (missing secrets) are cheap and high-consequence** — one bills real money, the other means a workflow that looks configured has never once run green. Always check them, even in a partial audit.
+- **`PC-03` (runner policy) and `PC-18` (missing secrets) are cheap and high-consequence** — on private repos cloud runners bill real money; on public repos, fork PR sandboxing requires standard hosted runners or ephemeral isolation, while self-hosted remains for trusted internal lanes. Always check them, even in a partial audit.
 - For `PC-17`, a workflow that exists but is disabled by a stale `if:` gate is a **FAIL, not a PASS** — a gate whose stated precondition has since been met is the most common way a repo loses its strongest test signal without anyone noticing.
 - Read-only. Do not fix anything during grading; grade first, so the report reflects the repo as found.
 
@@ -32,7 +32,7 @@ Sort failures by what they cost: a check that lets broken code reach production 
 
 Every FAIL becomes a Linear issue in `Triage` per `docs/protocol.md` §8: correct team/project from `config/repos.yaml` (§1), `type:maintenance` (or `type:security` where that's the real nature), the matching `area:*`, `source:agent`, priority from the severity column, and the check ID plus observed evidence in the description. Search first — a repeat audit must update or skip an existing ticket, never file a duplicate.
 
-Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, swapping `ubuntu-latest` for the self-hosted label, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
+Where a fix is small, mechanical, and unambiguous (adding `retention-days: 1`, aligning runner configuration with the repo's public/private isolation policy, adding a missing thin `CLAUDE.md`), write the issue to the full §5 AI-ready template, label it `ai:agent-ready`, and move it to `Todo` so the next `/factory-work` run picks it up without further human involvement. Anything needing a decision, a credential, or a plan upgrade stays in `Triage` with the specific question stated.
 
 ## 4. Offer, don't assume
 


### PR DESCRIPTION
## Problem
When public, any external contributor can open a pull request from a fork. Workflows executing on multi-tenant self-hosted runner infrastructure pose an untrusted code execution risk to the host machine and network.

## Mechanism
1. **GitHub-hosted runners for utility and security workflows**: Moved `cla.yml`, `security.yml`, `update-badge.yml`, and `publish-extension.yml` to `runs-on: ubuntu-latest`.
2. **Dual-routing in `ci.yml`**: Added a lightweight initial `route` job determining whether the event originates from a fork or bot/dispatch. Untrusted fork PRs route dynamically to `ubuntu-latest`. Trusted internal PRs and branch pushes continue on high-performance self-hosted runners (`[self-hosted, shadow]` / `[self-hosted, verify-lane]`).
3. **Hard gate on E2E**: Gated `.github/workflows/e2e.yml` to run only for internal branches (`github.event.pull_request.head.repo.full_name == github.repository`).
4. **Environment-conditional sweeps**: Host `/tmp` cleanup steps and shadow runner health checks run only when `runner.environment == 'self-hosted'`.
5. **Nightly exercise & manual test**: Added scheduled run (`0 4 * * *`) and `workflow_dispatch: force_hosted` input to continuously exercise the GitHub-hosted runner lane.
6. **Documentation & Policy**: Updated `docs/ci.md`, `SECURITY.md`, `CONTRIBUTING.md`, and `shared/commands/factory-audit.md` (re-emitted via `bun build/emit.mjs`).

Fixes WM-950