### PR TITLE
Fix same-identity dispatch claim races

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1040,8 +1040,9 @@ function defaultIsAlive(pid) {
 
 export function defaultLocksDir() {
   if (process.env.FACTORY_LOCKS_DIR) return process.env.FACTORY_LOCKS_DIR;
-  if (process.env.FACTORY_EVENT_HOME)
-    return path.join(process.env.FACTORY_EVENT_HOME, "locks");
+  // Ticket claims must share the dispatcher lock, not this runtime instance's
+  // private event home. Supervisors use one tracker identity, so an assignee
+  // read-back cannot distinguish two concurrent claims from this machine.
   return path.join(homedir(), ".factory", "locks");
 }
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3137,7 +3137,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       expect(claimCalls).toBe(0);
     } finally {
       releaseClaimLock(supervisorLock);
-      if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      if (previousEventHome === undefined)
+        delete process.env.FACTORY_EVENT_HOME;
       else process.env.FACTORY_EVENT_HOME = previousEventHome;
       if (previousLocksDir === undefined) delete process.env.FACTORY_LOCKS_DIR;
       else process.env.FACTORY_LOCKS_DIR = previousLocksDir;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -29,6 +29,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import {
   buildClaudeArgv,
@@ -3090,6 +3091,57 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       }),
     ).toBe(true);
     releaseClaimLock(lockFile);
+  });
+
+  test("same-identity dispatch claims share the supervisor lock when event home is isolated", async () => {
+    const previousEventHome = process.env.FACTORY_EVENT_HOME;
+    const previousLocksDir = process.env.FACTORY_LOCKS_DIR;
+    const repoName = "wt-worker";
+    const supervisorLock = dispatchLockPath(
+      repoName,
+      path.join(homedir(), ".factory", "locks"),
+    );
+    process.env.FACTORY_EVENT_HOME = tmpDir("evrt-isolated-event-home-");
+    delete process.env.FACTORY_LOCKS_DIR;
+    let claimCalls = 0;
+
+    try {
+      expect(acquireClaimLock(supervisorLock)).toBe(true);
+      const db = openDb(":memory:");
+      queueRun(
+        db,
+        makeDispatchSpec({
+          input: { repo: repoName, ticket: "WM-877" },
+        }),
+      );
+
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            random: () => 0,
+            fetchTicket: () => readyDispatchTicket("WM-877"),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => {
+              claimCalls += 1;
+              return { ok: true, assignee: "shared-bot" };
+            },
+          },
+        }),
+      );
+
+      expect(summary.reasonCode).toBe("claim_lock_contention");
+      expect(claimCalls).toBe(0);
+    } finally {
+      releaseClaimLock(supervisorLock);
+      if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      else process.env.FACTORY_EVENT_HOME = previousEventHome;
+      if (previousLocksDir === undefined) delete process.env.FACTORY_LOCKS_DIR;
+      else process.env.FACTORY_LOCKS_DIR = previousLocksDir;
+    }
   });
 
   test("contended claim lock requeues with jittered backoff without consuming an attempt, then runs", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#877

UX critique: skipped — backend dispatch-lock change; no user-facing surface.