### PR TITLE
feat(event-runtime): promote a runtime overlay into a git PR (#860)

### DIFF
--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -133,3 +133,33 @@ upgrade contract. `templates/starter/package.json` and
 `tools/publish-starter.mjs` still validate a Git commit pin as of this
 decision; migrating the starter template itself to the npm-published pin is
 follow-up scope, not part of this change.
+
+## Promote a runtime overlay into a git PR (gh-860)
+
+Decided 2026-08-25. Machine-local runtime overrides give a fast operational
+loop, but fleet defaults live in tracked agent/event-type definitions.
+Promotion is the explicit, reviewable path that turns selected effective
+overrides into a normal Git change — never an auto-commit on the live checkout
+(rejected 2026-08-19), because serve may run against production state and
+concurrent agents.
+
+Promotion is an explicit operator action. It shows a deterministic preview,
+lets the operator select all or a subset, creates an isolated ticket worktree
+via the configured repository `worktree_up` (checkout-only, from the
+configured base), writes the tracked defaults there, commits and pushes on one
+conventional commit, and opens a normal PR against the configured base. No
+merge is performed. The first version promotes only event-type adapter and
+agent `modelTier`/`model` overrides.
+
+Fail-closed rules: apply requires the exact preview digest and an explicit
+non-empty selected-key list. A stale preview, an unknown key, an unsupported
+field, invalid tracked JSON, or target drift fails before any worktree is
+created. Serve never edits, commits, or checks out branches in the live
+`FACTORY_ROOT`; the only live-root access is the read-only drift check.
+An empty selection is a typed no-op. A failure after checkout leaves the live
+checkout and the runtime override rows unchanged and returns the
+worktree/branch as recoverable evidence for operator cleanup.
+
+Promotion does not clear the runtime overrides. Clearing the overlay is a
+separate explicit action the operator takes after the promoted defaults have
+deployed, so the fast loop keeps winning until the fleet default catches up.

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -1,11 +1,13 @@
 /** Agent and repository registry endpoints. */
 import { readFileSync } from "node:fs";
 import { getArtifactView, resolveModel } from "./registry.mjs";
-import { RepoError, reposView } from "./repos.mjs";
+import { RepoError, resolvePromotionTarget, reposView } from "./repos.mjs";
 import {
   KIND_AGENT,
   KIND_EVENT_TYPE,
   OverlayError,
+  applyPromotion,
+  buildPromotionPreview,
   deleteOverride,
   emptyOverrides,
   knownAdapters,
@@ -123,10 +125,63 @@ export async function handleRegistryApiRoute({
   actor,
   db,
   nowMs,
+  promotionSeams,
 }) {
   if (route === "GET /agents") {
     const overrides = db ? listOverrides(db) : emptyOverrides();
     return send(200, agentsView(registry, { overrides }));
+  }
+
+  // Overlay promotion preview (gh-860): read-only snapshot of the promotable
+  // override rows against tracked definitions, with the digest an apply must
+  // echo back. Never touches the checkout.
+  if (route === "GET /promotion/preview") {
+    try {
+      return send(200, buildPromotionPreview({ db, registry }));
+    } catch (err) {
+      return sendOverlayError(send, err);
+    }
+  }
+
+  // Overlay promotion apply (gh-860): requires the confirmed digest and a
+  // non-empty selected-key subset, and drives the injected isolated-checkout
+  // seams. An empty selection is a typed no-op; unconfigured seams fail closed.
+  if (route === "POST /promotion/apply") {
+    const parsed = parseJson(await readBody(req));
+    if (parsed.error) return send(422, { error: parsed.error });
+    const body = parsed.value ?? {};
+    if (typeof body.repo !== "string" || body.repo.trim() === "") {
+      return send(422, { error: "repo is required" });
+    }
+    if (!Array.isArray(body.keys)) {
+      return send(422, { error: "keys must be an array" });
+    }
+    let target;
+    try {
+      target = resolvePromotionTarget(repos(), body.repo);
+    } catch (err) {
+      if (err instanceof RepoError) return send(422, { error: err.message });
+      throw err;
+    }
+    try {
+      const result = await applyPromotion({
+        db,
+        registry,
+        target,
+        digest: body.digest,
+        keys: body.keys,
+        seams: promotionSeams ?? {},
+        actor,
+      });
+      return send(200, { actor, repo: target.name, ...result });
+    } catch (err) {
+      if (err instanceof OverlayError) {
+        const payload = { error: err.message };
+        if (err.evidence) payload.evidence = err.evidence;
+        return send(err.status, payload);
+      }
+      throw err;
+    }
   }
 
   if (route === "GET /overrides") {

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -37,6 +37,8 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
+import { handleRegistryApiRoute } from "./api-registry.mjs";
+import { KIND_EVENT_TYPE, putOverride } from "./runtime-overrides.mjs";
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -454,5 +456,146 @@ describe("runtime overlay API (WM-887)", () => {
       close();
       server.close();
     }
+  });
+});
+
+describe("overlay promotion routes (gh-860)", () => {
+  const reg = loadRegistry();
+  const reposFn = () =>
+    loadRepos({
+      root: (() => {
+        const root = tmpDir("evrt-promo-repos-");
+        mkdirSync(path.join(root, "config"), { recursive: true });
+        writeFileSync(
+          path.join(root, "config", "repos.yaml"),
+          "repos:\n  - name: factory\n    path: /tmp/factory\n    github: watt-mind/factory\n    base: develop\n    worktree_up: bin/worktree-up.sh\n",
+        );
+        return root;
+      })(),
+    });
+
+  function seed(db) {
+    putOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: "factory.status-report.requested",
+      patch: { adapter: "cursor" },
+      actor: "operator",
+    });
+  }
+
+  async function invoke(method, pathname, { db, body, promotionSeams } = {}) {
+    const captured = {};
+    const send = (status, payload) => {
+      captured.status = status;
+      captured.body = payload;
+      return true;
+    };
+    await handleRegistryApiRoute({
+      route: `${method} ${pathname}`,
+      req: { method },
+      url: new URL(`http://x${pathname}`),
+      send,
+      readBody: async () => Buffer.from(JSON.stringify(body ?? {})),
+      parseJson: (buf) => {
+        try {
+          return { value: JSON.parse(buf.toString() || "{}") };
+        } catch (err) {
+          return { error: err.message };
+        }
+      },
+      registry: reg,
+      repos: reposFn,
+      actor: "operator",
+      db,
+      promotionSeams,
+    });
+    return captured;
+  }
+
+  test("GET /promotion/preview returns a digest and selectable rows", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const res = await invoke("GET", "/promotion/preview", { db });
+    expect(res.status).toBe(200);
+    expect(typeof res.body.digest).toBe("string");
+    expect(
+      res.body.selections.some(
+        (s) => s.ref === "factory.status-report.requested",
+      ),
+    ).toBe(true);
+    db.close();
+  });
+
+  test("POST /promotion/apply with an empty selection is a typed no-op", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const preview = await invoke("GET", "/promotion/preview", { db });
+    const res = await invoke("POST", "/promotion/apply", {
+      db,
+      body: { repo: "factory", digest: preview.body.digest, keys: [] },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("noop");
+    db.close();
+  });
+
+  test("POST /promotion/apply drives injected seams and returns the PR", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const preview = await invoke("GET", "/promotion/preview", { db });
+    const key = preview.body.selections.find(
+      (s) => s.ref === "factory.status-report.requested",
+    ).key;
+    const writes = new Map();
+    const promotionSeams = {
+      readTracked: (file) =>
+        readFileSync(path.join(registry.root, "..", file), "utf8"),
+      tracker: { ensure: () => ({ ticket: "gh-860-x" }) },
+      worktree: {
+        up: () => ({ dir: "/tmp/promo-x", branch: "promo/x" }),
+      },
+      readWorktree: (dir, file) =>
+        writes.has(file)
+          ? writes.get(file)
+          : readFileSync(path.join(registry.root, "..", file), "utf8"),
+      writeWorktree: (dir, file, text) => writes.set(file, text),
+      git: { commit: () => {}, push: () => {} },
+      forge: { openPr: () => ({ url: "u", number: 7 }) },
+    };
+    const res = await invoke("POST", "/promotion/apply", {
+      db,
+      body: { repo: "factory", digest: preview.body.digest, keys: [key] },
+      promotionSeams,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.pr).toEqual({ url: "u", number: 7 });
+    expect(res.body.repo).toBe("factory");
+    db.close();
+  });
+
+  test("POST /promotion/apply without configured seams fails closed (501)", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const preview = await invoke("GET", "/promotion/preview", { db });
+    const key = preview.body.selections.find(
+      (s) => s.ref === "factory.status-report.requested",
+    ).key;
+    const res = await invoke("POST", "/promotion/apply", {
+      db,
+      body: { repo: "factory", digest: preview.body.digest, keys: [key] },
+    });
+    expect(res.status).toBe(501);
+    db.close();
+  });
+
+  test("POST /promotion/apply rejects a missing repo", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const res = await invoke("POST", "/promotion/apply", {
+      db,
+      body: { digest: "x", keys: ["k"] },
+    });
+    expect(res.status).toBe(422);
+    db.close();
   });
 });

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -795,6 +795,16 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
     writable: true,
     configurable: true,
   });
