### PR TITLE
fix(agents): move disk-* SSH host allowlist to instance-local config

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -114,3 +114,13 @@ notify:
     - smoke_red
     - circuit_breaker_tripped
     - release_candidate_ready
+
+# Instance-local host allowlist for the disk maintenance agents
+# (disk-diagnose / disk-remediate). The tracked agent definitions ship with an
+# empty allowlist on purpose — set your own targets here (or leave unset to
+# keep the disk agents refusing).
+# agents:
+#   disk:
+#     hosts:
+#       lab: root@203.0.113.10
+#       web: ops@203.0.113.20

--- a/event-runtime/agents/disk-diagnose.json
+++ b/event-runtime/agents/disk-diagnose.json
@@ -20,7 +20,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/disk-diagnose.md": "sha256:8454c1519b8992f2b6e948b3f6ba147807d2ac49c7e192c431647e5e9ca37c43",
+    "agents/disk-diagnose.md": "sha256:2ad9598e1a2e7dad9a508942e65902e141bdd04842df0d95a3801ddcbcfd3007",
     "schemas/disk-diagnose.input.json": "sha256:b14b2a1cb4ffbc5f5666a1c56ef155fb048a421a47050a5623c11ab09b204e90",
     "schemas/disk-diagnose.output.json": "sha256:c5f6d4a93935d0f0a1ba7e3bc50d97a3f688afd78d0a4f373345a053780ac7b2"
   }

--- a/event-runtime/agents/disk-diagnose.md
+++ b/event-runtime/agents/disk-diagnose.md
@@ -9,10 +9,10 @@ directory.
 
 ## Host access (allowlist — nothing else)
 
-| host | ssh target              |
-| :--- | :---------------------- |
-| lab  | `root@100.110.36.96`    |
-| web  | `hdkiller@100.93.81.56` |
+The host allowlist is instance-local and intentionally not tracked in this
+repository. The operator configures `hosts` on the `disk-remediate` definition
+via an instance-local override (see `config/policy.example.yaml`); until
+configured, runs refuse with `host not in allowlist`.
 
 ## Method — read-only commands only
 

--- a/event-runtime/agents/disk-remediate.json
+++ b/event-runtime/agents/disk-remediate.json
@@ -14,10 +14,7 @@
     "{target}",
     "{remote}"
   ],
