### PR TITLE
fix(handoff): tolerate planner enrichment on retry (#1191)

### DIFF
--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -10,7 +10,6 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
-import { hashJson } from "../event-runtime/lib/canonical.mjs";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
 
 export const HANDOFF_SCHEMA_VERSION = "factory.handoff/v1";
@@ -211,7 +210,8 @@ function sameHandoffEnvelope(stored, expected) {
     stored.subject === expected.subject &&
     stored.correlationId === expected.correlationId &&
     (stored.causationId ?? null) === (expected.causationId ?? null) &&
-    hashJson(stored.payload) === hashJson(expected.payload),
+    stored.payload?.repo === expected.payload.repo &&
+    stored.payload?.ticket === expected.payload.ticket,
   );
 }
 

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -225,7 +225,14 @@ describe("forced-command accept server", () => {
                 subject: REQUEST.ticket,
                 correlationId: REQUEST.requestId,
                 causationId: null,
-                payload: { repo: REQUEST.repo, ticket: REQUEST.ticket },
+                payload: {
+                  repo: REQUEST.repo,
+                  ticket: REQUEST.ticket,
+                  memoPin: {
+                    foldedAt: "2026-08-24T12:00:01.000Z",
+                    entries: [{ sha256: "planner-owned" }],
+                  },
+                },
               },
             },
           ],


### PR DESCRIPTION
## Summary
- bind duplicate handoff comparison to immutable request identity fields
- ignore planner-owned `payload.memoPin` enrichment in stored envelopes
- preserve fail-closed conflicts for changed repo/ticket identity

## Verification
- regression observed failing before the fix
- `bun test tools/handoff.test.mjs --timeout 20000` — 12 pass
- `bun run lint` — pass
- `factory security` — pass
- independent review — SHIP

Fixes #1191