### PR TITLE
feat(extensions): discover packs for pin repair

### DIFF
--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -163,3 +163,19 @@ worktree/branch as recoverable evidence for operator cleanup.
 Promotion does not clear the runtime overrides. Clearing the overlay is a
 separate explicit action the operator takes after the promoted defaults have
 deployed, so the fast loop keeps winning until the fleet default catches up.
+
+## Extension pack pin repair metadata boundary (gh-857)
+
+Decided 2026-08-25. `update-pins --pack <name>` may discover packs contributed
+by configured extensions through a CLI-only metadata path. It reads the
+extension allow-list (path and package roots), parses and validates
+`factory-extension.json`, confines contributed pack paths by realpath, and
+rejects duplicate pack names. It then writes pins for only the selected pack.
+
+This discovery imports no extension modules and does not register adapters,
+connectors, hooks, panels, or any other contribution. It exists specifically
+so an absent or stale extension `pins.json` can be repaired: normal extension
+loading correctly fails closed on that state before executing extension code.
+Serve and work retain the ordinary full validated loader; they cannot request
+metadata-only loading, and a repaired extension still has to pass the normal
+fail-closed pin and registry checks before it is loaded.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -6,6 +6,8 @@ import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { backfillResultArtifacts } from "./lib/artifacts.mjs";
 import { initPack } from "./lib/pack-init.mjs";
 import { validatePack } from "./lib/pack-validate.mjs";
