### PR TITLE
fix(worker): claim-time gate honors operatorAuthorized so operator security dispatch executes

### DIFF
--- a/config/policy.yaml.bak-wm1006
+++ b/config/policy.yaml.bak-wm1006
@@ -1,0 +1,266 @@
+# Limits the dispatcher enforces. Changing these changes how much autonomy the
+# factory has, so they live in git and move by PR — not by editing a running box.
+
+# Explicit extension allowlist (WM-470). Empty preserves the built-in registry
+# exactly; packs are never discovered by scanning the filesystem.
+packs: []
+
+chain_auto_approval:
+  # Only internally admitted chain events in this closed set may be approved
+  # unattended. Every other proposal remains watched by default.
+  allowed_event_types:
+    - factory.work.requested
+    - factory.triage.requested
+    - factory.triage-apply.requested
+    - factory.dispatch.requested
+    # Autonomous merge lifecycle. Mutating stages are independently rechecked.
+    - factory.merge.requested
+    - factory.merge-review.requested
+    - factory.merge-fix.requested
+    - factory.merge-plan.requested
+    - factory.merge-apply.requested
+    - factory.merge-landed
+    - factory.merge-verify.requested
+    - factory.merge-escalate.requested
+
+merge:
+  max_fix_rounds: 2
+  # One writer (concurrency.max_concurrent_merges: 1) still serializes
+  # landing onto a base. batch_size is how many already-reviewed MERGE
+  # PRs that writer squashes per verify cycle. Default 4 so a 15-minute
+  # schedule plus verify can land ~16 PRs/hour instead of ~2–4.
+  batch_size: 4
+
+# Forge connector (WM-836): which code host implementation `lib/forge/`
+# loads. Everything that used to shell out to `gh` goes through it now.
+#   github — wraps the `gh` CLI (default when this stanza is absent)
+#   memory — in-process fake for tests and the offline demo; no network
+# Anything else is a configuration error: an unreachable forge must never
+# be silently read as "no open PRs".
+forge:
+  kind: github
+
+# ControlPlane connector (WM-797 / WM-894): which tracker implementation
+# `lib/control-plane/` loads. Everything that used to call Linear GraphQL
+# directly goes through it now.
+#   linear — wraps `gql()` from orchestrator/reaper.mjs (default when this
+#            stanza is absent)
+#   memory — in-process fake for tests and the offline demo; no network
+# Anything else is a configuration error: a tracker the factory cannot reach
+# must never be silently read as "no tickets". GitHub Issues is WM-798.
+controlPlane:
+  kind: linear
+
+dispatch:
+  # Owned Paths collision handling at dispatch (WM-677).
+  #   strict   — any overlap with an in-flight ticket refuses dispatch. Fail-closed
+  #              default when this key is absent.
+  #   advisory — the overlap is recorded on the proposal/run as evidence and
+  #              dispatch proceeds; only an IDENTICAL concrete file claim, or a
+  #              `**` claim on either side, still refuses (owned_paths_conflict_hard).
+  # Operator decision 2026-08-18: textual overlap is what rebase and merge-fix
+  # already resolve — six overlapping PRs rebased clean that day — and refusing
+  # it at dispatch was starving the pool (2 running workers from 9 attempts).
+  # Merging stays serialized (max_concurrent_merges below), which is where real
+  # conflicts are caught.
+  owned_paths_collision: advisory
+  # Owned Paths conformance at handoff (WM-718). After a dispatch agent
+  # returns PR_OPEN the worker diffs merge-base(origin/<base>)..HEAD in the
+  # worktree against the ticket's parsed Owned Paths.
+  #   advisory — files outside the set are listed in the worker-authored
+  #              Handoff verification comment as "Owned Paths deviations" and
+  #              the run completes. Default when this key is absent.
+  #   strict   — any deviation refuses the handoff (handoff_owned_paths_violation):
+  #              the PR is held as draft and the ticket returns to Todo + agent-ready.
+  # Advisory to start: surfacing the deviation is what was missing (#558's
+  # 800-line reflow, #593's four out-of-scope files went unnoticed); refusing
+  # is one key flip once the listing proves accurate.
+  owned_paths_conformance: advisory
+
+concurrency:
+  # Per-repo admission ceiling. Actual execution remains bounded by worker
+  # availability, ticket claims, and Owned Paths collision checks.
+  # This is the FALLBACK; a repo's own max_in_flight in repos.yaml wins.
+  max_in_flight_per_repo: 50
+  # Merging is never parallel. Two PRs landing in one base within seconds
+  # produce a base-CI failure that belongs to neither.
+  max_concurrent_merges: 1
+
+workers:
+  # Worker pool bounds for `cli.mjs supervise` (WM-226). Presence of this block
+  # is what makes `factory up` start the supervisor instead of one fixed worker;
+  # delete it and the stack goes back to a single `cli.mjs work` process.
+  #
+  # These are worker PROCESSES, not concurrent agent runs — and the distinction
+  # is the whole design. An idle worker costs a poll every 500ms; a busy one
+  # costs a worktree and an LLM subprocess. The supervisor spends the cheap
+  # resource (count) to manage the scarce ones, so `max` is the real ceiling on
+  # concurrent agent runs on this machine and should be read that way.
+  min:
+    1 # never zero: something has to notice the next
+    # queued run and grow the pool back
+  max:
+    20 # operator-selected throughput ceiling; the host
+    # has capacity for a wider pool, while subscription
+    # usage remains unobservable until WM-66 provides a
+    # budget-aware ceiling
+
+actions_cache:
+  # GitHub's cache API reports decimal bytes. The initial 73 GB quota is
+  # derived from the 2026-08 Actions alert (65.67 GB shown as 90% used); update
+  # it immediately if GitHub billing displays a different included allowance.
+  organization: watt-mind
+  included_gb: 73
+  # This command exits non-zero at the warning threshold, before billing risk.
+  warning_percent: 60
+
+budget:
+  # AUTH IS THE SUBSCRIPTION (claude.ai OAuth), not the API. run-agent.sh unsets
+  # ANTHROPIC_API_KEY unless --use-api is passed, because with it set every run
+  # bills per token instead of drawing on the subscription — and claude.ai
+  # connectors, including the Linear MCP, get disabled.
+  #
+  # So these numbers are NOT money. Claude still reports costUSD per model (a
+  # trivial one-turn run showed ~$0.14 notional, most of it cache creation), and
+  # --max-budget-usd caps against that figure. Read it as a RUNAWAY GUARD in
+  # notional API-equivalent units: it stops a session that has gone in circles,
+  # it does not protect a wallet.
+  #
+  # The real constraint on a subscription is the usage window, and nothing here
+  # can see it. That is what tickets-per-tick caps are for (schedule.yaml
+  # --args): they bound how much of a window one tick can consume.
+  per_ticket_usd:
+    15.00 # generous — a triage run that explores a codebase
+    # legitimately passes $5 notional
+  merge_usd:
+    40.00 # a merge pass reviews N open PRs, not one ticket —
+    # sized for a backlog, not a single diff. Added
+    # 2026-08-04 after a $15 cap on legalease's opus
+    # merge session ran out mid-review with a 13-PR
+    # backlog still open; run-agent.sh applies this
+    # instead of per_ticket_usd for factory-merge only.
+  per_day_usd:
+    2000.00 # enforced in every gate (lib/spend.mjs): today's
+    # logs are summed per tick; at the cap it drains —
+    # running tickets finish, nothing new starts.
+    # Raised to 1000 on 2026-08-04, then to 2000 same day.
+  on_exhausted: drain
+
+models:
+  # Model-tier routing (WM-135). Agent definitions declare INTENT — an
+  # optional "model_tier": strong | standard | light — and this map, keyed per
+  # adapter, decides what each tier means. The planner resolves tier → model
+  # at plan time and pins the value into the RunSpec, so the proposal an
+  # operator approves names the exact model. The literal value "default" is a
+  # sentinel: pass no --model, ride the CLI's own default (today's behavior).
+  # Any other value is passed verbatim as --model. A tier declared by a
+  # definition with no mapping here fails closed at registry load.
+  claude:
+    strong: default # CLI default — preserves today's dispatch behavior
+    standard: sonnet
+    light: haiku
+  # pi (OPS-296), Codex subscription window: sol/terra/luna are the
+  # provider's own strong/standard/light tier names, passed verbatim as
+  # `--model` (provider/id form; no separate --provider flag needed).
+  pi:
+    strong: openai-codex/gpt-5.6-sol
+    standard: openai-codex/gpt-5.6-terra
+    light: openai-codex/gpt-5.6-luna
+  # agy (WM-424, WM-428), Antigravity/Gemini subscription window.
+  agy:
+    strong: gemini-3.7-flash
+    standard: gemini-3.7-flash
+    light: gemini-3.7-flash
+  # cursor (WM-440), Cursor Agent CLI login/subscription window.
+  # IDs from `agent --list-models` on 2026.08.11.
+  # Grok 4.6 rather than Composer (WM-489). Grok ships eight variants —
+  # low/medium/high/xhigh, each with a -fast twin — so the tiers are effort
+  # levels of one model, not three different models. `-high` is the variant
+  # the CLI displays as plain "Cursor Grok 4.6"; `-xhigh` is available if
+  # strong should reach higher.
+  # WM-585 evidence: merge-scan@2 on cursor (strong tier) timed out at 900s
+  # twice and at 1500s once on 2026.08.17 (run_f8eeb97b, run_7b29aaca,
+  # run_4c42f4ce) with 20-25 open PRs on the non-fast `-high`, and the tiers
+  # were briefly moved to `-high-fast` (same reasoning effort, faster
+  # serving). Decision (operator preference 2026-08-17, WM-603): strong and
+  # standard stay on the non-fast `-high` — the `-fast` twins drain the
+  # Cursor subscription faster; merge-scan timeouts are addressed by scoping
+  # scans per PR (WM-576) rather than by faster serving. light keeps
+  # `-low-fast`.
+  cursor:
+    strong: cursor-grok-4.6-high
+    standard: cursor-grok-4.6-high
+    light: cursor-grok-4.6-low-fast
+
+limits:
+  # Hard wall-clock cap the FACTORY enforces, independent of whatever the
+  # harness does about its own timeouts. A harness timeout produces a clean
+  # error and is set slightly BELOW this; this is the backstop for the case
+  # where the harness itself wedges and never returns.
+  #
+  # Without it, raising a harness timeout to let long work finish also raises
+  # how long a stuck run holds a concurrency slot — that trade is only
+  # acceptable when something else guarantees the slot eventually frees.
+  #
+  # 90 min: raised from 45 (WM-567) after WM-470 run_5aec6675 — a large
+  # architecture ticket — hit the 45-min cap right after pushing its PR and
+  # lost the run. Must not sit below the dispatch agent's own
+  # `limits.timeout_seconds` (event-runtime/agents/dispatch.json, 5400s);
+  # a runtime "extend" for individual runs is WM-566.
+  max_run_minutes: 90
+
+circuit_breaker:
+  # Two consecutive environment/build failures (not ticket-specific ones) stop
+  # dispatch. A broken worktree template otherwise converts the whole queue into
+  # Blocked in minutes. Enforced by tick.mjs (worktree-up failures trip it);
+  # factory-work.md carries the same rule for interactive runs.
+  consecutive_env_failures: 2
+
+escalation:
+  # Never auto-merged, regardless of CI or review outcome. The test is whether
+  # the diff CHANGES security-relevant behavior, not whether a file sits near
+  # security code — read as file-adjacency this list swallows most PRs in an app
+  # where auth is everywhere, which trains everyone to rubber-stamp.
+  never_auto_merge:
+    - auth / authz
+    - payments / money movement
+    - credential and secret handling
+    - destructive DB migrations
+    - production infra config
+    - CLNT security behavior
+  # Base branches an agent may merge into without a human. master/main always
+  # goes through a human, on every repo.
+  auto_merge_base: [develop]
+  auto_merge_owners: [hdkiller, watt-mind]
+
+notify:
+  # Push these. Everything else goes to Linear and the end-of-run report — a
+  # channel that pings on every merge gets muted, and then the blocker
+  # notification is lost with it.
+  # Mechanism: python3 ~/Develop/hdkiller/scripts/notify.py "<EVENT> <TICKET>: <sentence>"
+  # (Telegram push to the human; a Linear comment or report line is NOT notifying.)
+  command: python3 ~/Develop/hdkiller/scripts/notify.py
+  on:
+    - ticket_blocked
+    - pr_escalated
+    - base_ci_red
+    - smoke_red
+    - circuit_breaker_tripped
+    - release_candidate_ready
+
+# Buzz connector (WM-921, quieter interrupt cards WM-974). Enabled 2026-08-20:
+# FACTORY_EXT_BUZZ_AGENT_NSEC and FACTORY_EXT_BUZZ_AUTH_TAG in
+# ~/.factory/secrets.env (chmod 600). #ops-factory is the pager; run-start
+# telemetry is WM-975 (#feed-factory). Telegram stays until a real BLOCKED
+# push is observed end-to-end.
+extensions:
+  - path: extensions/buzz
+    config:
+      channel: "ea70b81e-0b0c-4b48-82da-5f78c167a12b" # #ops-factory
+      postKinds:
+        - ESCALATED
+        - BLOCKED
+        - CI RED
+        - SMOKE RED
+        - CIRCUIT BREAKER
+        - RC READY

