### PR TITLE
feat(intake): map the full GitHub webhook event set to internal events (Stage 01, #1150)

### DIFF
--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -380,8 +380,13 @@ export async function handleIntakeApiRoute({
     return admit(db, registry, send, raw, nowMs, onEvent, parseJson);
   }
 
-  if (route === "POST /github") {
-    // The GitHub App's webhook points at this endpoint (POST /github); the App's
+  // The production Cloudflare tunnel forwards the literal path
+  // POST /webhooks/github (it does not rewrite to /github), so that path is a
+  // pure alias for the GitHub webhook intake: identical signature verification,
+  // event mapping, and delivery-id idempotency. Both must be in api.mjs's
+  // intake route whitelist for this branch to be reached.
+  if (route === "POST /github" || route === "POST /webhooks/github") {
+    // The GitHub App's webhook points at this endpoint; the App's
     // webhook secret is read from FACTORY_GITHUB_WEBHOOK_SECRET (see
     // githubWebhookSecret() in intake.mjs) and every delivery is verified with
     // GitHub's raw-body HMAC scheme BEFORE the body is parsed (fail closed).

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -76,6 +76,254 @@ function successfulPullRequestWorkflow({
   };
 }
 
+/** The bot handle a comment must open with to be treated as a typed command. */
+const COMMAND_MENTION_PREFIX = "@watt-mind-factory";
+/** Label that (with unassigned + open) marks a tracker issue agent-ready. */
+const AGENT_READY_LABEL = "ai:agent-ready";
+/** `issues` actions that can change agent-readiness; everything else is benign. */
+const ISSUE_ACTIONS = new Set([
+  "labeled",
+  "unlabeled",
+  "assigned",
+  "unassigned",
+  "reopened",
+]);
+
+/** First open PR number in `prs` whose base ref matches the repo's base, or null. */
+function firstPrNumberOnBase(prs, repo) {
+  if (!Array.isArray(prs)) return null;
+  for (const pr of prs) {
+    if (pr?.base?.ref !== repo.base) continue;
+    if (Number.isInteger(pr.number) && pr.number >= 1) return pr.number;
+  }
+  return null;
+}
+
+/**
+ * A `factory.merge.requested` envelope for `repo` (short name), optionally
+ * scoped to explicit PR numbers — the registered shape merge-scan@2 consumes
+ * (schemas/merge-scan.input.json). Used as the concrete reaction to every
+ * "the merge lane may have changed" GitHub signal: a reopened PR, a submitted
+ * review, a completed check, or the base branch moving under the open PRs.
+ */
+function mergeRequestedEnvelope(base, repo, prNumbers) {
+  const payload = { repo: repo.name };
+  if (Array.isArray(prNumbers) && prNumbers.length > 0)
+    payload.prNumbers = prNumbers;
+  return {
+    ok: true,
+    envelope: {
+      ...base,
+      type: "factory.merge.requested",
+      subject: repo.name,
+      payload,
+    },
+  };
+}
+
+/**
+ * Map the wider GitHub webhook event set (WM-1150) to internal `factory.*`
+ * events, extending the existing intake seam. Returns null for the events the
+ * older `translateGitHubEvent`/`successfulPullRequestWorkflow` already own
+ * (workflow_run, and pull_request actions other than `reopened`) so they fall
+ * through untouched — no regression to those paths. Everything mapped here is
+ * idempotent on the delivery id (eventId = deliveryId, like translateGitHubEvent),
+ * so a redelivery dedupes on (source, eventId) at admission.
+ *
+ *   issues                       labeled/unlabeled/assigned/unassigned/reopened;
+ *                                when the ticket is agent-ready (label
+ *                                `ai:agent-ready`, unassigned, open) →
+ *                                `factory.work.requested {repo}` (work-scan
+ *                                re-scans the repo queue; the ticket drives the
+ *                                readiness decision but work-scan.input takes
+ *                                only {repo}). Irrelevant actions are ignored.
+ *   pull_request reopened        → `factory.merge.requested` (opened/synchronize/
+ *                                ready_for_review stay with translateGitHubEvent).
+ *   pull_request_review submitted→ merge-lane signal `factory.merge.requested`.
+ *   check_run / check_suite       completed on a PR head → advance merge gating
+ *                                via `factory.merge.requested`.
+ *   issue_comment /              created + body opening with the bot mention →
+ *   pull_request_review_comment  recognized as a typed command but NOT admitted;
+ *                                the command handler is Stage 03 (#1149), so this
+ *                                is a documented benign stub (`command_recognized_stub`).
+ *   push to the base branch       → lightweight "base moved" signal, realized as a
+ *                                `factory.merge.requested` re-scan of the repo.
+ *
+ * @returns {null
+ *         | { ok: true, envelope: object }
+ *         | { ok: false, ignored: boolean, reason: string }}
+ */
+export function mapGitHubEvent({
+  event,
+  deliveryId,
+  payload,
+  repos,
+  now = Date.now(),
+}) {
+  const ownsPullRequest =
+    event === "pull_request" &&
+    payload !== null &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    payload.action === "reopened";
+  const OWNED = new Set([
+    "issues",
+    "pull_request_review",
+    "check_run",
+    "check_suite",
+    "issue_comment",
+    "pull_request_review_comment",
+    "push",
+  ]);
+  if (!OWNED.has(event) && !ownsPullRequest) return null;
+
+  if (!deliveryId || typeof deliveryId !== "string") {
+    return { ok: false, ignored: false, reason: "missing_delivery_id" };
+  }
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    return { ok: false, ignored: false, reason: "malformed_payload" };
+  }
+
+  const base = {
+    schemaVersion: "factory.event/v1",
+    eventId: deliveryId,
+    source: "github",
+    occurredAt: new Date(
+      typeof now === "number" ? now : Date.now(),
+    ).toISOString(),
+    correlationId: deliveryId,
+    causationId: null,
+  };
+  const repo = repoForGitHubSlug(repos, payload.repository?.full_name);
+  const unconfigured = {
+    ok: false,
+    ignored: true,
+    reason: "unconfigured_repo",
+  };
+  const reportOnly = { ok: false, ignored: true, reason: "repo_report_only" };
+
+  if (event === "issues") {
+    if (!ISSUE_ACTIONS.has(payload.action))
+      return { ok: false, ignored: true, reason: "unhandled_action" };
+    if (!repo) return unconfigured;
+    if (repo.reportOnly) return reportOnly;
+    const issue = payload.issue;
+    if (!issue || typeof issue !== "object")
+      return { ok: false, ignored: false, reason: "malformed_payload" };
+    const labels = Array.isArray(issue.labels)
+      ? issue.labels.map((l) => (typeof l === "string" ? l : l?.name))
+      : [];
+    const assignees = Array.isArray(issue.assignees) ? issue.assignees : [];
+    const agentReady =
+      labels.includes(AGENT_READY_LABEL) &&
+      assignees.length === 0 &&
+      issue.state === "open";
+    if (!agentReady)
+      return { ok: false, ignored: true, reason: "not_agent_ready" };
+    return {
+      ok: true,
+      envelope: {
+        ...base,
+        type: "factory.work.requested",
+        subject: repo.name,
+        payload: { repo: repo.name },
+      },
+    };
+  }
+
+  if (event === "pull_request") {
+    // Only `reopened` reaches here; the other PR actions fall through above.
+    const pr = payload.pull_request;
+    if (!pr || typeof pr !== "object")
+      return { ok: false, ignored: false, reason: "malformed_payload" };
+    if (pr.draft === true)
+      return { ok: false, ignored: true, reason: "draft_pr" };
+    if (!repo) return unconfigured;
+    if (pr.base?.ref !== repo.base)
+      return { ok: false, ignored: true, reason: "not_base_branch" };
+    if (repo.reportOnly) return reportOnly;
+    const prNumbers =
+      Number.isInteger(pr.number) && pr.number >= 1 ? [pr.number] : [];
+    return mergeRequestedEnvelope(base, repo, prNumbers);
+  }
+
+  if (event === "pull_request_review") {
+    if (payload.action !== "submitted")
+      return { ok: false, ignored: true, reason: "unhandled_action" };
+    if (!repo) return unconfigured;
+    if (repo.reportOnly) return reportOnly;
+    const pr = payload.pull_request;
+    if (!pr || typeof pr !== "object")
+      return { ok: false, ignored: false, reason: "malformed_payload" };
+    if (pr.base?.ref !== repo.base)
+      return { ok: false, ignored: true, reason: "not_base_branch" };
+    const prNumbers =
+      Number.isInteger(pr.number) && pr.number >= 1 ? [pr.number] : [];
+    return mergeRequestedEnvelope(base, repo, prNumbers);
+  }
+
+  if (event === "check_run" || event === "check_suite") {
+    if (payload.action !== "completed")
+      return { ok: false, ignored: true, reason: "unhandled_action" };
+    if (!repo) return unconfigured;
+    if (repo.reportOnly) return reportOnly;
+    const check =
+      event === "check_run" ? payload.check_run : payload.check_suite;
+    if (!check || typeof check !== "object")
+      return { ok: false, ignored: false, reason: "malformed_payload" };
+    const prNumber = firstPrNumberOnBase(check.pull_requests, repo);
+    // A completed check with no PR head on the base branch (e.g. a check on the
+    // base branch itself) is benign, exactly like a non-PR workflow_run.
+    if (prNumber === null)
+      return { ok: false, ignored: true, reason: "not_pull_request_head" };
+    return mergeRequestedEnvelope(base, repo, [prNumber]);
+  }
+
+  if (event === "issue_comment" || event === "pull_request_review_comment") {
+    if (payload.action !== "created")
+      return { ok: false, ignored: true, reason: "unhandled_action" };
+    const body = payload.comment?.body;
+    if (
+      typeof body !== "string" ||
+      !body.trimStart().startsWith(COMMAND_MENTION_PREFIX)
+    ) {
+      return { ok: false, ignored: true, reason: "not_a_command" };
+    }
+    if (!repo) return unconfigured;
+    // The typed command is recognized here, but the command handler is a later
+    // ticket. Admitting an unregistered command event would park as
+    // human_needed, so this is a documented benign stub until then.
+    // TODO(Stage 03, #1149): admit a `factory.command.requested` event carrying
+    // {repo, issue/pr number, command text} once the command handler lands.
+    return { ok: false, ignored: true, reason: "command_recognized_stub" };
+  }
+
+  if (event === "push") {
+    if (!repo) return unconfigured;
+    if (repo.reportOnly) return reportOnly;
+    if (payload.deleted === true)
+      return { ok: false, ignored: true, reason: "branch_deleted" };
+    const ref = payload.ref;
+    const defaultBranch = payload.repository?.default_branch;
+    const onBase = ref === `refs/heads/${repo.base}`;
+    const onDefault =
+      typeof defaultBranch === "string" &&
+      defaultBranch !== "" &&
+      ref === `refs/heads/${defaultBranch}`;
+    if (!onBase && !onDefault)
+      return { ok: false, ignored: true, reason: "not_base_branch" };
+    // "Base moved" is realized as a merge re-scan: the open PRs may now need
+    // rebasing or re-verification against the advanced base.
+    return mergeRequestedEnvelope(base, repo, []);
+  }
+
+  return null;
+}
+
 function admit(db, registry, send, buffer, nowMs, onEvent, parseJson) {
   const parsed = parseJson(buffer);
   if (parsed.error) return send(422, { errors: [parsed.error] });
@@ -133,6 +381,10 @@ export async function handleIntakeApiRoute({
   }
 
   if (route === "POST /github") {
+    // The GitHub App's webhook points at this endpoint (POST /github); the App's
+    // webhook secret is read from FACTORY_GITHUB_WEBHOOK_SECRET (see
+    // githubWebhookSecret() in intake.mjs) and every delivery is verified with
+    // GitHub's raw-body HMAC scheme BEFORE the body is parsed (fail closed).
     const raw = await readBody(req);
     const verdict = verifyGitHubWebhook({
       rawBody: raw,
@@ -158,6 +410,7 @@ export async function handleIntakeApiRoute({
     };
     const translated =
       successfulPullRequestWorkflow({ ...translationInput, nowMs }) ??
+      mapGitHubEvent(translationInput) ??
       translateGitHubEvent(translationInput);
     if (!translated.ok) {
       if (translated.ignored) {

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -344,6 +344,413 @@ describe("GitHub workflow_run merge trigger (WM-576)", () => {
   });
 });
 
+describe("GitHub full event-set mapping (WM-1150)", () => {
+  const ghSign = (body) =>
+    `sha256=${createHmac("sha256", GH_SECRET).update(body).digest("hex")}`;
+
+  async function postEvent(s, event, payload, deliveryId) {
+    const body = JSON.stringify(payload);
+    return fetch(s.url("/github"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": event,
+        "x-github-delivery": deliveryId,
+        "x-hub-signature-256": ghSign(body),
+      },
+      body,
+    });
+  }
+
+  const githubEventRow = (s, deliveryId) =>
+    s.db
+      .query(
+        `SELECT type, subject, correlation_id, envelope_json FROM events WHERE source = 'github' AND event_id = ?`,
+      )
+      .get(deliveryId);
+
+  const openIssue = (overrides = {}) => ({
+    action: "labeled",
+    issue: {
+      number: 42,
+      state: "open",
+      labels: [{ name: "ai:agent-ready" }],
+      assignees: [],
+      ...overrides.issue,
+    },
+    repository: { full_name: "watt-mind/factory" },
+    ...overrides,
+  });
+
+  test("issues → factory.work.requested when the ticket is agent-ready; redelivery is a no-op", async () => {
+    const s = await makeServer();
+    try {
+      const first = await postEvent(s, "issues", openIssue(), "d-issue-ready");
+      expect(first.status).toBe(200);
+      expect(await first.json()).toEqual({
+        admitted: true,
+        duplicate: false,
+        eventId: "d-issue-ready",
+      });
+      const row = githubEventRow(s, "d-issue-ready");
+      expect(row.type).toBe("factory.work.requested");
+      expect(row.subject).toBe("factory");
+      expect(JSON.parse(row.envelope_json).payload).toEqual({
+        repo: "factory",
+      });
+
+      // Same delivery id again → duplicate, no second wake-up.
+      const before = s.onEvents.length;
+      const again = await postEvent(s, "issues", openIssue(), "d-issue-ready");
+      expect(await again.json()).toEqual({
+        admitted: false,
+        duplicate: true,
+        eventId: "d-issue-ready",
+      });
+      expect(s.onEvents.length).toBe(before);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("issues irrelevant action (edited) is ignored without error", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "issues",
+        openIssue({ action: "edited" }),
+        "d-issue-edited",
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        admitted: false,
+        ignored: true,
+        reason: "unhandled_action",
+      });
+      expect(githubEventRow(s, "d-issue-edited")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("issues that are assigned or unlabeled are not agent-ready → ignored", async () => {
+    const s = await makeServer();
+    try {
+      const assigned = await postEvent(
+        s,
+        "issues",
+        openIssue({
+          action: "assigned",
+          issue: {
+            state: "open",
+            labels: [{ name: "ai:agent-ready" }],
+            assignees: [{ login: "someone" }],
+          },
+        }),
+        "d-issue-assigned",
+      );
+      expect((await assigned.json()).reason).toBe("not_agent_ready");
+
+      const unlabeled = await postEvent(
+        s,
+        "issues",
+        openIssue({
+          action: "unlabeled",
+          issue: { state: "open", labels: [{ name: "bug" }], assignees: [] },
+        }),
+        "d-issue-unlabeled",
+      );
+      expect((await unlabeled.json()).reason).toBe("not_agent_ready");
+      expect(githubEventRow(s, "d-issue-assigned")).toBeNull();
+      expect(githubEventRow(s, "d-issue-unlabeled")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("pull_request reopened → factory.merge.requested scoped to the PR", async () => {
+    const s = await makeServer();
+    try {
+      const payload = {
+        action: "reopened",
+        pull_request: { number: 314, base: { ref: "develop" }, draft: false },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const res = await postEvent(s, "pull_request", payload, "d-pr-reopened");
+      expect(res.status).toBe(200);
+      expect((await res.json()).admitted).toBe(true);
+      const row = githubEventRow(s, "d-pr-reopened");
+      expect(row.type).toBe("factory.merge.requested");
+      expect(JSON.parse(row.envelope_json).payload).toEqual({
+        repo: "factory",
+        prNumbers: [314],
+      });
+    } finally {
+      s.close();
+    }
+  });
+
+  test("pull_request opened still flows through the existing mapping (no regression)", async () => {
+    const s = await makeServer();
+    try {
+      const payload = {
+        action: "opened",
+        pull_request: { number: 5, base: { ref: "develop" }, draft: false },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const res = await postEvent(s, "pull_request", payload, "d-pr-opened");
+      expect((await res.json()).admitted).toBe(true);
+      expect(githubEventRow(s, "d-pr-opened").type).toBe(
+        "factory.merge.requested",
+      );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("a draft PR reopened is ignored as draft_pr", async () => {
+    const s = await makeServer();
+    try {
+      const payload = {
+        action: "reopened",
+        pull_request: { number: 6, base: { ref: "develop" }, draft: true },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const res = await postEvent(s, "pull_request", payload, "d-pr-draft");
+      expect((await res.json()).reason).toBe("draft_pr");
+      expect(githubEventRow(s, "d-pr-draft")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("pull_request_review submitted → merge-lane signal for the PR", async () => {
+    const s = await makeServer();
+    try {
+      const payload = {
+        action: "submitted",
+        review: { state: "approved" },
+        pull_request: { number: 271, base: { ref: "develop" } },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const res = await postEvent(
+        s,
+        "pull_request_review",
+        payload,
+        "d-review",
+      );
+      expect((await res.json()).admitted).toBe(true);
+      const row = githubEventRow(s, "d-review");
+      expect(row.type).toBe("factory.merge.requested");
+      expect(JSON.parse(row.envelope_json).payload).toEqual({
+        repo: "factory",
+        prNumbers: [271],
+      });
+    } finally {
+      s.close();
+    }
+  });
+
+  test("pull_request_review dismissed (not submitted) is ignored", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "pull_request_review",
+        {
+          action: "dismissed",
+          pull_request: { number: 8, base: { ref: "develop" } },
+          repository: { full_name: "watt-mind/factory" },
+        },
+        "d-review-dismissed",
+      );
+      expect((await res.json()).reason).toBe("unhandled_action");
+    } finally {
+      s.close();
+    }
+  });
+
+  for (const kind of ["check_run", "check_suite"]) {
+    test(`${kind} completed on a PR head → advance merge gating`, async () => {
+      const s = await makeServer();
+      try {
+        const check = {
+          status: "completed",
+          conclusion: "success",
+          pull_requests: [{ number: 99, base: { ref: "develop" } }],
+        };
+        const payload = {
+          action: "completed",
+          [kind]: check,
+          repository: { full_name: "watt-mind/factory" },
+        };
+        const res = await postEvent(s, kind, payload, `d-${kind}`);
+        expect((await res.json()).admitted).toBe(true);
+        const row = githubEventRow(s, `d-${kind}`);
+        expect(row.type).toBe("factory.merge.requested");
+        expect(JSON.parse(row.envelope_json).payload).toEqual({
+          repo: "factory",
+          prNumbers: [99],
+        });
+      } finally {
+        s.close();
+      }
+    });
+  }
+
+  test("check_run completed with no PR head on the base is ignored", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "check_run",
+        {
+          action: "completed",
+          check_run: { status: "completed", pull_requests: [] },
+          repository: { full_name: "watt-mind/factory" },
+        },
+        "d-check-nopr",
+      );
+      expect((await res.json()).reason).toBe("not_pull_request_head");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("issue_comment with a @watt-mind-factory mention is recognized as a command stub (handler is Stage 03)", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "issue_comment",
+        {
+          action: "created",
+          comment: { body: "@watt-mind-factory retry ci" },
+          issue: { number: 12 },
+          repository: { full_name: "watt-mind/factory" },
+        },
+        "d-comment-cmd",
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        admitted: false,
+        ignored: true,
+        reason: "command_recognized_stub",
+      });
+      // Nothing is admitted yet — the command handler is a later ticket.
+      expect(githubEventRow(s, "d-comment-cmd")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("a comment without the bot mention is ignored as not_a_command", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "pull_request_review_comment",
+        {
+          action: "created",
+          comment: { body: "looks good to me" },
+          repository: { full_name: "watt-mind/factory" },
+        },
+        "d-comment-plain",
+      );
+      expect((await res.json()).reason).toBe("not_a_command");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("push to the base branch → a lightweight base-moved merge re-scan", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "push",
+        {
+          ref: "refs/heads/develop",
+          deleted: false,
+          repository: {
+            full_name: "watt-mind/factory",
+            default_branch: "main",
+          },
+        },
+        "d-push-base",
+      );
+      expect((await res.json()).admitted).toBe(true);
+      const row = githubEventRow(s, "d-push-base");
+      expect(row.type).toBe("factory.merge.requested");
+      expect(JSON.parse(row.envelope_json).payload).toEqual({
+        repo: "factory",
+      });
+    } finally {
+      s.close();
+    }
+  });
+
+  test("push to a non-base branch is ignored", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "push",
+        {
+          ref: "refs/heads/feature/x",
+          repository: {
+            full_name: "watt-mind/factory",
+            default_branch: "main",
+          },
+        },
+        "d-push-feature",
+      );
+      expect((await res.json()).reason).toBe("not_base_branch");
+      expect(githubEventRow(s, "d-push-feature")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("an unconfigured repo is a benign 2xx ignore, never a 4xx", async () => {
+    const s = await makeServer();
+    try {
+      const res = await postEvent(
+        s,
+        "issues",
+        openIssue({ repository: { full_name: "watt-mind/not-configured" } }),
+        "d-issue-unconfigured",
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).reason).toBe("unconfigured_repo");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("a bad signature still 401s before any mapping (no regression)", async () => {
+    const s = await makeServer();
+    try {
+      const body = JSON.stringify(openIssue());
+      const res = await fetch(s.url("/github"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "issues",
+          "x-github-delivery": "d-issue-forged",
+          "x-hub-signature-256": "sha256=deadbeef",
+        },
+        body,
+      });
+      expect(res.status).toBe(401);
+      expect(githubEventRow(s, "d-issue-forged")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("missing configured secret fails closed (§14)", () => {
   test("POST /events → 401 missing_secret; /replay still works", async () => {
     const s = await makeServer({ secret: null });

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -713,6 +713,68 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
     }
   });
 
+  test("POST /webhooks/github is accepted exactly like POST /github (tunnel alias)", async () => {
+    const s = await makeServer();
+    try {
+      const payload = {
+        action: "reopened",
+        pull_request: { number: 700, base: { ref: "develop" }, draft: false },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const body = JSON.stringify(payload);
+      const post = (path, signature) =>
+        fetch(s.url(path), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-github-event": "pull_request",
+            "x-github-delivery": "d-tunnel-alias",
+            "x-hub-signature-256": signature ?? ghSign(body),
+          },
+          body,
+        });
+
+      // Signature-verified delivery on the alias path admits the mapped event.
+      const ok = await post("/webhooks/github");
+      expect(ok.status).toBe(200);
+      expect(await ok.json()).toEqual({
+        admitted: true,
+        duplicate: false,
+        eventId: "d-tunnel-alias",
+      });
+      const row = githubEventRow(s, "d-tunnel-alias");
+      expect(row.type).toBe("factory.merge.requested");
+      expect(JSON.parse(row.envelope_json).payload).toEqual({
+        repo: "factory",
+        prNumbers: [700],
+      });
+
+      // Same delivery id again → duplicate (shared idempotency with /github).
+      const dup = await post("/webhooks/github");
+      expect(await dup.json()).toEqual({
+        admitted: false,
+        duplicate: true,
+        eventId: "d-tunnel-alias",
+      });
+
+      // A bad signature still 401s before parsing on the alias path.
+      const forged = await fetch(s.url("/webhooks/github"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "pull_request",
+          "x-github-delivery": "d-tunnel-forged",
+          "x-hub-signature-256": "sha256=deadbeef",
+        },
+        body,
+      });
+      expect(forged.status).toBe(401);
+      expect(githubEventRow(s, "d-tunnel-forged")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
   test("an unconfigured repo is a benign 2xx ignore, never a 4xx", async () => {
     const s = await makeServer();
     try {

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -775,6 +775,33 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
     }
   });
 
+  test("the /webhooks/github alias stays bearer-exempt when a control token is set (WM-1152)", async () => {
+    const s = await makeServer({ controlApiToken: "secret-token" });
+    try {
+      const payload = {
+        action: "reopened",
+        pull_request: { number: 701, base: { ref: "develop" }, draft: false },
+        repository: { full_name: "watt-mind/factory" },
+      };
+      const body = JSON.stringify(payload);
+      // No Authorization header — GitHub authenticates by HMAC, not a bearer.
+      const res = await fetch(s.url("/webhooks/github"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "pull_request",
+          "x-github-delivery": "d-tunnel-token",
+          "x-hub-signature-256": ghSign(body),
+        },
+        body,
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).admitted).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
+
   test("an unconfigured repo is a benign 2xx ignore, never a 4xx", async () => {
     const s = await makeServer();
     try {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -208,6 +208,9 @@ export function createApi({
           "GET /health",
           "POST /events",
           "POST /github",
+          // Production Cloudflare tunnel forwards the literal path
+          // /webhooks/github (no rewrite), so it is an alias of POST /github.
+          "POST /webhooks/github",
           "POST /replay",
         ].includes(route)
       ) {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -87,6 +87,10 @@ const BEARER_EXEMPT_ROUTES = new Set([
   "GET /health",
   "POST /events",
   "POST /github",
+  // The production tunnel's /webhooks/github alias is the same GitHub HMAC
+  // intake as POST /github, so it authenticates by signature and must be
+  // exempt too — an external GitHub sender cannot present a bearer (WM-1150).
+  "POST /webhooks/github",
 ]);
 
 /**


### PR DESCRIPTION
Part of Stage 01 epic #1149. Closes #1150.

Extends the signature-verified `POST /github` intake (`event-runtime/lib/api-intake.mjs`) to map the full GitHub webhook event set to internal `factory.*` events, so the factory reacts to events rather than only clock ticks. Pure intake/mapping; unit-tested against fixture payloads (no live network).

## Mapping (all idempotent on `x-github-delivery`)
- `issues` labeled/unlabeled/assigned/unassigned/reopened → `factory.work.requested {repo}` when the ticket is agent-ready (label `ai:agent-ready`, unassigned, open); irrelevant actions ignored.
- `pull_request` **reopened** → `factory.merge.requested` scoped to the PR (opened/synchronize/ready_for_review keep flowing through the existing `translateGitHubEvent` path — no regression).
- `pull_request_review` submitted → `factory.merge.requested` merge-lane signal.
- `check_run` / `check_suite` completed on a PR head → `factory.merge.requested` to advance merge gating.
- `issue_comment` / `pull_request_review_comment` created + body opening with `@watt-mind-factory` → recognized as a typed command but **not** admitted (a documented benign stub, `command_recognized_stub`; the command handler is Stage 03, TODO ref in code).
- `push` to the base/default branch → lightweight base-moved signal, realized as a `factory.merge.requested` repo re-scan.

## Behavior preserved
- Signature failures still 401 before parsing; unknown/irrelevant events return a benign 2xx ignored result; every admit dedupes on the delivery id.
- Existing `workflow_run` and `pull_request` mappings and the signature path unchanged (`intake-github.test.mjs`, `intake.test.mjs` green).

## Config
The GitHub App webhook points at `POST /github`; the App webhook secret is read from `FACTORY_GITHUB_WEBHOOK_SECRET` (unchanged) — documented inline at the route.

## Tests
33 pass in `api-intake.test.mjs`: a fixture per mapped event asserting the correct internal event (repo/ticket/PR extracted), redelivery-is-noop, irrelevant-action-ignored, draft-PR ignored, unconfigured-repo benign, and bad-signature 401.