### PR TITLE
fix(artifacts): canonicalize workspaceRoot so realpath uri does not trigger PathViolation on macOS (#1017)

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -11,7 +11,13 @@
  * evidence checking is slice 2.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { globToRegExp } from "../../orchestrator/owned-paths.mjs";
@@ -1088,6 +1094,13 @@ function verifyCompleted({
 
   const violations = [];
   const collected = [];
+  // `confinedRegularFile` returns a realpath-canonical source, so the workspace
+  // provenance root recorded below must be canonicalized in the same namespace
+  // (WM-1017). On macOS the workspace enters as `/tmp/...` while the artifact
+  // URI resolves to `/private/tmp/...`; recording the unresolved root made
+  // `storeCollected`'s `path.relative(root, src)` escape the lexical root and
+  // reject a valid artifact with a PathViolation. One namespace, both ends.
+  const canonicalWorkspaceRoot = realpathSync(path.resolve(workspaceDir));
   for (const entry of [...declared, ...injected]) {
     let abs;
     try {
@@ -1108,9 +1121,11 @@ function verifyCompleted({
         sha256: sha256Hex(readFileSync(abs)),
       };
       // Internal, non-serializable provenance lets durable storage repeat the
-      // same confinement preflight at its own trust boundary.
+      // same confinement preflight at its own trust boundary. Canonicalized to
+      // match the realpath'd artifact URI so a symlinked workspace parent does
+      // not read as an escape (WM-1017).
       Object.defineProperty(collectedEntry, "workspaceRoot", {
-        value: workspaceDir,
+        value: canonicalWorkspaceRoot,
       });
       collected.push(collectedEntry);
     } catch (err) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -4,10 +4,12 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { storeCollected } from "./artifacts.mjs";
 import { hashJson, sha256Hex } from "./canonical.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import { execFileSync } from "node:child_process";
@@ -801,6 +803,77 @@ describe("verifyResult", () => {
         attempt: 1,
       }),
     ).toThrow(ContractViolation);
+  });
+
+  // WM-1017: on macOS a workspace enters as `/tmp/...` while its realpath is
+  // `/private/tmp/...`. verifyCompleted() must record the workspace provenance
+  // root in the same canonical namespace as the realpath'd artifact URI, or
+  // storeCollected()'s `path.relative(root, src)` escapes the lexical root and
+  // rejects a valid regular artifact with a PathViolation.
+  test("workspace behind a symlinked parent → canonical provenance persists via storeCollected", () => {
+    // A workspace directory reached through a symlinked parent, mimicking the
+    // /tmp → /private/tmp alias without depending on the host's own /tmp.
+    const realParent = tmpDir("evrt-verify-realparent-");
+    const realWorkspace = path.join(realParent, "ws");
+    mkdirSync(path.join(realWorkspace, "logs"), { recursive: true });
+
+    const linkBase = tmpDir("evrt-verify-linkbase-");
+    const aliasedParent = path.join(linkBase, "aliased");
+    symlinkSync(realParent, aliasedParent, "dir");
+    const workspaceDir = path.join(aliasedParent, "ws");
+
+    writeFileSync(
+      path.join(workspaceDir, "result.json"),
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+        artifacts: [{ kind: "log", path: "logs/agent.log" }],
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      path.join(workspaceDir, "logs", "agent.log"),
+      "hello\n",
+      "utf8",
+    );
+
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      attempt: 1,
+    });
+
+    // The URI is spelled in the resolved namespace, not the symlinked alias.
+    const canonicalFile = realpathSync(
+      path.join(workspaceDir, "logs", "agent.log"),
+    );
+    const entry = out.result.artifacts[0];
+    expect(entry.uri).toBe(`file://${canonicalFile}`);
+    expect(entry.uri).not.toContain("aliased");
+    expect(entry.sha256).toBe(sha256Hex("hello\n"));
+
+    // Provenance shares that canonical namespace and stays internal: the
+    // workspaceRoot property is non-enumerable and never serialized.
+    const descriptor = Object.getOwnPropertyDescriptor(entry, "workspaceRoot");
+    expect(descriptor.enumerable).toBe(false);
+    expect(entry.workspaceRoot).toBe(realpathSync(workspaceDir));
+    expect(JSON.stringify(out.result)).not.toContain("workspaceRoot");
+
+    // The end-to-end proof: durable storage repeats confinement against the
+    // canonical root and persists the artifact instead of throwing.
+    const storeRoot = tmpDir("evrt-verify-store-");
+    const stored = storeCollected({
+      entries: out.result.artifacts,
+      storeRoot,
+      workspaceDir,
+    });
+    expect(stored[0].uri).toBe(`file://${path.join(storeRoot, entry.sha256)}`);
+    expect(readFileSync(path.join(storeRoot, entry.sha256), "utf8")).toBe(
+      "hello\n",
+    );
   });
 
   test("declared artifact that does not exist → ContractViolation", () => {


### PR DESCRIPTION
## Summary

Fixes #1017. On macOS where `/tmp` is a symlink to `/private/tmp`, `verifyCompleted()` recorded the collected artifact's internal `workspaceRoot` provenance as the *unresolved* `workspaceDir`, while the artifact `uri` comes from `confinedRegularFile()`'s realpath-canonical source. The two then live in different namespaces, so `storeCollected()`'s `path.relative(root, declaredSrc)` produced a `../../../private/tmp/...` path that escaped the lexical root and rejected a valid regular artifact with a `PathViolation`.

## Fix

`verifyCompleted()` now records the workspace provenance root as `realpathSync(workspaceDir)`, the same canonical namespace as the URI returned by `confinedRegularFile()`. One namespace on both ends, so durable storage's confinement preflight resolves a clean relative path.

## Acceptance

- `verifyCompleted()` records a canonical provenance root consistent with the artifact URI.
- Regression reaches a workspace through a symlinked parent and proves the verified regular artifact persists via `storeCollected()` (fails without the fix, at the store step).
- Absolute / relative / intermediate / final symlink escape protections remain rejected (existing tests untouched).
- `workspaceRoot` stays non-enumerable and is not serialized into the result payload (asserted).
- Linux behavior and existing hashes/URIs unchanged (realpath == lexical when no symlinked parent).

## Verification

```
bun test event-runtime/lib/verify.test.mjs event-runtime/lib/artifacts.test.mjs event-runtime/lib/workspace.test.mjs --timeout 20000
```
101 pass / 0 fail locally.

Owned Paths: `event-runtime/lib/verify.mjs`, `event-runtime/lib/verify.test.mjs` (both touched; no other paths changed).
