### PR TITLE
fix(ci): extensions pack test tolerant of npm --json report shape (WM-1182)

### DIFF
--- a/event-runtime/cli/extensions.mjs
+++ b/event-runtime/cli/extensions.mjs
@@ -12,6 +12,34 @@ import path from "node:path";
 import { validateExtensionManifest } from "../lib/extensions.mjs";
 
 /**
+ * Normalize `npm pack --dry-run --json` into a flat list of report entries,
+ * tolerant of the shape differences between npm versions:
+ *   - older npm returns an array of report objects `[{ name, files, ... }]`;
+ *   - newer npm (>=12) returns an object keyed by package name
+ *     `{ "@scope/name": { name, files, ... } }`;
+ *   - a bare single report object `{ name, files, ... }` is also accepted.
+ * Each returned entry carries `name`/`version`/`files` when npm provides them.
+ *
+ * @param {unknown} report
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function normalizePackReport(report) {
+  if (Array.isArray(report)) return report;
+  if (report && typeof report === "object") {
+    // A single report object exposes its own file list at the top level;
+    // the keyed-by-name shape does not — its entries live under each key.
+    if (Array.isArray(report.files) || "filename" in report || "id" in report) {
+      return [report];
+    }
+    const entries = Object.values(report).filter(
+      (value) => value && typeof value === "object",
+    );
+    if (entries.length) return entries;
+  }
+  return [report];
+}
+
+/**
  * Validate `dir` (filesystem path or package name) and list the files
  * `npm pack --dry-run` would include.
  *
@@ -45,7 +73,7 @@ export function packExtension(
     console.log(packed.stdout);
     return checked;
   }
-  const entries = Array.isArray(report) ? report : [report];
+  const entries = normalizePackReport(report);
   for (const item of entries) {
     const files = item.files ?? [];
     const name = item.name ?? checked.manifest.name;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -6,6 +6,7 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   test,
@@ -1694,6 +1695,17 @@ describe("GET /tickets/:id/detail (WM-914)", () => {
 });
 
 describe("GET /tickets/supply (WM-824)", () => {
+  // Pin a healthy budget so the supply loader exercises its GraphQL path
+  // deterministically. Without this, readBudget() falls back to the on-disk
+  // Linear budget of whatever host runs the suite (the self-hosted CI runner's
+  // real budget is often exhausted), which would non-deterministically short
+  // these tests to `linear_budget_exhausted`. Exhaustion is still exercised
+  // through explicitly-injected budgets in the merge test below.
+  beforeEach(async () => {
+    const { setLinearSupplyBudget } = await import("./linear.mjs");
+    setLinearSupplyBudget({ remaining: 2000, limit: 2500 });
+  });
+
   afterEach(async () => {
     const {
       clearLinearSupplyCache,

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -1728,9 +1728,21 @@ describe("extension packages (WM-922)", () => {
       stderr: "pipe",
     });
     expect(packed.exitCode).toBe(0);
+    // The CLI parses `npm pack --dry-run --json` structurally and prints its
+    // own stable summary, so this asserts the code's behavior — not npm's
+    // human text, which varies by npm version (object-keyed vs array report).
     const text = packed.stdout.toString();
-    expect(text).toMatch(/@test\/pack-ext@0\.1\.0: would pack/);
-    expect(text).toMatch(/factory-extension\.json/);
-    expect(text).toMatch(/package\.json/);
+    const summary = text.match(
+      /@test\/pack-ext@0\.1\.0: would pack (\d+) files/,
+    );
+    expect(summary).not.toBeNull();
+    // A real file set was resolved from the manifest's `files` list, not the
+    // empty/fallback shape a mis-parsed report would yield.
+    expect(Number(summary[1])).toBeGreaterThan(0);
+    // The listing still names each packed path, so a genuinely broken pack
+    // (missing the manifest or a contributed dir) would fail here.
+    expect(text).toMatch(/^ {2}factory-extension\.json$/m);
+    expect(text).toMatch(/^ {2}adapters\/echo\.mjs$/m);
+    expect(text).toMatch(/^ {2}package\.json$/m);
   });
 });

--- a/event-runtime/lib/linear.test.mjs
+++ b/event-runtime/lib/linear.test.mjs
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   TICKET_SUPPLY_CACHE_TTL_MS,
   clearLinearSupplyCache,
@@ -7,6 +7,16 @@ import {
   setLinearSupplyBudget,
   setLinearSupplyGql,
 } from "./linear.mjs";
+
+// Pin a healthy budget by default so loadLinearSupply() exercises its GraphQL
+// path deterministically. readBudget() otherwise falls back to the on-disk
+// Linear budget of whatever host runs the suite (the self-hosted CI runner's
+// real budget is often exhausted), which would non-deterministically short
+// these tests to `linear_budget_exhausted`. The budget-exhaustion case is
+// still exercised: its test injects `{ remaining: 0 }` explicitly.
+beforeEach(() => {
+  setLinearSupplyBudget({ remaining: 2000, limit: 2500 });
+});
 
 afterEach(() => {
   clearLinearSupplyCache();


### PR DESCRIPTION
Closes #1182. Also resolves an independent WM-824 Linear-budget test-isolation leak that was red on develop's own head.

This PR turns develop's required **Verify** green by fixing BOTH deterministic failures that were blocking every PR.

## Blocker 1 — npm-pack `--json` shape (the #1182 target)
`cli/extensions.mjs pack` shells out to `npm pack --dry-run --json`. Newer npm (v12 on the self-hosted runner) emits that report as an **object keyed by package name** (`{ "@test/pack-ext": { name, files, ... } }`), while older npm emitted an **array**. The CLI's `Array.isArray(report) ? report : [report]` wrapped the object-map as one entry with no `name`/`files`, printing `factory/sample@1.0.0: would pack 0 files` and failing the WM-922 pack test deterministically.

- `event-runtime/cli/extensions.mjs`: add `normalizePackReport()` that flattens all npm shapes (array, keyed-by-name object, bare single object) into report entries carrying `name`/`version`/`files`.
- `event-runtime/lib/extensions.test.mjs`: assert on the CLI's own stable summary + per-file listing (parsed structurally) rather than npm's human text. Still fails if the packed file set is genuinely wrong.

## Blocker 2 — WM-824 Linear-supply tests read the host's disk budget
`readBudget()` in `lib/linear.mjs` falls back to `loadLinearBudget()` (the host's on-disk Linear budget) whenever a test doesn't inject one. On the self-hosted runner that real budget is often exhausted, so `loadLinearSupply()` short-circuits to `linear_budget_exhausted` and 6 WM-824 supply tests fail non-deterministically.

- `event-runtime/lib/linear.test.mjs` and `event-runtime/lib/api-runs.test.mjs`: inject a healthy budget in a `beforeEach` so the supply tests exercise the GraphQL path deterministically. Exhaustion is still covered via explicitly-injected `{ remaining: 0 }` budgets. **Production `readBudget()` / disk fallback unchanged.**

## Verification
`bun test event-runtime/lib/extensions.test.mjs event-runtime/lib/linear.test.mjs event-runtime/lib/api-runs.test.mjs` -> 91 pass, 0 fail. Full `event-runtime/lib` suite (as the Fast unit tests lane runs it): 1683 pass, 0 fail (was 6 fail). CI passing on this branch is itself the proof.
