### PR TITLE
sec(dispatch): trusted-author gate + body-hash pinning for GitHub-plane tickets

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -159,6 +159,96 @@ Linear API; a follow-up re-pin of `dispatch@1` plus `verify.mjs`
 `linear_rate_limited` without a contract violation. The planner and
 auto-approval path above is what stops the inbox escalation.
 
+### GitHub-plane trust gates (WM-879, operator decision 2026-08-22)
+
+The factory control plane moved to GitHub Issues on a **public** repo
+(WM-1006). The label gate above (§4's Owned Paths closure, this section's
+Todo + unassigned + `ai:agent-ready`) keeps a stranger-created issue out only
+until someone with triage permission labels it, and says nothing about a body
+edit made **after** labeling. An issue body is executable instructions to the
+factory — the Verification Command runs on the runner, Owned Paths scopes
+what an agent may touch — so a plausible-looking outside issue labeled by a
+hurried maintainer, or an author editing the body after labeling, is
+untrusted command execution inside a dispatch worktree. Two gates close that
+window. Both are **no-ops on the Linear plane** (there is no equivalent
+public-authorship risk there) and apply to **every** admission — a resumed
+claim, a re-plan, and an operator-injected dispatch alike. There is no
+bypass: the threat model is bad-actor issue _content_, not a bad-actor
+operator.
+
+**Gate 1 — trusted authorship.** `lib/control-plane/github.mjs`'s
+`getTicket()` is the only read that computes trust evidence (every other
+read — `listTickets`, `listDispatchable`, `claim`, … — omits it, so the cost
+is paid once, at admission, not on every board scan). It returns:
+
+- `authorAssociation` — the issue author's GitHub `author_association`
+  (`OWNER`/`MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`/`NONE`/…), read straight off
+  the REST issue payload.
+- `lastEditor: { login, association }` — who made the most recent body edit.
+  GitHub only exposes edit history (`userContentEdits`) over GraphQL, and an
+  edit's association is not itself part of that connection, so an edit by
+  someone other than the author costs one more REST call
+  (`GET /repos/{repo}/collaborators/{login}/permission`) to resolve their
+  association (`admin`→`OWNER`, `write`/`maintain`→`COLLABORATOR`,
+  `read`/`triage`→`CONTRIBUTOR`, `none`→`NONE`). No edits at all means the
+  editor **is** the author — the common case costs nothing extra.
+
+`event-runtime/lib/planner.mjs`'s dispatch admission
+(`worktreeDispatchAutoEligibility`) refuses `ticket_untrusted_author` unless
+**both** `authorAssociation` and `lastEditor.association` are one of
+`OWNER` / `MEMBER` / `COLLABORATOR` (`lib/control-plane/types.mjs`'s
+`TRUSTED_ASSOCIATIONS` — a closed allow-list, not an exclusion list, so a new
+GitHub association value must be added on purpose before it can grant
+trust). Any value the adapter could not resolve — a deleted account, an
+unreachable API, a 404 from the permission lookup — comes back as `null` and
+is **untrusted**, never defaulted to trusted: unknown fails closed. Refusal
+evidence includes the raw association values and the editor's login (never
+just a boolean), so the inbox item is actionable.
+
+The gate is keyed off **presence**, not truthiness: `authorAssociation` is
+only ever set (even to `null`) by a GitHub `getTicket` read, so a Linear
+ticket's evidence never carries the key at all and the gate is skipped
+entirely — "Linear-plane behavior unchanged" is a structural property of the
+check, not a branch that has to remember to skip it.
+
+**Gate 2 — body-hash pin at labeling.** Whenever `ai:agent-ready` is applied
+through `lib/control-plane/github.mjs` — `transition()`, `setLabels()`
+(what `tools/ticket.mjs state <id> ... --add ai:agent-ready` calls, which is
+also what `triage-apply`'s `label-agent-ready` action invokes), or `file()`
+creating a ticket straight into `Todo` + `ai:agent-ready` (an
+operator-injected dispatch) — the adapter posts an issue **comment**
+containing `<!-- factory:agent-ready-pin sha256:<hex> --><newline>Pinned
+description hash at 'ai:agent-ready' labeling …`, where the hash is
+`hashJson(description)` (`event-runtime/lib/canonical.mjs`) — the same
+sha256 description-hash convention `evidenceTicket()` already uses for
+`descriptionHash`, not a second format.
+
+A comment marker was chosen over a hidden body footer for two reasons: the
+adapter already reads comments back (`listComments`) so no new read path was
+needed, and a comment is immutable history a body edit cannot silently carry
+away or a markdown-reformatting tool cannot mangle — a footer living inside
+the very body it also rewrites is exactly the thing under suspicion. A
+re-label (add `ai:agent-ready` again, including after a remove+re-add) posts
+a **fresh** marker; `getTicket()` reads the **most recent** one back
+(`GET .../comments`, scanned newest-first) as `agentReadyPinHash`.
+
+Dispatch admission recomputes `descriptionHash` from the ticket's current
+body and refuses `ticket_body_changed_since_ready` when it does not match
+the pinned hash — including when there is **no** pin at all (a ticket
+labeled `ai:agent-ready` some other way, e.g. before this gate existed, or by
+hand outside the factory tooling): absence fails closed the same as a
+mismatch, it does not default to "trust it". Refusal evidence carries
+`pinned=<hash prefix>` / `current=<hash prefix>`, never the full body.
+Re-labeling (by triage, or a human) refreshes the pin and the next admission
+attempt succeeds.
+
+Both gates evaluate for **every** dispatch admission on a GitHub-plane
+ticket, not only a fresh claim — a resumed lease-loss retry and an
+operator-injected `factory.dispatch.requested` payload go through the
+identical check, using the identical evidence-fetch path, because the
+attack this defends against (content, not process) does not care which of
+those triggered the run.
+
 ---
 
 ## 3. Capacity: one budget, checked at plan and again at execute

--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -914,6 +914,17 @@ function fakeGithubApi(seed) {
       if (q.includes("ProjectItems")) {
         return { data: { node: { items: { nodes: seed.items } } } };
       }
+      // WM-879: getTicket always resolves the last-editor via this query.
+      // This minimal fake has no edit history — an empty connection means
+      // "no edits", i.e. the editor is the author, the same as a real issue
+      // nobody has ever edited. The trust-gate matrix itself lives in
+      // lib/control-plane/github.test.mjs; this fixture only needs to not
+      // 500 on the call.
+      if (q.includes("IssueLastEdit")) {
+        return {
+          data: { repository: { issue: { userContentEdits: { nodes: [] } } } },
+        };
+      }
       throw new ControlPlaneError("raw query not seeded");
     }
     const one = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues\/(\d+)$/);
