### PR TITLE
fix(dispatch): do not re-dispatch GitHub issues already fixed by merged PRs (#1050)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -22,7 +22,9 @@ import { byQueueOrder, ControlPlaneError } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
+  BLOCKED_LABEL,
   claimLabels,
+  IN_PROGRESS_LABEL,
   stampRun,
   validateLabels,
 } from "./labels.mjs";
@@ -131,11 +133,20 @@ const ISSUE_LAST_EDITOR = `query IssueLastEditor($owner: String!, $name: String!
 // also handles cross-reference syntax and edits. Twenty simultaneous closing
 // PRs for one issue is already pathological, and a hard ceiling protects the
 // unattended reaper from an unbounded forge walk.
-const ISSUE_OPEN_CLOSING_PULL_REQUESTS = `query IssueOpenClosingPullRequests($owner: String!, $name: String!, $number: Int!) {
+//
+// `number`/`url`/`mergeCommit` carry the merged-PR evidence the claim guard
+// (WM-1050) reconciles with; the open-PR reaper reads only `state`.
+const ISSUE_CLOSING_PULL_REQUESTS = `query IssueClosingPullRequests($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $number) {
       closedByPullRequestsReferences(first: 20) {
-        nodes { state repository { nameWithOwner } }
+        nodes {
+          state
+          number
+          url
+          repository { nameWithOwner }
+          mergeCommit { oid }
+        }
         pageInfo { hasNextPage }
       }
     }
@@ -687,6 +698,67 @@ export function githubControlPlane(options = {}) {
   }
 
   /**
+   * The repository-scoped closing-PR references for an issue, validated to
+   * fail closed (WM-1050).
+   *
+   * Both the open-PR reaper guard (`hasOpenPullRequest`) and the merged-work
+   * claim guard read this single edge. An unreadable transport error escapes
+   * (never caught here); a truncated, malformed, or over-ceiling response
+   * THROWS a ControlPlaneError. Neither caller may act on an inconclusive
+   * relationship: returning a partial answer would let the reaper destroy a
+   * live claim, or let a claim proceed on work that is already merged.
+   */
+  async function closingPullRequestRefs(repo, number) {
+    const [owner, name] = repo.split("/");
+    const d = await call("POST", "graphql", {
+      body: {
+        query: ISSUE_CLOSING_PULL_REQUESTS,
+        variables: { owner, name, number },
+      },
+    });
+    const issue = d?.repository?.issue;
+    if (!issue)
+      throw new ControlPlaneError(
+        `could not resolve pull requests for ${issueIdentifier(repo, number)}`,
+      );
+    const refs = issue.closedByPullRequestsReferences;
+    if (
+      !refs ||
+      !Array.isArray(refs.nodes) ||
+      typeof refs.pageInfo?.hasNextPage !== "boolean" ||
+      refs.nodes.some(
+        (pr) =>
+          typeof pr?.state !== "string" ||
+          typeof pr?.repository?.nameWithOwner !== "string",
+      )
+    )
+      throw new ControlPlaneError(
+        `pull-request lookup for ${issueIdentifier(repo, number)} returned an inconclusive response`,
+      );
+    if (refs.pageInfo.hasNextPage)
+      throw new ControlPlaneError(
+        `pull-request lookup for ${issueIdentifier(repo, number)} exceeded the 20-reference safety ceiling`,
+      );
+    return refs.nodes;
+  }
+
+  /**
+   * The first MERGED closing PR that lives in THIS repository, or null.
+   *
+   * Cross-repo references (a fork's PR, an unrelated "fixes" from another repo)
+   * are ignored: only a merged PR in the issue's own repository is proof the
+   * work shipped here.
+   */
+  function mergedClosingPullRequest(refs, repo) {
+    return (
+      refs.find(
+        (pr) =>
+          pr?.state === "MERGED" && pr?.repository?.nameWithOwner === repo,
+      ) ?? null
+    );
+  }
+
+  /**
    * number -> identifiers of its OPEN blockers (WM-1008).
    *
    * GitHub models this as issue dependencies (`blocked_by`). That endpoint is
@@ -1106,6 +1178,59 @@ export function githubControlPlane(options = {}) {
     async claim(identifier, { harness = "claude" } = {}) {
       const { repo, number } = locate(identifier);
       const { issue, ticket } = await fetchIssue(repo, number);
+
+      // Before touching labels, assignee, or project status, reconcile an
+      // issue whose implementation already merged (WM-1050). GitHub-backed
+      // dispatch otherwise trusts an open issue's Todo status and
+      // `ai:agent-ready` label even after its closing PR landed, so a shipped
+      // ticket (e.g. #1004 after PR #1006) is claimed again and only discovers
+      // the merged work after taking a worker slot.
+      //
+      // `closingPullRequestRefs` fails closed: a malformed, truncated, or
+      // failed lookup THROWS and the claim never proceeds — it is safer to
+      // skip a claim than to re-work merged code or clobber a live claim.
+      const refs = await closingPullRequestRefs(repo, number);
+      const merged = mergedClosingPullRequest(refs, repo);
+      if (merged) {
+        const remove = [
+          IN_PROGRESS_LABEL,
+          AGENT_READY_LABEL,
+          BLOCKED_LABEL,
+          ...(ticket.labels ?? [])
+            .map((l) => l.name)
+            .filter((n) => n.startsWith("agent:")),
+        ];
+        const nextLabels = resolveLabelNames(
+          (ticket.labels ?? []).map((l) => l.name),
+          { remove },
+        );
+        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+          body: { labels: nextLabels },
+        });
+        await call("PATCH", `repos/${repo}/issues/${number}`, {
+          body: { assignees: [], state: "closed" },
+        });
+        await setStatus(repo, number, issue.node_id ?? ticket.id, "Done");
+        const oid = merged.mergeCommit?.oid;
+        const evidence = [
+          `Skipped dispatch: closing PR #${merged.number} is already merged` +
+            `${merged.url ? ` (${merged.url})` : ""}.`,
+          oid ? `Merge commit \`${oid}\`.` : null,
+          `Reconciled to Done, claim labels removed, left unassigned.`,
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+        await call("POST", `repos/${repo}/issues/${number}/comments`, {
+          body: { body: stampRun(evidence) },
+        });
+        return {
+          ok: false,
+          identifier: issueIdentifier(repo, number),
+          assignee: null,
+          why: `closing PR #${merged.number} already merged`,
+        };
+      }
+
       const me = await call("GET", "user");
       if (!me?.id)
         throw new ControlPlaneError("github viewer is not available");
