### PR TITLE
feat(reaper): make the stale-claim reaper plane-aware (github + linear)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1192,11 +1192,24 @@ export function githubControlPlane(options = {}) {
           `could not resolve pull requests for ${issueIdentifier(repo, number)}`,
         );
       const refs = issue.closedByPullRequestsReferences;
-      if (refs?.pageInfo?.hasNextPage)
+      if (
+        !refs ||
+        !Array.isArray(refs.nodes) ||
+        typeof refs.pageInfo?.hasNextPage !== "boolean" ||
+        refs.nodes.some(
+          (pr) =>
+            typeof pr?.state !== "string" ||
+            typeof pr?.repository?.nameWithOwner !== "string",
+        )
+      )
+        throw new ControlPlaneError(
+          `pull-request lookup for ${issueIdentifier(repo, number)} returned an inconclusive response`,
+        );
+      if (refs.pageInfo.hasNextPage)
         throw new ControlPlaneError(
           `pull-request lookup for ${issueIdentifier(repo, number)} exceeded the 20-reference safety ceiling`,
         );
-      return (refs?.nodes ?? []).some(
+      return refs.nodes.some(
         (pr) => pr?.state === "OPEN" && pr?.repository?.nameWithOwner === repo,
       );
     },

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -126,6 +126,22 @@ const ISSUE_LAST_EDITOR = `query IssueLastEditor($owner: String!, $name: String!
   }
 }`;
 
+// Deliberately bounded and repository-scoped. The closing-reference edge is
+// GitHub's canonical interpretation of "Fixes #N"; unlike body parsing it
+// also handles cross-reference syntax and edits. Twenty simultaneous closing
+// PRs for one issue is already pathological, and a hard ceiling protects the
+// unattended reaper from an unbounded forge walk.
+const ISSUE_OPEN_CLOSING_PULL_REQUESTS = `query IssueOpenClosingPullRequests($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      closedByPullRequestsReferences(first: 20) {
+        nodes { state repository { nameWithOwner } }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}`;
+
 const ADD_PROJECT_ITEM = `mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
   addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
     item { id }
@@ -743,6 +759,11 @@ export function githubControlPlane(options = {}) {
       labels,
       priority: priorityFromLabels(labels),
       createdAt: issue.created_at ?? "",
+      // GitHub has no workflow-state startedAt. Leaving it null makes the
+      // reaper use updated_at, which advances on claim mutations/comments.
+      startedAt: null,
+      updatedAt: issue.updated_at ?? issue.created_at ?? null,
+      lastCommentAt: null,
       // Populated by listTickets/listDispatchable, which resolve dependency
       // state in one batch. A single-issue read leaves it empty rather than
       // firing an extra request per getTicket call.
@@ -974,7 +995,13 @@ export function githubControlPlane(options = {}) {
      * Callers that need the gate ask for it, and `listDispatchable` asks only
      * AFTER narrowing to real candidates.
      */
-    async listTickets({ team, project, states, resolveBlockers = false } = {}) {
+    async listTickets({
+      team,
+      project,
+      states,
+      resolveBlockers = false,
+      includeFinished = false,
+    } = {}) {
       if (!team) throw new ControlPlaneError("listTickets requires team");
       if (project && project !== projectTitle)
         throw new ControlPlaneError(
@@ -1005,7 +1032,11 @@ export function githubControlPlane(options = {}) {
             ? "Done"
             : (statusByNumber.get(issue.number) ?? "Triage");
         const name = String(statusName).toLowerCase();
-        if (wanted ? !wanted.has(name) : ["done", "canceled"].includes(name))
+        if (
+          wanted
+            ? !wanted.has(name)
+            : !includeFinished && ["done", "canceled"].includes(name)
+        )
           continue;
         kept.push({ issue, statusName });
       }
@@ -1142,6 +1173,32 @@ export function githubControlPlane(options = {}) {
         body: { labels: nextLabels },
       });
       await maybeStampReadyPin(repo, number, add, issue.body ?? "");
+    },
+
+    async hasOpenPullRequest(identifier) {
+      const { repo, number } = locate(identifier);
+      const [owner, name] = repo.split("/");
+      // `call` deliberately lets transport/schema failures escape. Returning
+      // false on an unreadable edge would let the reaper destroy a live claim.
+      const d = await call("POST", "graphql", {
+        body: {
+          query: ISSUE_OPEN_CLOSING_PULL_REQUESTS,
+          variables: { owner, name, number },
+        },
+      });
+      const issue = d?.repository?.issue;
+      if (!issue)
+        throw new ControlPlaneError(
+          `could not resolve pull requests for ${issueIdentifier(repo, number)}`,
+        );
+      const refs = issue.closedByPullRequestsReferences;
+      if (refs?.pageInfo?.hasNextPage)
+        throw new ControlPlaneError(
+          `pull-request lookup for ${issueIdentifier(repo, number)} exceeded the 20-reference safety ceiling`,
+        );
+      return (refs?.nodes ?? []).some(
+        (pr) => pr?.state === "OPEN" && pr?.repository?.nameWithOwner === repo,
+      );
     },
 
     async file({

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { hashJson } from "../../event-runtime/lib/canonical.mjs";
 import { ControlPlaneError } from "./types.mjs";
+import { loadControlPlane } from "./index.mjs";
 import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
 import {
   GITHUB_FACTORY_STATES,
@@ -613,6 +614,106 @@ describe("control-plane contract: github", () => {
     await expect(cp.hasOpenPullRequest(`${REPO}#2`)).rejects.toThrow(
       /20-reference safety ceiling/,
     );
