### PR TITLE
fix(worker): confine refused runtime artifacts

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -63,6 +63,7 @@ import {
 import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
 import {
   assertSandboxWorkspaceSupported,
+  confinedRegularFile,
   createWorkspace,
   destroyWorkspace,
   PathViolation,
@@ -3112,18 +3113,28 @@ export async function executeClaimed(
       for (const entry of RUNTIME_ARTIFACTS) {
         let abs;
         try {
-          abs = safeJoin(workspaceDir, entry.path);
+          // Refusal artifacts bypass verifyCompleted's collection path, so
+          // repeat the shared canonical/regular-file preflight before the
+          // first host-side read or hash. Missing and guest-supplied links are
+          // best-effort omissions, just like absent runtime artifacts.
+          abs = confinedRegularFile(workspaceDir, entry.path);
         } catch (err) {
+          if (err?.code === "ENOENT") continue;
           if (!(err instanceof PathViolation)) throw err;
           continue;
         }
-        if (existsSync(abs)) {
-          collected.push({
-            kind: entry.kind,
-            uri: `file://${abs}`,
-            sha256: sha256Hex(readFileSync(abs)),
-          });
-        }
+        const collectedEntry = {
+          kind: entry.kind,
+          uri: `file://${abs}`,
+          sha256: sha256Hex(readFileSync(abs)),
+        };
+        // The fixed runtime files live at the workspace root. The helper
+        // returned their canonical path, so dirname is canonical provenance
+        // for storeCollected's independent pre-copy confinement check.
+        Object.defineProperty(collectedEntry, "workspaceRoot", {
+          value: path.dirname(abs),
+        });
+        collected.push(collectedEntry);
       }
       const artifacts = storeCollected({
         entries: collected,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3123,18 +3123,24 @@ export async function executeClaimed(
           if (!(err instanceof PathViolation)) throw err;
           continue;
         }
-        const collectedEntry = {
-          kind: entry.kind,
-          uri: `file://${abs}`,
-          sha256: sha256Hex(readFileSync(abs)),
-        };
-        // The fixed runtime files live at the workspace root. The helper
-        // returned their canonical path, so dirname is canonical provenance
-        // for storeCollected's independent pre-copy confinement check.
-        Object.defineProperty(collectedEntry, "workspaceRoot", {
-          value: path.dirname(abs),
-        });
-        collected.push(collectedEntry);
+        try {
+          const collectedEntry = {
+            kind: entry.kind,
+            uri: `file://${abs}`,
+            sha256: sha256Hex(readFileSync(abs)),
+          };
+          // The fixed runtime files live at the workspace root. The helper
+          // returned their canonical path, so dirname is canonical provenance
+          // for storeCollected's independent pre-copy confinement check.
+          Object.defineProperty(collectedEntry, "workspaceRoot", {
+            value: path.dirname(abs),
+          });
+          collected.push(collectedEntry);
+        } catch (err) {
+          // The guest may unlink the artifact between the preflight and the
+          // read; that is the same best-effort omission as never writing it.
+          if (err?.code !== "ENOENT") throw err;
+        }
       }
       const artifacts = storeCollected({
         entries: collected,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -27,6 +27,7 @@ import {
   readdirSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -869,6 +870,75 @@ describe("worker", () => {
     ]);
     expect(parsed.artifacts[1].sha256).toMatch(/^[0-9a-f]{64}$/);
   });
+
+  for (const artifact of [
+    { kind: "transcript", path: ".transcript.json" },
+    { kind: "sandbox-console", path: ".sandbox-console.log" },
+  ]) {
+    for (const linkType of ["absolute", "relative"]) {
+      test(
+        `refusal omits ${artifact.kind} replaced by a ${linkType} final symlink before reading or storing it`,
+        async () => {
+          const db = openDb(":memory:");
+          const spec = queueRun(
+            db,
+            makeSpec({ input: { repos: ["refuse"] } }),
+          );
+          const artifactStore = freshRoot();
+          const outsideDir = freshRoot();
+          const secretBytes = `host bytes for ${artifact.kind} ${linkType}\n`;
+          const outsideFile = path.join(outsideDir, "host-secret.txt");
+          writeFileSync(outsideFile, secretBytes, "utf8");
+          // A non-privileged worker cannot open this target. The refusal must
+          // still complete because confinement rejects the link before read.
+          chmodSync(outsideFile, 0);
+          const secretHash = createHash("sha256")
+            .update(secretBytes)
+            .digest("hex");
+          const symlinkedArtifactAdapter = {
+            async execute(args) {
+              const outcome = await fake.execute(args);
+              const runtimePath = path.join(args.workspaceDir, artifact.path);
+              rmSync(runtimePath, { force: true });
+              const target =
+                linkType === "absolute"
+                  ? outsideFile
+                  : path.relative(args.workspaceDir, outsideFile);
+              symlinkSync(target, runtimePath);
+              return outcome;
+            },
+          };
+
+          const summary = await runOnce(
+            db,
+            registry,
+            { fake: symlinkedArtifactAdapter },
+            opts({ artifactStore }),
+          );
+
+          expect(summary).toMatchObject({
+            terminalState: "REFUSED",
+            reasonCode: "needs_human",
+          });
+          const parsed = JSON.parse(
+            db
+              .query(`SELECT result_json FROM results WHERE run_id = ?`)
+              .get(spec.runId).result_json,
+          );
+          expect(parsed.artifacts.map((entry) => entry.kind)).not.toContain(
+            artifact.kind,
+          );
+          if (artifact.kind === "sandbox-console") {
+            expect(parsed.artifacts.map((entry) => entry.kind)).toEqual([
+              "transcript",
+            ]);
+            expect(existsSync(new URL(parsed.artifacts[0].uri))).toBe(true);
+          }
+          expect(existsSync(path.join(artifactStore, secretHash))).toBe(false);
+        },
+      );
+    }
+  }
 
   test("needs_human preserves a valid authored ask, while an invalid ask falls back with its errors", async () => {
     const authored = {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,5 +1,5 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-worker-test-mjs";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
 /**
@@ -30,6 +30,8 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import * as nodeFs from "node:fs";
+const realReadFileSync = nodeFs.readFileSync;
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -871,72 +873,96 @@ describe("worker", () => {
     expect(parsed.artifacts[1].sha256).toMatch(/^[0-9a-f]{64}$/);
   });
 
+  test("refusal omits a runtime artifact unlinked between preflight and read", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ input: { repos: ["refuse"] } }));
+    // Simulate the guest deleting .transcript.json after confinement passed
+    // but before the host read it: the read itself reports ENOENT.
+    const readSpy = spyOn(nodeFs, "readFileSync").mockImplementation(
+      (file, ...rest) => {
+        if (String(file).endsWith(".transcript.json")) {
+          rmSync(file, { force: true });
+        }
+        return realReadFileSync(file, ...rest);
+      },
+    );
+    try {
+      const summary = await runOnce(db, registry, adapters, opts());
+      expect(summary).toMatchObject({
+        terminalState: "REFUSED",
+        reasonCode: "needs_human",
+      });
+      const parsed = JSON.parse(
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).result_json,
+      );
+      expect(parsed.artifacts).toEqual([]);
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   for (const artifact of [
     { kind: "transcript", path: ".transcript.json" },
     { kind: "sandbox-console", path: ".sandbox-console.log" },
   ]) {
     for (const linkType of ["absolute", "relative"]) {
-      test(
-        `refusal omits ${artifact.kind} replaced by a ${linkType} final symlink before reading or storing it`,
-        async () => {
-          const db = openDb(":memory:");
-          const spec = queueRun(
-            db,
-            makeSpec({ input: { repos: ["refuse"] } }),
-          );
-          const artifactStore = freshRoot();
-          const outsideDir = freshRoot();
-          const secretBytes = `host bytes for ${artifact.kind} ${linkType}\n`;
-          const outsideFile = path.join(outsideDir, "host-secret.txt");
-          writeFileSync(outsideFile, secretBytes, "utf8");
-          // A non-privileged worker cannot open this target. The refusal must
-          // still complete because confinement rejects the link before read.
-          chmodSync(outsideFile, 0);
-          const secretHash = createHash("sha256")
-            .update(secretBytes)
-            .digest("hex");
-          const symlinkedArtifactAdapter = {
-            async execute(args) {
-              const outcome = await fake.execute(args);
-              const runtimePath = path.join(args.workspaceDir, artifact.path);
-              rmSync(runtimePath, { force: true });
-              const target =
-                linkType === "absolute"
-                  ? outsideFile
-                  : path.relative(args.workspaceDir, outsideFile);
-              symlinkSync(target, runtimePath);
-              return outcome;
-            },
-          };
+      test(`refusal omits ${artifact.kind} replaced by a ${linkType} final symlink before reading or storing it`, async () => {
+        const db = openDb(":memory:");
+        const spec = queueRun(db, makeSpec({ input: { repos: ["refuse"] } }));
+        const artifactStore = freshRoot();
+        const outsideDir = freshRoot();
+        const secretBytes = `host bytes for ${artifact.kind} ${linkType}\n`;
+        const outsideFile = path.join(outsideDir, "host-secret.txt");
+        writeFileSync(outsideFile, secretBytes, "utf8");
+        // A non-privileged worker cannot open this target. The refusal must
+        // still complete because confinement rejects the link before read.
+        chmodSync(outsideFile, 0);
+        const secretHash = createHash("sha256")
+          .update(secretBytes)
+          .digest("hex");
+        const symlinkedArtifactAdapter = {
+          async execute(args) {
+            const outcome = await fake.execute(args);
+            const runtimePath = path.join(args.workspaceDir, artifact.path);
+            rmSync(runtimePath, { force: true });
+            const target =
+              linkType === "absolute"
+                ? outsideFile
+                : path.relative(args.workspaceDir, outsideFile);
+            symlinkSync(target, runtimePath);
+            return outcome;
+          },
+        };
 
-          const summary = await runOnce(
-            db,
-            registry,
-            { fake: symlinkedArtifactAdapter },
-            opts({ artifactStore }),
-          );
+        const summary = await runOnce(
+          db,
+          registry,
+          { fake: symlinkedArtifactAdapter },
+          opts({ artifactStore }),
+        );
 
-          expect(summary).toMatchObject({
-            terminalState: "REFUSED",
-            reasonCode: "needs_human",
-          });
-          const parsed = JSON.parse(
-            db
-              .query(`SELECT result_json FROM results WHERE run_id = ?`)
-              .get(spec.runId).result_json,
-          );
-          expect(parsed.artifacts.map((entry) => entry.kind)).not.toContain(
-            artifact.kind,
-          );
-          if (artifact.kind === "sandbox-console") {
-            expect(parsed.artifacts.map((entry) => entry.kind)).toEqual([
-              "transcript",
-            ]);
-            expect(existsSync(new URL(parsed.artifacts[0].uri))).toBe(true);
-          }
-          expect(existsSync(path.join(artifactStore, secretHash))).toBe(false);
-        },
-      );
+        expect(summary).toMatchObject({
+          terminalState: "REFUSED",
+          reasonCode: "needs_human",
+        });
+        const parsed = JSON.parse(
+          db
+            .query(`SELECT result_json FROM results WHERE run_id = ?`)
+            .get(spec.runId).result_json,
+        );
+        expect(parsed.artifacts.map((entry) => entry.kind)).not.toContain(
+          artifact.kind,
+        );
+        if (artifact.kind === "sandbox-console") {
+          expect(parsed.artifacts.map((entry) => entry.kind)).toEqual([
+            "transcript",
+          ]);
+          expect(existsSync(new URL(parsed.artifacts[0].uri))).toBe(true);
+        }
+        expect(existsSync(path.join(artifactStore, secretHash))).toBe(false);
+      });
     }
   }
 


### PR DESCRIPTION
Fixes watt-mind/factory#1009

Review refusal artifact confinement and symlink regressions; security scope authorised by `operator:preapproved-2026-08-29` at `2026-08-29T18:10:31.205Z`.

## Validation

| Check                | Command                                                         | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/worker.test.mjs`     | pass    | 137 tests, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1,709 pass, 9 VM-only skips; emit clean    |
| UX critique          | factory-ux-critic                                               | not run | backend security change; no user-facing surface |

UX critique: skipped — backend artifact-confinement hardening has no user-facing surface

## Handoff

**Post-review** (9077ed9b): wrapped the refused-run artifact read in an ENOENT guard (mirrors verify.mjs) and added a race test; `bunx prettier --check event-runtime/lib/worker.mjs event-runtime/lib/worker.test.mjs` → all files use Prettier code style; `bun test event-runtime/lib/worker.test.mjs --timeout 20000` → 138 pass, 0 fail; `bun run check` → exit 0.
