### PR TITLE
feat(cli): factory ask — one read-only surface for factory state (#1069)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -72,6 +72,7 @@ case "$cmd" in
     run_bun tools/ticket.mjs "$@"
     ;;
   queue)        run_bun orchestrator/queue.mjs "$@" ;;
+  ask)          run_bun orchestrator/ask.mjs "$@" ;;
   next)         run_bun orchestrator/next.mjs "$@" ;;
   state)        run_bun orchestrator/state.mjs "$@" ;;
   status)       run_bun orchestrator/status.mjs "$@" ;;
@@ -283,6 +284,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   ticket        tools/ticket.mjs
   linear        tools/ticket.mjs (deprecated alias for 'ticket')
   queue         orchestrator/queue.mjs
+  ask           orchestrator/ask.mjs (one read-only surface: queue, in-flight, held, runs, noop, spend)
   next          orchestrator/next.mjs
   state         orchestrator/state.mjs
   status        orchestrator/status.mjs (repo, deployment, and factory snapshot)

--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env bun
+/**
+ * One read-only surface for "what is the factory doing right now?" (WM-1069).
+ *
+ *   factory ask                       # human summary, every non-report-only repo
+ *   factory ask --json                # the stable document the summary renders
+ *   factory ask --repo factory        # scope the tracker sections to one repo
+ *   factory ask --section queue,held  # only the named sections
+ *
+ * Every other surface that answers this question re-derives it from a different
+ * place: queue.mjs knows what is dispatchable, economics.mjs parses transcripts
+ * for spend, the planner's decline reason lives only in `proposals.reason`. This
+ * verb consolidates them into ONE document of typed rows so the @factory agent,
+ * the context graph and the web Overview parse the nouns once instead of three
+ * times over the same prose.
+ *
+ * READ-ONLY BY CONSTRUCTION. This module imports no write verb — no claim,
+ * transition, setLabels, file or comment ever reaches the control plane. The
+ * document is the source of truth; the human render is derived from it, so the
+ * two cannot disagree.
+ *
+ * SECTIONS. `queue`, `inflight` and `held` are tracker-derived and scoped by
+ * `--repo`; `recent`, `noop` and `spend` describe the runtime instance as a
+ * whole (the transcript log and the event-runtime ledger are not repo-partitioned)
+ * and stay global. Each section is INDEPENDENTLY FALLIBLE: a section that cannot
+ * be read carries an error rather than pulling the rest of the document down, and
+ * a tracker read that fails is never rendered as an empty queue — an unreachable
+ * tracker must not read as "no tickets" (docs/protocol.md §"GitHub Issues binding").
+ */
+import { existsSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import { loadConfigYaml } from "../lib/schedule.mjs";
+import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import { liveWorkerLeases } from "../lib/worker-leases.mjs";
+import { todaysSpendBreakdown } from "../lib/spend.mjs";
+import { dbPath } from "../event-runtime/lib/config.mjs";
+import { AI_BLOCKED } from "./reply-detection.mjs";
+
+/** The `ai:escalated` hold label — its counterpart `ai:blocked` lives in reply-detection. */
+export const AI_ESCALATED = "ai:escalated";
+
+/** The two hold labels the `held` section reports on. */
+export const HELD_LABELS = Object.freeze([AI_BLOCKED, AI_ESCALATED]);
+
+/** Every valid section name, in render order. */
+export const SECTIONS = Object.freeze([
+  "queue",
+  "inflight",
+  "held",
+  "recent",
+  "noop",
+  "spend",
+]);
+
+/** How far back `recent` and `spend` look. */
+export const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const errorText = (e) => (e instanceof Error ? e.message : String(e));
+
+/**
+ * Parse argv into a normalised options object. Pure, so the CLI dispatch and
+ * the tests agree on exactly what a flag means.
+ *
+ * @param {string[]} argv
+ * @returns {{ json: boolean, help: boolean, repo: string|null,
+ *   sections: string[], unknownSections: string[] }}
+ */
+export function parseArgs(argv) {
+  const val = (flag) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const raw = val("--section");
+  const requested = raw
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [...SECTIONS];
+  const unknownSections = requested.filter((s) => !SECTIONS.includes(s));
+  // De-duplicate but keep canonical render order, not request order.
+  const sections = SECTIONS.filter((s) => requested.includes(s));
+  return {
+    json: argv.includes("--json"),
+    help: argv.includes("--help") || argv.includes("-h"),
+    repo: val("--repo"),
+    sections,
+    unknownSections,
+  };
+}
+
+/**
+ * The repos a bare `factory ask` covers: every configured repo that is not
+ * `report_only`. `--repo` narrows to one by name (report-only included, because
+ * the operator named it explicitly).
+ *
+ * @returns {{ repos: object[], error: string|null }}
+ */
+export function resolveRepos(repo, cfg = loadConfigYaml("repos")) {
+  const all = cfg.repos ?? [];
+  if (repo) {
+    const one = all.find((r) => r.name === repo);
+    if (!one)
+      return {
+        repos: [],
+        error: `no repo named "${repo}" in config/repos.yaml (known: ${
+          all.map((r) => r.name).join(", ") || "none"
+        })`,
+      };
+    return { repos: [one], error: null };
+  }
+  return { repos: all.filter((r) => !r.report_only), error: null };
+}
+
+const labelNames = (ticket) =>
+  (Array.isArray(ticket.labels) ? ticket.labels : (ticket.labels?.nodes ?? []))
+    .map((l) => l.name)
+    .filter(Boolean);
+
+const stateName = (ticket) => ticket.state?.name ?? null;
+
+/**
+ * Dispatchable tickets per repo, in the dispatcher's own queue order (the
+ * adapter's `listDispatchable`, so this view cannot disagree with what dispatch
+ * would start). Per-repo failures are isolated into `errors`, never swallowed
+ * into an empty list.
+ */
+async function queueSection(repos, controlPlaneFor) {
+  const rows = [];
+  const errors = [];
+  for (const repo of repos) {
+    try {
+      const cp = controlPlaneFor(repo);
+      const tickets = await cp.listDispatchable({
+        team: repo.team,
+        project: repo.project,
+      });
+      for (const t of tickets)
+        rows.push({
+          repo: repo.name,
+          identifier: t.identifier,
+          title: t.title,
+          url: t.url ?? null,
+          priority: t.priority ?? null,
+        });
+    } catch (e) {
+      errors.push({ repo: repo.name, error: errorText(e) });
+    }
+  }
+  return { rows, errors };
+}
+
+/**
+ * Claimed (In Progress) tickets with age since claim and the freshness of the
+ * local worker lease — a claimed ticket with no live lease is a worker that
+ * stopped heartbeating.
+ */
+async function inflightSection(repos, controlPlaneFor, leasesFor, now) {
+  const rows = [];
+  const errors = [];
+  for (const repo of repos) {
+    try {
+      const cp = controlPlaneFor(repo);
+      const tickets = await cp.listTickets({
+        team: repo.team,
+        project: repo.project,
+        states: ["In Progress"],
+      });
+      const leases = new Map((leasesFor(repo) ?? []).map((l) => [l.ticket, l]));
+      for (const t of tickets) {
+        const startedAt = t.startedAt ?? t.createdAt ?? null;
+        const startedMs = startedAt ? Date.parse(startedAt) : NaN;
+        const lease = leases.get(t.identifier);
+        rows.push({
+          repo: repo.name,
+          identifier: t.identifier,
+          title: t.title,
+          url: t.url ?? null,
+          assignee: t.assignee?.name ?? null,
+          ageMs: Number.isFinite(startedMs) ? now - startedMs : null,
+          heartbeatAgeMs: lease ? now - lease.heartbeatAt : null,
+          hasLiveLease: Boolean(lease),
+        });
+      }
+    } catch (e) {
+      errors.push({ repo: repo.name, error: errorText(e) });
+    }
+  }
+  return { rows, errors };
+}
+
+/**
+ * Held tickets (`ai:blocked` / `ai:escalated`) with the question the agent
+ * asked. The question is the newest comment; a comment read that fails leaves
+ * `question: null` rather than dropping the ticket, so a held ticket is always
+ * visible even when its question cannot be fetched.
+ */
+async function heldSection(repos, controlPlaneFor) {
+  const rows = [];
+  const errors = [];
+  for (const repo of repos) {
+    try {
+      const cp = controlPlaneFor(repo);
+      const tickets = await cp.listTickets({
+        team: repo.team,
+        project: repo.project,
+      });
+      for (const t of tickets) {
+        const held = labelNames(t).filter((n) => HELD_LABELS.includes(n));
+        if (!held.length) continue;
+        let question = null;
+        try {
+          const comments = await cp.listComments(t.identifier);
+          question = comments.length
+            ? (comments[comments.length - 1].body ?? null)
+            : null;
+        } catch {
+          question = null;
+        }
+        rows.push({
+          repo: repo.name,
+          identifier: t.identifier,
+          title: t.title,
+          url: t.url ?? null,
+          state: stateName(t),
+          labels: held,
+          question,
+        });
+      }
+    } catch (e) {
+      errors.push({ repo: repo.name, error: errorText(e) });
+    }
+  }
+  return { rows, errors };
+}
+
+/**
+ * Runs in the last `windowMs` from the event-runtime ledger: agent, adapter,
+ * model, terminal (or in-flight) state, and cost. Cost is summed across
+ * attempts; adapter/model prefer the recorded usage and fall back to the spec.
+ *
+ * @param {import("bun:sqlite").Database|null} db
+ */
+export function recentRuns(
+  db,
+  { now = Date.now(), windowMs = RECENT_WINDOW_MS } = {},
+) {
+  if (!db) return { error: "event-runtime ledger not found" };
+  try {
+    const since = new Date(now - windowMs).toISOString();
+    const rows = db
+      .query(
+        `SELECT r.run_id AS runId,
+              json_extract(r.spec_json, '$.agent')   AS agent,
+              json_extract(r.spec_json, '$.repo')    AS repo,
+              json_extract(r.spec_json, '$.adapter') AS specAdapter,
+              json_extract(r.spec_json, '$.model')   AS specModel,
+              r.state       AS state,
+              r.created_at  AS createdAt,
+              r.updated_at  AS updatedAt,
+              COALESCE(SUM(u.cost_usd), 0) AS cost,
+              MAX(u.adapter) AS usageAdapter,
+              MAX(u.model)   AS usageModel
+         FROM runs r
+         LEFT JOIN run_usage u ON u.run_id = r.run_id
+        WHERE r.created_at >= ?
+        GROUP BY r.run_id
+        ORDER BY r.created_at DESC`,
+      )
+      .all(since);
+    return {
+      rows: rows.map((row) => ({
+        runId: row.runId,
+        agent: row.agent ?? null,
+        repo: row.repo ?? null,
+        adapter: row.usageAdapter ?? row.specAdapter ?? null,
+        model: row.usageModel ?? row.specModel ?? null,
+        outcome: row.state,
+        cost: Number(row.cost ?? 0),
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      })),
+    };
+  } catch (e) {
+    return { error: errorText(e) };
+  }
+}
+
+/**
+ * The latest planner decline (`proposals.decision = 'noop'`) per event type,
+ * with its `reason`. This reason lives nowhere else — it is why the planner
+ * looked at an event and chose to do nothing.
+ *
+ * @param {import("bun:sqlite").Database|null} db
+ */
+export function noopReasons(db) {
+  if (!db) return { error: "event-runtime ledger not found" };
+  try {
+    const rows = db
+      .query(
+        `SELECT e.type AS eventType, p.reason AS reason, p.created_at AS at
+           FROM proposals p
+           JOIN events e
+             ON e.source = p.event_source AND e.event_id = p.event_id
+          WHERE p.decision = 'noop'
+          ORDER BY p.created_at DESC`,
+      )
+      .all();
+    const latest = new Map();
+    for (const row of rows) {
+      if (latest.has(row.eventType)) continue; // rows are newest-first
+      latest.set(row.eventType, {
+        eventType: row.eventType,
+        reason: row.reason ?? null,
+        at: row.at,
+      });
+    }
+    return { rows: [...latest.values()] };
+  } catch (e) {
+    return { error: errorText(e) };
+  }
+}
+
+/** Spend over the window, reusing lib/spend.mjs (not a second transcript parser). */
+function spendSection(spend) {
+  try {
+    const b = spend();
+    return {
+      window: "today",
+      usd: b.usd,
+      reported: b.reported,
+      estimated: b.estimated,
+      runs: b.runs,
+    };
+  } catch (e) {
+    return { error: errorText(e) };
+  }
+}
+
+/**
+ * Build the read-only factory-state document. Every dependency is injected so
+ * the whole surface can be exercised against a fake control plane and an
+ * in-memory ledger — which is also how the read-only invariant is tested.
+ *
+ * @param {{
+ *   repos: object[],
+ *   sections?: string[],
+ *   now?: number,
+ *   windowMs?: number,
+ *   controlPlaneFor?: (repo: object) => object,
+ *   leasesFor?: (repo: object) => object[],
+ *   db?: import("bun:sqlite").Database|null,
+ *   spend?: () => { usd: number, reported: number, estimated: number, runs: number },
+ * }} opts
+ */
+export async function buildAskDocument({
+  repos,
+  sections = [...SECTIONS],
+  now = Date.now(),
+  windowMs = RECENT_WINDOW_MS,
+  controlPlaneFor = (repo) => loadControlPlane({ repoName: repo.name }),
+  leasesFor = (repo) => liveWorkerLeases(repo.name),
+  db = null,
+  spend = todaysSpendBreakdown,
+}) {
+  const want = new Set(sections);
+  const doc = {
+    generatedAt: new Date(now).toISOString(),
+    repos: repos.map((r) => r.name),
+    sections: SECTIONS.filter((s) => want.has(s)),
+  };
+  if (want.has("queue")) doc.queue = await queueSection(repos, controlPlaneFor);
+  if (want.has("inflight"))
+    doc.inflight = await inflightSection(
+      repos,
+      controlPlaneFor,
+      leasesFor,
+      now,
+    );
+  if (want.has("held")) doc.held = await heldSection(repos, controlPlaneFor);
+  if (want.has("recent")) doc.recent = recentRuns(db, { now, windowMs });
+  if (want.has("noop")) doc.noop = noopReasons(db);
+  if (want.has("spend")) doc.spend = spendSection(spend);
+  return doc;
+}
+
+// ---------------------------------------------------------------- render ---
+
+const c = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+};
+
+function fmtAge(ms) {
+  if (ms == null || !Number.isFinite(ms)) return "?";
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 90) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 90) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+/** Render the document as a human summary. Reads only from `doc`, never re-derives. */
+export function renderHuman(doc) {
+  const out = [];
+  const P = (s = "") => out.push(s);
+  const renderErrors = (errors) => {
+    for (const e of errors ?? [])
+      P(`  ${c.red(`error (${e.repo}): ${e.error}`)}`);
+  };
+
+  P(
+    c.bold(`\nfactory ask`) +
+      c.dim(`  ${doc.repos.join(", ") || "(no repos)"}`),
+  );
+
+  if (doc.queue) {
+    P(c.bold(`\nQueue — dispatchable`));
+    renderErrors(doc.queue.errors);
+    if (!doc.queue.rows.length && !doc.queue.errors?.length) P(c.dim("  none"));
+    for (const t of doc.queue.rows)
+      P(
+        `  ${c.green(t.identifier.padEnd(12))} ${c.dim(t.repo)}  ${(t.title ?? "").slice(0, 60)}`,
+      );
+  }
+
+  if (doc.inflight) {
+    P(c.bold(`\nIn flight — claimed`));
+    renderErrors(doc.inflight.errors);
+    if (!doc.inflight.rows.length && !doc.inflight.errors?.length)
+      P(c.dim("  none"));
+    for (const t of doc.inflight.rows) {
+      const beat = t.hasLiveLease
+        ? c.green(`beat ${fmtAge(t.heartbeatAgeMs)}`)
+        : c.red("no live lease");
+      P(
+        `  ${t.identifier.padEnd(12)} ${c.dim(t.repo)}  age ${fmtAge(t.ageMs)}  ${beat}  ${(t.title ?? "").slice(0, 45)}`,
+      );
+    }
+  }
+
+  if (doc.held) {
+    P(c.bold(`\nHeld — needs a human`));
+    renderErrors(doc.held.errors);
+    if (!doc.held.rows.length && !doc.held.errors?.length) P(c.dim("  none"));
+    for (const t of doc.held.rows) {
+      P(
+        `  ${c.yellow(t.identifier.padEnd(12))} ${c.dim(t.repo)}  ${t.labels.join(",")}  ${(t.title ?? "").slice(0, 45)}`,
+      );
+      if (t.question)
+        P(`    ${c.dim(t.question.replace(/\s+/g, " ").slice(0, 90))}`);
+    }
+  }
+
+  if (doc.recent) {
+    P(c.bold(`\nRecent runs — last 24h`));
+    if (doc.recent.error) P(`  ${c.red(`error: ${doc.recent.error}`)}`);
+    else if (!doc.recent.rows.length) P(c.dim("  none"));
+    else
+      for (const r of doc.recent.rows)
+        P(
+          `  ${(r.outcome ?? "?").padEnd(10)} ${(r.agent ?? "?").padEnd(14)} ${(r.adapter ?? "?").padEnd(8)} ${(r.model ?? "?").padEnd(16)} $${r.cost.toFixed(2)}  ${c.dim(r.repo ?? "")}`,
+        );
+  }
+
+  if (doc.noop) {
+    P(c.bold(`\nNoop — latest planner decline per event type`));
+    if (doc.noop.error) P(`  ${c.red(`error: ${doc.noop.error}`)}`);
+    else if (!doc.noop.rows.length) P(c.dim("  none"));
+    else
+      for (const n of doc.noop.rows)
+        P(`  ${(n.eventType ?? "?").padEnd(24)} ${c.dim(n.reason ?? "")}`);
+  }
+
+  if (doc.spend) {
+    P(c.bold(`\nSpend — ${doc.spend.window ?? "today"}`));
+    if (doc.spend.error) P(`  ${c.red(`error: ${doc.spend.error}`)}`);
+    else
+      P(
+        `  $${doc.spend.usd.toFixed(2)} notional  ${c.dim(
+          `($${doc.spend.reported.toFixed(2)} reported + $${doc.spend.estimated.toFixed(2)} estimated, ${doc.spend.runs} run(s))`,
+        )}`,
+      );
+  }
+
+  P(
+    c.dim(
+      `\n\`factory ask --json\` is the machine-readable source of this view.`,
+    ),
+  );
+  return out.join("\n");
+}
+
+const HELP = `factory ask — one read-only surface for factory state
+
+  factory ask                       human summary of every non-report-only repo
+  factory ask --json                the stable JSON document the summary renders
+  factory ask --repo <name>         scope the tracker sections to one repo
+  factory ask --section a,b         only the named sections
+
+Sections: ${SECTIONS.join(", ")}
+  queue/inflight/held  tracker-derived, scoped by --repo
+  recent/noop/spend    runtime-instance wide
+
+Read-only: no ticket is ever claimed, transitioned, labelled or commented on.`;
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const opts = parseArgs(argv);
+
+  if (opts.help) {
+    console.log(HELP);
+    process.exit(0);
+  }
+
+  if (opts.unknownSections.length) {
+    console.error(
+      `unknown section(s): ${opts.unknownSections.join(", ")} — valid: ${SECTIONS.join(", ")}`,
+    );
+    process.exit(2);
+  }
+
+  const { repos, error } = resolveRepos(opts.repo);
+  if (error) {
+    console.error(error);
+    process.exit(2);
+  }
+
+  // Open the ledger read-only. A missing or unreadable ledger is not fatal: the
+  // recent/noop sections carry the error and the tracker sections still return.
+  let db = null;
+  const file = dbPath();
+  if (existsSync(file)) {
+    try {
+      db = new Database(file, { readonly: true });
+    } catch {
+      db = null;
+    }
+  }
+
+  try {
+    const doc = await buildAskDocument({ repos, sections: opts.sections, db });
+    if (opts.json) console.log(JSON.stringify(doc, null, 2));
+    else console.log(renderHuman(doc));
+  } finally {
+    db?.close();
+  }
+  process.exit(0);
+}

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -1,0 +1,425 @@
+import { describe, expect, test } from "bun:test";
+import { memoryControlPlane } from "../lib/control-plane/memory.mjs";
+import { openDb } from "../event-runtime/lib/db.mjs";
+import {
+  parseArgs,
+  resolveRepos,
+  buildAskDocument,
+  recentRuns,
+  noopReasons,
+  renderHuman,
+  SECTIONS,
+  RECENT_WINDOW_MS,
+} from "./ask.mjs";
+
+// A memory control plane seeded with one dispatchable, one in-flight, and one
+// held ticket. The workspace label set has to contain every label a ticket
+// carries, because the fake validates that on write — and `claim` writes.
+function seedPlane() {
+  const labels = [
+    { id: "l-ready", name: "ai:agent-ready" },
+    { id: "l-blocked", name: "ai:blocked" },
+    { id: "l-escalated", name: "ai:escalated" },
+  ];
+  return memoryControlPlane({
+    team: { id: "team-wm", key: "WM" },
+    labels,
+    tickets: [
+      {
+        id: "t-ready",
+        identifier: "WM-1",
+        title: "dispatch me",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        team: { key: "WM" },
+        project: { name: "Factory" },
+        labels: [{ id: "l-ready", name: "ai:agent-ready" }],
+        priority: 2,
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "t-flight",
+        identifier: "WM-2",
+        title: "in progress work",
+        state: { id: "s-progress", name: "In Progress", type: "started" },
+        team: { key: "WM" },
+        project: { name: "Factory" },
+        assignee: { id: "user-me", name: "Ada" },
+        labels: [],
+        startedAt: "2026-08-28T00:00:00.000Z",
+        createdAt: "2026-08-27T00:00:00.000Z",
+      },
+      {
+        id: "t-held",
+        identifier: "WM-3",
+        title: "waiting on a human",
+        state: { id: "s-blocked", name: "Blocked", type: "started" },
+        team: { key: "WM" },
+        project: { name: "Factory" },
+        labels: [{ id: "l-blocked", name: "ai:blocked" }],
+        createdAt: "2026-08-26T00:00:00.000Z",
+        comments: [{ id: "c-1", body: "Should I bump the major version?" }],
+      },
+    ],
+  });
+}
+
+const REPO = {
+  name: "factory",
+  team: "WM",
+  project: "Factory",
+  github: "watt-mind/factory",
+};
+
+/** An in-memory ledger seeded with one recent run and one noop proposal. */
+function seedLedger({ now = Date.now() } = {}) {
+  const db = openDb(":memory:");
+  const iso = (ms) => new Date(ms).toISOString();
+  const runId = "run-1";
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    runId,
+    "idem-1",
+    JSON.stringify({ agent: "factory-ticket", repo: "factory", model: "opus" }),
+    "hash-1",
+    "COMPLETED",
+    1,
+    iso(now - 60_000),
+    iso(now - 30_000),
+  );
+  db.query(
+    `INSERT INTO run_usage (run_id, attempt, adapter, model, input_tokens, output_tokens,
+        cache_creation_input_tokens, cache_read_input_tokens, cost_usd, recorded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    runId,
+    1,
+    "claude",
+    "claude-opus",
+    100,
+    50,
+    0,
+    0,
+    1.25,
+    iso(now - 30_000),
+  );
+
+  // A run older than the 24h window must not appear in `recent`.
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "run-old",
+    "idem-old",
+    JSON.stringify({ agent: "factory-ticket", repo: "factory" }),
+    "hash-old",
+    "COMPLETED",
+    1,
+    iso(now - 2 * RECENT_WINDOW_MS),
+    iso(now - 2 * RECENT_WINDOW_MS),
+  );
+
+  db.query(
+    `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at,
+        envelope_json, payload_hash, status, admitted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "github",
+    "evt-1",
+    "pull_request.opened",
+    "PR#7",
+    iso(now - 120_000),
+    iso(now - 120_000),
+    "{}",
+    "ph-1",
+    "admitted",
+    iso(now - 120_000),
+  );
+  db.query(
+    `INSERT INTO proposals (id, event_source, event_id, decision, status, reason, created_at, ttl_seconds)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "prop-1",
+    "github",
+    "evt-1",
+    "noop",
+    "closed",
+    "capacity_full",
+    iso(now - 110_000),
+    300,
+  );
+  return db;
+}
+
+const noSpend = () => ({ usd: 0, reported: 0, estimated: 0, runs: 0 });
+
+describe("parseArgs", () => {
+  test("defaults to every section, no repo, human output", () => {
+    const o = parseArgs([]);
+    expect(o.json).toBe(false);
+    expect(o.repo).toBeNull();
+    expect(o.sections).toEqual([...SECTIONS]);
+    expect(o.unknownSections).toEqual([]);
+  });
+
+  test("--section filters to the named sections in canonical order", () => {
+    const o = parseArgs(["--section", "held,queue"]);
+    expect(o.sections).toEqual(["queue", "held"]);
+    expect(o.unknownSections).toEqual([]);
+  });
+
+  test("unknown section names are surfaced", () => {
+    const o = parseArgs(["--section", "queue,bogus"]);
+    expect(o.sections).toEqual(["queue"]);
+    expect(o.unknownSections).toEqual(["bogus"]);
+  });
+
+  test("--json and --repo are parsed", () => {
+    const o = parseArgs(["--json", "--repo", "factory"]);
+    expect(o.json).toBe(true);
+    expect(o.repo).toBe("factory");
+  });
+});
+
+describe("resolveRepos", () => {
+  const cfg = {
+    repos: [
+      { name: "factory", team: "WM" },
+      { name: "site", team: "ST", report_only: true },
+    ],
+  };
+
+  test("bare invocation excludes report_only repos", () => {
+    const { repos, error } = resolveRepos(null, cfg);
+    expect(error).toBeNull();
+    expect(repos.map((r) => r.name)).toEqual(["factory"]);
+  });
+
+  test("--repo selects one by name, report_only included", () => {
+    const { repos } = resolveRepos("site", cfg);
+    expect(repos.map((r) => r.name)).toEqual(["site"]);
+  });
+
+  test("an unknown --repo is a named error", () => {
+    const { repos, error } = resolveRepos("nope", cfg);
+    expect(repos).toEqual([]);
+    expect(error).toContain("nope");
+  });
+});
+
+describe("buildAskDocument", () => {
+  test("all sections present on a seeded fixture", async () => {
+    const now = Date.parse("2026-08-28T12:00:00.000Z");
+    const plane = seedPlane();
+    const db = seedLedger({ now });
+    const doc = await buildAskDocument({
+      repos: [REPO],
+      now,
+      controlPlaneFor: () => plane,
+      leasesFor: () => [{ ticket: "WM-2", heartbeatAt: now - 5_000 }],
+      db,
+      spend: () => ({ usd: 3.5, reported: 3, estimated: 0.5, runs: 4 }),
+    });
+
+    expect(doc.sections).toEqual([...SECTIONS]);
+    expect(doc.repos).toEqual(["factory"]);
+
+    // queue — the one dispatchable ticket
+    expect(doc.queue.errors).toEqual([]);
+    expect(doc.queue.rows.map((r) => r.identifier)).toEqual(["WM-1"]);
+
+    // inflight — the claimed ticket, with age and live heartbeat
+    expect(doc.inflight.rows).toHaveLength(1);
+    const flight = doc.inflight.rows[0];
+    expect(flight.identifier).toBe("WM-2");
+    expect(flight.hasLiveLease).toBe(true);
+    expect(flight.heartbeatAgeMs).toBe(5_000);
+    expect(flight.ageMs).toBeGreaterThan(0);
+
+    // held — the blocked ticket, with its question
+    expect(doc.held.rows).toHaveLength(1);
+    expect(doc.held.rows[0].identifier).toBe("WM-3");
+    expect(doc.held.rows[0].labels).toEqual(["ai:blocked"]);
+    expect(doc.held.rows[0].question).toContain("major version");
+
+    // recent — the run inside the window, not the old one
+    expect(doc.recent.rows.map((r) => r.runId)).toEqual(["run-1"]);
+    expect(doc.recent.rows[0].adapter).toBe("claude");
+    expect(doc.recent.rows[0].model).toBe("claude-opus");
+    expect(doc.recent.rows[0].outcome).toBe("COMPLETED");
+    expect(doc.recent.rows[0].cost).toBeCloseTo(1.25);
+
+    // noop — the latest decline per event type
+    expect(doc.noop.rows).toEqual([
+      {
+        eventType: "pull_request.opened",
+        reason: "capacity_full",
+        at: expect.any(String),
+      },
+    ]);
+
+    // spend — the injected breakdown
+    expect(doc.spend).toMatchObject({ usd: 3.5, reported: 3, runs: 4 });
+
+    db.close();
+  });
+
+  test("--section filtering returns only the named sections", async () => {
+    const plane = seedPlane();
+    const doc = await buildAskDocument({
+      repos: [REPO],
+      sections: ["queue", "held"],
+      controlPlaneFor: () => plane,
+      leasesFor: () => [],
+      db: null,
+      spend: noSpend,
+    });
+    expect(doc.sections).toEqual(["queue", "held"]);
+    expect(doc.queue).toBeDefined();
+    expect(doc.held).toBeDefined();
+    expect(doc.inflight).toBeUndefined();
+    expect(doc.recent).toBeUndefined();
+    expect(doc.noop).toBeUndefined();
+    expect(doc.spend).toBeUndefined();
+  });
+
+  test("per-section error isolation: a failing tracker never reads as empty", async () => {
+    const throwingPlane = {
+      calls: [],
+      listDispatchable() {
+        throw new Error("control plane unreachable");
+      },
+      listTickets() {
+        throw new Error("control plane unreachable");
+      },
+      listComments() {
+        throw new Error("control plane unreachable");
+      },
+    };
+    const db = seedLedger();
+    const doc = await buildAskDocument({
+      repos: [REPO],
+      controlPlaneFor: () => throwingPlane,
+      leasesFor: () => [],
+      db,
+      spend: noSpend,
+    });
+
+    // The tracker sections carry an error keyed by repo — never an empty list
+    // that would read as "no tickets".
+    expect(doc.queue.rows).toEqual([]);
+    expect(doc.queue.errors).toEqual([
+      { repo: "factory", error: "control plane unreachable" },
+    ]);
+    expect(doc.held.errors[0].error).toContain("unreachable");
+    expect(doc.inflight.errors[0].error).toContain("unreachable");
+
+    // Ledger-backed sections are independent and still return.
+    expect(doc.recent.rows.length).toBeGreaterThan(0);
+    expect(doc.noop.rows.length).toBeGreaterThan(0);
+    expect(doc.spend.error).toBeUndefined();
+
+    db.close();
+  });
+
+  test("a missing ledger isolates to recent/noop, tracker sections still return", async () => {
+    const plane = seedPlane();
+    const doc = await buildAskDocument({
+      repos: [REPO],
+      controlPlaneFor: () => plane,
+      leasesFor: () => [],
+      db: null,
+      spend: noSpend,
+    });
+    expect(doc.recent).toEqual({ error: "event-runtime ledger not found" });
+    expect(doc.noop).toEqual({ error: "event-runtime ledger not found" });
+    expect(doc.queue.rows.map((r) => r.identifier)).toEqual(["WM-1"]);
+  });
+
+  test("read-only by construction: a full ask reaches no write verb", async () => {
+    const plane = seedPlane();
+    const db = seedLedger();
+    await buildAskDocument({
+      repos: [REPO],
+      controlPlaneFor: () => plane,
+      leasesFor: () => [],
+      db,
+      spend: noSpend,
+    });
+    const writeVerbs = new Set([
+      "claim",
+      "transition",
+      "setLabels",
+      "file",
+      "comment",
+    ]);
+    const writes = plane.calls.filter((call) => writeVerbs.has(call.op));
+    expect(writes).toEqual([]);
+    // And it did in fact read — otherwise the assertion above is vacuous.
+    expect(plane.calls.some((call) => call.op === "listDispatchable")).toBe(
+      true,
+    );
+    db.close();
+  });
+});
+
+describe("recentRuns / noopReasons", () => {
+  test("recentRuns errors cleanly without a ledger", () => {
+    expect(recentRuns(null)).toEqual({
+      error: "event-runtime ledger not found",
+    });
+  });
+
+  test("noopReasons keeps only the latest decline per event type", () => {
+    const now = Date.parse("2026-08-28T12:00:00.000Z");
+    const db = openDb(":memory:");
+    const iso = (ms) => new Date(ms).toISOString();
+    const event = (id, type, at) =>
+      db
+        .query(
+          `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at,
+              envelope_json, payload_hash, status, admitted_at)
+           VALUES ('github', ?, ?, '', ?, ?, '{}', ?, 'admitted', ?)`,
+        )
+        .run(id, type, iso(at), iso(at), `ph-${id}`, iso(at));
+    const proposal = (id, eventId, reason, at) =>
+      db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, decision, status, reason, created_at, ttl_seconds)
+           VALUES (?, 'github', ?, 'noop', 'closed', ?, ?, 300)`,
+        )
+        .run(id, eventId, reason, iso(at));
+
+    event("e1", "pull_request.opened", now - 200_000);
+    event("e2", "pull_request.opened", now - 100_000);
+    proposal("p1", "e1", "older_reason", now - 200_000);
+    proposal("p2", "e2", "newer_reason", now - 100_000);
+
+    const result = noopReasons(db);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      eventType: "pull_request.opened",
+      reason: "newer_reason",
+    });
+    db.close();
+  });
+});
+
+describe("renderHuman", () => {
+  test("renders the document without re-deriving, showing section errors", async () => {
+    const plane = seedPlane();
+    const doc = await buildAskDocument({
+      repos: [REPO],
+      controlPlaneFor: () => plane,
+      leasesFor: () => [],
+      db: null,
+      spend: () => ({ usd: 1, reported: 1, estimated: 0, runs: 1 }),
+    });
+    const text = renderHuman(doc);
+    expect(text).toContain("factory ask");
+    expect(text).toContain("WM-1"); // dispatchable ticket
+    expect(text).toContain("WM-3"); // held ticket
+    expect(text).toContain("event-runtime ledger not found"); // recent error surfaced
+  });
+});


