### PR TITLE
feat(dispatch): policy-gated security-ticket dispatch (WM-1060)

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -47,6 +47,12 @@ commitMsg:
 dispatch:
   owned_paths_collision: advisory
   owned_paths_conformance: advisory
+  # Whether the work loop may dispatch `type:security` tickets (WM-1060).
+  #   excluded — only an operator-sourced dispatch works one (fail-closed default).
+  #   auto     — the loop dispatches them too; the merge lane still refuses to
+  #              merge a security PR, so it is held for human merge, never
+  #              auto-merged. The escalate_paths gate still guards touched files.
+  security_tickets: excluded
 
 concurrency:
   max_in_flight_per_repo: 20

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "tracker:read",
-      "repo:read"
-    ]
+    "services": ["tracker:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -13,7 +13,10 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["tracker:read", "repo:read"]
+    "services": [
+      "tracker:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -21,8 +24,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:e24e94af8da518ecec063cb5f36a10ea293b98cab74a0353feef647db8197b18",
-    "schemas/work-scan.input.json": "sha256:34f273b7a3183c61ef94d6474a74d579826a3f4306a1f0aec54ccfdb84870bf1",
+    "agents/work-scan.md": "sha256:58fa6c8fcca6a29c0469162d9cb7053010604c5eb78b6549220004c6466000de",
+    "schemas/work-scan.input.json": "sha256:3f8835afa366cb7da6bf77ff0218301cc6cfd1554e76696e908037d0f9ef0eb9",
     "schemas/work-scan.output.json": "sha256:7250a4c26073e443552b2d0bfdec53b2d4348940a92f250013ad31efdd637055"
   }
 }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -36,12 +36,17 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    - its labels include `ai:agent-ready`; and
    - its `assignee` field is `null`.
 
-   Exclude a ticket before ordering when its labels include `ai:escalated` or
-   `type:security` (or any other label containing `security`, case
-   insensitively). The dispatch planner must refuse those tickets, so including
-   them in a bounded batch can exhaust the scan and strand dispatchable work.
-   These excluded tickets are not candidates and must not appear in `plan`,
-   `deferred`, or `evidence.candidates`.
+   Exclude a ticket before ordering when its labels include `ai:escalated`.
+   Also exclude a ticket whose labels include `type:security` (or any other
+   label containing `security`, case insensitively) **unless**
+   `input.dispatchSecurity` equals `"auto"` — when it does, the dispatch planner
+   admits security tickets (the merge lane still holds their PRs for human
+   merge), so treat them as ordinary candidates. When `input.dispatchSecurity`
+   is absent or any other value, security tickets stay excluded because the
+   planner would refuse them, and including them in a bounded batch can exhaust
+   the scan and strand dispatchable work. Any ticket excluded here is not a
+   candidate and must not appear in `plan`, `deferred`, or
+   `evidence.candidates`.
 
    Apply this filter before ordering, cap checks, or path checks. `Blocked`,
    `Backlog`, `In Progress`, `In Review`, and `Done` are never candidates. Any

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -335,6 +335,13 @@ export function buildRunSpec(
       if (!payload?.repoPin) throw err;
     }
   }
+  // Hand the work scan the same security-dispatch verdict the dispatch gate
+  // will apply (WM-1060), so it stops pre-filtering security tickets the gate
+  // would now admit. Scoped to work-scan to keep every other agent's input —
+  // and thus its idempotency key — untouched.
+  if (mapping.agent?.startsWith("work-scan") && payload?.repo) {
+    payload = { ...payload, dispatchSecurity: policyDispatchSecurity() };
+  }
   const inputHash = hashJson(payload);
   const placement = def.placement ?? mapping.placement ?? undefined;
   const specEnvelope =
