### PR TITLE
fix(stack): live-stack down/up must reap orphaned web + worker processes holding ports (#1068)

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -76,6 +76,76 @@ cleanup_stale_fake_runtimes() {
   done < <(ps -axo pid=,pgid=,etime=,command=)
 }
 
+# PIDs listening on <port> that THIS checkout started (WM-657, #1068). Ownership
+# is decided by the process argv naming this checkout ($REPO): every daemon we
+# spawn runs an absolute $REPO/... path, so a sibling worktree's stack or the
+# operator's own live stack on the same port is never matched — the reap stays
+# scoped to processes we are responsible for, which is what makes it safe to run
+# on the shared operator box.
+owned_port_holders() { # <port>
+  command -v lsof >/dev/null 2>&1 || return 0
+  local pid cmd
+  while read -r pid; do
+    [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
+    cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+    [[ "$cmd" == *"$REPO/"* ]] || continue
+    printf '%s\n' "$pid"
+  done < <(lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u)
+}
+
+# Reap an orphan of ours still holding <port> after the pidfile teardown, or
+# before `up` binds it. The recorded owner has already been dealt with (down) or
+# is known dead (up's pre-flight) by the time this runs, so anything of ours
+# still on the port is a leak: a serve.mjs the web supervisor re-exec'd into a
+# pid the group-kill missed, or a daemon whose process group split. SIGTERM
+# first, then SIGKILL what ignores it. A holder we do not own is left untouched
+# for the bind to reject with its existing diagnostic.
+reap_owned_port() { # <port> <label>
+  command -v lsof >/dev/null 2>&1 || return 0
+  local port="$1" label="$2" pid deadline holders
+  holders="$(owned_port_holders "$port")"
+  [[ -n "$holders" ]] || return 0
+  for pid in $holders; do
+    warn "reaping orphaned $label still holding port $port (pid $pid)"
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  deadline=$(( $(date +%s) + 3 ))
+  while [[ $(date +%s) -lt $deadline ]]; do
+    holders="$(owned_port_holders "$port")"
+    [[ -n "$holders" ]] || return 0
+    sleep 0.1
+  done
+  for pid in $(owned_port_holders "$port"); do
+    warn "$label on port $port ignored SIGTERM — killing (pid $pid)"
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+
+# Final backstop for `down` (#1068): after the pidfile teardown, sweep for any
+# serve, worker, or web process THIS checkout started that still survives — a
+# daemon whose process group split, or a serve.mjs re-exec'd into a pid the
+# group-kill missed. Scoped to this checkout's own paths ($REPO) and excluding
+# our own process group, so a sibling worktree's stack or the operator's own is
+# never touched. This is the acceptance guarantee that no cli.mjs serve/work or
+# web/serve.mjs the stack owns remains after `down`.
+reap_owned_processes() {
+  local pid pgid cmd current_pgid
+  current_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+  while read -r pid pgid cmd; do
+    [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
+    [[ "$pgid" =~ ^[0-9]+$ ]] || continue
+    [[ -z "$current_pgid" || "$pgid" != "$current_pgid" ]] || continue
+    case "$cmd" in
+      *"$REPO/event-runtime/cli.mjs "*) ;;
+      *"$REPO/event-runtime/web/serve.mjs"*) ;;
+      *"$REPO/bin/live-stack.sh __supervise"*) ;;
+      *) continue ;;
+    esac
+    warn "reaping orphaned stack process pid $pid: $cmd"
+    kill -KILL -- "-$pgid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  done < <(ps -axo pid=,pgid=,command=)
+}
+
 case "$ACTION" in
   up)
     ADAPTER_FLAG=()
@@ -214,6 +284,20 @@ case "$ACTION" in
         WEB_BUILD_SECONDS=$(( $(date +%s) - WEB_BUILD_STARTED ))
         WEB_BUILD_MESSAGE="web bundle $WEB_BUNDLE_REASON — rebuilt in ${WEB_BUILD_SECONDS}s"
       fi
+    fi
+
+    # Pre-flight port reclaim (#1068). A crashed or half-completed previous run
+    # can leave a process THIS checkout started still holding :API_PORT/:WEB_PORT
+    # after its pidfile is gone — the classic symptom is a web serve.mjs that
+    # held :7382 across restarts. `up` stays idempotent: a live daemon that still
+    # owns its pidfile is left to the "already running" checks below, so we only
+    # reclaim a port when its recorded owner is dead. reap_owned_port never
+    # touches a holder we do not own.
+    if ! pid_alive "$RUN_DIR/serve.pid"; then
+      reap_owned_port "$API_PORT" "event runtime"
+    fi
+    if ! pid_alive "$RUN_DIR/web.pid"; then
+      reap_owned_port "$WEB_PORT" "web server"
     fi
 
     # 1. Start or verify event runtime API server
@@ -420,6 +504,12 @@ case "$ACTION" in
     await_daemon "$RUN_DIR/web.pid" "web server"
     await_daemon "$RUN_DIR/worker.pid" "worker"
     await_daemon "$RUN_DIR/serve.pid" "event runtime"
+    # Backstop the pidfile teardown: reclaim the ports and sweep any serve /
+    # worker / web process of ours that outlived its recorded pid, so a restart
+    # never inherits an orphan holding :7381/:7382 or a lease (#1068).
+    reap_owned_port "$WEB_PORT" "web server"
+    reap_owned_port "$API_PORT" "event runtime"
+    reap_owned_processes
     rm -f "$RUN_DIR"/*.pid "$RUN_DIR"/*.drain "$RUN_DIR"/*.id
     cleanup_stale_fake_runtimes
     info "done — live factory stack is down (durable state preserved at $HOME_DIR)"


### PR DESCRIPTION
## What
Reap orphaned stack processes so `factory down`/`up` never leave a `serve`, `web/serve.mjs`, or `work` process holding `:7381`/`:7382` or a lease across a restart.

- **down**: after the existing pidfile teardown, reclaim `:7381`/`:7382` and sweep any serve/worker/web process this checkout started that outlived its recorded pid (`reap_owned_port` + `reap_owned_processes`).
- **up**: a pre-flight reclaims a port whose recorded owner is dead before binding; a live daemon that still owns its pidfile is left alone, so `up` stays idempotent.

## Why
`down` killed each daemon by recorded pid/group, but an orphan could outlive its pidfile: a web `serve.mjs` the supervisor re-exec'd into a pid the group-kill missed held `:7382` across multiple restarts on 2026-08-29 (WM-657), and split worker groups leak `cli.mjs` processes and their leases. The next `up` then failed to bind or ran against a stale process missing current env.

Ownership is decided by this checkout's absolute `$REPO` paths appearing in the process argv, so a sibling worktree's stack or the operator's own live stack on the same port is **never** touched — safe on the shared operator box. The reap adds no dependency on `worktree-common.sh` helpers, so the existing `bin/live-stack.test.mjs` suite (24 tests) stays green.

## Acceptance
- [x] After `down`, no `cli.mjs serve`, `web/serve.mjs`, or `cli.mjs work` process the stack started remains (`reap_owned_processes` sweep + port reclaim).
- [x] `up` clears a stale port holder of ours before binding (pre-flight `reap_owned_port`); a foreign holder is left for the bind to reject.
- [x] Documented reap step + verified: `bash -n` clean, all 24 `bin/live-stack.test.mjs` tests pass; reap identification exercised against a live listener.

## Owned Paths
- `bin/live-stack.sh`
