### PR TITLE
fix(supply): scope scan ticket reads to repo

### DIFF
--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:6e9d79e5ae9a9244e1f1e953b479df22c5b405ace5bf0c4338c476ba70f9a5f6",
+    "agents/triage-scan.md": "sha256:cc255d038a3ce53dc85af4f63f83116c52ea87593b93ced93399478bd53f3d98",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:7f9776d3e3c99cd59beb04a04fc15286bf63ecf33c1f790152c55b5a29ef8bcb"
   }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -26,7 +26,11 @@ You never modify it, never run its build, never install anything. Write
 
 1. Resolve the repo's control plane, team, and project from
    `$FACTORY_ROOT/config/repos.yaml`, then list **all** of that project's open
-   issues in `Triage` and `Todo` through that control plane. Do not issue
+   issues in `Triage` and `Todo` through that control plane. Every
+   `tools/ticket.mjs` read must pass `--repo "$REPO"`, where `$REPO` is the
+   `repo` value from `./input.json`; for example,
+   `bun "$FACTORY_ROOT/tools/ticket.mjs" raw '<query>' --repo "$REPO" --json`.
+   Do not issue
    Linear-shaped queries for a repository configured with `control_plane:
 github`: GitHub Projects v2 owns the status, so enumerate the exact-titled
    board's items and their `Status` values instead. The exact-title lookup must

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:d9395a312b03ce0a74a18ba82b6f8ce9dbc4bd6acff7fb30872201254a3b9541",
+    "agents/work-scan.md": "sha256:6965f81e5a08793ead2e970dc6aef8592de22588929dc2aa2f3f4cc8602d72ce",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
     "schemas/work-scan.output.json": "sha256:7250a4c26073e443552b2d0bfdec53b2d4348940a92f250013ad31efdd637055"
   }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -27,9 +27,10 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
 ## Method
 
 1. **Enumerate and filter candidates** with a complete repo queue read
-   (`bun "$FACTORY_ROOT/tools/ticket.mjs"`; all pages, no sampling). Build the
-   candidate set yourself from the returned fields. A ticket is a candidate
-   only when **all three** predicates hold:
+   (`bun "$FACTORY_ROOT/tools/ticket.mjs" queue --repo "$REPO" --json`, where
+   `$REPO` is the `repo` value from `./input.json`; all pages, no sampling).
+   Build the candidate set yourself from the returned fields. A ticket is a
+   candidate only when **all three** predicates hold:
 
    - its state name is exactly `Todo`;
    - its labels include `ai:agent-ready`; and
@@ -84,7 +85,11 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    `reasonCode: "needs_human"` if your candidate construction or ordering does
    not produce that result.
 
-3. **Count the cap**: the repo's `max_in_flight` from
+3. **Count the cap**: read the complete in-flight set with
+   `bun "$FACTORY_ROOT/tools/ticket.mjs" inflight --repo "$REPO" --team "$TEAM" --project "$PROJECT" --json`,
+   again taking `$REPO` from `./input.json` and `$TEAM`/`$PROJECT` from the
+   matching `$FACTORY_ROOT/config/repos.yaml` entry. Then read the repo's
+   `max_in_flight` from
    `$FACTORY_ROOT/config/repos.yaml`, falling back to
    `concurrency.max_in_flight_per_repo` in `config/policy.yaml`, else 3. Record
    that value as `evidence.maxInFlight`. The in-flight count against it is the

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -123,6 +123,19 @@ describe("registry", () => {
     expect(getEventType(registry, "unknown.event")).toBeNull();
   });
 
+  test("work-scan scopes every queue and inflight ticket read to its input repo", () => {
+    const prompt = readFileSync(
+      path.join(RUNTIME_ROOT, "agents", "work-scan.md"),
+      "utf8",
+    );
+    const ticketReads = [
+      ...prompt.matchAll(/ticket\.mjs"?\s+(?:queue|inflight)\b([^\n]*)/g),
+    ];
+    expect(ticketReads).toHaveLength(2);
+    for (const [, args] of ticketReads)
+      expect(args).toContain('--repo "$REPO"');
+  });
+
   test("zero-pack merged-view digest matches the develop baseline", () => {
     // Regenerate with registryDigest(loadRegistry({ packRoots: [] })) on develop.
     // The serializer omits only WM-470's new pack provenance and normalizes
@@ -184,8 +197,10 @@ describe("registry", () => {
     // registry inputs).
     // Regenerated (#924): triage-scan selects its configured control plane and
     // fails closed when a GitHub Project title does not match.
+    // Regenerated (#985): list-reading scan prompts pass their input repo to
+    // ticket.mjs, so ephemeral workspaces do not fall back to another plane.
     const expected =
-      "sha256:221bd1d7193e177898470c60c0e7c11e91574886e4c4b3671f99462ce8a95f24";
+      "sha256:7a172fc8a2ffa21bd95cfd1b22d786b85741be8b64a7577436e25d7d856ba02d";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#985

UX critique: skipped — internal agent prompt and registry test changes have no user-facing surface.