### PR TITLE
feat(site): align docs with Watt Mind brand shell

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -31,9 +31,16 @@ export default defineConfig({
       ],
       customCss: ["./src/styles/tokens.css", "./src/styles/custom.css"],
       components: {
+        Footer: "./src/components/Footer.astro",
         Hero: "./src/components/HomeHero.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
       head: [
+        {
+          tag: "script",
+          content:
+            'try { if (localStorage.getItem("starlight-theme") === null) localStorage.setItem("starlight-theme", "dark"); } catch {}',
+        },
         {
           tag: "script",
           attrs: {

--- a/site/design.md
+++ b/site/design.md
@@ -14,6 +14,9 @@ Modern-minimal, dark-first, technical, and restrained.
 - Use an asymmetric typographic marquee on the homepage: a large factual
   statement, compact supporting copy and actions, then one bounded execution
   rail. Do not repeat the brand mark as a floating hero illustration.
+- Give the homepage the Watt Mind marketing canvas: 16px mobile margins, 64px
+  desktop margins, and a 1440px maximum shell. Keep documentation prose at its
+  narrower readable measure.
 - Use a long-document rhythm: readable prose measure, quiet dividers, and dense
   reference surfaces.
 - Keep prose and diagram surfaces clean. Do not use background grids: they
@@ -37,11 +40,21 @@ Exact OKLCH conversions live in `src/styles/tokens.css`.
 - Body: Inter, 400–600.
 - Metadata and code: JetBrains Mono, 400–600.
 
-## Spacing and components
+## Brand shell and components
 
+- Use an 80px navigation shell with the Watt Mind mark, `WATT_MIND` display
+  lockup, and a compact mono `[ FACTORY ]` product label.
+- Active documentation navigation is transparent, phosphor teal, uppercase
+  mono text wrapped in brackets. Do not use a filled teal active chip.
+- Primary actions use the darker primary-container fill, dark ink, 8px radius,
+  and uppercase JetBrains Mono labels. Avoid pill-shaped product CTAs.
+- Close pages with a compact Watt Mind colophon while preserving Starlight's
+  edit, last-updated, and pagination controls.
+- Dark is the initial brand presentation. Keep the light and auto options as an
+  explicit accessibility preference rather than removing the theme selector.
 - 4px base scale, 24px content gutters.
 - Cards use translucent `surface-container`, a 12px blur, and a one-pixel
-  `outline-variant` border.
+  `outline-variant` border. Static cards do not animate on hover.
 - Interactive emphasis uses phosphor teal. Avoid decorative gradients outside
   restrained hero focus and diagram grid treatments.
 - Motion is limited to transform and opacity, with reduced-motion support.

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,0 +1,141 @@
+---
+import EditLink from "virtual:starlight/components/EditLink";
+import LastUpdated from "virtual:starlight/components/LastUpdated";
+import Pagination from "virtual:starlight/components/Pagination";
+import wattMindLogo from "../assets/watt-mind-logo.svg";
+
+const { siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<footer class="wm-footer">
+  <div class="wm-footer__meta">
+    <EditLink />
+    <LastUpdated />
+  </div>
+
+  <Pagination />
+
+  <div class="wm-footer__close">
+    <a
+      class="wm-footer__lockup"
+      href="https://watt-mind.com"
+      aria-label="Visit Watt Mind"
+    >
+      <img
+        src={wattMindLogo.src}
+        width={wattMindLogo.width}
+        height={wattMindLogo.height}
+        alt=""
+      />
+      <span>WATT_MIND</span>
+    </a>
+
+    <p>Factory is built and maintained by Watt Mind.</p>
+
+    <nav class="wm-footer__links" aria-label="Factory and Watt Mind links">
+      <a href={siteTitleHref}>Factory docs</a>
+      <a href="https://github.com/watt-mind/factory">GitHub</a>
+      <a href="https://watt-mind.com">Watt Mind</a>
+    </nav>
+  </div>
+</footer>
+
+<style>
+  @layer starlight.core {
+    .wm-footer {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wm-space-md);
+    }
+
+    .wm-footer__meta {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: var(--wm-space-xs) var(--wm-space-xl);
+      margin-block-start: var(--wm-space-xl);
+      color: var(--sl-color-gray-3);
+      font-size: var(--sl-text-sm);
+    }
+
+    .wm-footer__meta > :global(p:only-child) {
+      margin-inline-start: auto;
+    }
+
+    .wm-footer__close {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: var(--wm-space-sm) var(--wm-space-md);
+      align-items: center;
+      margin-block-start: var(--wm-space-md);
+      padding-block: var(--wm-space-lg);
+      border-block: var(--wm-rule);
+    }
+
+    .wm-footer__lockup {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wm-space-2xs);
+      color: var(--sl-color-white);
+      font-family: var(--wm-font-display);
+      font-size: var(--sl-text-sm);
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .wm-footer__lockup img {
+      width: 2rem;
+      height: 2rem;
+      object-fit: contain;
+    }
+
+    .wm-footer__close p {
+      margin: 0;
+      color: var(--sl-color-gray-2);
+      font-size: var(--sl-text-sm);
+      line-height: 1.5;
+    }
+
+    .wm-footer__links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wm-space-xs) var(--wm-space-md);
+      align-items: center;
+      justify-content: flex-end;
+      font-family: var(--wm-font-mono);
+      font-size: var(--sl-text-xs);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .wm-footer__links a {
+      color: var(--sl-color-gray-2);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .wm-footer__lockup:hover,
+    .wm-footer__links a:hover {
+      color: var(--wm-color-primary);
+    }
+
+    .wm-footer__lockup:active,
+    .wm-footer__links a:active {
+      color: var(--sl-color-white);
+    }
+
+    @media (max-width: 50rem) {
+      .wm-footer__close {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .wm-footer__links {
+        justify-content: flex-start;
+      }
+    }
+  }
+</style>

--- a/site/src/components/HomeHero.astro
+++ b/site/src/components/HomeHero.astro
@@ -66,7 +66,7 @@ const stages = [
 <style>
   /* Hallmark · genre: modern-minimal · macrostructure: asymmetric typographic marquee · design-system: design.md · designed-as-app */
   /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 · contrast: pass (40–41) · mobile: pass (34, 49, 50–57) */
-  @layer starlight.core {
+  @layer starlight.components {
     .home-hero {
       display: grid;
       grid-template-columns: minmax(0, 1fr);
@@ -117,17 +117,44 @@ const stages = [
     }
 
     .home-hero :global(.sl-link-button) {
-      min-height: 3rem;
+      min-height: 3.25rem;
       border-radius: var(--wm-radius-md);
-      font-weight: 600;
+      font-family: var(--wm-font-mono);
+      font-size: 0.75rem;
+      font-weight: 700;
+      padding-block: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
       white-space: nowrap;
       transition:
         transform var(--wm-duration-short) var(--wm-ease-out),
         background-color var(--wm-duration-short) var(--wm-ease-out),
-        border-color var(--wm-duration-short) var(--wm-ease-out);
+        border-color var(--wm-duration-short) var(--wm-ease-out),
+        color var(--wm-duration-short) var(--wm-ease-out);
+    }
+
+    .home-hero :global(.sl-link-button.primary) {
+      border-color: var(--wm-color-primary-container);
+      background: var(--wm-color-primary-container);
+      color: var(--wm-color-on-primary);
+    }
+
+    .home-hero :global(.sl-link-button.secondary) {
+      border-color: var(--wm-color-primary);
+      background: transparent;
+      color: var(--wm-color-primary);
+    }
+
+    .home-hero :global(.sl-link-button.minimal) {
+      border-color: transparent;
+      background: transparent;
+      color: var(--sl-color-gray-2);
     }
 
     .home-hero :global(.sl-link-button:hover) {
+      border-color: var(--wm-color-primary);
+      background: var(--wm-color-primary);
+      color: var(--wm-color-on-primary);
       transform: translateY(-2px);
     }
 

--- a/site/src/components/SiteTitle.astro
+++ b/site/src/components/SiteTitle.astro
@@ -1,0 +1,92 @@
+---
+import wattMindLogo from "../assets/watt-mind-logo.svg";
+
+const { siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<a
+  href={siteTitleHref}
+  class="wm-site-title"
+  aria-label="Factory documentation home, by Watt Mind"
+>
+  <img
+    src={wattMindLogo.src}
+    width={wattMindLogo.width}
+    height={wattMindLogo.height}
+    alt=""
+  />
+  <span class="wm-site-title__brand" translate="no">WATT_MIND</span>
+  <span class="wm-site-title__product" translate="no">[ FACTORY ]</span>
+</a>
+
+<style>
+  @layer starlight.core {
+    .wm-site-title {
+      display: inline-flex;
+      min-width: 0;
+      align-items: center;
+      gap: var(--wm-space-2xs);
+      color: var(--sl-color-white);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .wm-site-title img {
+      width: 2rem;
+      height: 2rem;
+      flex: none;
+      object-fit: contain;
+    }
+
+    .wm-site-title__brand {
+      overflow: hidden;
+      font-family: var(--wm-font-display);
+      font-size: 1.05rem;
+      font-weight: 800;
+      letter-spacing: -0.04em;
+      line-height: 1;
+    }
+
+    .wm-site-title__product {
+      color: var(--wm-color-primary);
+      font-family: var(--wm-font-mono);
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      line-height: 1;
+    }
+
+    .wm-site-title:hover .wm-site-title__product {
+      color: var(--sl-color-white);
+    }
+
+    .wm-site-title:active {
+      transform: translateY(1px);
+    }
+
+    @media (max-width: 22rem) {
+      .wm-site-title__brand {
+        display: none;
+      }
+    }
+
+    @media (min-width: 50rem) {
+      .wm-site-title {
+        gap: var(--wm-space-xs);
+      }
+
+      .wm-site-title img {
+        width: 2.5rem;
+        height: 2.5rem;
+      }
+
+      .wm-site-title__brand {
+        font-size: 1.25rem;
+      }
+
+      .wm-site-title__product {
+        font-size: 0.6875rem;
+      }
+    }
+  }
+</style>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -47,23 +47,25 @@ No checkout yet? The [Connect Your Repo](/factory/getting-started/quickstart/) p
 
 Not a demo benchmark — real dogfooding numbers across 17 days of continuous unattended operation:
 
-<CardGrid>
-  <Card title="1,825 Tickets Dispatched">
-    Dispatched across client repositories, infrastructure ops, and factory
-    self-maintenance.
-  </Card>
-  <Card title="1,620 Merged PRs">
-    Merged strictly after tests passed, CI turned green, and reviewer checks
-    succeeded.
-  </Card>
-  <Card title="87% Zero Touch">
-    Never visited Blocked, required zero human keyboard interaction from claim
-    to merge.
-  </Card>
-  <Card title="38 Min Median Merge">
-    Median wall-clock duration from agent claim to merged pull request.
-  </Card>
-</CardGrid>
+<div class="metrics-rail">
+  <CardGrid>
+    <Card title="1,825 Tickets Dispatched">
+      Dispatched across client repositories, infrastructure ops, and factory
+      self-maintenance.
+    </Card>
+    <Card title="1,620 Merged PRs">
+      Merged strictly after tests passed, CI turned green, and reviewer checks
+      succeeded.
+    </Card>
+    <Card title="87% Zero Touch">
+      Never visited Blocked, required zero human keyboard interaction from claim
+      to merge.
+    </Card>
+    <Card title="38 Min Median Merge">
+      Median wall-clock duration from agent claim to merged pull request.
+    </Card>
+  </CardGrid>
+</div>
 
 ---
 

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -15,6 +15,11 @@
   --sl-font: var(--wm-font-body);
   --sl-font-mono: var(--wm-font-mono);
   --sl-content-width: 52rem;
+  --sl-nav-height: 5rem;
+}
+
+:root[data-has-hero]:not([data-has-sidebar]) {
+  --sl-content-width: 82rem;
 }
 
 :root[data-theme="light"] {
@@ -94,9 +99,31 @@ pre {
 }
 
 header.header {
+  padding: 0;
   border-bottom: var(--wm-rule);
   background: color-mix(in oklch, var(--sl-color-black) 84%, transparent);
   backdrop-filter: blur(12px);
+}
+
+header.header > .header {
+  width: 100%;
+  max-width: var(--wm-container-max);
+  height: 100%;
+  margin-inline: auto;
+  padding-inline: var(--wm-page-margin);
+}
+
+header.header site-search > button[data-open-modal],
+header.header starlight-theme-select select {
+  border-radius: var(--wm-radius-sm);
+  font-family: var(--wm-font-mono);
+  font-size: var(--sl-text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+header.header starlight-theme-select select {
+  text-transform: uppercase;
 }
 
 .sidebar-pane,
@@ -109,20 +136,6 @@ header.header {
   border-radius: var(--wm-radius-lg) !important;
   background: var(--wm-color-panel) !important;
   backdrop-filter: blur(12px);
-  transition:
-    transform var(--wm-duration-short) var(--wm-ease-out),
-    border-color var(--wm-duration-short) var(--wm-ease-out),
-    background-color var(--wm-duration-short) var(--wm-ease-out) !important;
-}
-
-.card:hover {
-  border-color: color-mix(
-    in oklch,
-    var(--wm-color-primary) 55%,
-    transparent
-  ) !important;
-  background: var(--wm-color-panel-hover) !important;
-  transform: translateY(-2px);
 }
 
 .card .title {
@@ -139,6 +152,35 @@ header.header {
   line-height: 1.6 !important;
 }
 
+.sidebar-content a[aria-current="page"],
+.sidebar-content a[aria-current="page"]:hover,
+.sidebar-content a[aria-current="page"]:focus {
+  background: transparent;
+  color: var(--wm-color-primary);
+  font-family: var(--wm-font-mono);
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.sidebar-content a[aria-current="page"] > span:first-child::before {
+  content: "[ ";
+}
+
+.sidebar-content a[aria-current="page"] > span:first-child::after {
+  content: " ]";
+}
+
+.metrics-rail .card-grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--wm-space-md);
+}
+
+.metrics-rail .card {
+  height: 100%;
+  padding: var(--wm-space-md) !important;
+}
+
 .tenet-card-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -153,16 +195,6 @@ header.header {
   border-radius: var(--wm-radius-lg);
   background: var(--wm-color-panel);
   backdrop-filter: blur(12px);
-  transition:
-    transform var(--wm-duration-short) var(--wm-ease-out),
-    border-color var(--wm-duration-short) var(--wm-ease-out),
-    background-color var(--wm-duration-short) var(--wm-ease-out);
-}
-
-.tenet-card:hover {
-  border-color: color-mix(in oklch, var(--wm-color-primary) 55%, transparent);
-  background: var(--wm-color-panel-hover);
-  transform: translateY(-2px);
 }
 
 .tenet-card__illustration {
@@ -275,6 +307,24 @@ tr:last-child td {
 :focus-visible {
   outline: 2px solid var(--wm-color-focus);
   outline-offset: 3px;
+}
+
+@media (min-width: 40rem) {
+  .metrics-rail .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 50rem) {
+  :root {
+    --wm-page-margin: 4rem;
+  }
+}
+
+@media (min-width: 72rem) {
+  .metrics-rail .card-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 50rem) {

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -32,11 +32,13 @@
   --wm-space-xl: 3rem;
   --wm-space-2xl: 4rem;
   --wm-space-3xl: 6rem;
+  --wm-page-margin: 1rem;
+  --wm-container-max: 90rem;
   --wm-radius-sm: 0.25rem;
   --wm-radius-md: 0.5rem;
   --wm-radius-lg: 0.75rem;
   --wm-rule: 1px solid var(--wm-color-outline-variant);
   --wm-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --wm-duration-short: 180ms;
-  --wm-text-hero: clamp(3.5rem, 7vw, 6.75rem);
+  --wm-text-hero: clamp(3.5rem, 6.25vw, 6rem);
 }


### PR DESCRIPTION
## Summary
- replace the generic Starlight title and empty footer with a Watt Mind / Factory lockup and compact brand colophon
- align hero CTAs and active documentation navigation with Watt Mind’s mono, bracketed product language
- widen only the homepage to the 1440px marketing shell and render production metrics as a responsive 4/2/1 rail
- keep Starlight search, pagination, documentation IA, and theme choice while making dark the fresh-session default
- remove hover lift from non-interactive cards and reduce the hero scale

## Verification
- `bun run docs:build`
- `bunx prettier --check site/astro.config.mjs site/design.md site/src/styles/tokens.css site/src/styles/custom.css site/src/content/docs/index.mdx`
- `bun run lint` — 0 errors (existing repository warnings remain)
- `bun run check` — generated tree matches; external main-checkout floor warning unchanged
- `factory security`
- Browser QA at 320, 375, 414, 768, 1280, and 1440px — no horizontal overflow; dark default and theme switching verified
- UX critique: SHIP; cold diff review: MERGE

Fixes #1042