### PR TITLE
feat(control-plane): put priority and blocked-by in the ControlPlane contract

### DIFF
--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -129,7 +129,34 @@ function toLinearIssue(t) {
     project: t.project,
     labels: { nodes: t.labels ?? [] },
     comments: { nodes: t.comments ?? [] },
+    // WM-1008. The seed writes priority/createdAt flat and blockers as plain
+    // identifiers; this is where they take Linear's wire shape, so the SAME
+    // fixture drives both the memory fake and the Linear adapter.
+    priority: t.priority ?? 0,
+    createdAt: t.createdAt ?? "",
+    inverseRelations: {
+      nodes: (t.blockedBy ?? []).map((id) => ({
+        type: "blocks",
+        issue: {
+          identifier: id,
+          state: { type: stateTypeOfSeed(id) },
+        },
+      })),
+    },
   };
+}
+
+/** Linear state `type` of a seeded blocker, resolved from the shared seed. */
+let SEED_FOR_RELATIONS = null;
+function stateTypeOfSeed(identifier) {
+  const t = SEED_FOR_RELATIONS?.tickets?.find(
+    (x) => x.identifier === identifier,
+  );
+  const name = (t?.state?.name ?? "").toLowerCase();
+  if (!t) return "started"; // unknown blocker: fail closed, stays blocking
+  if (["done"].includes(name)) return "completed";
+  if (["canceled", "duplicate"].includes(name)) return "canceled";
+  return t.state?.type ?? "started";
 }
 
 /**
@@ -137,6 +164,7 @@ function toLinearIssue(t) {
  * implementations can be asserted through the same fixture.
  */
 function fakeGql(seed) {
+  SEED_FOR_RELATIONS = seed;
   const gql = async (query, variables = {}) => {
     gql.calls.push({ query, variables });
     const q = String(query).replace(/\s+/g, " ");
@@ -239,14 +267,21 @@ function fakeGql(seed) {
     }
 
     if (q.includes("issues(")) {
+      // WM-1008: listTickets sends either an explicit state-name list ($s) or
+      // a "not finished" type filter. Assignee is NOT filtered server-side any
+      // more — listDispatchable applies that, so the fake must return claimed
+      // tickets too or the dispatcher can never see In Progress work.
       const team = variables.t;
       const project = variables.p;
+      const wanted = variables.s?.length
+        ? new Set(variables.s.map((n) => String(n).toLowerCase()))
+        : null;
       const nodes = seed.tickets.filter((t) => {
         if ((t.team?.key ?? "") !== team) return false;
         if (project && t.project?.name !== project) return false;
-        if ((t.state?.name ?? "").toLowerCase() !== "todo") return false;
-        if (t.assignee) return false;
-        return true;
+        const name = (t.state?.name ?? "").toLowerCase();
+        if (wanted) return wanted.has(name);
+        return !["done", "canceled", "duplicate"].includes(name);
       });
       return { issues: { nodes: nodes.map(toLinearIssue) } };
     }
@@ -354,6 +389,152 @@ for (const [name, make] of IMPLEMENTATIONS) {
       });
       expect(none).toEqual([]);
       await expect(cp.listDispatchable({})).rejects.toThrow(ControlPlaneError);
+    });
+
+    // ------------------------------------------- WM-1008: order and gating ---
+    // These run against EVERY implementation. Both properties fail silently
+    // if an adapter skips them: a wrong order just dispatches the wrong
+    // ticket first, and a missed blocker runs work whose dependency is not
+    // finished. Neither raises an error, so only a test catches them.
+
+    /** Seed three ready tickets with explicit priorities and creation times. */
+    function withQueue(seed) {
+      const base = seed.tickets[0];
+      const mk = (n, priority, createdAt, extra = {}) => ({
+        ...base,
+        id: `id-q${n}`,
+        identifier: `WM-${n}`,
+        title: `queued ${n}`,
+        priority,
+        createdAt,
+        labels: [{ id: "l-ready", name: AGENT_READY_LABEL }],
+        assignee: null,
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        ...extra,
+      });
+      seed.tickets.push(
+        mk(20, 3, "2026-01-01T00:00:00Z"),
+        mk(21, 1, "2026-01-02T00:00:00Z"),
+        mk(22, null, "2026-01-03T00:00:00Z"),
+        mk(23, 1, "2026-01-01T00:00:00Z"),
+      );
+      return seed;
+    }
+
+    test("listDispatchable is ordered priority asc, then createdAt asc", async () => {
+      const { cp, seed } = make();
+      withQueue(seed);
+      const ready = (await cp.listDispatchable({ team: TEAM })).map(
+        (t) => t.identifier,
+      );
+      // WM-23 and WM-21 are both priority 1; WM-23 was created first.
+      expect(ready.indexOf("WM-23")).toBeLessThan(ready.indexOf("WM-21"));
+      expect(ready.indexOf("WM-21")).toBeLessThan(ready.indexOf("WM-20"));
+    });
+
+    test("a ticket with no priority sorts LAST, never first", async () => {
+      const { cp, seed } = make();
+      withQueue(seed);
+      const ready = (await cp.listDispatchable({ team: TEAM })).map(
+        (t) => t.identifier,
+      );
+      // WM-22 has null priority. Treated as 0 it would lead the queue, which
+      // is exactly backwards — "unset" must never outrank "urgent".
+      expect(ready.at(-1)).toBe("WM-22");
+      expect(ready[0]).not.toBe("WM-22");
+    });
+
+    test("priority is normalized: absent/zero reads as null", async () => {
+      const { cp } = make();
+      const t = await cp.getTicket("WM-1");
+      expect(t.priority ?? null).toBeNull();
+    });
+
+    test("a ticket with an OPEN blocker is excluded from listDispatchable", async () => {
+      const { cp, seed } = make();
+      const base = seed.tickets[0];
+      seed.tickets.push({
+        ...base,
+        id: "id-blocker",
+        identifier: "WM-30",
+        title: "the blocker",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        labels: [],
+        assignee: null,
+      });
+      seed.tickets.push({
+        ...base,
+        id: "id-blocked",
+        identifier: "WM-31",
+        title: "the dependent",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        labels: [{ id: "l-ready", name: AGENT_READY_LABEL }],
+        assignee: null,
+        blockedBy: ["WM-30"],
+      });
+      const ready = await cp.listDispatchable({ team: TEAM });
+      expect(ready.map((t) => t.identifier)).not.toContain("WM-31");
+    });
+
+    test("closing the blocker releases the dependent", async () => {
+      const { cp, seed } = make();
+      const base = seed.tickets[0];
+      const blocker = {
+        ...base,
+        id: "id-blocker",
+        identifier: "WM-30",
+        title: "the blocker",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        labels: [],
+        assignee: null,
+      };
+      seed.tickets.push(blocker, {
+        ...base,
+        id: "id-blocked",
+        identifier: "WM-31",
+        title: "the dependent",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        labels: [{ id: "l-ready", name: AGENT_READY_LABEL }],
+        assignee: null,
+        blockedBy: ["WM-30"],
+      });
+      expect(
+        (await cp.listDispatchable({ team: TEAM })).map((t) => t.identifier),
+      ).not.toContain("WM-31");
+
+      blocker.state = { id: "s-done", name: "Done", type: "completed" };
+      expect(
+        (await cp.listDispatchable({ team: TEAM })).map((t) => t.identifier),
+      ).toContain("WM-31");
+    });
+
+    test("listTickets returns In Progress work with descriptions", async () => {
+      // The dispatcher needs Owned Paths of RUNNING tickets to test collision.
+      const { cp, seed } = make();
+      const base = seed.tickets[0];
+      seed.tickets.push({
+        ...base,
+        id: "id-running",
+        identifier: "WM-40",
+        title: "running",
+        description: "## Owned Paths\n- lib/running/**\n",
+        state: { id: "s-progress", name: "In Progress", type: "started" },
+        labels: [{ id: "l-prog", name: IN_PROGRESS_LABEL }],
+        assignee: { id: "user-me", name: "Ada" },
+      });
+      const running = await cp.listTickets({
+        team: TEAM,
+        states: ["In Progress"],
+      });
+      expect(running.map((t) => t.identifier)).toContain("WM-40");
+      expect(
+        running.find((t) => t.identifier === "WM-40").description,
+      ).toContain("Owned Paths");
+    });
+
+    test("listTickets requires a team", async () => {
+      const { cp } = make();
+      await expect(cp.listTickets({})).rejects.toThrow(ControlPlaneError);
     });
 
     test("claim moves to In Progress, assigns the viewer, swaps claim labels", async () => {
@@ -744,6 +925,11 @@ function fakeGithubApi(seed) {
     }
     const list = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues$/);
     if (list && method === "GET") return [seed.issue];
+    // WM-1008: this minimal fake has no dependency data. Returning [] here
+    // exercises the "no blockers" path; the 404-tolerance path is covered in
+    // lib/control-plane/github.test.mjs.
+    if (method === "GET" && /\/dependencies\/blocked_by$/.test(pathOnly))
+      return [];
     throw new ControlPlaneError(`unknown github api ${method} ${pathName}`);
   };
   api.calls = [];

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -18,7 +18,7 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { ControlPlaneError } from "./types.mjs";
+import { byQueueOrder, ControlPlaneError } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
@@ -503,6 +503,55 @@ export function githubControlPlane(options = {}) {
     return opt;
   }
 
