### PR TITLE
feat(evals): evals/run.mjs — the case runner that gates every prompt change

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -25,4 +25,55 @@ Freeze a case once it's written. A case edited to match new behavior is no longe
     node evals/run.mjs                 # all
     node evals/run.mjs --skill ticket-spec
 
-Not yet implemented — the runner is the next piece. Cases are written first deliberately: they're the specification of what the skill is for, and writing them has already surfaced disagreements about what "agent-ready" means.
+One case is two model calls: the **subject** run puts the skill's own prompt (`shared/skills/<skill>/SKILL.md`, falling back to the emitted `plugins/core/skills/…`) in front of `input.md` and captures what it produces, then the **grader** judges that response against `expect.md` and answers with one line — `PASS: <reason>` or `FAIL: <reason>`. The subject may read the repo; the grader gets no tools, because it is judging text, not looking things up. Nothing is mutated: the subject is told this is an offline evaluation and is denied write tools.
+
+A grader that hangs, crashes, or answers with prose instead of a verdict **fails that case**, never the run.
+
+### Other flags
+
+    node evals/run.mjs --dry-run       # list the cases and their resolved skill source; zero model calls
+    node evals/run.mjs --json          # the run as JSON on stdout, for CI
+    node evals/run.mjs --compare evals/.results/<file>.json
+    node evals/run.mjs --timeout 240 --budget 1.50 --total-timeout 1800 --total-budget 10
+    node evals/run.mjs --results-dir <dir> | --no-results
+    node evals/run.mjs --help
+
+Exit codes: **0** everything passed · **1** a case failed or regressed · **2** the runner could not run (bad flag, no cases, unpinned grader). The non-zero exit is the whole CI contract — no wrapper script needed.
+
+### The grader is pinned, in policy
+
+A grader that floats with whatever the CLI defaults to today moves the pass bar silently: a suite that "went green" would be indistinguishable from one whose judge got more generous. So the models come from an `evals:` stanza in `config/policy.yaml`, and a real run **refuses to start** without one (`--dry-run` still works, so discovery stays testable without spend):
+
+```yaml
+evals:
+  # The model that RUNS the skill under test. "default" rides the CLI default,
+  # which is what dispatch does today.
+  subject:
+    model: default
+  # The model that GRADES the response against expect.md. Pinned by name so a
+  # grader upgrade is a deliberate, reviewable change and never a silent shift
+  # in the pass bar; the "default" sentinel is refused here for that reason.
+  grader:
+    model: claude-sonnet-4-6
+  limits:
+    case_timeout_seconds: 300
+    case_budget_usd: 2.00
+    total_seconds: 3600
+    total_budget_usd: 20.00
+```
+
+`config/policy.yaml` is operator-local and gitignored, so add the same stanza to the tracked `config/policy.example.yaml`. Every limit is optional and defaults to the values above; the grader model is not. Reaching a total cap fails the cases it stopped, naming the cap — passing them would be a lie, and skipping them would let a slow or expensive regression walk through the gate.
+
+### Runs are recorded, and drops are what you compare
+
+Two runs of the same cases on the same models can disagree, so an absolute score cannot tell you whether a prompt edit made things worse. The diff can. Every run writes `evals/.results/<timestamp>.json` — the models, the case set, and per-case pass/fail with the grader's reason — and `--compare <file>` reports the transitions against an earlier one: `pass -> fail` is a **regression** and exits non-zero; a grader change is flagged, because runs judged by different models are not a comparable measurement.
+
+`evals/.results/` is local run output, not repo content. Add it to `.gitignore` (tracked in [#1090](https://github.com/watt-mind/factory/issues/1090), together with the policy stanza above) or pass `--no-results`.
+
+### Tests
+
+    bun test --timeout 20000 evals/run.test.mjs
+
+`evals/run.test.mjs` covers discovery, the exit contract, `--skill` filtering, the timeout and cap paths, and `--compare` detecting a regression. **No test makes a model call**: `main()` takes the two model functions as a parameter and the tests pass fakes. A suite that needed a live grader to prove the gate works could never be the gate.
+
+Cases are written first deliberately: they're the specification of what the skill is for, and writing them has already surfaced disagreements about what "agent-ready" means.

--- a/evals/lib/case-run.mjs
+++ b/evals/lib/case-run.mjs
@@ -1,0 +1,196 @@
+/**
+ * Running cases, bounded (#1073).
+ *
+ * The bounds are the point. An eval suite is only usable as a CI gate if a
+ * hung grader costs one case, not the run — so every failure mode here
+ * (timeout, crash, a grader that answers with prose instead of a verdict,
+ * a malformed case directory) resolves to `fail` with a reason, and the run
+ * carries on. Nothing in this file makes a model call: `runSkill` and `grade`
+ * arrive as parameters, which is the seam the tests use.
+ */
+const TIMED_OUT = Symbol("timed-out");
+
+export const PASS = "pass";
+export const FAIL = "fail";
+
+/**
+ * Race `work` against a deadline, aborting it on the way out.
+ * Resolves `{ok: true, value}`, `{ok: false, error}`, or `{timedOut: true}`.
+ */
+export async function withDeadline(timeoutMs, work) {
+  const controller = new AbortController();
+  let timer = null;
+  const deadline = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      resolve(TIMED_OUT);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    const outcome = await Promise.race([
+      Promise.resolve()
+        .then(() => work(controller.signal))
+        .then(
+          (value) => ({ ok: true, value }),
+          (error) => ({ ok: false, error }),
+        ),
+      deadline,
+    ]);
+    if (outcome === TIMED_OUT) return { timedOut: true };
+    return outcome;
+  } finally {
+    if (timer) clearTimeout(timer);
+    controller.abort();
+  }
+}
+
+function message(error) {
+  const text = String(error?.message ?? error ?? "unknown error").trim();
+  return text.replace(/\s+/g, " ");
+}
+
+/**
+ * Run one case: subject model produces a response, grader judges it against
+ * `expect.md`. Both halves share the one per-case deadline, because a case
+ * that spends its whole budget in the subject run has not been graded.
+ *
+ * @returns {Promise<{id: string, skill: string, case: string, status: "pass"|"fail", reason: string, durationMs: number, costUsd: number, skillSource: string|null}>}
+ */
+export async function runCase({
+  evalCase,
+  runSkill,
+  grade,
+  timeoutMs,
+  budgetUsd,
+  now = () => Date.now(),
+}) {
+  const startedAt = now();
+  const record = (status, reason, costUsd = 0) => ({
+    id: evalCase.id,
+    skill: evalCase.skill,
+    case: evalCase.name,
+    status,
+    reason,
+    durationMs: Math.max(0, now() - startedAt),
+    costUsd,
+    skillSource: evalCase.skillSource,
+  });
+
+  // A case the runner cannot even read is a hole in the net, never a pass.
+  if (evalCase.problem)
+    return record(FAIL, `case not runnable: ${evalCase.problem}`);
+
+  let spent = 0;
+  const outcome = await withDeadline(timeoutMs, async (signal) => {
+    const response = await runSkill({ evalCase, timeoutMs, budgetUsd, signal });
+    spent += Number(response?.costUsd) || 0;
+    const verdict = await grade({
+      evalCase,
+      response,
+      timeoutMs,
+      budgetUsd,
+      signal,
+    });
+    spent += Number(verdict?.costUsd) || 0;
+    return verdict;
+  });
+
+  if (outcome.timedOut) {
+    return record(FAIL, `timed out after ${timeoutMs}ms`, spent);
+  }
+  if (!outcome.ok) {
+    return record(FAIL, message(outcome.error), spent);
+  }
+  const verdict = outcome.value;
+  return record(
+    verdict?.pass ? PASS : FAIL,
+    String(verdict?.reason ?? "").trim() || "(grader gave no reason)",
+    spent,
+  );
+}
+
+/**
+ * Run every case under the suite-wide caps.
+ *
+ * When a cap is reached the remaining cases are recorded as failures with the
+ * cap named as the reason. That is deliberate: reporting them as passes would
+ * be a lie, and reporting them as "skipped" with a zero exit would let a slow
+ * or expensive regression walk straight through the gate.
+ */
+export async function runSuite({
+  cases,
+  runSkill,
+  grade,
+  limits,
+  now = () => Date.now(),
+  onResult = null,
+}) {
+  const startedAt = now();
+  const caseTimeoutMs = limits.caseTimeoutSeconds * 1000;
+  const totalMs = limits.totalSeconds * 1000;
+  const results = [];
+  let spent = 0;
+
+  for (const evalCase of cases) {
+    const elapsed = now() - startedAt;
+    const remainingMs = totalMs - elapsed;
+    let result;
+    if (remainingMs <= 0) {
+      result = capped(
+        evalCase,
+        `run time cap of ${limits.totalSeconds}s reached before this case ran`,
+      );
+    } else if (spent >= limits.totalBudgetUsd) {
+      result = capped(
+        evalCase,
+        `run budget cap of $${limits.totalBudgetUsd} reached before this case ran`,
+      );
+    } else {
+      result = await runCase({
+        evalCase,
+        runSkill,
+        grade,
+        timeoutMs: Math.min(caseTimeoutMs, remainingMs),
+        budgetUsd: Math.min(
+          limits.caseBudgetUsd,
+          limits.totalBudgetUsd - spent,
+        ),
+        now,
+      });
+      spent += result.costUsd;
+    }
+    results.push(result);
+    onResult?.(result);
+  }
+
+  const failed = results.filter((r) => r.status === FAIL).length;
+  return {
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(now()).toISOString(),
+    cases: results,
+    totals: {
+      total: results.length,
+      passed: results.length - failed,
+      failed,
+      costUsd: round(spent),
+    },
+  };
+}
+
+function capped(evalCase, reason) {
+  return {
+    id: evalCase.id,
+    skill: evalCase.skill,
+    case: evalCase.name,
+    status: FAIL,
+    reason,
+    durationMs: 0,
+    costUsd: 0,
+    skillSource: evalCase.skillSource,
+  };
+}
+
+function round(value) {
+  return Math.round((Number(value) || 0) * 1e6) / 1e6;
+}

--- a/evals/lib/cases.mjs
+++ b/evals/lib/cases.mjs
@@ -1,0 +1,105 @@
+/**
+ * Case discovery (#1073). A case is exactly what `evals/README.md` specifies:
+ *
+ *   cases/<skill>/<case-name>/
+ *     input.md    what the skill receives
+ *     expect.md   the properties a correct response must and must not have
+ *
+ * Discovery is pure filesystem work and makes no model call, which is what
+ * lets `--dry-run` be the cheap, always-runnable half of this runner.
+ *
+ * A malformed case is reported, never skipped. A case directory missing its
+ * `expect.md`, or naming a skill with no source on disk, is a hole in the
+ * regression net; silently dropping it would make the suite report green for
+ * a case it never ran — the exact failure mode evals exist to prevent.
+ */
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Where a skill's prompt lives, most authoritative first. `shared/` is the
+ * source of truth; `plugins/core/` is emitted from it (`bun build/emit.mjs`)
+ * and is the fallback for a checkout where only the emitted tree is present.
+ */
+export function skillSourceCandidates(repoRoot, skill) {
+  return [
+    path.join(repoRoot, "shared", "skills", skill, "SKILL.md"),
+    path.join(repoRoot, "plugins", "core", "skills", skill, "SKILL.md"),
+  ];
+}
+
+export function resolveSkillSource(repoRoot, skill) {
+  for (const candidate of skillSourceCandidates(repoRoot, skill)) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function dirEntries(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => !name.startsWith("."))
+    .filter((name) => {
+      try {
+        return statSync(path.join(dir, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+/**
+ * Discover cases under `<evalsDir>/cases`, optionally filtered to one skill.
+ *
+ * @param {{evalsDir: string, repoRoot: string, skill?: string|null}} options
+ * @returns {Array<{id: string, skill: string, name: string, dir: string, inputPath: string, expectPath: string, skillSource: string|null, problem: string|null}>}
+ *   sorted by skill then case name, so a results file and its comparison are
+ *   stable across runs.
+ */
+export function discoverCases({ evalsDir, repoRoot, skill = null }) {
+  const casesDir = path.join(evalsDir, "cases");
+  const skills = dirEntries(casesDir).filter(
+    (name) => skill === null || name === skill,
+  );
+  const cases = [];
+  for (const skillName of skills) {
+    const skillDir = path.join(casesDir, skillName);
+    const skillSource = resolveSkillSource(repoRoot, skillName);
+    for (const caseName of dirEntries(skillDir)) {
+      const dir = path.join(skillDir, caseName);
+      const inputPath = path.join(dir, "input.md");
+      const expectPath = path.join(dir, "expect.md");
+      const missing = [
+        existsSync(inputPath) ? null : "input.md",
+        existsSync(expectPath) ? null : "expect.md",
+      ].filter(Boolean);
+      let problem = null;
+      if (missing.length > 0) problem = `missing ${missing.join(" and ")}`;
+      else if (!skillSource) {
+        problem = `no skill source for "${skillName}" (looked in ${skillSourceCandidates(
+          repoRoot,
+          skillName,
+        )
+          .map((p) => path.relative(repoRoot, p))
+          .join(", ")})`;
+      }
+      cases.push({
+        id: `${skillName}/${caseName}`,
+        skill: skillName,
+        name: caseName,
+        dir,
+        inputPath,
+        expectPath,
+        skillSource,
+        problem,
+      });
+    }
+  }
+  return cases;
+}
+
+/** The skills that have at least one case — what `--skill` can be given. */
+export function knownSkills({ evalsDir }) {
+  return dirEntries(path.join(evalsDir, "cases"));
+}

--- a/evals/lib/grader.mjs
+++ b/evals/lib/grader.mjs
@@ -1,0 +1,387 @@
+/**
+ * The two model calls a case needs, and nothing else (#1073).
+ *
+ *   runSkill — put the skill's own prompt in front of the case's `input.md`
+ *              and capture what it produces (the "subject" run)
+ *   grade    — hand `expect.md` and that response to the PINNED grader model
+ *              and read back one verdict line
+ *
+ * Both are injected into the runner as a seam (`evals/lib/case-run.mjs`), so
+ * every test in `evals/run.test.mjs` runs against fakes and the suite never
+ * makes a real model call.
+ *
+ * The spawn conventions here deliberately mirror
+ * `event-runtime/lib/adapters/claude.mjs`: detached process group so a TERM
+ * reaches the CLI's own children, SIGTERM then SIGKILL after a grace period,
+ * `--strict-mcp-config` with no config so no MCP server is loaded, and
+ * ANTHROPIC_API_KEY stripped so the CLI uses subscription auth rather than
+ * billing per token (docs/architecture.md §2.9). They are re-implemented
+ * rather than imported because that adapter pulls in the whole event-runtime
+ * registry graph, and `node evals/run.mjs` must stand alone.
+ */
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { DEFAULT_MODEL } from "./policy.mjs";
+
+export const KILL_GRACE_MS = 30_000;
+
+/** Env the CLI inherits. An allowlist, so a worker's authority is not passed on. */
+export const INHERITED_ENV = [
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+];
+
+/** The subject may read the repo (a skill legitimately consults docs); never write. */
+export const SUBJECT_TOOLS = ["Read", "Grep", "Glob"];
+
+/** The grader judges text. It gets no tools at all — it has nothing to look up. */
+export const GRADER_DENIED_TOOLS = [
+  "Bash",
+  "Edit",
+  "Write",
+  "NotebookEdit",
+  "Read",
+  "Grep",
+  "Glob",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+];
+
+export function childEnvironment(env = process.env) {
+  const child = Object.fromEntries(
+    INHERITED_ENV.flatMap((key) =>
+      env[key] === undefined ? [] : [[key, env[key]]],
+    ),
+  );
+  delete child.ANTHROPIC_API_KEY;
+  delete child.CLAUDECODE;
+  delete child.CLAUDE_CODE_ENTRYPOINT;
+  return child;
+}
+
+/**
+ * argv for one bounded, non-interactive CLI call. `model` uses the same
+ * "default" sentinel as the adapters: pass no `--model` and ride the CLI's own.
+ */
+export function buildClaudeArgv({
+  prompt,
+  model,
+  budgetUsd,
+  allowedTools = [],
+  disallowedTools = [],
+}) {
+  const args = ["-p", prompt, "--output-format", "json"];
+  if (typeof model === "string" && model !== "" && model !== DEFAULT_MODEL) {
+    args.push("--model", model);
+  }
+  if (allowedTools.length > 0)
+    args.push("--allowedTools", allowedTools.join(","));
+  if (disallowedTools.length > 0)
+    args.push("--disallowedTools", disallowedTools.join(","));
+  if (
+    typeof budgetUsd === "number" &&
+    Number.isFinite(budgetUsd) &&
+    budgetUsd > 0
+  ) {
+    args.push("--max-budget-usd", String(budgetUsd));
+  }
+  args.push("--strict-mcp-config");
+  return args;
+}
+
+/**
+ * Run the CLI once, bounded by `timeoutMs` and `budgetUsd`.
+ *
+ * Resolves — never rejects — on a timeout or a non-zero exit: a hung or
+ * failing call is evidence about ONE case, and the caller turns it into that
+ * case's failure rather than into a dead run.
+ *
+ * @returns {Promise<{text: string, costUsd: number, exitCode: number|null, timedOut: boolean, error: string|null}>}
+ */
+export function callClaude({
+  prompt,
+  model,
+  cwd,
+  timeoutMs,
+  budgetUsd,
+  allowedTools = [],
+  disallowedTools = [],
+  killGraceMs = KILL_GRACE_MS,
+  spawnFn = spawn,
+  env = process.env,
+  signal,
+}) {
+  const argv = buildClaudeArgv({
+    prompt,
+    model,
+    budgetUsd,
+    allowedTools,
+    disallowedTools,
+  });
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnFn("claude", argv, {
+        cwd,
+        env: childEnvironment(env),
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+    } catch (error) {
+      resolve({
+        text: "",
+        costUsd: 0,
+        exitCode: null,
+        timedOut: false,
+        error: String(error?.message ?? error),
+      });
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding?.("utf8");
+    child.stderr?.setEncoding?.("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    let timedOut = false;
+    let killTimer = null;
+    const escalate = () => {
+      killProcessGroup(child, "SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
+        killTimer.unref?.();
+      }
+    };
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      escalate();
+    }, timeoutMs);
+    termTimer.unref?.();
+    const onAbort = () => escalate();
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const finish = (exitCode, error) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      signal?.removeEventListener?.("abort", onAbort);
+      const parsed = parseCliJson(stdout);
+      resolve({
+        text: parsed.text,
+        costUsd: parsed.costUsd,
+        exitCode,
+        timedOut,
+        error:
+          error ??
+          (exitCode === 0 || timedOut
+            ? null
+            : stderr.trim() || `claude exited ${exitCode}`),
+      });
+    };
+
+    child.on("error", (error) => finish(null, String(error?.message ?? error)));
+    child.on("close", (exitCode) => finish(exitCode, null));
+  });
+}
+
+/** Terminate the CLI and everything it started (the adapter's WM-263 rule). */
+export function killProcessGroup(
+  child,
+  signal = "SIGTERM",
+  kill = process.kill,
+) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/**
+ * `--output-format json` emits one result object. Fall back to the raw bytes
+ * rather than losing a response to a shape change in the CLI.
+ */
+export function parseCliJson(stdout) {
+  const raw = String(stdout ?? "");
+  try {
+    const parsed = JSON.parse(raw);
+    const text =
+      typeof parsed?.result === "string"
+        ? parsed.result
+        : typeof parsed?.text === "string"
+          ? parsed.text
+          : raw;
+    const cost = parsed?.total_cost_usd;
+    return {
+      text,
+      costUsd: typeof cost === "number" && Number.isFinite(cost) ? cost : 0,
+    };
+  } catch {
+    return { text: raw, costUsd: 0 };
+  }
+}
+
+export const VERDICT_CONTRACT =
+  'Answer with exactly one line and nothing else: "PASS: <reason>" or "FAIL: <reason>". The reason is one sentence naming the specific property that was met or missed.';
+
+/**
+ * Read the grader's verdict. Anything that is not an unambiguous PASS/FAIL
+ * line is `null`, which the runner records as a failed case — a judge that
+ * did not answer must never be read as approval.
+ */
+export function parseVerdict(text) {
+  for (const line of String(text ?? "").split(/\r?\n/)) {
+    const match = /^\s*\**\s*(PASS|FAIL)\b\s*\**\s*[:\-–—]?\s*(.*)$/i.exec(
+      line,
+    );
+    if (!match) continue;
+    return {
+      pass: match[1].toUpperCase() === "PASS",
+      reason: match[2].trim().replace(/\s+/g, " ") || "(grader gave no reason)",
+    };
+  }
+  return null;
+}
+
+export function buildSubjectPrompt({ skillName, skillText, inputText }) {
+  return [
+    `You are being evaluated on the "${skillName}" skill. Its instructions follow verbatim; follow them exactly as written.`,
+    "",
+    `<<<SKILL ${skillName}>>>`,
+    skillText.trim(),
+    "<<<END SKILL>>>",
+    "",
+    "This is an offline evaluation against a frozen case. Do not call any tracker, issue tracker, or API; do not modify any file; do not open a pull request. You may read the repository you are running in to ground your answer.",
+    "",
+    "Apply the skill to the input below and write the outcome you would produce: the decision you reach, any comment text you would post, any labels or state changes you would make, and the evidence you consulted (cite paths).",
+    "",
+    "<<<INPUT>>>",
+    inputText.trim(),
+    "<<<END INPUT>>>",
+  ].join("\n");
+}
+
+export function buildGraderPrompt({
+  skillName,
+  inputText,
+  expectText,
+  responseText,
+}) {
+  return [
+    `You are grading one frozen evaluation case for the "${skillName}" skill.`,
+    "",
+    "Grade against the PROPERTIES in EXPECTED, not against its wording — the response is expected to be phrased differently. The case passes only if every 'Must' property holds and no 'Must not' property is violated. A violated 'Must not' is a FAIL even when everything else is right. Missing evidence for a required property is a FAIL, not a benefit of the doubt.",
+    "",
+    "<<<INPUT GIVEN TO THE SKILL>>>",
+    inputText.trim(),
+    "<<<END INPUT>>>",
+    "",
+    "<<<EXPECTED PROPERTIES>>>",
+    expectText.trim(),
+    "<<<END EXPECTED>>>",
+    "",
+    "<<<RESPONSE UNDER TEST>>>",
+    responseText.trim(),
+    "<<<END RESPONSE>>>",
+    "",
+    VERDICT_CONTRACT,
+  ].join("\n");
+}
+
+/**
+ * The real, model-backed pair. `case-run.mjs` never imports these directly —
+ * `run.mjs` passes them in, and the tests pass fakes in their place.
+ */
+export function modelRunners({
+  repoRoot,
+  policy,
+  spawnFn = spawn,
+  env = process.env,
+}) {
+  return {
+    async runSkill({ evalCase, timeoutMs, budgetUsd, signal }) {
+      const skillText = readFileSync(evalCase.skillSource, "utf8");
+      const inputText = readFileSync(evalCase.inputPath, "utf8");
+      const result = await callClaude({
+        prompt: buildSubjectPrompt({
+          skillName: evalCase.skill,
+          skillText,
+          inputText,
+        }),
+        model: policy.subject.model,
+        cwd: repoRoot,
+        timeoutMs,
+        budgetUsd,
+        allowedTools: SUBJECT_TOOLS,
+        spawnFn,
+        env,
+        signal,
+      });
+      if (result.timedOut)
+        throw new Error(`skill run timed out after ${timeoutMs}ms`);
+      if (result.error) throw new Error(`skill run failed: ${result.error}`);
+      return { text: result.text, costUsd: result.costUsd };
+    },
+
+    async grade({ evalCase, response, timeoutMs, budgetUsd, signal }) {
+      const inputText = readFileSync(evalCase.inputPath, "utf8");
+      const expectText = readFileSync(evalCase.expectPath, "utf8");
+      const result = await callClaude({
+        prompt: buildGraderPrompt({
+          skillName: evalCase.skill,
+          inputText,
+          expectText,
+          responseText: response.text,
+        }),
+        model: policy.grader.model,
+        cwd: repoRoot,
+        timeoutMs,
+        budgetUsd,
+        disallowedTools: GRADER_DENIED_TOOLS,
+        spawnFn,
+        env,
+        signal,
+      });
+      if (result.timedOut)
+        throw new Error(`grader timed out after ${timeoutMs}ms`);
+      if (result.error) throw new Error(`grader failed: ${result.error}`);
+      const verdict = parseVerdict(result.text);
+      if (!verdict) {
+        return {
+          pass: false,
+          reason: "grader returned no PASS/FAIL verdict",
+          costUsd: result.costUsd,
+        };
+      }
+      return { ...verdict, costUsd: result.costUsd };
+    },
+  };
+}

--- a/evals/lib/policy.mjs
+++ b/evals/lib/policy.mjs
@@ -1,0 +1,271 @@
+/**
+ * Where the eval runner gets its models and its bounds: the `evals:` stanza of
+ * `config/policy.yaml` (#1073).
+ *
+ * The grader is pinned BY NAME, in git-tracked operator policy, on purpose. A
+ * grader that floats with whatever the CLI defaults to today moves the pass bar
+ * silently — a suite that "went green" would be indistinguishable from a suite
+ * whose judge got more generous. Pinning it makes a grader upgrade a one-line
+ * policy PR that shows up in review next to the pass-rate change it causes.
+ *
+ * Why a hand-rolled reader instead of `Bun.YAML.parse` (which the rest of the
+ * runtime uses): the documented invocation is `node evals/run.mjs`, so the
+ * runner must work under plain node, and the repo has no YAML dependency. The
+ * parser below is deliberately not a YAML implementation — it extracts ONE
+ * top-level block by name and reads the scalar map inside it. Anything it does
+ * not understand (sequences, anchors, block scalars) is skipped rather than
+ * guessed at, and every value the runner actually depends on is validated
+ * fail-closed below, so a construct this reader mis-reads surfaces as a config
+ * error rather than as a silently wrong model.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export class EvalConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "EvalConfigError";
+  }
+}
+
+/** Matches the adapters' sentinel: "pass no --model, ride the CLI default". */
+export const DEFAULT_MODEL = "default";
+
+/** Bounds used when the stanza omits `limits:`. Every run is bounded. */
+export const DEFAULT_LIMITS = Object.freeze({
+  caseTimeoutSeconds: 300,
+  caseBudgetUsd: 2,
+  totalSeconds: 3600,
+  totalBudgetUsd: 20,
+});
+
+/**
+ * The stanza an operator must add to make real (non-`--dry-run`) runs possible.
+ * Printed verbatim in the error, so the fix never requires reading the source.
+ */
+export const REQUIRED_STANZA = `evals:
+  # The model that RUNS the skill under test. "default" rides the CLI default,
+  # which is what dispatch does today.
+  subject:
+    model: default
+  # The model that GRADES the response against expect.md. Pinned by name so a
+  # grader upgrade is a deliberate, reviewable change and never a silent shift
+  # in the pass bar; the "default" sentinel is refused here for that reason.
+  grader:
+    model: claude-sonnet-4-6
+  limits:
+    case_timeout_seconds: 300
+    case_budget_usd: 2.00
+    total_seconds: 3600
+    total_budget_usd: 20.00`;
+
+/** Strip a trailing `# comment`, honouring quotes so a `#` inside one survives. */
+export function stripComment(line) {
+  let single = false;
+  let double = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === "'" && !double) single = !single;
+    else if (ch === '"' && !single) double = !double;
+    else if (
+      ch === "#" &&
+      !single &&
+      !double &&
+      (i === 0 || /\s/.test(line[i - 1]))
+    ) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+/**
+ * Return the indented body of one top-level `<key>:` block, or null when the
+ * document has no such key. Reading only the block we own keeps every other
+ * construct in policy.yaml (sequences, nested maps, prose comments) out of the
+ * parser's way entirely.
+ */
+export function extractStanza(text, key) {
+  const lines = String(text ?? "").split(/\r?\n/);
+  const header = new RegExp(`^${key}:\\s*(#.*)?$`);
+  const start = lines.findIndex((line) => header.test(line));
+  if (start === -1) return null;
+  const body = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      body.push("");
+      continue;
+    }
+    if (/^\S/.test(line)) break; // next top-level key ends the block
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+/**
+ * Parse an indented map of scalars (arbitrary nesting) from a stanza body.
+ * Sequence entries are skipped: this subset has no use for them, and guessing
+ * at one is worse than not reading it.
+ */
+export function parseIndentedMap(text) {
+  const root = {};
+  const stack = [{ indent: -1, node: root }];
+  for (const raw of String(text ?? "").split(/\r?\n/)) {
+    const line = stripComment(raw);
+    if (line.trim() === "") continue;
+    if (/^\s*-/.test(line)) continue;
+    const match = /^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, pad, key, rest] = match;
+    const indent = pad.length;
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent)
+      stack.pop();
+    const parent = stack[stack.length - 1].node;
+    if (rest.trim() === "") {
+      const node = {};
+      parent[key] = node;
+      stack.push({ indent, node });
+    } else {
+      parent[key] = unquote(rest);
+    }
+  }
+  return root;
+}
+
+/**
+ * Resolve which policy file to read. Mirrors `event-runtime/lib/config.mjs`:
+ * the operator-local `config/policy.yaml` is gitignored, so a clean checkout
+ * falls back to the tracked example rather than reporting "no policy".
+ */
+export function resolvePolicyFile(root) {
+  const local = path.join(root, "config", "policy.yaml");
+  if (existsSync(local)) return local;
+  const example = path.join(root, "config", "policy.example.yaml");
+  if (existsSync(example)) return example;
+  return null;
+}
+
+function positiveNumber(raw, where) {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new EvalConfigError(
+      `${where} must be a positive number (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}
+
+function readLimits(stanza, file) {
+  const limits = stanza?.limits ?? {};
+  if (typeof limits !== "object" || Array.isArray(limits)) {
+    throw new EvalConfigError(`${file}: evals.limits must be a map`);
+  }
+  const pick = (key, fallback) =>
+    limits[key] === undefined
+      ? fallback
+      : positiveNumber(limits[key], `${file}: evals.limits.${key}`);
+  return {
+    caseTimeoutSeconds: pick(
+      "case_timeout_seconds",
+      DEFAULT_LIMITS.caseTimeoutSeconds,
+    ),
+    caseBudgetUsd: pick("case_budget_usd", DEFAULT_LIMITS.caseBudgetUsd),
+    totalSeconds: pick("total_seconds", DEFAULT_LIMITS.totalSeconds),
+    totalBudgetUsd: pick("total_budget_usd", DEFAULT_LIMITS.totalBudgetUsd),
+  };
+}
+
+/**
+ * Read the eval stanza.
+ *
+ * Never throws for an ABSENT pin: `--dry-run` must keep working on a checkout
+ * whose policy has not been extended yet (that is the whole point of a mode
+ * that spends nothing). The absence is reported as `problem`, and `requirePin`
+ * below is what turns it into the fail-closed error a real run needs.
+ *
+ * @param {{root: string, file?: string|null, text?: string|null}} options
+ * @returns {{file: string|null, grader: {model: string}|null, subject: {model: string}, limits: object, problem: string|null}}
+ */
+export function loadEvalPolicy({
+  root,
+  file = undefined,
+  text = undefined,
+} = {}) {
+  const policyFile = file === undefined ? resolvePolicyFile(root) : file;
+  const source =
+    text === undefined
+      ? policyFile && existsSync(policyFile)
+        ? readFileSync(policyFile, "utf8")
+        : null
+      : text;
+  const base = {
+    file: policyFile,
+    grader: null,
+    subject: { model: DEFAULT_MODEL },
+    limits: { ...DEFAULT_LIMITS },
+  };
+  if (source === null) {
+    return {
+      ...base,
+      problem: "no config/policy.yaml (or policy.example.yaml) found",
+    };
+  }
+  const body = extractStanza(source, "evals");
+  if (body === null) {
+    return { ...base, problem: `${policyFile} has no \`evals:\` stanza` };
+  }
+  const stanza = parseIndentedMap(body);
+  const limits = readLimits(stanza, policyFile);
+  const subjectModel = stanza?.subject?.model;
+  const subject = {
+    model:
+      typeof subjectModel === "string" && subjectModel.trim() !== ""
+        ? subjectModel.trim()
+        : DEFAULT_MODEL,
+  };
+  const graderModel = stanza?.grader?.model;
+  if (typeof graderModel !== "string" || graderModel.trim() === "") {
+    return {
+      ...base,
+      subject,
+      limits,
+      problem: `${policyFile}: evals.grader.model is not set`,
+    };
+  }
+  if (graderModel.trim() === DEFAULT_MODEL) {
+    return {
+      ...base,
+      subject,
+      limits,
+      problem: `${policyFile}: evals.grader.model is "${DEFAULT_MODEL}" — the grader must name a model, so that changing it is reviewable`,
+    };
+  }
+  return {
+    file: policyFile,
+    grader: { model: graderModel.trim() },
+    subject,
+    limits,
+    problem: null,
+  };
+}
+
+/** Fail closed: a run that would spend must know exactly which judge it used. */
+export function requirePin(policy) {
+  if (policy.grader) return policy;
+  throw new EvalConfigError(
+    `${policy.problem}\n\nAdd this stanza to config/policy.yaml (and config/policy.example.yaml) before running evals:\n\n${REQUIRED_STANZA}\n`,
+  );
+}

--- a/evals/lib/report.mjs
+++ b/evals/lib/report.mjs
@@ -1,0 +1,82 @@
+/**
+ * Output (#1073). Human-readable by default, `--json` for CI.
+ *
+ * The human form leads with the failures and their reasons, because the only
+ * question anyone asks a red eval run is "which case, and why". The JSON form
+ * is the same object that gets written to `evals/.results/`, plus the
+ * comparison when one was requested, so a CI job can consume stdout or the
+ * results file interchangeably.
+ */
+import path from "node:path";
+
+function rel(root, file) {
+  if (!file) return "(not found)";
+  const relative = path.relative(root, file);
+  return relative.startsWith("..") ? file : relative;
+}
+
+/** `--dry-run`: the case set and where each case's skill prompt resolves. */
+export function formatDryRun({ cases, policy, repoRoot }) {
+  const lines = [];
+  lines.push(
+    `${cases.length} case${cases.length === 1 ? "" : "s"} discovered (no model calls — dry run)`,
+  );
+  lines.push("");
+  const width = Math.max(0, ...cases.map((entry) => entry.id.length));
+  for (const entry of cases) {
+    const source = entry.problem
+      ? `!! ${entry.problem}`
+      : rel(repoRoot, entry.skillSource);
+    lines.push(`  ${entry.id.padEnd(width)}  ->  ${source}`);
+  }
+  lines.push("");
+  lines.push(
+    policy.grader
+      ? `grader: ${policy.grader.model} (pinned in ${rel(repoRoot, policy.file)})`
+      : `grader: UNPINNED — ${policy.problem}. A real run refuses to start until it is pinned; see evals/README.md.`,
+  );
+  lines.push(`subject: ${policy.subject.model}`);
+  const broken = cases.filter((entry) => entry.problem).length;
+  if (broken > 0)
+    lines.push(`${broken} case(s) are not runnable (marked !! above)`);
+  return lines.join("\n");
+}
+
+export function formatRun({ run, comparison = null, repoRoot }) {
+  const lines = [];
+  for (const entry of run.cases) {
+    const mark = entry.status === "pass" ? "PASS" : "FAIL";
+    lines.push(`${mark}  ${entry.id}  ${entry.reason}`);
+  }
+  lines.push("");
+  const { total, passed, failed, costUsd } = run.totals;
+  lines.push(
+    `${passed}/${total} passed, ${failed} failed  ·  grader ${run.grader.model}  ·  subject ${run.subject.model}  ·  $${costUsd.toFixed(4)} notional`,
+  );
+  if (run.resultsFile) lines.push(`results: ${rel(repoRoot, run.resultsFile)}`);
+  if (comparison) lines.push("", ...formatComparison(comparison));
+  return lines.join("\n");
+}
+
+export function formatComparison(comparison) {
+  const lines = [
+    `compared against ${comparison.previousFile}${comparison.previousAt ? ` (${comparison.previousAt})` : ""}`,
+  ];
+  if (comparison.graderChanged) {
+    lines.push(
+      `  WARNING: graded by a different model (${comparison.previousGrader} -> ${comparison.currentGrader}); these runs are not directly comparable`,
+    );
+  }
+  if (comparison.regressions.length === 0) lines.push("  no regressions");
+  for (const entry of comparison.regressions) {
+    lines.push(
+      `  REGRESSION  ${entry.id}: ${entry.was} -> ${entry.now}  ${entry.reason}`,
+    );
+  }
+  for (const entry of comparison.fixes) {
+    lines.push(`  fixed       ${entry.id}: ${entry.was} -> ${entry.now}`);
+  }
+  for (const id of comparison.added) lines.push(`  new case    ${id}`);
+  for (const id of comparison.removed) lines.push(`  gone        ${id}`);
+  return lines;
+}

--- a/evals/lib/results.mjs
+++ b/evals/lib/results.mjs
@@ -1,0 +1,90 @@
+/**
+ * Recorded runs and the comparison between two of them (#1073).
+ *
+ * Determinism is honest here rather than assumed: two runs of the same cases
+ * on the same models can disagree, so an absolute score alone cannot tell an
+ * operator whether a prompt edit made things worse. What can is the DIFF —
+ * which specific cases went from pass to fail — which is why every run is
+ * written to `evals/.results/<timestamp>.json` with the models and the case
+ * set it ran, and why `--compare` reports transitions rather than totals.
+ *
+ * The comparison also reports a grader change, because a run graded by a
+ * different judge is not a comparable measurement, and reading it as one is
+ * exactly the silent shift the pinned grader exists to prevent.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const RESULTS_DIRNAME = ".results";
+
+/** Colons are legal in a POSIX filename and miserable everywhere else. */
+export function resultsFilename(date = new Date()) {
+  return `${date.toISOString().replace(/[:.]/g, "-")}.json`;
+}
+
+export function writeResults(dir, run, { date = new Date() } = {}) {
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, resultsFilename(date));
+  writeFileSync(file, `${JSON.stringify(run, null, 2)}\n`, "utf8");
+  return file;
+}
+
+export function readResults(file) {
+  const parsed = JSON.parse(readFileSync(file, "utf8"));
+  if (!parsed || !Array.isArray(parsed.cases)) {
+    throw new Error(`${file}: not an evals results file (no "cases" array)`);
+  }
+  return parsed;
+}
+
+function byId(run) {
+  return new Map((run?.cases ?? []).map((entry) => [entry.id, entry]));
+}
+
+/**
+ * @returns {{regressions: Array, fixes: Array, added: Array<string>, removed: Array<string>, graderChanged: boolean, previousGrader: string|null, currentGrader: string|null, previousAt: string|null}}
+ */
+export function compareRuns(previous, current) {
+  const before = byId(previous);
+  const after = byId(current);
+  const regressions = [];
+  const fixes = [];
+  const added = [];
+  for (const [id, entry] of after) {
+    const prior = before.get(id);
+    if (!prior) {
+      added.push(id);
+      continue;
+    }
+    if (prior.status === "pass" && entry.status !== "pass") {
+      regressions.push({
+        id,
+        was: prior.status,
+        now: entry.status,
+        reason: entry.reason,
+      });
+    } else if (prior.status !== "pass" && entry.status === "pass") {
+      fixes.push({
+        id,
+        was: prior.status,
+        now: entry.status,
+        reason: entry.reason,
+      });
+    }
+  }
+  const removed = [...before.keys()].filter((id) => !after.has(id));
+  const previousGrader = previous?.grader?.model ?? null;
+  const currentGrader = current?.grader?.model ?? null;
+  return {
+    regressions,
+    fixes,
+    added,
+    removed,
+    graderChanged: Boolean(
+      previousGrader && currentGrader && previousGrader !== currentGrader,
+    ),
+    previousGrader,
+    currentGrader,
+    previousAt: previous?.startedAt ?? null,
+  };
+}

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -1,0 +1,337 @@
+/**
+ * evals/run.mjs — the case runner that gates every prompt change (#1073).
+ *
+ * Prompt changes are the only part of this system with no regression test.
+ * This runner is that test: it replays frozen cases through a skill and has a
+ * PINNED grader model judge the response against `expect.md`, so a prompt edit
+ * that quietly degrades a skill fails a PR instead of surfacing weeks later as
+ * a halved merge rate.
+ *
+ *   node evals/run.mjs                    # every case
+ *   node evals/run.mjs --skill ticket-spec
+ *   node evals/run.mjs --dry-run          # discovery only, zero model calls
+ *   node evals/run.mjs --json             # machine-readable, for CI
+ *   node evals/run.mjs --compare evals/.results/<file>.json
+ *
+ * Exit codes: 0 everything passed · 1 a case failed or regressed · 2 the
+ * runner could not run (bad flag, no cases, unpinned grader). The non-zero
+ * exit is the whole CI contract — no wrapper script required.
+ *
+ * Model calls live behind a two-function seam (`runSkill`, `grade`) that
+ * `main()` accepts as a parameter. `evals/run.test.mjs` passes fakes through
+ * it, so the suite exercises discovery, filtering, the exit contract, the
+ * timeout path, and regression comparison without spending anything.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runSuite } from "./lib/case-run.mjs";
+import { discoverCases, knownSkills } from "./lib/cases.mjs";
+import { modelRunners } from "./lib/grader.mjs";
+import { EvalConfigError, loadEvalPolicy, requirePin } from "./lib/policy.mjs";
+import { formatDryRun, formatRun } from "./lib/report.mjs";
+import {
+  RESULTS_DIRNAME,
+  compareRuns,
+  readResults,
+  writeResults,
+} from "./lib/results.mjs";
+
+export const EVALS_DIR = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.dirname(EVALS_DIR);
+
+export const EXIT_OK = 0;
+export const EXIT_FAILED = 1;
+export const EXIT_USAGE = 2;
+
+export const USAGE = `usage: node evals/run.mjs [options]
+
+  --skill <name>           run only this skill's cases
+  --dry-run                list the cases and their resolved skill source; makes no model calls
+  --json                   emit the run as JSON on stdout (for CI)
+  --compare <file>         diff this run against a previous results file; a pass -> fail
+                           transition is a regression and exits non-zero
+  --results-dir <dir>      where to write the run record (default evals/${RESULTS_DIRNAME})
+  --no-results             do not write a run record
+  --timeout <seconds>      per-case timeout override
+  --budget <usd>           per-case budget override
+  --total-timeout <seconds>  whole-run time cap override
+  --total-budget <usd>     whole-run budget cap override
+  -h, --help               this text
+
+Models come from the \`evals:\` stanza of config/policy.yaml. The grader is
+pinned by name there so a grader upgrade is a reviewable change, never a
+silent shift in the pass bar; see evals/README.md.`;
+
+class UsageError extends Error {}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new UsageError(`${flag} needs a value`);
+  }
+  return value;
+}
+
+function positive(raw, flag) {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new UsageError(
+      `${flag} must be a positive number (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    skill: null,
+    dryRun: false,
+    json: false,
+    compare: null,
+    resultsDir: null,
+    writeResults: true,
+    help: false,
+    overrides: {},
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "--no-results":
+        options.writeResults = false;
+        break;
+      case "--skill":
+        options.skill = requireValue(argv, i, arg);
+        i += 1;
+        break;
+      case "--compare":
+        options.compare = requireValue(argv, i, arg);
+        i += 1;
+        break;
+      case "--results-dir":
+        options.resultsDir = requireValue(argv, i, arg);
+        i += 1;
+        break;
+      case "--timeout":
+        options.overrides.caseTimeoutSeconds = positive(
+          requireValue(argv, i, arg),
+          arg,
+        );
+        i += 1;
+        break;
+      case "--budget":
+        options.overrides.caseBudgetUsd = positive(
+          requireValue(argv, i, arg),
+          arg,
+        );
+        i += 1;
+        break;
+      case "--total-timeout":
+        options.overrides.totalSeconds = positive(
+          requireValue(argv, i, arg),
+          arg,
+        );
+        i += 1;
+        break;
+      case "--total-budget":
+        options.overrides.totalBudgetUsd = positive(
+          requireValue(argv, i, arg),
+          arg,
+        );
+        i += 1;
+        break;
+      default:
+        throw new UsageError(`unknown argument ${JSON.stringify(arg)}`);
+    }
+  }
+  return options;
+}
+
+function writeLine(stream, text) {
+  stream?.write?.(`${text}\n`);
+}
+
+/**
+ * @param {object} options
+ * @param {string[]} options.argv           process.argv.slice(2)
+ * @param {{runSkill: Function, grade: Function}} [options.deps]  the model seam; tests pass fakes
+ * @returns {Promise<number>} the process exit code
+ */
+export async function main({
+  argv = [],
+  stdout = process.stdout,
+  stderr = process.stderr,
+  repoRoot = REPO_ROOT,
+  evalsDir = EVALS_DIR,
+  deps = null,
+  policy: injectedPolicy = null,
+  now = () => Date.now(),
+  date = () => new Date(),
+} = {}) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    writeLine(stderr, `evals: ${error.message}`);
+    writeLine(stderr, USAGE);
+    return EXIT_USAGE;
+  }
+  if (options.help) {
+    writeLine(stdout, USAGE);
+    return EXIT_OK;
+  }
+
+  let policy;
+  try {
+    policy = injectedPolicy ?? loadEvalPolicy({ root: repoRoot });
+  } catch (error) {
+    writeLine(stderr, `evals: ${error.message}`);
+    return EXIT_USAGE;
+  }
+  const limits = { ...policy.limits, ...options.overrides };
+
+  if (options.skill !== null) {
+    const available = knownSkills({ evalsDir });
+    if (!available.includes(options.skill)) {
+      writeLine(
+        stderr,
+        `evals: no cases for skill ${JSON.stringify(options.skill)} (have: ${available.join(", ") || "none"})`,
+      );
+      return EXIT_USAGE;
+    }
+  }
+  const cases = discoverCases({ evalsDir, repoRoot, skill: options.skill });
+  if (cases.length === 0) {
+    writeLine(
+      stderr,
+      `evals: no cases found under ${path.join(evalsDir, "cases")}`,
+    );
+    return EXIT_USAGE;
+  }
+
+  if (options.dryRun) {
+    const broken = cases.filter((entry) => entry.problem);
+    if (options.json) {
+      writeLine(
+        stdout,
+        JSON.stringify(
+          {
+            dryRun: true,
+            grader: policy.grader ?? null,
+            graderProblem: policy.problem ?? null,
+            subject: policy.subject,
+            limits,
+            cases: cases.map((entry) => ({
+              id: entry.id,
+              skill: entry.skill,
+              case: entry.name,
+              skillSource: entry.skillSource,
+              problem: entry.problem,
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      writeLine(stdout, formatDryRun({ cases, policy, repoRoot }));
+    }
+    // Discovery is the cheap place to catch a case the suite cannot run;
+    // reporting it and exiting 0 would hide a hole in the regression net.
+    return broken.length > 0 ? EXIT_FAILED : EXIT_OK;
+  }
+
+  try {
+    requirePin(policy);
+  } catch (error) {
+    if (!(error instanceof EvalConfigError)) throw error;
+    writeLine(stderr, `evals: ${error.message}`);
+    return EXIT_USAGE;
+  }
+
+  let previous = null;
+  if (options.compare) {
+    try {
+      previous = readResults(options.compare);
+    } catch (error) {
+      writeLine(
+        stderr,
+        `evals: --compare ${options.compare}: ${error.message}`,
+      );
+      return EXIT_USAGE;
+    }
+  }
+
+  const runners = deps ?? modelRunners({ repoRoot, policy });
+  const suite = await runSuite({
+    cases,
+    runSkill: runners.runSkill,
+    grade: runners.grade,
+    limits,
+    now,
+    onResult: options.json
+      ? null
+      : (result) =>
+          writeLine(
+            stderr,
+            `${result.status === "pass" ? "PASS" : "FAIL"}  ${result.id}  ${result.reason}`,
+          ),
+  });
+
+  const run = {
+    ...suite,
+    grader: { model: policy.grader.model, source: policy.file },
+    subject: { model: policy.subject.model },
+    limits,
+    skillFilter: options.skill,
+    caseSet: cases.map((entry) => entry.id),
+  };
+
+  if (options.writeResults) {
+    const dir = options.resultsDir ?? path.join(evalsDir, RESULTS_DIRNAME);
+    try {
+      run.resultsFile = writeResults(dir, run, { date: date() });
+    } catch (error) {
+      writeLine(
+        stderr,
+        `evals: could not write results to ${dir}: ${error.message}`,
+      );
+    }
+  }
+
+  const comparison = previous
+    ? { ...compareRuns(previous, run), previousFile: options.compare }
+    : null;
+
+  if (options.json) {
+    writeLine(stdout, JSON.stringify({ ...run, comparison }, null, 2));
+  } else {
+    writeLine(stdout, formatRun({ run, comparison, repoRoot }));
+  }
+
+  if (run.totals.failed > 0) return EXIT_FAILED;
+  if (comparison && comparison.regressions.length > 0) return EXIT_FAILED;
+  return EXIT_OK;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  main({ argv: process.argv.slice(2) }).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      process.stderr.write(`evals: ${error?.stack ?? error}\n`);
+      process.exitCode = EXIT_USAGE;
+    },
+  );
+}

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -1,0 +1,709 @@
+/**
+ * Tests for the eval runner (#1073).
+ *
+ * NOT ONE TEST IN THIS FILE MAKES A MODEL CALL. Every run goes through
+ * `main({ deps })` with fake `runSkill`/`grade` functions, and the fixtures
+ * are temporary directories rather than the repo's own cases — a suite that
+ * needed a live grader to prove the gate works could never be the gate.
+ */
+import { withTmpDir } from "../event-runtime/test-support/tmp.mjs?file=evals-run-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EXIT_FAILED, EXIT_OK, EXIT_USAGE, main, parseArgs } from "./run.mjs";
+import { discoverCases } from "./lib/cases.mjs";
+import {
+  buildClaudeArgv,
+  childEnvironment,
+  parseCliJson,
+  parseVerdict,
+} from "./lib/grader.mjs";
+import { loadEvalPolicy } from "./lib/policy.mjs";
+import { compareRuns } from "./lib/results.mjs";
+
+const EVALS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.dirname(EVALS_DIR);
+
+const PINNED_POLICY = Object.freeze({
+  file: "config/policy.yaml",
+  grader: { model: "claude-sonnet-4-6" },
+  subject: { model: "default" },
+  limits: {
+    caseTimeoutSeconds: 300,
+    caseBudgetUsd: 2,
+    totalSeconds: 3600,
+    totalBudgetUsd: 20,
+  },
+  problem: null,
+});
+
+/**
+ * A miniature repo: skill prompts under shared/skills, cases under evals/cases.
+ * `cases` maps "<skill>/<case>" to the files it should contain; omitting a file
+ * is how a malformed case is expressed.
+ */
+function buildFixture(
+  dir,
+  { skills = { "ticket-spec": "# ticket-spec" }, cases = {} } = {},
+) {
+  for (const [name, text] of Object.entries(skills)) {
+    const skillDir = path.join(dir, "shared", "skills", name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(path.join(skillDir, "SKILL.md"), `${text}\n`);
+  }
+  for (const [id, files] of Object.entries(cases)) {
+    const [skill, name] = id.split("/");
+    const caseDir = path.join(dir, "evals", "cases", skill, name);
+    mkdirSync(caseDir, { recursive: true });
+    if (files.input !== undefined)
+      writeFileSync(path.join(caseDir, "input.md"), files.input);
+    if (files.expect !== undefined)
+      writeFileSync(path.join(caseDir, "expect.md"), files.expect);
+  }
+  return { repoRoot: dir, evalsDir: path.join(dir, "evals") };
+}
+
+function twoCases() {
+  return {
+    "ticket-spec/hidden-decision": {
+      input: "ticket A",
+      expect: "must not promote",
+    },
+    "ticket-spec/green-but-empty": {
+      input: "ticket B",
+      expect: "must name a command",
+    },
+  };
+}
+
+function sink() {
+  const chunks = [];
+  return {
+    write(text) {
+      chunks.push(text);
+    },
+    get text() {
+      return chunks.join("");
+    },
+  };
+}
+
+/**
+ * The model seam, faked. `verdicts` maps a case id to the grader's answer (or
+ * to a function for the awkward shapes: hangs, throws, cost). Every call is
+ * recorded so a test can assert what was — and was not — run.
+ */
+function fakeDeps({ verdicts = {}, subjectCost = 0, onSubject = null } = {}) {
+  const calls = { subject: [], grade: [] };
+  const runSkill = async ({ evalCase }) => {
+    calls.subject.push(evalCase.id);
+    if (onSubject) return onSubject(evalCase);
+    return { text: `response for ${evalCase.id}`, costUsd: subjectCost };
+  };
+  const grade = async ({ evalCase }) => {
+    calls.grade.push(evalCase.id);
+    const verdict = verdicts[evalCase.id];
+    if (typeof verdict === "function") return verdict(evalCase);
+    return (
+      verdict ?? {
+        pass: true,
+        reason: "meets every stated property",
+        costUsd: 0,
+      }
+    );
+  };
+  return { runSkill, grade, calls };
+}
+
+function run(options) {
+  const stdout = sink();
+  const stderr = sink();
+  return main({ policy: PINNED_POLICY, stdout, stderr, ...options }).then(
+    (code) => ({
+      code,
+      stdout: stdout.text,
+      stderr: stderr.text,
+    }),
+  );
+}
+
+describe("discovery", () => {
+  test("finds cases/<skill>/<case> and resolves the skill source", () =>
+    withTmpDir("evals-discovery-", (dir) => {
+      const { repoRoot, evalsDir } = buildFixture(dir, { cases: twoCases() });
+      const cases = discoverCases({ evalsDir, repoRoot });
+      expect(cases.map((entry) => entry.id)).toEqual([
+        "ticket-spec/green-but-empty",
+        "ticket-spec/hidden-decision",
+      ]);
+      expect(cases[0].skillSource).toBe(
+        path.join(repoRoot, "shared", "skills", "ticket-spec", "SKILL.md"),
+      );
+      expect(cases[0].problem).toBeNull();
+    }));
+
+  test("falls back to the emitted plugins/core skill when shared/ has none", () =>
+    withTmpDir("evals-discovery-emitted-", (dir) => {
+      const { repoRoot, evalsDir } = buildFixture(dir, {
+        skills: {},
+        cases: { "ticket-spec/a": { input: "i", expect: "e" } },
+      });
+      const emitted = path.join(
+        repoRoot,
+        "plugins",
+        "core",
+        "skills",
+        "ticket-spec",
+      );
+      mkdirSync(emitted, { recursive: true });
+      writeFileSync(path.join(emitted, "SKILL.md"), "# emitted\n");
+      const [entry] = discoverCases({ evalsDir, repoRoot });
+      expect(entry.skillSource).toBe(path.join(emitted, "SKILL.md"));
+      expect(entry.problem).toBeNull();
+    }));
+
+  test("a case missing expect.md, or naming an unknown skill, is reported not skipped", () =>
+    withTmpDir("evals-discovery-broken-", (dir) => {
+      const { repoRoot, evalsDir } = buildFixture(dir, {
+        cases: {
+          "ticket-spec/no-expect": { input: "i" },
+          "ghost-skill/orphan": { input: "i", expect: "e" },
+        },
+      });
+      const problems = Object.fromEntries(
+        discoverCases({ evalsDir, repoRoot }).map((entry) => [
+          entry.id,
+          entry.problem,
+        ]),
+      );
+      expect(problems["ticket-spec/no-expect"]).toBe("missing expect.md");
+      expect(problems["ghost-skill/orphan"]).toContain("no skill source");
+    }));
+
+  test("discovers the repo's own cases against the real skill tree", () => {
+    const cases = discoverCases({ evalsDir: EVALS_DIR, repoRoot: REPO_ROOT });
+    expect(cases.length).toBeGreaterThan(0);
+    expect(cases.every((entry) => entry.problem === null)).toBe(true);
+  });
+});
+
+describe("--dry-run", () => {
+  test("lists each case and its resolved skill source without calling a model", () =>
+    withTmpDir("evals-dry-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps();
+      const result = await run({ argv: ["--dry-run"], deps, ...fixture });
+      expect(result.code).toBe(EXIT_OK);
+      expect(result.stdout).toContain("ticket-spec/hidden-decision");
+      expect(result.stdout).toContain(
+        path.join("shared", "skills", "ticket-spec", "SKILL.md"),
+      );
+      expect(deps.calls.subject).toEqual([]);
+      expect(deps.calls.grade).toEqual([]);
+    }));
+
+  test("works with an unpinned grader, and says so, so discovery is testable without spend", () =>
+    withTmpDir("evals-dry-unpinned-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const result = await run({
+        argv: ["--dry-run"],
+        deps: fakeDeps(),
+        policy: {
+          ...PINNED_POLICY,
+          grader: null,
+          problem: "no `evals:` stanza",
+        },
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_OK);
+      expect(result.stdout).toContain("UNPINNED");
+    }));
+
+  test("exits non-zero when a discovered case is not runnable", () =>
+    withTmpDir("evals-dry-broken-", async (dir) => {
+      const fixture = buildFixture(dir, {
+        cases: { "ticket-spec/no-expect": { input: "i" } },
+      });
+      const result = await run({
+        argv: ["--dry-run"],
+        deps: fakeDeps(),
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_FAILED);
+      expect(result.stdout).toContain("missing expect.md");
+    }));
+
+  test("the documented `node evals/run.mjs --dry-run` invocation works from the CLI", () => {
+    const result = spawnSync(
+      "node",
+      [path.join(EVALS_DIR, "run.mjs"), "--dry-run"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      },
+    );
+    expect(result.status).toBe(EXIT_OK);
+    expect(result.stdout).toContain("ticket-spec/");
+  });
+});
+
+describe("pass/fail exit contract", () => {
+  test("every case passing exits 0 and grades each case exactly once", () =>
+    withTmpDir("evals-pass-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps();
+      const result = await run({ argv: [], deps, ...fixture });
+      expect(result.code).toBe(EXIT_OK);
+      expect(deps.calls.grade.sort()).toEqual([
+        "ticket-spec/green-but-empty",
+        "ticket-spec/hidden-decision",
+      ]);
+      expect(result.stdout).toContain("2/2 passed");
+    }));
+
+  test("one failing case exits 1 and reports the grader's one-line reason", () =>
+    withTmpDir("evals-fail-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/hidden-decision": {
+            pass: false,
+            reason: "promoted the ticket anyway",
+          },
+        },
+      });
+      const result = await run({ argv: ["--json"], deps, ...fixture });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      expect(report.totals).toMatchObject({ total: 2, passed: 1, failed: 1 });
+      const failed = report.cases.find((entry) => entry.status === "fail");
+      expect(failed.id).toBe("ticket-spec/hidden-decision");
+      expect(failed.reason).toBe("promoted the ticket anyway");
+    }));
+
+  test("a case the runner cannot read fails rather than silently passing", () =>
+    withTmpDir("evals-unrunnable-", async (dir) => {
+      const fixture = buildFixture(dir, {
+        cases: { "ticket-spec/no-expect": { input: "i" } },
+      });
+      const deps = fakeDeps();
+      const result = await run({ argv: [], deps, ...fixture });
+      expect(result.code).toBe(EXIT_FAILED);
+      expect(result.stderr).toContain("case not runnable");
+      expect(deps.calls.subject).toEqual([]);
+    }));
+
+  test("a grader that throws fails its case and the run continues", () =>
+    withTmpDir("evals-grader-throws-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/green-but-empty": () => {
+            throw new Error("grader returned no PASS/FAIL verdict");
+          },
+        },
+      });
+      const result = await run({ argv: ["--json"], deps, ...fixture });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      expect(report.totals).toMatchObject({ passed: 1, failed: 1 });
+      expect(report.cases.find((c) => c.status === "fail").reason).toContain(
+        "no PASS/FAIL",
+      );
+    }));
+});
+
+describe("--skill filtering", () => {
+  test("runs only the named skill's cases", () =>
+    withTmpDir("evals-skill-", async (dir) => {
+      const fixture = buildFixture(dir, {
+        skills: { "ticket-spec": "# a", "merge-review": "# b" },
+        cases: {
+          "ticket-spec/hidden-decision": { input: "i", expect: "e" },
+          "merge-review/green-but-empty": { input: "i", expect: "e" },
+        },
+      });
+      const deps = fakeDeps();
+      const result = await run({
+        argv: ["--skill", "ticket-spec"],
+        deps,
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_OK);
+      expect(deps.calls.grade).toEqual(["ticket-spec/hidden-decision"]);
+    }));
+
+  test("an unknown skill is a usage error, not an empty green run", () =>
+    withTmpDir("evals-skill-unknown-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps();
+      const result = await run({ argv: ["--skill", "nope"], deps, ...fixture });
+      expect(result.code).toBe(EXIT_USAGE);
+      expect(result.stderr).toContain("no cases for skill");
+      expect(deps.calls.subject).toEqual([]);
+    }));
+
+  test("a cases directory with nothing in it is a usage error", () =>
+    withTmpDir("evals-empty-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: {} });
+      const result = await run({ argv: [], deps: fakeDeps(), ...fixture });
+      expect(result.code).toBe(EXIT_USAGE);
+      expect(result.stderr).toContain("no cases found");
+    }));
+});
+
+describe("bounds", () => {
+  test("a hung grader fails its own case, not the run", () =>
+    withTmpDir("evals-timeout-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/green-but-empty": () => new Promise(() => {}), // never settles
+        },
+      });
+      const result = await run({
+        argv: ["--json", "--timeout", "0.05"],
+        deps,
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      const hung = report.cases.find(
+        (entry) => entry.id === "ticket-spec/green-but-empty",
+      );
+      expect(hung.status).toBe("fail");
+      expect(hung.reason).toMatch(/timed out after \d+ms/);
+      // The second case still ran and still passed: one hung grader is one
+      // failed case, never a dead run.
+      expect(
+        report.cases.find((entry) => entry.id === "ticket-spec/hidden-decision")
+          .status,
+      ).toBe("pass");
+    }));
+
+  test("the total time cap fails the cases it stopped, naming the cap", () =>
+    withTmpDir("evals-total-time-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const clock = { t: 1_000_000 };
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/green-but-empty": () => {
+            clock.t += 60_000; // this case ate the whole window
+            return { pass: true, reason: "ok" };
+          },
+        },
+      });
+      const result = await run({
+        argv: ["--json", "--total-timeout", "30"],
+        deps,
+        now: () => clock.t,
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      const stopped = report.cases.find(
+        (entry) => entry.id === "ticket-spec/hidden-decision",
+      );
+      expect(stopped.status).toBe("fail");
+      expect(stopped.reason).toContain("run time cap of 30s");
+      expect(deps.calls.subject).toEqual(["ticket-spec/green-but-empty"]);
+    }));
+
+  test("the total budget cap stops spending and fails the remaining cases", () =>
+    withTmpDir("evals-total-budget-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/green-but-empty": {
+            pass: true,
+            reason: "ok",
+            costUsd: 9,
+          },
+        },
+      });
+      const result = await run({
+        argv: ["--json", "--total-budget", "4"],
+        deps,
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      expect(
+        report.cases.find((entry) => entry.id === "ticket-spec/hidden-decision")
+          .reason,
+      ).toContain("run budget cap of $4");
+      expect(deps.calls.subject).toEqual(["ticket-spec/green-but-empty"]);
+    }));
+});
+
+describe("--compare", () => {
+  test("a pass that becomes a fail is reported as a regression and exits non-zero", () =>
+    withTmpDir("evals-compare-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const previous = path.join(dir, "previous.json");
+      writeFileSync(
+        previous,
+        JSON.stringify({
+          startedAt: "2026-08-01T00:00:00.000Z",
+          grader: { model: "claude-sonnet-4-6" },
+          cases: [
+            { id: "ticket-spec/hidden-decision", status: "pass" },
+            { id: "ticket-spec/green-but-empty", status: "pass" },
+          ],
+        }),
+      );
+      const deps = fakeDeps({
+        verdicts: {
+          "ticket-spec/hidden-decision": {
+            pass: false,
+            reason: "promoted the ticket",
+          },
+        },
+      });
+      const result = await run({
+        argv: ["--json", "--compare", previous, "--no-results"],
+        deps,
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_FAILED);
+      const report = JSON.parse(result.stdout);
+      expect(report.comparison.regressions).toEqual([
+        {
+          id: "ticket-spec/hidden-decision",
+          was: "pass",
+          now: "fail",
+          reason: "promoted the ticket",
+        },
+      ]);
+      expect(report.comparison.fixes).toEqual([]);
+    }));
+
+  test("a fail that becomes a pass is a fix, not a regression", () =>
+    withTmpDir("evals-compare-fix-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const previous = path.join(dir, "previous.json");
+      writeFileSync(
+        previous,
+        JSON.stringify({
+          startedAt: "2026-08-01T00:00:00.000Z",
+          grader: { model: "claude-sonnet-4-6" },
+          cases: [{ id: "ticket-spec/hidden-decision", status: "fail" }],
+        }),
+      );
+      const result = await run({
+        argv: ["--json", "--compare", previous, "--no-results"],
+        deps: fakeDeps(),
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_OK);
+      const report = JSON.parse(result.stdout);
+      expect(report.comparison.regressions).toEqual([]);
+      expect(report.comparison.fixes.map((entry) => entry.id)).toEqual([
+        "ticket-spec/hidden-decision",
+      ]);
+      expect(report.comparison.added).toEqual(["ticket-spec/green-but-empty"]);
+    }));
+
+  test("a missing or malformed comparison file is a usage error", () =>
+    withTmpDir("evals-compare-bad-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const bad = path.join(dir, "not-results.json");
+      writeFileSync(bad, JSON.stringify({ hello: "world" }));
+      const result = await run({
+        argv: ["--compare", bad],
+        deps: fakeDeps(),
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_USAGE);
+      expect(result.stderr).toContain("not an evals results file");
+    }));
+
+  test("comparing across grader models is flagged as not comparable", () => {
+    const comparison = compareRuns(
+      {
+        grader: { model: "old-judge" },
+        cases: [{ id: "a/b", status: "pass" }],
+      },
+      {
+        grader: { model: "new-judge" },
+        cases: [{ id: "a/b", status: "fail" }],
+      },
+    );
+    expect(comparison.graderChanged).toBe(true);
+    expect(comparison.regressions).toHaveLength(1);
+  });
+});
+
+describe("results records", () => {
+  test("a run records the models, the case set, and per-case pass/fail", () =>
+    withTmpDir("evals-results-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const resultsDir = path.join(dir, "results");
+      const result = await run({
+        argv: ["--json", "--results-dir", resultsDir],
+        deps: fakeDeps(),
+        date: () => new Date("2026-08-29T10:11:12.000Z"),
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_OK);
+      const report = JSON.parse(result.stdout);
+      expect(report.resultsFile).toBe(
+        path.join(resultsDir, "2026-08-29T10-11-12-000Z.json"),
+      );
+      const recorded = JSON.parse(await Bun.file(report.resultsFile).text());
+      expect(recorded.grader.model).toBe("claude-sonnet-4-6");
+      expect(recorded.subject.model).toBe("default");
+      expect(recorded.caseSet).toEqual([
+        "ticket-spec/green-but-empty",
+        "ticket-spec/hidden-decision",
+      ]);
+      expect(recorded.cases.map((entry) => entry.status)).toEqual([
+        "pass",
+        "pass",
+      ]);
+    }));
+});
+
+describe("the grader pin", () => {
+  test("a real run refuses to start when the grader is not pinned, and spends nothing", () =>
+    withTmpDir("evals-unpinned-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const deps = fakeDeps();
+      const result = await run({
+        argv: [],
+        deps,
+        policy: {
+          ...PINNED_POLICY,
+          grader: null,
+          problem: "config/policy.yaml has no `evals:` stanza",
+        },
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_USAGE);
+      expect(result.stderr).toContain("Add this stanza to config/policy.yaml");
+      expect(result.stderr).toContain("grader:");
+      expect(deps.calls.subject).toEqual([]);
+    }));
+
+  test("the stanza is read out of policy.yaml, limits and all", () => {
+    const policy = loadEvalPolicy({
+      root: "/nowhere",
+      file: "/nowhere/config/policy.yaml",
+      text: `budget:\n  per_day_usd: 2000.00\n\nevals:\n  subject:\n    model: default\n  grader:\n    model: claude-sonnet-4-6 # pinned deliberately\n  limits:\n    case_timeout_seconds: 120\n    total_budget_usd: 5\n\nlimits:\n  max_run_minutes: 90\n`,
+    });
+    expect(policy.problem).toBeNull();
+    expect(policy.grader).toEqual({ model: "claude-sonnet-4-6" });
+    expect(policy.subject).toEqual({ model: "default" });
+    expect(policy.limits.caseTimeoutSeconds).toBe(120);
+    expect(policy.limits.totalBudgetUsd).toBe(5);
+    expect(policy.limits.totalSeconds).toBe(3600); // untouched default
+  });
+
+  test('a grader left on the "default" sentinel is refused — the judge must be named', () => {
+    const policy = loadEvalPolicy({
+      root: "/nowhere",
+      file: "/nowhere/config/policy.yaml",
+      text: "evals:\n  grader:\n    model: default\n",
+    });
+    expect(policy.grader).toBeNull();
+    expect(policy.problem).toContain("must name a model");
+  });
+
+  test("an absent stanza is reported, never guessed at", () => {
+    const policy = loadEvalPolicy({
+      root: "/nowhere",
+      file: "/nowhere/config/policy.yaml",
+      text: "models:\n  claude:\n    strong: default\n",
+    });
+    expect(policy.grader).toBeNull();
+    expect(policy.problem).toContain("no `evals:` stanza");
+  });
+});
+
+describe("the model call the runner would make", () => {
+  test("argv pins the grader model and loads no MCP server", () => {
+    const argv = buildClaudeArgv({
+      prompt: "grade this",
+      model: "claude-sonnet-4-6",
+      budgetUsd: 2,
+      disallowedTools: ["Bash", "Read"],
+    });
+    expect(argv.slice(0, 4)).toEqual([
+      "-p",
+      "grade this",
+      "--output-format",
+      "json",
+    ]);
+    expect(argv).toContain("--model");
+    expect(argv[argv.indexOf("--model") + 1]).toBe("claude-sonnet-4-6");
+    expect(argv[argv.indexOf("--disallowedTools") + 1]).toBe("Bash,Read");
+    expect(argv[argv.indexOf("--max-budget-usd") + 1]).toBe("2");
+    expect(argv).toContain("--strict-mcp-config");
+  });
+
+  test('the "default" sentinel passes no --model, matching the adapters', () => {
+    expect(buildClaudeArgv({ prompt: "p", model: "default" })).not.toContain(
+      "--model",
+    );
+  });
+
+  test("the child never inherits ANTHROPIC_API_KEY (subscription auth)", () => {
+    const env = childEnvironment({
+      HOME: "/home/x",
+      PATH: "/bin",
+      ANTHROPIC_API_KEY: "sk-secret",
+    });
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.HOME).toBe("/home/x");
+  });
+
+  test("a verdict is read from the grader's line, and prose alone is no verdict", () => {
+    expect(parseVerdict("PASS: leaves the ticket in Triage")).toEqual({
+      pass: true,
+      reason: "leaves the ticket in Triage",
+    });
+    expect(parseVerdict("**FAIL** — promoted the ticket")).toEqual({
+      pass: false,
+      reason: "promoted the ticket",
+    });
+    expect(
+      parseVerdict("I think this response is quite good overall."),
+    ).toBeNull();
+  });
+
+  test("cost and text come off the CLI's json result, with a raw fallback", () => {
+    expect(parseCliJson('{"result":"PASS: ok","total_cost_usd":0.25}')).toEqual(
+      {
+        text: "PASS: ok",
+        costUsd: 0.25,
+      },
+    );
+    expect(parseCliJson("not json at all")).toEqual({
+      text: "not json at all",
+      costUsd: 0,
+    });
+  });
+});
+
+describe("argument parsing", () => {
+  test("the two invocations evals/README.md documents parse", () => {
+    expect(parseArgs([])).toMatchObject({
+      skill: null,
+      dryRun: false,
+      json: false,
+    });
+    expect(parseArgs(["--skill", "ticket-spec"])).toMatchObject({
+      skill: "ticket-spec",
+    });
+  });
+
+  test("an unknown flag or a missing value is a usage error, not a default", async () => {
+    expect(() => parseArgs(["--nope"])).toThrow(/unknown argument/);
+    expect(() => parseArgs(["--skill"])).toThrow(/needs a value/);
+    const result = await run({ argv: ["--nope"], deps: fakeDeps() });
+    expect(result.code).toBe(EXIT_USAGE);
+    expect(result.stderr).toContain("usage: node evals/run.mjs");
+  });
+});


