### PR TITLE
fix(ci): scaffold local config before tests run on clean checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,20 @@ jobs:
       - name: Install root dependencies
         run: bun install --frozen-lockfile
 
+      - name: Initialize local config (factory init)
+        # WM-866: config/*.yaml went untracked in WM-794, so this fresh
+        # checkout has only the example fallbacks. Individual readers already
+        # fall back to config/*.example.yaml on their own, but scaffolding the
+        # local files here makes every job behave like a real operator
+        # checkout instead of depending on that fallback being wired into
+        # every current and future config consumer. `factory init` only
+        # writes gitignored config/*.yaml paths and never overwrites, so
+        # `git diff --exit-code` proves it stays a no-op against tracked
+        # files (and is safe to re-run every job, every time).
+        run: |
+          bin/factory init
+          git diff --exit-code
+
       - name: Test event-runtime library
         # Spawn-heavy suites can exceed Bun's 5s default on the shared host.
         # Explicit liveness bounds declared by individual tests still win.
@@ -304,6 +318,13 @@ jobs:
       # without it the job dies on `Cannot find module '@testing-library/react'`.
       - name: Install event-runtime/web deps
         run: cd event-runtime/web && bun install --frozen-lockfile
+
+      - name: Initialize local config (factory init)
+        # WM-866: see the same step in "Fast unit tests" — each job gets its
+        # own fresh checkout, so each needs its own scaffold.
+        run: |
+          bin/factory init
+          git diff --exit-code
 
       - name: Run timing-group tests
         shell: bash
@@ -414,6 +435,17 @@ jobs:
       # is why local `bun test event-runtime` was a false green.
       - name: Install event-runtime/web deps
         run: cd event-runtime/web && bun install --frozen-lockfile
+
+      - name: Initialize local config (factory init)
+        # WM-866: see the same step in "Fast unit tests" — each job gets its
+        # own fresh checkout, so each needs its own scaffold. Full
+        # verification also runs orchestrator/deploy commands (Supervisor
+        # lists jobs, Schedule renders match deploy/launchd) that read
+        # config/*.yaml, so this job needs the scaffold in place before those
+        # steps too.
+        run: |
+          bin/factory init
+          git diff --exit-code
 
       # WM-607: root JS + event-runtime/web TSX now lint via eslint.config.mjs.
       # --max-warnings pins the current warning count so it can only shrink;


### PR DESCRIPTION
Fixes #866

## What
Adds a `bin/factory init` step to each CI test job (fast-unit-tests, timing-bound-tests, verify) right after dependency install, followed by `git diff --exit-code` to prove it never touches tracked files.

## Why
WM-794 untracked `config/*.yaml`. Existing readers (`resolveConfigPath`, `lib/schedule.mjs`) already fall back to `config/*.example.yaml` gracefully — verified by simulating a clean checkout and running `bun test event-runtime/lib`, `bin/factory demo --dry`, `bun orchestrator/run.mjs --list`, and `bun deploy/gen.mjs` with the local config files removed; none of them error. But that fallback isn't guaranteed for every current and future config consumer (several `orchestrator/*.mjs` files still `readFileSync` the local path directly with no fallback). Explicitly scaffolding config in CI makes every job behave like a real operator checkout instead of depending on fallback plumbing being present everywhere, and gives the idempotency guarantee the ticket's negative test asks for.

## Verification
- Ticket command: `bun test event-runtime/lib --timeout 20000 && bun run check` — pass (0 fail with the ambient `FACTORY_RUN_ID` unset; the 2 failures seen with it set are a pre-existing test/env interaction unrelated to this change, reproduced identically on the base branch)
- Repo verify command — same as above, pass
- `actionlint .github/workflows/ci.yml` — clean
- Manually reproduced `bin/factory init` idempotency: first run creates `config/*.yaml`, second run reports `exists`, no tracked-file diff either time (these paths are gitignored)

UX critique: skipped — CI workflow-only change, no user-facing flow.

Files: 1 changed (`.github/workflows/ci.yml`), within Owned Paths.

run:factory-gh-866-20260822140016.