### PR TITLE
docs(protocol): sweep agent-facing prose onto tracker-neutral vocabulary

### DIFF
--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -12,7 +12,7 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `$FA
 
 **Event-runtime code follows the documented house conventions.** For module shape, dependency injection, adapter contracts, fail-closed boundaries, and tests, read [`docs/event-runtime-conventions.md`](https://github.com/watt-mind/factory/blob/develop/docs/event-runtime-conventions.md) before changing `event-runtime/`.
 
-**Work comes from Linear, and only when it's ready.** A ticket is dispatchable only if it is `Todo` + `ai:agent-ready` + unassigned. `Triage` and `Backlog` are not queues to pull from.
+**Work comes from the control plane, and only when it's ready.** A ticket is dispatchable only if it is `Todo` + `ai:agent-ready` + unassigned. `Triage` and `Backlog` are not queues to pull from.
 
 **An ad-hoc request gets a ticket too — file it, don't wait to be asked.** A request typed into a chat session is not exempt from the control plane; if it isn't tracked, it is invisible to every other agent and to tomorrow. **The trip wire is your first file edit:** before it, either find the issue that already covers this or create one, and say in one line which it is ("Tracking as OPS-91"). Commits still carry their `(ISSUE-ID)`. Skip the ticket only for ordinary questions, read-only lookups with no actionable finding, and inconsequential edits — and the human can always say "no ticket", which settles it. Sessions drift: one that began as a question and turned into a change trips the wire at that moment, not at the end.
 
@@ -42,7 +42,7 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `$FA
 
 **Negative testing and falsifiability.** New regression tests must be observed failing before applying the fix to prove they test the actual failure mode and are not vacuous. Verify that tests distinguish correct implementations from plausible incorrect ones (without using `git stash`; use safe per-file reverts such as `git show <ref>:<path> > <path>`). A test that passes before the fix is applied tests nothing.
 
-**Mandatory `## Handoff` comment.** Before moving a ticket to `In Review`, post a structured `## Handoff` comment on the Linear ticket with these exact fields:
+**Mandatory `## Handoff` comment.** Before moving a ticket to `In Review`, post a structured `## Handoff` comment on the ticket with these exact fields:
 
 ```
 ## Handoff
@@ -59,7 +59,7 @@ Posting this structured comment is a mandatory prerequisite before advancing a t
 
 ### Never auto-merge
 
-Regardless of CI or review outcome, these come back to a human with findings: **auth/authz, payments or money movement, credential and secret handling, destructive DB migrations, production infra config, and `CLNT` security behavior.** When escalating, add `ai:escalated` to the Linear ticket — that's what surfaces it in the human's "My Decisions Needed" view — and notify (see below).
+Regardless of CI or review outcome, these come back to a human with findings: **auth/authz, payments or money movement, credential and secret handling, destructive DB migrations, production infra config, and `CLNT` security behavior.** When escalating, add `ai:escalated` to the ticket — that's what surfaces it in the human's "My Decisions Needed" view — and notify (see below).
 
 The test is whether the diff **changes security-relevant behavior**, not whether a file sits near security code — read as file-adjacency this list swallows every PR in an app where auth is everywhere, and that trains everyone to rubber-stamp it. When it's genuinely ambiguous, escalate: a false escalation costs one message, a wrong merge costs a client incident.
 
@@ -89,15 +89,15 @@ Same care for force-pushes: never `--force` onto a `base` or `deploy_branch`, an
 
 Move the ticket to `Blocked`, say specifically what you need in one answerable question, and notify. Never leave a stalled ticket sitting in `In Progress`.
 
-**"Notify" means exactly this command** — a Linear comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
+**"Notify" means exactly this command** — a ticket comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
 
 ```bash
 factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
 ```
 
-Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a Linear comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to Linear and the run report, never here.
+Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a ticket comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to the ticket and the run report, never here.
 
-Before blocking on product intent, check whether it's already written down — the repo's `docs/product-decisions.md`, `docs/`, or the Linear project Overview. If you resolve a decision that wasn't recorded, record it.
+Before blocking on product intent, check whether it's already written down — the repo's `docs/product-decisions.md`, `docs/`, or the tracker project overview. If you resolve a decision that wasn't recorded, record it.
 
 ### Waiting
 
@@ -149,7 +149,7 @@ Ahead-only (clean, not behind, but carrying unpushed commits) still routes to `o
 
 Never pull over uncommitted work to get a fresher read — those files are a human's in-flight change, and losing them costs far more than a slightly stale spec. Reading `origin/<base>` gets the same correctness without touching the tree.
 
-Then **name the ref your evidence came from** in the report or the Linear comment. `origin/develop@a1b2c3d` is checkable by the next reader; "I read the file" is not.
+Then **name the ref your evidence came from** in the report or the ticket comment. `origin/develop@a1b2c3d` is checkable by the next reader; "I read the file" is not.
 
 Dispatch is exempt — the worktree script branches from `origin/<base>`, so ticket work always starts current. The exposure is the read-only stages (sweep, triage, audit), which read the main checkout: against a stale one, a shipped feature reads as unshipped and an overtaken ticket keeps its place in the queue.
 
