### PR TITLE
feat(control-plane): authenticate the factory stack as a GitHub App (Phase 2 of #1136)

### DIFF
--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -1,0 +1,374 @@
+/**
+ * GitHub App authentication for the factory stack (WM-1137, Phase 2 of #1136).
+ *
+ * `gh` honours the `GH_TOKEN` env var over its own config, so to give the
+ * factory its own rate budget we feed it a **GitHub App installation token**
+ * via `GH_TOKEN`, refreshed hourly (installation tokens expire in 1h). See
+ * epic #1136 §6 "Design A".
+ *
+ * This module is deliberately made of small, pure, injectable pieces so the
+ * whole flow is unit-testable against mocks — no real GitHub App exists yet:
+ *   - `buildAppJwt` signs a short-lived RS256 JWT from the App private key.
+ *   - `mintInstallationToken` exchanges that JWT for an installation token over
+ *     REST (unaffected by the GraphQL rate limit), via an injected `fetchImpl`.
+ *   - `resolveGhToken` reads a cached token file and re-mints only when it is
+ *     missing or near expiry, rewriting the file atomically with mode 0600.
+ *   - `readCachedAppToken` is the SYNC read `github.mjs` uses per `gh` spawn:
+ *     it returns the cached token when App auth is configured and the file is
+ *     fresh, and otherwise stays out of the way (see its contract below).
+ *   - `runDaemon` is the supervised refresher (`--daemon`).
+ *
+ * Security: the token and the private key must NEVER appear in a log line, an
+ * error message, or a thrown value. Every error here is phrased from status
+ * codes and file paths only.
+ */
+import { createSign } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** Installation tokens live 1h; re-mint when this close to expiry. */
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+/** Daemon refresh cadence — comfortably inside the 1h token lifetime. */
+const REFRESH_INTERVAL_MS = 45 * 60 * 1000;
+/** JWTs GitHub accepts must expire within 10 min; back-date `iat` for skew. */
+const JWT_LIFETIME_S = 9 * 60;
+const JWT_BACKDATE_S = 60;
+
+const b64url = (input) => Buffer.from(input).toString("base64url");
+
+/**
+ * A short-lived RS256 JWT authenticating as the App itself (`iss=appId`).
+ * Pure and testable: pass a fixed `now` and verify the signature with the
+ * matching public key. `iat` is back-dated 60s to tolerate clock skew and
+ * `exp` is kept under GitHub's 10-minute ceiling.
+ *
+ * @param {{ appId: string|number, privateKeyPem: string, now?: () => number }} args
+ * @returns {string} `header.payload.signature`, base64url, RS256.
+ */
+export function buildAppJwt({ appId, privateKeyPem, now = () => Date.now() }) {
+  if (!appId) throw new Error("buildAppJwt requires appId");
+  if (!privateKeyPem) throw new Error("buildAppJwt requires privateKeyPem");
+  const nowS = Math.floor(now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iat: nowS - JWT_BACKDATE_S,
+    exp: nowS + JWT_LIFETIME_S,
+    iss: String(appId),
+  };
+  const signingInput = `${b64url(JSON.stringify(header))}.${b64url(
+    JSON.stringify(payload),
+  )}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(privateKeyPem).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Exchange an App JWT for an installation access token over REST.
+ *
+ * REST is used deliberately — this path is unaffected by the GraphQL rate
+ * limit. `fetchImpl` defaults to the global `fetch` so tests can inject a mock
+ * and no real network call is made.
+ *
+ * @param {{
+ *   appId: string|number,
+ *   installationId: string|number,
+ *   privateKeyPem: string,
+ *   fetchImpl?: typeof fetch,
+ *   now?: () => number,
+ * }} args
+ * @returns {Promise<{ token: string, expiresAt: string|null }>}
+ */
+export async function mintInstallationToken({
+  appId,
+  installationId,
+  privateKeyPem,
+  fetchImpl = fetch,
+  now = () => Date.now(),
+}) {
+  if (!installationId)
+    throw new Error("mintInstallationToken requires installationId");
+  const jwt = buildAppJwt({ appId, privateKeyPem, now });
+  let res;
+  try {
+    res = await fetchImpl(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "watt-mind-factory",
+        },
+      },
+    );
+  } catch {
+    // Never surface the underlying error verbatim: it could carry the request
+    // (and thus the Bearer JWT) in some runtimes. Report only that it failed.
+    throw new Error("installation-token request failed to reach GitHub");
+  }
+  if (!res?.ok)
+    throw new Error(
+      `installation-token request rejected (status ${res?.status ?? "?"})`,
+    );
+  const data = await res.json();
+  if (!data?.token)
+    throw new Error("installation-token response contained no token");
+  return { token: data.token, expiresAt: data.expires_at ?? null };
+}
+
+/** Parse an ISO-8601 or epoch-ms expiry into epoch ms, or null. */
+function expiryMs(expiresAt) {
+  if (expiresAt == null) return null;
+  if (typeof expiresAt === "number") return expiresAt;
+  const ms = Date.parse(expiresAt);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** A cached record is usable when it has a token and enough life left. */
+function tokenIsFresh(cached, nowMs) {
+  if (!cached?.token) return false;
+  const exp = expiryMs(cached.expiresAt);
+  // No/unparseable expiry is treated as stale — safer to re-mint than to feed
+  // `gh` a token that may already be dead.
+  if (exp == null) return false;
+  return exp - nowMs > EXPIRY_SKEW_MS;
+}
+
+/** Read and parse the cached `{ token, expiresAt }` file, or null on any error. */
+function readTokenFile(tokenFile) {
+  let raw;
+  try {
+    raw = readFileSync(tokenFile, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.token === "string")
+      return { token: parsed.token, expiresAt: parsed.expiresAt ?? null };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Write `{ token, expiresAt }` atomically (tmp+rename) with mode 0600. */
+function writeTokenFileAtomic(tokenFile, record) {
+  mkdirSync(path.dirname(tokenFile), { recursive: true });
+  const tmp = `${tokenFile}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(
+    tmp,
+    JSON.stringify({ token: record.token, expiresAt: record.expiresAt }),
+    { mode: 0o600 },
+  );
+  // writeFileSync's mode only applies on create; enforce it before the rename
+  // in case the tmp path somehow pre-existed with looser perms.
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    // Best effort — the create-time mode already covers the common case.
+  }
+  renameSync(tmp, tokenFile);
+}
+
+/**
+ * Resolve a usable installation token, minting and caching only when needed.
+ *
+ * Reads the cached `{ token, expiresAt }` JSON from `tokenFile`; if it is
+ * missing or within the 5-minute expiry skew, calls `mint()`, writes the file
+ * atomically (tmp+rename, 0600), and returns the fresh token. Never logs the
+ * token.
+ *
+ * @param {{ tokenFile: string, now?: () => number, mint: () => Promise<{token:string,expiresAt:string|null}> }} args
+ * @returns {Promise<string>} the installation token.
+ */
+export async function resolveGhToken({
+  tokenFile,
+  now = () => Date.now(),
+  mint,
+}) {
+  if (!tokenFile) throw new Error("resolveGhToken requires tokenFile");
+  const cached = readTokenFile(tokenFile);
+  if (tokenIsFresh(cached, now())) return cached.token;
+  if (typeof mint !== "function")
+    throw new Error("resolveGhToken requires mint() to refresh the token");
+  const minted = await mint();
+  if (!minted?.token) throw new Error("mint() returned no token");
+  writeTokenFileAtomic(tokenFile, minted);
+  return minted.token;
+}
+
+/** The default cached-token path when `FACTORY_GH_APP_TOKEN_FILE` is unset. */
+export function defaultTokenFile(home = homedir()) {
+  return path.join(home, ".factory", "gh-app-token.json");
+}
+
+/**
+ * The App-auth config from env, or null when App auth is not configured.
+ *
+ * "Configured" requires the App id, installation id, and private-key path to
+ * all be present; the token file has a default. Absence of any of the three
+ * means the factory keeps running on its existing gh-config PAT — this is the
+ * no-op path callers must preserve.
+ */
+export function readAppConfig(env = process.env) {
+  const appId = env.FACTORY_GH_APP_ID;
+  const installationId = env.FACTORY_GH_APP_INSTALLATION_ID;
+  const privateKeyPath = env.FACTORY_GH_APP_PRIVATE_KEY_PATH;
+  if (!appId || !installationId || !privateKeyPath) return null;
+  return {
+    appId,
+    installationId,
+    privateKeyPath,
+    tokenFile: env.FACTORY_GH_APP_TOKEN_FILE || defaultTokenFile(),
+  };
+}
+
+/**
+ * The SYNC per-spawn token read used by `github.mjs`.
+ *
+ * Contract, chosen so wiring into a synchronous `spawnSync` path is safe:
+ *   - App auth NOT configured (env vars absent) → returns `null` WITHOUT
+ *     throwing. Callers add no `GH_TOKEN` and behave exactly as today.
+ *   - App auth configured but the cached file is missing, unreadable, or
+ *     expired → THROWS. The caller logs a single warning and falls back to the
+ *     default `gh` credentials. Minting is the daemon's job, never a `gh`
+ *     call's — a synchronous spawn path must not block on the network.
+ *
+ * The error text names only status/state, never the token.
+ *
+ * @param {{ env?: NodeJS.ProcessEnv, now?: () => number }} [args]
+ * @returns {string|null}
+ */
+export function readCachedAppToken({
+  env = process.env,
+  now = () => Date.now(),
+} = {}) {
+  const config = readAppConfig(env);
+  if (!config) return null;
+  const cached = readTokenFile(config.tokenFile);
+  if (!cached) throw new Error("gh App token file is missing or unreadable");
+  if (!tokenIsFresh(cached, now()))
+    throw new Error("gh App token is expired or near expiry");
+  return cached.token;
+}
+
+/**
+ * The supervised refresher (`--daemon`). Mints once on startup, then every
+ * ~45 min, and exits cleanly on SIGTERM/SIGINT. Reads config from env and the
+ * private key from `FACTORY_GH_APP_PRIVATE_KEY_PATH`. Logs only paths and
+ * expiry timestamps — never the token or the key.
+ *
+ * @param {{
+ *   env?: NodeJS.ProcessEnv,
+ *   fetchImpl?: typeof fetch,
+ *   now?: () => number,
+ *   log?: { log?: Function, warn?: Function },
+ *   signals?: { on?: Function },
+ *   intervalMs?: number,
+ * }} [args]
+ */
+export async function runDaemon({
+  env = process.env,
+  fetchImpl = fetch,
+  now = () => Date.now(),
+  log = console,
+  signals = process,
+  intervalMs = REFRESH_INTERVAL_MS,
+} = {}) {
+  const config = readAppConfig(env);
+  if (!config)
+    throw new Error(
+      "gh App auth not configured: set FACTORY_GH_APP_ID, " +
+        "FACTORY_GH_APP_INSTALLATION_ID and FACTORY_GH_APP_PRIVATE_KEY_PATH",
+    );
+  const privateKeyPem = readFileSync(config.privateKeyPath, "utf8");
+  const mint = () =>
+    mintInstallationToken({
+      appId: config.appId,
+      installationId: config.installationId,
+      privateKeyPem,
+      fetchImpl,
+      now,
+    });
+
+  const refresh = async () => {
+    try {
+      await resolveGhToken({ tokenFile: config.tokenFile, now, mint });
+      log.log?.(`[gh-app-auth] installation token ready (${config.tokenFile})`);
+    } catch (err) {
+      // `err.message` is deliberately status/path-only (see mint/resolve).
+      log.warn?.(`[gh-app-auth] token refresh failed: ${err?.message ?? err}`);
+    }
+  };
+
+  await refresh();
+  await new Promise((resolve) => {
+    let timer = null;
+    let stopped = false;
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      if (timer) clearInterval(timer);
+      resolve();
+    };
+    signals.on?.("SIGTERM", stop);
+    signals.on?.("SIGINT", stop);
+    timer = setInterval(() => {
+      refresh();
+    }, intervalMs);
+    if (typeof timer?.unref === "function") timer.unref();
+  });
+}
+
+if (import.meta.main) {
+  const daemon = process.argv.includes("--daemon");
+  const config = readAppConfig(process.env);
+  if (!config) {
+    process.stderr.write(
+      "gh-app-auth: not configured — set FACTORY_GH_APP_ID, " +
+        "FACTORY_GH_APP_INSTALLATION_ID and FACTORY_GH_APP_PRIVATE_KEY_PATH\n",
+    );
+    process.exit(2);
+  }
+  if (daemon) {
+    await runDaemon().catch((err) => {
+      process.stderr.write(`gh-app-auth: ${err?.message ?? err}\n`);
+      process.exit(1);
+    });
+  } else {
+    // One-shot: ensure a fresh cached token exists. Print only the file path
+    // and expiry — never the token itself.
+    try {
+      const privateKeyPem = readFileSync(config.privateKeyPath, "utf8");
+      await resolveGhToken({
+        tokenFile: config.tokenFile,
+        mint: () =>
+          mintInstallationToken({
+            appId: config.appId,
+            installationId: config.installationId,
+            privateKeyPem,
+          }),
+      });
+      const cached = readTokenFile(config.tokenFile);
+      process.stdout.write(
+        `gh-app-auth: token cached at ${config.tokenFile}` +
+          `${cached?.expiresAt ? ` (expires ${cached.expiresAt})` : ""}\n`,
+      );
+    } catch (err) {
+      process.stderr.write(`gh-app-auth: ${err?.message ?? err}\n`);
+      process.exit(1);
+    }
+  }
+}

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -1,0 +1,253 @@
+/**
+ * GitHub App auth unit suite (WM-1137, Phase 2 of #1136).
+ *
+ * No real GitHub App exists yet, so everything is exercised against mocks:
+ * a locally-generated RSA test keypair for the JWT, an injected `fetchImpl`
+ * for the token exchange, and a temp file for the token cache. No real network
+ * or `gh` calls are made.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { rmSync } from "node:fs";
+import {
+  buildAppJwt,
+  mintInstallationToken,
+  readCachedAppToken,
+  resolveGhToken,
+} from "./gh-app-auth.mjs";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const tmpDirs = [];
+function tmp(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function decodeSegment(seg) {
+  return JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+}
+
+describe("buildAppJwt", () => {
+  test("produces a verifiable RS256 JWT with iss/iat/exp", () => {
+    const now = () => 1_700_000_000_000; // fixed clock
+    const jwt = buildAppJwt({
+      appId: "123456",
+      privateKeyPem: privateKey,
+      now,
+    });
+    const [h, p, sig] = jwt.split(".");
+    expect(h && p && sig).toBeTruthy();
+
+    const header = decodeSegment(h);
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+
+    const payload = decodeSegment(p);
+    const nowS = Math.floor(now() / 1000);
+    expect(payload.iss).toBe("123456");
+    expect(payload.iat).toBe(nowS - 60); // back-dated for clock skew
+    expect(payload.exp).toBeGreaterThan(nowS);
+    expect(payload.exp - payload.iat).toBeLessThanOrEqual(600); // <=10 min
+
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(`${h}.${p}`);
+    verifier.end();
+    const ok = verifier.verify(publicKey, Buffer.from(sig, "base64url"));
+    expect(ok).toBe(true);
+  });
+
+  test("a tampered payload fails verification", () => {
+    const jwt = buildAppJwt({ appId: "1", privateKeyPem: privateKey });
+    const [h, , sig] = jwt.split(".");
+    const forged = Buffer.from(JSON.stringify({ iss: "999" })).toString(
+      "base64url",
+    );
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(`${h}.${forged}`);
+    verifier.end();
+    expect(verifier.verify(publicKey, Buffer.from(sig, "base64url"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("mintInstallationToken", () => {
+  test("POSTs to the installation endpoint with a Bearer JWT and returns token+expiry", async () => {
+    const seen = {};
+    const fetchImpl = async (url, init) => {
+      seen.url = url;
+      seen.init = init;
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({
+          token: "ghs_installationtoken",
+          expires_at: "2026-08-29T13:00:00Z",
+        }),
+      };
+    };
+    const res = await mintInstallationToken({
+      appId: "42",
+      installationId: "9001",
+      privateKeyPem: privateKey,
+      fetchImpl,
+    });
+    expect(res).toEqual({
+      token: "ghs_installationtoken",
+      expiresAt: "2026-08-29T13:00:00Z",
+    });
+    expect(seen.url).toBe(
+      "https://api.github.com/app/installations/9001/access_tokens",
+    );
+    expect(seen.init.method).toBe("POST");
+    expect(seen.init.headers.Accept).toBe("application/vnd.github+json");
+    expect(seen.init.headers.Authorization).toMatch(/^Bearer .+\..+\..+$/);
+  });
+
+  test("a non-ok response throws with status only (no token/key leak)", async () => {
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: "Bad credentials" }),
+    });
+    await expect(
+      mintInstallationToken({
+        appId: "42",
+        installationId: "9001",
+        privateKeyPem: privateKey,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/status 403/);
+  });
+});
+
+describe("resolveGhToken", () => {
+  test("mints, writes the cache 0600, and returns the token when no file exists", async () => {
+    const dir = tmp("gh-app-token-");
+    const tokenFile = path.join(dir, "gh-app-token.json");
+    let mints = 0;
+    const mint = async () => {
+      mints += 1;
+      return { token: "ghs_fresh", expiresAt: "2026-08-29T13:00:00Z" };
+    };
+    const token = await resolveGhToken({
+      tokenFile,
+      now: () => Date.parse("2026-08-29T12:00:00Z"),
+      mint,
+    });
+    expect(token).toBe("ghs_fresh");
+    expect(mints).toBe(1);
+    const onDisk = JSON.parse(readFileSync(tokenFile, "utf8"));
+    expect(onDisk).toEqual({
+      token: "ghs_fresh",
+      expiresAt: "2026-08-29T13:00:00Z",
+    });
+    expect(statSync(tokenFile).mode & 0o777).toBe(0o600);
+  });
+
+  test("a cached, unexpired token is returned without minting", async () => {
+    const dir = tmp("gh-app-token-");
+    const tokenFile = path.join(dir, "gh-app-token.json");
+    writeFileSync(
+      tokenFile,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: "2026-08-29T13:00:00Z",
+      }),
+    );
+    let mints = 0;
+    const token = await resolveGhToken({
+      tokenFile,
+      now: () => Date.parse("2026-08-29T12:00:00Z"),
+      mint: async () => {
+        mints += 1;
+        return { token: "ghs_new", expiresAt: "2026-08-29T14:00:00Z" };
+      },
+    });
+    expect(token).toBe("ghs_cached");
+    expect(mints).toBe(0);
+  });
+
+  test("a near-expiry token triggers exactly one re-mint and rewrites the file", async () => {
+    const dir = tmp("gh-app-token-");
+    const tokenFile = path.join(dir, "gh-app-token.json");
+    writeFileSync(
+      tokenFile,
+      JSON.stringify({ token: "ghs_old", expiresAt: "2026-08-29T12:03:00Z" }),
+    );
+    let mints = 0;
+    const mint = async () => {
+      mints += 1;
+      return { token: "ghs_reminted", expiresAt: "2026-08-29T13:00:00Z" };
+    };
+    const token = await resolveGhToken({
+      tokenFile,
+      // 12:00, token expires 12:03 — inside the 5-min skew, so stale.
+      now: () => Date.parse("2026-08-29T12:00:00Z"),
+      mint,
+    });
+    expect(token).toBe("ghs_reminted");
+    expect(mints).toBe(1);
+    const onDisk = JSON.parse(readFileSync(tokenFile, "utf8"));
+    expect(onDisk.token).toBe("ghs_reminted");
+  });
+});
+
+describe("readCachedAppToken", () => {
+  const appEnv = (dir) => ({
+    FACTORY_GH_APP_ID: "42",
+    FACTORY_GH_APP_INSTALLATION_ID: "9001",
+    FACTORY_GH_APP_PRIVATE_KEY_PATH: "/does/not/matter.pem",
+    FACTORY_GH_APP_TOKEN_FILE: path.join(dir, "gh-app-token.json"),
+  });
+
+  test("returns null (no throw) when App auth is not configured", () => {
+    expect(readCachedAppToken({ env: {} })).toBeNull();
+  });
+
+  test("returns the cached token when configured and fresh", () => {
+    const dir = tmp("gh-app-token-");
+    const env = appEnv(dir);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({ token: "ghs_live", expiresAt: "2026-08-29T13:00:00Z" }),
+    );
+    expect(
+      readCachedAppToken({
+        env,
+        now: () => Date.parse("2026-08-29T12:00:00Z"),
+      }),
+    ).toBe("ghs_live");
+  });
+
+  test("throws (never returns a stale token) when configured but the file is missing", () => {
+    const dir = tmp("gh-app-token-");
+    expect(() => readCachedAppToken({ env: appEnv(dir) })).toThrow();
+  });
+
+  test("throws when configured but the cached token is expired", () => {
+    const dir = tmp("gh-app-token-");
+    const env = appEnv(dir);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({ token: "ghs_dead", expiresAt: "2026-08-29T11:00:00Z" }),
+    );
+    expect(() =>
+      readCachedAppToken({
+        env,
+        now: () => Date.parse("2026-08-29T12:00:00Z"),
+      }),
+    ).toThrow();
+  });
+});

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -32,6 +32,7 @@ import {
   parseReadyPin,
   readyPinMarker,
 } from "../../event-runtime/lib/triage.mjs";
+import { readCachedAppToken } from "./gh-app-auth.mjs";
 
 export const GITHUB_FACTORY_STATES = Object.freeze([
   "Triage",
@@ -176,9 +177,39 @@ const text = (v) =>
 /**
  * Default `api` implementation: `gh api` / `gh api graphql` via `exec`.
  *
+ * GitHub App auth (WM-1137, Phase 2 of #1136): when the App env vars are set
+ * and a fresh cached installation token exists, each `gh` spawn is given
+ * `GH_TOKEN` in its child env so `gh` authenticates as the factory's App
+ * instead of the ambient gh-config PAT. Reading the cached token per spawn
+ * means the hourly rotation needs no restart. It is fully defensive and a
+ * strict no-op when unconfigured: `resolveToken` returns null (env untouched,
+ * today's behavior), and any failure resolving a configured token logs ONE
+ * warning and falls back to spawning `gh` with the env untouched — a `gh` call
+ * never crashes because App auth is misconfigured. The token never appears in
+ * a log or error.
+ *
  * @param {(cmd: string, args: string[], opts: object) => object} exec
+ * @param {{ env?: NodeJS.ProcessEnv, resolveToken?: (args: {env: NodeJS.ProcessEnv}) => (string|null) }} [options]
  */
