### PR TITLE
feat(oss): agent-ready issue form and the contributor intake path

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_ready_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_ready_task.yml
@@ -1,0 +1,106 @@
+name: Agent-ready task
+description: A fully specified task an agent can pick up and implement unattended
+title: "type(scope): "
+labels:
+  - source:human
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form produces a ticket the factory can dispatch **without a human in the loop**.
+        Every field maps to a required section of the protocol (`docs/protocol.md` §5).
+
+        A task missing `Owned Paths` or `Verification Command` is demoted to Triage automatically —
+        those two are what make unattended work safe, not paperwork.
+
+        Filing this does **not** queue the task. A maintainer adds `ai:agent-ready` once the spec
+        holds up. Anyone can file; only maintainers can dispatch.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and pull requests for this work.
+          required: true
+        - label: This does not contain credentials, personal data, or client data.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem & Context
+      description: What is wrong or missing, and why it matters. Link related issues.
+      placeholder: |
+        `factory doctor` reports a missing GitHub CLI as "unknown error", so a
+        first-run user cannot tell a setup problem from a bug.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: >-
+        Observable, falsifiable checks. An agent will treat these as the definition of done,
+        so "works correctly" is not usable — say what output proves it.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: pointers
+    attributes:
+      label: Source File Pointers
+      description: Where to start reading. Every path must already exist on the base branch.
+      placeholder: |
+        * `orchestrator/doctor.mjs` — the check that reports the error
+        * `docs/quickstart.md` — the remediation text it should point at
+    validations:
+      required: true
+  - type: textarea
+    id: owned_paths
+    attributes:
+      label: Owned Paths
+      description: >-
+        The files an agent may modify. This is the concurrency key — the dispatcher refuses to
+        run two tasks whose sets intersect, so tight globs beat convenient ones.
+        ONE PATH PER BULLET, keeping the leading "- ". No prose, no commas, and no
+        spaces inside a path — the parser keeps only bullet lines that look like a
+        path, so a comma-separated list or a stray space is silently dropped and the
+        task then dispatches with a narrower scope than you wrote.
+        Generated output must be listed with its source.
+      value: |
+        - 
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification Command
+      description: >-
+        A command that actually runs in this repo and fails when the work is wrong.
+        The agent runs exactly this and will not open a PR on failing output.
+        Include the formatting and lint checks CI runs, or a task can pass here and still land red.
+      value: |
+        ```
+        bun test --timeout 20000 --max-concurrency=4 event-runtime/lib && bun run format:check && bun run lint
+        ```
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Sets the `type:*` label. Exactly one.
+      options:
+        - feature
+        - bug
+        - maintenance
+        - docs
+        - performance
+        - security
+        - ui-ux
+        - a11y
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,8 @@ name: Bug report
 description: Report a reproducible problem in Factory
 title: "bug: "
 labels:
-  - bug
+  - type:bug
+  - source:human
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/watt-mind/factory/security/policy
     about: Report vulnerabilities privately by following the security policy.
+  - name: Questions and open-ended ideas
+    url: https://github.com/watt-mind/factory/discussions
+    about: For anything not yet shaped like a task. Issues here are work items, not a forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,8 @@ name: Feature request
 description: Propose a focused improvement to Factory
 title: "feat: "
 labels:
