### PR TITLE
feat(repos): implement WM-316 toolchain preflight

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -23,6 +23,27 @@ repos:
     worktree_root: ~/Develop/.worktrees/factory
     max_in_flight: 20
     verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
+    # Executables this repo's worktree script and verify command need, with the
+    # semver range each must satisfy (WM-316, docs/event-runtime-repos.md §5).
+    # Preflight resolves each one on the node and compares versions BEFORE a
+    # ticket is claimed, so "this box has node 18, not 22" surfaces as a typed
+    # refusal instead of a confusing agent error halfway through a run.
+    #
+    # It only validates: nothing here installs, upgrades, or switches a version
+    # manager, and each executable is spawned exactly once as `<exe> --version`.
+    # Omit the block entirely and the repo behaves as it always has — no
+    # preflight, no gating.
+    #
+    # The map form below and the explicit list form are equivalent:
+    #   toolchain:
+    #     - executable: bun
+    #       constraint: ">=1.3 <2"
+    #
+    # Constraints are validated at load: a range that is not semver (`latest`,
+    # a typo) is a config error rather than a gate that silently passes.
+    toolchain:
+      bun: ">=1.3 <2"
+      git: ">=2.40"
     owned_paths_policy:
       direct:
         - source: shared/**

--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -41,9 +41,15 @@ repos:
     #
     # Constraints are validated at load: a range that is not semver (`latest`,
     # a typo) is a config error rather than a gate that silently passes.
+    #
+    # Keep an example's floors genuinely low. This file is a LIVE fallback when
+    # config/repos.yaml is absent, so a tight floor here would make the factory
+    # repo refuse itself on a fresh `factory init`: `git >=2.40` rejects Debian
+    # 12 (2.39.5), Ubuntu 22.04 (2.34), and older Xcode git, for no benefit.
+    # Raise floors in your own config/repos.yaml, which describes one host.
     toolchain:
       bun: ">=1.3 <2"
-      git: ">=2.40"
+      git: ">=2.30"
     owned_paths_policy:
       direct:
         - source: shared/**

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -1,7 +1,8 @@
 # Event runtime: node-local repository provisioning
 
-Status: **design accepted; implementation split into WM-314..WM-318**. Tracking:
-WM-311. Companion to [event-runtime.md](event-runtime.md) §7,
+Status: **design accepted; implementation split into WM-314..WM-318**, of which
+the toolchain half of WM-316 has landed (§5, §6.2–6.3, §9). Tracking: WM-311.
+Companion to [event-runtime.md](event-runtime.md) §7,
 [event-runtime-workers.md](event-runtime-workers.md) §§3–5a, and
 [event-runtime-dispatch.md](event-runtime-dispatch.md).
 
@@ -319,6 +320,9 @@ a failed dispatch run.
 
 ## 5. Toolchain contract
 
+Status: **implemented** in `event-runtime/lib/repos.mjs` (WM-316 / gh-1076), for
+everything below except `repo_ready_check`, which is still design only.
+
 A full checkout is not useful if it cannot run the repo's worktree script or
 verification command. Each dispatchable repo declares executable version
 constraints:
@@ -333,6 +337,26 @@ repos:
     repo_ready_check: bin/repo-ready-check.sh
 ```
 
+The map form above and an explicit list are accepted and normalize to the same
+canonical `[{executable, constraint}]`:
+
+```yaml
+toolchain:
+  - executable: bun
+    constraint: ">=1.3 <2"
+```
+
+Both are validated at config load, and both are strict on purpose:
+
+- an executable must be a **bare command name** (`bun`, not `/usr/bin/bun` and
+  not `sh -c '…'`). It is spawned argv-style with no shell, so a path or a
+  shell fragment is a configuration error rather than something to sanitize at
+  spawn time; and
+- a constraint must parse as a semver range. This is not decoration:
+  `Bun.semver.satisfies("1.2.3", "not a range")` returns **true**, so an
+  unvalidated typo would produce a gate that silently admits every version.
+  `isToolchainConstraint` rejects it at load instead.
+
 The contract records what the repo requires; it does not select a version
 manager or install system packages. `repo doctor` resolves each executable in
 the same non-interactive environment a worker uses, captures its normalized
@@ -340,6 +364,24 @@ version, and checks the constraint. A mismatch is
 `repo_toolchain_mismatch` with node, executable, constraint, observed version,
 and recovery guidance. It happens before claim, workspace creation, dependency
 installation, or model spawn.
+
+`preflightToolchain(repo, {node, which, spawn})` is that check. The only
+subprocess it starts, per declared executable, is `<executable> --version`;
+PATH resolution and the probe are injected so the non-mutation property is
+asserted on the argv the real code builds. A resolution failure is
+`repo_toolchain_missing`; a version that is out of range, unparseable, or
+unobtainable (non-zero exit) is `repo_toolchain_mismatch`, which carries
+`observed` (normalized) and `observedRaw` (the tool's own first line) so an
+operator never has to go to the node to learn what is installed.
+
+Version output is normalized before comparison, because tools disagree about
+format: `v22.1.0`, `git version 2.39.5 (Apple Git-154)`, `Python 3.12.1`, and a
+bare `1.2` all reduce to a comparable `x.y.z`. Nothing version-shaped reduces
+to `null`, which fails closed rather than guessing.
+
+**A repo that declares no `toolchain:` block is unaffected.** `toolchain` reads
+as `null`, readiness short-circuits to ready, and no executable is resolved or
+probed. That is what keeps this additive for every repo already in production.
 
 The generic checks cannot know whether a repo needs a local Postgres role,
 Docker daemon, mobile SDK, signing setup, or another repo-specific service.
@@ -387,7 +429,57 @@ those conditions do not authorize repair.
 
 ### 6.2 Attestation and freshness
 
-The attestation is node-local durable state keyed by repo and includes:
+The **toolchain** attestation is implemented (WM-316 / gh-1076) as the value
+`preflightToolchain` returns:
+
+```json
+{
+  "repo": "factory",
+  "node": "runner",
+  "implementationVersion": 1,
+  "toolchainHash": "sha256:…",
+  "declared": true,
+  "verifiedAt": "2026-08-29T12:00:00.000Z",
+  "ok": true,
+  "tools": [
+    {
+      "executable": "bun",
+      "constraint": ">=1.3 <2",
+      "resolved": "/opt/bin/bun",
+      "observed": "1.3.14",
+      "observedRaw": "1.3.14",
+      "satisfied": true
+    }
+  ],
+  "reasons": []
+}
+```
+
+`toolchainAttestationCurrent` invalidates it on a changed config hash, a
+different node or repo, a bumped implementation version, an unparseable
+timestamp, or age beyond `TOOLCHAIN_ATTESTATION_MAX_AGE_MS` (one hour).
+`repoReadiness` then returns `ready` only for a **current and passing**
+attestation — a stale one is `repo_attestation_stale` with the specific detail
+(`absent`, `expired`, `config_changed`, `node_changed`,
+`implementation_changed`, `unverifiable_timestamp`), never a silent pass on a
+green-but-old result. Durable persistence of the attestation and its
+advertisement in worker registration remain WM-317; today it is computed and
+consumed in-process.
+
+`repoDispatchPreflight(repo, {node, attestation})` is the pre-claim gate: it
+reuses a current attestation, runs a fresh non-mutating preflight otherwise,
+and returns `{ready, reasons, refusal, attestation}` where `refusal` is one
+operator-readable line naming every failing constraint —
+
+```text
+repo factory toolchain preflight failed on mac-mini: node >=22 <25 (observed 18.19.1)
+```
+
+Calling it from `orchestrator/tick.mjs` before the claim is the remaining step
+and is tracked separately; the gate itself is implemented and tested.
+
+The full attestation, once durable, is node-local state keyed by repo and
+includes:
 
 - node and repo names;
 - resolved path, realpath, and managed/unmanaged ownership;
@@ -415,8 +507,12 @@ failures. At minimum the implementation distinguishes:
 - `repo_path_unconfigured`, `repo_path_escape`, `repo_path_conflict`;
 - `repo_auth_unavailable`, `repo_auth_denied`;
 - `repo_clone_failed`, `repo_origin_mismatch`, `repo_base_unavailable`;
-- `repo_toolchain_missing`, `repo_toolchain_mismatch`;
-- `repo_ready_check_failed`, `repo_attestation_stale`; and
+- `repo_toolchain_missing`, `repo_toolchain_mismatch` — **implemented**,
+  exported from `event-runtime/lib/repos.mjs`. `repo_toolchain_mismatch`
+  carries `node`, `repo`, `executable`, `constraint`, `observed`,
+  `observedRaw`, a `detail` discriminator, and one `action`;
+- `repo_ready_check_failed`, `repo_attestation_stale` — the latter
+  **implemented** for toolchain attestations; and
 - `repo_not_ready` at the final workspace gate.
 
 Every result names node, repo, failed check, and one operator action. No result
@@ -565,6 +661,15 @@ second path resolver, preflight, or inventory.
 3. **WM-316 — toolchain and readiness preflight.** Add `toolchain`, the
    repo-owned readiness check contract, typed doctor output, and the first
    factory-repo fixture. Depends on WM-314/WM-315.
+   **Partly landed (gh-1076):** the `toolchain:` block, its validation, the
+   non-mutating preflight, the typed reason codes, the toolchain attestation,
+   and the pre-claim readiness gate are implemented in
+   `event-runtime/lib/repos.mjs`. Still open: `repo_ready_check`, calling the
+   gate from `orchestrator/tick.mjs`, and reporting per-repo toolchain status
+   from `factory doctor`. WM-314/WM-315 are still unimplemented, so the
+   preflight currently runs against the local node's PATH rather than a
+   resolved remote node — that is why `node` is a plain label on every reason
+   and attestation rather than something this code resolves itself.
 4. **WM-317 — readiness advertisement and claim filtering.** Persist bounded
    attestations, register structured ready repos, gate tier-2 claim/workspace
    creation, and expose unsatisfied readiness. Depends on WM-314..WM-316 and

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -355,7 +355,12 @@ Both are validated at config load, and both are strict on purpose:
 - a constraint must parse as a semver range. This is not decoration:
   `Bun.semver.satisfies("1.2.3", "not a range")` returns **true**, so an
   unvalidated typo would produce a gate that silently admits every version.
-  `isToolchainConstraint` rejects it at load instead.
+  `isToolchainConstraint` rejects it at load instead. Whitespace after an
+  operator (`>= 1.2.3`) is valid node-semver and is accepted — a false reject
+  throws inside `loadRepos` and takes down every command that reads the
+  registry, so the validator is strict about garbage and lenient about
+  spelling. Known residue: some wildcard forms (`*.2.3`, `<*`) still validate
+  while constraining nothing (#1115).
 
 The contract records what the repo requires; it does not select a version
 manager or install system packages. `repo doctor` resolves each executable in
@@ -368,16 +373,29 @@ installation, or model spawn.
 `preflightToolchain(repo, {node, which, spawn})` is that check. The only
 subprocess it starts, per declared executable, is `<executable> --version`;
 PATH resolution and the probe are injected so the non-mutation property is
-asserted on the argv the real code builds. A resolution failure is
+asserted on the argv the real code builds. (Resolution and the probe currently
+perform two independent PATH lookups, so the attestation's `resolved` path and
+the binary that answered can in principle differ — #1116.) A resolution failure is
 `repo_toolchain_missing`; a version that is out of range, unparseable, or
 unobtainable (non-zero exit) is `repo_toolchain_mismatch`, which carries
 `observed` (normalized) and `observedRaw` (the tool's own first line) so an
 operator never has to go to the node to learn what is installed.
 
 Version output is normalized before comparison, because tools disagree about
-format: `v22.1.0`, `git version 2.39.5 (Apple Git-154)`, `Python 3.12.1`, and a
-bare `1.2` all reduce to a comparable `x.y.z`. Nothing version-shaped reduces
-to `null`, which fails closed rather than guessing.
+format: `v22.1.0`, `git version 2.39.5 (Apple Git-154)`, `Python 3.12.1`,
+`go version go1.22.0 darwin/arm64`, and a bare `1.2` all reduce to a comparable
+`x.y.z`.
+
+The normalizer requires a **dotted** version token, and that requirement is the
+gate's second fail-open guard rather than a formatting nicety. Accepting a bare
+integer anywhere in the line turns ordinary error output into a version:
+`"Error 404: not found"` reduces to `404.0.0`, and
+`satisfies("404.0.0", ">=1.3")` is `true` — a tool that exits 0 while printing
+something that is not a version would silently pass a loose constraint. So a
+lone integer counts only when it is the _entire_ line, and a token that is part
+of a longer dotted number (an IPv4 address, a four-part build) matches nothing
+rather than yielding a plausible prefix. Anything else is `null`, which fails
+closed: the constraint cannot be proven, so the repo is not ready.
 
 **A repo that declares no `toolchain:` block is unaffected.** `toolchain` reads
 as `null`, readiness short-circuits to ready, and no executable is resolved or
@@ -460,9 +478,12 @@ different node or repo, a bumped implementation version, an unparseable
 timestamp, or age beyond `TOOLCHAIN_ATTESTATION_MAX_AGE_MS` (one hour).
 `repoReadiness` then returns `ready` only for a **current and passing**
 attestation — a stale one is `repo_attestation_stale` with the specific detail
-(`absent`, `expired`, `config_changed`, `node_changed`,
+(`absent`, `expired`, `config_changed`, `node_changed`, `repo_changed`,
 `implementation_changed`, `unverifiable_timestamp`), never a silent pass on a
-green-but-old result. Durable persistence of the attestation and its
+green-but-old result. A malformed attestation — `ok: false` with no `reasons` —
+refuses with a generic line rather than throwing: once this sits on the
+pre-claim path a throw would stall dispatch where a refusal only skips one
+repo. Durable persistence of the attestation and its
 advertisement in worker registration remain WM-317; today it is computed and
 consumed in-process.
 

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -12,6 +12,7 @@
  * `deploy_branch`) are what an operator needs to tell a dispatch target from a
  * report-only one, and where its worktrees live (OPS-299).
  */
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
@@ -129,6 +130,453 @@ function normalizeOwnedPathsPolicy(raw = {}, repoName, file) {
   return { direct, pinManifests };
 }
 
