### PR TITLE
fix(worker): raise claim-lock requeue budget 8→24 to stop dispatch starvation

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -658,7 +658,15 @@ export function expireRunDeadline(
 export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
 
 /** Claim-lock contention is deferred independently from execution attempts. */
-export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 8;
+// Requeue budget for the per-repo dispatch lock. Contended runs re-queue with
+// exponential backoff and only give up (claim_lock_starvation → REFUSED) after
+// this many attempts. The lock is held briefly (claim + gate control-plane
+// reads, not the agent run), so a contended run reliably wins once the runs
+// ahead of it release — the ceiling only needs to exceed the worker pool's
+// concurrent same-repo contenders. At 8 a surge (a freshly-unblocked backlog,
+// a reaper mass-reclaim, or a merge-lane fan-out) starved legitimate dispatch
+// and merge-fix work; 24 clears a full worker pool of contenders with headroom.
+export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 24;
 export const DEFAULT_MAX_TRANSIENT_GATE_REQUEUES = 3;
 export const CLAIM_LOCK_BACKOFF_BASE_MS = 25;
 export const CLAIM_LOCK_BACKOFF_MAX_MS = 1_000;


### PR DESCRIPTION
## What `claim_lock_starvation` is

Each repo has one dispatch mutex (`<repo>.dispatch.lock`, an atomic file lock) that serializes the **claim + gate control-plane reads** (owned-paths resolution, ticket claim) so two runs can't mutate the same repo's tickets simultaneously. A run that can't acquire it re-queues with exponential backoff and, after `DEFAULT_MAX_CLAIM_LOCK_REQUEUES` attempts, gives up → `claim_lock_starvation` → **REFUSED**. That's the wall of blocked runs on the dashboard.

## Why so many now

**131 starved runs (52 today):** 64 dispatch/factory, 54 merge-fix/bj29, 12 dispatch/cashsaas. Two surges pushed >8 same-repo runs into flight at once:
- The **factory backlog I just unblocked** + the **reaper's mass reclaim** (48 stale claims → Todo in one cycle) → a burst of concurrent factory dispatches.
- The **bj29 merge-lane fan-out** (many merge-fix runs per cycle).

The lock is held only briefly (not for the agent run), so a contended run reliably wins once the runs ahead of it release — the ceiling just has to exceed the worker pool's concurrent same-repo contenders (~10). **At 8 it didn't**, so legitimate dispatch/merge-fix work was dropped.

## Fix

Raise the ceiling **8 → 24** (clears a full worker pool with headroom). Timing-neutral for the normal path — a run that can get the lock does so well before the ceiling; only the give-up point moves. Tests set `maxClaimLockContentionRequeues` explicitly, so the default bump doesn't change their behavior.

## Follow-ups (not in this PR)
- The **bj29 merge-fix** starvation compounds a separate bug: bj29 merge-*reviews* fail closed because `config/repos.yaml`/`config/policy.yaml` aren't in the client checkout (I mis-attributed this to a gemini refusal earlier). Worth its own fix so the bj29 merge lane isn't generating doomed fan-out at all.
- Longer term, a per-ticket (not per-repo) claim lock would remove same-repo contention entirely.