### PR TITLE
Fix macOS worktree path normalization

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -166,6 +166,20 @@ die() {
 info() { printf '\033[36m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarn:\033[0m %s\n' "$*" >&2; }
 
+# Resolve a path without requiring its final component to exist. GNU `realpath
+# -m` offers this, but BSD/macOS realpath does not support `-m`. The parent
+# must exist here (as it does for the config paths below); `cd -P` both makes
+# the result absolute and normalizes its existing directory components.
+normalize_path() { # <path>
+  local path="$1" directory basename
+  directory=$(dirname "$path")
+  basename=$(basename "$path")
+  (
+    cd -P "$directory"
+    printf '%s/%s\n' "$PWD" "$basename"
+  )
+}
+
 # Local config is intentionally gitignored, but a delegated checkout needs
 # the active instance's routing, policy, and schedule rather than examples.
 # Skip a checkout without the ignore rule so an agent can never stage it.
@@ -177,7 +191,7 @@ provision_instance_local_configs() { # <checkout> [primary-checkout]
     [[ -f "$source" ]] || continue
     destination="$checkout/config/$name.yaml"
     rel="config/$name.yaml"
-    [[ "$(realpath -m "$source")" == "$(realpath -m "$destination")" ]] && continue
+    [[ "$(normalize_path "$source")" == "$(normalize_path "$destination")" ]] && continue
     if git -C "$checkout" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
       && ! git -C "$checkout" check-ignore -q -- "$rel"; then
       continue

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -211,6 +211,65 @@ test("provision_instance_local_configs silently skips a source without local fil
   }
 });
 
+test("normalize_path is portable and accepts a missing final component", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "gh-937-normalize-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "gh-937-realpath-"));
+  try {
+    mkdirSync(path.join(root, "existing"));
+    writeFileSync(
+      path.join(mockBin, "realpath"),
+      "#!/usr/bin/env bash\nprintf '%s\\n' 'realpath: illegal option -- m' >&2\nexit 1\n",
+    );
+    chmodSync(path.join(mockBin, "realpath"), 0o755);
+    const missing = path.join(root, "existing", "missing-leaf");
+    const r = sh(`normalize_path "${root}/existing/../existing/missing-leaf"`, {
+      PATH: `${mockBin}:${process.env.PATH}`,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe(missing);
+    expect(r.stderr).toBe("");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+  }
+});
+
+test("provision_instance_local_configs does not invoke GNU-only realpath", () => {
+  const source = mkdtempSync(path.join(tmpdir(), "gh-937-config-source-"));
+  const checkout = mkdtempSync(
+    path.join(tmpdir(), "gh-937-config-checkout-"),
+  );
+  const mockBin = mkdtempSync(path.join(tmpdir(), "gh-937-realpath-"));
+  try {
+    mkdirSync(path.join(source, "config"));
+    mkdirSync(path.join(checkout, "config"));
+    writeFileSync(path.join(source, "config", "repos.yaml"), "repos: []\n");
+    writeFileSync(
+      path.join(checkout, ".gitignore"),
+      "config/repos.yaml\n",
+    );
+    writeFileSync(
+      path.join(mockBin, "realpath"),
+      "#!/usr/bin/env bash\nprintf '%s\\n' 'realpath: illegal option -- m' >&2\nexit 1\n",
+    );
+    chmodSync(path.join(mockBin, "realpath"), 0o755);
+    const r = sh(
+      [
+        `git -C "${checkout}" init -q`,
+        `provision_instance_local_configs "${checkout}" "${source}"`,
+        `test "$(cat "${checkout}/config/repos.yaml")" = "repos: []"`,
+      ].join("\n"),
+      { PATH: `${mockBin}:${process.env.PATH}` },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe("");
+  } finally {
+    rmSync(source, { recursive: true, force: true });
+    rmSync(checkout, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+  }
+});
+
 test("listen_tcp_port rejects a dead pid even if lsof returns a listener", () => {
   const dir = mockLsofDir();
   const pidfile = path.join(dir, "dead.pid");

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -236,18 +236,13 @@ test("normalize_path is portable and accepts a missing final component", () => {
 
 test("provision_instance_local_configs does not invoke GNU-only realpath", () => {
   const source = mkdtempSync(path.join(tmpdir(), "gh-937-config-source-"));
-  const checkout = mkdtempSync(
-    path.join(tmpdir(), "gh-937-config-checkout-"),
-  );
+  const checkout = mkdtempSync(path.join(tmpdir(), "gh-937-config-checkout-"));
   const mockBin = mkdtempSync(path.join(tmpdir(), "gh-937-realpath-"));
   try {
     mkdirSync(path.join(source, "config"));
     mkdirSync(path.join(checkout, "config"));
     writeFileSync(path.join(source, "config", "repos.yaml"), "repos: []\n");
-    writeFileSync(
-      path.join(checkout, ".gitignore"),
-      "config/repos.yaml\n",
-    );
+    writeFileSync(path.join(checkout, ".gitignore"), "config/repos.yaml\n");
     writeFileSync(
       path.join(mockBin, "realpath"),
       "#!/usr/bin/env bash\nprintf '%s\\n' 'realpath: illegal option -- m' >&2\nexit 1\n",


### PR DESCRIPTION
Fixes watt-mind/factory#937

UX critique: skipped — internal worktree tooling has no user-facing surface.