### PR TITLE
fix(triage): pass --repo to ticket.mjs in triage-apply action registry

### DIFF
--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -12,6 +12,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "state",
         "{issueId}",
         "Todo",
@@ -31,6 +33,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "state",
         "{issueId}",
         "Todo"
@@ -40,6 +44,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "detail",
         "{issueId}",
         "{detail}"
@@ -49,6 +55,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "comment",
         "{issueId}",
         "triage: {reason}"
@@ -58,6 +66,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "comment",
         "{issueId}",
         "triage: possible duplicate — {reason}"
@@ -67,6 +77,8 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
+        "--repo",
+        "{repo}",
         "comment",
         "{issueId}",
         "triage: needs a human decision — {reason}"

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -202,8 +202,14 @@ describe("registry", () => {
     // Regenerated (#996): added the work-factory clock (30m,
     // factory.work.requested, auto) so agent-ready supply self-dispatches
     // without a manual work.requested seed.
+    // Regenerated (triage-apply repo plane): the label/detail/comment action
+    // argv templates now pass `--repo {repo}` to ticket.mjs, so triage-apply
+    // resolves the issue's own control plane instead of defaulting to the
+    // cwd (github) plane — the apply-side sibling of #985's scan-side fix.
+    // Without it, applying a triage plan to any Linear repo fails closed with
+    // "not a GitHub issue identifier". triage-apply.json is a registry input.
     const expected =
-      "sha256:0b81a3dcf88337f3de27f0815b6c60a2676a073e1b10f2302a13d88c641ee31e";
+      "sha256:1b069c19a536663dab214898ac137184839aa1edb29b4d382ebc510c1c468d7c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
## Problem

Running the triage lane on **cashsaas** surfaced this: the `triage-scan` produced a correct 68-issue plan (43 agent-ready, 5 write-detail, 11 needs-detail, 9 needs-human), but `triage-apply` **FAILED** on the first item:

```
$ CLNT-1015:label-agent-ready: bun .../tools/ticket.mjs state CLNT-1015 Todo --add ai:agent-ready ...
ticket state: not a GitHub issue identifier: CLNT-1015 (want owner/repo#N)
FAILED on CLNT-1015:label-agent-ready (exit 1) after 0 applied
```

The closed action registry in `event-runtime/agents/triage-apply.json` invokes `tools/ticket.mjs` **without `--repo`**. `triage-apply` runs in an ephemeral workspace with `cwd = factory root`, so `ticket.mjs` resolves the control plane by cwd match → the **github** plane → every Linear ticket id is rejected. This breaks `triage-apply` for **every** `control_plane: linear` repo (cashsaas, bj29, legalease).

## Fix

Thread `--repo {repo}` into all six action argv templates (label-agent-ready, move-to-todo, write-detail, needs-detail, mark-duplicate, needs-human).

- `{repo}` is already in the apply input (`spec.input.repo`, confirmed `"cashsaas"`) and `substituteArgv` spreads `spec.input`, so it resolves per issue.
- `--repo` is a **global** `ticket.mjs` flag (resolves the control plane for all verbs, tools/ticket.mjs:302–385), so github repos (factory) are unaffected — they resolve `--repo factory` → github, same as the prior cwd match.

This is the **apply-side sibling of #985**, which fixed the identical default-to-cwd-plane bug on the `triage-scan` read side. The scan was fixed; the apply was missed.

## Digest

`triage-apply.json` is a registry input, so the zero-pack merged-view digest is regenerated (registry.test.mjs) with an explicit reason comment per the gate's rule.

## Verification

`bun test` registry + actions-adapter + triage + chain suites — **107 pass, 0 fail**. Diff is exactly the 12 `--repo {repo}` argv lines + the digest constant.