### PR TITLE
fix(ci): stop seed.test.mjs suite fixtures dying to a cross-file afterAll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,13 @@ jobs:
           bun test --timeout 30000 --max-concurrency=2 --retry 2 --test-name-pattern "$include" | tee "$RUNNER_TEMP/bun-timing.log"
           status="${PIPESTATUS[0]}"
           set -e
-          if grep -q 'Ran 0 tests' "$RUNNER_TEMP/bun-timing.log"; then
+          # bun 1.3.14 reports a zero-match --test-name-pattern as
+          # `error: regex "..." matched 0 tests.`, not `Ran 0 tests` — the
+          # prior grep here never matched that phrasing and this branch never
+          # fired (bun's own exit 1 papered over it). Match both so a stale
+          # TIMING_TEST_SUBSTRINGS entry gets the annotation, not just a raw
+          # bun error buried in the log (gh-875).
+          if grep -qE 'Ran 0 tests|matched 0 tests' "$RUNNER_TEMP/bun-timing.log"; then
             echo "::error::Timing-bound tests job matched 0 tests; TIMING_TEST_SUBSTRINGS is stale."
             exit 1
           fi

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -1,11 +1,10 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-demo-seed-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { loadAdjustedTimeout } from "../cli/test-helpers.mjs";
 import { validate } from "../lib/schema.mjs";
-import { spawnTracked } from "../lib/test-helpers-process.mjs";
 
 const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
 const SEED = fileURLToPath(new URL("./seed.mjs", import.meta.url));
@@ -41,9 +40,63 @@ const redact = (text) =>
     .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
     .replace(/(authorization\s*[:=]\s*)\S+/gi, "$1[REDACTED]");
 
-function expectSuccess(label, result) {
+/**
+ * Long-lived suite fixtures (serve/work) are spawned directly with node's
+ * child_process rather than the shared lib/test-helpers-process.mjs
+ * spawnTracked() helper (OPS-464 regression, root-caused for gh-875).
+ *
+ * That helper's afterEach/afterAll hooks are registered once, at ES module
+ * load time, against whichever test FILE happens to import it first in the
+ * process — bun's module cache means every other importing file's hooks
+ * never fire per-file. Several unrelated files in the timing-bound-tests
+ * group (cli/work.test.mjs, cli/supervise.test.mjs, lib/adapters/*.test.mjs)
+ * import the same module, so its process-wide `afterAll` fires when the
+ * FIRST of those files finishes — often seconds in, while this file's
+ * ~20-30s seed/verify run is still mid-flight — and SIGKILLs every tracked
+ * process globally, including this suite's serve/work children. That is the
+ * "Unable to connect" failure: the runtime under test was killed out from
+ * under it by an unrelated file's cleanup, not a real readiness or network
+ * problem. Spawning here keeps this suite's process lifecycle local to this
+ * file, immune to that cross-file collision.
+ */
+function spawnSuiteProcess(command, args, options) {
+  return spawn(command, args, {
+    ...options,
+    detached: process.platform !== "win32",
+  });
+}
+
+function killSuiteProcess(child) {
+  if (!child?.pid) return;
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-child.pid, "SIGKILL");
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {
+    /* intentionally ignored: already exited */
+  }
+}
+
+/** Distinguish "runtime unreachable" from "runtime rejected the request" on failure. */
+async function probeHealth(port) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(2_000),
+    });
+    return res.ok ? "reachable" : `reachable, HTTP ${res.status}`;
+  } catch (err) {
+    return `unreachable (${err.message})`;
+  }
+}
+
+async function expectSuccess(label, result, port) {
+  if (result.status === 0) return;
+  const health = await probeHealth(port);
   const diagnostic = [
     `${label} exited ${result.status ?? "null"}${result.signal ? ` (signal ${result.signal})` : ""}`,
+    `runtime on port ${port} at failure time: ${health}`,
     `stdout:\n${redact(result.stdout)}`,
     `stderr:\n${redact(result.stderr)}`,
   ].join("\n");
@@ -150,14 +203,13 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     port = String(probe.port);
     probe.stop(true);
 
-    serveChild = spawnTracked(
+    serveChild = spawnSuiteProcess(
       "bun",
       [CLI, "serve", "--adapter-override", "fake", "--port", port],
       {
         env: { ...process.env, FACTORY_EVENT_HOME: home },
         stdio: ["ignore", "pipe", "pipe"],
       },
-      { scope: "suite" },
     );
 
     // Wait for health
@@ -177,7 +229,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     }
     expect(up).toBe(true);
 
-    workerChild = spawnTracked(
+    workerChild = spawnSuiteProcess(
       "bun",
       [
         CLI,
@@ -193,7 +245,6 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
         env: { ...process.env, FACTORY_EVENT_HOME: home },
         stdio: ["ignore", "pipe", "pipe"],
       },
-      { scope: "suite" },
     );
 
     // Health only proves the control API is listening. Seed drives approvals
@@ -217,20 +268,8 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   });
 
   afterAll(async () => {
-    if (serveChild) {
-      try {
-        serveChild.kill("SIGKILL");
-      } catch {
-        /* intentionally ignored */
-      }
-    }
-    if (workerChild) {
-      try {
-        workerChild.kill("SIGKILL");
-      } catch {
-        /* intentionally ignored */
-      }
-    }
+    killSuiteProcess(serveChild);
+    killSuiteProcess(workerChild);
   });
 
   test(
@@ -245,7 +284,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
           env: { ...process.env, FACTORY_EVENT_HOME: home },
         },
       );
