### PR TITLE
fix(digest): count GitHub ai:blocked holds instead of reporting zero (#1062)

### DIFF
--- a/orchestrator/digest.mjs
+++ b/orchestrator/digest.mjs
@@ -5,11 +5,20 @@
  *   bun orchestrator/digest.mjs               # every configured repo
  *   bun orchestrator/digest.mjs --repo bj29
  *
- * Read-only, writes nothing to Linear. The real failure mode of a hold isn't
- * that no agent revisits it — it's that the one-reply question never reached
- * a human. This is the report that surfaces those questions in one place,
- * oldest hold first, with an ANSWERED marker on tickets whose reply the
+ * Read-only, writes nothing to the tracker. The real failure mode of a hold
+ * isn't that no agent revisits it — it's that the one-reply question never
+ * reached a human. This is the report that surfaces those questions in one
+ * place, oldest hold first, with an ANSWERED marker on tickets whose reply the
  * triage gate (reply-detection.mjs) will pick up on its next tick.
+ *
+ * Plane-aware (WM-1062): each repo is read through its OWN configured control
+ * plane, not the workspace default. Linear keeps the label-history raw query
+ * that dates the hold and detects the reply. GitHub has no label-history in
+ * the neutral contract, so its holds are collected through the adapter's
+ * `listTickets`/`listComments` verbs and shown with an explicit "timing
+ * unknown" note rather than being silently dropped (which reported `0 held`
+ * for a GitHub-backed repo whose board actually held work) or falsely marked
+ * as unanswered.
  *
  * Manual-start by design (watch TUI `b`, or this CLI) — see the unblock-digest
  * entry in config/schedule.yaml.
@@ -17,47 +26,17 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
-import { loadControlPlane } from "../lib/control-plane/index.mjs";
+import {
+  loadControlPlane,
+  controlPlaneKindFromRepo,
+  controlPlaneKindFromPolicy,
+} from "../lib/control-plane/index.mjs";
 import { AI_BLOCKED, blockedLabelIds, holdInfo } from "./reply-detection.mjs";
-
-const argv = process.argv.slice(2);
-const val = (f) => {
-  const i = argv.indexOf(f);
-  return i === -1 ? null : argv[i + 1];
-};
-const only = (val("--repo") || "")
-  .split(",")
-  .map((s) => s.trim())
-  .filter(Boolean);
-
-const cfg = Bun.YAML.parse(
-  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
-);
-const repos = (cfg.repos ?? []).filter(
-  (r) => !only.length || only.includes(r.name),
-);
-if (!repos.length) {
-  console.error(
-    only.length
-      ? `no repo named "${only}" in config/repos.yaml`
-      : "no repos configured",
-  );
-  process.exit(2);
-}
-
-// Plain text when piped — the watch TUI renders this output inside an Ink
-// pane, where ANSI escapes would come through as garbage.
-const tty = process.stdout.isTTY;
-const c = {
-  dim: (s) => (tty ? `\x1b[2m${s}\x1b[0m` : s),
-  bold: (s) => (tty ? `\x1b[1m${s}\x1b[0m` : s),
-  green: (s) => (tty ? `\x1b[32m${s}\x1b[0m` : s),
-  red: (s) => (tty ? `\x1b[31m${s}\x1b[0m` : s),
-};
 
 // Same shape reply-detection queries, plus comment bodies — the digest is the
 // one consumer that needs the question's text, so the heavier payload lives
