### PR TITLE
test(dispatch): cover FACTORY_ROOT ticket config resolution and NOT_CLAIMED release

### DIFF
--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -67,6 +67,7 @@ import {
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultLocksDir,
   defaultReturnHandoffTicket,
+  defaultUnclaimTicket,
   dispatchLockPath,
   DYNAMIC_DEADLINE_ADAPTERS,
   executeClaimed,
@@ -5849,6 +5850,120 @@ describe("defaultReturnHandoffTicket (WM-718 F2)", () => {
     });
     expect(result).toBe(false);
     expect(calls).toHaveLength(0);
+  });
+});
+
+// `defaultUnclaimTicket` is the worker's NOT_CLAIMED release: when a dispatch
+// run never reached handoff (the claim was lost, or the run failed while the
+// ticket still sat In Progress), the slot has to go back on the board. The
+// bug this guards (WM-1024) was that dropping `ai:in-progress` and stopping
+// left the ticket `Todo`/unassigned but WITHOUT `ai:agent-ready` — the board
+// read Todo, yet the dispatch predicate (Todo + ai:agent-ready + unassigned)
+// never matched again, so nothing redispatched it. These drive the real
+// function through injected `fetchTicket`/`runCli` seams, never mocking it.
+describe("defaultUnclaimTicket (NOT_CLAIMED release)", () => {
+  test("restores Todo + ai:agent-ready, strips ai:in-progress and the stale agent label", () => {
+    const calls = [];
+    const result = defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-9001",
+      why: "ticket_claim_lost",
+      fetchTicket: () => ({
+        state: { name: "In Progress" },
+        labels: {
+          nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }],
+        },
+      }),
+      runCli: (args) => (calls.push(args), ""),
+    });
+    expect(result).toBe(true);
+    // The state move re-adds ai:agent-ready (so the ticket is dispatchable
+    // again), unassigns, and strips the lifecycle + stale agent labels.
+    expect(calls[0]).toEqual([
+      "state",
+      "WM-9001",
+      "Todo",
+      "--unassign",
+      "--add",
+      "ai:agent-ready",
+      "--remove",
+      "ai:in-progress",
+      "--remove",
+      "ai:blocked",
+      "--remove",
+      "agent:claude-code",
+    ]);
+    // ...and a comment records the release and its cause.
+    const comment = calls.find((c) => c[0] === "comment");
+    expect(comment).toBeDefined();
+    expect(comment[2]).toContain("released back to Todo + ai:agent-ready");
+    expect(comment[2]).toContain("ticket_claim_lost");
+  });
+
+  test("folds an absolute log path down to ~ in the release comment", () => {
+    const calls = [];
+    defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-9001",
+      why: "agent_exit_1",
+      log: `${homedir()}/.factory/runs/run-9001.log`,
+      fetchTicket: () => ({
+        state: { name: "In Progress" },
+        labels: { nodes: [{ name: "ai:in-progress" }] },
+      }),
+      runCli: (args) => (calls.push(args), ""),
+    });
+    const comment = calls.find((c) => c[0] === "comment");
+    expect(comment[2]).toContain("~/.factory/runs/run-9001.log");
+    expect(comment[2]).not.toContain(homedir());
+  });
+
+  test("is a no-op when the ticket is no longer In Progress", () => {
+    const calls = [];
+    const result = defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-9001",
+      why: "ticket_claim_lost",
+      fetchTicket: () => ({
+        state: { name: "Todo" },
+        labels: { nodes: [{ name: "ai:agent-ready" }] },
+      }),
+      runCli: (args) => (calls.push(args), ""),
+    });
+    expect(result).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("is a no-op when In Progress but the ai:in-progress label is already gone", () => {
+    const calls = [];
+    const result = defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-9001",
+      why: "ticket_claim_lost",
+      fetchTicket: () => ({
+        state: { name: "In Progress" },
+        labels: { nodes: [{ name: "agent:claude-code" }] },
+      }),
+      runCli: (args) => (calls.push(args), ""),
+    });
+    expect(result).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("swallows a mutation failure and reports false rather than throwing", () => {
+    const result = defaultUnclaimTicket({
+      repo: "factory",
+      ticket: "WM-9001",
+      why: "ticket_claim_lost",
+      fetchTicket: () => ({
+        state: { name: "In Progress" },
+        labels: { nodes: [{ name: "ai:in-progress" }] },
+      }),
+      runCli: () => {
+        throw new Error("linear: rate limited");
+      },
+    });
+    expect(result).toBe(false);
   });
 });
 

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -32,6 +32,8 @@ import {
   closureCheckMessages,
   resolveRepoName,
   resolveRepoNameFromTicket,
+  instanceConfigRoot,
+  InstanceConfigMissingError,
   __resetLinearReposCache,
 } from "./ticket.mjs";
 
