### PR TITLE
fix(verify): isolate event-runtime lib tests from worktree schedule overlay

### DIFF
--- a/event-runtime/lib/api-schedules.test.mjs
+++ b/event-runtime/lib/api-schedules.test.mjs
@@ -35,8 +35,23 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 
-const makeServer = async (...args) => {
-  const result = await makeApiServer(...args);
+// Assertions here about shipped kernel defaults (reaper disabled, source
+// "kernel") must not inherit the operator's local config/schedule.yaml overlay
+// (#1053). Load the registry with the overlay pointed at an absent file so the
+// server sees only tracked kernel schedules, deterministic on any instance.
+const overlayFreeRegistry = loadRegistry({
+  scheduleConfigPath: path.join(
+    os.tmpdir(),
+    `evrt-no-schedule-overlay-${process.pid}`,
+    "schedule.yaml",
+  ),
+});
+
+const makeServer = async (opts = {}) => {
+  const result = await makeApiServer({
+    registry: overlayFreeRegistry,
+    ...opts,
+  });
   trackTmpDir(path.dirname(result.db.filename));
   return result;
 };

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -21,7 +21,16 @@ import {
 import { runOnce } from "./worker.mjs";
 
 const PV = "git:test-pv";
-const base = loadRegistry();
+// Assertions about shipped kernel defaults (reaper disabled, source "kernel")
+// must not inherit the operator's local config/schedule.yaml overlay (#1053).
+// Point the overlay at an absent file so `base` reflects only tracked kernel
+// schedules, deterministic regardless of instance config.
+const base = loadRegistry({
+  scheduleConfigPath: path.join(
+    tmpDir("evrt-sched-no-overlay-"),
+    "schedule.yaml",
+  ),
+});
 const db = () => openDb(path.join(tmpDir("evrt-sched-"), "runtime.db"));
 
 /** The real registry with one loop overridden — schedules are just data. */


### PR DESCRIPTION
## What
Isolate the event-runtime lib schedule tests from the operator's worktree-local `config/schedule.yaml` overlay so the declared verify gate is hermetic.

- `schedules.test.mjs`: build `base` via `loadRegistry({ scheduleConfigPath: <absent file> })`.
- `api-schedules.test.mjs`: the local `makeServer` wrapper now injects an overlay-free registry by default (callers passing their own registry still override).

## Why
The verify command `bun test event-runtime/lib` calls `loadRegistry()`, which reads the worktree-local `config/schedule.yaml`. When an instance overlay enables `reaper`, kernel-default assertions (reaper disabled, source `kernel`) failed — unrelated to the code under test — blocking dispatched work (#1002). Pointing the overlay at an absent file makes these tests read only tracked kernel schedules, deterministic on any instance.

## Acceptance
- [x] Verify command passes when a worktree-local overlay enables `reaper` (reproduced locally: 3 failures before, 0 after; full `event-runtime/lib` 1568 pass with overlay active).
- [x] Tests asserting shipped kernel defaults load an overlay-free registry.
- [x] Overlay-intentional tests remain covered (`registry.test.mjs` untouched; already deterministic).

## Owned Paths
- event-runtime/lib/api-schedules.test.mjs
- event-runtime/lib/schedules.test.mjs
- event-runtime/lib/registry.test.mjs (reviewed; no change needed)

Refs #1053
