### PR TITLE
feat(dispatch): validation table in the PR body

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -13,19 +13,8 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "tracker:write",
-      "repo:write",
-      "github:write"
-    ],
-    "tools": [
-      "Bash",
-      "Read",
-      "Write",
-      "Edit",
-      "Grep",
-      "Glob"
-    ]
+    "services": ["tracker:write", "repo:write", "github:write"],
+    "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
   "limits": {
     "timeout_seconds": 5400,
@@ -39,10 +28,7 @@
         "type": "ticket",
         "id": "$.input.ticket"
       },
-      "kinds": [
-        "postmortem",
-        "decision"
-      ],
+      "kinds": ["postmortem", "decision"],
       "max": 10
     },
     {
@@ -50,9 +36,7 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": [
-        "decision"
-      ],
+      "kinds": ["decision"],
       "max": 10
     }
   ],

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -13,8 +13,19 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["tracker:write", "repo:write", "github:write"],
-    "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
+    "services": [
+      "tracker:write",
+      "repo:write",
+      "github:write"
+    ],
+    "tools": [
+      "Bash",
+      "Read",
+      "Write",
+      "Edit",
+      "Grep",
+      "Glob"
+    ]
   },
   "limits": {
     "timeout_seconds": 5400,
@@ -28,7 +39,10 @@
         "type": "ticket",
         "id": "$.input.ticket"
       },
