### PR TITLE
feat(handoff): dispatch ready tickets to central Factory

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -95,6 +95,7 @@ case "$cmd" in
   warm)         run_bun orchestrator/warm.mjs "$@" ;;
   tick)         run_bun orchestrator/tick.mjs "$@" ;;
   dispatch)     run_bun tools/dispatch.mjs "$@" ;;
+  handoff)      run_bun tools/handoff.mjs "$@" ;;
   events)       run_bun event-runtime/cli.mjs "$@" ;;
   pack)         run_bun event-runtime/cli.mjs pack "$@" ;;
   inbox)        run_bun event-runtime/cli.mjs inbox "$@" ;;

--- a/dist/codex/skills/factory-handoff/SKILL.md
+++ b/dist/codex/skills/factory-handoff/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: factory-handoff
+description: Hand one exact agent-ready ticket to the central Factory runtime over the configured SSH forced-command boundary. Use when an operator asks to hand off an existing ticket or a prose request instead of implementing it in the current session.
+---
+
+# Remote Factory handoff
+
+Handoff means **capture/specify here, execute centrally**. Never claim the ticket, create a worktree, spawn an implementation subagent, or begin the implementation in this session.
+
+## Existing ticket identifier
+
+1. Resolve the current repository through Factory's configured repo registry.
+2. Read the ticket and confirm it is dispatchable: `Todo`, `ai:agent-ready`, unassigned, and complete under the five-section protocol (Problem & Context, Acceptance Criteria, Source File Pointers, Owned Paths, Verification Command). Do not "repair" an ambiguous ticket by guessing.
+3. If it is not ready, apply the `ticket-spec` skill: explore read-only, complete only derivable sections, verify the command exists/runs, and promote only when the specification is falsifiable. A genuine product decision remains Triage and is not handed off.
+4. Run the mechanical client with the canonical ticket identifier:
+
+   ```sh
+   factory handoff --repo <configured-short-name> <ticket>
+   ```
+
+   The repo flag may be omitted when cwd is inside the configured checkout or one of its worktrees. GitHub tickets use `OWNER/REPO#N`; Linear tickets use `TEAM-N`.
+
+5. Return the machine receipt's admission/duplicate disposition, event/proposal/run state, and dashboard URL. A watched/refused result is a safe outcome, not permission to start locally.
+
+## Prose request
+
+Follow the existing capture and specification protocols before handoff:
+
+1. Search for duplicates and use the existing ticket when one covers the request.
+2. Otherwise file exactly one meaningful ticket with `source:human`, the correct repo/team/project and taxonomy, and the five complete sections only when supported by code evidence.
+3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
+4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
+
+## Retry rule
+
+The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
+
+```sh
+factory handoff --request-id <original-id> --repo <repo> <ticket>
+```
+
+Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.

--- a/dist/gemini/skills/factory-handoff/SKILL.md
+++ b/dist/gemini/skills/factory-handoff/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: factory-handoff
+description: Hand one exact agent-ready ticket to the central Factory runtime over the configured SSH forced-command boundary. Use when an operator asks to hand off an existing ticket or a prose request instead of implementing it in the current session.
+---
+
+# Remote Factory handoff
+
+Handoff means **capture/specify here, execute centrally**. Never claim the ticket, create a worktree, spawn an implementation subagent, or begin the implementation in this session.
+
+## Existing ticket identifier
+
+1. Resolve the current repository through Factory's configured repo registry.
+2. Read the ticket and confirm it is dispatchable: `Todo`, `ai:agent-ready`, unassigned, and complete under the five-section protocol (Problem & Context, Acceptance Criteria, Source File Pointers, Owned Paths, Verification Command). Do not "repair" an ambiguous ticket by guessing.
+3. If it is not ready, apply the `ticket-spec` skill: explore read-only, complete only derivable sections, verify the command exists/runs, and promote only when the specification is falsifiable. A genuine product decision remains Triage and is not handed off.
+4. Run the mechanical client with the canonical ticket identifier:
+
+   ```sh
+   factory handoff --repo <configured-short-name> <ticket>
+   ```
+
+   The repo flag may be omitted when cwd is inside the configured checkout or one of its worktrees. GitHub tickets use `OWNER/REPO#N`; Linear tickets use `TEAM-N`.
+
+5. Return the machine receipt's admission/duplicate disposition, event/proposal/run state, and dashboard URL. A watched/refused result is a safe outcome, not permission to start locally.
+
+## Prose request
+
+Follow the existing capture and specification protocols before handoff:
+
+1. Search for duplicates and use the existing ticket when one covers the request.
+2. Otherwise file exactly one meaningful ticket with `source:human`, the correct repo/team/project and taxonomy, and the five complete sections only when supported by code evidence.
+3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
+4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
+
+## Retry rule
+
+The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
+
+```sh
+factory handoff --request-id <original-id> --repo <repo> <ticket>
+```
+
+Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.

--- a/dist/pi/skills/factory-handoff/SKILL.md
+++ b/dist/pi/skills/factory-handoff/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: factory-handoff
+description: Hand one exact agent-ready ticket to the central Factory runtime over the configured SSH forced-command boundary. Use when an operator asks to hand off an existing ticket or a prose request instead of implementing it in the current session.
+---
+
+# Remote Factory handoff
+
+Handoff means **capture/specify here, execute centrally**. Never claim the ticket, create a worktree, spawn an implementation subagent, or begin the implementation in this session.
+
+## Existing ticket identifier
+
+1. Resolve the current repository through Factory's configured repo registry.
+2. Read the ticket and confirm it is dispatchable: `Todo`, `ai:agent-ready`, unassigned, and complete under the five-section protocol (Problem & Context, Acceptance Criteria, Source File Pointers, Owned Paths, Verification Command). Do not "repair" an ambiguous ticket by guessing.
+3. If it is not ready, apply the `ticket-spec` skill: explore read-only, complete only derivable sections, verify the command exists/runs, and promote only when the specification is falsifiable. A genuine product decision remains Triage and is not handed off.
+4. Run the mechanical client with the canonical ticket identifier:
+
+   ```sh
+   factory handoff --repo <configured-short-name> <ticket>
+   ```
+
+   The repo flag may be omitted when cwd is inside the configured checkout or one of its worktrees. GitHub tickets use `OWNER/REPO#N`; Linear tickets use `TEAM-N`.
+
+5. Return the machine receipt's admission/duplicate disposition, event/proposal/run state, and dashboard URL. A watched/refused result is a safe outcome, not permission to start locally.
+
+## Prose request
+
+Follow the existing capture and specification protocols before handoff:
+
+1. Search for duplicates and use the existing ticket when one covers the request.
+2. Otherwise file exactly one meaningful ticket with `source:human`, the correct repo/team/project and taxonomy, and the five complete sections only when supported by code evidence.
+3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
+4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
+
+## Retry rule
+
+The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
+
+```sh
+factory handoff --request-id <original-id> --repo <repo> <ticket>
+```
+
+Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -521,6 +521,29 @@ Recorded, not silently decided:
   singletons, waits on the unattended-stage answer §3 already demands — it
   is not unlocked by anything here.
 
+## Remote handoff dispatch provenance (GH-1153)
+
+A remote operator may submit one exact agent-ready ticket through the dedicated
+SSH forced-command boundary documented in
+[remote-handoff.md](remote-handoff.md). The server, not the client, derives a
+`factory.dispatch.requested` event with `source=handoff` and HMAC-signs the
+exact `/events` request bytes using the existing runtime secret.
+
+`handoff` is reserved from every public/operator replay path. Signed `/events`
+is the only caller-facing boundary that may admit it; `chain` remains
+in-process-only. A handoff is unattended and its
+`operator_authorized` dispatch evidence is always false.
+
+Only `source=handoff` + `factory.dispatch.requested` joins the existing
+auto-approval path. It reuses the chain dispatch allowlist, immutable dispatch
+evidence, `approve.before` hooks, runtime budget/worker-cap/circuit-breaker
+guard, and evidence-changing execute-time recheck. It does not require a chain
+predecessor because the authenticated handoff boundary is its provenance.
+Every other handoff event type has no auto-approval policy. Ineligible,
+sensitive, escalated, changed, blocked, overlapping, capacity-limited, or
+otherwise unsafe dispatches therefore keep the same typed noop/watched outcomes
+as unattended chain dispatch; they never become operator-approved.
+
 ## Autonomous develop merge lifecycle (WM-398)
 
 Merge control is a durable runtime chain, not an interactive-orchestrator

