### PR TITLE
fix(tests): scope tracked process cleanup per test file

### DIFF
--- a/event-runtime/cli/process-cleanup.test.mjs
+++ b/event-runtime/cli/process-cleanup.test.mjs
@@ -7,10 +7,13 @@ import { fileURLToPath } from "node:url";
 import {
   cleanupTrackedProcesses,
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   spawnTracked,
   trackProcessGroupForPid,
 } from "../lib/test-helpers-process.mjs";
 import { loadAdjustedTimeout } from "../lib/test-helpers-timing.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 const EVENT_RUNTIME = fileURLToPath(new URL("..", import.meta.url));
 const LIVE_STACK = fileURLToPath(

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -29,9 +29,11 @@ import {
   spawnWorker,
   waitFor,
   registerCliTmpCleanup,
+  registerTestProcessCleanup,
 } from "./test-helpers.mjs";
 
 registerCliTmpCleanup();
+registerTestProcessCleanup(import.meta.url);
 
 describe("serve command", () => {
   test("serve --watch re-execs under bun --watch and binds", async () => {

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -9,6 +9,7 @@ import { cleanupTmpDirs, tmpDir } from "../test-support/tmp.mjs";
 export {
   cleanupTrackedProcesses,
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   spawnTracked,
   trackMarkedFakeRuntimeGroups,
   trackProcess,

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -29,9 +29,11 @@ import {
   spawnWorker,
   waitFor,
   registerCliTmpCleanup,
+  registerTestProcessCleanup,
 } from "./test-helpers.mjs";
 
 registerCliTmpCleanup();
+registerTestProcessCleanup(import.meta.url);
 
 const WORKER_POLICY_VERSION = policyVersion();
 

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -33,8 +33,11 @@ import { createAdapterRegistry, validateAdapterContract } from "./index.mjs";
 import { SandboxUnsupportedError } from "./sandboxed.mjs";
 import {
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 const tmpBase = tmpDir("evrt-acp-");
 const stubPath = path.join(tmpBase, "fake-acp.mjs");

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -30,8 +30,11 @@ import {
 import { SandboxUnsupportedError } from "./sandboxed.mjs";
 import {
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 describe("sandbox decision (WM-313): deferred, so refused — never ignored", () => {
   const sandboxedDef = (promptPath) => ({

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -30,9 +30,12 @@ import {
 } from "./cursor.mjs";
 import {
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
 import { loadAdjustedTimeout, until } from "../test-helpers-timing.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 describe("isHarnessDenial (WM-127, no confirmed Cursor refusal shapes yet)", () => {
   test("nothing matches — empty until a Cursor-authored shape is observed", () => {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -35,8 +35,11 @@ import { preflight, SandboxUnavailableError } from "../sandbox/gondolin.mjs";
 import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
 import {
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -4,7 +4,10 @@ import {
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-intake-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { spawnTracked } from "./test-helpers-process.mjs";
+import {
+  registerTestProcessCleanup,
+  spawnTracked,
+} from "./test-helpers-process.mjs";
 import { freePort, loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 import {
   GH_SECRET,
@@ -39,6 +42,8 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -41,7 +41,12 @@ import { emitDueTicks } from "./schedules.mjs";
 import { createInboxItem } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 import { hashJson } from "./canonical.mjs";
-import { spawnTracked } from "./test-helpers-process.mjs";
+import {
+  registerTestProcessCleanup,
+  spawnTracked,
+} from "./test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -12,9 +12,7 @@ function testFileForCaller() {
     /(?:file:\/\/)?[^()\s]+\.test\.mjs(?=:\d+:\d+)/,
   );
   if (!match) return null;
-  return match[0].startsWith("file:")
-    ? match[0]
-    : pathToFileURL(match[0]).href;
+  return match[0].startsWith("file:") ? match[0] : pathToFileURL(match[0]).href;
 }
 
 /**

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -1,9 +1,38 @@
 import { afterAll, afterEach } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const tracked = new Map();
+const registeredTestCleanupOwners = new Set();
 let handlingSignal = false;
 const defaultTestMarker = `spawn-tracked-${process.pid}`;
+
+function testFileForCaller() {
+  const match = new Error().stack?.match(
+    /(?:file:\/\/)?[^()\s]+\.test\.mjs(?=:\d+:\d+)/,
+  );
+  if (!match) return null;
+  return match[0].startsWith("file:")
+    ? match[0]
+    : pathToFileURL(match[0]).href;
+}
+
+/**
+ * Bind process cleanup to the importing test file rather than to this shared
+ * module's first loader. Tracked entries retain the same owner, so one file's
+ * afterAll cannot tear down another file's suite fixture.
+ */
+export function registerTestProcessCleanup(owner = testFileForCaller()) {
+  if (!owner) {
+    throw new Error(
+      "registerTestProcessCleanup must be called from a .test.mjs file",
+    );
+  }
+  if (registeredTestCleanupOwners.has(owner)) return;
+  registeredTestCleanupOwners.add(owner);
+  afterEach(() => cleanupTrackedProcesses({ scope: "test", owner }));
+  afterAll(() => cleanupTrackedProcesses({ scope: "all", owner }));
+}
 
 function processGroupForPid(pid) {
   if (process.platform === "win32") return null;
@@ -55,11 +84,14 @@ function isAlive(entry) {
  * detached group; notifier fixtures use group:false because they have no
  * descendants and share the test runner's process group.
  */
-export function trackProcess(pid, { group = true, scope = "test" } = {}) {
+export function trackProcess(
+  pid,
+  { group = true, scope = "test", owner = testFileForCaller() } = {},
+) {
   if (!Number.isInteger(Number(pid)) || Number(pid) <= 0) {
     throw new Error(`cannot track invalid test process pid ${pid}`);
   }
-  const entry = { pid: Number(pid), group, scope };
+  const entry = { pid: Number(pid), group, scope, owner };
   if (entry.group && testRunnerPgid !== null && entry.pid === testRunnerPgid) {
     throw new Error(
       `refusing to track the test runner process group ${testRunnerPgid}`,
@@ -186,9 +218,12 @@ export function spawnTracked(command, args = [], options = {}, tracking = {}) {
 export async function cleanupTrackedProcesses({
   scope = "all",
   graceMs = 250,
+  owner = testFileForCaller(),
 } = {}) {
   const entries = [...tracked.values()].filter(
-    (entry) => scope === "all" || entry.scope === scope,
+    (entry) =>
+      (scope === "all" || entry.scope === scope) &&
+      (owner === null || entry.owner === owner),
   );
   for (const entry of entries) signalTracked(entry, "SIGTERM");
 
@@ -207,8 +242,6 @@ function cleanupTrackedProcessesSync() {
   tracked.clear();
 }
 
-afterEach(() => cleanupTrackedProcesses({ scope: "test" }));
-afterAll(() => cleanupTrackedProcesses({ scope: "all" }));
 process.once("exit", cleanupTrackedProcessesSync);
 
 // Bun may terminate a timed-out test file with a signal, which does not emit

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -91,10 +91,13 @@ import {
 import {
   cleanupTrackedProcesses,
   processOwnerWatchdogSource,
+  registerTestProcessCleanup,
   trackMarkedFakeRuntimeGroups,
   trackProcess,
   trackProcessGroupsMatching,
 } from "./test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
 
 const registry = loadRegistry();
 const adapters = { fake };


### PR DESCRIPTION
Fixes watt-mind/factory#907

UX critique: skipped — backend test-helper cleanup has no user-facing surface.