### PR TITLE
fix: confine collected artifact sources

### DIFF
--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -25,9 +25,15 @@ import {
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { canonicalJson, hashJson } from "./canonical.mjs";
+import { confinedRegularFile } from "./workspace.mjs";
 
 const HEX64 = /^[0-9a-f]{64}$/;
 const SHA256 = /^sha256:([0-9a-f]{64})$/;
+const TRUSTED_ROOTLESS_SOURCES = new Map([
+  ["memo", null],
+  ["transcript", ".transcript.json"],
+  ["sandbox-console", ".sandbox-console.log"],
+]);
 
 function resultDigest(artifactHash) {
   return SHA256.exec(artifactHash ?? "")?.[1] ?? null;
@@ -82,18 +88,46 @@ export function artifactPath(storeRoot, sha256hex) {
  * rename, and source/destination hashes are verified to prevent corrupted or
  * truncated artifacts from landing in the store (OPS-439).
  */
-export function storeCollected({ entries, storeRoot }) {
+export function storeCollected({ entries, storeRoot, workspaceDir = null }) {
   if (!entries?.length) return entries ?? [];
   mkdirSync(storeRoot, { recursive: true });
   return entries.map((entry) => {
     const dest = artifactPath(storeRoot, entry.sha256);
-    const src = fileURLToPath(entry.uri);
+    const declaredSrc = fileURLToPath(entry.uri);
+    const sourceRoot = entry.workspaceRoot ?? workspaceDir;
+    let src;
+    try {
+      // Verified entries carry their workspace root as non-enumerable internal
+      // provenance. Other workspace producers must pass workspaceDir. The only
+      // rootless sources are host-authored memos and the runtime's fixed,
+      // top-level transcript files; for those, dirname is the complete set of
+      // possible components beneath the source root.
+      const trustedBasename = TRUSTED_ROOTLESS_SOURCES.get(entry.kind);
+      const trustedRootless =
+        TRUSTED_ROOTLESS_SOURCES.has(entry.kind) &&
+        (trustedBasename === null ||
+          path.basename(declaredSrc) === trustedBasename);
+      if (!sourceRoot && !trustedRootless) {
+        throw new Error(
+          `artifact source lacks workspace provenance: ${declaredSrc}`,
+        );
+      }
+      const root = sourceRoot ?? path.dirname(declaredSrc);
+      src = confinedRegularFile(root, path.relative(root, declaredSrc));
+    } catch (err) {
+      if (err?.code === "ENOENT") {
+        throw new Error(`artifact source does not exist: ${declaredSrc}`, {
+          cause: err,
+        });
+      }
+      throw err;
+    }
     if (!existsSync(src)) {
       throw new Error(`artifact source does not exist: ${src}`);
     }
     const stat = lstatSync(src);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`cannot store symlinked artifact: ${src}`);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`artifact source is not a regular file: ${src}`);
     }
     const srcHash = hashFile(src);
     if (srcHash !== entry.sha256) {

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -75,7 +75,7 @@ describe("storeCollected (OPS-406)", () => {
     const hash = sha256Hex(Buffer.from("hello world"));
 
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: hash }];
-    const stored = storeCollected({ entries, storeRoot });
+    const stored = storeCollected({ entries, storeRoot, workspaceDir });
     expect(stored[0].uri).toBe(`file://${path.join(storeRoot, hash)}`);
     expect(stored[0].sizeBytes).toBe(11);
     expect(readFileSync(path.join(storeRoot, hash), "utf8")).toBe(
@@ -98,10 +98,36 @@ describe("storeCollected (OPS-406)", () => {
       { kind: "key", uri: `file://${symlinkFile}`, sha256: hash },
     ];
 
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(
-      /cannot store symlinked artifact/,
+    expect(() => storeCollected({ entries, storeRoot, workspaceDir })).toThrow(
+      /symlink component/,
     );
   });
+
+  for (const linkType of ["absolute", "relative"]) {
+    test(`rejects ${linkType} intermediate symlink beneath the workspace`, () => {
+      const storeRoot = tmp("evrt-store-");
+      const outsideDir = tmp("evrt-outside-");
+      writeFileSync(path.join(outsideDir, "secret.key"), "secret-data");
+      const workspaceDir = tmp("evrt-ws-");
+      const target =
+        linkType === "absolute"
+          ? outsideDir
+          : path.relative(workspaceDir, outsideDir);
+      symlinkSync(target, path.join(workspaceDir, "hop"), "dir");
+      const entries = [
+        {
+          kind: "key",
+          uri: `file://${path.join(workspaceDir, "hop", "secret.key")}`,
+          sha256: sha256Hex(Buffer.from("secret-data")),
+        },
+      ];
+
+      expect(() =>
+        storeCollected({ entries, storeRoot, workspaceDir }),
+      ).toThrow(/symlink component/);
+      expect(readdirSync(storeRoot)).toEqual([]);
+    });
+  }
 
   test("rejects non-existent source file", () => {
     const storeRoot = tmp("evrt-store-");
@@ -111,7 +137,7 @@ describe("storeCollected (OPS-406)", () => {
     const entries = [
       { kind: "log", uri: `file://${missingFile}`, sha256: hash },
     ];
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+    expect(() => storeCollected({ entries, storeRoot, workspaceDir })).toThrow(
       /does not exist/,
     );
   });
@@ -124,7 +150,7 @@ describe("storeCollected (OPS-406)", () => {
     const wrongHash = sha256Hex(Buffer.from("expected different content"));
 
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: wrongHash }];
-    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+    expect(() => storeCollected({ entries, storeRoot, workspaceDir })).toThrow(
       /hash mismatch/,
     );
     expect(existsSync(path.join(storeRoot, wrongHash))).toBe(false);
@@ -143,7 +169,7 @@ describe("storeCollected (OPS-406)", () => {
     writeFileSync(dest, "truncated");
 
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: hash }];
-    const stored = storeCollected({ entries, storeRoot });
+    const stored = storeCollected({ entries, storeRoot, workspaceDir });
     expect(stored[0].uri).toBe(`file://${dest}`);
     expect(stored[0].sizeBytes).toBe(
       Buffer.byteLength("complete valid content"),
@@ -163,7 +189,7 @@ describe("storeCollected (OPS-406)", () => {
     writeFileSync(dest, "identical content");
 
     const entries = [{ kind: "log", uri: `file://${file}`, sha256: hash }];
-    const stored = storeCollected({ entries, storeRoot });
+    const stored = storeCollected({ entries, storeRoot, workspaceDir });
     expect(stored[0].uri).toBe(`file://${dest}`);
     expect(stored[0].sizeBytes).toBe(Buffer.byteLength("identical content"));
   });
@@ -179,12 +205,32 @@ describe("storeCollected (OPS-406)", () => {
     const entries = [
       { kind: "bin", uri: `file://${file}`, sha256: "0".repeat(64) },
     ];
-    expect(() => storeCollected({ entries, storeRoot })).toThrow();
+    expect(() =>
+      storeCollected({ entries, storeRoot, workspaceDir }),
+    ).toThrow();
 
     // Verify store directory has neither destination nor tmp files
     const remainingFiles = readdirSync(storeRoot);
     expect(remainingFiles).toEqual([]);
     expect(existsSync(path.join(storeRoot, hash))).toBe(false);
+  });
+
+  test("fails closed when a collected source has no workspace provenance", () => {
+    const storeRoot = tmp("evrt-store-");
+    const workspaceDir = tmp("evrt-ws-");
+    const file = path.join(workspaceDir, "out.log");
+    writeFileSync(file, "ordinary bytes");
+    const entries = [
+      {
+        kind: "log",
+        uri: `file://${file}`,
+        sha256: sha256Hex(Buffer.from("ordinary bytes")),
+      },
+    ];
+
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(
+      /lacks workspace provenance/,
+    );
   });
 });
 

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -13,6 +13,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { globToRegExp } from "../../orchestrator/owned-paths.mjs";
 import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { resolveConfigPath } from "./config.mjs";
@@ -20,7 +21,7 @@ import { validateDecisionRequest } from "./decision.mjs";
 import { processResultMemos } from "./memos.mjs";
 import { reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
-import { PathViolation, safeJoin } from "./workspace.mjs";
+import { confinedRegularFile, PathViolation } from "./workspace.mjs";
 
 /**
  * Declared evidence is retained inline in the accepted result (OPS-206): a
@@ -1075,21 +1076,32 @@ function verifyCompleted({
   for (const entry of [...declared, ...injected]) {
     let abs;
     try {
-      abs = safeJoin(workspaceDir, entry.path);
+      abs = confinedRegularFile(workspaceDir, entry.path);
     } catch (err) {
+      if (err?.code === "ENOENT") {
+        violations.push(`artifact_missing: ${entry.path}`);
+        continue;
+      }
       if (!(err instanceof PathViolation)) throw err;
       violations.push(`artifact_path_escape: ${entry.path}`);
       continue;
     }
-    if (!existsSync(abs)) {
+    try {
+      const collectedEntry = {
+        kind: entry.kind,
+        uri: pathToFileURL(abs).href,
+        sha256: sha256Hex(readFileSync(abs)),
+      };
+      // Internal, non-serializable provenance lets durable storage repeat the
+      // same confinement preflight at its own trust boundary.
+      Object.defineProperty(collectedEntry, "workspaceRoot", {
+        value: workspaceDir,
+      });
+      collected.push(collectedEntry);
+    } catch (err) {
+      if (err?.code !== "ENOENT") throw err;
       violations.push(`artifact_missing: ${entry.path}`);
-      continue;
     }
-    collected.push({
-      kind: entry.kind,
-      uri: `file://${abs}`,
-      sha256: sha256Hex(readFileSync(abs)),
-    });
   }
   if (violations.length > 0) throw new ContractViolation(violations);
 

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1,6 +1,6 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-verify-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { hashJson, sha256Hex } from "./canonical.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
@@ -622,6 +622,53 @@ describe("verifyResult", () => {
       expect(err).toBeInstanceOf(ContractViolation);
       expect(err.violations).toEqual(["artifact_path_escape: ../outside.txt"]);
     }
+  });
+
+  for (const linkType of ["absolute", "relative"]) {
+    test(`artifact path through ${linkType} intermediate symlink → ContractViolation`, () => {
+      const dir = makeWorkspace({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+        artifacts: [{ kind: "log", path: "hop/secret.txt" }],
+      });
+      const outside = tmpDir("evrt-verify-outside-");
+      writeFileSync(path.join(outside, "secret.txt"), "host secret\n", "utf8");
+      const target =
+        linkType === "absolute" ? outside : path.relative(dir, outside);
+      symlinkSync(target, path.join(dir, "hop"), "dir");
+
+      expect(() =>
+        verifyResult({
+          spec: makeSpec(),
+          def,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+        }),
+      ).toThrow(ContractViolation);
+    });
+  }
+
+  test("final symlink artifact → ContractViolation", () => {
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+      artifacts: [{ kind: "log", path: "linked.log" }],
+    });
+    writeFileSync(path.join(dir, "real.log"), "ordinary bytes\n", "utf8");
+    symlinkSync("real.log", path.join(dir, "linked.log"));
+
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("declared artifact that does not exist → ContractViolation", () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -11,8 +11,10 @@
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -40,11 +42,12 @@ function worktreeScriptTimeoutMs() {
 }
 
 export class PathViolation extends Error {
-  constructor(workspaceDir, relPath) {
-    super(`path "${relPath}" escapes workspace ${workspaceDir}`);
+  constructor(workspaceDir, relPath, detail = "escapes workspace") {
+    super(`path "${relPath}" ${detail} ${workspaceDir}`);
     this.name = "PathViolation";
     this.workspaceDir = workspaceDir;
     this.relPath = relPath;
+    this.detail = detail;
   }
 }
 
@@ -114,6 +117,67 @@ export function safeJoin(workspaceDir, relPath) {
   if (!resolved.startsWith(root + path.sep))
     throw new PathViolation(workspaceDir, relPath);
   return resolved;
+}
+
+/**
+ * Resolve one existing workspace-relative artifact source without following
+ * symlinks. Lexical confinement alone is insufficient here: the host later
+ * interprets symlinks preserved from a sandboxed guest in the host namespace.
+ * Every component beneath the workspace root is therefore checked with lstat,
+ * then both endpoints are canonicalized and the final source must be a regular
+ * file.
+ *
+ * This deliberately centralizes the preflight used by result verification and
+ * durable artifact storage. A check/open TOCTOU window remains between this
+ * path-based preflight and callers' subsequent read/hash/copy operations. Fully
+ * closing it requires descriptor-relative openat-style traversal with no-follow
+ * semantics, which node:fs does not expose; callers re-run this helper at each
+ * trust boundary and verify the copied bytes by hash in the meantime.
+ */
+export function confinedRegularFile(workspaceDir, relPath) {
+  const root = path.resolve(workspaceDir);
+  const source = safeJoin(root, relPath);
+  const canonicalRoot = realpathSync(root);
+  const relative = path.relative(root, source);
+  const components = relative.split(path.sep).filter(Boolean);
+  let cursor = root;
+
+  for (const [index, component] of components.entries()) {
+    cursor = path.join(cursor, component);
+    const stat = lstatSync(cursor);
+    if (stat.isSymbolicLink()) {
+      throw new PathViolation(
+        workspaceDir,
+        relPath,
+        `contains symlink component "${components.slice(0, index + 1).join(path.sep)}" beneath workspace`,
+      );
+    }
+    const final = index === components.length - 1;
+    if (!final && !stat.isDirectory()) {
+      throw new PathViolation(
+        workspaceDir,
+        relPath,
+        `contains non-directory component "${components.slice(0, index + 1).join(path.sep)}" beneath workspace`,
+      );
+    }
+    if (final && !stat.isFile()) {
+      throw new PathViolation(
+        workspaceDir,
+        relPath,
+        "does not name a regular file beneath workspace",
+      );
+    }
+  }
+
+  const canonicalSource = realpathSync(source);
+  if (!canonicalSource.startsWith(canonicalRoot + path.sep)) {
+    throw new PathViolation(
+      workspaceDir,
+      relPath,
+      "canonically escapes workspace",
+    );
+  }
+  return canonicalSource;
 }
 
 /**


### PR DESCRIPTION
Fixes watt-mind/factory#961

UX critique: skipped — backend artifact-confinement hardening has no user-facing surface.