### PR TITLE
fix(extensions): reject dynamic secret schema fields

### DIFF
--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -3,12 +3,13 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-config-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { configView, redactSecrets } from "./api-config.mjs";
 import { makeServer as makeApiServer } from "./api-test-helpers.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import {
+  EXTENSION_MANIFEST,
   extensionSecretEnvVar,
   loadExtensions,
   resetExtensionSecretsCache,
@@ -395,6 +396,66 @@ describe("GET /config view", () => {
       apiToken: { set: true, source: "env" },
     });
     expect(JSON.stringify(view)).not.toContain("super-secret-value");
+  });
+
+  test("GET /config cannot publish an innocently named secret beneath array items", async () => {
+    const dir = tmpDir("evrt-array-secret-extension-");
+    cpSync(SAMPLE_EXTENSION, dir, { recursive: true });
+    const manifestFile = path.join(dir, EXTENSION_MANIFEST);
+    const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
+    manifest.name = "factory/array-secret";
+    manifest.contributes.config.namespace = "array-secret";
+    writeFileSync(manifestFile, JSON.stringify(manifest));
+    writeFileSync(
+      path.join(dir, "config.schema.json"),
+      JSON.stringify({
+        type: "object",
+        properties: {
+          destinations: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                value: { type: "string", format: "secret" },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const secret = "plaintext-that-must-not-reach-config";
+    const loaded = await loadExtensions({
+      policy: {
+        extensions: [
+          {
+            path: dir,
+            config: {
+              destinations: [{ label: "prod", value: secret }],
+            },
+          },
+        ],
+      },
+      packRoots: [],
+    });
+    expect(loaded.extensions).toEqual([]);
+    expect(loaded.disabled[0].reason).toMatch(
+      /\$\.destinations\[\]\.value.*dynamic secret locations are unsupported/,
+    );
+
+    const view = configView({
+      root: fixtureRoot(),
+      registry: registry(),
+      repos: () => new Map(),
+      policyVersion: "git:test",
+      now: 0,
+    });
+    const section = view.sections.find((item) => item.id === "extensions");
+    expect(section.extensions[0].values).toBeNull();
+    expect(section.extensions[0].anomaly).toMatch(
+      /dynamic secret locations are unsupported/,
+    );
+    expect(JSON.stringify(view)).not.toContain(secret);
   });
 
   test("defaults to the extensions the process loaded (lib/extensions.mjs snapshot)", async () => {

--- a/event-runtime/lib/connectors.test.mjs
+++ b/event-runtime/lib/connectors.test.mjs
@@ -83,15 +83,22 @@ describe("splitConfigSecrets", () => {
       greeting: "hi",
       apiToken: "sk-live",
       nsec: "nsec1abc",
+      credentials: { value: "innocuous-secret-name" },
       nested: { signingKey: "k", retries: 1 },
     };
     const { config, secrets } = splitConfigSecrets(values, [
       { path: ["apiToken"] },
+      { path: ["credentials", "value"] },
     ]);
-    expect(config).toEqual({ greeting: "hi", nested: { retries: 1 } });
+    expect(config).toEqual({
+      greeting: "hi",
+      credentials: {},
+      nested: { retries: 1 },
+    });
     expect(secrets).toEqual({
       apiToken: "sk-live",
       nsec: "nsec1abc",
+      credentials: { value: "innocuous-secret-name" },
       nested: { signingKey: "k" },
     });
     expect(values.apiToken).toBe("sk-live");

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -704,17 +704,69 @@ export function extensionSecretEnvVar(namespace, keyPath) {
 }
 
 /**
- * Every `format: "secret"` property in a config schema, depth-first, with
- * the path used for env names and published `{ set, source }` overlays.
+ * Every supported `format: "secret"` property in a config schema,
+ * depth-first, with the path used for env names and published
+ * `{ set, source }` overlays.
+ *
+ * Array items and `additionalProperties` are valid schema locations, but
+ * their runtime keys are dynamic: one schema path cannot map their potentially
+ * many values to one unambiguous `FACTORY_EXT_*` variable. Fail those schemas
+ * closed at load rather than letting policy rejection, resolution, connector
+ * splitting and `/config` masking disagree about which values are secret.
  */
-export function collectSecretFields(schema, path = []) {
-  if (!isPlainObject(schema) || !isPlainObject(schema.properties)) return [];
+export function collectSecretFields(
+  schema,
+  path = [],
+  schemaPath = "$",
+  dynamicLocation = null,
+) {
+  if (!isPlainObject(schema)) return [];
+  if (schema.format === "secret") {
+    if (dynamicLocation) {
+      throw new ExtensionError(
+        `config schema ${schemaPath} declares format "secret" beneath ${dynamicLocation}; dynamic secret locations are unsupported — declare a fixed object property`,
+      );
+    }
+    if (path.length === 0) {
+      throw new ExtensionError(
+        'config schema $ declares format "secret" at the config root; secrets must be fixed object properties',
+      );
+    }
+    return [{ path, key: path[path.length - 1] }];
+  }
+
   const out = [];
-  for (const [key, sub] of Object.entries(schema.properties)) {
-    const next = [...path, key];
-    if (isPlainObject(sub) && sub.format === "secret")
-      out.push({ path: next, key });
-    else out.push(...collectSecretFields(sub, next));
+  if (isPlainObject(schema.properties)) {
+    for (const [key, sub] of Object.entries(schema.properties)) {
+      out.push(
+        ...collectSecretFields(
+          sub,
+          [...path, key],
+          `${schemaPath}.${key}`,
+          dynamicLocation,
+        ),
+      );
+    }
+  }
+  if (isPlainObject(schema.items)) {
+    out.push(
+      ...collectSecretFields(
+        schema.items,
+        path,
+        `${schemaPath}[]`,
+        dynamicLocation ?? `schema.items at ${schemaPath}`,
+      ),
+    );
+  }
+  if (isPlainObject(schema.additionalProperties)) {
+    out.push(
+      ...collectSecretFields(
+        schema.additionalProperties,
+        path,
+        `${schemaPath}.*`,
+        dynamicLocation ?? `schema.additionalProperties at ${schemaPath}`,
+      ),
+    );
   }
   return out;
 }

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -25,6 +25,7 @@ import {
   ExtensionError,
   RESERVED_CONTRIBUTIONS,
   applyConfigDefaults,
+  collectSecretFields,
   collectHarnessRoots,
   contributionCounts,
   discoverExtensionPackRoots,
@@ -36,6 +37,7 @@ import {
   loadExtensions,
   loadedExtensions,
   looksLikePackageName,
+  maskExtensionSecrets,
   resetExtensionSecretsCache,
   resolveExtensionPackage,
   validateExtensionManifest,
@@ -948,6 +950,172 @@ describe("extension config (contributes.config)", () => {
     expect(denied.anomalies[0]).toMatch(
       /config\.apiToken must not be set in policy\.yaml — use env FACTORY_EXT_SAMPLE_API_TOKEN/,
     );
+  });
+
+  test("secret discovery covers fixed nested objects and rejects dynamic schema locations", async () => {
+    const nestedSecretSchema = {
+      type: "object",
+      properties: {
+        auth: {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            value: { type: "string", format: "secret" },
+          },
+        },
+      },
+    };
+    expect(collectSecretFields(nestedSecretSchema)).toEqual([
+      { path: ["auth", "value"], key: "value" },
+    ]);
+
+    const nestedDir = tempExtension((manifest, extensionDir) => {
+      manifest.name = "factory/nested-secret";
+      manifest.contributes.config.namespace = "nested-secret";
+      writeFileSync(
+        path.join(extensionDir, "config.schema.json"),
+        JSON.stringify(nestedSecretSchema),
+      );
+    });
+    const nestedEnv = extensionSecretEnvVar("nested-secret", [
+      "auth",
+      "value",
+    ]);
+    const previousNestedEnv = process.env[nestedEnv];
+    try {
+      process.env[nestedEnv] = "resolved-innocuous-secret";
+      const nested = await load({
+        extensions: [
+          { path: nestedDir, config: { auth: { label: "primary" } } },
+        ],
+      });
+      expect(nested.anomalies).toEqual([]);
+      expect(nested.extensions[0].config.values).toEqual({
+        auth: { label: "primary", value: "resolved-innocuous-secret" },
+      });
+      const nestedMeta =
+        loadedExtensions().extensions[0].config.secretMeta["auth.value"];
+      expect(nestedMeta).toEqual({
+        set: true,
+        source: "env",
+      });
+      expect(
+        maskExtensionSecrets(
+          nested.extensions[0].config.values,
+          nestedSecretSchema,
+          { "auth.value": nestedMeta },
+        ),
+      ).toEqual({
+        auth: { label: "primary", value: { set: true, source: "env" } },
+      });
+    } finally {
+      if (previousNestedEnv === undefined) delete process.env[nestedEnv];
+      else process.env[nestedEnv] = previousNestedEnv;
+    }
+
+    const cases = [
+      {
+        name: "array of objects",
+        schema: {
+          type: "object",
+          properties: {
+            destinations: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  label: { type: "string" },
+                  value: { type: "string", format: "secret" },
+                },
+              },
+            },
+          },
+        },
+        error: /\$\.destinations\[\]\.value.*beneath schema\.items at \$\.destinations/,
+      },
+      {
+        name: "nested arrays",
+        schema: {
+          type: "object",
+          properties: {
+            groups: {
+              type: "array",
+              items: {
+                type: "array",
+                items: { type: "string", format: "secret" },
+              },
+            },
+          },
+        },
+        error: /\$\.groups\[\]\[\].*beneath schema\.items at \$\.groups/,
+      },
+      {
+        name: "additional properties",
+        schema: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              value: { type: "string", format: "secret" },
+            },
+          },
+        },
+        error: /\$\.\*\.value.*beneath schema\.additionalProperties at \$/,
+      },
+    ];
+
+    for (const item of cases) {
+      const dir = tempExtension((manifest, extensionDir) => {
+        manifest.name = `factory/${item.name.replaceAll(" ", "-")}`;
+        manifest.contributes.config.namespace = item.name.replaceAll(" ", "-");
+        writeFileSync(
+          path.join(extensionDir, "config.schema.json"),
+          JSON.stringify(item.schema),
+        );
+      });
+      const out = await load({
+        extensions: [{ path: dir, config: {} }],
+      });
+      expect(out.extensions, item.name).toEqual([]);
+      expect(out.anomalies[0], item.name).toMatch(item.error);
+      expect(out.anomalies[0], item.name).toMatch(
+        /dynamic secret locations are unsupported/,
+      );
+    }
+  });
+
+  test("ordinary non-secret arrays remain supported", async () => {
+    const dir = tempExtension((manifest, extensionDir) => {
+      manifest.name = "factory/array-config";
+      manifest.contributes.config.namespace = "array-config";
+      writeFileSync(
+        path.join(extensionDir, "config.schema.json"),
+        JSON.stringify({
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            destinations: {
+              type: "array",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                required: ["label", "value"],
+                properties: {
+                  label: { type: "string" },
+                  value: { type: "string" },
+                },
+              },
+            },
+          },
+        }),
+      );
+    });
+    const destinations = [{ label: "prod", value: "ordinary" }];
+    const out = await load({
+      extensions: [{ path: dir, config: { destinations } }],
+    });
+    expect(out.anomalies).toEqual([]);
+    expect(out.extensions[0].config.values.destinations).toEqual(destinations);
   });
 
   test("a group/world-readable secrets.env warns once, is ignored (not read), and does not fail the load", () => {

--- a/event-runtime/lib/extensions.test.mjs
+++ b/event-runtime/lib/extensions.test.mjs
@@ -977,10 +977,7 @@ describe("extension config (contributes.config)", () => {
         JSON.stringify(nestedSecretSchema),
       );
     });
-    const nestedEnv = extensionSecretEnvVar("nested-secret", [
-      "auth",
-      "value",
-    ]);
+    const nestedEnv = extensionSecretEnvVar("nested-secret", ["auth", "value"]);
     const previousNestedEnv = process.env[nestedEnv];
     try {
       process.env[nestedEnv] = "resolved-innocuous-secret";
@@ -1031,7 +1028,8 @@ describe("extension config (contributes.config)", () => {
             },
           },
         },
-        error: /\$\.destinations\[\]\.value.*beneath schema\.items at \$\.destinations/,
+        error:
+          /\$\.destinations\[\]\.value.*beneath schema\.items at \$\.destinations/,
       },
       {
         name: "nested arrays",


### PR DESCRIPTION
Fixes watt-mind/factory#964

Review fail-closed rejection of dynamic secret schemas; authorised by `inbox_555de32e-c279-4c24-af43-48727c841591` at `2026-08-29T18:03:39.780Z`.

## Validation

| Check                | Command                                                                                              | Result  | Notes                          |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/extensions.test.mjs event-runtime/lib/api-config.test.mjs` | pass    | 69 tests, 0 failures           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`                           | exit 1  | worker's repo-verify exited 1 on the develop-side `overlay promotion (gh-860)` / `timing-test registry (WM-918)` suites — unrelated to this diff; the branch's own suites pass 103/0; emit --check clean |
| UX critique          | factory-ux-critic                                                                                    | not run | no user-facing surface         |

UX critique: skipped — backend security hardening; no user-facing surface

## Handoff

- Verification (merge reviewer, fresh worktree of `feat/gh-964` merged with `origin/develop`, `bun install --frozen-lockfile`): `bun test --timeout 20000 event-runtime/lib/extensions.test.mjs event-runtime/lib/api-config.test.mjs event-runtime/lib/connectors.test.mjs` — 82 pass, 0 fail, 425 expect() calls; `bun run check` — exit 0 (floor-delivery warning only, pre-existing).
- UX: not applicable — loader-side security hardening (`format:"secret"` under `items`/`additionalProperties`/config root now rejected at load; extension disabled, `values: null`); no user-facing surface.
- File scope: `event-runtime/lib/extensions.mjs`, `event-runtime/lib/extensions.test.mjs`, `event-runtime/lib/api-config.test.mjs`, `event-runtime/lib/connectors.test.mjs` — all within #964 Owned Paths. `docs/event-runtime.md` is outside Owned Paths, so the doc note on the new rejection is deferred to a follow-up triage issue.
