### PR TITLE
fix(claude): do not enable an OS sandbox the host cannot start

### DIFF
--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -23,7 +23,7 @@
  * `SANDBOX_DEFERRAL_REASON` below is the whole rationale, and it names what
  * the pi path did not have to solve.
  */
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   createWriteStream,
   mkdirSync,
@@ -150,8 +150,58 @@ export function deriveAllowedTools(def) {
   return [...READ_ONLY_TOOLS];
 }
 
+/**
+ * Can Claude Code's own OS sandbox actually start on this host?
+ *
+ * It is seatbelt on macOS and a nested user namespace on Linux. Hosts that
+ * forbid unprivileged nesting (hardened kernels, some containers, LXC/LXD)
+ * fail *before* the policy matters: every Bash call, `echo hello` included,
+ * dies with `apply-seccomp: write /proc/self/setgroups: permission denied`.
+ * Combined with `allowUnsandboxedCommands: false` that makes a read-only
+ * agent unable to run any command at all, and the honest thing it can then
+ * do is refuse — which is exactly what a work-scan did here, at a cost of
+ * ~$0.70 and a human in the loop, on a host where the harness works fine
+ * outside the sandbox.
+ *
+ * So probe once per process, cheaply, with the same primitive Claude uses.
+ * FACTORY_CLAUDE_OS_SANDBOX=0/1 forces the answer for an operator who knows
+ * better than the probe.
+ *
+ * The write boundary does not depend on this: `permissions.deny` still
+ * refuses Edit under the checkout, and the worker's post-run repository
+ * integrity gate is what actually proves a read-only run changed nothing.
+ * The OS sandbox is defence in depth on top of those, so losing it degrades
+ * isolation rather than correctness — and it is visible in the run log.
+ */
+let _osSandboxUsable = null;
+export function osSandboxUsable(env = {}) {
+  // The run env wins, then the worker's own — a spawn env is a narrow
+  // allowlist, so the operator's export must still reach this decision.
+  const forced =
+    env?.FACTORY_CLAUDE_OS_SANDBOX ?? process.env.FACTORY_CLAUDE_OS_SANDBOX;
+  if (forced === "0" || forced === "false") return false;
+  if (forced === "1" || forced === "true") return true;
+  if (_osSandboxUsable !== null) return _osSandboxUsable;
+  if (process.platform !== "linux") {
+    _osSandboxUsable = true;
+    return _osSandboxUsable;
+  }
+  // Mirror what the sandbox actually does, not merely "can I unshare a user
+  // namespace". Plain `unshare -Ur` succeeds on this host; the step that
+  // fails is denying setgroups inside the new namespace, which is exactly
+  // the `write /proc/self/setgroups` in the observed error. Probing the
+  // weaker capability reports a sandbox that then dies on first use.
+  const probe = spawnSync(
+    "unshare",
+    ["--map-root-user", "--setgroups", "deny", "true"],
+    { stdio: "ignore" },
+  );
+  _osSandboxUsable = probe.status === 0;
+  return _osSandboxUsable;
+}
+
 /** Generate a per-run settings file; absolute paths cannot drift with cwd. */
-export function buildClaudeSettings({ spec, def, workspaceDir }) {
+export function buildClaudeSettings({ spec, def, workspaceDir, env }) {
   if (def?.mutating !== false) return null;
   const checkoutDir =
     spec?.workspace?.type === "repository"
@@ -166,12 +216,17 @@ export function buildClaudeSettings({ spec, def, workspaceDir }) {
         ? [`Edit(//${checkoutDir.replace(/^\/+/, "")}/**)`]
         : [],
     },
-    sandbox: {
-      enabled: true,
-      autoAllowBashIfSandboxed: true,
-      allowUnsandboxedCommands: false,
-      filesystem: checkoutDir ? { denyWrite: [checkoutDir] } : {},
-    },
+    sandbox: osSandboxUsable(env)
+      ? {
+          enabled: true,
+          autoAllowBashIfSandboxed: true,
+          allowUnsandboxedCommands: false,
+          filesystem: checkoutDir ? { denyWrite: [checkoutDir] } : {},
+        }
+      : // Unusable here: enabling it would deny every Bash call rather than
+        // confine it. permissions.deny above and the post-run integrity gate
+        // remain the write boundary.
+        { enabled: false },
   };
 }
 
