### PR TITLE
fix(cli): factory ask — correct in-flight age/heartbeat, qualify held comments, bound comment fan-out (#1069)

### DIFF
--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -633,6 +633,20 @@ const count = (section) =>
  * is only `updatedAt` says so, because "silent for 40m" and "last touched 40m
  * ago" are different claims about whether an agent is alive.
  */
+/**
+ * A comment read that FAILED must not render like a ticket that simply has no
+ * comments — falling back to the title in both cases is the section-level
+ * "unavailable vs empty" mistake repeated per row. Rate limits hit these reads
+ * one ticket at a time, so this is the common case, not the exotic one.
+ */
+const heldRowText = (r, repoW, idW) => {
+  const head = `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.holds.join(","), 22)}  `;
+  if (r.questionError)
+    return `${head}comment unreadable — ${oneLine(r.questionError, 60)}`;
+  if (r.question) return `${head}last comment: ${oneLine(r.question, 60)}`;
+  return `${head}${oneLine(r.title, 70)} (no comments)`;
+};
+
 const heartbeatText = (row) => {
   if (row.heartbeatSource === "comment")
     return `heartbeat ${humanAge(row.heartbeatAgeMs)} ago`;
@@ -687,12 +701,8 @@ export function formatAsk(doc) {
     // "what is waiting on me" into a lie.
     if (doc.held.rows?.length)
       lines.push("  (newest comment shown — may be the reply, not the ask)");
-    renderRows(
-      lines,
-      doc.held,
-      "nothing held",
-      (r) =>
-        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.holds.join(","), 22)}  ${r.question ? `last comment: ${oneLine(r.question, 60)}` : oneLine(r.title, 70)}`,
+    renderRows(lines, doc.held, "nothing held", (r) =>
+      heldRowText(r, repoW, idW),
     );
   }
 

--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -73,6 +73,24 @@ export const WRITE_OPS = Object.freeze([
 
 const DEFAULT_WINDOW_HOURS = 24;
 
+/**
+ * How many `listComments` reads for held tickets are in flight at once.
+ *
+ * Small on purpose: this is a read surface that may be polled, and the point
+ * is to stop paying N round trips in series, not to burst a tracker's rate
+ * limiter — which, when it trips, is exactly the failure this command is
+ * supposed to survive.
+ */
+const HELD_COMMENT_CONCURRENCY = 5;
+
+/** `Promise.all` over fixed-size chunks: bounded fan-out, input order kept. */
+async function mapWithConcurrency(items, limit, fn) {
+  const out = [];
+  for (let i = 0; i < items.length; i += limit)
+    out.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
+  return out;
+}
+
 const reasonOf = (error) =>
   error?.message ? String(error.message) : String(error);
 
@@ -98,6 +116,26 @@ const msSince = (iso, now) => {
   const at = Date.parse(iso);
   return Number.isFinite(at) ? Math.max(0, now - at) : null;
 };
+
+/**
+ * When this ticket last showed a sign of life, and how confident that is.
+ *
+ * `lastCommentAt` is a real heartbeat — an agent posting its phase change.
+ * `updatedAt` is a proxy: it advances on the claim mutation, on label swaps
+ * and on comments, so it is an upper bound on silence rather than a heartbeat.
+ * The GitHub adapter pins `lastCommentAt: null` (github.mjs), which is the
+ * whole reason the distinction has to be carried rather than collapsed.
+ *
+ * Reporting a missing heartbeat as `never` would be the same mistake this
+ * command exists to prevent, one level down: "we did not read it" rendered as
+ * "it did not happen". Hence the explicit `unknown` source.
+ */
+export function heartbeatOf(ticket) {
+  if (ticket?.lastCommentAt)
+    return { at: ticket.lastCommentAt, source: "comment" };
+  if (ticket?.updatedAt) return { at: ticket.updatedAt, source: "updatedAt" };
+  return { at: null, source: "unknown" };
+}
 
 /** Compact duration for the human view: 5s / 12m / 3h / 2d. */
 export function humanAge(ms) {
@@ -380,7 +418,13 @@ export async function gatherAsk({
         return tickets
           .filter((t) => stateName(t) === "In Progress")
           .map((t) => {
-            const claimedAt = t.startedAt ?? t.createdAt ?? null;
+            const heartbeat = heartbeatOf(t);
+            // `startedAt` before `updatedAt` before `createdAt`, the same
+            // precedence reaper.mjs `lastActivity()` uses. GitHub has no
+            // workflow-state startedAt (github.mjs pins it null), so without
+            // the `updatedAt` step a ticket claimed 12 minutes ago reads as
+            // "30d old" — issue-creation time wearing a claim's label.
+            const claimedAt = t.startedAt ?? t.updatedAt ?? t.createdAt ?? null;
             return {
               repo: repo.name,
               identifier: t.identifier,
@@ -389,9 +433,17 @@ export async function gatherAsk({
               assignee: t.assignee?.name ?? null,
               labels: labelNames(t),
               claimedAt,
+              claimedAtSource: t.startedAt
+                ? "startedAt"
+                : t.updatedAt
+                  ? "updatedAt"
+                  : t.createdAt
+                    ? "createdAt"
+                    : "unknown",
               ageMs: msSince(claimedAt, now),
-              lastHeartbeatAt: t.lastCommentAt ?? null,
-              heartbeatAgeMs: msSince(t.lastCommentAt, now),
+              lastHeartbeatAt: heartbeat.at,
+              heartbeatAgeMs: msSince(heartbeat.at, now),
+              heartbeatSource: heartbeat.source,
             };
           });
       });
@@ -402,42 +454,54 @@ export async function gatherAsk({
         const tickets = (await allTickets(repo)).filter((t) =>
           labelNames(t).some((name) => HELD_LABELS.includes(name)),
         );
-        const rows = [];
-        for (const t of tickets) {
-          // The question is the newest comment — the same conservative guess
-          // reply-detection makes when it has no label-add to anchor on. A
-          // per-ticket failure costs the question, never the row.
-          let question = null;
-          let questionAt = null;
-          let questionError = null;
-          try {
-            const comments = await planeFor(repo).listComments(t.identifier);
-            const newest = [...comments].sort(
-              (a, b) =>
-                Date.parse(a.createdAt ?? 0) - Date.parse(b.createdAt ?? 0),
-            )[comments.length - 1];
-            if (newest) {
-              question = oneLine(newest.body, 400);
-              questionAt = newest.createdAt ?? null;
+        // One listComments per held ticket, fully serialized, was the bulk of
+        // the wall-clock — and it got slowest exactly when the factory was
+        // unhealthy and the answer mattered most. Bounded concurrency keeps
+        // the per-ticket try/catch (a failure still costs one question, not
+        // the section) without paying for the round trips in series.
+        return mapWithConcurrency(
+          tickets,
+          HELD_COMMENT_CONCURRENCY,
+          async (t) => {
+            let question = null;
+            let questionAt = null;
+            let questionError = null;
+            try {
+              const comments = await planeFor(repo).listComments(t.identifier);
+              const newest = [...comments].sort(
+                (a, b) =>
+                  Date.parse(a.createdAt ?? 0) - Date.parse(b.createdAt ?? 0),
+              )[comments.length - 1];
+              if (newest) {
+                question = oneLine(newest.body, 400);
+                questionAt = newest.createdAt ?? null;
+              }
+            } catch (error) {
+              questionError = reasonOf(error);
             }
-          } catch (error) {
-            questionError = reasonOf(error);
-          }
-          rows.push({
-            repo: repo.name,
-            identifier: t.identifier,
-            title: t.title ?? null,
-            url: t.url ?? null,
-            state: stateName(t),
-            holds: labelNames(t).filter((n) => HELD_LABELS.includes(n)),
-            labels: labelNames(t),
-            question,
-            questionAt,
-            questionError,
-            ageMs: msSince(t.updatedAt ?? t.createdAt, now),
-          });
-        }
-        return rows;
+            return {
+              repo: repo.name,
+              identifier: t.identifier,
+              title: t.title ?? null,
+              url: t.url ?? null,
+              state: stateName(t),
+              holds: labelNames(t).filter((n) => HELD_LABELS.includes(n)),
+              labels: labelNames(t),
+              question,
+              questionAt,
+              // NOT necessarily the question. reply-detection anchors on the
+              // ai:blocked label-add and only falls back to newest-comment when
+              // there is no add event; the neutral contract exposes no label
+              // history (GitHub has none), so this is always the fallback. Once
+              // a human answers a held ticket, the newest comment is their
+              // ANSWER. Consumers must read this discriminator before calling
+              // the text a question, and the renderer labels it accordingly.
+              questionSource: "newest-comment",
+              questionError,
+              ageMs: msSince(t.updatedAt ?? t.createdAt, now),
+            };
+          },
+        );
       });
     }
 
@@ -557,6 +621,19 @@ const count = (section) =>
   section?.error ? "unavailable" : (section?.rows?.length ?? 0);
 
 /**
+ * A heartbeat we never read is `unknown`, not `never` — and a timestamp that
+ * is only `updatedAt` says so, because "silent for 40m" and "last touched 40m
+ * ago" are different claims about whether an agent is alive.
+ */
+const heartbeatText = (row) => {
+  if (row.heartbeatSource === "comment")
+    return `heartbeat ${humanAge(row.heartbeatAgeMs)} ago`;
+  if (row.heartbeatSource === "updatedAt")
+    return `updated ${humanAge(row.heartbeatAgeMs)} ago`;
+  return "heartbeat unknown";
+};
+
+/**
  * The human view, rendered from the document `gatherAsk` returned — never from
  * a second read. If a number here disagrees with `--json`, that is a bug in
  * this function, not a different answer.
@@ -589,7 +666,7 @@ export function formatAsk(doc) {
       doc.inflight,
       "nothing claimed",
       (r) =>
-        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(`${humanAge(r.ageMs)} old`, 9)}  heartbeat ${pad(r.lastHeartbeatAt ? `${humanAge(r.heartbeatAgeMs)} ago` : "never", 10)}  ${oneLine(r.title, 45)}`,
+        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(`${humanAge(r.ageMs)} old`, 9)}  ${pad(heartbeatText(r), 24)}  ${oneLine(r.title, 45)}`,
     );
   }
 
@@ -597,12 +674,17 @@ export function formatAsk(doc) {
     const repoW = columnWidth(doc.held.rows, "repo", 6, 16);
     const idW = columnWidth(doc.held.rows, "identifier", 8, 26);
     lines.push(`\nHELD — waiting on a human (${count(doc.held)})`);
+    // "last comment", never "question": once a human answers, the newest
+    // comment IS the answer, and this is the view where mislabelling it turns
+    // "what is waiting on me" into a lie.
+    if (doc.held.rows?.length)
+      lines.push("  (newest comment shown — may be the reply, not the ask)");
     renderRows(
       lines,
       doc.held,
       "nothing held",
       (r) =>
-        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.holds.join(","), 22)}  ${oneLine(r.question ?? r.title, 70)}`,
+        `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.holds.join(","), 22)}  ${r.question ? `last comment: ${oneLine(r.question, 60)}` : oneLine(r.title, 70)}`,
     );
   }
 

