### PR TITLE
feat(api): surface a repo's control_plane in reposView and GET /repos

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -96,6 +96,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         github: "watt-mind/dispatchable",
         team: "CLNT",
         project: null,
+        controlPlane: null,
         base: "develop",
         deployBranch: "master",
         reportOnly: false,

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -320,10 +320,10 @@ export function reposView(repos) {
     github: repo.github,
     team: repo.team,
     project: repo.project,
-    // controlPlane is deliberately NOT published here yet: the view is an
-    // allow-list with an exact-shape contract test in api-registry.test.mjs,
-    // which is outside WM-1007's Owned Paths. Surfacing it to operators is
-    // filed separately.
+    // null means "inherits config/policy.yaml"; an explicit value means the
+    // repo is pinned to that tracker. Distinguishable over the wire so an
+    // operator can tell one from the other (gh-870).
+    controlPlane: repo.controlPlane,
     base: repo.base,
     deployBranch: repo.deployBranch,
     reportOnly: repo.reportOnly,

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -394,6 +394,7 @@ describe("reposView is what the control API serves", () => {
     for (const row of rows) {
       expect(Object.keys(row).sort()).toEqual([
         "base",
+        "controlPlane",
         "deployBranch",
         "deployment",
         "effective",
@@ -505,12 +506,15 @@ describe("control_plane on a repo entry", () => {
     );
   });
 
-  test("reposView does not publish it yet (see follow-up)", () => {
-    const root = factoryRoot(
+  test("reposView publishes controlPlane, null for inherit and explicit for a pinned repo", () => {
+    const inherit = factoryRoot("repos:\n  - name: a\n    path: /tmp/a\n");
+    expect(reposView(loadRepos({ root: inherit }))[0].controlPlane).toBeNull();
+
+    const pinned = factoryRoot(
       "repos:\n  - name: a\n    path: /tmp/a\n    control_plane: github\n",
     );
-    expect(reposView(loadRepos({ root }))[0]).not.toHaveProperty(
-      "controlPlane",
+    expect(reposView(loadRepos({ root: pinned }))[0].controlPlane).toBe(
+      "github",
     );
   });
 });


### PR DESCRIPTION
Fixes #870

Publishes `controlPlane` through `reposView()` / `GET /repos`, completing the WM-1007 follow-up: `null` for repos that inherit `config/policy.yaml`, the explicit kind (`linear`/`github`/`memory`) for repos pinned via `control_plane:` in `config/repos.yaml`. No new credential-shaped field — straight passthrough of an already-loaded, already-validated value.

run:factory-gh-870-20260822140016.