### PR TITLE
fix(extensions): report missing in-tree paths correctly

### DIFF
--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -243,11 +243,15 @@ export function looksLikePackageName(value) {
 }
 
 function existingRealpath(p) {
-  try {
-    return realpathSync(p);
-  } catch {
-    return path.resolve(p);
+  const missing = [];
+  let current = path.resolve(p);
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(p);
+    missing.unshift(path.basename(current));
+    current = parent;
   }
+  return path.join(realpathSync(current), ...missing);
 }
 
 /**

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -1546,9 +1546,7 @@ describe("contributes.harness (WM-849)", () => {
 
     const out = validateExtensionManifest(linked);
     expect(out.valid).toBe(false);
-    expect(out.errors.join("\n")).toMatch(
-      /adapters\.echo .* is not a file/,
-    );
+    expect(out.errors.join("\n")).toMatch(/adapters\.echo .* is not a file/);
     expect(out.errors.join("\n")).toMatch(/harness\.floor .* is not a file/);
     expect(out.errors.join("\n")).toMatch(
       /hooks\["approve\.before"\] .* escapes the extension directory/,

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -1534,6 +1534,26 @@ describe("contributes.harness (WM-849)", () => {
     expect(out.errors.join("\n")).toMatch(/harness\.floor .* is not a file/);
     expect(out.errors.join("\n")).toMatch(/harness\.commands .* escapes/);
   });
+
+  test("missing in-tree paths stay in-tree through a symlinked extension root", () => {
+    const dir = tempExtension((m) => {
+      m.contributes.adapters = { echo: "./adapters/nope.mjs" };
+      m.contributes.hooks = { "approve.before": "../escape.mjs" };
+      m.contributes.harness = { floor: "./missing.md" };
+    });
+    const linked = path.join(tmpDir("event-extension-link-"), "extension");
+    symlinkSync(dir, linked, "dir");
+
+    const out = validateExtensionManifest(linked);
+    expect(out.valid).toBe(false);
+    expect(out.errors.join("\n")).toMatch(
+      /adapters\.echo .* is not a file/,
+    );
+    expect(out.errors.join("\n")).toMatch(/harness\.floor .* is not a file/);
+    expect(out.errors.join("\n")).toMatch(
+      /hooks\["approve\.before"\] .* escapes the extension directory/,
+    );
+  });
 });
 
 describe("extension packages (WM-922)", () => {


### PR DESCRIPTION
Fixes WM-1016

UX critique: skipped — backend-only extension manifest validation; no user-facing flow.