### PR TITLE
perf(dispatch): stop a dispatch burst from claim_lock_starving itself (#1124)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -707,14 +707,25 @@ export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
 
 /** Claim-lock contention is deferred independently from execution attempts. */
 // Requeue budget for the per-repo dispatch lock. Contended runs re-queue with
-// exponential backoff and only give up (claim_lock_starvation → REFUSED) after
-// this many attempts. The lock is held briefly (claim + gate control-plane
-// reads, not the agent run), so a contended run reliably wins once the runs
-// ahead of it release — the ceiling only needs to exceed the worker pool's
-// concurrent same-repo contenders. At 8 a surge (a freshly-unblocked backlog,
-// a reaper mass-reclaim, or a merge-lane fan-out) starved legitimate dispatch
-// and merge-fix work; 24 clears a full worker pool of contenders with headroom.
-export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 24;
+// exponential backoff without spending an execution attempt.
+//
+// WM-1124: the default is now unbounded (Infinity → never terminally REFUSE
+// with claim_lock_starvation). acquireClaimLock() only ever returns false for a
+// *live* lock owner — a dead owner's lock is reclaimed in place (see the
+// isAlive branch there), so a deferred run is, by construction, only ever
+// contending against an owner that WILL release. A live owner's hold is bounded
+// (claim + gate control-plane reads under the worker subprocess timeout, not
+// the agent run), so the contender reliably wins a later cycle. A fixed ceiling
+// turned that transient, self-healing contention into a terminal refusal: an
+// N-wide same-repo dispatch burst (observed 14–16 per scan) starved most of
+// itself — 11 of 14 terminally REFUSED in one 2026-08-29 cycle — wasting a full
+// scan and the agents' budget on tickets that were never actually un-claimable.
+// Durable defer-and-retry is strictly safer here than a terminal refusal, and
+// the atomic claim is untouched: the lock, gate read, and claim keep their
+// exact ordering. An explicit finite `maxClaimLockContentionRequeues` option
+// still caps the requeues (used by the starvation-ceiling test and available to
+// operators); only the production default stops being terminal.
+export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = Infinity;
 export const DEFAULT_MAX_TRANSIENT_GATE_REQUEUES = 3;
 export const CLAIM_LOCK_BACKOFF_BASE_MS = 25;
 export const CLAIM_LOCK_BACKOFF_MAX_MS = 1_000;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -58,6 +58,7 @@ import {
   acquireClaimLock,
   adapterExecuteTimeoutMs,
   cancelRun,
+  CLAIM_LOCK_BACKOFF_MAX_MS,
   claimNext,
   CODE_RELOAD_EXIT,
   codeStamp,
@@ -795,7 +796,9 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("REFUSED");
     expect(
       db
-        .query(`SELECT status, reason FROM proposals WHERE id = 'prop-stale-open'`)
+        .query(
+          `SELECT status, reason FROM proposals WHERE id = 'prop-stale-open'`,
+        )
         .get(),
     ).toEqual({ status: "rejected", reason: "run_refused" });
 
@@ -3531,6 +3534,153 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     ).toEqual([1, 1, 1]);
     expect(claimedTickets.sort()).toEqual(["WM-710", "WM-711", "WM-712"]);
     expect(maxActiveClaims).toBe(1);
+  });
+
+  // WM-1124: a full-width same-repo dispatch burst must not starve itself. One
+  // worker holds the claim lock across a long claim window while the rest of the
+  // burst contends against it for many more cycles than the old fixed requeue
+  // ceiling (24) allowed. Every contender must durably defer-and-retry — none
+  // may terminally REFUSE with claim_lock_starvation just because a live holder
+  // still owns the lock — and the atomic claim must be preserved throughout
+  // (at most one active tracker claim, each ticket claimed exactly once).
+  test("a same-repo dispatch burst never claim_lock_starves against a live holder", async () => {
+    const db = openDb(":memory:");
+    const lockDir = tmpDir("evrt-lock-burst20-");
+    const BURST = 20;
+    const tickets = Array.from({ length: BURST }, (_, i) => `WM-${720 + i}`);
+    const specs = tickets.map((ticket, index) =>
+      queueRun(
+        db,
+        makeDispatchSpec({
+          runId: `run_burst_${String(index + 1).padStart(2, "0")}`,
+          input: { repo: "wt-worker", ticket },
+        }),
+      ),
+    );
+
+    let now = T0;
+    let releaseHolder;
+    let markHolderStarted;
+    const holderStarted = new Promise((resolve) => {
+      markHolderStarted = resolve;
+    });
+    const holderRelease = new Promise((resolve) => {
+      releaseHolder = resolve;
+    });
+    let activeClaims = 0;
+    let maxActiveClaims = 0;
+    const claimedTickets = [];
+    const holderTicket = tickets[0];
+
+    const o = opts({
+      now: () => now,
+      dispatch: {
+        locksDir: lockDir,
+        // Deterministic worst case: full backoff (random -> the cap) every time.
+        random: () => 1,
+        fetchTicket: (ticket) => readyDispatchTicket(ticket),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: async ({ ticket }) => {
+          activeClaims += 1;
+          maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
+          claimedTickets.push(ticket);
+          if (ticket === holderTicket) {
+            // Pin the lock open so the rest of the burst repeatedly contends.
+            markHolderStarted();
+            await holderRelease;
+          }
+          activeClaims -= 1;
+          return { ok: true };
+        },
+      },
+    });
+
+    // One worker wins the lock and holds it across a long claim window.
+    const holder = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    await holderStarted;
+
+    // While the live holder keeps the lock, sweep the other 19 through far more
+    // contention cycles than the old fixed ceiling (24) permitted. Every sweep
+    // must defer (QUEUED / claim_lock_contention); none may terminally REFUSE.
+    const CONTENTION_ROUNDS = 30;
+    const contenders = specs.slice(1);
+    for (let round = 0; round < CONTENTION_ROUNDS; round++) {
+      // Advance past every deferred not-before so the whole cohort is eligible.
+      now += CLAIM_LOCK_BACKOFF_MAX_MS;
+      for (let i = 0; i < contenders.length; i++) {
+        const summary = await runOnce(
+          db,
+          registry,
+          { fake: dispatchFakeAdapter },
+          o,
+        );
+        expect(summary).toMatchObject({
+          terminalState: "QUEUED",
+          reasonCode: "claim_lock_contention",
+        });
+      }
+      // The holder is RUNNING and the rest are deferred to a future not-before,
+      // so nothing else is claimable within this round.
+      expect(claimNext(db, o)).toBeNull();
+    }
+
+    // Contention must not have spent an execution attempt or left an attempt row.
+    for (const spec of contenders) {
+      expect(
+        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+          .attempts,
+      ).toBe(0);
+      expect(
+        db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
+      ).toHaveLength(0);
+    }
+
+    // Release the holder and drain the whole burst.
+    releaseHolder();
+    expect((await holder).terminalState).toBe("COMPLETED");
+
+    let completed = 1; // the holder
+    let guard = 0;
+    while (completed < BURST && guard++ < BURST * 3) {
+      now += CLAIM_LOCK_BACKOFF_MAX_MS;
+      let summary;
+      while (
+        (summary = await runOnce(
+          db,
+          registry,
+          { fake: dispatchFakeAdapter },
+          o,
+        ))
+      ) {
+        expect(summary.terminalState).toBe("COMPLETED");
+        completed += 1;
+      }
+    }
+
+    // Every burst member ran to completion — none terminally REFUSED.
+    expect(completed).toBe(BURST);
+    expect(specs.map((spec) => runState(db, spec.runId))).toEqual(
+      Array.from({ length: BURST }, () => "COMPLETED"),
+    );
+    expect(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM attempts WHERE reason_code = 'claim_lock_starvation'`,
+        )
+        .get().n,
+    ).toBe(0);
+    // Claim atomicity: exactly one claim in flight at a time, each ticket once.
+    expect(maxActiveClaims).toBe(1);
+    expect(claimedTickets.slice().sort()).toEqual(tickets.slice().sort());
+    expect(new Set(claimedTickets).size).toBe(BURST);
+    expect(
+      specs.map(
+        (spec) =>
+          db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+            .attempts,
+      ),
+    ).toEqual(Array.from({ length: BURST }, () => 1));
   });
 
   test("merge-fix gate accepts an assigned In Review ticket without invoking the dispatch claim", async () => {


### PR DESCRIPTION
## What
Make the per-repo dispatch-lock requeue budget effectively unbounded by default so a same-repo dispatch burst no longer starves itself. `DEFAULT_MAX_CLAIM_LOCK_REQUEUES` becomes `Infinity`; live-owner lock contention now durably defers-and-retries with capped backoff instead of turning terminal after a fixed 24-requeue ceiling.

## Why
A work-scan chains N dispatches (observed 14–16) that auto-approve together and race the `<repo>.dispatch.lock` simultaneously. The lock is held across the claim + gate reads, so most of the burst lost the race and, after the 24-requeue ceiling, terminally REFUSED with `claim_lock_starvation` (11 of 14 in one 2026-08-29 cycle) — wasting a full scan and agent budget on tickets that were never actually un-claimable.

`acquireClaimLock()` only returns false for a **live** lock owner (a dead owner's lock is reclaimed in place), so a deferred run is by construction only ever contending against an owner that **will** release. Durable defer-and-retry is strictly safer than a terminal refusal here.

## Acceptance
- A work-scan planning up to `max_in_flight` dispatches yields **zero** terminal `claim_lock_starvation` refusals under nominal conditions.
- Claim atomicity preserved: the lock → gate read → claim ordering is untouched; contention is deferred **before** the claim and never spends an execution attempt. New test asserts at most one active tracker claim at a time and each ticket claimed exactly once.
- New 20-wide burst regression holds one live claim open while the rest contend for 30 cycles (past the old 24 ceiling): all defer-and-retry, none terminally REFUSE, requeues leave no attempt row / do not increment the attempt count. Verified failing on `develop@a699b535` before the fix.
- Existing starvation-ceiling test still passes via an explicit finite `maxClaimLockContentionRequeues` override (terminal path unchanged for operators/tests); dead-owner recovery and non-contention dispatch behavior unchanged.
- `bun test event-runtime/lib/worker.test.mjs` (133) and `planner.test.mjs` (84) green; prettier --check clean.

## Owned Paths
- event-runtime/lib/worker.mjs
- event-runtime/lib/worker.test.mjs
