### PR TITLE
fix(runtime): slug ticket ids used as filesystem paths

### DIFF
--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -18,6 +18,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { ticketSlug } from "../../lib/ticket-slug.mjs";
 import { Database } from "bun:sqlite";
 import { leaseDir, liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
@@ -409,7 +410,10 @@ function materializeWorktree({
       `repo "${repoName}" declares no worktree lifecycle in config/repos.yaml (worktree_up/worktree_down/worktree_root) — the planner should have refused this`,
     );
   }
-  const worktreePath = path.join(repo.worktreeRoot, ticket);
+  // MUST match `ticket_slug()` in bin/worktree-common.sh — bash creates this
+  // directory, this looks it up. A mismatch searches a path that was never
+  // created and reads as "worktree_up succeeded but produced nothing" (#884).
+  const worktreePath = path.join(repo.worktreeRoot, ticketSlug(ticket));
   if (existsSync(worktreePath)) {
     const conflict = ownershipConflict({
       repo: repoName,
@@ -468,7 +472,7 @@ function materializeWorktree({
       // lifecycle lock, narrowing the ownership-check/preservation race.
       FACTORY_WORKTREE_EXPECTED_LEASE_FILE: path.join(
         leaseDir(),
-        `${repoName}-${ticket}.json`,
+        `${repoName}-${ticketSlug(ticket)}.json`,
       ),
       FACTORY_WORKTREE_EXPECTED_LEASE_PID: String(process.pid),
     },

--- a/lib/ticket-slug.mjs
+++ b/lib/ticket-slug.mjs
@@ -1,0 +1,51 @@
+/**
+ * Filesystem- and git-ref-safe name for a ticket id (#884).
+ *
+ * GitHub identifiers are `owner/repo#123`. Several subsystems use the ticket
+ * id as a **path component** — the worktree directory, the worker-lease file,
+ * the preservation report — and `/` nests a directory while `#` is awkward in
+ * refs and shells. On the WM-1006 cutover that surfaced as:
+ *
+ *   ENOENT: .../worker-leases/factory-watt-mind/factory#863.json.<pid>.tmp
+ *
+ * after the claim had already landed, leaving a claimed ticket with no work.
+ *
+ * This MUST stay byte-identical to `ticket_slug()` in `bin/worktree-common.sh`
+ * (#881): bash creates the worktree directory, JS looks it up. If the two
+ * disagree the runtime searches a path that was never created, and the failure
+ * reads as "worktree_up succeeded but produced nothing". `ticket-slug.test.mjs`
+ * pins them together by invoking the bash function and comparing.
+ *
+ * Idempotent: `slug(slug(x)) === slug(x)`. Callers slugify defensively over
+ * values that may already be slugs (a directory name from a prune loop), and a
+ * non-idempotent version yields `gh-gh-123`.
+ */
+
+const TRACKER_KEY = /^[A-Z]+-\d+(-[A-Za-z0-9][A-Za-z0-9-]*)?$/;
+const ALREADY_SLUG = /^gh-\d+$/;
+const GITHUB_ID = /(?:^|#)(\d+)$/;
+
+/**
+ * @param {string} ticket `ABC-123`, `ABC-123-scratch`, `owner/repo#123`, `#123`
+ * @returns {string} a name safe as a single path component and a git ref segment
+ */
+export function ticketSlug(ticket) {
+  const id = String(ticket ?? "").trim();
+  if (ALREADY_SLUG.test(id)) return id;
+  if (TRACKER_KEY.test(id)) return id;
+  const m = GITHUB_ID.exec(id);
+  if (m) return `gh-${m[1]}`;
+  throw new Error(
+    `ticket must look like ABC-123 or owner/repo#123 (got ${JSON.stringify(ticket)})`,
+  );
+}
+
+/** True when `ticketSlug` can name this id without throwing. */
+export function isSluggableTicket(ticket) {
+  try {
+    ticketSlug(ticket);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/ticket-slug.test.mjs
+++ b/lib/ticket-slug.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * ticketSlug must agree with bash, exactly (#884).
+ *
+ * bin/worktree-up.sh CREATES the worktree directory; event-runtime looks it
+ * up. Two implementations of the same naming rule in two languages is a drift
+ * risk, so this test does not restate the rule — it invokes the bash function
+ * and compares. If either side changes, this fails.
+ */
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isSluggableTicket, ticketSlug } from "./ticket-slug.mjs";
+
+const COMMON = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "bin",
+  "worktree-common.sh",
+);
+const bashSlug = (id) => {
+  const r = Bun.spawnSync({
+    cmd: [
+      "bash",
+      "-c",
+      `source ${JSON.stringify(COMMON)}; ticket_slug ${JSON.stringify(id)}`,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return r.stdout.toString().trim();
+};
+
+const CASES = [
+  "OPS-123",
+  "OPS-123-scratch",
+  "watt-mind/factory#884",
+  "#884",
+  "gh-884",
+];
+
+describe("ticketSlug", () => {
+  test("matches bin/worktree-common.sh byte for byte", () => {
+    for (const id of CASES) {
+      expect({ id, js: ticketSlug(id) }).toEqual({ id, js: bashSlug(id) });
+    }
+  });
+
+  test("GitHub ids lose the path-hostile characters", () => {
+    const s = ticketSlug("watt-mind/factory#884");
+    expect(s).toBe("gh-884");
+    expect(s).not.toContain("/");
+    expect(s).not.toContain("#");
+  });
+
+  test("tracker-key ids are unchanged, so existing paths keep working", () => {
+    // The cutover must not rename any Linear worktree or lease file.
+    expect(ticketSlug("OPS-123")).toBe("OPS-123");
+    expect(ticketSlug("OPS-123-scratch")).toBe("OPS-123-scratch");
+  });
+
+  test("is idempotent", () => {
+    for (const id of CASES)
+      expect(ticketSlug(ticketSlug(id))).toBe(ticketSlug(id));
+  });
+
+  test("the two GitHub forms agree", () => {
+    expect(ticketSlug("watt-mind/factory#884")).toBe(ticketSlug("#884"));
+  });
+
+  test("rejects what it cannot name, rather than inventing a path", () => {
+    for (const bad of ["", "not a ticket", "OPS-", "../escape"]) {
+      expect(() => ticketSlug(bad)).toThrow();
+      expect(isSluggableTicket(bad)).toBe(false);
+    }
+  });
+
+  test("no site builds a lease or worktree path from a raw ticket id", () => {
+    // The defect was a call shape; the next site added would reintroduce it.
+    const root = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+    );
+    const proc = Bun.spawnSync({
+      cmd: [
+        "git",
+        "grep",
+        "-nE",
+        String.raw`path\.join\([^)]*, *ticket *\)|-\$\{ticket\}\.json`,
+        "--",
+        "lib",
+        "event-runtime/lib",
+        "orchestrator",
+      ],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const hits = (proc.stdout?.toString() || "")
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => !l.split(":")[0].endsWith(".test.mjs"));
+    expect(hits).toEqual([]);
+  });
+});

--- a/lib/worker-leases.mjs
+++ b/lib/worker-leases.mjs
@@ -17,6 +17,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { ticketSlug } from "./ticket-slug.mjs";
 
 export const LEASE_TTL_MS = 90_000;
 export const LEASE_HEARTBEAT_MS = 20_000;
@@ -26,7 +27,10 @@ export function leaseDir(root = path.join(homedir(), ".factory")) {
 }
 
 function leaseFile(repo, ticket, dir) {
-  return path.join(dir, `${repo}-${ticket}.json`);
+  // Slug, not the raw id: a GitHub identifier (`owner/repo#123`) contains a
+  // `/`, so the raw form nests a directory that does not exist and the write
+  // dies with ENOENT after the claim has already landed (#884).
+  return path.join(dir, `${repo}-${ticketSlug(ticket)}.json`);
 }
 
 function readLease(file) {


### PR DESCRIPTION
Fixes #884

Third failure of the same root cause on the WM-1006 cutover, after #880 and #881.

## The bug

GitHub ticket ids are `owner/repo#123`. Several subsystems use the raw id as a **filesystem path component**:

```
Dispatch error: ENOENT: no such file or directory, open
'/home/hdkiller/.factory/worker-leases/factory-watt-mind/factory#863.json.<pid>.tmp'
```

Both tickets in the first real dispatch wave **claimed successfully and then died here** — leaving claimed tickets with no work happening. I released them by hand.

Sites fixed: `lib/worker-leases.mjs` (lease file), `event-runtime/lib/workspace.mjs` (worktree path, preservation report).

## The fix

One shared `lib/ticket-slug.mjs`, used by every site that turns a ticket id into a path. `owner/repo#123` → `gh-123`, idempotent, and **byte-identical to `ticket_slug()` in `bin/worktree-common.sh`** (#881).

That last point is the whole risk: **bash creates the worktree directory, JS looks it up.** If the two disagree the runtime searches a path that was never created, and it surfaces as "worktree_up succeeded but produced nothing" — a confusing failure a long way from its cause.

So the test doesn't restate the rule. It **invokes the bash function and compares output**, for all five id shapes. If either side changes, it fails.

## Notes for the reviewer

- **Tracker-key ids are unchanged** (`OPS-123` → `OPS-123`), so the cutover renames no existing Linear worktree or lease file. Asserted explicitly.
- **It throws rather than inventing a path** for unnameable input — including `../escape`. A slug function that silently produces something for any string is a path-traversal shape.
- A **grep invariant** fails if a new site builds a lease or worktree path from a raw ticket id. The defect was a call shape, and the next one added would reintroduce it silently — that's how this reached its third instance.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 lib event-runtime/lib/workspace.test.mjs && bun run format:check && bun run lint
```

- 1714 pass, 1 fail — `execute against a fake ACP agent > timeout kills a long-lived grandchild`, the known pre-existing flake (WM-1033 / #873), **identical on clean develop**
- format:check clean; lint 0 errors

**Falsifiability:** reverting `worker-leases.mjs` to the raw id fails the grep invariant.
