### PR TITLE
fix(hooks): make the commit-msg ticket-reference pattern configurable

### DIFF
--- a/bin/check-commit-msg.sh
+++ b/bin/check-commit-msg.sh
@@ -5,9 +5,77 @@
 # locally, matching AGENTS.md / linear.md §6. Dependency-free bash regex —
 # no node_modules, <50ms — per the tier-4 hook rule in
 # docs/guides/code-security.md §4 (heavier checks belong in CI, not here).
+#
+# WM-1011: the accepted ticket-reference shapes are configuration, not a
+# literal. Two reasons, both about this repo going public:
+#
+#   1. The old pattern enumerated one workspace's tracker prefixes. An outside
+#      contributor working a GitHub issue has none of them, so their only way
+#      past the hook was FACTORY_NO_TICKET=1 — which trains everyone to bypass
+#      the check that exists to stop untracked commits.
+#   2. Those prefixes named internal team structure, including a client-facing
+#      one. A public script should not carry them, in code or in comments.
+#
+# The default accepts both `(ABC-123)` (any 2-5 letter tracker prefix, so no
+# specific workspace is named) and `(#123)` (GitHub issue form). Both at once
+# is deliberate: the WM-1006 cutover has a window where historical WM-* refs
+# and new #123 refs are both valid, and neither should need a hook edit.
 set -euo pipefail
 
 msg_file="${1:?usage: check-commit-msg.sh <path-to-COMMIT_EDITMSG>}"
