### PR TITLE
fix(event-runtime): require absolute config-listed pack roots

### DIFF
--- a/docs/kernel-and-packs.md
+++ b/docs/kernel-and-packs.md
@@ -13,14 +13,15 @@ never scans a directory for packs.
 ```yaml
 packs:
   - name: dreaming
-    path: packs/dreaming # relative to the factory checkout; absolute is allowed
+    path: /opt/factory-packs/dreaming
     namespace: dreaming # optional here when pack.json declares it
 ```
 
 An absent block and `packs: []` both load only the built-in root. Entries are
 loaded after the built-in root and in policy order. Each entry accepts only
-`name`, `path`, and optional `namespace`; malformed entries, duplicate names,
-or unreadable pack content fail registry startup closed.
+`name`, an absolute `path`, and optional `namespace`; relative paths are
+rejected rather than resolved against the factory checkout. Malformed entries,
+duplicate names, or unreadable pack content fail registry startup closed.
 
 A pack can also arrive inside an **extension** — one directory whose
 `factory-extension.json` lists its packs (and adapters) and is enabled with a

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -252,13 +252,16 @@ export function loadPackRoots({ root = reposRoot() } = {}) {
     if (typeof entry.path !== "string" || entry.path.trim() === "") {
       throw new RegistryError(`${at}.path must be a non-empty string`);
     }
+    if (!path.isAbsolute(entry.path)) {
+      throw new RegistryError(`${at}.path must be an absolute path`);
+    }
     if (entry.namespace !== undefined && typeof entry.namespace !== "string") {
       throw new RegistryError(`${at}.namespace must be a string when present`);
     }
     return {
       kind: "fs",
       name: entry.name,
-      path: path.resolve(root, entry.path),
+      path: path.resolve(entry.path),
       ...(entry.namespace !== undefined ? { namespace: entry.namespace } : {}),
     };
   });

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -682,17 +682,26 @@ describe("registry", () => {
     const root = tmpDir("event-policy-packs-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     const policy = path.join(root, "config", "policy.yaml");
+    const packRoot = path.join(root, "vendor", "sample");
     expect(loadPackRoots({ root })).toEqual([]);
 
     writeFileSync(
       policy,
       "packs:\n  - name: sample\n    path: vendor/sample\n    namespace: sample\n",
     );
+    expect(() => loadPackRoots({ root })).toThrow(
+      /packs\[0\]\.path must be an absolute path/,
+    );
+
+    writeFileSync(
+      policy,
+      `packs:\n  - name: sample\n    path: ${JSON.stringify(packRoot)}\n    namespace: sample\n`,
+    );
     expect(loadPackRoots({ root })).toEqual([
       {
         kind: "fs",
         name: "sample",
-        path: path.join(root, "vendor", "sample"),
+        path: packRoot,
         namespace: "sample",
       },
     ]);
@@ -700,7 +709,7 @@ describe("registry", () => {
     expect(() => loadPackRoots({ root })).toThrow(/packs.*array/);
     writeFileSync(
       policy,
-      "packs:\n  - name: sample\n    path: one\n  - name: sample\n    path: two\n",
+      `packs:\n  - name: sample\n    path: ${JSON.stringify(path.join(root, "one"))}\n  - name: sample\n    path: ${JSON.stringify(path.join(root, "two"))}\n`,
     );
     expect(() => loadPackRoots({ root })).toThrow(/duplicate pack name/);
   });


### PR DESCRIPTION
Fixes watt-mind/factory#1011

UX critique: skipped — backend registry validation and documentation only.