--- a/config/repos.yaml.bak-wm1006
+++ b/config/repos.yaml.bak-wm1006
@@ -1,0 +1,455 @@
+# Per-repo facts the loop needs. One entry only, on purpose.
+#
+# Repos need industrialized worktrees before dispatch can be enabled; a repo
+# may still configure its teardown script while remaining `report_only` for
+# dispatch. Entries without `report_only: true` are dispatch targets.
+
+repos:
+  - name: bj29
+    path: ~/Develop/pets/bj29
+    github: watt-mind/bakonszegi-coaching
+    icon: ph-fire
+    color: rose
+
+    # Linear routing (linear.md §1-2)
+    team: CLNT
+    project: BJ29 Coaching
+
+    # Branches
+    base: develop # agents merge here; master is human-only
+    deploy_branch: master
+
+    # Worktrees — MANDATORY here, this repo ships the scripts (W-1..W-12).
+    # Never hand-roll: ports and per-ticket databases come from these.
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/bj29
+
+    # What "verified" means. Agents run this before any PR.
+    verify: cd app && npm run lint && npm run typecheck && npm run format:check
+
+    # What "Done" means beyond a merge (linear.md §7).
+    smoke_workflow: smoke-dev.yml
+    smoke_url: https://bj29-dev.projects.watt-mind.com
+    # Optional public metadata; an origin is queried at /version.json.
+    deployment:
+      url: https://bj29.projects.watt-mind.com
+      branch: master
+
+    # Concurrency. Merges are always serialized regardless; this caps how many
+    # ticket agents run at once, and each one costs a worktree on disk.
+    #
+    # NOTE: this is a cap on the REPO, not on a supervisor. Two supervisors on
+    # different harnesses share it — a second one adds capacity only if there
+    # are free slots for it to claim, which is why this went up with agy.
+    max_in_flight: 20
+
+    # Surfaces where a diff is never auto-merged, on top of the global
+    # escalation list in policy.yaml. This is a CLNT revenue-share client
+    # product with live payments.
+    # Listed by BEHAVIOUR, not by neighbourhood. The old list was three
+    # directory globs, and it caught 6 of 6 open PRs — including a test file
+    # and a page component that change no payment behaviour at all. A list that
+    # escalates everything teaches you to wave things through, which is worse
+    # than a narrower list applied honestly. The judgment rule in policy.yaml
+    # still covers anything here that turns out to move money or grant access.
+    escalate_paths:
+      # Money actually moving, or entitlement being granted.
+      - app/src/payment/webhook.ts
+      - app/src/payment/stripe/webhook.ts
+      - app/src/payment/lemonSqueezy/webhook.ts
+      - app/src/payment/polar/webhook.ts
+      - app/src/payment/paymentProcessor.ts
+      - app/src/payment/stripe/paymentProcessor.ts
+      - app/src/payment/lemonSqueezy/paymentProcessor.ts
+      - app/src/payment/polar/paymentProcessor.ts
+      - app/src/payment/stripe/checkoutUtils.ts
+      - app/src/payment/lemonSqueezy/checkoutUtils.ts
+      - app/src/payment/polar/checkoutUtils.ts
+      - app/src/payment/operations.ts
+      - app/src/payment/mentorPayment.ts
+      - app/src/payment/user.ts
+      - app/src/payment/access.ts
+      # Prices and plan mapping — a wrong number here is a wrong charge.
+      - app/src/payment/plans.ts
+      - app/src/payment/paymentProcessorPlans.ts
+      # Provider clients: secret-key handling.
+      - app/src/payment/stripe/stripeClient.ts
+      - app/src/payment/polar/polarClient.ts
+      # Who you become at signup, and account recovery.
+      - app/src/auth/hooks.ts
+      - app/src/auth/userSignupFields.ts
+      - app/src/auth/email-and-pass/**
+      # Schema changes stay fully covered.
+      - app/migrations/**
+
+  # --------------------------------------------------------------------------
+  # REPORT-ONLY entries. These repos have worktrees accumulating but do NOT yet
+  # satisfy PC-15, so they deliberately carry no worktree_up/worktree_down:
+  #
+  #   - the janitor can SEE their orphans and tell you the count
+  #   - it CANNOT remove them (no down script means no safe teardown — dropping
+  #     a checkout by hand also orphans its database, which is how you end up
+  #     with a Postgres full of nameless dev databases)
+  #   - dispatch must never target them; concurrent agents there share ports and
+  #     databases
+  #
+  # A report-only repo may configure `worktree_down` for safe janitor cleanup.
+  # The janitor calls that repo-owned script; it never removes a worktree by
+  # hand. coach-wattz's scripts landed in CW-363. legalease (CLNT-609) and
+  # cashsaas (CLNT-791) have graduated to full lifecycle configuration.
+  # --------------------------------------------------------------------------
+
+  # --------------------------------------------------------------------------
+  # About `escalate_paths: []` below (WM-47).
+  #
+  # Since WM-15 a MISSING escalate_paths key is exit 3 from escalate.mjs — the
+  # gate could not be evaluated, so the PR is escalated. An explicit empty list
+  # is the opt-out and a real exit 0: "checked, this repo has nothing to match
+  # mechanically". It is not a weaker gate than a populated list — the judgment
+  # rule in policy.yaml (auth, payments, secrets, destructive migrations) applies
+  # to every repo regardless, and path matching cannot see whether a diff CHANGES
+  # security-relevant behaviour anyway.
+  #
+  # Empty here means nobody has written a behaviour-based list yet, not that one
+  # would be wrong. Inventing plausible auth/** and migrations/** globs for a
+  # repo nobody has read is how you get a list that escalates everything and
+  # teaches reviewers to wave things through. Per-repo lists are their own
+  # tickets, on the model of WM-10 for legalease.
+  # --------------------------------------------------------------------------
+
+  - name: wm-home
+    path: ~/Develop/pets/wm/wm-home
+    github: watt-mind/wm-home
+    icon: ph-globe
+    color: sky
+    team: WM
+    project: Corporate Marketing
+    base: develop
+    deploy_branch: master
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/wm-home
+    max_in_flight: 10
+    verify: npm run typecheck && npm run lint && npm run format:check
+    smoke_workflow: smoke-prod.yml
+    smoke_url: https://watt-mind.com
+    escalate_paths:
+      - schema.prisma
+      - migrations/**
+      - src/auth/**
+      - src/admin/**
+      - main.wasp
+      - Dockerfile
+      - Dockerfile.web
+      - docker-compose.yml
+      - nginx.conf
+      - .github/workflows/**
+
+  - name: coach-wattz
+    path: ~/Develop/coach-wattz
+    github: watt-mind/coach
+    icon: ph-pulse
+    color: indigo
+    team: CW
+    project: Coach Watts - Web & AI Core Platform
+    base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/coach-wattz
+    report_only: true # Dispatch remains disabled; janitor may use the teardown script.
+    escalate_paths:
+      - server/api/stripe/**
+      - server/api/subscriptions/**
+      - server/api/auth/**
+      - server/api/oauth/**
+      - server/middleware/auth.ts
+      - server/middleware/session-impersonation.ts
+      - prisma/schema.prisma
+      - prisma/migrations/**
+      - docker-compose.yml
+      - Dockerfile
+      - .github/workflows/**
+
+  - name: watts-mobile
+    path: ~/Develop/watts-mobile
+    github: watt-mind/watts-mobile
+    icon: ph-device-mobile
+    color: violet
+    team: CW
+    project: Mobile App
+    base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_root: ~/Develop/.worktrees/watts-mobile
+    report_only: true # Command distribution / janitor cleanup enabled; dispatch pending.
+    verify: pnpm typecheck && pnpm lint && pnpm test
+    escalate_paths:
+      - src/features/subscriptions/**
+      - src/auth/**
+      - credentials/**
+      - eas.json
+      - .env.example
+      - .github/workflows/**
+
+  - name: legalease
+    path: ~/Develop/legalease
+    github: watt-mind/legalease
+    icon: ph-scales
+    color: emerald
+    team: CLNT
+    project: Legalease
+    base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_root: ~/Develop/.worktrees/legalease
+    verify: cd legalease && ../.venv/bin/python manage.py check && ../.venv/bin/python manage.py test main.tests
+
+    # Pip-based (not uv-native) — pins the interpreter `factory security`'s
+    # pip-audit step resolves against (OPS-178); without it uvx's own default
+    # Python can mismatch this repo's pin and break resolution entirely.
+    security:
+      python_version: "3.12"
+
+    # Raised with bj29 for the second (agy) supervisor; see the note there —
+    # the cap is per repo, not per supervisor.
+    max_in_flight: 20
+
+    deployment:
+      url: https://legal-dev.projects.watt-mind.com/healthz
+      branch: develop
+      revision_field: revision
+
+    # Surfaces where a diff is never auto-merged, on top of the global list in
+    # policy.yaml. Without these, escalate.mjs has nothing to check and the
+    # whole mechanical half of the gate is missing — in a CLNT repo that
+    # generates legal documents and holds client personal data.
+    # Same behaviour test as bj29. document_generation/** came off the list:
+    # a wrong clause in a generated contract is a serious product bug, but it
+    # is not a security decision, and this list is what "never auto-merge"
+    # means. mcp/** narrowed to the OAuth boundary itself — the tool
+    # implementations under mcp/tools/ are ordinary CRUD behind that boundary.
+    escalate_paths:
+      - legalease/legalease/urls.py
+      - legalease/main/decorators.py
+      - legalease/main/migrations/**
+      - legalease/legalease/settings*.py
+      - legalease/main/services/access_control.py
+      # The MCP OAuth boundary — token validation and scope expansion (OPS-50).
+      # PR #87 changed exactly this and escalate.mjs exited 0 on it; the
+      # escalation held only because a reviewer made the judgment call.
+      - legalease/main/mcp/auth.py
+      - legalease/main/mcp/scopes.py
+      - legalease/main/mcp/security.py
+      # Third-party OAuth credentials at rest.
+      - legalease/main/services/google_drive_tokens.py
+
+  - name: cashsaas
+    path: ~/Develop/cashsaas
+    github: hdkiller/cashsaas
+    icon: ph-trend-up
+    color: amber
+    team: CLNT
+    project: CashMap
+    base: develop
+
+    # Worktrees — satisfies PC-15 (CLNT-791): bin/worktree-up.sh/down.sh/warm.sh,
+    # deterministic per-ticket ports + database, seeded warm template.
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/cashsaas
+
+    # Cap concurrent ticket agents for this repo. One agent receives one
+    # isolated worktree, so this also permits up to eight active worktrees.
+    max_in_flight: 20
+
+    deployment:
+      url: https://cashsaas.projects.watt-mind.com
+      branch: master
+
+    # What "verified" means. Agents run this before any PR.
+    verify: npm run typecheck && npm run lint && npm run format:check
+
+    # Surfaces where a path match alone requires human review. This is narrow on
+    # purpose: ordinary BI UI, analytics, and documentation work stays eligible
+    # for the normal merge policy judgment.
+    escalate_paths:
+      # Schema changes can be destructive; retain migration history as protected.
+      - schema.prisma
+      - migrations/**
+      # Production image, compose deployment, and CI/CD workflow changes.
+      - Dockerfile
+      - docker-compose.yml
+      - .github/workflows/**
+      # Credential configuration and the authentication/authorization boundary.
+      - .env.example
+      - src/auth/**
+      - src/server/serverMiddleware.ts
+
+  # Command distribution only. Its worktree scripts exist, but this entry has
+  # not yet authorized factory dispatch; retain the report-only guard (OPS-115).
+  - name: proxies
+    path: ~/Develop/pets/proxies
+    github: watt-mind/proxies
+    icon: ph-plugs-connected
+    color: teal
+    report_only: true
+
+    # Linear routing (AGENTS.md + linear.md §1)
+    team: LAB
+    project: Proxies
+
+    base: develop
+    deploy_branch: master
+
+    # Worktrees — PC-15 (bin/worktree-up.sh/down.sh/warm.sh, per-ticket DB/ports).
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/proxies
+
+    # Matches CI (pytest job in .github/workflows/ci.yml).
+    verify: uv run pytest -q -m "not integration"
+
+    max_in_flight: 10
+
+    deployment:
+      url: https://proxies.projects.watt-mind.com
+      branch: master
+
+    escalate_paths:
+      - grocery_platform/settings*.py
+      - "**/migrations/**"
+      - .github/workflows/**
+
+  # Infra docs source of truth. report_only: docs repo, no worktree tooling.
+  # The security block tunes `factory security` (OPS-165): this PRIVATE repo
+  # intentionally stores operational credentials in docs/ (allowlisted in its
+  # in-repo .gitleaks.toml — CI and the pre-commit hook need that file, so it
+  # stays in-repo), and its scripts/ call fixed API endpoints via urllib,
+  # which the dynamic-urllib audit rule false-positives on.
+  - name: hdkiller
+    path: ~/Develop/hdkiller
+    github: hdkiller/hdkiller
+    icon: ph-hard-drives
+    color: slate
+    team: OPS
+    base: master
+    report_only: true
+    security:
+      semgrep_args: "--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"
+
+    # Docs and scripts, no deployable application. Credentials living in docs/
+    # are handled by gitleaks and the global secrets rule, not by path matching
+    # (WM-47).
+    escalate_paths: []
+
+  # Shared ESLint presets (@watt-mind/eslint-config) — tier 2 of the
+  # code-security baseline (OPS-164). Stub until the package lands; report_only
+  # because a single-package repo needs no worktree isolation, and verify
+  # arrives with the package's own test setup.
+  - name: eslint-config
+    path: ~/Develop/watt-mind/eslint-config
+    github: watt-mind/eslint-config
+    icon: ph-checks
+    color: fuchsia
+    team: OPS
+    base: main
+    report_only: true # stub (OPS-164) — no package, no worktree tooling yet
+
+    # A lint-preset package has no runtime surface to protect (WM-47).
+    escalate_paths: []
+
+  # The factory itself — self-dispatch authorized by OPS-463. The old
+  # report_only rationale ("no worktree tooling") is obsolete: bin/worktree-up.sh
+  # and bin/worktree-down.sh give each dispatched ticket an isolated checkout,
+  # ports, runtime home, and demo runtime — never the live control plane's home.
+  # A dispatched change only takes effect after PR → CI → merge → the operator
+  # pulls and restarts; the deploy branch (main) stays human.
+  # NOTE (OPS-463 AC deviation): no worktree_warm here on purpose — the AC named
+  # bin/worktree-warm.sh, but that script does not exist in this repo and the
+  # field is optional. Do not add it until the script does.
+  # run-agent.sh still targets this checkout for the retro stage (cwd here makes
+  # friction.mjs/economics.mjs and docs/friction-log.md resolve naturally).
+  - name: factory
+    path: ~/Develop/factory
+    github: watt-mind/factory
+    icon: ph-robot
+    color: orange
+
+    # Linear routing (linear.md §1-2) — factory tickets moved to WM / Factory
+    # on 2026-08-05; the earlier team: OPS routing was stale.
+    team: WM
+    project: Factory
+
+    base: develop
+    deploy_branch: main # release target is main, not the master fallback
+
+    # Worktrees — MANDATORY here, this repo ships the scripts.
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_root: ~/Develop/.worktrees/factory
+
+    # Cap on concurrent ticket agents; per repo, not per supervisor, like bj29.
+    max_in_flight: 20
+
+    # Fast, deterministic local gate — deliberately a strict SUBSET of CI
+    # (WM-528). GitHub CI (.github/workflows/ci.yml, `bun test
+    # --max-concurrency=4` over the whole tree) remains the full-suite merge
+    # gate; merge already requires CI green, so re-running the full ~2050-test
+    # suite (~200-250s) inside every dispatched worktree only duplicated it and
+    # generated load-induced flakes: on 2026-08-17 four of six dispatches
+    # (WM-259, WM-350, WM-338, WM-512) failed `repo_verify_failed` on commits
+    # that were green in CI, because up to ~8 sibling worktrees run their own
+    # serve/worker/web daemons and suites at once. `event-runtime/lib` is the
+    # unit-only slice: it binds `port: 0` and shells out to git only — no
+    # daemons, no demo seed (those live in event-runtime/*.test.mjs, cli/,
+    # demo/, web/, bin/, orchestrator/ and stay CI-only). Measured 70-72s wall
+    # on the loaded host, 0 failures over repeated runs. `emit.mjs --check` is
+    # the contract check that must never be skipped locally.
+    #
+    # `--timeout 20000` (WM-651): bun's default 5 s per-test timeout kept
+    # failing VERIFYING on the loaded host for spawn/timing tests that pass in
+    # CI — 2026-08-17: WM-616/625/549/618/627 on the OPS-404 reaper-tick test
+    # (fixed WM-629), WM-563 on 'execute conformance (OPS-427) > abort kills a
+    # real long-lived grandchild (WM-263)' at 5000 ms, WM-551/538 on
+    # api-schedules. CI already runs with a higher timeout (WM-600). Tests that
+    # are genuine liveness bounds keep their explicit shorter timeouts; this
+    # only raises the default for tests that don't set one.
+    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
+
+    # Owned Paths closure rules for this repo's control-plane ticket types.
+    owned_paths_policy:
+      # Emitting source means owning its generated outputs.
+      direct:
+        - source: shared/**
+          requires:
+            - dist/**
+            - plugins/core/**
+      # JSON pin manifests are source-of-truth for generated contract files:
+      # owning any path referenced by a manifest requires owning the manifest
+      # file itself before dispatch.
+      pin_manifests:
+        - event-runtime/agents/*.json
+
+    # Git-owned fallback for autonomous develop merges. GitHub branch-protection
+    # required contexts remain preferred when present; this exact workflow/job
+    # set is used only because Factory intentionally has no required contexts.
+    merge_ci:
+      # WM-689 addressed the shared-host spawn flake: every runtime-spawning
+      # suite is now routed through the host flock, CI rejects spawn suites
+      # outside those routes, and liveness ceilings scale with measured load.
+      # Keep rerun classification for genuinely non-reproducible failures only.
+      workflow: CI
+      required_checks:
+        - Shadow runner fleet available
+        - Verify
+
+    # The control plane holds no client data and serves no traffic. Its risky
+    # surfaces (policy.yaml, the merge stage) are what a human reviews on every
+    # factory PR anyway, so a path list adds nothing here (WM-47).
+    escalate_paths: []

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -540,11 +540,17 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
       fetchTicket: () => readyTicket({ labels: { nodes: labels } }),
     });
 
-    admitEvent(
-      db,
-      registry,
-      dispatchEnvelope({ repo: "wt29", ticket: "WM-503" }, "d-stale-security"),
-    );
+    // A chain-sourced (unattended) dispatch: the claim-time recheck must still
+    // refuse a ticket that BECOMES security after approval. Operator-sourced
+    // dispatch legitimately bypasses this (see the operatorAuthorized case in
+    // worker.test.mjs / planner.test.mjs); an unattended run may not.
+    admitEvent(db, registry, {
+      ...dispatchEnvelope(
+        { repo: "wt29", ticket: "WM-503" },
+        "d-stale-security",
+      ),
+      source: "chain",
+    });
     planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: world });
     const proposal = openProposals(db, {}).find(
       (p) => p.spec?.agent === "dispatch@1",
@@ -580,6 +586,64 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     });
     expect(adapterCalls).toBe(0);
     expect(calls()).not.toContain("up WM-503");
+  });
+
+  test("operator-sourced dispatch proceeds past the claim-time security recheck (operatorAuthorized)", async () => {
+    const db = openDb(":memory:");
+    const workspaces = tmpDir("evrt-dispatch-ws-");
+    fixtures.push(workspaces);
+    // Security present from the start; an operator explicitly dispatching it IS
+    // the review the gate demands, so the claim-time recheck must NOT refuse it.
+    let adapterReached = false;
+    const world = openWorld({
+      fetchTicket: () =>
+        readyTicket({
+          labels: {
+            nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
+          },
+        }),
+    });
+
+    admitEvent(
+      db,
+      registry,
+      dispatchEnvelope(
+        { repo: "wt29", ticket: "WM-504" },
+        "d-operator-security",
+      ),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: world });
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "dispatch@1",
+    );
+    approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
+
+    const summary = await runOnce(
+      db,
+      registry,
+      {
+        pi: {
+          async execute() {
+            adapterReached = true;
+            throw new Error("stop after gate");
+          },
+        },
+      },
+      {
+        workspacesRoot: workspaces,
+        owner: "w-test",
+        policyVersion: PV,
+        dispatch: world,
+      },
+    );
+
+    // The claim-time security gate did not refuse: execution advanced to the
+    // worktree/adapter stage (where our stub fails on purpose).
+    expect(summary.reasonCode).not.toBe("ticket_security");
+    expect(adapterReached || calls().includes("up WM-504")).toBe(true);
   });
 
   test("a failing run without retain still tears the worktree down (down-on-failure)", async () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -914,7 +914,7 @@ function originatingEvent(db, runId) {
   return (
     db
       .query(
-        `SELECT e.type, e.correlation_id, e.causation_id
+        `SELECT e.type, e.correlation_id, e.causation_id, p.event_source AS source
        FROM proposals p
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE p.run_id = ?
@@ -2362,6 +2362,10 @@ export async function executeClaimed(
           gateResult = worktreeDispatchAutoEligibility(spec.input, {
             ...(dispatchOpts ?? {}),
             claimedRetry: claimedRetryFor(db, runId, attempt),
+            // Match the planner's operator-only bypass from the immutable
+            // proposal that admitted this run. Never trust caller options here:
+            // chain and schedule runs must keep the security/escalation gate.
+            operatorAuthorized: originatingEvent(db, runId)?.source === "operator",
           });
         }
       } catch (err) {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2365,7 +2365,8 @@ export async function executeClaimed(
             // Match the planner's operator-only bypass from the immutable
             // proposal that admitted this run. Never trust caller options here:
             // chain and schedule runs must keep the security/escalation gate.
-            operatorAuthorized: originatingEvent(db, runId)?.source === "operator",
+            operatorAuthorized:
+              originatingEvent(db, runId)?.source === "operator",
           });
         }
       } catch (err) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -151,14 +151,18 @@ function queueRun(db, spec, now = T0) {
 function linkEvent(
   db,
   runId,
-  { type = "factory.status-report.requested", correlationId = "corr-1" } = {},
+  {
+    type = "factory.status-report.requested",
+    correlationId = "corr-1",
+    source = "test",
+  } = {},
 ) {
   const at = new Date(T0).toISOString();
   db.query(
     `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at, correlation_id, causation_id, envelope_json, payload_hash, admitted_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    "test",
+    source,
     `evt-${runId}`,
     type,
     "factory",
@@ -173,7 +177,7 @@ function linkEvent(
   db.query(
     `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
      VALUES (?, ?, ?, ?, 'RUN_SPEC', ?, 1800)`,
-  ).run(`prop-${runId}`, "test", `evt-${runId}`, runId, at);
+  ).run(`prop-${runId}`, source, `evt-${runId}`, runId, at);
 }
 
 function freshRoot() {
@@ -3522,6 +3526,55 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       expect(["ticket_assigned", "ticket_not_todo"]).not.toContain(
         summary.reasonCode,
       );
+    }
+  });
+
+  test("claim-time dispatch gate honors only operator-sourced security runs (GH-1004)", async () => {
+    for (const [source, expectedTerminalState, expectedReasonCode] of [
+      ["operator", "COMPLETED", "ok"],
+      ["chain", "REFUSED", "ticket_security"],
+    ]) {
+      const db = openDb(":memory:");
+      const ticket = source === "operator" ? "WM-701" : "WM-702";
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({
+          runId: `run_security_${source}`,
+          input: { repo: "wt-worker", ticket },
+        }),
+      );
+      linkEvent(db, spec.runId, {
+        type: "factory.dispatch.requested",
+        source,
+      });
+
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: tmpDir(`evrt-security-${source}-locks-`),
+            fetchTicket: () =>
+              readyDispatchTicket(ticket, {
+                labels: {
+                  nodes: [
+                    { name: "ai:agent-ready" },
+                    { name: "type:security" },
+                  ],
+                },
+              }),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+          },
+        }),
+      );
+
+      expect(summary).toMatchObject({
+        terminalState: expectedTerminalState,
+        reasonCode: expectedReasonCode,
+      });
     }
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1004. Completes #999/#1003: the worker's claim-time `worktreeDispatchAutoEligibility` call now passes `operatorAuthorized` (from the run's operator source), so operator-dispatched security/escalated tickets execute instead of being refused `ticket_escalated` at claim time. Chain/schedule runs still refuse. Agent work committed as ed6fe70a.

## Verification
`bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs`