### PR TITLE
fix(planner): refresh stale Owned Paths closure cache

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -9,7 +9,7 @@
  * dead-lettered instead of wedging the sweep or silently vanishing.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -27,7 +27,7 @@ import { loadForge } from "../../lib/forge/index.mjs";
 import { budgetExhausted } from "../../lib/spend.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
-import { canonicalJson, hashJson } from "./canonical.mjs";
+import { canonicalJson, hashBytes, hashJson } from "./canonical.mjs";
 import { resolveConfigPath } from "./config.mjs";
 import { hashHarnessRoots } from "./pins.mjs";
 import { isTrustedAssociation } from "./triage.mjs";
@@ -572,21 +572,82 @@ function fetchPullRequestDefault(payload) {
 // WM-1006: in-flight tickets come from the control-plane adapter via the
 // `inflight` CLI verb — never raw tracker GraphQL (plane-specific).
 
+// Cache parsed manifest requirements, not the closure result. A repo can have
+// many tickets planned by one long-lived daemon, but the manifest set is
+// mutable while it is running. Entries are kept per repo name and refreshed
+// whenever the policy or the matching manifest files change.
 const OWNED_PATHS_CLOSURE_CACHE = new Map();
+const MAX_OWNED_PATHS_CLOSURE_CACHE_ENTRIES = 128;
+
+function pinManifestFreshness(repo) {
+  const repoPath = path.resolve(repo.path);
+  const policy = repo.ownedPathsPolicy ?? {};
+  const patterns = Array.isArray(policy.pinManifests)
+    ? policy.pinManifests
+    : [];
+  const matchers = patterns.map(globToRegExp);
+  const manifests = [];
+
+  // Match the owned-paths reader's file-only traversal. Directory mtime alone
+  // cannot observe a changed existing manifest, so include matched file mtime,
+  // size, and content identity; the manifest list observes additions/removals.
+  if (matchers.length && existsSync(repoPath)) {
+    const pending = [repoPath];
+    while (pending.length) {
+      const dir = pending.pop();
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const filePath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          pending.push(filePath);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        const relativePath = path
+          .relative(repoPath, filePath)
+          .replace(/\\/g, "/");
+        if (!matchers.some((matcher) => matcher.test(relativePath))) continue;
+        const stat = statSync(filePath);
+        manifests.push({
+          path: relativePath,
+          mtimeMs: stat.mtimeMs,
+          size: stat.size,
+          hash: hashBytes(readFileSync(filePath)),
+        });
+      }
+    }
+  }
+
+  manifests.sort((a, b) => a.path.localeCompare(b.path));
+  return canonicalJson({ repoPath, policy, manifests });
+}
+
+function cacheOwnedPathsClosureRequirements(repoName, freshness, requirements) {
+  // Delete first to refresh insertion order. The small LRU bound keeps a
+  // daemon that observes transient repo names from retaining requirements
+  // forever, while replacement makes each per-repo entry directly evictable.
+  OWNED_PATHS_CLOSURE_CACHE.delete(repoName);
+  OWNED_PATHS_CLOSURE_CACHE.set(repoName, { freshness, requirements });
+  if (OWNED_PATHS_CLOSURE_CACHE.size > MAX_OWNED_PATHS_CLOSURE_CACHE_ENTRIES) {
+    OWNED_PATHS_CLOSURE_CACHE.delete(
+      OWNED_PATHS_CLOSURE_CACHE.keys().next().value,
+    );
+  }
+}
 
 function ownedPathsClosureDetails(repoName, repo, ticketDescription) {
   if (!repo?.ownedPathsPolicy) return [];
-  const cacheKey = `${repoName}::${repo.path}`;
-  if (!OWNED_PATHS_CLOSURE_CACHE.has(cacheKey)) {
+  const freshness = pinManifestFreshness(repo);
+  const cached = OWNED_PATHS_CLOSURE_CACHE.get(repoName);
+  if (!cached || cached.freshness !== freshness) {
     const requirements = repo.ownedPathsPolicy.pinManifests?.length
       ? readPinManifestRequirements(
           repo.path,
           repo.ownedPathsPolicy.pinManifests,
         )
       : [];
-    OWNED_PATHS_CLOSURE_CACHE.set(cacheKey, requirements);
+    cacheOwnedPathsClosureRequirements(repoName, freshness, requirements);
   }
-  const requirements = OWNED_PATHS_CLOSURE_CACHE.get(cacheKey);
+  const requirements = OWNED_PATHS_CLOSURE_CACHE.get(repoName).requirements;
   const ownedPaths = parseOwnedPaths(ticketDescription ?? "");
   return ownedPathsClosureGaps({
     ownedPaths,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1,7 +1,7 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-planner-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes, hashJson } from "./canonical.mjs";
 import { DEAD_LETTER_AFTER, DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
@@ -1371,6 +1371,76 @@ describe("planEvent worktree gate (WM-108)", () => {
         expect(fetchedInFlight).toBe(false);
       },
     );
+  });
+
+  test("refreshes pin-manifest closure requirements after manifests are added and removed", () => {
+    const repoPath = tmpDir("evrt-plan-closure-cache-");
+    const manifestDir = path.join(repoPath, "manifests");
+    const manifestPath = path.join(manifestDir, "generated.json");
+    mkdirSync(manifestDir, { recursive: true });
+    const yaml =
+      `repos:\n  - name: closure-cache\n    path: ${repoPath}\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n` +
+      `    owned_paths_policy:\n      pin_manifests:\n        - manifests/*.json\n`;
+    const ticket = {
+      identifier: "WM-948",
+      state: { name: "Todo" },
+      assignee: null,
+      labels: { nodes: [{ name: "ai:agent-ready" }] },
+      description: "## Owned Paths\n- generated/contracts.mjs\n",
+    };
+    const dispatch = {
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      fetchTicket: () => ticket,
+      fetchInFlight: () => [],
+    };
+
+    withReposRoot(yaml, () => {
+      // Cache an empty set first, exactly as a long-lived daemon does before
+      // a new generated-contract pin is committed.
+      expect(
+        worktreeDispatchAutoEligibility(
+          { repo: "closure-cache", ticket: "WM-948" },
+          dispatch,
+        ).ok,
+      ).toBe(true);
+
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({ pins: { "generated/contracts.mjs": "sha256:pin" } }),
+      );
+      expect(
+        worktreeDispatchAutoEligibility(
+          { repo: "closure-cache", ticket: "WM-948" },
+          dispatch,
+        ).refusal?.reason,
+      ).toBe("owned_paths_not_closed");
+
+      // A changed existing manifest cannot retain its prior requirement.
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          pins: { "generated/other-contract.mjs": "sha256:new" },
+        }),
+      );
+      expect(
+        worktreeDispatchAutoEligibility(
+          { repo: "closure-cache", ticket: "WM-948" },
+          dispatch,
+        ).ok,
+      ).toBe(true);
+
+      // Removing the same manifest must evict its cached requirement too.
+      rmSync(manifestPath);
+      expect(
+        worktreeDispatchAutoEligibility(
+          { repo: "closure-cache", ticket: "WM-948" },
+          dispatch,
+        ).ok,
+      ).toBe(true);
+    });
   });
 
   test("flat labels array from the control-plane adapter still admits (WM-978)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#948

UX critique: skipped — backend planner/cache change; no user-facing surface.