### PR TITLE
fix(ask): read-only runtime.db open fails on an uncleanly-shut-down db (#1114)

### DIFF
--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -139,9 +139,22 @@ export function parseSections(raw) {
 /**
  * runtime.db opened READ-ONLY on purpose. `openDb()` would migrate and set
  * pragmas — writes, from a command whose whole contract is that it does none.
+ *
+ * A read-only connection cannot build the WAL index (`-shm`). After an unclean
+ * shutdown the database can be left with a `-wal` but no `-shm`; a strict
+ * read-only open of that state fails with a bare `unable to open database file`.
+ * We detect it up front and report an actionable reason instead — never falling
+ * back to an immutable snapshot, which could silently omit committed WAL frames
+ * and so return a stale read as if it were current (see #1114). We do not create
+ * the `-shm` ourselves: this verb writes nothing to the runtime directory.
  */
 export function openRuntimeDb(file = dbPath()) {
   if (!existsSync(file)) throw new Error(`no runtime database at ${file}`);
+  if (existsSync(`${file}-wal`) && !existsSync(`${file}-shm`))
+    throw new Error(
+      "runtime database was not shut down cleanly (WAL present without its index); " +
+        "start the event runtime or run any runtime writer once, then retry",
+    );
   return new Database(file, { readonly: true });
 }
 

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -1,5 +1,11 @@
 import { afterAll, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +16,7 @@ import {
   WRITE_OPS,
   formatAsk,
   gatherAsk,
+  openRuntimeDb,
   parseSections,
 } from "./ask.mjs";
 
@@ -408,6 +415,75 @@ test("runtime-database sections fail independently of the tracker", async () => 
   expect(doc.spend.today.runs).toBe(1);
   expect(doc.spend.errors[0]).toMatchObject({ source: "runtime.db" });
   expect(formatAsk(doc)).toContain("partial — runtime.db");
+});
+
+/**
+ * An on-disk runtime.db left with a `-wal` but no `-shm` — the state after an
+ * unclean shutdown. A read-only connection cannot build the missing WAL index,
+ * so `openRuntimeDb` must classify this before opening SQLite rather than fail
+ * with a bare "unable to open database file".
+ */
+function seedUncleanDbHome() {
+  const home = mkdtempSync(path.join(tmpdir(), "gh1114-home-"));
+  temps.push(home);
+  const file = path.join(home, "runtime.db");
+  // A real, valid main database; close it so no live handle holds sidecars.
+  openDb(file).close();
+  rmSync(`${file}-shm`, { force: true });
+  rmSync(`${file}-wal`, { force: true });
+  // Recreate only the WAL sidecar: WAL present, index absent.
+  writeFileSync(`${file}-wal`, Buffer.alloc(32));
+  return { home, file };
+}
+
+test("openRuntimeDb reports an unclean WAL shutdown without touching the db", () => {
+  const { file } = seedUncleanDbHome();
+
+  expect(() => openRuntimeDb(file)).toThrow(/not shut down cleanly/);
+  expect(() => openRuntimeDb(file)).toThrow(
+    /start the event runtime or run any runtime writer once/,
+  );
+  // The guard must not create the index it refused to build.
+  expect(existsSync(`${file}-shm`)).toBe(false);
+  expect(existsSync(`${file}-wal`)).toBe(true);
+});
+
+test("gatherAsk carries the unclean-shutdown reason into runtime sections", async () => {
+  const plane = seedPlane();
+  const { home, file } = seedUncleanDbHome();
+  const savedHome = process.env.FACTORY_EVENT_HOME;
+  process.env.FACTORY_EVENT_HOME = home;
+  try {
+    // db: undefined → gatherAsk opens the runtime db itself, hitting the guard.
+    const doc = await gatherAsk(
+      askArgs({ controlPlaneFor: () => plane, db: undefined }),
+    );
+
+    for (const name of ["recent", "noop"]) {
+      expect(doc[name].error).toContain("not shut down cleanly");
+      expect(doc[name].rows).toEqual([]);
+    }
+    const runtimeSpend = doc.spend.errors.find(
+      (e) => e.source === "runtime.db",
+    );
+    expect(runtimeSpend?.error).toContain("not shut down cleanly");
+
+    // Unaffected sections still return real data, and spend keeps transcripts.
+    expect(doc.queue.error).toBeNull();
+    expect(doc.queue.rows.length).toBe(1);
+    expect(doc.spend.error).toBeNull();
+    expect(doc.spend.today.runs).toBe(1);
+
+    const text = formatAsk(doc);
+    expect(text).toContain("unavailable — runtime database was not shut down");
+    expect(text).toContain("partial — runtime.db");
+
+    // Reading it must never fabricate the WAL index (no immutable fallback).
+    expect(existsSync(`${file}-shm`)).toBe(false);
+  } finally {
+    if (savedHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+    else process.env.FACTORY_EVENT_HOME = savedHome;
+  }
 });
 
 test("--section returns only the named sections", async () => {


### PR DESCRIPTION
Fixes #1114.

## Problem
`factory ask` opens `runtime.db` read-only on purpose (a read-only verb must not migrate or set pragmas). A read-only SQLite connection cannot build the WAL index (`-shm`), so a database left with a `-wal` but no `-shm` — the state after an unclean shutdown/crash — fails to open with a bare `unable to open database file`, and `ask`'s `recent`/`noop`/spend sections report an opaque error precisely when someone is running `ask` to find out what crashed.

## Fix (option 2 per the AI-Ready spec — the honest minimum)
- `openRuntimeDb()` now detects the WAL-without-SHM state **before opening SQLite** and throws a stable, actionable reason: *runtime database was not shut down cleanly … start the event runtime or run any runtime writer once, then retry*.
- No immutable-mode URI fallback is introduced — `ask` never returns a main-database-only snapshot that could omit committed WAL frames.
- The guard writes nothing to the runtime directory; in particular it does not create `-shm`.
- The reason flows through the existing db-open capture into `recent.error`, `noop.error`, and the `spend.errors` entry for source `runtime.db`; tracker-backed sections still return and partial-answer exit behavior is unchanged.
- Normal read-only behavior is unchanged when no WAL sidecar exists or when both sidecars exist.

## Test
Adds a regression test that seeds the on-disk WAL-without-SHM sidecar state, asserts the exact actionable classification, asserts no `-shm` file appears, and asserts unaffected sections still return. It fails if the guard is removed or replaced with an immutable fallback.

```
bun test --timeout 20000 orchestrator/ask.test.mjs
# 8 pass, 0 fail
```

Owned Paths only: `orchestrator/ask.mjs`, `orchestrator/ask.test.mjs`.