@@ -201,7 +201,7 @@ Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.
 Mechanical factory tools run from **any cwd** via the `factory` CLI on PATH — product checkouts and worktrees do not contain `orchestrator/` or `tools/`.
 
 ```bash
-factory linear get CLNT-616
+factory ticket get CLNT-616
 factory queue --repo bj29
 factory next --repo bj29
 factory label-guard --repo bj29 --apply
@@ -209,30 +209,30 @@ factory label-guard --repo bj29 --apply
 
 Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). `factory notify` is the cwd-independent wrapper around the human interrupt channel. Never `bun orchestrator/...` from a worktree — that path is not there.
 
-### Linear
+### Tickets
 
-**Use `factory linear` — not the Linear MCP, and not the standalone `linear` CLI.** The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
+**Use `factory ticket` — not the Linear MCP, and not the standalone `linear` CLI.** The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
 
-You work in a worktree, not in the factory checkout. **`factory linear` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/linear.mjs"`.
+You work in a worktree, not in the factory checkout. **`factory ticket` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/ticket.mjs"`.
 
 ```bash
-factory linear get CLNT-616                              # ticket, state, labels, criteria
-factory linear claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
-factory linear comment CLNT-616 "..."                    # the heartbeat
-factory linear state CLNT-616 "In Review" --add ai:needs-review
-factory linear file --team CLNT --title "..." --body "..." --type bug
-factory linear queue --team CLNT                         # what is dispatchable
+factory ticket get CLNT-616                              # ticket, state, labels, criteria
+factory ticket claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
+factory ticket comment CLNT-616 "..."                    # the heartbeat
+factory ticket state CLNT-616 "In Review" --add ai:needs-review
+factory ticket file --team CLNT --title "..." --body "..." --type bug
+factory ticket queue --team CLNT                         # what is dispatchable
 ```
 
 `claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.
 
-**Attribution.** Factory runs set `$FACTORY_RUN_ID`. Linear comments and issues filed through `tools/linear.mjs` are stamped with it automatically; the one surface the tool cannot reach is GitHub, so **end every PR body with a final line `run:$FACTORY_RUN_ID`** (after `Fixes <ISSUE-ID>`). That one line is what joins the PR back to its transcript and metrics row when someone asks "which run produced this?". Unset (interactive session) — omit it.
+**Attribution.** Factory runs set `$FACTORY_RUN_ID`. Comments and issues filed through `tools/ticket.mjs` are stamped with it automatically; the one surface the tool cannot reach is GitHub, so **end every PR body with a final line `run:$FACTORY_RUN_ID`** (after `Fixes <ISSUE-ID>`). That one line is what joins the PR back to its transcript and metrics row when someone asks "which run produced this?". Unset (interactive session) — omit it.
 
-**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory linear state` or `factory linear claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
+**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory ticket state` or `factory ticket claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
 
-**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
+**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
 
 ### Secrets
 
-Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a Linear comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.
+Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a ticket comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.
 <!-- FACTORY:FLOOR:END -->

--- a/dist/codex/skills/factory-capture/SKILL.md
+++ b/dist/codex/skills/factory-capture/SKILL.md
@@ -21,7 +21,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/dist/codex/skills/factory-friction/SKILL.md
+++ b/dist/codex/skills/factory-friction/SKILL.md
@@ -33,7 +33,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -75,7 +75,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/dist/codex/skills/factory-merge/SKILL.md
+++ b/dist/codex/skills/factory-merge/SKILL.md
@@ -78,7 +78,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -103,7 +103,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/dist/codex/skills/factory-sweep/SKILL.md
+++ b/dist/codex/skills/factory-sweep/SKILL.md
@@ -9,7 +9,7 @@ The user's accompanying request is this workflow's argument string. Wherever the
 
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/dist/codex/skills/factory-triage/SKILL.md
+++ b/dist/codex/skills/factory-triage/SKILL.md
@@ -9,7 +9,7 @@ The user's accompanying request is this workflow's argument string. Wherever the
 
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/dist/codex/skills/factory-unblock/SKILL.md
+++ b/dist/codex/skills/factory-unblock/SKILL.md
@@ -7,7 +7,7 @@ description: Re-examine held (ai:blocked) tickets for new evidence and release t
 
 The user's accompanying request is this workflow's argument string. Wherever these instructions refer to `$ARGUMENTS`, interpret it as that request.
 
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/dist/cursor/commands/factory-capture.md
+++ b/dist/cursor/commands/factory-capture.md
@@ -12,7 +12,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/dist/cursor/commands/factory-friction.md
+++ b/dist/cursor/commands/factory-friction.md
@@ -24,7 +24,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -66,7 +66,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/dist/cursor/commands/factory-merge.md
+++ b/dist/cursor/commands/factory-merge.md
@@ -69,7 +69,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -94,7 +94,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/dist/cursor/commands/factory-sweep.md
+++ b/dist/cursor/commands/factory-sweep.md
@@ -1,6 +1,6 @@
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/dist/cursor/commands/factory-triage.md
+++ b/dist/cursor/commands/factory-triage.md
@@ -1,6 +1,6 @@
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/dist/cursor/commands/factory-unblock.md
+++ b/dist/cursor/commands/factory-unblock.md
@@ -1,4 +1,4 @@
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/dist/gemini/skills/factory-capture/SKILL.md
+++ b/dist/gemini/skills/factory-capture/SKILL.md
@@ -21,7 +21,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/dist/gemini/skills/factory-friction/SKILL.md
+++ b/dist/gemini/skills/factory-friction/SKILL.md
@@ -33,7 +33,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -75,7 +75,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/dist/gemini/skills/factory-merge/SKILL.md
+++ b/dist/gemini/skills/factory-merge/SKILL.md
@@ -78,7 +78,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -103,7 +103,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/dist/gemini/skills/factory-sweep/SKILL.md
+++ b/dist/gemini/skills/factory-sweep/SKILL.md
@@ -9,7 +9,7 @@ The user's accompanying request is this workflow's argument string. Wherever the
 
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/dist/gemini/skills/factory-triage/SKILL.md
+++ b/dist/gemini/skills/factory-triage/SKILL.md
@@ -9,7 +9,7 @@ The user's accompanying request is this workflow's argument string. Wherever the
 
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/dist/gemini/skills/factory-unblock/SKILL.md
+++ b/dist/gemini/skills/factory-unblock/SKILL.md
@@ -7,7 +7,7 @@ description: Re-examine held (ai:blocked) tickets for new evidence and release t
 
 The user's accompanying request is this workflow's argument string. Wherever these instructions refer to `$ARGUMENTS`, interpret it as that request.
 
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/dist/pi/prompts/factory-capture.md
+++ b/dist/pi/prompts/factory-capture.md
@@ -16,7 +16,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/dist/pi/prompts/factory-friction.md
+++ b/dist/pi/prompts/factory-friction.md
@@ -28,7 +28,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -70,7 +70,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/dist/pi/prompts/factory-merge.md
+++ b/dist/pi/prompts/factory-merge.md
@@ -73,7 +73,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -98,7 +98,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/dist/pi/prompts/factory-sweep.md
+++ b/dist/pi/prompts/factory-sweep.md
@@ -4,7 +4,7 @@
 
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/dist/pi/prompts/factory-triage.md
+++ b/dist/pi/prompts/factory-triage.md
@@ -4,7 +4,7 @@
 
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/dist/pi/prompts/factory-unblock.md
+++ b/dist/pi/prompts/factory-unblock.md
@@ -2,7 +2,7 @@
 
 > Re-examine held (ai:blocked) tickets for new evidence and release the ones that no longer need a human
 
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -41,7 +41,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:04c6f34662c066c5aabb4c82d9718342fddcf04e70573097cd5df1416218610f",
+    "agents/dispatch.md": "sha256:b2a473a2120e065825e08e5f872759b575c75ed069007a026cfa8ea9ecb97653",
     "schemas/dispatch.input.json": "sha256:7949221631e30ad9c6f8fa8a92d071f6ee88ea03e7fbafcbf3af1dffa432cdee",
     "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -18,7 +18,7 @@ The planner verified the ticket was `Todo` + `ai:agent-ready` + unassigned
 when this run was proposed; the world may have moved since. Claim it now:
 
 ```
