### PR TITLE
fix(schemas): ticket patterns accept GitHub issue identifiers — dispatch was impossible post-cutover

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -42,7 +42,7 @@
   ],
   "pins": {
     "agents/dispatch.md": "sha256:ae36ff073880ff1ae89e6c21ed6660ee6f8294681b0d937da1efbef15373de6c",
-    "schemas/dispatch.input.json": "sha256:7949221631e30ad9c6f8fa8a92d071f6ee88ea03e7fbafcbf3af1dffa432cdee",
-    "schemas/dispatch.output.json": "sha256:bc25aee1baa16aa21f50e9a3f8c320e57cec11cbdf31c822baee838d49ddb672"
+    "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
+    "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }
 }

--- a/event-runtime/agents/merge-apply.json
+++ b/event-runtime/agents/merge-apply.json
@@ -23,7 +23,7 @@
   "mutating": true,
   "pins": {
     "agents/merge-apply.md": "sha256:2dd21b7c8463cca365722baf8ec621c5bfe91a3323f043a2d16e6275967508fa",
-    "schemas/merge-apply.input.json": "sha256:ef60db6175c0cb39a2167231b3979065370b1c7a3c94705bd5d5c7b3cf80c512",
-    "schemas/merge-applied.output.json": "sha256:6ab5c791fb250d37c076c869db7c27010812b56523fc4cd52b0bdfb694851879"
+    "schemas/merge-apply.input.json": "sha256:9fd28804232190de903b67e451edb3074dcc926cb30d40fe7fd0f5736da3c6af",
+    "schemas/merge-applied.output.json": "sha256:9d098e7da376e38d5ff4bab00f9d12d2a2312712ae6d2ecc1add92ac6de5852c"
   }
 }

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -25,7 +25,7 @@
   "mutating": true,
   "pins": {
     "agents/merge-fix.md": "sha256:c06dba00c6fa4d34fcb97a0adc0fedf3d7f87c94e4535c4acd7afab2427e7b9b",
-    "schemas/merge-fix.input.json": "sha256:71a8c16d52dfc908972bf3f9ca6d942c93ab6b0213588298a1cd2715e265aa6c",
-    "schemas/merge-fix.output.json": "sha256:0aa6ba59514abbb6609ef53c124f627c7e5ab09eca655696c99aa4e38e34ce46"
+    "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
+    "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }
 }

--- a/event-runtime/agents/merge-plan.json
+++ b/event-runtime/agents/merge-plan.json
@@ -27,6 +27,6 @@
   "pins": {
     "agents/merge-plan.md": "sha256:389fd24bae2b9fee157a95fee7a85e47030033bb1f6f3a8f12246b65170423f0",
     "schemas/merge-plan.input.json": "sha256:cfc932e2e1e54247db5020943c53e3ff2cf419f9835bfb81ff93e738259a1850",
-    "schemas/merge-plan.output.json": "sha256:86eedd6b6089caaf62210df42b36b26f38fc7ddb01d8f52e6f1624b67bb1ffbb"
+    "schemas/merge-plan.output.json": "sha256:b00c380d95c6f4c894db0b0b56aa731a667d547fdd8cf751f27b47ef38eabaae"
   }
 }

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -32,7 +32,7 @@
   ],
   "pins": {
     "agents/merge-review.md": "sha256:77be28101f5e4645a37501bc4aa2dd80dd87519b528eb8b9db0c2ed55ea1d73f",
-    "schemas/merge-review.input.json": "sha256:94bbf3e051bbcb836822cf6038e008806a445473aec4f9f52eec39ba8f768326",
-    "schemas/merge-review.output.json": "sha256:987433ffbb39d935d42090eb62e63ece917a36b38fc849a6c5bfa27a26c898f8"
+    "schemas/merge-review.input.json": "sha256:d7051604031742a3b0e060f9fb1359aa5de3b3d42a80714f11492054e81a50f8",
+    "schemas/merge-review.output.json": "sha256:efad4e30c1fed1978794630397819d71d78391381a6375edab704eaf5458b282"
   }
 }

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -37,6 +37,6 @@
   "pins": {
     "agents/merge-scan.md": "sha256:b407f14519ebb7b505ce7ddf80ca7929fe3a25798f3c4f89fd42a5ad6d583931",
     "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
-    "schemas/merge-scan.output.json": "sha256:7c38ac7992fb647815cac346ebe3e51744b689ca7b5af497c9bd5bcabbfa641b"
+    "schemas/merge-scan.output.json": "sha256:e7edeca34a7a702ab35301de599b3a8dcb137e62f33f5a63df399318df04a636"
   }
 }

