### PR TITLE
fix(worktree): accept bare numeric ticket ids on the github plane (#908)

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -211,16 +211,50 @@ repo_root() { git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel;
 #   ABC-123 / ABC-123-scratch   tracker-key form (Linear)
 #   owner/repo#123 / #123       GitHub forms
 #
-# A BARE number is deliberately NOT accepted: `worktree-up.sh 123` is far more
-# likely a typo than an intent, the existing arg-parsing test guards it as
-# such, and the GitHub adapter always emits the `owner/repo#123` contract form
-# anyway (issueIdentifier), so nothing needs it.
+# A BARE number is deliberately NOT accepted here: `worktree-up.sh 123` is far
+# more likely an interactive typo than an intent, and the arg-parsing test
+# guards it as such. A bare number arriving through automated dispatch is a
+# different case — see ticket_normalize below — so it is qualified to
+# `owner/repo#N` before it ever reaches this validator.
 ticket_is_valid() {
   [[ "$1" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] && return 0
   [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#[0-9]+$ ]] && return 0
   [[ "$1" =~ ^\#[0-9]+$ ]] && return 0
   [[ "$1" =~ ^gh-[0-9]+$ ]] && return 0
   return 1
+}
+
+# The run's GitHub `owner/repo`, used to qualify a bare issue number (#908).
+# Prefer an explicit override (the run's repo config can export it); otherwise
+# read the checkout's `origin` remote. Prints nothing when origin is not a
+# GitHub remote — there is then no repo to qualify a bare number against.
+github_repo_slug() { # [checkout]
+  local url
+  if [[ -n "${FACTORY_GITHUB_REPO:-}" ]]; then
+    printf '%s' "$FACTORY_GITHUB_REPO"
+    return 0
+  fi
+  url=$(git -C "${1:-$(repo_root)}" remote get-url origin 2>/dev/null) || return 0
+  [[ "$url" =~ github\.com[:/]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+) ]] || return 0
+  printf '%s' "${BASH_REMATCH[1]%.git}"
+}
+
+# Normalize a dispatched ticket id to a form ticket_is_valid accepts (#908).
+# The dispatch schema (WM-1006, #878) accepts a bare GitHub issue number
+# (`822`) because parseIssueIdentifier() reads it as repo-relative, but the
+# tracker-agnostic worktree scripts key everything off a fully-qualified id, so
+# a dispatched bare `N` used to die at validation. Qualify it to the run's
+# `owner/repo#N`, mirroring parseIssueIdentifier. Anything that is not a bare
+# number — every Linear key, every already-qualified GitHub form — is returned
+# untouched, and a bare number with no resolvable repo is left as-is so it
+# still fails validation (an interactive typo must not be silently invented).
+ticket_normalize() { # <ticket> [owner/repo]
+  local id="$1" repo="${2:-}"
+  if [[ "$id" =~ ^[0-9]+$ && "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    printf '%s#%s' "$repo" "$id"
+  else
+    printf '%s' "$id"
+  fi
 }
 
 ticket_number() {

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { afterAll, expect, test } from "bun:test";
 
 const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
@@ -932,6 +933,68 @@ test("ticket_number dies on malformed ticket inputs", () => {
     expect(r.status).not.toBe(0);
     expect(r.stderr).toContain("ticket must look like OPS-123");
   }
+});
+
+test("ticket_normalize qualifies a bare number with the run's repo", () => {
+  // The dispatch schema accepts a bare GitHub issue number (#908); qualify it
+  // to owner/repo#N so ticket_is_valid, ticket_slug, and ticket_number all
+  // treat it exactly like the canonical GitHub contract form.
+  expect(sh("ticket_normalize 822 watt-mind/factory").stdout.trim()).toBe(
+    "watt-mind/factory#822",
+  );
+  const id = sh("ticket_normalize 822 watt-mind/factory").stdout.trim();
+  expect(sh(`ticket_is_valid "${id}"`).status).toBe(0);
+  expect(sh(`ticket_slug "${id}"`).stdout.trim()).toBe("gh-822");
+  expect(sh(`ticket_number "${id}"`).stdout.trim()).toBe("822");
+});
+
+test("ticket_normalize leaves non-bare and unqualifiable ids untouched", () => {
+  // Linear keys and already-qualified GitHub forms pass through verbatim, so
+  // normalization never disturbs the existing id space.
+  expect(sh("ticket_normalize OPS-123 watt-mind/factory").stdout.trim()).toBe(
+    "OPS-123",
+  );
+  expect(
+    sh("ticket_normalize watt-mind/factory#7 watt-mind/factory").stdout.trim(),
+  ).toBe("watt-mind/factory#7");
+  expect(sh("ticket_normalize '#7' watt-mind/factory").stdout.trim()).toBe(
+    "#7",
+  );
+  // A bare number with no repo to qualify against is left as-is, so it still
+  // fails validation rather than being silently invented into a ticket.
+  const bare = sh('ticket_normalize 822 ""').stdout.trim();
+  expect(bare).toBe("822");
+  expect(sh(`ticket_is_valid "${bare}"`).status).not.toBe(0);
+});
+
+test("github_repo_slug prefers FACTORY_GITHUB_REPO and parses github remotes", () => {
+  expect(
+    sh("github_repo_slug", {
+      FACTORY_GITHUB_REPO: "acme/widgets",
+    }).stdout.trim(),
+  ).toBe("acme/widgets");
+
+  const withRemote = (url) => {
+    const repo = mkdtempSync(path.join(tmpdir(), "wm-908-remote-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: repo });
+      execFileSync("git", ["remote", "add", "origin", url], { cwd: repo });
+      // Empty FACTORY_GITHUB_REPO so the override does not shadow the remote.
+      return sh(`github_repo_slug "${repo}"`, {
+        FACTORY_GITHUB_REPO: "",
+      }).stdout.trim();
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  };
+  expect(withRemote("https://github.com/watt-mind/factory.git")).toBe(
+    "watt-mind/factory",
+  );
+  expect(withRemote("git@github.com:watt-mind/factory.git")).toBe(
+    "watt-mind/factory",
+  );
+  // A non-GitHub remote yields nothing — there is no repo to qualify against.
+  expect(withRemote("https://gitlab.com/watt-mind/factory.git")).toBe("");
 });
 
 test("web_build_hash computes deterministic sha1 and changes on file rename or content edit", () => {

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -117,6 +117,14 @@ if [[ "$HERE" -eq 1 ]]; then
   LABEL="here"
 else
   [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--checkout-only, --no-seed, --no-fetch, --reseed, --resume)"
+  # A dispatched run (marked by FACTORY_WORKTREE_REPORT) may hand us a bare
+  # GitHub issue number (#908): the dispatch schema accepts `822` as a
+  # repo-relative id, but this tracker-agnostic script needs the qualified
+  # form. Qualify it to the run's owner/repo#822 before validating. Interactive
+  # use has no dispatch marker, so a bare-number typo there still errors out.
+  if [[ -n "${FACTORY_WORKTREE_REPORT:-}" ]]; then
+    TICKET="$(ticket_normalize "$TICKET" "$(github_repo_slug "$REPO")")"
+  fi
   # Accepts ABC-123 and owner/repo#123 (#881). The directory and
   # branch use the slug, since `/` and `#` are not usable in either.
   ticket_is_valid "$TICKET" || die "ticket must look like OPS-123 or owner/repo#123 (got '$TICKET')"


### PR DESCRIPTION
## What
`worktree-up.sh` now accepts a bare numeric ticket id (e.g. `822`) when it arrives through automated dispatch on the GitHub plane, normalizing it to the run's `owner/repo#822` before validation.

## Why
The dispatch schemas (WM-1006, #878) accept a bare GitHub issue number because `parseIssueIdentifier()` reads it as repo-relative, but the tracker-agnostic worktree scripts hard-required `OPS-123` or `owner/repo#123` and died on a bare `N` (`ticket must look like OPS-123 or owner/repo#123 (got '822')`) — observed failing 3 dispatches on 2026-08-22. The issue prefers normalization for symmetry with `parseIssueIdentifier`.

## How
- `worktree-common.sh`: add `ticket_normalize` (bare `N` + `owner/repo` -> `owner/repo#N`, everything else untouched) and `github_repo_slug` (resolves the run's repo from `FACTORY_GITHUB_REPO` or the `origin` remote; empty for non-GitHub remotes).
- `worktree-up.sh`: qualify a bare ticket at entry, **gated on the dispatch marker** `FACTORY_WORKTREE_REPORT`. Interactive use has no marker, so a bare-number typo (`worktree-up.sh 822`) still errors out — keeping the existing arg-parsing guard green — while a dispatched bare number is accepted. Linear keys and already-qualified GitHub forms pass through unchanged.

## Acceptance
- `bun test bin/worktree-common.test.mjs` — 33 pass (3 new tests: bare-number qualification, pass-through of non-bare/unqualifiable ids, `github_repo_slug` remote parsing).
- `bun test bin/worktree-checkout.test.mjs` — 34 pass (bare-number rejection guard intact).
- `bash -n` clean on both shell files.

## Owned Paths
- bin/worktree-up.sh
- bin/worktree-common.sh
- bin/worktree-common.test.mjs