+import { updateHarnessPins } from "./lib/pins.mjs";
+import { loadPackRoots, RegistryError, updatePins } from "./lib/registry.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -18,6 +20,8 @@ import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
 import {
   contributionCounts,
+  collectHarnessRoots,
+  discoverExtensionPackRoots,
   formatContributionCounts,
   loadExtensions,
   validateExtensionManifest,
@@ -361,6 +365,75 @@ export function initCommand(args = []) {
   return results;
 }
 
+const UPDATE_PINS_USAGE = "usage: update-pins [--pack NAME] [--check]";
+
+function parseUpdatePinsArgs(args = []) {
+  let pack;
+  let check = false;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--check") {
+      check = true;
+      continue;
+    }
+    if (arg === "--pack") {
+      const name = args[i + 1];
+      if (!name || name.startsWith("--")) throw new Error(UPDATE_PINS_USAGE);
+      pack = name;
+      i += 1;
+      continue;
+    }
+    throw new Error(UPDATE_PINS_USAGE);
+  }
+  return { pack, check };
+}
+
+/** CLI-only metadata repair; serve/work continue to use full loading. */
+export async function updatePinsCommand(args = []) {
+  const { pack, check } = parseUpdatePinsArgs(args);
+  try {
+    let descriptor;
+    if (pack !== undefined) {
+      const policyPacks = loadPackRoots();
+      const extensionPacks = discoverExtensionPackRoots({
+        packRoots: policyPacks,
+      });
+      descriptor = [...policyPacks, ...extensionPacks].find(
+        (candidate) => candidate.name === pack,
+      );
+      if (!descriptor)
+        throw new RegistryError(`unknown configured pack "${pack}"`);
+    }
+    const changed =
+      pack === undefined
+        ? await updatePins({ check })
+        : await updatePins({ pack: descriptor, check });
+    if (pack === undefined) {
+      const { roots, anomalies } = collectHarnessRoots({
+        root: FACTORY_ROOT,
+        builtin: path.join(FACTORY_ROOT, "shared"),
+      });
+      for (const anomaly of anomalies) console.error(`harness: ${anomaly}`);
+      changed.push(
+        ...updateHarnessPins({ roots, check }).map((name) => `harness:${name}`),
+      );
+    }
+    if (check && changed.length) {
+      throw new Error(
+        `pins stale: ${changed.join(", ")} — run: bun event-runtime/cli.mjs update-pins`,
+      );
+    }
+    console.log(
+      changed.length
+        ? `re-pinned: ${changed.join(", ")}`
+        : "pins already current",
+    );
+  } catch (err) {
+    console.error(`update-pins: ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "init") return initCommand(args);
@@ -370,6 +443,7 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "extensions") return extensionsCommand(args);
   if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);
+  if (command === "update-pins") return updatePinsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -6,8 +6,6 @@ import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { backfillResultArtifacts } from "./lib/artifacts.mjs";
 import { initPack } from "./lib/pack-init.mjs";
 import { validatePack } from "./lib/pack-validate.mjs";
-import { updateHarnessPins } from "./lib/pins.mjs";
-import { loadPackRoots, RegistryError, updatePins } from "./lib/registry.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -20,8 +18,6 @@ import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
 import {
   contributionCounts,
-  collectHarnessRoots,
-  discoverExtensionPackRoots,
   formatContributionCounts,
   loadExtensions,
   validateExtensionManifest,
@@ -365,75 +361,6 @@ export function initCommand(args = []) {
   return results;
 }
 
-const UPDATE_PINS_USAGE = "usage: update-pins [--pack NAME] [--check]";
-
-function parseUpdatePinsArgs(args = []) {
-  let pack;
-  let check = false;
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (arg === "--check") {
-      check = true;
-      continue;
-    }
-    if (arg === "--pack") {
-      const name = args[i + 1];
-      if (!name || name.startsWith("--")) throw new Error(UPDATE_PINS_USAGE);
-      pack = name;
-      i += 1;
-      continue;
-    }
-    throw new Error(UPDATE_PINS_USAGE);
-  }
-  return { pack, check };
-}
-
-/** CLI-only metadata repair; serve/work continue to use full loading. */
-export async function updatePinsCommand(args = []) {
-  const { pack, check } = parseUpdatePinsArgs(args);
-  try {
-    let descriptor;
-    if (pack !== undefined) {
-      const policyPacks = loadPackRoots();
-      const extensionPacks = discoverExtensionPackRoots({
-        packRoots: policyPacks,
-      });
-      descriptor = [...policyPacks, ...extensionPacks].find(
-        (candidate) => candidate.name === pack,
-      );
-      if (!descriptor)
-        throw new RegistryError(`unknown configured pack "${pack}"`);
-    }
-    const changed =
-      pack === undefined
-        ? await updatePins({ check })
-        : await updatePins({ pack: descriptor, check });
-    if (pack === undefined) {
-      const { roots, anomalies } = collectHarnessRoots({
-        root: FACTORY_ROOT,
-        builtin: path.join(FACTORY_ROOT, "shared"),
-      });
-      for (const anomaly of anomalies) console.error(`harness: ${anomaly}`);
-      changed.push(
-        ...updateHarnessPins({ roots, check }).map((name) => `harness:${name}`),
-      );
-    }
-    if (check && changed.length) {
-      throw new Error(
-        `pins stale: ${changed.join(", ")} — run: bun event-runtime/cli.mjs update-pins`,
-      );
-    }
-    console.log(
-      changed.length
-        ? `re-pinned: ${changed.join(", ")}`
-        : "pins already current",
-    );
-  } catch (err) {
-    console.error(`update-pins: ${err.message}`);
-    process.exitCode = 1;
-  }
-}
-
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "init") return initCommand(args);
@@ -443,7 +370,6 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "extensions") return extensionsCommand(args);
   if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);
-  if (command === "update-pins") return updatePinsCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -1176,42 +1176,69 @@ function packRootFor(extensionRoot, rel) {
  * contribution. `update-pins --pack` uses it to repair a stale extension
  * pack, which full loading must reject before it can import extension code.
  *
- * @param {{ root?: string, policy?: object, packRoots?: Array<object> }} [options]
+ * Failures are scoped to the request. With no `name`, any rejected root,
+ * invalid manifest, unreadable pack, or duplicate pack name fails closed.
+ * With a `name`, an unrelated broken extension is skipped so it cannot block
+ * re-pinning a different pack; the collected errors are only raised when the
+ * requested pack is itself a duplicate or cannot be found.
+ *
+ * @param {{ root?: string, policy?: object, packRoots?: Array<object>, name?: string }} [options]
  * @returns {Array<{ kind: "fs", name: string, path: string }>}
  */
 export function discoverExtensionPackRoots({
   root = reposRoot(),
   policy,
   packRoots = [],
+  name,
 } = {}) {
   const { roots, anomalies } = loadExtensionRoots({ root, policy });
-  if (anomalies.length > 0) {
-    throw new ExtensionError(
-      `extension metadata discovery rejected configured roots: ${anomalies.join("; ")}`,
-    );
-  }
-
+  const errors = anomalies.map((anomaly) => `configured roots: ${anomaly}`);
   const discovered = [];
   const names = new Set(packRoots.map((pack) => pack.name));
   for (const { path: dir } of roots) {
     const checked = validateExtensionManifest(dir, { root });
     if (!checked.valid) {
-      throw new ExtensionError(
-        `extension metadata discovery rejected ${dir}: ${checked.errors.join("; ")}`,
-      );
+      errors.push(`${dir}: ${checked.errors.join("; ")}`);
+      continue;
     }
     for (const rel of checked.manifest.contributes?.packs ?? []) {
-      const pack = packRootFor(dir, rel);
+      let pack;
+      try {
+        pack = packRootFor(dir, rel);
+      } catch (err) {
+        errors.push(`${dir}: ${err.message}`);
+        continue;
+      }
       if (names.has(pack.name)) {
-        throw new ExtensionError(
-          `extension metadata discovery: pack name "${pack.name}" is already configured (policy packs: or an earlier extension)`,
-        );
+        const message = `pack name "${pack.name}" is already configured by a policy pack or an earlier extension`;
+        if (pack.name === name) {
+          throw new ExtensionError(
+            `extension metadata discovery: ${message} (${dir})`,
+          );
+        }
+        errors.push(`${dir}: ${message}`);
+        continue;
       }
       names.add(pack.name);
       discovered.push(pack);
     }
   }
-  return discovered;
+  if (name === undefined) {
+    if (errors.length > 0) {
+      throw new ExtensionError(
+        `extension metadata discovery rejected: ${errors.join("; ")}`,
+      );
+    }
+    return discovered;
+  }
+  const match = discovered.find((pack) => pack.name === name);
+  if (match) return [match];
+  if (errors.length > 0) {
+    throw new ExtensionError(
+      `extension metadata discovery: pack "${name}" not found; rejected: ${errors.join("; ")}`,
+    );
+  }
+  return [];
 }
 
 /**

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -1168,6 +1168,53 @@ function packRootFor(extensionRoot, rel) {
 }
 
 /**
+ * Read only the pack descriptors contributed by configured extensions.
+ *
+ * This is deliberately narrower than `loadExtensions`: it validates the
+ * allow-list, manifests, and realpath confinement needed to identify a pack,
+ * but does not validate pins, load a registry, import a module, or register a
+ * contribution. `update-pins --pack` uses it to repair a stale extension
+ * pack, which full loading must reject before it can import extension code.
+ *
+ * @param {{ root?: string, policy?: object, packRoots?: Array<object> }} [options]
+ * @returns {Array<{ kind: "fs", name: string, path: string }>}
+ */
+export function discoverExtensionPackRoots({
+  root = reposRoot(),
+  policy,
+  packRoots = [],
+} = {}) {
+  const { roots, anomalies } = loadExtensionRoots({ root, policy });
+  if (anomalies.length > 0) {
+    throw new ExtensionError(
+      `extension metadata discovery rejected configured roots: ${anomalies.join("; ")}`,
+    );
+  }
+
+  const discovered = [];
+  const names = new Set(packRoots.map((pack) => pack.name));
+  for (const { path: dir } of roots) {
+    const checked = validateExtensionManifest(dir, { root });
+    if (!checked.valid) {
+      throw new ExtensionError(
+        `extension metadata discovery rejected ${dir}: ${checked.errors.join("; ")}`,
+      );
+    }
+    for (const rel of checked.manifest.contributes?.packs ?? []) {
+      const pack = packRootFor(dir, rel);
+      if (names.has(pack.name)) {
+        throw new ExtensionError(
+          `extension metadata discovery: pack name "${pack.name}" is already configured (policy packs: or an earlier extension)`,
+        );
+      }
+      names.add(pack.name);
+      discovered.push(pack);
+    }
+  }
+  return discovered;
+}
+
+/**
  * Load every allow-listed extension: validate the manifest, prove its packs
  * load alongside everything accepted so far (a dry `loadRegistry`, so the
  * namespace/duplicate/pin/mutating rules of docs/kernel-and-packs.md apply

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -177,6 +177,51 @@ describe("extension pack metadata discovery (gh-857)", () => {
     ).toThrow(/pack name "sample-ext" is already configured/);
   });
 
+  test("scopes discovery failures to the requested pack name", () => {
+    const broken = tempExtension((manifest) => {
+      manifest.contributes.packs = ["../outside"];
+    });
+    const healthy = tempExtension((manifest) => {
+      manifest.name = "factory/healthy";
+    });
+    writeFileSync(
+      path.join(healthy, "pack", "pack.json"),
+      `${JSON.stringify({ name: "healthy-ext", version: "1.0.0", namespace: "healthy" })}\n`,
+    );
+    const policy = policyFor(broken, healthy);
+
+    // Unscoped discovery still fails closed on the unrelated broken manifest.
+    expect(() => discoverExtensionPackRoots({ policy })).toThrow(
+      /contributes\.packs\[0\].*escapes/,
+    );
+    // A request for the healthy pack is not blocked by the broken sibling.
+    expect(discoverExtensionPackRoots({ policy, name: "healthy-ext" })).toEqual([
+      { kind: "fs", name: "healthy-ext", path: path.join(healthy, "pack") },
+    ]);
+    // A miss surfaces the collected errors so the operator sees why.
+    expect(() =>
+      discoverExtensionPackRoots({ policy, name: "missing-ext" }),
+    ).toThrow(/pack "missing-ext" not found; rejected: .*escapes/);
+    // A clean miss stays a plain miss.
+    expect(
+      discoverExtensionPackRoots({ policy: policyFor(healthy), name: "nope" }),
+    ).toEqual([]);
+
+    // A duplicate of the requested name itself still fails closed, while a
+    // duplicate elsewhere is skipped.
+    const first = tempExtension();
+    const second = tempExtension();
+    const duplicated = policyFor(first, second, healthy);
+    expect(() =>
+      discoverExtensionPackRoots({ policy: duplicated, name: "sample-ext" }),
+    ).toThrow(/pack name "sample-ext" is already configured/);
+    expect(
+      discoverExtensionPackRoots({ policy: duplicated, name: "healthy-ext" }),
+    ).toEqual([
+      { kind: "fs", name: "healthy-ext", path: path.join(healthy, "pack") },
+    ]);
+  });
+
   test("update-pins repairs a stale extension pack without executing it", async () => {
     const factoryRoot = tmpDir("event-extension-repair-root-");
     const extension = tempExtension();

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -27,6 +27,7 @@ import {
   applyConfigDefaults,
   collectHarnessRoots,
   contributionCounts,
+  discoverExtensionPackRoots,
   extensionSecretEnvVar,
   formatContributionCounts,
   getExtensionConfig,
@@ -120,6 +121,130 @@ function load(
     packRoots: [],
   }).then((result) => ({ ...result, adapterRegistry, hookRegistry }));
 }
+
+describe("extension pack metadata discovery (gh-857)", () => {
+  test("discovers path and package extension packs without importing adapters", () => {
+    const pathExtension = tempExtension();
+    const sentinel = path.join(tmpDir("event-extension-sentinel-"), "ran");
+    writeFileSync(
+      path.join(pathExtension, "adapters", "echo.mjs"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(sentinel)}, "ran"); export default {};`,
+    );
+    const pathPacks = discoverExtensionPackRoots({
+      policy: policyFor(pathExtension),
+    });
+    expect(pathPacks).toEqual([
+      {
+        kind: "fs",
+        name: "sample-ext",
+        path: path.join(pathExtension, "pack"),
+      },
+    ]);
+    expect(existsSync(sentinel)).toBe(false);
+
+    const { factoryRoot, name, installed } = sampleAsPackage();
+    const packagePacks = discoverExtensionPackRoots({
+      root: factoryRoot,
+      policy: { extensions: [{ package: name }] },
+    });
+    expect(packagePacks).toEqual([
+      {
+        kind: "fs",
+        name: "sample-ext",
+        path: path.join(realpathSync(installed), "pack"),
+      },
+    ]);
+  });
+
+  test("fails closed for invalid manifests and duplicate contributed pack names", () => {
+    const escaped = tempExtension((manifest) => {
+      manifest.contributes.packs = ["../outside"];
+    });
+    expect(() =>
+      discoverExtensionPackRoots({ policy: policyFor(escaped) }),
+    ).toThrow(/contributes\.packs\[0\].*escapes/);
+
+    const first = tempExtension();
+    const second = tempExtension();
+    expect(() =>
+      discoverExtensionPackRoots({ policy: policyFor(first, second) }),
+    ).toThrow(/pack name "sample-ext" is already configured/);
+    expect(() =>
+      discoverExtensionPackRoots({
+        policy: policyFor(first),
+        packRoots: [{ kind: "fs", name: "sample-ext", path: SAMPLE_PACK }],
+      }),
+    ).toThrow(/pack name "sample-ext" is already configured/);
+  });
+
+  test("update-pins repairs a stale extension pack without executing it", async () => {
+    const factoryRoot = tmpDir("event-extension-repair-root-");
+    const extension = tempExtension();
+    const sentinel = path.join(factoryRoot, "extension-imported");
+    writeFileSync(
+      path.join(extension, "adapters", "echo.mjs"),
+      `import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(sentinel)}, "ran");
+export const SANDBOX_SUPPORT = "unsupported";
+export async function execute({ spec } = {}) {
+  return { ok: true, echoed: spec?.input ?? null };
+}
+`,
+    );
+    writeFileSync(
+      path.join(extension, "pack", "agents", "echo.md"),
+      "drifted extension prompt\n",
+    );
+    mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(factoryRoot, "config", "policy.yaml"),
+      `extensions:\n  - path: ${JSON.stringify(extension)}\n`,
+    );
+    const pins = path.join(extension, "pack", "pins.json");
+    const stalePins = readFileSync(pins, "utf8");
+    const policy = policyFor(extension);
+    const ordinaryLoad = () =>
+      loadExtensions({
+        root: factoryRoot,
+        policy,
+        adapterRegistry: createAdapterRegistry(),
+        hookRegistry: createHookRegistry(),
+        packRoots: [],
+      });
+    expect((await ordinaryLoad()).disabled[0].reason).toMatch(
+      /does not match pin/,
+    );
+
+    const run = (...args) =>
+      Bun.spawnSync({
+        cmd: [
+          process.execPath,
+          "event-runtime/cli.mjs",
+          "update-pins",
+          ...args,
+        ],
+        cwd: path.dirname(RUNTIME_ROOT),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_REPOS_ROOT: factoryRoot },
+      });
+    const checked = run("--pack", "sample-ext", "--check");
+    expect(checked.exitCode).not.toBe(0);
+    expect(checked.stderr.toString()).toContain("pins stale: sample-ext");
+    expect(readFileSync(pins, "utf8")).toBe(stalePins);
+    expect(existsSync(sentinel)).toBe(false);
+
+    const repaired = run("--pack", "sample-ext");
+    expect(repaired.exitCode).toBe(0);
+    expect(repaired.stdout.toString()).toContain("re-pinned: sample-ext");
+    expect(readFileSync(pins, "utf8")).not.toBe(stalePins);
+    expect(existsSync(sentinel)).toBe(false);
+
+    const loaded = await ordinaryLoad();
+    expect(loaded.anomalies).toEqual([]);
+    expect(loaded.extensions).toHaveLength(1);
+  });
+});
 
 describe("factory-extension.json schema", () => {
   test("accepts the decided manifest shape and rejects bad names/versions", () => {

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -195,9 +195,9 @@ describe("extension pack metadata discovery (gh-857)", () => {
       /contributes\.packs\[0\].*escapes/,
     );
     // A request for the healthy pack is not blocked by the broken sibling.
-    expect(discoverExtensionPackRoots({ policy, name: "healthy-ext" })).toEqual([
-      { kind: "fs", name: "healthy-ext", path: path.join(healthy, "pack") },
-    ]);
+    expect(discoverExtensionPackRoots({ policy, name: "healthy-ext" })).toEqual(
+      [{ kind: "fs", name: "healthy-ext", path: path.join(healthy, "pack") }],
+    );
     // A miss surfaces the collected errors so the operator sees why.
     expect(() =>
       discoverExtensionPackRoots({ policy, name: "missing-ext" }),

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -1448,7 +1448,18 @@ export async function updatePins({
   if (pack !== undefined) {
     let descriptor = pack;
     if (typeof pack === "string") {
-      descriptor = loadPackRoots().find((candidate) => candidate.name === pack);
+      const policyPacks = loadPackRoots();
+      descriptor = policyPacks.find((candidate) => candidate.name === pack);
+      if (!descriptor) {
+        // Extension-contributed packs (gh-857): metadata-only discovery so a
+        // stale extension pins.json can be repaired without importing the
+        // extension. Imported lazily — extensions.mjs depends on this module.
+        const { discoverExtensionPackRoots } = await import("./extensions.mjs");
+        [descriptor] = discoverExtensionPackRoots({
+          packRoots: policyPacks,
+          name: pack,
+        });
+      }
       if (!descriptor)
         throw new RegistryError(`unknown configured pack "${pack}"`);
     }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -1,6 +1,12 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-registry-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { format as prettierFormat, resolveConfig } from "prettier";
 import { canonicalJson, hashBytes } from "./canonical.mjs";
@@ -706,6 +712,48 @@ describe("registry", () => {
     writeFileSync(defFile, JSON.stringify({ ...def, command: ["true"] }));
     const registry = loadRegistry({ packRoots: [pack] });
     expect(getAgent(registry, "sample/echo@1").mutating).toBeUndefined();
+  });
+
+  test("updatePins resolves a pack name through extension metadata (gh-857)", async () => {
+    const factoryRoot = tmpDir("event-registry-ext-root-");
+    const extension = tmpDir("event-registry-ext-");
+    cpSync(
+      path.join(RUNTIME_ROOT, "test-support", "extensions", "sample"),
+      extension,
+      { recursive: true },
+    );
+    const sentinel = path.join(factoryRoot, "extension-imported");
+    writeFileSync(
+      path.join(extension, "adapters", "echo.mjs"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(sentinel)}, "ran"); export default {};`,
+    );
+    const prompt = path.join(extension, "pack", "agents", "echo.md");
+    writeFileSync(prompt, `${readFileSync(prompt, "utf8")}drift\n`);
+    mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(factoryRoot, "config", "policy.yaml"),
+      `extensions:\n  - path: ${JSON.stringify(extension)}\n`,
+    );
+    const pins = path.join(extension, "pack", "pins.json");
+    const stale = readFileSync(pins, "utf8");
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = factoryRoot;
+    try {
+      expect(await updatePins({ pack: "sample-ext", check: true })).toEqual([
+        "sample-ext",
+      ]);
+      expect(readFileSync(pins, "utf8")).toBe(stale);
+      expect(await updatePins({ pack: "sample-ext" })).toEqual(["sample-ext"]);
+      expect(readFileSync(pins, "utf8")).not.toBe(stale);
+      expect(await updatePins({ pack: "sample-ext" })).toEqual([]);
+      await expect(updatePins({ pack: "not-configured" })).rejects.toThrow(
+        /unknown configured pack "not-configured"/,
+      );
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+    }
+    expect(existsSync(sentinel)).toBe(false);
   });
 
   test("pack manifest and pins fail closed, and explicit pack pinning repairs drift", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#857

Repair stale extension pack pins safely with metadata-only discovery.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 30000 event-runtime/lib/registry.test.mjs event-runtime/lib/extensions.test.mjs event-runtime/cli.test.mjs` | pass    | 110 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1703 pass, emit clean  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — internal CLI and library change; no user-facing surface


## Handoff

### Changed after review (FIX verdict)

- Removed the duplicate `updatePinsCommand` / `parseUpdatePinsArgs` / early `update-pins` dispatch route from `event-runtime/cli.mjs` (it shadowed the registered command in `event-runtime/cli/update-pins.mjs`). `cli.mjs` is now untouched by this PR; `update-pins --bogus` still exits 1 with `usage: update-pins [--pack NAME] [--check]`.
- Extension-pack resolution moved into the real path: `event-runtime/lib/registry.mjs::updatePins` string-pack branch falls back to `discoverExtensionPackRoots({ packRoots, name })` when the name is not a policy pack (lazy `import()` because `extensions.mjs` already imports `registry.mjs`).
- `discoverExtensionPackRoots` now accepts `name` and scopes failures: with no name it fails closed on any rejected root / invalid manifest / unreadable pack / duplicate; with a name, an unrelated broken extension is skipped, a duplicate of the requested name still throws, and a miss reports the collected errors.
- Fixed the malformed error string (`... already configured (policy packs: or an earlier extension)`).
- Tests: `registry.test.mjs` covers `updatePins({ pack: "sample-ext" })` resolving an extension pack (check / write / no-op / unknown, adapter never imported); `extensions.test.mjs` covers the scoped-failure behaviour. The existing CLI spawn test now exercises the real `cli/update-pins.mjs` command.

### Verification

```
$ bun test --timeout 30000 event-runtime/lib/registry.test.mjs event-runtime/lib/extensions.test.mjs event-runtime/cli.test.mjs
 112 pass
 0 fail
 535 expect() calls
Ran 112 tests across 3 files. [2.38s]

$ bun run check
ok — 94 generated files match shared/
(exit 0; floor-delivery note refers to the operator checkout's AGENTS.md, not this branch)

$ bunx prettier --check event-runtime/lib event-runtime/cli.mjs
All matched files use Prettier code style!

$ bunx eslint <touched files>
0 errors (2 pre-existing no-unused-vars warnings on untouched lines)

$ bun event-runtime/cli.mjs update-pins --bogus
usage: update-pins [--pack NAME] [--check]   (exit 1)
```

### UX critique

not-applicable — CLI/internal

### File scope (all within #857 Owned Paths)

- docs/product-decisions.md
- event-runtime/lib/extensions.mjs
- event-runtime/lib/extensions.test.mjs
- event-runtime/lib/registry.mjs
- event-runtime/lib/registry.test.mjs
