### PR TITLE
fix(workspace): canonicalize containment roots

### DIFF
--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -112,7 +112,11 @@ export function safeJoin(workspaceDir, relPath) {
     throw new PathViolation(workspaceDir, relPath);
   }
   if (path.isAbsolute(relPath)) throw new PathViolation(workspaceDir, relPath);
-  const root = path.resolve(workspaceDir);
+  // Keep both ends of containment checks in the same namespace. On macOS the
+  // system temp root may enter as /var while realpath resolves it as
+  // /private/var; comparing a candidate in one spelling with a root in the
+  // other incorrectly rejects an in-workspace artifact as an escape.
+  const root = realpathSync(path.resolve(workspaceDir));
   const resolved = path.resolve(root, relPath);
   if (!resolved.startsWith(root + path.sep))
     throw new PathViolation(workspaceDir, relPath);
@@ -135,9 +139,8 @@ export function safeJoin(workspaceDir, relPath) {
  * trust boundary and verify the copied bytes by hash in the meantime.
  */
 export function confinedRegularFile(workspaceDir, relPath) {
-  const root = path.resolve(workspaceDir);
+  const root = realpathSync(path.resolve(workspaceDir));
   const source = safeJoin(root, relPath);
-  const canonicalRoot = realpathSync(root);
   const relative = path.relative(root, source);
   const components = relative.split(path.sep).filter(Boolean);
   let cursor = root;
@@ -170,7 +173,7 @@ export function confinedRegularFile(workspaceDir, relPath) {
   }
 
   const canonicalSource = realpathSync(source);
-  if (!canonicalSource.startsWith(canonicalRoot + path.sep)) {
+  if (!canonicalSource.startsWith(root + path.sep)) {
     throw new PathViolation(
       workspaceDir,
       relPath,

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -103,9 +103,28 @@ function worktreeScriptFailure(result) {
 }
 
 /**
+ * Canonicalize the workspace root for containment checks. A root that no
+ * longer exists (destroyed or retained-then-removed workspace) is reported as
+ * a PathViolation rather than a raw ENOENT so callers see one error class.
+ */
+function canonicalWorkspaceRoot(workspaceDir, relPath) {
+  try {
+    return realpathSync(path.resolve(workspaceDir));
+  } catch {
+    throw new PathViolation(
+      workspaceDir,
+      relPath,
+      "workspace root not resolvable",
+    );
+  }
+}
+
+/**
  * Resolve a declared workspace-relative path to an absolute one, rejecting
  * absolute inputs and anything that resolves outside the workspace. Strict:
- * the workspace directory itself is not a valid artifact path.
+ * the workspace directory itself is not a valid artifact path. Returns the
+ * canonical (realpath) absolute path, so symlinked roots resolve to their
+ * real location.
  */
 export function safeJoin(workspaceDir, relPath) {
   if (typeof relPath !== "string" || relPath.length === 0) {
@@ -116,7 +135,7 @@ export function safeJoin(workspaceDir, relPath) {
   // system temp root may enter as /var while realpath resolves it as
   // /private/var; comparing a candidate in one spelling with a root in the
   // other incorrectly rejects an in-workspace artifact as an escape.
-  const root = realpathSync(path.resolve(workspaceDir));
+  const root = canonicalWorkspaceRoot(workspaceDir, relPath);
   const resolved = path.resolve(root, relPath);
   if (!resolved.startsWith(root + path.sep))
     throw new PathViolation(workspaceDir, relPath);
@@ -139,7 +158,7 @@ export function safeJoin(workspaceDir, relPath) {
  * trust boundary and verify the copied bytes by hash in the meantime.
  */
 export function confinedRegularFile(workspaceDir, relPath) {
-  const root = realpathSync(path.resolve(workspaceDir));
+  const root = canonicalWorkspaceRoot(workspaceDir, relPath);
   const source = safeJoin(root, relPath);
   const relative = path.relative(root, source);
   const components = relative.split(path.sep).filter(Boolean);

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -73,6 +73,22 @@ describe("safeJoin", () => {
     );
   });
 
+  test("reports a missing workspace root as PathViolation, not ENOENT", () => {
+    const gone = path.join(tmpRoot(), "destroyed-workspace");
+    let caught;
+    try {
+      safeJoin(gone, ".transcript.json");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PathViolation);
+    expect(caught.code).toBeUndefined();
+    expect(caught.detail).toBe("workspace root not resolvable");
+    expect(() => confinedRegularFile(gone, ".transcript.json")).toThrow(
+      PathViolation,
+    );
+  });
+
   test("keeps symlink escapes closed below a canonicalized workspace", () => {
     const workspace = tmpRoot();
     const outside = tmpRoot();

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   realpathSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -18,6 +19,7 @@ import {
   WorktreeSandboxUnsupportedError,
   WorktreeError,
   MEMOS_JSON_NOTICE,
+  confinedRegularFile,
   createWorkspace,
   destroyWorkspace,
   detectWorktreeOwnershipConflict,
@@ -51,6 +53,35 @@ describe("safeJoin", () => {
     expect(() => safeJoin(ws, "")).toThrow(PathViolation);
     expect(() => safeJoin(ws, undefined)).toThrow(PathViolation);
     expect(() => safeJoin(ws, ".")).toThrow(PathViolation);
+  });
+
+  test("canonicalizes a workspace reached through a symlinked ancestor", () => {
+    const realParent = tmpRoot();
+    const realWorkspace = path.join(realParent, "workspace");
+    mkdirSync(realWorkspace);
+    writeFileSync(path.join(realWorkspace, ".transcript.json"), "{}\n");
+
+    const aliasBase = tmpRoot();
+    const aliasParent = path.join(aliasBase, "alias");
+    symlinkSync(realParent, aliasParent, "dir");
+    const aliasedWorkspace = path.join(aliasParent, "workspace");
+
+    const expected = realpathSync(path.join(realWorkspace, ".transcript.json"));
+    expect(safeJoin(aliasedWorkspace, ".transcript.json")).toBe(expected);
+    expect(confinedRegularFile(aliasedWorkspace, ".transcript.json")).toBe(
+      expected,
+    );
+  });
+
+  test("keeps symlink escapes closed below a canonicalized workspace", () => {
+    const workspace = tmpRoot();
+    const outside = tmpRoot();
+    writeFileSync(path.join(outside, "secret.txt"), "secret\n");
+    symlinkSync(outside, path.join(workspace, "outside"), "dir");
+
+    expect(() => confinedRegularFile(workspace, "outside/secret.txt")).toThrow(
+      PathViolation,
+    );
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1159

Review canonical root containment for macOS /var workspace paths. `safeJoin` and `confinedRegularFile` now canonicalize the workspace root with `realpathSync` before containment checks, and a root that cannot be resolved (destroyed/retained workspace) surfaces as `PathViolation("workspace root not resolvable")` instead of a raw ENOENT.

## Validation

| Check                | Command                                                                                                   | Result  | Notes                           |
| -------------------- | --------------------------------------------------------------------------------------------------------- | ------- | ------------------------------- |
| Verification Command | `bun test event-runtime/lib/workspace.test.mjs event-runtime/lib/trace.test.mjs --timeout 20000` | pass    | 41 pass, 0 fail (includes new missing-root test) |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun run check`                              | pass with 1 pre-existing flake | 1707 pass, 9 skip, 1 fail: `worker.test.mjs` WM-115 "contended claim lock requeues with jittered backoff" timed out at 20 s. The identical test fails identically on a clean `origin/develop` worktree run side by side (1704 pass, 9 skip, same 1 fail); it passes on both trees when `worker.test.mjs` is run alone (133 pass). Load-sensitive timing test on the shared runner box (load avg 12–17), not caused by this change. `runtime-overrides.test.mjs`: 12 pass on both trees. `bun run check`: exit 0. |
| UX critique          | factory-ux-critic                                                                                         | not run | no user-facing surface          |

## Handoff

- Verification: `bun test event-runtime/lib/workspace.test.mjs event-runtime/lib/trace.test.mjs --timeout 20000` → 41 pass / 0 fail. `bun run check` → exit 0. Full `event-runtime/lib` suite: 1707 pass, 9 skip, 1 fail (pre-existing WM-115 claim-lock timing flake, reproduced identically on `origin/develop`; see table).
- UX: not applicable — backend workspace-containment change, no user-facing surface.
- File scope: `event-runtime/lib/workspace.mjs`, `event-runtime/lib/workspace.test.mjs` only.