@@ -648,4 +650,82 @@ test("resolveRepoNameFromTicket: linear-style and bare ids resolve nothing", () 
   expect(resolveRepoNameFromTicket("WM-123", GH975_REPOS)).toBeNull();
   expect(resolveRepoNameFromTicket("975", GH975_REPOS)).toBeNull();
   expect(resolveRepoNameFromTicket(undefined, GH975_REPOS)).toBeNull();
+});
+
+// ----------------------------------- instance config resolution (GH-975) ---
+// Every ticket verb acts on instance-local control-plane state, so the CLI must
+// resolve which operator checkout owns `config/repos.yaml` BEFORE it touches
+// cwd or the ticket identifier. A dispatched agent runs from an ephemeral
+// runtime workspace that has no `config/repos.yaml`; it receives the operator
+// checkout through `FACTORY_ROOT`, and resolution must honour that rather than
+// falling back to the executing agent's own checkout (which would point at the
+// tracked example config and misroute a real GitHub ticket into a Linear
+// lookup).
+function makeConfiguredRoot(label) {
+  const root = mkdtempSync(path.join(os.tmpdir(), label));
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    "repos:\n  - name: wm\n    path: /nonexistent\n",
+  );
+  return root;
+}
+
+test("instanceConfigRoot uses FACTORY_ROOT when the execution checkout lacks config/repos.yaml", () => {
+  const factoryRoot = makeConfiguredRoot("ticket-facroot-");
+  // The execution checkout is a bare workspace with no config/ at all — the
+  // exact shape of a dispatched runtime workspace under ~/.factory.
+  const checkoutRoot = mkdtempSync(path.join(os.tmpdir(), "ticket-checkout-"));
+  try {
+    // The bare checkout on its own is not a valid instance config root...
+    expect(() => instanceConfigRoot({ env: {}, checkoutRoot })).toThrow(
+      InstanceConfigMissingError,
+    );
+    // ...but FACTORY_ROOT names the operator checkout that owns the config.
+    expect(
+      instanceConfigRoot({ env: { FACTORY_ROOT: factoryRoot }, checkoutRoot }),
+    ).toBe(path.resolve(factoryRoot));
+  } finally {
+    rmSync(factoryRoot, { recursive: true, force: true });
+    rmSync(checkoutRoot, { recursive: true, force: true });
+  }
+});
+
+test("instanceConfigRoot: FACTORY_REPOS_ROOT is the explicit override, ahead of FACTORY_ROOT", () => {
+  const reposRoot = makeConfiguredRoot("ticket-reposroot-");
+  const factoryRoot = makeConfiguredRoot("ticket-facroot2-");
+  try {
+    expect(
+      instanceConfigRoot({
+        env: { FACTORY_REPOS_ROOT: reposRoot, FACTORY_ROOT: factoryRoot },
+        checkoutRoot: "/nonexistent",
+      }),
+    ).toBe(path.resolve(reposRoot));
+  } finally {
+    rmSync(reposRoot, { recursive: true, force: true });
+    rmSync(factoryRoot, { recursive: true, force: true });
+  }
+});
+
+test("instanceConfigRoot throws instance_config_missing when no instance config is available", () => {
+  // No override env and a checkout without config/repos.yaml: a syntactically
+  // valid fallback is exactly what must NOT happen here, so this is an explicit
+  // refusal rather than a silent default-plane lookup.
+  const checkoutRoot = mkdtempSync(path.join(os.tmpdir(), "ticket-noconfig-"));
+  try {
+    let thrown;
+    try {
+      instanceConfigRoot({ env: {}, checkoutRoot });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(InstanceConfigMissingError);
+    expect(thrown.code).toBe("instance_config_missing");
+    expect(thrown.message).toContain("instance_config_missing");
+    expect(thrown.message).toContain(
+      path.join(path.resolve(checkoutRoot), "config", "repos.yaml"),
+    );
+  } finally {
+    rmSync(checkoutRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What

Adds the regression coverage that watt-mind/factory#975 left out (its scoped paths excluded `tools/ticket.test.mjs`, `event-runtime/lib/worker.mjs`, and `event-runtime/lib/worker.test.mjs`). Tests only — no production behaviour changes.

**`tools/ticket.test.mjs`** — `instanceConfigRoot` / `InstanceConfigMissingError`:
- Resolves the operator checkout via `FACTORY_ROOT` when the execution checkout lacks `config/repos.yaml`.
- `FACTORY_REPOS_ROOT` is honoured as the explicit override, ahead of `FACTORY_ROOT`.
- Raises an explicit `instance_config_missing` error when no instance config is available.

**`event-runtime/lib/worker.test.mjs`** — `defaultUnclaimTicket` (the worker NOT_CLAIMED release):
- Restores a lost claim to `Todo` + `ai:agent-ready`, strips `ai:in-progress` and the stale `agent:*` label.
- Folds an absolute log path down to `~` in the release comment.
- No-ops when the ticket already left In Progress or already lost `ai:in-progress`; swallows a mutation failure and returns `false`.

## Why

GH-975's acceptance required regression coverage for FACTORY_ROOT-based config resolution and the NOT_CLAIMED release path, but its Owned Paths excluded the files where those tests belong. This closes that gap so the WM-1024 (release must re-add `ai:agent-ready`) and GH-975 (`instance_config_missing` refusal) behaviours are pinned.

## Acceptance

- [x] Ticket CLI resolution uses FACTORY_ROOT when the execution checkout lacks `config/repos.yaml`.
- [x] Explicit `instance_config_missing` error is emitted when no instance config is available.
- [x] Worker NOT_CLAIMED outcome restores ticket release to Todo and ai:agent-ready.
- [x] `bun test tools/ticket.test.mjs event-runtime/lib/worker.test.mjs` — new tests pass. (Pre-existing timing-bound subprocess tests in "execute-side dispatch hardening (WM-115)" time out locally on the loaded operator box; they are load-adjusted on CI and untouched by this additive diff.)

## Owned Paths

- `event-runtime/lib/worker.mjs` (unchanged — production behaviour untouched)
- `event-runtime/lib/worker.test.mjs`
- `tools/ticket.test.mjs`

Closes #977
