### PR TITLE
fix(notify): resolve the transport from policy, not a hardcoded path (WM-879)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -240,15 +240,20 @@ case "$cmd" in
     fi
 
     # Unreachable runtime (or an unstructured legacy message): preserve the
-    # old argv/stdin transport exactly. WM-795 gave `factory notify`'s callers
-    # (runners/run-agent.sh) a policy-configurable command via lib/notify.mjs,
-    # but this direct fallback still hardcodes the operator's private
-    # notify.py path; WM-879 owns dropping it in favour of the same
-    # config/policy.yaml resolution.
+    # old argv/stdin transport, but resolve the command the same way every
+    # other caller does (lib/notify.mjs — WM-795), rather than hardcoding the
+    # operator's private notify.py path. A clone that has configured no
+    # transport is silent on this channel instead of crashing on a path that
+    # only exists on one machine; the durable record above is unaffected.
+    _notify_argv="$(FACTORY_ROOT="$ROOT" bun "$ROOT/lib/notify.mjs" 2>/dev/null || true)"
+    if [[ -z "$_notify_argv" ]]; then
+      echo "notify: no transport configured — set notify.command in config/policy.yaml or FACTORY_NOTIFY_CMD" >&2
+      exit 0
+    fi
     if [[ "$_notify_stdin" -eq 1 ]]; then
-      printf '%s' "$_notify_message" | exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" -
+      printf '%s' "$_notify_message" | exec $_notify_argv -
     else
-      exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" "$@"
+      exec $_notify_argv "$@"
     fi
     ;;
   security)

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -10,10 +10,11 @@
  * human, or it gets muted.
  *
  * WM-795 gave the rest of the factory (`lib/notify.mjs`, `factory notify`) a
- * policy-configurable transport with no in-tree default; this module's
- * `DEFAULT_NOTIFY_CMD` still hardcodes the operator's private `notify.py`
- * path pending WM-879, which owns dropping that default here (and in
- * `bin/factory`) in favour of the same `config/policy.yaml` resolution.
+ * policy-configurable transport with no in-tree default, and this module now
+ * resolves through the same path (WM-879). `DEFAULT_NOTIFY_CMD` is whatever
+ * `config/policy.yaml` `notify.command` says, or null in a clone that has
+ * configured nothing — silence on an unconfigured channel, never a spawn of a
+ * path that exists on one operator's machine only.
  *
  * Design (ticket WM-65):
  *   - Off by default; FACTORY_EVENT_NOTIFY=1 enables, FACTORY_EVENT_NOTIFY_CMD
@@ -27,14 +28,13 @@
  *     or hang is recorded on the notify_log row and logged, never thrown.
  */
 import { spawn } from "node:child_process";
-import { homedir } from "node:os";
-import path from "node:path";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
 import { txImmediate } from "./db.mjs";
 import { templateFor } from "./decision-templates.mjs";
 import { proposalSubject } from "./proposal-subject.mjs";
+import { notifyCommand as resolveNotifyCommand } from "../../lib/notify.mjs";
 
-export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hdkiller", "scripts", "notify.py")}`;
+export const DEFAULT_NOTIFY_CMD = resolveNotifyCommand() ?? null;
 
 /** A notifier that has not exited by then is killed and recorded as failed. */
 export const NOTIFY_TIMEOUT_MS = 30_000;
@@ -315,6 +315,14 @@ export function notifyPending(
     };
     log(`inbox ${n.kind} ${n.target}: ${n.title}`);
     if (!enabled) continue;
+    if (!command) {
+      // Enabled but unconfigured. The inbox row above is the durable record,
+      // so the human can still see this in the UI; only the push leg is off.
+      log(
+        `notify ${n.kind} ${n.target}: no transport configured — set notify.command in config/policy.yaml`,
+      );
+      continue;
+    }
     sent.push(notification);
     log(`notify ${n.kind} ${n.target}: ${pushMessage}`);
     deliveries.push(

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -102,14 +102,18 @@ function insertProposal(
 }
 
 describe("notify (WM-65)", () => {
-  test("config: off by default, FACTORY_EVENT_NOTIFY=1 enables, CMD overrides the notify.py default", () => {
+  test("config: off by default, FACTORY_EVENT_NOTIFY=1 enables, CMD overrides the resolved default", () => {
     expect(notifyEnabled({})).toBe(false);
     expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "0" })).toBe(false);
     expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "1" })).toBe(true);
     expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "true" })).toBe(true);
     expect(notifyCommand({})).toBe(DEFAULT_NOTIFY_CMD);
-    expect(DEFAULT_NOTIFY_CMD).toContain("python3 ");
-    expect(DEFAULT_NOTIFY_CMD).toContain("scripts/notify.py");
+    // WM-879: no in-tree default. Whatever config/policy.yaml resolves to, or
+    // null in a clone that configured nothing — never a hardcoded private path.
+    expect(
+      DEFAULT_NOTIFY_CMD === null || typeof DEFAULT_NOTIFY_CMD === "string",
+    ).toBe(true);
+    expect(String(DEFAULT_NOTIFY_CMD)).not.toContain("hdkiller");
     expect(notifyCommand({ FACTORY_EVENT_NOTIFY_CMD: "/x/stub" })).toBe(
       "/x/stub",
     );
@@ -242,6 +246,7 @@ describe("notify (WM-65)", () => {
       notifyPending(db, {
         now: at,
         enabled: true,
+        command: "/x/stub",
         send: () => Promise.resolve({ ok: true, exitCode: 0, error: null }),
       }).sent;
 


### PR DESCRIPTION
Closes the WM-879 debt that both `bin/factory` and `event-runtime/lib/notify.mjs` name in their own comments.

## What happened

Fresh instance, GitHub-Issues control plane, `factory-merge` running unattended. It reviewed two PRs, merged one, and correctly escalated the other — then this, from inside the escalation path:

```
python3: can't open file '/home/krily/Develop/hdkiller/scripts/notify.py': [Errno 2] No such file or directory
```

Nothing was lost (the escalation is traceable through the PR labels and the ticket comment), but the channel whose entire job is "tell a human this needs you" is the one that failed, at the one moment it mattered. On any machine that is not the original operator's, that fallback leg cannot succeed.

## Change

Two hardcoded paths, one resolution:

- `bin/factory notify` — the direct fallback used when the event runtime is unreachable, or the message is unstructured, now resolves via `lib/notify.mjs` like every other caller (the path WM-795 established). Unconfigured is silent-and-said-so at exit 0, not a crash.
- `event-runtime/lib/notify.mjs` — `DEFAULT_NOTIFY_CMD` is the resolved command or `null`. `notifyPending` skips only the push leg when enabled-but-unconfigured, and logs it once per referent. The durable inbox row is written before that branch, so the human can still see the item in the UI.

The test that asserted the private path now asserts the absence of one, which is the actual invariant.

## Verification

- `bun test event-runtime/lib --timeout 20000` — 1562 pass, 0 fail
- `bun build/emit.mjs --check` — clean
- `factory notify "msg"` and `... | factory notify -` against a stub transport: both deliver, argv and stdin shapes unchanged
- unconfigured: one line on stderr, exit 0