-      "kinds": ["postmortem", "decision"],
+      "kinds": [
+        "postmortem",
+        "decision"
+      ],
       "max": 10
     },
     {
@@ -36,12 +50,14 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": ["decision"],
+      "kinds": [
+        "decision"
+      ],
       "max": 10
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:ae36ff073880ff1ae89e6c21ed6660ee6f8294681b0d937da1efbef15373de6c",
+    "agents/dispatch.md": "sha256:8b9f9d8c2158935c09cf3f2936afeb7a7c5e56336f8a074d98afa9879f2242e7",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -105,14 +105,73 @@ shell` means the spawn prompt was defective: correct its path/launch details
    wedges the run until the timeout kills it.
 6. **Push and open a PR** against the configured `base` for this repo in
    `config/repos.yaml`; never rely on GitHub's default branch. Use the exact
-   shape `gh pr create --base <configured-base> --title "..." --body "Fixes
-<TICKET>"`. Record its numeric GitHub PR number as
+   shape `gh pr create --base <configured-base> --title "..." --body "..."`,
+   with the body specified below. Record its numeric GitHub PR number as
    `artifact.prNumber`; this is what scopes the immediate merge review chained
    from a `PR_OPEN` result. For a required UX critique, create the PR as a
    draft first. Run `gh pr ready <PR>` only after an evidence-backed `SHIP`
    verdict (including a `FIX-FIRST` resolved to `SHIP`). Leave `FIX-FIRST`,
    `NOT-ASSESSED`, and `BLOCKED` PRs in draft for review; skipped critiques may
-   open ready normally. Include `UX critique: <status>` in the PR body.
+   open ready normally.
+
+   The checks you already ran are the reviewer's starting point — carry them
+   into the artifact instead of leaving them in the transcript. The PR body is
+   exactly this, in this order, with `Fixes` first and `run:` last:
+
+   ```
+   Fixes <TICKET>
+
+   <one line an operator can act on>
+
+   ## Validation
+
+   | Check                | Command                          | Result  | Notes                  |
+   | -------------------- | -------------------------------- | ------- | ---------------------- |
+   | Verification Command | `<the ticket's exact command>`    | pass    | 214 tests, 0 failures  |
+   | Repo verify          | `<the repo's configured verify>`  | pass    | clean                  |
+   | UX critique          | factory-ux-critic                | not run | no user-facing surface |
+
+   UX critique: <status>
+
+   run:$FACTORY_RUN_ID
+   ```
+
+   `Fixes <TICKET>` and the trailing `run:$FACTORY_RUN_ID` are unchanged
+   required lines — the `## Validation` section is added between them, never
+   in place of either. Omit the `run:` line only when `$FACTORY_RUN_ID` is
+   unset (an interactive session). `UX critique: <status>` still appears in
+   the body, and the table's UX row carries the same status.
+
+   **Every row is an observation, not an assertion.** A row names a command you
+   actually ran in `./repo` and records the exit status you actually saw:
+   `pass` only for an exit-0 run you observed on the tree you pushed, `fail`
+   for a non-zero one. A check you did not run gets a row with result
+   `not run` and a one-line reason — never omit that row, and never write
+   `pass` in its place. **Recording a pass for a command you did not run, or
+   whose exit status you did not read, is a protocol violation**, in the same
+   class as reporting success on failing output: the worker re-runs these
+   commands after you return, and the contradiction lands on the ticket.
+
+   **A failed check means no PR at all.** The floor's gate stands — never open
+   a PR on failing output. Fix it, or take the `BLOCKED` / `FAILED` route in
+   §3. The table exists to show passes, not to normalise shipping a red; a PR
+   whose table admits a `fail` row should not have been opened.
+
+   **Keep it bounded: at most 15 rows, one line each.** At minimum the
+   ticket's exact `Verification Command` and the repo's configured `verify`
+   from `config/repos.yaml`, plus the UX gate row (`not run` with the reason
+   when the gate was skipped). Notes are a phrase — counts, the failing name,
+   the reason it did not run. No pasted output, no stack traces, no logs: the
+   full output stays in the transcript and in `artifact.verification.output`.
+   This is a reviewer's summary, not a log dump.
+
+   **The table and the `## Handoff` comment must agree.** The
+   `Verification Command` row carries the same command string and the same
+   result as the Handoff's `Verification:` line below — write one from the
+   other so the two cannot drift. If they disagree, both are void: no reader
+   can tell which run is being described. Both are agent-reported, and the
+   worker's `## Handoff verification (worker-observed)` comment is what
+   settles the question.
 
    Post the structured `## Handoff` comment on the ticket before transitioning:
 

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,7 +13,11 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["gh:read", "tracker:read", "repo:read"]
+    "services": [
+      "gh:read",
+      "tracker:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -26,12 +30,14 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": ["decision"],
+      "kinds": [
+        "decision"
+      ],
       "max": 10
     }
   ],
   "pins": {
-    "agents/merge-review.md": "sha256:77be28101f5e4645a37501bc4aa2dd80dd87519b528eb8b9db0c2ed55ea1d73f",
+    "agents/merge-review.md": "sha256:992f89bdeeae3280ced0a62e4ac33927fb3ef9062144578193bfe43373ad814d",
     "schemas/merge-review.input.json": "sha256:d7051604031742a3b0e060f9fb1359aa5de3b3d42a80714f11492054e81a50f8",
     "schemas/merge-review.output.json": "sha256:efad4e30c1fed1978794630397819d71d78391381a6375edab704eaf5458b282"
   }

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -13,11 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "gh:read",
-      "tracker:read",
-      "repo:read"
-    ]
+    "services": ["gh:read", "tracker:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 300,
@@ -30,9 +26,7 @@
         "type": "repo",
         "id": "$.input.repo"
       },
-      "kinds": [
-        "decision"
-      ],
+      "kinds": ["decision"],
       "max": 10
     }
   ],

--- a/event-runtime/agents/merge-review.md
+++ b/event-runtime/agents/merge-review.md
@@ -37,6 +37,24 @@ comments. Require a valid structured Handoff, diff containment in Owned Paths,
 mergeability, non-draft state, real required CI, behavior correctness, and
 falsifiable regression tests. Green CI alone is never MERGE.
 