+
+# Built-in default. Used verbatim in a fresh clone: config/policy.yaml is
+# gitignored, so the hook must work with no local config at all.
+DEFAULT_TICKET_PATTERNS=('\([A-Z]{2,5}-[0-9]+\)' '\(#[0-9]+\)')
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+policy_file="${FACTORY_COMMIT_MSG_CONFIG:-${script_dir}/../config/policy.yaml}"
+
+# Read commitMsg.ticketPatterns out of policy.yaml. awk is POSIX and always
+# present; "dependency-free" here means no node_modules and no install step,
+# not no coreutils. \047 is a single quote — spelled in octal so this stays a
+# single-quoted awk program with no shell quoting gymnastics.
+configured_patterns() {
+  [[ -r "$policy_file" ]] || return 0
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^commitMsg:[[:space:]]*$/ { in_cm = 1; next }
+    in_cm && /^[^[:space:]#]/ { in_cm = 0; in_tp = 0 }
+    in_cm && /^[[:space:]]+ticketPatterns:[[:space:]]*$/ { in_tp = 1; next }
+    in_tp && /^[[:space:]]*-[[:space:]]*/ {
+      line = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      gsub(/^["\047]+|["\047]+$/, "", line)
+      if (length(line)) print line
+      next
+    }
+    in_tp && /^[[:space:]]*[^[:space:]-]/ { in_tp = 0 }
+  ' "$policy_file" 2>/dev/null || true
+}
+
+ticket_patterns=()
+while IFS= read -r pattern; do
+  [[ -n "$pattern" ]] && ticket_patterns+=("$pattern")
+done < <(configured_patterns)
+# An unreadable or stanza-less policy.yaml means "no opinion", not "accept
+# nothing" — a config typo must not lock every commit out of the repo.
+if [[ ${#ticket_patterns[@]} -eq 0 ]]; then
+  ticket_patterns=("${DEFAULT_TICKET_PATTERNS[@]}")
+fi
+
+# Combine into one alternation, and build the human-readable list the error
+# messages show, so the message never drifts from what is enforced.
+ticket_re=""
+for pattern in "${ticket_patterns[@]}"; do
+  ticket_re+="${ticket_re:+|}(${pattern})"
+done
+accepted_display="$(
+  printf '%s\n' "${ticket_patterns[@]}" |
+    sed -e 's/\\(/(/g' -e 's/\\)/)/g' \
+      -e 's/\[A-Z\]{2,5}/ABC/' -e 's/\[0-9\]+/123/g' |
+    paste -sd' ' -
+)"
 
 # The subject is the first line that isn't a `#`-prefixed comment (git
 # strips these itself before the commit lands, but the hook sees the raw
@@ -39,7 +107,7 @@ if ! [[ "$subject" =~ $type_re ]]; then
 commit-msg: subject does not match conventional commit format.
 
   expected: type(scope): summary (ISSUE-ID)
-  example:  fix(scope): correct off-by-one in scheduler (WM-123)
+  example:  fix(scope): correct off-by-one in scheduler (ABC-123)
   got:      ${subject}
 
   allowed types: feat fix chore docs test refactor perf ci build style revert sec maint ui ui-ux spike epic
@@ -47,16 +115,16 @@ EOF
   exit 1
 fi
 
-ticket_re='\((WM|OPS|CLNT|CW|LAB)-[0-9]+\)'
 if ! [[ "$subject" =~ $ticket_re ]]; then
   if [[ "${FACTORY_NO_TICKET:-}" == "1" ]]; then
-    echo "commit-msg: warning: no ticket ref like (WM-123) in subject — allowed because FACTORY_NO_TICKET=1" >&2
+    echo "commit-msg: warning: no ticket ref in subject — allowed because FACTORY_NO_TICKET=1" >&2
     exit 0
   fi
   cat >&2 <<EOF
 commit-msg: subject is missing a ticket reference.
 
-  fix: append " (WM-123)" to the subject, or export FACTORY_NO_TICKET=1 for a deliberate no-ticket commit
+  accepted: ${accepted_display}
+  fix: append a ticket reference to the subject, or export FACTORY_NO_TICKET=1 for a deliberate no-ticket commit
   got: ${subject}
 EOF
   exit 1

--- a/bin/check-commit-msg.test.mjs
+++ b/bin/check-commit-msg.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
@@ -124,8 +124,107 @@ test("every allowed type is accepted with a ticket ref", () => {
   }
 });
 
-test("unknown ticket prefix is rejected", () => {
-  const r = run("fix(scope): thing (XX-1)\n");
-  expect(r.status).toBe(1);
-  expect(r.stderr).toContain("missing a ticket reference");
+// WM-1011: the hook no longer enumerates workspace team keys, so an
+// unrecognised-but-well-formed prefix like (XX-1) is now ACCEPTED on purpose —
+// which tracker a contributor uses is not this workspace's business. What
+// still gets rejected is anything not shaped like a ticket reference at all.
+test("a malformed ticket reference is still rejected", () => {
+  for (const subject of [
+    "fix(scope): thing (lower-1)", // not uppercase
+    "fix(scope): thing (TOOLONGPREFIX-1)", // over 5 letters
+    "fix(scope): thing (WM-)", // no number
+    "fix(scope): thing (123)", // no prefix and no #
+    "fix(scope): thing WM-1", // not parenthesised
+  ]) {
+    const r = run(`${subject}\n`);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("missing a ticket reference");
+  }
+});
+
+test("the default accepts any 2-5 letter tracker prefix, naming no workspace", () => {
+  for (const ref of ["(WM-1)", "(XX-1)", "(ENG-42)", "(ABCDE-7)"]) {
+    expect(run(`fix(scope): thing ${ref}\n`).status).toBe(0);
+  }
+});
+
+test("the default accepts the GitHub issue form", () => {
+  expect(run("fix(scope): thing (#123)\n").status).toBe(0);
+});
+
+test("both forms are accepted at once, for the cutover window", () => {
+  // WM-1006 Phase 3 has a period where historical WM-* refs and new #123 refs
+  // are both live. Neither should need a hook edit.
+  expect(run("fix(scope): historical (WM-999)\n").status).toBe(0);
+  expect(run("fix(scope): new work (#12)\n").status).toBe(0);
+});
+
+test("no private team key appears in the script or tracked example config", () => {
+  const script = readFileSync(SCRIPT, "utf8");
+  expect(script).not.toContain("CLNT");
+  expect(script).not.toMatch(/\(WM\|OPS/);
+  const example = readFileSync(
+    path.resolve(import.meta.dir, "..", "config", "policy.example.yaml"),
+    "utf8",
+  );
+  expect(example).not.toContain("CLNT");
+});
+
+test("ticketPatterns in policy.yaml replaces the default", () => {
+  const cfg = path.join(WORK_DIR, "policy-override.yaml");
+  writeFileSync(
+    cfg,
+    "merge:\n  max_fix_rounds: 2\ncommitMsg:\n  ticketPatterns:\n    - '\\(GH-[0-9]+\\)'\nconcurrency:\n  max_concurrent_merges: 1\n",
+  );
+  const env = { FACTORY_COMMIT_MSG_CONFIG: cfg };
+  expect(run("fix(s): thing (GH-9)\n", env).status).toBe(0);
+  // the built-in shapes are replaced, not merged
+  expect(run("fix(s): thing (WM-123)\n", env).status).toBe(1);
+  expect(run("fix(s): thing (#123)\n", env).status).toBe(1);
+  // the error message reports what is actually enforced
+  expect(run("fix(s): thing\n", env).stderr).toContain("(GH-123)");
+});
+
+test("multiple configured patterns are all accepted", () => {
+  const cfg = path.join(WORK_DIR, "policy-multi.yaml");
+  writeFileSync(
+    cfg,
+    "commitMsg:\n  ticketPatterns:\n    - '\\(GH-[0-9]+\\)'\n    - '\\(#[0-9]+\\)'\n",
+  );
+  const env = { FACTORY_COMMIT_MSG_CONFIG: cfg };
+  expect(run("fix(s): thing (GH-9)\n", env).status).toBe(0);
+  expect(run("fix(s): thing (#9)\n", env).status).toBe(0);
+  expect(run("fix(s): thing (WM-9)\n", env).status).toBe(1);
+});
+
+test("a missing or stanza-less config falls back to the default", () => {
+  const missing = {
+    FACTORY_COMMIT_MSG_CONFIG: path.join(WORK_DIR, "nope.yaml"),
+  };
+  expect(run("fix(s): thing (WM-1)\n", missing).status).toBe(0);
+  expect(run("fix(s): thing (#1)\n", missing).status).toBe(0);
+
+  const cfg = path.join(WORK_DIR, "policy-nostanza.yaml");
+  writeFileSync(cfg, "merge:\n  max_fix_rounds: 2\n");
+  const env = { FACTORY_COMMIT_MSG_CONFIG: cfg };
+  // "no opinion" must not mean "accept nothing" — a config typo must not lock
+  // every commit out of the repo.
+  expect(run("fix(s): thing (WM-1)\n", env).status).toBe(0);
+  expect(run("fix(s): thing\n", env).status).toBe(1);
+});
+
+test("FACTORY_NO_TICKET and the exemptions survive the rewrite", () => {
+  expect(run("fix(s): thing\n", { FACTORY_NO_TICKET: "1" }).status).toBe(0);
+  for (const subject of [
+    "Merge branch develop",
+    'Revert "fix(s): thing (WM-1)"',
+    "fixup! fix(s): thing",
+    "squash! fix(s): thing",
+    "build(deps): bump thing",
+  ]) {
+    expect(run(`${subject}\n`).status).toBe(0);
+  }
+  expect(run("whatever\n", { GIT_AUTHOR_NAME: "dependabot[bot]" }).status).toBe(
+    0,
+  );
 });

--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -32,6 +32,18 @@ forge:
 controlPlane:
   kind: linear
 
+commitMsg:
+  # Ticket-reference shapes the commit-msg hook accepts, as ERE alternatives.
+  # Omit the stanza to use the built-in default, which is exactly these two:
+  # any 2-5 letter tracker prefix, plus the GitHub issue form. Listing both is
+  # deliberate during a tracker cutover — historical `(ABC-123)` refs and new
+  # `(#123)` refs stay valid at the same time, with no hook edit.
+  #
+  # Setting this REPLACES the default rather than adding to it.
+  ticketPatterns:
+    - '\([A-Z]{2,5}-[0-9]+\)'
+    - '\(#[0-9]+\)'
+
 dispatch:
   owned_paths_collision: advisory
   owned_paths_conformance: advisory


### PR DESCRIPTION
Fixes WM-1011

Part of the WM-1006 epic (open-sourcing this repo).

## What

`bin/check-commit-msg.sh` hardcoded `\((WM|OPS|CLNT|CW|LAB)-[0-9]+\)`. Two problems once the repo is public:

1. **A contributor cannot satisfy it.** No valid prefix exists for someone working a GitHub issue, so the only way through was `FACTORY_NO_TICKET=1` — which trains everyone to bypass the check that exists to stop untracked commits.
2. **It leaked private vocabulary.** Those are internal team keys, one of them client-facing.

The accepted shapes now come from `config/policy.yaml` (`commitMsg.ticketPatterns`), defaulting to `(ABC-123)` (any 2–5 letter prefix, naming no workspace) **and** `(#123)` (GitHub form). Both at once is deliberate: the WM-1006 Phase 3 cutover has a window where historical `WM-*` refs and new `#123` refs are both live, and neither should need a hook edit.

## Notes for the reviewer

- **Behaviour change, on purpose:** the old test asserted `(XX-1)` was *rejected*. It is now accepted — which tracker a contributor uses is not this workspace's business. The replacement test covers what should still be rejected: lowercase, >5 letters, no number, unparenthesised, bare digits.
- **Stays dependency-free bash.** The hook runs from a git hook and from launchd with no install step. YAML is read with `awk` (POSIX, always present); `\047` is used for the single quote so the awk program needs no shell quoting gymnastics.
- **Fails open, not closed.** An unreadable or stanza-less policy.yaml means "no opinion" → built-in default. A config typo must not lock every commit out of the repo. Covered by a test.
- **The error message is derived from the active patterns**, so it cannot drift from what is enforced.
- `FACTORY_NO_TICKET=1` and every existing exemption (merge/revert/fixup/squash/build(deps)/dependabot) are unchanged, with a test pinning them.
- A test asserts no private team key appears in the script or in tracked example config. It caught my own explanatory comment naming one, which is why the comment now describes them generically.

## Verification

```
bun test --timeout 20000 bin/check-commit-msg.test.mjs && bun run lint
```

- 22 pass, 0 fail
- Lint: 0 errors, 616 warnings — identical to the `develop` baseline
- The 7 new tests were observed failing against the pre-fix script before the fix was applied, so they are not vacuous.
- This branch's own commit was validated by the rewritten hook.