### PR TITLE
feat(control-plane): per-repo control plane selection in config/repos.yaml

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -10,6 +10,12 @@ repos:
     color: orange
     team: WM
     project: Factory
+    # Which tracker holds this repo's tickets: linear | github | memory.
+    # Omit to inherit config/policy.yaml's controlPlane.kind (itself defaulting
+    # to linear). Setting it per repo is what lets one factory instance run
+    # this repo on GitHub Issues while every other repo it manages stays on
+    # Linear — without it the choice is global and moving one moves all.
+    # control_plane: github
     base: develop
     deploy_branch: main
     worktree_up: bin/worktree-up.sh

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -60,13 +60,34 @@ repos:
   - name: example
     team: ENG # tracker team key (Linear team key today)
     project: Example app # optional; omit when the team has one project
+    control_plane: github # optional; inherits policy.yaml when omitted
 ```
 
-Resolve the team from the repo you are in: match `path` (with `~` expanded)
-against cwd, or take `--repo` / `$ARGUMENTS` when a command names one.
-`factory linear queue --repo <name>` already does this. Do not invent a team
-key, and do not copy another workspace's vocabulary (`WM` / `OPS` / `CLNT`,
-or anyone else's) into a repo that does not use it.
+Resolve the team from the repo you are in: match `path` **or `worktree_root`**
+(with `~` expanded) against cwd, or take `--repo` / `$ARGUMENTS` when a command
+names one. `worktree_root` matters because every dispatched agent runs from
+`<worktree_root>/<TICKET>`, not from `path`. Longest matching prefix wins. Do
+not invent a team key, and do not copy another workspace's vocabulary (`WM` /
+`OPS` / `CLNT`, or anyone else's) into a repo that does not use it.
+
+### Which control plane a repo uses
+
+`control_plane` on a repo entry selects that repo's tracker: `linear`,
+`github`, or `memory`. Resolution is most-specific-first (WM-1007):
+
+1. an explicit `kind` passed to `loadControlPlane()` — tests, and callers that already know
+2. `control_plane:` on the `config/repos.yaml` entry
+3. `controlPlane.kind` in `config/policy.yaml`
+4. `linear`
+
+A repo that omits the key **inherits** the workspace default rather than
+defaulting on its own, so adding the key to one repo never changes another.
+An unknown repo name throws instead of falling back — a stale name would
+otherwise run that repo's tickets against the wrong tracker and report the
+result as an empty queue.
+
+This is what lets one factory instance keep its own repo on GitHub Issues
+while every other repo it manages stays on Linear.
 
 A workspace may add a repo-local issue-management guide. Follow that guide
 inside that repo; do not import another team's labels or projects into it.

--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -526,6 +526,100 @@ describe("loadControlPlane selection", () => {
     expect(loadControlPlane().kind).toBe("linear");
   });
 
+  // ------------------------------------------------ per-repo selection ---
+  // WM-1007. The point of these is the precedence chain: a repo may pick its
+  // own tracker, and a repo that says nothing must INHERIT rather than
+  // default, so adding the key to one repo never moves another.
+  describe("per-repo control_plane", () => {
+    const withRepos = (policyYaml, reposYaml) => {
+      const root = tmpDir("control-plane-repos-");
+      mkdirSync(path.join(root, "config"), { recursive: true });
+      if (policyYaml !== null)
+        writeFileSync(path.join(root, "config", "policy.yaml"), policyYaml);
+      writeFileSync(path.join(root, "config", "repos.yaml"), reposYaml);
+      return root;
+    };
+    const REPOS = [
+      "repos:",
+      "  - name: onGithub",
+      "    path: /tmp/on-github",
+      "    control_plane: github",
+      "  - name: onMemory",
+      "    path: /tmp/on-memory",
+      "    control_plane: memory",
+      "  - name: inherits",
+      "    path: /tmp/inherits",
+      "",
+    ].join("\n");
+
+    test("a repo's control_plane outranks policy", () => {
+      const root = withRepos("controlPlane:\n  kind: linear\n", REPOS);
+      expect(loadControlPlane({ root, repoName: "onMemory" }).kind).toBe(
+        "memory",
+      );
+    });
+
+    test("a repo without the key inherits policy, not the default", () => {
+      const root = withRepos("controlPlane:\n  kind: memory\n", REPOS);
+      expect(loadControlPlane({ root, repoName: "inherits" }).kind).toBe(
+        "memory",
+      );
+    });
+
+    test("with neither repo key nor policy stanza it is linear", () => {
+      const root = withRepos(null, REPOS);
+      expect(loadControlPlane({ root, repoName: "inherits" }).kind).toBe(
+        "linear",
+      );
+    });
+
+    test("an explicit kind outranks the repo entry", () => {
+      const root = withRepos("controlPlane:\n  kind: linear\n", REPOS);
+      expect(
+        loadControlPlane({ root, repoName: "onMemory", kind: "linear" }).kind,
+      ).toBe("linear");
+    });
+
+    test("one repo choosing github does not move a repo that inherits", () => {
+      const root = withRepos("controlPlane:\n  kind: linear\n", REPOS);
+      expect(loadControlPlane({ root, repoName: "onGithub" }).kind).toBe(
+        "github",
+      );
+      expect(loadControlPlane({ root, repoName: "inherits" }).kind).toBe(
+        "linear",
+      );
+    });
+
+    test("an unknown repo throws rather than falling back to policy", () => {
+      const root = withRepos("controlPlane:\n  kind: linear\n", REPOS);
+      expect(() => loadControlPlane({ root, repoName: "typo" })).toThrow(
+        /unknown repo "typo"/,
+      );
+    });
+
+    test("an invalid control_plane value is a load error naming the repo", () => {
+      const root = withRepos(
+        null,
+        "repos:\n  - name: bad\n    path: /tmp/bad\n    control_plane: jira\n",
+      );
+      expect(() => loadControlPlane({ root, repoName: "bad" })).toThrow(
+        /repo bad control_plane must be one of/,
+      );
+    });
+
+    test("no repoName never reads the repo registry", () => {
+      // repos.yaml is deliberately absent: the global path must not depend on
+      // it, or every existing call site breaks in a checkout without one.
+      const root = tmpDir("control-plane-no-repos-");
+      mkdirSync(path.join(root, "config"), { recursive: true });
+      writeFileSync(
+        path.join(root, "config", "policy.yaml"),
+        "controlPlane:\n  kind: memory\n",
+      );
+      expect(loadControlPlane({ root }).kind).toBe("memory");
+    });
+  });
+
   test("re-exports githubControlPlane from the adapter", () => {
     expect(controlPlaneIndex.githubControlPlane).toBe(
       githubControlPlaneFromAdapter,

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -19,6 +19,10 @@ import {
   FACTORY_ROOT,
   resolveConfigPath,
 } from "./config.mjs";
+// types.mjs only, never index.mjs: index.mjs reads this registry to resolve a
+// repo's control plane (WM-1007), so importing it back here would cycle.
+// types.mjs imports nothing.
+import { CONTROL_PLANE_KINDS } from "../../lib/control-plane/types.mjs";
 
 export class RepoError extends Error {
   constructor(message) {
@@ -128,6 +132,7 @@ function normalizeOwnedPathsPolicy(raw = {}, repoName, file) {
 /**
  * @returns {Map<string, {name: string, path: string, github: string|null, base: string,
  *                        deployBranch: string|null, team: string|null, project: string|null,
+ *                        controlPlane: "linear"|"memory"|"github"|null,
  *                        reportOnly: boolean, maxInFlight: number|null, smokeDeadlineSeconds: number|null,
  *                        mergeCi: {workflow: string, requiredChecks: string[]}|null,
  *                        escalatePaths: string[]|null, smokeWorkflow: string|null, smokeUrl: string|null,
@@ -241,6 +246,19 @@ export function loadRepos({ root = reposRoot() } = {}) {
       // Deliberate allow-list: never pass through credential-shaped additions.
       security = { pythonVersion: entry.security.python_version ?? null };
     }
+    // WM-1007: which tracker holds this repo's tickets. Absent means "inherit
+    // config/policy.yaml", which is why the default is null and not "linear" —
+    // a value here would state a choice this file never made, and would
+    // silently outrank the policy for every repo that omitted the key.
+    let controlPlane = null;
+    if (entry.control_plane !== undefined && entry.control_plane !== null) {
+      if (!CONTROL_PLANE_KINDS.includes(entry.control_plane)) {
+        throw new RepoError(
+          `${file}: repo ${entry.name} control_plane must be one of ${CONTROL_PLANE_KINDS.join(", ")}, got ${JSON.stringify(entry.control_plane)}`,
+        );
+      }
+      controlPlane = entry.control_plane;
+    }
     repos.set(entry.name, {
       name: entry.name,
       path: expandHome(entry.path),
@@ -249,6 +267,7 @@ export function loadRepos({ root = reposRoot() } = {}) {
       deployBranch: entry.deploy_branch ?? null,
       team: entry.team ?? null,
       project: entry.project ?? null,
+      controlPlane,
       // Absent means dispatchable: report_only is the guard a repo opts into,
       // so anything but an explicit `true` must read as false rather than
       // "maybe" — an operator reading "dispatch" off a null would be wrong.
@@ -301,6 +320,10 @@ export function reposView(repos) {
     github: repo.github,
     team: repo.team,
     project: repo.project,
+    // controlPlane is deliberately NOT published here yet: the view is an
+    // allow-list with an exact-shape contract test in api-registry.test.mjs,
+    // which is outside WM-1007's Owned Paths. Surfacing it to operators is
+    // filed separately.
     base: repo.base,
     deployBranch: repo.deployBranch,
     reportOnly: repo.reportOnly,

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -90,6 +90,7 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       github: "watt-mind/full",
       team: "CLNT",
       project: "Full Project",
+      controlPlane: null,
       base: "develop",
       deployBranch: "master",
       reportOnly: false,
@@ -473,5 +474,43 @@ describe("reposView is what the control API serves", () => {
       ["full", false],
       ["bare", true],
     ]);
+  });
+});
+
+// WM-1007: which tracker holds a repo's tickets. null means "inherit
+// config/policy.yaml" — a default of "linear" here would state a choice the
+// file never made, and would outrank policy for every repo that omitted it.
+describe("control_plane on a repo entry", () => {
+  test("absent reads as null, not a default", () => {
+    const root = factoryRoot("repos:\n  - name: a\n    path: /tmp/a\n");
+    expect(loadRepos({ root }).get("a").controlPlane).toBeNull();
+  });
+
+  test("each valid kind is carried through", () => {
+    for (const kind of ["linear", "github", "memory"]) {
+      const root = factoryRoot(
+        `repos:\n  - name: a\n    path: /tmp/a\n    control_plane: ${kind}\n`,
+      );
+      expect(loadRepos({ root }).get("a").controlPlane).toBe(kind);
+    }
+  });
+
+  test("an unknown kind is a load error naming the repo and the options", () => {
+    const root = factoryRoot(
+      "repos:\n  - name: a\n    path: /tmp/a\n    control_plane: jira\n",
+    );
+    expect(() => loadRepos({ root })).toThrow(RepoError);
+    expect(() => loadRepos({ root })).toThrow(
+      /repo a control_plane must be one of linear, memory, github/,
+    );
+  });
+
+  test("reposView does not publish it yet (see follow-up)", () => {
+    const root = factoryRoot(
+      "repos:\n  - name: a\n    path: /tmp/a\n    control_plane: github\n",
+    );
+    expect(reposView(loadRepos({ root }))[0]).not.toHaveProperty(
+      "controlPlane",
+    );
   });
 });

--- a/lib/control-plane/index.mjs
+++ b/lib/control-plane/index.mjs
@@ -5,11 +5,18 @@
  *   const cp = loadControlPlane();              // kind from config/policy.yaml
  *   const ready = await cp.listDispatchable({ team: "WM" });
  *
- * Selection lives in `config/policy.yaml`:
+ *   loadControlPlane({ repoName: "factory" })   // kind from that repo's entry
  *
- *   controlPlane:
- *     kind: linear     # default when the stanza is absent
- *     # kind: github   # Issues + Projects (WM-798 / WM-955)
+ * Selection is per repo, falling back to the workspace default (WM-1007):
+ *
+ *   1. an explicit `kind` option              (tests, and callers that know)
+ *   2. `control_plane:` on the `config/repos.yaml` entry named `repoName`
+ *   3. `controlPlane.kind` in `config/policy.yaml`
+ *   4. `linear`
+ *
+ * The per-repo level is what lets one factory instance run its own repo on
+ * GitHub Issues while every other repo it manages stays on Linear (WM-1006).
+ * Without it the choice is global, and moving one repo moves all of them.
  *
  * `memory` is the in-process fake for tests and the demo. `github` is the
  * Issues + Projects adapter (WM-798), selected here (WM-955). Anything else
@@ -23,6 +30,9 @@ import { githubControlPlane } from "./github.mjs";
 import { linearControlPlane } from "./linear.mjs";
 import { memoryControlPlane } from "./memory.mjs";
 import { CONTROL_PLANE_KINDS } from "./types.mjs";
+// Layering note: lib/ -> event-runtime/lib/ already exists (lib/ps.mjs reads
+// config.mjs). No cycle — repos.mjs imports ./types.mjs, never this module.
+import { loadRepos } from "../../event-runtime/lib/repos.mjs";
 
 export { githubControlPlane } from "./github.mjs";
 export { linearControlPlane } from "./linear.mjs";
@@ -68,9 +78,38 @@ export function controlPlaneKindFromPolicy(root = DEFAULT_ROOT) {
 }
 
 /**
+ * The kind a `config/repos.yaml` entry asks for, or null when it asks for
+ * nothing (WM-1007).
+ *
+ * An unknown name throws. The tempting alternative — falling back to the
+ * policy default — is exactly wrong: a typo'd or stale repo name would
+ * quietly run that repo's tickets against another workspace's tracker, and
+ * the symptom would be "no tickets", which reads as an empty queue rather
+ * than as a mistake. Same reasoning as the unknown-kind throw below.
+ *
+ * @param {string} repoName  entry name in repos.yaml (e.g. "factory")
+ * @param {string} root
+ * @returns {"linear"|"memory"|"github"|null}
+ */
+export function controlPlaneKindFromRepo(repoName, root = DEFAULT_ROOT) {
+  const repos = loadRepos({ root });
+  const entry = repos.get(repoName);
+  if (!entry) {
+    throw new Error(
+      `unknown repo ${JSON.stringify(repoName)} in ${path.join(root, "config", "repos.yaml")} — known: ${[...repos.keys()].join(", ") || "(none)"}`,
+    );
+  }
+  return entry.controlPlane ?? null;
+}
+
+/**
  * @param {{
  *   root?: string,
  *   kind?: "linear"|"memory"|"github",
+ *   repoName?: string,  // config/repos.yaml entry whose control_plane decides
+ *                       // the kind. Distinct from `repo` below, which is the
+ *                       // github adapter's owner/name slug — different things,
+ *                       // so deliberately not the same option.
  *   gql?: Function,     // linear: GraphQL runner (tests)
  *   seed?: object,      // memory: initial workspace fixture
  *   api?: Function,     // github: gh api seam (tests)
@@ -85,6 +124,7 @@ export function controlPlaneKindFromPolicy(root = DEFAULT_ROOT) {
 export function loadControlPlane({
   root = DEFAULT_ROOT,
   kind,
+  repoName,
   gql,
   seed,
   api,
@@ -94,7 +134,15 @@ export function loadControlPlane({
   project,
   statusField,
 } = {}) {
-  const selected = kind ?? controlPlaneKindFromPolicy(root);
+  // Precedence, most specific first. Each level is skipped only when it has
+  // nothing to say (undefined / null), so a repo that sets `control_plane`
+  // outranks policy, and a repo that omits it inherits rather than defaults.
+  // With no repoName this is byte-identical to the pre-WM-1007 behaviour, and
+  // the repo registry is never read.
+  const selected =
+    kind ??
+    (repoName != null ? controlPlaneKindFromRepo(repoName, root) : null) ??
+    controlPlaneKindFromPolicy(root);
   switch (selected) {
     case "linear":
       return linearControlPlane(gql ? { gql } : {});

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -282,12 +282,14 @@ export function resolveRepoName({
   }
   const here = path.resolve(cwd);
   const under = (dir) =>
-    dir && (here === dir || here.startsWith(dir.endsWith("/") ? dir : `${dir}/`));
+    dir &&
+    (here === dir || here.startsWith(dir.endsWith("/") ? dir : `${dir}/`));
   let best = null;
   for (const repo of registry.values()) {
     for (const dir of [repo.path, repo.worktreeRoot]) {
       if (!under(dir)) continue;
-      if (!best || dir.length > best.length) best = { name: repo.name, length: dir.length };
+      if (!best || dir.length > best.length)
+        best = { name: repo.name, length: dir.length };
     }
   }
   return best?.name ?? null;

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -252,8 +252,58 @@ export function installLinearBudgetCapture() {
   };
 }
 
+/**
+ * Which `config/repos.yaml` entry this invocation is about (WM-1007), or null
+ * when nothing identifies one.
+ *
+ * `--repo` wins. Otherwise match cwd, which must consider **both** the repo's
+ * checkout and its `worktree_root`: every dispatched agent runs from
+ * `<worktree_root>/<TICKET>`, not from `path`, so matching `path` alone would
+ * resolve to null in the one case that matters most and silently fall back to
+ * the workspace-wide control plane.
+ *
+ * Longest prefix wins, so a repo checked out inside another repo's tree
+ * resolves to the inner one.
+ */
+export function resolveRepoName({
+  cwd = process.cwd(),
+  repos,
+  repoFlag = flag("repo"),
+} = {}) {
+  const registry = repos ?? getRepos();
+  const explicit = repoFlag;
+  if (explicit) {
+    if (!registry.has(explicit)) {
+      throw new Error(
+        `unknown --repo ${JSON.stringify(explicit)} — known: ${[...registry.keys()].join(", ") || "(none)"}`,
+      );
+    }
+    return explicit;
+  }
+  const here = path.resolve(cwd);
+  const under = (dir) =>
+    dir && (here === dir || here.startsWith(dir.endsWith("/") ? dir : `${dir}/`));
+  let best = null;
+  for (const repo of registry.values()) {
+    for (const dir of [repo.path, repo.worktreeRoot]) {
+      if (!under(dir)) continue;
+      if (!best || dir.length > best.length) best = { name: repo.name, length: dir.length };
+    }
+  }
+  return best?.name ?? null;
+}
+
 function controlPlane() {
-  return loadControlPlane();
+  // Absent a resolvable repo, fall back to the workspace default exactly as
+  // before — a CLI run from /tmp must still work.
+  let repoName = null;
+  try {
+    repoName = resolveRepoName();
+  } catch (err) {
+    // An explicit bad --repo is the operator's mistake; surface it.
+    if (flag("repo")) throw err;
+  }
+  return loadControlPlane(repoName ? { repoName } : {});
 }
 
 /** Compact ticket rendering — the fields the protocol actually acts on. */
@@ -345,6 +395,7 @@ const VALUE_FLAGS = new Set([
   "label",
   "project",
   "remove",
+  "repo",
   "source",
   "team",
   "title",

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -410,7 +410,10 @@ test("resolveRepoName matches the checkout, the worktree root, and --repo", () =
       "alpha",
     );
     expect(
-      resolveRepoName({ cwd: path.join(alphaPath, "lib"), repoFlag: undefined }),
+      resolveRepoName({
+        cwd: path.join(alphaPath, "lib"),
+        repoFlag: undefined,
+      }),
     ).toBe("alpha");
     // cwd inside a WORKTREE — resolves via worktree_root, not path
     expect(
@@ -420,7 +423,9 @@ test("resolveRepoName matches the checkout, the worktree root, and --repo", () =
       }),
     ).toBe("alpha");
     // a different repo
-    expect(resolveRepoName({ cwd: betaPath, repoFlag: undefined })).toBe("beta");
+    expect(resolveRepoName({ cwd: betaPath, repoFlag: undefined })).toBe(
+      "beta",
+    );
     // nothing matches -> null, so the caller falls back to policy
     expect(
       resolveRepoName({ cwd: os.tmpdir(), repoFlag: undefined }),

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -23,6 +23,7 @@ import {
   formatComments,
   parsePositionalArgs,
   closureCheckMessages,
+  resolveRepoName,
   __resetLinearReposCache,
 } from "./linear.mjs";
 
@@ -382,4 +383,62 @@ test("no new call site imports gql outside lib/control-plane and the reaper tran
       return !GQL_IMPORT_ALLOWED.has(file) && !file.endsWith(".test.mjs");
     });
   expect(hits).toEqual([]);
+});
+
+// ------------------------------------------------ repo resolution (WM-1007) ---
+// The CLI must know which repos.yaml entry an invocation is about, because
+// that entry decides which control plane the verb talks to. The worktree case
+// is the one that matters: every dispatched agent runs from
+// <worktree_root>/<TICKET>, never from `path`.
+test("resolveRepoName matches the checkout, the worktree root, and --repo", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "linear-reporesolve-"));
+  const previous = process.env.FACTORY_REPOS_ROOT;
+  try {
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const alphaPath = path.join(root, "alpha");
+    const alphaWt = path.join(root, "wt", "alpha");
+    const betaPath = path.join(root, "beta");
+    writeFileSync(
+      path.join(root, "config", "repos.yaml"),
+      `repos:\n  - name: alpha\n    path: ${alphaPath}\n    worktree_root: ${alphaWt}\n  - name: beta\n    path: ${betaPath}\n`,
+    );
+    process.env.FACTORY_REPOS_ROOT = root;
+    __resetLinearReposCache();
+
+    // cwd inside the checkout
+    expect(resolveRepoName({ cwd: alphaPath, repoFlag: undefined })).toBe(
+      "alpha",
+    );
+    expect(
+      resolveRepoName({ cwd: path.join(alphaPath, "lib"), repoFlag: undefined }),
+    ).toBe("alpha");
+    // cwd inside a WORKTREE — resolves via worktree_root, not path
+    expect(
+      resolveRepoName({
+        cwd: path.join(alphaWt, "WM-1007"),
+        repoFlag: undefined,
+      }),
+    ).toBe("alpha");
+    // a different repo
+    expect(resolveRepoName({ cwd: betaPath, repoFlag: undefined })).toBe("beta");
+    // nothing matches -> null, so the caller falls back to policy
+    expect(
+      resolveRepoName({ cwd: os.tmpdir(), repoFlag: undefined }),
+    ).toBeNull();
+    // an explicit flag wins over cwd
+    expect(resolveRepoName({ cwd: alphaPath, repoFlag: "beta" })).toBe("beta");
+    // a bad flag is the operator's mistake, not a silent fallback
+    expect(() => resolveRepoName({ cwd: alphaPath, repoFlag: "nope" })).toThrow(
+      /unknown --repo "nope"/,
+    );
+    // a prefix that is not a path boundary must not match
+    expect(
+      resolveRepoName({ cwd: `${alphaPath}-other`, repoFlag: undefined }),
+    ).toBeNull();
+  } finally {
+    if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previous;
+    __resetLinearReposCache();
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Fixes WM-1007

Part of the WM-1006 epic: making GitHub Issues the control plane for this repo without moving every other repo the factory manages.

## What

Control-plane selection was global — one `controlPlane.kind` in `config/policy.yaml` — while repos are per-entry in `config/repos.yaml`. So `watt-mind/factory` could not move to GitHub Issues without dragging coach-wattz, CLNT and OPS with it.

Adds a `control_plane:` key to a repo entry, with resolution most-specific-first:

1. an explicit `kind` option
2. `control_plane:` on the repos.yaml entry
3. `controlPlane.kind` in policy.yaml
4. `linear`

A repo that omits the key **inherits** rather than defaults, so adding it to one repo never moves another. An unknown repo name throws instead of falling back — a stale name would otherwise run tickets against the wrong tracker and report it as an empty queue.

## Notes for the reviewer

- **`repoName`, not `repo`.** `loadControlPlane` already had a `repo` option meaning the github adapter's `owner/name` slug. Reusing it would have changed that meaning, so the registry key is a separate option.
- **cwd resolution matches `worktree_root` too.** Every dispatched agent runs from `<worktree_root>/<TICKET>`, never from `path`, so matching `path` alone would resolve to null in the case that matters most and silently fall back to the workspace-wide plane. Longest prefix wins.
- **`--repo` was never actually implemented** despite being documented in the CLI header; it is now, and validates its argument.
- **No `repoName` = no registry read.** The global path is byte-identical to before and does not depend on repos.yaml existing.
- `reposView()` deliberately does *not* publish the field — that touches an exact-shape contract test outside this ticket's Owned Paths. Filed as WM-1017.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 event-runtime/lib tools/linear.test.mjs && bun run lint && bun run check
```

- Tests on touched files: 105 pass, 0 fail
- Lint: 0 errors, 616 warnings — identical to the `develop` baseline, ratchet is 627
- `bun run check`: ok — 90 generated files match shared/

**Pre-existing failure, not from this branch:** `event-runtime/lib/extensions.test.mjs` fails 6 tests on a clean unmodified `develop` (verified before any edit). The validator reports "escapes the extension directory" for a path that is inside but missing. Filed as WM-1016.

New tests were observed failing against the pre-fix `index.mjs` (4 of them) and the pre-fix `linear.mjs` worktree matching (1), so they are not vacuous.