### PR TITLE
fix(dispatch): tick --apply must use the repo's control plane, not the default

### DIFF
--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -477,20 +477,20 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   // ----------------------------------------------------------------- claim ----
-  const cp = loadControlPlane();
-  const me = (await cp.raw(`query{ viewer{ id name } }`))?.viewer;
-  const states =
-    (
-      await cp.raw(
-        `query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name } } } }`,
-        { t: repo.team },
-      )
-    )?.team?.states?.nodes ?? [];
-  const todoId = states.find((s) => s.name.toLowerCase() === "todo")?.id;
-  const blockedId = states.find((s) => s.name.toLowerCase() === "blocked")?.id;
-  const allLabels =
-    (await cp.raw(`query{ issueLabels(first:250){ nodes{ id name } } }`))
-      ?.issueLabels?.nodes ?? [];
+  // ONE handle, resolved from the REPO (WM-1006 cutover). This block used to
+  // call a bare `loadControlPlane()`, which resolves to the workspace default
+  // — so the dispatcher read its queue from the repo's plane and then tried to
+  // claim on the default one, passing a GitHub identifier to Linear:
+  //   Entity not found: Issue — Could not find referenced Issue.
+  // It failed safe (no mutation), but no ticket could ever be dispatched.
+  const cp = loadControlPlane({ repoName: repo.name });
+
+  // `unclaim()` works in label NAMES, not tracker-native ids, so it can run on
+  // any plane. `computeUnclaimAction` maps names -> ids through `allLabels`;
+  // giving it an identity table (id === name) makes it return names, which is
+  // exactly what `transition()` takes. Its signature is deliberately left
+  // alone — event-runtime/lib/unclaim.test.mjs pins it against releaseLabels.
+  const identityLabels = (names) => names.map((n) => ({ id: n, name: n }));
 
   async function claim(t) {
     // Adapter claim: In Progress + assignee + claim labels, then read-back.
@@ -511,38 +511,52 @@ export async function main(argv = process.argv.slice(2)) {
    * to Blocked with a question, or to In Review with a PR — keeps that state.
    */
   async function unclaim(t, why, log) {
-    const cur = (
-      await cp.raw(
-        `query($id:String!){ issue(id:$id){ state{name} assignee{id} labels(first:20){nodes{id name}} comments(last:10){nodes{body createdAt}} } }`,
-        { id: t.id },
-      )
-    )?.issue;
-    if (!cur || cur.state?.name !== "In Progress" || cur.assignee?.id !== me.id)
+    let ticket;
+    let comments;
+    try {
+      ticket = await cp.getTicket(t.identifier);
+      comments = await cp.listComments(t.identifier);
+    } catch {
       return false;
-    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress"))
+    }
+    if (!ticket || ticket.state?.name !== "In Progress") return false;
+    // Assignee identity is NOT checked here. Every agent authenticates as the
+    // same tracker account, so "is it still mine" is unanswerable (WM-1045);
+    // the ai:in-progress label below is the honest guard. An agent that moved
+    // its own ticket to Blocked or In Review no longer matches and is left be.
+    if (!(ticket.labels ?? []).some((l) => l.name === "ai:in-progress"))
       return false;
+    const cur = {
+      state: ticket.state,
+      labels: {
+        nodes: (ticket.labels ?? []).map((l) => ({ id: l.name, name: l.name })),
+      },
+      comments: { nodes: comments ?? [] },
+    };
 
     const action = computeUnclaimAction({
       issue: cur,
       why,
       log,
-      todoStateId: todoId,
-      blockedStateId: blockedId,
-      allLabels,
+      todoStateId: "Todo",
+      blockedStateId: "Blocked",
+      allLabels: identityLabels([
+        ...(ticket.labels ?? []).map((l) => l.name),
+        "ai:agent-ready",
+        "ai:blocked",
+      ]),
       threshold: DISPATCH_FAILURE_THRESHOLD,
     });
 
-    await cp.raw(
-      `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
-      {
-        id: t.id,
-        in: {
-          stateId: action.stateId ?? undefined,
-          assigneeId: null,
-          labelIds: action.labelIds,
-        },
-      },
-    );
+    // action.labelIds are NAMES here (identity table above). Transition takes
+    // the complete resulting set as add/remove, so compute the delta.
+    const had = new Set((ticket.labels ?? []).map((l) => l.name));
+    const want = new Set(action.labelIds);
+    await cp.transition(t.identifier, action.stateId, {
+      add: [...want].filter((n) => !had.has(n)),
+      remove: [...had].filter((n) => !want.has(n)),
+      unassign: true,
+    });
     await cp.comment(t.identifier, action.commentBody);
 
     if (action.repeated) {

--- a/orchestrator/tick.test.mjs
+++ b/orchestrator/tick.test.mjs
@@ -110,3 +110,48 @@ describe("acquireClaimLock", () => {
     });
   });
 });
+
+// ------------------------------------------- control-plane selection (#880) ---
+// The dispatcher read its queue from the repo's control plane and then claimed
+// on the WORKSPACE DEFAULT, because the --apply block created a second, bare
+// `loadControlPlane()`. After the WM-1006 cutover that meant reading GitHub and
+// claiming against Linear with a GitHub identifier:
+//   Entity not found: Issue — Could not find referenced Issue.
+// It failed safe, but no ticket on a non-default plane could ever dispatch.
+describe("tick resolves its control plane from the repo (#880)", () => {
+  const SRC = readFileSync(new URL("./tick.mjs", import.meta.url), "utf8");
+
+  test("there is no bare loadControlPlane() call", () => {
+    // A bare call silently resolves to the workspace default. Two handles in
+    // one file is the defect; one handle, built from the repo, is the fix.
+    const calls = SRC.split("\n").filter(
+      (l) =>
+        /loadControlPlane\(\s*\)/.test(l) &&
+        !l.trim().startsWith("*") &&
+        !l.trim().startsWith("//"),
+    );
+    expect(calls).toEqual([]);
+  });
+
+  test("every loadControlPlane call passes repoName", () => {
+    const calls = [...SRC.matchAll(/loadControlPlane\(\{([^}]*)\}/g)].map(
+      (m) => m[1],
+    );
+    expect(calls.length).toBeGreaterThan(0);
+    for (const args of calls) expect(args).toContain("repoName");
+  });
+
+  test("the apply path issues no tracker-native GraphQL", () => {
+    // viewer / team.states / issueLabels / issueUpdate are Linear-shaped and
+    // unanswerable by any other adapter. unclaim() is the rollback that stops a
+    // dead run holding a cap slot, so it has to work on every plane.
+    for (const shape of [
+      "issueLabels(",
+      "issueUpdate(",
+      "team(id:",
+      "query{ viewer{",
+    ]) {
+      expect(SRC).not.toContain(shape);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #880

Found on the first real dispatch after the WM-1006 cutover. **Dispatch was impossible for any repo on a non-default control plane.**

## The bug

`orchestrator/tick.mjs` had **two** control-plane handles:

- `fetchState()` — `loadControlPlane({ repoName: repo.name })`, correct (WM-1008)
- the `--apply` block — a bare `loadControlPlane()`, resolving to the workspace default

So the dispatcher read its queue from GitHub and then claimed against **Linear**, passing a GitHub identifier:

```
Dispatch error: Entity not found: Issue — Could not find referenced Issue.
```

It failed safe (no mutation, queue unchanged), but nothing could ever dispatch. This is my miss in WM-1008: I converted the read path and didn't audit the apply path for a second handle.

## The fix

One handle, built from the repo. The apply block's Linear-shaped preamble (`viewer`, `team(id).states`, `issueLabels`) existed only to serve `unclaim()`, so `unclaim()` moved onto adapter verbs — `getTicket`, `listComments`, `transition`, `comment`. That matters beyond this bug: `unclaim()` is the rollback that stops a dead run holding a cap slot forever, and it would have failed the same way on GitHub.

## Notes for the reviewer

- **`computeUnclaimAction`'s signature is deliberately unchanged.** It maps label names to ids via `allLabels`; passing an identity table (`id === name`) makes it return names, which is what `transition()` takes. WM-1024's `event-runtime/lib/unclaim.test.mjs` pins that function against `releaseLabels` and is outside this ticket's Owned Paths — changing the signature would have broken it, which is the WM-1010 trap.
- **The assignee check in `unclaim()` is gone, on purpose.** It compared against `viewer.id`, but every agent authenticates as the same account, so "is it still mine" is unanswerable (WM-1045). The `ai:in-progress` label is the honest guard, and an agent that moved its ticket to Blocked or In Review still correctly keeps that state.
- The tests are **grep invariants over the source**, not behavioural mocks: the defect was a call shape, and the next bare handle added would reintroduce it silently.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 orchestrator && bun run format:check && bun run lint
```

- 348 pass, 1 fail — `browserLaunchCheck > skips cleanly when no browser is installed`, **identical on clean develop** (verified)
- WM-1024's unclaim contract test still green
- format:check clean; lint 0 errors, 616 warnings = baseline

**Falsifiability:** against the original `tick.mjs`, 2 of the 3 new tests fail.