+  });
+
+  test("hasOpenPullRequest fails closed on an inconclusive response", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      repo: REPO,
+      teams: { WM: REPO },
+      api(method, pathName, opts) {
+        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+          return { data: { repository: { issue: {} } } };
+        return api(method, pathName, opts);
+      },
+    });
+    await expect(cp.hasOpenPullRequest(`${REPO}#2`)).rejects.toThrow(
+      /inconclusive response/,
+    );
+  });
+
+  test("hasOpenPullRequest fails closed on malformed reference data", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      repo: REPO,
+      teams: { WM: REPO },
+      api(method, pathName, opts) {
+        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+          return {
+            data: {
+              repository: {
+                issue: {
+                  closedByPullRequestsReferences: {
+                    nodes: [null],
+                    pageInfo: {},
+                  },
+                },
+              },
+            },
+          };
+        return api(method, pathName, opts);
+      },
+    });
+    await expect(cp.hasOpenPullRequest(`${REPO}#2`)).rejects.toThrow(
+      /inconclusive response/,
+    );
+  });
+
+  test("loadControlPlane repoName binds GitHub to that repo entry", async () => {
+    const root = tmp("github-repo-binding-");
+    const config = path.join(root, "config");
+    mkdirSync(config, { recursive: true });
+    writeFileSync(
+      path.join(config, "policy.yaml"),
+      [
+        "controlPlane:",
+        "  kind: linear",
+        "  github:",
+        `    repo: ${OTHER_REPO}`,
+        "    teams:",
+        `      ${TEAM}: ${OTHER_REPO}`,
+        "    project: Wrong project",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      path.join(config, "repos.yaml"),
+      [
+        "repos:",
+        "  - name: widget",
+        "    path: /tmp/widget",
+        `    github: ${REPO}`,
+        `    team: ${TEAM}`,
+        `    project: ${PROJECT}`,
+        "    control_plane: github",
+        "",
+      ].join("\n"),
+    );
+    const seed = contractSeed();
+    const cp = loadControlPlane({
+      root,
+      repoName: "widget",
+      api: fakeApi(seed),
+    });
+    const tickets = await cp.listTickets({ team: TEAM, project: PROJECT });
+    expect(tickets.map((ticket) => ticket.identifier)).toEqual([
+      `${REPO}#1`,
+      `${REPO}#2`,
+      `${REPO}#3`,
+    ]);
+  });
+
+  test("loadControlPlane explicit kind does not require repo config", () => {
+    const root = tmp("control-plane-explicit-kind-");
+    expect(
+      loadControlPlane({
+        root,
+        kind: "memory",
+        repoName: "not-configured",
+      }).kind,
+    ).toBe("memory");
   });
 
   test("listTickets lists matching Triage and Todo items and fails closed on a project mismatch", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -100,6 +100,8 @@ function freshSeed() {
     raw: { [RAW_PING]: { ping: true } },
     loseNextClaim: null,
     collaboratorPermissions: {},
+    closingPullRequests: {},
+    closingPullRequestsHasNextPage: {},
   };
 }
 
@@ -119,6 +121,8 @@ function addIssue(seed, repo, spec) {
     pull_request: spec.pull_request,
     author_association: spec.authorAssociation,
     user: spec.authorLogin ? { login: spec.authorLogin } : undefined,
+    created_at: spec.createdAt ?? "2026-08-19T09:00:00Z",
+    updated_at: spec.updatedAt ?? spec.createdAt ?? "2026-08-19T09:00:00Z",
     // WM-879: chronological body-edit history, newest last. Each entry is
     // an editor login, or null to stand in for a ghost/deleted account.
     userContentEdits: spec.editedBy ?? [],
@@ -306,6 +310,31 @@ function fakeApi(seed) {
                   nodes: edits.map((login) => ({
                     editor: login ? { login } : null,
                   })),
+                },
+              },
+            },
+          },
+        };
+      }
+      if (gqlQuery.includes("IssueOpenClosingPullRequests")) {
+        const repoName = `${variables.owner}/${variables.name}`;
+        requireIssue(seed, repoName, variables.number);
+        return {
+          data: {
+            repository: {
+              issue: {
+                closedByPullRequestsReferences: {
+                  nodes:
+                    seed.closingPullRequests?.[
+                      `${repoName}#${variables.number}`
+                    ] ?? [],
+                  pageInfo: {
+                    hasNextPage: Boolean(
+                      seed.closingPullRequestsHasNextPage?.[
+                        `${repoName}#${variables.number}`
+                      ],
+                    ),
+                  },
                 },
               },
             },
@@ -547,6 +576,42 @@ describe("control-plane contract: github", () => {
     expect(await cp.listComments(`${REPO}#1`)).toEqual([]);
     await expect(cp.listComments(`${REPO}#999`)).rejects.toThrow(
       ControlPlaneError,
+    );
+  });
+
+  test("hasOpenPullRequest uses a bounded repository-scoped closing-reference lookup", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequests[`${REPO}#2`] = [
+      { state: "OPEN", repository: { nameWithOwner: OTHER_REPO } },
+      { state: "CLOSED", repository: { nameWithOwner: REPO } },
+      { state: "OPEN", repository: { nameWithOwner: REPO } },
+    ];
+    expect(await cp.hasOpenPullRequest(`${REPO}#2`)).toBe(true);
+    expect(await cp.hasOpenPullRequest(`${REPO}#1`)).toBe(false);
+  });
+
+  test("hasOpenPullRequest propagates transport failure so callers fail closed", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      repo: REPO,
+      teams: { WM: REPO },
+      api(method, pathName, opts) {
+        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+          throw new Error("forge unavailable");
+        return api(method, pathName, opts);
+      },
+    });
+    await expect(cp.hasOpenPullRequest(`${REPO}#2`)).rejects.toThrow(
+      /forge unavailable/,
+    );
+  });
+
+  test("hasOpenPullRequest fails closed when the bounded edge is truncated", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequestsHasNextPage[`${REPO}#2`] = true;
+    await expect(cp.hasOpenPullRequest(`${REPO}#2`)).rejects.toThrow(
+      /20-reference safety ceiling/,
     );
   });
 

