### PR TITLE
fix(control-plane): stop asking GitHub Linear-shaped questions

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -536,24 +536,70 @@ if (import.meta.main) {
         : "fine for triage (read-only), but specs are written against what's on disk",
     );
 
-    // Does the Linear project actually resolve? A typo here fails at dispatch
-    // time, after a worktree and a database already exist.
+    // Does this repo's tracker actually resolve? A typo here fails at dispatch
+    // time, after a worktree and a database already exist. The query has to be
+    // per-adapter: asking GitHub a Linear question fails as a `gh` error that
+    // reads like broken auth rather than like a misconfigured board.
+    const repoKind = repo.control_plane ?? controlPlaneKind;
+    const trackerLabel =
+      repoKind === "github"
+        ? "GitHub team/project resolves"
+        : repoKind === "memory"
+          ? "memory tracker"
+          : "Linear team/project resolves";
     try {
-      const q = `query($t:String!,$p:String!){ issues(first:1, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}} }){ nodes{ identifier } } }`;
-      const nodes =
-        (await loadControlPlane().raw(q, { t: repo.team, p: repo.project }))
-          ?.issues?.nodes ?? [];
-      check(
-        true,
-        "Linear team/project resolves",
-        `${repo.team} / ${repo.project}${nodes[0] ? ` (e.g. ${nodes[0].identifier})` : " (no open issues)"}`,
-      );
+      if (repoKind === "memory") {
+        check("warn", trackerLabel, "in-process tracker — demo/tests only");
+      } else if (repoKind === "github") {
+        // Repository-scoped, so the same query works whether the board's owner
+        // is a user or an organization — asking `organization(login:)` about a
+        // user login is a hard NOT_FOUND, not an empty result. The board must
+        // be linked to the repo anyway for the adapter to reach it.
+        const [owner, name] = String(repo.github ?? "").split("/");
+        const q = `query($owner:String!,$name:String!){
+          repository(owner:$owner,name:$name){
+            projectsV2(first:20){ nodes{ title number } }
+          }
+        }`;
+        const d = await loadControlPlane({ repoName: repo.name }).raw(q, {
+          owner,
+          name,
+        });
+        const nodes = d?.repository?.projectsV2?.nodes ?? [];
+        const hit = nodes.find((n) => n?.title === repo.project);
+        check(
+          Boolean(hit),
+          trackerLabel,
+          hit
+            ? `${repo.github} / ${repo.project} (project #${hit.number})`
+            : `no Projects v2 board titled ${JSON.stringify(repo.project)} linked to ${repo.github}`,
+          hit
+            ? null
+            : `create and link the board, then re-run: factory init --control-plane github --repo ${repo.github}`,
+        );
+      } else {
+        const q = `query($t:String!,$p:String!){ issues(first:1, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}} }){ nodes{ identifier } } }`;
+        const nodes =
+          (
+            await loadControlPlane({ repoName: repo.name }).raw(q, {
+              t: repo.team,
+              p: repo.project,
+            })
+          )?.issues?.nodes ?? [];
+        check(
+          true,
+          trackerLabel,
+          `${repo.team} / ${repo.project}${nodes[0] ? ` (e.g. ${nodes[0].identifier})` : " (no open issues)"}`,
+        );
+      }
     } catch (e) {
       check(
         false,
-        "Linear team/project resolves",
+        trackerLabel,
         String(e.message).slice(0, 60),
-        "check team key and project name against linear.md §1–2 (CW projects carry a 'Coach Watts - ' prefix)",
+        repoKind === "github"
+          ? `check controlPlane.github in config/policy.yaml and the board's Status field: factory init --control-plane github --repo ${repo.github}`
+          : "check team key and project name against linear.md §1–2 (CW projects carry a 'Coach Watts - ' prefix)",
       );
     }
 

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -14,7 +14,11 @@
 // rather than becoming a typed verb. What matters is that there is one
 // transport with one credential path, which is what the grep invariant in
 // tools/ticket.test.mjs enforces.
-import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import {
+  controlPlaneKindFromPolicy,
+  controlPlaneKindFromRepo,
+  loadControlPlane,
+} from "../lib/control-plane/index.mjs";
 
 export const AI_BLOCKED = "ai:blocked";
 
@@ -137,6 +141,15 @@ export async function blockedLabelIds() {
 
 /** Identifiers of the repo's held tickets that someone has replied to. */
 export async function answeredHeldTickets(repo) {
+  // Linear-only: both queries below need Linear's label history
+  // (`addedLabelIds`) to know when `ai:blocked` was applied, which no other
+  // adapter models. On GitHub the same GraphQL text is a hard `gh` error, and
+  // it surfaced as a crashed `factory queue` rather than as a missing feature.
+  // Reply detection simply stays off there until a GitHub-native signal exists;
+  // the held ticket is still counted and still shown, just never auto-released.
+  const kind =
+    controlPlaneKindFromRepo(repo.name) ?? controlPlaneKindFromPolicy();
+  if (kind !== "linear") return new Set();
   const ids = await blockedLabelIds();
   if (!ids.size) return new Set();
   const held =


### PR DESCRIPTION
Two checks assumed Linear regardless of the repo's `control_plane`, so a GitHub-Issues instance failed in ways that read like broken auth rather than like a misconfigured tracker. Found while connecting a fresh instance following `SETUP.md` + `docs/instances.md` with `controlPlane.kind: github`.

## 1. `factory doctor` — tracker check

`orchestrator/doctor.mjs` sent a Linear `issues(filter: {team, project})` query through whichever adapter was loaded. On GitHub that is a hard `gh` error, reported as:

```
✗ Linear team/project resolves  gh api graphql failed (status 1)
    fix: check team key and project name against linear.md §1–2
```

...on an instance that has no Linear at all, with a fix line pointing at the wrong system. Everything else was green, so the only failing check was one that could not pass by construction.

Now each adapter is asked its own question, and the label follows the kind. The GitHub query is repository-scoped: `organization(login:)` against a user-owned board is a `NOT_FOUND` error rather than an empty result, and the board must be linked to the repo for the adapter to reach it anyway, so scoping to the repo covers both owner types with one query.

```
✓ GitHub team/project resolves  vvb-1/workspace-file-server / Factory (project #3)
```

## 2. `factory queue` — crash on a held ticket

`answeredHeldTickets` needs Linear's `addedLabelIds` label history to know when `ai:blocked` was applied. The module comment already says the neutral contract does not model this, which is why it uses `raw()` — but nothing gated the call on the kind. The first time a GitHub repo had one `ai:blocked` ticket, `factory queue` stopped being a queue view and became a stack trace:

```
ControlPlaneError: gh api graphql failed (status 1)
    at blockedLabelIds (orchestrator/reply-detection.mjs:130:40)
    at answeredHeldTickets (orchestrator/reply-detection.mjs:140:21)
    at fetchQueueSummaries (lib/queue-summary.mjs:181:15)
```

Reply detection now returns empty for non-Linear repos. Held tickets are still counted and still listed under BLOCKED — they are just never auto-released until a GitHub-native signal exists. Degrading one optional feature beats taking down the everyday view.

## Verification

`bun test event-runtime/lib --timeout 20000` and `bun build/emit.mjs --check`, plus `factory doctor` / `factory queue` / `factory next` against a live GitHub-Issues instance (10 issues triaged, 2 promoted to `ai:agent-ready`).