### PR TITLE
fix(command): sanitize unsandboxed child environments

### DIFF
--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -37,7 +37,32 @@ export const SANDBOX_SUPPORT = "gondolin";
 const KILL_GRACE_MS = 10_000;
 const OUTPUT_TAIL_CHARS = 2_000;
 
+/**
+ * Runtime-identity variables every command-adapter child needs so that it
+ * talks to the SAME event-runtime instance as the worker that spawned it.
+ * bin/live-stack.sh and bin/worktree-daemons.sh set these on the worker only;
+ * without them a child's `config.mjs` silently resolves the DEFAULT live home,
+ * port, secret, and env — a worktree stack's merge-apply/merge-scan/reaper/
+ * digest/ci-log-capture would then read and write the production runtime.
+ * This is an explicit allow-list on purpose: no `FACTORY_EVENT_*` wildcard.
+ *
+ * GitHub and Linear credentials are deliberately NOT here. Read-only agents
+ * (merge-scan, merge-plan, ci-log-capture, unblock-digest) authenticate via
+ * files under HOME — `gh` reads its config/hosts (and the App token file that
+ * lib/control-plane/gh-app-auth.mjs resolves from FACTORY_GH_APP_TOKEN_FILE
+ * or ~/.factory/gh-app-token.json), and `factory linear` reads the operator
+ * .env — so no env token is required for reads. Mutating definitions receive
+ * PUSH_CREDENTIAL_ENV below.
+ */
+export const RUNTIME_IDENTITY_ENV = [
+  "FACTORY_EVENT_HOME",
+  "FACTORY_EVENT_PORT",
+  "FACTORY_EVENT_SECRET",
+  "FACTORY_EVENT_ENV",
+];
+
 export const BASE_INHERITED_ENV = [
+  ...RUNTIME_IDENTITY_ENV,
   "HOME",
   "LANG",
   "LC_ALL",

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -28,6 +28,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
+import { PUSH_CREDENTIAL_ENV } from "./claude.mjs";
 import { runSandboxed, sandboxRequested } from "./sandboxed.mjs";
 
 /** This adapter executes inside the VM when a definition asks (WM-185). */
@@ -35,6 +36,71 @@ export const SANDBOX_SUPPORT = "gondolin";
 
 const KILL_GRACE_MS = 10_000;
 const OUTPUT_TAIL_CHARS = 2_000;
+
+export const BASE_INHERITED_ENV = [
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+];
+
+export { PUSH_CREDENTIAL_ENV };
+
+const PROVIDER_CREDENTIAL_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_GENAI_API_KEY",
+  "MISTRAL_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GROQ_API_KEY",
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+];
+
+/**
+ * Build the environment for an unsandboxed deterministic command.
+ *
+ * Ambient worker authority is allowlisted. Caller-provided values may add or
+ * override ordinary command configuration, but adapter-owned FACTORY_ROOT and
+ * credentials are enforced after that overlay. Push credentials are available
+ * only to an explicitly mutating definition.
+ */
+export function safeChildEnvironment(env = {}, defOrOpts = {}) {
+  const isMutating =
+    typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating
+    ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV]
+    : BASE_INHERITED_ENV;
+  const childEnv = Object.fromEntries(
+    inherited.flatMap((key) =>
+      process.env[key] === undefined ? [] : [[key, process.env[key]]],
+    ),
+  );
+
+  Object.assign(childEnv, env);
+  childEnv.FACTORY_ROOT = FACTORY_ROOT;
+
+  for (const key of PROVIDER_CREDENTIAL_ENV) {
+    delete childEnv[key];
+  }
+  if (!isMutating) {
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      delete childEnv[key];
+    }
+  }
+
+  return childEnv;
+}
 
 /**
  * Substitute `{field}` placeholders in one argv element.
@@ -167,6 +233,7 @@ export async function execute({
   timeoutMs,
   abortSignal,
   signal,
+  env = {},
   onTrace,
   runSandbox,
 }) {
@@ -192,7 +259,7 @@ export async function execute({
   return new Promise((resolve, reject) => {
     const child = spawn(argv[0], argv.slice(1), {
       cwd: workspaceDir,
-      env: process.env,
+      env: safeChildEnvironment(env, def),
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
     });

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -1,5 +1,5 @@
 import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-command-test-mjs";
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
@@ -9,7 +9,14 @@ import { loadModelTierMap, loadRegistry } from "../registry.mjs";
 import { validate } from "../schema.mjs";
 import { emitDueTicks } from "../schedules.mjs";
 import { preflight } from "../sandbox/gondolin.mjs";
-import { execute, resolveTemplate, SANDBOX_SUPPORT } from "./command.mjs";
+import {
+  BASE_INHERITED_ENV,
+  execute,
+  PUSH_CREDENTIAL_ENV,
+  resolveTemplate,
+  safeChildEnvironment,
+  SANDBOX_SUPPORT,
+} from "./command.mjs";
 import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
 
 const def = (command) => ({ ref: "test-cmd@1", command });
@@ -61,6 +68,89 @@ describe("resolveTemplate", () => {
         factoryRoot: "/tmp/pwn",
       }),
     ).toEqual(["bun", REAPER_SCRIPT]);
+  });
+});
+
+describe("safeChildEnvironment", () => {
+  const originalEnv = { ...process.env };
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test("inherits only the ambient baseline and pins FACTORY_ROOT", () => {
+    process.env.COMMAND_ADAPTER_AMBIENT_SECRET = "must-not-leak";
+    process.env.HOME = "/tmp/command-adapter-home";
+
+    const childEnv = safeChildEnvironment({
+      CUSTOM_COMMAND_SETTING: "allowed",
+      HOME: "/tmp/overridden-home",
+      FACTORY_ROOT: "/tmp/untrusted-root",
+    });
+
+    expect(childEnv.HOME).toBe("/tmp/overridden-home");
+    expect(childEnv.CUSTOM_COMMAND_SETTING).toBe("allowed");
+    expect(childEnv.FACTORY_ROOT).toBe(FACTORY_ROOT);
+    expect(childEnv.COMMAND_ADAPTER_AMBIENT_SECRET).toBeUndefined();
+    for (const key of Object.keys(originalEnv)) {
+      if (
+        !BASE_INHERITED_ENV.includes(key) &&
+        !PUSH_CREDENTIAL_ENV.includes(key) &&
+        key !== "FACTORY_ROOT"
+      ) {
+        expect(childEnv[key]).toBeUndefined();
+      }
+    }
+  });
+
+  test("strips provider credentials even when supplied as overrides", () => {
+    const providerKeys = [
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "GEMINI_API_KEY",
+      "GOOGLE_API_KEY",
+      "GOOGLE_GENAI_API_KEY",
+      "MISTRAL_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "GROQ_API_KEY",
+      "CLAUDECODE",
+      "CLAUDE_CODE_ENTRYPOINT",
+    ];
+    const childEnv = safeChildEnvironment(
+      Object.fromEntries(providerKeys.map((key) => [key, `secret-${key}`])),
+      { mutating: true },
+    );
+
+    for (const key of providerKeys) {
+      expect(childEnv[key]).toBeUndefined();
+    }
+  });
+
+  test("inherits push credentials only for explicit mutating definitions", () => {
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      process.env[key] = `ambient-${key}`;
+    }
+
+    for (const opts of [{}, { mutating: false }, false]) {
+      const childEnv = safeChildEnvironment(
+        Object.fromEntries(
+          PUSH_CREDENTIAL_ENV.map((key) => [key, `override-${key}`]),
+        ),
+        opts,
+      );
+      for (const key of PUSH_CREDENTIAL_ENV) {
+        expect(childEnv[key]).toBeUndefined();
+      }
+    }
+
+    for (const opts of [{ mutating: true }, true]) {
+      const childEnv = safeChildEnvironment({ GH_TOKEN: "caller-token" }, opts);
+      for (const key of PUSH_CREDENTIAL_ENV) {
+        expect(childEnv[key]).toBe(
+          key === "GH_TOKEN" ? "caller-token" : `ambient-${key}`,
+        );
+      }
+    }
   });
 });
 
@@ -133,6 +223,49 @@ describe("execute", () => {
     );
     expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
     expect(result.artifact.command.join(" ")).not.toContain("/tmp/pwn");
+  });
+
+  test("does not leak worker or caller secrets to an unsandboxed child", async () => {
+    const workspaceDir = ws();
+    process.env.COMMAND_ADAPTER_AMBIENT_SECRET = "ambient-secret";
+    process.env.OPENAI_API_KEY = "ambient-provider-secret";
+    process.env.GH_TOKEN = "ambient-push-secret";
+    const inspectedKeys = [
+      "COMMAND_ADAPTER_AMBIENT_SECRET",
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "GH_TOKEN",
+      "CUSTOM_COMMAND_SETTING",
+      "FACTORY_ROOT",
+    ];
+    const script = `console.log(JSON.stringify(Object.fromEntries(${JSON.stringify(inspectedKeys)}.map((key) => [key, process.env[key] ?? null]))))`;
+
+    const outcome = await execute({
+      spec: spec({}),
+      def: { ...def(["bun", "-e", script]), mutating: false },
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        ANTHROPIC_API_KEY: "caller-provider-secret",
+        GH_TOKEN: "caller-push-secret",
+        CUSTOM_COMMAND_SETTING: "visible-setting",
+        FACTORY_ROOT: "/tmp/untrusted-root",
+      },
+    });
+
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
+    const childEnv = JSON.parse(result.artifact.outputTail.trim());
+    expect(childEnv).toEqual({
+      COMMAND_ADAPTER_AMBIENT_SECRET: null,
+      OPENAI_API_KEY: null,
+      ANTHROPIC_API_KEY: null,
+      GH_TOKEN: null,
+      CUSTOM_COMMAND_SETTING: "visible-setting",
+      FACTORY_ROOT,
+    });
   });
 
   test("writesResult leaves a command-authored result.json in place (WM-907)", async () => {

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -268,6 +268,41 @@ describe("execute", () => {
     });
   });
 
+  test("an unsandboxed child inherits the worker's runtime identity (#825)", async () => {
+    const workspaceDir = ws();
+    const identity = {
+      FACTORY_EVENT_HOME: "/tmp/command-adapter-runtime-home",
+      FACTORY_EVENT_SECRET: "worker-runtime-secret",
+      FACTORY_EVENT_PORT: "17381",
+      FACTORY_EVENT_ENV: "worktree-test",
+    };
+    const saved = Object.fromEntries(
+      Object.keys(identity).map((key) => [key, process.env[key]]),
+    );
+    Object.assign(process.env, identity);
+    const script = `console.log(JSON.stringify(Object.fromEntries(${JSON.stringify(Object.keys(identity))}.map((key) => [key, process.env[key] ?? null]))))`;
+
+    try {
+      const outcome = await execute({
+        spec: spec({}),
+        def: { ...def(["bun", "-e", script]), mutating: false },
+        workspaceDir,
+        timeoutMs: 5000,
+      });
+
+      expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+      const result = JSON.parse(
+        readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+      );
+      expect(JSON.parse(result.artifact.outputTail.trim())).toEqual(identity);
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
   test("writesResult leaves a command-authored result.json in place (WM-907)", async () => {
     const workspaceDir = ws();
     const script = `import { writeFileSync } from "node:fs";


### PR DESCRIPTION
Fixes watt-mind/factory#825

Review the command-adapter environment boundary; security scope was authorised by inbox_bb88f037-47f9-4bb9-bbe9-b22e1467e808 at 2026-08-29T17:58:28.489Z.

Review fix (0491a34): `BASE_INHERITED_ENV` now carries an explicit `RUNTIME_IDENTITY_ENV` allow-list (`FACTORY_EVENT_HOME`/`PORT`/`SECRET`/`ENV`) so command-adapter children (merge-apply, merge-scan, reaper, digest, ci-log-capture) address the same runtime as the worker that spawned them instead of the default live instance. Read-only agents need no env `GH_TOKEN`/`LINEAR_API_KEY`: the live worker carries neither, `gh` resolves its config and the App token file under HOME, and `factory linear` reads the operator `.env` — verified against the running worker's environ.

## Validation

| Check                | Command                                                                 | Result  | Notes                                  |
| -------------------- | ----------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/adapters/command.test.mjs`   | pass    | 24 pass, 2 skipped, 0 fail             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | fail (unrelated) | worker's run exited 1 on develop-side gh-860/WM-918 suites, unrelated to this change; fix landing via #1209. `bun run check` exits 0 on the merged branch |
| UX critique          | factory-ux-critic                                                       | not run | no user-facing surface                 |

UX critique: skipped — no user-facing surface

## Handoff

- Verification: `bun test --timeout 20000 event-runtime/lib/adapters/command.test.mjs` → 24 pass, 2 skip, 0 fail; `bun run check` → exit 0 (94 generated files match shared/).
- UX: not applicable — no user-facing surface.
- File scope: `event-runtime/lib/adapters/command.mjs`, `event-runtime/lib/adapters/command.test.mjs` only.
