### PR TITLE
perf(auto-approval): cache per-repo in-flight read across a pass (#1064)

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -872,6 +872,36 @@ function eligible(
   );
 }
 
+/**
+ * Bound the per-pass cost of a proposal backlog. The dispatch eligibility gate
+ * reads the per-repo in-flight list (`fetchInFlight`, a slow control-plane read)
+ * for every open dispatch proposal, so a backlog turned each planning pass into
+ * O(open-proposals × read-latency) — stalling the serve loop and letting fresh
+ * chain dispatch proposals expire before they were ever approved (#1064).
+ *
+ * Memoize that read by repo for the life of one pass so it is fetched at most
+ * once per repo, never once-per-proposal. The wrapper is transparent otherwise:
+ * every other option (including the `linearRateLimitedUntil` deferral that
+ * dispatchSafe writes back) stays on the same object across the pass. A dispatch
+ * bag without a `fetchInFlight` (the common non-dispatch pass) is returned
+ * unchanged.
+ */
+function withPassInFlightCache(dispatch) {
+  const base = dispatch?.fetchInFlight;
+  if (typeof base !== "function") return dispatch;
+  const byRepo = new Map();
+  return {
+    ...dispatch,
+    fetchInFlight(repoConfig) {
+      const key = repoConfig?.name ?? repoConfig?.team ?? repoConfig ?? "";
+      if (byRepo.has(key)) return byRepo.get(key);
+      const value = base(repoConfig);
+      byRepo.set(key, value);
+      return value;
+    },
+  };
+}
+
 function noteOpenReason(db, id, reason) {
   db.query(
     `UPDATE proposals SET reason = ? WHERE id = ? AND status = 'open'`,
@@ -938,6 +968,9 @@ async function runPass(
     const approved = [];
     const open = [];
     const errors = [];
+    // One in-flight read per repo for the whole pass, shared across every
+    // proposal's eligibility recheck (#1064).
+    const passDispatch = withPassInFlightCache(dispatch);
     let rows;
     try {
       rows = db
@@ -970,7 +1003,7 @@ async function runPass(
           try {
             reason = eligible(db, row, registry, policy, {
               dispatchEligibility,
-              dispatch,
+              dispatch: passDispatch,
               now,
               hooks,
               hookTimeoutMs,

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1829,4 +1829,36 @@ describe("chain auto approval (WM-357)", () => {
       "auto_approval_ineligible:dispatch_recheck_failed:linear_read_failed: HTTP 503 upstream",
     );
   });
+
+  test("a backlog of dispatch proposals for one repo reads in-flight at most once per pass (#1064)", async () => {
+    const db = openDb(":memory:");
+    const backlog = Array.from({ length: 6 }, (_, i) =>
+      dispatchSeed(db, `backlog-${i}`, { ticket: `WM-70${i}` }),
+    );
+    // The eligibility gate reads the per-repo in-flight list on every dispatch
+    // proposal; the pass must collapse that to one read for the shared repo.
+    let inFlightReads = 0;
+    const fetchInFlight = () => {
+      inFlightReads += 1;
+      return [];
+    };
+    const dispatchEligibility = (payload, dispatch) => {
+      dispatch.fetchInFlight({ name: payload.repo });
+      return {
+        ok: true,
+        evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+      };
+    };
+
+    const result = await auto(db, {
+      dispatchEligibility,
+      dispatch: { fetchInFlight },
+      runtimeGuard: () => null,
+    });
+
+    expect(result.approved.map((row) => row.proposalId).sort()).toEqual(
+      backlog.map((row) => row.id).sort(),
+    );
+    expect(inFlightReads).toBe(1);
+  });
 });


### PR DESCRIPTION
## What
Memoize the per-repo in-flight read across a single `autoApproveChains` pass. A
new `withPassInFlightCache` wrapper intercepts `dispatch.fetchInFlight` once per
pass and caches its result by repo, so every open dispatch proposal for the same
repo shares one read instead of triggering its own.

## Why
`autoApproveChains` re-runs the full dispatch eligibility gate — including the
slow control-plane `fetchInFlight` read — for every open chain proposal on each
planning pass. With a backlog of open proposals (observed 75, mostly stale
merge-scan/reaper) each pass became O(open-proposals x read-latency), blocking
the serve loop and letting fresh chain dispatch proposals expire (TTL churn)
before they were ever approved. Already-expired proposals are still skipped
before the eligibility recheck runs, so they cost nothing.

## Acceptance
- A large open-proposal backlog no longer stalls the pass or expires fresh
  dispatch proposals: the expensive read is now O(repos), not O(proposals).
- In-flight reads are performed at most once per repo per pass.
- Unit test: 6 open dispatch proposals for one repo trigger exactly one
  in-flight read (and all approve). `bun test event-runtime/lib/auto-approval.test.mjs` => 38 pass.

## Owned Paths
- event-runtime/lib/auto-approval.mjs
- event-runtime/lib/auto-approval.test.mjs