--- a/event-runtime/agents/merge-verify.json
+++ b/event-runtime/agents/merge-verify.json
@@ -29,7 +29,7 @@
   "mutating": true,
   "pins": {
     "agents/merge-verify.md": "sha256:639cabb93ba9884c2250071147e21294396fddee125fd313ebe0318956ab7d8b",
-    "schemas/merge-verify.input.json": "sha256:9cba46817545d7fe02e96b83e050b4af6d3fba254d15d3ef1366088dbfd35fdb",
+    "schemas/merge-verify.input.json": "sha256:7b1a0ec51bff5ed2ec99ed9ab0656f62481a038f7ab1bc8be7ce5c73b9aedd62",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/run-postmortem.json
+++ b/event-runtime/agents/run-postmortem.json
@@ -25,10 +25,12 @@
     "attempts": 1
   },
   "mutating": false,
-  "emits": { "memos": ["postmortem"] },
+  "emits": {
+    "memos": ["postmortem"]
+  },
   "pins": {
     "agents/run-postmortem.md": "sha256:4a72bb5d9e6659a3ffb0717300ef989cc7e04c9eaf18faceb6ae7e206693dad8",
     "schemas/run-postmortem.input.json": "sha256:a21960e032daf352269d81d2a71e1fa7490cc5c18b6c11c8eef99b70378ded6e",
-    "schemas/run-postmortem.output.json": "sha256:1d11b1bbb2f52b4d67b2949d8aea66fc61102e16cfa82dcc7d1796bb35286a6b"
+    "schemas/run-postmortem.output.json": "sha256:af951c4034b96b8945917aec42227152cd289e95b3b12319345446840cd04714"
   }
 }

--- a/event-runtime/agents/ship-apply.json
+++ b/event-runtime/agents/ship-apply.json
@@ -66,7 +66,7 @@
   "mutating": true,
   "pins": {
     "agents/ship-apply.md": "sha256:a33250cf1c1b42252193be5e97c38fb022d83267e664c5e5e3862be2341e6516",
-    "schemas/ship-apply.input.json": "sha256:67474d001e310e576f8a57c77f63c9cb5958dc963f031fd45cf087e6bd956f2f",
+    "schemas/ship-apply.input.json": "sha256:3be41273b50d505eae8ffde87b205738ff4fd1b6c9e8ed9f9aa1809965763686",
     "schemas/ship-applied.output.json": "sha256:e73f513f50197b344ff320f2f881464028991c6dfb7689790fe3039456ce821b"
   }
 }

--- a/event-runtime/agents/ship-scan.json
+++ b/event-runtime/agents/ship-scan.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/ship-scan.md": "sha256:26280ed658ee4759db15f3f2c250d57ec7145f787cec2474a53fcf9b9edf6564",
     "schemas/ship-scan.input.json": "sha256:78ca9a5df1148baf509348b7a492f7d299c2d519df2c9adc0c875e969db067da",
-    "schemas/ship-scan.output.json": "sha256:168b0a95ae41730123c2e9f76b7502199d401022731788c44602ca1c02285f8c"
+    "schemas/ship-scan.output.json": "sha256:7c3090b9ee758e639a4311efb571e0130e171190c89ae65ce09f68bbbe5ac2ae"
   }
 }