-      expectSuccess("initial seed", seedRes);
+      await expectSuccess("initial seed", seedRes, port);
       expect(seedRes.stdout).toContain("merge-apply@2 watched");
       expect(seedRes.stdout).not.toContain(
         "merge-verify@1 exact landed lifecycle",
@@ -262,7 +301,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
         encoding: "utf8",
         env: { ...process.env, FACTORY_EVENT_HOME: home },
       });
-      expectSuccess("initial verify", verifyRes);
+      await expectSuccess("initial verify", verifyRes, port);
     },
     loadAdjustedTimeout(30_000),
   );
@@ -296,7 +335,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
           env: { ...process.env, FACTORY_EVENT_HOME: home },
         },
       );
-      expectSuccess("re-seed", seedRes);
+      await expectSuccess("re-seed", seedRes, port);
       expect(seedRes.stdout).toContain("merge-apply@2 watched");
       expect(seedRes.stdout).not.toContain(
         "merge-verify@1 exact landed lifecycle",
@@ -315,7 +354,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
         encoding: "utf8",
         env: { ...process.env, FACTORY_EVENT_HOME: home },
       });
-      expectSuccess("re-seed verify", verifyRes);
+      await expectSuccess("re-seed verify", verifyRes, port);
     },
     loadAdjustedTimeout(30_000),
   );


### PR DESCRIPTION
Fixes #875

## Root cause
`lib/test-helpers-process.mjs` registers its `afterEach`/`afterAll` cleanup hooks once, at ES-module load time, bound to whichever test file bun loads first among all files that import it — every other importing file's hooks silently never fire (confirmed with a minimal bun repro). Several files in the `Timing-bound tests` group (`cli/work.test.mjs`, `cli/supervise.test.mjs`, `lib/adapters/*.test.mjs`, `demo/seed.test.mjs`) all import this shared module. Whichever finishes first triggers a process-wide `SIGKILL` of **every** tracked child via `cleanupTrackedProcesses({ scope: "all" })` — including `seed.test.mjs`'s long-lived `serve`/`work` fixtures, still mid-flight through their ~20-30s seed/verify run. The client then sees exactly "Unable to connect" — the runtime was killed by an unrelated file's cleanup, not a network or readiness problem.

Reproduced locally: running `seed.test.mjs` concurrently with a trivial second file that only imports the shared helper reliably reproduces "no control API on 127.0.0.1:`<port>`" on the pre-fix code, and stops reproducing after the fix (before/after diff verified with `git stash`).

## Fix (within this ticket's Owned Paths)
- `event-runtime/demo/seed.test.mjs`: spawn the suite's `serve`/`work` children directly via `node:child_process` (local `spawnSuiteProcess`/`killSuiteProcess`, same detached-process-group SIGKILL semantics) instead of the shared `spawnTracked`/`tracked` map, so this suite's process lifecycle is immune to another file's premature `afterAll`. Added a `probeHealth()` diagnostic so a future failure states whether the runtime was reachable at failure time.
- `.github/workflows/ci.yml`: the `TIMING_TEST_SUBSTRINGS is stale` guard grepped for `'Ran 0 tests'`, but bun 1.3.14 (the pinned version) reports a zero-match `--test-name-pattern` as `error: regex "..." matched 0 tests.` — the check never fired (bun's own exit 1 papered over it). Widened the grep to catch both phrasings. Checked `TIMING_TEST_SUBSTRINGS` itself against current test titles — all 7 entries still match real test names, so the list content isn't stale, only the detection was.

## Out of scope
The shared `lib/test-helpers-process.mjs` module-load-order bug also affects other files that route long-lived fixtures through `spawnTracked` — filing a separate `Triage` issue for that, since it's outside this ticket's Owned Paths.

## Verification
```
bun test --timeout 20000 event-runtime/demo/seed.test.mjs && bun run format:check && bun run lint
```
Pass — 5/5 tests, 0 lint errors (619 pre-existing warnings unrelated to this change), format clean. Ran seed.test.mjs 3x consecutively locally with no flakes.

Note: the ticket's AC calls for "10 consecutive green runs of the Timing-bound tests lane" as evidence — that requires observing this lane on real CI over multiple pushes/PRs post-merge; local reproduction (above) is the pre-merge evidence available in this worktree.

UX critique: skipped — CI/test-infrastructure change only, no user-facing flow.