### PR TITLE
fix(control-plane): resolve the plane from the ticket id when cwd matches no repo

### DIFF
--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -302,7 +302,29 @@ export function resolveRepoName({
   return best?.name ?? null;
 }
 
-function controlPlane() {
+/**
+ * When cwd identifies no repo (dispatched agents run from ephemeral runtime
+ * workspaces under ~/.factory, matching neither `path` nor `worktree_root` —
+ * GH-975), the ticket identifier itself still can: `owner/repo#N` names the
+ * GitHub repo, and a registry entry whose `github:` matches decides the
+ * plane. Without this, a workspace-run claim silently falls back to the
+ * workspace-wide default plane and misreads or misses the ticket entirely.
+ */
+export function resolveRepoNameFromTicket(ticketArg, repos) {
+  const registry = repos ?? getRepos();
+  const m =
+    typeof ticketArg === "string" &&
+    ticketArg.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#[0-9]+/);
+  if (!m) return null;
+  const github = m[1].toLowerCase();
+  for (const repo of registry.values()) {
+    if (typeof repo.github === "string" && repo.github.toLowerCase() === github)
+      return repo.name;
+  }
+  return null;
+}
+
+function controlPlane(ticketArg = positional[0]) {
   // Absent a resolvable repo, fall back to the workspace default exactly as
   // before — a CLI run from /tmp must still work.
   let repoName = null;
@@ -311,6 +333,13 @@ function controlPlane() {
   } catch (err) {
     // An explicit bad --repo is the operator's mistake; surface it.
     if (flag("repo")) throw err;
+  }
+  if (!repoName) {
+    try {
+      repoName = resolveRepoNameFromTicket(ticketArg);
+    } catch {
+      // registry unreadable — same fallback as before
+    }
   }
   return loadControlPlane(repoName ? { repoName } : {});
 }

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -30,6 +30,7 @@ import {
   parsePositionalArgs,
   closureCheckMessages,
   resolveRepoName,
+  resolveRepoNameFromTicket,
   __resetLinearReposCache,
 } from "./ticket.mjs";
 
@@ -529,4 +530,27 @@ test("factory exposes `ticket`, and `linear` as a deprecated alias", () => {
   // The alias must survive until the prompt sweep lands, or dispatch breaks.
   expect(script).toContain("linear)");
   expect(script).toMatch(/factory linear is deprecated/);
+});
+
+const GH975_REPOS = new Map([
+  ["factory", { name: "factory", github: "watt-mind/factory" }],
+  ["legalease", { name: "legalease", github: "watt-mind/legalease" }],
+]);
+
+test("resolveRepoNameFromTicket: owner/repo#N resolves the matching registry entry (GH-975)", () => {
+  expect(resolveRepoNameFromTicket("watt-mind/factory#975", GH975_REPOS)).toBe(
+    "factory",
+  );
+});
+
+test("resolveRepoNameFromTicket: case-insensitive on the github slug", () => {
+  expect(resolveRepoNameFromTicket("Watt-Mind/Factory#1", GH975_REPOS)).toBe(
+    "factory",
+  );
+});
+
+test("resolveRepoNameFromTicket: linear-style and bare ids resolve nothing", () => {
+  expect(resolveRepoNameFromTicket("WM-123", GH975_REPOS)).toBeNull();
+  expect(resolveRepoNameFromTicket("975", GH975_REPOS)).toBeNull();
+  expect(resolveRepoNameFromTicket(undefined, GH975_REPOS)).toBeNull();
 });


### PR DESCRIPTION
Fixes watt-mind/factory#975 (the claim half — adapter-side config provisioning can follow separately if still needed).

Agents run from ~/.factory workspaces; `resolveRepoName()` cwd-matching resolves null there, so claims of `owner/repo#N` tickets went to the Linear default plane and failed NOT_CLAIMED (every dispatch wave since ~02:45Z). New `resolveRepoNameFromTicket()` matches the ticket id against registry github slugs when cwd yields nothing.

## Verification
`bun test tools/ticket.test.mjs` 31 pass (3 new regression tests); manual: `ticket get watt-mind/factory#975` from an empty cwd now resolves via GitHub (was: Linear 'Entity not found').