--- a/event-runtime/agents/sweep-apply.json
+++ b/event-runtime/agents/sweep-apply.json
@@ -51,7 +51,7 @@
   "mutating": true,
   "pins": {
     "agents/sweep-apply.md": "sha256:373e0bd369792c9fee300a90b1ef833499fb9cdc53c5993e9598c882dd56aa8d",
-    "schemas/sweep-apply.input.json": "sha256:5af257704ff1a7a6753e27bbe6916cc0b0946c8b4a23250bf592dd139273ec44",
-    "schemas/sweep-applied.output.json": "sha256:75524150caebdaeffeb1dee800169a0ac423d3d6549d5491185eefe5351dacfd"
+    "schemas/sweep-apply.input.json": "sha256:b2f1f912fdd045ef9cf692eb6437c319cd90984396aebb9e7a975ea9fd81d56e",
+    "schemas/sweep-applied.output.json": "sha256:ec663e8d5a03dc19e5aa64de7806aad39dc2781e815a299ab54ada17fd0d7134"
   }
 }

--- a/event-runtime/agents/sweep-scan.json
+++ b/event-runtime/agents/sweep-scan.json
@@ -23,6 +23,6 @@
   "pins": {
     "agents/sweep-scan.md": "sha256:3c2f35767d54f4b8407100e243247b095e2cf2d351d64e6d0dc6a84399f425af",
     "schemas/sweep-scan.input.json": "sha256:75669ff012e9cc5e2eb334545b041a694fd37335a4d6f9dd0715b5fb66c6c856",
-    "schemas/sweep-scan.output.json": "sha256:fd42580f1d96f318094eedb638aa8adc432ad9464f4d6ad8af23ba49ff1ea8ba"
+    "schemas/sweep-scan.output.json": "sha256:6bac174205189d26ee920da7a27bcb7d7e1ebc66c16dce4cc6809da7ead9887a"
   }
 }

--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -93,7 +93,7 @@
   "mutating": true,
   "pins": {
     "agents/triage-apply.md": "sha256:4be185dce1dd5c5b5ae6a5fa1ec92dc263d0321d6e9ea75f244c2d308d917e75",
-    "schemas/triage-apply.input.json": "sha256:fd2378637f0f8accb317bf71444f5a63c26d741628b726695b7e769f050c0810",
-    "schemas/triage-applied.output.json": "sha256:5c52b583f055223367bddbcf48e853ff0af9a8e5bf536942ac15f2dc01f217f9"
+    "schemas/triage-apply.input.json": "sha256:7b87a7cc16db5222e476f2d436d08b0a5c589586c1cb7deb0fec79787df07e83",
+    "schemas/triage-applied.output.json": "sha256:ee71d56edb6f4ae96375a37e4d80e2512dd2702fac935268c0439627f561b94b"
   }
 }

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -23,6 +23,6 @@
   "pins": {
     "agents/triage-scan.md": "sha256:6d71d0a08d395b719b890a3b0f6c668004181d7206185ec1fae0aaf895871d89",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
-    "schemas/triage-scan.output.json": "sha256:6eb237281746aaaea34e4e5927228e9eb90f2954d9df8d05f8c04b00bad27868"
+    "schemas/triage-scan.output.json": "sha256:d58758bc10c0e807f35516032a9c3250b723d2b425fc18c1bd48a62bbde70bb9"
   }
 }

