### PR TITLE
fix(triage): detect root-relative agent prompt pin-manifest ownership gaps (#1002)

### DIFF
--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -426,6 +426,55 @@ function matchingManifestPaths(repoPath, manifestGlobs = []) {
   return [...matched].sort();
 }
 
+/**
+ * Normalize a raw pin key into a repository-root-relative path.
+ *
+ * Shipped manifests record their pins relative to the pack root — a manifest at
+ * `event-runtime/agents/triage-scan.json` pins `agents/triage-scan.md`, meaning
+ * `event-runtime/agents/triage-scan.md`. Owned Paths and the manifest path used
+ * for closure are both repo-root-relative, so the raw pack-relative key never
+ * matches and the closure guard silently misses the required manifest. Resolve
+ * the key against the pack root — derived from the manifest's own location
+ * (`<packRoot>/agents/<id>.json`), not a hard-coded `event-runtime` prefix — so
+ * any pack layout normalizes correctly.
+ *
+ * Keys that are already repo-root-relative (they begin with the pack root) are
+ * left untouched, so existing root-relative manifests are not double-prefixed.
+ * A key that normalizes outside the repository (via `..` or an absolute path) is
+ * a manifest/config error and throws — closure is fail-closed around it rather
+ * than silently resolving to a path beyond the repo.
+ */
+function normalizePinPath(pinKey, manifestPath) {
+  const key = String(pinKey ?? "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "");
+  if (!key) return null;
+
+  const manifestRel = String(manifestPath ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "");
+  const packRoot = path.posix.dirname(path.posix.dirname(manifestRel));
+  const rootPrefix = packRoot && packRoot !== "." ? `${packRoot}/` : "";
+
+  const joined =
+    rootPrefix && (key === packRoot || key.startsWith(rootPrefix))
+      ? key
+      : path.posix.join(packRoot, key);
+  const normalized = path.posix.normalize(joined);
+
+  if (
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(
+      `owned-path closure check failed: pin path ${JSON.stringify(pinKey)} in manifest ${manifestPath} normalizes outside the repository (${normalized})`,
+    );
+  }
+  return normalized;
+}
+
 function parsePinnedPaths(manifestPath) {
   let payload;
   try {
@@ -462,7 +511,11 @@ export function readPinManifestRequirements(repoPath, manifestGlobs = []) {
 
   for (const manifest of manifests) {
     const manifestPath = path.join(absoluteRepo, manifest);
-    const pinnedPaths = parsePinnedPaths(manifestPath);
+    // Raw pin keys are pack-root-relative; normalize them against the manifest's
+    // repo-root-relative location so closure compares like-for-like namespaces.
+    const pinnedPaths = parsePinnedPaths(manifestPath)
+      .map((pinKey) => normalizePinPath(pinKey, manifest))
+      .filter(Boolean);
     out.push({ manifestPath: manifest, pinnedPaths });
   }
 

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -305,6 +305,118 @@ test("pin manifests require owning generated output manifests", () => {
   }
 });
 
+// WM-1002: the shipped manifests pin pack-root-relative keys (`agents/*.md`),
+// but Owned Paths and the manifest path are repo-root-relative. Without
+// normalization the closure guard compared mismatched namespaces and never
+// flagged the missing JSON manifest, so a ticket could edit a pinned prompt
+// while lacking ownership of the manifest needed to re-pin it.
+test("pin-manifest gap: shipped layout (agents/*.md keys) flags the missing JSON manifest", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "owned-paths-closure-"));
+  try {
+    mkdirSync(path.join(repo, "event-runtime/agents"), { recursive: true });
+    writeFileSync(
+      path.join(repo, "event-runtime/agents/triage-scan.json"),
+      `${JSON.stringify({
+        pins: {
+          "agents/triage-scan.md": "sha256:aaa",
+          "schemas/triage-scan.input.json": "sha256:bbb",
+        },
+      })}\n`,
+    );
+    const requirements = readPinManifestRequirements(repo, [
+      "event-runtime/agents/*.json",
+    ]);
+    // Pin keys are normalized to repo-root-relative before comparison.
+    expectEqual(requirements, [
+      {
+        manifestPath: "event-runtime/agents/triage-scan.json",
+        pinnedPaths: [
+          "event-runtime/agents/triage-scan.md",
+          "event-runtime/schemas/triage-scan.input.json",
+        ],
+      },
+    ]);
+
+    // Owning the prompt but not its JSON manifest is a pin-manifest gap.
+    expectEqual(
+      ownedPathsClosureGaps({
+        ownedPaths: ["event-runtime/agents/triage-scan.md"],
+        ownedPathsPolicy: {
+          direct: [],
+          pinManifests: ["event-runtime/agents/*.json"],
+        },
+        pinManifestRequirements: requirements,
+      }),
+      [
+        {
+          rule: "pin-manifest",
+          requiredPath: "event-runtime/agents/triage-scan.json",
+          requiredBy: "event-runtime/agents/triage-scan.md",
+          manifestPath: "event-runtime/agents/triage-scan.json",
+        },
+      ],
+    );
+
+    // Owning both the prompt and its manifest satisfies closure.
+    expectEqual(
+      ownedPathsClosureGaps({
+        ownedPaths: [
+          "event-runtime/agents/triage-scan.md",
+          "event-runtime/agents/triage-scan.json",
+        ],
+        ownedPathsPolicy: {
+          direct: [],
+          pinManifests: ["event-runtime/agents/*.json"],
+        },
+        pinManifestRequirements: requirements,
+      }),
+      [],
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("pin-manifest normalization: already-root-relative keys are not double-prefixed", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "owned-paths-closure-"));
+  try {
+    mkdirSync(path.join(repo, "event-runtime/agents"), { recursive: true });
+    writeFileSync(
+      path.join(repo, "event-runtime/agents/triage-scan.json"),
+      `${JSON.stringify({
+        pins: { "event-runtime/schemas/triage-scan.output.json": "sha256:ccc" },
+      })}\n`,
+    );
+    expectEqual(
+      readPinManifestRequirements(repo, ["event-runtime/agents/*.json"]),
+      [
+        {
+          manifestPath: "event-runtime/agents/triage-scan.json",
+          pinnedPaths: ["event-runtime/schemas/triage-scan.output.json"],
+        },
+      ],
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("pin-manifest normalization: an escaping pin path fails closed", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "owned-paths-closure-"));
+  try {
+    mkdirSync(path.join(repo, "event-runtime/agents"), { recursive: true });
+    writeFileSync(
+      path.join(repo, "event-runtime/agents/triage-scan.json"),
+      `${JSON.stringify({ pins: { "../../etc/passwd": "sha256:ddd" } })}\n`,
+    );
+    expect(() =>
+      readPinManifestRequirements(repo, ["event-runtime/agents/*.json"]),
+    ).toThrow(/outside the repository/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("supports level 3 numbered headers (### 2. Owned Paths) and colons", () => {
   const desc = `## 1. Problem & Context
 


### PR DESCRIPTION
Closes #1002.

## Problem

The pin-manifest closure guard read repository-root-relative Owned Paths (e.g. `event-runtime/agents/triage-scan.md`) but `readPinManifestRequirements()` returned raw manifest pin keys (`agents/triage-scan.md`). Because `ownedPathsClosureGaps()` compared those namespaces directly, editing a pinned prompt did not require ownership of its adjacent JSON manifest — a dispatched ticket could pass admission while lacking the manifest path needed to re-pin the changed prompt, then fail `loadRegistry()` closed at runtime.

## Fix

Normalize each pin key into a repository-root-relative path before closure comparison, in `readPinManifestRequirements()`:

- The pack root is derived from the manifest's own location (`<packRoot>/agents/<id>.json`), not a hard-coded `event-runtime` prefix, so any pack layout normalizes correctly.
- Keys that are already root-relative (they begin with the pack root) are left untouched — no double-prefixing.
- A key that normalizes outside the repository (via `..` or an absolute path) throws; closure is fail-closed around it.

## Tests

- Regression fixture matching the shipped layout (`event-runtime/agents/*.json` with `agents/*.md` pin keys): owning the prompt without the JSON manifest produces a `pin-manifest` gap; owning both satisfies closure.
- Already-root-relative pin keys stay un-prefixed.
- An escaping pin path fails closed.

## Verification

```
bun test orchestrator/owned-paths.test.mjs tools/ticket.test.mjs --timeout 20000
```

76 pass, 0 fail. Adjacent consumer suites (dispatch, repos, label-guard) also green.