### PR TITLE
ui(web): hide Chains Root by default; Depth hops title; unclip Events header

### DIFF
--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -8,6 +8,7 @@ import {
   restoreApi,
   withApi,
 } from "../test-render";
+import { shortId } from "../components/ui";
 import { Chains } from "./Chains";
 
 afterEach(() => {
@@ -264,11 +265,41 @@ describe("Chains list (WM-537)", () => {
       expect(originCell.className).toContain("whitespace-nowrap");
       expect(originCell.querySelector("svg")).toBeTruthy();
 
-      // Repos cell should contain GitHub icon
-      const reposCell = activeRow.querySelectorAll("td")[7];
+      // Repos cell should contain GitHub icon (Root hidden by default, so index 6)
+      const reposCell = activeRow.querySelectorAll("td")[6];
       expect(reposCell.className).toContain("whitespace-nowrap");
       expect(reposCell.querySelector("svg")).toBeTruthy();
       expect(reposCell.textContent).toContain("factory");
+    });
+  });
+
+  test("hides the Root column by default and titles Depth as hops (WM-831)", async () => {
+    await withApi({ chains: async () => ({ chains: rows }) }, async () => {
+      const view = renderChains();
+      await waitFor(() => {
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
+      });
+
+      // Root event column is default-hidden: no header, no cell.
+      const headers = Array.from(
+        view.container.querySelectorAll("thead th"),
+      ).map((th) => th.textContent ?? "");
+      expect(headers.some((text) => text.includes("Root"))).toBe(false);
+      expect(view.queryByText(shortId("event-corr-active"))).toBeNull();
+
+      // Depth header abbreviates and explains the metric is hops in its title.
+      const depthTitle = view.container.querySelector('[title*="hops"]');
+      expect(depthTitle).toBeTruthy();
+      expect(depthTitle?.textContent).toContain("Dep");
+
+      // Cell values stay plain integers.
+      const activeRow = view.container.querySelector(
+        '[data-chain-id="corr-active"]',
+      ) as HTMLElement;
+      const depthCell = activeRow.querySelectorAll("td")[1];
+      expect(depthCell.textContent).toBe("1");
     });
   });
 });

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -81,6 +81,19 @@ const STATE_ORDER = Object.keys(STATE_HUES);
 
 const NARROW_COLS = new Set(["depth", "events", "runs"]);
 
+/**
+ * The integer cols sit in a `w-12` slot where their full labels clip; render an
+ * abbreviation and keep the full name (and, for Depth, its meaning) in `title`.
+ */
+const NARROW_HEADERS: Record<string, { label: string; title: string }> = {
+  depth: {
+    label: "Dep",
+    title: "Depth — longest path from the root in hops",
+  },
+  events: { label: "Evt", title: "Events in the chain" },
+  runs: { label: "Run", title: "Runs in the chain" },
+};
+
 function chainStateSegments(
   states: ChainListItem["states"],
 ): { state: string; count: number }[] {
@@ -239,7 +252,7 @@ const CHAINS_DISPLAY: DisplayConfig<ChainListItem> = {
   ],
   columns: [
     { key: "origin", label: "Origin", always: true },
-    { key: "root", label: "Root event" },
+    { key: "root", label: "Root event", defaultHidden: true },
     { key: "depth", label: "Depth" },
     { key: "events", label: "Events" },
     { key: "runs", label: "Runs" },
@@ -404,10 +417,12 @@ export function Chains({
                 const current = isCustom
                   ? display.sortBy === column.key
                   : sort && display.sortBy === sort.key;
+                const narrow = NARROW_HEADERS[column.key];
                 return (
                   <Th
                     key={column.key}
-                    label={column.label}
+                    label={narrow?.label ?? column.label}
+                    title={narrow?.title}
                     dir={current ? display.sortDir : null}
                     naturalDir={sort?.defaultDir ?? "asc"}
                     onSort={


### PR DESCRIPTION
## What
On `#/chains`:
- Root event column is now `defaultHidden` — a fresh view shows Origin, Depth, Events, Runs, States, Last activity, Repos. Root stays toggleable in Display.
- Depth / Events / Runs headers sit in a `w-12` slot where their full labels clipped. They now render abbreviated (`Dep` / `Evt` / `Run`) with the full name in `title`; Depth's title explains it is the longest path from the root in hops.
- Cell values stay plain integers.

## Why
Closes #852. Root duplicated Origin's event id and ate horizontal slack; Depth was unlabeled jargon; the integer headers clipped at the narrowed column width (compounding WM-826).

## Acceptance
- [x] Root column `defaultHidden: true`, still toggleable; fresh localStorage hides it.
- [x] Depth `<Th>` `title` explains hops; cell values remain integers.
- [x] Depth / Events / Runs headers no longer clip (abbreviated label + full `title`).
- [x] `Chains.test.tsx` covers default-hidden Root and the Depth hops title.
- [x] `bun test src/views/Chains.test.tsx` green; `tsc --noEmit` + build clean; prettier clean.

## Owned Paths
- `event-runtime/web/src/views/Chains.tsx`
- `event-runtime/web/src/views/Chains.test.tsx`