### PR DESCRIPTION
Fixes #1073

`evals/README.md` specified this runner and ended with "Not yet implemented". It is implemented now, exactly at the documented invocations (`node evals/run.mjs`, `node evals/run.mjs --skill ticket-spec`).

**One case, two model calls.** The *subject* run puts the skill's own prompt (`shared/skills/<skill>/SKILL.md`, falling back to the emitted `plugins/core/…`) in front of `input.md`; the *grader* then judges that response against `expect.md` and answers one line — `PASS: <reason>` / `FAIL: <reason>`. Graded, not diffed. The subject may read the repo (a skill legitimately consults `docs/product-decisions.md`); the grader gets no tools at all.

**The grader is pinned by name, in policy.** Models come from an `evals:` stanza in `config/policy.yaml`, and a real run refuses to start without one — including refusing the `default` sentinel, because a judge that floats with the CLI default moves the pass bar silently. `--dry-run` deliberately still works unpinned, so discovery stays testable without spend.

`config/policy.yaml` / `config/policy.example.yaml` / `.gitignore` are outside this ticket's Owned Paths, so the stanza and the `evals/.results/` ignore entry are documented in `evals/README.md` and filed as #1090 rather than edited here. Until that lands, `--dry-run` reports the grader as `UNPINNED` and a real run exits 2 with the stanza to paste.