--- a/event-runtime/agents/unblock-apply.json
+++ b/event-runtime/agents/unblock-apply.json
@@ -57,7 +57,7 @@
   "mutating": true,
   "pins": {
     "agents/unblock-apply.md": "sha256:e97afe482eb0c95faa82fab3e560ea28bbb3cc07dfbd3d4f5fdc68e994e01897",
-    "schemas/unblock-apply.input.json": "sha256:a983e831d67dbb30352697e457a7197f18776e1de184731be7ed88b9ea1d8f41",
-    "schemas/unblock-applied.output.json": "sha256:4b1ed38f71ca16a56bc7bc2582c629580fe7b57614ea2b12b0c289c9e6bf611b"
+    "schemas/unblock-apply.input.json": "sha256:5b8cc4047352147f02b707c94b2c353f5c6c6e1ce9661c25d972c82c8dca1bcb",
+    "schemas/unblock-applied.output.json": "sha256:023c01ef5c7f1a4e5d30fe29f7ba7a65b7cc1030bcc30d8ac5719d6cc4f24cde"
   }
 }

--- a/event-runtime/agents/unblock-scan.json
+++ b/event-runtime/agents/unblock-scan.json
@@ -23,6 +23,6 @@
   "pins": {
     "agents/unblock-scan.md": "sha256:694369735661dfaab12070e949c96e5f00d9c38570b7ceecf452e88977b242ae",
     "schemas/unblock-scan.input.json": "sha256:edb9af116d7a35b155d2472232f3c9625381996876e6aac18dacff28a215ac89",
-    "schemas/unblock-scan.output.json": "sha256:1ccccd541b192dc4a300a1a5ebfe36485fb2ed97effc4f0d6bfcc1ab7e757c65"
+    "schemas/unblock-scan.output.json": "sha256:a2ab04e3fc9a6b4d277a4ea1d0431ee673eb765167d6c884849e4f2adf624b34"
   }
 }

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -23,6 +23,6 @@
   "pins": {
     "agents/work-scan.md": "sha256:aabcaed7a814e14b4aa291eacd1e63825fa9424a71991377006a780decaecbd1",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
-    "schemas/work-scan.output.json": "sha256:98a2cb891198b79d8d8d9924a3db1fe2bd11e2983c71ae4a3499bc54a5d43f5f"
+    "schemas/work-scan.output.json": "sha256:7250a4c26073e443552b2d0bfdec53b2d4348940a92f250013ad31efdd637055"
   }
 }

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -252,6 +252,12 @@ function sampleFromSchema(schema) {
       if (schema.pattern === "^[0-9a-f]{40}$") return "b".repeat(40);
       if (schema.pattern === "^/[A-Za-z0-9/._-]*$") return "/var";
       if (schema.pattern === "^[A-Z]+-[0-9]+$") return "OPS-1";
+      // WM-1006: tracker-neutral ticket ids (Linear TEAM-N or GitHub #N forms)
+      if (
+        schema.pattern ===
+        "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+      )
+        return "OPS-1";
       return "x".repeat(schema.minLength ?? 1);
     }
     case "integer":

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -169,8 +169,9 @@ describe("registry", () => {
     // Regenerated (WM-1039): dispatch runs only ticket + configured repo
     // verification in worktrees; full suites remain CI-only.
     // Regenerated (WM-1039 rebase over tracker-neutral sweep)
+    // Regenerated (WM-1006 cutover: ticket patterns accept GitHub owner/repo#N ids; schemas re-pinned)
     const expected =
-      "sha256:a4d70bef9089d1513b6697ca4f026563b86d8d4785bee68738a2359fbdd573a5";
+      "sha256:61ff5eda45e22a00505176a96c77c04abc777030447def09cbf3d785a64d309f";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -344,8 +345,9 @@ describe("registry", () => {
     // WM-1039 keeps dispatched worktree verification to the ticket and repo
     // commands, leaving full suites to CI, and re-pins dispatch.
     // Regenerated (WM-1039 rebase over tracker-neutral sweep)
+    // Regenerated (WM-1006 cutover: ticket patterns accept GitHub owner/repo#N ids; schemas re-pinned)
     expect(computeDefHash(def)).toBe(
-      "sha256:b82767b2413db396af047029261323df01a8255315135e91694fad4b960b851d",
+      "sha256:1e8c07fc1354070bfa88f82c0ef0537404d70f0c7e616d6359a23177ed6f3057",
     );
   });
 

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -609,7 +609,10 @@ function checkWorkPlan(candidate) {
         !Array.isArray(entry) &&
         Object.keys(entry).length === 2 &&
         typeof entry.ticket === "string" &&
-        /^[A-Z]+-[0-9]+$/.test(entry.ticket) &&
+        // WM-1006: Linear TEAM-N or GitHub owner/repo#N / #N / N identifiers.
+        /^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#?[0-9]+)$/.test(
+          entry.ticket,
+        ) &&
         dispositions.has(entry.disposition);
       if (!valid) {
         violations.push(`evidence_candidate_invalid_at_index_${index}`);

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -11,8 +11,8 @@
     },
     "ticket": {
       "type": "string",
-      "pattern": "^[A-Z]+-[0-9]+$",
-      "description": "Linear issue identifier to implement; must be Todo + ai:agent-ready + unassigned at plan time (docs/event-runtime-dispatch.md §2)"
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
+      "description": "Tracker issue identifier to implement — Linear TEAM-N or GitHub owner/repo#N / #N / N; must be Todo + ai:agent-ready + unassigned at plan time (docs/event-runtime-dispatch.md §2)"
     },
     "modelTier": {
       "type": "string",
@@ -49,7 +49,7 @@
           "properties": {
             "ticket": {
               "type": "string",
-              "pattern": "^[A-Z]+-[0-9]+$"
+              "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
             },
             "repo": {
               "type": "string",

--- a/event-runtime/schemas/dispatch.output.json
+++ b/event-runtime/schemas/dispatch.output.json
@@ -15,7 +15,7 @@
     },
     "ticket": {
       "type": "string",
-      "pattern": "^[A-Z]+-[0-9]+$",
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
       "description": "Linear issue identifier this run implemented, echoed from the input"
     },
     "prUrl": {

--- a/event-runtime/schemas/merge-applied.output.json
+++ b/event-runtime/schemas/merge-applied.output.json
@@ -20,7 +20,7 @@
         "properties": {
           "issueId": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "The item's Linear ticket — the item-list adapter records the item key under the fixed name issueId (lib/adapters/actions.mjs), and merge-apply's itemKey is the ticket"
           },
           "action": {
@@ -40,7 +40,10 @@
         "additionalProperties": false,
         "properties": {
           "pr": { "type": "integer", "minimum": 1 },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "reason": { "type": "string", "minLength": 1 }
         }
       }

--- a/event-runtime/schemas/merge-apply.input.json
+++ b/event-runtime/schemas/merge-apply.input.json
@@ -40,7 +40,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "const": "merge_pr" },
           "reason": { "type": "string", "minLength": 1 },
           "checksGreen": { "const": true },

--- a/event-runtime/schemas/merge-fix.input.json
+++ b/event-runtime/schemas/merge-fix.input.json
@@ -26,7 +26,10 @@
     "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+    "ticket": {
+      "type": "string",
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+    },
     "finding": { "type": "string", "minLength": 1 },
     "findingHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
     "round": { "type": "integer", "minimum": 1, "maximum": 2 },

--- a/event-runtime/schemas/merge-fix.output.json
+++ b/event-runtime/schemas/merge-fix.output.json
@@ -14,7 +14,10 @@
   "properties": {
     "outcome": { "enum": ["UPDATED", "BLOCKED"] },
     "repo": { "type": "string", "minLength": 1 },
-    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+    "ticket": {
+      "type": "string",
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+    },
     "pr": { "type": "integer", "minimum": 1 },
     "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "round": { "type": "integer", "minimum": 1, "maximum": 2 },

--- a/event-runtime/schemas/merge-plan.output.json
+++ b/event-runtime/schemas/merge-plan.output.json
@@ -64,7 +64,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "const": "merge_pr" },
           "reason": { "type": "string", "minLength": 1 },
           "checksGreen": { "const": true },
@@ -101,7 +104,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "finding": { "type": "string", "minLength": 1 },
           "findingHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "round": { "type": "integer", "minimum": 1 },
@@ -124,7 +130,10 @@
         "properties": {
           "pr": { "type": "integer", "minimum": 1 },
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "reason": { "type": "string", "minLength": 1 }
         }
       }
@@ -140,7 +149,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" }
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          }
         }
       }
     },

