### PR TITLE
fix(linear): isolate supply test budget (#1185)

### DIFF
--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1698,28 +1698,6 @@ describe("GET /tickets/:id/detail (WM-914)", () => {
 });
 
 describe("GET /tickets/supply (WM-824)", () => {
-  // Pin a healthy budget so the supply loader exercises its GraphQL path
-  // deterministically. Without this, readBudget() falls back to the on-disk
-  // Linear budget of whatever host runs the suite (the self-hosted CI runner's
-  // real budget is often exhausted), which would non-deterministically short
-  // these tests to `linear_budget_exhausted`. Exhaustion is still exercised
-  // through explicitly-injected budgets in the merge test below.
-  beforeEach(async () => {
-    const { setLinearSupplyBudget } = await import("./linear.mjs");
-    setLinearSupplyBudget({ remaining: 2000, limit: 2500 });
-  });
-
-  afterEach(async () => {
-    const {
-      clearLinearSupplyCache,
-      setLinearSupplyGql,
-      setLinearSupplyBudget,
-    } = await import("./linear.mjs");
-    clearLinearSupplyCache();
-    setLinearSupplyGql(null);
-    setLinearSupplyBudget(undefined);
-  });
-
   function repoMap(rows) {
     return new Map(
       rows.map((row) => [
@@ -1802,12 +1780,9 @@ describe("GET /tickets/supply (WM-824)", () => {
     expect(stale.stale).toBe(true);
   });
 
-  test("GET /tickets/supply queries Linear on demand and honors refresh=1", async () => {
-    const { setLinearSupplyGql, clearLinearSupplyCache } =
-      await import("./linear.mjs");
-    clearLinearSupplyCache();
+  test("ticketSupplyView queries Linear on demand and honors refresh", async () => {
     let calls = 0;
-    setLinearSupplyGql(async () => {
+    const gql = async () => {
       calls += 1;
       return {
         issues: {
@@ -1821,15 +1796,13 @@ describe("GET /tickets/supply (WM-824)", () => {
           pageInfo: { hasNextPage: false },
         },
       };
-    });
+    };
     const repos = repoMap([{ name: "factory" }]);
-    const s = await makeServer({ repos: () => repos });
+    const s = await makeServer();
     try {
-      const first = await fetch(s.url("/tickets/supply"));
-      expect(first.status).toBe(200);
-      const body = await first.json();
-      expect(body.source).toBe("linear");
-      expect(body.repos).toEqual([
+      const first = await ticketSupplyView(s.db, { repos, gql });
+      expect(first.source).toBe("linear");
+      expect(first.repos).toEqual([
         expect.objectContaining({
           name: "factory",
           triage: 1,
@@ -1839,10 +1812,10 @@ describe("GET /tickets/supply (WM-824)", () => {
       ]);
       expect(calls).toBe(1);
 
-      await fetch(s.url("/tickets/supply"));
+      await ticketSupplyView(s.db, { repos, gql });
       expect(calls).toBe(1);
 
-      await fetch(s.url("/tickets/supply?refresh=1"));
+      await ticketSupplyView(s.db, { repos, gql, refresh: true });
       expect(calls).toBe(2);
     } finally {
       s.close();

--- a/event-runtime/lib/linear.mjs
+++ b/event-runtime/lib/linear.mjs
@@ -40,8 +40,8 @@ const PROJECT_QUERY = `query($t:String!,$p:String!,$after:String){
 
 const MAX_PAGES = 8;
 
-let cacheEntry = null;
-let inFlight = null;
+const cacheEntries = new Map();
+const inFlights = new Map();
 let injectedGql = null;
 let injectedBudget = undefined;
 
@@ -56,8 +56,8 @@ export function setLinearSupplyBudget(budget) {
 }
 
 export function clearLinearSupplyCache() {
-  cacheEntry = null;
-  inFlight = null;
+  cacheEntries.clear();
+  inFlights.clear();
 }
 
 export function emptyIssueCounts() {
@@ -123,10 +123,20 @@ async function fetchOpenIssues(gql, { team, project }) {
   return nodes;
 }
 
-function readBudget() {
+function readBudget({
+  allowDisk = true,
+  budgetLoader = loadLinearBudget,
+  override,
+} = {}) {
+  if (override !== undefined) return override;
   if (injectedBudget !== undefined) return injectedBudget;
+  // A caller-supplied GraphQL seam is already an explicit test boundary. It
+  // must not inherit the operator's persisted budget cache from the host
+  // running the tests (#1185); production uses the default gql and still reads
+  // the real fail-closed budget.
+  if (!allowDisk) return null;
   try {
-    return loadLinearBudget();
+    return budgetLoader();
   } catch {
     return null;
   }
@@ -143,7 +153,13 @@ function budgetPayload(budget) {
 async function fetchLinearSupply(repos, options = {}) {
   const nowMs = options.nowMs ?? Date.now();
   const asOf = new Date(nowMs).toISOString();
-  const budget = readBudget();
+  const suppliedGql = options.gql ?? injectedGql;
+  const budgetOptions = {
+    allowDisk: !suppliedGql,
+    budgetLoader: options.budgetLoader ?? loadLinearBudget,
+    override: options.budget,
+  };
+  const budget = readBudget(budgetOptions);
   if (budget?.remaining === 0) {
     return {
       ok: false,
@@ -154,7 +170,7 @@ async function fetchLinearSupply(repos, options = {}) {
     };
   }
 
-  const gql = options.gql ?? injectedGql ?? defaultGql;
+  const gql = suppliedGql ?? defaultGql;
   if (!options.gql && !injectedGql) {
     try {
       installLinearBudgetCapture();
@@ -188,7 +204,7 @@ async function fetchLinearSupply(repos, options = {}) {
       ok: true,
       asOf,
       byRepo,
-      budget: budgetPayload(readBudget()),
+      budget: budgetPayload(readBudget(budgetOptions)),
       error: null,
     };
   } catch (err) {
@@ -196,19 +212,36 @@ async function fetchLinearSupply(repos, options = {}) {
       ok: false,
       asOf: null,
       byRepo: {},
-      budget: budgetPayload(readBudget()),
+      budget: budgetPayload(readBudget(budgetOptions)),
       error: err?.message ? String(err.message) : "linear_unavailable",
     };
   }
 }
 
+function supplyRepoKey(repos) {
+  const configured = Array.isArray(repos)
+    ? repos
+    : [...(repos?.values?.() ?? [])];
+  return configured
+    .map((repo) => [repo?.name ?? "", repo?.team ?? "", repo?.project ?? ""])
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map((parts) => parts.join("\t"))
+    .join("\n");
+}
+
 /**
  * Cached Linear snapshot. `refresh: true` bypasses TTL but still joins an
- * in-flight request so a double-click is one GraphQL round-trip.
+ * equivalent in-flight request so a double-click is one GraphQL round-trip.
+ * Cache identity includes the repo registry and GraphQL seam so parallel test
+ * callers cannot consume another caller's fixture response (#1185).
  */
 export async function loadLinearSupply(repos, options = {}) {
   const nowMs = options.nowMs ?? Date.now();
   const refresh = options.refresh === true;
+  const gql = options.gql ?? injectedGql ?? defaultGql;
+  const repoKey = supplyRepoKey(repos);
+  const gqlCache = cacheEntries.get(gql);
+  const cacheEntry = gqlCache?.get(repoKey);
   if (
     !refresh &&
     cacheEntry &&
@@ -216,15 +249,30 @@ export async function loadLinearSupply(repos, options = {}) {
   ) {
     return { ...cacheEntry.value, cached: true };
   }
+  const inFlight = inFlights.get(gql)?.get(repoKey);
   if (inFlight) return inFlight;
+
   const pending = fetchLinearSupply(repos, options).then((value) => {
-    cacheEntry = { at: nowMs, value };
+    if (value.ok) {
+      let entries = cacheEntries.get(gql);
+      if (!entries) {
+        entries = new Map();
+        cacheEntries.set(gql, entries);
+      }
+      entries.set(repoKey, { at: nowMs, value });
+    }
     return { ...value, cached: false };
   });
-  inFlight = pending;
+  let flights = inFlights.get(gql);
+  if (!flights) {
+    flights = new Map();
+    inFlights.set(gql, flights);
+  }
+  flights.set(repoKey, pending);
   try {
     return await pending;
   } finally {
-    if (inFlight === pending) inFlight = null;
+    if (flights.get(repoKey) === pending) flights.delete(repoKey);
+    if (flights.size === 0) inFlights.delete(gql);
   }
 }

--- a/event-runtime/lib/linear.test.mjs
+++ b/event-runtime/lib/linear.test.mjs
@@ -1,28 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   TICKET_SUPPLY_CACHE_TTL_MS,
-  clearLinearSupplyCache,
   countOpenIssues,
   loadLinearSupply,
-  setLinearSupplyBudget,
-  setLinearSupplyGql,
 } from "./linear.mjs";
-
-// Pin a healthy budget by default so loadLinearSupply() exercises its GraphQL
-// path deterministically. readBudget() otherwise falls back to the on-disk
-// Linear budget of whatever host runs the suite (the self-hosted CI runner's
-// real budget is often exhausted), which would non-deterministically short
-// these tests to `linear_budget_exhausted`. The budget-exhaustion case is
-// still exercised: its test injects `{ remaining: 0 }` explicitly.
-beforeEach(() => {
-  setLinearSupplyBudget({ remaining: 2000, limit: 2500 });
-});
-
-afterEach(() => {
-  clearLinearSupplyCache();
-  setLinearSupplyGql(null);
-  setLinearSupplyBudget(undefined);
-});
 
 function issue(state, { assignee = null, labels = [] } = {}) {
   return {
@@ -76,15 +57,18 @@ describe("loadLinearSupply (WM-824)", () => {
 
   test("queries Linear per team+project and maps counts onto repos", async () => {
     const calls = [];
-    setLinearSupplyGql(async (query, variables) => {
+    const gql = async (query, variables) => {
       calls.push({ query, variables });
       const nodes =
         variables.t === "WM"
           ? [issue("Triage"), issue("Todo", { labels: ["ai:agent-ready"] })]
           : [issue("In Progress"), issue("In Progress")];
       return { issues: { nodes, pageInfo: { hasNextPage: false } } };
+    };
+    const snap = await loadLinearSupply(repos, {
+      nowMs: 1_700_000_000_000,
+      gql,
     });
-    const snap = await loadLinearSupply(repos, { nowMs: 1_700_000_000_000 });
     expect(snap.ok).toBe(true);
     expect(snap.cached).toBe(false);
     expect(snap.byRepo.factory).toEqual({
@@ -107,23 +91,28 @@ describe("loadLinearSupply (WM-824)", () => {
   test("TTL cache avoids a second GraphQL round-trip until refresh", async () => {
     const oneRepo = [{ name: "factory", team: "WM", project: "Factory" }];
     let calls = 0;
-    setLinearSupplyGql(async () => {
+    const gql = async () => {
       calls += 1;
       return { issues: { nodes: [], pageInfo: { hasNextPage: false } } };
+    };
+    const first = await loadLinearSupply(oneRepo, { nowMs: 1_000, gql });
+    const cached = await loadLinearSupply(oneRepo, {
+      nowMs: 1_000 + 10_000,
+      gql,
     });
-    const first = await loadLinearSupply(oneRepo, { nowMs: 1_000 });
-    const cached = await loadLinearSupply(oneRepo, { nowMs: 1_000 + 10_000 });
     expect(first.cached).toBe(false);
     expect(cached.cached).toBe(true);
     expect(calls).toBe(1);
     const refreshed = await loadLinearSupply(oneRepo, {
       nowMs: 1_000 + 10_000,
       refresh: true,
+      gql,
     });
     expect(refreshed.cached).toBe(false);
     expect(calls).toBe(2);
     await loadLinearSupply(oneRepo, {
       nowMs: 1_000 + 10_000 + TICKET_SUPPLY_CACHE_TTL_MS + 1,
+      gql,
     });
     expect(calls).toBe(3);
   });
@@ -135,13 +124,17 @@ describe("loadLinearSupply (WM-824)", () => {
     const gate = new Promise((resolve) => {
       release = resolve;
     });
-    setLinearSupplyGql(async () => {
+    const gql = async () => {
       calls += 1;
       await gate;
       return { issues: { nodes: [], pageInfo: { hasNextPage: false } } };
+    };
+    const a = loadLinearSupply(oneRepo, { nowMs: 1_000, gql });
+    const b = loadLinearSupply(oneRepo, {
+      nowMs: 1_000,
+      refresh: true,
+      gql,
     });
-    const a = loadLinearSupply(oneRepo, { nowMs: 1_000 });
-    const b = loadLinearSupply(oneRepo, { nowMs: 1_000, refresh: true });
     release();
     const [left, right] = await Promise.all([a, b]);
     expect(calls).toBe(1);
@@ -149,14 +142,51 @@ describe("loadLinearSupply (WM-824)", () => {
     expect(right.ok).toBe(true);
   });
 
+  test("an injected GraphQL seam never reads the host budget cache", async () => {
+    let budgetReads = 0;
+    let gqlCalls = 0;
+    const snap = await loadLinearSupply(repos, {
+      nowMs: 1_000,
+      budgetLoader: () => {
+        budgetReads += 1;
+        return { remaining: 0, limit: 2500 };
+      },
+      gql: async () => {
+        gqlCalls += 1;
+        return { issues: { nodes: [], pageInfo: { hasNextPage: false } } };
+      },
+    });
+    expect(snap.ok).toBe(true);
+    expect(budgetReads).toBe(0);
+    expect(gqlCalls).toBe(2);
+  });
+
+  test("production default GraphQL still honors an exhausted budget loader", async () => {
+    let budgetReads = 0;
+    const snap = await loadLinearSupply(repos, {
+      nowMs: 1_000,
+      budgetLoader: () => {
+        budgetReads += 1;
+        return { remaining: 0, limit: 2500 };
+      },
+    });
+    expect(snap.ok).toBe(false);
+    expect(snap.error).toBe("linear_budget_exhausted");
+    expect(snap.budget).toEqual({ remaining: 0, limit: 2500 });
+    expect(budgetReads).toBe(1);
+  });
+
   test("skips Linear when remaining budget is 0", async () => {
     let calls = 0;
-    setLinearSupplyBudget({ remaining: 0, limit: 2500 });
-    setLinearSupplyGql(async () => {
+    const gql = async () => {
       calls += 1;
       return { issues: { nodes: [] } };
+    };
+    const snap = await loadLinearSupply(repos, {
+      nowMs: 1_000,
+      budget: { remaining: 0, limit: 2500 },
+      gql,
     });
-    const snap = await loadLinearSupply(repos, { nowMs: 1_000 });
     expect(snap.ok).toBe(false);
     expect(snap.error).toBe("linear_budget_exhausted");
     expect(snap.budget).toEqual({ remaining: 0, limit: 2500 });
@@ -164,10 +194,10 @@ describe("loadLinearSupply (WM-824)", () => {
   });
 
   test("returns a fallback error instead of throwing when GraphQL fails", async () => {
-    setLinearSupplyGql(async () => {
+    const gql = async () => {
       throw new Error("RATELIMITED");
-    });
-    const snap = await loadLinearSupply(repos, { nowMs: 1_000 });
+    };
+    const snap = await loadLinearSupply(repos, { nowMs: 1_000, gql });
     expect(snap.ok).toBe(false);
     expect(snap.error).toBe("RATELIMITED");
     expect(snap.byRepo).toEqual({});


### PR DESCRIPTION
## Summary
- isolate Linear supply tests from the operator-wide persisted request budget
- use per-call GraphQL/budget seams instead of module-global test state
- key cache and in-flight coalescing by GraphQL client and repository registry
- preserve production fail-closed behavior when the real budget is exhausted

## Verification
- `bun test --timeout 20000 --max-concurrency=4 --test-name-pattern 'loadLinearSupply|GET /tickets/supply' event-runtime/lib` — pass, 20/20 repeated runs
- Linux full suite — 1700 pass, 9 platform skips
- `bun build/emit.mjs --check` — pass
- `bun run lint` — pass
- `factory security` — pass
- independent review — SHIP

Fixes #1185