+  // The definition's own JSON file, kept non-enumerably for the same reason as
+  // `pack`: it is loader-injected filesystem provenance, not definition content
+  // hashed into the defHash. Overlay promotion (gh-860) needs the owning file to
+  // write a tracked model_tier/model default; `agentDefinitionFile` reads it.
+  Object.defineProperty(loaded, "defSource", {
+    value: entry?.source ?? null,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
   if (def.memos !== undefined) {
     validateMemosDeclaration(def.memos, {
       source,
@@ -1362,6 +1372,42 @@ export function getAgent(registry, ref) {
   const def = registry.agents.get(ref);
   if (!def) throw new RegistryError(`unregistered agent ${ref}`);
   return def;
+}
+
+/**
+ * The repo-relative JSON file that owns an agent's tracked defaults (gh-860).
+ * Overlay promotion writes model_tier/model into this file inside an isolated
+ * worktree; it never resolves against the live checkout. `root` defaults to the
+ * registry root the definition was loaded from, so the returned `file` is the
+ * path a `worktree_up` checkout of the same repo would carry.
+ *
+ * @returns {{ ref: string, file: string, absSource: string }}
+ */
+export function agentDefinitionFile(
+  registry,
+  ref,
+  { root = registry.root } = {},
+) {
+  const def = registry.agents.get(ref);
+  if (!def) throw new RegistryError(`unregistered agent ${ref}`);
+  const absSource = def.defSource;
+  if (typeof absSource !== "string" || absSource.trim() === "") {
+    throw new RegistryError(
+      `agent ${JSON.stringify(ref)} has no owning definition file (not a filesystem pack)`,
+    );
+  }
+  if (!path.isAbsolute(absSource)) {
+    throw new RegistryError(
+      `agent ${JSON.stringify(ref)} definition source ${JSON.stringify(absSource)} is not an absolute path`,
+    );
+  }
+  const file = path.relative(path.resolve(root), absSource);
+  if (file.startsWith("..") || path.isAbsolute(file)) {
+    throw new RegistryError(
+      `agent ${JSON.stringify(ref)} definition ${JSON.stringify(absSource)} is outside root ${JSON.stringify(root)}`,
+    );
+  }
+  return { ref: def.ref, file, absSource };
 }
 
 export function getEventType(registry, type) {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -7,6 +7,7 @@ import { RUNTIME_ROOT } from "./config.mjs";
 import {
   DEFAULT_MODEL,
   RegistryError,
+  agentDefinitionFile,
   createFsPackLoader,
   getAgent,
   getArtifactView,
@@ -121,6 +122,32 @@ describe("registry", () => {
       getEventType(registry, "factory.status-report.requested").agent,
     ).toBe("factory-status-report@1");
     expect(getEventType(registry, "unknown.event")).toBeNull();
+  });
+
+  test("agentDefinitionFile resolves the owning JSON relative to a chosen root (gh-860)", () => {
+    const registry = loadRegistry();
+    const packRelative = agentDefinitionFile(
+      registry,
+      "factory-status-report@1",
+    );
+    expect(packRelative.file).toBe("agents/factory-status-report.json");
+    expect(packRelative.absSource).toBe(
+      path.join(RUNTIME_ROOT, "agents", "factory-status-report.json"),
+    );
+    // Given the repo root, the path is what a full checkout carries.
+    const repoRelative = agentDefinitionFile(
+      registry,
+      "factory-status-report@1",
+      {
+        root: path.dirname(RUNTIME_ROOT),
+      },
+    );
+    expect(repoRelative.file).toBe(
+      "event-runtime/agents/factory-status-report.json",
+    );
+    expect(() => agentDefinitionFile(registry, "no-such@9")).toThrow(
+      RegistryError,
+    );
   });
 
   test("work-scan scopes every queue and inflight ticket read to its input repo", () => {

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -359,6 +359,42 @@ export function getRepo(repos, name) {
 }
 
 /**
+ * The isolated-checkout target for an overlay promotion PR (gh-860).
+ *
+ * Promotion never edits the live checkout: it hands `worktree_up` a base and a
+ * ticket branch, writes tracked defaults in that worktree, and opens a PR
+ * against the configured base. This resolver fails closed when the repo does
+ * not declare the machinery that isolation requires — a base branch, a
+ * `worktree_up` script, and a GitHub slug for the forge — so an operator can
+ * never accidentally promote onto the wrong branch or into the live root.
+ *
+ * @returns {{ name: string, path: string, base: string, github: string,
+ *             worktreeUp: string, worktreeRoot: string|null }}
+ */
+export function resolvePromotionTarget(repos, name) {
+  const repo = getRepo(repos, name);
+  if (typeof repo.base !== "string" || repo.base.trim() === "") {
+    throw new RepoError(`repo "${name}" has no base branch for promotion`);
+  }
+  if (typeof repo.worktreeUp !== "string" || repo.worktreeUp.trim() === "") {
+    throw new RepoError(
+      `repo "${name}" has no worktree_up script; promotion requires an isolated checkout`,
+    );
+  }
+  if (typeof repo.github !== "string" || repo.github.trim() === "") {
+    throw new RepoError(`repo "${name}" has no github slug for a promotion PR`);
+  }
+  return {
+    name: repo.name,
+    path: repo.path,
+    base: repo.base,
+    github: repo.github,
+    worktreeUp: repo.worktreeUp,
+    worktreeRoot: repo.worktreeRoot,
+  };
+}
+
+/**
  * Select the merge gate without treating an empty branch-protection response
  * as green. GitHub-owned required contexts win whenever they are nonempty;
  * the repo-owned declaration is the only permitted fallback.

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -8,6 +8,7 @@ import {
   proveMergeChecks,
   RepoError,
   reposView,
+  resolvePromotionTarget,
   selectMergeCheckGate,
 } from "./repos.mjs";
 
@@ -515,6 +516,38 @@ describe("control_plane on a repo entry", () => {
     );
     expect(reposView(loadRepos({ root: pinned }))[0].controlPlane).toBe(
       "github",
+    );
+  });
+});
+
+describe("resolvePromotionTarget requires an isolated-checkout target (gh-860)", () => {
+  const repos = loadRepos({ root: factoryRoot(YAML) });
+
+  test("a fully configured repo yields base, github, and worktree_up", () => {
+    const target = resolvePromotionTarget(repos, "full");
+    expect(target.base).toBe("develop");
+    expect(target.github).toBe("watt-mind/full");
+    expect(target.worktreeUp).toBe("bin/worktree-up.sh");
+    expect(target.name).toBe("full");
+  });
+
+  test("a repo without worktree_up fails closed", () => {
+    // `bare` has no worktree_up, github, and only the default base.
+    expect(() => resolvePromotionTarget(repos, "bare")).toThrow(
+      /no worktree_up script/,
+    );
+  });
+
+  test("an unknown repo fails closed", () => {
+    expect(() => resolvePromotionTarget(repos, "nope")).toThrow(RepoError);
+  });
+
+  test("a repo with worktree_up but no github fails closed", () => {
+    const root = factoryRoot(
+      "repos:\n  - name: a\n    path: /tmp/a\n    base: develop\n    worktree_up: bin/x.sh\n",
+    );
+    expect(() => resolvePromotionTarget(loadRepos({ root }), "a")).toThrow(
+      /no github slug/,
     );
   });
 });

--- a/event-runtime/lib/runtime-overrides.mjs
+++ b/event-runtime/lib/runtime-overrides.mjs
@@ -6,8 +6,12 @@
  * in runtime.db and the planner applies it at plan time. Packs cannot shadow
  * built-ins (WM-470); this is not a pack.
  */
+import path from "node:path";
 import { builtinAdapters } from "./adapters/index.mjs";
+import { hashJson } from "./canonical.mjs";
 import { txImmediate } from "./db.mjs";
+import { agentDefinitionFile } from "./registry.mjs";
+import { reposRoot } from "./repos.mjs";
 
 export const KIND_EVENT_TYPE = "eventType";
 export const KIND_AGENT = "agent";
@@ -263,4 +267,414 @@ export function overlayForAgent(overrides, ref) {
 
 export function effectiveAdapter(mapping, overrides, type) {
   return overlayForEventType(overrides, type)?.adapter ?? mapping.adapter;
+}
+
+/*
+ * Overlay promotion (gh-860).
+ *
+ * Operators run a fast machine-local overlay; promotion is the explicit,
+ * reviewable path that turns selected effective overrides into a tracked Git
+ * default. It is deliberately fenced:
+ *   - `buildPromotionPreview` snapshots the live override rows against the
+ *     tracked definitions and returns stable selectable keys plus a digest.
+ *   - `applyPromotion` refuses unless the caller echoes that digest and names a
+ *     non-empty subset of keys, then drives injected tracker/worktree/git/forge
+ *     seams to write the tracked defaults in an ISOLATED checkout and open a PR.
+ * Serve never edits, commits, or checks out the live `FACTORY_ROOT`; the only
+ * live-root access is the read-only drift check before any worktree exists.
+ * First version promotes event-type `adapter` and agent `modelTier`/`model`.
+ */
+
+const EVENT_TYPES_FILE = "event-types.json";
+
+/** Repo-relative path of the built-in pack's event-types map. */
+function eventTypesFile(registry, root) {
+  const pack =
+    registry.packs?.find((p) => p.name === "event-runtime") ??
+    registry.packs?.[0];
+  if (!pack?.root) {
+    throw new OverlayError(500, "no pack root to resolve event-types.json");
+  }
+  const file = path.relative(
+    path.resolve(root),
+    path.join(pack.root, EVENT_TYPES_FILE),
+  );
+  if (file.startsWith("..") || path.isAbsolute(file)) {
+    throw new OverlayError(
+      500,
+      "event-types.json is outside the registry root",
+    );
+  }
+  return file;
+}
+
+/**
+ * Snapshot the current override rows against tracked definitions. Every row is
+ * a selectable promotion candidate with a stable key, the tracked `before` and
+ * overlay `effective` values, the exact target file, and whether it still
+ * diverges (`current`). Only event-type adapter and agent modelTier/model are
+ * supported; unsupported overlay shapes and rows whose target is no longer
+ * registered are skipped rather than offered.
+ *
+ * @returns {{ digest: string, selections: Array<{
+ *   key: string, kind: "eventType"|"agent", ref: string, field: string,
+ *   target: { file: string, path: string }, before: unknown, effective: unknown,
+ *   current: boolean }> }}
+ */
+export function buildPromotionPreview({ db, registry, root = reposRoot() }) {
+  const overrides = listOverrides(db);
+  const selections = [];
+  const etFile = (() => {
+    try {
+      return eventTypesFile(registry, root);
+    } catch {
+      return null;
+    }
+  })();
+
+  for (const [type, patch] of Object.entries(overrides.eventTypes)) {
+    if (!patch || typeof patch.adapter !== "string") continue;
+    const mapping = registry.eventTypes?.[type];
+    if (!mapping || etFile === null) continue;
+    const before = mapping.adapter ?? null;
+    const effective = patch.adapter;
+    selections.push({
+      key: `eventType:${type}:adapter`,
+      kind: KIND_EVENT_TYPE,
+      ref: type,
+      field: "adapter",
+      target: { file: etFile, path: `["${type}"].adapter` },
+      before,
+      effective,
+      current: effective !== before,
+    });
+  }
+
+  for (const [ref, patch] of Object.entries(overrides.agents)) {
+    const def = registry.agents?.get(ref);
+    if (!def || !patch) continue;
+    let file;
+    try {
+      file = agentDefinitionFile(registry, ref, { root }).file;
+    } catch {
+      continue;
+    }
+    if (Object.hasOwn(patch, "modelTier")) {
+      const before = def.model_tier ?? null;
+      const effective = patch.modelTier ?? null;
+      selections.push({
+        key: `agent:${ref}:modelTier`,
+        kind: KIND_AGENT,
+        ref,
+        field: "modelTier",
+        target: { file, path: "model_tier" },
+        before,
+        effective,
+        current: effective !== before,
+      });
+    }
+    if (Object.hasOwn(patch, "model")) {
+      const before = def.model ?? null;
+      const effective = patch.model ?? null;
+      selections.push({
+        key: `agent:${ref}:model`,
+        kind: KIND_AGENT,
+        ref,
+        field: "model",
+        target: { file, path: "model" },
+        before,
+        effective,
+        current: effective !== before,
+      });
+    }
+  }
+
+  selections.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  const digest = hashJson(
+    selections.map((s) => ({
+      key: s.key,
+      before: s.before,
+      effective: s.effective,
+    })),
+  );
+  return { digest, selections };
+}
+
+/** Serialize a tracked definition object deterministically (2-space, LF). */
+function serializeTracked(obj) {
+  return `${JSON.stringify(obj, null, 2)}\n`;
+}
+
+/** Apply one selection's effective value onto a parsed tracked object. */
+function writeSelectionValue(obj, selection) {
+  const { effective } = selection;
+  if (selection.kind === KIND_EVENT_TYPE) {
+    const mapping = obj[selection.ref];
+    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
+      throw new OverlayError(
+        409,
+        `target drift: ${selection.ref} is not an object in ${selection.target.file}`,
+      );
+    }
+    mapping.adapter = effective;
+    return;
+  }
+  // agent modelTier -> model_tier ; model -> model. null clears the tracked key.
+  const jsonField = selection.field === "modelTier" ? "model_tier" : "model";
+  if (effective === null) delete obj[jsonField];
+  else obj[jsonField] = effective;
+}
+
+/** The tracked value a parsed object currently carries for a selection. */
+function readSelectionValue(obj, selection) {
+  if (selection.kind === KIND_EVENT_TYPE) {
+    const mapping = obj?.[selection.ref];
+    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
+      throw new OverlayError(
+        409,
+        `target drift: ${selection.ref} is not an object in ${selection.target.file}`,
+      );
+    }
+    return mapping.adapter ?? null;
+  }
+  const jsonField = selection.field === "modelTier" ? "model_tier" : "model";
+  return obj?.[jsonField] ?? null;
+}
+
+function requireSeam(seams, dotted) {
+  let node = seams;
+  for (const part of dotted.split(".")) {
+    node = node?.[part];
+  }
+  if (typeof node !== "function") {
+    throw new OverlayError(501, `promotion seam ${dotted} is not configured`);
+  }
+  return node;
+}
+
+/**
+ * Promote a non-empty subset of preview keys into a PR against the configured
+ * base. Fails closed before touching any seam when the preview digest is stale,
+ * a key is unknown, a selection no longer diverges, tracked JSON is invalid, or
+ * the tracked value drifted from the preview. An empty selection is a typed
+ * no-op that touches nothing.
+ *
+ * All mutation is driven through injected seams so nothing here can reach the
+ * live checkout: `tracker.ensure`, `worktree.up` (checkout-only, from the
+ * configured base), `readWorktree`/`writeWorktree`, `git.commit`, `git.push`,
+ * and `forge.openPr`. There is deliberately no merge or delete seam.
+ *
+ * @param {object} args
+ * @param {import("bun:sqlite").Database} args.db
+ * @param {object} args.registry
+ * @param {{ base: string, github: string, worktreeUp: string, path: string, name: string }} args.target
+ * @param {string} args.digest        preview digest the operator confirmed
+ * @param {string[]} args.keys        selected selection keys (non-empty)
+ * @param {object} args.seams         injected tracker/worktree/git/forge seams
+ * @param {string} [args.root]        live checkout root (never written)
+ */
+export async function applyPromotion({
+  db,
+  registry,
+  target,
+  digest,
+  keys,
+  seams,
+  root = reposRoot(),
+  actor = "operator",
+}) {
+  if (!Array.isArray(keys)) {
+    throw new OverlayError(422, "keys must be an array");
+  }
+  if (keys.length === 0) {
+    // Typed no-op: an empty selection promotes nothing and drives no seam.
+    return { status: "noop", promoted: [], ticket: null, pr: null };
+  }
+  if (new Set(keys).size !== keys.length) {
+    throw new OverlayError(422, "keys must be unique");
+  }
+  if (typeof digest !== "string" || digest === "") {
+    throw new OverlayError(422, "preview digest is required");
+  }
+  if (!target?.base) {
+    throw new OverlayError(422, "promotion target base is not configured");
+  }
+
+  const preview = buildPromotionPreview({ db, registry, root });
+  if (preview.digest !== digest) {
+    throw new OverlayError(
+      409,
+      "promotion preview is stale; refresh the preview and retry",
+    );
+  }
+  const byKey = new Map(preview.selections.map((s) => [s.key, s]));
+  const selected = [];
+  for (const key of keys) {
+    const selection = byKey.get(key);
+    if (!selection) throw new OverlayError(422, `unknown promotion key ${key}`);
+    if (!selection.current) {
+      throw new OverlayError(
+        409,
+        `${key} no longer diverges from its tracked default`,
+      );
+    }
+    selected.push(selection);
+  }
+
+  // Read-only drift check against the LIVE checkout before any worktree exists:
+  // parse each target file and confirm the tracked value still equals the
+  // preview `before`. Invalid JSON or drift fails closed here.
+  const readTracked = requireSeam(seams, "readTracked");
+  const byFile = new Map();
+  for (const selection of selected) {
+    const file = selection.target.file;
+    if (!byFile.has(file)) {
+      let text;
+      try {
+        text = readTracked(file);
+      } catch (err) {
+        throw new OverlayError(
+          409,
+          `cannot read tracked ${file}: ${err.message}`,
+        );
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (err) {
+        throw new OverlayError(
+          422,
+          `tracked ${file} is not valid JSON: ${err.message}`,
+        );
+      }
+      byFile.set(file, { parsed });
+    }
+    const current = readSelectionValue(byFile.get(file).parsed, selection);
+    if (current !== (selection.before ?? null)) {
+      throw new OverlayError(
+        409,
+        `target drift on ${selection.key}: tracked value changed since preview`,
+      );
+    }
+  }
+
+  // Everything validated. Create the ticket and the ISOLATED checkout.
+  const ticket = await requireSeam(seams, "tracker.ensure")({ actor, keys });
+  if (!ticket?.ticket) {
+    throw new OverlayError(500, "tracker did not return a ticket");
+  }
+  const worktree = await requireSeam(
+    seams,
+    "worktree.up",
+  )({
+    base: target.base,
+    ticket: ticket.ticket,
+    checkoutOnly: true,
+  });
+  const dir = worktree?.dir;
+  const branch = worktree?.branch;
+  if (typeof dir !== "string" || dir === "") {
+    throw new OverlayError(500, "worktree_up did not return a directory");
+  }
+  if (path.resolve(dir) === path.resolve(root)) {
+    throw new OverlayError(
+      500,
+      "refusing to promote: worktree resolved to the live checkout root",
+    );
+  }
+  if (typeof branch !== "string" || branch === "") {
+    throw new OverlayError(500, "worktree_up did not return a branch");
+  }
+
+  try {
+    const readWorktree = requireSeam(seams, "readWorktree");
+    const writeWorktree = requireSeam(seams, "writeWorktree");
+    const written = [];
+    for (const file of byFile.keys()) {
+      const parsed = JSON.parse(readWorktree(dir, file));
+      for (const selection of selected) {
+        if (selection.target.file !== file) continue;
+        writeSelectionValue(parsed, selection);
+      }
+      writeWorktree(dir, file, serializeTracked(parsed));
+      written.push(file);
+    }
+
+    const promoted = selected.map((s) => ({
+      key: s.key,
+      target: s.target,
+      before: s.before ?? null,
+      after: s.effective ?? null,
+    }));
+    const message = promotionCommitMessage(ticket.ticket, promoted);
+    const body = promotionPrBody(ticket.ticket, promoted);
+    await requireSeam(seams, "git.commit")({ dir, message, files: written });
+    await requireSeam(seams, "git.push")({ dir, branch });
+    const pr = await requireSeam(
+      seams,
+      "forge.openPr",
+    )({
+      base: target.base,
+      head: branch,
+      title: `feat(overlay): promote ${promoted.length} runtime override${
+        promoted.length === 1 ? "" : "s"
+      }`,
+      body,
+    });
+    return {
+      status: "opened",
+      ticket: ticket.ticket,
+      worktree: dir,
+      branch,
+      files: written,
+      promoted,
+      pr: pr ?? null,
+    };
+  } catch (err) {
+    // Preserve the worktree/branch for operator cleanup; nothing was merged.
+    const wrapped =
+      err instanceof OverlayError
+        ? err
+        : new OverlayError(
+            500,
+            `promotion failed after checkout: ${err.message}`,
+          );
+    wrapped.evidence = { worktree: dir, branch, ticket: ticket.ticket };
+    throw wrapped;
+  }
+}
+
+function promotionCommitMessage(ticket, promoted) {
+  const lines = promoted.map(
+    (p) =>
+      `- ${p.key}: ${JSON.stringify(p.before)} -> ${JSON.stringify(p.after)}`,
+  );
+  return `feat(overlay): promote runtime overrides to tracked defaults\n\n${lines.join(
+    "\n",
+  )}\n\nFixes ${ticket}`;
+}
+
+function promotionPrBody(ticket, promoted) {
+  const rows = promoted
+    .map(
+      (p) =>
+        `| \`${p.key}\` | \`${p.target.file}\` | ${JSON.stringify(
+          p.before,
+        )} | ${JSON.stringify(p.after)} |`,
+    )
+    .join("\n");
+  return [
+    "## What",
+    "Promote selected machine-local runtime overrides into tracked fleet defaults.",
+    "",
+    "| Override key | Target | Tracked before | Effective after |",
+    "| --- | --- | --- | --- |",
+    rows,
+    "",
+    "## Verification",
+    "Values written from a deterministic preview digest into an isolated worktree; no merge performed.",
+    "Promotion does not clear the runtime overrides — clearing is a separate explicit action after deployment.",
+    "",
+    `Fixes ${ticket}`,
+  ].join("\n");
 }

--- a/event-runtime/lib/runtime-overrides.test.mjs
+++ b/event-runtime/lib/runtime-overrides.test.mjs
@@ -1,10 +1,15 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, test } from "bun:test";
 import { openDb } from "./db.mjs";
 import { loadRegistry } from "./registry.mjs";
+import { reposRoot } from "./repos.mjs";
 import {
   KIND_AGENT,
   KIND_EVENT_TYPE,
   OverlayError,
+  applyPromotion,
+  buildPromotionPreview,
   deleteOverride,
   knownAdapters,
   listOverrideJournal,
@@ -17,6 +22,91 @@ import {
 } from "./runtime-overrides.mjs";
 
 const registry = loadRegistry();
+const REPO_ROOT = reposRoot();
+
+/** The event type + agent this repo ships that we can diverge in a preview. */
+const PROMO_TYPE = "factory.status-report.requested";
+const PROMO_AGENT = "agy-smoke@1";
+
+/** Seed the overlay with one divergent event-type adapter and one agent tier. */
+function seedDivergentOverrides(db) {
+  putOverride(db, {
+    kind: KIND_EVENT_TYPE,
+    key: PROMO_TYPE,
+    patch: { adapter: "cursor" },
+    actor: "operator",
+  });
+  putOverride(db, {
+    kind: KIND_AGENT,
+    key: PROMO_AGENT,
+    patch: { modelTier: "light" },
+    actor: "operator",
+  });
+}
+
+/**
+ * Injected promotion seams that read the repo's real tracked files but never
+ * write outside a captured in-memory worktree. Records every seam call so a
+ * test can prove nothing targets the live root and no merge/delete occurs.
+ */
+function fakeSeams({ worktreeDir = "/tmp/promo-wt-860", readTracked } = {}) {
+  const calls = [];
+  const writes = new Map();
+  return {
+    calls,
+    writes,
+    seams: {
+      readTracked:
+        readTracked ??
+        ((file) => readFileSync(path.join(REPO_ROOT, file), "utf8")),
+      tracker: {
+        ensure(args) {
+          calls.push(["tracker.ensure", args]);
+          return { ticket: "gh-860-promo" };
+        },
+      },
+      worktree: {
+        up(args) {
+          calls.push(["worktree.up", args]);
+          return { dir: worktreeDir, branch: "promo/gh-860" };
+        },
+      },
+      readWorktree(dir, file) {
+        calls.push(["readWorktree", dir, file]);
+        return writes.has(file)
+          ? writes.get(file)
+          : readFileSync(path.join(REPO_ROOT, file), "utf8");
+      },
+      writeWorktree(dir, file, text) {
+        calls.push(["writeWorktree", dir, file]);
+        writes.set(file, text);
+      },
+      git: {
+        commit(args) {
+          calls.push(["git.commit", args]);
+        },
+        push(args) {
+          calls.push(["git.push", args]);
+        },
+      },
+      forge: {
+        openPr(args) {
+          calls.push(["forge.openPr", args]);
+          return { url: "https://example/pr/1", number: 1 };
+        },
+      },
+    },
+  };
+}
+
+const TARGET = {
+  name: "factory",
+  path: "/does/not/matter",
+  base: "develop",
+  github: "watt-mind/factory",
+  worktreeUp: "bin/worktree-up.sh",
+  worktreeRoot: null,
+};
 
 describe("runtime-overrides (WM-887)", () => {
   test("put, get, delete, and journal an event-type adapter overlay", () => {
@@ -103,5 +193,224 @@ describe("runtime-overrides (WM-887)", () => {
     );
     expect(planned.model).toBeUndefined();
     expect(planned.model_tier).toBe("standard");
+  });
+});
+
+describe("overlay promotion (gh-860)", () => {
+  test("preview snapshots divergent rows with stable keys, targets, and digest", () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const et = preview.selections.find((s) => s.ref === PROMO_TYPE);
+    const agent = preview.selections.find((s) => s.ref === PROMO_AGENT);
+
+    expect(et).toMatchObject({
+      key: `eventType:${PROMO_TYPE}:adapter`,
+      kind: KIND_EVENT_TYPE,
+      field: "adapter",
+      before: "pi",
+      effective: "cursor",
+      current: true,
+    });
+    expect(et.target.file).toBe("event-runtime/event-types.json");
+    expect(agent).toMatchObject({
+      key: `agent:${PROMO_AGENT}:modelTier`,
+      kind: KIND_AGENT,
+      field: "modelTier",
+      before: "strong",
+      effective: "light",
+      current: true,
+    });
+    expect(agent.target.file).toBe("event-runtime/agents/agy-smoke.json");
+    expect(typeof preview.digest).toBe("string");
+    // Digest is stable for identical override state.
+    expect(buildPromotionPreview({ db, registry }).digest).toBe(preview.digest);
+    db.close();
+  });
+
+  test("empty selection is a typed no-op that drives no seam", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const { seams, calls } = fakeSeams();
+    const preview = buildPromotionPreview({ db, registry });
+    const result = await applyPromotion({
+      db,
+      registry,
+      target: TARGET,
+      digest: preview.digest,
+      keys: [],
+      seams,
+    });
+    expect(result.status).toBe("noop");
+    expect(calls).toHaveLength(0);
+    db.close();
+  });
+
+  test("apply writes only the selected subset, keeps pins, and opens one PR", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const { seams, calls, writes } = fakeSeams();
+    const keys = preview.selections
+      .filter((s) => s.ref === PROMO_TYPE || s.ref === PROMO_AGENT)
+      .map((s) => s.key);
+
+    const result = await applyPromotion({
+      db,
+      registry,
+      target: TARGET,
+      digest: preview.digest,
+      keys,
+      seams,
+    });
+
+    expect(result.status).toBe("opened");
+    expect(result.pr).toEqual({ url: "https://example/pr/1", number: 1 });
+
+    // The event-type write flips only the selected adapter; siblings untouched.
+    const etOut = JSON.parse(writes.get("event-runtime/event-types.json"));
+    expect(etOut[PROMO_TYPE].adapter).toBe("cursor");
+    expect(etOut[PROMO_TYPE].agent).toBe(registry.eventTypes[PROMO_TYPE].agent);
+
+    // The agent write flips only model_tier and RETAINS the pins block.
+    const agentOut = JSON.parse(
+      writes.get("event-runtime/agents/agy-smoke.json"),
+    );
+    expect(agentOut.model_tier).toBe("light");
+    expect(agentOut.pins).toEqual(registry.agents.get(PROMO_AGENT).pins);
+
+    // Base is the configured branch; worktree is never the live root.
+    const up = calls.find((c) => c[0] === "worktree.up")[1];
+    expect(up.base).toBe("develop");
+    expect(up.checkoutOnly).toBe(true);
+    for (const call of calls) {
+      if (call[0] === "writeWorktree" || call[0] === "readWorktree") {
+        expect(call[1]).not.toBe(registry.root);
+      }
+    }
+    const pr = calls.find((c) => c[0] === "forge.openPr")[1];
+    expect(pr.base).toBe("develop");
+    expect(pr.head).toBe("promo/gh-860");
+    expect(pr.body).toContain("Fixes gh-860-promo");
+
+    // No merge or delete seam is ever reachable.
+    const seamNames = calls.map((c) => c[0]);
+    expect(seamNames).not.toContain("git.merge");
+    expect(seamNames).not.toContain("forge.merge");
+    expect(seamNames).not.toContain("worktree.down");
+    db.close();
+  });
+
+  test("stale preview digest fails closed before any seam runs", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const { seams, calls } = fakeSeams();
+    await expect(
+      applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: "sha256:staaaale",
+        keys: [preview.selections[0].key],
+        seams,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(calls).toHaveLength(0);
+    db.close();
+  });
+
+  test("unknown key fails closed before any seam runs", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const { seams, calls } = fakeSeams();
+    await expect(
+      applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: preview.digest,
+        keys: ["agent:no-such@1:model"],
+        seams,
+      }),
+    ).rejects.toThrow(/unknown promotion key/);
+    expect(calls).toHaveLength(0);
+    db.close();
+  });
+
+  test("target drift fails closed before any worktree exists", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const key = preview.selections.find((s) => s.ref === PROMO_AGENT).key;
+    // Tracked model_tier now reads "standard", not the previewed "strong".
+    const { seams, calls } = fakeSeams({
+      readTracked: () =>
+        JSON.stringify({ id: "agy-smoke", model_tier: "standard" }),
+    });
+    await expect(
+      applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: preview.digest,
+        keys: [key],
+        seams,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+    // Failed drift means no worktree was ever created.
+    expect(calls.some((c) => c[0] === "worktree.up")).toBe(false);
+    db.close();
+  });
+
+  test("invalid tracked JSON fails closed", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const key = preview.selections.find((s) => s.ref === PROMO_AGENT).key;
+    const { seams } = fakeSeams({ readTracked: () => "{ not json" });
+    await expect(
+      applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: preview.digest,
+        keys: [key],
+        seams,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+    db.close();
+  });
+
+  test("failure after checkout returns recoverable worktree evidence", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const key = preview.selections.find((s) => s.ref === PROMO_AGENT).key;
+    const { seams } = fakeSeams();
+    seams.git.push = () => {
+      throw new Error("network down");
+    };
+    let caught;
+    try {
+      await applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: preview.digest,
+        keys: [key],
+        seams,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OverlayError);
+    expect(caught.evidence).toMatchObject({
+      worktree: "/tmp/promo-wt-860",
+      branch: "promo/gh-860",
+      ticket: "gh-860-promo",
+    });
+    db.close();
   });
 });

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -1,6 +1,8 @@
 import type {
   AdmittedEvent,
   AgentsView,
+  PromotionPreview,
+  PromotionResult,
   ArtifactInventoryItem,
   ArtifactView,
   ChainListItem,
@@ -437,6 +439,13 @@ export const api = {
       "DELETE",
       `/overrides/agents/${encodeURIComponent(ref)}`,
     ),
+  // Overlay promotion (gh-860): a read-only preview of which runtime overrides
+  // can become tracked Git defaults, and the digest an apply must echo back.
+  promotionPreview: () => call<PromotionPreview>("GET", "/promotion/preview"),
+  // Promote a non-empty subset of preview keys into a PR against the repo's
+  // configured base. Never clears the runtime overrides — that is separate.
+  promotionApply: (body: { repo: string; digest: string; keys: string[] }) =>
+    call<PromotionResult>("POST", "/promotion/apply", body),
   // Declarative Overview panels (WM-840) and the data behind one of them:
   // `panelSource` only ever GETs an endpoint the runtime already
   // allow-listed for the panel; the query is the panel's own `source.query`.

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -386,6 +386,13 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       async (_endpoint: string, _query?: Record<string, string>) => ({}),
     ),
     repos: mock(async (): Promise<{ repos: RepoItem[] }> => ({ repos: [] })),
+    // Overlay promotion (gh-860): default mocks return an empty, no-op preview.
+    promotionPreview: mock(async () => ({ digest: "", selections: [] })),
+    promotionApply: mock(async () => ({
+      status: "noop" as const,
+      ticket: null,
+      pr: null,
+    })),
     janitor: mock(
       async (name: string, apply = false): Promise<JanitorResult> => ({
         repo: name,

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -596,6 +596,41 @@ export interface AgentsView {
   adapters?: string[];
 }
 
+/** One promotable runtime override row in a promotion preview (gh-860). */
+export interface PromotionSelection {
+  key: string;
+  kind: "eventType" | "agent";
+  ref: string;
+  field: "adapter" | "modelTier" | "model";
+  target: { file: string; path: string };
+  before: unknown;
+  effective: unknown;
+  /** Whether the override still diverges from the tracked default. */
+  current: boolean;
+}
+
+/** Preview of the overrides that can be promoted, plus the digest apply echoes. */
+export interface PromotionPreview {
+  digest: string;
+  selections: PromotionSelection[];
+}
+
+export interface PromotionResult {
+  status: "noop" | "opened";
+  repo?: string;
+  ticket: string | null;
+  worktree?: string;
+  branch?: string;
+  files?: string[];
+  promoted?: Array<{
+    key: string;
+    target: { file: string; path: string };
+    before: unknown;
+    after: unknown;
+  }>;
+  pr: { url: string; number: number } | null;
+}
+
 /** A worker's own report of what it is doing; "stopped" is a clean exit. */
 export type WorkerState = "idle" | "busy" | "stopped";
 

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 import {
   Agents,
+  PromotionPanel,
   adapterText,
   agentTabCounts,
   modelText,
@@ -570,6 +571,98 @@ describe("Agents copy chords and hints (WM-233)", () => {
       // 2. Press 'l' immediately after 'c' -> 'c l' copies link
       fireEvent.keyDown(document.body, { key: "l" });
       expect(written).toBe(window.location.href);
+    });
+  });
+});
+
+describe("PromotionPanel (gh-860)", () => {
+  const preview = {
+    digest: "sha256:deadbeef",
+    selections: [
+      {
+        key: "eventType:factory.demo/v1:adapter",
+        kind: "eventType" as const,
+        ref: "factory.demo/v1",
+        field: "adapter" as const,
+        target: {
+          file: "event-runtime/event-types.json",
+          path: '["x"].adapter',
+        },
+        before: "pi",
+        effective: "cursor",
+        current: true,
+      },
+      {
+        key: "agent:stale@1:modelTier",
+        kind: "agent" as const,
+        ref: "stale@1",
+        field: "modelTier" as const,
+        target: { file: "event-runtime/agents/stale.json", path: "model_tier" },
+        before: "strong",
+        effective: "strong",
+        current: false,
+      },
+    ],
+  };
+
+  function withPromotionStubs(fn: () => Promise<void>) {
+    const origPreview = api.promotionPreview;
+    const origRepos = api.repos;
+    const origApply = api.promotionApply;
+    api.promotionPreview = async () => preview;
+    api.repos = async () =>
+      ({ repos: [{ name: "factory" }] }) as Awaited<
+        ReturnType<typeof api.repos>
+      >;
+    return fn().finally(() => {
+      api.promotionPreview = origPreview;
+      api.repos = origRepos;
+      api.promotionApply = origApply;
+    });
+  }
+
+  test("previews divergent overrides, promotes a selected subset, and links the PR", async () => {
+    await withPromotionStubs(async () => {
+      const applied: { repo: string; digest: string; keys: string[] }[] = [];
+      api.promotionApply = async (body) => {
+        applied.push(body);
+        return {
+          status: "opened",
+          repo: body.repo,
+          ticket: "gh-860-x",
+          branch: "promo/x",
+          pr: { url: "https://example/pr/9", number: 9 },
+        };
+      };
+
+      const r = renderWithClient(<PromotionPanel defaultRepo="factory" />);
+
+      // Collapsed by default: only the opener button, no preview fetch implied.
+      fireEvent.click(
+        r.getByRole("button", { name: "Promote overrides to Git…" }),
+      );
+
+      // The divergent row is selectable; the non-current one is disabled.
+      const good = await waitFor(() =>
+        r.getByLabelText("eventType:factory.demo/v1:adapter"),
+      );
+      const stale = r.getByLabelText("agent:stale@1:modelTier");
+      expect((stale as HTMLInputElement).disabled).toBe(true);
+
+      fireEvent.click(good);
+      fireEvent.click(r.getByRole("button", { name: "Promote 1 selected" }));
+
+      await waitFor(() => r.getByText("PR #9"));
+      expect(applied).toEqual([
+        {
+          repo: "factory",
+          digest: "sha256:deadbeef",
+          keys: ["eventType:factory.demo/v1:adapter"],
+        },
+      ]);
+      expect(r.getByText("PR #9").getAttribute("href")).toBe(
+        "https://example/pr/9",
+      );
     });
   });
 });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -255,6 +255,189 @@ function ModelPinEditor({
   );
 }
 
+function promotionLabel(value: unknown): string {
+  if (value === null || value === undefined) return EMPTY;
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/**
+ * Promote runtime overrides into a Git PR (gh-860). This is the reviewable
+ * counterpart to the machine-local overlay editor: it previews which effective
+ * overrides diverge from the tracked defaults, lets the operator select a
+ * subset, and opens a PR against the target repo's configured base through an
+ * isolated worktree. It never clears the runtime overrides — clearing the
+ * overlay stays a separate explicit action after the promoted defaults deploy.
+ */
+export function PromotionPanel({
+  defaultRepo = "factory",
+}: {
+  defaultRepo?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [repo, setRepo] = useState(defaultRepo);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const preview = useQuery({
+    queryKey: ["promotion-preview"],
+    queryFn: api.promotionPreview,
+    enabled: open,
+    retry: false,
+  });
+  const repos = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    enabled: open,
+    retry: false,
+  });
+
+  const apply = useMutation({
+    mutationFn: () =>
+      api.promotionApply({
+        repo,
+        digest: preview.data?.digest ?? "",
+        keys: [...selected],
+      }),
+    onSuccess: () => {
+      setSelected(new Set());
+      preview.refetch();
+    },
+    onError: (err: unknown) =>
+      notify(err instanceof ApiError ? err.message : "promotion failed", "err"),
+  });
+
+  const selections = preview.data?.selections ?? [];
+  const toggle = (key: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  if (!open) {
+    return (
+      <div className="mt-6">
+        <PrimitiveButton onClick={() => setOpen(true)}>
+          Promote overrides to Git…
+        </PrimitiveButton>
+      </div>
+    );
+  }
+
+  const result = apply.data;
+  return (
+    <div className="mt-6 rounded-md border border-(--border) p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[13px] font-semibold text-(--text)">
+          Promote overrides to Git
+        </span>
+        <PrimitiveButton onClick={() => setOpen(false)}>Close</PrimitiveButton>
+      </div>
+      <p className="mb-3 text-[11px] text-(--text-faint)">
+        Opens a PR against the target repo's base through an isolated worktree.
+        This does not clear the runtime overrides — clear the overlay separately
+        after the promoted defaults deploy.
+      </p>
+      <label className="mb-3 flex items-center gap-2 text-[12px]">
+        <span className="text-(--text-faint)">Target repo</span>
+        <select
+          className={SELECT_CLASS}
+          value={repo}
+          onChange={(e) => setRepo(e.target.value)}
+        >
+          {(repos.data?.repos ?? []).map((r) => (
+            <option key={r.name} value={r.name}>
+              {r.name}
+            </option>
+          ))}
+          {!repos.data && <option value={repo}>{repo}</option>}
+        </select>
+      </label>
+
+      {preview.isError && (
+        <div className="text-[12px] text-(--hue-err)">
+          Preview failed:{" "}
+          {preview.error instanceof ApiError
+            ? preview.error.message
+            : "unavailable"}
+        </div>
+      )}
+      {preview.isSuccess && selections.length === 0 && (
+        <div className="text-[12px] text-(--text-faint)">
+          No runtime overrides diverge from tracked defaults.
+        </div>
+      )}
+      {selections.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {selections.map((s) => (
+            <li key={s.key} className="flex items-start gap-2 text-[12px]">
+              <input
+                type="checkbox"
+                aria-label={s.key}
+                checked={selected.has(s.key)}
+                disabled={!s.current}
+                onChange={() => toggle(s.key)}
+              />
+              <span className="min-w-0">
+                <span className="mono text-(--text)">{s.key}</span>
+                <span className="ml-2 text-(--text-faint)">
+                  {promotionLabel(s.before)} → {promotionLabel(s.effective)}
+                </span>
+                <span className="mono ml-2 text-[11px] text-(--text-faint)">
+                  {s.target.file}
+                </span>
+                {!s.current && (
+                  <span className="ml-2 text-[11px] text-(--hue-err)">
+                    stale
+                  </span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        <PrimitiveButton
+          disabled={selected.size === 0 || apply.isPending}
+          onClick={() => apply.mutate()}
+        >
+          {apply.isPending ? "Promoting…" : `Promote ${selected.size} selected`}
+        </PrimitiveButton>
+      </div>
+
+      {result && result.status === "opened" && (
+        <div className="mt-3 text-[12px] text-(--text-dim)">
+          Opened{" "}
+          {result.pr ? (
+            <a
+              className="text-(--accent)"
+              href={result.pr.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              PR #{result.pr.number}
+            </a>
+          ) : (
+            "a PR"
+          )}
+          {result.ticket && (
+            <span className="ml-2">ticket {result.ticket}</span>
+          )}
+          {result.branch && (
+            <span className="mono ml-2 text-[11px]">{result.branch}</span>
+          )}
+        </div>
+      )}
+      {result && result.status === "noop" && (
+        <div className="mt-3 text-[12px] text-(--text-faint)">
+          Nothing selected — no PR opened.
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * Agents (webui doc §10.6) — the registry, fully readable, plus a narrow
  * operational overlay editor (WM-884) for event-type adapter and agent
@@ -470,6 +653,9 @@ export function Agents({
                 {rows.length} agents · {mutatingCount} mutating ·{" "}
                 {rows.length - mutatingCount} read-only
               </div>
+              <PromotionPanel
+                defaultRepo={context.kind === "repo" ? context.name : "factory"}
+              />
               <ListToolbar
                 tabs={
                   <div


### PR DESCRIPTION
## What

Adds an explicit, reviewable path that turns selected machine-local runtime overrides into tracked fleet defaults via an isolated-worktree PR — the reviewable counterpart to the WM-887 overlay editor. Serve never edits, commits, or checks out the live `FACTORY_ROOT`.

- `runtime-overrides.mjs`
  - `buildPromotionPreview` snapshots the live override rows against the tracked definitions and returns stable selectable keys, before/effective values, the exact target file, whether each row is still `current`, and a binding `digest`. Supports only event-type `adapter` and agent `modelTier`/`model`.
  - `applyPromotion` requires the confirmed digest and a non-empty selected-key subset. It fails closed (before any worktree) on a stale digest, unknown key, non-current selection, invalid tracked JSON, or target drift, then drives injected `tracker` / `worktree` (checkout-only, configured base) / `git` / `forge` seams to write the tracked defaults, commit, push, and open a PR. Empty selection is a typed no-op. There is deliberately no merge or delete seam; a failure after checkout returns `{ worktree, branch, ticket }` evidence.
- `registry.mjs`: non-enumerable `defSource` + `agentDefinitionFile()` to resolve an agent's owning JSON relative to a chosen root (defHash unaffected).
- `repos.mjs`: `resolvePromotionTarget()` fails closed unless base, `worktree_up`, and github are configured.
- `api-registry.mjs`: `GET /promotion/preview` and `POST /promotion/apply` routes (apply drives injected `promotionSeams`; unconfigured seams fail closed 501).
- web: `PromotionPanel` (preview, subset selection, confirm, ticket/PR links; copy never implies overrides are cleared) + `api.ts`/`types.ts`.
- `docs/product-decisions.md`: records the 2026-08-25 operator decision.

## Why

Fleet defaults live in tracked agent/event-type definitions; the runtime overlay is a fast local loop with no safe path to Git. Auto-commit on the live checkout was rejected (serve may run against production state and concurrent agents). This lands the deterministic-preview + subset + isolated-worktree PR mechanism the operator chose.

## Acceptance

- Preview returns selectable keys, before/effective, target file, and `current`; digest binds it. Only adapter + modelTier/model.
- Apply requires the digest and a non-empty subset; stale/unknown/unsupported/invalid-JSON/drift fail before a worktree exists.
- Isolated `worktree_up` in checkout-only mode from the configured base; live root never edited/committed/checked out.
- Only selected values written; pins retained; canonical 2-space JSON.
- One conventional commit, push, PR against the configured base with source keys / before-after / verification / `Fixes <ticket>`; no merge.
- Empty selection is a typed no-op; failure returns recoverable worktree/branch evidence.
- UI presents preview, subset selection, confirmation, progress, and ticket/PR links; never implies promotion clears overrides.
- Tests inject tracker/worktree/git/forge seams and prove no command targets the live root, base is configured, stale preview fails closed, subset writes are exact, pins update, and no merge/delete occurs.

**Deferrals (outside Owned Paths):** wiring the `/promotion/*` prefix and real git/forge/tracker seams lives in `event-runtime/lib/api.mjs` + serve, which are not in this ticket's Owned Paths. The routes and orchestration are fully implemented and tested against injected seams; enabling the live HTTP path is a one-line dispatch addition in a follow-up.

## Owned Paths

- event-runtime/lib/runtime-overrides.mjs (+ test)
- event-runtime/lib/api-registry.mjs (+ test)
- event-runtime/lib/registry.mjs (+ test)
- event-runtime/lib/repos.mjs (+ test)
- event-runtime/web/src/views/Agents.tsx (+ test)
- event-runtime/web/src/api.ts, types.ts
- docs/product-decisions.md
- (also event-runtime/web/src/test-render.tsx: mechanical mock update required by the api.ts surface change to keep the web build green)

Refs #860