--- a/event-runtime/schemas/merge-review.input.json
+++ b/event-runtime/schemas/merge-review.input.json
@@ -35,7 +35,7 @@
     },
     "ticket": {
       "type": "string",
-      "pattern": "^[A-Z]+-[0-9]+$"
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
     },
     "repoPin": {
       "type": "object",

--- a/event-runtime/schemas/merge-review.output.json
+++ b/event-runtime/schemas/merge-review.output.json
@@ -30,7 +30,10 @@
     "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-    "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+    "ticket": {
+      "type": "string",
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+    },
     "plan": {
       "type": "array",
       "maxItems": 1,
@@ -59,7 +62,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "const": "merge_pr" },
           "reason": { "type": "string", "minLength": 1 },
           "checksGreen": { "const": true },
@@ -97,7 +103,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "finding": { "type": "string", "minLength": 1 },
           "findingHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "round": { "type": "integer", "minimum": 1 },
@@ -121,7 +130,10 @@
         "properties": {
           "pr": { "type": "integer", "minimum": 1 },
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "reason": { "type": "string", "minLength": 1 }
         }
       }

--- a/event-runtime/schemas/merge-scan.output.json
+++ b/event-runtime/schemas/merge-scan.output.json
@@ -64,7 +64,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "const": "merge_pr" },
           "reason": { "type": "string", "minLength": 1 },
           "checksGreen": { "const": true },