--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -80,6 +80,14 @@ const DEFAULT_WINDOW_HOURS = 24;
  * is to stop paying N round trips in series, not to burst a tracker's rate
  * limiter — which, when it trips, is exactly the failure this command is
  * supposed to survive.
+ *
+ * MEASURED CAVEAT: this buys real wall-clock only on the Linear adapter, whose
+ * transport is `await fetch`. `lib/control-plane/github.mjs` shells out through
+ * `spawnSync`, which blocks the event loop, so its reads serialize no matter
+ * what is awaited around them — measured on the factory repo at 13.0s
+ * concurrent vs 12.5s serial for five held tickets. The fan-out is correct and
+ * bounded here; making it *pay* on GitHub is an adapter-level fix, filed
+ * separately. Do not "fix" this by raising the limit.
  */
 const HELD_COMMENT_CONCURRENCY = 5;
 

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -28,6 +28,9 @@ const NOW = Date.parse("2026-08-29T12:00:00.000Z");
 const ago = (ms) => new Date(NOW - ms).toISOString();
 const MIN = 60_000;
 const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+const byId = (rows) => Object.fromEntries(rows.map((r) => [r.identifier, r]));
 
 const REPO = {
   name: "factory",
@@ -125,6 +128,25 @@ function seedPlane() {
             createdAt: ago(2 * HOUR),
           },
         ],
