### PR TITLE
fix(dispatch): whole-repo Owned Paths claims are advisory, not a hard block

### DIFF
--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -21,7 +21,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:6965f81e5a08793ead2e970dc6aef8592de22588929dc2aa2f3f4cc8602d72ce",
+    "agents/work-scan.md": "sha256:e24e94af8da518ecec063cb5f36a10ea293b98cab74a0353feef647db8197b18",
     "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
     "schemas/work-scan.output.json": "sha256:7250a4c26073e443552b2d0bfdec53b2d4348940a92f250013ad31efdd637055"
   }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -110,17 +110,22 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    in-flight ticket or an already-selected ticket does NOT disqualify — select
    the ticket while a free slot remains and record the overlap in its `reason`
    (`overlaps WM-123 on event-runtime/web/src/App.tsx`); rebase and merge-fix
-   resolve real conflicts later. Only two collisions are hard and defer a
-   candidate as `owned_paths_overlap`: (a) an in-flight or selected ticket
-   claims `**` (including a ticket with no parseable Owned Paths section — see
-   step 4), or (b) the candidate and an in-flight/selected ticket claim the
-   _identical_ concrete file (no globs on either side). Selected in order, each
-   item pins `{ticket, ownedPaths, reason}`. Every candidate not selected goes
-   in `deferred` as `{ticket, reason}`, where `reason` is the typed value
-   `owned_paths_overlap` for a hard collision or `cap_full` when no slot
-   remains. When a hard collision comes from an in-flight ticket with no
-   parseable Owned Paths, name that ticket in the `summary` so the operator can
-   fix its description (WM-868).
+   resolve real conflicts later. A whole-repo (`**`) claim is advisory too: an
+   in-flight or selected ticket that claims `**` — including one with no
+   parseable Owned Paths section (see step 4) — must NOT freeze the queue. A
+   single scope-unknown in-flight ticket (an epic or auto-filed issue parked
+   "In Progress") would otherwise claim the entire repository and stall every
+   ready candidate while the factory sits idle; select the candidate anyway and
+   record `overlaps WM-123 (whole-repo/unknown scope)` in its `reason`. Only one
+   collision is hard and defers a candidate as `owned_paths_overlap`: the
+   candidate and an in-flight/selected ticket claim the _identical_ concrete
+   file (no globs on either side) — a guaranteed conflict worth serializing.
+   Selected in order, each item pins `{ticket, ownedPaths, reason}`. Every
+   candidate not selected goes in `deferred` as `{ticket, reason}`, where
+   `reason` is the typed value `owned_paths_overlap` for a hard collision or
+   `cap_full` when no slot remains. When a candidate rode a whole-repo overlap
+   with an in-flight ticket that has no parseable Owned Paths, name that ticket
+   in the `summary` so the operator can still fix its description (WM-868).
    Do not stop accounting when the slots fill: mark every remaining candidate
    `cap_full`.
 

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1253,10 +1253,16 @@ export function worktreeDispatchAutoEligibility(
         }),
       ),
     );
-    if (hard.length) {
-      evidence.ownedPathsHardConflicts = hard;
-      return refusal("owned_paths_conflict_hard", evidence);
-    }
+    // Advisory means advisory: a whole-repo (`**`) overlap — which is what a
+    // missing/unparseable Owned Paths section on an in-flight ticket resolves
+    // to (ownedPathsForCollision → ["**"]) — is recorded for visibility but
+    // must NOT block. A single scope-unknown in-flight ticket (e.g. an epic or
+    // an auto-filed issue parked "In Progress" without an Owned Paths section)
+    // would otherwise claim the entire repository and freeze the whole queue,
+    // stalling the factory while ready work waits. Overlaps are reconciled
+    // downstream by rebase + merge-fix and the cold merge review. Strict mode
+    // (owned_paths_collision != "advisory") still refuses on any overlap above.
+    if (hard.length) evidence.ownedPathsHardConflicts = hard;
   } else {
     evidence.checks.owned_paths_disjoint = true;
   }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1432,7 +1432,7 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