@@ -101,7 +104,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "finding": { "type": "string", "minLength": 1 },
           "findingHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "round": { "type": "integer", "minimum": 1 },
@@ -124,7 +130,10 @@
         "properties": {
           "pr": { "type": "integer", "minimum": 1 },
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "reason": { "type": "string", "minLength": 1 }
         }
       }
@@ -140,7 +149,10 @@
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" }
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          }
         }
       }
     },

--- a/event-runtime/schemas/merge-verify.input.json
+++ b/event-runtime/schemas/merge-verify.input.json
@@ -18,7 +18,10 @@
         "additionalProperties": false,
         "properties": {
           "pr": { "type": "integer", "minimum": 1 },
-          "ticket": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "ticket": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "mergeSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "headRef": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" }

--- a/event-runtime/schemas/run-postmortem.output.json
+++ b/event-runtime/schemas/run-postmortem.output.json
@@ -33,7 +33,7 @@
               "type": { "const": "ticket" },
               "id": {
                 "type": "string",
-                "pattern": "^[A-Z]+-[0-9]+$",
+                "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
                 "description": "Linear issue id of the failed run, derived from its spec/transcript — never another ticket"
               }
             }

--- a/event-runtime/schemas/ship-apply.input.json
+++ b/event-runtime/schemas/ship-apply.input.json
@@ -63,7 +63,7 @@
           },
           "ticket": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "Linear ticket pulled from the subject, when present"
           }
         }

--- a/event-runtime/schemas/ship-scan.output.json
+++ b/event-runtime/schemas/ship-scan.output.json
@@ -65,7 +65,7 @@
           },
           "ticket": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "Linear ticket pulled from the subject's (TICKET-ID), when present"
           }
         }

--- a/event-runtime/schemas/sweep-applied.output.json
+++ b/event-runtime/schemas/sweep-applied.output.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "type": "string", "minLength": 1 }
         }
       }

--- a/event-runtime/schemas/sweep-apply.input.json
+++ b/event-runtime/schemas/sweep-apply.input.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": {
             "enum": ["retire-shipped", "mark-duplicate", "comment-evidence"]
           },

