### PR TITLE
feat(event-runtime): presentation v1 block contract — $ref resolution, admitted on agent-result, tolerant verification (#832)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -220,7 +220,7 @@ The LLM appears only inside `execute`.
 
 ## 5. Versioned contracts
 
-Besides the three below, `factory.decision-request/v1` and `factory.decision-response/v1` (`event-runtime/schemas/`, validated by `lib/decision.mjs`) define a bounded human question — 1–6 options with runtime effects plus gated fields from a closed widget vocabulary — and its hash-bound answer; a refused agent-result may carry a request as `decision` (docs/event-runtime-inbox.md §2–§4).
+Besides the three below, `factory.decision-request/v1` and `factory.decision-response/v1` (`event-runtime/schemas/`, validated by `lib/decision.mjs`) define a bounded human question — 1–6 options with runtime effects plus gated fields from a closed widget vocabulary — and its hash-bound answer; a refused agent-result may carry a request as `decision` (docs/event-runtime-inbox.md §2–§4). `factory.presentation/v1` (`event-runtime/schemas/`, validated by `lib/presentation.mjs`) is an optional view-only block document an agent may emit beside its `artifact`, its `$ref` values resolving into the accepted artifact; verification is tolerant — an invalid one is dropped to `presentationErrors` and the run still completes (docs/event-runtime-artifact-views.md §3).
 
 ### 5.1 Event envelope
 

--- a/event-runtime/lib/fixtures/presentation-cases.json
+++ b/event-runtime/lib/fixtures/presentation-cases.json
@@ -1,0 +1,203 @@
+{
+  "artifact": {
+    "summary": "58 issues in Triage; 14 can be made agent-ready today",
+    "recommendation": "DISPATCH",
+    "evidence": { "issuesSeen": 58, "readyToday": 14 },
+    "plan": [
+      { "issueId": "WM-101" },
+      { "issueId": "WM-102" },
+      { "issueId": "WM-103" },
+      { "issueId": "WM-201" },
+      { "issueId": "WM-104" },
+      { "issueId": "WM-105" },
+      { "issueId": "WM-106" },
+      { "issueId": "WM-312" },
+      { "issueId": "WM-108" },
+      { "issueId": "WM-109" },
+      { "issueId": "WM-110" },
+      { "issueId": "WM-118" },
+      { "issueId": "WM-112" },
+      { "issueId": "WM-113" },
+      { "issueId": "WM-114" },
+      { "issueId": "WM-115" },
+      { "issueId": "WM-116" },
+      { "issueId": "WM-117" },
+      { "issueId": "WM-119" },
+      { "issueId": "WM-336" }
+    ]
+  },
+  "cases": [
+    {
+      "name": "valid-full-document",
+      "valid": true,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "heading",
+            "text": "58 issues in Triage; 14 can be made agent-ready today"
+          },
+          {
+            "type": "markdown",
+            "text": "Most of the backlog is under-specified rather than wrong."
+          },
+          {
+            "type": "keyvalue",
+            "items": [
+              {
+                "label": "Recommendation",
+                "value": { "$ref": "/recommendation" },
+                "format": "state"
+              },
+              {
+                "label": "Issues seen",
+                "value": { "$ref": "/evidence/issuesSeen" },
+                "format": "count"
+              },
+              { "label": "Note", "value": "computed by hand" }
+            ]
+          },
+          {
+            "type": "list",
+            "label": "Needs a human",
+            "items": [
+              {
+                "text": "WM-312 — production infra; incompatible deploy paths",
+                "ref": "/plan/7",
+                "tone": "warn"
+              },
+              {
+                "text": "WM-336 — tool allowlist; wants a security owner",
+                "ref": "/plan/19",
+                "tone": "warn"
+              }
+            ]
+          },
+          {
+            "type": "table",
+            "label": "Duplicates",
+            "columns": ["Issue", "Duplicate of"],
+            "rows": [
+              [{ "$ref": "/plan/3/issueId" }, "WM-201"],
+              [{ "$ref": "/plan/11/issueId" }, "WM-118"]
+            ]
+          },
+          { "type": "badge", "text": "DISPATCH", "tone": "ok" },
+          {
+            "type": "code",
+            "language": "json",
+            "text": "{ \"ok\": true }"
+          },
+          {
+            "type": "section",
+            "label": "Method",
+            "collapsed": true,
+            "blocks": [{ "type": "markdown", "text": "How this was computed." }]
+          },
+          {
+            "type": "links",
+            "items": [
+              {
+                "label": "Repo",
+                "issue": null,
+                "url": "https://github.com/watt-mind/factory"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "unresolved-ref-in-keyvalue",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "keyvalue",
+            "items": [{ "label": "Missing", "value": { "$ref": "/nope/here" } }]
+          }
+        ]
+      },
+      "errors": ["$ref \"/nope/here\" does not resolve"]
+    },
+    {
+      "name": "unresolved-list-ref-pointer",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [{ "text": "a claim", "ref": "/plan/999" }]
+          }
+        ]
+      },
+      "errors": ["ref \"/plan/999\" does not resolve"]
+    },
+    {
+      "name": "links-item-two-targets",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "links",
+            "items": [
+              {
+                "label": "Both",
+                "issue": "WM-1",
+                "url": "https://example.com"
+              }
+            ]
+          }
+        ]
+      },
+      "errors": ["exactly one non-null target"]
+    },
+    {
+      "name": "section-nested-too-deep",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "section",
+            "label": "outer",
+            "blocks": [
+              {
+                "type": "section",
+                "label": "inner",
+                "blocks": [{ "type": "markdown", "text": "one level too deep" }]
+              }
+            ]
+          }
+        ]
+      },
+      "errors": ["not in enum"]
+    },
+    {
+      "name": "heading-too-long",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [
+          {
+            "type": "heading",
+            "text": "This heading is deliberately far longer than one hundred and twenty characters so that the lib bound on heading text length is exercised."
+          }
+        ]
+      },
+      "errors": ["heading text is"]
+    },
+    {
+      "name": "wrong-key-for-type",
+      "valid": false,
+      "presentation": {
+        "schemaVersion": "factory.presentation/v1",
+        "blocks": [{ "type": "heading", "text": "hi", "label": "nope" }]
+      },
+      "errors": ["\"label\" is not a key of type=heading"]
+    }
+  ]
+}

