### PR TITLE
feat(evals): evals/run.mjs — the case runner that gates every prompt change (#1073)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -25,4 +25,52 @@ Freeze a case once it's written. A case edited to match new behavior is no longe
     node evals/run.mjs                 # all
     node evals/run.mjs --skill ticket-spec
 
-Not yet implemented — the runner is the next piece. Cases are written first deliberately: they're the specification of what the skill is for, and writing them has already surfaced disagreements about what "agent-ready" means.
+Each case runs the skill under test against its `input.md`, then a model grades
+the response against `expect.md` — **graded, not diffed**: `expect.md` states
+properties, and the wording of a correct response will vary. Every case yields
+`pass | fail` and the grader's one-line reason. Output is human-readable by
+default; `--json` emits the same for CI.
+
+The runner exits non-zero if any case fails, so it drops into CI as a gate with
+no wrapper:
+
+    node evals/run.mjs && echo "prompts safe to merge"
+
+Other flags:
+
+    --dry-run              list the cases that would run and their resolved
+                           skill source; makes no model calls (testable without spend)
+    --compare <file>       diff this run against a prior .results/<ts>.json and
+                           report any *regression* — a case that passed then and
+                           fails now — so a drop is detectable, not just a score
+    --timeout <ms>         per-case bound for the subject run and the grader
+    --total-timeout <ms>   total cap for the whole run
+    --json                 machine-readable output
+
+### The grader is pinned
+
+Grading uses a model call, and the grader model is pinned in
+`config/policy.yaml` so a grader upgrade is a deliberate, reviewable change —
+never a silent shift in the pass bar. Set it under an `evals:` block:
+
+    evals:
+      grader:
+        model: <your-strong-model>
+
+If that pin is absent the runner falls back to `models.claude.strong`, and
+finally to the CLI's own default. The resolved model and its source are printed
+at the top of every non-`--json` run, and recorded into the results file.
+
+### Determinism is honest
+
+Every run records the model, the case set, and per-case pass/fail into
+`evals/.results/<timestamp>.json`. `--compare` reads one of those back and
+flags regressions. A hung grader fails its own case rather than wedging the run.
+
+### Scope of the current runner
+
+The subject run is a lightweight harness: it applies the skill's `SKILL.md` to
+the case `input.md` with a bounded model call — no repository workspace, no MCP,
+no Linear. That is enough for the self-contained judgement cases this corpus is
+built from. Cases that require the skill to explore a live repository are a
+follow-up, not silently unsupported.

--- a/evals/lib/discover.mjs
+++ b/evals/lib/discover.mjs
@@ -1,0 +1,93 @@
+/**
+ * Case discovery for the eval runner (watt-mind/factory#1073).
+ *
+ * A case is `cases/<skill>/<case-name>/` with `input.md` (what the skill
+ * receives) and `expect.md` (the observable properties a correct response must
+ * and must not have), exactly as `evals/README.md` specifies. Discovery is
+ * pure filesystem work — no model calls — so `--dry-run` can list what would
+ * run without spend, and the discovery contract is unit-testable.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const CASES_DIRNAME = "cases";
+export const INPUT_FILE = "input.md";
+export const EXPECT_FILE = "expect.md";
+
+/** Resolve where a skill's source lives, so a dry run can show it (or flag it missing). */
+export function resolveSkillSource(skill, { factoryRoot }) {
+  const rel = path.join("shared", "skills", skill, "SKILL.md");
+  const abs = path.join(factoryRoot, rel);
+  return existsSync(abs) ? rel : null;
+}
+
+function isDir(p) {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listDirs(dir) {
+  if (!isDir(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => !name.startsWith("."))
+    .filter((name) => isDir(path.join(dir, name)))
+    .sort();
+}
+
+/**
+ * Discover eval cases under `<root>/cases`.
+ *
+ * @param {object} opts
+ * @param {string} opts.root - the evals directory (contains `cases/`)
+ * @param {string} [opts.factoryRoot] - repo root, for skill-source resolution
+ * @param {string} [opts.skill] - restrict to one skill's cases (`--skill`)
+ * @returns {Array<{skill,name,dir,inputPath,expectPath,skillSource,error}>}
+ *   Sorted by `skill` then `name`. A case missing `input.md`/`expect.md`
+ *   carries a non-null `error` string rather than being silently dropped —
+ *   a broken case must be visible, not invisible.
+ */
+export function discoverCases({
+  root,
+  factoryRoot = path.dirname(root),
+  skill,
+} = {}) {
+  const casesRoot = path.join(root, CASES_DIRNAME);
+  const skills = skill ? [skill] : listDirs(casesRoot);
+  const cases = [];
+  for (const skillName of skills) {
+    const skillDir = path.join(casesRoot, skillName);
+    const skillSource = resolveSkillSource(skillName, { factoryRoot });
+    for (const caseName of listDirs(skillDir)) {
+      const dir = path.join(skillDir, caseName);
+      const inputPath = path.join(dir, INPUT_FILE);
+      const expectPath = path.join(dir, EXPECT_FILE);
+      let error = null;
+      if (!existsSync(inputPath)) error = `missing ${INPUT_FILE}`;
+      else if (!existsSync(expectPath)) error = `missing ${EXPECT_FILE}`;
+      cases.push({
+        skill: skillName,
+        name: caseName,
+        dir,
+        inputPath,
+        expectPath,
+        skillSource,
+        error,
+      });
+    }
+  }
+  return cases;
+}
+
+/** Read a case's input/expect text. Throws if the case is malformed. */
+export function readCase(testCase) {
+  if (testCase.error) {
+    throw new Error(`${testCase.skill}/${testCase.name}: ${testCase.error}`);
+  }
+  return {
+    input: readFileSync(testCase.inputPath, "utf8"),
+    expect: readFileSync(testCase.expectPath, "utf8"),
+  };
+}

--- a/evals/lib/grade.mjs
+++ b/evals/lib/grade.mjs
@@ -1,0 +1,88 @@
+/**
+ * Grading for the eval runner (watt-mind/factory#1073).
+ *
+ * `expect.md` states observable properties, not exact wording, so grading is a
+ * model judgement, not a diff. The grader receives the case's `expect.md` and
+ * the skill's response and returns `pass | fail` plus a one-line reason. It is
+ * pinned to a named model (see `lib/policy.mjs`) so the pass bar only moves on
+ * a reviewable config change.
+ *
+ * The prompt/parse contract here is pure and unit-testable; the model call is
+ * injected, so tests grade against a fake and never spend.
+ */
+import { runClaude } from "./spawn.mjs";
+
+export const GRADER_INSTRUCTIONS = `You are a strict evaluator for an AI agent skill.
+
+You are given:
+  1. EXPECTATIONS — the observable properties a correct response MUST have and
+     MUST NOT have. Wording will differ from the response; grade on properties,
+     never on phrasing.
+  2. RESPONSE — what the skill actually produced.
+
+A response PASSES only if it satisfies every "Must" and violates no "Must not".
+When in doubt, FAIL: this is a regression gate, and a false pass hides a
+degraded skill.
+
+Reply with EXACTLY two lines and nothing else:
+VERDICT: PASS   (or)   VERDICT: FAIL
+REASON: <one short line naming the decisive property, met or violated>`;
+
+/** Build the grader prompt for one case. Pure. */
+export function buildGraderPrompt({ expect, response }) {
+  return [
+    GRADER_INSTRUCTIONS,
+    "",
+    "=== EXPECTATIONS ===",
+    String(expect).trim(),
+    "",
+    "=== RESPONSE ===",
+    String(response).trim(),
+    "",
+    "=== YOUR VERDICT ===",
+  ].join("\n");
+}
+
+/**
+ * Parse a grader reply into `{ pass, reason }`.
+ * Unparseable output is a FAIL — a grader that will not say cannot pass a gate.
+ */
+export function parseVerdict(text) {
+  const raw = String(text ?? "");
+  const verdictMatch = /verdict:\s*(pass|fail)/i.exec(raw);
+  const reasonMatch = /reason:\s*(.+)/i.exec(raw);
+  const reason = reasonMatch
+    ? reasonMatch[1].trim().split(/\r?\n/)[0].slice(0, 300)
+    : "";
+  if (!verdictMatch) {
+    return {
+      pass: false,
+      reason: reason || "grader returned no parseable verdict",
+    };
+  }
+  const pass = verdictMatch[1].toLowerCase() === "pass";
+  return {
+    pass,
+    reason: reason || (pass ? "meets expectations" : "fails expectations"),
+  };
+}
+
+/**
+ * Default grader: a bounded `claude -p` call, verdict parsed from its text.
+ * A timed-out or empty grader fails the case (never the run) — the runner's
+ * per-case timeout is the outer bound; this is the inner honest default.
+ */
+export function makeClaudeGrader({ runFn = runClaude } = {}) {
+  return async function grade({ expect, response, model, timeoutMs, cwd }) {
+    const { text, timedOut } = await runFn({
+      prompt: buildGraderPrompt({ expect, response }),
+      model,
+      timeoutMs,
+      cwd,
+    });
+    if (timedOut) {
+      return { pass: false, reason: "grader timed out" };
+    }
+    return parseVerdict(text);
+  };
+}

--- a/evals/lib/policy.mjs
+++ b/evals/lib/policy.mjs
@@ -1,0 +1,84 @@
+/**
+ * Grader-model resolution (watt-mind/factory#1073).
+ *
+ * The grader is pinned to a named model in `config/policy.yaml` so a grader
+ * upgrade is a deliberate, reviewable change — not a silent shift in the pass
+ * bar. This module reads that pin. It deliberately does NOT import
+ * `event-runtime/lib`: the acceptance invocation is `node evals/run.mjs`, and
+ * that path uses `Bun.YAML`, which is absent under plain node. A pin is a
+ * single scalar, so a narrow, dependency-free reader is honest here.
+ *
+ * Resolution order (first hit wins):
+ *   1. `evals.grader.model` — the eval-specific pin operators add to policy.yaml
+ *   2. `models.claude.strong` — the fleet's strong-tier claude model
+ *   3. DEFAULT_GRADER_MODEL — the CLI's own default ("default" sentinel)
+ *
+ * `config/policy.yaml` is operator-local and git-ignored; a clean checkout
+ * falls back to `config/policy.example.yaml` (same rule the registry uses).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/** The "ride the CLI's own default model" sentinel, matching the claude adapter. */
+export const DEFAULT_GRADER_MODEL = "default";
+
+/**
+ * Read one scalar at a known key path out of a simple 2-space-indented YAML
+ * document. Narrow by design: it handles the nested scalar the grader pin is,
+ * not arbitrary YAML. Quotes are stripped; inline comments after a value are
+ * not (policy.yaml keeps comments on their own lines).
+ */
+export function readYamlScalar(text, keyPath) {
+  const lines = String(text).split(/\r?\n/);
+  const stack = []; // { indent, key }
+  for (const raw of lines) {
+    if (/^\s*#/.test(raw) || raw.trim() === "") continue;
+    const m = /^(\s*)([A-Za-z0-9_.-]+):\s?(.*)$/.exec(raw);
+    if (!m) continue;
+    const indent = m[1].length;
+    const key = m[2];
+    const value = m[3].trim();
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const depth = stack.length;
+    if (depth < keyPath.length && key === keyPath[depth]) {
+      if (depth === keyPath.length - 1) {
+        if (value === "" || value === "|" || value === ">") return null;
+        return value.replace(/^["']|["']$/g, "");
+      }
+      stack.push({ indent, key });
+    } else {
+      stack.push({ indent, key });
+    }
+  }
+  return null;
+}
+
+/** Locate the operator-local policy.yaml, falling back to the tracked example. */
+export function resolvePolicyPath(factoryRoot) {
+  const local = path.join(factoryRoot, "config", "policy.yaml");
+  if (existsSync(local)) return local;
+  const example = path.join(factoryRoot, "config", "policy.example.yaml");
+  if (existsSync(example)) return example;
+  return null;
+}
+
+/**
+ * Resolve the grader model pin for a factory checkout.
+ * @returns {{ model: string, source: string }}
+ */
+export function resolveGraderModel({ factoryRoot } = {}) {
+  const file = resolvePolicyPath(factoryRoot);
+  if (!file) return { model: DEFAULT_GRADER_MODEL, source: "default" };
+  const text = readFileSync(file, "utf8");
+  const rel = path.relative(factoryRoot, file);
+
+  const pinned = readYamlScalar(text, ["evals", "grader", "model"]);
+  if (pinned) return { model: pinned, source: `${rel}:evals.grader.model` };
+
+  const strong = readYamlScalar(text, ["models", "claude", "strong"]);
+  if (strong) return { model: strong, source: `${rel}:models.claude.strong` };
+
+  return { model: DEFAULT_GRADER_MODEL, source: "default" };
+}

--- a/evals/lib/results.mjs
+++ b/evals/lib/results.mjs
@@ -1,0 +1,90 @@
+/**
+ * Run records and comparison for the eval runner (watt-mind/factory#1073).
+ *
+ * Determinism is honest, not assumed: every run records the model, the case
+ * set, and per-case pass/fail into `evals/.results/<timestamp>.json`, and
+ * `--compare <file>` diffs a run against a previous one. That makes a *drop*
+ * detectable — a case that passed and now fails — not just an absolute score,
+ * which is the number that quietly halves while nobody is looking.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const RESULTS_VERSION = 1;
+export const RESULTS_DIRNAME = ".results";
+
+const caseKey = (c) => `${c.skill}/${c.name}`;
+
+/** Assemble a run record from per-case results. Pure. */
+export function buildRunRecord({ graderModel, cases, timestamp }) {
+  const normalized = cases.map((c) => ({
+    skill: c.skill,
+    name: c.name,
+    pass: c.pass === true,
+    reason: c.reason ?? "",
+  }));
+  const passed = normalized.filter((c) => c.pass).length;
+  return {
+    version: RESULTS_VERSION,
+    timestamp: timestamp ?? new Date().toISOString(),
+    graderModel: graderModel ?? null,
+    summary: {
+      total: normalized.length,
+      passed,
+      failed: normalized.length - passed,
+    },
+    cases: normalized,
+  };
+}
+
+/** A timestamp safe for a filename (colons break some filesystems/tools). */
+export function resultsFilename(timestamp) {
+  return `${String(timestamp).replace(/[:.]/g, "-")}.json`;
+}
+
+/** Persist a run record under `<root>/.results/`. Returns the file path. */
+export function writeResults(root, record) {
+  const dir = path.join(root, RESULTS_DIRNAME);
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, resultsFilename(record.timestamp));
+  writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+  return file;
+}
+
+/** Load a previously written run record. */
+export function loadResults(file) {
+  if (!existsSync(file)) {
+    throw new Error(`compare file not found: ${file}`);
+  }
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+/**
+ * Diff a current run against a baseline.
+ *
+ * @returns {{ regressions, fixed, added, removed }} where a **regression** is a
+ *   case that passed in the baseline and fails now — the signal the whole
+ *   `--compare` feature exists to surface.
+ */
+export function compareRuns(baseline, current) {
+  const before = new Map((baseline.cases ?? []).map((c) => [caseKey(c), c]));
+  const after = new Map((current.cases ?? []).map((c) => [caseKey(c), c]));
+
+  const regressions = [];
+  const fixed = [];
+  const added = [];
+  for (const [key, cur] of after) {
+    const prev = before.get(key);
+    if (!prev) {
+      added.push(key);
+      continue;
+    }
+    if (prev.pass && !cur.pass) regressions.push(key);
+    else if (!prev.pass && cur.pass) fixed.push(key);
+  }
+  const removed = [];
+  for (const key of before.keys()) {
+    if (!after.has(key)) removed.push(key);
+  }
+  return { regressions, fixed, added, removed };
+}

--- a/evals/lib/skill.mjs
+++ b/evals/lib/skill.mjs
@@ -1,0 +1,66 @@
+/**
+ * Subject run for the eval runner (watt-mind/factory#1073).
+ *
+ * Before a response can be graded it has to exist: this runs the skill under
+ * test against a case's `input.md` and returns the response text. The default
+ * loads the skill's `SKILL.md` and applies it to the input via a bounded
+ * `claude -p` call. It is injected into the runner, so tests substitute a fake
+ * subject and never spend.
+ *
+ * This is intentionally a lightweight harness, not the full dispatch path: it
+ * has no repository workspace, no MCP, no Linear. That is enough to exercise a
+ * skill's judgement on a self-contained case (the shape #1074 writes), and it
+ * keeps the runner runnable as a CI gate. Cases needing a live repo are a
+ * deferral noted in evals/README.md, not a silent gap.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { runClaude } from "./spawn.mjs";
+
+/** Build the subject prompt: the skill's own instructions, applied to the case input. */
+export function buildSubjectPrompt({ skillText, input }) {
+  return [
+    "You are executing the following skill. Follow it exactly.",
+    "",
+    "=== SKILL ===",
+    String(skillText).trim(),
+    "",
+    "=== INPUT ===",
+    String(input).trim(),
+    "",
+    "=== TASK ===",
+    "Produce the response this skill would produce for the input above.",
+    "State the decision you reach and the reasoning behind it.",
+  ].join("\n");
+}
+
+/** Read a skill's SKILL.md text. Throws if the skill source is missing. */
+export function readSkillText({ skill, skillSource, factoryRoot }) {
+  const rel = skillSource ?? path.join("shared", "skills", skill, "SKILL.md");
+  const abs = path.join(factoryRoot, rel);
+  if (!existsSync(abs)) {
+    throw new Error(`skill source not found for "${skill}" (${rel})`);
+  }
+  return readFileSync(abs, "utf8");
+}
+
+/**
+ * Default subject runner: a bounded `claude -p` call executing the skill on the
+ * case input. Returns `{ response, timedOut }`.
+ */
+export function makeClaudeSubject({ factoryRoot, runFn = runClaude } = {}) {
+  return async function runSkill({ testCase, input, model, timeoutMs, cwd }) {
+    const skillText = readSkillText({
+      skill: testCase.skill,
+      skillSource: testCase.skillSource,
+      factoryRoot,
+    });
+    const { text, timedOut } = await runFn({
+      prompt: buildSubjectPrompt({ skillText, input }),
+      model,
+      timeoutMs,
+      cwd,
+    });
+    return { response: text, timedOut };
+  };
+}

--- a/evals/lib/spawn.mjs
+++ b/evals/lib/spawn.mjs
@@ -1,0 +1,117 @@
+/**
+ * Bounded `claude -p` spawn for the eval runner (watt-mind/factory#1073).
+ *
+ * The runner makes model calls (run a skill on a case, grade the response) and
+ * they must be bounded exactly the way real factory runs are. Rather than
+ * re-derive the discipline, this mirrors the one in
+ * `event-runtime/lib/adapters/claude.mjs`:
+ *   - subscription auth: ANTHROPIC_API_KEY is stripped so the CLI uses the
+ *     operator's Claude subscription (docs/architecture.md §2.9)
+ *   - TERM, then KILL after a grace period, against the whole process group
+ *     (the CLI spawns children) — a hung model never wedges the run
+ *   - `--model` is passed verbatim unless it is the "default" sentinel
+ *
+ * It stays deliberately smaller than the adapter: an eval call needs plain
+ * text out, no MCP, no workspace policy, no trace mapping. `--output-format
+ * text` is enough. The adapter owns real dispatch; this owns evaluation.
+ */
+import { spawn } from "node:child_process";
+
+export const DEFAULT_MODEL_SENTINEL = "default";
+export const KILL_GRACE_MS = 10_000;
+
+/** Terminate the CLI and every subprocess it started (mirrors the adapter). */
+export function killProcessGroup(child, signal, kill = process.kill) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/** Assemble a safe child environment: inherit the shell, drop the API key. */
+export function graderEnv(env = process.env) {
+  const child = { ...env };
+  delete child.ANTHROPIC_API_KEY;
+  delete child.CLAUDECODE;
+  delete child.CLAUDE_CODE_ENTRYPOINT;
+  return child;
+}
+
+export function buildArgv({ prompt, model }) {
+  const args = ["-p", prompt, "--output-format", "text"];
+  if (typeof model === "string" && model && model !== DEFAULT_MODEL_SENTINEL) {
+    args.push("--model", model);
+  }
+  return args;
+}
+
+/**
+ * Run one bounded `claude -p` call.
+ *
+ * @returns {Promise<{ text: string, exitCode: number|null, timedOut: boolean }>}
+ *   Never rejects on a non-zero exit or a timeout — the caller decides what a
+ *   given exit means for the case. Rejects only if the CLI cannot be spawned
+ *   at all (e.g. `claude` not on PATH), which is an environment fault.
+ */
+export function runClaude({
+  prompt,
+  model,
+  cwd = process.cwd(),
+  timeoutMs = 120_000,
+  killGraceMs = KILL_GRACE_MS,
+  env = process.env,
+  command = "claude",
+  spawnFn = spawn,
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(command, buildArgv({ prompt, model }), {
+      cwd,
+      env: graderEnv(env),
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    let timedOut = false;
+    let killTimer = null;
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        killGraceMs,
+      );
+      killTimer.unref?.();
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      reject(err);
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      resolve({
+        text: stdout.trim() || stderr.trim(),
+        exitCode,
+        timedOut,
+      });
+    });
+  });
+}

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+/**
+ * evals/run.mjs — the case runner that gates every prompt change
+ * (watt-mind/factory#1073).
+ *
+ * Prompt changes are the only part of this system with no regression test.
+ * This runs the frozen cases in `evals/cases/` against the skills under test
+ * and grades each response against its `expect.md`. A case that regresses
+ * fails the run, and the process exits non-zero — so the runner drops into CI
+ * as a gate with no wrapper.
+ *
+ * Usage (matches evals/README.md):
+ *   node evals/run.mjs                    run every case
+ *   node evals/run.mjs --skill ticket-spec  run one skill's cases
+ *   node evals/run.mjs --dry-run          list cases + skill source, no calls
+ *   node evals/run.mjs --json             machine-readable output for CI
+ *   node evals/run.mjs --compare <file>   diff this run against a prior one
+ *
+ * Bounds: --timeout <ms> per case (subject + grader each), --total-timeout
+ * <ms> for the whole run. A hung grader fails its case, never the run.
+ */
+import { parseArgs } from "node:util";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { discoverCases, readCase } from "./lib/discover.mjs";
+import { resolveGraderModel } from "./lib/policy.mjs";
+import { makeClaudeGrader } from "./lib/grade.mjs";
+import { makeClaudeSubject } from "./lib/skill.mjs";
+import {
+  buildRunRecord,
+  compareRuns,
+  loadResults,
+  writeResults,
+} from "./lib/results.mjs";
+import { DEFAULT_MODEL_SENTINEL } from "./lib/spawn.mjs";
+
+export const DEFAULT_PER_CASE_TIMEOUT_MS = 120_000;
+export const DEFAULT_TOTAL_TIMEOUT_MS = 30 * 60_000;
+
+const HELP = `evals/run.mjs — the case runner that gates every prompt change
+
+Usage:
+  node evals/run.mjs [options]
+
+Options:
+  --skill <name>       Run only this skill's cases
+  --dry-run            List the cases that would run and their skill source; no model calls
+  --json               Emit machine-readable JSON (for CI)
+  --compare <file>     Diff this run against a prior .results/<ts>.json; report regressions
+  --timeout <ms>       Per-case bound for the subject run and the grader (default ${DEFAULT_PER_CASE_TIMEOUT_MS})
+  --total-timeout <ms> Total cap for the whole run (default ${DEFAULT_TOTAL_TIMEOUT_MS})
+  --root <dir>         evals directory (default: the one containing this script)
+  -h, --help           Show this help
+
+Exit code is non-zero when any case fails, so this is usable as a CI gate.`;
+
+/** Race a promise against a deadline; on timeout resolve to onTimeout() rather than reject. */
+export function withDeadline(promise, ms, onTimeout) {
+  if (!ms || ms <= 0) return Promise.resolve(promise);
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(onTimeout());
+    }, ms);
+    timer.unref?.();
+    Promise.resolve(promise).then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(onTimeout());
+      },
+    );
+  });
+}
+
+/**
+ * Run cases and grade them. Model calls are injected (`runSkill`, `grade`) so
+ * tests exercise the whole contract — discovery, exit, filtering, timeout,
+ * compare — against fakes, with no real model call.
+ *
+ * @returns {Promise<{ record, cases, anyFail, totalCapped }>}
+ */
+export async function runEvals({
+  root,
+  factoryRoot = path.dirname(root),
+  skill,
+  runSkill,
+  grade,
+  graderModel,
+  subjectModel = DEFAULT_MODEL_SENTINEL,
+  perCaseTimeoutMs = DEFAULT_PER_CASE_TIMEOUT_MS,
+  totalTimeoutMs = DEFAULT_TOTAL_TIMEOUT_MS,
+  clock = () => Date.now(),
+  timestamp,
+  persist = true,
+  writeResultsFn = writeResults,
+} = {}) {
+  const discovered = discoverCases({ root, factoryRoot, skill });
+  const started = clock();
+  const elapsed = () => clock() - started;
+  const results = [];
+  let totalCapped = false;
+
+  for (const testCase of discovered) {
+    if (totalTimeoutMs && elapsed() > totalTimeoutMs) {
+      totalCapped = true;
+      results.push({
+        skill: testCase.skill,
+        name: testCase.name,
+        pass: false,
+        reason: "run exceeded total time cap",
+      });
+      continue;
+    }
+    if (testCase.error) {
+      results.push({
+        skill: testCase.skill,
+        name: testCase.name,
+        pass: false,
+        reason: testCase.error,
+      });
+      continue;
+    }
+
+    let input;
+    let expect;
+    try {
+      ({ input, expect } = readCase(testCase));
+    } catch (err) {
+      results.push({
+        skill: testCase.skill,
+        name: testCase.name,
+        pass: false,
+        reason: `unreadable case: ${err.message}`,
+      });
+      continue;
+    }
+
+    const subject = await withDeadline(
+      Promise.resolve().then(() =>
+        runSkill({
+          testCase,
+          input,
+          model: subjectModel,
+          timeoutMs: perCaseTimeoutMs,
+          cwd: factoryRoot,
+        }),
+      ),
+      perCaseTimeoutMs,
+      () => ({ timedOut: true }),
+    );
+    if (!subject || subject.timedOut) {
+      results.push({
+        skill: testCase.skill,
+        name: testCase.name,
+        pass: false,
+        reason: "skill run timed out",
+      });
+      continue;
+    }
+
+    const verdict = await withDeadline(
+      Promise.resolve().then(() =>
+        grade({
+          testCase,
+          expect,
+          response: subject.response,
+          model: graderModel,
+          timeoutMs: perCaseTimeoutMs,
+          cwd: factoryRoot,
+        }),
+      ),
+      perCaseTimeoutMs,
+      () => ({ pass: false, reason: "grader timed out" }),
+    );
+
+    results.push({
+      skill: testCase.skill,
+      name: testCase.name,
+      pass: verdict?.pass === true,
+      reason: verdict?.reason ?? "",
+    });
+  }
+
+  const record = buildRunRecord({ graderModel, cases: results, timestamp });
+  let resultsFile = null;
+  if (persist) resultsFile = writeResultsFn(root, record);
+
+  return {
+    record,
+    resultsFile,
+    cases: results,
+    anyFail: record.summary.failed > 0,
+    totalCapped,
+  };
+}
+
+function printHuman(out, { record, resultsFile, comparison }) {
+  for (const c of record.cases) {
+    out(`${c.pass ? "PASS" : "FAIL"}  ${c.skill}/${c.name} — ${c.reason}`);
+  }
+  const { total, passed, failed } = record.summary;
+  out("");
+  out(
+    `${passed}/${total} passed, ${failed} failed  (grader: ${record.graderModel})`,
+  );
+  if (resultsFile) out(`results: ${resultsFile}`);
+  if (comparison) {
+    if (comparison.regressions.length > 0) {
+      out(`REGRESSIONS vs baseline: ${comparison.regressions.join(", ")}`);
+    } else {
+      out("no regressions vs baseline");
+    }
+    if (comparison.fixed.length > 0) {
+      out(`fixed vs baseline: ${comparison.fixed.join(", ")}`);
+    }
+  }
+}
+
+export function parseCliArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      skill: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+      compare: { type: "string" },
+      timeout: { type: "string" },
+      "total-timeout": { type: "string" },
+      root: { type: "string" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: false,
+  });
+  return values;
+}
+
+export async function main(argv = process.argv.slice(2), io = {}, deps = {}) {
+  const out = io.out ?? ((line) => console.log(line));
+  const err = io.err ?? ((line) => console.error(line));
+  let values;
+  try {
+    values = parseCliArgs(argv);
+  } catch (e) {
+    err(e.message);
+    return 2;
+  }
+  if (values.help) {
+    out(HELP);
+    return 0;
+  }
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const root = values.root ? path.resolve(values.root) : here;
+  const factoryRoot = path.dirname(root);
+  const skill = values.skill;
+
+  if (values["dry-run"]) {
+    const cases = discoverCases({ root, factoryRoot, skill });
+    if (values.json) {
+      out(
+        JSON.stringify(
+          {
+            dryRun: true,
+            skill: skill ?? null,
+            cases: cases.map((c) => ({
+              skill: c.skill,
+              name: c.name,
+              skillSource: c.skillSource,
+              error: c.error,
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      out(`Would run ${cases.length} case(s):`);
+      for (const c of cases) {
+        const src = c.skillSource ?? "MISSING skill source";
+        const flag = c.error ? `  [${c.error}]` : "";
+        out(`  ${c.skill}/${c.name}  <- ${src}${flag}`);
+      }
+    }
+    return 0;
+  }
+
+  const { model: graderModel, source: graderSource } = resolveGraderModel({
+    factoryRoot,
+  });
+  const perCaseTimeoutMs = values.timeout
+    ? Number(values.timeout)
+    : DEFAULT_PER_CASE_TIMEOUT_MS;
+  const totalTimeoutMs = values["total-timeout"]
+    ? Number(values["total-timeout"])
+    : DEFAULT_TOTAL_TIMEOUT_MS;
+
+  if (!values.json) {
+    out(`grader model: ${graderModel} (${graderSource})`);
+  }
+
+  const runSkill = deps.runSkill ?? makeClaudeSubject({ factoryRoot });
+  const grade = deps.grade ?? makeClaudeGrader();
+
+  let result;
+  try {
+    result = await runEvals({
+      root,
+      factoryRoot,
+      skill,
+      runSkill,
+      grade,
+      graderModel,
+      perCaseTimeoutMs,
+      totalTimeoutMs,
+      persist: deps.persist ?? true,
+    });
+  } catch (e) {
+    err(`eval run failed: ${e.message}`);
+    return 2;
+  }
+
+  let comparison = null;
+  if (values.compare) {
+    try {
+      const baseline = loadResults(path.resolve(values.compare));
+      comparison = compareRuns(baseline, result.record);
+    } catch (e) {
+      err(`--compare failed: ${e.message}`);
+      return 2;
+    }
+  }
+
+  if (values.json) {
+    out(JSON.stringify({ ...result.record, comparison }, null, 2));
+  } else {
+    printHuman(out, {
+      record: result.record,
+      resultsFile: result.resultsFile,
+      comparison,
+    });
+  }
+
+  const regressed = comparison ? comparison.regressions.length > 0 : false;
+  return result.anyFail || regressed ? 1 : 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then(
+    (code) => process.exit(code),
+    (e) => {
+      console.error(e);
+      process.exit(2);
+    },
+  );
+}

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -1,0 +1,439 @@
+/**
+ * Tests for the eval case runner (watt-mind/factory#1073).
+ *
+ * Covers discovery, the pass/fail exit contract, `--skill` filtering, timeout
+ * handling, and `--compare` regression detection — all against a fake grader
+ * and a fake subject. No test makes a real model call.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { discoverCases, readCase } from "./lib/discover.mjs";
+import { parseVerdict, buildGraderPrompt } from "./lib/grade.mjs";
+import { readYamlScalar, resolveGraderModel } from "./lib/policy.mjs";
+import { buildRunRecord, compareRuns } from "./lib/results.mjs";
+import { main, runEvals, withDeadline } from "./run.mjs";
+
+/** Build a throwaway factory-shaped tree: <tmp>/evals + <tmp>/shared/skills. */
+function makeFixture() {
+  const factoryRoot = mkdtempSync(path.join(tmpdir(), "evals-fixture-"));
+  const root = path.join(factoryRoot, "evals");
+  const addCase = (skill, name, { input = "in", expect = "out" } = {}) => {
+    const dir = path.join(root, "cases", skill, name);
+    mkdirSync(dir, { recursive: true });
+    if (input !== null) writeFileSync(path.join(dir, "input.md"), input);
+    if (expect !== null) writeFileSync(path.join(dir, "expect.md"), expect);
+  };
+  const addSkill = (skill) => {
+    const dir = path.join(factoryRoot, "shared", "skills", skill);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "SKILL.md"), `# ${skill}\nDo the thing.`);
+  };
+  return {
+    factoryRoot,
+    root,
+    addCase,
+    addSkill,
+    cleanup: () => rmSync(factoryRoot, { recursive: true, force: true }),
+  };
+}
+
+/** A fake grader: PASS unless the expect text contains a word in `failOn`. */
+const fakeGrader =
+  (failOn = []) =>
+  async ({ expect: expectText }) => {
+    const fail = failOn.some((w) => expectText.includes(w));
+    return {
+      pass: !fail,
+      reason: fail ? `violates ${failOn}` : "meets expectations",
+    };
+  };
+
+const fakeSubject = async ({ input }) => ({ response: `did: ${input}` });
+
+describe("discoverCases", () => {
+  test("finds cases across skills, sorted, with skill source resolved", () => {
+    const fx = makeFixture();
+    try {
+      fx.addSkill("skill-a");
+      fx.addCase("skill-a", "beta");
+      fx.addCase("skill-a", "alpha");
+      fx.addCase("skill-b", "only");
+      const cases = discoverCases({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+      });
+      expect(cases.map((c) => `${c.skill}/${c.name}`)).toEqual([
+        "skill-a/alpha",
+        "skill-a/beta",
+        "skill-b/only",
+      ]);
+      const a = cases.find((c) => c.skill === "skill-a");
+      expect(a.skillSource).toBe(
+        path.join("shared", "skills", "skill-a", "SKILL.md"),
+      );
+      // skill-b has no SKILL.md — source is honestly null, not invented
+      expect(cases.find((c) => c.skill === "skill-b").skillSource).toBeNull();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("--skill filters to one skill's cases", () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "one");
+      fx.addCase("skill-b", "two");
+      const cases = discoverCases({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        skill: "skill-b",
+      });
+      expect(cases).toHaveLength(1);
+      expect(cases[0].skill).toBe("skill-b");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("a case missing expect.md is surfaced as an error, not dropped", () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "broken", { expect: null });
+      const [c] = discoverCases({ root: fx.root, factoryRoot: fx.factoryRoot });
+      expect(c.error).toBe("missing expect.md");
+      expect(() => readCase(c)).toThrow();
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+describe("grade parsing", () => {
+  test("parses PASS/FAIL and the one-line reason", () => {
+    expect(parseVerdict("VERDICT: PASS\nREASON: names a real command")).toEqual(
+      {
+        pass: true,
+        reason: "names a real command",
+      },
+    );
+    expect(
+      parseVerdict("verdict: fail\nreason: promoted a blocked ticket"),
+    ).toEqual({ pass: false, reason: "promoted a blocked ticket" });
+  });
+
+  test("unparseable grader output fails closed", () => {
+    const v = parseVerdict("I think it's probably fine?");
+    expect(v.pass).toBe(false);
+  });
+
+  test("grader prompt carries both expectations and response", () => {
+    const p = buildGraderPrompt({ expect: "MUST cite", response: "cited X" });
+    expect(p).toContain("MUST cite");
+    expect(p).toContain("cited X");
+  });
+});
+
+describe("runEvals — pass/fail exit contract", () => {
+  test("all pass -> anyFail false", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "one");
+      fx.addCase("skill-a", "two");
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: fakeGrader([]),
+        graderModel: "fake-model",
+        persist: false,
+      });
+      expect(res.anyFail).toBe(false);
+      expect(res.record.summary).toEqual({ total: 2, passed: 2, failed: 0 });
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("any fail -> anyFail true and the record records the reason", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "good", { expect: "fine" });
+      fx.addCase("skill-a", "bad", { expect: "TRAP here" });
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: fakeGrader(["TRAP"]),
+        graderModel: "fake-model",
+        persist: false,
+      });
+      expect(res.anyFail).toBe(true);
+      const bad = res.record.cases.find((c) => c.name === "bad");
+      expect(bad.pass).toBe(false);
+      expect(bad.reason).toContain("violates");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("a malformed case fails the run rather than being skipped", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "broken", { input: null });
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: fakeGrader([]),
+        graderModel: "fake-model",
+        persist: false,
+      });
+      expect(res.anyFail).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+describe("runEvals — timeout handling", () => {
+  test("a hung grader fails its case, not the run", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "hang");
+      fx.addCase("skill-a", "ok");
+      const hungGrader = ({ testCase }) =>
+        testCase.name === "hang"
+          ? new Promise(() => {}) // never resolves
+          : Promise.resolve({ pass: true, reason: "fine" });
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: hungGrader,
+        graderModel: "fake-model",
+        perCaseTimeoutMs: 30,
+        persist: false,
+      });
+      const hang = res.record.cases.find((c) => c.name === "hang");
+      const ok = res.record.cases.find((c) => c.name === "ok");
+      expect(hang.pass).toBe(false);
+      expect(hang.reason).toContain("timed out");
+      expect(ok.pass).toBe(true); // the run continued past the hang
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("total cap fails remaining cases instead of hanging the run", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "a");
+      fx.addCase("skill-a", "b");
+      // clock jumps past the cap after the first case
+      let ticks = 0;
+      const clock = () => {
+        ticks += 1;
+        return ticks === 1 ? 0 : 10_000;
+      };
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: fakeGrader([]),
+        graderModel: "fake-model",
+        totalTimeoutMs: 100,
+        clock,
+        persist: false,
+      });
+      expect(res.totalCapped).toBe(true);
+      expect(res.anyFail).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+describe("withDeadline", () => {
+  test("resolves to the timeout value when the promise never settles", async () => {
+    const v = await withDeadline(new Promise(() => {}), 10, () => "timed-out");
+    expect(v).toBe("timed-out");
+  });
+  test("passes the resolved value through when it settles first", async () => {
+    const v = await withDeadline(
+      Promise.resolve("done"),
+      1000,
+      () => "timed-out",
+    );
+    expect(v).toBe("done");
+  });
+});
+
+describe("compareRuns", () => {
+  test("detects a regression: passed before, fails now", () => {
+    const before = buildRunRecord({
+      graderModel: "m",
+      timestamp: "t0",
+      cases: [
+        { skill: "s", name: "keep", pass: true },
+        { skill: "s", name: "drop", pass: true },
+      ],
+    });
+    const after = buildRunRecord({
+      graderModel: "m",
+      timestamp: "t1",
+      cases: [
+        { skill: "s", name: "keep", pass: true },
+        { skill: "s", name: "drop", pass: false },
+      ],
+    });
+    const diff = compareRuns(before, after);
+    expect(diff.regressions).toEqual(["s/drop"]);
+    expect(diff.fixed).toEqual([]);
+  });
+
+  test("reports fixed, added and removed cases", () => {
+    const before = buildRunRecord({
+      graderModel: "m",
+      cases: [
+        { skill: "s", name: "flaky", pass: false },
+        { skill: "s", name: "gone", pass: true },
+      ],
+    });
+    const after = buildRunRecord({
+      graderModel: "m",
+      cases: [
+        { skill: "s", name: "flaky", pass: true },
+        { skill: "s", name: "fresh", pass: true },
+      ],
+    });
+    const diff = compareRuns(before, after);
+    expect(diff.fixed).toEqual(["s/flaky"]);
+    expect(diff.added).toEqual(["s/fresh"]);
+    expect(diff.removed).toEqual(["s/gone"]);
+  });
+});
+
+describe("policy — grader model pin", () => {
+  test("reads a nested scalar out of simple YAML", () => {
+    const yaml = ["evals:", "  grader:", '    model: "grader-x"', ""].join(
+      "\n",
+    );
+    expect(readYamlScalar(yaml, ["evals", "grader", "model"])).toBe("grader-x");
+  });
+
+  test("falls back to models.claude.strong then the default sentinel", () => {
+    const fx = makeFixture();
+    try {
+      const cfg = path.join(fx.factoryRoot, "config");
+      mkdirSync(cfg, { recursive: true });
+      writeFileSync(
+        path.join(cfg, "policy.yaml"),
+        ["models:", "  claude:", "    strong: strong-claude", ""].join("\n"),
+      );
+      const resolved = resolveGraderModel({ factoryRoot: fx.factoryRoot });
+      expect(resolved.model).toBe("strong-claude");
+      expect(resolved.source).toContain("models.claude.strong");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("no policy at all -> default sentinel, never a throw", () => {
+    const fx = makeFixture();
+    try {
+      const resolved = resolveGraderModel({ factoryRoot: fx.factoryRoot });
+      expect(resolved.model).toBe("default");
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+describe("main — CLI surface", () => {
+  test("--help returns 0 and prints usage", async () => {
+    const lines = [];
+    const code = await main(["--help"], { out: (l) => lines.push(l) });
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("case runner");
+  });
+
+  test("--dry-run lists cases with skill source and makes no model calls", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addSkill("skill-a");
+      fx.addCase("skill-a", "one");
+      const lines = [];
+      const code = await main(["--dry-run", "--root", fx.root], {
+        out: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      const text = lines.join("\n");
+      expect(text).toContain("skill-a/one");
+      expect(text).toContain(path.join("shared", "skills", "skill-a"));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("exit code is 1 when a case fails (via injected fake grader)", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "trap", { expect: "TRAP" });
+      const code = await main(
+        ["--root", fx.root, "--json"],
+        { out: () => {} },
+        {
+          runSkill: fakeSubject,
+          grade: fakeGrader(["TRAP"]),
+          persist: false,
+        },
+      );
+      expect(code).toBe(1);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("exit code is 0 when every case passes", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "fine");
+      const code = await main(
+        ["--root", fx.root, "--json"],
+        { out: () => {} },
+        { runSkill: fakeSubject, grade: fakeGrader([]), persist: false },
+      );
+      expect(code).toBe(0);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("results are written to .results/<ts>.json", async () => {
+    const fx = makeFixture();
+    try {
+      fx.addCase("skill-a", "fine");
+      const res = await runEvals({
+        root: fx.root,
+        factoryRoot: fx.factoryRoot,
+        runSkill: fakeSubject,
+        grade: fakeGrader([]),
+        graderModel: "fake-model",
+      });
+      expect(res.resultsFile).toBeTruthy();
+      const files = readdirSync(path.join(fx.root, ".results"));
+      expect(files).toHaveLength(1);
+      expect(files[0]).toMatch(/\.json$/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Implements `evals/run.mjs` — the case runner that gates every prompt change (closes #1073), plus its library under `evals/lib/**`, its self-test, and real usage docs in `evals/README.md`.

The runner discovers `cases/<skill>/<case>/` (each `input.md` + `expect.md`), runs the skill under test against the input, and **grades** the response against `expect.md` with a model call — graded, not diffed, since `expect.md` states properties and wording varies. Each case yields `pass | fail` plus the grader's one-line reason.

- `node evals/run.mjs` runs every case; `--skill <name>` runs one skill's cases (invocations already documented in the README).
- **Grader pinned** in `config/policy.yaml` (`evals.grader.model`, falling back to `models.claude.strong`, then the CLI default) so a grader upgrade is a deliberate, reviewable change. The resolved model + source is printed and recorded.
- **Exit non-zero on any failure** — usable as a CI gate with no wrapper.
- **Bounded**: per-case `--timeout`, whole-run `--total-timeout`; a hung grader fails its own case, not the run (TERM→KILL, `ANTHROPIC_API_KEY` stripped — same discipline as the claude adapter).
- **Determinism is honest**: runs recorded to `evals/.results/<ts>.json`; `--compare <file>` diffs against a prior run and flags *regressions* (passed then, fails now).
- `--dry-run` lists cases + resolved skill source, making no model calls; `--json` for CI.

## Why

`docs/architecture.md` §2.7 names the missing eval coverage as the reason every scheduled loop is `enabled: false`. Prompt changes were the only part of the system with no regression test. This is the runner `evals/README.md` said was "the next piece"; #1074 writes the case corpus.

## Acceptance

- [x] `node evals/run.mjs` / `--skill <name>` per the README
- [x] Case = `cases/<skill>/<case>/` with `input.md` + `expect.md`
- [x] Graded via a model call; grader pinned in `config/policy.yaml`
- [x] Per-case `pass|fail` + one-line reason; human + `--json`
- [x] Non-zero exit on any failure
- [x] Bounded: per-case timeout, total cap; hung grader fails the case
- [x] Runs recorded to `.results/`; `--compare` detects a drop
- [x] `--dry-run` lists cases + skill source, no model calls
- [x] Tests cover discovery, exit contract, `--skill`, timeout, `--compare`, all against a fake grader — no real model call
- [x] README "Not yet implemented" paragraph replaced with usage

**Verification:** `bun test --timeout 20000 evals/run.test.mjs && node evals/run.mjs --dry-run` (23 tests pass; dry-run exits 0)

### Deferral
The subject run is a lightweight harness (skill `SKILL.md` applied to `input.md` via a bounded model call — no repo workspace/MCP/Linear), enough for self-contained judgement cases. Cases needing a live-repo exploration are a documented follow-up.

## Owned Paths
- `evals/run.mjs`
- `evals/run.test.mjs`
- `evals/README.md`
- `evals/lib/**`