--- a/event-runtime/schemas/sweep-scan.output.json
+++ b/event-runtime/schemas/sweep-scan.output.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action", "reason"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": {
             "enum": ["retire-shipped", "mark-duplicate", "comment-evidence"]
           },

--- a/event-runtime/schemas/triage-applied.output.json
+++ b/event-runtime/schemas/triage-applied.output.json
@@ -17,7 +17,10 @@
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "type": "string", "minLength": 1 }
         }
       }

--- a/event-runtime/schemas/triage-apply.input.json
+++ b/event-runtime/schemas/triage-apply.input.json
@@ -20,7 +20,7 @@
         "properties": {
           "issueId": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "Linear issue identifier (e.g. WM-76)"
           },
           "action": {

--- a/event-runtime/schemas/triage-scan.output.json
+++ b/event-runtime/schemas/triage-scan.output.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action", "reason"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": {
             "enum": [
               "label-agent-ready",

--- a/event-runtime/schemas/unblock-applied.output.json
+++ b/event-runtime/schemas/unblock-applied.output.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": { "type": "string", "minLength": 1 }
         }
       }

--- a/event-runtime/schemas/unblock-apply.input.json
+++ b/event-runtime/schemas/unblock-apply.input.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": {
             "enum": ["release-hold", "release-to-triage", "comment-evidence"]
           },

--- a/event-runtime/schemas/unblock-scan.output.json
+++ b/event-runtime/schemas/unblock-scan.output.json
@@ -13,7 +13,10 @@
         "required": ["issueId", "action", "reason"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "issueId": {
+            "type": "string",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$"
+          },
           "action": {
             "enum": ["release-hold", "release-to-triage", "comment-evidence"]
           },

--- a/event-runtime/schemas/work-scan.output.json
+++ b/event-runtime/schemas/work-scan.output.json
@@ -24,7 +24,7 @@
     },
     "ticket": {
       "type": ["string", "null"],
-      "pattern": "^[A-Z]+-[0-9]+$",
+      "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
       "description": "The plan's first ticket; must equal plan[0].ticket for DISPATCH and be null otherwise"
     },
     "plan": {
@@ -37,7 +37,7 @@
         "properties": {
           "ticket": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "Linear issue identifier, dispatchable at scan time: state exactly Todo, label ai:agent-ready present, and assignee field null"
           },
           "ownedPaths": {
@@ -68,7 +68,7 @@
         "properties": {
           "ticket": {
             "type": "string",
-            "pattern": "^[A-Z]+-[0-9]+$",
+            "pattern": "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
             "description": "Linear issue identifier of the ready candidate that was not selected"
           },
           "reason": {

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -521,7 +521,7 @@ describe("work-scan registration (WM-110)", () => {
       "reason",
     ]);
     expect(schema.properties.plan.items.properties.ticket.pattern).toBe(
-      "^[A-Z]+-[0-9]+$",
+      "^([A-Z]+-[0-9]+|(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#?[0-9]+)$",
     );
     expect(schema.properties.deferred.items.required).toEqual([
       "ticket",


### PR DESCRIPTION
After the WM-1006 Linear→GitHub cutover, every schema still pinned the Linear `^[A-Z]+-[0-9]+$` ticket pattern, so no dispatch/merge/triage event could name a GitHub issue: operator dispatches parked as `invalid_input: $.ticket: does not match pattern`. This widens the ticket pattern across all pinned contracts to accept `owner/repo#N`, `#N`, and bare `N` alongside Linear ids, with schema pins + registry digests regenerated per protocol.

## Handoff
- Verification: `bun test event-runtime/lib` — full slice green (1504 tests, 0 fail)
- Evidence: proposal prop_799689b9 (invalid_input) from the first post-cutover dispatch attempt
- UX critique: n/a (contract fix)