### PR TITLE
feat(repos): implement WM-316 toolchain preflight — declare constraints, verify before claim, fail with a reason

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -23,6 +23,23 @@ repos:
     worktree_root: ~/Develop/.worktrees/factory
     max_in_flight: 20
     verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
+    # Toolchain preflight (WM-316). Each entry is an { executable, constraint }
+    # pair; constraint is a semver range. Before a ticket is claimed, dispatch
+    # resolves each executable on the target node and checks its version. A
+    # missing executable fails with repo_toolchain_missing; a version outside
+    # the range fails with repo_toolchain_mismatch (carrying the observed
+    # version), so the mismatch surfaces pre-claim instead of mid-run.
+    #
+    # Preflight only ever runs `<executable> --version`; it never installs or
+    # upgrades host tooling. Omit this block entirely to keep today's behaviour
+    # (no preflight, no gating) — it is additive.
+    toolchain:
+      - executable: bun
+        constraint: ">=1.2 <2"
+      - executable: node
+        constraint: ">=22 <25"
+      - executable: git
+        constraint: ">=2.40"
     owned_paths_policy:
       direct:
         - source: shared/**

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -327,19 +327,38 @@ constraints:
 repos:
   - name: factory
     toolchain:
-      bun: ">=1.3 <2"
-      node: ">=22 <25"
-      git: ">=2.40"
+      - executable: bun
+        constraint: ">=1.2 <2"
+      - executable: node
+        constraint: ">=22 <25"
+      - executable: git
+        constraint: ">=2.40"
     repo_ready_check: bin/repo-ready-check.sh
 ```
 
+Each `toolchain` entry is an `{ executable, constraint }` pair, where
+`constraint` is a semver range; the list is ordered so failures report in
+declaration order. **Implemented in WM-316**
+(`event-runtime/lib/repos.mjs`): `loadRepos` parses and validates the block,
+`preflightToolchain` resolves each executable's version and evaluates the
+constraint, `assertRepoReadyForClaim` is the pre-claim gate dispatch consults,
+and `toolchainReport` surfaces per-repo status for doctor. A repo with no
+`toolchain:` block is unaffected — no preflight, no gating.
+
 The contract records what the repo requires; it does not select a version
-manager or install system packages. `repo doctor` resolves each executable in
-the same non-interactive environment a worker uses, captures its normalized
-version, and checks the constraint. A mismatch is
-`repo_toolchain_mismatch` with node, executable, constraint, observed version,
-and recovery guidance. It happens before claim, workspace creation, dependency
-installation, or model spawn.
+manager or install system packages. Preflight resolves each executable in the
+same non-interactive environment a worker uses by running `<executable>
+--version` — and nothing else — captures its normalized version, and checks the
+constraint. A resolvable version outside the range is `repo_toolchain_mismatch`
+with node, executable, constraint, observed version, and recovery guidance; an
+executable that cannot be resolved is `repo_toolchain_missing`. It happens
+before claim, workspace creation, dependency installation, or model spawn.
+
+> Persisting bounded readiness attestations (freshness/staleness of the whole
+> preflight) and wiring the gate into `orchestrator/tick.mjs` and
+> `orchestrator/doctor.mjs` land in WM-317; WM-316 delivers the toolchain
+> contract, the non-mutating preflight, the typed reasons, and the reusable
+> gate/report the dispatcher and doctor call.
 
 The generic checks cannot know whether a repo needs a local Postgres role,
 Docker daemon, mobile SDK, signing setup, or another repo-specific service.

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -32,6 +32,219 @@ export class RepoError extends Error {
 }
 
 /**
+ * A repo cannot be safely dispatched into on the target node because its
+ * toolchain preflight did not pass. Thrown by the pre-claim gate so the refusal
+ * carries the failing constraint instead of surfacing mid-run (WM-316). Carries
+ * the full preflight result on `.detail` for diagnostics and doctor output.
+ */
+export class RepoNotReadyError extends RepoError {
+  constructor(message, detail) {
+    super(message);
+    this.name = "RepoNotReadyError";
+    this.detail = detail;
+  }
+}
+
+// The typed reason codes the design already names (docs/event-runtime-repos.md
+// §6.3, line 418). A declared executable that cannot be resolved on the node is
+// `missing`; one whose version fails the constraint is `mismatch`, and the
+// mismatch payload carries node, executable, constraint, and observed version
+// (design line 340) so the operator sees "node X has 18, not 22" pre-claim.
+export const TOOLCHAIN_MISSING = "repo_toolchain_missing";
+export const TOOLCHAIN_MISMATCH = "repo_toolchain_mismatch";
+
+function normalizeToolchain(raw, repoName, file) {
+  if (raw === undefined || raw === null) return null;
+  if (!Array.isArray(raw)) {
+    throw new RepoError(
+      `${file}: repo ${repoName} toolchain must be a list of { executable, constraint } entries`,
+    );
+  }
+  if (raw.length === 0) {
+    throw new RepoError(
+      `${file}: repo ${repoName} toolchain is empty — omit the block instead of declaring no constraints`,
+    );
+  }
+  const constraints = [];
+  const seen = new Set();
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain entries must be objects with executable and constraint`,
+      );
+    }
+    const { executable, constraint } = entry;
+    if (typeof executable !== "string" || !executable.trim()) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain.executable must be a non-empty string`,
+      );
+    }
+    if (typeof constraint !== "string" || !constraint.trim()) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain ${executable} constraint must be a non-empty semver range`,
+      );
+    }
+    const exe = executable.trim();
+    if (seen.has(exe)) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain declares ${exe} more than once`,
+      );
+    }
+    seen.add(exe);
+    constraints.push({ executable: exe, constraint: constraint.trim() });
+  }
+  return constraints;
+}
+
+/**
+ * Pull the first semver-shaped token out of a `<tool> --version` line. Tools
+ * print wildly different banners ("git version 2.47.3", "1.2.8", "v22.4.1"),
+ * so we normalize by locating the version rather than parsing per tool.
+ */
+export function parseToolVersion(output) {
+  const match = String(output ?? "").match(
+    /\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?/,
+  );
+  return match ? match[0] : null;
+}
+
+/**
+ * Resolve one executable's version on the current node by running
+ * `<executable> --version`. Deliberately non-mutating: it only ever asks a tool
+ * to print its version and never installs, upgrades, or otherwise touches host
+ * tooling (design §10). `spawnSync` is injectable so tests can assert exactly
+ * that. A binary that is absent (ENOENT) or that fails to print a parseable
+ * version resolves to `found: false`.
+ *
+ * @returns {{ found: boolean, version: string|null }}
+ */
+export function probeToolVersion(
+  executable,
+  { spawnSync = Bun.spawnSync } = {},
+) {
+  let proc;
+  try {
+    proc = spawnSync([executable, "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch {
+    // ENOENT and friends: the executable is not on PATH for this node.
+    return { found: false, version: null };
+  }
+  if (!proc || proc.exitCode !== 0) return { found: false, version: null };
+  const decode = (buf) => (buf ? new TextDecoder().decode(buf) : "");
+  const version = parseToolVersion(
+    `${decode(proc.stdout)}\n${decode(proc.stderr)}`,
+  );
+  if (!version) return { found: false, version: null };
+  return { found: true, version };
+}
+
+/**
+ * Verify a repo's declared toolchain constraints against the tools actually
+ * present on the target node, before any claim (WM-316). Purely a validator: it
+ * resolves versions through `resolve` (default: the non-mutating
+ * `probeToolVersion`) and never installs anything.
+ *
+ * A repo with no `toolchain:` block is ready with zero checks — the feature is
+ * additive and must not turn today's repos not-ready on upgrade.
+ *
+ * @returns {{ ready: boolean, node: string|null, repo: string|null,
+ *             checks: Array<{executable: string, constraint: string,
+ *                            observed: string|null, ok: boolean,
+ *                            reason: string|null}>,
+ *             failures: Array<object> }}
+ */
+export function preflightToolchain(
+  repo,
+  { node = null, resolve = probeToolVersion } = {},
+) {
+  const constraints = repo?.toolchain ?? null;
+  const repoName = repo?.name ?? null;
+  if (!constraints || constraints.length === 0) {
+    return { ready: true, node, repo: repoName, checks: [], failures: [] };
+  }
+  const checks = [];
+  for (const { executable, constraint } of constraints) {
+    const { found, version } = resolve(executable) ?? {
+      found: false,
+      version: null,
+    };
+    if (!found) {
+      checks.push({
+        executable,
+        constraint,
+        observed: null,
+        ok: false,
+        reason: TOOLCHAIN_MISSING,
+      });
+      continue;
+    }
+    const ok = Bun.semver.satisfies(version ?? "", constraint);
+    checks.push({
+      executable,
+      constraint,
+      observed: version,
+      ok,
+      reason: ok ? null : TOOLCHAIN_MISMATCH,
+    });
+  }
+  const failures = checks.filter((check) => !check.ok);
+  return {
+    ready: failures.length === 0,
+    node,
+    repo: repoName,
+    checks,
+    failures,
+  };
+}
+
+function describeFailure(node, failure) {
+  const where = node ? ` on node ${node}` : "";
+  if (failure.reason === TOOLCHAIN_MISSING) {
+    return `executable ${failure.executable} (needs ${failure.constraint}) is not installed${where}`;
+  }
+  return `executable ${failure.executable} is ${failure.observed}${where}, needs ${failure.constraint}`;
+}
+
+/**
+ * The pre-claim readiness gate dispatch consults before burning a slot on a
+ * repo (WM-316). Throws {@link RepoNotReadyError} naming the failing constraint
+ * when toolchain preflight fails, so the failure lands before claim/worktree/
+ * spawn instead of mid-run. Returns the passing preflight result otherwise.
+ */
+export function assertRepoReadyForClaim(repo, opts = {}) {
+  const result = preflightToolchain(repo, opts);
+  if (!result.ready) {
+    const first = result.failures[0];
+    throw new RepoNotReadyError(
+      `repo ${result.repo} is not ready: ${first.reason} — ${describeFailure(result.node, first)}`,
+      result,
+    );
+  }
+  return result;
+}
+
+/**
+ * Toolchain status for every repo, for `factory doctor` to render so a mismatch
+ * is diagnosable without reading run logs (WM-316). One row per repo in file
+ * order; a repo with no `toolchain:` block reports `declared: false` and stays
+ * ready.
+ */
+export function toolchainReport(repos, opts = {}) {
+  return [...repos.values()].map((repo) => {
+    const result = preflightToolchain(repo, opts);
+    return {
+      repo: repo.name,
+      declared: (repo.toolchain?.length ?? 0) > 0,
+      ready: result.ready,
+      checks: result.checks,
+    };
+  });
+}
+
+/**
  * Which factory checkout supplies repos.yaml. Defaults to the running one;
  * FACTORY_REPOS_ROOT points elsewhere (a runtime serving another checkout —
  * and the hook that makes these tests hermetic instead of depending on
@@ -289,6 +502,10 @@ export function loadRepos({ root = reposRoot() } = {}) {
       worktreeDown: entry.worktree_down ?? null,
       worktreeWarm: entry.worktree_warm ?? null,
       verify: entry.verify ?? null,
+      // WM-316: declared executable version constraints, verified before claim.
+      // Absent means "no preflight, no gating" — additive, so nine working
+      // repos stay ready on upgrade.
+      toolchain: normalizeToolchain(entry.toolchain, entry.name, file),
       ownedPathsPolicy: normalizeOwnedPathsPolicy(
         entry.owned_paths_policy,
         entry.name,
@@ -339,6 +556,9 @@ export function reposView(repos) {
     security: repo.security,
     mergeCi: repo.mergeCi,
     escalatePaths: repo.escalatePaths,
+    // WM-316: null when the repo declares no constraints; otherwise the list a
+    // reader (and doctor) needs to see what this repo requires of its node.
+    toolchain: repo.toolchain,
     ownedPathsPolicy: repo.ownedPathsPolicy,
     worktreeRoot: repo.worktreeRoot,
     hasWorktreeUp: repo.worktreeUp !== null,

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -4,11 +4,19 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import {
+  assertRepoReadyForClaim,
   loadRepos,
+  parseToolVersion,
+  preflightToolchain,
+  probeToolVersion,
   proveMergeChecks,
   RepoError,
+  RepoNotReadyError,
   reposView,
   selectMergeCheckGate,
+  TOOLCHAIN_MISMATCH,
+  TOOLCHAIN_MISSING,
+  toolchainReport,
 } from "./repos.mjs";
 
 const scratch = [];
@@ -114,6 +122,7 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       worktreeDown: "bin/worktree-down.sh",
       worktreeWarm: "bin/worktree-warm.sh",
       verify: "npm run typecheck",
+      toolchain: null,
       ownedPathsPolicy: {
         direct: [
           { source: "shared/**", requires: ["dist/**", "plugins/core/**"] },
@@ -415,6 +424,7 @@ describe("reposView is what the control API serves", () => {
         "smokeUrl",
         "smokeWorkflow",
         "team",
+        "toolchain",
         "verify",
         "worktreeRoot",
       ]);
@@ -516,5 +526,287 @@ describe("control_plane on a repo entry", () => {
     expect(reposView(loadRepos({ root: pinned }))[0].controlPlane).toBe(
       "github",
     );
+  });
+});
+
+// WM-316: toolchain preflight — declare executable version constraints per repo,
+// verify them before claim, and fail with a typed reason instead of mid-run.
+describe("toolchain constraints parse and validate", () => {
+  const TOOLCHAIN_YAML = `repos:
+  - name: pinned
+    path: /tmp/pinned
+    toolchain:
+      - executable: bun
+        constraint: ">=1.2"
+      - executable: node
+        constraint: ">=22 <25"
+  - name: none
+    path: /tmp/none
+`;
+
+  test("a declared toolchain becomes an ordered list of { executable, constraint }", () => {
+    const repos = loadRepos({ root: factoryRoot(TOOLCHAIN_YAML) });
+    expect(repos.get("pinned").toolchain).toEqual([
+      { executable: "bun", constraint: ">=1.2" },
+      { executable: "node", constraint: ">=22 <25" },
+    ]);
+  });
+
+  test("a repo with no toolchain block reads as null — additive, no gating", () => {
+    const repos = loadRepos({ root: factoryRoot(TOOLCHAIN_YAML) });
+    expect(repos.get("none").toolchain).toBeNull();
+  });
+
+  test("the constraint list is published on the wire for doctor and operators", () => {
+    const rows = reposView(loadRepos({ root: factoryRoot(TOOLCHAIN_YAML) }));
+    expect(rows.find((r) => r.name === "pinned").toolchain).toEqual([
+      { executable: "bun", constraint: ">=1.2" },
+      { executable: "node", constraint: ">=22 <25" },
+    ]);
+    expect(rows.find((r) => r.name === "none").toolchain).toBeNull();
+  });
+
+  test("malformed toolchain blocks fail the load with a RepoError", () => {
+    const invalidCases = [
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain: "bun"\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain: []\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain:\n      - executable: bun\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain:\n      - constraint: ">=1"\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain:\n      - executable: ""\n        constraint: ">=1"\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain:\n      - executable: bun\n        constraint: ""\n`,
+      `repos:\n  - name: a\n    path: /tmp/a\n    toolchain:\n      - executable: bun\n        constraint: ">=1"\n      - executable: bun\n        constraint: ">=2"\n`,
+    ];
+    for (const yaml of invalidCases) {
+      expect(() => loadRepos({ root: factoryRoot(yaml) })).toThrow(RepoError);
+    }
+  });
+});
+
+describe("parseToolVersion normalizes tool banners", () => {
+  test("extracts the first semver from assorted --version output", () => {
+    expect(parseToolVersion("git version 2.47.3")).toBe("2.47.3");
+    expect(parseToolVersion("v22.4.1")).toBe("22.4.1");
+    expect(parseToolVersion("1.2.8")).toBe("1.2.8");
+    expect(parseToolVersion("Python 3.12.4")).toBe("3.12.4");
+    expect(parseToolVersion("no digits here")).toBeNull();
+    expect(parseToolVersion(null)).toBeNull();
+  });
+});
+
+describe("preflightToolchain verifies constraints before claim", () => {
+  // A repo shaped like loadRepos output, minimal to the fields preflight reads.
+  const repo = (toolchain) => ({ name: "sut", toolchain });
+  const constraints = [
+    { executable: "bun", constraint: ">=1.2" },
+    { executable: "node", constraint: ">=22 <25" },
+  ];
+
+  test("all constraints satisfied → ready, one passing check per executable", () => {
+    const resolve = (exe) =>
+      ({
+        bun: { found: true, version: "1.2.8" },
+        node: { found: true, version: "22.4.1" },
+      })[exe];
+    const result = preflightToolchain(repo(constraints), {
+      node: "runner-a",
+      resolve,
+    });
+    expect(result.ready).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.checks.map((c) => [c.executable, c.ok])).toEqual([
+      ["bun", true],
+      ["node", true],
+    ]);
+  });
+
+  test("a missing executable fails with repo_toolchain_missing and no observed version", () => {
+    const resolve = (exe) =>
+      ({
+        bun: { found: true, version: "1.2.8" },
+        node: { found: false, version: null },
+      })[exe];
+    const result = preflightToolchain(repo(constraints), { resolve });
+    expect(result.ready).toBe(false);
+    const failure = result.failures[0];
+    expect(failure).toMatchObject({
+      executable: "node",
+      reason: TOOLCHAIN_MISSING,
+      observed: null,
+    });
+  });
+
+  test("a version mismatch carries node, executable, constraint, and observed version", () => {
+    const resolve = (exe) =>
+      ({
+        bun: { found: true, version: "1.2.8" },
+        node: { found: true, version: "18.19.0" },
+      })[exe];
+    const result = preflightToolchain(repo(constraints), {
+      node: "runner-b",
+      resolve,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.node).toBe("runner-b");
+    expect(result.failures[0]).toEqual({
+      executable: "node",
+      constraint: ">=22 <25",
+      observed: "18.19.0",
+      ok: false,
+      reason: TOOLCHAIN_MISMATCH,
+    });
+  });
+
+  test("a repo with no toolchain block is ready with zero checks (passthrough)", () => {
+    const called = [];
+    const resolve = (exe) => {
+      called.push(exe);
+      return { found: true, version: "1.0.0" };
+    };
+    for (const tc of [null, undefined]) {
+      const result = preflightToolchain(repo(tc), { resolve });
+      expect(result.ready).toBe(true);
+      expect(result.checks).toEqual([]);
+    }
+    // Passthrough must not probe anything — additive means untouched.
+    expect(called).toEqual([]);
+  });
+});
+
+describe("preflight is non-mutating — it never installs or upgrades tooling", () => {
+  test("probeToolVersion only ever runs `<exe> --version`", () => {
+    const spawned = [];
+    const spawnSync = (argv) => {
+      spawned.push(argv);
+      return {
+        exitCode: 0,
+        stdout: new TextEncoder().encode("1.2.8"),
+        stderr: new Uint8Array(),
+      };
+    };
+    const result = probeToolVersion("bun", { spawnSync });
+    expect(result).toEqual({ found: true, version: "1.2.8" });
+    expect(spawned).toEqual([["bun", "--version"]]);
+    // Structural guarantee: no install/add/upgrade verb is ever spawned.
+    const flat = spawned.flat().join(" ");
+    expect(flat).not.toMatch(/\b(install|add|upgrade|update|get)\b/);
+  });
+
+  test("a probe for an absent binary resolves to not-found, never an install", () => {
+    const spawned = [];
+    const spawnSync = (argv) => {
+      spawned.push(argv);
+      const err = new Error("spawn ENOENT");
+      err.code = "ENOENT";
+      throw err;
+    };
+    expect(probeToolVersion("ghost", { spawnSync })).toEqual({
+      found: false,
+      version: null,
+    });
+    expect(spawned).toEqual([["ghost", "--version"]]);
+  });
+
+  test("preflight drives only the injected resolver and spawns nothing itself", () => {
+    const repo = {
+      name: "sut",
+      toolchain: [{ executable: "bun", constraint: ">=1" }],
+    };
+    const seen = [];
+    preflightToolchain(repo, {
+      resolve: (exe) => {
+        seen.push(exe);
+        return { found: true, version: "1.5.0" };
+      },
+    });
+    expect(seen).toEqual(["bun"]);
+  });
+});
+
+describe("dispatch consults readiness before claiming (WM-316)", () => {
+  test("assertRepoReadyForClaim returns the passing result for a ready repo", () => {
+    const repo = {
+      name: "ready",
+      toolchain: [{ executable: "bun", constraint: ">=1.2" }],
+    };
+    const result = assertRepoReadyForClaim(repo, {
+      resolve: () => ({ found: true, version: "1.2.8" }),
+    });
+    expect(result.ready).toBe(true);
+  });
+
+  test("a not-ready repo is refused before claim, and the refusal names the failing constraint", () => {
+    const repo = {
+      name: "stale",
+      toolchain: [{ executable: "node", constraint: ">=22" }],
+    };
+    let thrown;
+    try {
+      assertRepoReadyForClaim(repo, {
+        node: "runner-c",
+        resolve: () => ({ found: true, version: "18.19.0" }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RepoNotReadyError);
+    expect(thrown.message).toContain("node");
+    expect(thrown.message).toContain(">=22");
+    expect(thrown.message).toContain("18.19.0");
+    expect(thrown.message).toContain(TOOLCHAIN_MISMATCH);
+    // The full preflight result rides along for diagnostics/doctor.
+    expect(thrown.detail.failures[0].observed).toBe("18.19.0");
+  });
+
+  test("a missing-executable repo is refused naming the tool and constraint", () => {
+    const repo = {
+      name: "nobun",
+      toolchain: [{ executable: "bun", constraint: ">=1.2" }],
+    };
+    expect(() =>
+      assertRepoReadyForClaim(repo, {
+        resolve: () => ({ found: false, version: null }),
+      }),
+    ).toThrow(/repo_toolchain_missing[\s\S]*bun/);
+  });
+
+  test("a repo with no toolchain block is never refused — nine working repos stay dispatchable", () => {
+    const repo = { name: "legacy", toolchain: null };
+    expect(assertRepoReadyForClaim(repo).ready).toBe(true);
+  });
+});
+
+describe("toolchainReport surfaces per-repo status for factory doctor", () => {
+  test("one row per repo: declared flag, readiness, and per-executable checks", () => {
+    const repos = loadRepos({
+      root: factoryRoot(`repos:
+  - name: pinned
+    path: /tmp/pinned
+    toolchain:
+      - executable: bun
+        constraint: ">=99"
+  - name: plain
+    path: /tmp/plain
+`),
+    });
+    const report = toolchainReport(repos, {
+      resolve: () => ({ found: true, version: "1.2.8" }),
+    });
+    expect(report).toEqual([
+      {
+        repo: "pinned",
+        declared: true,
+        ready: false,
+        checks: [
+          {
+            executable: "bun",
+            constraint: ">=99",
+            observed: "1.2.8",
+            ok: false,
+            reason: TOOLCHAIN_MISMATCH,
+          },
+        ],
+      },
+      { repo: "plain", declared: false, ready: true, checks: [] },
+    ]);
   });
 });


### PR DESCRIPTION
## What

Implements the designed toolchain preflight (WM-316) in `event-runtime/lib/repos.mjs`:

- **Declare**: `config/repos.yaml` accepts a `toolchain:` block per repo — a list of `{ executable, constraint }` entries where `constraint` is a semver range. Parsed and validated by `loadRepos`; documented in `config/repos.example.yaml`.
- **Verify**: `preflightToolchain(repo, { node, resolve })` resolves each executable's version and evaluates its constraint, emitting the design's typed reasons — `repo_toolchain_missing` and `repo_toolchain_mismatch` (the latter carrying node, executable, constraint, and **observed version**).
- **Non-mutating**: `probeToolVersion` only ever runs `<executable> --version`; it never installs or upgrades host tooling. A test asserts no install verb is spawned.
- **Gate**: `assertRepoReadyForClaim` is the pre-claim readiness gate dispatch consults; a not-ready repo is refused with the failing constraint named.
- **Diagnose**: `toolchainReport` returns per-repo status for `factory doctor`.
- **Additive**: a repo with no `toolchain:` block reads as `null` — no preflight, no gating; existing repos stay ready on upgrade.

## Why

Repos have divergent system needs. Without a preflight a mismatch surfaces mid-run: the ticket is claimed, the worktree built, the slot burned, and the operator sees a confusing agent-side error. This moves the failure to pre-claim with a clear reason ("node X has 18, not 22").

## Acceptance

- [x] `toolchain:` block accepted and documented
- [x] Preflight resolves + evaluates constraints; typed reasons with observed version
- [x] Non-mutating; test asserts no install spawned
- [x] Pre-claim gate refuses a not-ready repo, naming the constraint
- [x] Absent-block passthrough (no gating)
- [x] Per-repo status function for doctor
- [x] Tests: satisfied / missing / mismatch(observed) / passthrough / non-mutation / dispatch-refusal — 41 pass

**Deferred (outside Owned Paths):** persisting bounded readiness *attestations* (freshness/staleness) and wiring the gate into `orchestrator/tick.mjs` / `orchestrator/doctor.mjs` belong to WM-317 per the doc roadmap; this PR delivers the reusable, tested contract, preflight, typed reasons, and gate/report those consumers call. Noted in the design doc.

## Owned Paths

- `event-runtime/lib/repos.mjs`
- `event-runtime/lib/repos.test.mjs`
- `config/repos.example.yaml`
- `docs/event-runtime-repos.md`

Refs #1076