### PR TITLE
perf(control-plane): cache the Projects v2 board read so it stops blocking serve

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -425,6 +425,7 @@ export function setRepoControlPlaneGithub(root, repo) {
  *   teams?: Record<string, string>,
  *   project?: string,
  *   statusField?: string,
+ *   now?: () => number,
  * }} [options]
  * @returns {import("./types.mjs").ControlPlane}
  */
@@ -437,6 +438,7 @@ export function githubControlPlane(options = {}) {
     teams: teamsOpt,
     project: projectOpt,
     statusField: statusFieldOpt,
+    now = () => Date.now(),
   } = options;
 
   const fromPolicy = root ? readGithubPolicy(root) : {};
@@ -449,6 +451,17 @@ export function githubControlPlane(options = {}) {
   const api = apiOpt ?? makeGhApi(exec);
 
   let projectCache = null;
+  // Short-TTL memo of the Projects v2 board read (WM-1067). `projectItems`
+  // re-paginates the whole board over GraphQL and is called synchronously on
+  // the dispatch/queue path — every concurrent claim and status lookup used to
+  // pay its own full board fetch, blocking the serve event loop under load.
+  // Within this window they share ONE in-flight fetch instead. The window is
+  // deliberately tiny: a few seconds of staleness is acceptable for status
+  // reads, and any mutation that changes the board (adding an item, setting a
+  // status) invalidates the memo immediately below, so the only staleness is
+  // from writes made through a *different* client within the window.
+  const PROJECT_ITEMS_TTL_MS = 3000;
+  let projectItemsCache = null; // { at: number, promise: Promise<{project, items}> }
 
   async function call(method, pathName, opts) {
     try {
@@ -573,34 +586,46 @@ export function githubControlPlane(options = {}) {
 
   async function projectItems() {
     const project = await loadProject();
-    const items = [];
-    let after = null;
-    for (let page = 1; page <= MAX_PAGES; page += 1) {
-      const d = await call("POST", "graphql", {
-        body: {
-          query: PROJECT_ITEMS,
-          variables: {
-            projectId: project.id,
-            statusField: statusFieldName,
-            after,
+    const t = now();
+    if (projectItemsCache && t - projectItemsCache.at < PROJECT_ITEMS_TTL_MS)
+      return projectItemsCache.promise;
+    const promise = (async () => {
+      const items = [];
+      let after = null;
+      for (let page = 1; page <= MAX_PAGES; page += 1) {
+        const d = await call("POST", "graphql", {
+          body: {
+            query: PROJECT_ITEMS,
+            variables: {
+              projectId: project.id,
+              statusField: statusFieldName,
+              after,
+            },
           },
-        },
-      });
-      const connection = d?.node?.items;
-      items.push(...(connection?.nodes ?? []));
-      if (!connection?.pageInfo?.hasNextPage) return { project, items };
-      if (!connection.pageInfo.endCursor) {
-        console.warn(
-          "GitHub Projects v2 item pagination reported another page without an end cursor; results may be incomplete",
-        );
-        return { project, items };
+        });
+        const connection = d?.node?.items;
+        items.push(...(connection?.nodes ?? []));
+        if (!connection?.pageInfo?.hasNextPage) return { project, items };
+        if (!connection.pageInfo.endCursor) {
+          console.warn(
+            "GitHub Projects v2 item pagination reported another page without an end cursor; results may be incomplete",
+          );
+          return { project, items };
+        }
+        after = connection.pageInfo.endCursor;
       }
-      after = connection.pageInfo.endCursor;
-    }
-    console.warn(
-      `GitHub Projects v2 item pagination reached the ${MAX_PAGES}-page safety ceiling; results may be incomplete`,
-    );
-    return { project, items };
+      console.warn(
+        `GitHub Projects v2 item pagination reached the ${MAX_PAGES}-page safety ceiling; results may be incomplete`,
+      );
+      return { project, items };
+    })();
+    projectItemsCache = { at: t, promise };
+    // A rejected fetch must not be served for the rest of the TTL window: drop
+    // the memo so the next caller retries instead of inheriting the failure.
+    promise.catch(() => {
+      if (projectItemsCache?.promise === promise) projectItemsCache = null;
+    });
+    return promise;
   }
 
   // `state` defaults to "open": the queue (Todo) and in-flight (In Progress)
@@ -665,6 +690,7 @@ export function githubControlPlane(options = {}) {
         `failed to add ${issueIdentifier(repo, number)} to project ${project.title}`,
       );
     projectCache = null;
+    projectItemsCache = null;
     return { project, item };
   }
 
@@ -683,6 +709,7 @@ export function githubControlPlane(options = {}) {
       },
     });
     projectCache = null;
+    projectItemsCache = null;
     return opt;
   }
 

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1667,11 +1667,15 @@ describe("GitHub issue and project-item pagination", () => {
       "1",
       "2",
     ]);
+    // Two pages, fetched once: the board read spans both pages (page 1 reports
+    // another page, page 2 does not), and the short-TTL memo (WM-1067) lets the
+    // back-to-back listDispatchable reuse that same read instead of paginating
+    // the board a second time within the window.
     expect(
       api.calls.filter((call) =>
         String(call.body?.query ?? "").includes("ProjectItems"),
       ),
-    ).toHaveLength(4);
+    ).toHaveLength(2);
   });
 });
 
