### PR TITLE
fix(extensions): reject prototype-polluting config paths

### DIFF
--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -3,7 +3,7 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-config-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { configView, redactSecrets } from "./api-config.mjs";
 import { makeServer as makeApiServer } from "./api-test-helpers.mjs";
@@ -472,6 +472,49 @@ describe("GET /config view", () => {
       if (prevEnv === undefined) delete process.env[envVar];
       else process.env[envVar] = prevEnv;
       resetExtensionSecretsCache();
+    }
+  });
+
+  test("GET /config serves a disabled malicious schema without prototype pollution", async () => {
+    const marker = "factoryConfigApiPrototypePollution";
+    const extensionDir = tmpDir("evrt-config-malicious-extension-");
+    cpSync(SAMPLE_EXTENSION, extensionDir, { recursive: true });
+    const schemaFile = path.join(extensionDir, "config.schema.json");
+    const schema = JSON.parse(readFileSync(schemaFile, "utf8"));
+    schema.properties = {
+      ["__proto__"]: {
+        type: "object",
+        properties: {
+          [marker]: { type: "string", format: "secret" },
+        },
+      },
+    };
+    writeFileSync(schemaFile, JSON.stringify(schema));
+
+    delete Object.prototype[marker];
+    let apiServer;
+    try {
+      const loaded = await loadExtensions({
+        policy: { extensions: [{ path: extensionDir }] },
+        packRoots: [],
+      });
+      expect(loaded.extensions).toEqual([]);
+      expect(loaded.anomalies[0]).toMatch(
+        /config schema path contains forbidden segment "__proto__"/,
+      );
+
+      apiServer = await makeServer({ configRoot: fixtureRoot() });
+      const response = await fetch(apiServer.url("/config"));
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const section = body.sections.find((item) => item.id === "extensions");
+      expect(section.extensions[0].anomaly).toMatch(
+        /config schema path contains forbidden segment "__proto__"/,
+      );
+      expect(Object.prototype[marker]).toBeUndefined();
+    } finally {
+      apiServer?.close();
+      delete Object.prototype[marker];
     }
   });
 

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -656,6 +656,7 @@ function assertSafeConfigPath(keyPath) {
 }
 
 function assertSafeConfigSchemaPaths(schema, path = []) {
+  assertSafeConfigPath(path);
   if (!isPlainObject(schema)) return;
   if (isPlainObject(schema.properties)) {
     for (const [key, sub] of Object.entries(schema.properties)) {

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -787,7 +787,7 @@ function setAt(obj, keyPath, value) {
       !isPrototypeSafeRecord(node[key])
     ) {
       Object.defineProperty(node, key, {
-        value: Object.create(null),
+        value: {},
         writable: true,
         enumerable: true,
         configurable: true,

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -639,6 +639,42 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const FORBIDDEN_CONFIG_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "prototype",
+  "constructor",
+]);
+
+function assertSafeConfigPath(keyPath) {
+  for (const key of keyPath) {
+    if (FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key)) {
+      throw new ExtensionError(
+        `config schema path contains forbidden segment "${key}"`,
+      );
+    }
+  }
+}
+
+function assertSafeConfigSchemaPaths(schema, path = []) {
+  if (!isPlainObject(schema)) return;
+  if (isPlainObject(schema.properties)) {
+    for (const [key, sub] of Object.entries(schema.properties)) {
+      const next = [...path, key];
+      assertSafeConfigPath(next);
+      assertSafeConfigSchemaPaths(sub, next);
+    }
+  }
+  if (isPlainObject(schema.items)) {
+    assertSafeConfigSchemaPaths(schema.items, path);
+  }
+}
+
+function isPrototypeSafeRecord(value) {
+  if (!isPlainObject(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 /**
  * Fill `default`s from a schema into a value, recursively through
  * `properties` and `items`. A nested object property with no value is only
@@ -648,6 +684,11 @@ function isPlainObject(value) {
  * invented unless the schema supplies a `default`).
  */
 export function applyConfigDefaults(schema, value) {
+  assertSafeConfigSchemaPaths(schema);
+  return applyConfigDefaultsUnchecked(schema, value);
+}
+
+function applyConfigDefaultsUnchecked(schema, value) {
   if (!isPlainObject(schema)) return cloneJson(value);
   let out = cloneJson(value);
   if (out === undefined) {
@@ -659,17 +700,17 @@ export function applyConfigDefaults(schema, value) {
   if (isPlainObject(out) && isPlainObject(schema.properties)) {
     for (const [key, sub] of Object.entries(schema.properties)) {
       if (Object.hasOwn(out, key)) {
-        out[key] = applyConfigDefaults(sub, out[key]);
+        out[key] = applyConfigDefaultsUnchecked(sub, out[key]);
         continue;
       }
-      const filled = applyConfigDefaults(sub, undefined);
+      const filled = applyConfigDefaultsUnchecked(sub, undefined);
       if (filled === undefined) continue;
       if (isPlainObject(filled) && Object.keys(filled).length === 0) continue;
       out[key] = filled;
     }
   }
   if (Array.isArray(out) && isPlainObject(schema.items)) {
-    out = out.map((item) => applyConfigDefaults(schema.items, item));
+    out = out.map((item) => applyConfigDefaultsUnchecked(schema.items, item));
   }
   return out;
 }
@@ -708,44 +749,76 @@ export function extensionSecretEnvVar(namespace, keyPath) {
  * the path used for env names and published `{ set, source }` overlays.
  */
 export function collectSecretFields(schema, path = []) {
+  assertSafeConfigSchemaPaths(schema, path);
+  return collectSecretFieldsUnchecked(schema, path);
+}
+
+function collectSecretFieldsUnchecked(schema, path = []) {
   if (!isPlainObject(schema) || !isPlainObject(schema.properties)) return [];
   const out = [];
   for (const [key, sub] of Object.entries(schema.properties)) {
     const next = [...path, key];
     if (isPlainObject(sub) && sub.format === "secret")
       out.push({ path: next, key });
-    else out.push(...collectSecretFields(sub, next));
+    else out.push(...collectSecretFieldsUnchecked(sub, next));
   }
   return out;
 }
 
 function hasAt(obj, keyPath) {
+  assertSafeConfigPath(keyPath);
   let node = obj;
   for (const key of keyPath) {
-    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return false;
+    if (!isPrototypeSafeRecord(node) || !Object.hasOwn(node, key)) return false;
     node = node[key];
   }
   return true;
 }
 
 function setAt(obj, keyPath, value) {
+  assertSafeConfigPath(keyPath);
   let node = obj;
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
-    if (!isPlainObject(node[key])) node[key] = {};
+    if (!isPrototypeSafeRecord(node)) return;
+    if (
+      !Object.hasOwn(node, key) ||
+      !isPrototypeSafeRecord(node[key])
+    ) {
+      Object.defineProperty(node, key, {
+        value: Object.create(null),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
     node = node[key];
   }
-  node[keyPath[keyPath.length - 1]] = value;
+  if (!isPrototypeSafeRecord(node)) return;
+  Object.defineProperty(node, keyPath[keyPath.length - 1], {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 function deleteAt(obj, keyPath) {
+  assertSafeConfigPath(keyPath);
   let node = obj;
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
-    if (!isPlainObject(node[key])) return;
+    if (
+      !isPrototypeSafeRecord(node) ||
+      !Object.hasOwn(node, key) ||
+      !isPrototypeSafeRecord(node[key])
+    )
+      return;
     node = node[key];
   }
-  delete node[keyPath[keyPath.length - 1]];
+  if (!isPrototypeSafeRecord(node)) return;
+  const key = keyPath[keyPath.length - 1];
+  if (Object.hasOwn(node, key)) delete node[key];
 }
 
 /** Public config vs secrets bag for a connector's `ctx`. */

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -782,10 +782,7 @@ function setAt(obj, keyPath, value) {
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
     if (!isPrototypeSafeRecord(node)) return;
-    if (
-      !Object.hasOwn(node, key) ||
-      !isPrototypeSafeRecord(node[key])
-    ) {
+    if (!Object.hasOwn(node, key) || !isPrototypeSafeRecord(node[key])) {
       Object.defineProperty(node, key, {
         value: {},
         writable: true,

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -36,6 +36,7 @@ import {
   loadExtensions,
   loadedExtensions,
   looksLikePackageName,
+  maskExtensionSecrets,
   resetExtensionSecretsCache,
   resolveExtensionPackage,
   validateExtensionManifest,
@@ -948,6 +949,91 @@ describe("extension config (contributes.config)", () => {
     expect(denied.anomalies[0]).toMatch(
       /config\.apiToken must not be set in policy\.yaml — use env FACTORY_EXT_SAMPLE_API_TOKEN/,
     );
+  });
+
+  test("rejects prototype-polluting schema paths before loading or masking", async () => {
+    const marker = "factoryExtensionPrototypePollution";
+    delete Object.prototype[marker];
+
+    try {
+      for (const segment of ["__proto__", "prototype", "constructor"]) {
+        const schema = {
+          type: "object",
+          properties: {
+            [segment]: {
+              type: "object",
+              properties: {
+                [marker]: { type: "string", format: "secret" },
+              },
+            },
+          },
+        };
+        expect(() => maskExtensionSecrets({}, schema)).toThrow(
+          `config schema path contains forbidden segment "${segment}"`,
+        );
+        expect(Object.prototype[marker]).toBeUndefined();
+      }
+
+      const dir = tempExtension((_manifest, extensionDir) => {
+        writeFileSync(
+          path.join(extensionDir, "config.schema.json"),
+          JSON.stringify({
+            type: "object",
+            properties: {
+              ["__proto__"]: {
+                type: "object",
+                properties: {
+                  [marker]: { type: "string", format: "secret" },
+                },
+              },
+            },
+          }),
+        );
+      });
+      const out = await load({ extensions: [{ path: dir }] });
+      expect(out.extensions).toEqual([]);
+      expect(out.anomalies[0]).toMatch(
+        /config schema path contains forbidden segment "__proto__"/,
+      );
+      expect(Object.prototype[marker]).toBeUndefined();
+    } finally {
+      delete Object.prototype[marker];
+    }
+  });
+
+  test("secret masking never descends through an inherited config record", () => {
+    const inheritedKey = "factoryInheritedExtensionConfig";
+    const inherited = {};
+    Object.defineProperty(Object.prototype, inheritedKey, {
+      value: inherited,
+      configurable: true,
+    });
+
+    try {
+      const masked = maskExtensionSecrets(
+        {},
+        {
+          type: "object",
+          properties: {
+            [inheritedKey]: {
+              type: "object",
+              properties: {
+                token: { type: "string", format: "secret" },
+              },
+            },
+          },
+        },
+        { [`${inheritedKey}.token`]: { set: true, source: "env" } },
+      );
+      expect(inherited).toEqual({});
+      expect(Object.hasOwn(masked, inheritedKey)).toBe(true);
+      expect(masked[inheritedKey].token).toEqual({
+        set: true,
+        source: "env",
+      });
+    } finally {
+      delete Object.prototype[inheritedKey];
+    }
   });
 
   test("a group/world-readable secrets.env warns once, is ignored (not read), and does not fail the load", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#963

Review the prototype-safe traversal and malicious-schema regressions; security scope authorised by operator:preapproved-2026-08-29 at 2026-08-29T18:03:00.094Z.

## Validation

| Check                | Command                                                                                 | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/extensions.test.mjs event-runtime/lib/api-config.test.mjs` | pass    | 69 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`               | pass    | 1708 pass, 9 skip; generated files match   |
| UX critique          | factory-ux-critic                                                                       | not run | backend security hardening; no user flow   |

UX critique: skipped — backend security hardening with no user-completable flow

## Handoff

- Post-review: `setAt` now creates plain `{}` intermediates instead of null-prototype records (0f6403c9); every segment is forbidden-segment- and own-property-checked already, and null-prototype objects were leaking into the effective config / `/config` payload. Tests + `bun run check` pass.