-  "hosts": {
-    "lab": "root@100.110.36.96",
-    "web": "hdkiller@100.93.81.56"
-  },
+  "hosts": {},
   "probeRemote": "df --output=used -B1 {mount} | tail -1",
   "actionRegistry": {
     "docker-builder-prune": {
@@ -44,7 +41,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/disk-remediate.md": "sha256:1d8c7afa476ae5b41c62e92bc6b036993d129869fe3fbda2d5fa7ef04cebdffa",
+    "agents/disk-remediate.md": "sha256:17449eb77f7fb7595470fa8b36317ce5e8da45edb65b4bd7775a23786f99f127",
     "schemas/disk-remediate.input.json": "sha256:7edfcd06c8d3508355c02a92810ebd9dd621509d18cd6f871f107f38fea7265e",
     "schemas/disk-remediation.output.json": "sha256:1339cd92145c5f30637ba92449e4b1fe1a3bb146af7fb81b45ff0f55da909610"
   }

--- a/event-runtime/agents/disk-remediate.md
+++ b/event-runtime/agents/disk-remediate.md
@@ -11,7 +11,9 @@ Registered actions (the closed registry — nothing else can execute):
 | `docker-system-prune`  | `sudo docker system prune -af`     |
 | `journal-vacuum-3d`    | `sudo journalctl --vacuum-time=3d` |
 
-Host allowlist: `lab` (`root@100.110.36.96`), `web` (`hdkiller@100.93.81.56`).
+Host allowlist: instance-local, intentionally empty in the tracked definition —
+the operator supplies `hosts` via an instance-local override (see
+`config/policy.example.yaml`). An unconfigured instance refuses before executing.
 
 The adapter probes `df --output=used -B1 <mount>` before and after, records
 raw probe output as evidence, and the verifier **recomputes** reclaimed bytes

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2188,8 +2188,10 @@ describe("planAdmittedEvents", () => {
       expect(hashJson(replannedSpec)).toBe(outcome.proposal.spec_hash);
       expect(replannedSpec.idempotencyKey).toBe(originalSpec.idempotencyKey);
     } finally {
-      process.env.FACTORY_REPOS_ROOT = oldReposRoot;
-      process.env.FACTORY_EVENT_HOME = oldHome;
+      if (oldReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = oldReposRoot;
+      if (oldHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      else process.env.FACTORY_EVENT_HOME = oldHome;
     }
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -177,8 +177,11 @@ describe("registry", () => {
     // tier:* values before adding the proposed one (triage-apply.json is a
     // registry input); the schema's tier/tierReason requirement was
     // reverted (the runtime's closed validator has no allOf/if/then).
+    // Regenerated (#941): disk-diagnose/disk-remediate host allowlists moved
+    // to instance-local config; tracked definitions ship empty (both are
+    // registry inputs).
     const expected =
-      "sha256:150c9a7ad59111642fe3b8fa443a45412969377247309d048e825f78ba88332f";
+      "sha256:afb4cc92abd9a45299ceb2f28ec7b76d026e4922ef217fdcc6ec0e085994e850";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/pins.json
+++ b/event-runtime/pins.json
@@ -9,7 +9,7 @@
       "agents/factory-merge-reviewer.md": "sha256:d601ff66c9813565dc90643dfa2534041d7953d8dd1cfd8d34e563db491b3399",
       "agents/factory-ux-critic.md": "sha256:9d298a6e8bcdf96e5143f4cb6324949c424011cd51ff2a96220c92cd61edc6ac",
       "commands/factory-audit.md": "sha256:68f87be9a5d17c3753db3260317853fb3def6e9593bb4239b098654c99ee757a",
-      "commands/factory-capture.md": "sha256:6b19222bd718a2e9d6c2778b55c9b18b9ab1e36d840f0f1b2c4f831a1f29691b",
+      "commands/factory-capture.md": "sha256:f67044989f33695340d723b7e85ddcdd21d412a1f416aea58d1a39d943f4ff57",
       "commands/factory-friction.md": "sha256:952b6573aad2e8cc8bbe3c7de2724336d0505e450c84b66abd0a5f028f2bd021",
       "commands/factory-merge.md": "sha256:a92a0e54602519828e23656ac9fdd96fa219db1bbeb3cd3e82852bdea7437e06",
       "commands/factory-next.md": "sha256:26d5a4f03b301d1bbf967a35aa93e643730bf10f5932a688e195f8d64d535ee6",
@@ -18,11 +18,11 @@
       "commands/factory-ship.md": "sha256:b29f7a3e9acf8dfc2467ea75db6d14a6f44755303408c3ef9ee3d1b9deb10183",
       "commands/factory-sweep.md": "sha256:f7dc737e45bcce94442cd78aea01868c5d9cce3312da83d3cc51322ab0bef4b4",
       "commands/factory-ticket.md": "sha256:0e9e4b8f5bfc33a11ecc9103a9845af88431e1560f1917a74b70ceb8ce3b0c28",
-      "commands/factory-triage.md": "sha256:cfd126ce9145018e20469cfb3d0ee1776b024b1d437f0af43f474e61d9e12581",
+      "commands/factory-triage.md": "sha256:20d538ca3c7358b22ea2f263fa1ec8b75affbf222e58c77989b43d34750c0ff1",
       "commands/factory-unblock.md": "sha256:496bffc002afea8eca9d6c1b80f38c6732eb2163f3e41f6d04f0357c4e2905cb",
       "commands/factory-work.md": "sha256:e617db40b00227ed180884bbe005f57a264f3d5dbae48bb9743777ef7b092693",
       "floor.md": "sha256:b24b46d2e4766a288e056d525d9286bfca21dbe9ae837f820e5fb98f00f95460",
-      "skills/ticket-spec/SKILL.md": "sha256:63d77d616e18b3f55c3f70eecf9ce2f10169c9e046ae6c2b3169d4ca0184071a"
+      "skills/ticket-spec/SKILL.md": "sha256:6cd7e613072a1f4bd360389b62f3482432cbeb167b1e34b27b4a6099d4685b23"
     }
   }
 }


### PR DESCRIPTION
Fixes watt-mind/factory#941

Removes the operator's private tailnet SSH targets from the tracked disk-diagnose / disk-remediate definitions. The allowlist ships empty; an unconfigured instance refuses before executing (`host not in allowlist`). `config/policy.example.yaml` documents the instance-local shape. Registry digests re-pinned per protocol.

Unblocks release PR #940.

## Verification
`bun test event-runtime/lib/registry.test.mjs` 45 pass; `bun test event-runtime/lib/adapters/actions.test.mjs` 23 pass; tracked-tree grep for the two targets returns nothing.