-  test("advisory mode hard-refuses an in-flight **/* claim", () => {
+  test("advisory mode records but does not block an in-flight **/* claim", () => {
     withReposRoot(
       tierRepo,
       () => {
@@ -1453,7 +1453,14 @@ describe("planEvent worktree gate (WM-108)", () => {
             ],
           },
         );
-        expect(result.refusal?.reason).toBe("owned_paths_conflict_hard");
+        // A whole-repo (`**`) claim from an in-flight ticket no longer hard-
+        // refuses in advisory mode — it is recorded for visibility and the
+        // candidate stays dispatchable (a scope-unknown in-flight ticket must
+        // not freeze the queue).
+        expect(result.refusal?.reason).not.toBe("owned_paths_conflict_hard");
+        expect(result.evidence.ownedPathsHardConflicts).toEqual([
+          { ticket: "WM-953", path: "src/a.ts", inFlightPath: "**/*" },
+        ]);
       },
       "dispatch:\n  owned_paths_collision: advisory\n",
     );

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -220,8 +220,11 @@ describe("registry", () => {
     // rejected it (additionalProperties:false) — failing reaper/label-guard/
     // reconcile/warm/unblock-digest every run. Added captured to the schema;
     // 11 command defs re-pinned. Registry inputs changed.
+    // Regenerated (advisory whole-repo claims): work-scan.md no longer defers
+    // a candidate on an in-flight `**`/no-parseable-Owned-Paths overlap — a
+    // scope-unknown ticket must not freeze the queue. work-scan.md re-pinned.
     const expected =
-      "sha256:0014d85678ba3ab1fd7b66f2f3fec6eb313447280e313e6ace7c6baf44fa032e";
+      "sha256:ea488a081ef38922cf242b06a2749805fd1090d75dd1599fa9523045c5e48bd5";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3772,7 +3772,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       expect(sumB.terminalState).not.toBe("REFUSED");
       expect(sumB.reasonCode).not.toBe("owned_paths_conflict_hard");
 
-      // A `**` claim on the in-flight side: still a hard conflict.
+      // A `**` claim on the in-flight side is now advisory: a scope-unknown
+      // in-flight ticket (missing Owned Paths → whole-repo claim) must not
+      // freeze the queue, so the candidate dispatches rather than hard-refusing.
       queueRun(
         db,
         makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-709" } }),
@@ -3795,8 +3797,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           },
         }),
       );
-      expect(sumC.terminalState).toBe("REFUSED");
-      expect(sumC.reasonCode).toBe("owned_paths_conflict_hard");
+      expect(sumC.terminalState).not.toBe("REFUSED");
+      expect(sumC.reasonCode).not.toBe("owned_paths_conflict_hard");
     } finally {
       writeFileSync(policyPath, priorPolicy);
     }


### PR DESCRIPTION
## Problem

The factory kept going **idle**: an in-flight ticket with a missing/unparseable `## Owned Paths` section resolves to a whole-repo claim (`ownedPathsForCollision → ["**"]`), and under **advisory** collision mode (the default) that was still treated as a **hard conflict** — so every ready candidate collided with it and `work-scan` returned `all_overlapping` / NOOP, dispatching nothing.

A single epic or auto-filed issue parked in the 'In Progress' column without an Owned Paths section claims the entire repository and freezes the whole queue. This has now happened twice (the 12 stale issues, then epics #829/#831), each requiring manual intervention to move the blockers out of In Progress.

## Fix — advisory means advisory

- **Planner gate** (`event-runtime/lib/planner.mjs`): in advisory mode a whole-repo (`**`) overlap is recorded in `evidence.ownedPathsHardConflicts` for visibility but **no longer refuses**; the candidate stays dispatchable.
- **work-scan plan** (`work-scan.md`): an in-flight/selected ticket claiming `**` — including one with no parseable Owned Paths — is advisory (candidate selected, overlap noted in its `reason`). The **only** hard collision left is an *identical concrete file* (no globs) on both sides — a guaranteed conflict worth serializing.
- **Strict mode** (`owned_paths_collision != advisory`) still refuses on any overlap — unchanged escape hatch.

Real conflicts are reconciled downstream by rebase + merge-fix + the cold merge review, exactly as they already are for every other advisory overlap (WM-677).

## Verification

planner + owned-paths + registry suites — **163 pass, 0 fail**. The guarding test that asserted advisory-hard-refuses is updated to assert advisory-records-but-dispatches. work-scan.md re-pinned; merged-view digest regenerated with reason.