### PR TITLE
perf(control-plane): make gh calls non-blocking (spawnSync stalls serve's event loop) (#1166)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -13,9 +13,10 @@
  *
  * `api` is the seam: `(method, path, { body, query }) => json`, so the
  * contract suite can drive the implementation with a fake tracker and no
- * network. When omitted, `exec` (spawnSync-shaped) wraps `gh`.
+ * network. When omitted, `exec` (a spawnSync-shaped result, but async and
+ * non-blocking — see `ghSpawn`) wraps `gh`.
  */
-import { spawnSync } from "node:child_process";
+import { spawn as spawnProcess } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { byQueueOrder, ControlPlaneError } from "./types.mjs";
@@ -177,6 +178,13 @@ const text = (v) =>
 /**
  * Default `api` implementation: `gh api` / `gh api graphql` via `exec`.
  *
+ * `exec` runs the `gh` subprocess and returns (or resolves to) a
+ * spawnSync-shaped `{ status, stdout, stderr, error }`. The default `ghSpawn`
+ * is an ASYNC, non-blocking spawn: serve's single event loop yields while
+ * `gh` runs instead of stalling in a blocking `spawnSync` (WM-1166). `ghJson`
+ * awaits the result, so a synchronous spawnSync-shaped stub (the tests) and
+ * the async default both work unchanged.
+ *
  * GitHub App auth (WM-1137, Phase 2 of #1136): when the App env vars are set
  * and a fresh cached installation token exists, each `gh` spawn is given
  * `GH_TOKEN` in its child env so `gh` authenticates as the factory's App
@@ -188,10 +196,10 @@ const text = (v) =>
  * never crashes because App auth is misconfigured. The token never appears in
  * a log or error.
  *
- * @param {(cmd: string, args: string[], opts: object) => object} exec
+ * @param {(cmd: string, args: string[], opts: object) => (object|Promise<object>)} exec
  * @param {{ env?: NodeJS.ProcessEnv, resolveToken?: (args: {env: NodeJS.ProcessEnv}) => (string|null) }} [options]
  */
-export function makeGhApi(exec = spawnSync, options = {}) {
+export function makeGhApi(exec = ghSpawn, options = {}) {
   const { env = process.env, resolveToken = readCachedAppToken } = options;
   let warnedAppAuth = false;
   const spawn = (cmd, args, opts) => {
@@ -244,14 +252,75 @@ export function makeGhApi(exec = spawnSync, options = {}) {
   };
 }
 
-function ghJson(exec, args, input) {
+/**
+ * Non-blocking default `exec`: run `gh` via `child_process.spawn` and collect
+ * its result into a spawnSync-shaped `{ status, stdout, stderr, error }` on a
+ * Promise (WM-1166). Unlike `spawnSync`, this yields serve's event loop while
+ * `gh` runs. It reads the same `opts` the previous blocking path used — `env`
+ * (the per-call GH_TOKEN injection) and `input` (graphql `--input -` stdin) —
+ * and reports failures the same way spawnSync did: a non-zero exit as
+ * `status`, an unspawnable `gh` as `error` with `status: null`.
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{ env?: NodeJS.ProcessEnv, input?: string }} [opts]
+ * @returns {Promise<{status: number|null, stdout: string, stderr: string, error: Error|null}>}
+ */
+function ghSpawn(cmd, args, opts = {}) {
+  const { env, input } = opts;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (r) => {
+      if (settled) return;
+      settled = true;
+      resolve(r);
+    };
+    let child;
+    try {
+      child = spawnProcess(cmd, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+        ...(env ? { env } : {}),
+      });
+    } catch (error) {
+      finish({ status: null, stdout: "", stderr: "", error });
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    // A spawn failure (e.g. `gh` not on PATH) fires 'error' and no 'close'.
+    child.on("error", (error) => {
+      finish({ status: null, stdout, stderr, error });
+    });
+    // status is the exit code, or null when the process died on a signal —
+    // exactly spawnSync's `status` semantics.
+    child.on("close", (code) => {
+      finish({ status: code, stdout, stderr, error: null });
+    });
+    if (child.stdin) {
+      // Never let a broken pipe (gh exiting before reading stdin) crash serve.
+      child.stdin.on("error", () => {});
+      if (input != null) child.stdin.write(input);
+      child.stdin.end();
+    }
+  });
+}
+
+async function ghJson(exec, args, input) {
   const r =
-    exec("gh", args, {
+    (await exec("gh", args, {
       encoding: "utf8",
       stdio:
         input != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
       input: input != null ? input : undefined,
-    }) ?? {};
+    })) ?? {};
   const status = r.status ?? r.exitCode ?? null;
   const stdout = text(r.stdout);
   const stderr =
@@ -473,7 +542,7 @@ export function setRepoControlPlaneGithub(root, repo) {
  */
 export function githubControlPlane(options = {}) {
   const {
-    exec = spawnSync,
+    exec = ghSpawn,
     api: apiOpt,
     root,
     repo: repoOpt,

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -2152,3 +2152,175 @@ describe("makeGhApi GitHub App token injection (WM-1137)", () => {
     expect(warnings[0]).not.toContain("ghs_");
   });
 });
+
+describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
+  // The default `gh` runner is now an async, non-blocking spawn. `makeGhApi`
+  // must (a) let concurrent calls overlap instead of serializing the event
+  // loop, and (b) preserve EXACTLY the prior spawnSync behavior — same argv,
+  // same graphql stdin, same status/stdout/stderr handling, identical error
+  // strings, identical JSON parse + invalid-JSON error. These tests drive the
+  // seam with async, Promise-returning stubs (the shape the real default has).
+
+  test("two concurrent calls overlap — the event loop is not serialized", async () => {
+    let active = 0;
+    let maxActive = 0;
+    let releaseAll;
+    const started = [];
+    const gate = new Promise((resolve) => {
+      releaseAll = resolve;
+    });
+    // A deliberately slow stub that does not resolve until BOTH calls are
+    // in-flight. Under the old blocking spawnSync this could never happen:
+    // the second call could not start until the first returned.
+    const exec = (cmd, args) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      started.push(args.join(" "));
+      return gate.then(() => {
+        active -= 1;
+        return { status: 0, stdout: "{}", stderr: "" };
+      });
+    };
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    const p1 = api("GET", "user");
+    const p2 = api("GET", "repos/x/y/issues");
+    // Both spawns registered synchronously before either resolves — proof they
+    // overlap rather than run one-after-another.
+    expect(maxActive).toBe(2);
+    expect(started).toHaveLength(2);
+    releaseAll();
+    expect(await p1).toEqual({});
+    expect(await p2).toEqual({});
+    expect(active).toBe(0);
+  });
+
+  test("a slow first call does not block a second from making progress", async () => {
+    // Order proof: a second, fast call resolves before a slow first one —
+    // impossible if the runner serialized the loop.
+    const order = [];
+    const exec = (cmd, args) =>
+      new Promise((resolve) => {
+        const slow = args.includes("user");
+        setTimeout(
+          () => {
+            order.push(slow ? "slow" : "fast");
+            resolve({ status: 0, stdout: "{}", stderr: "" });
+          },
+          slow ? 40 : 5,
+        );
+      });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    await Promise.all([api("GET", "user"), api("GET", "repos/x/y/issues")]);
+    expect(order).toEqual(["fast", "slow"]);
+  });
+
+  // An async, Promise-returning stub that records argv + stdin and replays a
+  // scripted spawnSync-shaped result.
+  function asyncExec(result) {
+    const calls = [];
+    const exec = async (cmd, args, opts) => {
+      calls.push({ cmd, args, input: opts?.input, opts });
+      return result;
+    };
+    exec.calls = calls;
+    return exec;
+  }
+
+  test("REST argv, method, query string and JSON parse are unchanged", async () => {
+    const exec = asyncExec({ status: 0, stdout: '{"ok":true}', stderr: "" });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    const out = await api("POST", "/repos/x/y/issues", {
+      query: { state: "open", empty: "", skip: null },
+    });
+    expect(out).toEqual({ ok: true });
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].cmd).toBe("gh");
+    // Leading slash stripped, -X for non-GET, blank/null query keys dropped.
+    expect(exec.calls[0].args).toEqual([
+      "api",
+      "-X",
+      "POST",
+      "repos/x/y/issues?state=open",
+    ]);
+    expect(exec.calls[0].input).toBeUndefined();
+  });
+
+  test("a body is sent on stdin via --input -", async () => {
+    const exec = asyncExec({ status: 0, stdout: "{}", stderr: "" });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    await api("PATCH", "repos/x/y/issues/1", { body: { state: "closed" } });
+    expect(exec.calls[0].args).toEqual([
+      "api",
+      "-X",
+      "PATCH",
+      "repos/x/y/issues/1",
+      "--input",
+      "-",
+    ]);
+    expect(exec.calls[0].input).toBe(JSON.stringify({ state: "closed" }));
+  });
+
+  test("graphql uses `graphql --input -` with query+variables on stdin", async () => {
+    const exec = asyncExec({ status: 0, stdout: '{"data":{}}', stderr: "" });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    await api("POST", "graphql", {
+      body: { query: "query{x}", variables: { a: 1 } },
+    });
+    expect(exec.calls[0].args).toEqual(["api", "graphql", "--input", "-"]);
+    expect(JSON.parse(exec.calls[0].input)).toEqual({
+      query: "query{x}",
+      variables: { a: 1 },
+    });
+  });
+
+  test("a non-zero status surfaces the github api message from stdout", async () => {
+    const exec = asyncExec({
+      status: 1,
+      stdout: '{"message":"Not Found"}',
+      stderr: "",
+    });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    await expect(api("GET", "repos/x/y/issues/9")).rejects.toThrow(
+      "github api: Not Found",
+    );
+  });
+
+  test("a non-zero status with no JSON body falls back to stderr text", async () => {
+    const exec = asyncExec({
+      status: 2,
+      stdout: "",
+      stderr: "boom\n",
+    });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    // The message stitches together the first two argv tokens (`api user`) —
+    // the exact spawnSync-era string.
+    await expect(api("GET", "user")).rejects.toThrow(
+      "gh api user failed (status 2): boom",
+    );
+  });
+
+  test("invalid JSON on a 0 status throws the invalid-JSON error", async () => {
+    const exec = asyncExec({ status: 0, stdout: "not json", stderr: "" });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    await expect(api("GET", "user")).rejects.toThrow(
+      "gh api user returned invalid JSON",
+    );
+  });
+
+  test("empty stdout on a 0 status resolves to {}", async () => {
+    const exec = asyncExec({ status: 0, stdout: "", stderr: "" });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    expect(await api("DELETE", "repos/x/y/issues/comments/5")).toEqual({});
+  });
+
+  test("GH_TOKEN injection still lands on the async child env", async () => {
+    const exec = asyncExec({ status: 0, stdout: "{}", stderr: "" });
+    const api = makeGhApi(exec, {
+      env: { PATH: "/usr/bin" },
+      resolveToken: () => "ghs_async",
+    });
+    await api("GET", "user");
+    expect(exec.calls[0].opts.env.GH_TOKEN).toBe("ghs_async");
+    expect(exec.calls[0].opts.env.PATH).toBe("/usr/bin");
+  });
+});


### PR DESCRIPTION
Closes #1166.

## What

`makeGhApi`'s default `gh` runner was a blocking `spawnSync`, so every control-plane GitHub call stalled serve's single event loop for the full duration of the `gh` process. This replaces it with **`ghSpawn`** — an async `child_process.spawn` collected on a Promise — and `ghJson` now `await`s the runner. Both `makeGhApi` and `githubControlPlane` defaults use `ghSpawn`.

## Behavior preserved exactly

- Same argv, same graphql `--input -` stdin, same body-on-stdin path.
- Same `status`/`stdout`/`stderr` handling; identical error strings and JSON parse + invalid-JSON error.
- Same per-call `GH_TOKEN` App-auth injection.
- The injectable `exec` seam stays: because `ghJson` awaits, synchronous spawnSync-shaped stubs (existing tests) still work unchanged. No caller signature changes — `call()` already awaits `api(...)`.

## Tests

Adds a describe proving two concurrent calls against a slow stub overlap (event loop not serialized) plus a fast-before-slow ordering proof, and coverage that argv/method/query, graphql stdin, error strings, JSON parse, invalid-JSON, empty-body, and GH_TOKEN injection are unchanged. `bun test lib/control-plane/github.test.mjs`: 82 pass.