-// here and not in the every-5-minutes gate.
+// here and not in the every-5-minutes gate. Linear-only: it reads label
+// history (`addedLabelIds`), which no other adapter models.
 const DIGEST_QUERY = `
   query($team: String!, $project: String!, $label: String!) {
     issues(first: 100, filter: {
@@ -75,84 +54,221 @@ const DIGEST_QUERY = `
     }
   }`;
 
+// The two documented hold shapes. An In Progress ticket carrying a stale
+// ai:blocked is the reconciler's drift to explain, not a human-attention hold.
+const HOLD_STATES = ["Triage", "Blocked"];
+
 const DAY = 24 * 60 * 60 * 1000;
-const age = (ms) => {
+export const age = (ms) => {
   if (ms == null) return "?";
   const d = Date.now() - ms;
   if (d >= DAY) return `${Math.floor(d / DAY)}d`;
   if (d >= 60 * 60_000) return `${Math.floor(d / 3_600_000)}h`;
   return `${Math.max(1, Math.floor(d / 60_000))}m`;
 };
-const excerpt = (body, n = 110) => {
+export const excerpt = (body, n = 110) => {
   const s = String(body ?? "")
     .replace(/\s+/g, " ")
     .trim();
   return s.length > n ? s.slice(0, n - 1) + "…" : s;
 };
 
-const ids = await blockedLabelIds();
-let totalHeld = 0;
-let totalAnswered = 0;
+/**
+ * The kind this repo's tickets live on: its explicit `control_plane`, else the
+ * workspace default. The digest branches on this so a GitHub repo never has a
+ * Linear GraphQL query issued through its adapter, and vice versa (WM-1062).
+ */
+export function planeKindForRepo(repo) {
+  return controlPlaneKindFromRepo(repo.name) ?? controlPlaneKindFromPolicy();
+}
 
-for (const repo of repos) {
+/**
+ * Normalized held item the renderer consumes, plane-independent:
+ *
+ *   identifier   ticket id (e.g. WM-840 or watt-mind/factory#840)
+ *   title        ticket title
+ *   heldAtMs     when the hold began; null when unknown
+ *   question     newest comment at hold time — the blocking question; null
+ *   reply        newest comment after the hold — an answer; null when none
+ *   timingKnown  true when the plane dates the hold and can detect a reply
+ *                (Linear); false when it cannot (GitHub label history is not
+ *                in the neutral contract), so `reply` stays null and the row
+ *                carries an explicit limitation note instead of a false
+ *                "unanswered" claim.
+ */
+
+/** Linear: label-history raw query → holdInfo dates the hold and the reply. */
+export async function heldFromLinear(repo, cp, ids) {
   const nodes =
     (
-      await loadControlPlane().raw(DIGEST_QUERY, {
+      await cp.raw(DIGEST_QUERY, {
         team: repo.team,
         project: repo.project,
         label: AI_BLOCKED,
       })
     )?.issues?.nodes ?? [];
-  const held = nodes
+  return nodes
     .map((n) => ({ node: n, info: holdInfo(n, ids) }))
     .filter((h) => h.info)
-    // Oldest hold first; unknown hold times sink to the bottom rather than
-    // masquerading as the most urgent.
-    .sort(
-      (a, b) => (a.info.heldAtMs ?? Infinity) - (b.info.heldAtMs ?? Infinity),
-    );
-
-  console.log(
-    c.bold(`\n${repo.name}`) +
-      c.dim(`  ${repo.team} / ${repo.project} — ${held.length} held`),
-  );
-  if (!held.length) {
-    console.log(c.dim("  nothing held — no ai:blocked tickets"));
-    continue;
-  }
-
-  for (const { node, info } of held) {
-    totalHeld++;
-    const answered = Boolean(info.reply);
-    if (answered) totalAnswered++;
-    const marker = answered
-      ? c.green(
-          `  ANSWERED ${age(info.reply.atMs)} ago — triage will re-examine`,
-        )
-      : "";
-    console.log(
-      `  ${c.red(node.identifier.padEnd(10))} held ${age(info.heldAtMs)}${marker}`,
-    );
-    console.log(c.dim(`    ${excerpt(node.title, 100)}`));
-    if (info.question?.body)
-      console.log(`    Q: ${excerpt(info.question.body)}`);
-    else
-      console.log(
-        c.dim(
-          `    (no blocking comment found — the hold never said what it needs)`,
-        ),
-      );
-  }
+    .map(({ node, info }) => ({
+      identifier: node.identifier,
+      title: node.title,
+      heldAtMs: info.heldAtMs,
+      question: info.question,
+      reply: info.reply,
+      timingKnown: true,
+    }));
 }
 
-console.log(
-  c.bold(`\n${totalHeld} held ticket(s)`) +
-    (totalAnswered
-      ? c.green(
-          `, ${totalAnswered} answered and waiting for the next triage tick`,
-        )
-      : c.dim(
-          ", none answered — every hold above is waiting on a human reply",
-        )),
-);
-console.log();
+/**
+ * Non-Linear (GitHub, memory): the neutral adapter. `listTickets` gives the
+ * open Triage/Blocked tickets; keep the ai:blocked ones and read their newest
+ * comment as the blocking question. The plane cannot date the hold or time a
+ * reply, so `timingKnown` is false — the ticket is still counted and shown.
+ */
+export async function heldFromAdapter(repo, cp) {
+  const tickets = await cp.listTickets({
+    team: repo.team,
+    project: repo.project,
+    states: HOLD_STATES,
+  });
+  const held = tickets.filter((t) =>
+    (t.labels ?? []).some((l) => l.name === AI_BLOCKED),
+  );
+  const items = [];
+  for (const t of held) {
+    const comments = await cp.listComments(t.identifier);
+    const sorted = [...comments].sort(
+      (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
+    );
+    items.push({
+      identifier: t.identifier,
+      title: t.title,
+      heldAtMs: null,
+      // Newest comment is the best guess at the blocking question when there
+      // is no label-add event to anchor on.
+      question: sorted.length ? sorted[sorted.length - 1] : null,
+      reply: null,
+      timingKnown: false,
+    });
+  }
+  return items;
+}
+
+/**
+ * Every held ticket for one repo, read through THAT repo's plane, oldest hold
+ * first. Unknown hold times sink to the bottom rather than masquerading as the
+ * most urgent.
+ */
+export async function heldForRepo(
+  repo,
+  { load = loadControlPlane, kind } = {},
+) {
+  const resolved = kind ?? planeKindForRepo(repo);
+  const cp = load({ repoName: repo.name });
+  // blockedLabelIds() is fetched only on the Linear branch: it dates the hold
+  // via label history. The GitHub branch must never issue that Linear GraphQL.
+  const items =
+    resolved === "linear"
+      ? await heldFromLinear(repo, cp, await blockedLabelIds())
+      : await heldFromAdapter(repo, cp);
+  return items.sort(
+    (a, b) => (a.heldAtMs ?? Infinity) - (b.heldAtMs ?? Infinity),
+  );
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const only = (val("--repo") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const repos = (cfg.repos ?? []).filter(
+    (r) => !only.length || only.includes(r.name),
+  );
+  if (!repos.length) {
+    console.error(
+      only.length
+        ? `no repo named "${only}" in config/repos.yaml`
+        : "no repos configured",
+    );
+    process.exit(2);
+  }
+
+  // Plain text when piped — the watch TUI renders this output inside an Ink
+  // pane, where ANSI escapes would come through as garbage.
+  const tty = process.stdout.isTTY;
+  const c = {
+    dim: (s) => (tty ? `\x1b[2m${s}\x1b[0m` : s),
+    bold: (s) => (tty ? `\x1b[1m${s}\x1b[0m` : s),
+    green: (s) => (tty ? `\x1b[32m${s}\x1b[0m` : s),
+    red: (s) => (tty ? `\x1b[31m${s}\x1b[0m` : s),
+  };
+
+  let totalHeld = 0;
+  let totalAnswered = 0;
+  let totalUntimed = 0;
+
+  for (const repo of repos) {
+    const held = await heldForRepo(repo);
+
+    console.log(
+      c.bold(`\n${repo.name}`) +
+        c.dim(`  ${repo.team} / ${repo.project} — ${held.length} held`),
+    );
+    if (!held.length) {
+      console.log(c.dim("  nothing held — no ai:blocked tickets"));
+      continue;
+    }
+
+    for (const item of held) {
+      totalHeld++;
+      const answered = item.timingKnown && Boolean(item.reply);
+      if (answered) totalAnswered++;
+      if (!item.timingKnown) totalUntimed++;
+      const marker = answered
+        ? c.green(
+            `  ANSWERED ${age(item.reply.atMs)} ago — triage will re-examine`,
+          )
+        : "";
+      console.log(
+        `  ${c.red(item.identifier.padEnd(10))} held ${age(item.heldAtMs)}${marker}`,
+      );
+      console.log(c.dim(`    ${excerpt(item.title, 100)}`));
+      if (!item.timingKnown)
+        console.log(
+          c.dim(
+            `    (hold age and reply timing unknown — this plane exposes no label history)`,
+          ),
+        );
+      if (item.question?.body)
+        console.log(`    Q: ${excerpt(item.question.body)}`);
+      else
+        console.log(
+          c.dim(
+            `    (no blocking comment found — the hold never said what it needs)`,
+          ),
+        );
+    }
+  }
+
+  const summaryTail = totalAnswered
+    ? c.green(
+        `, ${totalAnswered} answered and waiting for the next triage tick`,
+      )
+    : totalUntimed === totalHeld
+      ? c.dim(", reply timing unavailable — check each ticket's latest comment")
+      : c.dim(", none answered — every hold above is waiting on a human reply");
+  console.log(c.bold(`\n${totalHeld} held ticket(s)`) + summaryTail);
+  console.log();
+}
+
+if (import.meta.main) await main();

--- a/orchestrator/digest.test.mjs
+++ b/orchestrator/digest.test.mjs
@@ -1,0 +1,203 @@
+/**
+ * Digest is plane-aware (WM-1062). The regression this file locks in: a
+ * GitHub-backed repo whose board holds an open `ai:blocked` ticket used to
+ * report `0 held`, because the digest ran a Linear-only raw GraphQL query
+ * through whatever plane the workspace default happened to be. It now reads
+ * each repo through its OWN plane — Linear via the label-history raw query,
+ * GitHub via the neutral `listTickets`/`listComments` verbs.
+ */
+import { describe, test, expect } from "bun:test";
+import { heldForRepo, heldFromLinear, heldFromAdapter } from "./digest.mjs";
+import { AI_BLOCKED } from "./reply-detection.mjs";
+
+const REPO = { name: "factory", team: "WM", project: "Factory" };
+
+/**
+ * A GitHub-shaped control-plane fake: it answers the two neutral verbs the
+ * digest uses and REFUSES `raw`, standing in for the hard `gh` error a Linear
+ * GraphQL query is on a GitHub adapter.
+ */
+function githubFake({ tickets = [], comments = {} } = {}) {
+  const calls = [];
+  return {
+    kind: "github",
+    async listTickets({ team, project, states } = {}) {
+      calls.push({ op: "listTickets", team, project, states });
+      const wanted = states?.length
+        ? new Set(states.map((s) => s.toLowerCase()))
+        : null;
+      return tickets.filter(
+        (t) => !wanted || wanted.has((t.state?.name ?? "").toLowerCase()),
+      );
+    },
+    async listComments(identifier) {
+      calls.push({ op: "listComments", identifier });
+      return comments[identifier] ?? [];
+    },
+    raw() {
+      throw new Error(
+        "Linear GraphQL must not be issued through the GitHub adapter",
+      );
+    },
+    calls,
+  };
+}
+
+/** A Linear-shaped fake: `raw` returns the seeded issue nodes. */
+function linearFake(nodes = []) {
+  return {
+    kind: "linear",
+    async raw() {
+      return { issues: { nodes } };
+    },
+  };
+}
+
+describe("digest: GitHub held-ticket accounting (WM-1062)", () => {
+  test("an open Blocked ai:blocked GitHub ticket is counted as held (was false-zero)", async () => {
+    const cp = githubFake({
+      tickets: [
+        {
+          identifier: "watt-mind/factory#840",
+          title: "Something needs a human decision",
+          state: { name: "Blocked" },
+          labels: [{ name: AI_BLOCKED }],
+        },
+      ],
+      comments: {
+        "watt-mind/factory#840": [
+          {
+            body: "Should we ship A or B? Need a call before proceeding.",
+            createdAt: "2026-08-27T10:00:00Z",
+          },
+        ],
+      },
+    });
+
+    const held = await heldForRepo(REPO, { kind: "github", load: () => cp });
+
+    expect(held).toHaveLength(1);
+    expect(held[0].identifier).toBe("watt-mind/factory#840");
+    // GitHub label history is not in the neutral contract: hold age and reply
+    // timing are unknown, so the row is shown with a limitation note and never
+    // claimed as answered — but it IS counted and IS shown.
+    expect(held[0].timingKnown).toBe(false);
+    expect(held[0].heldAtMs).toBeNull();
+    expect(held[0].reply).toBeNull();
+    expect(held[0].question?.body).toMatch(/ship A or B/);
+    // Never a Linear GraphQL query through the GitHub adapter.
+    expect(cp.calls.some((c) => c.op === "listTickets")).toBe(true);
+  });
+
+  test("only Triage/Blocked ai:blocked tickets are held; other labels/states are ignored", async () => {
+    const cp = githubFake({
+      tickets: [
+        {
+          identifier: "watt-mind/factory#1",
+          title: "held in triage",
+          state: { name: "Triage" },
+          labels: [{ name: AI_BLOCKED }],
+        },
+        {
+          identifier: "watt-mind/factory#2",
+          title: "blocked but not ai:blocked",
+          state: { name: "Blocked" },
+          labels: [{ name: "type:bug" }],
+        },
+      ],
+      comments: {},
+    });
+
+    const held = await heldFromAdapter(REPO, cp);
+    expect(held.map((h) => h.identifier)).toEqual(["watt-mind/factory#1"]);
+    // No comment on the hold — surfaced, not dropped.
+    expect(held[0].question).toBeNull();
+    // listTickets asked only for the two hold states.
+    expect(cp.calls[0]).toMatchObject({ states: ["Triage", "Blocked"] });
+  });
+
+  test("newest comment is used as the blocking question", async () => {
+    const cp = githubFake({
+      tickets: [
+        {
+          identifier: "watt-mind/factory#5",
+          title: "t",
+          state: { name: "Blocked" },
+          labels: [{ name: AI_BLOCKED }],
+        },
+      ],
+      comments: {
+        "watt-mind/factory#5": [
+          { body: "older note", createdAt: "2026-08-20T10:00:00Z" },
+          {
+            body: "newest blocking question",
+            createdAt: "2026-08-25T10:00:00Z",
+          },
+        ],
+      },
+    });
+    const held = await heldFromAdapter(REPO, cp);
+    expect(held[0].question.body).toBe("newest blocking question");
+  });
+});
+
+describe("digest: Linear behavior unchanged (WM-1062)", () => {
+  const labelIds = new Set(["lbl-blocked"]);
+
+  test("Linear hold is dated from label history and reply is detected", async () => {
+    const heldAt = "2026-08-20T10:00:00Z";
+    const node = {
+      identifier: "WM-840",
+      title: "linear hold",
+      state: { name: "Blocked" },
+      comments: {
+        nodes: [
+          { createdAt: "2026-08-20T10:00:30Z", body: "blocking question?" },
+          { createdAt: "2026-08-22T09:00:00Z", body: "here is the answer" },
+        ],
+      },
+      history: {
+        nodes: [{ createdAt: heldAt, addedLabelIds: ["lbl-blocked"] }],
+      },
+    };
+    const held = await heldFromLinear(REPO, linearFake([node]), labelIds);
+
+    expect(held).toHaveLength(1);
+    expect(held[0].timingKnown).toBe(true);
+    expect(held[0].heldAtMs).toBe(Date.parse(heldAt));
+    expect(held[0].question.body).toBe("blocking question?");
+    expect(held[0].reply.body).toBe("here is the answer");
+  });
+
+  test("Linear ticket not in a hold state is excluded", async () => {
+    const node = {
+      identifier: "WM-1",
+      title: "in progress, stale label",
+      state: { name: "In Progress" },
+      comments: { nodes: [] },
+      history: { nodes: [] },
+    };
+    const held = await heldFromLinear(REPO, linearFake([node]), labelIds);
+    expect(held).toHaveLength(0);
+  });
+});
+
+describe("digest: mixed Linear/GitHub run (WM-1062)", () => {
+  test("GitHub repo is read through the adapter, never through raw GraphQL", async () => {
+    const cp = githubFake({
+      tickets: [
+        {
+          identifier: "watt-mind/factory#840",
+          title: "held",
+          state: { name: "Blocked" },
+          labels: [{ name: AI_BLOCKED }],
+        },
+      ],
+      comments: {},
+    });
+    // If the digest fell back to a Linear raw query on the GitHub plane, this
+    // would throw from githubFake.raw.
+    const held = await heldForRepo(REPO, { kind: "github", load: () => cp });
+    expect(held).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

`factory digest --repo factory` reported `0 held` even when the GitHub-backed board held an open `ai:blocked` ticket (e.g. #840). The digest ran a Linear-only raw GraphQL query through the workspace-default plane instead of resolving each repo's configured plane.

## Fix (`orchestrator/digest.mjs`, Owned Paths)

- Resolve each repo's own control plane (`controlPlaneKindFromRepo` → policy default).
- **Linear**: unchanged — the label-history raw query still dates the hold and detects the reply (ANSWERED markers, age ordering intact).
- **GitHub / neutral**: collect holds via the adapter's `listTickets({ states: ["Triage","Blocked"] })` + `listComments`; keep the `ai:blocked` ones, use the newest comment as the blocking question.
- GitHub label history is not in the neutral contract, so hold age / reply timing are reported as **unknown** with an explicit note, rather than dropping the ticket or falsely marking it unanswered.
- The GitHub branch never issues Linear GraphQL through the adapter.

## Test (`orchestrator/digest.test.mjs`, new)

Regression reproduces the false-zero with a GitHub fake holding one `ai:blocked` ticket (now counted as 1 held), plus label/state filtering, newest-comment selection, Linear dating+reply detection unchanged, and a mixed-run assertion that the GitHub plane's `raw` is never called.

## Verify

```
bun test orchestrator/digest.test.mjs orchestrator/reply-detection.test.mjs --timeout 20000
```
20 pass / 0 fail.

Closes #1062