### PR TITLE
fix(triage): place --repo after the verb in triage-apply argv (regression from #1035)

### DIFF
--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -12,8 +12,6 @@
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "state",
         "{issueId}",
         "Todo",
@@ -26,62 +24,64 @@
         "--remove",
         "tier:strong",
         "--add",
-        "tier:{tier}"
+        "tier:{tier}",
+        "--repo",
+        "{repo}"
       ]
     },
     "move-to-todo": {
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "state",
         "{issueId}",
-        "Todo"
+        "Todo",
+        "--repo",
+        "{repo}"
       ]
     },
     "write-detail": {
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "detail",
         "{issueId}",
-        "{detail}"
+        "{detail}",
+        "--repo",
+        "{repo}"
       ]
     },
     "needs-detail": {
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "comment",
         "{issueId}",
-        "triage: {reason}"
+        "triage: {reason}",
+        "--repo",
+        "{repo}"
       ]
     },
     "mark-duplicate": {
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "comment",
         "{issueId}",
-        "triage: possible duplicate — {reason}"
+        "triage: possible duplicate — {reason}",
+        "--repo",
+        "{repo}"
       ]
     },
     "needs-human": {
       "argv": [
         "bun",
         "{factoryRoot}/tools/ticket.mjs",
-        "--repo",
-        "{repo}",
         "comment",
         "{issueId}",
-        "triage: needs a human decision — {reason}"
+        "triage: needs a human decision — {reason}",
+        "--repo",
+        "{repo}"
       ]
     }
   },

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -208,8 +208,13 @@ describe("registry", () => {
     // cwd (github) plane — the apply-side sibling of #985's scan-side fix.
     // Without it, applying a triage plan to any Linear repo fails closed with
     // "not a GitHub issue identifier". triage-apply.json is a registry input.
+    // Regenerated (triage-apply repo-flag position): --repo {repo} moved from
+    // before the verb to the END of each argv. ticket.mjs takes the verb from
+    // argv[0] (tools/ticket.mjs:526), so a leading --repo was parsed as the
+    // verb and every action exited non-zero; --repo is in VALUE_FLAGS so it
+    // parses correctly anywhere after the verb (matches `queue --repo bj29`).
     const expected =
-      "sha256:1b069c19a536663dab214898ac137184839aa1edb29b4d382ebc510c1c468d7c";
+      "sha256:0a3dc3e55fce8c033bd6c95db09a01a161bb3b89f11f07b11d67cc480e38ba2c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
## Regression from #1035

#1035 correctly identified that triage-apply must pass `--repo` to `ticket.mjs`, but placed `--repo {repo}` **immediately after the script path — before the verb**:

```
bun .../ticket.mjs --repo cashsaas state CLNT-1015 Todo ...
```

`ticket.mjs` reads the verb from `argv[0]` (tools/ticket.mjs:526), so `--repo` became the 'verb', printed usage, and exited 2. **triage-apply still failed on every Linear repo** — just with a different error than before #1035. My end-to-end verification in #1035 only ran the unit suites (which assert argv are strings, not that ticket.mjs accepts the order); this time I ran the real command.

## Fix

Move `--repo {repo}` to the **end** of each of the six argv templates. `repo` is in `VALUE_FLAGS` (tools/ticket.mjs:468–483), so `parsePositionalArgs` consumes the `--repo <value>` pair wherever it appears after the verb, leaving the verb's positionals ({issueId}, Todo, {detail}, {reason}) intact. This matches the documented `queue --repo bj29` convention.

## Verified end-to-end (not just units this time)

Ran the corrected command against a live cashsaas ticket:
```
bun tools/ticket.mjs state CLNT-1015 Todo --add ai:agent-ready --remove tier:light --remove tier:standard --remove tier:strong --add tier:strong --repo cashsaas
```
→ parsed correctly, applied `ai:agent-ready`, moved to Todo. (It then surfaced a **separate** gap — the cashsaas Linear workspace is missing the `tier:*` labels — which is being handled independently of this arg-order fix.)

Digest regenerated (triage-apply.json is a registry input). registry/actions/triage suites: **90 pass, 0 fail**.