-export function makeGhApi(exec = spawnSync) {
+export function makeGhApi(exec = spawnSync, options = {}) {
+  const { env = process.env, resolveToken = readCachedAppToken } = options;
+  let warnedAppAuth = false;
+  const spawn = (cmd, args, opts) => {
+    let childEnv;
+    try {
+      const token = resolveToken({ env });
+      if (token) childEnv = { ...env, GH_TOKEN: token };
+    } catch (err) {
+      if (!warnedAppAuth) {
+        warnedAppAuth = true;
+        // Status/state only — never the token (see gh-app-auth.mjs).
+        console.warn(
+          `GitHub App auth unavailable; falling back to default gh credentials: ${err?.message ?? err}`,
+        );
+      }
+    }
+    return exec(cmd, args, childEnv ? { ...opts, env: childEnv } : opts);
+  };
   return function ghApi(method, pathName, { body, query } = {}) {
     const args = ["api"];
     const isGraphql =
@@ -186,7 +217,7 @@ export function makeGhApi(exec = spawnSync) {
     if (isGraphql) {
       args.push("graphql", "--input", "-");
       return ghJson(
-        exec,
+        spawn,
         args,
         JSON.stringify({
           query: body?.query ?? body,
@@ -207,9 +238,9 @@ export function makeGhApi(exec = spawnSync) {
     args.push(url);
     if (body !== undefined) {
       args.push("--input", "-");
-      return ghJson(exec, args, JSON.stringify(body));
+      return ghJson(spawn, args, JSON.stringify(body));
     }
-    return ghJson(exec, args);
+    return ghJson(spawn, args);
   };
 }
 

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -25,6 +25,7 @@ import {
   GITHUB_FACTORY_STATES,
   githubControlPlane,
   githubPolicyStanza,
+  makeGhApi,
   parseIssueIdentifier,
   protocolLabelSpecs,
   provisionGithubRepo,
@@ -2059,5 +2060,95 @@ describe("Projects v2 board read is cached for a short TTL (WM-1067)", () => {
     // though it lands inside the TTL window. Without invalidation this would be
     // 1 (every read served from the pre-write memo).
     expect(api.state.boardReads).toBe(2);
+  });
+});
+
+describe("makeGhApi GitHub App token injection (WM-1137)", () => {
+  // A spawnSync-shaped fake that records the child options each `gh` call gets.
+  function recordingExec() {
+    const calls = [];
+    const exec = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return { status: 0, stdout: "{}", stderr: "" };
+    };
+    exec.calls = calls;
+    return exec;
+  }
+
+  function appEnv(dir) {
+    return {
+      PATH: "/usr/bin",
+      FACTORY_GH_APP_ID: "42",
+      FACTORY_GH_APP_INSTALLATION_ID: "9001",
+      FACTORY_GH_APP_PRIVATE_KEY_PATH: "/does/not/matter.pem",
+      FACTORY_GH_APP_TOKEN_FILE: path.join(dir, "gh-app-token.json"),
+    };
+  }
+
+  test("with App env vars set and a fresh cached token, the gh child env gets GH_TOKEN", () => {
+    const dir = tmp("gh-app-inject-");
+    const env = appEnv(dir);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({ token: "ghs_live", expiresAt: "2999-01-01T00:00:00Z" }),
+    );
+    const exec = recordingExec();
+    const api = makeGhApi(exec, { env });
+    api("GET", "user");
+    expect(exec.calls).toHaveLength(1);
+    const childEnv = exec.calls[0].opts.env;
+    expect(childEnv.GH_TOKEN).toBe("ghs_live");
+    // The rest of the parent env is carried through unchanged.
+    expect(childEnv.FACTORY_GH_APP_ID).toBe("42");
+    expect(childEnv.PATH).toBe("/usr/bin");
+  });
+
+  test("no mint happens on the injection path — a fresh cache is read as-is", () => {
+    const dir = tmp("gh-app-inject-");
+    const env = appEnv(dir);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({ token: "ghs_live", expiresAt: "2999-01-01T00:00:00Z" }),
+    );
+    const before = readFileSync(env.FACTORY_GH_APP_TOKEN_FILE, "utf8");
+    const exec = recordingExec();
+    makeGhApi(exec, { env })("GET", "user");
+    // The cache file is untouched — the spawn path only ever reads it.
+    expect(readFileSync(env.FACTORY_GH_APP_TOKEN_FILE, "utf8")).toBe(before);
+  });
+
+  test("with App env vars ABSENT, the gh child env is unchanged (no GH_TOKEN added)", () => {
+    const exec = recordingExec();
+    // A parent env with no FACTORY_GH_APP_* vars: today's PAT path.
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    api("GET", "user");
+    expect(exec.calls).toHaveLength(1);
+    // The child options carry no `env` override at all — exec runs exactly as
+    // it did before this feature.
+    expect("env" in exec.calls[0].opts).toBe(false);
+  });
+
+  test("a configured-but-broken token resolution logs one warning and falls back cleanly", () => {
+    const dir = tmp("gh-app-inject-");
+    // Configured, but no token file written — resolution throws internally.
+    const env = appEnv(dir);
+    const warnings = [];
+    const orig = console.warn;
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      const exec = recordingExec();
+      const api = makeGhApi(exec, { env });
+      api("GET", "user"); // call 1
+      api("GET", "user"); // call 2 — must not re-warn
+      // Both gh calls still ran, with no GH_TOKEN injected (env untouched).
+      expect(exec.calls).toHaveLength(2);
+      expect("env" in exec.calls[0].opts).toBe(false);
+      expect("env" in exec.calls[1].opts).toBe(false);
+    } finally {
+      console.warn = orig;
+    }
+    // Exactly one warning across both calls, and it never contains a token.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).not.toContain("ghs_");
   });
 });


### PR DESCRIPTION
## What
Implements Phase 2 of #1136 (closes #1137): the factory stack can authenticate `gh` as its own **GitHub App** via a minted installation token, instead of the ambient gh-config PAT.

- New `lib/control-plane/gh-app-auth.mjs`:
  - `buildAppJwt({ appId, privateKeyPem, now })` — short-lived RS256 JWT (`iss`/`iat`/`exp`, `iat` back-dated 60s, `exp` <=10 min) via `node:crypto` `createSign("RSA-SHA256")` + base64url.
  - `mintInstallationToken({ appId, installationId, privateKeyPem, fetchImpl })` — POSTs the App-installations access-token REST endpoint with a `Bearer <jwt>`; returns `{ token, expiresAt }`. Injected `fetchImpl` (default global `fetch`).
  - `resolveGhToken({ tokenFile, now, mint })` — reads cached `{ token, expiresAt }`, re-mints only within the 5-min expiry skew, writes atomically (tmp+rename) with mode `0600`.
  - `readCachedAppToken` — the sync per-spawn read used by `github.mjs`.
  - `runDaemon` (`--daemon`) — ~45-min refresher, clean SIGTERM/SIGINT exit.
- `github.mjs` `makeGhApi`: before each `gh` spawn, injects `GH_TOKEN` from a fresh cached token when App auth is configured; otherwise leaves the child env untouched.

## Why
`gh` honours `GH_TOKEN` over its config; feeding it an App installation token (refreshed hourly) gives the factory its own rate budget. See epic #1136 §6 "Design A".

## Acceptance
- App env vars set + mocked `fetchImpl` → a `gh` call receives `GH_TOKEN=<installation-token>`; a cached unexpired file mints nothing; a near-expiry file re-mints exactly once and rewrites `0600`.
- App env vars **absent** → `makeGhApi` behaves exactly as today (test asserts the child env has no `GH_TOKEN` added).
- `buildAppJwt` yields a verifiable RS256 JWT (verified against a test keypair); token/private key never appear in logs or errors.
- Configured-but-broken resolution logs exactly one warning and falls back — a `gh` call never crashes on misconfigured App auth.
- `bun test lib/control-plane/gh-app-auth.test.mjs lib/control-plane/github.test.mjs` green (83 pass).

## Owned Paths
- lib/control-plane/gh-app-auth.mjs
- lib/control-plane/gh-app-auth.test.mjs
- lib/control-plane/github.mjs
- lib/control-plane/github.test.mjs

Note: this is **Phase 2 of #1136** and is **inert until the App env vars are set** — no real GitHub App exists yet, so it is a strict no-op on the current PAT path and fully unit-tested against mocks.

Ref #1137