### PR TITLE
fix(dispatch): slug the worktree path in tick.mjs

### DIFF
--- a/lib/ticket-slug.test.mjs
+++ b/lib/ticket-slug.test.mjs
@@ -75,7 +75,13 @@ describe("ticketSlug", () => {
   });
 
   test("no site builds a lease or worktree path from a raw ticket id", () => {
-    // The defect was a call shape; the next site added would reintroduce it.
+    // The defect is a call shape, and it has now recurred FOUR times (#881
+    // bash, #884 workspace + leases, #887 tick). The first version of this
+    // matched a variable literally named `ticket` and therefore missed
+    // `t.identifier` in tick.mjs — so match any ticket-id-shaped expression.
+    // POSIX ERE only: `git grep -E` has no \w and no \d. And `.*`, not
+    // `[^)]*` — the latter cannot cross a nested call like `expand(...)`,
+    // which is how the widened pattern was ALSO vacuous on first attempt.
     const root = path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
       "..",
@@ -85,7 +91,7 @@ describe("ticketSlug", () => {
         "git",
         "grep",
         "-nE",
-        String.raw`path\.join\([^)]*, *ticket *\)|-\$\{ticket\}\.json`,
+        String.raw`path\.join\(.*, *(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier) *\)|-\$\{(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier)\}\.json`,
         "--",
         "lib",
         "event-runtime/lib",
@@ -100,5 +106,17 @@ describe("ticketSlug", () => {
       .filter(Boolean)
       .filter((l) => !l.split(":")[0].endsWith(".test.mjs"));
     expect(hits).toEqual([]);
+  });
+
+  test("the invariant's pattern actually matches a raw-id path", () => {
+    // Guard on the guard. If the pattern stops matching, the test above passes
+    // vacuously and the fifth recurrence ships — exactly how the gql grep
+    // invariant in tools/ticket.test.mjs stayed broken for months (#962).
+    const probe =
+      "const wt = path.join(expand(repo.worktree_root), t.identifier);";
+    const re = new RegExp(
+      String.raw`path\.join\(.*, *(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier) *\)`,
+    );
+    expect(re.test(probe)).toBe(true);
   });
 });

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -33,6 +33,7 @@ import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { loadConfigYaml, ROOT } from "../lib/schedule.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import { ticketSlug } from "../lib/ticket-slug.mjs";
 import {
   parseOwnedPaths,
   effectiveOwnedPaths,
@@ -645,7 +646,13 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   async function runTicket(t) {
-    const wt = path.join(expand(repo.worktree_root), t.identifier);
+    // Slug, not the raw identifier: worktree-up.sh creates `gh-863` for
+    // `watt-mind/factory#863` (#881/#884). Computing the raw path here made
+    // tick report "worktree ready" for a directory that does not exist and
+    // then spawn the agent with that cwd — which surfaces as ENOENT on the
+    // EXECUTABLE, so it read as a missing /usr/bin/timeout rather than a path
+    // bug, and tripped the circuit breaker as an environment failure (#887).
+    const wt = path.join(expand(repo.worktree_root), ticketSlug(t.identifier));
     const up = spawnSync("/bin/bash", [repo.worktree_up, t.identifier], {
       cwd: repoPath,
       encoding: "utf8",
@@ -1072,7 +1079,10 @@ export async function main(argv = process.argv.slice(2)) {
         ticket: t.identifier,
         owner: leaseOwner,
       });
-      const wt = path.join(expand(repo.worktree_root), t.identifier);
+      const wt = path.join(
+        expand(repo.worktree_root),
+        ticketSlug(t.identifier),
+      );
       preserveWip(wt, t.identifier);
       await unclaim(
         t,


### PR DESCRIPTION
Fixes #887

Fourth site of the #884 defect, found by the next dispatch attempt.

## The bug

`orchestrator/tick.mjs` builds the worktree path independently of `workspace.mjs`, from the **raw** identifier:

```js
648:  const wt = path.join(expand(repo.worktree_root), t.identifier);
1075: const wt = path.join(expand(repo.worktree_root), t.identifier);
```

`worktree-up.sh` creates `.../factory/gh-863`; tick computed `.../factory/watt-mind/factory#863`. It reported "worktree ready" for a path that does not exist, then spawned the agent with that cwd:

```
watt-mind/factory#863 worktree ready .../factory/watt-mind/factory#863
[watt-mind/factory#863] FAILED agent spawn failed (ENOENT: posix_spawn '/usr/bin/timeout')
```

`/usr/bin/timeout` **exists**. A missing cwd surfaces as ENOENT on the *executable*, so this read as a broken environment and tripped the circuit breaker as an environment failure — sending the investigation to the wrong subsystem entirely.

## The thing worth reading

**#884's grep invariant did not catch this**, because it matched a variable literally named `ticket`; here it is `t.identifier`.

So I widened it — and then my new *guard-on-the-guard* test caught that the widened version was **still vacuous**: `[^)]*` cannot cross the nested `expand(...)` call, so the pattern never matched the real line either. Fixed to `.*`.

Two invariants in this repo have now shipped vacuous (the `gql` import check in #962 was broken for months by `\b` in POSIX ERE). A grep invariant that cannot fail is worse than none, because it reads as coverage. This one now carries a test asserting its pattern matches a known-bad line.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 orchestrator lib && bun run format:check && bun run lint
```

- 2007 pass, 1 fail — `browserLaunchCheck > skips cleanly when no browser is installed`, **identical on clean develop**
- format:check clean; lint 0 errors

**Falsifiability:** against the unfixed `tick.mjs` the invariant fails and names both offending lines (648, 1075).
