### PR TITLE
fix(runtime): restore ai:agent-ready when releasing a claim back to Todo

### DIFF
--- a/event-runtime/lib/unclaim.test.mjs
+++ b/event-runtime/lib/unclaim.test.mjs
@@ -1,0 +1,249 @@
+/**
+ * Release-path regressions (WM-1024).
+ *
+ * On 2026-08-22 three tickets (WM-1008, WM-1015, WM-534) were released back
+ * to `Todo` after transient test failures and silently left the queue. The
+ * dispatchable predicate is `Todo` + `ai:agent-ready` + unassigned
+ * (docs/protocol.md §4); the release dropped `ai:in-progress` and stopped,
+ * so the tickets read `Todo` on every board while being invisible to every
+ * dispatcher. WM-1015's agent even wrote "Returning to Todo + ai:agent-ready"
+ * in its own comment — the prose was right, the mutation was not.
+ *
+ * These assert the resulting LABEL SET, not that some mutation ran. "It
+ * called the CLI" was already true of the broken version.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  AGENT_READY_LABEL,
+  BLOCKED_LABEL,
+  IN_PROGRESS_LABEL,
+  claimLabels,
+  releaseLabels,
+} from "../../lib/control-plane/labels.mjs";
+import { computeUnclaimAction } from "../../orchestrator/tick.mjs";
+import { defaultUnclaimTicket } from "./worker.mjs";
+
+/** Apply an {add, remove} change the way a complete-set tracker update does. */
+function applyChange(currentNames, { add = [], remove = [] }) {
+  const dropped = new Set(remove);
+  return [...new Set([...currentNames.filter((n) => !dropped.has(n)), ...add])];
+}
+
+const CLAIMED = [
+  "type:feature",
+  "area:architecture",
+  "source:human",
+  IN_PROGRESS_LABEL,
+  "agent:pi",
+];
+
+describe("releaseLabels", () => {
+  test("release to Todo yields a DISPATCHABLE ticket", () => {
+    const after = applyChange(CLAIMED, releaseLabels(CLAIMED, { to: "Todo" }));
+    // The whole bug, in one assertion.
+    expect(after).toContain(AGENT_READY_LABEL);
+    expect(after).not.toContain(IN_PROGRESS_LABEL);
+    expect(after.filter((n) => n.startsWith("agent:"))).toEqual([]);
+    // Non-lifecycle labels a human curated are untouched.
+    expect(after).toContain("type:feature");
+    expect(after).toContain("area:architecture");
+    expect(after).toContain("source:human");
+  });
+
+  test("Todo is the default target", () => {
+    expect(releaseLabels(CLAIMED)).toEqual(
+      releaseLabels(CLAIMED, { to: "Todo" }),
+    );
+  });
+
+  test("release to Blocked must NOT re-enter the queue", () => {
+    const after = applyChange(
+      CLAIMED,
+      releaseLabels(CLAIMED, { to: "Blocked" }),
+    );
+    expect(after).toContain(BLOCKED_LABEL);
+    // A blocked ticket waits for a human; agent-ready would loop it.
+    expect(after).not.toContain(AGENT_READY_LABEL);
+    expect(after).not.toContain(IN_PROGRESS_LABEL);
+    expect(after.filter((n) => n.startsWith("agent:"))).toEqual([]);
+  });
+
+  test("releasing a Blocked ticket to Todo clears ai:blocked", () => {
+    const blocked = ["type:bug", BLOCKED_LABEL];
+    const after = applyChange(blocked, releaseLabels(blocked, { to: "Todo" }));
+    expect(after).toContain(AGENT_READY_LABEL);
+    expect(after).not.toContain(BLOCKED_LABEL);
+  });
+
+  test("is idempotent — a double release does not accumulate labels", () => {
+    const once = applyChange(CLAIMED, releaseLabels(CLAIMED, { to: "Todo" }));
+    const twice = applyChange(once, releaseLabels(once, { to: "Todo" }));
+    expect(twice.sort()).toEqual(once.sort());
+  });
+
+  test("strips EVERY agent:* label, not just the current harness", () => {
+    const messy = [...CLAIMED, "agent:claude-code", "agent:codex"];
+    const after = applyChange(messy, releaseLabels(messy, { to: "Todo" }));
+    expect(after.filter((n) => n.startsWith("agent:"))).toEqual([]);
+  });
+
+  test("is the exact inverse of claimLabels", () => {
+    const base = ["type:feature", "source:human", AGENT_READY_LABEL];
+    const claimed = applyChange(base, claimLabels(base, "pi"));
+    expect(claimed).toContain(IN_PROGRESS_LABEL);
+    expect(claimed).toContain("agent:pi");
+    expect(claimed).not.toContain(AGENT_READY_LABEL);
+
+    const released = applyChange(
+      claimed,
+      releaseLabels(claimed, { to: "Todo" }),
+    );
+    expect(released.sort()).toEqual(base.sort());
+  });
+});
+
+describe("the two release implementations agree (WM-1024)", () => {
+  // orchestrator/tick.mjs already did this correctly; event-runtime's worker
+  // did not. They drifted because each rolled its own. This pins them
+  // together so the next divergence fails a test instead of eating tickets.
+  const issue = {
+    labels: {
+      nodes: [
+        { id: "l-type", name: "type:feature" },
+        { id: "l-src", name: "source:human" },
+        { id: "l-prog", name: IN_PROGRESS_LABEL },
+        { id: "l-agent", name: "agent:pi" },
+      ],
+    },
+    comments: { nodes: [] },
+  };
+  const allLabels = [
+    { id: "l-type", name: "type:feature" },
+    { id: "l-src", name: "source:human" },
+    { id: "l-prog", name: IN_PROGRESS_LABEL },
+    { id: "l-agent", name: "agent:pi" },
+    { id: "l-ready", name: AGENT_READY_LABEL },
+    { id: "l-blocked", name: BLOCKED_LABEL },
+  ];
+  const nameOf = (id) => allLabels.find((l) => l.id === id)?.name;
+  const currentNames = issue.labels.nodes.map((l) => l.name);
+
+  test("tick.mjs unclaim produces the same set as releaseLabels(Todo)", () => {
+    const action = computeUnclaimAction({
+      issue,
+      why: "transient failure",
+      todoStateId: "s-todo",
+      blockedStateId: "s-blocked",
+      allLabels,
+    });
+    expect(action.repeated).toBe(false);
+    expect(action.labelIds.map(nameOf).sort()).toEqual(
+      applyChange(
+        currentNames,
+        releaseLabels(currentNames, { to: "Todo" }),
+      ).sort(),
+    );
+  });
+
+  test("tick.mjs repeated-failure demotion matches releaseLabels(Blocked)", () => {
+    const action = computeUnclaimAction({
+      issue,
+      why: "transient failure",
+      todoStateId: "s-todo",
+      blockedStateId: "s-blocked",
+      allLabels,
+      threshold: 1,
+    });
+    expect(action.repeated).toBe(true);
+    expect(action.labelIds.map(nameOf).sort()).toEqual(
+      applyChange(
+        currentNames,
+        releaseLabels(currentNames, { to: "Blocked" }),
+      ).sort(),
+    );
+  });
+});
+
+describe("worker defaultUnclaimTicket (the actual defect)", () => {
+  // This is the test that would have caught it. The helper tests above
+  // cannot fail against the old code, because releaseLabels did not exist —
+  // this one drives the real release path and asserts the argv it builds.
+  const claimedTicket = {
+    state: { name: "In Progress" },
+    labels: [
+      { name: "type:feature" },
+      { name: "source:human" },
+      { name: IN_PROGRESS_LABEL },
+      { name: "agent:pi" },
+    ],
+  };
+
+  function release(ticket = claimedTicket) {
+    const calls = [];
+    const ok = defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-1008",
+      why: "verification timed out",
+      fetchTicket: () => ticket,
+      runCli: (args) => {
+        calls.push(args);
+        return "";
+      },
+    });
+    return { ok, calls };
+  }
+
+  test("re-adds ai:agent-ready so the ticket is dispatchable again", () => {
+    const { ok, calls } = release();
+    expect(ok).toBe(true);
+    const state = calls.find((a) => a[0] === "state");
+    expect(state).toBeDefined();
+    expect(state).toContain("Todo");
+    expect(state).toContain("--unassign");
+    // The regression, precisely: this pair was missing.
+    expect(state.join(" ")).toContain(`--add ${AGENT_READY_LABEL}`);
+    expect(state.join(" ")).toContain(`--remove ${IN_PROGRESS_LABEL}`);
+  });
+
+  test("strips the stale agent:* label", () => {
+    const { calls } = release();
+    const state = calls.find((a) => a[0] === "state");
+    expect(state.join(" ")).toContain("--remove agent:pi");
+  });
+
+  test("the resulting label set matches releaseLabels exactly", () => {
+    const { calls } = release();
+    const state = calls.find((a) => a[0] === "state");
+    const names = claimedTicket.labels.map((l) => l.name);
+    const { add, remove } = releaseLabels(names, { to: "Todo" });
+    for (const n of add) expect(state.join(" ")).toContain(`--add ${n}`);
+    for (const n of remove) expect(state.join(" ")).toContain(`--remove ${n}`);
+  });
+
+  test("the posted comment states the ticket is agent-ready again", () => {
+    const { calls } = release();
+    const comment = calls.find((a) => a[0] === "comment");
+    expect(comment[2]).toContain(AGENT_READY_LABEL);
+  });
+
+  test("refuses to release a ticket it does not hold", () => {
+    expect(release({ state: { name: "Todo" }, labels: [] }).ok).toBe(false);
+    expect(
+      release({
+        state: { name: "In Progress" },
+        labels: [{ name: "type:feature" }],
+      }).ok,
+    ).toBe(false);
+  });
+
+  test("tolerates the GraphQL nodes label shape (WM-978)", () => {
+    const { ok, calls } = release({
+      state: { name: "In Progress" },
+      labels: { nodes: [{ name: IN_PROGRESS_LABEL }, { name: "agent:pi" }] },
+    });
+    expect(ok).toBe(true);
+    expect(calls.find((a) => a[0] === "state").join(" ")).toContain(
+      `--add ${AGENT_READY_LABEL}`,
+    );
+  });
+});

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -33,6 +33,7 @@ import {
   writeWorkerLease,
 } from "../../lib/worker-leases.mjs";
 import { loadForge } from "../../lib/forge/index.mjs";