--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -1,0 +1,104 @@
+# Remote ticket handoff
+
+`factory handoff` sends one already-specified ticket from an operator's configured repository to the central Factory runtime. The transport is a dedicated OpenSSH key over Tailscale. It does **not** expose the runtime webhook secret to clients and does not make the operator HTTP API public.
+
+## Trust boundary
+
+The client sends one bounded `factory.handoff/v1` JSON document containing only:
+
+```json
+{
+  "schemaVersion": "factory.handoff/v1",
+  "requestId": "handoff-unique-id",
+  "repo": "factory",
+  "ticket": "watt-mind/factory#1153"
+}
+```
+
+The forced-command server rejects unknown fields, malformed IDs, unconfigured repos, report-only repos, ticket/repo mismatches, and any caller-supplied `SSH_ORIGINAL_COMMAND`. It derives the `factory.dispatch.requested` envelope, including `source: "handoff"`, then signs the exact POST `/events` bytes with the server's existing `FACTORY_EVENT_SECRET`. The secret is never accepted from the request or printed in a receipt.
+
+`handoff` is reserved provenance. Unsigned intake still fails, `/replay` rejects both `handoff` and `chain`, and only authenticated signed `/events` may admit `handoff`. A handoff is unattended, not operator authorization: sensitive/escalated and `escalate_paths` bypasses remain false.
+
+## Client SSH alias
+
+Create a dedicated key for this purpose; do not reuse an interactive-login key. No key is committed to Factory. Configure an alias on the client:
+
+```sshconfig
+Host factory-runner
+  HostName runner
+  User factory-handoff
+  IdentityFile ~/.ssh/factory-handoff
+  IdentitiesOnly yes
+  RequestTTY no
+```
+
+Set the alias once per client environment, or pass it explicitly:
+
+```sh
+export FACTORY_HANDOFF_SSH_HOST=factory-runner
+factory handoff --repo factory watt-mind/factory#1153
+# equivalent: factory handoff --host factory-runner --repo factory watt-mind/factory#1153
+```
+
+When cwd is under a configured repo `path` or `worktree_root`, `--repo` may be omitted. The client supplies no remote command, so the server's forced command is the only executable path.
+
+## Server forced command
+
+Create a root-owned wrapper, for example `/usr/local/sbin/factory-handoff-accept`:
+
+```sh
+#!/bin/sh
+set -eu
+. /etc/factory/event-runtime.env
+exec /opt/factory/current/bin/factory handoff accept
+```
+
+The environment file must be readable by the dedicated account and must load the same `FACTORY_EVENT_SECRET` used by the running event runtime. It may also set:
+
+```sh
+FACTORY_EVENT_URL=http://127.0.0.1:7381
+FACTORY_DASHBOARD_URL=https://factory.whale-pike.ts.net
+FACTORY_REPOS_ROOT=/opt/factory/current
+# When the runtime's existing control API bearer gate is enabled:
+FACTORY_CONTROL_API_TOKEN=...
+```
+
+Do not echo the environment, enable shell tracing, place either secret in `authorized_keys`, or copy them to clients. `POST /events` continues to authenticate with the event HMAC; the optional control API token is sent only on the broker's read-only receipt-enrichment requests.
+
+Install the client's **public** key for the dedicated account using a forced command. Replace the example Tailscale address and key with deployment-local values:
+
+```text
+restrict,from="100.64.0.10",command="/usr/local/sbin/factory-handoff-accept" ssh-ed25519 AAAA... factory-handoff-client
+```
+
+`restrict` disables forwarding, agent/X11 forwarding, PTY allocation, and user commands. Keep `from=` narrowed to the expected Tailscale source IP (or the smallest stable source range). In addition, restrict sshd/firewall access to the Tailscale interface and ACL the dedicated account/host to approved operator devices. The `from=` check is defense in depth, not a substitute for Tailscale ACLs.
+
+## Receipt and retries
+
+The server returns one `factory.handoff-receipt/v1` JSON document with admission/duplicate status, event state, proposal/run IDs and states when already visible, and `FACTORY_DASHBOARD_URL` when configured. State fields can be pending because planning runs asynchronously after durable admission.
+
+`requestId` is the idempotency key for `(source=handoff, eventId=requestId)`. If SSH disconnects after submission, retry with the same ID:
+
+```sh
+factory handoff --request-id handoff-original-id --repo factory watt-mind/factory#1153
+```
+
+A retry returns `duplicate: true` and the original event rather than dispatching a second run. Reusing that request ID for a different repo or ticket fails with `idempotency_conflict`; it never reports the original dispatch as if it covered the new request.
+
+## Rollout
+
+1. Deploy code and regenerate/install the Factory CLI before installing any key.
+2. Confirm the runtime has `FACTORY_EVENT_SECRET` and loopback `/health` reports `webhookSecret: "set"`.
+3. Install the environment wrapper and verify its owner/mode without running it under a tracing shell.
+4. Add the dedicated user, Tailscale ACL/source restriction, and one forced-command public key.
+5. Configure one client alias and hand off a disposable agent-ready ticket with an explicit request ID.
+6. Confirm the receipt, `source=handoff` event, auto-approval evidence, and ordinary worker claim/worktree lifecycle in the dashboard.
+7. Retry the same ID and confirm `duplicate: true` with no second run.
+
+## Rollback
+
+Remove or comment out the dedicated `authorized_keys` entry first; this stops new handoffs immediately without affecting the runtime. Then remove the client alias/key and wrapper if desired. Already admitted events remain in the durable ledger and continue under normal dispatch policy; reject/cancel them through existing operator procedures if necessary. No HTTP route, bearer credential, production key, or new runtime secret needs rollback.
+
+## Out of scope
+
+This feature does not introduce or configure bearer auth; it only interoperates with the runtime's existing `FACTORY_CONTROL_API_TOKEN` gate when that token is already enabled. It does not add direct remote `/replay` access, public `/events` access, production keys, or a second dispatch policy.

--- a/event-runtime/cli/extensions.mjs
+++ b/event-runtime/cli/extensions.mjs
@@ -8,6 +8,8 @@
  * Wiring `pack` into cli.mjs is outside this ticket's Owned Paths.
  */
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { validateExtensionManifest } from "../lib/extensions.mjs";
 
@@ -44,11 +46,16 @@ export function normalizePackReport(report) {
  * `npm pack --dry-run` would include.
  *
  * @param {string} dir
- * @param {{ spawn?: typeof spawnSync, exit?: (code: number) => never }} [options]
+ * @param {{ spawn?: typeof spawnSync, exit?: (code: number) => never, log?: (message: string) => void, error?: (message: string) => void }} [options]
  */
 export function packExtension(
   dir,
-  { spawn = spawnSync, exit = (code) => process.exit(code) } = {},
+  {
+    spawn = spawnSync,
+    exit = (code) => process.exit(code),
+    log = console.log,
+    error = console.error,
+  } = {},
 ) {
   const checked = validateExtensionManifest(dir);
   for (const warning of checked.warnings) console.error(`warning: ${warning}`);
@@ -57,32 +64,98 @@ export function packExtension(
     return exit(1);
   }
   const cwd = path.dirname(checked.file);
-  const packed = spawn("npm", ["pack", "--dry-run", "--json"], {
-    cwd,
-    encoding: "utf8",
-  });
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(path.join(cwd, "package.json"), "utf8"));
+  } catch (err) {
+    error(`npm_pack_metadata_invalid: package.json: ${err.message}`);
+    return exit(1);
+  }
+  if (
+    typeof pkg?.name !== "string" ||
+    pkg.name === "" ||
+    typeof pkg?.version !== "string" ||
+    pkg.version === ""
+  ) {
+    error("npm_pack_metadata_invalid: package.json needs name and version");
+    return exit(1);
+  }
+
+  // npm's shared cache produced another fixture's package metadata twice on a
+  // busy self-hosted runner (#1161). One private cache plus an explicit target
+  // keeps concurrent pack probes independent and makes the inspected package
+  // unambiguous.
+  const cache = mkdtempSync(path.join(os.tmpdir(), "factory-npm-pack-"));
+  let packed;
+  try {
+    packed = spawn(
+      "npm",
+      [
+        "pack",
+        ".",
+        "--dry-run",
+        "--json",
+        "--ignore-scripts",
+        "--cache",
+        cache,
+      ],
+      { cwd, encoding: "utf8" },
+    );
+  } finally {
+    rmSync(cache, { recursive: true, force: true });
+  }
   if (packed.status !== 0) {
     const detail = String(packed.stderr || packed.stdout || "").trim();
-    console.error(detail || "npm pack --dry-run failed");
+    error(detail || "npm pack --dry-run failed");
     return exit(packed.status === null ? 1 : packed.status);
   }
+
   let report;
   try {
     report = JSON.parse(packed.stdout);
-  } catch {
-    console.log(packed.stdout);
-    return checked;
+  } catch (err) {
+    error(`npm_pack_metadata_invalid: invalid JSON: ${err.message}`);
+    return exit(1);
   }
+  // Tolerate npm's shape differences via the shared normalizer (older npm
+  // returns an array, newer npm a `{ "package-name": metadata }` map, and a
+  // bare single object is also accepted); every identity is still revalidated
+  // strictly below against the package we asked npm to inspect.
   const entries = normalizePackReport(report);
-  for (const item of entries) {
-    const files = item.files ?? [];
-    const name = item.name ?? checked.manifest.name;
-    const version = item.version ?? checked.manifest.version;
-    console.log(`${name}@${version}: would pack ${files.length} files`);
-    for (const file of files) {
-      console.log(`  ${file.path ?? file}`);
-    }
+  if (entries.length !== 1) {
+    error(
+      `npm_pack_metadata_invalid: expected one package, got ${Array.isArray(report) ? report.length : typeof report}`,
+    );
+    return exit(1);
   }
+  const [item] = entries;
+  if (item?.name !== pkg.name || item?.version !== pkg.version) {
+    const shape =
+      item && typeof item === "object"
+        ? `keys=${Object.keys(item).sort().join(",") || "<none>"}${item.error?.code ? ` error=${item.error.code}` : ""}`
+        : `type=${typeof item}`;
+    error(
+      `npm_pack_metadata_invalid: expected ${pkg.name}@${pkg.version}, got ${String(item?.name)}@${String(item?.version)} (${shape})`,
+    );
+    return exit(1);
+  }
+  if (
+    !Array.isArray(item.files) ||
+    item.files.length === 0 ||
+    !item.files.every(
+      (file) =>
+        typeof file === "string" ||
+        (file && typeof file.path === "string" && file.path !== ""),
+    )
+  ) {
+    error(
+      `npm_pack_metadata_invalid: ${pkg.name}@${pkg.version} returned no valid files`,
+    );
+    return exit(1);
+  }
+
+  log(`${item.name}@${item.version}: would pack ${item.files.length} files`);
+  for (const file of item.files) log(`  ${file.path ?? file}`);
   return { ...checked, pack: entries };
 }
 

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -1,6 +1,7 @@
 /** Health, signed webhook intake, GitHub intake, and loopback replay. */
 import {
   admitExternalEvent,
+  admitSignedEvent,
   translateGitHubEvent,
   verifyGitHubWebhook,
   verifyWebhook,
@@ -348,10 +349,19 @@ function planAfterResponse(onEvent, kind = "admitted") {
   });
 }
 