@@ -1823,5 +1827,156 @@ describe("listDispatchable request cost does not scale with open issues", () => 
     expect(api2.calls.filter((c) => c.includes("/dependencies/")).length).toBe(
       50,
     );
+  });
+});
+
+// ------------------------------------------- Projects v2 board memo (WM-1067) -
+// `projectItems` re-paginates the whole board over GraphQL and runs on the
+// synchronous dispatch/queue path, so concurrent claims and status reads each
+// used to pay their own full board fetch and block serve. A short-TTL memo lets
+// them share ONE fetch. The behaviour under test is the underlying board read
+// count, so assert it directly with an injected clock.
+describe("Projects v2 board read is cached for a short TTL (WM-1067)", () => {
+  const REPO4 = "acme/board";
+
+  /** A one-issue board that counts how often the items query is issued. */
+  function boardApi() {
+    const issues = [
+      {
+        number: 1,
+        id: 1,
+        node_id: "N1",
+        title: "issue 1",
+        body: "",
+        state: "open",
+        assignee: null,
+        created_at: "2026-01-01T00:00:00Z",
+        labels: [],
+      },
+    ];
+    const items = () => ({
+      node: {
+        items: {
+          nodes: issues.map((i) => ({
+            id: `it${i.number}`,
+            fieldValueByName: { name: "Todo" },
+            content: {
+              number: i.number,
+              repository: { nameWithOwner: REPO4 },
+            },
+          })),
+        },
+      },
+    });
+    const state = { boardReads: 0 };
+    const calls = [];
+    const api = async (method, pathName, opts) => {
+      calls.push(`${method} ${pathName}`);
+      if (method === "GET" && pathName === `repos/${REPO4}/issues`)
+        return issues;
+      if (/^repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(pathName)) return issues[0];
+      if (pathName === "graphql") {
+        const q = String(opts?.body?.query ?? "");
+        if (q.includes("projectsV2")) {
+          return {
+            repository: {
+              projectsV2: {
+                nodes: [
+                  {
+                    id: "p1",
+                    title: "Factory",
+                    field: {
+                      id: "f1",
+                      name: "Status",
+                      options: GITHUB_FACTORY_STATES.map((name, i) => ({
+                        id: `o${i}`,
+                        name,
+                      })),
+                    },
+                  },
+                ],
+              },
+            },
+          };
+        }
+        if (q.includes("ProjectItems")) {
+          state.boardReads += 1;
+          return items();
+        }
+        if (q.includes("SetProjectStatus"))
+          return {
+            updateProjectV2ItemFieldValue: { projectV2Item: { id: "it1" } },
+          };
+        throw new ControlPlaneError(`unexpected graphql ${q.slice(0, 24)}`);
+      }
+      throw new ControlPlaneError(`unexpected ${method} ${pathName}`, {
+        status: 400,
+      });
+    };
+    api.calls = calls;
+    api.state = state;
+    return api;
+  }
+
+  const mk = (api, now) =>
+    githubControlPlane({
+      api,
+      now,
+      repo: REPO4,
+      teams: { WM: REPO4 },
+      project: "Factory",
+    });
+
+  test("two board reads inside the window collapse to one fetch", async () => {
+    const api = boardApi();
+    const clock = { t: 1000 };
+    const cp = mk(api, () => clock.t);
+
+    await cp.listTickets({ team: "WM" });
+    clock.t += 500; // still well inside the 3s window
+    await cp.listTickets({ team: "WM" });
+
+    expect(api.state.boardReads).toBe(1);
+  });
+
+  test("the board is refetched once the window has passed", async () => {
+    const api = boardApi();
+    const clock = { t: 1000 };
+    const cp = mk(api, () => clock.t);
+
+    await cp.listTickets({ team: "WM" });
+    clock.t += 5000; // past the 3s TTL
+    await cp.listTickets({ team: "WM" });
+
+    expect(api.state.boardReads).toBe(2);
+  });
+
+  test("concurrent reads in the window share a single in-flight fetch", async () => {
+    const api = boardApi();
+    const clock = { t: 1000 };
+    const cp = mk(api, () => clock.t);
+
+    await Promise.all([
+      cp.listTickets({ team: "WM" }),
+      cp.listTickets({ team: "WM" }),
+      cp.listTickets({ team: "WM" }),
+    ]);
+
+    expect(api.state.boardReads).toBe(1);
+  });
+
+  test("a status write invalidates the memo so the next read is fresh", async () => {
+    const api = boardApi();
+    const clock = { t: 1000 };
+    const cp = mk(api, () => clock.t);
+
+    await cp.listTickets({ team: "WM" }); // read 1, memo warm
+    await cp.transition(`${REPO4}#1`, "In Progress"); // reuses memo, then writes
+    await cp.listTickets({ team: "WM" }); // read 2 — must NOT serve stale memo
+
+    // The write invalidates the memo, so the trailing list read refetches even
+    // though it lands inside the TTL window. Without invalidation this would be
+    // 1 (every read served from the pre-write memo).
+    expect(api.state.boardReads).toBe(2);
   });
 });


