### PR TITLE
fix(cli): banner states Apache-2.0 instead of claiming proprietary (WM-1029)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -42,10 +42,10 @@ show_banner() {
   echo '  ║   ██║     ██║  ██║╚██████╗   ██║   ╚██████╔╝██║  ██║   ██║    ║'
   echo '  ║   ╚═╝     ╚═╝  ╚═╝ ╚═════╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝   ╚═╝    ║'
   echo '  ║                                                               ║'
-  _pad "${_d}Agent control plane · Linear · dispatch · merge${_r}"
+  _pad "${_d}A runtime for self-improving agentic loops${_r}"
   echo '  ║                                                               ║'
-  _pad "${_m}▸ Proprietary software of Watt Mind${_r}"
-  _pad "${_d}Unauthorized use or distribution is prohibited.${_r}"
+  _pad "${_m}▸ Apache-2.0 · github.com/watt-mind/factory${_r}"
+  _pad "${_d}New here? Run: factory demo${_r}"
   echo '  ║                                                               ║'
   echo '  ╚═══════════════════════════════════════════════════════════════╝'
   printf '%s\n' "$_r"


### PR DESCRIPTION
Fixes WM-1029

`bin/factory` greeted every visitor of the now-public, Apache-2.0 repo with:

```
  ▸ Proprietary software of Watt Mind
  Unauthorized use or distribution is prohibited.
```

Clone, run the CLI, get told you are not allowed to use it. That contradicts
`LICENSE`, `README.md`, and the repo's own Apache-2.0 metadata.

Same banner, same three lines: the tagline `Agent control plane · Linear ·
dispatch · merge` hard-wired Linear, which contradicts the `ControlPlane`
adapter story (Linear is v1; GitHub Issues is the first roadmap adapter).

Now:

```
  ║   A runtime for self-improving agentic loops                  ║
  ║                                                               ║
  ║   ▸ Apache-2.0 · github.com/watt-mind/factory                 ║
  ║   New here? Run: factory demo                                 ║
```

Padding structure is untouched, so box alignment behaves exactly as before.

**Verification**

```
$ bin/factory --help | grep -iE 'proprietary|unauthorized'   # no match
$ bun test bin/factory.test.mjs
 12 pass  0 fail  38 expect() calls
```