### PR TITLE
docs(readme): use the Graph screenshot as the hero instead of the demo GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ source of truth, and CI is the reward signal. Nothing merges because an agent
 said it was done; it merges because the tests passed and a reviewer (agent or
 human) approved.
 
-![A recorded `factory demo` run: a ticket is claimed, implemented, verified, and merged.](docs/media/demo.gif)
+[![The factory's Graph view: every registered event route and recommendation edge in a running instance, laid out as a directed graph.](docs/screenshots/15-graph.jpg)](docs/screenshots/15-graph.jpg)
+
+<sub>The Graph view of a live instance — every event type, every agent it
+routes to, and the recommendation edges between them. This is the whole
+control loop as the runtime actually has it registered, not a diagram someone
+drew. <a href="docs/screenshots/">More screenshots</a>.</sub>
 
 **Status:** the first commit landed on 2026-08-03. The badge above counts the
 pull requests the factory has since merged through its own loop. Young
@@ -42,6 +47,8 @@ bun install
 bin/factory demo --dry   # print the plan — offline, and what CI runs
 bin/factory demo         # claim → implement → verify → PR → merge
 ```
+
+![A recorded `factory demo` run: a ticket is claimed, implemented, verified, and merged.](docs/media/demo.gif)
 
 The demo needs no accounts: no tracker token, no GitHub token, no model API
 key. It copies a bundled repository into a temporary checkout, implements the


### PR DESCRIPTION
Fixes #889

## What

Above-the-fold image is now `docs/screenshots/15-graph.jpg` — the Graph view of a live instance, showing every registered event route and recommendation edge.

The demo GIF is **moved, not deleted**: it now sits in `## Try it`, immediately after the `bin/factory demo` commands it depicts. That is where it is the thing being described rather than the first impression.

## Why

A GIF was a weak hero here. It shows a *toy* run — the bundled starter ticket on an in-memory forge — so the most valuable space on the page undersold the project. It also can't be read at a glance: a reader scrolling GitHub got a few frames of a terminal before deciding whether this is serious software.

The Graph view shows the real topology of a working system in one frame. It reads as scale rather than as a demo, and it is the runtime's own registered routes, not a diagram someone drew.

## Note for the reviewer

At README width the node labels are **illegible** — that is expected and is why the caption carries the meaning rather than describing the picture, and why the image links to the full-size asset. If you'd rather have something readable above the fold, `01-overview.jpg` or `20-ticket-journey.jpg` are the legible alternatives; I picked density deliberately, but it's a taste call and easy to swap.

## Verification

`bun run format:check` — clean.

Both assets confirmed present. Rendered-page check is on the reviewer, since it only exists once this is on `develop`.
