### PR TITLE
Migrate starter to published Factory package pin

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -9,8 +9,8 @@ contains one organization's operational choices.
 
 Use the [`templates/starter/`](../templates/starter/) scaffold to create an
 instance repository. Its `package.json` intentionally pins the kernel to an
-exact commit, while the instance owns the files that should differ between
-organizations:
+exact published npm version, while the instance owns the files that should
+differ between organizations:
 
 | Kernel                                 | Instance                                                 |
 | -------------------------------------- | -------------------------------------------------------- |
@@ -50,9 +50,9 @@ rules that protect the kernel namespace.
 
 `@watt-mind/factory` publishes to npm as a public, Apache-2.0 package
 (WM-949). An instance should pin an exact version (`"@watt-mind/factory":
-"0.1.0"`, not a `^`/`~` range), the same exact-pin discipline
-[`templates/starter/`](../templates/starter/) already applies with its Git
-commit pin, so a kernel upgrade is always a reviewed, explicit change:
+"0.1.0"`, not a `^`/`~` range), as
+[`templates/starter/`](../templates/starter/) does, so a kernel upgrade is
+always a reviewed, explicit change:
 
 1. Read the kernel release notes for the target version — each published
    version has a corresponding tag and GitHub Release on
@@ -111,5 +111,5 @@ bun tools/publish-starter.mjs --dry-run
 ```
 
 The command confirms the required scaffold files, checks that the kernel
-dependency is an exact commit pin, and runs `npm pack --dry-run --json` to
-show the package contents. It never publishes or writes files.
+dependency is an exact SemVer pin, and runs `npm pack --dry-run --json` to show
+the package contents. It never publishes or writes files.

--- a/templates/starter/README.md
+++ b/templates/starter/README.md
@@ -14,8 +14,8 @@ separate from the Factory kernel.
    bun run check
    ```
 
-3. Review the exact kernel commit in `package.json`, then install it when your
-   environment can read the kernel's GitHub repository:
+3. Review the exact published kernel version in `package.json`, then install
+   it from npm:
 
    ```sh
    bun install
@@ -24,10 +24,10 @@ separate from the Factory kernel.
 4. Keep every schedule disabled while you verify repository credentials,
    worktree scripts, and the proposed workflow.
 
-The committed kernel reference is deliberately an exact Git commit. Upgrades
-are an explicit dependency change: review the Factory release or commit,
-update `package.json`, run `bun install`, then run this instance's checks
-before merging.
+The committed kernel reference is deliberately an exact npm version, without
+a `^` or `~` range. Upgrades are an explicit dependency change: review the
+Factory release, update `package.json`, run `bun install`, then run this
+instance's checks before merging.
 
 ## What belongs here
 

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -9,6 +9,6 @@
     "check": "bun scripts/check.mjs"
   },
   "dependencies": {
-    "@watt-mind/factory": "github:watt-mind/factory#4336a1633f432e5473ba237116628b64ceb66537"
+    "@watt-mind/factory": "0.1.0"
   }
 }

--- a/templates/starter/scripts/check.mjs
+++ b/templates/starter/scripts/check.mjs
@@ -3,6 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXACT_SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED = [
   "AGENTS.md",
   "README.md",
@@ -22,11 +24,10 @@ const manifest = JSON.parse(
   readFileSync(path.join(ROOT, "package.json"), "utf8"),
 );
 const kernel = manifest.dependencies?.["@watt-mind/factory"];
-if (
-  typeof kernel !== "string" ||
-  !/^github:watt-mind\/factory#[0-9a-f]{40}$/.test(kernel)
-) {
-  throw new Error("@watt-mind/factory must be pinned to an exact Git commit");
+if (typeof kernel !== "string" || !EXACT_SEMVER_RE.test(kernel)) {
+  throw new Error(
+    "@watt-mind/factory must be pinned to an exact SemVer version (no ranges)",
+  );
 }
 
 console.log(`factory-starter: valid (${REQUIRED.length} required files)`);

--- a/tools/publish-starter.mjs
+++ b/tools/publish-starter.mjs
@@ -12,6 +12,8 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const STARTER = path.join(ROOT, "templates", "starter");
+const EXACT_SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED_FILES = [
   "package.json",
   "AGENTS.md",
@@ -45,12 +47,9 @@ export function validateStarter(dir = STARTER) {
     readFileSync(path.join(dir, "package.json"), "utf8"),
   );
   const kernel = manifest.dependencies?.["@watt-mind/factory"];
-  if (
-    typeof kernel !== "string" ||
-    !/^github:watt-mind\/factory#[0-9a-f]{40}$/.test(kernel)
-  ) {
+  if (typeof kernel !== "string" || !EXACT_SEMVER_RE.test(kernel)) {
     throw new Error(
-      "starter package.json must pin @watt-mind/factory to an exact Git commit",
+      "starter package.json must pin @watt-mind/factory to an exact SemVer version (no ranges)",
     );
   }
   return { dir, manifest, kernel, requiredFiles: REQUIRED_FILES };


### PR DESCRIPTION
Fixes watt-mind/factory#898

UX critique: skipped — tooling/template/documentation change with no user-facing flow