### PR TITLE
test(schedules): decouple ship schedule API test from client kernel loops (#1052)

### DIFF
--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -315,7 +315,26 @@ describe("schedule trigger metadata (WM-259)", () => {
   });
 
   test("Ship uses the existing schedule route and correlates its proposal to RC READY", async () => {
+    // Client ship loops (ship-bj29) live in the instance overlay, not the
+    // public kernel's schedules.json (#1052). Supply an explicit ship-bj29
+    // fixture so this exercises the ship route hermetically instead of
+    // depending on a client loop being tracked in the kernel registry.
+    const shipRegistry = {
+      ...registry,
+      schedules: {
+        "ship-bj29": {
+          every: "7d",
+          eventType: "factory.ship.requested",
+          payload: { repo: "bj29" },
+          catchUp: "none",
+          singleton: true,
+          approval: "watched",
+          enabled: false,
+        },
+      },
+    };
     const s = await makeServer({
+      registry: shipRegistry,
       now: () => Date.parse("2026-08-18T12:00:00Z"),
     });
     try {


### PR DESCRIPTION
## What
Makes the ship schedule API test in `event-runtime/lib/api.test.mjs` hermetic so it passes against the public kernel once client loops are removed from `schedules.json` (per #1028).

## Why
The "Ship uses the existing schedule route" test posted to `/schedules/ship-bj29/run` and expected 200, relying on `ship-bj29` being tracked in the kernel's `schedules.json`. `ship-bj29` is a **client** loop that correctly becomes instance-overlay state; once the kernel schedules are trimmed to the four public loops (reaper, work/merge/triage-factory), the kernel-only registry returns 404 and the test fails.

## Change
The test now builds an explicit `ship-bj29` registry fixture and passes it to `makeServer`, exercising the ship route independent of which client loops the kernel tracks. No kernel/agent-def/`schedules.json` changes, so no pin or registry-digest updates are required.

The companion concern in the issue — `api-schedules.test.mjs` inheriting the ambient operator overlay — was already resolved by the `overlayFreeRegistry` fixture (#1053/#1084); its remaining schedule assertions reference only kernel loops (`reaper`, `merge-factory`).

## Verification
`bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-schedules.test.mjs --timeout 20000` → 23 pass / 0 fail.

Closes #1052