### PR TITLE
fix(tests): scale execute-side subprocess ceilings with host load

### DIFF
--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,5 +1,22 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-worker-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
+
+/**
+ * Ceiling for the execute-side adapter spawn tests (WM-1025).
+ *
+ * These spawn a real CLI subprocess. 5s is comfortable on a quiet machine and
+ * demonstrably not comfortable on a contended one: on 2026-08-22 four of these
+ * timed out under concurrent runners and took WM-1008, WM-1015 and WM-534 out
+ * of the queue with them — WM-1015 was a documentation-only diff that could
+ * not merge because of it.
+ *
+ * `loadAdjustedTimeout` is the repo's existing answer (CI sets CI_LOAD_FACTOR,
+ * capped at 4x). This file was simply not wired into it. Scaling a liveness
+ * ceiling changes no assertion: every check below still waits on observable
+ * state, so a real hang still fails, just not a slow host.
+ */
+const EXECUTE_SPAWN_TIMEOUT_MS = loadAdjustedTimeout(5_000);
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
@@ -1468,7 +1485,7 @@ describe("worker", () => {
       spec,
       def,
       workspaceDir: claudeWorkspace,
-      timeoutMs: 5_000,
+      timeoutMs: EXECUTE_SPAWN_TIMEOUT_MS,
       env: {
         PATH: `${bin}${path.delimiter}${process.env.PATH}`,
         FACTORY_TEST_ARGV: claudeArgv,
@@ -1491,7 +1508,7 @@ describe("worker", () => {
       spec,
       def,
       workspaceDir: piWorkspace,
-      timeoutMs: 5_000,
+      timeoutMs: EXECUTE_SPAWN_TIMEOUT_MS,
       env: {
         PATH: `${bin}${path.delimiter}${process.env.PATH}`,
         FACTORY_TEST_ARGV: piArgv,
@@ -5537,5 +5554,48 @@ describe("defaultReturnHandoffTicket (WM-718 F2)", () => {
     });
     expect(result).toBe(false);
     expect(calls).toHaveLength(0);
+  });
+});
+
+// ------------------------------------------ liveness-ceiling invariant ---
+// WM-1025. Same shape as the GQL_IMPORT_ALLOWED grep invariant in
+// tools/linear.test.mjs: the bug was not that 5s is the wrong number, it was
+// that these call sites bypassed the load-adjustment mechanism the repo
+// already had. A number typed inline cannot scale, and the next one typed
+// inline will not either — so guard the pattern, not the value.
+describe("subprocess liveness ceilings scale with host load (WM-1025)", () => {
+  const SOURCES = [
+    "event-runtime/lib/worker.test.mjs",
+    "event-runtime/work.test.mjs",
+  ];
+
+  test("no raw sub-30s timeoutMs literal bypasses loadAdjustedTimeout", () => {
+    const root = path.resolve(import.meta.dir, "..", "..");
+    const offenders = [];
+    for (const rel of SOURCES) {
+      const file = path.join(root, rel);
+      if (!existsSync(file)) continue;
+      readFileSync(file, "utf8")
+        .split("\n")
+        .forEach((line, i) => {
+          // `timeoutMs: 25` style intentional-hang probes are far below the
+          // range that host contention affects; only flag plausible liveness
+          // ceilings (1s..30s) written as bare literals.
+          const m = line.match(/timeoutMs:\s*([0-9][0-9_]*)\s*,/);
+          if (!m) return;
+          const ms = Number(m[1].replace(/_/g, ""));
+          if (ms < 1_000 || ms > 30_000) return;
+          if (line.includes("loadAdjustedTimeout")) return;
+          offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
+        });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("the execute-side ceiling actually scales", () => {
+    // Guards the wiring itself: a constant that ignores CI_LOAD_FACTOR would
+    // satisfy the grep above while still pinning the timeout at 5s.
+    expect(EXECUTE_SPAWN_TIMEOUT_MS).toBe(loadAdjustedTimeout(5_000));
+    expect(EXECUTE_SPAWN_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
   });
 });


### PR DESCRIPTION
Fixes WM-1025

## What happened

Three tickets failed to ship on 2026-08-22 for reasons unrelated to their own diffs — WM-1008, WM-1015, WM-534 — all citing execute-side dispatch hardening tests timing out at 5s under concurrent runners. WM-1015 is the sharpest case: a **documentation-only** change could not merge.

Combined with WM-1024 (release dropped `ai:agent-ready`), each of those failures also removed the ticket from the queue entirely.

## The defect

`event-runtime/lib/worker.test.mjs` spawns real CLI subprocesses with `timeoutMs: 5_000` written inline, twice.

The repo already has the mechanism for exactly this: `loadAdjustedTimeout()` in `event-runtime/lib/test-helpers-timing.mjs`, driven by `CI_LOAD_FACTOR` (set by all three CI lanes, capped at 4x) and already used by `demo/seed.test.mjs` and `cli/work.test.mjs`.

`worker.test.mjs` **never imported it at all**. Not a wrong constant — a call site outside the mechanism.

## The fix

Route both ceilings through `loadAdjustedTimeout(5_000)` via a named `EXECUTE_SPAWN_TIMEOUT_MS`, and add a grep invariant — the same shape as the existing `GQL_IMPORT_ALLOWED` guard in `tools/linear.test.mjs` — that fails on any bare 1s–30s `timeoutMs:` literal in these files. The bug was the pattern, not the number, and the next inline number would have had the same problem.

No assertion changed. Every check still waits on observable state, so a genuine hang still fails — a slow host no longer does.

## Honest limitation, please read

**I could not reproduce the original race on this machine.** 10 cores, and it survived 6 concurrent suites plus 5 CPU-burn processes. So this fix is justified by the *mechanism* being provably bypassed, not by a captured repro. If the timeouts recur in CI, the next step is raising the base 5s, not re-plumbing.

One data point in passing: across 6 runs of the full `worker.test.mjs` + `work.test.mjs` gate, **one run failed once** and I could not capture which test before it passed again on all 4 subsequent runs. So there is at least one more intermittent failure in this suite that this PR does not address.

Out of scope, spotted nearby: `event-runtime/cli/process-cleanup.test.mjs` has `waitForFile`/`waitForExit` defaulting to 5_000 without load adjustment. Outside this ticket's Owned Paths.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/worker.test.mjs event-runtime/work.test.mjs && bun run format:check && bun run lint
```

- 149 pass, 0 fail (including WM-1024's `unclaim.test.mjs`, merged into this branch)
- Passes with `CI_LOAD_FACTOR=4`
- format:check clean; lint 0 errors, 616 warnings = `develop` baseline

**Falsifiability:** restoring the raw `5_000` literals fails the new invariant, and it names both offending lines (1488, 1511).