### PR TITLE
sec(ci): verify downloaded tool archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -296,7 +304,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
@@ -426,7 +442,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -43,7 +43,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -89,10 +89,12 @@ jobs:
             # Pinned release download (WM-950)
             tag="v8.24.0"
             ver="${tag#v}"
+            archive="$RUNNER_TEMP/gitleaks_${ver}_linux_x64.tar.gz"
             mkdir -p "$HOME/.local/bin"
-            curl -fsSL -o "$RUNNER_TEMP/gitleaks.tar.gz" \
+            curl -fsSL -o "$archive" \
               "https://github.com/gitleaks/gitleaks/releases/download/${tag}/gitleaks_${ver}_linux_x64.tar.gz"
-            tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$HOME/.local/bin" gitleaks
+            echo "cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4  $archive" | sha256sum -c -
+            tar -xzf "$archive" -C "$HOME/.local/bin" gitleaks
             chmod +x "$HOME/.local/bin/gitleaks"
             echo "bin=$HOME/.local/bin/gitleaks" >> "$GITHUB_OUTPUT"
           fi
@@ -143,13 +145,22 @@ jobs:
           git log -1 --oneline
 
       # uv is on the runner host per code-security.md §4 tier 2b; only install
-      # (from astral.sh, not codeload) if it is missing.
+      # a checksum-pinned release archive if it is missing.
       - name: Setup uv (no action download)
         shell: bash
         run: |
           set -euo pipefail
           if ! command -v uvx >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/uvx" ]; then
-            curl -LsSf https://astral.sh/uv/install.sh | sh
+            version="0.6.5"
+            archive="$RUNNER_TEMP/uv-x86_64-unknown-linux-gnu.tar.gz"
+            extract_dir="$RUNNER_TEMP/uv-x86_64-unknown-linux-gnu"
+            mkdir -p "$HOME/.local/bin"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-unknown-linux-gnu.tar.gz"
+            echo "8fc9895719a1291ecd193cb86f9282ff3649cef797d29eacc74c4f573aab1e2f  $archive" | sha256sum -c -
+            tar -xzf "$archive" -C "$RUNNER_TEMP"
+            install -m 0755 "$extract_dir/uv" "$extract_dir/uvx" "$HOME/.local/bin/"
           fi
           # $GITHUB_PATH only takes effect starting the *next* step, not this
           # one — resolve the binary directly here rather than relying on PATH.
@@ -190,8 +201,14 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v actionlint >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/actionlint" ]; then
+            version="1.7.7"
+            archive="$RUNNER_TEMP/actionlint_${version}_linux_amd64.tar.gz"
             mkdir -p "$HOME/.local/bin"
-            bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7 "$HOME/.local/bin"
+            curl -fsSL -o "$archive" \
+              "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz"
+            echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $archive" | sha256sum -c -
+            tar -xzf "$archive" -C "$HOME/.local/bin" actionlint
+            chmod +x "$HOME/.local/bin/actionlint"
           fi
           # $GITHUB_PATH only takes effect starting the *next* step, not this
           # one — resolve the binary directly here rather than relying on PATH.

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -46,7 +46,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
-            curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+            version="1.3.14"
+            archive="$RUNNER_TEMP/bun-linux-x64.zip"
+            extract_dir="$RUNNER_TEMP/bun-linux-x64"
+            rm -rf "$extract_dir"
+            curl -fsSL -o "$archive" \
+              "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip"
+            echo "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f  $archive" | sha256sum -c -
+            unzip -q "$archive" -d "$RUNNER_TEMP"
+            install -Dm755 "$extract_dir/bun" "$HOME/.bun/bin/bun"
           fi
           if [ -x "$HOME/.bun/bin/bun" ]; then
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Fixes watt-mind/factory#958

Review the pinned archive checksums and fail-closed extraction paths; authorised by inbox_d5cbe2bd-2f03-4e4b-b401-af077bee9289 at 2026-08-29T18:00:16.301Z.

## Validation

| Check                | Command                                                                   | Result  | Notes                       |
| -------------------- | ------------------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `actionlint -color .github/workflows/*.yml`                                | pass    | exit 0, no diagnostics      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | exit 1  | develop-side `timing-test registry (WM-918)` / overlay-promotion suites failed; this workflow-only diff cannot affect them (develop head is green on ci.yml) |
| UX critique          | factory-ux-critic                                                         | not run | no user-facing surface      |

UX critique: skipped — CI workflow-only change; no user-facing surface

## Handoff

- Verification: `actionlint -color .github/workflows/*.yml` exit 0; the four pinned checksums verified against upstream release assets: bun 1.3.14 `951ee2ae…`, gitleaks 8.24.0 `cb49b7de…`, uv 0.6.5 `8fc98957…`, actionlint 1.7.7 `023070a2…`.
- Repo verify: exit 1 on the develop-side `timing-test registry (WM-918)` / overlay-promotion suites only — unrelated to this diff (a fix is in progress on develop).
- UX critique: not applicable — CI workflows only, no user-facing surface.
- File scope: the five `.github/workflows/*.yml` files; no runtime code touched.
