### PR TITLE
feat(api): bearer-token auth on the control API (#1152)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -5,6 +5,7 @@
  * and their view builders live in api-*.mjs and status-view.mjs so unrelated
  * endpoint work no longer contends on one source file.
  */
+import { timingSafeEqual } from "node:crypto";
 import http from "node:http";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -73,6 +74,37 @@ export {
   workerCapacityView,
 };
 
+/**
+ * Routes exempt from the bearer gate (WM-1152). Liveness stays open; the two
+ * webhook intakes authenticate by their own HMAC signature (`POST /events`
+ * factory HMAC, `POST /github` GitHub HMAC) — an external sender cannot present
+ * a bearer, so requiring one would break intake. Every other route — including
+ * the loopback `POST /replay` inject — is gated when a token is configured.
+ * Exact `METHOD path` matches, so `GET /events` (list) and `POST /events/*`
+ * stay gated.
+ */
+const BEARER_EXEMPT_ROUTES = new Set([
+  "GET /health",
+  "POST /events",
+  "POST /github",
+]);
+
+/**
+ * Constant-time bearer check (WM-1152). Returns true only for a well-formed
+ * `Authorization: Bearer <token>` whose token equals the configured one. The
+ * length guard is required because timingSafeEqual throws on unequal-length
+ * buffers; it leaks only the token length, never its content.
+ */
+function bearerAuthorized(authHeader, token) {
+  if (typeof authHeader !== "string") return false;
+  const prefix = "Bearer ";
+  if (!authHeader.startsWith(prefix)) return false;
+  const presented = Buffer.from(authHeader.slice(prefix.length), "utf8");
+  const expected = Buffer.from(token, "utf8");
+  if (presented.length !== expected.length) return false;
+  return timingSafeEqual(presented, expected);
+}
+
 /** Build the request handler independently so tests can compose it directly. */
 export function createApi({
   db,
@@ -99,6 +131,10 @@ export function createApi({
   configRoot = reposRoot(),
   // Root of the config/policy.yaml the run endpoints consult (tests point it elsewhere).
   policyRoot = FACTORY_ROOT,
+  // WM-1152: application-level bearer for the control API. Unset (empty/null)
+  // keeps the historical loopback-trust behavior byte-for-byte; set requires
+  // `Authorization: Bearer <token>` on every non-exempt route. Never logged.
+  controlApiToken = process.env.FACTORY_CONTROL_API_TOKEN || null,
 } = {}) {
   const actor = "operator";
   const registryLoadedAt = new Date(now()).toISOString();
@@ -133,6 +169,16 @@ export function createApi({
 
       const url = new URL(req.url, `http://${API_HOST}`);
       const route = `${req.method} ${url.pathname}`;
+
+      // WM-1152: bearer gate. Only when a token is configured; otherwise the
+      // API behaves exactly as before (loopback-trust). Reject before any work
+      // or body read, so an unauthorized caller never triggers side effects.
+      if (controlApiToken && !BEARER_EXEMPT_ROUTES.has(route)) {
+        if (!bearerAuthorized(req.headers.authorization, controlApiToken)) {
+          return sendJson(res, 401, { error: "unauthorized" });
+        }
+      }
+
       const nowMs = now();
       const send = (status, body) => sendJson(res, status, body);
       const common = {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -568,6 +568,122 @@ describe("environment identity (webui chip)", () => {
   });
 });
 
+describe("bearer-token auth on the control API (WM-1152)", () => {
+  const TOKEN = "s3cr3t-control-token";
+
+  test("token set: privileged route needs a correct bearer (401 without/with-wrong, 200 with correct)", async () => {
+    const s = await makeServer({ controlApiToken: TOKEN });
+    try {
+      const missing = await fetch(s.url("/status"));
+      expect(missing.status).toBe(401);
+      expect((await missing.json()).error).toBe("unauthorized");
+
+      const wrong = await fetch(s.url("/status"), {
+        headers: { authorization: "Bearer not-the-token" },
+      });
+      expect(wrong.status).toBe(401);
+      expect((await wrong.json()).error).toBe("unauthorized");
+
+      // A same-length-but-different token still fails (constant-time compare).
+      const sameLength = await fetch(s.url("/status"), {
+        headers: { authorization: `Bearer ${"x".repeat(TOKEN.length)}` },
+      });
+      expect(sameLength.status).toBe(401);
+
+      const ok = await fetch(s.url("/status"), {
+        headers: { authorization: `Bearer ${TOKEN}` },
+      });
+      expect(ok.status).toBe(200);
+      expect(typeof (await ok.json()).events).toBe("object");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("token set: the apiClient carries the bearer, so internal callers do not 401 themselves", async () => {
+    const s = await makeServer({ controlApiToken: TOKEN });
+    const client = apiClient({ port: s.port, token: TOKEN });
+    try {
+      const status = await client.status();
+      expect(status.env.name).toBeDefined();
+      // A client without the token is rejected, proving the header is required.
+      const anon = apiClient({ port: s.port, token: null });
+      const err = await rejection(anon.status());
+      expect(err.status).toBe(401);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("token set: GET /health stays open (liveness, no bearer)", async () => {
+    const s = await makeServer({ controlApiToken: TOKEN });
+    try {
+      const res = await fetch(s.url("/health"));
+      expect(res.status).toBe(200);
+      expect((await res.json()).ok).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("token set: POST /events stays signature-gated, not bearer-gated", async () => {
+    const s = await makeServer({ controlApiToken: TOKEN });
+    try {
+      // A correctly signed webhook is admitted with NO bearer present.
+      const body = JSON.stringify(envelope({ eventId: "hook-1152" }));
+      const ts = String(Date.now());
+      const admitted = await fetch(s.url("/events"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-factory-timestamp": ts,
+          "x-factory-signature": sign(body, ts),
+        },
+        body,
+      });
+      expect(admitted.status).toBe(200);
+      expect(await admitted.json()).toEqual({
+        admitted: true,
+        duplicate: false,
+        eventId: "hook-1152",
+      });
+
+      // A bad signature is still rejected by signature (not the bearer 401),
+      // even when a valid bearer is supplied — the HMAC governs this route.
+      const forged = JSON.stringify(envelope({ eventId: "hook-forged-1152" }));
+      const ts2 = String(Date.now());
+      const rejected = await fetch(s.url("/events"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${TOKEN}`,
+          "x-factory-timestamp": ts2,
+          "x-factory-signature": sign(forged, ts2, "wrong-secret"),
+        },
+        body: forged,
+      });
+      expect(rejected.status).toBe(401);
+      expect((await rejected.json()).error).toBe("bad_signature");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("token unset: behavior is unchanged — privileged routes work with no bearer (no regression)", async () => {
+    const s = await makeServer({ controlApiToken: null });
+    try {
+      const res = await fetch(s.url("/status"));
+      expect(res.status).toBe(200);
+      expect(typeof (await res.json()).events).toBe("object");
+      // No Authorization header is sent and none is required.
+      const agents = await fetch(s.url("/agents"));
+      expect(agents.status).toBe(200);
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("serve PID lock (OPS-458)", () => {
   test("acquireServeLock acquires lock in empty runtime home and releaseServeLock removes it", async () => {
     const { acquireServeLock, releaseServeLock, serveLockPath } =

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -9,13 +9,26 @@
  */
 import { API_HOST, DEFAULT_PORT } from "./config.mjs";
 
-export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
+export function apiClient({
+  port = DEFAULT_PORT,
+  host = API_HOST,
+  // WM-1152: bearer the control API requires when FACTORY_CONTROL_API_TOKEN is
+  // set. Read from env by default so every CLI/worker caller authenticates
+  // without changes; sent on every request (webhook/health ignore it). Never
+  // logged. Unset means no header, matching the pre-token behavior.
+  token = process.env.FACTORY_CONTROL_API_TOKEN || null,
+} = {}) {
   const base = `http://${host}:${port}`;
+  const authHeader = token ? { authorization: `Bearer ${token}` } : {};
 
   async function call(method, path, { body, headers = {} } = {}) {
     const res = await fetch(`${base}${path}`, {
       method,
-      headers: { "content-type": "application/json", ...headers },
+      headers: {
+        "content-type": "application/json",
+        ...authHeader,
+        ...headers,
+      },
       body,
     });
     const text = await res.text();

--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -4,9 +4,10 @@
  *
  * Static bundle + /api/* proxy to the loopback control API, so the browser
  * has one origin. Deliberately imports nothing from ../lib/ — it is a client
- * of the runtime, not part of it (spec §9). Loopback only: no auth by
- * decision (spec §1); binding beyond 127.0.0.1 is the moment auth becomes a
- * precondition, so no --host flag exists here.
+ * of the runtime, not part of it (spec §9). Loopback only; binding beyond
+ * 127.0.0.1 is the moment auth becomes a precondition, so no --host flag
+ * exists here. When the control API is token-gated (WM-1152), this proxy adds
+ * the bearer from its own env so the browser stays token-free.
  */
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -36,6 +37,12 @@ function hostOf(value) {
   if (m) return m[1].toLowerCase();
   return value.replace(/:\d+$/, "").toLowerCase();
 }
+
+// WM-1152: the bearer this proxy presents to the control API. When the API is
+// token-gated (FACTORY_CONTROL_API_TOKEN set), the browser never sees or sends
+// the token — this same-origin proxy adds it from its own env when forwarding
+// to :7381. Unset = nothing added, exactly the old pass-through. Never logged.
+const CONTROL_API_TOKEN = process.env.FACTORY_CONTROL_API_TOKEN || "";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 
@@ -109,6 +116,11 @@ Bun.serve({
       // proxy IS the same-origin boundary, so present as loopback upstream.
       headers.set("host", `127.0.0.1:${API_PORT}`);
       headers.delete("origin");
+      // WM-1152: authenticate to a token-gated control API. Overwrite any
+      // client-supplied header so the browser can never inject its own bearer.
+      if (CONTROL_API_TOKEN)
+        headers.set("authorization", `Bearer ${CONTROL_API_TOKEN}`);
+      else headers.delete("authorization");
       const init = { method: req.method, headers };
       try {
         if (bodyless) {


### PR DESCRIPTION
Closes #1152. Part of Stage 01 ingress (#1149); the control-API half of #956.

## What

When `FACTORY_CONTROL_API_TOKEN` is set, the loopback control API requires `Authorization: Bearer <token>` on every mutating/privileged route; missing or wrong -> `401` before any work or body read. Comparison is constant-time (`node:crypto` `timingSafeEqual` on equal-length buffers, with a length guard).

Exempt routes:
- `GET /health` stays open (liveness).
- `POST /events` (factory HMAC) and `POST /github` (GitHub HMAC) stay **signature-gated, not bearer-gated** — an external sender cannot present a bearer. Matching is exact `METHOD path`, so `GET /events` (list) and `POST /events/*` remain gated. The privileged loopback `POST /replay` inject is gated.

**No regression when unset:** with the env var absent the API behaves byte-for-byte as before (loopback-trust). Proven by a dedicated test.

## Threading the token through internal callers
- `event-runtime/web/serve.mjs`: the `/api` proxy adds the bearer from its own env when forwarding to :7381 (overwrites any client-supplied Authorization, so the browser stays token-free).
- `event-runtime/lib/client.mjs`: `apiClient` reads the token from env by default and sends it on every call, so the CLI and any worker/orchestrator path authenticates without code changes.

Token is never logged.

## Tests (`event-runtime/lib/api.test.mjs`)
- token set: privileged route 401 without / with-wrong (incl. same-length wrong token) / 200 with correct;
- token set: `apiClient` with the token succeeds, without it 401;
- token set: `GET /health` open;
- token set: `POST /events` admitted on valid signature with no bearer, still `bad_signature` 401 on a forged signature even with a valid bearer;
- token unset: privileged routes work with no bearer (no regression).

`bun test event-runtime/lib/api.test.mjs` (18 pass) and `event-runtime/lib/api-intake.test.mjs` (16 pass) green.

## Note
The `secrets.env` guidance doc lives under `docs/` (outside this ticket's Owned Paths), so the env var is documented in code comments across all three touched source files instead. A one-line addition to the secrets.env doc can follow separately.