-bun "$FACTORY_ROOT/tools/linear.mjs" claim <TICKET>
+bun "$FACTORY_ROOT/tools/ticket.mjs" claim <TICKET>
 ```
 
 The claim verb enforces the read-back — if it reports a lost race, or the
@@ -50,11 +50,11 @@ new ticket.
 
 ## 2. Implement
 
-1. **Read the ticket** (`bun "$FACTORY_ROOT/tools/linear.mjs" get <TICKET>`)
+1. **Read the ticket** (`bun "$FACTORY_ROOT/tools/ticket.mjs" get <TICKET>`)
    and restate your approach as a comment on it.
 2. **Implement in `./repo`**, touching only files matching the ticket's
    `Owned Paths`. Work discovered outside that set becomes a new `Triage`
-   issue (`tools/linear.mjs file`) — never a widening of this one.
+   issue (`tools/ticket.mjs file`) — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`, run inside
    `./repo` on the final tree (after your last commit), **and** the full
    `bun test` (or the repo's full suite) before you return. Never proceed

--- a/event-runtime/agents/sweep-apply.json
+++ b/event-runtime/agents/sweep-apply.json
@@ -50,7 +50,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/sweep-apply.md": "sha256:7d48b3ee14077107110246a2e5fdda7c0997fd47f8b4d047f859fa883a4203da",
+    "agents/sweep-apply.md": "sha256:373e0bd369792c9fee300a90b1ef833499fb9cdc53c5993e9598c882dd56aa8d",
     "schemas/sweep-apply.input.json": "sha256:5af257704ff1a7a6753e27bbe6916cc0b0946c8b4a23250bf592dd139273ec44",
     "schemas/sweep-applied.output.json": "sha256:75524150caebdaeffeb1dee800169a0ac423d3d6549d5491185eefe5351dacfd"
   }

--- a/event-runtime/agents/sweep-apply.md
+++ b/event-runtime/agents/sweep-apply.md
@@ -4,7 +4,7 @@ Not a prompt: this definition applies an **approved per-issue action list**
 via the deterministic actions adapter in item-list mode
 (`lib/adapters/actions.mjs`). No model runs.
 
-Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+Registered actions — each resolves to one fixed `tools/ticket.mjs` invocation:
 
 | action id          | effect                                                                                 |
 | :----------------- | :------------------------------------------------------------------------------------- |

--- a/event-runtime/agents/sweep-scan.json
+++ b/event-runtime/agents/sweep-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/sweep-scan.md": "sha256:e4fcb3985a5d2e281f129c1bac5cdddfb2044222d0f9c762a8a512039870e7c8",
+    "agents/sweep-scan.md": "sha256:3c2f35767d54f4b8407100e243247b095e2cf2d351d64e6d0dc6a84399f425af",
     "schemas/sweep-scan.input.json": "sha256:75669ff012e9cc5e2eb334545b041a694fd37335a4d6f9dd0715b5fb66c6c856",
     "schemas/sweep-scan.output.json": "sha256:fd42580f1d96f318094eedb638aa8adc432ad9464f4d6ad8af23ba49ff1ea8ba"
   }

--- a/event-runtime/agents/sweep-scan.md
+++ b/event-runtime/agents/sweep-scan.md
@@ -25,8 +25,8 @@ You never modify it, never run its build, never install anything. Write
 ## Method
 
 1. List the repo's open issues in `Backlog`, `Triage`, and `Todo`,
-   oldest-updated first: `factory linear issues --repo <name>` (or
-   `bun "$FACTORY_ROOT/tools/linear.mjs"`). **Skip, always:** anything
+   oldest-updated first: `factory ticket issues --repo <name>` (or
+   `bun "$FACTORY_ROOT/tools/ticket.mjs"`). **Skip, always:** anything
    `In Progress`, `In Review`, carrying `ai:blocked`, with an open PR, or
    with recent human activity — those are live claims, holds, or
    conversations, not this route's to touch.

--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -92,7 +92,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/triage-apply.md": "sha256:bf9ec61ac7bbc39e4fa37123bf64a02fd6f806e392f1d1c747531bd3cfdc4994",
+    "agents/triage-apply.md": "sha256:4be185dce1dd5c5b5ae6a5fa1ec92dc263d0321d6e9ea75f244c2d308d917e75",
     "schemas/triage-apply.input.json": "sha256:fd2378637f0f8accb317bf71444f5a63c26d741628b726695b7e769f050c0810",
     "schemas/triage-applied.output.json": "sha256:5c52b583f055223367bddbcf48e853ff0af9a8e5bf536942ac15f2dc01f217f9"
   }

--- a/event-runtime/agents/triage-apply.md
+++ b/event-runtime/agents/triage-apply.md
@@ -16,7 +16,7 @@ Registered actions — each resolves to one fixed, non-shell-interpolated argv:
 | `needs-human`       | `comment {issueId} "<reason>"`                                                                                                   |
 
 `write-detail` is intentionally separate from `label-agent-ready`. It calls
-`tools/linear.mjs detail`, which preserves the description read immediately
+`tools/ticket.mjs detail`, which preserves the description read immediately
 before the mutation and appends only the approved Markdown suffix. Its
 `DETAIL_CHANGED` outcome no longer chains into an immediate re-scan (WM:
 operator decision 2026-08-18, to stop burning the pi/codex adapter's quota on

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:a29b89ed8ecedadd0815a3b772f7996882f700e753847ec55e1fd21ce23a1840",
+    "agents/triage-scan.md": "sha256:6d71d0a08d395b719b890a3b0f6c668004181d7206185ec1fae0aaf895871d89",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:6eb237281746aaaea34e4e5927228e9eb90f2954d9df8d05f8c04b00bad27868"
   }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -26,8 +26,8 @@ You never modify it, never run its build, never install anything. Write
 
 1. Resolve the repo's Linear team and project from
    `$FACTORY_ROOT/config/repos.yaml`, then list **all** of that project's open
-   issues in `Triage` and `Todo` with paginated `factory linear raw` queries (or
-   `bun "$FACTORY_ROOT/tools/linear.mjs" raw`). Hard-code the state list as
+   issues in `Triage` and `Todo` with paginated `factory ticket raw` queries (or
+   `bun "$FACTORY_ROOT/tools/ticket.mjs" raw`). Hard-code the state list as
    `in:["Triage","Todo"]` in the GraphQL document: `linear.mjs raw` passes every
    `--var` value as a string, so passing a JSON-looking array through `--var`
    silently searches for one state with that literal name and can return a

--- a/event-runtime/agents/unblock-apply.json
+++ b/event-runtime/agents/unblock-apply.json
@@ -56,7 +56,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/unblock-apply.md": "sha256:17d92c9242795a5d67ce8be80e05762ec9216b4aaab88c7c7c96c33aaedb142a",
+    "agents/unblock-apply.md": "sha256:e97afe482eb0c95faa82fab3e560ea28bbb3cc07dfbd3d4f5fdc68e994e01897",
     "schemas/unblock-apply.input.json": "sha256:a983e831d67dbb30352697e457a7197f18776e1de184731be7ed88b9ea1d8f41",
     "schemas/unblock-applied.output.json": "sha256:4b1ed38f71ca16a56bc7bc2582c629580fe7b57614ea2b12b0c289c9e6bf611b"
   }