@@ -925,6 +936,13 @@ function fakeGithubApi(seed) {
     }
     const list = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/issues$/);
     if (list && method === "GET") return [seed.issue];
+    // WM-879: getTicket also reads back the ai:agent-ready pin marker
+    // comment. No comments in this fixture — same "nothing pinned yet"
+    // path exercised deliberately in lib/control-plane/github.test.mjs.
+    const comments = pathOnly.match(
+      /^repos\/([^/]+\/[^/]+)\/issues\/(\d+)\/comments$/,
+    );
+    if (comments && method === "GET") return seed.issue.comments ?? [];
     // WM-1008: this minimal fake has no dependency data. Returning [] here
     // exercises the "no blockers" path; the 404-tolerance path is covered in
     // lib/control-plane/github.test.mjs.

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -79,6 +79,11 @@ import {
   isLinearRateLimitMessage,
   isLinearRateLimited,
 } from "../../tools/linear.mjs";
+// WM-879: the trusted-author gate is plane-neutral policy that lives beside
+// the ControlPlane contract, not inside any one adapter. types.mjs has no
+// imports of its own, so this cannot cycle back through
+// lib/control-plane/index.mjs (which imports event-runtime/lib/repos.mjs).
+import { TRUSTED_ASSOCIATIONS } from "../../lib/control-plane/types.mjs";
 
 /** In-flight issues list is stable across one scan; 60s is the ticket cap. */
 export const IN_FLIGHT_CACHE_TTL_MS = 60_000;
@@ -753,6 +758,14 @@ function evidenceTicket(ticket, ticketId) {
     ownedPaths: effectiveOwnedPaths(description),
     ownedPathsParsed: parsed.length > 0,
     descriptionHash: hashJson(description),
+    // WM-879: present (string|null) only on a GitHub-plane getTicket read;
+    // absent (undefined, dropped by the JSON round-trip) on every other
+    // plane. Presence, not truthiness, is what tells the trust gate below
+    // "this is GitHub — evaluate me" vs. "Linear — this gate is a no-op".
+    authorAssociation: ticket?.authorAssociation,
+    lastEditorAssociation: ticket?.lastEditor?.association,
+    lastEditorLogin: ticket?.lastEditor?.login ?? null,
+    agentReadyPinHash: ticket?.agentReadyPinHash,
   };
 }
 