--- a/event-runtime/lib/presentation.mjs
+++ b/event-runtime/lib/presentation.mjs
@@ -1,0 +1,376 @@
+/**
+ * Presentation contract — `factory.presentation/v1`
+ * (docs/event-runtime-artifact-views.md §3.1–3.3).
+ *
+ * Layer B: an agent may emit a bounded block document (`presentation`) beside
+ * its `artifact` in result.json. A value (a `keyvalue` value, a `table` cell, a
+ * `links` target) is a scalar/null literal or `{ "$ref": "<pointer>" }` into
+ * the artifact, and a `list` item may cite the artifact through a bare pointer
+ * `ref` — the narrative points at its evidence. Everything the runtime's
+ * deliberately small JSON Schema subset (lib/schema.mjs, no conditional
+ * keywords) cannot express lives here, exactly as lib/artifact-view.mjs does
+ * for views and lib/decision.mjs for decisions: per-type key applicability and
+ * bounds, one-level `section` nesting, the exactly-one-`links`-target rule, the
+ * serialised size ceiling, and — the point of the layer — that every `$ref`
+ * resolves against the accepted artifact. Pure and fail-closed:
+ * `{ valid, errors }`, never throws on data, `resolvePointer` (shared with
+ * WM-454) the only dependency beyond loading the schema once.
+ *
+ * `format` and `tone` reuse the Layer A (`factory.artifact-view/v1`)
+ * vocabularies verbatim — one set of hues and formatters across both layers.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { resolvePointer, TONES } from "./artifact-view.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { validate } from "./schema.mjs";
+
+export const PRESENTATION_SCHEMA_VERSION = "factory.presentation/v1";
+export const PRESENTATION_SCHEMA = JSON.parse(
+  readFileSync(
+    path.join(RUNTIME_ROOT, "schemas", "factory.presentation.v1.json"),
+    "utf8",
+  ),
+);
+
+/** §3.1 block vocabulary — closed. */
+export const BLOCK_TYPES = [
+  "heading",
+  "markdown",
+  "keyvalue",
+  "table",
+  "list",
+  "badge",
+  "code",
+  "section",
+  "links",
+];
+
+/** §3.1 "Whole document ≤ 40 blocks, ≤ 16 KiB serialised." Size is a byte count. */
+export const MAX_DOC_BYTES = 16 * 1024;
+/** Per-type text bounds (§3.1). `heading` counts characters; the KiB ones are byte sizes. */
+export const HEADING_MAX_CHARS = 120;
+export const MARKDOWN_MAX_BYTES = 2 * 1024;
+export const CODE_MAX_BYTES = 4 * 1024;
+
+/** Per-type item counts (§3.1). */
+const MAX_KEYVALUE_ITEMS = 16;
+const MAX_LIST_ITEMS = 30;
+const MAX_LINKS_ITEMS = 12;
+const MAX_TABLE_COLUMNS = 6;
+const MAX_TABLE_ROWS = 50;
+const MAX_SECTION_CHILDREN = 20;
+const LINK_TARGETS = ["issue", "pr", "run", "url"];
+
+const TONE_SET = new Set(TONES);
+
+/** The keys each block `type` may carry beyond `type` (§3.1 table). */
+const KEYS_BY_TYPE = {
+  heading: new Set(["text"]),
+  markdown: new Set(["text"]),
+  keyvalue: new Set(["items"]),
+  table: new Set(["label", "columns", "rows", "formats", "tone"]),
+  list: new Set(["label", "items"]),
+  badge: new Set(["text", "tone"]),
+  code: new Set(["text", "language"]),
+  section: new Set(["label", "collapsed", "blocks"]),
+  links: new Set(["items"]),
+};
+
+/** The keys each block `type` must carry (§3.1 table). */
+const REQUIRED_BY_TYPE = {
+  heading: ["text"],
+  markdown: ["text"],
+  keyvalue: ["items"],
+  table: ["columns", "rows"],
+  list: ["items"],
+  badge: ["text", "tone"],
+  code: ["text"],
+  section: ["label", "blocks"],
+  links: ["items"],
+};
+
+/** The keys each item-bearing block's items may carry, and must carry. */
+const ITEM_KEYS_BY_TYPE = {
+  keyvalue: new Set(["label", "value", "format", "tone"]),
+  list: new Set(["text", "ref", "tone"]),
+  links: new Set(["label", "issue", "pr", "run", "url"]),
+};
+const ITEM_REQUIRED_BY_TYPE = {
+  keyvalue: ["label", "value"],
+  list: ["text"],
+  links: [],
+};
+
+const isObject = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+const hasOwn = (obj, key) =>
+  isObject(obj) && Object.prototype.hasOwnProperty.call(obj, key);
+const isRef = (v) =>
+  isObject(v) && Object.keys(v).length === 1 && typeof v.$ref === "string";
+
+function utf8Bytes(text) {
+  return Buffer.byteLength(String(text ?? ""), "utf8");
+}
+
+/**
+ * A "value" slot (keyvalue value, table cell, links target): a scalar/null
+ * literal, or a `{ "$ref": pointer }` that must resolve in the artifact. A
+ * pointer that does not resolve names the block index and the pointer (§3.2).
+ */
+function checkValue(value, at, artifact, errors) {
+  if (!isRef(value)) return;
+  if (resolvePointer(artifact, value.$ref) === undefined) {
+    errors.push(`${at}: $ref "${value.$ref}" does not resolve in the artifact`);
+  }
+}
+
+/** A bare pointer citation (`list` item `ref`) that must resolve in the artifact. */
+function checkPointer(pointer, at, artifact, errors) {
+  if (typeof pointer !== "string") return;
+  if (resolvePointer(artifact, pointer) === undefined) {
+    errors.push(`${at}: ref "${pointer}" does not resolve in the artifact`);
+  }
+}
+
+function checkItemKeys(item, type, at, errors) {
+  const allowed = ITEM_KEYS_BY_TYPE[type];
+  for (const key of Object.keys(item)) {
+    if (!allowed.has(key)) {
+      errors.push(`${at}: "${key}" is not a key of a ${type} item`);
+    }
+  }
+  for (const key of ITEM_REQUIRED_BY_TYPE[type]) {
+    if (!hasOwn(item, key)) {
+      errors.push(`${at}: a ${type} item requires "${key}"`);
+    }
+  }
+}
+
+/**
+ * Validate one block: the per-type key applicability and bounds the schema
+ * cannot express, plus every `$ref`/`ref` resolution against `artifact`.
+ * `depth` is 0 for a top-level block and 1 for a `section` child; a `section`
+ * at depth > 0 is the one-level-nesting violation (§3.1).
+ */
+function checkBlock(block, at, artifact, errors, depth) {
+  const type = block.type;
+
+  const allowed = KEYS_BY_TYPE[type];
+  for (const key of Object.keys(block)) {
+    if (key === "type") continue;
+    if (!allowed.has(key)) {
+      errors.push(`${at}: "${key}" is not a key of type=${type}`);
+    }
+  }
+  for (const key of REQUIRED_BY_TYPE[type]) {
+    if (!hasOwn(block, key)) {
+      errors.push(`${at}: type=${type} requires "${key}"`);
+    }
+  }
+
+  if (type === "heading" && typeof block.text === "string") {
+    if (block.text.length > HEADING_MAX_CHARS) {
+      errors.push(
+        `${at}: heading text is ${block.text.length} chars > ${HEADING_MAX_CHARS}`,
+      );
+    }
+    return;
+  }
+  if (type === "markdown" && typeof block.text === "string") {
+    const bytes = utf8Bytes(block.text);
+    if (bytes > MARKDOWN_MAX_BYTES) {
+      errors.push(
+        `${at}: markdown text is ${bytes} bytes > ${MARKDOWN_MAX_BYTES}`,
+      );
+    }
+    return;
+  }
+  if (type === "code" && typeof block.text === "string") {
+    const bytes = utf8Bytes(block.text);
+    if (bytes > CODE_MAX_BYTES) {
+      errors.push(`${at}: code text is ${bytes} bytes > ${CODE_MAX_BYTES}`);
+    }
+    return;
+  }
+  if (type === "badge") {
+    if (typeof block.tone === "string" && !TONE_SET.has(block.tone)) {
+      errors.push(`${at}.tone: badge tone must be one of ${TONES.join("|")}`);
+    } else if (block.tone !== undefined && typeof block.tone !== "string") {
+      errors.push(`${at}.tone: badge tone must be a single tone string`);
+    }
+    return;
+  }
+
+  if (type === "keyvalue") {
+    const items = Array.isArray(block.items) ? block.items : [];
+    if (items.length > MAX_KEYVALUE_ITEMS) {
+      errors.push(`${at}.items: ${items.length} items > ${MAX_KEYVALUE_ITEMS}`);
+    }
+    items.forEach((item, i) => {
+      const itemAt = `${at}.items[${i}]`;
+      checkItemKeys(item, "keyvalue", itemAt, errors);
+      if (hasOwn(item, "value")) {
+        checkValue(item.value, `${itemAt}.value`, artifact, errors);
+      }
+    });
+    return;
+  }
+
+  if (type === "list") {
+    const items = Array.isArray(block.items) ? block.items : [];
+    if (items.length > MAX_LIST_ITEMS) {
+      errors.push(`${at}.items: ${items.length} items > ${MAX_LIST_ITEMS}`);
+    }
+    items.forEach((item, i) => {
+      const itemAt = `${at}.items[${i}]`;
+      checkItemKeys(item, "list", itemAt, errors);
+      if (hasOwn(item, "ref")) {
+        checkPointer(item.ref, `${itemAt}.ref`, artifact, errors);
+      }
+    });
+    return;
+  }
+
+  if (type === "links") {
+    const items = Array.isArray(block.items) ? block.items : [];
+    if (items.length > MAX_LINKS_ITEMS) {
+      errors.push(`${at}.items: ${items.length} items > ${MAX_LINKS_ITEMS}`);
+    }
+    items.forEach((item, i) => {
+      const itemAt = `${at}.items[${i}]`;
+      checkItemKeys(item, "links", itemAt, errors);
+      const present = LINK_TARGETS.filter(
+        (key) => hasOwn(item, key) && item[key] !== null,
+      );
+      if (present.length !== 1) {
+        errors.push(
+          `${itemAt}: a links item needs exactly one non-null target of ${LINK_TARGETS.join("|")} (found ${present.length})`,
+        );
+      }
+      for (const key of LINK_TARGETS) {
+        if (hasOwn(item, key)) {
+          checkValue(item[key], `${itemAt}.${key}`, artifact, errors);
+        }
+      }
+    });
+    return;
+  }
+
+  if (type === "table") {
+    const columns = Array.isArray(block.columns) ? block.columns : [];
+    const rows = Array.isArray(block.rows) ? block.rows : [];
+    if (columns.length > MAX_TABLE_COLUMNS) {
+      errors.push(
+        `${at}.columns: ${columns.length} columns > ${MAX_TABLE_COLUMNS}`,
+      );
+    }
+    if (rows.length > MAX_TABLE_ROWS) {
+      errors.push(`${at}.rows: ${rows.length} rows > ${MAX_TABLE_ROWS}`);
+    }
+    if (Array.isArray(block.formats) && block.formats.length > columns.length) {
+      errors.push(
+        `${at}.formats: ${block.formats.length} formats > ${columns.length} columns`,
+      );
+    }
+    rows.forEach((row, r) => {
+      if (Array.isArray(row) && row.length !== columns.length) {
+        errors.push(
+          `${at}.rows[${r}]: ${row.length} cells != ${columns.length} columns`,
+        );
+      }
+      if (Array.isArray(row)) {
+        row.forEach((cell, c) => {
+          checkValue(cell, `${at}.rows[${r}][${c}]`, artifact, errors);
+        });
+      }
+    });
+    checkTableTone(block.tone, `${at}.tone`, errors);
+    return;
+  }
+
+  if (type === "section") {
+    // One level of nesting only (§3.1). The v1 schema already forbids a
+    // `section` among a section's child blocks, so a schema-valid document
+    // never reaches this branch; it is kept as defense in depth so the rule
+    // still holds if the schema is ever relaxed.
+    if (depth > 0) {
+      errors.push(`${at}: section nesting exceeds one level`);
+    }
+    const children = Array.isArray(block.blocks) ? block.blocks : [];
+    if (children.length > MAX_SECTION_CHILDREN) {
+      errors.push(
+        `${at}.blocks: ${children.length} child blocks > ${MAX_SECTION_CHILDREN}`,
+      );
+    }
+    children.forEach((child, i) => {
+      checkBlock(child, `${at}.blocks[${i}]`, artifact, errors, depth + 1);
+    });
+  }
+}
+
+/** A table's optional `tone` object maps a column/value to a hue; leaves must be tones. */
+function checkTableTone(tone, at, errors) {
+  if (tone === undefined) return;
+  if (typeof tone === "string") {
+    if (!TONE_SET.has(tone)) {
+      errors.push(`${at}: tone must be one of ${TONES.join("|")}`);
+    }
+    return;
+  }
+  if (!isObject(tone)) return;
+  for (const [key, value] of Object.entries(tone)) {
+    checkTableTone(value, `${at}.${key}`, errors);
+  }
+}
+
+/**
+ * Validate a `factory.presentation/v1` document against the v1 schema, its
+ * bounds, one-level section nesting, the exactly-one-`links`-target rule, the
+ * serialised size ceiling, and — the point of the layer — that every `$ref`
+ * (and every `list` item `ref`) resolves in `artifact` (§3.1–3.3). Never
+ * throws.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validatePresentation(presentation, artifact) {
+  const shape = validate(PRESENTATION_SCHEMA, presentation);
+  if (!shape.valid) return shape;
+
+  const errors = [];
+  const bytes = utf8Bytes(JSON.stringify(presentation));
+  if (bytes > MAX_DOC_BYTES) {
+    errors.push(
+      `$: serialised presentation is ${bytes} bytes > ${MAX_DOC_BYTES}`,
+    );
+  }
+  presentation.blocks.forEach((block, i) => {
+    checkBlock(block, `blocks[${i}]`, artifact ?? {}, errors, 0);
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * A deep copy of `presentation` with every `{ "$ref": pointer }` value replaced
+ * by `{ value, ref }` — the resolved value plus the pointer it came from — so a
+ * renderer can show the value and, on hover, the artifact path it came from
+ * ("show source", §3.2). A pointer that does not resolve yields
+ * `value: undefined`; callers gate rendering on `validatePresentation` first.
+ * Bare `list` item `ref` citations are left as-is (they annotate, they are not
+ * value slots). Pure.
+ */
+export function resolveRefs(presentation, artifact) {
+  const doc = artifact ?? {};
+  const map = (node) => {
+    if (Array.isArray(node)) return node.map(map);
+    if (isRef(node)) {
+      return { value: resolvePointer(doc, node.$ref), ref: node.$ref };
+    }
+    if (isObject(node)) {
+      const out = {};
+      for (const [key, value] of Object.entries(node)) out[key] = map(value);
+      return out;
+    }
+    return node;
+  };
+  return map(presentation);
+}

