### PR TITLE
fix(outbox): retain published rows and index drain

### DIFF
--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -415,6 +415,16 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 13,
+    name: "outbox_publish_drain_index",
+    up(db) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_outbox_published_seq
+          ON outbox (published_at, seq);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/outbox.mjs
+++ b/event-runtime/lib/outbox.mjs
@@ -9,14 +9,48 @@
  */
 import { tx } from "./db.mjs";
 
+export const DEFAULT_OUTBOX_RETENTION_DAYS = 14;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Delete published rows older than the configured retention window. */
+export function sweepPublishedOutbox(
+  db,
+  { retentionDays = DEFAULT_OUTBOX_RETENTION_DAYS, now = Date.now() } = {},
+) {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+    throw new Error("retentionDays must be a positive number of days");
+  }
+  const cutoff = new Date(now - retentionDays * DAY_MS).toISOString();
+  return tx(
+    db,
+    () =>
+      db
+        .query(
+          `DELETE FROM outbox
+           WHERE published_at IS NOT NULL AND published_at < ?`,
+        )
+        .run(cutoff).changes,
+  );
+}
+
 /**
  * Deliver every unpublished outbox event to `sink(envelope, row)` in insertion
  * order, stamping each row after a successful delivery. Stops at the first
  * sink failure (order preserved for the retry).
  *
+ * Published rows are pruned only after delivery, retaining a configurable
+ * bounded window. Unpublished rows are never eligible for pruning.
+ *
  * @returns {number} rows delivered
  */
-export function publishOutbox(db, { sink, now = Date.now() } = {}) {
+export function publishOutbox(
+  db,
+  {
+    sink,
+    now = Date.now(),
+    retentionDays = DEFAULT_OUTBOX_RETENTION_DAYS,
+  } = {},
+) {
   const rows = db
     .query(
       `SELECT seq, event_json FROM outbox WHERE published_at IS NULL ORDER BY seq`,
@@ -33,5 +67,6 @@ export function publishOutbox(db, { sink, now = Date.now() } = {}) {
     });
     delivered += 1;
   }
+  sweepPublishedOutbox(db, { retentionDays, now });
   return delivered;
 }

--- a/event-runtime/lib/outbox.test.mjs
+++ b/event-runtime/lib/outbox.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { openDb } from "./db.mjs";
-import { publishOutbox } from "./outbox.mjs";
+import { publishOutbox, sweepPublishedOutbox } from "./outbox.mjs";
 
 function seedOutbox(db, eventId) {
   db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`).run(
@@ -44,5 +44,66 @@ describe("publishOutbox", () => {
     const seen = [];
     expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toBe(1);
     expect(seen).toEqual(["a"]);
+  });
+});
+
+describe("outbox retention and drain index", () => {
+  test("retention deletes only published rows outside its bounded window", () => {
+    const db = openDb(":memory:");
+    const now = 30 * 24 * 60 * 60 * 1000;
+    const old = new Date(0).toISOString();
+    const recent = new Date(now - 24 * 60 * 60 * 1000).toISOString();
+    const insert = db.query(
+      `INSERT INTO outbox (event_json, created_at, published_at) VALUES (?, ?, ?)`,
+    );
+    insert.run('{"eventId":"old"}', old, old);
+    insert.run('{"eventId":"recent"}', recent, recent);
+    insert.run('{"eventId":"pending"}', old, null);
+
+    expect(sweepPublishedOutbox(db, { now, retentionDays: 14 })).toBe(1);
+    expect(
+      db.query(`SELECT event_json, published_at FROM outbox ORDER BY seq`).all(),
+    ).toEqual([
+      { event_json: '{"eventId":"recent"}', published_at: recent },
+      { event_json: '{"eventId":"pending"}', published_at: null },
+    ]);
+  });
+
+  test("drains a pending row through the published-at index", () => {
+    const db = openDb(":memory:");
+    const publishedAt = new Date(0).toISOString();
+    const insert = db.query(
+      `INSERT INTO outbox (event_json, created_at, published_at) VALUES (?, ?, ?)`,
+    );
+    db.transaction(() => {
+      for (let i = 0; i < 200_000; i += 1) {
+        insert.run("{}", publishedAt, publishedAt);
+      }
+      insert.run(
+        JSON.stringify({ eventId: "pending" }),
+        publishedAt,
+        null,
+      );
+    })();
+
+    const plan = db
+      .query(
+        `EXPLAIN QUERY PLAN
+         SELECT seq, event_json FROM outbox
+         WHERE published_at IS NULL ORDER BY seq`,
+      )
+      .all()
+      .map((row) => row.detail)
+      .join(" ");
+    expect(plan).toContain("USING INDEX idx_outbox_published_seq");
+
+    const seen = [];
+    expect(
+      publishOutbox(db, {
+        sink: (event) => seen.push(event.eventId),
+        now: 24 * 60 * 60 * 1000,
+      }),
+    ).toBe(1);
+    expect(seen).toEqual(["pending"]);
   });
 });

--- a/event-runtime/lib/outbox.test.mjs
+++ b/event-runtime/lib/outbox.test.mjs
@@ -62,7 +62,9 @@ describe("outbox retention and drain index", () => {
 
     expect(sweepPublishedOutbox(db, { now, retentionDays: 14 })).toBe(1);
     expect(
-      db.query(`SELECT event_json, published_at FROM outbox ORDER BY seq`).all(),
+      db
+        .query(`SELECT event_json, published_at FROM outbox ORDER BY seq`)
+        .all(),
     ).toEqual([
       { event_json: '{"eventId":"recent"}', published_at: recent },
       { event_json: '{"eventId":"pending"}', published_at: null },
@@ -79,11 +81,7 @@ describe("outbox retention and drain index", () => {
       for (let i = 0; i < 200_000; i += 1) {
         insert.run("{}", publishedAt, publishedAt);
       }
-      insert.run(
-        JSON.stringify({ eventId: "pending" }),
-        publishedAt,
-        null,
-      );
+      insert.run(JSON.stringify({ eventId: "pending" }), publishedAt, null);
     })();
 
     const plan = db


### PR DESCRIPTION
Fixes #953

UX critique: skipped — backend/database maintenance; no user-facing flow.