### PR TITLE
fix(control-plane): closed GitHub issue is Done, not its stale board status

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -963,9 +963,14 @@ export function githubControlPlane(options = {}) {
       // Narrow FIRST; only then pay per-issue costs.
       const kept = [];
       for (const issue of issues) {
+        // A closed issue is Done regardless of a stale board status. Reading
+        // the board first let a closed issue whose Projects v2 status still
+        // said "In Progress" be counted as in-flight — inflating the cap and
+        // stalling dispatch (the board does not always move to Done on close).
         const statusName =
-          statusByNumber.get(issue.number) ??
-          (issue.state === "closed" ? "Done" : "Triage");
+          issue.state === "closed"
+            ? "Done"
+            : (statusByNumber.get(issue.number) ?? "Triage");
         const name = String(statusName).toLowerCase();
         if (wanted ? !wanted.has(name) : ["done", "canceled"].includes(name))
           continue;


### PR DESCRIPTION
**Unblocks the autonomous supply loop.** `listTickets` (github plane) read the Projects v2 board status first, so a CLOSED issue whose board status was still 'In Progress' (the board doesn't auto-move to Done on close) counted as in-flight. That inflated factory's in-flight to 25 vs cap 20, so work-scan found 21 ready candidates but correctly declined to dispatch (over cap) — the loop fired but produced nothing. A closed issue is Done regardless of board status.

## Verification
`bun test lib/control-plane/github.test.mjs` → 50 pass; live inflight count dropped 25 → 10 after the fix.