### PR TITLE
fix(schema): allow artifact.captured in command-result output contract

### DIFF
--- a/event-runtime/agents/ci-notify.json
+++ b/event-runtime/agents/ci-notify.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/ci-notify.md": "sha256:c12a7d0613ed8fc030f29447f495fd0d70c55ec099f42ac9c08e07629283510d",
     "schemas/ci-notify.input.json": "sha256:ad1596d31e703c7af6233f752a7bedcf6f97509d4a295b07a9c630f5284110bd",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/ci-rerun.json
+++ b/event-runtime/agents/ci-rerun.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/ci-rerun.md": "sha256:1e357287cb35d28f110040f665733cb6db76d8fcc2c2bd43d412148ed3d27ad6",
     "schemas/ci-rerun.input.json": "sha256:d3e79e158029b58c0d4c37b36d0f1233c78763cadc9db8edda92d3d212300284",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/janitor-apply.json
+++ b/event-runtime/agents/janitor-apply.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/janitor-apply.md": "sha256:b39c76f7970935eaa03c2eb841843ba7b08cbe4b8441efa32a2745f40ecfde17",
     "schemas/janitor.input.json": "sha256:bc78f62fa90f56d78587bf472fba015eda2cd805bdefe19283d618590ecc6969",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/janitor-scan.json
+++ b/event-runtime/agents/janitor-scan.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/janitor-scan.md": "sha256:b9785a8576f64e1d40c82970377b7d806b26935243c3a459d6b73e30dd776a89",
     "schemas/janitor.input.json": "sha256:bc78f62fa90f56d78587bf472fba015eda2cd805bdefe19283d618590ecc6969",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/label-guard.json
+++ b/event-runtime/agents/label-guard.json
@@ -30,6 +30,6 @@
   "pins": {
     "agents/label-guard.md": "sha256:c830c11cc98ada2c13a412985e91e6c7befbffa7400bcac084c8b13d1c5fb0ed",
     "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/merge-notify.json
+++ b/event-runtime/agents/merge-notify.json
@@ -22,6 +22,6 @@
   "pins": {
     "agents/merge-notify.md": "sha256:08c6b9c75db11728b3959b7f75e15d88f5d38d4dc39009b4c5ff77211011df17",
     "schemas/merge-notify.input.json": "sha256:cf759d06e47abd5e60335da8881358e82670b09f81e95a7df69e0d9216b30f26",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/merge-verify.json
+++ b/event-runtime/agents/merge-verify.json
@@ -30,6 +30,6 @@
   "pins": {
     "agents/merge-verify.md": "sha256:639cabb93ba9884c2250071147e21294396fddee125fd313ebe0318956ab7d8b",
     "schemas/merge-verify.input.json": "sha256:7b1a0ec51bff5ed2ec99ed9ab0656f62481a038f7ab1bc8be7ce5c73b9aedd62",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/reaper.json
+++ b/event-runtime/agents/reaper.json
@@ -24,6 +24,6 @@
   "pins": {
     "agents/reaper.md": "sha256:87836b6d71a90d39c0a27639f3bb959c9a8f1919186bfa0bc2fe11697fc557cb",
     "schemas/reaper.input.json": "sha256:f97328e93b2cbc9b782322d8aebc9373cc29352906b686e817b327b92cf88f2b",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/reconcile.json
+++ b/event-runtime/agents/reconcile.json
@@ -30,6 +30,6 @@
   "pins": {
     "agents/reconcile.md": "sha256:f2c7e089132677a70e82346b1e51ad68739746da36abef29e2a17a9f172dfb4a",
     "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/unblock-digest.json
+++ b/event-runtime/agents/unblock-digest.json
@@ -29,6 +29,6 @@
   "pins": {
     "agents/unblock-digest.md": "sha256:551dc3472350c0f40b7ce445b7d1b9b101d6a08473ab3c5afd3bd38c42036bc5",
     "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/agents/warm.json
+++ b/event-runtime/agents/warm.json
@@ -30,6 +30,6 @@
   "pins": {
     "agents/warm.md": "sha256:3c873b0f2ed6cc1c98200773218f3ffb83379c138107597f2ec088e45dbe3238",
     "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
-    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+    "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }
 }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -215,8 +215,13 @@ describe("registry", () => {
     // parses correctly anywhere after the verb (matches `queue --repo bj29`).
     // Regenerated (#910): label-agent-ready also passes its schema-constrained
     // tierReason as a separate state --comment argv element (before --repo).
+    // Regenerated (command-result captured property): the command adapter
+    // emits artifact.captured for any def with captureStdout, but the schema
+    // rejected it (additionalProperties:false) — failing reaper/label-guard/
+    // reconcile/warm/unblock-digest every run. Added captured to the schema;
+    // 11 command defs re-pinned. Registry inputs changed.
     const expected =
-      "sha256:19d3890b35bb760fac2f0343f59fb94c35be7f42aaafd15313e20a32f42895c2";
+      "sha256:0014d85678ba3ab1fd7b66f2f3fec6eb313447280e313e6ace7c6baf44fa032e";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/command-result.output.json
+++ b/event-runtime/schemas/command-result.output.json
@@ -7,9 +7,19 @@
     "command": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "exitCode": { "const": 0 },
-    "outputTail": { "type": "string" }
+    "exitCode": {
+      "const": 0
+    },
+    "outputTail": {
+      "type": "string"
+    },
+    "captured": {
+      "type": "string",
+      "description": "Relative path of the captured stdout log artifact (set when the agent def declares captureStdout)."
+    }
   }
 }


### PR DESCRIPTION
## Problem

Surfaced when the **reaper was re-enabled** this session: it reclaimed **48 stale claims correctly**, but the run was marked **FAILED** with:

```
contract_violation: $: unknown property "captured"
```

The command adapter (`lib/adapters/command.mjs:101`) writes `artifact.captured` for any agent def that sets `captureStdout`, but `schemas/command-result.output.json` is `additionalProperties: false` and never declared `captured`. So **every command agent with `captureStdout` fails contract validation on every run**, even though the command itself succeeds (exit 0).

Affected loops (all set `captureStdout`): **reaper, label-guard, reconcile, warm, unblock-digest** — each silently marked FAILED every cycle. (merge-notify's failures are a separate `exit 2` issue, not this.)

## Fix

Add `captured` (optional string) to the artifact schema. Backward-compatible. The 11 command defs that pin the schema are re-pinned via `update-pins`; the registry merged-view digest is regenerated (documented in the test).

## Verification

`bun test` registry + command-adapter suites — **67 pass, 2 skip, 0 fail**. `format:check` clean. Diff is the schema property + 11 mechanical re-pins + the digest constant.