### PR TITLE
chore(janitor): retention sweep for terminal proposals/runs/events + VACUUM (#1065)

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { artifactsRoot, runtimeHome } from "./config.mjs";
-import { openDb } from "./db.mjs";
+import { openDb, txImmediate } from "./db.mjs";
 import { reposRoot } from "./repos.mjs";
 
 /** Bound so a hung Linear call cannot freeze serve forever (OPS-301 review). */
@@ -10,9 +10,89 @@ export const JANITOR_TIMEOUT_MS = 120_000;
 export const JANITOR_MAX_BUFFER = 1_000_000;
 export const DEFAULT_TRACE_RETENTION_DAYS = 14;
 export const DEFAULT_ARTIFACT_RETENTION_DAYS = 30;
+export const DEFAULT_ROW_RETENTION_DAYS = 30;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SHA256 = /^[a-f0-9]{64}$/;
+
+/**
+ * Run states that are terminal for retention purposes (#1065). FAILED is
+ * re-queueable while attempts remain, so it is NOT in lifecycle's
+ * TERMINAL_STATES — but a FAILED run untouched since before the retention
+ * cutoff is never mid-retry, so the `updated_at < cutoff` gate makes it safe
+ * to sweep here. Active/in-flight states (PROPOSED, APPROVED, QUEUED, LEASED,
+ * RUNNING, VERIFYING) are deliberately absent so they can never be removed.
+ */
+const TERMINAL_RUN_STATES = [
+  "COMPLETED",
+  "REFUSED",
+  "TIMED_OUT",
+  "CANCELLED",
+  "FAILED",
+];
+
+/** Per-run child tables keyed by run_id, cleared alongside a swept run. */
+const RUN_CHILD_TABLES = [
+  "results",
+  "attempts",
+  "lifecycle_events",
+  "run_usage",
+  "attempt_trace",
+];
+
+/**
+ * Delete terminal proposal/run/event rows past the retention window, keeping
+ * all active/in-flight state (#1065). Dry-by-default: with `apply: false` it
+ * only counts. Returns per-table counts.
+ */
+function sweepTerminalRows(db, { rowCutoff, nowIso, apply }) {
+  const terminalList = TERMINAL_RUN_STATES.map((s) => `'${s}'`).join(", ");
+  const runFilter = `state IN (${terminalList}) AND updated_at < ?`;
+
+  const runsDeleted = db
+    .query(`SELECT COUNT(*) AS count FROM runs WHERE ${runFilter}`)
+    .get(rowCutoff).count;
+
+  // Terminal proposals: decided (rejected/superseded) or open-but-expired past
+  // their per-row TTL. Active 'open' proposals still within TTL and 'approved'
+  // decisions are never removed.
+  const proposalFilter = `created_at < ?
+      AND (status IN ('rejected', 'superseded')
+           OR (status = 'open'
+               AND (strftime('%s', ?) - strftime('%s', created_at)) > ttl_seconds))`;
+  const proposalsDeleted = db
+    .query(`SELECT COUNT(*) AS count FROM proposals WHERE ${proposalFilter}`)
+    .get(rowCutoff, nowIso).count;
+
+  // Archived (dead-lettered) events past the window.
+  const eventFilter = `archived_at IS NOT NULL AND archived_at < ?`;
+  const eventsDeleted = db
+    .query(`SELECT COUNT(*) AS count FROM events WHERE ${eventFilter}`)
+    .get(rowCutoff).count;
+
+  if (apply) {
+    txImmediate(db, () => {
+      // Subquery predicates (not an id list) so a large sweep can never trip
+      // SQLite's bound-variable limit. Children first, then the runs.
+      const runSubquery = `run_id IN (SELECT run_id FROM runs WHERE ${runFilter})`;
+      for (const table of RUN_CHILD_TABLES) {
+        db.query(`DELETE FROM ${table} WHERE ${runSubquery}`).run(rowCutoff);
+      }
+      db.query(`DELETE FROM runs WHERE ${runFilter}`).run(rowCutoff);
+      db.query(`DELETE FROM proposals WHERE ${proposalFilter}`).run(
+        rowCutoff,
+        nowIso,
+      );
+      db.query(`DELETE FROM events WHERE ${eventFilter}`).run(rowCutoff);
+    });
+  }
+
+  return {
+    runs: { deleted: runsDeleted, dryRun: !apply },
+    proposals: { deleted: proposalsDeleted, dryRun: !apply },
+    events: { deleted: eventsDeleted, dryRun: !apply },
+  };
+}
 
 function retentionMs(days, name) {
   if (!Number.isFinite(days) || days <= 0)
@@ -43,6 +123,7 @@ export function sweepRuntimeRetention(
   {
     traceRetentionDays = DEFAULT_TRACE_RETENTION_DAYS,
     artifactRetentionDays = DEFAULT_ARTIFACT_RETENTION_DAYS,
+    rowRetentionDays = DEFAULT_ROW_RETENTION_DAYS,
     now = Date.now(),
     apply = false,
     log = () => {},
@@ -53,6 +134,10 @@ export function sweepRuntimeRetention(
   ).toISOString();
   const artifactCutoffMs =
     now - retentionMs(artifactRetentionDays, "artifactRetentionDays");
+  const rowCutoff = new Date(
+    now - retentionMs(rowRetentionDays, "rowRetentionDays"),
+  ).toISOString();
+  const nowIso = new Date(now).toISOString();
   const trace = db
     .query(`SELECT COUNT(*) AS count FROM attempt_trace WHERE ts < ?`)
     .get(traceCutoff).count;
@@ -104,12 +189,24 @@ export function sweepRuntimeRetention(
       if (apply) rmSync(file, { force: true });
     }
   }
+  const rows = sweepTerminalRows(db, { rowCutoff, nowIso, apply });
+
+  // VACUUM reclaims the file space freed by the row deletions (#1065). It must
+  // run outside any transaction, so it follows the sweep's own commit.
+  if (apply) db.exec("VACUUM");
+
   const result = {
     trace: { deleted: trace, dryRun: !apply },
     artifacts: { deleted, freedBytes, retained, dryRun: !apply },
+    runs: rows.runs,
+    proposals: rows.proposals,
+    events: rows.events,
+    vacuum: { ran: apply },
   };
   log(
-    `retention: ${trace} trace rows and ${deleted} artifacts (${freedBytes} bytes) ${apply ? "deleted" : "would be deleted"}`,
+    `retention: ${trace} trace rows and ${deleted} artifacts (${freedBytes} bytes)` +
+      `, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
+      `${apply ? "deleted (VACUUMed)" : "would be deleted"}`,
   );
   return result;
 }
@@ -119,14 +216,16 @@ export function runtimeRetentionCommand(args = [], options = {}) {
   let apply = false;
   let traceRetentionDays = DEFAULT_TRACE_RETENTION_DAYS;
   let artifactRetentionDays = DEFAULT_ARTIFACT_RETENTION_DAYS;
+  let rowRetentionDays = DEFAULT_ROW_RETENTION_DAYS;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--apply") apply = true;
     else if (args[i] === "--trace-days") traceRetentionDays = Number(args[++i]);
     else if (args[i] === "--artifact-days")
       artifactRetentionDays = Number(args[++i]);
+    else if (args[i] === "--row-days") rowRetentionDays = Number(args[++i]);
     else
       throw new Error(
-        "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N]",
+        "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N] [--row-days N]",
       );
   }
   const db = options.db ?? openDb();
@@ -137,6 +236,7 @@ export function runtimeRetentionCommand(args = [], options = {}) {
       {
         traceRetentionDays,
         artifactRetentionDays,
+        rowRetentionDays,
         apply,
         now: options.now,
         log: options.log ?? console.log,
@@ -286,7 +386,7 @@ if (import.meta.main) {
   const [command, ...args] = process.argv.slice(2);
   if (command !== "retention") {
     throw new Error(
-      "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N]",
+      "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N] [--row-days N]",
     );
   }
   runtimeRetentionCommand(args);

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -5,6 +5,7 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-janitor-t
 import { openDb } from "./db.mjs";
 import {
   DEFAULT_ARTIFACT_RETENTION_DAYS,
+  DEFAULT_ROW_RETENTION_DAYS,
   janitorArgv,
   JANITOR_MAX_BUFFER,
   JANITOR_TIMEOUT_MS,
@@ -116,5 +117,184 @@ describe("runtime retention", () => {
 
   test("retention defaults preserve the documented 30-day artifact window", () => {
     expect(DEFAULT_ARTIFACT_RETENTION_DAYS).toBe(30);
+  });
+});
+
+describe("terminal row retention (#1065)", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+  const old = new Date(now - 40 * DAY).toISOString();
+  const recent = new Date(now - 1 * DAY).toISOString();
+  const cutoff = new Date(now - DEFAULT_ROW_RETENTION_DAYS * DAY).toISOString();
+
+  function insertRun(db, runId, state, updatedAt) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, '{}', 'sha256:test', ?, 1, ?, ?)`,
+    ).run(runId, `${runId}-key`, state, updatedAt, updatedAt);
+  }
+
+  function insertProposal(db, id, status, createdAt, ttlSeconds) {
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, 'run', ?, ?, ?)`,
+    ).run(id, `${id}-evt`, status, createdAt, ttlSeconds);
+  }
+
+  function insertEvent(db, eventId, admittedAt, archivedAt) {
+    db.query(
+      `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at, archived_at)
+       VALUES ('test', ?, 'ping', ?, ?, '{}', 'h', ?, ?, ?)`,
+    ).run(
+      eventId,
+      admittedAt,
+      admittedAt,
+      archivedAt ? "dead_lettered" : "admitted",
+      admittedAt,
+      archivedAt,
+    );
+  }
+
+  function seed(db) {
+    // Runs: two terminal-old (deleted), everything else kept.
+    insertRun(db, "run-completed-old", "COMPLETED", old);
+    insertRun(db, "run-failed-old", "FAILED", old);
+    insertRun(db, "run-running-old", "RUNNING", old); // active — keep
+    insertRun(db, "run-queued-old", "QUEUED", old); // active — keep
+    insertRun(db, "run-completed-recent", "COMPLETED", recent); // within window
+    insertRun(db, "run-completed-boundary", "COMPLETED", cutoff); // == cutoff, strict < keeps
+
+    // Child rows for one deleted run and one kept run.
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run-completed-old', 1, '{}', 'sha256:test', '{}', '{}', ?)`,
+    ).run(old);
+    db.query(
+      `INSERT INTO lifecycle_events (run_id, to_state, actor, at, record_hash)
+       VALUES ('run-completed-old', 'COMPLETED', 'test', ?, 'h')`,
+    ).run(old);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run-running-old', 1, '{}', 'sha256:test', '{}', '{}', ?)`,
+    ).run(old);
+
+    // Proposals: three terminal-old (deleted), three kept.
+    insertProposal(db, "prop-rejected-old", "rejected", old, 3600);
+    insertProposal(db, "prop-superseded-old", "superseded", old, 3600);
+    insertProposal(db, "prop-open-expired-old", "open", old, 3600); // past TTL
+    insertProposal(db, "prop-open-within-ttl-old", "open", old, 100 * 86400); // TTL not reached
+    insertProposal(db, "prop-approved-old", "approved", old, 3600); // decided, kept
+    insertProposal(db, "prop-open-fresh", "open", recent, 3600); // inside window
+
+    // Events: one archived-old (deleted), two kept.
+    insertEvent(db, "evt-archived-old", old, old);
+    insertEvent(db, "evt-archived-recent", recent, recent);
+    insertEvent(db, "evt-admitted-old", old, null);
+  }
+
+  function counts(db) {
+    return {
+      runs: db.query(`SELECT COUNT(*) AS c FROM runs`).get().c,
+      proposals: db.query(`SELECT COUNT(*) AS c FROM proposals`).get().c,
+      events: db.query(`SELECT COUNT(*) AS c FROM events`).get().c,
+      results: db.query(`SELECT COUNT(*) AS c FROM results`).get().c,
+      lifecycle: db.query(`SELECT COUNT(*) AS c FROM lifecycle_events`).get().c,
+    };
+  }
+
+  test("dry-run counts terminal rows without deleting; --apply removes them and keeps active state", () => {
+    const root = tmpDir("evrt-rows-");
+    const store = path.join(root, "artifacts");
+    const db = openDb(path.join(root, "runtime.db"));
+    try {
+      mkdirSync(store);
+      seed(db);
+
+      const dry = sweepRuntimeRetention(db, store, { now });
+      expect(dry.runs).toEqual({ deleted: 2, dryRun: true });
+      expect(dry.proposals).toEqual({ deleted: 3, dryRun: true });
+      expect(dry.events).toEqual({ deleted: 1, dryRun: true });
+      expect(dry.vacuum).toEqual({ ran: false });
+      // Nothing actually removed on a dry run.
+      expect(counts(db)).toMatchObject({ runs: 6, proposals: 6, events: 3 });
+
+      const applied = sweepRuntimeRetention(db, store, { now, apply: true });
+      expect(applied.runs).toEqual({ deleted: 2, dryRun: false });
+      expect(applied.proposals).toEqual({ deleted: 3, dryRun: false });
+      expect(applied.events).toEqual({ deleted: 1, dryRun: false });
+      expect(applied.vacuum).toEqual({ ran: true });
+
+      const after = counts(db);
+      expect(after.runs).toBe(4);
+      expect(after.proposals).toBe(3);
+      expect(after.events).toBe(2);
+      // Child rows of a deleted run are swept; a kept run's children remain.
+      expect(after.results).toBe(1);
+      expect(after.lifecycle).toBe(0);
+
+      const survivingRuns = db
+        .query(`SELECT run_id FROM runs ORDER BY run_id`)
+        .all()
+        .map((r) => r.run_id);
+      expect(survivingRuns).toEqual([
+        "run-completed-boundary",
+        "run-completed-recent",
+        "run-queued-old",
+        "run-running-old",
+      ]);
+
+      const survivingProps = db
+        .query(`SELECT id FROM proposals ORDER BY id`)
+        .all()
+        .map((r) => r.id);
+      expect(survivingProps).toEqual([
+        "prop-approved-old",
+        "prop-open-fresh",
+        "prop-open-within-ttl-old",
+      ]);
+
+      const survivingEvents = db
+        .query(`SELECT event_id FROM events ORDER BY event_id`)
+        .all()
+        .map((r) => r.event_id);
+      expect(survivingEvents).toEqual([
+        "evt-admitted-old",
+        "evt-archived-recent",
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("cutoff boundary is strict: a terminal run updated exactly at the cutoff is retained", () => {
+    const root = tmpDir("evrt-boundary-");
+    const store = path.join(root, "artifacts");
+    const db = openDb(path.join(root, "runtime.db"));
+    try {
+      mkdirSync(store);
+      insertRun(db, "run-at-cutoff", "COMPLETED", cutoff);
+      insertRun(
+        db,
+        "run-just-before",
+        "COMPLETED",
+        new Date(now - 40 * DAY).toISOString(),
+      );
+
+      const dry = sweepRuntimeRetention(db, store, { now });
+      expect(dry.runs.deleted).toBe(1);
+
+      sweepRuntimeRetention(db, store, { now, apply: true });
+      const remaining = db
+        .query(`SELECT run_id FROM runs`)
+        .all()
+        .map((r) => r.run_id);
+      expect(remaining).toEqual(["run-at-cutoff"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("row retention default is 30 days", () => {
+    expect(DEFAULT_ROW_RETENTION_DAYS).toBe(30);
   });
 });


### PR DESCRIPTION
## What
Extend the janitor retention sweep (`event-runtime/lib/janitor.mjs`) to prune terminal database rows and reclaim space, closing the unbounded growth that produced a 229MB `runtime.db`.

- **Runs**: deletes terminal runs (`COMPLETED`/`REFUSED`/`TIMED_OUT`/`CANCELLED`/`FAILED`) whose `updated_at` is older than the window, plus their per-run child rows (`results`, `attempts`, `lifecycle_events`, `run_usage`, `attempt_trace`). Child rows are removed via subquery predicates, not an id list, so a large sweep cannot trip SQLite's bound-variable limit.
- **Proposals**: deletes decided (`rejected`/`superseded`) and open-but-expired-past-TTL proposals older than the window — the "stale open/expired" rows called out in the issue.
- **Events**: deletes archived (dead-lettered) events past the window.
- **VACUUM** runs after the deletions (outside any transaction) to return the freed pages to the OS.
- New `--row-days N` flag (default 30) on the `retention` command; dry-by-default with per-table counts, applies on `--apply`.

## Why
Terminal proposals/runs/events accumulated unboundedly in `runtime.db` (observed 229MB), bloating every scan/plan pass. The janitor previously pruned only `attempt_trace` and artifact files.

## Safety
Active/in-flight state is never touched: an allowlist of terminal run states means `PROPOSED`/`APPROVED`/`QUEUED`/`LEASED`/`RUNNING`/`VERIFYING` runs are always retained; open-within-TTL and `approved` proposals stay; un-archived events stay. `FAILED` (re-queueable) is included only because the `updated_at < cutoff` gate guarantees such a run is not mid-retry.

## Acceptance
- [x] Expired/decided proposals and terminal runs older than the window are removed; active/in-flight state is never touched.
- [x] Dry-run reports counts before applying (`vacuum.ran` reflects apply).
- [x] Unit test covers the cutoff boundary (a run updated exactly at the cutoff is retained) and that active state survives.
- [x] `bun test event-runtime/lib/janitor.test.mjs` — 8 pass.

## Owned Paths
- event-runtime/lib/janitor.mjs
- event-runtime/lib/janitor.test.mjs