+      },
+      {
+        // The GITHUB shape. lib/control-plane/github.mjs pins `startedAt` and
+        // `lastCommentAt` to null unconditionally, and config/repos.yaml puts
+        // the factory repo on that adapter — so this, not WM-2, is the primary
+        // in-flight path. Without it the suite only ever sees Linear's richer
+        // ticket and cannot tell a real heartbeat from a missing one.
+        id: "t5",
+        identifier: "WM-5",
+        title: "Claimed on a GitHub-shaped tracker",
+        state: { id: "s-progress", name: "In Progress", type: "started" },
+        team,
+        project,
+        labels: [],
+        assignee: { id: "u-2", name: "Grace" },
+        createdAt: ago(30 * DAY),
+        startedAt: null,
+        updatedAt: ago(12 * MIN),
+        comments: [],
       },
       {
         id: "t4",
@@ -310,17 +332,26 @@ test("every section is present and typed on a seeded fixture", async () => {
   expect(doc.queue.rows[0].ageMs).toBe(6 * HOUR);
 
   // inflight — claimed, with age and last heartbeat
-  expect(doc.inflight.rows.map((r) => r.identifier)).toEqual(["WM-2"]);
-  expect(doc.inflight.rows[0].ageMs).toBe(3 * HOUR);
-  expect(doc.inflight.rows[0].heartbeatAgeMs).toBe(11 * MIN);
-  expect(doc.inflight.rows[0].assignee).toBe("Ada");
+  expect(doc.inflight.rows.map((r) => r.identifier).sort()).toEqual([
+    "WM-2",
+    "WM-5",
+  ]);
+  const claimed = byId(doc.inflight.rows);
+  expect(claimed["WM-2"]).toMatchObject({
+    assignee: "Ada",
+    ageMs: 3 * HOUR,
+    claimedAtSource: "startedAt",
+    heartbeatAgeMs: 11 * MIN,
+    heartbeatSource: "comment",
+  });
 
-  // held — with the question
+  // held — with the newest comment, explicitly marked as such
   expect(doc.held.rows.map((r) => r.identifier)).toEqual(["WM-3"]);
   expect(doc.held.rows[0].holds).toEqual(["ai:blocked"]);
   expect(doc.held.rows[0].question).toBe(
     "Which base branch should this target?",
   );
+  expect(doc.held.rows[0].questionSource).toBe("newest-comment");
 
   // recent — 24h window, scoped to the requested repos
   expect(doc.recent.rows.map((r) => r.runId)).toEqual([
@@ -360,6 +391,157 @@ test("every section is present and typed on a seeded fixture", async () => {
   expect(text).toContain("Which base branch should this target?");
   expect(text).toContain("owned_paths_overlap");
   expect(text).toContain("$1.25");
+});
+
+test("in-flight age and heartbeat survive a tracker with no startedAt or lastCommentAt", async () => {
+  // github.mjs pins startedAt and lastCommentAt to null, so this is the shape
+  // the factory repo's own tickets arrive in. The bug this guards: age falling
+  // back to createdAt (a 12-minute-old claim reading as "30d old") and an
+  // UNKNOWN heartbeat rendering as a definite "never".
+  const plane = seedPlane();
+  const doc = await gatherAsk(askArgs({ controlPlaneFor: () => plane }));
+  const row = byId(doc.inflight.rows)["WM-5"];
+
+  expect(row.claimedAtSource).toBe("updatedAt");
+  expect(row.ageMs).toBe(12 * MIN);
+  expect(row.ageMs).not.toBe(30 * DAY);
+  expect(row.heartbeatSource).toBe("updatedAt");
+  expect(row.heartbeatAgeMs).toBe(12 * MIN);
+  expect(row.lastHeartbeatAt).toBe(ago(12 * MIN));
+
+  // A heartbeat that was never read must not render as one that never happened.
+  const text = formatAsk(doc);
+  expect(text).toContain("updated 12m ago");
+  expect(text).not.toContain("never");
+  expect(text).not.toContain("30d old");
+});
+
+test("a heartbeat the tracker cannot answer reads unknown, not never", async () => {
+  const silent = {
+    kind: "memory",
+    async listTickets() {
+      return [
+        {
+          identifier: "WM-9",
+          title: "No timestamps at all",
+          state: { name: "In Progress" },
+          labels: [],
+          createdAt: null,
+          startedAt: null,
+          updatedAt: null,
+          lastCommentAt: null,
+        },
+      ];
+    },
+    async listDispatchable() {
+      return [];
+    },
+    async listComments() {
+      return [];
+    },
+  };
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => silent, sections: ["inflight"] }),
+  );
+
+  expect(doc.inflight.rows[0]).toMatchObject({
+    heartbeatSource: "unknown",
+    lastHeartbeatAt: null,
+    heartbeatAgeMs: null,
+    claimedAtSource: "unknown",
+    ageMs: null,
+  });
+  expect(formatAsk(doc)).toContain("heartbeat unknown");
+  expect(formatAsk(doc)).not.toContain("never");
+});
+
+test("held rows never present a comment as the outstanding question", async () => {
+  // The human has ALREADY answered; the newest comment is their reply. Calling
+  // that "the question" is the specific way this view lies, because it is the
+  // view that answers "what is waiting on me".
+  const answered = {
+    kind: "memory",
+    async listTickets() {
+      return [
+        {
+          identifier: "WM-8",
+          title: "Held, and answered",
+          state: { name: "Blocked" },
+          labels: [{ name: "ai:blocked" }],
+          createdAt: ago(6 * HOUR),
+          updatedAt: ago(1 * HOUR),
+        },
+      ];
+    },
+    async listDispatchable() {
+      return [];
+    },
+    async listComments() {
+      return [
+        {
+          id: "q",
+          body: "Which base branch should this target?",
+          createdAt: ago(5 * HOUR),
+        },
+        { id: "a", body: "develop, always.", createdAt: ago(1 * HOUR) },
+      ];
+    },
+  };
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => answered, sections: ["held"] }),
+  );
+
+  expect(doc.held.rows[0].question).toBe("develop, always.");
+  expect(doc.held.rows[0].questionSource).toBe("newest-comment");
+
+  const text = formatAsk(doc);
+  expect(text).toContain("last comment: develop, always.");
+  expect(text).toContain("may be the reply, not the ask");
+});
+
+test("held comment reads are bounded-concurrent, not serialized", async () => {
+  const HELD = 12;
+  let inFlight = 0;
+  let peak = 0;
+  const plane = {
+    kind: "memory",
+    async listTickets() {
+      return Array.from({ length: HELD }, (_, i) => ({
+        identifier: `WM-${100 + i}`,
+        title: `Held ${i}`,
+        state: { name: "Blocked" },
+        labels: [{ name: "ai:blocked" }],
+        createdAt: ago(6 * HOUR),
+        updatedAt: ago(1 * HOUR),
+      }));
+    },
+    async listDispatchable() {
+      return [];
+    },
+    async listComments(identifier) {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await Bun.sleep(5);
+      inFlight -= 1;
+      return [{ id: "c", body: `note for ${identifier}`, createdAt: ago(MIN) }];
+    },
+  };
+
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => plane, sections: ["held"] }),
+  );
+
+  expect(doc.held.rows.length).toBe(HELD);
+  // Serialized would peak at 1; unbounded would peak at HELD. Neither is right.
+  expect(peak).toBeGreaterThan(1);
+  expect(peak).toBeLessThanOrEqual(5);
+  // Input order is preserved despite the fan-out.
+  expect(doc.held.rows.map((r) => r.identifier)).toEqual(
+    Array.from({ length: HELD }, (_, i) => `WM-${100 + i}`),
+  );
+  expect(doc.held.rows.every((r) => r.question?.includes("note for"))).toBe(
+    true,
+  );
 });
 
 test("a failing section carries its error and never renders as empty", async () => {

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -499,6 +499,48 @@ test("held rows never present a comment as the outstanding question", async () =
   expect(text).toContain("may be the reply, not the ask");
 });
 
+test("a held comment read that failed does not render like a ticket with no comments", async () => {
+  // Rate limits hit these reads one ticket at a time, so a per-row failure is
+  // the common case. Falling back to the title in both cases would repeat the
+  // section-level "unavailable vs empty" mistake once per row.
+  const flaky = {
+    kind: "memory",
+    async listTickets() {
+      return ["WM-6", "WM-7"].map((identifier) => ({
+        identifier,
+        title: `Held ${identifier}`,
+        state: { name: "Blocked" },
+        labels: [{ name: "ai:blocked" }],
+        createdAt: ago(6 * HOUR),
+        updatedAt: ago(1 * HOUR),
+      }));
+    },
+    async listDispatchable() {
+      return [];
+    },
+    async listComments(identifier) {
+      if (identifier === "WM-6") throw new Error("HTTP 403 rate limited");
+      return [];
+    },
+  };
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => flaky, sections: ["held"] }),
+  );
+
+  // The section survives: both rows are present, neither is dropped.
+  expect(doc.held.error).toBeNull();
+  expect(doc.held.rows.length).toBe(2);
+  const held = byId(doc.held.rows);
+  expect(held["WM-6"].questionError).toContain("rate limited");
+  expect(held["WM-6"].question).toBeNull();
+  expect(held["WM-7"].questionError).toBeNull();
+  expect(held["WM-7"].question).toBeNull();
+
+  const text = formatAsk(doc);
+  expect(text).toContain("comment unreadable — HTTP 403 rate limited");
+  expect(text).toContain("(no comments)");
+});
+
 test("held comment reads are bounded-concurrent, not serialized", async () => {
   const HELD = 12;
   let inFlight = 0;


### PR DESCRIPTION
Follow-up to #1102 (merged). Addresses the cold review of #1069; #1102 landed while these fixes were in progress, so they ship as their own PR on top of it. Same Owned Paths.

Fixes #1069

## BLOCKING 1 — in-flight age and heartbeat were wrong on every GitHub-bound repo

`lib/control-plane/github.mjs` pins `startedAt: null` and `lastCommentAt: null`, and `config/repos.yaml` puts the factory repo on that adapter — so this was the primary path, not an edge case. A ticket claimed 12 minutes ago rendered as `30d old / heartbeat never`.

- `claimedAt` now follows `startedAt → updatedAt → createdAt`, the same precedence as `reaper.mjs` `lastActivity()`, instead of silently degrading to issue-creation time.
- `heartbeatOf()` returns `{ at, source }` with `heartbeatSource: "comment" | "updatedAt" | "unknown"`, so a consumer can tell a real heartbeat from a proxy. `updatedAt` advances on claims and label swaps, so it is an upper bound on silence, not a heartbeat — the JSON now says which it is.
- The renderer prints `heartbeat 11m ago` / `updated 12m ago` / `heartbeat unknown`. A heartbeat we never read is no longer reported as one that never happened — the same "unavailable is not empty" rule the section level already follows.

## BLOCKING 2 — the fixture was more capable than the adapter it stood in for

`memoryControlPlane.asTicket()` synthesizes `lastCommentAt` from the last comment, and the old fixture set `startedAt` explicitly, so the suite only ever saw Linear's richer ticket and could not see finding 1. Added a GitHub-shaped in-flight ticket (`startedAt: null`, `lastCommentAt: null`, `comments: []`, `updatedAt` 12m ago, `createdAt` 30d ago) and a dedicated regression test asserting age and heartbeat resolve from `updatedAt` — explicitly not `30 * DAY`, explicitly not `never`.

## FIX 3 — `held` could present the human's ANSWER as "the question"

`reply-detection` anchors on the `ai:blocked` label-add and only falls back to newest-comment when there is no add event; the neutral contract exposes no label history (GitHub has none), so this is always the fallback. Once a human replies but before the ticket is unblocked, the newest comment is their answer — wrong in exactly the "what is waiting on me" view.

True parity is not reachable through the contract, so the fix is provenance: rows carry `questionSource: "newest-comment"`, and the renderer says `last comment:` under a `(newest comment shown — may be the reply, not the ask)` header rather than presenting it unqualified.

## FIX 4 — bounded concurrency for the held comment fan-out

`listComments` reads now run through `mapWithConcurrency(..., 5, ...)` — bounded, input order preserved, per-ticket `try/catch` still isolating failures. Tested by peak-concurrency instrumentation: serialized would peak at 1, unbounded at N; the assertion requires `1 < peak <= 5`.

**Measured caveat, recorded in the code:** this buys real wall-clock only on the Linear adapter (`await fetch`). `github.mjs` shells out via `spawnSync`, which blocks the event loop, so its reads serialize regardless — 13.0s concurrent vs 12.5s serial for five held tickets on the factory repo, and 43s to 40s for the whole section. The fan-out here is correct and bounded; making it *pay* on GitHub is an adapter-level fix, filed as #1113. The comment says so, and says not to "fix" it by raising the limit.

## Also fixed (found while verifying)

A held comment read that **failed** rendered identically to a ticket with no comments — the section-level "unavailable vs empty" mistake repeated per row, and rate limits hit these reads one at a time so it is the common case. Now `comment unreadable — <reason>` vs `<title> (no comments)`.

## Verification

```
bun test --timeout 20000 orchestrator/ask.test.mjs && ./bin/factory ask --json | head -40 && ./bin/factory ask --section queue,held
```

11 pass / 0 fail / 112 expect() calls. The live run happened to hit the GitHub GraphQL secondary rate limit, which demonstrated the partial-failure path end to end: `legalease` returned 21 queued and 4 held, `factory` failed, the renderer printed `partial — factory: gh api graphql failed (status 1)`, and the command still exited 0.

Every new behaviour was observed failing against a deliberately broken build first (5 mutations: old `claimedAt` precedence + `heartbeatOf` without the `updatedAt` branch; `questionSource` and the renderer qualification removed; `HELD_COMMENT_CONCURRENCY = 1`; `unknown` rendered as `never`; the failed-read fallback collapsed into the title). Each killed the intended test and only that test.

## Filed to triage, not fixed here

- #1110 — a partially-failed section reads as authoritative to a JSON consumer (`error` is null when only some repos failed). Reproduced live on this very run.
- #1111 — `lib/spend.mjs` cannot distinguish "nothing spent" from "log dir unreadable"; `budgetExhausted` fails open on it.
- #1112 — `QUEUE — dispatchable now` overstates; it is the tracker predicate, not what `next` would start.
- #1113 — the GitHub adapter's `spawnSync` transport serializes every read, defeating caller concurrency.
- #1114 — read-only `runtime.db` open fails on an uncleanly-shut-down WAL database.