### PR TITLE
chore(reaper): prune dead-pid worker registry rows across restarts (#1125)

### DIFF
--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -34,13 +34,14 @@ import {
   statSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
 import { dbPath } from "../event-runtime/lib/config.mjs";
+import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 import { ticketSlug } from "../lib/ticket-slug.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
@@ -837,6 +838,126 @@ export async function reapDeadDispatchWorktrees(
   return totals;
 }
 
+/**
+ * Is a local process still alive? `kill(pid, 0)` sends no signal — it only asks
+ * the kernel whether the pid exists. ESRCH means gone; EPERM means it exists but
+ * is owned by another user (still alive, so keep the row). Exported so the pid
+ * probe can be stubbed in tests without spawning real processes.
+ */
+export function localPidAlive(pid, kill = process.kill.bind(process)) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
+  }
+}
+
+/**
+ * True when a worker registry row is a dead husk safe to delete: its heartbeat
+ * has expired past the threshold AND its process is not alive. The heartbeat
+ * gate is what protects a live worker — one that checked in within the window,
+ * or whose clock briefly lagged, is never prunable however its pid probes. Pure
+ * and exported so the decision stays testable without a database.
+ *
+ * `alive` is the pid probe's verdict: true (running — keep), false (gone —
+ * prune), or null (a worker on another host, whose pid this box cannot probe;
+ * an expired heartbeat is then the only proof of death, so it prunes).
+ */
+export function workerIsPrunable(
+  row,
+  { now = Date.now(), staleMs = HEARTBEAT_STALE_MS, alive } = {},
+) {
+  const lastSeen = Date.parse(row.last_seen);
+  const heartbeatExpired =
+    !Number.isFinite(lastSeen) || now - lastSeen > staleMs;
+  if (!heartbeatExpired) return false; // live or briefly-lagged — never touch it
+  return alive !== true;
+}
+
+/**
+ * Prune dead-pid / expired-heartbeat worker rows from the runtime registry
+ * (WM-1125). The `workers` table is durable, so every stack restart and host
+ * crash leaves the dead process's rows behind — they never claim work, but they
+ * clutter `factory workers`, mislead idle/capacity views, and used to need a
+ * manual DELETE after a reboot. This reclaims them on the reaper's cadence.
+ *
+ * A currently-heartbeating worker is never removed: the heartbeat gate in
+ * workerIsPrunable() is measured against the same HEARTBEAT_STALE_MS the
+ * registry itself uses to call a worker stale. A local row also gets a
+ * definitive pid probe, so a hung-but-alive process is kept, not pruned.
+ * Deleting a `busy!stale` row that pointed at a terminal run releases it as a
+ * side effect — the row was the only thing still "holding" the finished run.
+ *
+ * Dependencies are injectable so selection and deletion can be tested without a
+ * live runtime database, the local process table, or a real hostname.
+ */
+export function reapDeadWorkers(
+  args,
+  {
+    databasePath = dbPath(),
+    openDatabase = (file) => new Database(file),
+    fileExists = existsSync,
+    now = Date.now(),
+    staleMs = HEARTBEAT_STALE_MS,
+    localHost = hostname(),
+    pidAlive = localPidAlive,
+    log = (...values) => console.log(...values),
+  } = {},
+) {
+  const totals = { considered: 0, pruned: 0, live: 0, failed: 0 };
+  if (!fileExists(databasePath)) return totals;
+
+  let db;
+  try {
+    db = openDatabase(databasePath);
+  } catch (err) {
+    totals.failed += 1;
+    log(`  ! dead-worker reap: registry unreadable: ${err.message || err}`);
+    return totals;
+  }
+
+  try {
+    const rows = db
+      .query(
+        `SELECT worker_id, host, pid, state, last_seen, current_run FROM workers`,
+      )
+      .all();
+    const remove = db.query(`DELETE FROM workers WHERE worker_id = ?`);
+
+    for (const row of rows) {
+      // A worker on another host cannot have its pid probed from here, so its
+      // heartbeat is the only proof of life (alive = null). Local rows get the
+      // definitive check, keeping a hung-but-alive local process off the list.
+      const alive = row.host === localHost ? pidAlive(row.pid) : null;
+      if (!workerIsPrunable(row, { now, staleMs, alive })) {
+        totals.live += 1;
+        continue;
+      }
+
+      totals.considered += 1;
+      const label =
+        `${row.worker_id} (host ${row.host} pid ${row.pid}, state ${row.state}` +
+        `${row.current_run ? `, holding ${row.current_run}` : ""})`;
+      if (!args.apply) {
+        log(`  STALE worker ${label} — dead process, heartbeat expired`);
+        continue;
+      }
+      remove.run(row.worker_id);
+      totals.pruned += 1;
+      log(`  pruned worker ${label}`);
+    }
+  } catch (err) {
+    totals.failed += 1;
+    log(`  ! dead-worker reap failed: ${err.message || err}`);
+  } finally {
+    db.close?.();
+  }
+
+  return totals;
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
@@ -885,6 +1006,21 @@ Options:
     );
   } catch (err) {
     console.error(`Dead-dispatch worktree reap failed: ${err.message || err}`);
+  }
+
+  // WM-1125: prune dead-pid / expired-heartbeat worker registry rows so they
+  // stop accumulating across restarts. Best-effort and isolated — a failure
+  // here must never mask the reaps above.
+  try {
+    console.log(`\n=== Dead-worker registry prune [${mode}] ===\n`);
+    const workerTotals = reapDeadWorkers(args);
+    console.log(
+      `\n=== Workers ${args.apply ? "pruned" : "prunable"}: ${
+        args.apply ? workerTotals.pruned : workerTotals.considered
+      } | Live: ${workerTotals.live} | Failures: ${workerTotals.failed} ===`,
+    );
+  } catch (err) {
+    console.error(`Dead-worker registry prune failed: ${err.message || err}`);
   }
 
   return totals;

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -166,6 +166,8 @@ import { memoryControlPlane } from "../lib/control-plane/memory.mjs";
 import { runReaper } from "./reaper.mjs";
 import { Database } from "bun:sqlite";
 import { reapDeadDispatchWorktrees, ticketHasLiveRun } from "./reaper.mjs";
