### PR TITLE
fix(supply): filter legacy IDs from GitHub dispatches

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -23,6 +23,7 @@ import {
   ownedPathsClosureGaps,
 } from "../../orchestrator/owned-paths.mjs";
 import { openBlockers } from "../../orchestrator/blockers.mjs";
+import { parseIssueIdentifier } from "../../lib/control-plane/github.mjs";
 import { loadForge } from "../../lib/forge/index.mjs";
 import { budgetExhausted } from "../../lib/spend.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
@@ -895,6 +896,28 @@ function evidenceTicket(ticket, ticketId) {
 }
 
 /**
+ * Reject malformed dispatch candidates before asking their tracker to look
+ * them up. A work-scan result is advisory input, and a legacy Linear ID on a
+ * GitHub-controlled repo would otherwise throw from the adapter, retry until
+ * the event is dead-lettered, and consume a chain slot each time.
+ *
+ * Linear's control plane deliberately accepts its opaque identifiers at
+ * lookup time. GitHub is the parser-bearing plane today, so use the same
+ * parser its adapter uses rather than duplicating a narrower regex here.
+ */
+function invalidTicketIdentifierReason(repo, ticket) {
+  const controlPlane =
+    repo.controlPlane ?? loadRuntimePolicy()?.controlPlane?.kind ?? "linear";
+  if (controlPlane !== "github") return null;
+  try {
+    parseIssueIdentifier(ticket, repo.github ?? undefined);
+    return null;
+  } catch (err) {
+    return `ticket_identifier_unresolvable: ${err.message}`;
+  }
+}
+
+/**
  * Parse the closed per-ticket model-tier label vocabulary. A ticket may carry
  * either no tier label or exactly one valid `tier:<MODEL_TIERS>` label. The
  * full matching label set is returned so refusal evidence explains malformed
@@ -1002,6 +1025,16 @@ export function worktreeDispatchAutoEligibility(
   if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot)
     return refusal("no_worktree_scripts", evidence, "human_needed");
   evidence.checks.worktree_scripts_configured = true;
+
+  const invalidTicketIdentifier = invalidTicketIdentifierReason(
+    repo,
+    payload?.ticket,
+  );
+  if (invalidTicketIdentifier) {
+    evidence.checks.ticket_identifier_parseable = false;
+    return refusal(invalidTicketIdentifier, evidence);
+  }
+  evidence.checks.ticket_identifier_parseable = true;
 
   let budgetReason;
   try {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1218,7 +1218,7 @@ describe("planEvent worktree gate (WM-108)", () => {
     const dispatch = admit(dispatchDb, {
       type: "factory.dispatch.requested",
       eventId: "dispatch-gate-characterization",
-      payload: { repo: "factory", ticket: "WM-469" },
+      payload: { repo: "factory", ticket: "watt-mind/factory#469" },
     });
     const outcome = planEvent(dispatchDb, registry, dispatch, {
       now: NOW,
@@ -2827,6 +2827,119 @@ describe("Linear rate limit (WM-878)", () => {
       expect(counts.deadLettered).toBe(0);
       expect(cache.inFlightCalls).toBeLessThanOrEqual(3);
       expect(cache.inFlightCalls).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("GitHub dispatch candidate parsing (GH-974)", () => {
+  function withGithubRepo(fn) {
+    const root = tmpDir("evrt-plan-github-");
+    const checkout = path.join(root, "checkout");
+    mkdirSync(checkout, { recursive: true });
+    execFileSync("git", ["init", "-q", checkout]);
+    execFileSync("git", [
+      "-C",
+      checkout,
+      "config",
+      "user.email",
+      "test@example.com",
+    ]);
+    execFileSync("git", ["-C", checkout, "config", "user.name", "Test"]);
+    writeFileSync(path.join(checkout, "README.md"), "fixture\n");
+    execFileSync("git", ["-C", checkout, "add", "README.md"]);
+    execFileSync("git", ["-C", checkout, "commit", "-qm", "fixture"]);
+
+    const configRoot = path.join(root, "config-root");
+    mkdirSync(path.join(configRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(configRoot, "config", "repos.yaml"),
+      [
+        "repos:",
+        "  - name: github-candidates",
+        `    path: ${checkout}`,
+        "    github: watt-mind/factory",
+        "    control_plane: github",
+        "    base: develop",
+        "    team: WM",
+        "    project: Factory",
+        "    worktree_up: bin/up",
+        "    worktree_down: bin/down",
+        "    worktree_root: /tmp/worktrees",
+        "    escalate_paths: []",
+        "",
+      ].join("\n"),
+    );
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = configRoot;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  test("drops legacy Linear IDs from a GitHub candidate list before ticket reads", () => {
+    withGithubRepo(() => {
+      const db = openDb(":memory:");
+      const valid = "watt-mind/factory#534";
+      const legacy = "WM-621";
+      for (const [eventId, ticket] of [
+        ["github-candidate-valid", valid],
+        ["github-candidate-legacy", legacy],
+      ]) {
+        admit(db, {
+          type: "factory.dispatch.requested",
+          eventId,
+          correlationId: eventId,
+          payload: { repo: "github-candidates", ticket },
+        });
+      }
+
+      const reads = [];
+      const logs = [];
+      const counts = planAdmittedEvents(db, registry, {
+        now: NOW,
+        policyVersion: "git:test",
+        log: (line) => logs.push(line),
+        dispatch: {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: (ticket) => {
+            reads.push(ticket);
+            return {
+              identifier: ticket,
+              state: { name: "Todo" },
+              assignee: null,
+              labels: [{ name: "ai:agent-ready" }],
+              description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+              controlPlaneKind: "github",
+              authorAssociation: "MEMBER",
+              lastEditorAssociation: "MEMBER",
+            };
+          },
+          fetchInFlight: () => [],
+        },
+      });
+
+      expect(counts).toEqual({ planned: 2, failed: 0, deadLettered: 0 });
+      expect(reads).toEqual([valid]);
+      expect(
+        db.query(`SELECT status FROM events WHERE event_id = ?`).get(
+          "github-candidate-valid",
+        ).status,
+      ).toBe("planned");
+      const dropped = db
+        .query(`SELECT status, last_plan_error FROM events WHERE event_id = ?`)
+        .get("github-candidate-legacy");
+      expect(dropped.status).toBe("noop");
+      expect(dropped.last_plan_error).toMatch(
+        /^ticket_identifier_unresolvable: not a GitHub issue identifier: WM-621/,
+      );
+      expect(logs).toContain(
+        "planned noop (ticket_identifier_unresolvable: not a GitHub issue identifier: WM-621 (want owner/repo#N)) — operator-webhook:github-candidate-legacy",
+      );
     });
   });
 });

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2926,9 +2926,9 @@ describe("GitHub dispatch candidate parsing (GH-974)", () => {
       expect(counts).toEqual({ planned: 2, failed: 0, deadLettered: 0 });
       expect(reads).toEqual([valid]);
       expect(
-        db.query(`SELECT status FROM events WHERE event_id = ?`).get(
-          "github-candidate-valid",
-        ).status,
+        db
+          .query(`SELECT status FROM events WHERE event_id = ?`)
+          .get("github-candidate-valid").status,
       ).toBe("planned");
       const dropped = db
         .query(`SELECT status, last_plan_error FROM events WHERE event_id = ?`)


### PR DESCRIPTION
Fixes watt-mind/factory#974

UX critique: skipped — backend planner behavior with no user-facing surface.