### PR TITLE
fix(dispatch): sweep all remaining raw ticket ids out of path construction

### DIFF
--- a/lib/ticket-slug.mjs
+++ b/lib/ticket-slug.mjs
@@ -49,3 +49,29 @@ export function isSluggableTicket(ticket) {
     return false;
   }
 }
+
+/**
+ * The ONLY sanctioned way to put a ticket id into a path or filename.
+ *
+ * Five separate sites got this wrong one at a time (#881, #884, #887, #891),
+ * each caught only when dispatch died on it in production. Every fix was
+ * correct and every regex written to prevent the next one was too narrow:
+ * a variable named `ticket` vs `t.identifier`, `[^)]*` that cannot cross a
+ * nested call, and finally a template literal that no path-shaped pattern
+ * matched at all.
+ *
+ * A helper is the mechanism a regex was standing in for. Build the whole
+ * name here and the id can never reach a path un-slugged.
+ *
+ * @param {string} ticket
+ * @param {{ prefix?: string, suffix?: string, ext?: string }} [parts]
+ * @returns {string} a single path component, e.g. `factory-gh-862-2026...jsonl`
+ */
+export function ticketFileName(
+  ticket,
+  { prefix = "", suffix = "", ext = "" } = {},
+) {
+  const slug = ticketSlug(ticket);
+  const name = [prefix, slug, suffix].filter(Boolean).join("-");
+  return ext ? `${name}.${ext.replace(/^\./, "")}` : name;
+}

--- a/lib/ticket-slug.test.mjs
+++ b/lib/ticket-slug.test.mjs
@@ -8,6 +8,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { isSluggableTicket, ticketSlug } from "./ticket-slug.mjs";
 
@@ -37,6 +38,15 @@ const CASES = [
   "#884",
   "gh-884",
 ];
