### PR TITLE
fix(ticket): queue --repo derives team so work-scan can read the queue

### DIFF
--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -708,8 +708,17 @@ const VERBS = {
   },
 
   async queue() {
-    const team = flag("team") ?? teamOf(positional[0] ?? "");
-    if (!team) throw new Error(`usage: queue --team CLNT`);
+    let team = flag("team") ?? teamOf(positional[0] ?? "");
+    if (!team) {
+      // Repo-scoped read (work-scan calls `queue --repo <name>`): derive the
+      // team from the repo's config. GitHub-plane repos have no meaningful
+      // team of their own — listDispatchable maps it back to the repo — but
+      // the verb still needs *a* team, and requiring the caller to pass it for
+      // a --repo read is exactly the mismatch that made work-scan refuse.
+      const repoName = flag("repo");
+      if (repoName) team = getRepos().get(repoName)?.team ?? null;
+    }
+    if (!team) throw new Error(`usage: queue --team CLNT (or --repo <name>)`);
     // Dispatchable == Todo + ai:agent-ready + unassigned. The same predicate
     // the dispatcher uses; agents must not invent their own.
     const ready = await controlPlane().listDispatchable({ team });


### PR DESCRIPTION
**Unblocks autonomous supply.** The work-factory clock (#1012) fires but work-scan refused every time: it reads `ticket.mjs queue --repo <name> --json`, but the queue verb hard-required `--team`, and the github-plane factory repo has no Linear team → 'usage: queue --team CLNT' → work-scan can't build candidates → needs_human. Derives team from the repo config when `--team` is absent (github's listDispatchable maps it back to the repo regardless). Verified: `queue --repo factory` (github) and `queue --repo cashsaas` (linear) both return issues with no --team.

## Verification
`bun test tools/ticket.test.mjs` → 31 pass 0 fail