@@ -1194,39 +1319,11 @@ export function githubControlPlane(options = {}) {
 
     async hasOpenPullRequest(identifier) {
       const { repo, number } = locate(identifier);
-      const [owner, name] = repo.split("/");
-      // `call` deliberately lets transport/schema failures escape. Returning
-      // false on an unreadable edge would let the reaper destroy a live claim.
-      const d = await call("POST", "graphql", {
-        body: {
-          query: ISSUE_OPEN_CLOSING_PULL_REQUESTS,
-          variables: { owner, name, number },
-        },
-      });
-      const issue = d?.repository?.issue;
-      if (!issue)
-        throw new ControlPlaneError(
-          `could not resolve pull requests for ${issueIdentifier(repo, number)}`,
-        );
-      const refs = issue.closedByPullRequestsReferences;
-      if (
-        !refs ||
-        !Array.isArray(refs.nodes) ||
-        typeof refs.pageInfo?.hasNextPage !== "boolean" ||
-        refs.nodes.some(
-          (pr) =>
-            typeof pr?.state !== "string" ||
-            typeof pr?.repository?.nameWithOwner !== "string",
-        )
-      )
-        throw new ControlPlaneError(
-          `pull-request lookup for ${issueIdentifier(repo, number)} returned an inconclusive response`,
-        );
-      if (refs.pageInfo.hasNextPage)
-        throw new ControlPlaneError(
-          `pull-request lookup for ${issueIdentifier(repo, number)} exceeded the 20-reference safety ceiling`,
-        );
-      return refs.nodes.some(
+      // `closingPullRequestRefs` deliberately lets transport/schema failures
+      // escape. Returning false on an unreadable edge would let the reaper
+      // destroy a live claim.
+      const refs = await closingPullRequestRefs(repo, number);
+      return refs.some(
         (pr) => pr?.state === "OPEN" && pr?.repository?.nameWithOwner === repo,
       );
     },

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -317,7 +317,7 @@ function fakeApi(seed) {
           },
         };
       }