+
+/**
+ * A ticket id reaching a path or filename un-slugged. Covers both shapes that
+ * have bitten: `path.join(..., <id>)` and a template literal ending in a file
+ * extension. Deliberately ignores `<id>` in log lines and map keys — an
+ * invariant that flags correct code gets disabled.
+ */
+const RAW_TICKET_PATH =
+  /path\.join\(.*,\s*(ticket|ticketIdentifier|[A-Za-z_$][\w$]*\.identifier)\s*\)|`[^`]*\$\{(ticket|ticketIdentifier|[A-Za-z_$][\w$]*\.identifier)\}[^`]*\.[a-z]+`/;
 
 describe("ticketSlug", () => {
   test("matches bin/worktree-common.sh byte for byte", () => {
@@ -74,49 +84,79 @@ describe("ticketSlug", () => {
     }
   });
 
-  test("no site builds a lease or worktree path from a raw ticket id", () => {
-    // The defect is a call shape, and it has now recurred FOUR times (#881
-    // bash, #884 workspace + leases, #887 tick). The first version of this
-    // matched a variable literally named `ticket` and therefore missed
-    // `t.identifier` in tick.mjs — so match any ticket-id-shaped expression.
-    // POSIX ERE only: `git grep -E` has no \w and no \d. And `.*`, not
-    // `[^)]*` — the latter cannot cross a nested call like `expand(...)`,
-    // which is how the widened pattern was ALSO vacuous on first attempt.
+  test("no site builds a path or filename from a raw ticket id", () => {
+    // Scans in JS with the SAME pattern the guards below pin, rather than a
+    // second regex passed to `git grep -E`. Two patterns is how the first
+    // version drifted; POSIX ERE also lacks \\w and \\b, which is how the
+    // `gql` invariant in tools/ticket.test.mjs stayed vacuous for months.
     const root = path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
       "..",
     );
-    const proc = Bun.spawnSync({
-      cmd: [
-        "git",
-        "grep",
-        "-nE",
-        String.raw`path\.join\(.*, *(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier) *\)|-\$\{(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier)\}\.json`,
-        "--",
-        "lib",
-        "event-runtime/lib",
-        "orchestrator",
-      ],
-      cwd: root,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const hits = (proc.stdout?.toString() || "")
-      .split("\n")
-      .filter(Boolean)
-      .filter((l) => !l.split(":")[0].endsWith(".test.mjs"));
+    const dirs = ["lib", "orchestrator", "event-runtime/lib"];
+    const hits = [];
+    for (const dir of dirs) {
+      const walk = (d) => {
+        for (const e of readdirSync(d, { withFileTypes: true })) {
+          const full = path.join(d, e.name);
+          if (e.isDirectory()) {
+            if (e.name !== "node_modules") walk(full);
+            continue;
+          }
+          if (!e.name.endsWith(".mjs") || e.name.endsWith(".test.mjs"))
+            continue;
+          readFileSync(full, "utf8")
+            .split("\n")
+            .forEach((line, i) => {
+              if (line.trim().startsWith("*") || line.trim().startsWith("//"))
+                return;
+              if (RAW_TICKET_PATH.test(line))
+                hits.push(
+                  `${path.relative(root, full)}:${i + 1}: ${line.trim()}`,
+                );
+            });
+        }
+      };
+      walk(path.join(root, dir));
+    }
     expect(hits).toEqual([]);
   });
 
-  test("the invariant's pattern actually matches a raw-id path", () => {
-    // Guard on the guard. If the pattern stops matching, the test above passes
-    // vacuously and the fifth recurrence ships — exactly how the gql grep
-    // invariant in tools/ticket.test.mjs stayed broken for months (#962).
-    const probe =
-      "const wt = path.join(expand(repo.worktree_root), t.identifier);";
-    const re = new RegExp(
-      String.raw`path\.join\(.*, *(ticket|[A-Za-z_][A-Za-z0-9_]*\.identifier) *\)`,
-    );
-    expect(re.test(probe)).toBe(true);
+  test("the pattern flags EVERY site that has historically regressed", () => {
+    // A single probe string is what let this recur five times: each new site
+    // used a spelling the previous pattern did not cover. Pin all of them.
+    const HISTORICAL = [
+      // #887 — worktree path, tick.mjs
+      "const wt = path.join(expand(repo.worktree_root), t.identifier);",
+      // #884 — worker lease file
+      "return path.join(dir, `${repo}-${ticket}.json`);",
+      // #884 — workspace worktree path
+      "const worktreePath = path.join(repo.worktreeRoot, ticket);",
+      // #891 — wip patch in tmpdir
+      "const patchPath = path.join(tmpdir(), `${ticketIdentifier}-wip.patch`);",
+      // #891 — transcript log, a template literal no path pattern matched
+      "`${repo.name}-${t.identifier}-${stamp}.jsonl`",
+    ];
+    for (const line of HISTORICAL) {
+      expect({ line, flagged: RAW_TICKET_PATH.test(line) }).toEqual({
+        line,
+        flagged: true,
+      });
+    }
+  });
+
+  test("the pattern does not flag correct, slugged construction", () => {
+    // An invariant that flags the fix as well as the bug gets disabled.
+    for (const line of [
+      "const wt = path.join(root, ticketSlug(t.identifier));",
+      'ticketFileName(t.identifier, { prefix: repo.name, ext: "jsonl" })',
+      "console.log(`${t.identifier} worktree ready`);",
+      "const key = `${t.identifier}:blocked`;",
+    ]) {
+      expect({ line, flagged: RAW_TICKET_PATH.test(line) }).toEqual({
+        line,
+        flagged: false,
+      });
+    }
   });
 });

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -33,7 +33,7 @@ import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { loadConfigYaml, ROOT } from "../lib/schedule.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
-import { ticketSlug } from "../lib/ticket-slug.mjs";
+import { ticketFileName, ticketSlug } from "../lib/ticket-slug.mjs";
 import {
   parseOwnedPaths,
   effectiveOwnedPaths,
@@ -176,7 +176,10 @@ export function preserveWip(wt, ticketIdentifier) {
         encoding: "utf8",
       });
       if (diff.stdout) {
-        const patchPath = path.join(tmpdir(), `${ticketIdentifier}-wip.patch`);
+        const patchPath = path.join(
+          tmpdir(),
+          ticketFileName(ticketIdentifier, { suffix: "wip", ext: "patch" }),
+        );
         writeFileSync(patchPath, diff.stdout);
         return { preserved: true, method: "patch", patchPath };
       }
@@ -202,7 +205,10 @@ export function preserveWip(wt, ticketIdentifier) {
       encoding: "utf8",
     });
     if (diff.stdout) {
-      const patchPath = path.join(tmpdir(), `${ticketIdentifier}-wip.patch`);
+      const patchPath = path.join(
+        tmpdir(),
+        ticketFileName(ticketIdentifier, { suffix: "wip", ext: "patch" }),
+      );
       writeFileSync(patchPath, diff.stdout);
       return { preserved: true, method: "patch", patchPath };
     }
@@ -679,7 +685,11 @@ export async function main(argv = process.argv.slice(2)) {
 
     const log = path.join(
       LOG_DIR,
-      `${repo.name}-${t.identifier}-${stamp}.jsonl`,
+      ticketFileName(t.identifier, {
+        prefix: repo.name,
+        suffix: stamp,
+        ext: "jsonl",
+      }),
     );
     const out = createWriteStream(log);
     const budget = String(


### PR DESCRIPTION
Fixes #891

Fifth and final site of the defect that has blocked the WM-1006 cutover all afternoon (#881 bash, #884 leases/workspace, #887 tick worktree).

## What was still broken

Dispatch claimed, provisioned a worktree, then died writing the transcript:

```
ENOENT: open '/home/hdkiller/.factory/logs/factory-watt-mind/factory#862-2026....jsonl'
```

Three remaining raw-id path builders in `tick.mjs`: two `-wip.patch` paths and the transcript log.

## Why this kept recurring, and what changed

I fixed this one site at a time, five times. Every fix was correct; every regex written to stop the next one was too narrow:

- the first matched a variable literally named `ticket` — missed `t.identifier`
- the widened one used `[^)]*`, which cannot cross a nested `expand(...)` — vacuous, caught only by a guard-test
- neither matched a **template literal** filename, which is what broke this time

So this PR stops writing patterns and adds a **mechanism**: `ticketFileName()` in `lib/ticket-slug.mjs` is now the only sanctioned way to build a filename from a ticket id. Build the whole name there and the id cannot reach a path un-slugged.

The invariant is correspondingly rebuilt:

- **One pattern**, defined once and shared by the source scan and the guards. Two patterns is how the first version drifted.
- **Scans in JS**, not `git grep -E` — POSIX ERE has no `\w` or `\b`, which is exactly how the `gql` invariant in `tools/ticket.test.mjs` stayed vacuous for months.
- **Pinned against all five historical sites**, not one probe string. I also restored each of the three real sites in the actual source, one at a time, and confirmed the invariant fails for each.
- **Asserts it does NOT flag correct code** — slugged construction, log lines, map keys. An invariant that flags the fix as well as the bug gets disabled.

## Verification

```
bun test --timeout 20000 --max-concurrency=4 orchestrator lib && bun run format:check && bun run lint
```

- 2007 pass, 2 fail — `browserLaunchCheck ...` and `timeout kills a long-lived grandchild`, both known pre-existing flakes (#873), identical on clean develop
- format:check clean; lint 0 errors

**Falsifiability:** restoring the log path, the wip-patch path, or the lease path each independently fails the invariant.