-function admit(db, registry, send, buffer, nowMs, onEvent, parseJson) {
+function admit(
+  db,
+  registry,
+  send,
+  buffer,
+  nowMs,
+  onEvent,
+  parseJson,
+  admitEnvelope = admitExternalEvent,
+) {
   const parsed = parseJson(buffer);
   if (parsed.error) return send(422, { errors: [parsed.error] });
-  const outcome = admitExternalEvent(db, registry, parsed.value, {
+  const outcome = admitEnvelope(db, registry, parsed.value, {
     now: nowMs,
   });
   if (!outcome.admitted && !outcome.duplicate)
@@ -403,7 +413,16 @@ export async function handleIntakeApiRoute({
     });
     // Fail closed: nothing is parsed, nothing is written (§14).
     if (!verdict.ok) return send(401, { error: verdict.reason });
-    return admit(db, registry, send, raw, nowMs, onEvent, parseJson);
+    return admit(
+      db,
+      registry,
+      send,
+      raw,
+      nowMs,
+      onEvent,
+      parseJson,
+      admitSignedEvent,
+    );
   }
 
   // The production Cloudflare tunnel forwards the literal path

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -233,6 +233,43 @@ describe("webhook intake (§14)", () => {
     ).toBe(0);
   });
 
+  test("signed webhook admits reserved handoff provenance while replay refuses it", async () => {
+    const handoff = envelope({
+      eventId: "handoff-api-1",
+      type: "factory.dispatch.requested",
+      source: "handoff",
+      subject: "watt-mind/factory#1153",
+      payload: { repo: "factory", ticket: "watt-mind/factory#1153" },
+    });
+    const body = JSON.stringify(handoff);
+    const ts = String(Date.now());
+    const signed = await fetch(s.url("/events"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-factory-timestamp": ts,
+        "x-factory-signature": sign(body, ts),
+      },
+      body,
+    });
+    expect(signed.status).toBe(200);
+    expect(await signed.json()).toEqual({
+      admitted: true,
+      duplicate: false,
+      eventId: "handoff-api-1",
+    });
+
+    const replay = await fetch(s.url("/replay"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...handoff, eventId: "handoff-api-forged" }),
+    });
+    expect(replay.status).toBe(422);
+    expect((await replay.json()).errors).toContain(
+      'source: reserved internal provenance "handoff"',
+    );
+  });
+
   test("envelope schema failure → 422 with errors, no admission", async () => {
     const body = JSON.stringify({
       schemaVersion: "factory.event/v1",
@@ -250,7 +287,7 @@ describe("webhook intake (§14)", () => {
     });
     expect(res.status).toBe(422);
     expect((await res.json()).errors.length).toBeGreaterThan(0);
-    expect(s.db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
+    expect(s.db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(2);
   });
 });
 

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -22,6 +22,7 @@ import {
 } from "../../tools/linear.mjs";
 
 export const CHAIN_APPROVAL_SOURCE = "chain";
+export const HANDOFF_APPROVAL_SOURCE = "handoff";
 export const CHAIN_APPROVAL_MODE_AUTO = "auto";
 export const CHAIN_APPROVAL_MODE_WATCHED = "watched";
 export const CHAIN_AUTO_APPROVAL_EVENT_TYPES = new Set([
@@ -51,6 +52,9 @@ const MERGE_EVENT_TYPES = new Set([
 ]);
 export const CHAIN_AUTO_APPROVAL_REASON = "auto_approved:chain-policy@1";
 export const CHAIN_AUTO_APPROVAL_ACTOR = "chain-auto-approval";
+export const HANDOFF_AUTO_APPROVAL_REASON =
+  "auto_approved:handoff-dispatch-policy@1";
+export const HANDOFF_AUTO_APPROVAL_ACTOR = "handoff-auto-approval";
 const NEVER_AUTO_APPROVE = new Set(["factory.ship-apply.requested"]);
 
 function policyPath(root = reposRoot()) {
@@ -120,21 +124,29 @@ export function loadChainAutoApprovalPolicy({ root = reposRoot() } = {}) {
   }
 }
 
-/** Build the immutable approval policy embedded in a chain run spec. */
+/**
+ * Build the immutable unattended approval policy embedded in a run spec.
+ * Chain keeps its full closed allowlist. Handoff may reuse it for exactly one
+ * event type: factory.dispatch.requested.
+ */
 export function buildChainApprovalPolicy(
   eventType,
   { source = "operator", policy = loadChainAutoApprovalPolicy() } = {},
 ) {
-  if (source !== CHAIN_APPROVAL_SOURCE) return null;
+  const chain = source === CHAIN_APPROVAL_SOURCE;
+  const handoffDispatch =
+    source === HANDOFF_APPROVAL_SOURCE &&
+    eventType === "factory.dispatch.requested";
+  if (!chain && !handoffDispatch) return null;
   if (policy.allowed.has(eventType)) {
     return {
-      source: CHAIN_APPROVAL_SOURCE,
+      source,
       mode: CHAIN_APPROVAL_MODE_AUTO,
       eventType,
     };
   }
   return {
-    source: CHAIN_APPROVAL_SOURCE,
+    source,
     mode: CHAIN_APPROVAL_MODE_WATCHED,
     eventType,
     reason: policy.reason ?? "event_type_not_allowlisted",
@@ -780,8 +792,11 @@ function eligible(
   policy,
   { dispatchEligibility, dispatch, now, hooks, hookTimeoutMs },
 ) {
-  if (candidate.event_source !== CHAIN_APPROVAL_SOURCE)
-    return "event_source_not_chain";
+  const isChain = candidate.event_source === CHAIN_APPROVAL_SOURCE;
+  const isHandoff = candidate.event_source === HANDOFF_APPROVAL_SOURCE;
+  if (!isChain && !isHandoff) return "event_source_not_unattended";
+  if (isHandoff && candidate.event_type !== "factory.dispatch.requested")
+    return "handoff_event_type_not_dispatch";
 
   let envelope;
   try {
@@ -799,7 +814,7 @@ function eligible(
 
   const approvalPolicy = runSpec?.approvalPolicy;
   if (!approvalPolicy) return "run_approval_policy_missing";
-  if (approvalPolicy.source !== CHAIN_APPROVAL_SOURCE)
+  if (approvalPolicy.source !== candidate.event_source)
     return "run_approval_policy_source_unknown";
   if (approvalPolicy.mode !== CHAIN_APPROVAL_MODE_AUTO)
     return `run_approval_policy_${approvalPolicy.mode}`;
@@ -809,13 +824,15 @@ function eligible(
   if (!policy.allowed.has(candidate.event_type))
     return policy.reason ?? "policy_unknown";
 
-  const predecessorReason = chainPredecessorReason(
-    db,
-    registry,
-    candidate,
-    envelope,
-  );
-  if (predecessorReason) return predecessorReason;
+  if (isChain) {
+    const predecessorReason = chainPredecessorReason(
+      db,
+      registry,
+      candidate,
+      envelope,
+    );
+    if (predecessorReason) return predecessorReason;
+  }
 
   const mergeReason = mergeEligibility(
     db,
@@ -981,7 +998,8 @@ async function runPass(
          FROM proposals p
          JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
          JOIN runs r ON r.run_id = p.run_id
-        WHERE p.status = 'open' AND p.decision = 'run' AND e.source = 'chain'
+        WHERE p.status = 'open' AND p.decision = 'run'
+          AND e.source IN ('chain', 'handoff')
         ORDER BY p.created_at, p.rowid`,
         )
         .all();
@@ -1030,9 +1048,14 @@ async function runPass(
           continue;
         }
         try {
+          const handoff = row.event_source === HANDOFF_APPROVAL_SOURCE;
           const outcome = approveProposal(db, registry, row.id, {
-            actor: CHAIN_AUTO_APPROVAL_ACTOR,
-            reason: CHAIN_AUTO_APPROVAL_REASON,
+            actor: handoff
+              ? HANDOFF_AUTO_APPROVAL_ACTOR
+              : CHAIN_AUTO_APPROVAL_ACTOR,
+            reason: handoff
+              ? HANDOFF_AUTO_APPROVAL_REASON
+              : CHAIN_AUTO_APPROVAL_REASON,
             now,
             policyVersion,
           });

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1031,6 +1031,94 @@ describe("chain auto approval (WM-357)", () => {
     expect(reasons).toContain("escalate_paths_intersect");
   });
 
+  test("handoff dispatch reuses evidence, hooks, runtime guard, and execute-time recheck", async () => {
+    const safeDb = openDb(":memory:");
+    const safeEvidence = {
+      ticket: { labels: ["ai:agent-ready"] },
+      escalatePathIntersections: [],
+    };
+    const safe = seed(safeDb, {
+      id: "handoff-safe",
+      source: "handoff",
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket: "WM-1153" },
+      approvalPolicy: {
+        source: "handoff",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: safeEvidence,
+      },
+    });
+    let guardCalls = 0;
+    const safeResult = await auto(safeDb, {
+      dispatchEligibility: () => ({ ok: true, evidence: safeEvidence }),
+      runtimeGuard: () => {
+        guardCalls += 1;
+        return null;
+      },
+    });
+    expect(safeResult.approved).toEqual([
+      { proposalId: safe.id, runId: safe.runId },
+    ]);
+    expect(guardCalls).toBe(1);
+
+    const changedDb = openDb(":memory:");
+    const changed = seed(changedDb, {
+      id: "handoff-changed",
+      source: "handoff",
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket: "WM-1154" },
+      approvalPolicy: {
+        source: "handoff",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: safeEvidence,
+      },
+    });
+    const changedResult = await auto(changedDb, {
+      dispatchEligibility: () => ({
+        ok: true,
+        evidence: {
+          ticket: { labels: ["ai:agent-ready"], descriptionHash: "changed" },
+          escalatePathIntersections: [],
+        },
+      }),
+      runtimeGuard: () => null,
+    });
+    expect(changedResult.approved).toEqual([]);
+    expect(runState(changedDb, changed.runId)).toBe("PROPOSED");
+    expect(openProposals(changedDb, {})[0].reason).toContain(
+      "evidence_changed_since_plan",
+    );
+
+    const sensitiveDb = openDb(":memory:");
+    const sensitiveEvidence = {
+      ticket: { labels: ["ai:agent-ready", "ai:escalated"] },
+      escalatePathIntersections: [],
+    };
+    const sensitive = seed(sensitiveDb, {
+      id: "handoff-sensitive",
+      source: "handoff",
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket: "WM-1155" },
+      approvalPolicy: {
+        source: "handoff",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: sensitiveEvidence,
+      },
+    });
+    const sensitiveResult = await auto(sensitiveDb, {
+      dispatchEligibility: () => ({ ok: true, evidence: sensitiveEvidence }),
+      runtimeGuard: () => null,
+    });
+    expect(sensitiveResult.approved).toEqual([]);
+    expect(runState(sensitiveDb, sensitive.runId)).toBe("PROPOSED");
+    expect(openProposals(sensitiveDb, {})[0].reason).toContain(
+      "escalated_or_security",
+    );
+  });
+
   test("a spoofed chain event without a durable registered predecessor remains watched", async () => {
     const db = openDb(":memory:");
     const spoofed = seed(db, {

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   chmodSync,
   cpSync,
+  existsSync,
   mkdirSync,
   readFileSync,
   realpathSync,
@@ -12,6 +13,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { packExtension } from "../cli/extensions.mjs";
 import { createAdapterRegistry } from "./adapters/index.mjs";
 import { RUNTIME_ROOT, resolveConfigPath } from "./config.mjs";
 import { openDb } from "./db.mjs";
@@ -1710,6 +1712,75 @@ describe("extension packages (WM-922)", () => {
     );
   });
 
+  test("extensions pack rejects mismatched or incomplete npm metadata", () => {
+    const dir = tempExtension();
+    writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "@test/pack-ext",
+        version: "0.1.0",
+        type: "module",
+        files: ["factory-extension.json", "pack", "adapters"],
+      }),
+    );
+    const diagnostics = [];
+    for (const report of [
+      [{ name: "factory/sample", version: "1.0.0", files: [] }],
+      [{ name: "@test/pack-ext", version: "0.1.0" }],
+      [{}],
+    ]) {
+      expect(() =>
+        packExtension(dir, {
+          spawn: () => ({
+            status: 0,
+            stdout: JSON.stringify(report),
+            stderr: "",
+          }),
+          exit: (code) => {
+            throw new Error(`exit:${code}`);
+          },
+          error: (message) => diagnostics.push(message),
+        }),
+      ).toThrow("exit:1");
+    }
+    expect(diagnostics.join("\n")).toContain("npm_pack_metadata_invalid");
+    expect(diagnostics.join("\n")).toContain("@test/pack-ext@0.1.0");
+  });
+
+  test("extensions pack uses an isolated npm cache and explicit target", () => {
+    const dir = tempExtension();
+    writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "@test/pack-ext", version: "0.1.0" }),
+    );
+    let invocation;
+    packExtension(dir, {
+      spawn: (command, args, options) => {
+        invocation = { command, args, options };
+        return {
+          status: 0,
+          // Workspace-aware npm may key the one metadata object by package.
+          stdout: JSON.stringify({
+            "@test/pack-ext": {
+              name: "@test/pack-ext",
+              version: "0.1.0",
+              files: [{ path: "package.json" }],
+            },
+          }),
+          stderr: "",
+        };
+      },
+    });
+    expect(invocation.command).toBe("npm");
+    expect(invocation.args).toContain(".");
+    expect(invocation.args).toContain("--cache");
+    expect(invocation.args).toContain("--ignore-scripts");
+    const cache = invocation.args[invocation.args.indexOf("--cache") + 1];
+    expect(cache).toContain("factory-npm-pack-");
+    expect(existsSync(cache)).toBe(false);
+    expect(invocation.options.cwd).toBe(dir);
+  });
+
   test("extensions pack validates then lists npm pack --dry-run files", () => {
     const dir = tempExtension();
     writeFileSync(
@@ -1727,7 +1798,11 @@ describe("extension packages (WM-922)", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    expect(packed.exitCode).toBe(0);
+    if (packed.exitCode !== 0) {
+      throw new Error(
+        `extensions pack CLI exited ${packed.exitCode}: ${packed.stderr.toString().trim() || "no stderr"}`,
+      );
+    }
     // The CLI parses `npm pack --dry-run --json` structurally and prints its
     // own stable summary, so this asserts the code's behavior — not npm's
     // human text, which varies by npm version (object-keyed vs array report).

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -248,7 +248,24 @@ export function translateGitHubEvent({
  *         | { admitted: false, duplicate: true, event: object }
  *         | { admitted: false, duplicate: false, errors: string[] }}
  */
-export const RESERVED_INTERNAL_SOURCES = new Set(["chain"]);
+export const RESERVED_INTERNAL_SOURCES = new Set(["chain", "handoff"]);
+
+function reservedSourceRefusal(envelope, allowed = new Set()) {
+  if (
+    envelope &&
+    typeof envelope === "object" &&
+    !Array.isArray(envelope) &&
+    RESERVED_INTERNAL_SOURCES.has(envelope.source) &&
+    !allowed.has(envelope.source)
+  ) {
+    return {
+      admitted: false,
+      duplicate: false,
+      errors: [`source: reserved internal provenance "${envelope.source}"`],
+    };
+  }
+  return null;
+}
 
 /**
  * Persist an envelope supplied by a public/operator boundary. Reserved runtime
@@ -257,19 +274,18 @@ export const RESERVED_INTERNAL_SOURCES = new Set(["chain"]);
  * the event, rather than untrusted envelope text.
  */
 export function admitExternalEvent(db, registry, envelope, options = {}) {
-  if (
-    envelope &&
-    typeof envelope === "object" &&
-    !Array.isArray(envelope) &&
-    RESERVED_INTERNAL_SOURCES.has(envelope.source)
-  ) {
-    return {
-      admitted: false,
-      duplicate: false,
-      errors: [`source: reserved internal provenance "${envelope.source}"`],
-    };
-  }
-  return admitEvent(db, registry, envelope, options);
+  const refusal = reservedSourceRefusal(envelope);
+  return refusal ?? admitEvent(db, registry, envelope, options);
+}
+
+/**
+ * Persist an envelope after the existing factory HMAC boundary authenticated
+ * its exact bytes. Handoff is the one reserved provenance that boundary may
+ * admit; chain remains in-process-only and caller text can never select it.
+ */
+export function admitSignedEvent(db, registry, envelope, options = {}) {
+  const refusal = reservedSourceRefusal(envelope, new Set(["handoff"]));
+  return refusal ?? admitEvent(db, registry, envelope, options);
 }
 
 /**

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { openDb } from "./db.mjs";
-import { admitEvent, admitExternalEvent, verifyWebhook } from "./intake.mjs";
+import {
+  admitEvent,
+  admitExternalEvent,
+  admitSignedEvent,
+  verifyWebhook,
+} from "./intake.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -209,21 +214,50 @@ describe("admitEvent", () => {
     expect(rows.n).toBe(1);
   });
 
-  test("external admission rejects reserved chain provenance before persistence", () => {
+  test("external admission rejects all reserved provenance before persistence", () => {
+    for (const source of ["chain", "handoff"]) {
+      const db = openDb(":memory:");
+      const result = admitExternalEvent(
+        db,
+        registry,
+        envelope({ source, causationId: "forged-parent" }),
+        { now: NOW },
+      );
+
+      expect(result).toEqual({
+        admitted: false,
+        duplicate: false,
+        errors: [`source: reserved internal provenance "${source}"`],
+      });
+      expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+    }
+  });
+
+  test("authenticated signed admission may admit handoff but still rejects chain", () => {
     const db = openDb(":memory:");
-    const result = admitExternalEvent(
+    const handoff = admitSignedEvent(
       db,
       registry,
-      envelope({ source: "chain", causationId: "forged-parent" }),
+      envelope({ source: "handoff", eventId: "handoff-1" }),
       { now: NOW },
     );
+    expect(handoff.admitted).toBe(true);
 
-    expect(result).toEqual({
+    const chain = admitSignedEvent(
+      db,
+      registry,
+      envelope({
+        source: "chain",
+        eventId: "chain-1",
+        causationId: "forged-parent",
+      }),
+      { now: NOW },
+    );
+    expect(chain).toEqual({
       admitted: false,
       duplicate: false,
       errors: ['source: reserved internal provenance "chain"'],
     });
-    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
   });
 
   test("schema-invalid envelope returns errors and writes no row", () => {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2124,7 +2124,7 @@ export function planEvent(
 
     let approvalPolicy = null;
     let dispatchEvidence = worktreeEligibility?.evidence ?? null;
-    if (envelope.source === "chain") {
+    if (envelope.source === "chain" || envelope.source === "handoff") {
       approvalPolicy = buildChainApprovalPolicy(envelope.type, {
         source: envelope.source,
       });
@@ -2136,7 +2136,9 @@ export function planEvent(
           ? worktreeEligibility
           : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
               ...dispatch,
-              operatorAuthorized: envelope.source === "operator",
+              // Remote handoff is unattended. Only a durable operator event
+              // may exercise the sensitive/escalate-path bypass.
+              operatorAuthorized: false,
             });
         if (!result?.ok) {
           return humanNeeded(

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -995,23 +995,58 @@ describe("planEvent worktree gate (WM-108)", () => {
         }).decision,
       ).toBe("run");
 
-      const chainDb = openDb(":memory:");
-      const chainRef = admit(chainDb, {
-        type: "factory.dispatch.requested",
-        source: "chain",
-        eventId: "chain-security-dispatch",
-        correlationId: "chain-security-dispatch",
-        causationId: "run-parent",
-        payload: { repo: "tiered", ticket: "WM-694" },
-      });
-      expect(
-        planEvent(chainDb, registry, chainRef, {
+      for (const source of ["chain", "handoff"]) {
+        const unattendedDb = openDb(":memory:");
+        const unattendedRef = admit(unattendedDb, {
+          type: "factory.dispatch.requested",
+          source,
+          eventId: `${source}-security-dispatch`,
+          correlationId: `${source}-security-dispatch`,
+          causationId: source === "chain" ? "run-parent" : null,
+          payload: { repo: "tiered", ticket: "WM-694" },
+        });
+        expect(
+          planEvent(unattendedDb, registry, unattendedRef, {
+            now: NOW,
+            policyVersion: "git:test",
+            dispatch: securityDispatch,
+          }),
+        ).toMatchObject({ decision: "noop", reason: "ticket_security" });
+      }
+    });
+  });
+
+  test("eligible handoff dispatch pins auto-approval evidence without operator authorization", () => {
+    withReposRoot(
+      tierRepo,
+      () => {
+        const db = openDb(":memory:");
+        const ref = admit(db, {
+          type: "factory.dispatch.requested",
+          source: "handoff",
+          eventId: "handoff-safe-dispatch",
+          correlationId: "handoff-safe-dispatch",
+          causationId: null,
+          payload: { repo: "tiered", ticket: "WM-694" },
+        });
+        const outcome = planEvent(db, registry, ref, {
           now: NOW,
           policyVersion: "git:test",
-          dispatch: securityDispatch,
-        }),
-      ).toMatchObject({ decision: "noop", reason: "ticket_security" });
-    });
+          dispatch: tierDispatch(),
+        });
+        expect(outcome.decision).toBe("run");
+        const spec = JSON.parse(outcome.proposal.spec_json);
+        expect(spec.approvalPolicy).toMatchObject({
+          source: "handoff",
+          mode: "auto",
+          eventType: "factory.dispatch.requested",
+          dispatchEvidence: {
+            checks: { operator_authorized: false },
+          },
+        });
+      },
+      "chain_auto_approval:\n  allowed_event_types:\n    - factory.dispatch.requested\n",
+    );
   });
 
   test("dispatch.security_tickets: auto admits a chain security dispatch, held for human merge (WM-1060)", () => {

--- a/event-runtime/pins.json
+++ b/event-runtime/pins.json
@@ -22,6 +22,7 @@
       "commands/factory-unblock.md": "sha256:496bffc002afea8eca9d6c1b80f38c6732eb2163f3e41f6d04f0357c4e2905cb",
       "commands/factory-work.md": "sha256:e617db40b00227ed180884bbe005f57a264f3d5dbae48bb9743777ef7b092693",
       "floor.md": "sha256:b24b46d2e4766a288e056d525d9286bfca21dbe9ae837f820e5fb98f00f95460",
+      "skills/factory-handoff/SKILL.md": "sha256:c6e452e33a8101cd4fdca70f650c52b626688a5555826039ebfac26847de8fd9",
       "skills/ticket-spec/SKILL.md": "sha256:6cd7e613072a1f4bd360389b62f3482432cbeb167b1e34b27b4a6099d4685b23"
     }
   }

--- a/plugins/core/skills/factory-handoff/SKILL.md
+++ b/plugins/core/skills/factory-handoff/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: factory-handoff
+description: Hand one exact agent-ready ticket to the central Factory runtime over the configured SSH forced-command boundary. Use when an operator asks to hand off an existing ticket or a prose request instead of implementing it in the current session.
+---
+
+# Remote Factory handoff
+
+Handoff means **capture/specify here, execute centrally**. Never claim the ticket, create a worktree, spawn an implementation subagent, or begin the implementation in this session.
+
+## Existing ticket identifier
+
+1. Resolve the current repository through Factory's configured repo registry.
+2. Read the ticket and confirm it is dispatchable: `Todo`, `ai:agent-ready`, unassigned, and complete under the five-section protocol (Problem & Context, Acceptance Criteria, Source File Pointers, Owned Paths, Verification Command). Do not "repair" an ambiguous ticket by guessing.
+3. If it is not ready, apply the `ticket-spec` skill: explore read-only, complete only derivable sections, verify the command exists/runs, and promote only when the specification is falsifiable. A genuine product decision remains Triage and is not handed off.
+4. Run the mechanical client with the canonical ticket identifier:
+
+   ```sh
+   factory handoff --repo <configured-short-name> <ticket>
+   ```
+
+   The repo flag may be omitted when cwd is inside the configured checkout or one of its worktrees. GitHub tickets use `OWNER/REPO#N`; Linear tickets use `TEAM-N`.
+
+5. Return the machine receipt's admission/duplicate disposition, event/proposal/run state, and dashboard URL. A watched/refused result is a safe outcome, not permission to start locally.
+
+## Prose request
+
+Follow the existing capture and specification protocols before handoff:
+
+1. Search for duplicates and use the existing ticket when one covers the request.
+2. Otherwise file exactly one meaningful ticket with `source:human`, the correct repo/team/project and taxonomy, and the five complete sections only when supported by code evidence.
+3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
+4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
+
+## Retry rule
+
+The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
+
+```sh
+factory handoff --request-id <original-id> --repo <repo> <ticket>
+```
+
+Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.

--- a/shared/skills/factory-handoff/SKILL.md
+++ b/shared/skills/factory-handoff/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: factory-handoff
+description: Hand one exact agent-ready ticket to the central Factory runtime over the configured SSH forced-command boundary. Use when an operator asks to hand off an existing ticket or a prose request instead of implementing it in the current session.
+---
+
+# Remote Factory handoff
+
+Handoff means **capture/specify here, execute centrally**. Never claim the ticket, create a worktree, spawn an implementation subagent, or begin the implementation in this session.
+
+## Existing ticket identifier
+
+1. Resolve the current repository through Factory's configured repo registry.
+2. Read the ticket and confirm it is dispatchable: `Todo`, `ai:agent-ready`, unassigned, and complete under the five-section protocol (Problem & Context, Acceptance Criteria, Source File Pointers, Owned Paths, Verification Command). Do not "repair" an ambiguous ticket by guessing.
+3. If it is not ready, apply the `ticket-spec` skill: explore read-only, complete only derivable sections, verify the command exists/runs, and promote only when the specification is falsifiable. A genuine product decision remains Triage and is not handed off.
+4. Run the mechanical client with the canonical ticket identifier:
+
+   ```sh
+   factory handoff --repo <configured-short-name> <ticket>
+   ```
+
+   The repo flag may be omitted when cwd is inside the configured checkout or one of its worktrees. GitHub tickets use `OWNER/REPO#N`; Linear tickets use `TEAM-N`.
+
+5. Return the machine receipt's admission/duplicate disposition, event/proposal/run state, and dashboard URL. A watched/refused result is a safe outcome, not permission to start locally.
+
+## Prose request
+
+Follow the existing capture and specification protocols before handoff:
+
+1. Search for duplicates and use the existing ticket when one covers the request.
+2. Otherwise file exactly one meaningful ticket with `source:human`, the correct repo/team/project and taxonomy, and the five complete sections only when supported by code evidence.
+3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
+4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
+
+## Retry rule
+
+The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
+
+```sh
+factory handoff --request-id <original-id> --repo <repo> <ticket>
+```
+
+Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.

--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -1,0 +1,500 @@
+#!/usr/bin/env bun
+/**
+ * Remote ticket handoff over a dedicated OpenSSH forced-command boundary.
+ *
+ * Client: `factory handoff [--repo <short-name>] [--host <ssh-alias>] <ticket>`
+ * Server: `factory handoff accept` (the only authorized_keys command)
+ */
+import { createHmac, randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+import { hashJson } from "../event-runtime/lib/canonical.mjs";
+import { loadRepos } from "../event-runtime/lib/repos.mjs";
+
+export const HANDOFF_SCHEMA_VERSION = "factory.handoff/v1";
+export const HANDOFF_RECEIPT_VERSION = "factory.handoff-receipt/v1";
+export const HANDOFF_MAX_BYTES = 4096;
+const REQUEST_FIELDS = new Set([
+  "schemaVersion",
+  "requestId",
+  "repo",
+  "ticket",
+]);
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const REPO_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const LINEAR_TICKET = /^[A-Z][A-Z0-9]{1,9}-[1-9][0-9]{0,9}$/;
+const GITHUB_TICKET = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#[1-9][0-9]{0,9}$/;
+
+export class HandoffError extends Error {
+  constructor(code, message = code) {
+    super(message);
+    this.name = "HandoffError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new HandoffError(code, message);
+}
+
+export function createHandoffRequest({ requestId, repo, ticket }) {
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    requestId,
+    repo,
+    ticket,
+  };
+}
+
+/** Strict, bounded request parsing. Unknown fields are protocol errors. */
+export function validateHandoffRequest(
+  raw,
+  { maxBytes = HANDOFF_MAX_BYTES } = {},
+) {
+  if (typeof raw !== "string") return { ok: false, error: "request_not_text" };
+  if (Buffer.byteLength(raw) > maxBytes)
+    return { ok: false, error: "request_too_large" };
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: "invalid_json" };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return { ok: false, error: "request_not_object" };
+  const keys = Object.keys(value);
+  if (
+    keys.length !== REQUEST_FIELDS.size ||
+    keys.some((key) => !REQUEST_FIELDS.has(key))
+  ) {
+    return { ok: false, error: "request_fields_invalid" };
+  }
+  if (value.schemaVersion !== HANDOFF_SCHEMA_VERSION)
+    return { ok: false, error: "schema_version_invalid" };
+  if (typeof value.requestId !== "string" || !REQUEST_ID.test(value.requestId))
+    return { ok: false, error: "request_id_invalid" };
+  if (typeof value.repo !== "string" || !REPO_NAME.test(value.repo))
+    return { ok: false, error: "repo_invalid" };
+  if (
+    typeof value.ticket !== "string" ||
+    (!LINEAR_TICKET.test(value.ticket) && !GITHUB_TICKET.test(value.ticket))
+  ) {
+    return { ok: false, error: "ticket_invalid" };
+  }
+  return { ok: true, value };
+}
+
+function directoryContains(directory, cwd) {
+  if (!directory) return false;
+  const root = path.resolve(directory);
+  const here = path.resolve(cwd);
+  return here === root || here.startsWith(`${root}${path.sep}`);
+}
+
+/** Resolve the configured short repo name, with an explicit flag taking priority. */
+export function resolveHandoffRepo({ repos, cwd = process.cwd(), repo } = {}) {
+  const registry = repos ?? loadRepos();
+  if (repo) {
+    if (!registry.has(repo))
+      fail("repo_unconfigured", `unconfigured repo ${JSON.stringify(repo)}`);
+    return repo;
+  }
+  let best = null;
+  for (const configured of registry.values()) {
+    for (const directory of [configured.path, configured.worktreeRoot]) {
+      if (!directoryContains(directory, cwd)) continue;
+      const length = path.resolve(directory).length;
+      if (!best || length > best.length)
+        best = { name: configured.name, length };
+    }
+  }
+  if (!best)
+    fail(
+      "repo_unresolved",
+      "cwd is not inside a configured repository; pass --repo <short-name>",
+    );
+  return best.name;
+}
+
+function validateTicketForRepo(ticket, repo) {
+  const github = ticket.match(GITHUB_TICKET);
+  if (repo.controlPlane === "github") {
+    if (!github || !repo.github)
+      fail("ticket_invalid_for_repo", "GitHub repos require OWNER/REPO#N");
+    if (github[1].toLowerCase() !== repo.github.toLowerCase())
+      fail("ticket_repo_mismatch", "ticket does not belong to requested repo");
+    return;
+  }
+  if (github) {
+    if (!repo.github || github[1].toLowerCase() !== repo.github.toLowerCase())
+      fail("ticket_repo_mismatch", "ticket does not belong to requested repo");
+    return;
+  }
+  if (!LINEAR_TICKET.test(ticket))
+    fail("ticket_invalid_for_repo", "invalid ticket identifier");
+  if (repo.team && !ticket.startsWith(`${repo.team}-`))
+    fail("ticket_repo_mismatch", "ticket does not belong to requested repo");
+}
+
+async function responseJson(response, code) {
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    fail(code, `${code}: runtime returned non-JSON`);
+  }
+  if (!response.ok) {
+    const reason =
+      body?.error ?? body?.errors?.join("; ") ?? `HTTP ${response.status}`;
+    fail(code, `${code}: ${reason}`);
+  }
+  return body;
+}
+
+async function runtimeState(fetchImpl, eventUrl, eventId, controlApiToken) {
+  const auth = controlApiToken
+    ? { headers: { authorization: `Bearer ${controlApiToken}` } }
+    : undefined;
+  let before = null;
+  const seenCursors = new Set();
+  let event;
+  while (true) {
+    const suffix = before
+      ? `&before=${encodeURIComponent(before)}`
+      : "";
+    const list = await responseJson(
+      await fetchImpl(`${eventUrl}/events?limit=100${suffix}`, auth),
+      "runtime_status_failed",
+    );
+    event = list?.events?.find(
+      (item) => item.source === "handoff" && item.eventId === eventId,
+    );
+    if (event) break;
+    if (!list?.nextBefore || seenCursors.has(list.nextBefore)) return null;
+    seenCursors.add(list.nextBefore);
+    before = list.nextBefore;
+  }
+
+  let proposalState = null;
+  let runState = null;
+  if (event.proposalId) {
+    const detail = await responseJson(
+      await fetchImpl(
+        `${eventUrl}/proposals/${encodeURIComponent(event.proposalId)}`,
+        auth,
+      ),
+      "runtime_status_failed",
+    );
+    proposalState = detail?.proposal?.status ?? null;
+  }
+  if (event.runId) {
+    const detail = await responseJson(
+      await fetchImpl(
+        `${eventUrl}/runs/${encodeURIComponent(event.runId)}`,
+        auth,
+      ),
+      "runtime_status_failed",
+    );
+    runState = detail?.run?.state ?? null;
+  }
+  return { event, proposalState, runState };
+}
+
+function sameHandoffEnvelope(stored, expected) {
+  return Boolean(
+    stored &&
+      stored.schemaVersion === expected.schemaVersion &&
+      stored.eventId === expected.eventId &&
+      stored.type === expected.type &&
+      stored.source === expected.source &&
+      stored.subject === expected.subject &&
+      stored.correlationId === expected.correlationId &&
+      (stored.causationId ?? null) === (expected.causationId ?? null) &&
+      hashJson(stored.payload) === hashJson(expected.payload),
+  );
+}
+
+/** Forced-command server core: validate, derive, sign, and POST exact bytes. */
+export async function acceptHandoff(
+  raw,
+  {
+    repos = loadRepos(),
+    secret = process.env.FACTORY_EVENT_SECRET || null,
+    eventUrl = process.env.FACTORY_EVENT_URL ||
+      `http://127.0.0.1:${process.env.FACTORY_EVENT_PORT || "7381"}`,
+    dashboardUrl = process.env.FACTORY_DASHBOARD_URL || null,
+    controlApiToken = process.env.FACTORY_CONTROL_API_TOKEN || null,
+    fetchImpl = fetch,
+    now = Date.now(),
+  } = {},
+) {
+  const parsed = validateHandoffRequest(raw);
+  if (!parsed.ok) fail(parsed.error, parsed.error);
+  const request = parsed.value;
+  const repo = repos.get(request.repo);
+  if (!repo) fail("repo_unconfigured", `unconfigured repo ${request.repo}`);
+  if (repo.reportOnly)
+    fail("repo_report_only", `repo ${request.repo} is report-only`);
+  validateTicketForRepo(request.ticket, repo);
+  if (!secret)
+    fail(
+      "event_secret_missing",
+      "FACTORY_EVENT_SECRET is required by the forced-command server",
+    );
+
+  const nowMs = typeof now === "function" ? now() : now;
+  const envelope = {
+    schemaVersion: "factory.event/v1",
+    eventId: request.requestId,
+    type: "factory.dispatch.requested",
+    source: "handoff",
+    subject: request.ticket,
+    occurredAt: new Date(nowMs).toISOString(),
+    correlationId: request.requestId,
+    causationId: null,
+    payload: { repo: request.repo, ticket: request.ticket },
+  };
+  // These exact bytes are both signed and posted. Never canonicalize or rebuild
+  // the body after computing the signature.
+  const body = JSON.stringify(envelope);
+  const timestamp = String(nowMs);
+  const signature = `sha256=${createHmac("sha256", secret)
+    .update(`${timestamp}.${body}`)
+    .digest("hex")}`;
+  const admission = await responseJson(
+    await fetchImpl(`${eventUrl}/events`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-factory-timestamp": timestamp,
+        "x-factory-signature": signature,
+      },
+      body,
+    }),
+    "runtime_admission_failed",
+  );
+  if (
+    typeof admission?.admitted !== "boolean" ||
+    typeof admission?.duplicate !== "boolean" ||
+    admission.eventId !== request.requestId
+  ) {
+    fail("runtime_receipt_invalid", "runtime admission receipt is invalid");
+  }
+
+  let state = null;
+  try {
+    state = await runtimeState(
+      fetchImpl,
+      eventUrl,
+      request.requestId,
+      controlApiToken,
+    );
+  } catch (err) {
+    // Fresh admission is already durable; state enrichment is best-effort.
+    // A duplicate must be bound to its original request, so lookup failures
+    // fail closed instead of returning a misleading retry receipt.
+    if (admission.duplicate) throw err;
+  }
+  if (admission.duplicate) {
+    if (!state?.event)
+      fail(
+        "duplicate_state_unavailable",
+        "duplicate_state_unavailable: original event could not be loaded",
+      );
+    if (!sameHandoffEnvelope(state.event.envelope, envelope))
+      fail(
+        "idempotency_conflict",
+        "idempotency_conflict: requestId belongs to a different handoff",
+      );
+  }
+  return {
+    schemaVersion: HANDOFF_RECEIPT_VERSION,
+    requestId: request.requestId,
+    admitted: admission.admitted,
+    duplicate: admission.duplicate,
+    event: {
+      id: request.requestId,
+      state: state?.event?.status ?? "admitted",
+    },
+    proposal: state?.event?.proposalId
+      ? { id: state.event.proposalId, state: state.proposalState }
+      : null,
+    run: state?.event?.runId
+      ? { id: state.event.runId, state: state.runState }
+      : null,
+    dashboardUrl,
+  };
+}
+
+function validReceipt(value, requestId) {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    value.schemaVersion === HANDOFF_RECEIPT_VERSION &&
+    value.requestId === requestId &&
+    typeof value.admitted === "boolean" &&
+    typeof value.duplicate === "boolean" &&
+    value.event?.id === requestId &&
+    typeof value.event?.state === "string",
+  );
+}
+
+function validateSshHost(host) {
+  if (
+    typeof host !== "string" ||
+    host.length === 0 ||
+    host.startsWith("-") ||
+    host.trim() !== host ||
+    /[\0\r\n]/.test(host)
+  ) {
+    fail("ssh_host_invalid", "ssh_host_invalid");
+  }
+}
+
+export function sshProcess(host, input) {
+  validateSshHost(host);
+  return new Promise((resolve, reject) => {
+    const child = spawn("ssh", ["--", host], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (exitCode) =>
+      resolve({ exitCode: exitCode ?? 1, stdout, stderr }),
+    );
+    child.stdin.end(input);
+  });
+}
+
+/** Send one strict request. No remote command is supplied: sshd forces accept. */
+export async function sendHandoff(request, { host, ssh = sshProcess } = {}) {
+  if (!host) fail("ssh_host_missing", "set --host or FACTORY_HANDOFF_SSH_HOST");
+  validateSshHost(host);
+  const validation = validateHandoffRequest(JSON.stringify(request));
+  if (!validation.ok) fail(validation.error, validation.error);
+  const result = await ssh(host, JSON.stringify(request));
+  let parsed;
+  try {
+    parsed = result.stdout ? JSON.parse(result.stdout) : null;
+  } catch {
+    fail("receipt_invalid", "invalid receipt from handoff server");
+  }
+  if (result.exitCode !== 0) {
+    const message =
+      parsed?.error ??
+      parsed?.message ??
+      result.stderr?.trim() ??
+      "remote handoff failed";
+    fail("remote_handoff_failed", message);
+  }
+  if (!validReceipt(parsed, request.requestId))
+    fail("receipt_invalid", "invalid receipt from handoff server");
+  return parsed;
+}
+
+async function readBoundedStdin(limit = HANDOFF_MAX_BYTES) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of process.stdin) {
+    const buffer = Buffer.from(chunk);
+    bytes += buffer.length;
+    if (bytes > limit) fail("request_too_large", "request_too_large");
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const HELP = `factory handoff — send one agent-ready ticket to central Factory
+
+Usage:
+  factory handoff [--repo <short-name>] [--host <ssh-alias>] [--request-id <id>] <ticket>
+  factory handoff accept
+
+The client sends only factory.handoff/v1 JSON through SSH. The accept form is
+for a dedicated authorized_keys forced command and reads one bounded document
+from stdin.
+`;
+
+export function assertForcedCommandEnvironment(env = process.env) {
+  if (typeof env.SSH_ORIGINAL_COMMAND === "string" && env.SSH_ORIGINAL_COMMAND) {
+    fail(
+      "ssh_original_command_forbidden",
+      "ssh_original_command_forbidden: the handoff client must not supply a remote command",
+    );
+  }
+}
+
+async function main(argv = process.argv.slice(2)) {
+  if (argv[0] === "accept") {
+    if (argv.length !== 1)
+      fail("accept_arguments_forbidden", "accept takes no arguments");
+    assertForcedCommandEnvironment();
+    const receipt = await acceptHandoff(await readBoundedStdin());
+    process.stdout.write(`${JSON.stringify(receipt)}\n`);
+    return;
+  }
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      repo: { type: "string" },
+      host: { type: "string" },
+      "request-id": { type: "string" },
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (positionals.length !== 1)
+    fail("ticket_required", "exactly one ticket identifier is required");
+  const repos = loadRepos();
+  const repo = resolveHandoffRepo({ repos, repo: values.repo });
+  const request = createHandoffRequest({
+    requestId: values["request-id"] ?? `handoff-${randomUUID()}`,
+    repo,
+    ticket: positionals[0],
+  });
+  const receipt = await sendHandoff(request, {
+    host: values.host ?? process.env.FACTORY_HANDOFF_SSH_HOST,
+  });
+  if (values.json) {
+    console.log(JSON.stringify(receipt));
+    return;
+  }
+  const disposition = receipt.duplicate ? "duplicate" : "admitted";
+  console.log(`Handoff ${disposition}: ${receipt.requestId}`);
+  console.log(`Event: ${receipt.event.state}`);
+  if (receipt.proposal)
+    console.log(
+      `Proposal: ${receipt.proposal.id} (${receipt.proposal.state ?? "pending"})`,
+    );
+  if (receipt.run)
+    console.log(`Run: ${receipt.run.id} (${receipt.run.state ?? "pending"})`);
+  if (receipt.dashboardUrl) console.log(`Dashboard: ${receipt.dashboardUrl}`);
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    const body = {
+      schemaVersion: "factory.handoff-error/v1",
+      error: err?.code ?? "handoff_failed",
+      message: String(err?.message ?? err),
+    };
+    // Forced-command clients need one machine-readable failure. No environment
+    // values (especially the signing secret) are projected into this object.
+    process.stdout.write(`${JSON.stringify(body)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -162,9 +162,7 @@ async function runtimeState(fetchImpl, eventUrl, eventId, controlApiToken) {
   const seenCursors = new Set();
   let event;
   while (true) {
-    const suffix = before
-      ? `&before=${encodeURIComponent(before)}`
-      : "";
+    const suffix = before ? `&before=${encodeURIComponent(before)}` : "";
     const list = await responseJson(
       await fetchImpl(`${eventUrl}/events?limit=100${suffix}`, auth),
       "runtime_status_failed",
@@ -206,14 +204,14 @@ async function runtimeState(fetchImpl, eventUrl, eventId, controlApiToken) {
 function sameHandoffEnvelope(stored, expected) {
   return Boolean(
     stored &&
-      stored.schemaVersion === expected.schemaVersion &&
-      stored.eventId === expected.eventId &&
-      stored.type === expected.type &&
-      stored.source === expected.source &&
-      stored.subject === expected.subject &&
-      stored.correlationId === expected.correlationId &&
-      (stored.causationId ?? null) === (expected.causationId ?? null) &&
-      hashJson(stored.payload) === hashJson(expected.payload),
+    stored.schemaVersion === expected.schemaVersion &&
+    stored.eventId === expected.eventId &&
+    stored.type === expected.type &&
+    stored.source === expected.source &&
+    stored.subject === expected.subject &&
+    stored.correlationId === expected.correlationId &&
+    (stored.causationId ?? null) === (expected.causationId ?? null) &&
+    hashJson(stored.payload) === hashJson(expected.payload),
   );
 }
 
@@ -424,7 +422,10 @@ from stdin.
 `;
 
 export function assertForcedCommandEnvironment(env = process.env) {
-  if (typeof env.SSH_ORIGINAL_COMMAND === "string" && env.SSH_ORIGINAL_COMMAND) {
+  if (
+    typeof env.SSH_ORIGINAL_COMMAND === "string" &&
+    env.SSH_ORIGINAL_COMMAND
+  ) {
     fail(
       "ssh_original_command_forbidden",
       "ssh_original_command_forbidden: the handoff client must not supply a remote command",

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -1,0 +1,371 @@
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+
+import {
+  HANDOFF_MAX_BYTES,
+  acceptHandoff,
+  assertForcedCommandEnvironment,
+  createHandoffRequest,
+  resolveHandoffRepo,
+  sendHandoff,
+  validateHandoffRequest,
+} from "./handoff.mjs";
+
+const REQUEST = {
+  schemaVersion: "factory.handoff/v1",
+  requestId: "handoff-1153-test",
+  repo: "factory",
+  ticket: "watt-mind/factory#1153",
+};
+
+const repos = new Map([
+  [
+    "factory",
+    {
+      name: "factory",
+      path: "/work/factory",
+      worktreeRoot: "/work/worktrees/factory",
+      github: "watt-mind/factory",
+      controlPlane: "github",
+      reportOnly: false,
+    },
+  ],
+  [
+    "reports",
+    {
+      name: "reports",
+      path: "/work/reports",
+      worktreeRoot: null,
+      github: "watt-mind/reports",
+      controlPlane: "github",
+      reportOnly: true,
+    },
+  ],
+]);
+
+describe("strict handoff request", () => {
+  test("contains only the four protocol fields", () => {
+    expect(
+      createHandoffRequest({
+        requestId: REQUEST.requestId,
+        repo: REQUEST.repo,
+        ticket: REQUEST.ticket,
+      }),
+    ).toEqual(REQUEST);
+  });
+
+  test("rejects unknown/missing fields, invalid identifiers, and oversized input", () => {
+    const cases = [
+      { ...REQUEST, source: "operator" },
+      { ...REQUEST, schemaVersion: "factory.event/v1" },
+      { ...REQUEST, requestId: "spaces are invalid" },
+      { ...REQUEST, repo: "../factory" },
+      { ...REQUEST, ticket: "not-an-issue" },
+    ];
+    for (const value of cases) {
+      expect(validateHandoffRequest(JSON.stringify(value)).ok).toBe(false);
+    }
+    expect(validateHandoffRequest("{").ok).toBe(false);
+    expect(validateHandoffRequest("x".repeat(HANDOFF_MAX_BYTES + 1)).ok).toBe(
+      false,
+    );
+  });
+
+  test("derives the configured repo from cwd and validates explicit names", () => {
+    expect(resolveHandoffRepo({ repos, cwd: "/work/factory/src" })).toBe(
+      "factory",
+    );
+    expect(
+      resolveHandoffRepo({ repos, cwd: "/work/worktrees/factory/GH-1153" }),
+    ).toBe("factory");
+    expect(resolveHandoffRepo({ repos, cwd: "/tmp", repo: "factory" })).toBe(
+      "factory",
+    );
+    expect(() =>
+      resolveHandoffRepo({ repos, cwd: "/tmp", repo: "missing" }),
+    ).toThrow(/unconfigured repo/);
+  });
+});
+
+describe("forced-command accept server", () => {
+  test("derives handoff provenance and signs the exact POST /events bytes", async () => {
+    const calls = [];
+    const secret = "existing-runtime-secret";
+    const now = Date.parse("2026-08-24T12:00:00.000Z");
+    const fetchImpl = async (url, options = {}) => {
+      calls.push({ url, options });
+      let response;
+      if (options.method === "POST") {
+        response = {
+          admitted: true,
+          duplicate: false,
+          eventId: REQUEST.requestId,
+        };
+      } else if (url.endsWith("/proposals/prop-1")) {
+        response = { proposal: { status: "approved" } };
+      } else if (url.endsWith("/runs/run-1")) {
+        response = { run: { state: "QUEUED" } };
+      } else {
+        response = {
+          events: [
+            {
+              source: "handoff",
+              eventId: REQUEST.requestId,
+              status: "planned",
+              proposalId: "prop-1",
+              runId: "run-1",
+            },
+          ],
+        };
+      }
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const receipt = await acceptHandoff(JSON.stringify(REQUEST), {
+      repos,
+      secret,
+      now,
+      fetchImpl,
+      eventUrl: "http://127.0.0.1:7381",
+      dashboardUrl: "https://factory.example.test",
+      controlApiToken: "control-token",
+    });
+
+    const posted = calls[0];
+    expect(posted.url).toBe("http://127.0.0.1:7381/events");
+    const envelope = JSON.parse(posted.options.body);
+    expect(envelope).toEqual({
+      schemaVersion: "factory.event/v1",
+      eventId: REQUEST.requestId,
+      type: "factory.dispatch.requested",
+      source: "handoff",
+      subject: REQUEST.ticket,
+      occurredAt: "2026-08-24T12:00:00.000Z",
+      correlationId: REQUEST.requestId,
+      causationId: null,
+      payload: { repo: "factory", ticket: "watt-mind/factory#1153" },
+    });
+    const timestamp = posted.options.headers["x-factory-timestamp"];
+    const expected = `sha256=${createHmac("sha256", secret)
+      .update(`${timestamp}.${posted.options.body}`)
+      .digest("hex")}`;
+    expect(posted.options.headers["x-factory-signature"]).toBe(expected);
+    for (const call of calls.slice(1)) {
+      expect(call.options.headers.authorization).toBe("Bearer control-token");
+    }
+    expect(receipt).toEqual({
+      schemaVersion: "factory.handoff-receipt/v1",
+      requestId: REQUEST.requestId,
+      admitted: true,
+      duplicate: false,
+      event: { id: REQUEST.requestId, state: "planned" },
+      proposal: { id: "prop-1", state: "approved" },
+      run: { id: "run-1", state: "QUEUED" },
+      dashboardUrl: "https://factory.example.test",
+    });
+  });
+
+  test("rejects unconfigured, report-only, and mismatched ticket repos before HTTP", async () => {
+    let called = false;
+    const options = {
+      repos,
+      secret: "secret",
+      fetchImpl: async () => {
+        called = true;
+        throw new Error("must not fetch");
+      },
+    };
+    for (const request of [
+      { ...REQUEST, repo: "missing" },
+      {
+        ...REQUEST,
+        repo: "reports",
+        ticket: "watt-mind/reports#1",
+      },
+      { ...REQUEST, ticket: "other/repo#1153" },
+    ]) {
+      await expect(
+        acceptHandoff(JSON.stringify(request), options),
+      ).rejects.toThrow();
+    }
+    expect(called).toBe(false);
+  });
+
+  test("paginates event history so retries receive the original run receipt", async () => {
+    const calls = [];
+    const fetchImpl = async (url, options = {}) => {
+      calls.push(url);
+      if (options.method === "POST") {
+        return Response.json({
+          admitted: false,
+          duplicate: true,
+          eventId: REQUEST.requestId,
+        });
+      }
+      if (url.endsWith("/events?limit=100")) {
+        return Response.json({ events: [], nextBefore: "older-page" });
+      }
+      if (url.endsWith("/events?limit=100&before=older-page")) {
+        return Response.json({
+          events: [
+            {
+              source: "handoff",
+              eventId: REQUEST.requestId,
+              status: "planned",
+              proposalId: "prop-old",
+              runId: "run-old",
+              envelope: {
+                schemaVersion: "factory.event/v1",
+                eventId: REQUEST.requestId,
+                type: "factory.dispatch.requested",
+                source: "handoff",
+                subject: REQUEST.ticket,
+                correlationId: REQUEST.requestId,
+                causationId: null,
+                payload: { repo: REQUEST.repo, ticket: REQUEST.ticket },
+              },
+            },
+          ],
+          nextBefore: null,
+        });
+      }
+      if (url.endsWith("/proposals/prop-old"))
+        return Response.json({ proposal: { status: "approved" } });
+      if (url.endsWith("/runs/run-old"))
+        return Response.json({ run: { state: "QUEUED" } });
+      throw new Error(`unexpected URL ${url}`);
+    };
+
+    const receipt = await acceptHandoff(JSON.stringify(REQUEST), {
+      repos,
+      secret: "secret",
+      fetchImpl,
+      now: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+    expect(calls).toContain(
+      "http://127.0.0.1:7381/events?limit=100&before=older-page",
+    );
+    expect(receipt.run).toEqual({ id: "run-old", state: "QUEUED" });
+  });
+
+  test("rejects request-id reuse for a different ticket", async () => {
+    const fetchImpl = async (url, options = {}) => {
+      if (options.method === "POST") {
+        return Response.json({
+          admitted: false,
+          duplicate: true,
+          eventId: REQUEST.requestId,
+        });
+      }
+      if (url.endsWith("/events?limit=100")) {
+        return Response.json({
+          events: [
+            {
+              source: "handoff",
+              eventId: REQUEST.requestId,
+              status: "planned",
+              proposalId: null,
+              runId: null,
+              envelope: {
+                schemaVersion: "factory.event/v1",
+                eventId: REQUEST.requestId,
+                type: "factory.dispatch.requested",
+                source: "handoff",
+                subject: "watt-mind/factory#999",
+                correlationId: REQUEST.requestId,
+                causationId: null,
+                payload: { repo: "factory", ticket: "watt-mind/factory#999" },
+              },
+            },
+          ],
+          nextBefore: null,
+        });
+      }
+      throw new Error(`unexpected URL ${url}`);
+    };
+
+    await expect(
+      acceptHandoff(JSON.stringify(REQUEST), {
+        repos,
+        secret: "secret",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/idempotency_conflict/);
+  });
+
+  test("fails closed without the existing runtime secret", async () => {
+    await expect(
+      acceptHandoff(JSON.stringify(REQUEST), { repos, secret: null }),
+    ).rejects.toThrow(/FACTORY_EVENT_SECRET/);
+  });
+
+  test("rejects a caller-supplied SSH original command", () => {
+    expect(() =>
+      assertForcedCommandEnvironment({ SSH_ORIGINAL_COMMAND: "uname -a" }),
+    ).toThrow(/ssh_original_command_forbidden/);
+    expect(() => assertForcedCommandEnvironment({})).not.toThrow();
+  });
+});
+
+describe("handoff SSH client", () => {
+  test("rejects option-like SSH hosts before spawning ssh", async () => {
+    let called = false;
+    await expect(
+      sendHandoff(REQUEST, {
+        host: "-oProxyCommand=touch /tmp/nope",
+        ssh: async () => {
+          called = true;
+          throw new Error("must not spawn");
+        },
+      }),
+    ).rejects.toThrow(/ssh_host_invalid/);
+    expect(called).toBe(false);
+  });
+
+  test("writes only the strict request and parses a machine receipt", async () => {
+    let invocation;
+    const receipt = {
+      schemaVersion: "factory.handoff-receipt/v1",
+      requestId: REQUEST.requestId,
+      admitted: false,
+      duplicate: true,
+      event: { id: REQUEST.requestId, state: "queued" },
+      proposal: { id: "prop-1", state: "approved" },
+      run: { id: "run-1", state: "QUEUED" },
+      dashboardUrl: null,
+    };
+    const ssh = async (host, input) => {
+      invocation = { host, input };
+      return { exitCode: 0, stdout: JSON.stringify(receipt), stderr: "" };
+    };
+    expect(await sendHandoff(REQUEST, { host: "factory-runner", ssh })).toEqual(
+      receipt,
+    );
+    expect(invocation).toEqual({
+      host: "factory-runner",
+      input: JSON.stringify(REQUEST),
+    });
+  });
+
+  test("surfaces forced-command errors and rejects malformed receipts", async () => {
+    await expect(
+      sendHandoff(REQUEST, {
+        host: "factory-runner",
+        ssh: async () => ({
+          exitCode: 1,
+          stdout: JSON.stringify({ error: "repo_report_only" }),
+          stderr: "",
+        }),
+      }),
+    ).rejects.toThrow(/repo_report_only/);
+    await expect(
+      sendHandoff(REQUEST, {
+        host: "factory-runner",
+        ssh: async () => ({ exitCode: 0, stdout: "not-json", stderr: "" }),
+      }),
+    ).rejects.toThrow(/invalid receipt/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a strict `factory handoff` SSH client and forced-command accept broker
- reserve signed `source=handoff` provenance while keeping replay unable to forge it
- reuse dispatch evidence, hooks, runtime guards, and execute-time rechecks for immediate policy-safe handoff
- ship the first-party handoff skill, generated harness copies, integrity pin, and deployment runbook

## Verification
- `bun test tools/handoff.test.mjs event-runtime/lib/intake.test.mjs event-runtime/lib/api-intake.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/auto-approval.test.mjs --timeout 20000 && bun build/emit.mjs --check` — 168 pass, 730 assertions
- configured repo verify in Linux Bun 1.3.14 environment — 1662 pass, 9 platform skips, 0 fail
- `bun run lint` — pass
- `factory security` — pass
- independent cold review — SHIP after four MAJOR findings were fixed

## Notes
- Bearer authentication and production SSH key provisioning remain explicitly out of scope.
- Follow-up #1159 records the pre-existing macOS `/var` → `/private/var` workspace containment test failure.

Fixes #1153
Fixes #1157
Fixes #1161