### PR TITLE
refactor(config): migrate remaining unowned YAML readers to local/example fallback

### DIFF
--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -668,12 +668,23 @@ describe("loadControlPlane selection", () => {
     return root;
   };
 
-  test("defaults to linear when the stanza or the file is absent", () => {
+  test("defaults to linear when the stanza is absent", () => {
     expect(
       controlPlaneKindFromPolicy(withPolicy("merge:\n  max_fix_rounds: 2\n")),
     ).toBe("linear");
-    expect(controlPlaneKindFromPolicy(withPolicy(null))).toBe("linear");
-    expect(loadControlPlane({ root: withPolicy(null) }).kind).toBe("linear");
+  });
+
+  test("falls back to config/policy.example.yaml, and fails closed when neither exists", () => {
+    const root = tmpDir("control-plane-policy-fallback-");
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    expect(() => controlPlaneKindFromPolicy(root)).toThrow(/policy\.yaml/);
+
+    writeFileSync(
+      path.join(root, "config", "policy.example.yaml"),
+      "controlPlane:\n  kind: memory\n",
+    );
+    expect(controlPlaneKindFromPolicy(root)).toBe("memory");
+    expect(loadControlPlane({ root }).kind).toBe("memory");
   });
 
   test("selects memory from policy and passes the seed through", async () => {
@@ -715,8 +726,16 @@ describe("loadControlPlane selection", () => {
     const withRepos = (policyYaml, reposYaml) => {
       const root = tmpDir("control-plane-repos-");
       mkdirSync(path.join(root, "config"), { recursive: true });
-      if (policyYaml !== null)
-        writeFileSync(path.join(root, "config", "policy.yaml"), policyYaml);
+      // null means "no explicit controlPlane stanza", not "no config file at
+      // all" — write the example so the policy reader still resolves.
+      writeFileSync(
+        path.join(
+          root,
+          "config",
+          policyYaml !== null ? "policy.yaml" : "policy.example.yaml",
+        ),
+        policyYaml ?? "",
+      );
       writeFileSync(path.join(root, "config", "repos.yaml"), reposYaml);
       return root;
     };

--- a/lib/control-plane/index.mjs
+++ b/lib/control-plane/index.mjs
@@ -33,6 +33,7 @@ import { CONTROL_PLANE_KINDS } from "./types.mjs";
 // Layering note: lib/ -> event-runtime/lib/ already exists (lib/ps.mjs reads
 // config.mjs). No cycle — repos.mjs imports ./types.mjs, never this module.
 import { loadRepos } from "../../event-runtime/lib/repos.mjs";
+import { resolveConfigPath } from "../../event-runtime/lib/config.mjs";
 
 export { githubControlPlane } from "./github.mjs";
 export { linearControlPlane } from "./linear.mjs";
@@ -57,17 +58,16 @@ const DEFAULT_ROOT = path.resolve(
   "..",
 );
 
-/** `controlPlane.kind` from `<root>/config/policy.yaml`; `linear` when unset. */
+/**
+ * `controlPlane.kind` from local-first `config/policy.yaml` (falling back to
+ * the tracked `config/policy.example.yaml`); `linear` when the stanza is
+ * absent. Fails closed — resolveConfigPath's warning is the only accepted
+ * silent path — when neither file exists at all.
+ */
 export function controlPlaneKindFromPolicy(root = DEFAULT_ROOT) {
-  let policy;
-  try {
-    policy = Bun.YAML.parse(
-      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
-    );
-  } catch (err) {
-    if (err?.code === "ENOENT") return "linear";
-    throw err;
-  }
+  const policy = Bun.YAML.parse(
+    readFileSync(resolveConfigPath("policy", { root }), "utf8"),
+  );
   const kind = policy?.controlPlane?.kind ?? "linear";
   if (!CONTROL_PLANE_KINDS.includes(kind)) {
     throw new Error(

--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -680,12 +680,23 @@ describe("loadForge selection", () => {
     return root;
   };
 
-  test("defaults to github when the stanza or the file is absent", () => {
+  test("defaults to github when the stanza is absent", () => {
     expect(
       forgeKindFromPolicy(withPolicy("merge:\n  max_fix_rounds: 2\n")),
     ).toBe("github");
-    expect(forgeKindFromPolicy(withPolicy(null))).toBe("github");
-    expect(loadForge({ root: withPolicy(null) }).kind).toBe("github");
+  });
+
+  test("falls back to config/policy.example.yaml, and fails closed when neither exists", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "forge-policy-"));
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    expect(() => forgeKindFromPolicy(root)).toThrow(/policy\.yaml/);
+
+    writeFileSync(
+      path.join(root, "config", "policy.example.yaml"),
+      "forge:\n  kind: memory\n",
+    );
+    expect(forgeKindFromPolicy(root)).toBe("memory");
+    expect(loadForge({ root }).kind).toBe("memory");
   });
 
   test("selects memory from policy and passes the seed through", () => {

--- a/lib/forge/index.mjs
+++ b/lib/forge/index.mjs
@@ -17,6 +17,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveConfigPath } from "../../event-runtime/lib/config.mjs";
 import { githubForge } from "./github.mjs";
 import { memoryForge } from "./memory.mjs";
 import { FORGE_KINDS } from "./types.mjs";
@@ -31,17 +32,15 @@ const DEFAULT_ROOT = path.resolve(
   "..",
 );
 
-/** `forge.kind` from `<root>/config/policy.yaml`; `github` when unset. */
+/**
+ * `forge.kind` from local-first `config/policy.yaml` (falling back to the
+ * tracked `config/policy.example.yaml`); `github` when the stanza is absent.
+ * Fails closed when neither file exists at all.
+ */
 export function forgeKindFromPolicy(root = DEFAULT_ROOT) {
-  let policy;
-  try {
-    policy = Bun.YAML.parse(
-      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
-    );
-  } catch (err) {
-    if (err?.code === "ENOENT") return "github";
-    throw err;
-  }
+  const policy = Bun.YAML.parse(
+    readFileSync(resolveConfigPath("policy", { root }), "utf8"),
+  );
   const kind = policy?.forge?.kind ?? "github";
   if (!FORGE_KINDS.includes(kind)) {
     throw new Error(


### PR DESCRIPTION
Fixes #864

## Summary
- `lib/control-plane/index.mjs` (`controlPlaneKindFromPolicy`) and `lib/forge/index.mjs` (`forgeKindFromPolicy`) still read `config/policy.yaml` with a raw `readFileSync` and silently defaulted the kind on `ENOENT`. Migrated both to the shared `resolveConfigPath` (`event-runtime/lib/config.mjs`), already used by `event-runtime/lib/repos.mjs`, `event-runtime/lib/worker.mjs`, and `build/emit.mjs`.
- `event-runtime/lib/repos.mjs`, `event-runtime/lib/worker.mjs`, and `build/emit.mjs` were already routed through `resolveConfigPath` — no changes needed there.
- Behavior: prefers local `config/policy.yaml`, falls back to tracked `config/policy.example.yaml` with a stderr warning, and now fails closed (throws) when neither file exists, instead of silently defaulting the control-plane/forge kind.
- Updated `event-runtime/lib/control-plane.test.mjs` and `lib/forge/contract.test.mjs` (directly coupled to the changed functions) to assert the new fallback/fail-closed behavior.

## Test plan
- [x] `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` (repo's configured verify) — pass, aside from 2-3 pre-existing failures in "comment lands on the ticket and is readable back" tests caused by `$FACTORY_RUN_ID` being set in this dispatched worktree's environment (reproduces identically on unmodified `develop`, unrelated to this change).
- [x] `bun test lib/control-plane lib/forge --timeout 20000` — same pre-existing unrelated failures only.