-  - enhancement
+  - type:feature
+  - source:human
 body:
   - type: checkboxes
     id: preflight

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,45 @@ documentation, tests, fixes, and focused feature proposals.
 All participation in this project is governed by our
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## How work gets picked up
+
+Factory is maintained partly by the thing in it: coding agents implement tickets
+from this repo's issue tracker, unattended. That shapes how issues are written.
+
+The path from idea to merged change:
+
+1. **Anyone files an issue.** Use the _Agent-ready task_ form if you already know
+   the fix; otherwise a bug report or feature request is fine and a maintainer
+   will shape it.
+2. **A maintainer specifies and labels it `ai:agent-ready`.** On a public
+   repository only users with triage permission can apply labels, so this gate is
+   enforced by GitHub itself: anyone can file, only a maintainer can queue.
+3. **An agent or a human claims it**, works in an isolated worktree, and runs the
+   ticket's own verification command.
+4. **A pull request opens against `develop`**, subject to CI and review like any
+   other. Nothing merges because an agent said it was done.
+
+An issue is only dispatchable when it carries all five sections the _Agent-ready
+task_ form asks for. Two of them are load-bearing rather than bureaucratic:
+
+- **Owned Paths** is the concurrency key. The dispatcher refuses to run two
+  tasks whose path sets intersect, which is what makes parallel unattended work
+  safe. One path per bullet — a comma-separated list is silently dropped.
+- **Verification Command** is the gate. An agent runs exactly that command and
+  will not open a pull request on failing output. Include the formatting and lint
+  checks CI runs, or a task can pass locally and still land red.
+
+Reviewing an agent-authored pull request is the same job as any other: read the
+diff, not the description.
+
+### A note on issue numbers
+
+Issues here start from this repository's own numbering. Commit subjects in the
+history also reference identifiers like `(WM-123)` from the private tracker this
+project was developed in before it opened up. Those tickets are not public and
+are not being migrated; the commits, pull requests, and code they produced are
+the durable record.
+
 ## Development setup
 
 Factory requires Git and [Bun](https://bun.sh/) 1.3 or newer.

--- a/orchestrator/issue-templates.test.mjs
+++ b/orchestrator/issue-templates.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * The agent-ready issue form must produce Owned Paths the real parser accepts
+ * (WM-1013).
+ *
+ * This is not a formality. `parseOwnedPaths` keeps only bullet lines, fenced
+ * blocks, and indented blocks — a plain unindented list is silently dropped.
+ * The first draft of this form used plain lines, and every task filed through
+ * it would have parsed to zero Owned Paths: undispatchable, or worse,
+ * dispatched with a narrower scope than the author wrote. The form and the
+ * parser have to be checked against each other, not assumed compatible.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseOwnedPaths } from "./owned-paths.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const FORM = path.join(
+  ROOT,
+  ".github",
+  "ISSUE_TEMPLATE",
+  "agent_ready_task.yml",
+);
+
+/** How GitHub renders a completed issue form: "### <label>\n\n<value>". */
+function renderedIssueBody(ownedPathsValue) {
+  return [
+    "### Problem & Context",
+    "",
+    "Doctor reports a missing CLI as an unknown error.",
+    "",
+    "### Acceptance Criteria",
+    "",
+    "- [ ] names the missing binary",
+    "",
+    "### Source File Pointers",
+    "",
+    "* `orchestrator/doctor.mjs` — the check",
+    "",
+    "### Owned Paths",
+    "",
+    ownedPathsValue,
+    "",
+    "### Verification Command",
+    "",
+    "```",
+    "bun test --timeout 20000 event-runtime/lib && bun run lint",
+    "```",
+    "",
+  ].join("\n");
+}
+
+describe("agent-ready issue form", () => {
+  const form = readFileSync(FORM, "utf8");
+
+  test("carries all five protocol sections", () => {
+    for (const label of [
+      "Problem & Context",
+      "Acceptance Criteria",
+      "Source File Pointers",
+      "Owned Paths",
+      "Verification Command",
+    ]) {
+      expect(form).toContain(`label: ${label}`);
+    }
+  });
+
+  test("its Owned Paths output parses to the paths the author typed", () => {
+    const body = renderedIssueBody(
+      ["- orchestrator/doctor.mjs", "- docs/quickstart.md"].join("\n"),
+    );
+    expect(parseOwnedPaths(body)).toEqual([
+      "orchestrator/doctor.mjs",
+      "docs/quickstart.md",
+    ]);
+  });
+
+  test("the field pre-seeds bullets, because plain lines parse to nothing", () => {
+    // Guards the exact regression this test was written for.
+    expect(
+      parseOwnedPaths(renderedIssueBody("orchestrator/doctor.mjs")),
+    ).toEqual([]);
+    // ...so the form must hand the author a bullet to type after.
+    const ownedBlock = form.slice(form.indexOf("id: owned_paths"));
+    expect(ownedBlock.slice(0, ownedBlock.indexOf("validations"))).toContain(
+      "value: |",
+    );
+  });
+
+  test("globs survive, since tight globs are the documented norm", () => {
+    expect(
+      parseOwnedPaths(renderedIssueBody("- event-runtime/agents/*.json")),
+    ).toEqual(["event-runtime/agents/*.json"]);
+  });
+
+  test("does not apply ai:agent-ready — dispatch stays maintainer-gated", () => {
+    // On a public repo only users with triage permission can set labels, so
+    // "anyone files, only a maintainer queues" is enforced by GitHub itself.
+    // The form must not undo that by requesting the label up front.
+    expect(form).not.toContain("ai:agent-ready\n");
+    expect(form).toContain("source:human");
+  });
+});


### PR DESCRIPTION
Fixes WM-1013 — WM-1006 Phase 4.

## What

- **New `agent_ready_task.yml` issue form**, one field per required protocol section (`docs/protocol.md` §5).
- Bug and feature forms now apply the real taxonomy (`type:bug`/`type:feature` + `source:human`) instead of bare `bug`/`enhancement`, so an inbound issue lands with labels the factory actually reads.
- Discussions added to `config.yml` as the home for unshaped ideas; security still routes to the private advisory policy.
- `CONTRIBUTING.md` documents how work is picked up, and why `Owned Paths` / `Verification Command` are load-bearing rather than paperwork.

## The bug this caught

**The first draft of the form produced Owned Paths that parse to nothing.**

`parseOwnedPaths()` keeps only bullet lines, fenced blocks, and indented blocks. My form used a plain-line placeholder, so every task filed through it would have parsed to **zero** Owned Paths — undispatchable, or worse, dispatched with a narrower scope than the author wrote.

Verified against the real parser rather than assumed compatible, which is what the ticket asked for. The field now pre-seeds `- ` bullets, and a regression test drives `parseOwnedPaths` over GitHub's rendered form output. That test fails if the field goes back to plain lines.

## Notes for the reviewer

- **The form deliberately does NOT request `ai:agent-ready`.** On a public repo only users with triage permission can apply labels, so "anyone files, only a maintainer queues" is enforced by GitHub itself. Documented as an intentional gate, with a test asserting the form doesn't undo it.
- The `Verification Command` field pre-fills a command **including `format:check`** — WM-1018's finding was that omitting it lets a task verify clean locally and land red.
- CONTRIBUTING explains the `(WM-123)` identifiers in the history as a private tracker that is not being migrated, so a contributor reading `git log` isn't hunting for issues that don't exist.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 orchestrator/issue-templates.test.mjs orchestrator/owned-paths.test.mjs && bun run format:check && bun run lint
```

- 34 pass, 0 fail
- format:check clean; lint 0 errors, 616 warnings = baseline

**Falsifiability:** reverting the field to a plain-line placeholder fails the pre-seeds-bullets test.