### PR TITLE
fix(control-plane): resolve GitHub blockers per candidate, not per open issue

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -652,7 +652,22 @@ export function githubControlPlane(options = {}) {
       }));
     },
 
-    async listTickets({ team, project, states } = {}) {
+    /**
+     * @param {{ team: string, project?: string, states?: string[],
+     *           resolveBlockers?: boolean }} [opts]
+     *
+     * `resolveBlockers` is OFF by default and that default is load-bearing
+     * (WM-1044). GitHub has no bulk dependency read, so resolving blockers
+     * costs one request per issue. Doing it for every open issue made a single
+     * `listDispatchable` cost `1 + N` requests — measured at 6 for 6 issues,
+     * which projects to ~251 on a 250-issue board and 15,000/hr against a
+     * 5,000/hr limit. The factory would rate-limit itself within minutes and
+     * take merges and PR creation down with it, since they share the budget.
+     *
+     * Callers that need the gate ask for it, and `listDispatchable` asks only
+     * AFTER narrowing to real candidates.
+     */
+    async listTickets({ team, project, states, resolveBlockers = false } = {}) {
       if (!team) throw new ControlPlaneError("listTickets requires team");
       if (project && project !== projectTitle) return [];
       const repo = repoForTeam(team);
@@ -673,8 +688,8 @@ export function githubControlPlane(options = {}) {
       const wanted = states?.length
         ? new Set(states.map((n) => n.toLowerCase()))
         : null;
-      const open = await blockedByMap(repo, issues);
-      const out = [];
+      // Narrow FIRST; only then pay per-issue costs.
+      const kept = [];
       for (const issue of issues) {
         const statusName =
           statusByNumber.get(issue.number) ??
@@ -682,26 +697,52 @@ export function githubControlPlane(options = {}) {
         const name = String(statusName).toLowerCase();
         if (wanted ? !wanted.has(name) : ["done", "canceled"].includes(name))
           continue;
-        out.push(
+        kept.push({ issue, statusName });
+      }
+      const open = resolveBlockers
+        ? await blockedByMap(
+            repo,
+            kept.map((k) => k.issue),
+          )
+        : null;
+      return kept
+        .map(({ issue, statusName }) =>
           normalizeIssue(
-            { ...issue, __blockedBy: open.get(issue.number) ?? [] },
+            { ...issue, __blockedBy: open?.get(issue.number) ?? [] },
             repo,
             { name: statusName, opt: null },
           ),
-        );
-      }
-      return out.sort(byQueueOrder);
+        )
+        .sort(byQueueOrder);
     },
 
     async listDispatchable({ team, project } = {}) {
       if (!team) throw new ControlPlaneError("listDispatchable requires team");
-      const todo = await this.listTickets({ team, project, states: ["Todo"] });
-      return todo.filter(
+      // Cheap predicate first — state, labels, assignee are already in the
+      // issue list response and cost nothing extra. Only the survivors are
+      // worth a dependency request each.
+      const candidates = (
+        await this.listTickets({ team, project, states: ["Todo"] })
+      ).filter(
         (t) =>
           !t.assignee &&
-          (t.labels ?? []).some((l) => l.name === AGENT_READY_LABEL) &&
-          (t.blockedBy ?? []).length === 0,
+          (t.labels ?? []).some((l) => l.name === AGENT_READY_LABEL),
       );
+      if (!candidates.length) return [];
+      const repo = repoForTeam(team);
+      const open = await blockedByMap(
+        repo,
+        candidates.map((t) => ({
+          number: Number(t.identifier.split("#")[1]),
+          state: "open",
+        })),
+      );
+      return candidates
+        .map((t) => ({
+          ...t,
+          blockedBy: open.get(Number(t.identifier.split("#")[1])) ?? [],
+        }))
+        .filter((t) => t.blockedBy.length === 0);
     },
 
     async claim(identifier, { harness = "claude" } = {}) {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -951,3 +951,147 @@ describe("provisionGithubRepo", () => {
     );
   });
 });
+
+// ------------------------------------------ request-count scaling (WM-1044) ---
+// The live spike (WM-1012) measured 1 + N requests per listDispatchable — one
+// dependency read for every OPEN issue, not every candidate. On the WM board
+// (250+ open issues) that projects to ~251 requests per call and ~15,000/hr
+// against a 5,000/hr limit: the factory would rate-limit itself within minutes
+// of cutover and take merges and PR creation down with it, since they share the
+// budget. Cost is the behaviour under test here, so assert the call count.
+describe("listDispatchable request cost does not scale with open issues", () => {
+  const REPO3 = "acme/widget";
+
+  /** A repo with `total` open issues, of which `ready` are dispatchable. */
+  function bigApi({ total, ready }) {
+    const issues = [];
+    for (let n = 1; n <= total; n += 1) {
+      const isReady = n <= ready;
+      issues.push({
+        number: n,
+        id: n,
+        node_id: `N${n}`,
+        title: `issue ${n}`,
+        body: "",
+        state: "open",
+        assignee: null,
+        created_at: "2026-01-01T00:00:00Z",
+        labels: isReady ? [{ id: n, name: AGENT_READY_LABEL }] : [],
+      });
+    }
+    const calls = [];
+    const api = async (method, pathName, opts) => {
+      calls.push(`${method} ${pathName}`);
+      if (method === "GET" && pathName === `repos/${REPO3}/issues`)
+        return issues;
+      if (pathName === "graphql") {
+        // Two distinct GraphQL shapes: FIND_REPO_PROJECT (the board) and
+        // PROJECT_ITEMS (its items, keyed off `node`).
+        const q = String(opts?.body?.query ?? "");
+        if (q.includes("projectsV2")) {
+          return {
+            repository: {
+              projectsV2: {
+                nodes: [
+                  {
+                    id: "p1",
+                    title: "Factory",
+                    field: {
+                      id: "f1",
+                      name: "Status",
+                      options: GITHUB_FACTORY_STATES.map((name, i) => ({
+                        id: `o${i}`,
+                        name,
+                      })),
+                    },
+                  },
+                ],
+              },
+            },
+          };
+        }
+        // Every issue sits in Todo.
+        return {
+          node: {
+            items: {
+              nodes: issues.map((i) => ({
+                id: `it${i.number}`,
+                fieldValueByName: { name: "Todo" },
+                content: {
+                  number: i.number,
+                  repository: { nameWithOwner: REPO3 },
+                },
+              })),
+            },
+          },
+        };
+      }
+      if (/\/dependencies\/blocked_by$/.test(pathName)) return [];
+      throw new ControlPlaneError(`unexpected ${method} ${pathName}`, {
+        status: 400,
+      });
+    };
+    api.calls = calls;
+    return api;
+  }
+
+  test("250 open issues with 5 ready costs a bounded number of requests", async () => {
+    const api = bigApi({ total: 250, ready: 5 });
+    const cp = githubControlPlane({
+      api,
+      repo: REPO3,
+      teams: { WM: REPO3 },
+      project: "Factory",
+    });
+    const ready = await cp.listDispatchable({ team: "WM" });
+    expect(ready.length).toBe(5);
+
+    const deps = api.calls.filter((c) => c.includes("/dependencies/"));
+    // One per CANDIDATE, not one per open issue. Pre-fix this was 250.
+    expect(deps.length).toBe(5);
+    expect(api.calls.length).toBeLessThanOrEqual(15);
+  });
+
+  test("the cost is flat as the board grows", async () => {
+    // Same 5 ready, 10x the issues: the request count must not move.
+    const small = bigApi({ total: 25, ready: 5 });
+    const large = bigApi({ total: 250, ready: 5 });
+    const mk = (api) =>
+      githubControlPlane({
+        api,
+        repo: REPO3,
+        teams: { WM: REPO3 },
+        project: "Factory",
+      });
+    await mk(small).listDispatchable({ team: "WM" });
+    await mk(large).listDispatchable({ team: "WM" });
+    expect(large.calls.length).toBe(small.calls.length);
+  });
+
+  test("listTickets does not resolve blockers unless asked", async () => {
+    const api = bigApi({ total: 50, ready: 50 });
+    const cp = githubControlPlane({
+      api,
+      repo: REPO3,
+      teams: { WM: REPO3 },
+      project: "Factory",
+    });
+    const all = await cp.listTickets({ team: "WM" });
+    expect(all.length).toBe(50);
+    expect(api.calls.filter((c) => c.includes("/dependencies/")).length).toBe(
+      0,
+    );
+
+    const api2 = bigApi({ total: 50, ready: 50 });
+    const cp2 = githubControlPlane({
+      api: api2,
+      repo: REPO3,
+      teams: { WM: REPO3 },
+      project: "Factory",
+    });
+    await cp2.listTickets({ team: "WM", resolveBlockers: true });
+    expect(api2.calls.filter((c) => c.includes("/dependencies/")).length).toBe(
+      50,
+    );
+  });
+});


### PR DESCRIPTION
Fixes WM-1044 — **the migration blocker** found by the WM-1012 live spike.

## The problem

`blockedByMap()` issued one `GET /issues/{n}/dependencies/blocked_by` **per open issue**, then `listDispatchable` filtered. Measured live: **6 requests for 6 open issues** — confirmed `1 + N`.

The WM board has **250+ open issues**:

| Open issues | Requests/call | At 1 tick/min | vs 5000/hr |
| ---: | ---: | ---: | :--- |
| 50 | ~51 | 3,060/hr | ok |
| 100 | ~101 | 6,060/hr | **over** |
| 250 | ~251 | 15,060/hr | **3× over** |

And `fetchState()` runs more than once per tick. The factory would have rate-limited itself within minutes of cutover — and taken merges and PR creation down with it, since they share the budget.

## The fix

Narrow first, pay later.

- `listDispatchable` applies the free predicate (state, labels, assignee — all already in the issue-list response), then resolves blockers only for the survivors.
- `listTickets` gains `resolveBlockers` (**default off**). The dispatcher needs `blockedBy` on the ready queue, not on every In Progress ticket, so it shouldn't pay for it always.

Cost is now bounded by the *ready* count, not the board size: 250 open / 5 ready → **5 dependency requests**, ≤15 total.

## Notes for the reviewer

- **The tests assert request counts, not behaviour comments.** Three of them: bounded cost at 250 issues, cost flat as the board grows 25→250, and `listTickets` making zero dependency calls unless asked. Restoring the O(N) version fails all three.
- Gating semantics are unchanged — the existing contract tests (94 pass) still hold, and the live spike confirmed exclusion-while-blocked and release-on-close.
- The default being off is load-bearing, and the comment says why, because the next person to add a caller needs to know they're choosing a cost.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 lib/control-plane event-runtime/lib/control-plane.test.mjs && bun run format:check && bun run lint
```

- 94 pass, 0 fail
- format:check clean; lint 0 errors, 616 warnings = baseline

**Falsifiability:** reverting to per-open-issue resolution fails all 3 new scaling tests.