--- a/event-runtime/agents/unblock-apply.md
+++ b/event-runtime/agents/unblock-apply.md
@@ -4,7 +4,7 @@ Not a prompt: this definition applies an **approved per-issue action list**
 via the deterministic actions adapter in item-list mode
 (`lib/adapters/actions.mjs`). No model runs.
 
-Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+Registered actions — each resolves to one fixed `tools/ticket.mjs` invocation:
 
 | action id           | effect                                                                                                                      |
 | :------------------ | :-------------------------------------------------------------------------------------------------------------------------- |

--- a/event-runtime/agents/unblock-scan.json
+++ b/event-runtime/agents/unblock-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/unblock-scan.md": "sha256:c6e20de77d9171eee4d55f8895d798ca521fb83af82ec15ffaf72152b19f9a6a",
+    "agents/unblock-scan.md": "sha256:694369735661dfaab12070e949c96e5f00d9c38570b7ceecf452e88977b242ae",
     "schemas/unblock-scan.input.json": "sha256:edb9af116d7a35b155d2472232f3c9625381996876e6aac18dacff28a215ac89",
     "schemas/unblock-scan.output.json": "sha256:1ccccd541b192dc4a300a1a5ebfe36485fb2ed97effc4f0d6bfcc1ab7e757c65"
   }

--- a/event-runtime/agents/unblock-scan.md
+++ b/event-runtime/agents/unblock-scan.md
@@ -25,7 +25,7 @@ You never modify it, never run its build, never install anything. Write
 ## Method
 
 1. List the repo's open issues carrying `ai:blocked`, **oldest hold first**:
-   `factory linear issues --repo <name>` (or `bun "$FACTORY_ROOT/tools/linear.mjs"`).
+   `factory ticket issues --repo <name>` (or `bun "$FACTORY_ROOT/tools/ticket.mjs"`).
 2. For each, reconstruct the hold: what did the blocking comment say is
    missing?
 3. Hunt for **new** evidence that the hold has resolved without a reply:

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:650c43e6d15e1fe48fe7521bf831ad2d1f122d7ea154825757cb901332618334",
+    "agents/work-scan.md": "sha256:aabcaed7a814e14b4aa291eacd1e63825fa9424a71991377006a780decaecbd1",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
     "schemas/work-scan.output.json": "sha256:98a2cb891198b79d8d8d9924a3db1fe2bd11e2983c71ae4a3499bc54a5d43f5f"
   }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -27,7 +27,7 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
 ## Method
 
 1. **Enumerate and filter candidates** with a complete repo queue read
