### PR TITLE
fix(dispatch): keep full suites in CI (WM-1039)

### DIFF
--- a/dist/codex/skills/factory-ticket/SKILL.md
+++ b/dist/codex/skills/factory-ticket/SKILL.md
@@ -15,7 +15,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:

--- a/dist/cursor/commands/factory-ticket.md
+++ b/dist/cursor/commands/factory-ticket.md
@@ -6,7 +6,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:

--- a/dist/gemini/skills/factory-ticket/SKILL.md
+++ b/dist/gemini/skills/factory-ticket/SKILL.md
@@ -15,7 +15,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:

--- a/dist/pi/prompts/factory-ticket.md
+++ b/dist/pi/prompts/factory-ticket.md
@@ -10,7 +10,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -41,7 +41,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:bd86de248e844c5866a7477feda34707eceff06685e06dcb05034b281a866171",
+    "agents/dispatch.md": "sha256:ae36ff073880ff1ae89e6c21ed6660ee6f8294681b0d937da1efbef15373de6c",
     "schemas/dispatch.input.json": "sha256:7949221631e30ad9c6f8fa8a92d071f6ee88ea03e7fbafcbf3af1dffa432cdee",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -41,7 +41,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:b2a473a2120e065825e08e5f872759b575c75ed069007a026cfa8ea9ecb97653",
+    "agents/dispatch.md": "sha256:bd86de248e844c5866a7477feda34707eceff06685e06dcb05034b281a866171",
     "schemas/dispatch.input.json": "sha256:7949221631e30ad9c6f8fa8a92d071f6ee88ea03e7fbafcbf3af1dffa432cdee",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -55,12 +55,15 @@ new ticket.
 2. **Implement in `./repo`**, touching only files matching the ticket's
    `Owned Paths`. Work discovered outside that set becomes a new `Triage`
    issue (`tools/ticket.mjs file`) — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`, run inside
-   `./repo` on the final tree (after your last commit), **and** the full
-   `bun test` (or the repo's full suite) before you return. Never proceed
-   past failing output; never weaken a test to get green. **The worker
-   verifies the handoff mechanically after you return:** it re-runs the
-   repo's declared verify command and the ticket's exact
+3. **Verify** with the ticket's exact `Verification Command` and the repo's
+   configured `verify` command, run inside `./repo` on the final tree (after
+   your last commit). Run **only** those two worktree gates: do **not** run
+   `bun test` or the repo's full suite as a PR-opening gate. The full suite is
+   CI's job; duplicating it in concurrent dispatched worktrees causes
+   load-induced flakes and must not prevent a PR. Never proceed past failing
+   output; never weaken a test to get green. **The worker verifies the handoff
+   mechanically after you return:** it re-runs the repo's declared verify
+   command and the ticket's exact
    `Verification Command`, runs `cd event-runtime/web && bun run build` when
    your diff touches `event-runtime/web/src/**`, and diffs
    `origin/<base>..HEAD` against the ticket's Owned Paths. A non-zero exit

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -168,8 +168,9 @@ describe("registry", () => {
     // surfaces wrong-base PRs; both agent definitions are registry inputs.
     // Regenerated (WM-1039): dispatch runs only ticket + configured repo
     // verification in worktrees; full suites remain CI-only.
+    // Regenerated (WM-1039 rebase over tracker-neutral sweep)
     const expected =
-      "sha256:5a8aeabaab1f3f111286106bb15ec76977c88340cb7578045e6cf74a1dd346fc";
+      "sha256:a4d70bef9089d1513b6697ca4f026563b86d8d4785bee68738a2359fbdd573a5";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -342,8 +343,9 @@ describe("registry", () => {
     // WM-938 adds the explicit-base PR command and re-pins dispatch.
     // WM-1039 keeps dispatched worktree verification to the ticket and repo
     // commands, leaving full suites to CI, and re-pins dispatch.
+    // Regenerated (WM-1039 rebase over tracker-neutral sweep)
     expect(computeDefHash(def)).toBe(
-      "sha256:d004d6500d8ba0cac57573f8d0836a1ec2f18e083dd414d0348adb230387f893",
+      "sha256:b82767b2413db396af047029261323df01a8255315135e91694fad4b960b851d",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -166,6 +166,8 @@ describe("registry", () => {
     // Regenerated (merge-factory clock scan 15m -> 4h in schedules.json).
     // Regenerated (WM-938): dispatch pins explicit PR bases and merge-scan
     // surfaces wrong-base PRs; both agent definitions are registry inputs.
+    // Regenerated (WM-1039): dispatch runs only ticket + configured repo
+    // verification in worktrees; full suites remain CI-only.
     const expected =
       "sha256:5a8aeabaab1f3f111286106bb15ec76977c88340cb7578045e6cf74a1dd346fc";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
@@ -338,6 +340,8 @@ describe("registry", () => {
     // for WM-610. Still not a provenance break: `pack` stays non-enumerable.
     // WM-812 adds decision-memo declarations and re-pins the dispatch brief.
     // WM-938 adds the explicit-base PR command and re-pins dispatch.
+    // WM-1039 keeps dispatched worktree verification to the ticket and repo
+    // commands, leaving full suites to CI, and re-pins dispatch.
     expect(computeDefHash(def)).toBe(
       "sha256:d004d6500d8ba0cac57573f8d0836a1ec2f18e083dd414d0348adb230387f893",
     );

--- a/plugins/core/commands/factory-ticket.md
+++ b/plugins/core/commands/factory-ticket.md
@@ -12,7 +12,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:

--- a/shared/commands/factory-ticket.md
+++ b/shared/commands/factory-ticket.md
@@ -12,7 +12,7 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 
 1. **Read the ticket** and restate your approach as a comment on it.
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
-3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
+3. **Verify** with the ticket's exact `Verification Command` and the repo's configured `verify` command, on the final tree. Run **only** those two worktree gates: do **not** run `bun test` or the repo's full suite as a PR-opening gate. The full suite is CI's job, and concurrent dispatched worktrees make it a load-induced flake source. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** after verification and before opening the PR when this introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action. Spawn `factory-ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, and file the rest to `Triage`. Skip it for isolated styling, copy-only edits, static content, icons/assets, and internal/admin-only surfaces unless the ticket identifies UX risk. State `UX critique: required` or `UX critique: skipped — <reason>` in the PR.
 
    **The spawn prompt must carry the environment, spelled out** — the subagent does not inherit your working directory, and sibling worktrees for other tickets exist right now:


### PR DESCRIPTION
Fixes WM-1039

UX critique: skipped — internal dispatch-agent instructions and generated prompt artifacts; no user-facing flow.

Evidence: the 08:1x dispatch-wave runs for [WM-1032](https://linear.app/watt-mind/issue/WM-1032), [WM-1009](https://linear.app/watt-mind/issue/WM-1009), [WM-962](https://linear.app/watt-mind/issue/WM-962), [WM-621](https://linear.app/watt-mind/issue/WM-621), [WM-1015](https://linear.app/watt-mind/issue/WM-1015), [WM-534](https://linear.app/watt-mind/issue/WM-534), and [WM-696](https://linear.app/watt-mind/issue/WM-696) motivated keeping full suites in CI rather than gating dispatched worktree PRs.