+The PR body may carry a `## Validation` table from the agent that wrote the
+diff. It is **claimed** evidence, never verified evidence: one run's own
+account of what it ran, written by the author. Read it as a map of where to
+look first. **Your own verification still governs** — every gate above is
+yours to evidence, and a table can never be the reason you skipped one.
+Required checks come only from the resolver below; Owned Paths containment,
+Handoff validity, falsifiable tests, and behavior correctness come only from
+the diff, the checks, and the ticket. If you find yourself accepting a row in
+place of running a gate, that is exactly the failure this paragraph exists to
+stop.
+
+A `pass` row contradicted by a red required check, or by the worker's
+`## Handoff verification (worker-observed)` comment, softens neither: the
+observed exit code wins, and the contradiction is itself a finding. An absent,
+partial, or malformed table is not by itself FIX or ESCALATE — it only means
+you start with less. Judge the PR on the gates, exactly as you would with no
+table at all.
+
 Resolve the CI gate mechanically for the pinned head SHA with the supported
 PR-level command and the checked-in resolver. Capture status and combined
 output from exactly:

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -223,8 +223,13 @@ describe("registry", () => {
     // Regenerated (security-ticket dispatch, WM-1060): work-scan.md now admits
     // `type:security` candidates when input.dispatchSecurity == "auto" instead
     // of always pre-filtering them. work-scan.md re-pinned.
+    // Regenerated (#1077): dispatch.md specifies the PR body's `## Validation`
+    // table and merge-review.md is told to treat it as claimed, not verified,
+    // evidence. Both prompts are registry inputs; dispatch.json and
+    // merge-review.json are re-pinned. Prompt text only — no schema, contract,
+    // route, or capability changed.
     const expected =
-      "sha256:2a45a320768f5d1f70657b4fb2940742ba0418637b22b65cc5ce4808256c33df";
+      "sha256:5af0bf31532d3fcd8e119e4c054d2a3f119dea89004fe95bce4ed061bb2e44e8";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -464,8 +469,12 @@ describe("registry", () => {
     // commands, leaving full suites to CI, and re-pins dispatch.
     // Regenerated (WM-1039 rebase over tracker-neutral sweep)
     // Regenerated (WM-1006 cutover: ticket patterns accept GitHub owner/repo#N ids; schemas re-pinned)
+    // Regenerated (#1077): dispatch.md specifies the PR body's `## Validation`
+    // table (observed results, no PR on a fail, bounded rows, must agree with
+    // the Handoff), so the prompt pin moved. Prompt text only — `pack` stays
+    // non-enumerable and no enumerable key was added.
     expect(computeDefHash(def)).toBe(
-      "sha256:1e8c07fc1354070bfa88f82c0ef0537404d70f0c7e616d6359a23177ed6f3057",
+      "sha256:9b9f59322454c0935cef3a83c85adf2dee84e6b1e6d5301d1b1de46267b05ea4",
     );
   });
 


### PR DESCRIPTION
Fixes #1077

Dispatched agents already run the ticket's Verification Command and the repo's `verify`; that evidence died in the transcript. The PR body now carries it as a `## Validation` table, and `merge-review` is told the table is claimed evidence that never displaces its own verification. This PR body is the first instance of the format it specifies.

## Validation

| Check                | Command                                                                                      | Result  | Notes                                                                    |
| -------------------- | -------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------ |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib`                              | fail    | 1576/1577 locally; sole failure `acp.test.mjs > timeout kills a long-lived grandchild` — pre-existing host issue, see below |
| Verification Command | `bun run check`                                                                                | pass    | `ok — 90 generated files match shared/`, exit 0                           |
| Formatting           | `npx prettier --check .`                                                                       | pass    | All matched files use Prettier code style (red on the first push; fixed)  |
| Agent pins           | `bun event-runtime/cli.mjs update-pins --check`                                                 | pass    | pins already current after re-pin + prettier                              |
| CI required checks   | `gh pr checks 1101`                                                                            | pass    | Verify / Full verification / Fast unit tests / Timing-bound all green      |
| UX critique          | factory-ux-critic                                                                              | not run | agent-definition prose; no user-facing surface                            |

**About the `fail` row — read it, don't wave it through.** The one failing test is `event-runtime/lib/adapters/acp.test.mjs > timeout kills a long-lived grandchild`. It is not caused by this diff and is not fixable inside this ticket's Owned Paths:

- `event-runtime/lib/adapters/**` is byte-identical to `origin/develop` on this branch (`git diff origin/develop -- event-runtime/lib/adapters/` is empty).
- It reproduces on `origin/develop` content on this host, with and without the sandbox.
- **CI settles it**: `Fast unit tests` — the same `event-runtime/lib` suite — passes on the runner for this branch. The failure is local to the macOS host.

Filed as #1099 with the triage detail (that host also needs `TMPDIR` realpath'd, `/var` → `/private/var`, or ~28 worker/dispatch tests fail with `path "…" escapes workspace`).

## What changed

`event-runtime/agents/dispatch.md` (step 6) now specifies the whole PR body rather than just `Fixes <TICKET>`:

- `Fixes <TICKET>` first, `## Validation` in the middle, `run:$FACTORY_RUN_ID` last — both existing required lines are unchanged and the section is added between them, never in place of either.
- **Observed, not asserted.** A row records the exit status the agent actually saw. `pass` only for an exit-0 run on the tree that was pushed. A check that was not run is a `not run` row with a reason — never omitted, never marked passing. Recording a pass for a command whose exit status was not read is stated, in those terms, to be a protocol violation, in the same class as reporting success on failing output.
- **A failed check means no PR at all.** The floor's existing gate stands; the table exists to show passes, not to normalise shipping reds.
- **Bounded**: at most 15 rows, one line each, minimum the ticket's Verification Command and the repo's configured `verify`, plus the UX gate row. Full output stays in the transcript and `artifact.verification.output`.
- **No drift with the Handoff**: the `Verification Command` row must carry the same command string and result as the `## Handoff` comment's `Verification:` line, written one from the other; if they disagree, both are void.

`event-runtime/agents/merge-review.md` gains an explicit paragraph: the table is **claimed** evidence, never verified evidence — the author's own account of what it ran. The reviewer's own verification still governs, a table can never be the reason a gate was skipped, a `pass` row contradicted by a red check or by the worker-observed Handoff loses to the exit code, and an absent or malformed table is not by itself FIX or ESCALATE.

## Files outside Owned Paths (2), and why

The ticket's Owned Paths are `dispatch.md`, `dispatch.json`, `merge-review.md`. Two more files changed as the mechanical companions of an owned edit — the same pattern as every prior agent-definition commit (e.g. #812, #777):

- `event-runtime/agents/merge-review.json` — the content pin for `merge-review.md`. A stale pin is a hard `RegistryError` at registry load ("content … does not match pin"), so editing the prompt without re-pinning ships a broken registry. Written by `bun event-runtime/cli.mjs update-pins`, not by hand.
- `event-runtime/lib/registry.test.mjs` — the two change-detector baselines (`zero-pack merged-view digest`, `pack provenance never enters the receipt defHash`). Both are documented as requiring an explicit reason in the PR body when regenerated; the reason is recorded as a comment above each constant. No assertion was weakened: the constants still pin exact hashes, and `pack` remains non-enumerable (that half of the defHash test is untouched and still passing).

Owned Paths omitting the pin file and the digest baseline is a recurring papercut for every agent-prompt ticket; recorded in #1099 rather than widened here.

Second commit note: `update-pins` rewrites the whole definition file with `JSON.stringify(…, 2)`, expanding short arrays that prettier collapses, so re-pinning alone turns those JSON files into a red `format:check`. Running prettier afterwards is required and leaves `update-pins --check` satisfied.
