### PR TITLE
feat(schedules): explicit overlay auto-approval opt-in

### DIFF
--- a/config/schedule.example.yaml
+++ b/config/schedule.example.yaml
@@ -15,12 +15,18 @@ jobs: []
 # Runtime schedule overlay (optional). `event-runtime/schedules.json` defines
 # tracked kernel defaults; these ignored, instance-specific values are merged
 # at runtime and do not change the registry digest. Existing loop names may
-# override only enabled, every, and payload fields. A new name must provide a
-# complete schedule entry (including eventType) and is visible as source:
-# overlay in `factory schedules` / GET /schedules.
+# override enabled, every, and payload fields. They can request `approval: auto`
+# only when this top-level, explicit operator allowlist names the same loop;
+# otherwise the request is forced to watched. An authorized loop is visible as
+# source: operator-authorized-auto in `factory schedules` / GET /schedules.
+# A new name must provide a complete schedule entry (including eventType) and
+# remains watched even if it appears in the allowlist.
 #
 # Replace client-repo with a real local repo name. These commented examples
 # mirror the current instance migration without publishing a client name:
+# This acknowledgement must name every existing loop that requests auto.
+# overlay_auto_approve:
+#   - merge-client-repo
 # schedules:
 #   merge-factory:
 #     enabled: true
@@ -29,3 +35,4 @@ jobs: []
 #     enabled: true
 #   merge-client-repo:
 #     enabled: true