--- a/lib/control-plane/index.mjs
+++ b/lib/control-plane/index.mjs
@@ -92,6 +92,16 @@ export function controlPlaneKindFromPolicy(root = DEFAULT_ROOT) {
  * @returns {"linear"|"memory"|"github"|null}
  */
 export function controlPlaneKindFromRepo(repoName, root = DEFAULT_ROOT) {
+  return controlPlaneConfigFromRepo(repoName, root).controlPlane;
+}
+
+/**
+ * The parsed repository entry that owns a per-repo control-plane selection.
+ * Keeping the entry (rather than only its kind) lets the GitHub adapter bind
+ * itself to this repository's forge slug/team/project instead of accidentally
+ * falling back to another repository in the workspace-wide GitHub policy.
+ */
+function controlPlaneConfigFromRepo(repoName, root = DEFAULT_ROOT) {
   const repos = loadRepos({ root });
   const entry = repos.get(repoName);
   if (!entry) {
@@ -99,7 +109,7 @@ export function controlPlaneKindFromRepo(repoName, root = DEFAULT_ROOT) {
       `unknown repo ${JSON.stringify(repoName)} in ${path.join(root, "config", "repos.yaml")} — known: ${[...repos.keys()].join(", ") || "(none)"}`,
     );
   }
-  return entry.controlPlane ?? null;
+  return entry;
 }
 
 /**
@@ -134,15 +144,20 @@ export function loadControlPlane({
   project,
   statusField,
 } = {}) {
+  // An explicit kind is the highest-precedence test/caller override and must
+  // not make an otherwise irrelevant repo registry mandatory. Repo-derived
+  // adapter binding applies when repoName itself selects the plane.
+  const repoConfig =
+    kind == null && repoName != null
+      ? controlPlaneConfigFromRepo(repoName, root)
+      : null;
   // Precedence, most specific first. Each level is skipped only when it has
   // nothing to say (undefined / null), so a repo that sets `control_plane`
   // outranks policy, and a repo that omits it inherits rather than defaults.
   // With no repoName this is byte-identical to the pre-WM-1007 behaviour, and
   // the repo registry is never read.
   const selected =
-    kind ??
-    (repoName != null ? controlPlaneKindFromRepo(repoName, root) : null) ??
-    controlPlaneKindFromPolicy(root);
+    kind ?? repoConfig?.controlPlane ?? controlPlaneKindFromPolicy(root);
   switch (selected) {
     case "linear":
       return linearControlPlane(gql ? { gql } : {});
@@ -153,9 +168,13 @@ export function loadControlPlane({
         root,
         api,
         exec,
-        repo,
-        teams,
-        project,
+        repo: repo ?? repoConfig?.github ?? undefined,
+        teams:
+          teams ??
+          (repoConfig?.team && repoConfig?.github
+            ? { [repoConfig.team]: repoConfig.github }
+            : undefined),
+        project: project ?? repoConfig?.project ?? undefined,
         statusField,
       });
     default:

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -29,10 +29,11 @@ import {
 // give what X blocks — the wrong direction). State `type`, not name: workflow
 // names are per-team config, the types are Linear's own enum.
 const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } }`;
-const ISSUE_FIELDS = `id identifier title url description createdAt priority
+const ISSUE_FIELDS = `id identifier title url description createdAt startedAt updatedAt priority
   state{ id name type } assignee{ id name }
   team{ key } project{ name }
   labels(first:30){ nodes{ id name } }
+  comments(last:1){ nodes{ createdAt } }
   ${BLOCKERS}`;
 
 const teamOf = (key) => String(key).split("-")[0];
@@ -61,6 +62,11 @@ export function normalizeTicket(issue) {
         ? issue.priority
         : null,
     createdAt: issue.createdAt ?? "",
+    startedAt: issue.startedAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    lastCommentAt:
+      issue.comments?.nodes?.[issue.comments.nodes.length - 1]?.createdAt ??
+      null,
     blockedBy: openBlockerIdentifiers(issue),
   };
 }
@@ -159,23 +165,26 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
       return d.issue.comments?.nodes ?? [];
     },
 
-    async listTickets({ team, project, states } = {}) {
+    async listTickets({ team, project, states, includeFinished = false } = {}) {
       if (!team) throw new ControlPlaneError("listTickets requires team");
       // No `states` means "everything not finished" — the dispatcher needs
       // In Progress (for Owned Paths of running work) and Todo from one read.
       const stateFilter = states?.length
         ? `state:{ name:{ in:$s } }`
-        : `state:{ type:{ nin:["completed","canceled"] } }`;
+        : includeFinished
+          ? null
+          : `state:{ type:{ nin:["completed","canceled"] } }`;
+      const stateClause = stateFilter ? `${stateFilter},` : "";
       const decl = states?.length ? ", $s:[String!]" : "";
       const vars = { t: team, ...(project ? { p: project } : {}) };
       if (states?.length) vars.s = states;
       const d = project
         ? await call(
-            `query($t:String!,$p:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateFilter} }){ nodes{ ${ISSUE_FIELDS} } } }`,
+            `query($t:String!,$p:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } } }`,
             vars,
           )
         : await call(
-            `query($t:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, ${stateFilter} }){ nodes{ ${ISSUE_FIELDS} } } }`,
+            `query($t:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } } }`,
             vars,
           );
       return (d?.issues?.nodes ?? []).map(normalizeTicket).sort(byQueueOrder);
@@ -279,6 +288,13 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
       await issueUpdate(issue.id, {
         labelIds: await labelIdsFor(issue, add, remove),
       });
+    },
+
+    // Linear-plane behaviour predates PR protection in the GitHub adapter.
+    // Keep it byte-for-byte: Linear remains governed by the existing claim
+    // activity predicate and does not invent a forge lookup here.
+    async hasOpenPullRequest(_identifier) {
+      return false;
     },
 
     async file({

--- a/lib/control-plane/memory.mjs
+++ b/lib/control-plane/memory.mjs
@@ -81,6 +81,12 @@ export function memoryControlPlane(seed = {}) {
       priority:
         typeof t.priority === "number" && t.priority > 0 ? t.priority : null,
       createdAt: t.createdAt ?? "",
+      startedAt: t.startedAt ?? null,
+      updatedAt: t.updatedAt ?? null,
+      lastCommentAt:
+        t.lastCommentAt ??
+        t.comments?.[t.comments.length - 1]?.createdAt ??
+        null,
       blockedBy: openBlockersOf(t),
     });
   }
@@ -150,8 +156,14 @@ export function memoryControlPlane(seed = {}) {
       return clone(requireTicket(identifier).comments ?? []);
     },
 
-    async listTickets({ team, project, states } = {}) {
-      calls.push({ op: "listTickets", team, project, states });
+    async listTickets({ team, project, states, includeFinished = false } = {}) {
+      calls.push({
+        op: "listTickets",
+        team,
+        project,
+        states,
+        includeFinished,
+      });
       if (!team) throw new ControlPlaneError("listTickets requires team");
       const wanted = states?.length
         ? new Set(states.map((n) => n.toLowerCase()))
@@ -162,7 +174,9 @@ export function memoryControlPlane(seed = {}) {
           if (project && t.project?.name !== project) return false;
           const name = (t.state?.name ?? "").toLowerCase();
           if (wanted) return wanted.has(name);
-          return !["done", "canceled", "duplicate"].includes(name);
+          return (
+            includeFinished || !["done", "canceled", "duplicate"].includes(name)
+          );
         })
         .map(asTicket)
         .sort(byQueueOrder);
@@ -248,6 +262,11 @@ export function memoryControlPlane(seed = {}) {
       const ticket = requireTicket(identifier);
       if (!add.length && !remove.length) return;
       applyLabels(ticket, add, remove);
+    },
+
+    async hasOpenPullRequest(identifier) {
+      calls.push({ op: "hasOpenPullRequest", identifier });
+      return Boolean(requireTicket(identifier).openPullRequest);
     },
 
     async file({

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -54,6 +54,9 @@
  *   tracker's completion semantics, so callers never interpret workflow
  *   states themselves.
  * @property {string} [createdAt]
+ * @property {string|null} [startedAt]
+ * @property {string|null} [updatedAt]
+ * @property {string|null} [lastCommentAt]
  */
 
 /**
@@ -99,11 +102,13 @@
  * @property {"linear"|"memory"|"github"} kind
  * @property {(identifier: string) => Promise<Ticket>} getTicket
  * @property {(identifier: string) => Promise<TicketComment[]>} listComments
- * @property {(opts: { team: string, project?: string, states?: string[] }) => Promise<Ticket[]>} listTickets
+ * @property {(opts: { team: string, project?: string, states?: string[], includeFinished?: boolean }) => Promise<Ticket[]>} listTickets
  *   Every ticket in the given factory states (default: all not-finished),
  *   in queue order — priority asc, then createdAt asc. `description`,
  *   `priority` and `blockedBy` are populated, because the dispatcher needs
  *   Owned Paths and ordering from the same read (WM-1008).
+ *   `includeFinished` asks for every tracker state and is used by maintenance
+ *   jobs that must find stale protocol labels even on canceled/custom states.
  * @property {(opts: { team: string, project?: string }) => Promise<Ticket[]>} listDispatchable
  *   Todo + `ai:agent-ready` + unassigned + **no open blocker**, in queue
  *   order. The same predicate AND the same ordering the dispatcher uses;
@@ -124,6 +129,10 @@
  *   Linear's update takes the COMPLETE label set. Implementations compute
  *   that set from the current names plus `add`/`remove`; they must not send
  *   a delta.
+ * @property {(identifier: string) => Promise<boolean>} hasOpenPullRequest
+ *   Whether an open pull request in the ticket's repository closes this
+ *   ticket. Implementations must fail closed: an inconclusive lookup throws,
+ *   rather than returning false.
  * @property {(opts: FileTicketOpts) => Promise<{ identifier: string, url: string }>} file
  * @property {(identifier: string, markdown: string) => Promise<{ appended: boolean }>} appendDetail
  * @property {(query: string, variables?: object) => Promise<object>} raw

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -36,6 +36,8 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
+import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import { loadRepos } from "../event-runtime/lib/repos.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
 
@@ -283,7 +285,9 @@ export async function fetchInProgress(teamKey = null, anyAssignee = false) {
 }
 
 export function isAgentClaim(issue) {
-  const labels = issue.labels?.nodes || [];
+  const labels = Array.isArray(issue.labels)
+    ? issue.labels
+    : issue.labels?.nodes || [];
   const names = labels.map((l) => (l.name || "").toLowerCase());
   return names.some(
     (n) => n === HEARTBEAT_LABEL || n.startsWith(AGENT_LABEL_PREFIX),
@@ -300,6 +304,9 @@ export function lastActivity(issue) {
     const lastCommentTs = parseTs(comments[comments.length - 1].createdAt);
     if (lastCommentTs) stamps.push(lastCommentTs);
   }
+
+  const lastComment = parseTs(issue.lastCommentAt);
+  if (lastComment) stamps.push(lastComment);
 
   if (stamps.length > 0) {
     return new Date(Math.max(...stamps.map((d) => d.getTime())));
@@ -455,11 +462,200 @@ export function parseArgs(argv = process.argv.slice(2)) {
   return { apply, minutes, team, anyAssignee, markersOnly, help };
 }
 
+function claimLabelsFor(issue) {
+  const labels = Array.isArray(issue.labels)
+    ? issue.labels
+    : issue.labels?.nodes || [];
+  return labels
+    .map((label) => label.name)
+    .filter((name) => {
+      const lower = String(name).toLowerCase();
+      return lower === HEARTBEAT_LABEL || lower.startsWith(AGENT_LABEL_PREFIX);
+    });
+}
+
+function auditComment(issue, minutes, returnsToTodo) {
+  const who = issue.assignee?.name || "an agent";
+  return (
+    `**Reclaimed by the stale-claim reaper.**\n\n` +
+    `This ticket was claimed by ${who} with no heartbeat for over ${minutes} ` +
+    `minutes, so the claim was presumed abandoned. ` +
+    (returnsToTodo
+      ? `It has been unassigned and returned to \`Todo\`.`
+      : `Its \`ai:in-progress\` marker was cleared; state and assignee are unchanged.`) +
+    `\n\n` +
+    `If the agent is still working, it must re-claim the ticket before ` +
+    `continuing — see the claim protocol in \`docs/protocol.md\`.`
+  );
+}
+
+function formatTicket(prefix, issue, seen, now) {
+  const age = seen
+    ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString()
+    : "?";
+  const who = issue.assignee?.name || "unassigned";
+  const id = (issue.identifier || "").padEnd(10);
+  return `  ${prefix} ${id} ${age.padStart(4)}m  ${who.padEnd(16)} ${(issue.title || "").slice(0, 44)}`;
+}
+
+/**
+ * Plane-neutral reaper engine. Dependencies are injectable so selection,
+ * failure and mutation behaviour can be tested without live trackers.
+ */
+export async function runReaper(
+  args,
+  {
+    repos = loadRepos(),
+    loadPlane = ({ repoName }) => loadControlPlane({ repoName }),
+    now = new Date(),
+    emit = emitFactoryEvent,
+    log = (...values) => console.log(...values),
+  } = {},
+) {
+  const cutoff = new Date(now.getTime() - args.minutes * 60 * 1000);
+  const configured = [...repos.values()].filter(
+    (repo) => repo.team && (!args.team || repo.team === args.team),
+  );
+  const seenIdentifiers = new Set();
+  const totals = { considered: 0, healthy: 0, reclaimed: 0, failed: 0 };
+
+  for (const repo of configured) {
+    let plane;
+    let listed;
+    try {
+      plane = loadPlane({ repoName: repo.name });
+      listed = await plane.listTickets({
+        team: repo.team,
+        project: repo.project ?? undefined,
+        states: args.anyAssignee ? ["In Progress"] : undefined,
+        includeFinished: !args.anyAssignee,
+      });
+    } catch (err) {
+      totals.failed += 1;
+      log(`  ! ${repo.name}: control plane failed: ${err.message || err}`);
+      continue;
+    }
+
+    // The old Linear query was a union: In Progress OR a claim marker. Keep
+    // that exact candidate set after the adapter's tracker-neutral read.
+    let issues = listed.filter(
+      (issue) =>
+        (issue.state?.name || "").toLowerCase() === IN_PROGRESS ||
+        isAgentClaim(issue),
+    );
+    issues = issues.filter((issue) => {
+      if (seenIdentifiers.has(issue.identifier)) return false;
+      seenIdentifiers.add(issue.identifier);
+      return true;
+    });
+
+    if (!args.anyAssignee) {
+      const claims = issues.filter(isAgentClaim);
+      const skipped = issues.length - claims.length;
+      if (skipped > 0)
+        log(
+          `  (${repo.name}: skipping ${skipped} In Progress ticket(s) with no agent claim labels -- not agent work)\n`,
+        );
+      issues = claims;
+    }
+
+    for (const issue of issues) {
+      const seen = lastActivity(issue);
+      if (!seen || seen >= cutoff) {
+        totals.healthy += 1;
+        log(formatTicket("ok   ", issue, seen, now));
+        continue;
+      }
+      if (
+        args.markersOnly &&
+        (issue.state?.name || "").toLowerCase() === IN_PROGRESS
+      ) {
+        log(`  (markers-only: leaving ${issue.identifier} alone)`);
+        continue;
+      }
+
+      totals.considered += 1;
+      log(formatTicket("STALE", issue, seen, now));
+
+      // Defence in depth for --any-assignee: humans are visible, never reaped.
+      if (!isAgentClaim(issue)) {
+        log(`        (no agent claim label — a human's work, not touching it)`);
+        continue;
+      }
+
+      try {
+        // This lookup runs in dry-run too: a protected ticket must not be
+        // advertised as reclaimable. Any adapter error fails closed.
+        if (await plane.hasOpenPullRequest(issue.identifier)) {
+          log(`        (open pull request — not touching it)`);
+          continue;
+        }
+      } catch (err) {
+        totals.failed += 1;
+        log(
+          `        ! pull-request lookup failed closed: ${err.message || err}`,
+        );
+        continue;
+      }
+
+      const returnsToTodo =
+        (issue.state?.name || "").toLowerCase() === IN_PROGRESS;
+      const remove = claimLabelsFor(issue);
+      try {
+        if (args.apply) {
+          if (returnsToTodo) {
+            await plane.transition(issue.identifier, "Todo", {
+              add: [AGENT_READY_LABEL],
+              remove,
+              unassign: true,
+            });
+          } else {
+            await plane.setLabels(issue.identifier, { remove });
+          }
+          await plane.comment(
+            issue.identifier,
+            auditComment(issue, args.minutes, returnsToTodo),
+          );
+        }
+      } catch (err) {
+        totals.failed += 1;
+        log(`        ! failed: ${err.message || err}`);
+        continue;
+      }
+
+      if (args.apply) {
+        totals.reclaimed += 1;
+        log(
+          returnsToTodo
+            ? `        -> unassigned, returned to Todo`
+            : `        -> claim marker cleared; state and assignee preserved`,
+        );
+        await emit(
+          "factory.ticket.reaped",
+          {
+            ticket: issue.identifier,
+            reason: returnsToTodo ? "returned_to_todo" : "marker_cleared",
+          },
+          {
+            eventId: `reap:${issue.identifier}:${seen?.getTime() ?? "unknown"}`,
+            subject: issue.identifier,
+          },
+        );
+      }
+    }
+  }
+
+  log(
+    `\n=== ${args.apply ? "Reclaimed" : "Would reclaim"}: ${args.apply ? totals.reclaimed : totals.considered} | Healthy: ${totals.healthy} | Failures: ${totals.failed} ===`,
+  );
+  if (!args.apply) log("Run again with --apply to reclaim these.");
+  return totals;
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-
   if (args.help) {
-    console.log(`Reclaim stale agent claims in Linear.
+    console.log(`Reclaim stale agent claims through each repository's control plane.
 
 Usage:
   bun orchestrator/reaper.mjs [options]
@@ -467,175 +663,24 @@ Usage:
 Options:
   --apply          Actually reclaim tickets (default is dry-run)
   --minutes <N>    Silence threshold before a claim is stale (default: 45)
-  --team <KEY>     Limit reaping to a single team key (e.g. CW)
+  --team <KEY>     Limit reaping to repositories for one team key (e.g. CW)
   --any-assignee   Audit all In Progress tickets regardless of agent claim labels
-  --markers-only   Only clear stale ai:in-progress markers from tickets that are
-                   NOT In Progress (finished or unstarted work whose claim label
-                   was never removed). Never touches running work — pure
-                   cleanup, so "Agents In Flight" means what it says.
+  --markers-only   Only clear stale claim markers outside In Progress
   -h, --help       Show this help message
 `);
-    process.exit(0);
+    return;
   }
-
   teeToLogFile();
-
   const mode = args.apply ? "APPLY" : "DRY RUN";
   console.log(
     `=== Stale-claim reaper [${mode}] threshold=${args.minutes}min${args.team ? ` team=${args.team}` : ""} ===\n`,
   );
-
-  const teams = await fetchTeams();
-  let agentReadyLabelId = null;
-  if (args.apply) {
-    try {
-      agentReadyLabelId = await fetchAgentReadyLabelId();
-    } catch {
-      /* intentionally ignored */
-    }
-  }
-  let issues = await fetchInProgress(args.team, args.anyAssignee);
-  const now = new Date();
-  const cutoff = new Date(now.getTime() - args.minutes * 60 * 1000);
-
-  if (!args.anyAssignee) {
-    const claims = issues.filter(isAgentClaim);
-    const skipped = issues.length - claims.length;
-    if (skipped > 0) {
-      console.log(
-        `  (skipping ${skipped} In Progress ticket(s) with no agent claim labels -- not agent work)\n`,
-      );
-    }
-    issues = claims;
-  }
-
-  const stale = [];
-  const live = [];
-
-  for (const issue of issues) {
-    const seen = lastActivity(issue);
-    if (seen && seen < cutoff) {
-      stale.push({ issue, seen });
-    } else {
-      live.push({ issue, seen });
-    }
-  }
-
-  for (const { issue, seen } of live) {
-    const age = seen
-      ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString()
-      : "?";
-    const who = issue.assignee?.name || "unassigned";
-    const id = (issue.identifier || "").padEnd(10);
-    const ageStr = age.padStart(4);
-    const whoStr = who.padEnd(16);
-    const titleStr = (issue.title || "").slice(0, 44);
-    console.log(`  ok    ${id} ${ageStr}m  ${whoStr} ${titleStr}`);
-  }
-
-  if (stale.length === 0) {
-    console.log(
-      `\n=== No stale claims among ${issues.length} in progress. ===`,
-    );
-    return;
-  }
-
-  console.log();
-  const considered = args.markersOnly
-    ? stale.filter(
-        ({ issue }) => (issue.state?.name || "").toLowerCase() !== IN_PROGRESS,
-      )
-    : stale;
-  if (args.markersOnly && considered.length !== stale.length) {
-    console.log(
-      `  (markers-only: leaving ${stale.length - considered.length} In Progress claim(s) alone)\n`,
-    );
-  }
-
-  for (const { issue, seen } of considered) {
-    const age = seen
-      ? Math.floor((now.getTime() - seen.getTime()) / 60000).toString()
-      : "?";
-    const who = issue.assignee?.name || "unassigned";
-    const id = (issue.identifier || "").padEnd(10);
-    const ageStr = age.padStart(4);
-    const whoStr = who.padEnd(16);
-    const titleStr = (issue.title || "").slice(0, 44);
-    console.log(`  STALE ${id} ${ageStr}m  ${whoStr} ${titleStr}`);
-
-    // Enforced here, not just by the upstream fetch: --any-assignee queries by
-    // state so it can show human work for audit purposes, which means a stale
-    // ticket in `considered` may not be an agent claim at all. Unassigning a
-    // human's ticket because they didn't comment in 45 minutes would be far
-    // worse than the crashed agent this reaper exists to clean up after.
-    if (!isAgentClaim(issue)) {
-      console.log(
-        `        (no agent claim label — a human's work, not touching it)`,
-      );
-      continue;
-    }
-
-    const teamKey = issue.team?.key;
-    const team = teams[teamKey];
-    const stateName = (issue.state?.name || "").toLowerCase();
-
-    // An implementation claim goes back to Todo so it can be picked up again.
-    // A triage claim (any other state) only loses its markers — moving a ticket
-    // that was mid-specification into Todo would assert it is ready when it is
-    // not.
-    const todoId =
-      stateName === IN_PROGRESS ? team?.states?.[RECLAIM_TO] : null;
-    if (stateName === IN_PROGRESS && !todoId) {
-      console.log(
-        `        ! no '${RECLAIM_TO}' state on team ${teamKey}, skipping`,
-      );
-      continue;
-    }
-
-    try {
-      await reclaim(
-        issue,
-        todoId,
-        args.minutes,
-        args.apply,
-        !todoId,
-        agentReadyLabelId,
-      );
-    } catch (err) {
-      console.log(`        ! failed: ${err.message || err}`);
-      continue;
-    }
-
-    if (args.apply) {
-      console.log(`        -> unassigned, returned to Todo`);
-      // Lifecycle observation (WM-75): fire-and-forget; the last-activity
-      // timestamp keys the id, so retrying the same stale claim re-admits
-      // nothing while the next genuine reap is a new event.
-      await emitFactoryEvent(
-        "factory.ticket.reaped",
-        {
-          ticket: issue.identifier,
-          reason: todoId ? "returned_to_todo" : "marker_cleared",
-        },
-        {
-          eventId: `reap:${issue.identifier}:${seen?.getTime() ?? "unknown"}`,
-          subject: issue.identifier,
-        },
-      );
-    }
-  }
-
-  console.log(
-    `\n=== ${args.apply ? "Reclaimed" : "Would reclaim"}: ${considered.length} | Healthy: ${live.length} ===`,
-  );
-  if (!args.apply) {
-    console.log("Run again with --apply to reclaim these.");
-  }
+  return runReaper(args);
 }
 
 if (import.meta.main || process.argv[1]?.endsWith("reaper.mjs")) {
   main().catch((err) => {
-    console.error(`Linear API error: ${err.message || err}`);
+    console.error(`Control-plane error: ${err.message || err}`);
     process.exit(1);
   });
 }

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -574,11 +574,9 @@ export async function runReaper(
         continue;
       }
 
-      totals.considered += 1;
-      log(formatTicket("STALE", issue, seen, now));
-
       // Defence in depth for --any-assignee: humans are visible, never reaped.
       if (!isAgentClaim(issue)) {
+        log(formatTicket("skip ", issue, seen, now));
         log(`        (no agent claim label — a human's work, not touching it)`);
         continue;
       }
@@ -587,16 +585,21 @@ export async function runReaper(
         // This lookup runs in dry-run too: a protected ticket must not be
         // advertised as reclaimable. Any adapter error fails closed.
         if (await plane.hasOpenPullRequest(issue.identifier)) {
+          log(formatTicket("skip ", issue, seen, now));
           log(`        (open pull request — not touching it)`);
           continue;
         }
       } catch (err) {
         totals.failed += 1;
+        log(formatTicket("skip ", issue, seen, now));
         log(
           `        ! pull-request lookup failed closed: ${err.message || err}`,
         );
         continue;
       }
+
+      totals.considered += 1;
+      log(formatTicket("STALE", issue, seen, now));
 
       const returnsToTodo =
         (issue.state?.name || "").toLowerCase() === IN_PROGRESS;
@@ -612,10 +615,14 @@ export async function runReaper(
           } else {
             await plane.setLabels(issue.identifier, { remove });
           }
-          await plane.comment(
-            issue.identifier,
-            auditComment(issue, args.minutes, returnsToTodo),
-          );
+          // Preserve the existing Linear lifecycle: finished/triage marker
+          // cleanup is deliberately quiet. The implementation reclaim is the
+          // state-changing recovery that receives the audit trail.
+          if (returnsToTodo)
+            await plane.comment(
+              issue.identifier,
+              auditComment(issue, args.minutes, returnsToTodo),
+            );
         }
       } catch (err) {
         totals.failed += 1;

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -369,6 +369,7 @@ describe("plane-aware reaper (GH-1044)", () => {
     expect(ticket.state.name).toBe("Triage");
     expect(ticket.assignee).toEqual({ id: "agent", name: "Agent" });
     expect(ticket.labels.map((l) => l.name)).toEqual(["type:bug"]);
+    expect(ticket.comments ?? []).toEqual([]);
   });
 
   test("Linear marker cleanup still sees canceled/custom states", async () => {
@@ -380,6 +381,7 @@ describe("plane-aware reaper (GH-1044)", () => {
     const ticket = cp.seed.tickets[0];
     expect(ticket.state.name).toBe("Canceled");
     expect(ticket.labels.map((l) => l.name)).toEqual(["type:bug"]);
+    expect(ticket.comments ?? []).toEqual([]);
   });
 
   test("an open PR protects the claim and lookup failure also fails closed", async () => {
@@ -401,6 +403,8 @@ describe("plane-aware reaper (GH-1044)", () => {
     expect(logs.join("\n")).toContain("open pull request");
     expect(logs.join("\n")).toContain("failed closed: forge unavailable");
     expect(totals.failed).toBe(1);
+    expect(totals.considered).toBe(0);
+    expect(logs.filter((line) => line.includes("STALE"))).toEqual([]);
     for (const cp of [protectedCp, failingCp]) {
       expect(
         cp.calls.some((c) =>

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -162,6 +162,8 @@ import {
   DISPATCH_FAILURE_THRESHOLD,
 } from "./tick.mjs";
 import { spawnSync } from "node:child_process";
+import { memoryControlPlane } from "../lib/control-plane/memory.mjs";
+import { runReaper } from "./reaper.mjs";
 
 describe("reclaim label computation (WM-14)", () => {
   test("restores ai:agent-ready when returning In Progress ticket to Todo", () => {
@@ -233,6 +235,179 @@ describe("reclaim label computation (WM-14)", () => {
     expect(res.labelIds).toContain("lbl-ready");
     expect(res.labelIds).toContain("lbl-bug");
     expect(res.labelIds).not.toContain("lbl-prog");
+  });
+});
+
+const REAPER_NOW = new Date("2026-08-28T12:00:00Z");
+const staleAt = "2026-08-28T10:00:00Z";
+
+function reaperPlane(ticket, kind = "memory") {
+  const cp = memoryControlPlane({
+    team: { id: "team-wm", key: "WM" },
+    labels: [
+      { id: "ready", name: "ai:agent-ready" },
+      { id: "progress", name: "ai:in-progress" },
+      { id: "agent", name: "agent:claude-code" },
+      { id: "bug", name: "type:bug" },
+    ],
+    tickets: [ticket],
+  });
+  cp.kind = kind;
+  return cp;
+}
+
+function staleClaim(overrides = {}) {
+  return {
+    id: "ticket-1",
+    identifier: "WM-1",
+    title: "abandoned work",
+    state: { id: "s-progress", name: "In Progress" },
+    assignee: { id: "agent", name: "Agent" },
+    team: { key: "WM" },
+    project: { name: "Factory" },
+    labels: [
+      { id: "progress", name: "ai:in-progress" },
+      { id: "agent", name: "agent:claude-code" },
+      { id: "bug", name: "type:bug" },
+    ],
+    updatedAt: staleAt,
+    ...overrides,
+  };
+}
+
+function reaperArgs(...argv) {
+  return parseArgs(["--minutes", "45", ...argv]);
+}
+
+async function runWithPlanes(args, planes) {
+  const selected = [];
+  const logs = [];
+  const repos = new Map(
+    Object.keys(planes).map((name) => [
+      name,
+      { name, team: "WM", project: "Factory" },
+    ]),
+  );
+  const totals = await runReaper(args, {
+    repos,
+    loadPlane({ repoName }) {
+      selected.push(repoName);
+      return planes[repoName];
+    },
+    now: REAPER_NOW,
+    emit: async () => {},
+    log: (...parts) => logs.push(parts.join(" ")),
+  });
+  return { selected, logs, totals };
+}
+
+describe("plane-aware reaper (GH-1044)", () => {
+  test("selects an adapter for every configured GitHub and Linear repository", async () => {
+    const github = reaperPlane(
+      staleClaim({ identifier: "acme/widget#1" }),
+      "github",
+    );
+    const linear = reaperPlane(staleClaim({ identifier: "WM-2" }), "linear");
+    const { selected } = await runWithPlanes(reaperArgs(), { github, linear });
+    expect(selected).toEqual(["github", "linear"]);
+    expect(github.calls.some((c) => c.op === "listTickets")).toBe(true);
+    expect(linear.calls.some((c) => c.op === "listTickets")).toBe(true);
+  });
+
+  test("dry-run reports a stale GitHub claim without mutating it", async () => {
+    const cp = reaperPlane(
+      staleClaim({ identifier: "acme/widget#1" }),
+      "github",
+    );
+    const { logs } = await runWithPlanes(reaperArgs(), { github: cp });
+    expect(logs.join("\n")).toContain("STALE acme/widget#1");
+    expect(
+      cp.calls.some((c) =>
+        ["transition", "setLabels", "comment"].includes(c.op),
+      ),
+    ).toBe(false);
+  });
+
+  test("apply returns a stale GitHub implementation claim to ready Todo", async () => {
+    const cp = reaperPlane(
+      staleClaim({ identifier: "acme/widget#1" }),
+      "github",
+    );
+    await runWithPlanes(reaperArgs("--apply"), { github: cp });
+    const ticket = cp.seed.tickets[0];
+    expect(ticket.state.name).toBe("Todo");
+    expect(ticket.assignee).toBeNull();
+    expect(ticket.labels.map((l) => l.name)).toContain("ai:agent-ready");
+    expect(ticket.labels.map((l) => l.name)).not.toContain("ai:in-progress");
+    expect(ticket.comments[0].body).toContain(
+      "Reclaimed by the stale-claim reaper",
+    );
+  });
+
+  test("a human In Progress ticket without claim markers is never mutated", async () => {
+    const cp = reaperPlane(
+      staleClaim({ labels: [{ id: "bug", name: "type:bug" }] }),
+      "github",
+    );
+    await runWithPlanes(reaperArgs("--apply", "--any-assignee"), {
+      github: cp,
+    });
+    expect(
+      cp.calls.some((c) =>
+        ["transition", "setLabels", "comment"].includes(c.op),
+      ),
+    ).toBe(false);
+  });
+
+  test("a stale marker outside In Progress only loses claim labels", async () => {
+    const cp = reaperPlane(
+      staleClaim({ state: { id: "s-triage", name: "Triage" } }),
+      "github",
+    );
+    await runWithPlanes(reaperArgs("--apply"), { github: cp });
+    const ticket = cp.seed.tickets[0];
+    expect(ticket.state.name).toBe("Triage");
+    expect(ticket.assignee).toEqual({ id: "agent", name: "Agent" });
+    expect(ticket.labels.map((l) => l.name)).toEqual(["type:bug"]);
+  });
+
+  test("Linear marker cleanup still sees canceled/custom states", async () => {
+    const cp = reaperPlane(
+      staleClaim({ state: { id: "s-canceled", name: "Canceled" } }),
+      "linear",
+    );
+    await runWithPlanes(reaperArgs("--apply"), { linear: cp });
+    const ticket = cp.seed.tickets[0];
+    expect(ticket.state.name).toBe("Canceled");
+    expect(ticket.labels.map((l) => l.name)).toEqual(["type:bug"]);
+  });
+
+  test("an open PR protects the claim and lookup failure also fails closed", async () => {
+    const protectedCp = reaperPlane(
+      staleClaim({ openPullRequest: true }),
+      "github",
+    );
+    const failingCp = reaperPlane(
+      staleClaim({ identifier: "acme/widget#2" }),
+      "github",
+    );
+    failingCp.hasOpenPullRequest = async () => {
+      throw new Error("forge unavailable");
+    };
+    const { logs, totals } = await runWithPlanes(reaperArgs("--apply"), {
+      protected: protectedCp,
+      failing: failingCp,
+    });
+    expect(logs.join("\n")).toContain("open pull request");
+    expect(logs.join("\n")).toContain("failed closed: forge unavailable");
+    expect(totals.failed).toBe(1);
+    for (const cp of [protectedCp, failingCp]) {
+      expect(
+        cp.calls.some((c) =>
+          ["transition", "setLabels", "comment"].includes(c.op),
+        ),
+      ).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
Implements #1044 (the PR-open step failed on the original dispatch; opening manually — the agent's implementation is on `feat/gh-1044`).

## What

Makes `orchestrator/reaper.mjs` reap stale `ai:in-progress` claims across **every configured repo through its control plane** (github + linear), not just Linear. Previously the reaper was Linear-only, so the **github-plane factory** — the repo that keeps freezing when an epic/auto-filed issue is parked In Progress without Owned Paths — was never reaped.

- `orchestrator/reaper.mjs` (+357/-212): routes through the control-plane abstraction per repo instead of raw Linear GraphQL.
- `lib/control-plane/{github,linear,memory,types}.mjs`: the reap primitives each plane needs.
- `orchestrator/reaper.test.mjs` (+175): coverage for the new behavior.

## Safety (unchanged intent)

Only tickets carrying the agent claim markers (`ai:in-progress`/`agent:*`) are touched — never a human's In Progress work; dry-run by default, `--apply` to act.

## Note

Opened manually because the automated PR-open step failed on dispatch — a separate handoff bug worth tracking (the agent completed the work and pushed the branch, but no PR was created). CI + review will confirm; if it conflicts with the recently-merged #1049 (both touch planner.mjs/registry.test.mjs), it needs a rebase.