### PR TITLE
fix(ci): make Actionlint and Semgrep self-sufficient on GitHub-hosted runners

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -162,7 +162,14 @@ jobs:
           "$uvx_bin" --version
 
       - name: Semgrep scan
-        run: uvx --from semgrep==1.111.0 semgrep scan --config p/security-audit --error --metrics=off .
+        # `--with 'setuptools<81'`: semgrep's opentelemetry instrumentation
+        # still imports pkg_resources, which setuptools removed starting
+        # with 81 (deprecated since 80). uv's default resolver picks the
+        # newest setuptools, which no longer ships that module — pin below
+        # the removal so the import keeps working (WM-950 moved this job off
+        # the shadow fleet, whose pre-provisioned image had an older
+        # setuptools already on PATH).
+        run: uvx --from semgrep==1.111.0 --with 'setuptools<81' semgrep scan --config p/security-audit --error --metrics=off .
 
   actionlint:
     name: Actionlint
@@ -190,6 +197,11 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v actionlint >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/actionlint" ]; then
+            # download-actionlint.bash requires DIR to already exist (it
+            # doesn't mkdir it); the shadow fleet had ~/.local/bin
+            # pre-provisioned, but a clean GitHub-hosted image doesn't
+            # (WM-950 moved this job off the shadow fleet).
+            mkdir -p "$HOME/.local/bin"
             bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7 "$HOME/.local/bin"
           fi
           # $GITHUB_PATH only takes effect starting the *next* step, not this


### PR DESCRIPTION
## Problem

develop's Security workflow has been red since #782 (WM-950, "sandbox fork PR CI on GitHub-hosted") re-routed `actionlint` and `semgrep` from the self-hosted shadow fleet to `ubuntu-latest`. Both jobs assumed environment state that only the shadow fleet's image had pre-provisioned. See the failing run on develop head 5494f6e2: https://github.com/watt-mind/factory/actions/runs/32422709478

This fixes forward — it does not undo #782's fork-PR sandboxing.

## Root causes

**Actionlint** — "Resolve actionlint binary" step exits 1:
```
Directory '/home/runner/.local/bin' does not exist
```
`download-actionlint.bash` does not create its target directory; the shadow fleet had `~/.local/bin` pre-provisioned, a clean `ubuntu-latest` image doesn't. Fix: `mkdir -p "$HOME/.local/bin"` before invoking the download script. The self-hosted fast path (binary already on PATH or already present) is untouched.

**Semgrep** — `uvx --from semgrep==1.111.0 semgrep scan ...` fails:
```
ModuleNotFoundError: No module named 'pkg_resources'
```
`uv` resolves the newest `setuptools` by default for the ephemeral tool env, and `setuptools` dropped `pkg_resources` starting with 81 (deprecated since 80). Semgrep's opentelemetry instrumentation still imports it, so pysemgrep crashes on Python 3.12+ images. Fix: pin `--with 'setuptools<81'` on the uvx invocation, so `pkg_resources` stays available. `semgrep==1.111.0` stays pinned as-is; adding a plain `--with setuptools` was tried first and does not fix it (uv still picks the latest, pkg_resources-less setuptools).

## Validation

- `actionlint .github/workflows/security.yml` — clean, exit 0.
- Ran the exact `uvx --from semgrep==1.111.0 --with 'setuptools<81' semgrep --version` locally against Python 3.13 (3.12+) — imports and runs cleanly (only the expected pkg_resources deprecation warning, no crash). Confirmed `--with setuptools` alone (no version pin) still reproduces the crash, since it resolves setuptools 84.