### PR TITLE
fix(intake): webhook handler must ack fast and plan async (#1162)

### DIFF
--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -324,6 +324,30 @@ export function mapGitHubEvent({
   return null;
 }
 
+/**
+ * Decouple RESPONDING from PLANNING (WM-1162). A webhook handler must return
+ * 2xx immediately; the plan signal (`onEvent` → serve's `loopTick`, whose
+ * control-plane `gh` calls are blocking `spawnSync`) must run OFF the HTTP
+ * response path, or a single delivery stalls serve's event loop for seconds and
+ * GitHub gives up past its ~10s webhook timeout. We schedule the signal with
+ * `setImmediate` so it fires only after the response has been written to the
+ * socket (the check phase runs after the poll phase's I/O), never awaited before
+ * responding. The event is *persisted* (admitted) before we respond, so if the
+ * process dies between the response and the deferred plan, the tick loop's
+ * periodic re-scan of admitted-but-unplanned events recovers it — the event is
+ * never dropped, only planned slightly later.
+ */
+function planAfterResponse(onEvent, kind = "admitted") {
+  setImmediate(() => {
+    try {
+      onEvent(kind);
+    } catch {
+      // A planning failure must never surface on the already-sent response;
+      // the tick loop re-scans admitted events, so a miss here is recoverable.
+    }
+  });
+}
+
 function admit(db, registry, send, buffer, nowMs, onEvent, parseJson) {
   const parsed = parseJson(buffer);
   if (parsed.error) return send(422, { errors: [parsed.error] });
@@ -332,12 +356,14 @@ function admit(db, registry, send, buffer, nowMs, onEvent, parseJson) {
   });
   if (!outcome.admitted && !outcome.duplicate)
     return send(422, { errors: outcome.errors });
-  if (outcome.admitted) onEvent("admitted");
-  return send(200, {
+  // Respond first, then plan off the response path (WM-1162).
+  const response = send(200, {
     admitted: outcome.admitted,
     duplicate: outcome.duplicate,
     eventId: outcome.event.event_id,
   });
+  if (outcome.admitted) planAfterResponse(onEvent);
+  return response;
 }
 
 export async function handleIntakeApiRoute({
@@ -432,12 +458,14 @@ export async function handleIntakeApiRoute({
     });
     if (!outcome.admitted && !outcome.duplicate)
       return send(422, { errors: outcome.errors });
-    if (outcome.admitted) onEvent("admitted");
-    return send(200, {
+    // Ack GitHub immediately; plan off the response path (WM-1162).
+    const response = send(200, {
       admitted: outcome.admitted,
       duplicate: outcome.duplicate,
       eventId: outcome.event.event_id,
     });
+    if (outcome.admitted) planAfterResponse(onEvent);
+    return response;
   }
 
   if (route === "POST /replay") {

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -51,6 +51,13 @@ const makeServer = async (...args) => {
   return result;
 };
 
+// WM-1162: planning now runs OFF the response path via setImmediate, so the
+// `onEvent("admitted")` wake-up fires after the HTTP response returns. The
+// server and these tests share one event loop, so a single setImmediate hop
+// (scheduled after the server's, which is enqueued during request handling)
+// drains any pending plan signal before we assert on `onEvents`.
+const flushPlanning = () => new Promise((resolve) => setImmediate(resolve));
+
 describe("webhook intake (§14)", () => {
   let s;
   beforeAll(async () => {
@@ -95,6 +102,7 @@ describe("webhook intake (§14)", () => {
       duplicate: false,
       eventId: "hook-1",
     });
+    await flushPlanning(); // planning is deferred off the response path (WM-1162)
     expect(s.onEvents).toEqual(["admitted"]);
 
     const again = await fetch(s.url("/events"), {
@@ -108,6 +116,7 @@ describe("webhook intake (§14)", () => {
       duplicate: true,
       eventId: "hook-1",
     });
+    await flushPlanning();
     expect(s.onEvents).toEqual(["admitted"]); // no second wake-up for a duplicate
   });
 
@@ -400,6 +409,7 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
       });
 
       // Same delivery id again → duplicate, no second wake-up.
+      await flushPlanning(); // drain the first admit's deferred plan (WM-1162)
       const before = s.onEvents.length;
       const again = await postEvent(s, "issues", openIssue(), "d-issue-ready");
       expect(await again.json()).toEqual({
@@ -407,6 +417,7 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
         duplicate: true,
         eventId: "d-issue-ready",
       });
+      await flushPlanning();
       expect(s.onEvents.length).toBe(before);
     } finally {
       s.close();
@@ -834,6 +845,170 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
       });
       expect(res.status).toBe(401);
       expect(githubEventRow(s, "d-issue-forged")).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("webhook ack-fast, plan-async (WM-1162)", () => {
+  const ghSign = (body) =>
+    `sha256=${createHmac("sha256", GH_SECRET).update(body).digest("hex")}`;
+
+  const agentReadyIssue = () => ({
+    action: "labeled",
+    issue: {
+      number: 1162,
+      state: "open",
+      labels: [{ name: "ai:agent-ready" }],
+      assignees: [],
+    },
+    repository: { full_name: "watt-mind/factory" },
+  });
+
+  const postGitHub = (s, event, payload, deliveryId, sig) => {
+    const body = JSON.stringify(payload);
+    return fetch(s.url("/webhooks/github"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": event,
+        "x-github-delivery": deliveryId,
+        "x-hub-signature-256": sig ?? ghSign(body),
+      },
+      body,
+    });
+  };
+
+  // A planner stub standing in for serve's blocking `loopTick`: it records when
+  // planning starts and, after an async sleep, when it finishes. If the handler
+  // (wrongly) awaited planning before responding, the response would be delayed
+  // by SLEEP_MS; the assertions prove it is not.
+  const SLEEP_MS = 500;
+  function sleepingPlanner() {
+    const marks = { startedAt: null, finishedAt: null, calls: 0 };
+    return {
+      marks,
+      onEvent: (kind) => {
+        marks.calls += 1;
+        marks.startedAt = Date.now();
+        setTimeout(() => {
+          marks.finishedAt = Date.now();
+        }, SLEEP_MS);
+      },
+    };
+  }
+
+  test("a signed webhook returns 2xx before the sleeping planner completes, then plans", async () => {
+    const planner = sleepingPlanner();
+    const s = await makeServer({ onEvent: planner.onEvent });
+    try {
+      const started = Date.now();
+      const res = await postGitHub(
+        s,
+        "issues",
+        agentReadyIssue(),
+        "d-1162-ack",
+      );
+      const ackMs = Date.now() - started;
+
+      // Ack is fast and the slow planner has NOT finished on the response path.
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        admitted: true,
+        duplicate: false,
+        eventId: "d-1162-ack",
+      });
+      expect(planner.marks.finishedAt).toBeNull();
+      expect(ackMs).toBeLessThan(SLEEP_MS);
+
+      // The event is persisted (admitted) regardless of planning timing.
+      const row = s.db
+        .query(
+          `SELECT type FROM events WHERE source = 'github' AND event_id = ?`,
+        )
+        .get("d-1162-ack");
+      expect(row.type).toBe("factory.work.requested");
+
+      // Planning runs after the response is sent (off the response path).
+      await flushPlanning();
+      expect(planner.marks.startedAt).not.toBeNull();
+      expect(planner.marks.calls).toBe(1);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("/health stays responsive while a webhook is being processed", async () => {
+    const planner = sleepingPlanner();
+    const s = await makeServer({ onEvent: planner.onEvent });
+    try {
+      // Fire the webhook and a liveness probe without awaiting the webhook first.
+      const webhook = postGitHub(s, "issues", agentReadyIssue(), "d-1162-live");
+      const health = fetch(s.url("/health"));
+      const [wres, hres] = await Promise.all([webhook, health]);
+      expect(wres.status).toBe(200);
+      expect(hres.status).toBe(200);
+      expect((await hres.json()).ok).toBe(true);
+      // Both responses came back before the slow planner could finish.
+      expect(planner.marks.finishedAt).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("bad GitHub signature → 401 and planning is never scheduled (unchanged)", async () => {
+    const planner = sleepingPlanner();
+    const s = await makeServer({ onEvent: planner.onEvent });
+    try {
+      const res = await postGitHub(
+        s,
+        "issues",
+        agentReadyIssue(),
+        "d-1162-badsig",
+        "sha256=deadbeef",
+      );
+      expect(res.status).toBe(401);
+      await flushPlanning();
+      expect(planner.marks.calls).toBe(0);
+      const row = s.db
+        .query(
+          `SELECT type FROM events WHERE source = 'github' AND event_id = ?`,
+        )
+        .get("d-1162-badsig");
+      expect(row).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
+
+  test("a duplicate delivery short-circuits to 2xx and schedules no second plan", async () => {
+    const planner = sleepingPlanner();
+    const s = await makeServer({ onEvent: planner.onEvent });
+    try {
+      const first = await postGitHub(
+        s,
+        "issues",
+        agentReadyIssue(),
+        "d-1162-dupe",
+      );
+      expect((await first.json()).admitted).toBe(true);
+      await flushPlanning();
+      expect(planner.marks.calls).toBe(1);
+
+      const again = await postGitHub(
+        s,
+        "issues",
+        agentReadyIssue(),
+        "d-1162-dupe",
+      );
+      expect(await again.json()).toEqual({
+        admitted: false,
+        duplicate: true,
+        eventId: "d-1162-dupe",
+      });
+      await flushPlanning();
+      expect(planner.marks.calls).toBe(1); // no second wake-up for a duplicate
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1011,6 +1011,9 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
       duplicate: false,
       eventId: "flow-1",
     });
+    // Planning runs off the response path (WM-1162): drain the deferred
+    // setImmediate before asserting the admitted wake-up.
+    await new Promise((resolve) => setImmediate(resolve));
     expect(s.onEvents).toEqual(["admitted"]);
   });
 

--- a/event-runtime/lib/intake-github.test.mjs
+++ b/event-runtime/lib/intake-github.test.mjs
@@ -423,6 +423,9 @@ describe("POST /github route (WM-112)", () => {
       duplicate: false,
       eventId: "d-admit-1",
     });
+    // Planning runs off the response path (WM-1162), so drain the deferred
+    // setImmediate before asserting the wake-up.
+    await new Promise((resolve) => setImmediate(resolve));
     expect(s.onEvents).toEqual(["admitted"]);
 
     const again = await deliver(prPayload(), { deliveryId: "d-admit-1" });
@@ -432,6 +435,7 @@ describe("POST /github route (WM-112)", () => {
       duplicate: true,
       eventId: "d-admit-1",
     });
+    await new Promise((resolve) => setImmediate(resolve));
     expect(s.onEvents).toEqual(["admitted"]); // dedup planned nothing new
 
     const row = s.db


### PR DESCRIPTION
Closes #1162.

## Problem
The `POST /events`, `POST /github` and `POST /webhooks/github` handlers called `onEvent("admitted")` **synchronously before** `send()`. serve's `onEvent` runs `loopTick()`, whose control-plane `gh` calls are blocking `spawnSync`, so a single webhook stalled serve's event loop ~9.6s and GitHub's ~10s webhook timeout was exceeded through Cloudflare (HTTP 500).

## Fix
Decouple **responding** from **planning** in `api-intake.mjs`: verify signature -> admit/persist the event -> return 2xx immediately, then schedule the plan signal with `setImmediate` so it fires *after* the response is written to the socket, never awaited. Signature verification, event mapping, and `x-github-delivery` idempotency are unchanged; a duplicate still short-circuits to 2xx with no wake-up.

Applies to both the factory-scheme intake (`admit()`) and the GitHub intake branch.

## Tradeoff
The event is persisted (admitted) **before** responding, so a crash in the window between the response and the deferred plan is recovered by the tick loop's periodic re-scan of admitted-but-unplanned events — the event is never dropped, only planned slightly later.

## Tests (in api-intake.test.mjs)
- A signed webhook with a sleeping planner stub returns 2xx **before** the stub completes, and the event is admitted; planning runs afterward (off the response path).
- `/health` stays responsive while a webhook is being processed.
- Bad GitHub signature -> 401 with no planning scheduled; duplicate delivery -> 2xx with no second wake-up.
- Existing `onEvents` assertions updated to drain the now-deferred plan via a one-hop `setImmediate` flush.

Owned Paths only: `event-runtime/lib/api-intake.mjs`, `event-runtime/lib/api-intake.test.mjs` (api.mjs/api.test.mjs needed no change).