### PR TITLE
fix(worker): finalize stalled lease retries

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3446,7 +3446,10 @@ export async function executeClaimed(
 /**
  * Explicit operator recovery for a worker that stopped heartbeating while it
  * still owned a run. This mirrors the lease reaper's retry/exhaustion rules,
- * but targets exactly the selected worker/run and records an operator reason.
+ * but targets exactly the selected worker/run. When the run is retried it is
+ * re-queued with the fixed `retry:environment` reason (matching the reaper's
+ * lease-expiry requeue); operator provenance is carried by `actor` (default
+ * "operator") on the recorded transitions, not by the reason string.
  */
 export function releaseStalledWorkerLease(
   db,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1333,7 +1333,7 @@ function hasPlanTimeDispatchEvidence(spec) {
  * ledger that this new attempt belongs to the same run and immediately follows
  * a lease-expired claim before relaxing the Todo/unassigned dispatch gate.
  */
-function claimedRetryFor(db, runId, attempt) {
+export function claimedRetryFor(db, runId, attempt) {
   if (!Number.isInteger(attempt) || attempt <= 1) return null;
   const priorAttempt = attempt - 1;
   const prior = db
@@ -3503,36 +3503,35 @@ export function releaseStalledWorkerLease(
       `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
     ).run(iso(currentNow - 1), heldRunId, run.attempts);
     if (run.attempts < spec.maxAttempts) {
+      const failureReason = typedFailureReason("lease_expired");
       if (run.state === "VERIFYING") {
         transition(db, {
           runId: heldRunId,
           to: "FAILED",
           actor,
-          reason,
-          attempt: run.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-        transition(db, {
-          runId: heldRunId,
-          to: "QUEUED",
-          actor,
-          reason: "retry_after_stalled_worker_release",
-          attempt: run.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-      } else {
-        transition(db, {
-          runId: heldRunId,
-          to: "QUEUED",
-          actor,
-          reason,
+          reason: failureReason,
           attempt: run.attempts,
           policyVersion,
           now: currentNow,
         });
       }
+      finishAttempt(
+        db,
+        heldRunId,
+        run.attempts,
+        "FAILED",
+        "lease_expired",
+        currentNow,
+      );
+      transition(db, {
+        runId: heldRunId,
+        to: "QUEUED",
+        actor,
+        reason: "retry:environment",
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
+      });
     } else {
       if (run.state === "LEASED") {
         transition(db, {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -60,6 +60,7 @@ import {
   cancelRun,
   CLAIM_LOCK_BACKOFF_MAX_MS,
   claimNext,
+  claimedRetryFor,
   CODE_RELOAD_EXIT,
   codeStamp,
   codeStampFiles,
@@ -80,6 +81,7 @@ import {
   policyMaxRunMinutes,
   materializeRunHarness,
   reapExpiredLeases,
+  releaseStalledWorkerLease,
   releaseClaimLock,
   repositoryIsClean,
   repositoryStatus,
@@ -2239,6 +2241,52 @@ describe("worker", () => {
       { reason_code: "lease_expired" },
     ]);
     expect(claimNext(db, opts())).toBeNull();
+  });
+
+  test("releasing a stalled worker finalizes and marks a retry as a lease expiry", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ maxAttempts: 2 }));
+    const claim = claimNext(db, opts());
+    const staleAt = T0 - 90_001;
+    db.query(
+      `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "w1",
+      "test-host",
+      1,
+      "{}",
+      "fake",
+      new Date(T0).toISOString(),
+      new Date(staleAt).toISOString(),
+      "busy",
+      spec.runId,
+    );
+
+    expect(
+      releaseStalledWorkerLease(
+        db,
+        { workerId: "w1", runId: spec.runId },
+        { now: T0, policyVersion: "test" },
+      ),
+    ).toEqual({ released: true, runId: spec.runId });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(
+      db
+        .query(
+          `SELECT terminal_state, reason_code, finished_at FROM attempts WHERE run_id = ? AND attempt = ?`,
+        )
+        .get(spec.runId, claim.attempt),
+    ).toEqual({
+      terminal_state: "FAILED",
+      reason_code: "lease_expired",
+      finished_at: new Date(T0).toISOString(),
+    });
+    expect(claimedRetryFor(db, spec.runId, claim.attempt + 1)).toEqual({
+      runId: spec.runId,
+      priorAttempt: claim.attempt,
+      reasonCode: "lease_expired",
+    });
   });
 
   test("cancelRun on a RUNNING attempt aborts adapter immediately and records attempt (OPS-417)", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#947

Review the stalled-worker retry path and regression coverage for finalized lease-expired attempts.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/worker.test.mjs` | pass | 134 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1706 pass, 9 skip; generated files match |
| UX critique          | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface