### PR TITLE
fix(ci): cloud-lane jobs tolerate skipped shadow-runner-health (#1122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,23 @@ jobs:
       - name: Formatting check (prettier)
         run: bun run format:check
 
+      # WM-1122: the shadow/verify self-hosted image ships ripgrep, but the
+      # GitHub-hosted ubuntu-latest cloud lane (nightly/fork/force_hosted) does
+      # not. Without it the guard below hits `rg: command not found` and
+      # misreports it as a stale search contract, failing Verify on every
+      # cloud-lane run. Install it only when missing so the self-hosted lane is
+      # untouched.
+      - name: Ensure ripgrep is available
+        if: runner.environment != 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y ripgrep
+          fi
+          rg --version | head -1
+
       - name: Guard host-serialized spawn suites
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,15 @@ jobs:
 
   fast-unit-tests:
     name: Fast unit tests
+    # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
+    # this job is still evaluated when `shadow-runner-health` is intentionally
+    # skipped on the cloud lane (WM-1122). It stays fail-closed: a cancelled
+    # workflow or a failed `route` skips it, and on the self-hosted lane it
+    # still requires a healthy shadow fleet.
     if: >-
       ${{
+        !cancelled() &&
+        needs.route.result == 'success' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
         (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
       }}
@@ -247,8 +254,14 @@ jobs:
     # shared-host contention. Not a required check — required Verify and Fast
     # unit tests exclude this group. A red result here is a flake signal, not
     # a merge blocker.
+    # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
+    # this job still reaches a hosted runner when `shadow-runner-health` is
+    # intentionally skipped on the cloud lane (WM-1122). Same fail-closed guards
+    # as Fast unit tests.
     if: >-
       ${{
+        !cancelled() &&
+        needs.route.result == 'success' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
         (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
       }}
@@ -356,8 +369,16 @@ jobs:
 
   verify:
     name: Full verification
+    # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
+    # this job is still evaluated when `shadow-runner-health` is intentionally
+    # skipped on the cloud lane (WM-1122). It stays fail-closed: a cancelled
+    # workflow or a failed `route` skips it, on the self-hosted lane it still
+    # requires a healthy shadow fleet, and it always still requires successful
+    # fast unit tests.
     if: >-
       ${{
+        !cancelled() &&
+        needs.route.result == 'success' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
         (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success') &&
         needs.fast-unit-tests.result == 'success'


### PR DESCRIPTION
Fixes #1122.

## Root cause
`.github/workflows/ci.yml` gates `shadow-runner-health` to the self-hosted lane (`if: needs.route.outputs.self_hosted == 'true'`), so it is intentionally **skipped** on the cloud lane. `fast-unit-tests`, `timing-bound-tests`, and `verify` all declared `needs: [route, shadow-runner-health, ...]` but their job-level `if:` used **no status-check function**. GitHub therefore applies its implicit `success()` prerequisite on every `needs`, and a *skipped* dependency is not `success` — so those jobs were skipped before their own boolean cloud-lane conditions could take effect. The always-running `required-verify` aggregator then saw `FAST_RESULT=skipped` / `FULL_RESULT=skipped` and failed the required `Verify` check on **every** cloud-lane run (nightly WM-950 schedule, fork PRs, `force_hosted`).

## Fix (commit 1 — the gate)
Prepend two clauses to the `if:` of `fast-unit-tests`, `timing-bound-tests`, and `verify`:

- `!cancelled() &&` — a status-check function, which disables GitHub's implicit `success()` gate so the explicit boolean conditions are actually evaluated when `shadow-runner-health` is skipped.
- `needs.route.result == 'success' &&` — restores the fail-closed behaviour the implicit gate used to provide for a failed/cancelled `route`.

Otherwise unchanged: draft PRs still skip (`draft == false`); the self-hosted lane still requires healthy runners; `verify` still additionally requires `fast-unit-tests.result == 'success'`; cancellation short-circuits via `!cancelled()`. No `runs-on`, route output, event trigger, or runner label changed.

## Fix (commit 2 — cloud-lane provisioning)
Making `verify` actually *run* on ubuntu-latest surfaced a latent gap: the self-hosted image ships `ripgrep`, but the GitHub-hosted `ubuntu-latest` image does not, so the "Guard host-serialized spawn suites" step died with `rg: command not found` (misreported as a stale search contract). Added an "Ensure ripgrep is available" step, guarded `if: runner.environment != 'self-hosted'` and idempotent (`command -v rg`), so trusted internal CI is untouched.

## Validation — the gate is proven
`actionlint` passes. A `workflow_dispatch` run with `force_hosted=true` (run 33259252427, all jobs on ubuntu-latest) now shows:

| Job | Before (develop) | After (this branch) |
|-----|------------------|---------------------|
| Route CI lane | success | success |
| Shadow runner fleet available | skipped | **skipped** (correct) |
| Fast unit tests | **skipped** | **success on ubuntu-latest** |
| Timing-bound tests | **skipped** | **success on ubuntu-latest** |
| Full verification | **skipped** | **runs on ubuntu-latest** (reaches the real tests) |

The dependency-gate root cause is fixed: the cloud-lane test jobs now execute and pass instead of being skipped.

## Known residual — needs a follow-up (outside this ticket's Owned Paths)
With the gate fixed, `Full verification` now runs the real suite on ubuntu-latest for the first time ever and two **pre-existing, hardware-tuned** tests fail on the smaller/shared cloud runner — these are unrelated to this workflow-only diff and live in **test files outside this ticket's Owned Paths** (`.github/workflows/ci.yml`):

- `bin/worktree-checkout.test.mjs:337` — "8 parallel locked_bun_install processes serializes cleanly" asserts all 8 contenders exit 0; one returns exit 1 under fewer vCPUs.
- `event-runtime/web/src/components/RunDetailBlocks.test.tsx` ("artifact position renders the agent's view", WM-455) — 3 React-Testing-Library `waitFor` timeouts under shared-host CPU contention.

Both were tuned against the self-hosted fleet and pass cleanly there. Relaxing them (or gating them off the cloud lane) requires editing those test files, which is out of scope here. Recommend a follow-up ticket to make those two suites cloud-runner-tolerant so the nightly/fork/`force_hosted` `Full verification` goes fully green. This PR fixes the routing/gate root cause the issue diagnosed and the `rg` provisioning gap it exposed.

## Merge status — blocked by a pre-existing red `develop`
`develop` itself is currently failing the required `Verify` check independent of this PR: the self-hosted `Fast unit tests` / `Test event-runtime library` step is red on **WM-824** (`GET /tickets/supply` / `loadLinearSupply` — "Received: 0") and **WM-922** (`extensions pack ... npm pack --dry-run` picks up the repo-root `factory/sample@1.0.0` instead of the test's `@test/pack-ext` fixture). Verified on develop push run 33259182255 (sha 6a3e603a) with the identical failing tests. These live in source/test files outside this ticket's Owned Paths, so they cannot be fixed here; any PR branched off develop inherits the red required check until develop is repaired. This PR is therefore correct and ready but `mergeable_state=blocked` until the pre-existing develop failures are resolved by their own tickets.
