### PR TITLE
fix(control-plane): quiet the public GitHub timeline (empty pin comments + run: stamps)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -855,9 +855,42 @@ export function githubControlPlane(options = {}) {
    */
   async function maybeStampReadyPin(repo, number, add, description) {
     if (!add?.includes(AGENT_READY_LABEL)) return;
-    await call("POST", `repos/${repo}/issues/${number}/comments`, {
-      body: { body: stampRun(readyPinMarker(description)) },
+    // WM-879 stored the pin as an HTML-comment-only body, which renders as an
+    // empty comment bubble and was re-posted on every (re-)promotion — a wall
+    // of blank duplicates on the public timeline. Keep exactly one pin comment:
+    // a short human-readable line carries the hidden marker (parseReadyPin still
+    // finds it), updated in place, with any older duplicates removed.
+    const body = `Queued for automated implementation.\n\n${readyPinMarker(description)}`;
+    let comments = [];
+    try {
+      const rows = await call(
+        "GET",
+        `repos/${repo}/issues/${number}/comments`,
+        { query: { per_page: "100" } },
+      );
+      comments = Array.isArray(rows) ? rows : [];
+    } catch {
+      // Comment list unreadable — fall back to a single POST below.
+    }
+    const pins = comments.filter((c) => parseReadyPin(c.body));
+    if (pins.length === 0) {
+      await call("POST", `repos/${repo}/issues/${number}/comments`, {
+        body: { body: stampRun(body) },
+      });
+      return;
+    }
+    // Newest pin survives (updated in place); older duplicates are pruned.
+    const newest = pins[pins.length - 1];
+    await call("PATCH", `repos/${repo}/issues/comments/${newest.id}`, {
+      body: { body: stampRun(body) },
     });
+    for (const c of pins.slice(0, -1)) {
+      try {
+        await call("DELETE", `repos/${repo}/issues/comments/${c.id}`);
+      } catch {
+        // Best effort — a leftover duplicate is cosmetic, never a failure.
+      }
+    }
   }
 
   /**

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -358,6 +358,28 @@ function fakeApi(seed) {
       }
     }
 
+    // Comment-by-id endpoint (no issue number): update/delete in place.
+    const commentByIdMatch = pathOnly.match(
+      /^repos\/([^/]+\/[^/]+)\/issues\/comments\/(\d+)$/,
+    );
+    if (commentByIdMatch) {
+      const cid = Number(commentByIdMatch[2]);
+      for (const iss of seed.repos[commentByIdMatch[1]]?.issues ?? []) {
+        const idx = (iss.comments ?? []).findIndex((c) => c.id === cid);
+        if (idx >= 0) {
+          if (method === "PATCH") {
+            iss.comments[idx] = { ...iss.comments[idx], body: body.body };
+            return iss.comments[idx];
+          }
+          if (method === "DELETE") {
+            iss.comments.splice(idx, 1);
+            return {};
+          }
+        }
+      }
+      return {};
+    }
+
     const collabPerm = pathOnly.match(
       /^repos\/([^/]+\/[^/]+)\/collaborators\/([^/]+)\/permission$/,
     );
@@ -828,6 +850,39 @@ describe("trusted-author + body-hash-pin gates (GH-879)", () => {
     await cp.setLabels(`${REPO}#3`, { add: [AGENT_READY_LABEL] });
     const t = await cp.getTicket(`${REPO}#3`);
     expect(t.readyPinHash).toBe(hashJson(t.description));
+  });
+
+  test("re-labeling keeps exactly one pin comment (no blank-bubble duplicates)", async () => {
+    const { cp, seed } = makePlane();
+    await cp.setLabels(`${REPO}#3`, { add: [AGENT_READY_LABEL] });
+    await cp.setLabels(`${REPO}#3`, { add: [AGENT_READY_LABEL] });
+    await cp.setLabels(`${REPO}#3`, { add: [AGENT_READY_LABEL] });
+    const pins = (requireIssue(seed, REPO, 3).comments ?? []).filter((c) =>
+      /factory:ready-pin/.test(c.body),
+    );
+    expect(pins).toHaveLength(1);
+    // The single pin carries a human-readable line, not a blank HTML comment.
+    expect(pins[0].body).toContain("Queued for automated implementation");
+  });
+
+  test("prunes pre-existing duplicate pin comments down to one", async () => {
+    const { cp, seed } = makePlane();
+    const issue = requireIssue(seed, REPO, 3);
+    issue.comments = [
+      {
+        id: 301,
+        body: "<!-- factory:ready-pin sha256:" + "0".repeat(64) + " -->",
+      },
+      {
+        id: 302,
+        body: "<!-- factory:ready-pin sha256:" + "1".repeat(64) + " -->",
+      },
+    ];
+    await cp.setLabels(`${REPO}#3`, { add: [AGENT_READY_LABEL] });
+    const pins = (requireIssue(seed, REPO, 3).comments ?? []).filter((c) =>
+      /factory:ready-pin/.test(c.body),
+    );
+    expect(pins).toHaveLength(1);
   });
 });
 

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -147,8 +147,14 @@ export function appendIssueDetail(currentDescription, rawDetail) {
  * transcript basename; stamping it here makes every comment and filed issue
  * joinable back to the exact run that wrote it. Skipped when the id is
  * already in the body and when unset (interactive human use stays clean).
+ *
+ * Off by default so the public tracker timeline stays clean: run→ticket
+ * attribution already lives in the runtime DB (lifecycle_events), so the
+ * visible `run:<id>` tail on every comment is redundant noise. Opt back in
+ * with FACTORY_COMMENT_ATTRIBUTION=1 when a deployment wants it in-band.
  */
 export function stampRun(body) {
+  if (process.env.FACTORY_COMMENT_ATTRIBUTION !== "1") return body;
   const id = process.env.FACTORY_RUN_ID;
   if (!id || !body || body.includes(`run:${id}`)) return body;
   return `${body}\n\nrun:${id}`;


### PR DESCRIPTION
## Problem

The factory's GitHub presence looked unprofessional — a survey of live issues showed:
- **Empty comment bubbles**, often several per issue: the WM-879 ready-pin was stored as an HTML-comment-only body (`<!-- factory:ready-pin sha256:… -->`), which renders **blank**, and was **re-posted on every (re-)promotion** → duplicates.
- **`run:<id>` tails on every comment** (the OPS-76 attribution stamp) — internal bookkeeping leaking onto the public timeline.

## Fix (Phase 1 — no hash-semantics change, dispatch gate untouched)

1. **Ready-pin → one clean, deduplicated comment.** `maybeStampReadyPin` now finds existing pin comments, **updates the newest in place** (PATCH) with a short human-readable line — `Queued for automated implementation.` — carrying the hidden marker (`parseReadyPin` regex still extracts the hash), and **prunes older duplicates** (DELETE). Result: exactly one professional, non-blank comment per ready issue. The pin stays an API-readable comment because it *must* be — written by triage-apply via the CLI, read by the planner in the runtime (a runtime-DB store would break that split; triage.mjs also documents why it can't be a body footer).
2. **`run:` stamp off by default.** `stampRun` no-ops unless `FACTORY_COMMENT_ATTRIBUTION=1`; run→ticket attribution already lives in the runtime DB.

## Verification

Mock gains PATCH/DELETE on the comment-by-id endpoint. New tests: re-labeling keeps exactly one pin comment; pre-existing duplicates are pruned. **154 pass, 0 fail** (control-plane + triage + planner), format clean.

## Phase 2 (proposed, not in this PR)

Further cleanup needs your steer since it touches more surface: dedup the triage `needs-human`/`needs-detail` comments (e.g. #908 had the same one ×4), and move internal bookkeeping (claim/handoff/reaper notes) off-comment into the runtime DB. Happy to follow up.