@@ -439,7 +494,7 @@ export async function execute({
   const childEnv = safeChildEnvironment(env, def);
 
   const mcpConfig = path.join(FACTORY_ROOT, "config", "mcp", "claude.json");
-  const settings = buildClaudeSettings({ spec, def, workspaceDir });
+  const settings = buildClaudeSettings({ spec, def, workspaceDir, env });
   const settingsPath = settings
     ? path.join(workspaceDir, ".claude-policy.json")
     : null;

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -14,6 +14,7 @@ import {
   BASE_INHERITED_ENV,
   buildClaudeArgv,
   buildClaudeSettings,
+  osSandboxUsable,
   deriveAllowedTools,
   execute,
   isHarnessDenial,
@@ -397,6 +398,7 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
       spec: { workspace: { type: "repository", checkoutDir: "repo" } },
       def: { mutating: false },
       workspaceDir: "/private/tmp/run-a1",
+      env: { FACTORY_CLAUDE_OS_SANDBOX: "1" },
     });
     expect(settings.permissions.allow).toEqual(READ_ONLY_TOOLS);
     expect(settings.permissions.deny).toEqual([
@@ -408,6 +410,33 @@ describe("buildClaudeArgv (OPS-407, WM-62, WM-137)", () => {
       allowUnsandboxedCommands: false,
       filesystem: { denyWrite: ["/private/tmp/run-a1/repo"] },
     });
+  });
+
+  test("a host whose OS sandbox cannot start keeps the deny policy and turns the sandbox off, rather than denying every command", () => {
+    // Nested user namespaces are refused on some hosts. Claude's sandbox then
+    // fails on `apply-seccomp` before its policy applies and, with
+    // allowUnsandboxedCommands: false, a read-only agent cannot run `echo`.
+    const settings = buildClaudeSettings({
+      spec: { workspace: { type: "repository", checkoutDir: "repo" } },
+      def: { mutating: false },
+      workspaceDir: "/private/tmp/run-a1",
+      env: { FACTORY_CLAUDE_OS_SANDBOX: "0" },
+    });
+    expect(settings.sandbox).toEqual({ enabled: false });
+    // The write boundary is unchanged: it never depended on the OS sandbox.
+    expect(settings.permissions.deny).toEqual([
+      "Edit(//private/tmp/run-a1/repo/**)",
+    ]);
+    expect(settings.permissions.allow).toEqual(READ_ONLY_TOOLS);
+  });
+
+  test("osSandboxUsable honours an explicit override in either env, and probes otherwise", () => {
+    expect(osSandboxUsable({ FACTORY_CLAUDE_OS_SANDBOX: "1" })).toBe(true);
+    expect(osSandboxUsable({ FACTORY_CLAUDE_OS_SANDBOX: "true" })).toBe(true);
+    expect(osSandboxUsable({ FACTORY_CLAUDE_OS_SANDBOX: "0" })).toBe(false);
+    expect(osSandboxUsable({ FACTORY_CLAUDE_OS_SANDBOX: "false" })).toBe(false);
+    // No override: a boolean answer for this host, never a throw.
+    expect(typeof osSandboxUsable({})).toBe("boolean");
   });
 
   test("mutating runs include --dangerously-skip-permissions and omit --settings (WM-137)", () => {
@@ -756,6 +785,10 @@ if (behavior === "emit_denial_then_recovery") {
         CUSTOM_VAR: "custom_value",
         FACTORY_TEST_BEHAVIOR: "normal",
         FACTORY_TEST_RECORD_FILE: recordFile,
+        // Assert the sandboxed policy shape regardless of whether this
+        // particular host can start Claude's OS sandbox; the host-dependent
+        // branch has its own test above.
+        FACTORY_CLAUDE_OS_SANDBOX: "1",
       },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });


### PR DESCRIPTION
## Symptom

A read-only `work-scan@1` run on a fresh Linux instance, twice, ~$0.70 each:

```
Refused with `needs_human`: the Bash tool is non-functional in this environment
(every invocation, even `echo hello`, fails with
`apply-seccomp: write /proc/self/setgroups ... Permission denied`)
```

The agent behaved correctly — it refused rather than inventing data. But the harness works perfectly on that host outside the sandbox, so the refusal was caused by the adapter's own policy, and it burned a full context window plus a human's attention to say so.

## Cause

`buildClaudeSettings` emits, for `mutating: false`:

```js
sandbox: {
  enabled: true,
  autoAllowBashIfSandboxed: true,
  allowUnsandboxedCommands: false,
  ...
}
```

On Linux that sandbox is a nested user namespace. Hosts that forbid one (hardened kernels, containers, LXC/LXD) fail *before* the policy is applied, and `allowUnsandboxedCommands: false` turns "sandbox unavailable" into "no Bash at all". The comment at the top of the file already anticipates this for the guest case ("with `allowUnsandboxedCommands: false`, would deny every Bash call if absent") — it is equally true on an unsupported host.

## Fix

Probe once per process; when unavailable emit `sandbox: { enabled: false }`.

The probe mirrors the failing step exactly rather than a nearby one:

```
unshare --map-root-user --setgroups deny true
```

On the affected host plain `unshare -Ur` **succeeds** and only the setgroups-deny fails, so the weaker probe would have reported a sandbox that dies on first use.

`FACTORY_CLAUDE_OS_SANDBOX=0/1` forces the decision for an operator who knows better.

## Why this does not weaken the boundary

The write boundary never rested on the OS sandbox:

1. the `permissions.deny` entry still refuses Edit under the checkout;
2. the worker's post-run repository integrity gate is what actually proves a read-only run mutated nothing.

The OS sandbox is defence in depth on top of those, so this degrades isolation on hosts that could never provide it anyway — instead of degrading the run to a refusal. It is visible in the emitted policy, so an operator can see which mode a run used.

## Verification

- `bun test event-runtime/lib --timeout 20000` — 1564 pass, 0 fail (two new tests: the disabled branch keeps the deny policy, and the override/probe contract)
- `bun build/emit.mjs --check` — clean
- the same injected `factory.work.requested` run that refused twice now reaches COMPLETED with a valid `factory.work-plan/v1` artifact