-      if (gqlQuery.includes("IssueOpenClosingPullRequests")) {
+      if (gqlQuery.includes("IssueClosingPullRequests")) {
         const repoName = `${variables.owner}/${variables.name}`;
         requireIssue(seed, repoName, variables.number);
         return {
@@ -598,7 +598,7 @@ describe("control-plane contract: github", () => {
       repo: REPO,
       teams: { WM: REPO },
       api(method, pathName, opts) {
-        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+        if (opts?.body?.query?.includes("IssueClosingPullRequests"))
           throw new Error("forge unavailable");
         return api(method, pathName, opts);
       },
@@ -623,7 +623,7 @@ describe("control-plane contract: github", () => {
       repo: REPO,
       teams: { WM: REPO },
       api(method, pathName, opts) {
-        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+        if (opts?.body?.query?.includes("IssueClosingPullRequests"))
           return { data: { repository: { issue: {} } } };
         return api(method, pathName, opts);
       },
@@ -640,7 +640,7 @@ describe("control-plane contract: github", () => {
       repo: REPO,
       teams: { WM: REPO },
       api(method, pathName, opts) {
-        if (opts?.body?.query?.includes("IssueOpenClosingPullRequests"))
+        if (opts?.body?.query?.includes("IssueClosingPullRequests"))
           return {
             data: {
               repository: {
@@ -815,6 +815,87 @@ describe("control-plane contract: github", () => {
     const result = await cp.claim(`${REPO}#1`);
     expect(result.ok).toBe(false);
     expect(result.assignee).toBe("Other");
+  });
+
+  // WM-1050: an open Todo issue whose closing PR already merged (the #1004 /
+  // #1006 casualty) must not be claimed again. Instead the adapter reconciles
+  // it to Done, drops the claim labels, leaves it unassigned, and records the
+  // merged-PR evidence — and reports ok:false so the orchestrator skips it.
+  test("claim reconciles an issue with a MERGED closing PR instead of dispatching it", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequests[`${REPO}#1`] = [
+      {
+        state: "MERGED",
+        number: 1006,
+        url: `https://github.com/${REPO}/pull/1006`,
+        repository: { nameWithOwner: REPO },
+        mergeCommit: { oid: "2a19b48944f078ba81afef9b0d69b6b35bd23469" },
+      },
+    ];
+    const result = await cp.claim(`${REPO}#1`);
+    expect(result.ok).toBe(false);
+    expect(result.identifier).toBe(`${REPO}#1`);
+    expect(result.assignee).toBeNull();
+    expect(result.why).toMatch(/1006/);
+
+    const t = await cp.getTicket(`${REPO}#1`);
+    expect(t.state.name).toBe("Done");
+    expect(t.assignee).toBeNull();
+    const names = t.labels.map((l) => l.name);
+    expect(names).not.toContain(AGENT_READY_LABEL);
+    expect(names).not.toContain(IN_PROGRESS_LABEL);
+    expect(names.some((n) => n.startsWith("agent:"))).toBe(false);
+
+    const comments = await cp.listComments(`${REPO}#1`);
+    expect(comments.length).toBe(1);
+    expect(comments[0].body).toMatch(/#1006/);
+    expect(comments[0].body).toMatch(
+      /2a19b48944f078ba81afef9b0d69b6b35bd23469/,
+    );
+  });
+
+  test("claim proceeds normally when the closing PR is only OPEN", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequests[`${REPO}#1`] = [
+      {
+        state: "OPEN",
+        number: 1006,
+        url: `https://github.com/${REPO}/pull/1006`,
+        repository: { nameWithOwner: REPO },
+        mergeCommit: null,
+      },
+    ];
+    const result = await cp.claim(`${REPO}#1`);
+    expect(result.ok).toBe(true);
+    expect((await cp.getTicket(`${REPO}#1`)).state.name).toBe("In Progress");
+  });
+
+  test("claim ignores a MERGED closing PR that lives in another repository", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequests[`${REPO}#1`] = [
+      {
+        state: "MERGED",
+        number: 7,
+        url: `https://github.com/${OTHER_REPO}/pull/7`,
+        repository: { nameWithOwner: OTHER_REPO },
+        mergeCommit: { oid: "deadbeef" },
+      },
+    ];
+    const result = await cp.claim(`${REPO}#1`);
+    expect(result.ok).toBe(true);
+    expect((await cp.getTicket(`${REPO}#1`)).state.name).toBe("In Progress");
+  });
+
+  test("claim fails closed on a truncated closing-reference lookup and does not mutate the ticket", async () => {
+    const { cp, seed } = makePlane();
+    seed.closingPullRequestsHasNextPage[`${REPO}#1`] = true;
+    await expect(cp.claim(`${REPO}#1`)).rejects.toThrow(
+      /20-reference safety ceiling/,
+    );
+    const t = await cp.getTicket(`${REPO}#1`);
+    expect(t.state.name).toBe("Todo");
+    expect(t.assignee).toBeNull();
+    expect(t.labels.map((l) => l.name)).toContain(AGENT_READY_LABEL);
   });
 
   test("comment lands on the ticket and is readable back", async () => {


### PR DESCRIPTION
## What

GitHub `claim()` now checks an issue's repository-scoped closing-PR references before it mutates anything. If a closing PR for the issue is already **MERGED** in the same repo, the adapter does not claim/dispatch: it reconciles the issue/project item to **Done**, removes the lifecycle/agent claim labels (`ai:in-progress`, `ai:agent-ready`, `ai:blocked`, `agent:*`), leaves it unassigned, records the merged-PR evidence (PR number, URL, merge commit) in a comment, and returns `ok: false` so the orchestrator skips it.

## Why

GitHub-backed dispatch trusted an open issue's Todo status and `ai:agent-ready` label even after its closing PR merged. `#1004` was consequently re-claimed after PR `#1006` had merged into `develop`; the duplicate run only discovered the shipped implementation after taking a worker slot.

The `closedByPullRequestsReferences` edge already backed the open-PR reaper guard (`hasOpenPullRequest`); this reuses that same authoritative relationship, extracted into a shared `closingPullRequestRefs()` helper, for the merged-work claim guard. The lookup **fails closed**: a malformed, truncated, over-ceiling, or failed response throws and the claim never proceeds — safer to skip than to re-work merged code or clobber a live claim. Open or closed-without-merge PRs, and merged PRs in another repository, do not trigger reconciliation. The existing read-back race protection is untouched for genuinely claimable issues.

## Acceptance

- [x] Claim checks closing-PR references for a merged PR before mutating labels/assignee/status.
- [x] Merged closing PR → no claim; reconciled to Done, claim labels removed, unassigned, evidence comment.
- [x] Open / closed-without-merge PR does not trigger reconciliation.
- [x] Malformed/truncated/failed lookup fails closed (no claim).
- [x] Existing read-back race protection intact.
- [x] Regression coverage reproduces #1004/#1006 (open Todo + merged closing PR → no claim, settled ticket).
- [x] `bun test lib/control-plane/github.test.mjs` — 64 pass.

## Owned Paths

- `lib/control-plane/github.mjs`
- `lib/control-plane/github.test.mjs`

Closes #1050
