### PR TITLE
feat(planner): authorize operator security dispatch

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -992,6 +992,7 @@ export function worktreeDispatchAutoEligibility(
     maxInFlightFallback,
     budgetRefusal = defaultBudgetRefusal,
     claimedRetry = null,
+    operatorAuthorized = false,
     now = Date.now(),
   } = {},
 ) {
@@ -1003,6 +1004,11 @@ export function worktreeDispatchAutoEligibility(
     inFlight: [],
     escalatePathIntersections: [],
   };
+  // This is deliberately an explicit caller-supplied fact rather than a
+  // ticket label: only the planner may derive it from an operator envelope.
+  // Keep it in the proof so bypasses are auditable alongside every other
+  // dispatch admission fact.
+  evidence.checks.operator_authorized = operatorAuthorized === true;
   let repo;
   try {
     repo = getRepo(loadRepos(), payload?.repo);
@@ -1123,7 +1129,10 @@ export function worktreeDispatchAutoEligibility(
   } else {
     evidence.checks.ticket_agent_ready = true;
   }
-  if (evidence.ticket.labels.includes("ai:escalated")) {
+  if (
+    evidence.ticket.labels.includes("ai:escalated") &&
+    !evidence.checks.operator_authorized
+  ) {
     return refusal("ticket_escalated", evidence);
   }
 
@@ -1186,8 +1195,9 @@ export function worktreeDispatchAutoEligibility(
 
   evidence.checks.ticket_not_escalated = true;
   if (
-    evidence.ticket.labels.includes("type:security") ||
-    evidence.ticket.labels.some((label) => /security/i.test(label))
+    (evidence.ticket.labels.includes("type:security") ||
+      evidence.ticket.labels.some((label) => /security/i.test(label))) &&
+    !evidence.checks.operator_authorized
   ) {
     return refusal("ticket_security", evidence);
   }
@@ -1615,7 +1625,10 @@ export function planEvent(
         try {
           worktreeEligibility = worktreeDispatchAutoEligibility(
             preEnvelope.payload,
-            dispatch,
+            {
+              ...dispatch,
+              operatorAuthorized: preEnvelope.source === "operator",
+            },
           );
         } catch (err) {
           if (!isLinearRateLimited(err)) throw err;
@@ -2044,7 +2057,10 @@ export function planEvent(
       ) {
         const result = worktreeEligibility?.ok
           ? worktreeEligibility
-          : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, dispatch);
+          : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
+              ...dispatch,
+              operatorAuthorized: envelope.source === "operator",
+            });
         if (!result?.ok) {
           return humanNeeded(
             db,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -893,6 +893,60 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  test("only operator-sourced dispatches bypass escalated and security gates (GH-999)", () => {
+    withReposRoot(tierRepo, () => {
+      const escalatedDispatch = tierDispatch(["ai:escalated"]);
+      const securityDispatch = tierDispatch(["type:security"]);
+
+      const direct = worktreeDispatchAutoEligibility(
+        { repo: "tiered", ticket: "WM-694" },
+        escalatedDispatch,
+      );
+      expect(direct.refusal.reason).toBe("ticket_escalated");
+      expect(direct.evidence.checks.operator_authorized).toBe(false);
+
+      const authorized = worktreeDispatchAutoEligibility(
+        { repo: "tiered", ticket: "WM-694" },
+        { ...securityDispatch, operatorAuthorized: true },
+      );
+      expect(authorized.ok).toBe(true);
+      expect(authorized.evidence.checks.operator_authorized).toBe(true);
+
+      const operatorDb = openDb(":memory:");
+      const operatorRef = admit(operatorDb, {
+        type: "factory.dispatch.requested",
+        source: "operator",
+        eventId: "operator-security-dispatch",
+        correlationId: "operator-security-dispatch",
+        payload: { repo: "tiered", ticket: "WM-694" },
+      });
+      expect(
+        planEvent(operatorDb, registry, operatorRef, {
+          now: NOW,
+          policyVersion: "git:test",
+          dispatch: securityDispatch,
+        }).decision,
+      ).toBe("run");
+
+      const chainDb = openDb(":memory:");
+      const chainRef = admit(chainDb, {
+        type: "factory.dispatch.requested",
+        source: "chain",
+        eventId: "chain-security-dispatch",
+        correlationId: "chain-security-dispatch",
+        causationId: "run-parent",
+        payload: { repo: "tiered", ticket: "WM-694" },
+      });
+      expect(
+        planEvent(chainDb, registry, chainRef, {
+          now: NOW,
+          policyVersion: "git:test",
+          dispatch: securityDispatch,
+        }),
+      ).toMatchObject({ decision: "noop", reason: "ticket_security" });
+    });
+  });
+
   test("duplicate or unknown ticket tier labels refuse with typed evidence (WM-694)", () => {
     withReposRoot(tierRepo, () => {
       for (const labels of [["tier:light", "tier:standard"], ["tier:turbo"]]) {


### PR DESCRIPTION
Fixes watt-mind/factory#999

UX critique: skipped — planner-only change with no user-facing surface