### PR TITLE
fix(worktree): auto-push matching stale branch

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -887,11 +887,23 @@ test("re-dispatch auto-resumes a branch whose unique commits are already on orig
     ).toBe(0);
     expect(existsSync(expectedPath)).toBe(false);
 
+    const realGit = Bun.which("git");
     writeFileSync(
       path.join(mockBin, "gh"),
       "#!/usr/bin/env bash\nprintf '0\\n'\n",
       { mode: 0o755 },
     ); // no open PR
+    writeFileSync(
+      path.join(mockBin, "git"),
+      `#!/usr/bin/env bash
+if [[ "$*" == *"ls-remote --heads origin refs/heads/${branch}"* ]]; then
+  printf "%s\\trefs/heads/${branch}\\n" "${tip}"
+  exit 0
+fi
+exec "${realGit}" "$@"
+`,
+      { mode: 0o755 },
+    );
     const secondUp = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
       stdout: "pipe",
@@ -977,9 +989,21 @@ test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservati
       "uncommitted after unique commit\n",
     );
 
+    const realGit = Bun.which("git");
     writeFileSync(
       path.join(mockBin, "gh"),
       "#!/usr/bin/env bash\nprintf '0\\n'\n",
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(mockBin, "git"),
+      `#!/usr/bin/env bash
+if [[ "$*" == *"push origin "* ]]; then
+  echo "simulated push failure" >&2
+  exit 1
+fi
+exec "${realGit}" "$@"
+`,
       { mode: 0o755 },
     );
     const secondUp = Bun.spawnSync({

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -1,5 +1,7 @@
 import {
   chmodSync,
+  cpSync,
+  existsSync,
   mkdtempSync,
   rmSync,
   mkdirSync,
@@ -11,6 +13,8 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 
 const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
+const WORKTREE_UP = path.resolve(import.meta.dir, "worktree-up.sh");
+const WORKTREE_DAEMONS = path.resolve(import.meta.dir, "worktree-daemons.sh");
 
 // Private port band for this test run (WM-113). Fixed in-band ports (7752,
 // 7772, …) collide with real runtimes, leftover servers, and concurrent CI
@@ -76,6 +80,66 @@ function sh(body, extraEnv = {}) {
     stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
   };
+}
+
+function command(cmd, cwd, extraEnv = {}) {
+  const result = Bun.spawnSync({
+    cmd,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+function git(cwd, ...args) {
+  const result = command(["git", ...args], cwd);
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+function worktreeUpFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "wm-934-worktree-up-"));
+  const remote = path.join(root, "origin.git");
+  const worktrees = mkdtempSync(path.join(tmpdir(), "wm-934-worktrees-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "wm-934-gh-"));
+  mkdirSync(path.join(root, "bin"));
+  cpSync(COMMON, path.join(root, "bin", "worktree-common.sh"));
+  cpSync(WORKTREE_DAEMONS, path.join(root, "bin", "worktree-daemons.sh"));
+  cpSync(WORKTREE_UP, path.join(root, "bin", "worktree-up.sh"));
+  chmodSync(path.join(root, "bin", "worktree-up.sh"), 0o755);
+  writeFileSync(
+    path.join(mockBin, "gh"),
+    "#!/usr/bin/env bash\nprintf '0\\n'\n",
+  );
+  chmodSync(path.join(mockBin, "gh"), 0o755);
+  git(root, "init", "-q", "-b", "develop");
+  git(root, "config", "user.name", "Worktree test");
+  git(root, "config", "user.email", "worktree-test@example.test");
+  git(root, "add", "bin");
+  git(root, "commit", "-qm", "base");
+  git(root, "init", "-q", "--bare", remote);
+  git(root, "remote", "add", "origin", remote);
+  git(root, "push", "-qu", "origin", "develop");
+  return { root, remote, worktrees, mockBin };
+}
+
+function runWorktreeUp(fixture, ticket) {
+  return command(
+    ["bash", "bin/worktree-up.sh", ticket, "--checkout-only"],
+    fixture.root,
+    {
+      FACTORY_WT_ROOT: fixture.worktrees,
+      PATH: `${fixture.mockBin}:${process.env.PATH}`,
+    },
+  );
 }
 
 async function shAsync(body, extraEnv = {}) {
@@ -782,6 +846,78 @@ test("port_listening detects active and closed ports", async () => {
     listener.stop(true);
   }
   expect(sh(`port_listening ${P(396)}`).status).not.toBe(0);
+});
+
+test("worktree-up pushes a matching local-only ticket branch and resumes it", () => {
+  const fixture = worktreeUpFixture();
+  const ticket = "WM-934";
+  const branch = `feat/${ticket}`;
+  try {
+    git(fixture.root, "switch", "-qc", branch);
+    writeFileSync(path.join(fixture.root, "local-only.txt"), "local work\n");
+    git(fixture.root, "add", "local-only.txt");
+    git(fixture.root, "commit", "-qm", "local-only work");
+    const tip = git(fixture.root, "rev-parse", branch);
+    git(fixture.root, "switch", "-q", "develop");
+
+    const result = runWorktreeUp(fixture, ticket);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      `auto-pushed matching ticket branch ${branch} at ${tip}`,
+    );
+    expect(git(fixture.remote, "rev-parse", `refs/heads/${branch}`)).toBe(
+      tip,
+    );
+    expect(
+      git(path.join(fixture.worktrees, ticket), "branch", "--show-current"),
+    ).toBe(branch);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(fixture.worktrees, { recursive: true, force: true });
+    rmSync(fixture.mockBin, { recursive: true, force: true });
+  }
+});
+
+test("worktree-up fails closed when a matching remote branch diverged after a stale fetch", () => {
+  const fixture = worktreeUpFixture();
+  const ticket = "WM-935";
+  const branch = `feat/${ticket}`;
+  const remoteClone = mkdtempSync(path.join(tmpdir(), "wm-935-origin-work-"));
+  try {
+    git(fixture.root, "switch", "-qc", branch);
+    writeFileSync(path.join(fixture.root, "local.txt"), "local work\n");
+    git(fixture.root, "add", "local.txt");
+    git(fixture.root, "commit", "-qm", "local work");
+    const localTip = git(fixture.root, "rev-parse", branch);
+    git(fixture.root, "update-ref", `refs/remotes/origin/${branch}`, localTip);
+
+    git(remoteClone, "clone", "-q", fixture.remote, ".");
+    git(remoteClone, "config", "user.name", "Remote test");
+    git(remoteClone, "config", "user.email", "remote-test@example.test");
+    git(remoteClone, "switch", "-qc", branch, "origin/develop");
+    writeFileSync(path.join(remoteClone, "remote.txt"), "remote work\n");
+    git(remoteClone, "add", "remote.txt");
+    git(remoteClone, "commit", "-qm", "remote work");
+    git(remoteClone, "push", "-q", "origin", branch);
+    const remoteTip = git(remoteClone, "rev-parse", branch);
+
+    const result = runWorktreeUp(fixture, ticket);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("worktree_branch_has_commits");
+    expect(result.stderr).toContain(localTip);
+    expect(result.stderr).toContain(remoteTip);
+    expect(git(fixture.remote, "rev-parse", `refs/heads/${branch}`)).toBe(
+      remoteTip,
+    );
+    expect(existsSync(path.join(fixture.worktrees, ticket))).toBe(false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(fixture.worktrees, { recursive: true, force: true });
+    rmSync(fixture.mockBin, { recursive: true, force: true });
+    rmSync(remoteClone, { recursive: true, force: true });
+  }
 });
 
 test("ticket_number extracts numeric ID from valid ticket strings", () => {

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -866,9 +866,7 @@ test("worktree-up pushes a matching local-only ticket branch and resumes it", ()
     expect(result.stdout).toContain(
       `auto-pushed matching ticket branch ${branch} at ${tip}`,
     );
-    expect(git(fixture.remote, "rev-parse", `refs/heads/${branch}`)).toBe(
-      tip,
-    );
+    expect(git(fixture.remote, "rev-parse", `refs/heads/${branch}`)).toBe(tip);
     expect(
       git(path.join(fixture.worktrees, ticket), "branch", "--show-current"),
     ).toBe(branch);

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -168,19 +168,27 @@ else
       [[ "$OPEN_PR_COUNT" == "1" ]] && RESUMING=1
     fi
 
-    # WM-680: a branch whose tip is already on origin is preserved work, not
-    # litter — an orphaned or blocked run's WIP that the orchestrator (or the
-    # worker's own preservation) pushed so nothing is lost. Refusing to build
-    # on it forces a human to run --resume by hand for every re-dispatch, and
-    # an unattended loop just loses the slot. Resume it. A branch with unique
-    # commits that exist ONLY locally still refuses below: that is the case
-    # where nobody has vouched for the work by pushing it.
+    # A matching ticket branch is the only branch this invocation may resume
+    # or publish. It can be local-only when a prior worker committed but died
+    # before pushing. Publish it with Git's normal non-force semantics, then
+    # resume it in this invocation. A remote tip that differs is deliberately
+    # not overwritten: plain `git push` rejects a diverged remote branch.
     if [[ "$RESUMING" -eq 0 && "$UNIQUE_COMMITS" -gt 0 ]]; then
       if [[ "${FACTORY_WORKTREE_RESUME:-0}" == "1" ]]; then
         RESUMING=1
-      elif REMOTE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH") \
-           && [[ "$REMOTE_SHA" == "$BRANCH_SHA" ]]; then
-        RESUMING=1
+      else
+        REMOTE_BRANCH_SHA=$(git -C "$REPO" ls-remote --heads origin "refs/heads/$BRANCH" | awk 'NR == 1 { print $1 }') \
+          || die "worktree_branch_inspection_failed: could not inspect origin branch '$BRANCH'"
+        if [[ "$REMOTE_BRANCH_SHA" == "$BRANCH_SHA" ]]; then
+          RESUMING=1
+        elif git -C "$REPO" push origin "$BRANCH" >/dev/null 2>&1; then
+          info "auto-pushed matching ticket branch $BRANCH at $BRANCH_SHA"
+          RESUMING=1
+        elif [[ -n "$REMOTE_BRANCH_SHA" ]]; then
+          die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF; local tip $BRANCH_SHA differs from origin tip $REMOTE_BRANCH_SHA — refusing to overwrite origin without force"
+        else
+          die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF that are not on origin — auto-push failed; re-run with --resume or push branch '$BRANCH' explicitly before re-dispatch"
+        fi
       fi
     fi
 


### PR DESCRIPTION
Fixes watt-mind/factory#934

UX critique: skipped — backend/infrastructure worktree script change; no user-facing flow.