### PR TITLE
fix(planner): pass --repo to the inflight cap-check read

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -670,22 +670,23 @@ function ownedPathsClosureDetails(repoName, repo, ticketDescription) {
 
 function fetchInFlightDefault(repoConfig) {
   try {
-    const out = execFileSync(
-      "bun",
-      [
-        linearCli(),
-        "inflight",
-        "--team",
-        String(repoConfig.team),
-        "--project",
-        String(repoConfig.project),
-        "--json",
-      ],
-      {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
+    // --repo so ticket.mjs resolves this repo's own control plane (a Linear
+    // team/project query against the GitHub plane fails as a project-title
+    // mismatch, blocking the cap check for control_plane: linear repos).
+    const args = [
+      linearCli(),
+      "inflight",
+      "--team",
+      String(repoConfig.team),
+      "--project",
+      String(repoConfig.project),
+      "--json",
+    ];
+    if (repoConfig.name) args.push("--repo", repoConfig.name);
+    const out = execFileSync("bun", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     const rows = JSON.parse(out);
     return Array.isArray(rows) ? rows : [];
   } catch (err) {


### PR DESCRIPTION
Follow-up to #1014. `fetchInFlightDefault` queried Linear team/project against the GitHub plane (no `--repo`), failing `Project title mismatch: requested CashMap, configured Factory` and blocking dispatch for `control_plane: linear` repos (bj29/cashsaas). Adds `--repo`.

## Verification
`bun test event-runtime/lib/planner.test.mjs` green; cashsaas CLNT-1504 dispatch reaches planning instead of dead-lettering.