@@ -732,6 +739,28 @@ export function policyOwnedPathsCollision(root = reposRoot()) {
     return value === "advisory" ? "advisory" : DEFAULT_OWNED_PATHS_COLLISION;
   } catch {
     return DEFAULT_OWNED_PATHS_COLLISION;
+  }
+}
+
+/**
+ * Whether a `type:security` ticket may enter the dispatch loop (WM-1060).
+ * `excluded` (the fail-closed default) keeps the historical behavior: only an
+ * operator-sourced dispatch may work a security ticket. `auto` lets the normal
+ * work loop dispatch them too — safe because the merge lane still refuses to
+ * merge any PR whose ticket holds a security flag (merge-plan §escalation), so
+ * a security ticket becomes a PR held for human merge, never an auto-merge. The
+ * `escalate_paths` sensitive-file gate is unaffected and still applies.
+ */
+export const DEFAULT_DISPATCH_SECURITY = "excluded";
+export function policyDispatchSecurity(root = reposRoot()) {
+  const file = resolveConfigPath("policy", { root });
+  if (!existsSync(file)) return DEFAULT_DISPATCH_SECURITY;
+  try {
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch
+      ?.security_tickets;
+    return value === "auto" ? "auto" : DEFAULT_DISPATCH_SECURITY;
+  } catch {
+    return DEFAULT_DISPATCH_SECURITY;
   }
 }
 
@@ -1205,10 +1234,19 @@ export function worktreeDispatchAutoEligibility(
   }
 
   evidence.checks.ticket_not_escalated = true;