+import { releaseLabels } from "../../lib/control-plane/labels.mjs";
 import { storeCollected, storeResultArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT, resolveConfigPath } from "./config.mjs";
@@ -1496,13 +1497,23 @@ function defaultClaimTicket({ repo, ticket, harness = "claude" }) {
   }
 }
 
-function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
+// `runCli` is the test seam, mirroring the `fetchTicket` injection already
+// here: the interesting behaviour is the exact argv this builds (WM-1024),
+// and asserting "some mutation ran" was already true of the broken version.
+export function defaultUnclaimTicket({
+  repo,
+  ticket,
+  why,
+  log = null,
+  fetchTicket,
+  runCli = runLinearCli,
+}) {
   try {
     let cur = null;
     if (typeof fetchTicket === "function") {
       cur = fetchTicket(ticket);
     } else {
-      const out = runLinearCli(["get", ticket, "--json"]);
+      const out = runCli(["get", ticket, "--json"]);
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
@@ -1512,16 +1523,26 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
     )
       return false;
 
-    runLinearCli([
+    // WM-1024: `Todo` + unassigned is NOT dispatchable — the predicate in
+    // docs/protocol.md §4 also requires `ai:agent-ready`. This path used to
+    // drop `ai:in-progress` and stop there, which did not re-queue the ticket
+    // but hid it: the board still read `Todo`, and no dispatcher ever picked
+    // it up again. Also strips the stale `agent:*` label, which otherwise
+    // claims a harness still holds work it has given up.
+    const currentNames = (
+      Array.isArray(cur.labels) ? cur.labels : (cur.labels?.nodes ?? [])
+    ).map((l) => l.name);
+    const { add, remove } = releaseLabels(currentNames, { to: "Todo" });
+    runCli([
       "state",
       ticket,
       "Todo",
       "--unassign",
-      "--remove",
-      "ai:in-progress",
+      ...add.flatMap((n) => ["--add", n]),
+      ...remove.flatMap((n) => ["--remove", n]),
     ]);
-    const body = `Dispatch run failed, claim released back to Todo.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}`;
-    runLinearCli(["comment", ticket, body]);
+    const body = `Dispatch run failed, claim released back to Todo + ai:agent-ready.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}`;
+    runCli(["comment", ticket, body]);
     return true;
   } catch {
     return false;

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -21,6 +21,7 @@ export const SOURCE_LABELS = ["agent", "human", "sentry", "client-support"];
 
 export const AGENT_READY_LABEL = "ai:agent-ready";
 export const IN_PROGRESS_LABEL = "ai:in-progress";
+export const BLOCKED_LABEL = "ai:blocked";
 
 /** Reject label typos before the tracker does, with a useful message. */
 export function validateLabels(names) {
@@ -77,6 +78,43 @@ export function claimLabels(currentNames, harness) {
       AGENT_READY_LABEL,
       ...currentNames.filter((n) => n.startsWith("agent:") && n !== mine),
     ],
+  };
+}
+
+/**
+ * The exact inverse of {@link claimLabels}: give the ticket back (WM-1024).
+ *
+ * `to: "Todo"` must produce a **dispatchable** ticket — `Todo` + no assignee
+ * is not enough, the dispatchable predicate (docs/protocol.md §4) also
+ * requires `ai:agent-ready`. Releasing without it does not re-queue the
+ * ticket, it makes it invisible: the board still shows `Todo`, every view
+ * looks healthy, and no dispatcher will ever pick it up again. Three tickets
+ * (WM-1008, WM-1015, WM-534) were lost this way in one night, each after a
+ * transient test failure.
+ *
+ * `to: "Blocked"` is the opposite requirement: `ai:blocked` and explicitly
+ * NOT `ai:agent-ready`, or a ticket a human must look at re-enters the queue
+ * and loops.
+ *
+ * Both drop every `agent:*` label. A stale one claims a harness still holds
+ * work it has already given up, which is what made the casualties look
+ * claimed rather than dropped.
+ *
+ * @param {string[]} currentNames
+ * @param {{ to?: "Todo"|"Blocked" }} [opts]
+ * @returns {{ add: string[], remove: string[] }}
+ */
+export function releaseLabels(currentNames, { to = "Todo" } = {}) {
+  const staleAgents = currentNames.filter((n) => n.startsWith("agent:"));
+  if (to === "Blocked") {
+    return {
+      add: [BLOCKED_LABEL],
+      remove: [IN_PROGRESS_LABEL, AGENT_READY_LABEL, ...staleAgents],
+    };
+  }
+  return {
+    add: [AGENT_READY_LABEL],
+    remove: [IN_PROGRESS_LABEL, BLOCKED_LABEL, ...staleAgents],
   };
 }
 


### PR DESCRIPTION
Fixes WM-1024

## The bug

`Todo` + unassigned is **not** dispatchable. The predicate (`docs/protocol.md` §4) also requires `ai:agent-ready`. `defaultUnclaimTicket()` in `event-runtime/lib/worker.mjs` ran:

```
state <ticket> Todo --unassign --remove ai:in-progress
```

and stopped. So a released ticket did not go back in the queue — it went **invisible**. The board still read `Todo`, every view looked healthy, and no dispatcher would ever pick it up again.

Three tickets were lost this way in one night (WM-1008, WM-1015, WM-534), each after a transient test timeout unrelated to its own diff. WM-1015 is the clearest: its agent's comment says verbatim *"Returning to Todo + ai:agent-ready"* — the prose was right, the mutation was not.

## The cause

Two independent release implementations that drifted:

- `orchestrator/tick.mjs:105` `computeUnclaimAction()` — **already correct**: strips `ai:in-progress`, `agent:*`, `ai:agent-ready`, `ai:blocked`, then adds back `ai:agent-ready` (or `ai:blocked` past the repeat threshold).
- `event-runtime/lib/worker.mjs` `defaultUnclaimTicket()` — the broken twin.
- A third path (`worker.mjs:2841`, handoff return) already restored agent-ready and even reported `agentReadyRestored: false` on failure. The correct behaviour was known; it was just missing from the dispatch-failure path.

## The fix

`releaseLabels(currentNames, { to })` in `lib/control-plane/labels.mjs`, the exact inverse of the existing `claimLabels()`, used by the broken path.

- `to: "Todo"` → add `ai:agent-ready`, remove `ai:in-progress`, `ai:blocked`, and **every** `agent:*`
- `to: "Blocked"` → add `ai:blocked`, and explicitly **not** `ai:agent-ready`, so a ticket awaiting a human cannot loop back into the queue

## Notes for the reviewer

- **`orchestrator/tick.mjs` is deliberately untouched.** It is already correct and WM-1008 owns it. Instead the test suite imports `computeUnclaimAction` read-only and asserts it produces the same label set as `releaseLabels`, for both the Todo and Blocked branches — so the two cannot drift again without failing a test. Adopting the helper inside tick.mjs is a follow-up, not a prerequisite.
- **`defaultUnclaimTicket` is now exported with a `runCli` seam.** The interesting behaviour is the exact argv it builds; asserting "some mutation ran" was already true of the broken version. The seam matches the `fetchTicket` injection already in that function and the `runCli` pattern already used elsewhere in the same file.
- **Owned Paths were corrected before implementation.** As filed, this ticket owned the helper but not `worker.mjs` — the same unsatisfiable shape that made WM-1010 fail three times. The regression lives in a new `unclaim.test.mjs` rather than `worker.test.mjs` specifically because WM-1025 owns that file and is running concurrently.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 lib/control-plane event-runtime/lib/control-plane.test.mjs event-runtime/lib/unclaim.test.mjs && bun run format:check && bun run lint
```

- 80 pass, 0 fail
- `event-runtime/lib/worker.test.mjs` + `orchestrator/tick.test.mjs`: 128 pass, 0 fail (unchanged by the seam)
- format:check clean; lint 0 errors, 616 warnings = `develop` baseline

**Falsifiability:** with the old release logic restored, 4 of the new tests fail. The helper-level tests alone could not have proven this — `releaseLabels` did not exist before — which is why the suite drives the real release path.