-   (`bun "$FACTORY_ROOT/tools/linear.mjs"`; all pages, no sampling). Build the
+   (`bun "$FACTORY_ROOT/tools/ticket.mjs"`; all pages, no sampling). Build the
    candidate set yourself from the returned fields. A ticket is a candidate
    only when **all three** predicates hold:
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -167,7 +167,7 @@ describe("registry", () => {
     // Regenerated (WM-938): dispatch pins explicit PR bases and merge-scan
     // surfaces wrong-base PRs; both agent definitions are registry inputs.
     const expected =
-      "sha256:7b8947e3cb825922f935f7821ff085403a80747edf0a2fd2ce81fb520991a1f8";
+      "sha256:5a8aeabaab1f3f111286106bb15ec76977c88340cb7578045e6cf74a1dd346fc";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -339,7 +339,7 @@ describe("registry", () => {
     // WM-812 adds decision-memo declarations and re-pins the dispatch brief.
     // WM-938 adds the explicit-base PR command and re-pins dispatch.
     expect(computeDefHash(def)).toBe(
-      "sha256:85b4dd48a2eacc1fb8d238bf72dbe98a442988b5ef74c28f130ed59e9da83323",
+      "sha256:d004d6500d8ba0cac57573f8d0836a1ec2f18e083dd414d0348adb230387f893",
     );
   });
 

--- a/plugins/core/commands/factory-capture.md
+++ b/plugins/core/commands/factory-capture.md
@@ -22,7 +22,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/plugins/core/commands/factory-friction.md
+++ b/plugins/core/commands/factory-friction.md
@@ -30,7 +30,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -72,7 +72,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/plugins/core/commands/factory-merge.md
+++ b/plugins/core/commands/factory-merge.md
@@ -79,7 +79,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -104,7 +104,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/plugins/core/commands/factory-sweep.md
+++ b/plugins/core/commands/factory-sweep.md
@@ -11,7 +11,7 @@ model: sonnet
 
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/plugins/core/commands/factory-triage.md
+++ b/plugins/core/commands/factory-triage.md
@@ -6,7 +6,7 @@ model: sonnet
 
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/plugins/core/commands/factory-unblock.md
+++ b/plugins/core/commands/factory-unblock.md
@@ -4,7 +4,7 @@ argument-hint: [optional: issue IDs or a max count]
 model: sonnet
 ---
 
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/shared/commands/factory-capture.md
+++ b/shared/commands/factory-capture.md
@@ -22,7 +22,7 @@ Repo → team/project mapping, and the full `ai:*`/`source:*`/`type:*`/`area:*` 
 
 If the current working directory matches a repo in `config/repos.yaml`, use its `team`/`project`. Otherwise infer team/project from what the conversation was actually about — ask if it's genuinely ambiguous rather than guessing.
 
-**Search for duplicates first** (`factory linear`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
+**Search for duplicates first** (`factory ticket`, per `docs/protocol.md` §13) — don't file a second issue for something already tracked; comment on the existing one with the new evidence instead and report that back, not a new issue.
 
 ## 3. Label and specify
 

--- a/shared/commands/factory-friction.md
+++ b/shared/commands/factory-friction.md
@@ -30,7 +30,7 @@ Same bar as `docs/friction-log.md` — only two things:
 
 ## 4. Search before filing
 
-Search Linear (`factory linear` or `docs/protocol.md` §13) for:
+Search Linear (`factory ticket` or `docs/protocol.md` §13) for:
 
 - Existing `FIP:` issues describing the same shape
 - Prior issues whose body contains `## Session friction` with the same **Shape**
@@ -72,7 +72,7 @@ Factory-wide items: prefix the title with `FIP:`. Do not write the full §5 agen
 - **`area:*`** — `area:factory` for OPS/FIP items; match the repo's area labels for product-repo friction
 - **State:** `Triage` only — never `Todo` + `ai:agent-ready` from this command
 
-Use `factory linear file ...` from a worktree.
+Use `factory ticket file ...` from a worktree.
 
 ## 8. Report
 

--- a/shared/commands/factory-merge.md
+++ b/shared/commands/factory-merge.md
@@ -79,7 +79,7 @@ Why this matters: a legalease run on 2026-08-04 landed 3 PRs in 15 minutes again
 
 If the repo has GitHub's native merge queue enabled, prefer it over any of this — it tests batches and drops the failures for you.
 
-After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory linear state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
+After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done` (`factory ticket state <ID> Done --remove ai:needs-review --remove ai:escalated --remove ai:blocked`). Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
 Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, run `factory branch-guard` to mechanically verify that the branch is not protected (`base` / `deploy_branch` / `develop` / `master` / `main`) and that no **other open PR** still has it as its head (WM-17, WM-51):
 
@@ -104,7 +104,7 @@ If base CI or the smoke check breaks after a batch, stop merging further batches
 
 Reviewing diffs is where follow-up work surfaces. Anything the review reveals that doesn't block this merge — defects elsewhere, missing test coverage, tech debt, refactor opportunities, UX rough edges, improvement ideas — gets a Linear issue in `Triage` **at the moment you spot it**: correct team/project, `type:*` + `area:*` + `source:agent` labels, evidence-based priority, linked to the PR and ticket that surfaced it. A finding mentioned only in this report or a PR comment is a finding lost. Filing is cheap; err on the side of filing. This applies to escalated and left-open PRs too, not just merged ones.
 
-**Order of operations for discovered work:** File follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
+**Order of operations for discovered work:** File follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs. Ticket IDs cannot be known prior to creation; pre-writing cross-references in comments or reports before filing produces fake or broken identifiers.
 
 ## Capture session friction (interactive runs only)
 

--- a/shared/commands/factory-sweep.md
+++ b/shared/commands/factory-sweep.md
@@ -11,7 +11,7 @@ model: sonnet
 
 Find tickets in this project's backlog that no longer need to exist, and retire them — never delete them. "Retire" means moving to Linear's `Canceled` or `Duplicate` state with a comment citing the evidence. Those states already exist for exactly this (`docs/protocol.md` §4) and keep the ticket recoverable; an actual delete does not, so **never call a delete/archive mutation, only a state transition.**
 
-Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Resolve the team/project from the repo via `config/repos.yaml` (`docs/protocol.md` §1–2), or from `$ARGUMENTS` if a project name is given. Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 **First, before judging anything: `git fetch --quiet` and check `git rev-list --count HEAD..origin/<base>`** (never `@{upstream}` — it depends on tracking config the checkout may not have). This stage's entire job is deciding what is already true of the code, so it is the stage a stale checkout hurts most — a feature merged last week reads as unshipped and its ticket keeps a dispatch slot it no longer deserves. Follow the floor's **Checkout freshness** rule: fast-forward a clean tree, and read `origin/<base>` rather than the working tree when it's dirty, ahead, or the fetch/rev-list itself fails. State the ref you swept against at the top of the report.
 

--- a/shared/commands/factory-triage.md
+++ b/shared/commands/factory-triage.md
@@ -6,7 +6,7 @@ model: sonnet
 
 Triage the open Linear issues for the repository I'm currently in: turn raw `Triage` tickets into fully specified, agent-dispatchable ones where possible.
 
-Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
+Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor. Interpret $ARGUMENTS as specific issue IDs, a max count, or "all" (workspace-wide); default is this repo's team, up to 10 issues.
 
 ## Claim what you are triaging
 

--- a/shared/commands/factory-unblock.md
+++ b/shared/commands/factory-unblock.md
@@ -4,7 +4,7 @@ argument-hint: [optional: issue IDs or a max count]
 model: sonnet
 ---
 
-Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory linear`; on failure retry once then fall back to `factory linear raw` per the floor.
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via `config/repos.yaml` (`docs/protocol.md` §1). Use `factory ticket`; on failure retry once then fall back to `factory ticket raw` per the floor.
 
 Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
 

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -12,7 +12,7 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `$FA
 
 **Event-runtime code follows the documented house conventions.** For module shape, dependency injection, adapter contracts, fail-closed boundaries, and tests, read [`docs/event-runtime-conventions.md`](https://github.com/watt-mind/factory/blob/develop/docs/event-runtime-conventions.md) before changing `event-runtime/`.
 
-**Work comes from Linear, and only when it's ready.** A ticket is dispatchable only if it is `Todo` + `ai:agent-ready` + unassigned. `Triage` and `Backlog` are not queues to pull from.
+**Work comes from the control plane, and only when it's ready.** A ticket is dispatchable only if it is `Todo` + `ai:agent-ready` + unassigned. `Triage` and `Backlog` are not queues to pull from.
 
 **An ad-hoc request gets a ticket too — file it, don't wait to be asked.** A request typed into a chat session is not exempt from the control plane; if it isn't tracked, it is invisible to every other agent and to tomorrow. **The trip wire is your first file edit:** before it, either find the issue that already covers this or create one, and say in one line which it is ("Tracking as OPS-91"). Commits still carry their `(ISSUE-ID)`. Skip the ticket only for ordinary questions, read-only lookups with no actionable finding, and inconsequential edits — and the human can always say "no ticket", which settles it. Sessions drift: one that began as a question and turned into a change trips the wire at that moment, not at the end.
 
@@ -42,7 +42,7 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `$FA
 
 **Negative testing and falsifiability.** New regression tests must be observed failing before applying the fix to prove they test the actual failure mode and are not vacuous. Verify that tests distinguish correct implementations from plausible incorrect ones (without using `git stash`; use safe per-file reverts such as `git show <ref>:<path> > <path>`). A test that passes before the fix is applied tests nothing.
 
-**Mandatory `## Handoff` comment.** Before moving a ticket to `In Review`, post a structured `## Handoff` comment on the Linear ticket with these exact fields:
+**Mandatory `## Handoff` comment.** Before moving a ticket to `In Review`, post a structured `## Handoff` comment on the ticket with these exact fields:
 
 ```
 ## Handoff
@@ -59,7 +59,7 @@ Posting this structured comment is a mandatory prerequisite before advancing a t
 
 ### Never auto-merge
 
-Regardless of CI or review outcome, these come back to a human with findings: **auth/authz, payments or money movement, credential and secret handling, destructive DB migrations, production infra config, and `CLNT` security behavior.** When escalating, add `ai:escalated` to the Linear ticket — that's what surfaces it in the human's "My Decisions Needed" view — and notify (see below).
+Regardless of CI or review outcome, these come back to a human with findings: **auth/authz, payments or money movement, credential and secret handling, destructive DB migrations, production infra config, and `CLNT` security behavior.** When escalating, add `ai:escalated` to the ticket — that's what surfaces it in the human's "My Decisions Needed" view — and notify (see below).
 
 The test is whether the diff **changes security-relevant behavior**, not whether a file sits near security code — read as file-adjacency this list swallows every PR in an app where auth is everywhere, and that trains everyone to rubber-stamp it. When it's genuinely ambiguous, escalate: a false escalation costs one message, a wrong merge costs a client incident.
 
@@ -89,15 +89,15 @@ Same care for force-pushes: never `--force` onto a `base` or `deploy_branch`, an
 
 Move the ticket to `Blocked`, say specifically what you need in one answerable question, and notify. Never leave a stalled ticket sitting in `In Progress`.
 
-**"Notify" means exactly this command** — a Linear comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
+**"Notify" means exactly this command** — a ticket comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
 
 ```bash
 factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
 ```
 
-Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a Linear comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to Linear and the run report, never here.
+Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a ticket comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to the ticket and the run report, never here.
 
-Before blocking on product intent, check whether it's already written down — the repo's `docs/product-decisions.md`, `docs/`, or the Linear project Overview. If you resolve a decision that wasn't recorded, record it.
+Before blocking on product intent, check whether it's already written down — the repo's `docs/product-decisions.md`, `docs/`, or the tracker project overview. If you resolve a decision that wasn't recorded, record it.
 
 ### Waiting
 
@@ -149,7 +149,7 @@ Ahead-only (clean, not behind, but carrying unpushed commits) still routes to `o
 
 Never pull over uncommitted work to get a fresher read — those files are a human's in-flight change, and losing them costs far more than a slightly stale spec. Reading `origin/<base>` gets the same correctness without touching the tree.
 
-Then **name the ref your evidence came from** in the report or the Linear comment. `origin/develop@a1b2c3d` is checkable by the next reader; "I read the file" is not.
+Then **name the ref your evidence came from** in the report or the ticket comment. `origin/develop@a1b2c3d` is checkable by the next reader; "I read the file" is not.
 
 Dispatch is exempt — the worktree script branches from `origin/<base>`, so ticket work always starts current. The exposure is the read-only stages (sweep, triage, audit), which read the main checkout: against a stale one, a shipped feature reads as unshipped and an overtaken ticket keeps its place in the queue.
 
@@ -201,7 +201,7 @@ Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.
 Mechanical factory tools run from **any cwd** via the `factory` CLI on PATH — product checkouts and worktrees do not contain `orchestrator/` or `tools/`.
 
 ```bash
-factory linear get CLNT-616
+factory ticket get CLNT-616
 factory queue --repo bj29
 factory next --repo bj29
 factory label-guard --repo bj29 --apply
@@ -209,30 +209,30 @@ factory label-guard --repo bj29 --apply
 
 Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). `factory notify` is the cwd-independent wrapper around the human interrupt channel. Never `bun orchestrator/...` from a worktree — that path is not there.
 
-### Linear
+### Tickets
 
-**Use `factory linear` — not the Linear MCP, and not the standalone `linear` CLI.** The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
+**Use `factory ticket` — not the Linear MCP, and not the standalone `linear` CLI.** The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
 
-You work in a worktree, not in the factory checkout. **`factory linear` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/linear.mjs"`.
+You work in a worktree, not in the factory checkout. **`factory ticket` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/ticket.mjs"`.
 
 ```bash
-factory linear get CLNT-616                              # ticket, state, labels, criteria
-factory linear claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
-factory linear comment CLNT-616 "..."                    # the heartbeat
-factory linear state CLNT-616 "In Review" --add ai:needs-review
-factory linear file --team CLNT --title "..." --body "..." --type bug
-factory linear queue --team CLNT                         # what is dispatchable
+factory ticket get CLNT-616                              # ticket, state, labels, criteria
+factory ticket claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
+factory ticket comment CLNT-616 "..."                    # the heartbeat
+factory ticket state CLNT-616 "In Review" --add ai:needs-review
+factory ticket file --team CLNT --title "..." --body "..." --type bug
+factory ticket queue --team CLNT                         # what is dispatchable
 ```
 
 `claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.
 
-**Attribution.** Factory runs set `$FACTORY_RUN_ID`. Linear comments and issues filed through `tools/linear.mjs` are stamped with it automatically; the one surface the tool cannot reach is GitHub, so **end every PR body with a final line `run:$FACTORY_RUN_ID`** (after `Fixes <ISSUE-ID>`). That one line is what joins the PR back to its transcript and metrics row when someone asks "which run produced this?". Unset (interactive session) — omit it.
+**Attribution.** Factory runs set `$FACTORY_RUN_ID`. Comments and issues filed through `tools/ticket.mjs` are stamped with it automatically; the one surface the tool cannot reach is GitHub, so **end every PR body with a final line `run:$FACTORY_RUN_ID`** (after `Fixes <ISSUE-ID>`). That one line is what joins the PR back to its transcript and metrics row when someone asks "which run produced this?". Unset (interactive session) — omit it.
 
-**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory linear state` or `factory linear claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
+**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory ticket state` or `factory ticket claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
 
-**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
+**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
 
 ### Secrets
 
-Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a Linear comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.
+Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a ticket comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.
 <!-- FACTORY:FLOOR:END -->


### PR DESCRIPTION
Fixes WM-1028 — split 3 of 3 replacing WM-1010. Last Phase-1 ticket of the WM-1006 epic.

## What

`docs/protocol.md` §3 already said it: *"These names are part of the protocol, not tracker branding."* The agent-facing surface didn't follow — and that surface is what a contributor reads first.

Swept 15 files: every `event-runtime/agents/*.md` prompt, all 13 `shared/commands/factory-*.md`, and `shared/floor.md`. `factory linear` → `factory ticket`, `tools/linear.mjs` → `tools/ticket.mjs`, and prose like *"Work comes from Linear"* → *"Work comes from the control plane"*. Regenerated `AGENTS.md`, `GEMINI.md`, `dist/**` and `plugins/core/**`.

## Notes for the reviewer

- **8 prompt `pins` sha256 were regenerated**, one per swept `.md`. This is load-bearing, not cosmetic: I verified it by corrupting one pin, which fails 4 registry tests including `loads the committed registry (pins verified)`.
- **Registry digests regenerated** for the same reason — prompt content is part of the definition.
- **Genuinely Linear-specific statements were kept**, because they are still true: the "why not the Linear MCP / the schpet `linear` CLI" rationale with its measured failure numbers, and the `linear issue update -l` label-stripping example. Only the section heading became `### Tickets`. Scrubbing accurate statements in the name of neutrality would make the docs worse, not more portable.
- **Scope correction:** `event-runtime/lib/registry.test.mjs` was added to Owned Paths. Changing prompts changes the registry digest, so the baseline had to move with them — the same manifests-and-consumers-together lesson that made WM-1010 unsatisfiable. It belonged to WM-1027, which is now merged, so there is no collision.

## Process note, worth recording

I used `git stash` in a worktree while rebasing. **The operating floor forbids exactly that** — the stash stack is repository-global (`.git/refs/stash`), so a `stash push` that no-ops on a clean tree followed by `stash pop` silently takes another agent's work.

I verified no loss: two pre-existing stashes sit untouched below mine, my tree was dirty so the push created a real entry, and the swept content is all present. But it worked by luck, not by rule. The safe alternative was `git diff > /tmp/patch` or a WIP commit.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 event-runtime/lib && bun run format:check && bun run lint && bun run check
```

- **1503 pass, 0 fail** across 89 files
- `bun run check`: ok — 90 generated files match `shared/`
- 0 stale pins (verified programmatically across all manifests)
- format:check clean; lint 0 errors, 616 warnings = baseline