### PR TITLE
feat(cli): factory ask — one read-only surface for factory state (#1069)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -71,6 +71,7 @@ case "$cmd" in
     echo "factory linear is deprecated — use 'factory ticket'" >&2
     run_bun tools/ticket.mjs "$@"
     ;;
+  ask)          run_bun orchestrator/ask.mjs "$@" ;;
   queue)        run_bun orchestrator/queue.mjs "$@" ;;
   next)         run_bun orchestrator/next.mjs "$@" ;;
   state)        run_bun orchestrator/state.mjs "$@" ;;
@@ -282,6 +283,8 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   init          scaffold config/*.yaml from tracked examples (never overwrites)
   ticket        tools/ticket.mjs
   linear        tools/ticket.mjs (deprecated alias for 'ticket')
+  ask           orchestrator/ask.mjs (read-only factory state: queue, in-flight,
+                held, recent runs, planner declines, spend; --json --section --repo)
   queue         orchestrator/queue.mjs
   next          orchestrator/next.mjs
   state         orchestrator/state.mjs

--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -1,0 +1,697 @@
+#!/usr/bin/env bun
+/**
+ * factory ask — ONE read-only surface for "what is the factory doing?" (#1069).
+ *
+ *   factory ask                       # human summary, every non-report_only repo
+ *   factory ask --json                # the document the summary is rendered from
+ *   factory ask --repo factory        # scope to one repo
+ *   factory ask --section queue,held  # only those sections
+ *
+ * Why this exists: every consumer that wants factory state re-derives it from a
+ * different place — queue.mjs knows what is dispatchable, economics.mjs parses
+ * transcripts for spend, and the reason a planner declined to act lives only in
+ * `proposals.reason` inside runtime.db. Three consumers are queued (the @factory
+ * Buzz agent, the context graph, the web Overview) and building the read surface
+ * once is strictly cheaper than three parsers over the same prose.
+ *
+ * Two invariants hold this together:
+ *
+ *   READ-ONLY BY CONSTRUCTION. This module imports no write verb and calls
+ *   none. `orchestrator/ask.test.mjs` asserts both — statically over this
+ *   source, and dynamically by running a whole `ask` against a fake control
+ *   plane and checking that no claim/transition/setLabels/file/comment call
+ *   ever reached it. `ask` is safe to run from anywhere, at any cadence.
+ *
+ *   EVERY SECTION IS INDEPENDENTLY FALLIBLE. A tracker that cannot be reached
+ *   is not "no tickets" (docs/protocol.md, "GitHub Issues binding"): the
+ *   failing section carries `{ error }` and the renderer prints "unavailable",
+ *   never an empty list, while every other section still returns. The command
+ *   exits 0 — a partial answer is the point.
+ *
+ * The JSON is the source; the text is rendered from it by `formatAsk`, so the
+ * two cannot disagree.
+ */
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { dbPath } from "../event-runtime/lib/config.mjs";
+import { usageSpend } from "../event-runtime/lib/db.mjs";
+import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import { loadQueueConfig } from "../lib/queue-summary.mjs";
+import {
+  LOG_DIR,
+  budgetExhausted,
+  todaysSpendBreakdown,
+} from "../lib/spend.mjs";
+import { AI_BLOCKED } from "./reply-detection.mjs";
+
+/** `ai:blocked` waits on an answer; `ai:escalated` waits on a decision. */
+export const AI_ESCALATED = "ai:escalated";
+export const HELD_LABELS = Object.freeze([AI_BLOCKED, AI_ESCALATED]);
+
+/** Top-level keys of the document, in render order. */
+export const SECTIONS = Object.freeze([
+  "queue",
+  "inflight",
+  "held",
+  "recent",
+  "noop",
+  "spend",
+]);
+
+/**
+ * Control-plane verbs `ask` must never reach. Exported so the test asserts
+ * against this list rather than a second copy of it that can drift.
+ */
+export const WRITE_OPS = Object.freeze([
+  "claim",
+  "transition",
+  "setLabels",
+  "file",
+  "comment",
+  "appendDetail",
+]);
+
+const DEFAULT_WINDOW_HOURS = 24;
+
+const reasonOf = (error) =>
+  error?.message ? String(error.message) : String(error);
+
+const oneLine = (value, max = 300) => {
+  const text = String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+};
+
+const labelNames = (ticket) =>
+  (Array.isArray(ticket?.labels)
+    ? ticket.labels
+    : (ticket?.labels?.nodes ?? [])
+  )
+    .map((l) => l?.name)
+    .filter(Boolean);
+
+const stateName = (ticket) => ticket?.state?.name ?? null;
+
+const msSince = (iso, now) => {
+  if (!iso) return null;
+  const at = Date.parse(iso);
+  return Number.isFinite(at) ? Math.max(0, now - at) : null;
+};
+
+/** Compact duration for the human view: 5s / 12m / 3h / 2d. */
+export function humanAge(ms) {
+  if (ms == null) return "unknown";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+/**
+ * `--section` -> the requested subset, in SECTIONS order.
+ *
+ * Throws (rather than silently dropping) on an unknown name: a typo that
+ * returns fewer sections looks exactly like a quiet factory, which is the one
+ * failure mode this whole command exists to prevent.
+ */
+export function parseSections(raw) {
+  if (raw == null || raw === "") return [...SECTIONS];
+  const wanted = String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const unknown = wanted.filter((s) => !SECTIONS.includes(s));
+  if (unknown.length) {
+    const error = new Error(
+      `unknown section ${unknown.map((s) => JSON.stringify(s)).join(", ")} — valid sections: ${SECTIONS.join(", ")}`,
+    );
+    error.code = "UNKNOWN_SECTION";
+    throw error;
+  }
+  if (!wanted.length) return [...SECTIONS];
+  return SECTIONS.filter((s) => wanted.includes(s));
+}
+
+/**
+ * runtime.db opened READ-ONLY on purpose. `openDb()` would migrate and set
+ * pragmas — writes, from a command whose whole contract is that it does none.
+ */
+export function openRuntimeDb(file = dbPath()) {
+  if (!existsSync(file)) throw new Error(`no runtime database at ${file}`);
+  return new Database(file, { readonly: true });
+}
+
+const emptySection = (extra = {}) => ({ error: null, errors: [], ...extra });
+
+/**
+ * Run `fn` for each repo, collecting rows and per-repo failures.
+ *
+ * `error` is set only when NO repo produced a trustworthy answer — that is the
+ * "this section is unavailable" signal. A partial failure keeps its rows and
+ * still names the repos it could not read in `errors`, because dropping them
+ * silently is how an unreachable tracker starts reading as an empty queue.
+ */
+async function perRepo(repos, fn) {
+  if (!repos.length) {
+    return {
+      rows: [],
+      error: "no repositories configured (config/repos.yaml)",
+      errors: [],
+    };
+  }
+  const rows = [];
+  const errors = [];
+  for (const repo of repos) {
+    try {
+      rows.push(...(await fn(repo)));
+    } catch (error) {
+      errors.push({ repo: repo.name, error: reasonOf(error) });
+    }
+  }
+  return {
+    rows,
+    error:
+      errors.length === repos.length
+        ? errors.map((e) => `${e.repo}: ${e.error}`).join("; ")
+        : null,
+    errors,
+  };
+}
+
+/** Runs started inside the window, with their last attempt's usage. */
+function recentRuns(db, { sinceIso }) {
+  return db
+    .query(
+      `SELECT r.run_id                                   AS runId,
+              r.state                                    AS outcome,
+              r.attempts                                 AS attempts,
+              r.created_at                               AS createdAt,
+              r.updated_at                               AS updatedAt,
+              json_extract(r.spec_json, '$.agent')       AS agent,
+              json_extract(r.spec_json, '$.adapter')     AS adapter,
+              json_extract(r.spec_json, '$.modelTier')   AS modelTier,
+              json_extract(r.spec_json, '$.input.repo')  AS repo,
+              COALESCE(u.model, json_extract(r.spec_json, '$.model')) AS model,
+              COALESCE(u.cost_usd, 0)                    AS costUSD,
+              COALESCE(u.input_tokens, 0)                AS inputTokens,
+              COALESCE(u.output_tokens, 0)               AS outputTokens
+         FROM runs r
+         LEFT JOIN run_usage u
+           ON u.run_id = r.run_id
+          AND u.attempt = (SELECT MAX(attempt) FROM run_usage WHERE run_id = r.run_id)
+        WHERE r.created_at >= ?
+        ORDER BY r.created_at DESC`,
+    )
+    .all(sinceIso);
+}
+
+/**
+ * The latest planner decline per event type, with its reason.
+ *
+ * Deliberately NOT windowed: "nothing has dispatched since Tuesday" is
+ * answered by a decline that is itself days old, and hiding it behind a 24h
+ * cutoff would leave the question unanswerable. `ageMs` carries the staleness
+ * instead.
+ */
+function noopReasons(db, { now }) {
+  return db
+    .query(
+      `SELECT event_type AS eventType, reason, created_at AS at,
+              proposal_id AS proposalId, subject, total
+         FROM (
+           SELECT e.type       AS event_type,
+                  p.reason     AS reason,
+                  p.created_at AS created_at,
+                  p.id         AS proposal_id,
+                  e.subject    AS subject,
+                  COUNT(*)   OVER (PARTITION BY e.type) AS total,
+                  ROW_NUMBER() OVER (PARTITION BY e.type ORDER BY p.created_at DESC) AS rn
+             FROM proposals p
+             JOIN events e
+               ON e.source = p.event_source AND e.event_id = p.event_id
+            WHERE p.decision = 'noop'
+         )
+        WHERE rn = 1
+        ORDER BY created_at DESC`,
+    )
+    .all()
+    .map((row) => ({ ...row, ageMs: msSince(row.at, now) }));
+}
+
+/**
+ * Build the whole document.
+ *
+ * Every dependency is injectable so the test drives a fake control plane, an
+ * in-memory runtime.db and a temp log dir — and so no test ever touches the
+ * operator's live state.
+ *
+ * @param {object}   [opts]
+ * @param {string[]} [opts.sections]        subset of SECTIONS to produce
+ * @param {object[]} [opts.repos]           config/repos.yaml entries
+ * @param {object}   [opts.policy]          config/policy.yaml (budget)
+ * @param {Function} [opts.controlPlaneFor] repo -> ControlPlane
+ * @param {object|null} [opts.db]           open runtime.db handle; null skips it
+ * @param {string}   [opts.logDir]          transcript directory for spend
+ * @param {number}   [opts.now]             clock, epoch ms
+ * @param {number}   [opts.windowHours]     `recent` window
+ */
+export async function gatherAsk({
+  sections = SECTIONS,
+  repos,
+  policy,
+  controlPlaneFor,
+  db,
+  logDir = LOG_DIR,
+  now = Date.now(),
+  windowHours = DEFAULT_WINDOW_HOURS,
+} = {}) {
+  const want = new Set(sections);
+  const order = SECTIONS.filter((s) => want.has(s));
+
+  let repoList = repos;
+  let policyConfig = policy;
+  if (!repoList) {
+    const config = loadQueueConfig();
+    repoList = (config.repos ?? []).filter((r) => !r.report_only);
+    policyConfig ??= config.policy;
+  }
+
+  const makePlane =
+    controlPlaneFor ?? ((repo) => loadControlPlane({ repoName: repo.name }));
+  const planes = new Map();
+  const planeFor = (repo) => {
+    if (!planes.has(repo.name)) planes.set(repo.name, makePlane(repo));
+    return planes.get(repo.name);
+  };
+
+  // One listTickets per repo feeds both `inflight` and `held`. Memoised as a
+  // promise, awaited inside each section's own try/catch, so a rejection is
+  // reported per section rather than taking the document down.
+  const ticketReads = new Map();
+  const allTickets = (repo) => {
+    if (!ticketReads.has(repo.name)) {
+      ticketReads.set(
+        repo.name,
+        (async () =>
+          planeFor(repo).listTickets({
+            team: repo.team,
+            project: repo.project,
+          }))(),
+      );
+    }
+    return ticketReads.get(repo.name);
+  };
+
+  const needsDb = want.has("recent") || want.has("noop") || want.has("spend");
+  let handle = db;
+  let dbError = null;
+  let ownsDb = false;
+  if (handle === undefined) {
+    if (!needsDb) handle = null;
+    else {
+      try {
+        handle = openRuntimeDb();
+        ownsDb = true;
+      } catch (error) {
+        dbError = reasonOf(error);
+        handle = null;
+      }
+    }
+  }
+  const noDbReason = () =>
+    dbError ?? "runtime database not available to this process";
+
+  const sinceMs = now - windowHours * 60 * 60 * 1000;
+  const sinceIso = new Date(sinceMs).toISOString();
+  const repoNames = new Set(repoList.map((r) => r.name));
+
+  const doc = {
+    generatedAt: new Date(now).toISOString(),
+    window: {
+      hours: windowHours,
+      since: sinceIso,
+      until: new Date(now).toISOString(),
+    },
+    repos: repoList.map((r) => r.name),
+    sections: order,
+  };
+
+  try {
+    if (want.has("queue")) {
+      doc.queue = await perRepo(repoList, async (repo) => {
+        const tickets = await planeFor(repo).listDispatchable({
+          team: repo.team,
+          project: repo.project,
+        });
+        return tickets.map((t, index) => ({
+          repo: repo.name,
+          position: index + 1,
+          identifier: t.identifier,
+          title: t.title ?? null,
+          url: t.url ?? null,
+          priority: t.priority ?? null,
+          labels: labelNames(t),
+          createdAt: t.createdAt ?? null,
+          ageMs: msSince(t.createdAt, now),
+        }));
+      });
+    }
+
+    if (want.has("inflight")) {
+      doc.inflight = await perRepo(repoList, async (repo) => {
+        const tickets = await allTickets(repo);
+        return tickets
+          .filter((t) => stateName(t) === "In Progress")
+          .map((t) => {
+            const claimedAt = t.startedAt ?? t.createdAt ?? null;
+            return {
+              repo: repo.name,
+              identifier: t.identifier,
+              title: t.title ?? null,
+              url: t.url ?? null,
+              assignee: t.assignee?.name ?? null,
+              labels: labelNames(t),
+              claimedAt,
+              ageMs: msSince(claimedAt, now),
+              lastHeartbeatAt: t.lastCommentAt ?? null,
+              heartbeatAgeMs: msSince(t.lastCommentAt, now),
+            };
+          });
+      });
+    }
+
+    if (want.has("held")) {
+      doc.held = await perRepo(repoList, async (repo) => {
+        const tickets = (await allTickets(repo)).filter((t) =>
+          labelNames(t).some((name) => HELD_LABELS.includes(name)),
+        );
+        const rows = [];
+        for (const t of tickets) {
+          // The question is the newest comment — the same conservative guess
+          // reply-detection makes when it has no label-add to anchor on. A
+          // per-ticket failure costs the question, never the row.
+          let question = null;
+          let questionAt = null;
+          let questionError = null;
+          try {
+            const comments = await planeFor(repo).listComments(t.identifier);
+            const newest = [...comments].sort(
+              (a, b) =>
+                Date.parse(a.createdAt ?? 0) - Date.parse(b.createdAt ?? 0),
+            )[comments.length - 1];
+            if (newest) {
+              question = oneLine(newest.body, 400);
+              questionAt = newest.createdAt ?? null;
+            }
+          } catch (error) {
+            questionError = reasonOf(error);
+          }
+          rows.push({
+            repo: repo.name,
+            identifier: t.identifier,
+            title: t.title ?? null,
+            url: t.url ?? null,
+            state: stateName(t),
+            holds: labelNames(t).filter((n) => HELD_LABELS.includes(n)),
+            labels: labelNames(t),
+            question,
+            questionAt,
+            questionError,
+            ageMs: msSince(t.updatedAt ?? t.createdAt, now),
+          });
+        }
+        return rows;
+      });
+    }
+
+    if (want.has("recent")) {
+      doc.recent = emptySection({ rows: [], byOutcome: {}, totalCostUSD: 0 });
+      if (!handle) doc.recent.error = noDbReason();
+      else {
+        try {
+          // A run whose spec names no repo (maintenance, scans) belongs to
+          // every scope; one that names a repo outside the scope does not.
+          const rows = recentRuns(handle, { sinceIso }).filter(
+            (row) => !row.repo || repoNames.has(row.repo),
+          );
+          doc.recent.rows = rows.map((row) => ({
+            ...row,
+            ageMs: msSince(row.createdAt, now),
+          }));
+          doc.recent.byOutcome = rows.reduce((acc, row) => {
+            const key = row.outcome ?? "UNKNOWN";
+            acc[key] = (acc[key] ?? 0) + 1;
+            return acc;
+          }, {});
+          doc.recent.totalCostUSD = rows.reduce(
+            (sum, row) => sum + (row.costUSD ?? 0),
+            0,
+          );
+        } catch (error) {
+          doc.recent.error = reasonOf(error);
+        }
+      }
+    }
+
+    if (want.has("noop")) {
+      doc.noop = emptySection({ rows: [] });
+      if (!handle) doc.noop.error = noDbReason();
+      else {
+        try {
+          doc.noop.rows = noopReasons(handle, { now });
+        } catch (error) {
+          doc.noop.error = reasonOf(error);
+        }
+      }
+    }
+
+    if (want.has("spend")) {
+      // lib/spend.mjs is the shared parser the budget gate uses. Reusing it is
+      // the point: a second parser here would let `ask` and the gate disagree
+      // about whether the day is spent.
+      doc.spend = emptySection({
+        today: null,
+        budget: {
+          perDayUSD: policyConfig?.budget?.per_day_usd ?? null,
+          exhausted: null,
+        },
+        runtime: null,
+      });
+      try {
+        doc.spend.today = todaysSpendBreakdown(logDir);
+        doc.spend.budget.exhausted = budgetExhausted(policyConfig, logDir);
+      } catch (error) {
+        doc.spend.error = reasonOf(error);
+      }
+      if (!handle) {
+        doc.spend.errors.push({ source: "runtime.db", error: noDbReason() });
+      } else {
+        try {
+          doc.spend.runtime = usageSpend(handle, { now });
+        } catch (error) {
+          doc.spend.errors.push({
+            source: "runtime.db",
+            error: reasonOf(error),
+          });
+        }
+      }
+    }
+  } finally {
+    if (ownsDb && handle) handle.close();
+  }
+
+  return doc;
+}
+
+// ---------------------------------------------------------------- render ----
+
+const pad = (value, width) => String(value ?? "").padEnd(width);
+
+/**
+ * Column width from the rows themselves, clamped.
+ *
+ * Identifiers are `WM-1060` on Linear and `watt-mind/factory#1060` on GitHub —
+ * a hardcoded width lines up for exactly one of them.
+ */
+const columnWidth = (rows, key, min, max) =>
+  Math.min(
+    max,
+    Math.max(min, ...(rows ?? []).map((r) => String(r?.[key] ?? "").length)),
+  );
+
+function renderRows(lines, section, emptyText, render, limit = 12) {
+  if (!section) return;
+  if (section.error) {
+    lines.push(`  unavailable — ${section.error}`);
+    return;
+  }
+  if (!section.rows?.length) {
+    lines.push(`  ${emptyText}`);
+  } else {
+    for (const row of section.rows.slice(0, limit)) lines.push(render(row));
+    if (section.rows.length > limit)
+      lines.push(`  … and ${section.rows.length - limit} more`);
+  }
+  for (const e of section.errors ?? [])
+    lines.push(`  partial — ${e.repo ?? e.source}: ${e.error}`);
+}
+
+const count = (section) =>
+  section?.error ? "unavailable" : (section?.rows?.length ?? 0);
+
+/**
+ * The human view, rendered from the document `gatherAsk` returned — never from
+ * a second read. If a number here disagrees with `--json`, that is a bug in
+ * this function, not a different answer.
+ */
+export function formatAsk(doc) {
+  const lines = [];
+  lines.push(
+    `factory ask — ${doc.generatedAt}  ·  repos: ${doc.repos?.join(", ") || "(none)"}`,
+  );
+
+  if (doc.queue) {
+    const repoW = columnWidth(doc.queue.rows, "repo", 6, 16);
+    const idW = columnWidth(doc.queue.rows, "identifier", 8, 26);
+    lines.push(`\nQUEUE — dispatchable now (${count(doc.queue)})`);
+    renderRows(
+      lines,
+      doc.queue,
+      "no dispatchable tickets",
+      (r) =>
+        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.priority == null ? "p-" : `p${r.priority}`, 3)}  ${oneLine(r.title, 60)}`,
+    );
+  }
+
+  if (doc.inflight) {
+    const repoW = columnWidth(doc.inflight.rows, "repo", 6, 16);
+    const idW = columnWidth(doc.inflight.rows, "identifier", 8, 26);
+    lines.push(`\nIN FLIGHT — claimed (${count(doc.inflight)})`);
+    renderRows(
+      lines,
+      doc.inflight,
+      "nothing claimed",
+      (r) =>
+        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(`${humanAge(r.ageMs)} old`, 9)}  heartbeat ${pad(r.lastHeartbeatAt ? `${humanAge(r.heartbeatAgeMs)} ago` : "never", 10)}  ${oneLine(r.title, 45)}`,
+    );
+  }
+
+  if (doc.held) {
+    const repoW = columnWidth(doc.held.rows, "repo", 6, 16);
+    const idW = columnWidth(doc.held.rows, "identifier", 8, 26);
+    lines.push(`\nHELD — waiting on a human (${count(doc.held)})`);
+    renderRows(
+      lines,
+      doc.held,
+      "nothing held",
+      (r) =>
+        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.holds.join(","), 22)}  ${oneLine(r.question ?? r.title, 70)}`,
+    );
+  }
+
+  if (doc.recent) {
+    const outcomes = Object.entries(doc.recent.byOutcome ?? {})
+      .map(([k, v]) => `${k} ${v}`)
+      .join(" · ");
+    lines.push(
+      `\nRECENT RUNS — last ${doc.window?.hours ?? DEFAULT_WINDOW_HOURS}h (${count(doc.recent)})${outcomes ? `  ${outcomes}` : ""}`,
+    );
+    renderRows(
+      lines,
+      doc.recent,
+      "no runs in the window",
+      (r) =>
+        `  ${pad(humanAge(r.ageMs), 6)} ${pad(r.agent ?? "?", 22)} ${pad(r.adapter ?? "?", 10)} ${pad(r.model ?? "?", 24)} ${pad(r.outcome, 12)} $${(r.costUSD ?? 0).toFixed(2)}`,
+      10,
+    );
+  }
+
+  if (doc.noop) {
+    lines.push(
+      `\nPLANNER DECLINES — latest per event type (${count(doc.noop)})`,
+    );
+    renderRows(
+      lines,
+      doc.noop,
+      "no recorded declines",
+      (r) =>
+        `  ${pad(humanAge(r.ageMs), 6)} ${pad(r.eventType, 34)} ${pad(r.reason ?? "(no reason recorded)", 28)} ×${r.total}`,
+    );
+  }
+
+  if (doc.spend) {
+    lines.push("\nSPEND");
+    if (doc.spend.error) {
+      lines.push(`  unavailable — ${doc.spend.error}`);
+    } else {
+      const t = doc.spend.today ?? {};
+      const budget = doc.spend.budget?.perDayUSD;
+      lines.push(
+        `  today  ~$${(t.usd ?? 0).toFixed(2)}${budget ? ` of $${budget}` : ""}  (reported $${(t.reported ?? 0).toFixed(2)} + estimated $${(t.estimated ?? 0).toFixed(2)}, ${t.runs ?? 0} run(s))`,
+      );
+      if (doc.spend.budget?.exhausted)
+        lines.push(`  BUDGET — ${doc.spend.budget.exhausted}`);
+      const rolling = doc.spend.runtime?.rolling24h;
+      if (rolling)
+        lines.push(
+          `  runtime 24h  $${(rolling.costUSD ?? 0).toFixed(2)}  ${rolling.totalTokens ?? 0} tokens`,
+        );
+    }
+    for (const e of doc.spend.errors ?? [])
+      lines.push(`  partial — ${e.source ?? e.repo}: ${e.error}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+// ------------------------------------------------------------------- cli ----
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const val = (flag) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? null : argv[i + 1];
+  };
+
+  // Section validation first: it needs no config and no network, so a typo
+  // fails immediately rather than after a minute of tracker reads.
+  let sections;
+  try {
+    sections = parseSections(val("--section"));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(2);
+  }
+
+  const { repos: configured, policy } = loadQueueConfig();
+  const only = (val("--repo") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  let repos;
+  if (only.length) {
+    const missing = only.filter((n) => !configured.some((r) => r.name === n));
+    if (missing.length) {
+      console.error(
+        `no repo named ${missing.map((n) => JSON.stringify(n)).join(", ")} in config/repos.yaml — known: ${configured.map((r) => r.name).join(", ") || "(none)"}`,
+      );
+      process.exit(2);
+    }
+    repos = configured.filter((r) => only.includes(r.name));
+  } else {
+    repos = configured.filter((r) => !r.report_only);
+  }
+  if (!repos.length) {
+    console.error("no repos configured in config/repos.yaml");
+    process.exit(2);
+  }
+
+  const doc = await gatherAsk({ sections, repos, policy });
+  console.log(
+    argv.includes("--json") ? JSON.stringify(doc, null, 2) : formatAsk(doc),
+  );
+}

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -1,0 +1,467 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { openDb } from "../event-runtime/lib/db.mjs";
+import { memoryControlPlane } from "../lib/control-plane/memory.mjs";
+import {
+  SECTIONS,
+  WRITE_OPS,
+  formatAsk,
+  gatherAsk,
+  parseSections,
+} from "./ask.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ASK = path.join(HERE, "ask.mjs");
+const ROOT = path.resolve(HERE, "..");
+
+const NOW = Date.parse("2026-08-29T12:00:00.000Z");
+const ago = (ms) => new Date(NOW - ms).toISOString();
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+const REPO = {
+  name: "factory",
+  team: "WM",
+  project: "Factory",
+  github: "watt-mind/factory",
+};
+
+const temps = [];
+afterAll(() => {
+  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A transcript directory lib/spend.mjs will read as today's spend. */
+function seedLogDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), "gh1069-logs-"));
+  temps.push(dir);
+  writeFileSync(
+    path.join(dir, "dispatch-factory-20260829-120000.jsonl"),
+    [
+      JSON.stringify({
+        type: "assistant",
+        message: { usage: { input_tokens: 10, output_tokens: 5 }, content: [] },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        num_turns: 3,
+        total_cost_usd: 1.25,
+        duration_ms: 1000,
+      }),
+      "",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+/** Tickets covering every ticket-shaped section: queued, claimed, held. */
+function seedPlane() {
+  const project = { name: "Factory" };
+  const team = { key: "WM" };
+  return memoryControlPlane({
+    labels: [
+      { id: "l-ready", name: "ai:agent-ready" },
+      { id: "l-blocked", name: "ai:blocked" },
+      { id: "l-escalated", name: "ai:escalated" },
+    ],
+    tickets: [
+      {
+        id: "t1",
+        identifier: "WM-1",
+        title: "Dispatchable ticket",
+        state: { id: "s-todo", name: "Todo", type: "unstarted" },
+        team,
+        project,
+        labels: [{ id: "l-ready", name: "ai:agent-ready" }],
+        priority: 2,
+        createdAt: ago(6 * HOUR),
+      },
+      {
+        id: "t2",
+        identifier: "WM-2",
+        title: "Claimed ticket",
+        state: { id: "s-progress", name: "In Progress", type: "started" },
+        team,
+        project,
+        labels: [],
+        assignee: { id: "u-1", name: "Ada" },
+        createdAt: ago(5 * HOUR),
+        startedAt: ago(3 * HOUR),
+        comments: [
+          { id: "c1", body: "claimed", createdAt: ago(3 * HOUR) },
+          {
+            id: "c2",
+            body: "implemented, verifying",
+            createdAt: ago(11 * MIN),
+          },
+        ],
+      },
+      {
+        id: "t3",
+        identifier: "WM-3",
+        title: "Held ticket",
+        state: { id: "s-blocked", name: "Blocked", type: "started" },
+        team,
+        project,
+        labels: [{ id: "l-blocked", name: "ai:blocked" }],
+        createdAt: ago(30 * HOUR),
+        updatedAt: ago(2 * HOUR),
+        comments: [
+          { id: "c3", body: "starting", createdAt: ago(4 * HOUR) },
+          {
+            id: "c4",
+            body: "Which base branch should this target?",
+            createdAt: ago(2 * HOUR),
+          },
+        ],
+      },
+      {
+        id: "t4",
+        identifier: "WM-4",
+        title: "Finished ticket",
+        state: { id: "s-done", name: "Done", type: "completed" },
+        team,
+        project,
+        labels: [],
+        createdAt: ago(40 * HOUR),
+      },
+    ],
+  });
+}
+
+/** An in-memory runtime.db with runs, usage, events and a noop proposal. */
+function seedDb() {
+  const db = openDb(":memory:");
+  const insertRun = (runId, agent, adapter, model, state, createdAt, repo) =>
+    db
+      .query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, 'sha256:x', ?, 1, ?, ?)`,
+      )
+      .run(
+        runId,
+        `key-${runId}`,
+        JSON.stringify({
+          agent,
+          adapter,
+          model,
+          modelTier: "standard",
+          input: { repo },
+        }),
+        state,
+        createdAt,
+        createdAt,
+      );
+
+  insertRun(
+    "run_recent",
+    "dispatch@3",
+    "claude",
+    "sonnet-4.6",
+    "SUCCEEDED",
+    ago(2 * HOUR),
+    "factory",
+  );
+  insertRun(
+    "run_failed",
+    "merge-scan@2",
+    "cursor",
+    "cursor-grok-4.6-high",
+    "FAILED",
+    ago(4 * HOUR),
+    "factory",
+  );
+  // Outside the 24h window: must not appear in `recent`.
+  insertRun(
+    "run_old",
+    "dispatch@3",
+    "claude",
+    "sonnet-4.6",
+    "SUCCEEDED",
+    ago(40 * HOUR),
+    "factory",
+  );
+  // Another repo: must not appear when the scope is `factory` alone.
+  insertRun(
+    "run_other_repo",
+    "dispatch@3",
+    "claude",
+    "sonnet-4.6",
+    "SUCCEEDED",
+    ago(3 * HOUR),
+    "legalease",
+  );
+
+  db.query(
+    `INSERT INTO run_usage (run_id, attempt, adapter, model, input_tokens, output_tokens,
+       cache_creation_input_tokens, cache_read_input_tokens, cost_usd, recorded_at)
+     VALUES (?, 1, 'claude', 'sonnet-4.6', 100, 50, 0, 0, 0.75, ?)`,
+  ).run("run_recent", ago(2 * HOUR));
+
+  const insertEvent = (source, eventId, type, subject, at) =>
+    db
+      .query(
+        `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at,
+           envelope_json, payload_hash, admitted_at)
+         VALUES (?, ?, ?, ?, ?, ?, '{}', 'sha256:y', ?)`,
+      )
+      .run(source, eventId, type, subject, at, at, at);
+  const insertProposal = (id, eventId, decision, reason, at) =>
+    db
+      .query(
+        `INSERT INTO proposals (id, event_source, event_id, decision, status, reason, created_at, ttl_seconds)
+         VALUES (?, 'scheduler', ?, ?, 'open', ?, ?, 600)`,
+      )
+      .run(id, eventId, decision, reason, at);
+
+  insertEvent(
+    "scheduler",
+    "e-dispatch-old",
+    "factory.dispatch.requested",
+    "factory",
+    ago(5 * HOUR),
+  );
+  insertEvent(
+    "scheduler",
+    "e-dispatch-new",
+    "factory.dispatch.requested",
+    "factory",
+    ago(20 * MIN),
+  );
+  insertEvent(
+    "scheduler",
+    "e-merge",
+    "factory.merge.requested",
+    "factory",
+    ago(90 * MIN),
+  );
+  insertProposal(
+    "prop-old",
+    "e-dispatch-old",
+    "noop",
+    "capacity_full",
+    ago(5 * HOUR),
+  );
+  insertProposal(
+    "prop-new",
+    "e-dispatch-new",
+    "noop",
+    "owned_paths_overlap",
+    ago(20 * MIN),
+  );
+  insertProposal(
+    "prop-merge",
+    "e-merge",
+    "noop",
+    "previous_run_in_flight",
+    ago(90 * MIN),
+  );
+  // An accepted proposal is not a decline and must not surface in `noop`.
+  insertEvent(
+    "scheduler",
+    "e-accepted",
+    "factory.triage.requested",
+    "factory",
+    ago(10 * MIN),
+  );
+  insertProposal("prop-ok", "e-accepted", "run", null, ago(10 * MIN));
+
+  return db;
+}
+
+function askArgs(overrides = {}) {
+  return {
+    repos: [REPO],
+    policy: { budget: { per_day_usd: 200 } },
+    db: seedDb(),
+    logDir: seedLogDir(),
+    now: NOW,
+    ...overrides,
+  };
+}
+
+test("every section is present and typed on a seeded fixture", async () => {
+  const plane = seedPlane();
+  const doc = await gatherAsk(askArgs({ controlPlaneFor: () => plane }));
+
+  expect(doc.sections).toEqual([...SECTIONS]);
+  for (const name of SECTIONS) expect(doc[name]).toBeDefined();
+  expect(doc.repos).toEqual(["factory"]);
+
+  // queue — dispatchable only, as typed rows
+  expect(doc.queue.error).toBeNull();
+  expect(doc.queue.rows.map((r) => r.identifier)).toEqual(["WM-1"]);
+  expect(doc.queue.rows[0]).toMatchObject({
+    repo: "factory",
+    priority: 2,
+    labels: ["ai:agent-ready"],
+  });
+  expect(doc.queue.rows[0].ageMs).toBe(6 * HOUR);
+
+  // inflight — claimed, with age and last heartbeat
+  expect(doc.inflight.rows.map((r) => r.identifier)).toEqual(["WM-2"]);
+  expect(doc.inflight.rows[0].ageMs).toBe(3 * HOUR);
+  expect(doc.inflight.rows[0].heartbeatAgeMs).toBe(11 * MIN);
+  expect(doc.inflight.rows[0].assignee).toBe("Ada");
+
+  // held — with the question
+  expect(doc.held.rows.map((r) => r.identifier)).toEqual(["WM-3"]);
+  expect(doc.held.rows[0].holds).toEqual(["ai:blocked"]);
+  expect(doc.held.rows[0].question).toBe(
+    "Which base branch should this target?",
+  );
+
+  // recent — 24h window, scoped to the requested repos
+  expect(doc.recent.rows.map((r) => r.runId)).toEqual([
+    "run_recent",
+    "run_failed",
+  ]);
+  expect(doc.recent.rows[0]).toMatchObject({
+    agent: "dispatch@3",
+    adapter: "claude",
+    model: "sonnet-4.6",
+    outcome: "SUCCEEDED",
+    costUSD: 0.75,
+  });
+  expect(doc.recent.byOutcome).toEqual({ SUCCEEDED: 1, FAILED: 1 });
+
+  // noop — the LATEST decline per event type, with its reason
+  expect(doc.noop.rows.map((r) => r.eventType)).toEqual([
+    "factory.dispatch.requested",
+    "factory.merge.requested",
+  ]);
+  expect(doc.noop.rows[0]).toMatchObject({
+    reason: "owned_paths_overlap",
+    total: 2,
+  });
+  expect(doc.noop.rows.some((r) => r.reason === "capacity_full")).toBe(false);
+
+  // spend — from lib/spend.mjs, not a second parser
+  expect(doc.spend.error).toBeNull();
+  expect(doc.spend.today).toMatchObject({ runs: 1, reported: 1.25 });
+  expect(doc.spend.budget.perDayUSD).toBe(200);
+  expect(doc.spend.runtime.rolling24h.costUSD).toBe(0.75);
+
+  // The text view is rendered from this document, so it agrees by construction.
+  const text = formatAsk(doc);
+  expect(text).toContain("WM-1");
+  expect(text).toContain("WM-2");
+  expect(text).toContain("Which base branch should this target?");
+  expect(text).toContain("owned_paths_overlap");
+  expect(text).toContain("$1.25");
+});
+
+test("a failing section carries its error and never renders as empty", async () => {
+  const unreachable = () => {
+    throw new Error("control plane unreachable: HTTP 403 secondary rate limit");
+  };
+  const brokenPlane = {
+    kind: "memory",
+    async listTickets() {
+      unreachable();
+    },
+    async listDispatchable() {
+      unreachable();
+    },
+    async listComments() {
+      unreachable();
+    },
+  };
+  const doc = await gatherAsk(askArgs({ controlPlaneFor: () => brokenPlane }));
+
+  for (const name of ["queue", "inflight", "held"]) {
+    expect(doc[name].error).toContain("secondary rate limit");
+    expect(doc[name].rows).toEqual([]);
+  }
+  // …and every other section still returns real data.
+  expect(doc.recent.error).toBeNull();
+  expect(doc.recent.rows.length).toBe(2);
+  expect(doc.noop.error).toBeNull();
+  expect(doc.noop.rows.length).toBe(2);
+  expect(doc.spend.error).toBeNull();
+
+  const text = formatAsk(doc);
+  expect(text).toContain("unavailable — factory: control plane unreachable");
+  expect(text).not.toContain("no dispatchable tickets");
+  expect(text).not.toContain("nothing claimed");
+  expect(text).not.toContain("nothing held");
+});
+
+test("runtime-database sections fail independently of the tracker", async () => {
+  const plane = seedPlane();
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => plane, db: null }),
+  );
+
+  expect(doc.recent.error).toContain("runtime database not available");
+  expect(doc.recent.rows).toEqual([]);
+  expect(doc.noop.error).toContain("runtime database not available");
+  // Tracker sections are untouched by a missing runtime database.
+  expect(doc.queue.error).toBeNull();
+  expect(doc.queue.rows.length).toBe(1);
+  // Spend still reports transcript totals, and names the part it lost.
+  expect(doc.spend.error).toBeNull();
+  expect(doc.spend.today.runs).toBe(1);
+  expect(doc.spend.errors[0]).toMatchObject({ source: "runtime.db" });
+  expect(formatAsk(doc)).toContain("partial — runtime.db");
+});
+
+test("--section returns only the named sections", async () => {
+  const plane = seedPlane();
+  const doc = await gatherAsk(
+    askArgs({
+      controlPlaneFor: () => plane,
+      sections: parseSections("held,queue"),
+    }),
+  );
+
+  expect(doc.sections).toEqual(["queue", "held"]);
+  expect(Object.keys(doc).filter((k) => SECTIONS.includes(k))).toEqual([
+    "queue",
+    "held",
+  ]);
+  for (const absent of ["inflight", "recent", "noop", "spend"])
+    expect(doc[absent]).toBeUndefined();
+  const text = formatAsk(doc);
+  expect(text).toContain("QUEUE");
+  expect(text).not.toContain("RECENT RUNS");
+});
+
+test("an unknown section name exits non-zero naming the valid set", () => {
+  expect(() => parseSections("queue,bogus")).toThrow(/"bogus"/);
+  expect(() => parseSections("queue,bogus")).toThrow(
+    /valid sections: queue, inflight, held, recent, noop, spend/,
+  );
+
+  const proc = Bun.spawnSync({
+    cmd: ["bun", ASK, "--section", "bogus"],
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(proc.exitCode).toBe(2);
+  expect(proc.stderr.toString()).toContain(
+    "valid sections: queue, inflight, held, recent, noop, spend",
+  );
+});
+
+test("a full ask reaches the control plane with read verbs only", async () => {
+  const plane = seedPlane();
+  await gatherAsk(askArgs({ controlPlaneFor: () => plane }));
+
+  expect(plane.calls.length).toBeGreaterThan(0);
+  const used = [...new Set(plane.calls.map((c) => c.op))].sort();
+  expect(used).toEqual(["listComments", "listDispatchable", "listTickets"]);
+  for (const write of WRITE_OPS)
+    expect(plane.calls.some((c) => c.op === write)).toBe(false);
+
+  // Read-only by CONSTRUCTION, not only by this run's luck: the module must
+  // not contain a call to a write verb on any path, reached or not.
+  const source = readFileSync(ASK, "utf8");
+  for (const write of WRITE_OPS)
+    expect(source).not.toMatch(new RegExp(`\\.${write}\\s*\\(`));
+});


### PR DESCRIPTION
Fixes #1069

Adds `factory ask`, a single read-only verb that returns factory state as a
stable JSON document instead of prose that three future consumers (the
`@factory` Buzz agent, the context graph, the web Overview) would each have to
re-parse.

**Sections** (`queue`, `inflight`, `held`, `recent`, `noop`, `spend`) are typed
rows, never pre-formatted strings. `factory ask` with no `--json` renders the
human summary *from that same document*, so the two cannot disagree.
`--section queue,held` filters; an unknown name exits 2 naming the valid set.
`--repo <name>` scopes; absent, every non-`report_only` repo is included.

**Reuse, not reimplementation:** dispatchable order comes from the control-plane
contract's `listDispatchable`, spend from `lib/spend.mjs` (the same parser the
budget gate uses), repo/policy config from `lib/queue-summary.mjs`, and
`recent`/`noop` from `runs`/`run_usage` and `proposals ⋈ events` in `runtime.db`
— opened **read-only**, because `openDb()` migrates and this command writes
nothing.

**Every section is independently fallible.** A control plane that cannot be
reached puts `{ error }` on its own sections while the rest still return, and
the renderer prints `unavailable — <reason>` rather than an empty list — an
unreachable tracker must never read as "no tickets". The command still exits 0.

**Read-only by construction:** the module imports no write verb; the test suite
asserts it both dynamically (a full `ask` against a fake control plane records
only `listTickets` / `listDispatchable` / `listComments`) and statically (the
source contains no call to `claim`/`transition`/`setLabels`/`file`/`comment`/
`appendDetail`).

## Verification

```
bun test --timeout 20000 orchestrator/ask.test.mjs && ./bin/factory ask --json | head -40 && ./bin/factory ask --section queue,held
```

6 pass / 0 fail / 84 expect() calls; live `--json` returned all six sections
(queue 58, inflight 20, held 16, recent 0, noop 8, spend) with no section
errors, and `--section queue,held` returned exactly those two. Chain exit 0.

Each test was observed failing against a deliberately broken build first
(errors propagating instead of isolating; `noop` returning every decline rather
than the latest per event type; a `comment()` call spliced into the held path).

## Risks

- `held` takes the newest comment as "the question" — the same conservative
  guess `reply-detection` makes with no label-add to anchor on. It costs one
  `listComments` per held ticket, which is the bulk of the wall-clock on a
  multi-repo run (~60s live with 16 held tickets across two trackers).
- `noop` is deliberately unwindowed: the decline that explains a quiet factory
  is often older than 24h. `ageMs` carries the staleness instead.