### PR TITLE
fix(control-plane): factory init must create tier labels

### DIFF
--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -10,6 +10,7 @@ import {
   copyFileSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -1187,6 +1188,28 @@ describe("provisionGithubRepo", () => {
     const names = protocolLabelSpecs().map((s) => s.name);
     for (const t of TYPE_LABELS) expect(names).toContain(`type:${t}`);
     for (const src of SOURCE_LABELS) expect(names).toContain(`source:${src}`);
+  });
+
+  test("every literal label in an agent action-registry argv is provisioned", () => {
+    // Action registries call ticket.mjs directly. A label missing here makes a
+    // fresh GitHub control plane fail only when an unattended action runs.
+    const agentDir = path.resolve(import.meta.dir, "../../event-runtime/agents");
+    const labelArgs = readdirSync(agentDir)
+      .filter((name) => name.endsWith(".json"))
+      .flatMap((name) => {
+        const agent = JSON.parse(readFileSync(path.join(agentDir, name), "utf8"));
+        return Object.values(agent.actionRegistry ?? {}).flatMap(
+          (action) => action.argv ?? [],
+        );
+      })
+      .filter(
+        (arg) =>
+          typeof arg === "string" &&
+          /^(?:ai|agent|priority|source|tier|type):[a-z0-9-]+$/.test(arg),
+      );
+    const provisioned = new Set(protocolLabelSpecs().map((spec) => spec.name));
+
+    for (const label of labelArgs) expect(provisioned).toContain(label);
   });
 
   test("is idempotent: a second run creates nothing", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1193,11 +1193,16 @@ describe("provisionGithubRepo", () => {
   test("every literal label in an agent action-registry argv is provisioned", () => {
     // Action registries call ticket.mjs directly. A label missing here makes a
     // fresh GitHub control plane fail only when an unattended action runs.
-    const agentDir = path.resolve(import.meta.dir, "../../event-runtime/agents");
+    const agentDir = path.resolve(
+      import.meta.dir,
+      "../../event-runtime/agents",
+    );
     const labelArgs = readdirSync(agentDir)
       .filter((name) => name.endsWith(".json"))
       .flatMap((name) => {
-        const agent = JSON.parse(readFileSync(path.join(agentDir, name), "utf8"));
+        const agent = JSON.parse(
+          readFileSync(path.join(agentDir, name), "utf8"),
+        );
         return Object.values(agent.actionRegistry ?? {}).flatMap(
           (action) => action.argv ?? [],
         );


### PR DESCRIPTION
Fixes watt-mind/factory#997

UX critique: skipped — backend control-plane regression test only; no user-facing surface.