### PR TITLE
fix(planner): plane-neutral in-flight fetch — dispatch dead-lettered on the github plane

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -499,7 +499,8 @@ function fetchPullRequestDefault(payload) {
   }
 }
 
-const IN_FLIGHT_QUERY = `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
+// WM-1006: in-flight tickets come from the control-plane adapter via the
+// `inflight` CLI verb — never raw tracker GraphQL (plane-specific).
 
 const OWNED_PATHS_CLOSURE_CACHE = new Map();
 
@@ -530,19 +531,20 @@ function fetchInFlightDefault(repoConfig) {
       "bun",
       [
         linearCli(),
-        "raw",
-        IN_FLIGHT_QUERY,
-        "--var",
-        `t=${repoConfig.team}`,
-        "--var",
-        `p=${repoConfig.project}`,
+        "inflight",
+        "--team",
+        String(repoConfig.team),
+        "--project",
+        String(repoConfig.project),
+        "--json",
       ],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
-    return JSON.parse(out)?.issues?.nodes ?? [];
+    const rows = JSON.parse(out);
+    return Array.isArray(rows) ? rows : [];
   } catch (err) {
     throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -615,6 +615,28 @@ const VERBS = {
     );
   },
 
+  async inflight() {
+    // In Progress tickets for a team/project — the planner's Owned Paths
+    // collision set (WM-1006: control-plane-neutral, replaces raw Linear GQL).
+    const team = flag("team") ?? teamOf(positional[0] ?? "");
+    if (!team) throw new Error(`usage: inflight --team WM [--project Factory]`);
+    const rows = await controlPlane().listTickets({
+      team,
+      project: flag("project") ?? undefined,
+      states: ["In Progress"],
+    });
+    const slim = rows.map((i) => ({
+      identifier: i.identifier,
+      description: i.description ?? "",
+    }));
+    out(
+      slim,
+      slim.length
+        ? slim.map((i) => i.identifier).join("\n")
+        : "no in-progress tickets",
+    );
+  },
+
   async queue() {
     const team = flag("team") ?? teamOf(positional[0] ?? "");
     if (!team) throw new Error(`usage: queue --team CLNT`);


### PR DESCRIPTION
Post-WM-1006, planner's Owned-Paths collision fetch still ran Linear GraphQL (`IN_FLIGHT_QUERY` via `ticket.mjs raw`), which the github plane routes to `gh api graphql` → status 1 → `linear_read_failed` → **every dispatch dead-lettered** (evidence: 7 events `operator-dispatch-*-1787404*`). New `ticket.mjs inflight --team --project --json` verb backed by `controlPlane().listTickets({states:[\"In Progress\"]})`; planner shells to it. Verified live on both planes (returns WM-872/WM-935 residuals via Linear config; GitHub plane resolves through the adapter).

## Handoff
- Verification: bun test event-runtime/lib — slice green locally (known load-flaky spawn suites excepted); planner.test.mjs 68 pass
- UX critique: n/a