### PR TITLE
fix(owned-paths): ignore prose before section heading

### DIFF
--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -30,10 +30,15 @@ import path from "node:path";
  * everything" rather than "not dispatchable".
  */
 export function parseOwnedPaths(description = "") {
-  const section = description.split(/^#{2,4}\s+/m).find((s) => {
-    const heading = s.split("\n")[0];
-    return /\bOwned Paths\b/i.test(heading);
-  });
+  // `split` retains the pre-heading prose as index 0. It cannot be a section,
+  // even when it mentions "Owned Paths", so only inspect heading-led chunks.
+  const section = description
+    .split(/^#{2,4}\s+/m)
+    .slice(1)
+    .find((s) => {
+      const heading = s.split("\n")[0];
+      return /\bOwned Paths\b/i.test(heading);
+    });
   if (!section) return [];
 
   // Real tickets write this section three different ways — bullet lists, fenced

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -46,6 +46,27 @@ Something is broken.
   ]);
 });
 
+test("ignores intro prose that mentions Owned Paths before its heading", () => {
+  const desc = `The Owned Paths section below identifies the safe files to change.
+
+## Problem & Context
+
+Something is broken.
+
+## Owned Paths
+
+- \`orchestrator/owned-paths.mjs\`
+- \`orchestrator/owned-paths.test.mjs\`
+
+## Verification Command
+
+    bun test`;
+  expectEqual(parseOwnedPaths(desc), [
+    "orchestrator/owned-paths.mjs",
+    "orchestrator/owned-paths.test.mjs",
+  ]);
+});
+
 test("missing section yields no paths (caller decides what that means)", () => {
   expectEqual(parseOwnedPaths("## Problem\n\nno paths here"), []);
 });


### PR DESCRIPTION
Fixes watt-mind/factory#991

UX critique: skipped — parser-only orchestration change with no user-facing surface.