### PR TITLE
fix(worktree): accept GitHub ticket identifiers in the worktree scripts

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 const UP = path.resolve(import.meta.dir, "worktree-up.sh");
 const DOWN = path.resolve(import.meta.dir, "worktree-down.sh");
@@ -1520,4 +1520,75 @@ test("worktree-down refuses dirty worktree without --force and cleans up with --
     rmSync(tempWtRoot, { recursive: true, force: true });
     Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticketId}`] });
   }
+});
+
+// ------------------------------------------------ GitHub ticket ids (#881) ---
+// After the WM-1006 cutover the worker passes GitHub identifiers. The scripts
+// validated `^[A-Z]+-[0-9]+` only, so a claim landed and then worktree creation
+// died — leaving a claimed ticket with no work happening.
+describe("ticket id forms", () => {
+  const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
+  /** Run a helper from worktree-common.sh and return its stdout. */
+  const call = (fn, arg) => {
+    const r = Bun.spawnSync({
+      cmd: ["bash", "-c", `source "${COMMON}"; ${fn} ${JSON.stringify(arg)}`],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return { out: r.stdout.toString().trim(), code: r.exitCode };
+  };
+
+  test("accepts tracker-key and GitHub contract forms, rejects bare numbers", () => {
+    for (const id of [
+      "OPS-123",
+      "OPS-123-scratch",
+      "watt-mind/factory#881",
+      "#881",
+    ]) {
+      expect(call("ticket_is_valid", id).code).toBe(0);
+    }
+    expect(call("ticket_is_valid", "not a ticket").code).not.toBe(0);
+  });
+
+  test("slugs are filesystem- and ref-safe", () => {
+    const slug = call("ticket_slug", "watt-mind/factory#881").out;
+    expect(slug).toBe("gh-881");
+    expect(slug).not.toContain("/");
+    expect(slug).not.toContain("#");
+    // Tracker-key ids are unchanged, so existing worktrees keep their paths.
+    expect(call("ticket_slug", "OPS-123").out).toBe("OPS-123");
+  });
+
+  test("slug is idempotent", () => {
+    // The lifecycle lock and the prune loop slugify defensively; a
+    // non-idempotent slug would produce gh-gh-881 or die on its own output.
+    const once = call("ticket_slug", "watt-mind/factory#881").out;
+    expect(call("ticket_slug", once).out).toBe(once);
+  });
+
+  test("both GitHub forms agree on slug AND port", () => {
+    // They resolve to one directory, so a differing port would be a torn
+    // allocation: same worktree, two port leases.
+    const a = "watt-mind/factory#881";
+    const b = "#881";
+    expect(call("ticket_slug", a).out).toBe(call("ticket_slug", b).out);
+    expect(call("ticket_api_port", a).out).toBe(call("ticket_api_port", b).out);
+  });
+
+  test("distinct tickets do not share a port", () => {
+    const p = (id) => call("ticket_api_port", id).out;
+    expect(p("OPS-123")).not.toBe(p("watt-mind/factory#123"));
+    expect(p("OPS-123")).not.toBe(p("OPS-123-scratch"));
+  });
+
+  test("ticket_number extracts the number from every form", () => {
+    for (const [id, want] of [
+      ["OPS-123", "123"],
+      ["watt-mind/factory#881", "881"],
+      ["#881", "881"],
+      ["gh-881", "881"],
+    ]) {
+      expect(call("ticket_number", id).out).toBe(want);
+    }
+  });
 });

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -193,16 +193,58 @@ provision_instance_local_configs() { # <checkout> [primary-checkout]
 
 repo_root() { git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel; }
 
-ticket_number() {
-  [[ "$1" =~ ^[A-Z]+-([0-9]+) ]] || die "ticket must look like OPS-123 (got '$1')"
-  printf '%s' "${BASH_REMATCH[1]}"
+# Accepted ticket id forms (WM-1006 cutover, #881):
+#   ABC-123 / ABC-123-scratch   tracker-key form (Linear)
+#   owner/repo#123 / #123       GitHub forms
+#
+# A BARE number is deliberately NOT accepted: `worktree-up.sh 123` is far more
+# likely a typo than an intent, the existing arg-parsing test guards it as
+# such, and the GitHub adapter always emits the `owner/repo#123` contract form
+# anyway (issueIdentifier), so nothing needs it.
+ticket_is_valid() {
+  [[ "$1" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] && return 0
+  [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#[0-9]+$ ]] && return 0
+  [[ "$1" =~ ^\#[0-9]+$ ]] && return 0
+  [[ "$1" =~ ^gh-[0-9]+$ ]] && return 0
+  return 1
 }
 
-# Preferred even API port for a ticket. Hashes the full id so a numeric
-# collision (N and N+200) or a -scratch suffix cannot share a port.
+ticket_number() {
+  [[ "$1" =~ ^[A-Z]+-([0-9]+) ]] && { printf '%s' "${BASH_REMATCH[1]}"; return; }
+  [[ "$1" =~ \#([0-9]+)$ ]] && { printf '%s' "${BASH_REMATCH[1]}"; return; }
+  [[ "$1" =~ ^gh-([0-9]+)$ ]] && { printf '%s' "${BASH_REMATCH[1]}"; return; }
+  die "ticket must look like OPS-123 or owner/repo#123 (got '$1')"
+}
+
+# Filesystem- and git-ref-safe name for a ticket id.
+#
+# `owner/repo#123` cannot be a directory component or a branch segment: `/`
+# nests a path and `#` is awkward in refs and shell. Both GitHub forms collapse
+# to `gh-123`. That is unambiguous in practice because `worktree_root` is
+# per-repo, so two different repositories' #123 never share a root — and PORTS
+# hash the full original id (ticket_api_port), not this slug, so even a
+# hypothetical name clash cannot produce a port clash.
+# IDEMPOTENT: slug(slug(x)) == slug(x). Callers slugify defensively (the
+# lifecycle lock, the prune loop over existing directory names), and a
+# non-idempotent version would turn `gh-881` into `gh-gh-881` or die.
+ticket_slug() {
+  [[ "$1" =~ ^gh-[0-9]+$ ]] && { printf '%s' "$1"; return; }
+  if [[ "$1" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]]; then
+    printf '%s' "$1"
+  else
+    printf 'gh-%s' "$(ticket_number "$1")"
+  fi
+}
+
+# Preferred even API port for a ticket. Hashes the SLUG so a numeric collision
+# (N and N+200) or a -scratch suffix cannot share a port, while the two GitHub
+# id forms — `owner/repo#123` and `123` — agree with each other. Hashing the
+# raw id gave those two the same worktree directory but different ports, which
+# is a torn allocation waiting to happen (#881). For `ABC-123` the slug is the
+# id, so existing Linear ports are unchanged.
 ticket_api_port() {
   local hash
-  hash=$(printf '%s' "$1" | cksum | awk '{print $1}')
+  hash=$(printf '%s' "$(ticket_slug "$1")" | cksum | awk '{print $1}')
   printf '%s' "$((PORT_BASE + 2 * (hash % PORT_SPAN)))"
 }
 

--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -39,7 +39,7 @@ worktree_lifecycle_lock_path() { # <ticket>
   local common
   common=$(git -C "$REPO" rev-parse --git-common-dir)
   [[ "$common" == /* ]] || common="$REPO/$common"
-  printf '%s/factory-worktree-locks/%s.lock' "$common" "$1"
+  printf '%s/factory-worktree-locks/%s.lock' "$common" "$(ticket_slug "$1")"
 }
 
 try_worktree_lifecycle_lock() { # <ticket>
@@ -164,6 +164,10 @@ if [[ "$HERE" -eq 1 ]]; then
   WT="$REPO"
 else
   [[ -n "$TICKET" ]] || die "usage: worktree-down.sh <TICKET-ID> [--force] | --here | --prune"
+  # Same slug as worktree-up.sh, or a GitHub-id worktree can be created and
+  # never torn down — which leaks disk and a port lease (#881).
+  ticket_is_valid "$TICKET" || die "ticket must look like OPS-123 or owner/repo#123 (got '$TICKET')"
+  TICKET="$(ticket_slug "$TICKET")"
   WT="$WT_ROOT/$TICKET"
   [[ -d "$WT" ]] || die "no worktree at $WT"
 

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -89,7 +89,7 @@ try_worktree_lifecycle_lock() { # <ticket>
   common=$(git -C "$REPO" rev-parse --git-common-dir)
   [[ "$common" == /* ]] || common="$REPO/$common"
   root="$common/factory-worktree-locks"
-  lock="$root/$1.lock"
+  lock="$root/$(ticket_slug "$1").lock"
   mkdir -p "$root"
   if ! mkdir "$lock" 2>/dev/null; then
     holder=$(cat "$lock/pid" 2>/dev/null || true)
@@ -117,10 +117,14 @@ if [[ "$HERE" -eq 1 ]]; then
   LABEL="here"
 else
   [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--checkout-only, --no-seed, --no-fetch, --reseed, --resume)"
-  [[ "$TICKET" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || die "ticket must look like OPS-123 or OPS-123-scratch"
-  WT="$WT_ROOT/$TICKET"
-  LABEL="$TICKET"
-  BRANCH="$TYPE/$TICKET${SLUG:+-$SLUG}"
+  # Accepts ABC-123 and owner/repo#123 (#881). The directory and
+  # branch use the slug, since `/` and `#` are not usable in either.
+  ticket_is_valid "$TICKET" || die "ticket must look like OPS-123 or owner/repo#123 (got '$TICKET')"
+  TICKET_SLUG="$(ticket_slug "$TICKET")"
+  WT="$WT_ROOT/$TICKET_SLUG"
+  LABEL="$TICKET_SLUG"
+  # Slug, not raw id: `owner/repo#123` would make an invalid ref (#881).
+  BRANCH="$TYPE/$TICKET_SLUG${SLUG:+-$SLUG}"
 
   try_worktree_lifecycle_lock "$TICKET" \
     || die "worktree_lifecycle_busy: another process is provisioning or removing $TICKET"


### PR DESCRIPTION
Fixes #881

Second cutover blocker, independent of #880. **Blocked every dispatch on a GitHub control plane.**

## The bug

`bin/worktree-up.sh` validated `^[A-Z]+-[0-9]+...` only. GitHub identifiers are `owner/repo#123`, so:

```
$ bin/worktree-up.sh watt-mind/factory#881 fix probe --checkout-only
error: ticket must look like OPS-123 or OPS-123-scratch
```

The claim lands (that part already worked on GitHub), then worktree creation dies — leaving a claimed ticket with no work happening. The script is mandatory because it isolates ports and `FACTORY_EVENT_HOME`, so "just use `git worktree add`" is not an out.

## The fix

`ticket_is_valid` / `ticket_slug` / `ticket_number` in `worktree-common.sh`, used by up and down. `owner/repo#123` and `#123` collapse to the slug `gh-123`; `/` and `#` are usable in neither a path component nor a git ref.

## Notes for the reviewer

- **Bare `123` is deliberately rejected.** My first pass accepted it and broke the existing arg-parsing test, which guards `123` as a typo. That guard is right, and the adapter always emits the `owner/repo#123` contract form (`issueIdentifier`), so nothing needs bare numbers. The test caught my overreach — I narrowed rather than relaxing it.
- **Ports now hash the SLUG, not the raw id.** Hashing the raw id gave `owner/repo#881` and `#881` the same worktree directory but *different* ports — a torn allocation: one worktree, two port leases. For `ABC-123` the slug is the id, so **existing Linear worktree ports are unchanged** (verified: `OPS-123` → 7442 before and after).
- **`ticket_slug` is idempotent.** The lifecycle lock and the prune loop slugify defensively, over values that may already be slugs; a non-idempotent version produced `gh-gh-881` or died on its own output.
- **The lifecycle lock had the same latent bug** — `$root/$1.lock` with a `/` in the id nests a path that cannot be created, which reported as `worktree_lifecycle_busy`. Found it by running the real script, not by reading.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 bin && bun run format:check && bun run lint
```

- 133 pass, 1 fail — `provision_instance_local_configs ...`, **identical on clean develop** (verified)
- format:check clean; lint 0 errors
- **Live**: `worktree-up.sh watt-mind/factory#881` created `gh-881` on branch `fix/gh-881-probe`, and `worktree-down.sh watt-mind/factory#881` removed it.

**Falsifiability:** against the original `worktree-common.sh`, 4 of the 6 new tests fail.