+  const isSecurityTicket =
+    evidence.ticket.labels.includes("type:security") ||
+    evidence.ticket.labels.some((label) => /security/i.test(label));
+  // A security ticket may still dispatch when the operator sourced it OR when
+  // policy opts the repo into `dispatch.security_tickets: auto` (WM-1060). The
+  // merge lane refuses to merge a security PR (merge-plan §escalation), so this
+  // only ever produces a PR held for human merge — never an auto-merge — and
+  // the escalate_paths sensitive-file gate below still guards touched files.
+  evidence.checks.security_dispatch_mode = policyDispatchSecurity();
   if (
-    (evidence.ticket.labels.includes("type:security") ||
-      evidence.ticket.labels.some((label) => /security/i.test(label))) &&
-    !evidence.checks.operator_authorized
+    isSecurityTicket &&
+    !evidence.checks.operator_authorized &&
+    evidence.checks.security_dispatch_mode !== "auto"
   ) {
     return refusal("ticket_security", evidence);
   }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -947,6 +947,54 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  test("dispatch.security_tickets: auto admits a chain security dispatch, held for human merge (WM-1060)", () => {
+    const autoPolicy = "dispatch:\n  security_tickets: auto\n";
+    const securityDispatch = tierDispatch(["type:security"]);
+
+    // Default policy (key absent) still refuses a non-operator security dispatch.
+    withReposRoot(tierRepo, () => {
+      const direct = worktreeDispatchAutoEligibility(
+        { repo: "tiered", ticket: "WM-694" },
+        securityDispatch,
+      );
+      expect(direct.ok).toBe(false);
+      expect(direct.refusal.reason).toBe("ticket_security");
+      expect(direct.evidence.checks.security_dispatch_mode).toBe("excluded");
+    });
+
+    // With auto, the same non-operator (chain) dispatch is admitted.
+    withReposRoot(
+      tierRepo,
+      () => {
+        const admitted = worktreeDispatchAutoEligibility(
+          { repo: "tiered", ticket: "WM-694" },
+          securityDispatch,
+        );
+        expect(admitted.ok).toBe(true);
+        expect(admitted.evidence.checks.security_dispatch_mode).toBe("auto");
+        expect(admitted.evidence.checks.operator_authorized).toBe(false);
+
+        const db = openDb(":memory:");
+        const ref = admit(db, {
+          type: "factory.dispatch.requested",
+          source: "chain",
+          eventId: "chain-security-auto",
+          correlationId: "chain-security-auto",
+          causationId: "run-parent",
+          payload: { repo: "tiered", ticket: "WM-694" },
+        });
+        expect(
+          planEvent(db, registry, ref, {
+            now: NOW,
+            policyVersion: "git:test",
+            dispatch: securityDispatch,
+          }).decision,
+        ).toBe("run");
+      },
+      autoPolicy,
+    );
+  });
+
   test("duplicate or unknown ticket tier labels refuse with typed evidence (WM-694)", () => {
     withReposRoot(tierRepo, () => {
       for (const labels of [["tier:light", "tier:standard"], ["tier:turbo"]]) {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -220,11 +220,11 @@ describe("registry", () => {
     // rejected it (additionalProperties:false) — failing reaper/label-guard/
     // reconcile/warm/unblock-digest every run. Added captured to the schema;
     // 11 command defs re-pinned. Registry inputs changed.
-    // Regenerated (advisory whole-repo claims): work-scan.md no longer defers
-    // a candidate on an in-flight `**`/no-parseable-Owned-Paths overlap — a
-    // scope-unknown ticket must not freeze the queue. work-scan.md re-pinned.
+    // Regenerated (security-ticket dispatch, WM-1060): work-scan.md now admits
+    // `type:security` candidates when input.dispatchSecurity == "auto" instead
+    // of always pre-filtering them. work-scan.md re-pinned.
     const expected =
-      "sha256:ea488a081ef38922cf242b06a2749805fd1090d75dd1599fa9523045c5e48bd5";
+      "sha256:2a45a320768f5d1f70657b4fb2940742ba0418637b22b65cc5ce4808256c33df";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/work-scan.input.json
+++ b/event-runtime/schemas/work-scan.input.json
@@ -42,6 +42,11 @@
     "loop": { "type": "string", "minLength": 1 },
     "slot": { "type": "string", "minLength": 1 },
     "cadenceSeconds": { "type": "integer", "minimum": 1 },
-    "skippedSlots": { "type": "integer", "minimum": 0 }
+    "skippedSlots": { "type": "integer", "minimum": 0 },
+    "dispatchSecurity": {
+      "type": "string",
+      "enum": ["excluded", "auto"],
+      "description": "Filled by the planner (WM-1060) from dispatch.security_tickets policy: whether the scan may treat type:security tickets as candidates. Absent or 'excluded' keeps them pre-filtered; 'auto' admits them."
+    }
   }
 }


### PR DESCRIPTION
## What

Adds a `dispatch.security_tickets` policy (default `excluded`, opt-in `auto`) so the work loop can dispatch `type:security` tickets instead of excluding every one.

## Why

The dispatch gate refused every security-labeled ticket unless an operator sourced it. On the factory's own repo that stranded ~a third of the agent-ready queue (11+ `sec(...)` tickets) while the pool sat idle. Operator asked to work them autonomously.

## Safe by construction

- The **merge lane already refuses to merge** any PR whose ticket holds a security flag (`merge-plan`), so a security ticket becomes a **PR held for human merge — never an auto-merge**.
- The `escalate_paths` sensitive-file gate is **unchanged** and still guards touched files.
- Default stays `excluded`; `auto` is per-instance opt-in via `config/policy.yaml`.

## Changes

- `planner.mjs`: `policyDispatchSecurity()`; the dispatch gate honors it or operator auth; work-scan input carries the verdict as `input.dispatchSecurity` (scoped to work-scan, no other agent's idempotency key moves).
- `work-scan.md` / `work-scan.input.json`: exclusion becomes conditional on `input.dispatchSecurity == \"auto\"`.
- `policy.example.yaml`: documents the key.
- Tests: chain security dispatch admitted under `auto`, refused by default; registry digest re-pinned.

## Owned Paths
- event-runtime/lib/planner.mjs
- event-runtime/lib/planner.test.mjs
- event-runtime/agents/work-scan.md
- event-runtime/agents/work-scan.json
- event-runtime/schemas/work-scan.input.json
- event-runtime/lib/registry.test.mjs
- config/policy.example.yaml