### PR TITLE
fix(dispatch): auto-recover a dead dispatch so its ticket is not wedged (same_ticket_worktree_held)

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1572,7 +1572,16 @@ function liveRunForInput(
     .query(
       `SELECT run_id, state FROM runs
      WHERE state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
-       AND (? = 1 OR state <> 'FAILED')
+       AND (
+         state <> 'FAILED'
+         OR (
+           ? = 1
+           AND (
+             json_extract(spec_json, '$.maxAttempts') IS NULL
+             OR attempts < json_extract(spec_json, '$.maxAttempts')
+           )
+         )
+       )
        AND json_extract(spec_json, '$.agent') GLOB ?
        AND json_extract(spec_json, '$.input.repo') = ?
        AND (? IS NULL OR json_extract(spec_json, '$.input.ticket') = ?)
@@ -1820,8 +1829,12 @@ export function planEvent(
       const blockingDispatch = liveRunForInput(db, mapping.agent, {
         repo: envelope.payload.repo,
         ticket: envelope.payload.ticket,
-        // FAILED dispatches remain retryable and retain their worktree; a new
-        // run for the same ticket would still collide with that owner.
+        // A still-retryable FAILED dispatch retains its worktree; a new run for
+        // the same ticket would collide with that owner, so it keeps blocking.
+        // An attempts-exhausted FAILED dispatch (WM-1066) is never retried and
+        // its worktree is reaped, so liveRunForInput excludes it — otherwise the
+        // dead run wedges the ticket forever and work-scan re-dispatch NOOPs
+        // with same_ticket_worktree_held behind a run that will never move.
         includeFailed: true,
       });
       if (blockingDispatch) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -709,6 +709,68 @@ describe("planEvent", () => {
     ).toBe("run");
   });
 
+  test("an attempts-exhausted FAILED dispatch stops wedging a fresh dispatch for the same ticket (WM-1066)", () => {
+    const synthetic = { ...registry, agents: new Map(registry.agents) };
+    synthetic.agents.set("dispatch@1", {
+      ...registry.agents.get("dispatch@1"),
+      // Keep the focus on the ledger block; the worktree eligibility gate and
+      // its Linear/lease reads are irrelevant to what liveRunForInput decides.
+      workspace: { type: "ephemeral" },
+    });
+    const db = openDb(":memory:");
+    const dispatch = (eventId) => ({
+      eventId,
+      type: "factory.dispatch.requested",
+      source: "operator",
+      correlationId: eventId,
+      causationId: null,
+      payload: { repo: "factory", ticket: "WM-1066" },
+    });
+
+    const firstRef = admit(db, dispatch("dispatch-dead-1"));
+    const first = planEvent(db, synthetic, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(first.decision).toBe("run");
+
+    // Drive the run to FAILED — the dead dispatch that used to hold this
+    // ticket's worktree forever.
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "FAILED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    // While the attempt budget is not yet spent the worktree is still owned and
+    // the run is genuinely retryable, so a fresh dispatch MUST keep NOOPing.
+    const retryableRef = admit(db, dispatch("dispatch-while-retryable"));
+    expect(
+      planEvent(db, synthetic, retryableRef, {
+        now: NOW + 1000,
+        policyVersion: "git:test",
+      }),
+    ).toMatchObject({
+      decision: "noop",
+      reason: `ticket_dispatch_already_live:${first.runId}:same_ticket_worktree_held`,
+    });
+
+    // Exhaust the attempt budget (maxAttempts is 1). The dead run will never
+    // retry and the reaper reclaims its worktree, so it must stop blocking a
+    // fresh work-scan re-dispatch instead of wedging the ticket.
+    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(
+      1,
+      first.runId,
+    );
+
+    const freshRef = admit(db, dispatch("dispatch-fresh-work-scan"));
+    const fresh = planEvent(db, synthetic, freshRef, {
+      now: NOW + 2000,
+      policyVersion: "git:test",
+    });
+    expect(fresh.decision).toBe("run");
+    expect(fresh.reason ?? "").not.toContain("same_ticket_worktree_held");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+  });
+
   test("unregistered event type → human_needed", () => {
     const db = openDb(":memory:");
     const ref = admit(db, { type: "totally.unknown.type" });

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -33,11 +33,15 @@ import {
   readdirSync,
   statSync,
 } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import path from "node:path";
+import { Database } from "bun:sqlite";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
+import { dbPath } from "../event-runtime/lib/config.mjs";
+import { ticketSlug } from "../lib/ticket-slug.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
 
@@ -659,6 +663,180 @@ export async function runReaper(
   return totals;
 }
 
+/**
+ * Selects dead dispatch runs whose per-ticket worktree is safe to reclaim: a
+ * FAILED run that has spent its whole attempt budget (so it will never retry)
+ * and whose workspace is a worktree. Exported so the selection stays testable
+ * without a live runtime ledger.
+ *
+ * This is the runtime half of WM-1066. The planner already excludes such a run
+ * from the `same_ticket_worktree_held` block so a fresh dispatch can proceed;
+ * this reclaims the stale tree it left behind so provisioning finds no stale
+ * checkout and no operator `retry --force` is needed.
+ */
+export const DEAD_DISPATCH_WORKTREE_SQL = `
+  SELECT run_id AS runId,
+         json_extract(spec_json, '$.input.repo')   AS repo,
+         json_extract(spec_json, '$.input.ticket') AS ticket
+    FROM runs
+   WHERE state = 'FAILED'
+     AND json_extract(spec_json, '$.workspace.type') = 'worktree'
+     AND json_extract(spec_json, '$.maxAttempts') IS NOT NULL
+     AND attempts >= json_extract(spec_json, '$.maxAttempts')
+     AND json_extract(spec_json, '$.input.repo') IS NOT NULL
+     AND json_extract(spec_json, '$.input.ticket') IS NOT NULL
+   ORDER BY run_id ASC`;
+
+/**
+ * True when a repo/ticket still has a live run besides the dead one — someone
+ * may be actively holding the worktree, so it must be left alone. A
+ * still-retryable FAILED sibling counts as live; an attempts-exhausted one does
+ * not (mirrors the planner's liveRunForInput exclusion exactly).
+ */
+export function ticketHasLiveRun(db, repo, ticket) {
+  const row = db
+    .query(
+      `SELECT 1 FROM runs
+        WHERE state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
+          AND (
+            state <> 'FAILED'
+            OR json_extract(spec_json, '$.maxAttempts') IS NULL
+            OR attempts < json_extract(spec_json, '$.maxAttempts')
+          )
+          AND json_extract(spec_json, '$.input.repo') = ?
+          AND json_extract(spec_json, '$.input.ticket') = ?
+        LIMIT 1`,
+    )
+    .get(repo, ticket);
+  return Boolean(row);
+}
+
+/**
+ * Reclaim worktrees stranded by dead (attempts-exhausted FAILED) dispatch runs.
+ *
+ * Teardown is delegated to the repo's own `worktree_down`, NEVER with --force:
+ * a dirty or unpushed tree refuses and stays visible to the janitor, exactly
+ * like the runtime's own completion teardown (WM-108). A worktree whose ticket
+ * still has an open pull request is left alone (mirrors janitor WM-17), and the
+ * pull-request lookup fails closed — a lookup error keeps the tree, never tears
+ * it down blind.
+ *
+ * Dependencies are injectable so selection and teardown can be tested without a
+ * live runtime database, a real filesystem, or spawning bash.
+ */
+export async function reapDeadDispatchWorktrees(
+  args,
+  {
+    repos = loadRepos(),
+    databasePath = dbPath(),
+    openDatabase = (file) => new Database(file, { readonly: true }),
+    fileExists = existsSync,
+    spawn = spawnSync,
+    hasOpenPullRequest = null,
+    log = (...values) => console.log(...values),
+  } = {},
+) {
+  const totals = { considered: 0, cleaned: 0, held: 0, failed: 0 };
+  if (!fileExists(databasePath)) return totals;
+
+  let db;
+  try {
+    db = openDatabase(databasePath);
+  } catch (err) {
+    totals.failed += 1;
+    log(
+      `  ! dead-dispatch worktree reap: ledger unreadable: ${err.message || err}`,
+    );
+    return totals;
+  }
+
+  try {
+    const seen = new Set();
+    for (const { runId, repo: repoName, ticket } of db
+      .query(DEAD_DISPATCH_WORKTREE_SQL)
+      .all()) {
+      const key = `${repoName} ${ticket}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const repo = repos.get(repoName);
+      if (!repo?.worktreeRoot || !repo?.worktreeDown || !repo?.path) {
+        // The repo declares no worktree lifecycle — never ours to reclaim.
+        continue;
+      }
+      let slug;
+      try {
+        slug = ticketSlug(ticket);
+      } catch {
+        // An unsluggable ticket never had a deterministic worktree path.
+        continue;
+      }
+      const worktreePath = path.join(repo.worktreeRoot, slug);
+      if (!fileExists(worktreePath)) continue; // already clean
+
+      if (ticketHasLiveRun(db, repoName, ticket)) {
+        totals.held += 1;
+        log(
+          `  hold  ${repoName}/${ticket}: a live run still owns ${worktreePath}`,
+        );
+        continue;
+      }
+
+      totals.considered += 1;
+      log(
+        `  STALE ${repoName}/${ticket} worktree at ${worktreePath} (dead dispatch ${runId})`,
+      );
+
+      if (hasOpenPullRequest) {
+        let open;
+        try {
+          open = await hasOpenPullRequest(repoName, ticket);
+        } catch (err) {
+          totals.failed += 1;
+          log(
+            `        ! pull-request lookup failed closed: ${err.message || err}`,
+          );
+          continue;
+        }
+        if (open) {
+          totals.held += 1;
+          log(`        (open pull request — not touching it)`);
+          continue;
+        }
+      }
+
+      if (!args.apply) continue;
+
+      const downPath = path.isAbsolute(repo.worktreeDown)
+        ? repo.worktreeDown
+        : path.join(repo.path, repo.worktreeDown);
+      const result = spawn("/bin/bash", [downPath, ticket], {
+        cwd: repo.path,
+        encoding: "utf8",
+      });
+      if (result.error || result.status !== 0) {
+        totals.failed += 1;
+        const detail = String(
+          result.stderr ||
+            result.stdout ||
+            result.error?.message ||
+            `exit ${result.status}`,
+        )
+          .trim()
+          .slice(0, 200);
+        log(`        ! worktree_down refused/failed: ${detail}`);
+        continue;
+      }
+      totals.cleaned += 1;
+      log(`        -> worktree reclaimed`);
+    }
+  } finally {
+    db.close?.();
+  }
+
+  return totals;
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
@@ -682,7 +860,34 @@ Options:
   console.log(
     `=== Stale-claim reaper [${mode}] threshold=${args.minutes}min${args.team ? ` team=${args.team}` : ""} ===\n`,
   );