### PR DESCRIPTION
## What
Memoize the Projects v2 board read (`projectItems()`) behind a small (3s) TTL so concurrent claims and status lookups reuse one GraphQL fetch instead of each re-paginating the whole board.

## Why
`projectItems()` re-paginates the entire board over GraphQL and runs on the synchronous dispatch/queue path. Every concurrent claim and status read paid its own full board fetch, blocking the serve event loop under load. A short shared memo removes the duplicate fetches.

- TTL is deliberately tiny (`PROJECT_ITEMS_TTL_MS = 3000`); a few seconds of staleness is acceptable for status reads.
- Concurrent callers share the in-flight promise (not just the resolved value).
- A rejected fetch is dropped from the memo so the next caller retries instead of inheriting the failure.
- Board mutations (`ensureProjectItem`, `setStatus`) invalidate the memo immediately, so correctness is preserved — the only staleness is against writes made through a *different* client within the window.
- Clock is injectable (`now` option) for deterministic tests.

## Acceptance
- Two board reads inside the window collapse to one underlying fetch.
- The board is refetched once the TTL window has passed.
- Concurrent reads in the window share a single in-flight fetch.
- A status write invalidates the memo so the next read is fresh.
- `bun test lib/control-plane/github.test.mjs` — 51 pass / 0 fail.

## Owned Paths
- lib/control-plane/github.mjs
- lib/control-plane/github.test.mjs

Refs #1067
