### PR TITLE
docs(oss): link ADOPTERS.md and PACKS.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Agents are isolated specialist contexts, not workflow entry points.
 | [docs/quickstart.md](docs/quickstart.md)           | 15-minute `factory demo`                                      |
 | [docs/architecture.md](docs/architecture.md)       | Why the factory is shaped this way                            |
 | [docs/orchestrator.md](docs/orchestrator.md)       | Master orchestrator guide and operating loops                 |
+| [ADOPTERS.md](ADOPTERS.md)                         | Organizations and teams using the factory                     |
+| [PACKS.md](PACKS.md)                               | Directory of reusable factory packs                           |
 | [SETUP.md](SETUP.md)                               | First-time setup, harness links, event-runtime daemon         |
 | [CONTRIBUTING.md](CONTRIBUTING.md)                 | Setup, tests, commit conventions, CLA                         |
 | [SECURITY.md](SECURITY.md)                         | Vulnerability reporting and the autonomous-agent threat model |


### PR DESCRIPTION
Fixes WM-964

UX critique: skipped — README documentation-table links only