### PR TITLE
fix(control-plane): read open issues only for queue/in-flight (WM-1061)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -603,12 +603,19 @@ export function githubControlPlane(options = {}) {
     return { project, items };
   }
 
-  async function listIssues(repo) {
+  // `state` defaults to "open": the queue (Todo) and in-flight (In Progress)
+  // reads only ever keep open issues — listTickets maps every closed issue to
+  // "Done" and drops it unless a caller explicitly asks for finished tickets.
+  // On a long-lived repo the closed backlog dwarfs the open set (1000+ issues,
+  // 8+ pages of `state=all`), and this read runs synchronously inside the
+  // dispatch claim lock, so paginating it stalled serve and starved claims
+  // (WM-1061). Callers that need finished tickets pass state="all".
+  async function listIssues(repo, state = "open") {
     const issuesByNumber = new Map();
     for (let page = 1; page <= MAX_PAGES; page += 1) {
       const rows = await call("GET", `repos/${repo}/issues`, {
         query: {
-          state: "all",
+          state,
           per_page: String(PAGE_SIZE),
           page: String(page),
         },
@@ -1008,7 +1015,17 @@ export function githubControlPlane(options = {}) {
           `GitHub Project title mismatch: requested "${project}", configured "${projectTitle}"`,
         );
       const repo = repoForTeam(team);
-      const issues = await listIssues(repo);
+      // Only pay for the closed backlog when a caller actually wants finished
+      // tickets — either explicitly (includeFinished) or by naming a finished
+      // status in `states`. Every other read (queue, in-flight) is open-only.
+      const wantsFinished =
+        includeFinished ||
+        Boolean(
+          states?.some((n) =>
+            ["done", "canceled"].includes(String(n).toLowerCase()),
+          ),
+        );
+      const issues = await listIssues(repo, wantsFinished ? "all" : "open");
       const { items } = await projectItems();
       const statusByNumber = new Map(
         items

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -705,6 +705,51 @@ describe("control-plane contract: github", () => {
     ]);
   });
 
+  test("listTickets reads open issues only unless finished tickets are wanted (WM-1061)", async () => {
+    const seed = contractSeed();
+    // A closed issue whose board status is a stale "In Progress" — the exact
+    // row the open-only read must never page in during a dispatch claim.
+    addIssue(seed, REPO, {
+      id: 105,
+      node_id: "I_5",
+      number: 5,
+      title: "closed but board still says In Progress",
+      state: "closed",
+      labels: [{ id: 11, name: IN_PROGRESS_LABEL }],
+      comments: [],
+      status: "In Progress",
+    });
+    const inner = fakeApi(seed);
+    const issueListStates = [];
+    const api = (method, pathName, opts) => {
+      if (method === "GET" && /\/issues$/.test(String(pathName).split("?")[0]))
+        issueListStates.push(opts?.query?.state);
+      return inner(method, pathName, opts);
+    };
+    const cp = githubControlPlane({
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+      api,
+    });
+
+    // Default (queue/in-flight) read: open only, and the closed row is absent.
+    issueListStates.length = 0;
+    const openTickets = await cp.listTickets({ team: TEAM, project: PROJECT });
+    expect(issueListStates.every((s) => s === "open")).toBe(true);
+    expect(openTickets.map((t) => t.identifier)).not.toContain(`${REPO}#5`);
+
+    // includeFinished: pays for the closed backlog and surfaces the closed row.
+    issueListStates.length = 0;
+    const withFinished = await cp.listTickets({
+      team: TEAM,
+      project: PROJECT,
+      includeFinished: true,
+    });
+    expect(issueListStates.every((s) => s === "all")).toBe(true);
+    expect(withFinished.map((t) => t.identifier)).toContain(`${REPO}#5`);
+  });
+
   test("loadControlPlane explicit kind does not require repo config", () => {
     const root = tmp("control-plane-explicit-kind-");
     expect(


### PR DESCRIPTION
## Problem

`listIssues` fetched `state=all` and paginated the **entire open + closed backlog** (1000+ issues, 8+ pages) on every queue and in-flight read. `listTickets` then maps each closed issue to `Done` and discards it — so those closed pages were pure waste.

Worse, this read runs **synchronously inside the per-repo dispatch claim lock**. On a long-lived repo it:
- stalled the serve event loop (observed: 10s `/health` at ~2% CPU — I/O-bound on `gh api ...issues?state=all&page=8`), and
- held the claim lock through the slow paginated read, starving concurrent dispatch claims → `claim_lock_starvation` REFUSALs on burst dispatch.

## Fix

Default `listIssues` to `state=open`. `listTickets` requests `state=all` only when a caller actually wants finished tickets (`includeFinished`, or a `done`/`canceled` status in `states`).

**Behavior-preserving** — closed issues were already discarded for open-only reads — but collapses the read to the open set, which is a small fraction of the backlog.

## Test

- default read is open-only and omits a closed issue with a stale `In Progress` board status;
- `includeFinished` pages `state=all` and surfaces it.

## Owned Paths
- lib/control-plane/github.mjs
- lib/control-plane/github.test.mjs