### PR DESCRIPTION
## What
Adds `factory ask` — one read-only verb that returns factory state as a stable
JSON document (and a human summary rendered from it): `queue` (dispatchable),
`inflight` (claimed, with age + heartbeat), `held` (`ai:blocked`/`ai:escalated`,
with the question), `recent` (runs in the last 24h with agent/adapter/model/
outcome/cost), `noop` (latest planner decline per event type with its reason),
and `spend` (window totals via `lib/spend.mjs`).

## Why
Every surface that answers "what is the factory doing right now" re-derives it
from a different place. This builds the read surface once so the `@factory`
agent, the context graph and the web Overview parse typed nouns instead of
three parsers over the same prose (#1069).

## Acceptance
- `factory ask --json` returns one document of typed rows (never pre-formatted strings).
- Bare `factory ask` prints a human summary rendered from that same document.
- `--section queue,held` filters; an unknown section exits non-zero naming the valid set.
- Every section is independently fallible: a failing tracker read carries an
  error keyed by repo and is never rendered as an empty queue; a missing ledger
  isolates to `recent`/`noop` while the others still return.
- `--repo <name>` scopes the tracker sections; absent, every non-`report_only`
  repo in `config/repos.yaml` is included. (`recent`/`noop`/`spend` are runtime-
  instance wide, since the ledger and transcript log are not repo-partitioned.)
- Read-only by construction: the module imports no write verb, and a test
  asserts no `claim`/`transition`/`setLabels`/`file`/`comment` reaches a fake
  control plane during a full `ask`.
- Tests: all sections on a seeded fixture, per-section error isolation,
  `--section` filtering, unknown-section exit code, and the read-only assertion
  (15 tests, all pass).

## Owned Paths
- `orchestrator/ask.mjs`
- `orchestrator/ask.test.mjs`
- `bin/factory`

## Notes / deferrals
- The held-ticket `question` is taken from the newest comment via the neutral
  `listComments` verb (adapter-agnostic), rather than Linear-only label-history
  reconstruction — a reasonable first cut that stays read-only and works on
  GitHub Issues too.