@@ -949,6 +962,48 @@ export function worktreeDispatchAutoEligibility(
   }
   if (evidence.ticket.labels.includes("ai:escalated")) {
     return refusal("ticket_escalated", evidence);
+  }
+
+  // WM-879 (operator decision 2026-08-22): the public-repo GitHub control
+  // plane's dispatch label gate keeps stranger-created issues out only until
+  // someone with triage permission labels one, and says nothing about a body
+  // edit made AFTER labeling. Issue bodies are executable instructions to the
+  // factory (the Verification Command runs on the runner; Owned Paths scope
+  // edits), so both checks apply to EVERY admission — including a resumed
+  // claim and an operator-injected dispatch. There is no bypass; the point is
+  // bad-actor content, not bad-actor operators. Both gates are no-ops on the
+  // Linear plane, keyed off `authorAssociation` being present at all
+  // (github.mjs only sets it on a GitHub-plane `getTicket` read).
+  if (evidence.ticket.authorAssociation !== undefined) {
+    const authorTrusted =
+      typeof evidence.ticket.authorAssociation === "string" &&
+      TRUSTED_ASSOCIATIONS.includes(evidence.ticket.authorAssociation);
+    const editorTrusted =
+      typeof evidence.ticket.lastEditorAssociation === "string" &&
+      TRUSTED_ASSOCIATIONS.includes(evidence.ticket.lastEditorAssociation);
+    evidence.checks.ticket_author_trusted = authorTrusted;
+    evidence.checks.ticket_last_editor_trusted = editorTrusted;
+    if (!authorTrusted || !editorTrusted) {
+      return refusal(
+        "ticket_untrusted_author",
+        evidence,
+        "human_needed",
+        `authorAssociation=${JSON.stringify(evidence.ticket.authorAssociation)} lastEditor=${evidence.ticket.lastEditorLogin ?? "null"} lastEditorAssociation=${JSON.stringify(evidence.ticket.lastEditorAssociation ?? null)}`,
+      );
+    }
+
+    const pinned = evidence.ticket.agentReadyPinHash ?? null;
+    const current = evidence.ticket.descriptionHash;
+    evidence.checks.ticket_body_hash_pinned = pinned !== null;
+    evidence.checks.ticket_body_hash_matches = pinned === current;
+    if (pinned === null || pinned !== current) {
+      return refusal(
+        "ticket_body_changed_since_ready",
+        evidence,
+        "human_needed",
+        `pinned=${pinned ? `${pinned.slice(0, 15)}…` : "none"} current=${current.slice(0, 15)}…`,
+      );
+    }
   }
 
   const blockers = openBlockers(ticket);

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -909,6 +909,177 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  describe("trusted-author gate + body-hash pin (WM-879)", () => {
+    const DESCRIPTION = "## Owned Paths\n- event-runtime/lib/planner.mjs\n";
+    const PIN = hashJson(DESCRIPTION);
+
+    // Mirrors tierTicket, but with the GitHub-plane trust fields
+    // github.mjs's getTicket() populates. `authorAssociation` present at
+    // all (even null) is what marks a ticket "GitHub plane" to the gate —
+    // a Linear ticket (tierTicket above) never carries this key.
+    const githubTicket = (overrides = {}) => ({
+      identifier: "acme/widget#42",
+      state: { name: "Todo" },
+      assignee: null,
+      labels: { nodes: [{ name: "ai:agent-ready" }] },
+      description: DESCRIPTION,
+      authorAssociation: "OWNER",
+      lastEditor: { login: "owner", association: "OWNER" },
+      agentReadyPinHash: PIN,
+      ...overrides,
+    });
+    const githubDispatch = (ticket) => ({
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      fetchTicket: () => ticket,
+      fetchInFlight: () => [],
+    });
+
+    test("untrusted author refuses ticket_untrusted_author", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(githubTicket({ authorAssociation: "NONE" })),
+        );
+        expect(result.refusal.reason).toBe("ticket_untrusted_author");
+        expect(result.refusal.decision).toBe("human_needed");
+        expect(result.evidence.checks.ticket_author_trusted).toBe(false);
+        expect(result.refusal.detail).toContain('authorAssociation="NONE"');
+      });
+    });
+
+    test("unknown/unfetchable author association fails closed", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(githubTicket({ authorAssociation: null })),
+        );
+        expect(result.refusal.reason).toBe("ticket_untrusted_author");
+        expect(result.evidence.checks.ticket_author_trusted).toBe(false);
+      });
+    });
+
+    test("trusted author + untrusted last editor refuses ticket_untrusted_author", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(
+            githubTicket({
+              lastEditor: { login: "outsider", association: "NONE" },
+            }),
+          ),
+        );
+        expect(result.refusal.reason).toBe("ticket_untrusted_author");
+        expect(result.evidence.checks.ticket_author_trusted).toBe(true);
+        expect(result.evidence.checks.ticket_last_editor_trusted).toBe(false);
+        expect(result.refusal.detail).toContain("lastEditor=outsider");
+      });
+    });
+
+    test("unresolvable last editor (association: null) fails closed", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(
+            githubTicket({ lastEditor: { login: "ghost", association: null } }),
+          ),
+        );
+        expect(result.refusal.reason).toBe("ticket_untrusted_author");
+        expect(result.evidence.checks.ticket_last_editor_trusted).toBe(false);
+      });
+    });
+
+    test("trusted author + trusted last editor + matching pin admits", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(githubTicket()),
+        );
+        expect(result.ok).toBe(true);
+        expect(result.evidence.checks.ticket_author_trusted).toBe(true);
+        expect(result.evidence.checks.ticket_last_editor_trusted).toBe(true);
+        expect(result.evidence.checks.ticket_body_hash_matches).toBe(true);
+      });
+    });
+
+    test("a body edit after labeling refuses ticket_body_changed_since_ready", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(
+            githubTicket({
+              description: `${DESCRIPTION}\ninjected instruction`,
+            }),
+          ),
+        );
+        expect(result.refusal.reason).toBe("ticket_body_changed_since_ready");
+        expect(result.refusal.decision).toBe("human_needed");
+        expect(result.evidence.checks.ticket_body_hash_matches).toBe(false);
+        expect(result.refusal.detail).toContain("pinned=");
+        expect(result.refusal.detail).toContain("current=");
+      });
+    });
+
+    test("no pin at all (never labeled through the factory path) fails closed", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(githubTicket({ agentReadyPinHash: null })),
+        );
+        expect(result.refusal.reason).toBe("ticket_body_changed_since_ready");
+        expect(result.evidence.checks.ticket_body_hash_pinned).toBe(false);
+      });
+    });
+
+    test("a re-label refreshes the pin and admits", () => {
+      withReposRoot(tierRepo, () => {
+        const newDescription = `${DESCRIPTION}\nclarified scope`;
+        const refreshedPin = hashJson(newDescription);
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42" },
+          githubDispatch(
+            githubTicket({
+              description: newDescription,
+              agentReadyPinHash: refreshedPin,
+            }),
+          ),
+        );
+        expect(result.ok).toBe(true);
+        expect(result.evidence.checks.ticket_body_hash_matches).toBe(true);
+      });
+    });
+
+    test("Linear-plane tickets are unaffected — no authorAssociation key, gate is a no-op", () => {
+      withReposRoot(tierRepo, () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "WM-694" },
+          tierDispatch(),
+        );
+        expect(result.ok).toBe(true);
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            result.evidence.checks,
+            "ticket_author_trusted",
+          ),
+        ).toBe(false);
+        expect(result.evidence.ticket.authorAssociation).toBeUndefined();
+      });
+    });
+
+    test("no operator bypass: an operator-supplied payload goes through the same gates", () => {
+      withReposRoot(tierRepo, () => {
+        // Nothing distinguishes an "operator" dispatch from any other at
+        // this layer — the payload shape is identical. This asserts that
+        // fact: there is no flag, override, or field that skips the gate.
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "acme/widget#42", operator: true },
+          githubDispatch(githubTicket({ authorAssociation: "NONE" })),
+        );
+        expect(result.refusal.reason).toBe("ticket_untrusted_author");
+      });
+    });
+  });
+
   test("open Linear blockers refuse dispatch with blocker ids in evidence (WM-709)", () => {
     withReposRoot(tierRepo, () => {
       const openRelations = {

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -18,11 +18,18 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+// Layering note: lib/ -> event-runtime/lib/ already exists (see
+// lib/control-plane/index.mjs, lib/ps.mjs). hashJson is the one canonical
+// sha256-description-hash convention (WM-879 reuses it rather than growing
+// a second hash format for the same value).
+import { hashJson } from "../../event-runtime/lib/canonical.mjs";
 import { byQueueOrder, ControlPlaneError } from "./types.mjs";
 import {
+  agentReadyPinComment,
   AGENT_READY_LABEL,
   appendIssueDetail,
   claimLabels,
+  parseAgentReadyPinHash,
   stampRun,
   validateLabels,
 } from "./labels.mjs";
@@ -112,6 +119,22 @@ const SET_PROJECT_STATUS = `mutation SetProjectStatus($projectId: ID!, $itemId: 
       value: { singleSelectOptionId: $optionId }
     }
   ) { projectV2Item { id } }
+}`;
+
+// WM-879: who most recently edited the issue body. REST's issue payload
+// carries `author_association` for the author but has no equivalent for
+// edits, so the last editor's login can only come from GraphQL
+// `userContentEdits`. Their association is then resolved separately (see
+// `associationFromPermission`) — an edit's association is not itself part of
+// this connection.
+const ISSUE_LAST_EDIT = `query IssueLastEdit($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      userContentEdits(last: 1) {
+        nodes { editor { login } }
+      }
+    }
+  }
 }`;
 
 const text = (v) =>
@@ -553,7 +576,7 @@ export function githubControlPlane(options = {}) {
     return out;
   }
 
-  function normalizeIssue(issue, repo, status) {
+  function normalizeIssue(issue, repo, status, trust) {
     const labels = (issue.labels ?? []).map((l) => ({
       id: l.id != null ? String(l.id) : undefined,
       name: l.name,
@@ -588,7 +611,127 @@ export function githubControlPlane(options = {}) {
       // state in one batch. A single-issue read leaves it empty rather than
       // firing an extra request per getTicket call.
       blockedBy: issue.__blockedBy ?? [],
+      // WM-879: only `getTicket` (dispatch admission's read) computes trust —
+      // omitted (not merely null) everywhere else, including listTickets, so
+      // the fields stay absent-when-uncomputed rather than misleadingly
+      // null. Undefined values are dropped by JSON.stringify, so a Linear
+      // ticket and an un-trust-checked GitHub read look identical on the
+      // wire: the presence of the key IS the "this is a GitHub getTicket
+      // read" signal the planner's trust gate keys off.
+      ...(trust
+        ? {
+            authorAssociation: trust.authorAssociation,
+            lastEditor: trust.lastEditor,
+            agentReadyPinHash: trust.agentReadyPinHash,
+          }
+        : {}),
     };
+  }
+
+  /**
+   * Map a repo permission level (`GET .../collaborators/{login}/permission`)
+   * onto the GitHub `authorAssociation` vocabulary, so the last-editor check
+   * can be compared against the same {@link TRUSTED_ASSOCIATIONS} the author
+   * check uses. `null` means "could not be determined" and the caller must
+   * treat that as untrusted (fail closed, WM-879) — never default it to a
+   * trusted value.
+   */
+  function associationFromPermission(permission) {
+    switch (permission) {
+      case "admin":
+        return "OWNER";
+      case "maintain":
+      case "write":
+        return "COLLABORATOR";
+      case "triage":
+      case "read":
+        return "CONTRIBUTOR";
+      case "none":
+        return "NONE";
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * WM-879 trust evidence for one issue: the author's `author_association`
+   * (already on the REST issue payload) plus the most recent body editor and
+   * their association. No edits means the editor IS the author — the common
+   * case costs zero extra requests beyond the `userContentEdits` GraphQL
+   * call. An edit by someone else costs one more REST call to resolve their
+   * permission level; a failure there (rather than a clean "not a
+   * collaborator" `none`) is `null`, so it fails closed rather than silently
+   * trusting an unresolvable editor.
+   */
+  async function fetchTrust(repo, number, issue) {
+    const authorAssociation = issue.author_association ?? null;
+    const authorLogin = issue.user?.login ?? null;
+    let editorLogin = authorLogin;
+    try {
+      const [owner, name] = repo.split("/");
+      const d = await call("POST", "graphql", {
+        body: {
+          query: ISSUE_LAST_EDIT,
+          variables: { owner, name, number },
+        },
+      });
+      const nodes = d?.repository?.issue?.userContentEdits?.nodes ?? [];
+      if (nodes.length > 0) editorLogin = nodes[0]?.editor?.login ?? null;
+    } catch {
+      editorLogin = null; // unresolvable edit history fails closed below
+    }
+
+    let editorAssociation;
+    if (editorLogin === null) {
+      editorAssociation = null;
+    } else if (editorLogin === authorLogin) {
+      editorAssociation = authorAssociation;
+    } else {
+      try {
+        const perm = await call(
+          "GET",
+          `repos/${repo}/collaborators/${editorLogin}/permission`,
+        );
+        editorAssociation = associationFromPermission(perm?.permission);
+      } catch {
+        editorAssociation = null;
+      }
+    }
+
+    const pinComments = await call(
+      "GET",
+      `repos/${repo}/issues/${number}/comments`,
+      { query: { per_page: "100", sort: "created", direction: "desc" } },
+    );
+    let agentReadyPinHash = null;
+    for (const c of Array.isArray(pinComments) ? pinComments : []) {
+      const hash = parseAgentReadyPinHash(c?.body);
+      if (hash) {
+        agentReadyPinHash = hash;
+        break;
+      }
+    }
+
+    return {
+      authorAssociation,
+      lastEditor: { login: editorLogin, association: editorAssociation },
+      agentReadyPinHash,
+    };
+  }
+
+  /**
+   * WM-879: whenever a label change applies `ai:agent-ready`, pin the
+   * CURRENT description hash as a marker comment. Fires on every label
+   * change that adds the label, including a re-label of a ticket that
+   * already carried it — "a re-label refreshes the pin" is the intended
+   * behaviour, not idempotence to avoid.
+   */
+  async function pinAgentReadyIfLabeling(repo, number, description, add) {
+    if (!add.includes(AGENT_READY_LABEL)) return;
+    const hash = hashJson(description ?? "");
+    await call("POST", `repos/${repo}/issues/${number}/comments`, {
+      body: { body: agentReadyPinComment(hash) },
+    });
   }
 
   /**
@@ -632,7 +775,9 @@ export function githubControlPlane(options = {}) {
 
     async getTicket(identifier) {
       const { repo, number } = locate(identifier);
-      return (await fetchIssue(repo, number)).ticket;
+      const { issue, status } = await fetchIssue(repo, number);
+      const trust = await fetchTrust(repo, number, issue);
+      return normalizeIssue(issue, repo, status, trust);
     },
 
     async listComments(identifier) {
@@ -809,6 +954,7 @@ export function githubControlPlane(options = {}) {
         await call("PUT", `repos/${repo}/issues/${number}/labels`, {
           body: { labels: nextLabels },
         });
+        await pinAgentReadyIfLabeling(repo, number, ticket.description, add);
       }
       const patch = {};
       if (unassign) patch.assignees = [];
@@ -830,6 +976,7 @@ export function githubControlPlane(options = {}) {
       await call("PUT", `repos/${repo}/issues/${number}/labels`, {
         body: { labels: nextLabels },
       });
+      await pinAgentReadyIfLabeling(repo, number, ticket.description, add);
     },
 
     async file({
@@ -844,10 +991,11 @@ export function githubControlPlane(options = {}) {
         throw new ControlPlaneError("file requires team and title");
       const repo = repoForTeam(team);
       await requireLabelsExist(repo, labels);
+      const stampedBody = stampRun(body);
       const created = await call("POST", `repos/${repo}/issues`, {
         body: {
           title,
-          body: stampRun(body),
+          body: stampedBody,
           labels,
         },
       });
@@ -863,6 +1011,11 @@ export function githubControlPlane(options = {}) {
         await call("PATCH", `repos/${repo}/issues/${created.number}`, {
           body: { state: "closed" },
         });
+      // WM-879: `file --todo` can hand a ticket straight to Todo +
+      // ai:agent-ready without ever calling transition/setLabels — an
+      // operator-injected dispatch is exactly the case "no operator bypass"
+      // covers, so it is pinned here too.
+      await pinAgentReadyIfLabeling(repo, created.number, stampedBody, labels);
       return {
         identifier: issueIdentifier(repo, created.number),
         url: created.html_url ?? "",

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -271,11 +271,9 @@ function fakeApi(seed) {
             repository: {
               issue: {
                 userContentEdits: {
-                  nodes: edits
-                    .slice(-1)
-                    .map((e) => ({
-                      editor: { login: e.editor?.login ?? null },
-                    })),
+                  nodes: edits.slice(-1).map((e) => ({
+                    editor: { login: e.editor?.login ?? null },
+                  })),
                 },
               },
             },

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -16,6 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { hashJson } from "../../event-runtime/lib/canonical.mjs";
 import { ControlPlaneError } from "./types.mjs";
 import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
 import {
@@ -114,6 +115,9 @@ function addIssue(seed, repo, spec) {
     labels: spec.labels ?? [],
     comments: spec.comments ?? [],
     pull_request: spec.pull_request,
+    author_association: spec.author_association ?? "OWNER",
+    user: spec.user ?? { login: "Ada" },
+    userContentEdits: spec.userContentEdits ?? [],
   };
   bucket.issues.push(issue);
   if (spec.status) {
@@ -256,6 +260,28 @@ function fakeApi(seed) {
           },
         };
       }
+      if (gqlQuery.includes("IssueLastEdit")) {
+        const repo = `${variables.owner}/${variables.name}`;
+        const issue = seed.repos[repo]?.issues.find(
+          (i) => i.number === variables.number,
+        );
+        const edits = issue?.userContentEdits ?? [];
+        return {
+          data: {
+            repository: {
+              issue: {
+                userContentEdits: {
+                  nodes: edits
+                    .slice(-1)
+                    .map((e) => ({
+                      editor: { login: e.editor?.login ?? null },
+                    })),
+                },
+              },
+            },
+          },
+        };
+      }
       if (gqlQuery.includes("AddProjectItem")) {
         const contentId = variables.contentId;
         let found = null;
@@ -310,7 +336,14 @@ function fakeApi(seed) {
         commentsMatch[1],
         Number(commentsMatch[2]),
       );
-      if (method === "GET") return issue.comments ?? [];
+      if (method === "GET") {
+        const rows = issue.comments ?? [];
+        // Insertion order is oldest-first, same as the real API's default;
+        // honour direction=desc (WM-879's pin lookup asks for newest-first)
+        // so the fake matches production ordering instead of coincidentally
+        // matching only when identical timestamps do not matter.
+        return q.direction === "desc" ? [...rows].reverse() : rows;
+      }
       if (method === "POST") {
         const comment = {
           id: 300 + (issue.comments?.length ?? 0),
@@ -394,6 +427,22 @@ function fakeApi(seed) {
         }
         return rows;
       }
+    }
+
+    // WM-879: repo permission of a would-be body editor. Seeded as
+    // `seed.collaborators[repo][login] = "admin"|"write"|"read"|"none"`; a
+    // login absent from that map fails (standing in for a 404/403 the real
+    // API can return for an unresolvable user), exercising the fail-closed
+    // path.
+    const collabPerm =
+      /^repos\/([^/]+\/[^/]+)\/collaborators\/([^/]+)\/permission$/.exec(
+        pathOnly,
+      );
+    if (collabPerm && method === "GET") {
+      const repoCollabs = seed.collaborators?.[collabPerm[1]] ?? {};
+      const login = collabPerm[2];
+      if (!(login in repoCollabs)) fail(`no such collaborator: ${login}`, 404);
+      return { permission: repoCollabs[login] };
     }
 
     // WM-1008: issue dependencies. Seeded per issue as `blockedBy: [number]`;
@@ -1093,5 +1142,241 @@ describe("listDispatchable request cost does not scale with open issues", () => 
     expect(api2.calls.filter((c) => c.includes("/dependencies/")).length).toBe(
       50,
     );
+  });
+});
+
+describe("WM-879: trust and body-hash pin evidence", () => {
+  test("getTicket reports authorAssociation and lastEditor (no edits => editor is the author)", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 200,
+      node_id: "I_200",
+      number: 5,
+      title: "never edited",
+      body: "body",
+      author_association: "COLLABORATOR",
+      user: { login: "trusted-author" },
+      status: "Todo",
+    });
+    const t = await cp.getTicket(`${REPO}#5`);
+    expect(t.authorAssociation).toBe("COLLABORATOR");
+    expect(t.lastEditor).toEqual({
+      login: "trusted-author",
+      association: "COLLABORATOR",
+    });
+  });
+
+  test("an edit by a different, resolvable user reports the editor's own association", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 201,
+      node_id: "I_201",
+      number: 6,
+      title: "edited by a stranger",
+      body: "body",
+      author_association: "OWNER",
+      user: { login: "owner" },
+      userContentEdits: [{ editor: { login: "outsider" } }],
+      status: "Todo",
+    });
+    seed.collaborators = { [REPO]: { outsider: "read" } };
+    const t = await cp.getTicket(`${REPO}#6`);
+    expect(t.authorAssociation).toBe("OWNER");
+    expect(t.lastEditor).toEqual({
+      login: "outsider",
+      association: "CONTRIBUTOR",
+    });
+  });
+
+  test("an edit by a write/maintain collaborator resolves to COLLABORATOR", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 202,
+      node_id: "I_202",
+      number: 7,
+      title: "edited by a collaborator",
+      body: "body",
+      author_association: "OWNER",
+      user: { login: "owner" },
+      userContentEdits: [{ editor: { login: "helper" } }],
+      status: "Todo",
+    });
+    seed.collaborators = { [REPO]: { helper: "write" } };
+    const t = await cp.getTicket(`${REPO}#7`);
+    expect(t.lastEditor).toEqual({
+      login: "helper",
+      association: "COLLABORATOR",
+    });
+  });
+
+  test("an editor whose permission cannot be resolved fails closed (association: null)", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 203,
+      node_id: "I_203",
+      number: 8,
+      title: "editor unresolvable",
+      body: "body",
+      author_association: "OWNER",
+      user: { login: "owner" },
+      userContentEdits: [{ editor: { login: "ghost" } }],
+      status: "Todo",
+    });
+    // No seed.collaborators entry for "ghost" => the fake 404s, same as a
+    // real deployment that cannot resolve the editor's permission.
+    const t = await cp.getTicket(`${REPO}#8`);
+    expect(t.lastEditor).toEqual({ login: "ghost", association: null });
+  });
+
+  test("a deleted/ghost editor (no login) fails closed", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 204,
+      node_id: "I_204",
+      number: 9,
+      title: "editor account deleted",
+      body: "body",
+      author_association: "OWNER",
+      user: { login: "owner" },
+      userContentEdits: [{ editor: { login: null } }],
+      status: "Todo",
+    });
+    const t = await cp.getTicket(`${REPO}#9`);
+    expect(t.lastEditor).toEqual({ login: null, association: null });
+  });
+
+  test("no author_association from the API fails closed (null, not a default)", async () => {
+    const { cp, seed } = makePlane();
+    const issue = addIssue(seed, REPO, {
+      id: 205,
+      node_id: "I_205",
+      number: 10,
+      title: "association missing",
+      body: "body",
+      status: "Todo",
+    });
+    delete issue.author_association;
+    const t = await cp.getTicket(`${REPO}#10`);
+    expect(t.authorAssociation).toBeNull();
+  });
+
+  test("listTickets/listDispatchable do not compute trust fields (only getTicket pays that cost)", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 206,
+      node_id: "I_206",
+      number: 11,
+      title: "listed, not getTicket'd",
+      body: "body",
+      labels: [{ id: 10, name: AGENT_READY_LABEL }],
+      status: "Todo",
+    });
+    const [t] = await cp.listTickets({ team: "WM", states: ["Todo"] });
+    expect(Object.prototype.hasOwnProperty.call(t, "authorAssociation")).toBe(
+      false,
+    );
+  });
+
+  test("transition({add: ai:agent-ready}) posts a pin comment with the description's sha256", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 207,
+      node_id: "I_207",
+      number: 12,
+      title: "about to be labeled ready",
+      body: "the description at labeling time",
+      labels: [],
+      status: "Triage",
+    });
+    await cp.transition(`${REPO}#12`, "Todo", { add: [AGENT_READY_LABEL] });
+    const t = await cp.getTicket(`${REPO}#12`);
+    expect(t.agentReadyPinHash).toBe(
+      hashJson("the description at labeling time"),
+    );
+  });
+
+  test("setLabels({add: ai:agent-ready}) also pins", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 208,
+      node_id: "I_208",
+      number: 13,
+      title: "labeled via setLabels",
+      body: "pinned via setLabels",
+      labels: [],
+      status: "Todo",
+    });
+    await cp.setLabels(`${REPO}#13`, { add: [AGENT_READY_LABEL] });
+    const t = await cp.getTicket(`${REPO}#13`);
+    expect(t.agentReadyPinHash).toBe(hashJson("pinned via setLabels"));
+  });
+
+  test("a label change that does not add ai:agent-ready does not pin", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 209,
+      node_id: "I_209",
+      number: 14,
+      title: "unrelated label change",
+      body: "irrelevant",
+      labels: [{ id: 14, name: "type:bug" }],
+      status: "Todo",
+    });
+    await cp.setLabels(`${REPO}#14`, { add: ["type:feature"] });
+    const t = await cp.getTicket(`${REPO}#14`);
+    expect(t.agentReadyPinHash).toBeNull();
+  });
+
+  test("re-labeling posts a fresh pin comment and getTicket reads the MOST RECENT one back", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 210,
+      node_id: "I_210",
+      number: 15,
+      title: "re-labeled after a body edit",
+      body: "first description",
+      labels: [],
+      status: "Triage",
+    });
+    await cp.transition(`${REPO}#15`, "Todo", { add: [AGENT_READY_LABEL] });
+    // The body changes and the ticket is re-labeled — a fresh pin must win.
+    const issue = seed.repos[REPO].issues.find((i) => i.number === 15);
+    issue.body = "second description";
+    await cp.setLabels(`${REPO}#15`, {
+      remove: [AGENT_READY_LABEL],
+      add: [],
+    });
+    await cp.setLabels(`${REPO}#15`, { add: [AGENT_READY_LABEL] });
+    const t = await cp.getTicket(`${REPO}#15`);
+    expect(t.agentReadyPinHash).toBe(hashJson("second description"));
+    expect(t.agentReadyPinHash).not.toBe(hashJson("first description"));
+  });
+
+  test("filing straight into Todo + ai:agent-ready (operator injection) pins too", async () => {
+    const { cp } = makePlane();
+    const created = await cp.file({
+      team: TEAM,
+      title: "operator-injected",
+      body: "operator-authored body",
+      labels: [AGENT_READY_LABEL],
+      state: "Todo",
+    });
+    const t = await cp.getTicket(created.identifier);
+    expect(t.agentReadyPinHash).toBe(hashJson("operator-authored body"));
+  });
+
+  test("no pin ever posted => agentReadyPinHash is null, not undefined", async () => {
+    const { cp, seed } = makePlane();
+    addIssue(seed, REPO, {
+      id: 211,
+      node_id: "I_211",
+      number: 16,
+      title: "never labeled through the factory",
+      body: "irrelevant",
+      labels: [{ id: 10, name: AGENT_READY_LABEL }],
+      status: "Todo",
+    });
+    const t = await cp.getTicket(`${REPO}#16`);
+    expect(t.agentReadyPinHash).toBeNull();
   });
 });

--- a/lib/control-plane/index.mjs
+++ b/lib/control-plane/index.mjs
@@ -37,7 +37,11 @@ import { loadRepos } from "../../event-runtime/lib/repos.mjs";
 export { githubControlPlane } from "./github.mjs";
 export { linearControlPlane } from "./linear.mjs";
 export { memoryControlPlane } from "./memory.mjs";
-export { ControlPlaneError, CONTROL_PLANE_KINDS } from "./types.mjs";
+export {
+  ControlPlaneError,
+  CONTROL_PLANE_KINDS,
+  TRUSTED_ASSOCIATIONS,
+} from "./types.mjs";
 export {
   TYPE_LABELS,
   SOURCE_LABELS,

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -137,6 +137,42 @@ export function appendIssueDetail(currentDescription, rawDetail) {
 }
 
 /**
+ * Body-hash pin marker (WM-879, operator decision 2026-08-22).
+ *
+ * A public-repo issue body is an executable instruction to the factory (the
+ * Verification Command runs on the runner; Owned Paths scope edits), so
+ * labeling `ai:agent-ready` must pin the description a human/triage agent
+ * actually judged safe. The pin rides an issue COMMENT rather than a hidden
+ * body footer: the github adapter already reads comments back
+ * (`listComments`), a comment is immutable history a body edit cannot
+ * silently drop, and it never risks a triage tool's markdown formatter
+ * mangling a marker that lives inside the body it also rewrites. A re-label
+ * posts a fresh marker comment; dispatch admission always reads the MOST
+ * RECENT one back.
+ */
+const AGENT_READY_PIN_RE =
+  /^<!-- factory:agent-ready-pin sha256:([0-9a-f]{64}) -->$/m;
+
+/** Build the marker comment posted when `ai:agent-ready` is applied. */
+export function agentReadyPinComment(descriptionHash) {
+  const hex = String(descriptionHash).startsWith("sha256:")
+    ? descriptionHash.slice("sha256:".length)
+    : descriptionHash;
+  return (
+    `<!-- factory:agent-ready-pin sha256:${hex} -->\n` +
+    "Pinned description hash at `ai:agent-ready` labeling (WM-879). " +
+    "Dispatch admission refuses `ticket_body_changed_since_ready` if the " +
+    "description no longer matches; a re-label refreshes this pin."
+  );
+}
+
+/** Read the pinned hash (`sha256:<hex>`) back out of a marker comment, or null. */
+export function parseAgentReadyPinHash(commentBody) {
+  const match = AGENT_READY_PIN_RE.exec(String(commentBody ?? ""));
+  return match ? `sha256:${match[1]}` : null;
+}
+
+/**
  * Attribution stamp (OPS-76). Factory spawns set FACTORY_RUN_ID to the
  * transcript basename; stamping it here makes every comment and filed issue
  * joinable back to the exact run that wrote it. Skipped when the id is

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -50,6 +50,22 @@
  *   tracker's completion semantics, so callers never interpret workflow
  *   states themselves.
  * @property {string} [createdAt]
+ * @property {string|null} [authorAssociation]
+ *   GitHub-plane only (WM-879): the issue author's `author_association`
+ *   (`OWNER`/`MEMBER`/`COLLABORATOR`/...). Absent (`undefined`) on every
+ *   other plane — dispatch admission's trust gate is a no-op unless this key
+ *   is present, which is how it stays a GitHub-only check. `null` means the
+ *   association could not be determined and must fail closed, never be
+ *   treated as trusted.
+ * @property {{ login: string|null, association: string|null }} [lastEditor]
+ *   GitHub-plane only: who made the most recent body edit
+ *   (`userContentEdits`), and their association. No edits means the editor
+ *   IS the author, so this mirrors `authorAssociation`. `association: null`
+ *   fails closed, same as above.
+ * @property {string|null} [agentReadyPinHash]
+ *   GitHub-plane only: the `sha256:<hex>` description hash pinned by the
+ *   most recent `ai:agent-ready` labeling marker comment, or `null` when no
+ *   such marker exists yet.
  */
 
 /**
@@ -166,3 +182,18 @@ export function byQueueOrder(a, b) {
 
 /** Factory states an adapter treats as "not finished" for blocker gating. */
 export const OPEN_STATE_TYPES = Object.freeze(["completed", "canceled"]);
+
+/**
+ * GitHub `authorAssociation` values dispatch admission treats as trusted
+ * (WM-879, operator decision 2026-08-22): a repo OWNER, org/repo MEMBER, or
+ * an explicitly-added COLLABORATOR. Everything else — CONTRIBUTOR,
+ * FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE, and any value this factory does
+ * not recognise — is untrusted. Deliberately closed rather than an
+ * exclusion list: a new GitHub association value must be added here on
+ * purpose before it can grant trust.
+ */
+export const TRUSTED_ASSOCIATIONS = Object.freeze([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);


### PR DESCRIPTION
Fixes #879

## Summary

Operator-approved security gates (2026-08-22) for the public-repo GitHub control plane. The label gate (Todo + `ai:agent-ready` + unassigned) only kept stranger-created issues out until a maintainer labeled one, and said nothing about a body edit made **after** labeling — issue bodies are executable instructions to the factory (Verification Command runs on the runner; Owned Paths scope edits).

**Gate 1 — trusted authorship.** `lib/control-plane/github.mjs`'s `getTicket()` now resolves `authorAssociation` (from the REST issue payload) and the last body editor's association (GraphQL `userContentEdits`, plus a `GET .../collaborators/{login}/permission` lookup when the editor differs from the author). `event-runtime/lib/planner.mjs`'s dispatch admission refuses `ticket_untrusted_author` unless **both** are `OWNER`/`MEMBER`/`COLLABORATOR`; anything unresolved comes back `null` and fails closed. Only a GitHub `getTicket` read ever sets `authorAssociation` (even to `null`) — its mere presence is what turns the gate on, so the Linear plane is structurally unaffected rather than skipped by a branch.

**Gate 2 — body-hash pin at labeling.** Whenever `ai:agent-ready` is applied through the GitHub adapter (`transition()`/`setLabels()` — what `tools/ticket.mjs state ... --add ai:agent-ready` and `triage-apply`'s `label-agent-ready` action call — and `file()` for an operator-injected Todo+ready ticket), the adapter posts an issue **comment** marker (`<!-- factory:agent-ready-pin sha256:<hex> -->`) pinning `hashJson(description)` — the same sha256 convention `evidenceTicket()` already uses, reused rather than duplicated. Dispatch admission recomputes the hash and refuses `ticket_body_changed_since_ready` on mismatch, **including when there is no pin at all** (fails closed, does not default to trusted). A re-label posts a fresh marker; `getTicket()` reads the most recent one back.

No operator bypass: both gates run on every admission (fresh claim, resumed lease-loss retry, operator-injected dispatch) — the threat model is issue content, not the operator. Refusal evidence carries the raw association values, the editor's login, and hash prefixes (never the full body), so inbox items stay actionable.

A comment marker was chosen over a hidden body footer because the adapter already reads comments back and a comment is immutable history a body edit or reformatting tool cannot silently carry away — documented in `docs/event-runtime-dispatch.md`.

## Diff summary for cold review (security-relevant)

- **New refusal paths**: `ticket_untrusted_author` and `ticket_body_changed_since_ready` in `worktreeDispatchAutoEligibility` (`event-runtime/lib/planner.mjs`), both `human_needed` decisions, both fail-closed on unresolved/unknown evidence.
- **New reads**: `getTicket()` now issues one extra GraphQL call (`userContentEdits`, always) and one extra REST call (issue comments, always) per admission; a body edit by a non-author additionally costs one `collaborators/{login}/permission` REST call. No new reads on `listTickets`/`listDispatchable` (trust fields are only computed by `getTicket`).
- **New writes**: the GitHub adapter now posts one issue **comment** (never a body edit) whenever `ai:agent-ready` is applied — in `transition()`, `setLabels()`, and `file()`. No existing write behavior changed.
- **No schema/agent-pin changes**: the pin logic lives entirely inside the control-plane adapter, so `tools/ticket.mjs state <id> ... --add ai:agent-ready` (the CLI `triage-apply`'s `label-agent-ready` action already calls) is unchanged at the contract level — no `triage-apply.json`/schema edits, no pin-protocol regeneration needed.
- **Linear plane**: byte-for-byte unaffected (`authorAssociation` absent means the gate short-circuits before any check runs).

## Test plan

- [x] `bun test event-runtime/lib/planner.test.mjs lib/control-plane/github.test.mjs event-runtime/lib/triage.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000` (the issue's Verification Command) — 265 pass, 0 fail
- [x] `bun test event-runtime/lib --timeout 20000` — 1505 pass, 9 skip (pre-existing QEMU-gated sandbox tests), 0 fail
- [x] New coverage: untrusted author refused; unknown/unresolvable author or editor fails closed; trusted author + untrusted editor refused; trusted+trusted admitted; body edit after labeling refused; no pin at all refused; re-label refreshes pin and admits; Linear-plane tickets carry no `authorAssociation` key at all (gate structurally skipped); operator-injected dispatch goes through the identical gates
- [x] Fixed a pre-existing fake `gh api` in `event-runtime/lib/control-plane.test.mjs` that didn't stub the new GraphQL/comments calls `getTicket()` now always makes (not in this ticket's Owned Paths, but broken by this change so fixed here)

## Handoff

This is a security diff — stopping short of merge per instructions. PR is pushed, checks will run; **do not merge** without a cold review of the diff summary above. All tests pass locally including the full `event-runtime/lib` suite. No schema/agent-pin protocol changes were needed since the pin logic is entirely internal to the GitHub control-plane adapter, invoked transparently by the existing `tools/ticket.mjs state` command triage-apply already calls.