### PR TITLE
fix(cli): update-pins emits prettier-canonical JSON so re-pins pass format:check (#1119)

### DIFF
--- a/event-runtime/cli/update-pins.mjs
+++ b/event-runtime/cli/update-pins.mjs
@@ -28,11 +28,13 @@ function parseUpdatePinsArgs(args = []) {
   return { pack, check };
 }
 
-export default function updatePinsCommand(args = []) {
+export default async function updatePinsCommand(args = []) {
   const { pack, check } = parseUpdatePinsArgs(args);
   try {
     const changed =
-      pack === undefined ? updatePins({ check }) : updatePins({ pack, check });
+      pack === undefined
+        ? await updatePins({ check })
+        : await updatePins({ pack, check });
     // Harness content (contributes.harness, WM-849) is pack-independent —
     // one top-level event-runtime/pins.json covers shared/ plus every
     // policy-listed extension, so it only re-pins on the bare invocation.

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -10,6 +10,7 @@
  */
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { format as prettierFormat, resolveConfig } from "prettier";
 import { hashBytes } from "./canonical.mjs";
 import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT, resolveConfigPath } from "./config.mjs";
@@ -1417,12 +1418,33 @@ export function getEventType(registry, type) {
 }
 
 /**
+ * Serialize `value` as JSON exactly as Prettier 3 would under the repository
+ * configuration for `file`, so a re-pin write leaves the definition canonical
+ * (WM-1119). Prettier's formatter is async; `updatePins` awaits it. `file` is
+ * only used to select the parser and resolve `.prettierrc`, not read or written.
+ */
+async function formatJsonCanonical(file, value) {
+  const options = await resolveConfig(file);
+  return prettierFormat(`${JSON.stringify(value)}\n`, {
+    ...options,
+    filepath: file,
+  });
+}
+
+/**
  * Recompute pins deliberately. With no `pack`, this is byte-for-byte the
  * built-in behavior: inline pins in built-in definitions only. A configured
  * pack must be named explicitly and receives one root-level pins.json.
  * `check: true` reports the same changed names without writing (WM-811).
+ * Changed built-in definitions are re-emitted in Prettier-canonical form so a
+ * re-pin does not redden `format:check` (WM-1119); this makes `updatePins`
+ * async — callers must await it.
  */
-export function updatePins({ root = RUNTIME_ROOT, pack, check = false } = {}) {
+export async function updatePins({
+  root = RUNTIME_ROOT,
+  pack,
+  check = false,
+} = {}) {
   if (pack !== undefined) {
     let descriptor = pack;
     if (typeof pack === "string") {
@@ -1469,7 +1491,7 @@ export function updatePins({ root = RUNTIME_ROOT, pack, check = false } = {}) {
       if (!check) {
         writeFileSync(
           file,
-          `${JSON.stringify({ ...def, pins }, null, 2)}\n`,
+          await formatJsonCanonical(file, { ...def, pins }),
           "utf8",
         );
       }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -2,6 +2,7 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-registry-
 import { describe, expect, test } from "bun:test";
 import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { format as prettierFormat, resolveConfig } from "prettier";
 import { canonicalJson, hashBytes } from "./canonical.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import {
@@ -702,17 +703,17 @@ describe("registry", () => {
     expect(getAgent(registry, "sample/echo@1").mutating).toBeUndefined();
   });
 
-  test("pack manifest and pins fail closed, and explicit pack pinning repairs drift", () => {
+  test("pack manifest and pins fail closed, and explicit pack pinning repairs drift", async () => {
     const pack = tempPack();
     const prompt = path.join(pack.path, "agents", "echo.md");
     writeFileSync(prompt, `${readFileSync(prompt, "utf8")}drift\n`);
     expect(() => loadRegistry({ packRoots: [pack] })).toThrow(
       /does not match pin/,
     );
-    expect(updatePins({ pack })).toEqual(["sample"]);
+    expect(await updatePins({ pack })).toEqual(["sample"]);
     expect(() => loadRegistry({ packRoots: [pack] })).not.toThrow();
     writeFileSync(path.join(pack.path, "pins.json"), "not-json\n");
-    expect(updatePins({ pack })).toEqual(["sample"]);
+    expect(await updatePins({ pack })).toEqual(["sample"]);
     expect(() => loadRegistry({ packRoots: [pack] })).not.toThrow();
 
     const mismatched = tempPack({ name: "policy-name" });
@@ -791,7 +792,7 @@ describe("registry", () => {
     );
   });
 
-  test("editing a pinned file without re-pinning fails closed", () => {
+  test("editing a pinned file without re-pinning fails closed", async () => {
     const root = tempRegistry();
     const promptFile = path.join(root, "agents", "factory-status-report.md");
     writeFileSync(
@@ -799,13 +800,61 @@ describe("registry", () => {
       `${readFileSync(promptFile, "utf8")}\n<!-- drift -->\n`,
     );
     expect(() => loadRegistry({ root })).toThrow(RegistryError);
-    expect(updatePins({ root, check: true })).toContain(
+    expect(await updatePins({ root, check: true })).toContain(
       "factory-status-report.json",
     );
     expect(() => loadRegistry({ root })).toThrow(RegistryError);
-    updatePins({ root });
+    await updatePins({ root });
     expect(() => loadRegistry({ root })).not.toThrow();
-    expect(updatePins({ root, check: true })).toEqual([]);
+    expect(await updatePins({ root, check: true })).toEqual([]);
+  });
+
+  test("re-pinning a changed built-in definition leaves it Prettier-canonical (WM-1119)", async () => {
+    const root = tempRegistry();
+    // dispatch.json carries short arrays (capabilities.services/tools, memo
+    // kinds) that Prettier keeps on one line but raw JSON.stringify(…, 2)
+    // expands — the exact churn the issue reproduced.
+    const defFile = path.join(root, "agents", "dispatch.json");
+    const before = JSON.parse(readFileSync(defFile, "utf8"));
+    // Resolve the repository's Prettier options (canonical for .json) so the
+    // assertion mirrors what `prettier --check` would decide.
+    const prettierOptions = {
+      ...(await resolveConfig(
+        path.join(RUNTIME_ROOT, "agents", "dispatch.json"),
+      )),
+      filepath: defFile,
+    };
+    const canonical = (content) => prettierFormat(content, prettierOptions);
+    // Guard: the committed definition must start canonical, or the test is void.
+    const original = readFileSync(defFile, "utf8");
+    expect(await canonical(original)).toBe(original);
+
+    // Force a real pin change by editing the pinned prompt.
+    const promptFile = path.join(root, before.prompt);
+    writeFileSync(
+      promptFile,
+      `${readFileSync(promptFile, "utf8")}\n<!-- WM-1119 -->\n`,
+    );
+
+    expect(await updatePins({ root })).toContain("dispatch.json");
+
+    const written = readFileSync(defFile, "utf8");
+    // Fails against origin/develop: JSON.stringify(…, 2) expands the short
+    // arrays, so `prettier --check` would redden here.
+    expect(await canonical(written)).toBe(written);
+
+    // Only the pins moved; every other parsed field is byte-identical content.
+    const after = JSON.parse(written);
+    expect({ ...after, pins: undefined }).toEqual({
+      ...before,
+      pins: undefined,
+    });
+    expect(after.pins).not.toEqual(before.pins);
+
+    // A second update is idempotent: no changed names, no byte changes.
+    const bytes = readFileSync(defFile);
+    expect(await updatePins({ root })).toEqual([]);
+    expect(readFileSync(defFile)).toEqual(bytes);
   });
 
   test("mutating agents are refused in the MVP", () => {
@@ -1147,7 +1196,7 @@ describe("registry", () => {
     expect(() => loadRegistry({ root })).toThrow(/unregistered agent/);
   });
 
-  test("artifact-view sidecars load beside their definition and are served off the pinned identity (WM-454)", () => {
+  test("artifact-view sidecars load beside their definition and are served off the pinned identity (WM-454)", async () => {
     const registry = loadRegistry();
     // The committed views: present, validated, keyed by ref, not on the def.
     const merge = getArtifactView(registry, "merge-scan@2");
@@ -1207,7 +1256,7 @@ describe("registry", () => {
       [...registry.agents.keys()].some((ref) => ref.includes(".view")),
     ).toBe(false);
     const root = tempRegistry();
-    expect(updatePins({ root })).toEqual([]);
+    expect(await updatePins({ root })).toEqual([]);
   });
 
   test("a view that drifts from its schema is a configuration anomaly, not a load error (WM-454)", () => {


### PR DESCRIPTION
Closes #1119.

## Problem
`updatePins()` (the built-in agent-definition writer in `event-runtime/lib/registry.mjs`) rewrote changed definitions with `JSON.stringify(…, null, 2)`, which expands short arrays that Prettier 3 keeps on one line (e.g. `capabilities.services`, `capabilities.tools`, memo `kinds`). A plain re-pin therefore turned a canonical agent JSON into a deterministic `format:check` failure — it cost #1077 a fix round and hit every agent-definition ticket.

## Fix
- Route changed-definition writes through Prettier's programmatic formatter (`resolveConfig` + `format` with the file's parser), so the output matches exactly what `prettier --check` expects.
- Prettier 3's formatter is async, so `updatePins()` becomes async and the CLI (`event-runtime/cli/update-pins.mjs`) awaits it — the command does not print success or exit until canonical writes complete. `dispatch()` already awaits command results.
- `check: true` stays read-only (unchanged); pack/harness `pins.json` writers are flat hash maps already prettier-canonical and out of scope.

## Test
Added a focused regression test in `event-runtime/lib/registry.test.mjs`: starts from the canonical committed `dispatch.json` (short arrays), forces a real pin change via its pinned prompt, runs normal `updatePins({ root })`, and asserts the written file is still Prettier-canonical, that only `pins` changed, and that a second update is byte-idempotent. This test fails against `origin/develop` (old serialization is not canonical — verified) and passes with the fix.

## Verification
- `bun test event-runtime/lib/registry.test.mjs` — 50 pass
- `bun event-runtime/cli.mjs update-pins --check` — pins already current (non-mutating)
- `prettier --check .` — clean
- No tracked pin outputs drifted

Owned Paths: `event-runtime/cli/update-pins.mjs`, `event-runtime/lib/registry.mjs`, `event-runtime/lib/registry.test.mjs`.