+// ---------------------------------------------------------------- toolchain ---
+// WM-316 (docs/event-runtime-repos.md §5). A repo declares the executables its
+// worktree script and verify command need, and the version range each must
+// satisfy. Preflight *validates* — it never installs, upgrades, or otherwise
+// mutates host tooling (§10, "Toolchain preflight validates; it does not
+// install or mutate host tooling"). The point is to move "node 18 cannot run
+// this repo" from mid-run, after a claim burned a slot, to before the claim.
+
+/** Typed readiness outcomes from docs/event-runtime-repos.md §6.3. */
+export const REPO_TOOLCHAIN_MISSING = "repo_toolchain_missing";
+export const REPO_TOOLCHAIN_MISMATCH = "repo_toolchain_mismatch";
+export const REPO_ATTESTATION_STALE = "repo_attestation_stale";
+
+/**
+ * How long a toolchain attestation stays current. Deliberately short: the
+ * attestation is a claim about another process's disk, and a version manager
+ * can move `node` under us between two runs. Freshness is defence in depth,
+ * not the only gate — the config hash invalidates it too.
+ */
+export const TOOLCHAIN_ATTESTATION_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** Bumped when the meaning of an attestation changes; old ones then read stale. */
+export const TOOLCHAIN_PREFLIGHT_VERSION = 1;
+
+/** A probe is one `<exe> --version` and nothing else. */
+export const TOOLCHAIN_VERSION_ARG = "--version";
+const TOOLCHAIN_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * A bare command name, resolved on PATH. Not a path, not a shell fragment:
+ * the executable is spawned argv-style with no shell, and anything carrying a
+ * separator, a space, or a metacharacter is a configuration error rather than
+ * something to sanitize at spawn time.
+ */
+const TOOLCHAIN_EXECUTABLE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+
+/**
+ * One comparator of a semver range: an optional operator followed by a
+ * partial version (`>=22`, `^1.2.3`, `1.x`, `*`).
+ */
+const SEMVER_COMPARATOR =
+  /^(?:[<>]=?|=|\^|~)?v?(?:\d+|[xX*])(?:\.(?:\d+|[xX*]))?(?:\.(?:\d+|[xX*]))?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Whether a string is a semver range this implementation will evaluate.
+ *
+ * This exists because `Bun.semver.satisfies` is fail-OPEN on a malformed
+ * range: `satisfies("1.2.3", "not a range")` returns true. A gate whose
+ * unparseable constraint silently passes everything is worse than no gate, so
+ * ranges are validated at config load and a bad one is a load error.
+ */
+export function isToolchainConstraint(constraint) {
+  if (typeof constraint !== "string") return false;
+  const trimmed = constraint.trim();
+  if (!trimmed) return false;
+  for (const clause of trimmed.split("||")) {
+    const tokens = clause.trim().split(/\s+/).filter(Boolean);
+    if (!tokens.length) return false;
+    // `A - B` hyphen range: exactly two comparators around a lone hyphen.
+    if (tokens.includes("-")) {
+      if (tokens.length !== 3 || tokens[1] !== "-") return false;
+      if (!SEMVER_COMPARATOR.test(tokens[0])) return false;
+      if (!SEMVER_COMPARATOR.test(tokens[2])) return false;
+      continue;
+    }
+    if (!tokens.every((token) => SEMVER_COMPARATOR.test(token))) return false;
+  }
+  return true;
+}
+
+/**
+ * Parse `toolchain:` into a canonical `[{executable, constraint}]` list.
+ *
+ * Two spellings are accepted because the design doc writes the map form
+ * (`bun: ">=1.3 <2"`) and it reads well for the common case, while the list
+ * form is explicit and survives a future per-entry field. They normalize to
+ * the same thing; the list is what everything downstream sees.
+ *
+ * Absent/null returns null — "not declared" — which is what keeps this change
+ * additive for every repo that has no block.
+ */
+function normalizeToolchain(raw, repoName, file) {
+  if (raw === undefined || raw === null) return null;
+
+  /** @type {Array<[unknown, unknown]>} */
+  let pairs;
+  if (Array.isArray(raw)) {
+    pairs = raw.map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        throw new RepoError(
+          `${file}: repo ${repoName} toolchain entries must be objects with executable and constraint`,
+        );
+      }
+      const unknown = Object.keys(item).filter(
+        (key) => !["executable", "constraint"].includes(key),
+      );
+      if (unknown.length) {
+        throw new RepoError(
+          `${file}: repo ${repoName} toolchain entry has unknown keys (${unknown.join(", ")})`,
+        );
+      }
+      return [item.executable, item.constraint];
+    });
+  } else if (typeof raw === "object") {
+    pairs = Object.entries(raw);
+  } else {
+    throw new RepoError(
+      `${file}: repo ${repoName} toolchain must be a map of executable to constraint, or a list of {executable, constraint}`,
+    );
+  }
+
+  const seen = new Set();
+  const toolchain = [];
+  for (const [rawExecutable, rawConstraint] of pairs) {
+    const executable =
+      typeof rawExecutable === "string" ? rawExecutable.trim() : "";
+    if (!TOOLCHAIN_EXECUTABLE.test(executable)) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain executable must be a bare command name, got ${JSON.stringify(rawExecutable)}`,
+      );
+    }
+    if (seen.has(executable)) {
+      throw new RepoError(
+        `${file}: repo ${repoName} declares toolchain executable ${JSON.stringify(executable)} twice`,
+      );
+    }
+    seen.add(executable);
+    if (!isToolchainConstraint(rawConstraint)) {
+      throw new RepoError(
+        `${file}: repo ${repoName} toolchain constraint for ${JSON.stringify(executable)} must be a semver range, got ${JSON.stringify(rawConstraint)}`,
+      );
+    }
+    toolchain.push({ executable, constraint: rawConstraint.trim() });
+  }
+  return toolchain;
+}
+
+/**
+ * Extract a comparable version from whatever a tool prints. `node --version`
+ * says `v22.1.0`, `git --version` says `git version 2.39.5 (Apple Git-154)`,
+ * `bun --version` says `1.2.23`. Only the first non-empty line is considered,
+ * and a partial version is widened to x.y.z so semver can compare it.
+ *
+ * Returns null when nothing version-shaped is there — which fails closed
+ * rather than guessing.
+ */
+export function normalizeToolVersion(raw) {
+  if (typeof raw !== "string") return null;
+  const line = raw.split("\n").find((candidate) => candidate.trim());
+  if (!line) return null;
+  // Anchored at a token boundary and tolerant of the `v` prefix, so `v22.1.0`
+  // reads as 22.1.0 while `Git-154` inside `git version 2.39.5 (Apple
+  // Git-154)` never wins over the real version earlier in the line.
+  const match = line.match(
+    /(?:^|[^\w.])v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?/,
+  );
+  if (!match) return null;
+  const [, major, minor = "0", patch = "0", prerelease] = match;
+  const base = `${Number(major)}.${Number(minor)}.${Number(patch)}`;
+  return prerelease ? `${base}-${prerelease}` : base;
+}
+
+/** Stable fingerprint of a repo's declared toolchain; a change invalidates attestations. */
+export function toolchainHash(toolchain) {
+  const canonical = JSON.stringify(
+    (toolchain ?? []).map(({ executable, constraint }) => [
+      executable,
+      constraint,
+    ]),
+  );
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}
+
+function satisfiesConstraint(version, constraint) {
+  if (!version) return false;
+  try {
+    return Bun.semver.satisfies(version, constraint) === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Default PATH resolution. Injectable so tests never depend on the host. */
+async function defaultWhich(executable) {
+  return Bun.which(executable) ?? null;
+}
+
+/**
+ * Default probe: run the resolved executable with exactly one argument,
+ * `--version`, with no shell and no inherited stdin. This is the only
+ * subprocess toolchain preflight ever starts.
+ */
+async function defaultSpawn(argv) {
+  const proc = Bun.spawn(argv, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: TOOLCHAIN_PROBE_TIMEOUT_MS,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { exitCode, stdout, stderr };
+}
+
+/**
+ * Verify one node's tooling against a repo's declared constraints and return
+ * an attestation (docs/event-runtime-repos.md §6.2).
+ *
+ * Non-mutating by construction: the only command built here is
+ * `[executable, "--version"]`. There is no install, upgrade, or version-manager
+ * path, and adding one would be reopening a §10 decision.
+ *
+ * A repo with nothing declared is attested `ok` without probing anything —
+ * that is what makes this additive for repos that have no `toolchain:` block.
+ */
+export async function preflightToolchain(
+  repo,
+  {
+    node = "local",
+    now = () => new Date(),
+    which = defaultWhich,
+    spawn = defaultSpawn,
+  } = {},
+) {
+  const toolchain = repo?.toolchain ?? null;
+  const tools = [];
+  const reasons = [];
+
+  for (const { executable, constraint } of toolchain ?? []) {
+    const resolved = await which(executable);
+    if (!resolved) {
+      tools.push({
+        executable,
+        constraint,
+        resolved: null,
+        observed: null,
+        observedRaw: null,
+        satisfied: false,
+      });
+      reasons.push({
+        reason: REPO_TOOLCHAIN_MISSING,
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        observed: null,
+        action: `install ${executable} ${constraint} on ${node}, or drop it from repo ${repo.name}'s toolchain in config/repos.yaml`,
+      });
+      continue;
+    }
+
+    const { exitCode, stdout, stderr } = await spawn([
+      executable,
+      TOOLCHAIN_VERSION_ARG,
+    ]);
+    const output = stdout?.trim() ? stdout : (stderr ?? "");
+    const observedRaw =
+      output
+        .split("\n")
+        .find((l) => l.trim())
+        ?.trim() ?? null;
+    const observed = exitCode === 0 ? normalizeToolVersion(output) : null;
+    const satisfied = satisfiesConstraint(observed, constraint);
+    tools.push({
+      executable,
+      constraint,
+      resolved,
+      observed,
+      observedRaw,
+      satisfied,
+    });
+    if (satisfied) continue;
+    reasons.push({
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      node,
+      repo: repo.name,
+      executable,
+      constraint,
+      // The observed version is the whole point of the payload: without it the
+      // operator still has to go to the node to find out what is installed.
+      observed,
+      observedRaw,
+      detail:
+        exitCode !== 0
+          ? "version_probe_failed"
+          : observed === null
+            ? "unparseable_version"
+            : "constraint_unsatisfied",
+      action: `make ${executable} ${constraint} the resolved version on ${node} (observed ${observed ?? observedRaw ?? "nothing"}), or relax repo ${repo.name}'s constraint in config/repos.yaml`,
+    });
+  }
+
+  return {
+    repo: repo?.name ?? null,
+    node,
+    implementationVersion: TOOLCHAIN_PREFLIGHT_VERSION,
+    toolchainHash: toolchainHash(toolchain),
+    declared: toolchain !== null,
+    verifiedAt: now().toISOString(),
+    ok: reasons.length === 0,
+    tools,
+    reasons,
+  };
+}
+
+/** Does this attestation still describe this repo on this node, recently enough? */
+export function toolchainAttestationCurrent(
+  attestation,
+  repo,
+  {
+    node = "local",
+    now = () => new Date(),
+    maxAgeMs = TOOLCHAIN_ATTESTATION_MAX_AGE_MS,
+  } = {},
+) {
+  if (!attestation) return { current: false, detail: "absent" };
+  if (attestation.implementationVersion !== TOOLCHAIN_PREFLIGHT_VERSION) {
+    return { current: false, detail: "implementation_changed" };
+  }
+  if (attestation.repo !== repo?.name) {
+    return { current: false, detail: "repo_changed" };
+  }
+  if (attestation.node !== node)
+    return { current: false, detail: "node_changed" };
+  if (attestation.toolchainHash !== toolchainHash(repo?.toolchain ?? null)) {
+    return { current: false, detail: "config_changed" };
+  }
+  const verifiedAt = Date.parse(attestation.verifiedAt ?? "");
+  if (!Number.isFinite(verifiedAt)) {
+    return { current: false, detail: "unverifiable_timestamp" };
+  }
+  if (now().getTime() - verifiedAt > maxAgeMs) {
+    return { current: false, detail: "expired" };
+  }
+  return { current: true, detail: null };
+}
+
+/**
+ * Is this repo dispatchable on this node, given an attestation?
+ *
+ * The readiness table at docs/event-runtime-repos.md §1 makes `ready` mean
+ * "has a current attestation", so a stale attestation is not-ready even when
+ * its last result was green. A repo that declares nothing is ready without an
+ * attestation: there is nothing to attest, and the nine repos in production
+ * today declare nothing.
+ */
+export function repoReadiness({
+  repo,
+  attestation = null,
+  node = "local",
+  now = () => new Date(),
+  maxAgeMs = TOOLCHAIN_ATTESTATION_MAX_AGE_MS,
+} = {}) {
+  if (!repo?.toolchain?.length) {
+    return { ready: true, attested: false, reasons: [], refusal: null };
+  }
+  const { current, detail } = toolchainAttestationCurrent(attestation, repo, {
+    node,
+    now,
+    maxAgeMs,
+  });
+  if (!current) {
+    return {
+      ready: false,
+      attested: false,
+      reasons: [
+        {
+          reason: REPO_ATTESTATION_STALE,
+          node,
+          repo: repo.name,
+          detail,
+          action: `run \`factory repo doctor ${repo.name}\` on ${node} to refresh the toolchain attestation`,
+        },
+      ],
+      refusal: `repo ${repo.name} has no current toolchain attestation on ${node} (${detail})`,
+    };
+  }
+  if (!attestation.ok) {
+    return {
+      ready: false,
+      attested: true,
+      reasons: attestation.reasons,
+      refusal: refusalLine(repo, node, attestation.reasons),
+    };
+  }
+  return { ready: true, attested: true, reasons: [], refusal: null };
+}
+
+/** One line an operator can act on, naming every failing constraint. */
+function refusalLine(repo, node, reasons) {
+  const failures = reasons.map((r) =>
+    r.reason === REPO_TOOLCHAIN_MISSING
+      ? `${r.executable} ${r.constraint} (not found)`
+      : `${r.executable} ${r.constraint} (observed ${r.observed ?? r.observedRaw ?? "nothing"})`,
+  );
+  return `repo ${repo.name} toolchain preflight failed on ${node}: ${failures.join("; ")}`;
+}
+
+/**
+ * The gate dispatch calls before claiming a ticket (WM-316 acceptance
+ * criterion "dispatch consults readiness before claiming").
+ *
+ * Returns `{ready, reasons, refusal, attestation}`. A repo with no declared
+ * toolchain short-circuits to ready without probing — no subprocess, no
+ * latency, no behaviour change. Otherwise a current attestation is reused and
+ * a stale or absent one triggers a fresh, non-mutating preflight.
+ *
+ * Wiring this into orchestrator/tick.mjs is deliberately a separate change:
+ * tick.mjs is outside this ticket's Owned Paths.
+ */
+export async function repoDispatchPreflight(
+  repo,
+  {
+    node = "local",
+    attestation = null,
+    now = () => new Date(),
+    maxAgeMs = TOOLCHAIN_ATTESTATION_MAX_AGE_MS,
+    which,
+    spawn,
+  } = {},
+) {
+  if (!repo?.toolchain?.length) {
+    return {
+      ready: true,
+      attested: false,
+      reasons: [],
+      refusal: null,
+      attestation: null,
+    };
+  }
+  const { current } = toolchainAttestationCurrent(attestation, repo, {
+    node,
+    now,
+    maxAgeMs,
+  });
+  const fresh = current
+    ? attestation
+    : await preflightToolchain(repo, { node, now, which, spawn });
+  return {
+    ...repoReadiness({ repo, attestation: fresh, node, now, maxAgeMs }),
+    attestation: fresh,
+  };
+}
+
 /**
  * @returns {Map<string, {name: string, path: string, github: string|null, base: string,
  *                        deployBranch: string|null, team: string|null, project: string|null,
@@ -140,6 +588,7 @@ function normalizeOwnedPathsPolicy(raw = {}, repoName, file) {
  *                        security: {pythonVersion: string|null}|null,
  *                        worktreeRoot: string|null, worktreeUp: string|null, worktreeDown: string|null,
  *                        worktreeWarm: string|null, verify: string|null,
+ *                        toolchain: Array<{executable: string, constraint: string}>|null,
  *                        ownedPathsPolicy: { direct: Array<{source: string, requires: string[]}>, pinManifests: string[] }}>
  */
 export function loadRepos({ root = reposRoot() } = {}) {
@@ -289,6 +738,9 @@ export function loadRepos({ root = reposRoot() } = {}) {
       worktreeDown: entry.worktree_down ?? null,
       worktreeWarm: entry.worktree_warm ?? null,
       verify: entry.verify ?? null,
+      // null means "no toolchain declared": no preflight, no gating, exactly
+      // today's behaviour (WM-316).
+      toolchain: normalizeToolchain(entry.toolchain, entry.name, file),
       ownedPathsPolicy: normalizeOwnedPathsPolicy(
         entry.owned_paths_policy,
         entry.name,
@@ -345,6 +797,11 @@ export function reposView(repos) {
     hasWorktreeDown: repo.worktreeDown !== null,
     hasWorktreeWarm: repo.worktreeWarm !== null,
     verify: repo.verify,
+    // `toolchain` is deliberately NOT published here yet. Adding a field to
+    // this projection changes /repos and the config view in the same commit,
+    // and both are asserted exactly in files outside gh-1076's Owned Paths.
+    // The follow-up that teaches `factory doctor` to report toolchain status
+    // publishes it, with those assertions updated alongside.
   }));
 }
 

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -183,7 +183,12 @@ const SEMVER_COMPARATOR =
  */
 export function isToolchainConstraint(constraint) {
   if (typeof constraint !== "string") return false;
-  const trimmed = constraint.trim();
+  // node-semver allows whitespace between an operator and its version
+  // (`>= 1.2.3`), so collapse it before tokenizing. A false reject here is
+  // louder than a missed constraint: this throws inside `loadRepos`, which
+  // would take down every command that reads the registry, not just the repo
+  // with the odd spelling.
+  const trimmed = constraint.trim().replace(/([<>]=?|=|\^|~)\s+/g, "$1");
   if (!trimmed) return false;
   for (const clause of trimmed.split("||")) {
     const tokens = clause.trim().split(/\s+/).filter(Boolean);
@@ -268,28 +273,51 @@ function normalizeToolchain(raw, repoName, file) {
 }
 
 /**
+ * A **dotted** version token: `1.2`, `1.2.3`, `1.3.0-canary.1`, with an
+ * optional prefix glued to it so `go1.22.0` reads as `1.22.0`.
+ *
+ * The dot is load-bearing. An earlier version of this accepted any bare
+ * integer anywhere in the line, which manufactured a version out of ordinary
+ * error output — `"Error 404: not found"` became `404.0.0`, and
+ * `satisfies("404.0.0", ">=1.3")` is **true**. A tool that exits 0 and prints
+ * a non-version line would have silently passed a loose constraint: the same
+ * fail-open hazard `isToolchainConstraint` exists to close, one field over.
+ *
+ * The leading `(?<![\d.])` and trailing `(?![\d.])` keep the token whole, so
+ * an IPv4 address (`10.0.0.1`) or a four-part build number matches nothing
+ * rather than yielding a plausible-looking prefix.
+ */
+const VERSION_TOKEN =
+  /(?<![\d.])v?(\d+)\.(\d+)(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?![\d.])/;
+
+/**
  * Extract a comparable version from whatever a tool prints. `node --version`
  * says `v22.1.0`, `git --version` says `git version 2.39.5 (Apple Git-154)`,
- * `bun --version` says `1.2.23`. Only the first non-empty line is considered,
- * and a partial version is widened to x.y.z so semver can compare it.
+ * `go version` says `go version go1.22.0 darwin/arm64`, `bun --version` says
+ * `1.2.23`. Only the first non-empty line is considered, and a partial version
+ * is widened to x.y.z so semver can compare it.
  *
- * Returns null when nothing version-shaped is there — which fails closed
- * rather than guessing.
+ * Anything that is not a dotted version token is null — including a stray
+ * integer inside an error message. The one exception is a line that is
+ * *nothing but* an integer (`22`), which is unambiguous. Null fails closed:
+ * the constraint cannot be proven, so the repo is not ready.
  */
 export function normalizeToolVersion(raw) {
   if (typeof raw !== "string") return null;
   const line = raw.split("\n").find((candidate) => candidate.trim());
   if (!line) return null;
-  // Anchored at a token boundary and tolerant of the `v` prefix, so `v22.1.0`
-  // reads as 22.1.0 while `Git-154` inside `git version 2.39.5 (Apple
-  // Git-154)` never wins over the real version earlier in the line.
-  const match = line.match(
-    /(?:^|[^\w.])v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?/,
-  );
-  if (!match) return null;
-  const [, major, minor = "0", patch = "0", prerelease] = match;
-  const base = `${Number(major)}.${Number(minor)}.${Number(patch)}`;
-  return prerelease ? `${base}-${prerelease}` : base;
+  const trimmed = line.trim();
+
+  const match = trimmed.match(VERSION_TOKEN);
+  if (match) {
+    const [, major, minor, patch = "0", prerelease] = match;
+    const base = `${Number(major)}.${Number(minor)}.${Number(patch)}`;
+    return prerelease ? `${base}-${prerelease}` : base;
+  }
+  // A bare integer counts only when it is the entire line. `bun --version`
+  // could legitimately print `2`; `Segmentation fault: 11` must not.
+  if (/^\d+$/.test(trimmed)) return `${Number(trimmed)}.0.0`;
+  return null;
 }
 
 /** Stable fingerprint of a repo's declared toolchain; a change invalidates attestations. */
@@ -504,18 +532,27 @@ export function repoReadiness({
           node,
           repo: repo.name,
           detail,
-          action: `run \`factory repo doctor ${repo.name}\` on ${node} to refresh the toolchain attestation`,
+          // Must be runnable: `bin/factory` has no `repo` subcommand, so the
+          // repo-scoped `factory repo doctor <name>` the design sketches does
+          // not exist yet. Name what exists and what is pending.
+          action: `re-run toolchain preflight for repo ${repo.name} on ${node} — \`factory doctor\` reports it once #1097 lands`,
         },
       ],
       refusal: `repo ${repo.name} has no current toolchain attestation on ${node} (${detail})`,
     };
   }
   if (!attestation.ok) {
+    // Tolerate a malformed attestation rather than throwing. WM-317 persists
+    // and reloads these, and once #1096 puts this on the pre-claim path a
+    // throw would stall dispatch where a refusal merely skips one repo.
+    const reasons = Array.isArray(attestation.reasons)
+      ? attestation.reasons
+      : [];
     return {
       ready: false,
       attested: true,
-      reasons: attestation.reasons,
-      refusal: refusalLine(repo, node, attestation.reasons),
+      reasons,
+      refusal: refusalLine(repo, node, reasons),
     };
   }
   return { ready: true, attested: true, reasons: [], refusal: null };
@@ -523,6 +560,9 @@ export function repoReadiness({
 
 /** One line an operator can act on, naming every failing constraint. */
 function refusalLine(repo, node, reasons) {
+  if (!Array.isArray(reasons) || reasons.length === 0) {
+    return `repo ${repo.name} toolchain preflight failed on ${node} with no recorded reason — re-run preflight`;
+  }
   const failures = reasons.map((r) =>
     r.reason === REPO_TOOLCHAIN_MISSING
       ? `${r.executable} ${r.constraint} (not found)`
@@ -540,8 +580,8 @@ function refusalLine(repo, node, reasons) {
  * latency, no behaviour change. Otherwise a current attestation is reused and
  * a stale or absent one triggers a fresh, non-mutating preflight.
  *
- * Wiring this into orchestrator/tick.mjs is deliberately a separate change:
- * tick.mjs is outside this ticket's Owned Paths.
+ * Wiring this into orchestrator/tick.mjs is deliberately a separate change
+ * (#1096): tick.mjs is outside this ticket's Owned Paths.
  */
 export async function repoDispatchPreflight(
   repo,
@@ -799,9 +839,10 @@ export function reposView(repos) {
     verify: repo.verify,
     // `toolchain` is deliberately NOT published here yet. Adding a field to
     // this projection changes /repos and the config view in the same commit,
-    // and both are asserted exactly in files outside gh-1076's Owned Paths.
-    // The follow-up that teaches `factory doctor` to report toolchain status
-    // publishes it, with those assertions updated alongside.
+    // and both are asserted exactly in files outside gh-1076's Owned Paths
+    // (api-registry.test.mjs, api-config.test.mjs). Issue #1097 — teach
+    // `factory doctor` to report toolchain status — publishes it and updates
+    // those assertions alongside.
   }));
 }
 

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -4,11 +4,22 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import {
+  isToolchainConstraint,
   loadRepos,
+  normalizeToolVersion,
+  preflightToolchain,
   proveMergeChecks,
+  REPO_ATTESTATION_STALE,
+  REPO_TOOLCHAIN_MISMATCH,
+  REPO_TOOLCHAIN_MISSING,
   RepoError,
+  repoDispatchPreflight,
+  repoReadiness,
   reposView,
   selectMergeCheckGate,
+  TOOLCHAIN_ATTESTATION_MAX_AGE_MS,
+  toolchainAttestationCurrent,
+  toolchainHash,
 } from "./repos.mjs";
 
 const scratch = [];
@@ -46,6 +57,9 @@ const YAML = `repos:
     worktree_root: ~/Develop/.worktrees/full
     max_in_flight: 20
     verify: npm run typecheck
+    toolchain:
+      bun: ">=1.3 <2"
+      node: ">=22 <25"
     smoke_workflow: smoke-prod.yml
     smoke_url: https://full.example.com/healthz
     smoke_deadline_seconds: 420
@@ -114,6 +128,10 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       worktreeDown: "bin/worktree-down.sh",
       worktreeWarm: "bin/worktree-warm.sh",
       verify: "npm run typecheck",
+      toolchain: [
+        { executable: "bun", constraint: ">=1.3 <2" },
+        { executable: "node", constraint: ">=22 <25" },
+      ],
       ownedPathsPolicy: {
         direct: [
           { source: "shared/**", requires: ["dist/**", "plugins/core/**"] },
@@ -145,6 +163,8 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
       worktreeRoot: null,
       worktreeDown: null,
       verify: null,
+      // No `toolchain:` block is the nine-repos-today case: null, never [].
+      toolchain: null,
     });
   });
 
@@ -475,6 +495,490 @@ describe("reposView is what the control API serves", () => {
       ["full", false],
       ["bare", true],
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WM-316 toolchain preflight (docs/event-runtime-repos.md §§5–6).
+// ---------------------------------------------------------------------------
+
+const CLOCK = new Date("2026-08-29T12:00:00.000Z");
+const now = () => CLOCK;
+
+/**
+ * A fake node. `which`/`spawn` are injected at the level the production code
+ * actually uses them, so the argv the real preflight builds is the argv these
+ * assertions see — a fake at the `probe` level would only test the fake.
+ */
+function fakeNode({ versions = {}, missing = [], exitCodes = {} } = {}) {
+  const whichCalls = [];
+  const spawnCalls = [];
+  return {
+    whichCalls,
+    spawnCalls,
+    which: async (executable) => {
+      whichCalls.push(executable);
+      return missing.includes(executable) ? null : `/opt/bin/${executable}`;
+    },
+    spawn: async (argv) => {
+      spawnCalls.push(argv);
+      return {
+        exitCode: exitCodes[argv[0]] ?? 0,
+        stdout: versions[argv[0]] ?? "",
+        stderr: "",
+      };
+    },
+  };
+}
+
+function repoWith(toolchainYaml, name = "tc") {
+  return loadRepos({
+    root: factoryRoot(
+      `repos:\n  - name: ${name}\n    path: /tmp/${name}\n${toolchainYaml}`,
+    ),
+  }).get(name);
+}
+
+describe("toolchain: declaration parsing and validation", () => {
+  test("the documented map form and the explicit list form normalize identically", () => {
+    const mapForm = repoWith(
+      `    toolchain:\n      bun: ">=1.3 <2"\n      git: ">=2.40"\n`,
+    );
+    const listForm = repoWith(
+      `    toolchain:\n      - executable: bun\n        constraint: ">=1.3 <2"\n      - executable: git\n        constraint: ">=2.40"\n`,
+    );
+    const expected = [
+      { executable: "bun", constraint: ">=1.3 <2" },
+      { executable: "git", constraint: ">=2.40" },
+    ];
+    expect(mapForm.toolchain).toEqual(expected);
+    expect(listForm.toolchain).toEqual(expected);
+    expect(toolchainHash(mapForm.toolchain)).toBe(
+      toolchainHash(listForm.toolchain),
+    );
+  });
+
+  test("absent reads null and an empty block reads [] — neither is a default constraint", () => {
+    expect(repoWith("").toolchain).toBeNull();
+    expect(repoWith(`    toolchain: {}\n`).toolchain).toEqual([]);
+    expect(repoWith(`    toolchain: []\n`).toolchain).toEqual([]);
+  });
+
+  test("an executable must be a bare command name, never a path or a shell fragment", () => {
+    const invalid = [
+      `    toolchain:\n      "/usr/local/bin/bun": ">=1.3"\n`,
+      `    toolchain:\n      "sh -c 'brew install bun'": ">=1.3"\n`,
+      `    toolchain:\n      "bun; rm -rf /": ">=1.3"\n`,
+      `    toolchain:\n      "": ">=1.3"\n`,
+      `    toolchain:\n      "../bun": ">=1.3"\n`,
+    ];
+    for (const yaml of invalid) {
+      expect(() => repoWith(yaml)).toThrow(RepoError);
+    }
+    expect(() =>
+      repoWith(`    toolchain:\n      "/usr/bin/bun": ">=1"\n`),
+    ).toThrow(/bare command name/);
+  });
+
+  test("a constraint must be a semver range, because Bun.semver is fail-open on garbage", () => {
+    // Guard on the real reason this validation exists: an unvalidated
+    // `satisfies("1.2.3", "not a range")` returns true, so a typo'd range
+    // would silently pass every version instead of gating anything.
+    expect(Bun.semver.satisfies("1.2.3", "not a range")).toBe(true);
+    expect(isToolchainConstraint("not a range")).toBe(false);
+
+    for (const good of [
+      ">=1.3 <2",
+      ">=22",
+      "^1.2.3",
+      "~2.0",
+      "1.x",
+      "*",
+      "1.2.3 || >=4.0.0",
+      "1.2.3 - 2.0.0",
+      ">=1.3.0-canary.1",
+    ]) {
+      expect([good, isToolchainConstraint(good)]).toEqual([good, true]);
+    }
+    for (const bad of [
+      "not a range",
+      "",
+      "   ",
+      ">=",
+      "latest",
+      ">=1.2; echo hi",
+      "$(id)",
+      ">=1.2 || ",
+      42,
+      null,
+    ]) {
+      expect([bad, isToolchainConstraint(bad)]).toEqual([bad, false]);
+    }
+    expect(() => repoWith(`    toolchain:\n      bun: latest\n`)).toThrow(
+      /must be a semver range/,
+    );
+  });
+
+  test("structural errors name the repo instead of loading a half-understood block", () => {
+    const invalid = [
+      `    toolchain: "bun >=1.3"\n`,
+      `    toolchain:\n      - bun\n`,
+      `    toolchain:\n      - executable: bun\n        constraint: ">=1"\n        install: brew install bun\n`,
+      `    toolchain:\n      - executable: bun\n        constraint: ">=1"\n      - executable: bun\n        constraint: ">=2"\n`,
+      `    toolchain:\n      bun: 13\n`,
+    ];
+    for (const yaml of invalid) {
+      expect(() => repoWith(yaml)).toThrow(RepoError);
+    }
+    expect(() =>
+      repoWith(
+        `    toolchain:\n      - executable: bun\n        constraint: ">=1"\n      - executable: bun\n        constraint: ">=2"\n`,
+      ),
+    ).toThrow(/declares toolchain executable "bun" twice/);
+  });
+
+  test("the registry projection does not publish toolchain yet", () => {
+    // Not an oversight: /repos and the config view assert this projection
+    // exactly, in files outside gh-1076's Owned Paths. Publishing toolchain
+    // belongs to the follow-up that surfaces it in `factory doctor`, which can
+    // update those assertions in the same commit.
+    const rows = reposView(loadRepos({ root: factoryRoot(YAML) }));
+    expect(rows[0]).not.toHaveProperty("toolchain");
+  });
+});
+
+describe("normalizeToolVersion reads what real tools actually print", () => {
+  test("the version formats of the tools this factory depends on", () => {
+    expect(normalizeToolVersion("1.2.23\n")).toBe("1.2.23");
+    expect(normalizeToolVersion("v22.1.0\n")).toBe("22.1.0");
+    expect(normalizeToolVersion("git version 2.39.5 (Apple Git-154)")).toBe(
+      "2.39.5",
+    );
+    expect(normalizeToolVersion("Python 3.12.1")).toBe("3.12.1");
+    expect(normalizeToolVersion("Docker version 24.0.7, build afdd53b")).toBe(
+      "24.0.7",
+    );
+    expect(normalizeToolVersion("1.3.0-canary.20260101")).toBe(
+      "1.3.0-canary.20260101",
+    );
+  });
+
+  test("a partial version widens to x.y.z so semver can compare it", () => {
+    expect(normalizeToolVersion("22")).toBe("22.0.0");
+    expect(normalizeToolVersion("1.2")).toBe("1.2.0");
+  });
+
+  test("nothing version-shaped is null, not a guess", () => {
+    expect(normalizeToolVersion("command not found")).toBeNull();
+    expect(normalizeToolVersion("")).toBeNull();
+    expect(normalizeToolVersion(undefined)).toBeNull();
+  });
+});
+
+describe("preflightToolchain verifies without mutating the host", () => {
+  test("every satisfied constraint attests ok with the observed versions", async () => {
+    const repo = repoWith(
+      `    toolchain:\n      bun: ">=1.3 <2"\n      node: ">=22 <25"\n`,
+    );
+    const node = fakeNode({
+      versions: { bun: "1.3.14\n", node: "v22.14.0\n" },
+    });
+    const attestation = await preflightToolchain(repo, {
+      node: "runner",
+      now,
+      ...node,
+    });
+    expect(attestation.ok).toBe(true);
+    expect(attestation.reasons).toEqual([]);
+    expect(attestation.node).toBe("runner");
+    expect(attestation.declared).toBe(true);
+    expect(attestation.verifiedAt).toBe(CLOCK.toISOString());
+    expect(
+      attestation.tools.map((t) => [t.executable, t.observed, t.satisfied]),
+    ).toEqual([
+      ["bun", "1.3.14", true],
+      ["node", "22.14.0", true],
+    ]);
+  });
+
+  test("an unresolvable executable is repo_toolchain_missing, naming node and constraint", async () => {
+    const repo = repoWith(`    toolchain:\n      uv: ">=0.5"\n`);
+    const node = fakeNode({ missing: ["uv"] });
+    const { ok, reasons } = await preflightToolchain(repo, {
+      node: "runner",
+      now,
+      ...node,
+    });
+    expect(ok).toBe(false);
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toMatchObject({
+      reason: REPO_TOOLCHAIN_MISSING,
+      node: "runner",
+      repo: "tc",
+      executable: "uv",
+      constraint: ">=0.5",
+      observed: null,
+    });
+    expect(reasons[0].action).toContain("uv");
+    // A missing executable is never probed for a version.
+    expect(node.spawnCalls).toEqual([]);
+  });
+
+  test("a version mismatch carries node, executable, constraint AND the observed version", async () => {
+    const repo = repoWith(`    toolchain:\n      node: ">=22 <25"\n`);
+    const node = fakeNode({ versions: { node: "v18.19.1\n" } });
+    const { ok, reasons } = await preflightToolchain(repo, {
+      node: "mac-mini",
+      now,
+      ...node,
+    });
+    expect(ok).toBe(false);
+    expect(reasons[0]).toMatchObject({
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      node: "mac-mini",
+      repo: "tc",
+      executable: "node",
+      constraint: ">=22 <25",
+      observed: "18.19.1",
+      detail: "constraint_unsatisfied",
+    });
+    // The whole point of the payload: "node 18, not 22" without going to the box.
+    expect(reasons[0].action).toContain("18.19.1");
+  });
+
+  test("an unreadable or failing version probe fails closed, keeping the raw output", async () => {
+    const repo = repoWith(
+      `    toolchain:\n      broken: ">=1"\n      garbled: ">=1"\n`,
+    );
+    const node = fakeNode({
+      versions: { broken: "boom\n", garbled: "no version here\n" },
+      exitCodes: { broken: 1 },
+    });
+    const { ok, reasons } = await preflightToolchain(repo, { now, ...node });
+    expect(ok).toBe(false);
+    expect(reasons.map((r) => [r.executable, r.reason, r.detail])).toEqual([
+      ["broken", REPO_TOOLCHAIN_MISMATCH, "version_probe_failed"],
+      ["garbled", REPO_TOOLCHAIN_MISMATCH, "unparseable_version"],
+    ]);
+    expect(reasons[1].observed).toBeNull();
+    expect(reasons[1].observedRaw).toBe("no version here");
+  });
+
+  test("preflight is non-mutating: the only command spawned is `<exe> --version`", async () => {
+    const repo = repoWith(
+      `    toolchain:\n      bun: ">=1.3 <2"\n      node: ">=22 <25"\n      git: ">=2.40"\n`,
+    );
+    const node = fakeNode({
+      versions: { bun: "1.3.14", node: "v22.14.0", git: "git version 2.39.5" },
+    });
+    await preflightToolchain(repo, { now, ...node });
+
+    expect(node.whichCalls).toEqual(["bun", "node", "git"]);
+    expect(node.spawnCalls).toEqual([
+      ["bun", "--version"],
+      ["node", "--version"],
+      ["git", "--version"],
+    ]);
+    // Not just "the expected commands ran" — no install/upgrade verb reached
+    // the host under any name. Toolchain preflight validates; it does not
+    // install or mutate host tooling (docs/event-runtime-repos.md §10).
+    const mutating =
+      /\b(install|upgrade|update|add|remove|uninstall|link|use|brew|apt|apt-get|yum|pacman|port|npm|pnpm|yarn|pip|pipx|corepack|nvm|fnm|asdf|volta|rustup|curl|wget|sh|bash|zsh|sudo)\b/i;
+    for (const argv of node.spawnCalls) {
+      expect(argv).toHaveLength(2);
+      expect(argv[1]).toBe("--version");
+      expect(mutating.test(argv.join(" "))).toBe(false);
+    }
+  });
+
+  test("a repo with no toolchain block is attested without touching the host", async () => {
+    const repo = repoWith("");
+    const node = fakeNode();
+    const attestation = await preflightToolchain(repo, { now, ...node });
+    expect(attestation.ok).toBe(true);
+    expect(attestation.declared).toBe(false);
+    expect(attestation.tools).toEqual([]);
+    expect(node.whichCalls).toEqual([]);
+    expect(node.spawnCalls).toEqual([]);
+  });
+});
+
+describe("readiness: a repo is ready only on a current, passing attestation", () => {
+  const declared = () => repoWith(`    toolchain:\n      bun: ">=1.3 <2"\n`);
+  const passing = async (repo, overrides = {}) =>
+    preflightToolchain(repo, {
+      node: "runner",
+      now,
+      ...fakeNode({ versions: { bun: "1.3.14" } }),
+      ...overrides,
+    });
+
+  test("no declared toolchain is ready with no attestation at all — the additive case", () => {
+    // The nine repos in production today declare nothing; the upgrade must
+    // not turn a single one of them not-ready.
+    for (const repo of [repoWith(""), repoWith(`    toolchain: {}\n`)]) {
+      expect(repoReadiness({ repo, node: "runner", now })).toEqual({
+        ready: true,
+        attested: false,
+        reasons: [],
+        refusal: null,
+      });
+    }
+  });
+
+  test("a current passing attestation is ready", async () => {
+    const repo = declared();
+    const readiness = repoReadiness({
+      repo,
+      attestation: await passing(repo),
+      node: "runner",
+      now,
+    });
+    expect(readiness).toEqual({
+      ready: true,
+      attested: true,
+      reasons: [],
+      refusal: null,
+    });
+  });
+
+  test("absent, expired, re-declared, and wrong-node attestations are all stale", async () => {
+    const repo = declared();
+    const attestation = await passing(repo);
+    const cases = [
+      [null, "absent", { node: "runner", now }],
+      [
+        attestation,
+        "expired",
+        {
+          node: "runner",
+          now: () =>
+            new Date(CLOCK.getTime() + TOOLCHAIN_ATTESTATION_MAX_AGE_MS + 1000),
+        },
+      ],
+      [attestation, "node_changed", { node: "mac-mini", now }],
+      [
+        { ...attestation, toolchainHash: "sha256:stale" },
+        "config_changed",
+        { node: "runner", now },
+      ],
+      [
+        { ...attestation, implementationVersion: 0 },
+        "implementation_changed",
+        { node: "runner", now },
+      ],
+      [
+        { ...attestation, verifiedAt: "whenever" },
+        "unverifiable_timestamp",
+        { node: "runner", now },
+      ],
+    ];
+    for (const [candidate, detail, opts] of cases) {
+      expect(toolchainAttestationCurrent(candidate, repo, opts)).toEqual({
+        current: false,
+        detail,
+      });
+      const readiness = repoReadiness({
+        repo,
+        attestation: candidate,
+        ...opts,
+      });
+      expect(readiness.ready).toBe(false);
+      expect(readiness.reasons[0]).toMatchObject({
+        reason: REPO_ATTESTATION_STALE,
+        detail,
+      });
+    }
+  });
+
+  test("a failing attestation is not ready and the refusal names the failing constraint", async () => {
+    const repo = declared();
+    const attestation = await preflightToolchain(repo, {
+      node: "runner",
+      now,
+      ...fakeNode({ versions: { bun: "1.1.45" } }),
+    });
+    const readiness = repoReadiness({ repo, attestation, node: "runner", now });
+    expect(readiness.ready).toBe(false);
+    expect(readiness.reasons[0]).toMatchObject({
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      observed: "1.1.45",
+    });
+    expect(readiness.refusal).toBe(
+      "repo tc toolchain preflight failed on runner: bun >=1.3 <2 (observed 1.1.45)",
+    );
+  });
+});
+
+describe("repoDispatchPreflight is the gate dispatch consults before claiming", () => {
+  test("a repo whose preflight fails is refused, with the failing constraint named", async () => {
+    const repo = repoWith(`    toolchain:\n      node: ">=22 <25"\n`);
+    const node = fakeNode({ versions: { node: "v18.19.1" } });
+    const gate = await repoDispatchPreflight(repo, {
+      node: "mac-mini",
+      now,
+      ...node,
+    });
+    expect(gate.ready).toBe(false);
+    expect(gate.refusal).toBe(
+      "repo tc toolchain preflight failed on mac-mini: node >=22 <25 (observed 18.19.1)",
+    );
+    expect(gate.reasons[0]).toMatchObject({
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      node: "mac-mini",
+      executable: "node",
+      constraint: ">=22 <25",
+      observed: "18.19.1",
+    });
+    expect(gate.attestation.ok).toBe(false);
+  });
+
+  test("a passing repo is admitted and carries the attestation forward", async () => {
+    const repo = repoWith(`    toolchain:\n      bun: ">=1.3 <2"\n`);
+    const gate = await repoDispatchPreflight(repo, {
+      node: "runner",
+      now,
+      ...fakeNode({ versions: { bun: "1.3.14" } }),
+    });
+    expect(gate.ready).toBe(true);
+    expect(gate.refusal).toBeNull();
+    expect(gate.attestation.toolchainHash).toBe(toolchainHash(repo.toolchain));
+  });
+
+  test("a current attestation is reused instead of re-probing the host", async () => {
+    const repo = repoWith(`    toolchain:\n      bun: ">=1.3 <2"\n`);
+    const attestation = await preflightToolchain(repo, {
+      node: "runner",
+      now,
+      ...fakeNode({ versions: { bun: "1.3.14" } }),
+    });
+    const node = fakeNode({ versions: { bun: "1.3.14" } });
+    const gate = await repoDispatchPreflight(repo, {
+      node: "runner",
+      attestation,
+      now,
+      ...node,
+    });
+    expect(gate.ready).toBe(true);
+    expect(node.spawnCalls).toEqual([]);
+  });
+
+  test("an undeclared toolchain short-circuits: no probe, no gate, no latency", async () => {
+    const node = fakeNode();
+    const gate = await repoDispatchPreflight(repoWith(""), {
+      node: "runner",
+      now,
+      ...node,
+    });
+    expect(gate).toEqual({
+      ready: true,
+      attested: false,
+      reasons: [],
+      refusal: null,
+      attestation: null,
+    });
+    expect(node.whichCalls).toEqual([]);
+    expect(node.spawnCalls).toEqual([]);
   });
 });
 

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -597,6 +597,13 @@ describe("toolchain: declaration parsing and validation", () => {
       "1.2.3 || >=4.0.0",
       "1.2.3 - 2.0.0",
       ">=1.3.0-canary.1",
+      // node-semver allows whitespace after an operator. Rejecting these
+      // throws inside loadRepos, which takes down every command that reads
+      // the registry — a false reject is louder than a missed constraint.
+      ">= 1.2.3",
+      "> 1.2.3 < 2.0.0",
+      "^ 1.2.3",
+      ">= 1.2.3 || < 1.0.0",
     ]) {
       expect([good, isToolchainConstraint(good)]).toEqual([good, true]);
     }
@@ -637,11 +644,12 @@ describe("toolchain: declaration parsing and validation", () => {
     ).toThrow(/declares toolchain executable "bun" twice/);
   });
 
-  test("the registry projection does not publish toolchain yet", () => {
+  test("the registry projection does not publish toolchain yet (removed by #1097)", () => {
     // Not an oversight: /repos and the config view assert this projection
-    // exactly, in files outside gh-1076's Owned Paths. Publishing toolchain
-    // belongs to the follow-up that surfaces it in `factory doctor`, which can
-    // update those assertions in the same commit.
+    // exactly, in api-registry.test.mjs and api-config.test.mjs, both outside
+    // gh-1076's Owned Paths. Issue #1097 — toolchain status in `factory
+    // doctor` — publishes the field and updates those assertions in the same
+    // commit, and deletes this pin.
     const rows = reposView(loadRepos({ root: factoryRoot(YAML) }));
     expect(rows[0]).not.toHaveProperty("toolchain");
   });
@@ -661,11 +669,49 @@ describe("normalizeToolVersion reads what real tools actually print", () => {
     expect(normalizeToolVersion("1.3.0-canary.20260101")).toBe(
       "1.3.0-canary.20260101",
     );
+    expect(normalizeToolVersion("GNU bash, version 5.2.15(1)-release")).toBe(
+      "5.2.15",
+    );
+  });
+
+  test("a version glued to its own name still reads — `go` must be usable", () => {
+    // `[^\w.]`-style boundaries reject `go1.22.0`, which would give every Go
+    // repo a permanent unparseable_version and make the gate undispatchable
+    // for them. Fails closed, but unusable.
+    expect(normalizeToolVersion("go version go1.22.0 darwin/arm64")).toBe(
+      "1.22.0",
+    );
+    expect(normalizeToolVersion("go1.22")).toBe("1.22.0");
   });
 
   test("a partial version widens to x.y.z so semver can compare it", () => {
     expect(normalizeToolVersion("22")).toBe("22.0.0");
     expect(normalizeToolVersion("1.2")).toBe("1.2.0");
+  });
+
+  test("a stray integer in error output is never a version — the gate must not fail open", () => {
+    // Each of these once produced a version that satisfies a loose range:
+    // "Error 404: not found" became "404.0.0", and
+    // satisfies("404.0.0", ">=1.3") is true. A tool that exits 0 while
+    // printing a non-version line would have passed the constraint.
+    for (const line of [
+      "Error 404: not found",
+      "Permission denied (os error 13)",
+      "Segmentation fault: 11",
+      "Tool (build 1234)",
+      "usage: tool [-h] [--verbose]",
+      "released 2024-01-15",
+    ]) {
+      expect([line, normalizeToolVersion(line)]).toEqual([line, null]);
+    }
+    expect(Bun.semver.satisfies("404.0.0", ">=1.3")).toBe(true);
+  });
+
+  test("a partial token of a longer number is not a version either", () => {
+    // An IPv4 address or a four-part build must match nothing rather than
+    // yielding a plausible-looking prefix like "10.0.0".
+    expect(normalizeToolVersion("connect: 10.0.0.1 refused")).toBeNull();
+    expect(normalizeToolVersion("1.2.3.4")).toBeNull();
   });
 
   test("nothing version-shaped is null, not a guess", () => {
@@ -907,6 +953,39 @@ describe("readiness: a repo is ready only on a current, passing attestation", ()
     expect(readiness.refusal).toBe(
       "repo tc toolchain preflight failed on runner: bun >=1.3 <2 (observed 1.1.45)",
     );
+  });
+
+  test("a malformed attestation refuses instead of throwing", async () => {
+    // WM-317 persists and reloads attestations, and once #1096 puts this on
+    // the pre-claim path a throw stalls dispatch where a refusal only skips
+    // one repo. `reasons` missing entirely must still produce a refusal.
+    const repo = declared();
+    const attestation = await passing(repo);
+    for (const reasons of [undefined, null, "not-an-array"]) {
+      const readiness = repoReadiness({
+        repo,
+        attestation: { ...attestation, ok: false, reasons },
+        node: "runner",
+        now,
+      });
+      expect(readiness.ready).toBe(false);
+      expect(readiness.reasons).toEqual([]);
+      expect(readiness.refusal).toBe(
+        "repo tc toolchain preflight failed on runner with no recorded reason — re-run preflight",
+      );
+    }
+  });
+
+  test("the stale-attestation action names a command that exists", () => {
+    // `bin/factory` has no `repo` subcommand; an action an operator cannot run
+    // is not an action. Publishing this through `factory doctor` is #1097.
+    const { reasons } = repoReadiness({
+      repo: declared(),
+      node: "runner",
+      now,
+    });
+    expect(reasons[0].action).not.toContain("factory repo doctor");
+    expect(reasons[0].action).toContain("factory doctor");
   });
 });
 


### PR DESCRIPTION
Fixes #1076

Implements the toolchain half of WM-316, the design already written in `docs/event-runtime-repos.md` §§5–6 — no new design, and the doc is updated to say what actually landed.

**What's in `event-runtime/lib/repos.mjs`:**

- `toolchain:` on a repo entry, accepting the doc's map form (`bun: ">=1.3 <2"`) and the ticket's list form (`{executable, constraint}`), normalizing to one canonical list. Executables must be bare command names (no paths, no shell fragments — they are spawned argv-style). Constraints must parse as semver ranges, because `Bun.semver.satisfies("1.2.3", "not a range")` returns **true**: an unvalidated typo would be a gate that silently admits everything.
- `preflightToolchain` — resolves each executable and reads its version. **Non-mutating by construction:** the only command it ever builds is `[executable, "--version"]`. PATH resolution and the probe are injected, so the non-mutation test asserts on the argv the real code builds, not on a fake.
- Typed reasons: `repo_toolchain_missing` and `repo_toolchain_mismatch`, the latter carrying node, repo, executable, constraint, **observed version**, the tool's raw first line, a `detail` discriminator, and one operator action.
- Version normalization for what tools actually print (`v22.1.0`, `git version 2.39.5 (Apple Git-154)`, `Python 3.12.1`, bare `1.2`); nothing version-shaped fails closed.
- The attestation + `toolchainAttestationCurrent` (invalidated by config hash, node, repo, implementation version, unparseable timestamp, or age) and `repoReadiness` — ready means a **current and passing** attestation, so a green-but-stale one is `repo_attestation_stale`, never a silent pass.
- `repoDispatchPreflight` — the pre-claim gate, returning `{ready, reasons, refusal, attestation}` with a refusal line naming every failing constraint.

**Additive by design.** A repo with no `toolchain:` block reads `null`, short-circuits to ready, and is never probed — no subprocess, no latency, no behaviour change for the nine repos running today. Tests cover that path explicitly.

**Deliberately not here** (both outside this ticket's Owned Paths, both filed):

- #1096 — calling `repoDispatchPreflight` from `orchestrator/tick.mjs` before the claim. The gate is implemented and tested; nothing consults it yet.
- #1097 — `factory doctor` reporting toolchain status, and publishing `toolchain` from `reposView`. The projection change was backed out because `api-registry.test.mjs` asserts a `/repos` row with an exact `toEqual` and is not in Owned Paths; a test pins the current behaviour so the follow-up has to flip it consciously.

Also filed #1098: `factory doctor` exits 1 on unmodified `develop` because 12 of 13 `/factory-*` command symlinks are missing. Unrelated to this diff, reproduces identically on the main checkout.

**Verification:** `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/repos.test.mjs` — 47 pass, 0 fail. The five new behaviours were mutation-tested (disable constraint validation, make every constraint satisfy, spawn `install` instead of `--version`, remove the undeclared short-circuit, remove the missing-executable branch) and each mutation is caught by its intended test.