+import { reapDeadWorkers, workerIsPrunable, localPidAlive } from "./reaper.mjs";
+import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 
 describe("reclaim label computation (WM-14)", () => {
   test("restores ai:agent-ready when returning In Progress ticket to Todo", () => {
@@ -872,5 +874,196 @@ describe("dead-dispatch worktree reaper (WM-1066)", () => {
       "2026-08-29T00:00:00Z",
     );
     expect(ticketHasLiveRun(db, "factory", "WM-1066")).toBe(true);
+  });
+});
+
+describe("dead-worker registry prune (WM-1125)", () => {
+  const DB_FILE = "/runtime/factory.db";
+  const HOST = "operator-box";
+  const NOW = Date.parse("2026-08-29T12:00:00Z");
+  const fresh = new Date(NOW - 5_000).toISOString(); // 5s ago — heartbeating
+  const laggy = new Date(NOW - (HEARTBEAT_STALE_MS - 5_000)).toISOString(); // just inside window
+  const expired = new Date(NOW - 60 * 60 * 1000).toISOString(); // an hour ago
+
+  function registryWith(rows) {
+    const db = new Database(":memory:");
+    db.run(
+      `CREATE TABLE workers (
+        worker_id   TEXT PRIMARY KEY,
+        host        TEXT NOT NULL,
+        pid         INTEGER NOT NULL,
+        labels_json TEXT NOT NULL DEFAULT '{}',
+        adapters    TEXT NOT NULL DEFAULT '',
+        started_at  TEXT NOT NULL,
+        last_seen   TEXT NOT NULL,
+        state       TEXT NOT NULL DEFAULT 'idle',
+        current_run TEXT,
+        stopped_at  TEXT
+      )`,
+    );
+    const insert = db.query(
+      `INSERT INTO workers (worker_id, host, pid, started_at, last_seen, state, current_run)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const r of rows) {
+      insert.run(
+        r.worker_id,
+        r.host ?? HOST,
+        r.pid,
+        r.started_at ?? r.last_seen,
+        r.last_seen,
+        r.state ?? "idle",
+        r.current_run ?? null,
+      );
+    }
+    return db;
+  }
+
+  function reapWith(db, args, overrides = {}) {
+    const logs = [];
+    // Keep the in-memory db open so the test can inspect it after the reap;
+    // production still closes the handle it opens.
+    db.close = () => {};
+    const totals = reapDeadWorkers(args, {
+      databasePath: DB_FILE,
+      openDatabase: () => db,
+      fileExists: (p) => p === DB_FILE,
+      now: NOW,
+      localHost: HOST,
+      // Default: every pid is dead unless the row opts into `alivePids`.
+      pidAlive: (pid) => (overrides.alivePids ?? []).includes(pid),
+      log: (...parts) => logs.push(parts.join(" ")),
+      ...overrides,
+    });
+    return { totals, logs };
+  }
+
+  test("prunes a table of live + dead rows down to only the live set", () => {
+    const db = registryWith([
+      // live: fresh heartbeat, pid running
+      { worker_id: "live-1", pid: 1001, last_seen: fresh, state: "idle" },
+      { worker_id: "live-2", pid: 1002, last_seen: fresh, state: "busy" },
+      // dead: crashed process, heartbeat long expired
+      { worker_id: "dead-idle", pid: 2001, last_seen: expired, state: "idle" },
+      {
+        worker_id: "dead-busy",
+        pid: 2002,
+        last_seen: expired,
+        state: "busy",
+        current_run: "run_terminal",
+      },
+      {
+        worker_id: "dead-stop",
+        pid: 2003,
+        last_seen: expired,
+        state: "stopped",
+      },
+    ]);
+    const { totals } = reapWith(db, parseArgs(["--apply"]), {
+      alivePids: [1001, 1002],
+    });
+    expect(totals.pruned).toBe(3);
+    expect(totals.live).toBe(2);
+    const remaining = db
+      .query(`SELECT worker_id FROM workers ORDER BY worker_id`)
+      .all()
+      .map((r) => r.worker_id);
+    expect(remaining).toEqual(["live-1", "live-2"]);
+  });
+
+  test("never prunes a worker whose heartbeat briefly lagged within the threshold", () => {
+    const db = registryWith([
+      // pid reported dead, but heartbeat is still inside the stale window
+      { worker_id: "lagging", pid: 3001, last_seen: laggy, state: "busy" },
+    ]);
+    const { totals } = reapWith(db, parseArgs(["--apply"]), { alivePids: [] });
+    expect(totals.pruned).toBe(0);
+    expect(totals.live).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM workers`).get().n).toBe(1);
+  });
+
+  test("keeps a hung-but-alive local process (expired heartbeat, pid still up)", () => {
+    const db = registryWith([
+      { worker_id: "hung", pid: 4001, last_seen: expired, state: "busy" },
+    ]);
+    const { totals } = reapWith(db, parseArgs(["--apply"]), {
+      alivePids: [4001],
+    });
+    expect(totals.pruned).toBe(0);
+    expect(totals.live).toBe(1);
+  });
+
+  test("prunes an expired remote worker whose pid cannot be probed from here", () => {
+    const db = registryWith([
+      {
+        worker_id: "remote-dead",
+        host: "worker-node-2",
+        pid: 5001,
+        last_seen: expired,
+        state: "idle",
+      },
+    ]);
+    // pidAlive would say alive for 5001, but it must not be consulted for a
+    // different host — the row still prunes on its expired heartbeat alone.
+    const { totals } = reapWith(db, parseArgs(["--apply"]), {
+      alivePids: [5001],
+    });
+    expect(totals.pruned).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM workers`).get().n).toBe(0);
+  });
+
+  test("dry run reports the prunable rows without deleting anything", () => {
+    const db = registryWith([
+      { worker_id: "dead-1", pid: 6001, last_seen: expired, state: "idle" },
+    ]);
+    const { totals, logs } = reapWith(db, parseArgs([]), { alivePids: [] });
+    expect(totals.considered).toBe(1);
+    expect(totals.pruned).toBe(0);
+    expect(db.query(`SELECT COUNT(*) AS n FROM workers`).get().n).toBe(1);
+    expect(logs.join("\n")).toContain("STALE worker dead-1");
+  });
+
+  test("no runtime registry on disk is a safe no-op", () => {
+    const totals = reapDeadWorkers(parseArgs(["--apply"]), {
+      databasePath: DB_FILE,
+      openDatabase: () => {
+        throw new Error("should not open");
+      },
+      fileExists: () => false,
+      log: () => {},
+    });
+    expect(totals).toEqual({ considered: 0, pruned: 0, live: 0, failed: 0 });
+  });
+
+  test("workerIsPrunable gates on the heartbeat before the pid verdict", () => {
+    // Fresh heartbeat is never prunable, whatever the pid probe says.
+    expect(
+      workerIsPrunable({ last_seen: fresh }, { now: NOW, alive: false }),
+    ).toBe(false);
+    // Expired + dead pid → prune; expired + alive pid → keep.
+    expect(
+      workerIsPrunable({ last_seen: expired }, { now: NOW, alive: false }),
+    ).toBe(true);
+    expect(
+      workerIsPrunable({ last_seen: expired }, { now: NOW, alive: true }),
+    ).toBe(false);
+    // Expired + unprobeable (remote, alive undefined/null) → prune.
+    expect(
+      workerIsPrunable({ last_seen: expired }, { now: NOW, alive: null }),
+    ).toBe(true);
+  });
+
+  test("localPidAlive: dead pid is false, EPERM-owned pid counts as alive", () => {
+    expect(localPidAlive(999999)).toBe(false);
+    expect(localPidAlive(0)).toBe(false);
+    expect(localPidAlive(-1)).toBe(false);
+    expect(localPidAlive(process.pid)).toBe(true);
+    // A kernel EPERM means the process exists but is another user's — alive.
+    const eperm = () => {
+      const err = new Error("operation not permitted");
+      err.code = "EPERM";
+      throw err;
+    };
+    expect(localPidAlive(4242, eperm)).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Closes #1125. Prune dead-pid / expired-heartbeat worker registry rows so they stop accumulating across restarts.

The durable `workers` table is never cleared on restart, so every stack restart and host crash leaves the dead process's rows behind (observed 23 dead-pid rows vs 3 live after a reboot). They never claim work, but clutter `factory workers`, mislead idle/capacity views, and needed a manual `DELETE`.

## How

New `reapDeadWorkers()` runs on the reaper's cadence (wired into `main()` alongside the existing dead-dispatch worktree reap, best-effort and isolated). A row is pruned only when **both**:

- its heartbeat has expired past `HEARTBEAT_STALE_MS` (the same threshold the registry uses to call a worker stale), **and**
- its process is gone.

The heartbeat gate protects any live or briefly-lagged worker. Local rows get a definitive `kill(pid, 0)` probe, so a hung-but-alive local process is kept, not pruned; a remote row (whose pid this box cannot probe) prunes on its expired heartbeat alone. Deleting a `busy!stale` row releases the terminal run it was still "holding" as a side effect. Dry-run reports; `--apply` deletes.

Pure predicate `workerIsPrunable()` and the pid probe `localPidAlive()` are exported for testing.

## Tests

`orchestrator/reaper.test.mjs` — new suite: a table seeded with live + dead-pid/expired/stopped rows prunes to only the live set; a briefly-lagged worker is never removed; a hung-but-alive local process is kept; an expired remote worker prunes; dry-run deletes nothing; missing DB is a no-op; predicate + pid-probe edge cases. `bun test orchestrator/reaper.test.mjs` → 46 pass.

## Owned Paths
- orchestrator/reaper.mjs
- orchestrator/reaper.test.mjs
