### PR TITLE
fix(worker): provision instance config into client-repo checkouts (unblocks client merge-review)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -85,6 +85,42 @@ const INSTANCE_LOCAL_CONFIG_FILES = Object.freeze([
 ]);
 
 /**
+ * Ensure `rel` is git-ignored in `checkoutPath`, adding it to the checkout's
+ * local `info/exclude` if the repo does not already ignore it. Returns true
+ * when the path is (or becomes) ignored. A client repo does not gitignore the
+ * factory's instance config, so this is how that config can be copied in for a
+ * run while staying un-stageable — a copied-but-committable instance config
+ * would leak the operator's routing/policy into the repo.
+ */
+function ensureLocallyIgnored(checkoutPath, rel) {
+  const isIgnored = () =>
+    spawnSync("git", ["-C", checkoutPath, "check-ignore", "-q", "--", rel], {
+      encoding: "utf8",
+    }).status === 0;
+  if (isIgnored()) return true;
+  const resolved = spawnSync(
+    "git",
+    ["-C", checkoutPath, "rev-parse", "--git-path", "info/exclude"],
+    { encoding: "utf8" },
+  );
+  if (resolved.status !== 0) return false;
+  const excludeFile = path.resolve(checkoutPath, resolved.stdout.trim());
+  try {
+    mkdirSync(path.dirname(excludeFile), { recursive: true });
+    const existing = existsSync(excludeFile)
+      ? readFileSync(excludeFile, "utf8")
+      : "";
+    if (!existing.split(/\r?\n/).includes(`/${rel}`)) {
+      const sep = existing === "" || existing.endsWith("\n") ? "" : "\n";
+      writeFileSync(excludeFile, `${existing}${sep}/${rel}\n`);
+    }
+  } catch {
+    return false;
+  }
+  return isIgnored();
+}
+
+/**
  * Bring the operator-owned config files into a delegated checkout. These
  * files are intentionally untracked, so a fresh worktree otherwise falls
  * back to examples and cannot use this factory instance's routing or policy.
@@ -113,15 +149,18 @@ export function provisionInstanceLocalConfigs({
     const destination = path.join(destinationConfig, filename);
     if (path.resolve(source) === path.resolve(destination)) continue;
 
-    // Never introduce an instance config into a checkout where an agent could
-    // stage it. Non-factory repository fixtures and repositories without this
-    // local-config contract continue using their tracked examples.
-    if (
-      isGitCheckout &&
-      spawnSync("git", ["-C", checkoutPath, "check-ignore", "-q", "--", rel], {
-        encoding: "utf8",
-      }).status !== 0
-    ) {
+    // The instance config must never be stageable in the checkout — an agent
+    // could otherwise commit the operator's routing/policy (with client names)
+    // into a repo. The factory repo already gitignores these paths; a client
+    // repo (bj29, cashsaas, …) has no such entry, so make the path locally
+    // ignored (`.git/info/exclude`) first. Either way the copied config is
+    // present for the run — merge-review resolves the repo's control plane and
+    // merge_ci gate from it — but can never be `git add`-ed. Before this,
+    // client-repo merge-review failed closed on the missing config (the guard
+    // silently skipped the copy, leaving only the tracked example, which the
+    // client repo does not ship). Only fall back to the example if the path
+    // cannot be made ignore-protected.
+    if (isGitCheckout && !ensureLocallyIgnored(checkoutPath, rel)) {
       continue;
     }
     mkdirSync(destinationConfig, { recursive: true });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -327,7 +327,12 @@ describe("worker", () => {
     }
   });
 
-  test("does not provision instance config into a checkout that could stage it", () => {
+  test("provisions instance config into a client checkout but makes it un-stageable", () => {
+    // A client repo (bj29, cashsaas, …) does not gitignore config/repos.yaml,
+    // so the old guard skipped the copy and left the review with no config —
+    // failing it closed. Now the path is added to the checkout's local exclude
+    // and the config IS copied, so merge-review can resolve the repo's control
+    // plane and merge_ci gate, while an agent still cannot `git add` it.
     const factoryRoot = tmpDir("evrt-instance-config-protected-source-");
     const checkout = tmpDir("evrt-instance-config-protected-checkout-");
     try {
@@ -342,10 +347,19 @@ describe("worker", () => {
 
       expect(
         provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
-      ).toEqual([]);
+      ).toEqual(["config/repos.yaml"]);
+      // Copied in, so the run can read it.
       expect(existsSync(path.join(checkout, "config", "repos.yaml"))).toBe(
-        false,
+        true,
       );
+      // But un-stageable: git now ignores it (via .git/info/exclude).
+      expect(
+        spawnSync(
+          "git",
+          ["-C", checkout, "check-ignore", "-q", "--", "config/repos.yaml"],
+          { encoding: "utf8" },
+        ).status,
+      ).toBe(0);
     } finally {
       rmSync(factoryRoot, { recursive: true, force: true });
       rmSync(checkout, { recursive: true, force: true });


### PR DESCRIPTION
## The real cause of the bj29 merge-review refusals

merge-review reads `./repo/config/repos.yaml` + `config/policy.yaml` from the pinned checkout and **fails closed** (`needs_human`) if absent. Those files are gitignored, so `provisionInstanceLocalConfigs` copies them from `FACTORY_ROOT` — **but only where the path is already gitignored in the target checkout** (a guard so an agent can't stage/commit the operator's routing/policy, which includes client names).

- **factory** repo gitignores `config/repos.yaml` → copied → reviews work.
- **client** repos (bj29, cashsaas, legalease) have no such gitignore entry → the guard **silently skipped the copy** → **every client-repo merge-review failed closed** on missing config.

That's ~54 of the bj29 refusals (and it compounds the claim-lock starvation in #1047). I'd earlier mis-attributed these to a gemini safety refusal — the real cause is this config-provisioning guard.

## Fix

When the path isn't already ignored, add it to the checkout's **local `.git/info/exclude`** (`ensureLocallyIgnored`) *then* copy. The config is present for the run — merge-review resolves the client repo's control plane and `merge_ci` gate from it — but stays **un-stageable**, preserving the original safety intent for every repo. Falls back to the tracked example only if the path can't be made ignore-protected.

## Verification

Config-provisioning tests green; the updated test proves a client checkout now gets the config **and** `git check-ignore` protects it (can't be `git add`-ed). Factory-gitignored path unchanged.