### PR TITLE
fix(repos): toolchain probe spawns the resolved path, not the bare name (#1116)

### DIFF
--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -370,12 +370,14 @@ version, and checks the constraint. A mismatch is
 and recovery guidance. It happens before claim, workspace creation, dependency
 installation, or model spawn.
 
-`preflightToolchain(repo, {node, which, spawn})` is that check. The only
-subprocess it starts, per declared executable, is `<executable> --version`;
+`preflightToolchain(repo, {node, which, spawn})` is that check. Config declares
+a bare executable name; `which` resolves it on PATH, and the probe then spawns
+that **resolved path** — `<resolved> --version`, exactly one argument, no shell.
 PATH resolution and the probe are injected so the non-mutation property is
-asserted on the argv the real code builds. (Resolution and the probe currently
-perform two independent PATH lookups, so the attestation's `resolved` path and
-the binary that answered can in principle differ — #1116.) A resolution failure is
+asserted on the argv the real code builds. Spawning the resolved path rather
+than the bare name closes a second, independent PATH lookup, so the version the
+attestation reports is provably from the binary its `resolved` path names
+(#1116). A resolution failure is
 `repo_toolchain_missing`; a version that is out of range, unparseable, or
 unobtainable (non-zero exit) is `repo_toolchain_mismatch`, which carries
 `observed` (normalized) and `observedRaw` (the tool's own first line) so an

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -370,7 +370,9 @@ async function defaultSpawn(argv) {
  * an attestation (docs/event-runtime-repos.md §6.2).
  *
  * Non-mutating by construction: the only command built here is
- * `[executable, "--version"]`. There is no install, upgrade, or version-manager
+ * `[resolved, "--version"]` — the PATH-resolved path from `which`, so the
+ * version reported is provably from the binary the attestation names. There is
+ * no install, upgrade, or version-manager
  * path, and adding one would be reopening a §10 decision.
  *
  * A repo with nothing declared is attested `ok` without probing anything —
@@ -413,7 +415,7 @@ export async function preflightToolchain(
     }
 
     const { exitCode, stdout, stderr } = await spawn([
-      executable,
+      resolved,
       TOOLCHAIN_VERSION_ARG,
     ]);
     const output = stdout?.trim() ? stdout : (stderr ?? "");

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -523,9 +523,12 @@ function fakeNode({ versions = {}, missing = [], exitCodes = {} } = {}) {
     },
     spawn: async (argv) => {
       spawnCalls.push(argv);
+      // The production probe spawns the PATH-resolved path (argv[0] is
+      // `/opt/bin/<exe>`), so key the fake's canned output by basename.
+      const key = argv[0].split("/").pop();
       return {
-        exitCode: exitCodes[argv[0]] ?? 0,
-        stdout: versions[argv[0]] ?? "",
+        exitCode: exitCodes[key] ?? 0,
+        stdout: versions[key] ?? "",
         stderr: "",
       };
     },
@@ -821,10 +824,12 @@ describe("preflightToolchain verifies without mutating the host", () => {
     await preflightToolchain(repo, { now, ...node });
 
     expect(node.whichCalls).toEqual(["bun", "node", "git"]);
+    // The probe spawns the PATH-resolved path from `which`, not the bare name,
+    // so the version reported is provably from the binary the attestation names.
     expect(node.spawnCalls).toEqual([
-      ["bun", "--version"],
-      ["node", "--version"],
-      ["git", "--version"],
+      ["/opt/bin/bun", "--version"],
+      ["/opt/bin/node", "--version"],
+      ["/opt/bin/git", "--version"],
     ]);
     // Not just "the expected commands ran" — no install/upgrade verb reached
     // the host under any name. Toolchain preflight validates; it does not
@@ -836,6 +841,37 @@ describe("preflightToolchain verifies without mutating the host", () => {
       expect(argv[1]).toBe("--version");
       expect(mutating.test(argv.join(" "))).toBe(false);
     }
+  });
+
+  test("the probe spawns the resolved path, not the bare name (WM-1116)", async () => {
+    // `which` and `spawn` each resolve PATH independently; if the probe spawned
+    // the bare name it could run a different binary than the one attested. A
+    // `which` that returns a path unrelated to the bare name proves the spawn
+    // used argv[0] = the resolved path, so `resolved` and `observed` describe
+    // the same binary.
+    const repo = repoWith(`    toolchain:\n      bun: ">=1.3 <2"\n`);
+    const spawnCalls = [];
+    const resolvedPath = "/opt/homebrew/Cellar/bun/1.3.14/bin/bun";
+    const node = {
+      which: async () => resolvedPath,
+      spawn: async (argv) => {
+        spawnCalls.push(argv);
+        // Only answer for the resolved path; a bare-name spawn would get "".
+        return {
+          exitCode: 0,
+          stdout: argv[0] === resolvedPath ? "1.3.14\n" : "",
+          stderr: "",
+        };
+      },
+    };
+    const attestation = await preflightToolchain(repo, { now, ...node });
+
+    expect(spawnCalls).toEqual([[resolvedPath, "--version"]]);
+    const [tool] = attestation.tools;
+    expect(tool.resolved).toBe(resolvedPath);
+    expect(tool.observed).toBe("1.3.14");
+    expect(tool.satisfied).toBe(true);
+    expect(attestation.ok).toBe(true);
   });
 
   test("a repo with no toolchain block is attested without touching the host", async () => {


### PR DESCRIPTION
Fixes #1116.

## Problem
`preflightToolchain` (event-runtime/lib/repos.mjs) resolved the executable with `which(executable)` but spawned the **bare name** to probe `--version`. `Bun.which` and `Bun.spawn` each resolve PATH independently, so the attestation could record `resolved: "/opt/homebrew/bin/bun"` while the reported version came from a different binary (PATH ordering, a shim, or on-disk change between calls) — a truthful-looking attestation about the wrong binary.

## Fix
- Probe now spawns the **resolved path**: `spawn([resolved, "--version"])`, so `observed` and `resolved` provably describe the same binary.
- Bare-name config validation and `which(executable)` are unchanged — only what gets spawned changed.
- Non-mutation guarantee preserved: exactly one argument, `--version`, no shell.

## Tests
- Updated the non-mutation test to assert on the resolved argv (`/opt/bin/<exe> --version`) and keep asserting no install verb reaches the host.
- Added a regression test where `which` returns a path unrelated to the bare name, proving the spawn used argv[0] = the resolved path.
- `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/repos.test.mjs` — 57 pass.

Docs (§5) updated to describe spawning the resolved path.