### PR TITLE
feat(planner): operator dispatch may authorize escalate_paths work

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1278,7 +1278,7 @@ export function worktreeDispatchAutoEligibility(
     configured: evidence.repo.escalatePaths.length > 0,
     intersect: evidence.escalatePathIntersections,
   };
-  if (evidence.escalatePathIntersections.length > 0) {
+  if (evidence.escalatePathIntersections.length > 0 && !operatorAuthorized) {
     return refusal(
       "escalate_paths_intersect",
       evidence,


### PR DESCRIPTION
escalate_paths marks sensitive code (auth/payment/sessions) agents must not auto-touch. The gate noop'd unconditionally, blocking even operator dispatch. Mirrors the security-gate treatment (#1004/GH-1004): operator-sourced dispatch bypasses; chain/schedule dispatch still refuses, so the autonomous clock never auto-runs a sensitive-path ticket.

## Verification
`bun test event-runtime/lib/planner.test.mjs` green.