**Bounds, because a CI gate cannot hang.** Per-case timeout and budget, whole-run time and spend caps, TERM→KILL on the process group, `--strict-mcp-config` with no config, `ANTHROPIC_API_KEY` stripped (subscription auth) — the conventions from `event-runtime/lib/adapters/claude.mjs`, re-implemented rather than imported so `node evals/run.mjs` stands alone without the registry graph. A hung or crashed grader, or one that answers with prose instead of a verdict, fails *that case*; the run continues. Reaching a cap fails the cases it stopped, naming the cap.

**Drops are detectable, not just scores.** Every run records the models, the case set, and per-case pass/fail into `evals/.results/<timestamp>.json`; `--compare <file>` reports transitions against an earlier run, `pass -> fail` is a regression and exits non-zero, and a grader change is flagged as not-comparable.

Exit codes: 0 pass · 1 a case failed or regressed · 2 the runner could not run. Usable as a CI gate with no wrapper.

## Verification

```
bun test --timeout 20000 evals/run.test.mjs && node evals/run.mjs --dry-run
```

34 pass, 0 fail; dry-run lists `ticket-spec/hidden-product-decision -> shared/skills/ticket-spec/SKILL.md` and exits 0.

**No test makes a model call** — `main()` takes the two model functions as a parameter and every test passes fakes. Falsifiability was checked with five mutations (never report failure; unrunnable case passes; timeout read as a pass; malformed cases silently skipped; `default` accepted as the grader pin) — each was observed failing 1–6 tests before the file was restored. The real spawn path was separately smoke-checked once against the live CLI (flags accepted, JSON result and cost parsed) outside the test suite.