### PR TITLE
fix(tools): dogfood badge block is prettier-clean so the weekly commit keeps develop green (WM-1031)

### DIFF
--- a/tools/update-dogfood-badge.mjs
+++ b/tools/update-dogfood-badge.mjs
@@ -106,10 +106,16 @@ export function shieldsBadgeUrl(count) {
   return `https://img.shields.io/static/v1?${params.toString()}`;
 }
 
+/**
+ * The blank lines around the badge are the Prettier contract, not decoration
+ * (WM-1031). CI runs `prettier --check .` over README.md, and the weekly job
+ * commits its rewrite straight to `develop`; a block Prettier would reformat
+ * turns the base branch red every week from a commit nobody is watching.
+ */
 export function renderBadgeBlock(count, { repo = DEFAULT_REPO } = {}) {
   const img = shieldsBadgeUrl(count);
   const href = `https://github.com/${repo}/pulls?q=is%3Apr+is%3Amerged`;
-  return `${BADGE_START}\n[![${BADGE_LABEL}](${img})](${href})\n${BADGE_END}`;
+  return `${BADGE_START}\n\n[![${BADGE_LABEL}](${img})](${href})\n\n${BADGE_END}`;
 }
 
 function escapeRegExp(s) {

--- a/tools/update-dogfood-badge.test.mjs
+++ b/tools/update-dogfood-badge.test.mjs
@@ -115,6 +115,18 @@ test("applyBadgeToReadme is idempotent for the same count", () => {
   expect(applyBadgeToReadme(once, 4)).toBe(once);
 });
 
+test("the rewritten README survives prettier untouched (WM-1031)", async () => {
+  const prettier = (await import("prettier")).default;
+  const readme = applyBadgeToReadme(
+    "# factory\n\n**A tagline.**\n\nBody paragraph.\n",
+    742,
+  );
+  const options = { ...(await prettier.resolveConfig(import.meta.dir)) };
+  expect(
+    await prettier.format(readme, { ...options, parser: "markdown" }),
+  ).toBe(readme);
+});
+
 test("shields payload matches the endpoint schema", () => {
   const payload = shieldsEndpointPayload(12);
   expect(payload).toEqual({


### PR DESCRIPTION
Fixes WM-1031

`.github/workflows/update-badge.yml` runs weekly (`0 0 * * 0`, first fire
2026-08-23) with `contents: write` and commits `README.md` straight to
`develop`. A push to `develop` runs CI, and CI runs `bun run format:check`
(`prettier --check .`).

`renderBadgeBlock` emitted a block Prettier reformats — it wants a blank line
after the opening marker. So the first badge commit would have failed the
formatting gate and turned the base branch red, from a commit nobody is
watching, every week.

The block now carries the blank lines Prettier expects, with a comment saying
why they are load-bearing, and a test that formats the rewritten README with
the repo's own Prettier config and asserts it comes back byte-identical.

**Verification**

```
$ bun test tools/update-dogfood-badge.test.mjs
 16 pass  0 fail  50 expect() calls

$ npx prettier --check tools/update-dogfood-badge.mjs tools/update-dogfood-badge.test.mjs
All matched files use Prettier code style!

$ # end-to-end against the restructured README from #809
$ bun tools/update-dogfood-badge.mjs --readme /tmp/badge-fmt.md --repo watt-mind/factory
$ npx prettier --check /tmp/badge-fmt.md
All matched files use Prettier code style!
$ diff <(git show origin/docs/WM-1030-readme-restructure:README.md) /tmp/badge-fmt.md
# only the count line differs (742 → 743) — structure identical, no churn
```