+  /**
+   * number -> identifiers of its OPEN blockers (WM-1008).
+   *
+   * GitHub models this as issue dependencies (`blocked_by`). That endpoint is
+   * comparatively new and not present on every deployment, so a 404/403 is
+   * treated as "this repo has no dependency data" — every ticket unblocked —
+   * rather than as a hard failure. That is the same direction Linear's
+   * `openBlockers` takes for an issue whose relations were never fetched:
+   * absent data must not silently gate the entire queue to empty.
+   *
+   * It deliberately does NOT fall back to parsing task lists out of issue
+   * bodies. A prose-derived blocker that nobody can see in the UI is worse
+   * than no blocker at all, because the ticket then stalls invisibly — the
+   * exact failure WM-1024 was filed for.
+   */
+  async function blockedByMap(repo, issues) {
+    const out = new Map();
+    const openNumbers = new Set(
+      issues.filter((i) => i.state !== "closed").map((i) => i.number),
+    );
+    for (const issue of issues) {
+      if (issue.state === "closed") continue;
+      let deps;
+      try {
+        deps = await call(
+          "GET",
+          `repos/${repo}/issues/${issue.number}/dependencies/blocked_by`,
+          { query: { per_page: "100" } },
+        );
+      } catch (err) {
+        if (
+          err instanceof ControlPlaneError &&
+          (err.status === 404 || err.status === 403 || err.status === 410)
+        ) {
+          out.set(issue.number, []);
+          continue;
+        }
+        throw err;
+      }
+      const blockers = (Array.isArray(deps) ? deps : [])
+        .filter((d) =>
+          d.state ? d.state !== "closed" : openNumbers.has(d.number),
+        )
+        .map((d) => issueIdentifier(d.repository?.full_name ?? repo, d.number));
+      out.set(issue.number, blockers);
+    }
+    return out;
+  }
+
   function normalizeIssue(issue, repo, status) {
     const labels = (issue.labels ?? []).map((l) => ({
       id: l.id != null ? String(l.id) : undefined,
@@ -532,7 +581,27 @@ export function githubControlPlane(options = {}) {
       team: teamKeyForRepo(repo),
       project: { name: projectTitle },
       labels,
+      priority: priorityFromLabels(labels),
+      createdAt: issue.created_at ?? "",
+      // Populated by listTickets/listDispatchable, which resolve dependency
+      // state in one batch. A single-issue read leaves it empty rather than
+      // firing an extra request per getTicket call.
+      blockedBy: issue.__blockedBy ?? [],
     };
+  }
+
+  /**
+   * GitHub has no priority field, so the protocol binds it to a `priority:N`
+   * label (WM-1008). Absent means null, which sorts LAST — an unprovisioned
+   * repo degrades to createdAt order instead of erroring or, worse, treating
+   * every unlabelled ticket as most urgent.
+   */
+  function priorityFromLabels(labels) {
+    for (const l of labels) {
+      const m = /^priority:(\d+)$/.exec(l.name ?? "");
+      if (m) return Number(m[1]);
+    }
+    return null;
   }
 
   async function fetchIssue(repo, number) {
@@ -582,40 +651,56 @@ export function githubControlPlane(options = {}) {
       }));
     },
 
-    async listDispatchable({ team, project } = {}) {
-      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+    async listTickets({ team, project, states } = {}) {
+      if (!team) throw new ControlPlaneError("listTickets requires team");
       if (project && project !== projectTitle) return [];
       const repo = repoForTeam(team);
       const rows = await call("GET", `repos/${repo}/issues`, {
-        query: {
-          state: "open",
-          assignee: "none",
-          labels: AGENT_READY_LABEL,
-          per_page: "100",
-        },
+        query: { state: "all", per_page: "100" },
       });
       const issues = (Array.isArray(rows) ? rows : []).filter(
         (i) => !i.pull_request,
       );
       const { items } = await projectItems();
-      const todo = new Set(
+      const statusByNumber = new Map(
         items
-          .filter((it) => it.fieldValueByName?.name?.toLowerCase() === "todo")
           .filter(
             (it) => (it.content?.repository?.nameWithOwner ?? repo) === repo,
           )
-          .map((it) => it.content?.number),
+          .map((it) => [it.content?.number, it.fieldValueByName?.name]),
       );
+      const wanted = states?.length
+        ? new Set(states.map((n) => n.toLowerCase()))
+        : null;
+      const open = await blockedByMap(repo, issues);
       const out = [];
       for (const issue of issues) {
-        if (!todo.has(issue.number)) continue;
-        if (issue.assignee) continue;
-        const names = (issue.labels ?? []).map((l) => l.name);
-        if (!names.includes(AGENT_READY_LABEL)) continue;
-        const status = await statusOf(repo, issue.number);
-        out.push(normalizeIssue(issue, repo, status));
+        const statusName =
+          statusByNumber.get(issue.number) ??
+          (issue.state === "closed" ? "Done" : "Triage");
+        const name = String(statusName).toLowerCase();
+        if (wanted ? !wanted.has(name) : ["done", "canceled"].includes(name))
+          continue;
+        out.push(
+          normalizeIssue(
+            { ...issue, __blockedBy: open.get(issue.number) ?? [] },
+            repo,
+            { name: statusName, opt: null },
+          ),
+        );
       }
-      return out;
+      return out.sort(byQueueOrder);
+    },
+
+    async listDispatchable({ team, project } = {}) {
+      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+      const todo = await this.listTickets({ team, project, states: ["Todo"] });
+      return todo.filter(
+        (t) =>
+          !t.assignee &&
+          (t.labels ?? []).some((l) => l.name === AGENT_READY_LABEL) &&
+          (t.blockedBy ?? []).length === 0,
+      );
     },
 
     async claim(identifier, { harness = "claude" } = {}) {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -392,6 +392,27 @@ function fakeApi(seed) {
       }
     }
 
+    // WM-1008: issue dependencies. Seeded per issue as `blockedBy: [number]`;
+    // a repo whose seed sets `noDependencies: true` answers 404, standing in
+    // for a deployment where the endpoint is not available.
+    const dep =
+      /^repos\/([^/]+\/[^/]+)\/issues\/(\d+)\/dependencies\/blocked_by$/.exec(
+        pathOnly,
+      );
+    if (dep && method === "GET") {
+      const bucket = seed.repos[dep[1]] ?? { issues: [] };
+      if (bucket.noDependencies) fail(`not found`, 404);
+      const issue = bucket.issues.find((i) => i.number === Number(dep[2]));
+      return (issue?.blockedBy ?? []).map((n) => {
+        const target = bucket.issues.find((i) => i.number === n);
+        return {
+          number: n,
+          state: target?.state ?? "open",
+          repository: { full_name: dep[1] },
+        };
+      });
+    }
+
     fail(`unknown github api ${method} ${pathName}`);
   };
   api.calls = [];

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -12,7 +12,7 @@
  * network.
  */
 import { gql as defaultGql } from "../../orchestrator/reaper.mjs";
-import { ControlPlaneError } from "./types.mjs";
+import { byQueueOrder, ControlPlaneError, OPEN_STATE_TYPES } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
@@ -22,10 +22,18 @@ import {
   validateLabels,
 } from "./labels.mjs";
 
-const ISSUE_FIELDS = `id identifier title url description
+// WM-1008: priority, createdAt and the blocker relations travel with every
+// issue read, so ordering and gating never need a second round trip. For
+// issue X, `inverseRelations` are the relations where X is the relatedIssue;
+// on a `blocks` node the blocker is `node.issue` (plain `relations` would
+// give what X blocks — the wrong direction). State `type`, not name: workflow
+// names are per-team config, the types are Linear's own enum.
+const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } }`;
+const ISSUE_FIELDS = `id identifier title url description createdAt priority
   state{ id name type } assignee{ id name }
   team{ key } project{ name }
-  labels(first:30){ nodes{ id name } }`;
+  labels(first:30){ nodes{ id name } }
+  ${BLOCKERS}`;
 
 const teamOf = (key) => String(key).split("-")[0];
 
@@ -46,7 +54,24 @@ export function normalizeTicket(issue) {
     team: issue.team ?? null,
     project: issue.project ?? null,
     labels: labels.map((l) => ({ id: l.id, name: l.name })),
+    // Linear encodes "no priority" as 0. Left as 0 it would sort as the MOST
+    // urgent value, i.e. exactly backwards, so it becomes null and sorts last.
+    priority:
+      typeof issue.priority === "number" && issue.priority > 0
+        ? issue.priority
+        : null,
+    createdAt: issue.createdAt ?? "",
+    blockedBy: openBlockerIdentifiers(issue),
   };
+}
+
+/** Identifiers of unfinished `blocks` relations. `related`/`duplicate` never gate. */
+function openBlockerIdentifiers(issue) {
+  return (issue?.inverseRelations?.nodes ?? [])
+    .filter((r) => r.type === "blocks")
+    .map((r) => r.issue)
+    .filter((b) => b && !OPEN_STATE_TYPES.includes(b.state?.type))
+    .map((b) => b.identifier);
 }
 
 /**
@@ -134,22 +159,37 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
       return d.issue.comments?.nodes ?? [];
     },
 
-    async listDispatchable({ team, project } = {}) {
-      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+    async listTickets({ team, project, states } = {}) {
+      if (!team) throw new ControlPlaneError("listTickets requires team");
+      // No `states` means "everything not finished" — the dispatcher needs
+      // In Progress (for Owned Paths of running work) and Todo from one read.
+      const stateFilter = states?.length
+        ? `state:{ name:{ in:$s } }`
+        : `state:{ type:{ nin:["completed","canceled"] } }`;
+      const decl = states?.length ? ", $s:[String!]" : "";
+      const vars = { t: team, ...(project ? { p: project } : {}) };
+      if (states?.length) vars.s = states;
       const d = project
         ? await call(
-            `query($t:String!,$p:String!){ issues(first:100, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"Todo"}}, assignee:{null:true} }){ nodes{ ${ISSUE_FIELDS} } } }`,
-            { t: team, p: project },
+            `query($t:String!,$p:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateFilter} }){ nodes{ ${ISSUE_FIELDS} } } }`,
+            vars,
           )
         : await call(
-            `query($t:String!){ issues(first:100, filter:{ team:{key:{eq:$t}}, state:{name:{eq:"Todo"}}, assignee:{null:true} }){ nodes{ ${ISSUE_FIELDS} } } }`,
-            { t: team },
+            `query($t:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, ${stateFilter} }){ nodes{ ${ISSUE_FIELDS} } } }`,
+            vars,
           );
-      return (d?.issues?.nodes ?? [])
-        .map(normalizeTicket)
-        .filter((i) =>
-          (i.labels ?? []).some((l) => l.name === AGENT_READY_LABEL),
-        );
+      return (d?.issues?.nodes ?? []).map(normalizeTicket).sort(byQueueOrder);
+    },
+
+    async listDispatchable({ team, project } = {}) {
+      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+      const todo = await this.listTickets({ team, project, states: ["Todo"] });
+      return todo.filter(
+        (i) =>
+          !i.assignee &&
+          (i.labels ?? []).some((l) => l.name === AGENT_READY_LABEL) &&
+          (i.blockedBy ?? []).length === 0,
+      );
     },
 
     async claim(identifier, { harness = "claude" } = {}) {

--- a/lib/control-plane/memory.mjs
+++ b/lib/control-plane/memory.mjs
@@ -17,7 +17,7 @@
  * Every mutation is recorded on `plane.calls` so a test can assert what
  * would have been done.
  */
-import { ControlPlaneError } from "./types.mjs";
+import { byQueueOrder, ControlPlaneError, OPEN_STATE_TYPES } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
@@ -78,6 +78,32 @@ export function memoryControlPlane(seed = {}) {
       team: t.team ?? null,
       project: t.project ?? null,
       labels: [...(t.labels ?? [])],
+      priority:
+        typeof t.priority === "number" && t.priority > 0 ? t.priority : null,
+      createdAt: t.createdAt ?? "",
+      blockedBy: openBlockersOf(t),
+    });
+  }
+
+  /**
+   * Blockers named on the seed ticket that have not finished (WM-1008).
+   * The fake stores them as plain identifiers (`blockedBy: ["WM-1"]`) and
+   * resolves their state from the same ticket list, so the contract suite can
+   * close a blocker and watch its dependent become dispatchable.
+   */
+  function openBlockersOf(t) {
+    return (t.blockedBy ?? []).filter((id) => {
+      const blocker = state.tickets.find((x) => x.identifier === id);
+      if (!blocker) return true; // unknown blocker: fail closed, stay blocked
+      const type = (
+        blocker.state?.type ??
+        (["done", "canceled", "duplicate"].includes(
+          (blocker.state?.name ?? "").toLowerCase(),
+        )
+          ? "completed"
+          : "started")
+      ).toLowerCase();
+      return !OPEN_STATE_TYPES.includes(type);
     });
   }
 
@@ -124,18 +150,35 @@ export function memoryControlPlane(seed = {}) {
       return clone(requireTicket(identifier).comments ?? []);
     },
 
-    async listDispatchable({ team, project } = {}) {
-      calls.push({ op: "listDispatchable", team, project });
-      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+    async listTickets({ team, project, states } = {}) {
+      calls.push({ op: "listTickets", team, project, states });
+      if (!team) throw new ControlPlaneError("listTickets requires team");
+      const wanted = states?.length
+        ? new Set(states.map((n) => n.toLowerCase()))
+        : null;
       return state.tickets
         .filter((t) => {
           if ((t.team?.key ?? teamOf(t.identifier)) !== team) return false;
           if (project && t.project?.name !== project) return false;
-          if ((t.state?.name ?? "").toLowerCase() !== "todo") return false;
-          if (t.assignee) return false;
-          return (t.labels ?? []).some((l) => l.name === AGENT_READY_LABEL);
+          const name = (t.state?.name ?? "").toLowerCase();
+          if (wanted) return wanted.has(name);
+          return !["done", "canceled", "duplicate"].includes(name);
         })
-        .map(asTicket);
+        .map(asTicket)
+        .sort(byQueueOrder);
+    },
+
+    async listDispatchable({ team, project } = {}) {
+      calls.push({ op: "listDispatchable", team, project });
+      if (!team) throw new ControlPlaneError("listDispatchable requires team");
+      return (
+        await this.listTickets({ team, project, states: ["Todo"] })
+      ).filter(
+        (t) =>
+          !t.assignee &&
+          (t.labels ?? []).some((l) => l.name === AGENT_READY_LABEL) &&
+          (t.blockedBy ?? []).length === 0,
+      );
     },
 
     async claim(identifier, { harness = "claude" } = {}) {

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -38,6 +38,18 @@
  * @property {{ key: string }|null} [team]
  * @property {{ name: string }|null} [project]
  * @property {TicketLabel[]} labels
+ * @property {number|null} [priority]
+ *   Lower is more urgent. `null` when the tracker has no such concept, or the
+ *   ticket carries no value — those sort LAST, never first, so an
+ *   unprioritised workspace degrades to createdAt order rather than jumping
+ *   the queue. GitHub has no priority field; its adapter reads `priority:N`
+ *   labels (WM-1008).
+ * @property {string[]} [blockedBy]
+ *   Identifiers of tickets that block this one and are NOT finished. Empty
+ *   means dispatchable. The adapter resolves "finished" against its own
+ *   tracker's completion semantics, so callers never interpret workflow
+ *   states themselves.
+ * @property {string} [createdAt]
  */
 
 /**
@@ -83,9 +95,18 @@
  * @property {"linear"|"memory"|"github"} kind
  * @property {(identifier: string) => Promise<Ticket>} getTicket
  * @property {(identifier: string) => Promise<TicketComment[]>} listComments
+ * @property {(opts: { team: string, project?: string, states?: string[] }) => Promise<Ticket[]>} listTickets
+ *   Every ticket in the given factory states (default: all not-finished),
+ *   in queue order — priority asc, then createdAt asc. `description`,
+ *   `priority` and `blockedBy` are populated, because the dispatcher needs
+ *   Owned Paths and ordering from the same read (WM-1008).
  * @property {(opts: { team: string, project?: string }) => Promise<Ticket[]>} listDispatchable
- *   Todo + `ai:agent-ready` + unassigned. The same predicate the dispatcher
- *   uses; agents must not invent their own.
+ *   Todo + `ai:agent-ready` + unassigned + **no open blocker**, in queue
+ *   order. The same predicate AND the same ordering the dispatcher uses;
+ *   agents must not invent their own. Blocker exclusion and priority order
+ *   live here rather than at each call site: a caller that forgets either
+ *   does not fail loudly, it silently dispatches out of order or runs a
+ *   ticket whose dependency is unfinished.
  * @property {(identifier: string, opts?: { harness?: string }) => Promise<ClaimResult>} claim
  *   Move to In Progress, assign the viewer, swap claim labels, then read
  *   the assignee back. `ok: false` means another actor won the race.
@@ -122,3 +143,26 @@ export const CONTROL_PLANE_KINDS = Object.freeze([
   "memory",
   "github",
 ]);
+
+/**
+ * Queue order, shared by every adapter (WM-1008).
+ *
+ * Priority ascending, then createdAt ascending. `null`/absent priority sorts
+ * LAST: an unprioritised ticket must not outrank an explicitly urgent one,
+ * and a workspace that never sets priority degrades to plain FIFO. Linear
+ * itself uses 0 for "no priority", so 0 is normalised to null by the adapter
+ * before it reaches here — otherwise "unset" would sort as most urgent, which
+ * is exactly backwards.
+ */
+export function byQueueOrder(a, b) {
+  const pa = a?.priority == null ? Number.POSITIVE_INFINITY : a.priority;
+  const pb = b?.priority == null ? Number.POSITIVE_INFINITY : b.priority;
+  if (pa !== pb) return pa - pb;
+  const ca = a?.createdAt ?? "";
+  const cb = b?.createdAt ?? "";
+  if (ca && cb && ca !== cb) return ca < cb ? -1 : 1;
+  return 0;
+}
+
+/** Factory states an adapter treats as "not finished" for blocker gating. */
+export const OPEN_STATE_TYPES = Object.freeze(["completed", "canceled"]);

--- a/lib/queue-summary.mjs
+++ b/lib/queue-summary.mjs
@@ -16,26 +16,29 @@ import {
   answeredHeldTickets,
 } from "../orchestrator/reply-detection.mjs";
 import { liveWorkerLeases } from "./worker-leases.mjs";
-import {
-  openBlockers,
-  BLOCKING_RELATIONS_GQL,
-} from "../orchestrator/blockers.mjs";
+import { openBlockers } from "../orchestrator/blockers.mjs";
 
-const QUERY = `
+/**
+ * What the neutral contract still cannot answer (WM-1008).
+ *
+ * `attachments` is Linear's PR-link model and closed-state COUNTS need a
+ * count verb; neither exists on `ControlPlane` and neither should be invented
+ * in a hurry here. Active tickets — the part carrying priority, labels and
+ * blockers, i.e. everything this module gates on — now come from
+ * `listTickets()`. This residue is deliberately the smallest Linear-shaped
+ * query that still answers the rest, and is tracked for removal.
+ *
+ * Under `controlPlane.kind: github` this degrades rather than throws: the
+ * counts read 0 and PR links are absent, while queue gating stays correct.
+ */
+const EXTRAS_QUERY = `
   query($team: String!, $project: String!) {
     active: issues(first: 250, filter: {
       team: { key: { eq: $team } },
       project: { name: { eq: $project } },
       state: { type: { nin: ["completed", "canceled"] } }
     }) {
-      nodes {
-        identifier title description priority url
-        attachments(first: 20) { nodes { url } }
-        state { name type }
-        assignee { name }
-        labels(first: 20) { nodes { name } }
-        ${BLOCKING_RELATIONS_GQL}
-      }
+      nodes { identifier attachments(first: 20) { nodes { url } } }
     }
     closed: issues(first: 250, filter: {
       team: { key: { eq: $team } },
@@ -113,16 +116,38 @@ export async function fetchQueueSummaries(repos, defaultCap) {
   const summary = [];
 
   for (const repo of repos) {
-    const data = await loadControlPlane().raw(QUERY, {
+    const cp = loadControlPlane({ repoName: repo.name });
+    // Priority order and blocker resolution come from the adapter, so this
+    // summary and the dispatcher cannot disagree about what "ready" means.
+    const nodes = await cp.listTickets({
       team: repo.team,
       project: repo.project,
     });
-    const nodes = data?.active?.nodes ?? [];
+    let data;
+    try {
+      data = await cp.raw(EXTRAS_QUERY, {
+        team: repo.team,
+        project: repo.project,
+      });
+    } catch {
+      // A control plane that cannot answer a Linear-shaped query must not
+      // take the whole queue view down — gating above is already correct.
+      data = null;
+    }
+    const attachmentsBy = new Map(
+      (data?.active?.nodes ?? []).map((n) => [n.identifier, n.attachments]),
+    );
+    for (const n of nodes) n.attachments = attachmentsBy.get(n.identifier);
     const closed = data?.closed?.nodes ?? [];
     const done = closed.filter((i) => i.state?.type === "completed").length;
     const total = nodes.length + closed.length;
     const countCapped = nodes.length === 250 || closed.length === 250;
-    const labels = (i) => (i.labels?.nodes ?? []).map((l) => l.name);
+    // Flat array from the adapter; the {nodes} wrapper only if something
+    // still hands us a raw Linear issue (WM-978 tolerance).
+    const labels = (i) =>
+      (Array.isArray(i.labels) ? i.labels : (i.labels?.nodes ?? [])).map(
+        (l) => l.name,
+      );
     const state = (i) => i.state?.name ?? "?";
 
     const triage = nodes.filter(

--- a/orchestrator/blockers.mjs
+++ b/orchestrator/blockers.mjs
@@ -43,6 +43,11 @@ export const BLOCKING_RELATIONS_GQL =
  * `duplicate`/`related` relation types are ignored; only `blocks` gates.
  */
 export function openBlockers(issue) {
+  // WM-1008: the control-plane adapter resolves this and hands back a plain
+  // `blockedBy` array, so prefer it. The raw-relations path below stays for
+  // callers still reading Linear GraphQL directly; it is the fallback, not
+  // the contract.
+  if (Array.isArray(issue?.blockedBy)) return [...issue.blockedBy];
   return (issue?.inverseRelations?.nodes ?? [])
     .filter((r) => r.type === "blocks")
     .map((r) => r.issue)

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -38,7 +38,7 @@ import {
   effectiveOwnedPaths,
   pathsCollide,
 } from "./owned-paths.mjs";
-import { openBlockers, BLOCKING_RELATIONS_GQL } from "./blockers.mjs";
+import { openBlockers } from "./blockers.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
 import {
   LEASE_HEARTBEAT_MS,
@@ -357,30 +357,49 @@ export async function main(argv = process.argv.slice(2)) {
   const COMMAND_BODY = COMMAND_MD.replace(/^---\n[\s\S]*?\n---\n/, "");
   const promptFor = (id) => COMMAND_BODY.replaceAll("$ARGUMENTS", id);
 
-  const Q = `query($t:String!,$p:String!){ issues(first:250, filter:{
-    team:{key:{eq:$t}}, project:{name:{eq:$p}},
-    state:{ type:{ nin:["completed","canceled"] } } }){
-  nodes{ id identifier title description state{name} assignee{id} labels(first:20){nodes{name}} priority ${BLOCKING_RELATIONS_GQL} } } }`;
-
-  /** Current queue straight from Linear — never cached, because it changes under us. */
+  /**
+   * Current queue straight from the control plane — never cached, because it
+   * changes under us.
+   *
+   * WM-1008: this used to build a Linear GraphQL string and push it through
+   * `cp.raw()`, which meant `controlPlane.kind: github` produced an unsorted
+   * queue with blocker gating silently disabled — every verb "worked", so the
+   * factory looked healthy while dispatching in the wrong order. Priority
+   * ordering and blocker exclusion now live in the adapter, where every
+   * implementation is held to them by the shared contract suite.
+   */
   async function fetchState() {
-    const nodes =
-      (await loadControlPlane().raw(Q, { t: repo.team, p: repo.project }))
-        ?.issues?.nodes ?? [];
-    const has = (i, n) => (i.labels?.nodes ?? []).some((l) => l.name === n);
+    const cp = loadControlPlane({ repoName: repo.name });
+    const [running, ready] = await Promise.all([
+      cp.listTickets({
+        team: repo.team,
+        project: repo.project,
+        states: ["In Progress"],
+      }),
+      cp.listDispatchable({ team: repo.team, project: repo.project }),
+    ]);
     return {
-      inProgress: nodes.filter((i) => i.state?.name === "In Progress"),
-      // Assignee is NOT a gate: this workspace hasn't landed per-agent Linear
-      // identities (OPS-40) yet, so every claim -- human or agent -- writes the
-      // same shared account. That makes "has an assignee" indistinguishable
-      // from "was claimed and never cleared," which is exactly the reaper's
-      // job to fix, not dispatch's job to avoid by skipping the ticket forever.
-      // The actual collision guard is claim()'s read-back compare-and-swap
-      // below, which is assignee-based but per-ticket at claim time, not a
-      // blanket "already has anyone" skip.
-      ready: nodes
-        .filter((i) => i.state?.name === "Todo" && has(i, "ai:agent-ready"))
-        .sort((a, b) => (a.priority || 99) - (b.priority || 99)),
+      inProgress: running,
+      // `ready` arrives already filtered (Todo + ai:agent-ready + unassigned +
+      // no open blocker) and already ordered (priority asc, createdAt asc).
+      // Re-sorting or re-filtering here would be a second opinion that can
+      // drift from the adapter's, which is how this broke the first time.
+      ready,
+      // Blocked-but-otherwise-ready tickets. `listDispatchable` correctly
+      // excludes them, but they must stay VISIBLE: a ticket starved by a
+      // wrong or forgotten relation holds no slot and raises no error, so
+      // reporting it on its own line is the only way anyone finds out.
+      held: (
+        await cp.listTickets({
+          team: repo.team,
+          project: repo.project,
+          states: ["Todo"],
+        })
+      ).filter(
+        (t) =>
+          (t.labels ?? []).some((l) => l.name === "ai:agent-ready") &&
+          (t.blockedBy ?? []).length > 0,
+      ),
     };
   }
 
@@ -425,7 +444,7 @@ export async function main(argv = process.argv.slice(2)) {
 
   if (!APPLY) {
     const picked = selectable(first, new Set(), Math.min(freeNow, MAX));
-    for (const t of first.ready) {
+    for (const t of [...first.held, ...first.ready]) {
       const blockers = openBlockers(t);
       if (blockers.length)
         console.log(
@@ -1142,7 +1161,7 @@ export async function main(argv = process.argv.slice(2)) {
       // starts" is invisible in exactly the mode that matters (see F-7). Keyed per
       // reason: a blocked ticket can unblock mid-run and then be worth re-warning
       // about its missing Owned Paths, and vice versa.
-      for (const t of state.ready) {
+      for (const t of [...state.held, ...state.ready]) {
         if (seen.has(t.identifier)) continue;
         const blockers = openBlockers(t);
         if (blockers.length && !warned.has(`${t.identifier}:blocked`)) {


### PR DESCRIPTION
Fixes WM-1008

The functional blocker for GitHub mode.

## The bug

`orchestrator/tick.mjs` imported `loadControlPlane` and then built a **Linear GraphQL string** and pushed it through the `cp.raw()` escape hatch, selecting `priority` and `inverseRelations`. `lib/queue-summary.mjs` did the same.

Neither field existed in the `Ticket` contract. So under `controlPlane.kind: github`:

- every verb "worked", so the factory looked healthy
- the ready queue came back **unsorted**
- **blocker gating silently stopped working** — a ticket whose dependency was unfinished became dispatchable

Silent wrong-order dispatch is worse than a hard error, which is why this ranked above the cosmetic work in the epic.

## What changed

`Ticket` gains `priority`, `blockedBy` and `createdAt`. A new `listTickets({team, project, states})` verb returns tickets in queue order with descriptions — the dispatcher needs Owned Paths of *running* work and the ready queue from the same read. `listDispatchable` is now defined in terms of it and applies the full predicate: Todo + `ai:agent-ready` + unassigned + **no open blocker**, ordered priority asc then createdAt asc.

Ordering and gating live in the adapter, not at each call site — a caller that forgets either doesn't fail loudly.

Implemented in all three adapters and held there by the shared contract suite.

## Notes for the reviewer

- **`null` priority sorts LAST, not first.** Linear encodes "no priority" as `0`; left as 0 it sorts as *most urgent*, exactly backwards. Normalised to null at the adapter boundary. There's a test that fails if you treat null as 0.
- **GitHub priority is a `priority:N` label** (no such field exists). Absent → null, so an unprovisioned repo degrades to createdAt order rather than erroring.
- **GitHub blockers use native issue dependencies** (`/dependencies/blocked_by`). A 404/403/410 is treated as "this deployment has no dependency data" → unblocked, rather than gating the whole queue to empty. It deliberately does **not** fall back to parsing task lists out of issue bodies: a prose-derived blocker nobody can see in the UI stalls a ticket invisibly, which is the exact failure WM-1024 was filed for.
- **Held tickets stay visible.** `listDispatchable` now excludes blocked tickets, so `fetchState` also returns `held` and both the dry-run and apply-mode warnings iterate it. `blockers.mjs` explicitly calls out that a starved ticket holds no slot and raises no error, so hiding it was not an option.
- **`queue-summary.mjs` is only partly converted, on purpose.** The queue read — everything it gates on — now goes through `listTickets`. A small Linear-shaped `raw()` remains for `attachments` (Linear's PR-link model) and closed-state *counts*; both need contract verbs that don't exist and would be designed badly in a hurry. It's wrapped in try/catch so a control plane that can't answer it degrades instead of taking the queue view down. Follow-up filed.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 event-runtime/lib lib/control-plane && bun run format:check && bun run lint
```

- **1522 pass, 0 fail** across 90 files
- format:check clean; lint 0 errors, 616 warnings = `develop` baseline
- `orchestrator` suite matches the `develop` baseline exactly (1 pre-existing failure from a missing local `config/repos.yaml`, verified identical on a clean checkout)

**Falsifiability**, both properties proven non-vacuous:
- removing the blocker filter → 4 contract tests fail (2 memory, 2 linear)
- treating null priority as 0 → 2 contract tests fail