### PR TITLE
docs(event-runtime): fix presentation links example

### DIFF
--- a/docs/event-runtime-artifact-views.md
+++ b/docs/event-runtime-artifact-views.md
@@ -397,7 +397,6 @@ An optional `presentation` in `result.json`, beside `artifact`, exactly as
       "items": [
         {
           "label": "Repo",
-          "issue": null,
           "url": "https://github.com/watt-mind/factory"
         }
       ]


### PR DESCRIPTION
Fixes watt-mind/factory#1039

UX critique: skipped — documentation-only change; no user-facing flow.