### PR TITLE
fix(worktree): stop materializing stale operator schedule overlay (#1051)

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -180,13 +180,22 @@ normalize_path() { # <path>
   )
 }
 
-# Local config is intentionally gitignored, but a delegated checkout needs
-# the active instance's routing, policy, and schedule rather than examples.
-# Skip a checkout without the ignore rule so an agent can never stage it.
+# Local config is intentionally gitignored, but a delegated checkout needs the
+# active instance's routing and policy rather than examples. Skip a checkout
+# without the ignore rule so an agent can never stage it.
+#
+# schedule.yaml is deliberately NOT provisioned. Unlike repos/policy — pure
+# instance state — the schedule overlay layers on top of the branch's tracked
+# kernel schedules (event-runtime/schedules.json). A worktree branch may have
+# trimmed a loop out of the kernel (e.g. #1028) while the live operator overlay
+# still carries a stale, partial entry for it (`enabled: true`, no cadence);
+# copied in, it loads as a new overlay loop with no `every` and the repo verify
+# gate dies with `unparseable cadence "undefined"` (#1051). Omitting it lets the
+# checkout fall back to the tracked schedule.example.yaml, which always verifies.
 provision_instance_local_configs() { # <checkout> [primary-checkout]
   local checkout="$1" primary="${2:-${FACTORY_ROOT:-$(repo_root)}}"
   local name source destination rel
-  for name in repos policy schedule; do
+  for name in repos policy; do
     source="$primary/config/$name.yaml"
     [[ -f "$source" ]] || continue
     destination="$checkout/config/$name.yaml"

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -239,19 +239,48 @@ test("provision_instance_local_configs copies ignored local config and skips abs
       "config/repos.yaml\nconfig/policy.yaml\nconfig/schedule.yaml\n",
     );
     writeFileSync(path.join(source, "config", "repos.yaml"), "repos: []\n");
+    writeFileSync(path.join(source, "config", "policy.yaml"), "limits: {}\n");
+    const r = sh(
+      [
+        `git -C "${checkout}" init -q`,
+        `provision_instance_local_configs "${checkout}" "${source}"`,
+        `test "$(cat "${checkout}/config/repos.yaml")" = "repos: []"`,
+        `test "$(cat "${checkout}/config/policy.yaml")" = "limits: {}"`,
+        `git -C "${checkout}" check-ignore -q config/repos.yaml`,
+        `git -C "${checkout}" check-ignore -q config/policy.yaml`,
+      ].join("\n"),
+    );
+    expect(r.status).toBe(0);
+  } finally {
+    rmSync(source, { recursive: true, force: true });
+    rmSync(checkout, { recursive: true, force: true });
+  }
+});
+
+test("provision_instance_local_configs never materializes the operator schedule overlay (#1051)", () => {
+  const source = mkdtempSync(path.join(tmpdir(), "gh-1051-config-source-"));
+  const checkout = mkdtempSync(path.join(tmpdir(), "gh-1051-config-checkout-"));
+  try {
+    mkdirSync(path.join(source, "config"), { recursive: true });
+    mkdirSync(path.join(checkout, "config"), { recursive: true });
+    writeFileSync(
+      path.join(checkout, ".gitignore"),
+      "config/repos.yaml\nconfig/policy.yaml\nconfig/schedule.yaml\n",
+    );
+    writeFileSync(path.join(source, "config", "repos.yaml"), "repos: []\n");
+    // A stale, partial operator overlay: a loop trimmed out of the branch's
+    // kernel, left with `enabled: true` and no cadence. Copied in, it would
+    // break the repo verify gate with `unparseable cadence "undefined"`.
     writeFileSync(
       path.join(source, "config", "schedule.yaml"),
-      "schedules: []\n",
+      "schedules:\n  work-bj29:\n    enabled: true\n",
     );
     const r = sh(
       [
         `git -C "${checkout}" init -q`,
         `provision_instance_local_configs "${checkout}" "${source}"`,
         `test "$(cat "${checkout}/config/repos.yaml")" = "repos: []"`,
-        `test "$(cat "${checkout}/config/schedule.yaml")" = "schedules: []"`,
-        `test ! -e "${checkout}/config/policy.yaml"`,
-        `git -C "${checkout}" check-ignore -q config/repos.yaml`,
-        `git -C "${checkout}" check-ignore -q config/schedule.yaml`,
+        `test ! -e "${checkout}/config/schedule.yaml"`,
       ].join("\n"),
     );
     expect(r.status).toBe(0);

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -78,16 +78,25 @@ const HARNESS_UNKNOWN_CODES = Object.freeze({
   subagents: "harness_unknown_subagent",
 });
 
+// schedule.yaml is deliberately absent. Unlike repos/policy — pure instance
+// state a delegated checkout needs verbatim — the schedule overlay layers on
+// top of the branch's tracked kernel schedules (event-runtime/schedules.json).
+// A worktree's branch may have trimmed a loop out of the kernel (e.g. #1028),
+// yet the live operator overlay can still carry a stale, partial entry for it
+// (`enabled: true` with no cadence). Copied in, that entry loads as a brand-new
+// overlay loop with no `every`, and the repo verify gate dies with
+// `unparseable cadence "undefined"` (#1051). Omitting it lets the checkout fall
+// back to the tracked schedule.example.yaml, which always verifies.
 const INSTANCE_LOCAL_CONFIG_FILES = Object.freeze([
   "repos.yaml",
   "policy.yaml",
-  "schedule.yaml",
 ]);
 
 /**
  * Bring the operator-owned config files into a delegated checkout. These
  * files are intentionally untracked, so a fresh worktree otherwise falls
  * back to examples and cannot use this factory instance's routing or policy.
+ * The schedule overlay is excluded on purpose (see INSTANCE_LOCAL_CONFIG_FILES).
  */
 export function provisionInstanceLocalConfigs({
   checkoutPath,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -314,6 +314,64 @@ describe("worker", () => {
     }
   });
 
+  test("does not materialize a stale operator schedule overlay, so a worktree stays verifiable after client schedules leave the kernel (#1051)", () => {
+    const factoryRoot = tmpDir("evrt-schedule-overlay-source-");
+    const checkout = tmpDir("evrt-schedule-overlay-checkout-");
+    try {
+      mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+      mkdirSync(path.join(checkout, "config"), { recursive: true });
+      writeFileSync(
+        path.join(checkout, ".gitignore"),
+        "config/repos.yaml\nconfig/policy.yaml\nconfig/schedule.yaml\n",
+      );
+      expect(spawnSync("git", ["init", "-q"], { cwd: checkout }).status).toBe(
+        0,
+      );
+      writeFileSync(
+        path.join(factoryRoot, "config", "repos.yaml"),
+        "repos: []\n",
+      );
+      // A checkout tracks only the example overlay; the branch has trimmed the
+      // client loop out of the kernel, so the tracked example carries no
+      // `work-bj29`.
+      writeFileSync(
+        path.join(checkout, "config", "schedule.example.yaml"),
+        "jobs: []\n",
+      );
+      // The live operator overlay still carries a stale, partial entry for the
+      // now-kernel-less loop: `enabled: true` with no cadence. Copied into the
+      // checkout it would load as a brand-new overlay loop with no `every` and
+      // detonate the repo verify gate with `unparseable cadence "undefined"`.
+      writeFileSync(
+        path.join(factoryRoot, "config", "schedule.yaml"),
+        "schedules:\n  work-bj29:\n    enabled: true\n",
+      );
+
+      expect(
+        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+      ).toEqual(["config/repos.yaml"]);
+
+      // The stale overlay never lands in the checkout ...
+      expect(existsSync(path.join(checkout, "config", "schedule.yaml"))).toBe(
+        false,
+      );
+      // ... so schedule resolution falls back to the tracked example, which
+      // parses cleanly and has no cadence-less loop to break verify.
+      const resolved = resolveConfigPath("schedule", {
+        root: checkout,
+        warn: false,
+      });
+      expect(resolved).toBe(
+        path.join(checkout, "config", "schedule.example.yaml"),
+      );
+      const parsed = Bun.YAML.parse(readFileSync(resolved, "utf8"));
+      expect(parsed?.schedules?.["work-bj29"]).toBeUndefined();
+    } finally {
+      rmSync(factoryRoot, { recursive: true, force: true });
+      rmSync(checkout, { recursive: true, force: true });
+    }
+  });
+
   test("silently skips instance config provisioning when no local files exist", () => {
     const factoryRoot = tmpDir("evrt-instance-config-empty-source-");
     const checkout = tmpDir("evrt-instance-config-empty-checkout-");


### PR DESCRIPTION
## What
Stop delegated worktrees from materializing the live operator `config/schedule.yaml` overlay. Instance-local config provisioning now copies only `repos.yaml` and `policy.yaml`; the schedule overlay is omitted so the checkout falls back to the tracked `config/schedule.example.yaml`.

## Why
The schedule overlay layers on top of the branch's tracked kernel schedules (`event-runtime/schedules.json`). When a branch trims a loop out of the kernel (e.g. #1028) while the live operator overlay still carries a stale, partial entry for it (`enabled: true`, no cadence), the copied-in entry loads as a brand-new overlay loop with no `every`, and the configured-repo verify gate dies mechanically across `event-runtime/lib` with `unparseable cadence "undefined"` (#1051). `repos`/`policy` are pure instance state and remain provisioned verbatim; the schedule overlay is the only config coupled to per-branch kernel code.

## Acceptance
- `bin/worktree-common.sh` and `event-runtime/lib/worker.mjs` no longer copy `schedule.yaml` into delegated checkouts.
- A worktree whose operator overlay carries a kernel-less `work-bj29: { enabled: true }` entry remains verifiable — schedule resolution falls back to the tracked example.
- Regression tests added for both provisioning paths (bash + event-runtime), plus a test proving the checkout resolves to `schedule.example.yaml` and carries no stale loop.

## Owned Paths
- `bin/worktree-common.sh`, `bin/worktree-common.test.mjs`
- `event-runtime/lib/worker.mjs`, `event-runtime/lib/worker.test.mjs`