+#     approval: auto

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -1233,10 +1233,9 @@ export function loadRegistry({
   // cadence or an unregistered event type must be a startup error, not a
   // surprise at 03:00 when nothing fires.
   for (const [loop, schedule] of Object.entries(effectiveSchedules)) {
-    const scheduleFile =
-      isOverlayScheduleSource(effectiveScheduleSources[loop])
-        ? scheduleConfigPath
-        : "schedules.json";
+    const scheduleFile = isOverlayScheduleSource(effectiveScheduleSources[loop])
+      ? scheduleConfigPath
+      : "schedules.json";
     if (!/^[a-z][a-z0-9-]*$/.test(loop))
       throw new RegistryError(`${scheduleFile}: bad loop name "${loop}"`);
     if (

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -52,6 +52,7 @@ function nullDict() {
 }
 
 const SCHEDULE_OVERLAY_FIELDS = new Set(["enabled", "every", "payload"]);
+const OPERATOR_AUTHORIZED_AUTO_SOURCE = "operator-authorized-auto";
 
 function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -60,10 +61,14 @@ function isPlainObject(value) {
 /**
  * Instance schedule settings intentionally sit outside the pinned registry.
  * They may turn a kernel loop on, change its cadence, or add static payload
- * keys, but cannot change its event routing or approval policy.
+ * keys, but cannot change its event routing. Unattended approval is the one
+ * exception: it requires both `approval: auto` on the loop and the same loop
+ * named in the top-level `overlay_auto_approve` allowlist.
  */
 function loadScheduleOverlay(file) {
-  if (!existsSync(file)) return nullDict();
+  if (!existsSync(file)) {
+    return { schedules: nullDict(), autoApprove: new Set() };
+  }
   let parsed;
   try {
     parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
@@ -75,12 +80,28 @@ function loadScheduleOverlay(file) {
   if (parsed !== null && parsed !== undefined && !isPlainObject(parsed)) {
     throw new RegistryError(`${file}: schedule.yaml must be an object`);
   }
-  if (parsed?.schedules === undefined || parsed.schedules === null)
-    return nullDict();
-  if (!isPlainObject(parsed.schedules)) {
+  const allowedLoops = parsed?.overlay_auto_approve;
+  if (
+    allowedLoops !== undefined &&
+    (!Array.isArray(allowedLoops) ||
+      allowedLoops.some((loop) => typeof loop !== "string" || !loop) ||
+      new Set(allowedLoops).size !== allowedLoops.length)
+  ) {
+    throw new RegistryError(
+      `${file}: "overlay_auto_approve" must be an array of unique, non-empty loop names`,
+    );
+  }
+  if (
+    parsed?.schedules !== undefined &&
+    parsed.schedules !== null &&
+    !isPlainObject(parsed.schedules)
+  ) {
     throw new RegistryError(`${file}: "schedules" must be an object`);
   }
-  return parsed.schedules;
+  return {
+    schedules: parsed?.schedules ?? nullDict(),
+    autoApprove: new Set(allowedLoops ?? []),
+  };
 }
 
 function cloneSchedules(schedules) {
@@ -98,7 +119,12 @@ function cloneSchedules(schedules) {
   return clone;
 }
 
-function applyScheduleOverlay(kernelSchedules, overlay, file) {
+function isOverlayScheduleSource(source) {
+  return source === "overlay" || source === OPERATOR_AUTHORIZED_AUTO_SOURCE;
+}
+
+function applyScheduleOverlay(kernelSchedules, overlayConfig, file) {
+  const { schedules: overlay, autoApprove } = overlayConfig;
   const schedules = cloneSchedules(kernelSchedules);
   const sources = nullDict();
   for (const loop of Object.keys(schedules)) sources[loop] = "kernel";
@@ -115,15 +141,25 @@ function applyScheduleOverlay(kernelSchedules, overlay, file) {
     }
     if (Object.hasOwn(schedules, loop)) {
       for (const field of Object.keys(override)) {
-        if (!SCHEDULE_OVERLAY_FIELDS.has(field)) {
+        if (
+          !SCHEDULE_OVERLAY_FIELDS.has(field) &&
+          !(field === "approval" && override.approval === "auto")
+        ) {
           throw new RegistryError(
-            `${file}: schedules.${loop}.${field} cannot override a kernel schedule (allowed: enabled, every, payload)`,
+            `${file}: schedules.${loop}.${field} cannot override a kernel schedule (allowed: enabled, every, payload, and approval: auto with overlay_auto_approve)`,
           );
         }
       }
       if (override.payload !== undefined && !isPlainObject(override.payload)) {
         throw new RegistryError(
           `${file}: schedules.${loop}.payload must be a plain object`,
+        );
+      }
+      const requestedAuto = override.approval === "auto";
+      const authorizedAuto = requestedAuto && autoApprove.has(loop);
+      if (requestedAuto && !authorizedAuto) {
+        console.warn(
+          `${file}: schedules.${loop}.approval "auto" ignored — ${loop} is not named in overlay_auto_approve, so the loop remains "watched"`,
         );
       }
       schedules[loop] = {
@@ -137,8 +173,14 @@ function applyScheduleOverlay(kernelSchedules, overlay, file) {
               },
             }
           : {}),
+        ...(requestedAuto
+          ? { approval: authorizedAuto ? "auto" : "watched" }
+          : {}),
       };
       overlayFields[loop] = new Set(Object.keys(override));
+      sources[loop] = authorizedAuto
+        ? OPERATOR_AUTHORIZED_AUTO_SOURCE
+        : "overlay";
     } else {
       // A brand-new loop the overlay is introducing has no kernel-reviewed
       // approval policy behind it. It always queues for human approval: an
@@ -161,7 +203,7 @@ function applyScheduleOverlay(kernelSchedules, overlay, file) {
       };
       overlayFields[loop] = new Set(Object.keys(override));
     }
-    sources[loop] = "overlay";
+    if (!Object.hasOwn(sources, loop)) sources[loop] = "overlay";
   }
   return { schedules, sources, overlayFields };
 }
@@ -1192,7 +1234,7 @@ export function loadRegistry({
   // surprise at 03:00 when nothing fires.
   for (const [loop, schedule] of Object.entries(effectiveSchedules)) {
     const scheduleFile =
-      effectiveScheduleSources[loop] === "overlay"
+      isOverlayScheduleSource(effectiveScheduleSources[loop])
         ? scheduleConfigPath
         : "schedules.json";
     if (!/^[a-z][a-z0-9-]*$/.test(loop))
@@ -1238,7 +1280,7 @@ export function loadRegistry({
     // of an already-disabled kernel loop does not touch the approval
     // boundary and must still fail closed (WM-998 review).
     const overlayDisabledThisLoop =
-      effectiveScheduleSources[loop] === "overlay" &&
+      isOverlayScheduleSource(effectiveScheduleSources[loop]) &&
       Boolean(effectiveScheduleOverlayFields[loop]?.has("enabled"));
     if (approval === "auto" && !schedule.enabled && !overlayDisabledThisLoop) {
       throw new RegistryError(

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -220,7 +220,13 @@ describe("registry", () => {
       packRoots: [],
       scheduleConfigPath: config,
     });
-    const withoutOverlay = loadRegistry({ packRoots: [] });
+    const withoutOverlay = loadRegistry({
+      packRoots: [],
+      scheduleConfigPath: path.join(
+        tmpDir("event-schedule-overlay-auto-absent-"),
+        "schedule.yaml",
+      ),
+    });
 
     expect(overlaid.schedules["work-bj29"]).toMatchObject({
       every: "9h",
@@ -231,6 +237,65 @@ describe("registry", () => {
     expect(overlaid.scheduleSources["work-bj29"]).toBe("overlay");
     expect(overlaid.scheduleSources.reaper).toBe("kernel");
     expect(registryDigest(overlaid)).toBe(registryDigest(withoutOverlay));
+  });
+
+  test("an explicitly allowlisted overlay loop may use auto approval and reports its authorization", () => {
+    const config = path.join(
+      tmpDir("event-schedule-overlay-auto-"),
+      "schedule.yaml",
+    );
+    writeFileSync(
+      config,
+      `overlay_auto_approve:\n  - work-bj29\nschedules:\n  work-bj29:\n    enabled: true\n    approval: auto\n`,
+    );
+    const authorized = loadRegistry({
+      packRoots: [],
+      scheduleConfigPath: config,
+    });
+    const withoutOverlay = loadRegistry({
+      packRoots: [],
+      scheduleConfigPath: path.join(
+        tmpDir("event-schedule-overlay-auto-absent-"),
+        "schedule.yaml",
+      ),
+    });
+
+    expect(authorized.schedules["work-bj29"]).toMatchObject({
+      enabled: true,
+      approval: "auto",
+    });
+    expect(authorized.scheduleSources["work-bj29"]).toBe(
+      "operator-authorized-auto",
+    );
+    expect(withoutOverlay.schedules["work-bj29"].approval).toBe("watched");
+    expect(withoutOverlay.scheduleSources["work-bj29"]).toBe("kernel");
+    expect(registryDigest(authorized)).toBe(registryDigest(withoutOverlay));
+  });
+
+  test("an unallowlisted overlay auto request is forced to watched and explains why", () => {
+    const config = path.join(
+      tmpDir("event-schedule-overlay-unlisted-auto-"),
+      "schedule.yaml",
+    );
+    writeFileSync(
+      config,
+      `schedules:\n  work-bj29:\n    enabled: true\n    approval: auto\n`,
+    );
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (message) => warnings.push(message);
+    let registry;
+    try {
+      registry = loadRegistry({ packRoots: [], scheduleConfigPath: config });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(registry.schedules["work-bj29"].approval).toBe("watched");
+    expect(registry.scheduleSources["work-bj29"]).toBe("overlay");
+    expect(warnings).toEqual([
+      expect.stringContaining("not named in overlay_auto_approve"),
+    ]);
   });
 
   test("local schedule overlay permits new complete entries and rejects kernel routing changes", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1032

UX critique: skipped — backend registry/configuration change; no user-facing flow.