--- a/event-runtime/lib/presentation.test.mjs
+++ b/event-runtime/lib/presentation.test.mjs
@@ -1,0 +1,449 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { FORMATS, TONES } from "./artifact-view.mjs";
+import {
+  BLOCK_TYPES,
+  CODE_MAX_BYTES,
+  HEADING_MAX_CHARS,
+  MARKDOWN_MAX_BYTES,
+  MAX_DOC_BYTES,
+  PRESENTATION_SCHEMA,
+  PRESENTATION_SCHEMA_VERSION,
+  resolveRefs,
+  validatePresentation,
+} from "./presentation.mjs";
+import { validate } from "./schema.mjs";
+
+const FIXTURE = JSON.parse(
+  readFileSync(
+    new URL("./fixtures/presentation-cases.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+const ARTIFACT = {
+  recommendation: "DISPATCH",
+  count: 58,
+  ok: true,
+  nested: { value: 14 },
+  plan: [{ issueId: "WM-101" }, { issueId: "WM-102" }, { issueId: "WM-118" }],
+};
+
+/** A one-block presentation of the given block, for focused pass/fail checks. */
+function doc(block) {
+  return { schemaVersion: PRESENTATION_SCHEMA_VERSION, blocks: [block] };
+}
+
+describe("presentation schema keywords", () => {
+  test("uses only the keywords lib/schema.mjs supports (fails closed otherwise)", () => {
+    // A self-referential guard: validating any object against the presentation
+    // schema must not raise "unsupported schema keyword".
+    const check = validate(PRESENTATION_SCHEMA, {
+      schemaVersion: PRESENTATION_SCHEMA_VERSION,
+      blocks: [{ type: "heading", text: "hi" }],
+    });
+    expect(check.errors.join("\n")).not.toContain("unsupported schema keyword");
+    expect(check.valid).toBe(true);
+  });
+
+  test("format and tone vocabularies are identical to factory.artifact-view/v1", () => {
+    const view = JSON.parse(
+      readFileSync(
+        new URL("../schemas/factory.artifact-view.v1.json", import.meta.url),
+        "utf8",
+      ),
+    );
+    const viewFormats =
+      view.properties.sections.items.properties.formats.additionalProperties
+        .enum;
+    const viewTones =
+      view.properties.status.properties.tone.additionalProperties.enum;
+    expect(FORMATS).toEqual(viewFormats);
+    expect(TONES).toEqual(viewTones);
+  });
+});
+
+describe("validatePresentation — envelope", () => {
+  test("valid minimal document", () => {
+    const out = validatePresentation(doc({ type: "heading", text: "hi" }), {});
+    expect(out).toEqual({ valid: true, errors: [] });
+  });
+
+  test("wrong schemaVersion fails closed", () => {
+    const out = validatePresentation(
+      { schemaVersion: "nope", blocks: [{ type: "heading", text: "hi" }] },
+      {},
+    );
+    expect(out.valid).toBe(false);
+  });
+
+  test("blocks required and 1–40", () => {
+    expect(
+      validatePresentation(
+        { schemaVersion: PRESENTATION_SCHEMA_VERSION, blocks: [] },
+        {},
+      ).valid,
+    ).toBe(false);
+    const many = Array.from({ length: 41 }, () => ({
+      type: "heading",
+      text: "x",
+    }));
+    expect(
+      validatePresentation(
+        { schemaVersion: PRESENTATION_SCHEMA_VERSION, blocks: many },
+        {},
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("serialised size ceiling (≤ 16 KiB)", () => {
+    const big = "x".repeat(MAX_DOC_BYTES);
+    const out = validatePresentation(doc({ type: "markdown", text: big }), {});
+    expect(out.valid).toBe(false);
+    expect(out.errors.some((e) => e.includes("serialised presentation"))).toBe(
+      true,
+    );
+  });
+
+  test("BLOCK_TYPES matches the schema enum", () => {
+    expect(BLOCK_TYPES).toEqual(
+      PRESENTATION_SCHEMA.properties.blocks.items.properties.type.enum,
+    );
+  });
+});
+
+describe("validatePresentation — each block type pass/fail", () => {
+  test("heading: passes, and fails over the char bound", () => {
+    expect(
+      validatePresentation(doc({ type: "heading", text: "ok" }), {}).valid,
+    ).toBe(true);
+    const long = "x".repeat(HEADING_MAX_CHARS + 1);
+    const out = validatePresentation(doc({ type: "heading", text: long }), {});
+    expect(out.valid).toBe(false);
+    expect(out.errors[0]).toContain("heading text is");
+  });
+
+  test("markdown: passes, and fails over the byte bound", () => {
+    expect(
+      validatePresentation(doc({ type: "markdown", text: "hello" }), {}).valid,
+    ).toBe(true);
+    const long = "x".repeat(MARKDOWN_MAX_BYTES + 1);
+    const out = validatePresentation(doc({ type: "markdown", text: long }), {});
+    expect(out.valid).toBe(false);
+    expect(out.errors.some((e) => e.includes("markdown text is"))).toBe(true);
+  });
+
+  test("code: passes with language, and fails over the byte bound", () => {
+    expect(
+      validatePresentation(
+        doc({ type: "code", text: "{}", language: "json" }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const long = "x".repeat(CODE_MAX_BYTES + 1);
+    const out = validatePresentation(doc({ type: "code", text: long }), {});
+    expect(out.valid).toBe(false);
+    expect(out.errors.some((e) => e.includes("code text is"))).toBe(true);
+  });
+
+  test("badge: passes with a tone, fails on an unknown tone", () => {
+    expect(
+      validatePresentation(doc({ type: "badge", text: "OK", tone: "ok" }), {})
+        .valid,
+    ).toBe(true);
+    expect(
+      validatePresentation(
+        doc({ type: "badge", text: "OK", tone: "purple" }),
+        {},
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("keyvalue: passes; caps at 16 items; rejects a stray key", () => {
+    expect(
+      validatePresentation(
+        doc({
+          type: "keyvalue",
+          items: [{ label: "R", value: "x", format: "state", tone: "ok" }],
+        }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const many = Array.from({ length: 17 }, () => ({ label: "l", value: "v" }));
+    const out = validatePresentation(
+      doc({ type: "keyvalue", items: many }),
+      {},
+    );
+    expect(out.valid).toBe(false);
+    expect(out.errors.some((e) => e.includes("> 16"))).toBe(true);
+    // value is required on a keyvalue item
+    expect(
+      validatePresentation(
+        doc({ type: "keyvalue", items: [{ label: "l" }] }),
+        {},
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("list: passes; caps at 30 items", () => {
+    expect(
+      validatePresentation(
+        doc({
+          type: "list",
+          label: "L",
+          items: [{ text: "a", tone: "warn" }],
+        }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const many = Array.from({ length: 31 }, () => ({ text: "t" }));
+    const out = validatePresentation(doc({ type: "list", items: many }), {});
+    expect(out.valid).toBe(false);
+    expect(out.errors.some((e) => e.includes("> 30"))).toBe(true);
+  });
+
+  test("table: passes; caps columns×rows; row width must match columns", () => {
+    expect(
+      validatePresentation(
+        doc({
+          type: "table",
+          columns: ["A", "B"],
+          rows: [["1", "2"]],
+          formats: ["issue", "count"],
+        }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const wideCols = validatePresentation(
+      doc({
+        type: "table",
+        columns: ["a", "b", "c", "d", "e", "f", "g"],
+        rows: [],
+      }),
+      {},
+    );
+    expect(wideCols.valid).toBe(false);
+    const tooManyRows = validatePresentation(
+      doc({
+        type: "table",
+        columns: ["A"],
+        rows: Array.from({ length: 51 }, () => ["x"]),
+      }),
+      {},
+    );
+    expect(tooManyRows.valid).toBe(false);
+    expect(tooManyRows.errors.some((e) => e.includes("rows"))).toBe(true);
+    const misaligned = validatePresentation(
+      doc({ type: "table", columns: ["A", "B"], rows: [["only-one"]] }),
+      {},
+    );
+    expect(misaligned.valid).toBe(false);
+    expect(misaligned.errors.some((e) => e.includes("cells"))).toBe(true);
+  });
+
+  test("section: passes with a child; caps at 20 children; rejects a nested section", () => {
+    expect(
+      validatePresentation(
+        doc({
+          type: "section",
+          label: "M",
+          collapsed: true,
+          blocks: [{ type: "markdown", text: "x" }],
+        }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const many = Array.from({ length: 21 }, () => ({
+      type: "markdown",
+      text: "x",
+    }));
+    expect(
+      validatePresentation(
+        doc({ type: "section", label: "M", blocks: many }),
+        {},
+      ).valid,
+    ).toBe(false);
+    // one level of nesting only — a section inside a section is rejected
+    expect(
+      validatePresentation(
+        doc({
+          type: "section",
+          label: "outer",
+          blocks: [
+            {
+              type: "section",
+              label: "inner",
+              blocks: [{ type: "markdown", text: "x" }],
+            },
+          ],
+        }),
+        {},
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("links: passes with exactly one target; fails on zero or two", () => {
+    expect(
+      validatePresentation(
+        doc({
+          type: "links",
+          items: [{ label: "Repo", issue: null, url: "https://x.test" }],
+        }),
+        {},
+      ).valid,
+    ).toBe(true);
+    const none = validatePresentation(
+      doc({ type: "links", items: [{ label: "x", issue: null }] }),
+      {},
+    );
+    expect(none.valid).toBe(false);
+    const two = validatePresentation(
+      doc({
+        type: "links",
+        items: [{ label: "x", issue: "WM-1", url: "https://x.test" }],
+      }),
+      {},
+    );
+    expect(two.valid).toBe(false);
+    expect(
+      two.errors.some((e) => e.includes("exactly one non-null target")),
+    ).toBe(true);
+  });
+
+  test("a key that does not belong to the block type is rejected", () => {
+    const out = validatePresentation(
+      doc({ type: "heading", text: "hi", tone: "ok" }),
+      {},
+    );
+    expect(out.valid).toBe(false);
+    expect(
+      out.errors.some((e) => e.includes("is not a key of type=heading")),
+    ).toBe(true);
+  });
+});
+
+describe("validatePresentation — $ref resolution into the artifact", () => {
+  test("resolving refs pass in keyvalue value, table cell, links target, list ref", () => {
+    const out = validatePresentation(
+      {
+        schemaVersion: PRESENTATION_SCHEMA_VERSION,
+        blocks: [
+          {
+            type: "keyvalue",
+            items: [
+              { label: "Rec", value: { $ref: "/recommendation" } },
+              { label: "N", value: { $ref: "/nested/value" } },
+            ],
+          },
+          {
+            type: "table",
+            columns: ["Issue"],
+            rows: [[{ $ref: "/plan/0/issueId" }]],
+          },
+          {
+            type: "list",
+            items: [{ text: "cite", ref: "/plan/2" }],
+          },
+          {
+            type: "links",
+            items: [{ label: "x", url: { $ref: "/recommendation" } }],
+          },
+        ],
+      },
+      ARTIFACT,
+    );
+    expect(out).toEqual({ valid: true, errors: [] });
+  });
+
+  test("an unresolved $ref names the block index and the pointer", () => {
+    const out = validatePresentation(
+      doc({
+        type: "keyvalue",
+        items: [{ label: "x", value: { $ref: "/missing/path" } }],
+      }),
+      ARTIFACT,
+    );
+    expect(out.valid).toBe(false);
+    expect(out.errors[0]).toContain("blocks[0]");
+    expect(out.errors[0]).toContain("/missing/path");
+    expect(out.errors[0]).toContain("does not resolve");
+  });
+
+  test("an unresolved bare list ref pointer is an error", () => {
+    const out = validatePresentation(
+      doc({ type: "list", items: [{ text: "x", ref: "/plan/99" }] }),
+      ARTIFACT,
+    );
+    expect(out.valid).toBe(false);
+    expect(out.errors[0]).toContain("/plan/99");
+  });
+
+  test("a literal value (not a $ref) is left alone", () => {
+    const out = validatePresentation(
+      doc({
+        type: "keyvalue",
+        items: [{ label: "x", value: "a literal string" }],
+      }),
+      ARTIFACT,
+    );
+    expect(out.valid).toBe(true);
+  });
+});
+
+describe("resolveRefs", () => {
+  test("replaces every $ref with { value, ref } and leaves literals and list refs", () => {
+    const presentation = {
+      schemaVersion: PRESENTATION_SCHEMA_VERSION,
+      blocks: [
+        {
+          type: "keyvalue",
+          items: [
+            { label: "Rec", value: { $ref: "/recommendation" } },
+            { label: "Lit", value: "plain" },
+          ],
+        },
+        { type: "list", items: [{ text: "cite", ref: "/plan/0" }] },
+      ],
+    };
+    const resolved = resolveRefs(presentation, ARTIFACT);
+    expect(resolved.blocks[0].items[0].value).toEqual({
+      value: "DISPATCH",
+      ref: "/recommendation",
+    });
+    expect(resolved.blocks[0].items[1].value).toBe("plain");
+    // the bare list ref citation is untouched
+    expect(resolved.blocks[1].items[0].ref).toBe("/plan/0");
+    // input is not mutated
+    expect(presentation.blocks[0].items[0].value).toEqual({
+      $ref: "/recommendation",
+    });
+  });
+
+  test("an unresolved $ref becomes { value: undefined, ref }", () => {
+    const resolved = resolveRefs(
+      doc({
+        type: "keyvalue",
+        items: [{ label: "x", value: { $ref: "/nope" } }],
+      }),
+      ARTIFACT,
+    );
+    const cell = resolved.blocks[0].items[0].value;
+    expect(cell.ref).toBe("/nope");
+    expect(cell.value).toBeUndefined();
+  });
+});
+
+describe("shared fixture presentation-cases.json", () => {
+  test("every case validates as its fixture declares (server test reads the same file)", () => {
+    for (const c of FIXTURE.cases) {
+      const out = validatePresentation(c.presentation, FIXTURE.artifact);
+      expect(out.valid, `${c.name}: expected valid=${c.valid}`).toBe(c.valid);
+      for (const substring of c.errors ?? []) {
+        expect(
+          out.errors.some((e) => e.includes(substring)),
+          `${c.name}: expected an error containing "${substring}" in ${JSON.stringify(out.errors)}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -19,6 +19,7 @@ import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { resolveConfigPath } from "./config.mjs";
 import { validateDecisionRequest } from "./decision.mjs";
 import { processResultMemos } from "./memos.mjs";
+import { validatePresentation } from "./presentation.mjs";
 import { reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { confinedRegularFile, PathViolation } from "./workspace.mjs";
@@ -533,6 +534,20 @@ function verifyRefused({ spec, def, candidate, attempt }) {
     context.artifact = candidate.artifact;
     context.artifactHash = hashJson(candidate.artifact);
     checks.push("hash_recomputed");
+  }
+
+  // Presentation is tolerant on the ask (§3.3): a valid one rides on the
+  // result, an invalid one is dropped with its errors — a refusal is never
+  // failed by a malformed summary. Resolved against the accepted artifact, or
+  // {} when the refusal carries none. Not in the artifact hash or the receipt.
+  if (candidate.presentation !== undefined) {
+    const check = validatePresentation(
+      candidate.presentation,
+      candidate.artifact ?? {},
+    );
+    if (check.valid) context.presentation = candidate.presentation;
+    else context.presentationErrors = check.errors;
+    checks.push("presentation_validated");
   }
 
   const { evidence, evidenceSetHash } = retainedEvidence(candidate);
@@ -1120,6 +1135,22 @@ function verifyCompleted({
 
   const { evidence, evidenceSetHash } = retainedEvidence(candidate);
 
+  // Presentation is tolerant on the ask (§3.3): a valid one rides on the run
+  // result, an invalid one is dropped with its errors — a completed run whose
+  // artifact passed is never failed by a malformed summary. Resolved against
+  // the accepted artifact, and excluded from artifactHash and the receipt.
+  const presentationContext = {};
+  const presentationChecks = [];
+  if (candidate.presentation !== undefined) {
+    const check = validatePresentation(
+      candidate.presentation,
+      candidate.artifact,
+    );
+    if (check.valid) presentationContext.presentation = candidate.presentation;
+    else presentationContext.presentationErrors = check.errors;
+    presentationChecks.push("presentation_validated");
+  }
+
   const result = {
     schemaVersion: "factory.run-result/v1",
     runId: spec.runId,
@@ -1131,6 +1162,7 @@ function verifyCompleted({
     artifactHash,
     ...(evidence !== undefined ? { evidence } : {}),
     evidenceSetHash,
+    ...presentationContext,
     verification: {
       status: "passed",
       checks: [
@@ -1143,6 +1175,7 @@ function verifyCompleted({
           ? ["evidence_recomputed"]
           : []),
         ...handoffChecks,
+        ...presentationChecks,
         ...memoOutcome.checks,
       ],
     },

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -511,6 +511,132 @@ describe("verifyResult", () => {
     }
   });
 
+  test("completed with a valid presentation → kept on the result, hash unchanged, run completes", () => {
+    const presentation = {
+      schemaVersion: "factory.presentation/v1",
+      blocks: [
+        { type: "heading", text: "Status report" },
+        {
+          type: "keyvalue",
+          items: [
+            {
+              label: "Action",
+              value: { $ref: "/recommendedAction" },
+              format: "state",
+            },
+          ],
+        },
+      ],
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+      presentation,
+    });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.kind).toBe("completed");
+    expect(out.result.presentation).toEqual(presentation);
+    expect(out.result.presentationErrors).toBeUndefined();
+    // presentation is view-only: not in the artifact hash or the receipt.
+    expect(out.result.artifactHash).toBe(hashJson(VALID_ARTIFACT));
+    expect(out.receipt.artifactHash).toBe(hashJson(VALID_ARTIFACT));
+    expect(out.receipt.presentation).toBeUndefined();
+    expect(out.result.verification.checks).toContain("presentation_validated");
+  });
+
+  test("completed with an invalid presentation → dropped with errors, still completed, hash unchanged", () => {
+    const bad = {
+      schemaVersion: "factory.presentation/v1",
+      blocks: [
+        {
+          type: "keyvalue",
+          items: [{ label: "x", value: { $ref: "/no/such/path" } }],
+        },
+      ],
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+      presentation: bad,
+    });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.kind).toBe("completed");
+    expect(out.result.terminalState).toBe("completed");
+    expect(out.result.presentation).toBeUndefined();
+    expect(out.result.presentationErrors).toBeArray();
+    expect(out.result.presentationErrors[0]).toContain("/no/such/path");
+    // a malformed summary must not change the artifact hash vs no presentation
+    expect(out.result.artifactHash).toBe(hashJson(VALID_ARTIFACT));
+    expect(out.receipt.artifactHash).toBe(hashJson(VALID_ARTIFACT));
+  });
+
+  test("refused with a presentation → validated against the accepted artifact (or {})", () => {
+    const presentation = {
+      schemaVersion: "factory.presentation/v1",
+      blocks: [{ type: "heading", text: "Why I stopped" }],
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "refused",
+      reasonCode: "needs_human",
+      presentation,
+    });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.kind).toBe("refused");
+    expect(out.result.presentation).toEqual(presentation);
+    expect(out.result.presentationErrors).toBeUndefined();
+    expect(out.result.verification.checks).toContain("presentation_validated");
+  });
+
+  test("refused with a presentation whose $ref needs the artifact → dropped when no artifact", () => {
+    const presentation = {
+      schemaVersion: "factory.presentation/v1",
+      blocks: [
+        {
+          type: "keyvalue",
+          items: [{ label: "x", value: { $ref: "/anything" } }],
+        },
+      ],
+    };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "refused",
+      reasonCode: "needs_human",
+      presentation,
+    });
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+    });
+    expect(out.kind).toBe("refused");
+    expect(out.result.presentation).toBeUndefined();
+    expect(out.result.presentationErrors).toBeArray();
+    expect(out.result.presentationErrors[0]).toContain("/anything");
+  });
+
   test("refused with an unknown reasonCode → ContractViolation", () => {
     const dir = makeWorkspace({
       schemaVersion: "factory.agent-result/v1",

--- a/event-runtime/schemas/factory.agent-result.v1.json
+++ b/event-runtime/schemas/factory.agent-result.v1.json
@@ -8,6 +8,7 @@
     "terminalState": { "enum": ["completed", "refused"] },
     "reasonCode": { "type": "string", "minLength": 1 },
     "decision": {},
+    "presentation": {},
     "artifact": {},
     "evidence": {},
     "artifacts": {

--- a/event-runtime/schemas/factory.presentation.v1.json
+++ b/event-runtime/schemas/factory.presentation.v1.json
@@ -1,0 +1,333 @@
+{
+  "title": "factory.presentation/v1 — an optional agent-emitted block document beside the artifact (docs/event-runtime-artifact-views.md §3.1)",
+  "description": "Layer B: a bounded, view-only block document an agent may emit in result.json alongside its artifact. A value (keyvalue value, table cell, links target) is a scalar/null literal or { \"$ref\": <RFC 6901 pointer into the artifact> }; a list item may cite the artifact through a bare pointer `ref`. The bounds, per-type key applicability, one-level section nesting, exactly-one-links-target rule, serialised size, and $ref resolution that this deliberately small schema subset (lib/schema.mjs, no conditional keywords) cannot express are enforced by lib/presentation.mjs — the same split lib/artifact-view.mjs and lib/decision.mjs use. format/tone reuse the factory.artifact-view/v1 vocabularies verbatim. additionalProperties: false throughout.",
+  "type": "object",
+  "required": ["schemaVersion", "blocks"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.presentation/v1" },
+    "blocks": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 40,
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": [
+              "heading",
+              "markdown",
+              "keyvalue",
+              "table",
+              "list",
+              "badge",
+              "code",
+              "section",
+              "links"
+            ]
+          },
+          "text": { "type": "string" },
+          "language": { "type": "string", "minLength": 1, "maxLength": 40 },
+          "label": { "type": "string", "minLength": 1, "maxLength": 120 },
+          "collapsed": { "type": "boolean" },
+          "columns": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 6,
+            "items": { "type": "string", "minLength": 1, "maxLength": 120 }
+          },
+          "rows": {
+            "type": "array",
+            "maxItems": 50,
+            "items": {
+              "type": "array",
+              "maxItems": 6,
+              "items": {
+                "type": ["string", "number", "boolean", "null", "object"],
+                "required": ["$ref"],
+                "additionalProperties": false,
+                "properties": { "$ref": { "type": "string", "minLength": 1 } }
+              }
+            }
+          },
+          "formats": {
+            "type": "array",
+            "maxItems": 6,
+            "items": {
+              "enum": [
+                "issue",
+                "pr",
+                "url",
+                "sha",
+                "repo",
+                "run",
+                "duration",
+                "datetime",
+                "state",
+                "bytes",
+                "count"
+              ]
+            }
+          },
+          "tone": { "type": ["string", "object"] },
+          "items": {
+            "type": "array",
+            "maxItems": 50,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "label": { "type": "string", "minLength": 1, "maxLength": 120 },
+                "value": {
+                  "type": ["string", "number", "boolean", "null", "object"],
+                  "required": ["$ref"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "$ref": { "type": "string", "minLength": 1 }
+                  }
+                },
+                "format": {
+                  "enum": [
+                    "issue",
+                    "pr",
+                    "url",
+                    "sha",
+                    "repo",
+                    "run",
+                    "duration",
+                    "datetime",
+                    "state",
+                    "bytes",
+                    "count"
+                  ]
+                },
+                "tone": { "enum": ["ok", "warn", "error", "muted", "neutral"] },
+                "text": { "type": "string", "minLength": 1, "maxLength": 2048 },
+                "ref": { "type": "string", "minLength": 1 },
+                "issue": {
+                  "type": ["string", "number", "boolean", "null", "object"],
+                  "required": ["$ref"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "$ref": { "type": "string", "minLength": 1 }
+                  }
+                },
+                "pr": {
+                  "type": ["string", "number", "boolean", "null", "object"],
+                  "required": ["$ref"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "$ref": { "type": "string", "minLength": 1 }
+                  }
+                },
+                "run": {
+                  "type": ["string", "number", "boolean", "null", "object"],
+                  "required": ["$ref"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "$ref": { "type": "string", "minLength": 1 }
+                  }
+                },
+                "url": {
+                  "type": ["string", "number", "boolean", "null", "object"],
+                  "required": ["$ref"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "$ref": { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
+            }
+          },
+          "blocks": {
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "type": "object",
+              "required": ["type"],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "enum": [
+                    "heading",
+                    "markdown",
+                    "keyvalue",
+                    "table",
+                    "list",
+                    "badge",
+                    "code",
+                    "links"
+                  ]
+                },
+                "text": { "type": "string" },
+                "language": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 40
+                },
+                "label": { "type": "string", "minLength": 1, "maxLength": 120 },
+                "columns": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 6,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  }
+                },
+                "rows": {
+                  "type": "array",
+                  "maxItems": 50,
+                  "items": {
+                    "type": "array",
+                    "maxItems": 6,
+                    "items": {
+                      "type": ["string", "number", "boolean", "null", "object"],
+                      "required": ["$ref"],
+                      "additionalProperties": false,
+                      "properties": {
+                        "$ref": { "type": "string", "minLength": 1 }
+                      }
+                    }
+                  }
+                },
+                "formats": {
+                  "type": "array",
+                  "maxItems": 6,
+                  "items": {
+                    "enum": [
+                      "issue",
+                      "pr",
+                      "url",
+                      "sha",
+                      "repo",
+                      "run",
+                      "duration",
+                      "datetime",
+                      "state",
+                      "bytes",
+                      "count"
+                    ]
+                  }
+                },
+                "tone": { "type": ["string", "object"] },
+                "items": {
+                  "type": "array",
+                  "maxItems": 50,
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 120
+                      },
+                      "value": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "null",
+                          "object"
+                        ],
+                        "required": ["$ref"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": { "type": "string", "minLength": 1 }
+                        }
+                      },
+                      "format": {
+                        "enum": [
+                          "issue",
+                          "pr",
+                          "url",
+                          "sha",
+                          "repo",
+                          "run",
+                          "duration",
+                          "datetime",
+                          "state",
+                          "bytes",
+                          "count"
+                        ]
+                      },
+                      "tone": {
+                        "enum": ["ok", "warn", "error", "muted", "neutral"]
+                      },
+                      "text": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 2048
+                      },
+                      "ref": { "type": "string", "minLength": 1 },
+                      "issue": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "null",
+                          "object"
+                        ],
+                        "required": ["$ref"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": { "type": "string", "minLength": 1 }
+                        }
+                      },
+                      "pr": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "null",
+                          "object"
+                        ],
+                        "required": ["$ref"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": { "type": "string", "minLength": 1 }
+                        }
+                      },
+                      "run": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "null",
+                          "object"
+                        ],
+                        "required": ["$ref"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": { "type": "string", "minLength": 1 }
+                        }
+                      },
+                      "url": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "null",
+                          "object"
+                        ],
+                        "required": ["$ref"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": { "type": "string", "minLength": 1 }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Implements Layer B of the artifact-views epic (WM-452): `factory.presentation/v1`, an optional view-only block document an agent may emit beside its `artifact` in `result.json`. Closes #832 (WM-456).

- **`event-runtime/schemas/factory.presentation.v1.json`** (new) — encodes §3.1: `blocks` 1–40, the block vocabulary (`heading`, `markdown`, `keyvalue`, `table`, `list`, `badge`, `code`, `section`, `links`) with their keys, a value that is a scalar/null literal **or** `{ "$ref": string }`, and `format`/`tone` enums identical to `factory.artifact-view.v1.json`. Only `lib/schema.mjs` keywords, `additionalProperties: false` throughout.
- **`event-runtime/lib/presentation.mjs`** (new) — `validatePresentation(presentation, artifact)` → `{ valid, errors }`: schema-valid, serialised size ≤ 16 KiB, section nesting one level, `links` items carry exactly one non-null `issue|pr|run|url` target, per-type bounds, and **every** `$ref` (and every `list` item `ref`) resolves in `artifact` via `resolvePointer` (unresolved → error naming the block index + pointer). Also `resolveRefs(presentation, artifact)` returning a copy with refs replaced by `{ value, ref }` for renderers.
- **`event-runtime/schemas/factory.agent-result.v1.json`** — gains optional `presentation`.
- **`event-runtime/lib/verify.mjs`** — `verifyCompleted` and `verifyRefused` validate `presentation` against the accepted artifact (`candidate.artifact`, or `{}` when a refusal carries none): valid → `result.presentation`; invalid → `result.presentationErrors[]` with the run still completing/refusing. Excluded from `artifactHash`, `evidenceSetHash`, and the receipt.
- **`event-runtime/lib/fixtures/presentation-cases.json`** (new) — shared valid/invalid cases with expected error substrings, read by `presentation.test.mjs` (WM-457's web port will read the same file).
- **`docs/event-runtime.md`** §5 — one-line mention of `factory.presentation/v1`.

## Why

Layer B lets a run carry the agent's *interpretation* ("here is what I found and why") as a bounded, renderable block document whose numbers/ids point back at the artifact via `$ref`, without ever becoming chain input or part of the artifact hash. Verification is deliberately tolerant (§3.3): a run whose artifact passed must never fail because its summary was malformed — the bad presentation is dropped with its errors and the run still completes.

## Acceptance

- [x] `factory.presentation.v1.json` per §3.1, lib/schema.mjs keywords only, `additionalProperties: false`, shared format/tone enums.
- [x] `validatePresentation` (schema, size, depth, links target, bounds, `$ref` resolution) + `resolveRefs`.
- [x] `agent-result` gains optional `presentation`; `verify.mjs` admits it on completed and refused; excluded from hash/receipt.
- [x] `presentation.test.mjs` (each block type pass/fail, bounds, `$ref` resolve/unresolve, depth, size) + `verify.test.mjs` (completed-valid, completed-invalid still-completed with hash unchanged, refused-with-presentation).
- [x] Shared `presentation-cases.json` fixture.
- [x] `docs/event-runtime.md` §5 line.

`bun test event-runtime/lib/presentation.test.mjs event-runtime/lib/verify.test.mjs` → 66 pass. `bun build/emit.mjs --check` exit 0. `bun run format:check` clean. (Full-suite `web/src` failures are pre-existing missing-web-deps in the worktree, outside the Owned Paths.)

Note: no pin/registry-digest regeneration — the registry digest covers agent defs/eventTypes/edges/schedules only, and pins cover agent/command `.md` files; the new standalone schema and the `agent-result` change touch neither.

## Owned Paths

`event-runtime/lib/presentation.mjs`, `event-runtime/lib/presentation.test.mjs`, `event-runtime/lib/fixtures/presentation-cases.json`, `event-runtime/lib/verify.mjs`, `event-runtime/lib/verify.test.mjs`, `event-runtime/schemas/factory.presentation.v1.json`, `event-runtime/schemas/factory.agent-result.v1.json`, `docs/event-runtime.md`