-  return runReaper(args);
+  const totals = await runReaper(args);
+
+  // Runtime half of WM-1066: reclaim worktrees stranded by dead dispatch runs
+  // so a fresh dispatch is not wedged behind a checkout no one will ever reuse.
+  // Best-effort and isolated — a failure here must never mask the claim reap
+  // above. The open-PR lookup reuses each repo's control plane and fails closed.
+  const planeCache = new Map();
+  const planeFor = (repoName) => {
+    if (!planeCache.has(repoName))
+      planeCache.set(repoName, loadControlPlane({ repoName }));
+    return planeCache.get(repoName);
+  };
+  try {
+    console.log(`\n=== Dead-dispatch worktree reap [${mode}] ===\n`);
+    const worktreeTotals = await reapDeadDispatchWorktrees(args, {
+      hasOpenPullRequest: (repoName, ticket) =>
+        planeFor(repoName).hasOpenPullRequest(ticket),
+    });
+    console.log(
+      `\n=== Worktrees ${args.apply ? "reclaimed" : "reclaimable"}: ${
+        args.apply ? worktreeTotals.cleaned : worktreeTotals.considered
+      } | Held: ${worktreeTotals.held} | Failures: ${worktreeTotals.failed} ===`,
+    );
+  } catch (err) {
+    console.error(`Dead-dispatch worktree reap failed: ${err.message || err}`);
+  }
+
+  return totals;
 }
 
 if (import.meta.main || process.argv[1]?.endsWith("reaper.mjs")) {

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -164,6 +164,8 @@ import {
 import { spawnSync } from "node:child_process";
 import { memoryControlPlane } from "../lib/control-plane/memory.mjs";
 import { runReaper } from "./reaper.mjs";
+import { Database } from "bun:sqlite";
+import { reapDeadDispatchWorktrees, ticketHasLiveRun } from "./reaper.mjs";
 
 describe("reclaim label computation (WM-14)", () => {
   test("restores ai:agent-ready when returning In Progress ticket to Todo", () => {
@@ -610,5 +612,265 @@ describe("WIP preservation (WM-12)", () => {
     expect(status.stdout.trim()).toBe("");
 
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("dead-dispatch worktree reaper (WM-1066)", () => {
+  const DB_FILE = "/runtime/factory.db";
+  const repos = () =>
+    new Map([
+      [
+        "factory",
+        {
+          name: "factory",
+          path: "/repo/factory",
+          worktreeRoot: "/wt/factory",
+          worktreeDown: "bin/worktree-down.sh",
+        },
+      ],
+    ]);
+
+  function ledgerWith(runs) {
+    const db = new Database(":memory:");
+    db.run(
+      `CREATE TABLE runs (
+        run_id TEXT PRIMARY KEY,
+        idempotency_key TEXT,
+        spec_json TEXT,
+        spec_hash TEXT,
+        state TEXT,
+        attempts INTEGER,
+        created_at TEXT,
+        updated_at TEXT
+      )`,
+    );
+    const insert = db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const r of runs) {
+      const spec = {
+        input: { repo: r.repo, ticket: r.ticket },
+        workspace: { type: r.workspace ?? "worktree" },
+        maxAttempts: r.maxAttempts ?? 1,
+      };
+      insert.run(
+        r.runId,
+        `${r.runId}-key`,
+        JSON.stringify(spec),
+        "hash",
+        r.state,
+        r.attempts ?? 0,
+        "2026-08-29T00:00:00Z",
+        "2026-08-29T00:00:00Z",
+      );
+    }
+    return db;
+  }
+
+  function reapWith(db, args, overrides = {}) {
+    const spawned = [];
+    const logs = [];
+    const promise = reapDeadDispatchWorktrees(args, {
+      repos: repos(),
+      databasePath: DB_FILE,
+      openDatabase: () => db,
+      fileExists: (p) => p === DB_FILE || p === "/wt/factory/WM-1066",
+      spawn: (cmd, argv, opts) => {
+        spawned.push({ cmd, argv, opts });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      log: (...parts) => logs.push(parts.join(" ")),
+      ...overrides,
+    });
+    return { promise, spawned, logs };
+  }
+
+  test("tears down the stale worktree of an attempts-exhausted FAILED dispatch", async () => {
+    const db = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    const { promise, spawned } = reapWith(db, parseArgs(["--apply"]));
+    const totals = await promise;
+    expect(totals.cleaned).toBe(1);
+    expect(totals.failed).toBe(0);
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0].cmd).toBe("/bin/bash");
+    expect(spawned[0].argv).toEqual([
+      "/repo/factory/bin/worktree-down.sh",
+      "WM-1066",
+    ]);
+    // Never --force: a dirty or unpushed tree must refuse, not be nuked.
+    expect(spawned[0].argv).not.toContain("--force");
+    expect(spawned[0].opts.cwd).toBe("/repo/factory");
+  });
+
+  test("dry run reports the reclaimable worktree without spawning teardown", async () => {
+    const db = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    const { promise, spawned, logs } = reapWith(db, parseArgs([]));
+    const totals = await promise;
+    expect(totals.considered).toBe(1);
+    expect(totals.cleaned).toBe(0);
+    expect(spawned).toHaveLength(0);
+    expect(logs.join("\n")).toContain("STALE factory/WM-1066");
+  });
+
+  test("a still-retryable FAILED dispatch keeps its worktree (not attempts-exhausted)", async () => {
+    const db = ledgerWith([
+      {
+        runId: "run_retryable",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 0,
+        maxAttempts: 1,
+      },
+    ]);
+    const { promise, spawned } = reapWith(db, parseArgs(["--apply"]));
+    const totals = await promise;
+    expect(totals.considered).toBe(0);
+    expect(totals.cleaned).toBe(0);
+    expect(spawned).toHaveLength(0);
+  });
+
+  test("a live run for the same ticket holds the worktree", async () => {
+    const db = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+      {
+        runId: "run_live",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "RUNNING",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    const { promise, spawned, logs } = reapWith(db, parseArgs(["--apply"]));
+    const totals = await promise;
+    expect(totals.held).toBe(1);
+    expect(totals.cleaned).toBe(0);
+    expect(spawned).toHaveLength(0);
+    expect(logs.join("\n")).toContain("a live run still owns");
+  });
+
+  test("an open pull request protects the worktree and lookup failure fails closed", async () => {
+    const db = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    const held = reapWith(db, parseArgs(["--apply"]), {
+      hasOpenPullRequest: async () => true,
+    });
+    const heldTotals = await held.promise;
+    expect(heldTotals.held).toBe(1);
+    expect(heldTotals.cleaned).toBe(0);
+    expect(held.spawned).toHaveLength(0);
+
+    const db2 = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    const failing = reapWith(db2, parseArgs(["--apply"]), {
+      hasOpenPullRequest: async () => {
+        throw new Error("forge unavailable");
+      },
+    });
+    const failingTotals = await failing.promise;
+    expect(failingTotals.failed).toBe(1);
+    expect(failingTotals.cleaned).toBe(0);
+    expect(failing.spawned).toHaveLength(0);
+    expect(failing.logs.join("\n")).toContain(
+      "failed closed: forge unavailable",
+    );
+  });
+
+  test("no runtime ledger on disk is a safe no-op", async () => {
+    const db = ledgerWith([]);
+    let spawned = 0;
+    const totals = await reapDeadDispatchWorktrees(parseArgs(["--apply"]), {
+      repos: repos(),
+      databasePath: DB_FILE,
+      openDatabase: () => db,
+      fileExists: () => false,
+      spawn: () => {
+        spawned += 1;
+        return { status: 0 };
+      },
+      log: () => {},
+    });
+    expect(totals).toEqual({
+      considered: 0,
+      cleaned: 0,
+      held: 0,
+      failed: 0,
+    });
+    expect(spawned).toBe(0);
+  });
+
+  test("ticketHasLiveRun ignores the exhausted dead run but sees a queued sibling", () => {
+    const db = ledgerWith([
+      {
+        runId: "run_dead",
+        repo: "factory",
+        ticket: "WM-1066",
+        state: "FAILED",
+        attempts: 1,
+        maxAttempts: 1,
+      },
+    ]);
+    expect(ticketHasLiveRun(db, "factory", "WM-1066")).toBe(false);
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run_queued",
+      "run_queued-key",
+      JSON.stringify({
+        input: { repo: "factory", ticket: "WM-1066" },
+        workspace: { type: "worktree" },
+        maxAttempts: 1,
+      }),
+      "hash",
+      "QUEUED",
+      0,
+      "2026-08-29T00:00:00Z",
+      "2026-08-29T00:00:00Z",
+    );
+    expect(ticketHasLiveRun(db, "factory", "WM-1066")).toBe(true);
   });
 });


### PR DESCRIPTION
## What
Auto-recover a dead dispatch so its ticket is no longer wedged behind a `same_ticket_worktree_held` NOOP.

- **planner** (`event-runtime/lib/planner.mjs`): `liveRunForInput` now excludes an attempts-exhausted FAILED dispatch (`attempts >= maxAttempts`) from the worktree-held block. A fresh dispatch for the same ticket proceeds instead of NOOPing forever. A still-retryable FAILED run (budget not spent) keeps blocking, exactly as before, because it still owns its worktree.
- **reaper** (`orchestrator/reaper.mjs`): new `reapDeadDispatchWorktrees` reclaims the stale worktree of a dead dispatch through the repo's own `worktree_down` — **never `--force`**, so a dirty/unpushed tree refuses and stays visible to the janitor. It holds any tree still owned by a live run or an open PR, and the PR lookup **fails closed**. Invoked from `main()`, so the plane-aware `runReaper` path (and its tests) are untouched.

## Why
A dispatch that reached terminal FAILED/attempts-exhausted retained its worktree, and `ticket_dispatch_already_live` treated the ticket as live indefinitely — so work-scan re-dispatch NOOPed with `same_ticket_worktree_held` until an operator ran `retry --force`. This stranded #838 / #1002 / #1017 / #852 during the 2026-08-29 recovery.

Once the reaper removes the stale tree, `materializeWorktree` sees no existing checkout (`existsSync` false, so its ownership check is skipped) and the fresh dispatch materializes cleanly — no operator intervention.

## Acceptance
- A FAILED/attempts-exhausted dispatch no longer blocks a fresh dispatch for the same ticket. ✅ (planner unit test)
- The stale worktree is cleaned. ✅ (reaper unit tests: tears down via `worktree_down`, never `--force`; holds live-run / open-PR trees; fails closed)
- `bun test orchestrator/reaper.test.mjs event-runtime/lib/planner.test.mjs` → 122 pass.

The security/escalation gates are untouched: only the dead-dispatch block behavior changed. A still-retryable FAILED run keeps its worktree-held block.

## Owned Paths
- `orchestrator/reaper.mjs`
- `orchestrator/reaper.test.mjs`
- `event-runtime/lib/planner.mjs`

Refs #1066
