### PR TITLE
fix(security): bind pack prompts to verified bytes

### DIFF
--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -478,7 +478,8 @@ export async function execute({
 }) {
   refuseSandbox("acp", def, SANDBOX_DEFERRAL_REASON);
 
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   const acpConfig = resolveAcpConfig({ spec, def, config });
   const childEnv = safeChildEnvironment({ ...acpConfig.env, ...env }, def);
   const resolved = resolveAcpCommand(acpConfig, {

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -30,6 +30,7 @@ import {
   usageFromUpdate,
 } from "./acp.mjs";
 import { createAdapterRegistry, validateAdapterContract } from "./index.mjs";
+import { PROMPT_SUFFIX } from "./claude.mjs";
 import { SandboxUnsupportedError } from "./sandboxed.mjs";
 import {
   processOwnerWatchdogSource,
@@ -267,6 +268,12 @@ rl.on("line", (line) => {
     return;
   }
   if (msg.method === "session/prompt") {
+    if (process.env.ACP_FAKE_PROMPT_RECORD) {
+      writeFileSync(
+        process.env.ACP_FAKE_PROMPT_RECORD,
+        msg.params?.prompt?.[0]?.text ?? "",
+      );
+    }
     currentPromptId = msg.id;
     handlePrompt(msg.params.sessionId).catch((err) => {
       send({
@@ -311,6 +318,7 @@ const ws = () => realpathSync(tmpDir("ws-", tmpBase));
 const defaultDef = {
   ref: "test-acp@1",
   promptPath,
+  promptText: "You are a test agent.",
   mutating: false,
 };
 const mutatingDef = { ...defaultDef, mutating: true };
@@ -599,14 +607,19 @@ describe("permission policy", () => {
 });
 
 describe("execute against a fake ACP agent", () => {
-  test("session lifecycle, update folding, usage, result.json, subscription env stripped", async () => {
+  test("session lifecycle uses the verified prompt snapshot after its path changes", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");
+    const promptRecord = path.join(workspaceDir, "prompt.txt");
+    const replacedPrompt = path.join(workspaceDir, "replaced-prompt.md");
+    writeFileSync(replacedPrompt, "mutable replacement", "utf8");
     const traceEvents = [];
     const usageSeen = [];
     const outcome = await run(workspaceDir, {
+      def: { ...defaultDef, promptPath: replacedPrompt },
       env: {
         ACP_FAKE_RECORD: recordFile,
+        ACP_FAKE_PROMPT_RECORD: promptRecord,
         ANTHROPIC_API_KEY: "sk-must-strip",
         CLAUDECODE: "1",
       },
@@ -620,6 +633,9 @@ describe("execute against a fake ACP agent", () => {
     expect(record.cwd).toBe(workspaceDir);
     expect(record.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(record.env.CLAUDECODE).toBeUndefined();
+    expect(readFileSync(promptRecord, "utf8")).toBe(
+      `You are a test agent.${PROMPT_SUFFIX}`,
+    );
     expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(true);
     expect(
       readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8"),

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -405,7 +405,8 @@ export async function execute({
   signal,
 }) {
   refuseSandbox("agy", def, SANDBOX_REFUSAL_REASON);
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
   const resolved = resolveAgyCommand({

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -434,7 +434,11 @@ describe("execute with fake binary", () => {
     const body = lines
       .map((l) => `echo ${JSON.stringify(JSON.stringify(l))}`)
       .join("\n");
-    writeFileSync(fakeAgy, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+    writeFileSync(
+      fakeAgy,
+      `#!/usr/bin/env bash\nif [[ -n "\${FACTORY_TEST_ARGV_FILE:-}" ]]; then printf '%s\\n' "$@" > "$FACTORY_TEST_ARGV_FILE"; fi\n${body}\n`,
+      { mode: 0o755 },
+    );
     return fakeAgy;
   }
 
@@ -459,14 +463,18 @@ describe("execute with fake binary", () => {
     ]);
 
     const promptFile = path.join(tmp, "prompt.md");
-    writeFileSync(promptFile, "Do task");
+    writeFileSync(promptFile, "mutable replacement");
+    const argvFile = path.join(tmp, "argv.txt");
 
     const traces = [];
     const res = await execute({
       spec: { model: "gemini-3.7-flash" },
-      def: { promptPath: promptFile },
+      def: { promptPath: promptFile, promptText: "Do task" },
       workspaceDir: tmp,
-      env: { PATH: `${binDir}:${process.env.PATH}` },
+      env: {
+        PATH: `${binDir}:${process.env.PATH}`,
+        FACTORY_TEST_ARGV_FILE: argvFile,
+      },
       onTrace: (kind, payload) => traces.push({ kind, payload }),
     });
 
@@ -482,6 +490,8 @@ describe("execute with fake binary", () => {
     expect(traces[1].payload.toolUseId).toBe("3");
     expect(traces[2].payload.text).toBe("Listed the workspace.");
     expect(res.usage).toEqual({ input: 10, output: 20, turns: 2 });
+    expect(readFileSync(argvFile, "utf8")).toContain(`Do task${PROMPT_SUFFIX}`);
+    expect(readFileSync(argvFile, "utf8")).not.toContain("mutable replacement");
     expect(existsSync(path.join(tmp, ".transcript.json"))).toBe(true);
   });
 
@@ -512,7 +522,7 @@ describe("execute with fake binary", () => {
     const traces = [];
     await execute({
       spec: {},
-      def: { promptPath: promptFile },
+      def: { promptPath: promptFile, promptText: "Do task" },
       workspaceDir: tmp,
       env: { PATH: `${binDir}:${process.env.PATH}` },
       onTrace: (kind, payload) => traces.push({ kind, payload }),
@@ -547,7 +557,7 @@ describe("execute with fake binary", () => {
     const attempted = [];
     const res = await execute({
       spec: {},
-      def: { promptPath: promptFile },
+      def: { promptPath: promptFile, promptText: "Do task" },
       workspaceDir: tmp,
       env: { PATH: `${binDir}:${process.env.PATH}` },
       onTrace: (kind) => {

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -490,7 +490,8 @@ export async function execute({
   // definition never reaches the host spawn below (WM-313).
   refuseSandbox("claude", def, SANDBOX_DEFERRAL_REASON);
 
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
   const mcpConfig = path.join(FACTORY_ROOT, "config", "mcp", "claude.json");

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -41,6 +41,7 @@ describe("sandbox decision (WM-313): deferred, so refused — never ignored", ()
   const sandboxedDef = (promptPath) => ({
     ref: "sandboxed-claude@1",
     promptPath,
+    promptText: "hello",
     mutating: false,
     sandbox: { provider: "gondolin", allowedHosts: ["api.anthropic.com"] },
   });
@@ -720,6 +721,7 @@ if (behavior === "emit_denial_then_recovery") {
   const defaultDef = {
     ref: "test-agent@1",
     promptPath: promptFile,
+    promptText: "You are a test agent.",
     mutating: false,
     capabilities: { tools: ["Read", "Grep"] },
   };
@@ -767,14 +769,16 @@ if (behavior === "emit_denial_then_recovery") {
     }
   }
 
-  test("executes stub binary in workspaceDir, strips ANTHROPIC_API_KEY, captures .transcript.json and trace", async () => {
+  test("executes the verified prompt snapshot after its path changes and captures trace", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");
+    const replacedPrompt = path.join(workspaceDir, "replaced-prompt.md");
+    writeFileSync(replacedPrompt, "mutable replacement", "utf8");
     const traceEvents = [];
 
     const outcome = await execute({
       spec: defaultSpec,
-      def: defaultDef,
+      def: { ...defaultDef, promptPath: replacedPrompt },
       workspaceDir,
       timeoutMs: 5000,
       env: {
@@ -1136,6 +1140,7 @@ if (behavior === "emit_denial_then_recovery") {
     const mutatingDef = {
       ref: "dispatch@1",
       promptPath: promptFile,
+      promptText: "You are a test agent.",
       mutating: true,
       capabilities: { tools: ["Bash", "Read", "Write", "Edit"] },
     };
@@ -1177,6 +1182,7 @@ if (behavior === "emit_denial_then_recovery") {
     const readOnlyDef = {
       ref: "status-report@1",
       promptPath: promptFile,
+      promptText: "You are a test agent.",
       mutating: false,
       capabilities: { tools: ["Read", "Grep"] },
     };

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -330,7 +330,8 @@ export async function execute({
   signal,
 }) {
   refuseSandbox("cursor", def, SANDBOX_REFUSAL_REASON);
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
   const resolved = resolveCursorCommand({

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -455,6 +455,7 @@ if (behavior === "emit_error_tool_result") {
   const defaultDef = {
     ref: "test-cursor-agent@1",
     promptPath: promptFile,
+    promptText: "You are a test agent.",
     mutating: false,
   };
   const defaultSpec = {
@@ -498,14 +499,16 @@ if (behavior === "emit_error_tool_result") {
     }
   }
 
-  test("executes stub binary in workspaceDir, passes CURSOR_API_KEY, prompt on argv, captures transcript + trace", async () => {
+  test("executes the verified prompt snapshot after its path changes and captures trace", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");
+    const replacedPrompt = path.join(workspaceDir, "replaced-prompt.md");
+    writeFileSync(replacedPrompt, "mutable replacement", "utf8");
     const traceEvents = [];
 
     const outcome = await execute({
       spec: { ...defaultSpec, model: "composer-2.5" },
-      def: defaultDef,
+      def: { ...defaultDef, promptPath: replacedPrompt },
       workspaceDir,
       timeoutMs: 5000,
       env: {

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -648,7 +648,8 @@ async function executeSandboxed({
   // this preflight also covers injected VM runners used by tests and leaves
   // no stray prompt behind when the definition itself is invalid.
   normalizePolicy(def.sandbox, { workspaceDir });
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
   const argv = [
     bin,
@@ -731,7 +732,8 @@ export async function execute({
     });
   }
 
-  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const prompt =
+    (def.promptText ?? readFileSync(def.promptPath, "utf8")) + PROMPT_SUFFIX;
   // A remote worker can execute this checked-out adapter from a persistent
   // runner checkout, whose ignored config/ is intentionally absent. Preserve
   // the launching operator's root for the ticket CLI instead of replacing it

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -638,6 +638,7 @@ process.stdin.on("end", () => {
   const defaultDef = {
     ref: "test-pi-agent@1",
     promptPath: promptFile,
+    promptText: "You are a test agent.",
     mutating: false,
   };
   const defaultSpec = {
@@ -684,14 +685,16 @@ process.stdin.on("end", () => {
     }
   }
 
-  test("executes stub binary in workspaceDir, strips API keys, pipes prompt on stdin, captures transcript + trace", async () => {
+  test("executes the verified prompt snapshot after its path changes, strips API keys, and captures trace", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");
+    const replacedPrompt = path.join(workspaceDir, "replaced-prompt.md");
+    writeFileSync(replacedPrompt, "mutable replacement", "utf8");
     const traceEvents = [];
 
     const outcome = await execute({
       spec: { ...defaultSpec, model: "openai-codex/gpt-5.6-terra" },
-      def: defaultDef,
+      def: { ...defaultDef, promptPath: replacedPrompt },
       workspaceDir,
       timeoutMs: 5000,
       env: {
@@ -1011,6 +1014,7 @@ describe("sandboxed execution (WM-313)", () => {
   const sandboxDef = (extra = {}) => ({
     ref: "sandboxed-pi@1",
     promptPath: promptFile,
+    promptText: "You are a sandboxed test agent.",
     mutating: false,
     sandbox: {
       provider: "gondolin",

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -1,5 +1,4 @@
 /** Agent and repository registry endpoints. */
-import { readFileSync } from "node:fs";
 import { getArtifactView, resolveModel } from "./registry.mjs";
 import { RepoError, resolvePromotionTarget, reposView } from "./repos.mjs";
 import {
@@ -45,7 +44,7 @@ export function agentsView(registry, { overrides = emptyOverrides() } = {}) {
         limits: def.limits,
         mutating: def.mutating,
         promptFile: def.prompt,
-        prompt: readFileSync(def.promptPath, "utf8"),
+        prompt: def.promptText,
         inputSchemaFile: def.input_schema,
         inputSchema: def.inputSchema,
         outputSchemaFile: def.output_schema,

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -37,7 +37,7 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
-import { handleRegistryApiRoute } from "./api-registry.mjs";
+import { agentsView, handleRegistryApiRoute } from "./api-registry.mjs";
 import { KIND_EVENT_TYPE, putOverride } from "./runtime-overrides.mjs";
 
 const makeServer = async (...args) => {
@@ -76,6 +76,20 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
     } finally {
       server.close();
     }
+  });
+
+  test("GET /agents publishes the verified prompt snapshot, not the mutable path", () => {
+    const isolated = loadRegistry();
+    const def = isolated.agents.get("factory-status-report@1");
+    const mutablePath = path.join(tmpDir("evrt-api-prompt-"), "prompt.md");
+    writeFileSync(mutablePath, "replacement after registry load\n");
+    def.promptPath = mutablePath;
+
+    const published = agentsView(isolated).agents.find(
+      (candidate) => candidate.ref === def.ref,
+    );
+    expect(published.prompt).toBe(def.promptText);
+    expect(published.prompt).not.toContain("replacement after registry load");
   });
 
   test("GET /repos serves the repos.yaml registry, dispatch mode included (OPS-299)", async () => {

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -8,7 +8,13 @@
  * promptVersion is provenance recorded at planning time, not a second
  * identity.
  */
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { format as prettierFormat, resolveConfig } from "prettier";
 import { hashBytes } from "./canonical.mjs";
@@ -50,6 +56,37 @@ function readJson(file, description = file) {
 
 function nullDict() {
   return Object.create(null);
+}
+
+function isStrictDescendant(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+/** Resolve a pack-owned resource without allowing lexical or symlink escape. */
+function resolvePackResource(root, canonicalRoot, relative) {
+  if (typeof relative !== "string" || relative === "") {
+    throw new RegistryError("pinned resource path must be a non-empty string");
+  }
+  const resolved = path.resolve(root, relative);
+  if (!isStrictDescendant(root, resolved)) {
+    throw new RegistryError(
+      `${relative}: resource resolves outside pack root ${root}`,
+    );
+  }
+  if (!existsSync(resolved)) return resolved;
+  const canonical = realpathSync(resolved);
+  if (!isStrictDescendant(canonicalRoot, canonical)) {
+    throw new RegistryError(
+      `${relative}: resource resolves outside canonical pack root ${canonicalRoot}`,
+    );
+  }
+  return canonical;
 }
 
 const SCHEDULE_OVERLAY_FIELDS = new Set(["enabled", "every", "payload"]);
@@ -278,6 +315,7 @@ export function createFsPackLoader(
   { builtIn = false, ignorePins = false } = {},
 ) {
   const root = path.resolve(pack.path);
+  const canonicalRoot = realpathSync(root);
   let pins;
   return {
     listAgentDefs() {
@@ -295,7 +333,7 @@ export function createFsPackLoader(
     // notion, so only the fs loader offers them. loadRegistry treats an
     // absent method as "this pack has no views".
     readArtifactView(entry, def) {
-      return loadArtifactView(root, entry.source, def);
+      return loadArtifactView(root, canonicalRoot, entry.source, def);
     },
     // Optional seam member (WM-840): `panels/*.panel.json` under the pack
     // root, validated by lib/panel-view.mjs; a pack without the directory
@@ -312,7 +350,7 @@ export function createFsPackLoader(
           throw new RegistryError(`${file}: pins must be a path-to-hash map`);
         }
       }
-      const file = path.join(root, relative);
+      const file = resolvePackResource(root, canonicalRoot, relative);
       return {
         expected: builtIn
           ? Object.hasOwn(def.pins ?? nullDict(), relative)
@@ -487,14 +525,14 @@ function readViewFile(abs, rel, def, source) {
   return { file: rel, view, source, anomaly: null };
 }
 
-function loadArtifactView(root, defFile, def) {
+function loadArtifactView(root, canonicalRoot, defFile, def) {
   const agentRel = path.relative(root, defFile).replace(/\.json$/, VIEW_SUFFIX);
-  const agentAbs = path.join(root, agentRel);
+  const agentAbs = resolvePackResource(root, canonicalRoot, agentRel);
   if (existsSync(agentAbs))
     return readViewFile(agentAbs, agentRel, def, "agent");
   const contractRel = contractViewRel(def.output_contract);
   if (contractRel) {
-    const contractAbs = path.join(root, contractRel);
+    const contractAbs = resolvePackResource(root, canonicalRoot, contractRel);
     if (existsSync(contractAbs))
       return readViewFile(contractAbs, contractRel, def, "contract");
   }
@@ -795,6 +833,13 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
     enumerable: false,
     writable: true,
     configurable: true,
+  });
+  // Prompt execution and publication must use the exact immutable bytes whose
+  // digest was accepted above, never a later read through the mutable path.
+  // Keep this runtime snapshot non-enumerable for receipt/registry identity.
+  Object.defineProperty(loaded, "promptText", {
+    value: Buffer.from(resources.prompt.bytes).toString("utf8"),
+    enumerable: false,
   });
   // The definition's own JSON file, kept non-enumerably for the same reason as
   // `pack`: it is loader-injected filesystem provenance, not definition content
@@ -1489,14 +1534,20 @@ export async function updatePins({
   }
 
   const changed = [];
-  const agentsDir = path.join(root, "agents");
+  const resolvedRoot = path.resolve(root);
+  const canonicalRoot = realpathSync(resolvedRoot);
+  const agentsDir = path.join(resolvedRoot, "agents");
   for (const name of readdirSync(agentsDir).filter(isDefinitionFile).sort()) {
     const file = path.join(agentsDir, name);
     const def = readJson(file);
     const pins = {};
     for (const field of PINNED_FIELDS) {
       if (!def[field]) continue;
-      pins[def[field]] = hashBytes(readFileSync(path.join(root, def[field])));
+      pins[def[field]] = hashBytes(
+        readFileSync(
+          resolvePackResource(resolvedRoot, canonicalRoot, def[field]),
+        ),
+      );
     }
     if (JSON.stringify(def.pins) !== JSON.stringify(pins)) {
       if (!check) {

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -315,7 +315,14 @@ export function createFsPackLoader(
   { builtIn = false, ignorePins = false } = {},
 ) {
   const root = path.resolve(pack.path);
-  const canonicalRoot = realpathSync(root);
+  let canonicalRoot;
+  try {
+    canonicalRoot = realpathSync(root);
+  } catch (err) {
+    throw new RegistryError(
+      `pack "${pack.name}": root ${root} is not accessible — ${err.message}`,
+    );
+  }
   let pins;
   return {
     listAgentDefs() {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -5,6 +5,8 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -29,8 +31,7 @@ import { computeDefHash } from "./receipts.mjs";
 import { updateHarnessPins } from "./pins.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
-function tempRegistry() {
-  const root = tmpDir("event-registry-");
+function tempRegistry(root = tmpDir("event-registry-")) {
   for (const dir of ["agents", "schemas"]) {
     cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), {
       recursive: true,
@@ -64,8 +65,11 @@ function samplePack(
   return { kind: "fs", name, path: root, namespace };
 }
 
-function tempPack({ name = "sample", namespace = "sample" } = {}) {
-  const root = tmpDir("event-pack-");
+function tempPack({
+  name = "sample",
+  namespace = "sample",
+  root = tmpDir("event-pack-"),
+} = {}) {
   cpSync(SAMPLE_PACK_ROOT, root, { recursive: true });
   writeFileSync(
     path.join(root, "pack.json"),
@@ -524,6 +528,9 @@ describe("registry", () => {
     expect(def.promptPath).toBe(
       path.join(SAMPLE_PACK_ROOT, "agents", "echo.md"),
     );
+    expect(def.promptText).toBe(
+      readFileSync(path.join(SAMPLE_PACK_ROOT, "agents", "echo.md"), "utf8"),
+    );
     expect(def.pins).toEqual(
       JSON.parse(
         readFileSync(path.join(SAMPLE_PACK_ROOT, "pins.json"), "utf8"),
@@ -544,6 +551,89 @@ describe("registry", () => {
       "event-runtime",
       "sample",
     ]);
+  });
+
+  test("filesystem packs reject lexical and symlink resource escapes, including pin generation", async () => {
+    const lexicalContainer = tmpDir("event-pack-lexical-");
+    const lexical = tempPack({ root: path.join(lexicalContainer, "pack") });
+    const lexicalDefFile = path.join(lexical.path, "agents", "echo.json");
+    const lexicalDef = JSON.parse(readFileSync(lexicalDefFile, "utf8"));
+    const outsideRel = "../outside.md";
+    const outsideFile = path.join(lexicalContainer, "outside.md");
+    writeFileSync(outsideFile, "definition-controlled host bytes\n");
+    lexicalDef.prompt = outsideRel;
+    writeFileSync(lexicalDefFile, JSON.stringify(lexicalDef));
+    const lexicalPins = JSON.parse(
+      readFileSync(path.join(lexical.path, "pins.json"), "utf8"),
+    );
+    lexicalPins[outsideRel] = hashBytes(readFileSync(outsideFile));
+    writeFileSync(
+      path.join(lexical.path, "pins.json"),
+      JSON.stringify(lexicalPins),
+    );
+
+    expect(() => loadRegistry({ packRoots: [lexical] })).toThrow(
+      /resource resolves outside pack root/,
+    );
+    await expect(updatePins({ pack: lexical })).rejects.toThrow(
+      /resource resolves outside pack root/,
+    );
+
+    const symlinkContainer = tmpDir("event-pack-symlink-");
+    const symlinked = tempPack({ root: path.join(symlinkContainer, "pack") });
+    const prompt = path.join(symlinked.path, "agents", "echo.md");
+    const outsidePrompt = path.join(symlinkContainer, "outside.md");
+    writeFileSync(outsidePrompt, readFileSync(prompt));
+    unlinkSync(prompt);
+    symlinkSync(outsidePrompt, prompt);
+
+    expect(() => loadRegistry({ packRoots: [symlinked] })).toThrow(
+      /resource resolves outside canonical pack root/,
+    );
+    await expect(updatePins({ pack: symlinked })).rejects.toThrow(
+      /resource resolves outside canonical pack root/,
+    );
+
+    const builtInContainer = tmpDir("event-registry-lexical-");
+    const builtInRoot = tempRegistry(
+      path.join(builtInContainer, "event-runtime"),
+    );
+    const builtInDefFile = path.join(
+      builtInRoot,
+      "agents",
+      "factory-status-report.json",
+    );
+    const builtInDef = JSON.parse(readFileSync(builtInDefFile, "utf8"));
+    builtInDef.prompt = "../outside.md";
+    writeFileSync(builtInDefFile, JSON.stringify(builtInDef));
+    writeFileSync(path.join(builtInContainer, "outside.md"), "outside\n");
+    await expect(updatePins({ root: builtInRoot })).rejects.toThrow(
+      /resource resolves outside pack root/,
+    );
+  });
+
+  test("filesystem pack artifact views cannot escape through symlinks", () => {
+    const container = tmpDir("event-pack-view-symlink-");
+    const pack = tempPack({ root: path.join(container, "pack") });
+    const outsideView = path.join(container, "outside.view.json");
+    writeFileSync(outsideView, "{}\n");
+    symlinkSync(outsideView, path.join(pack.path, "agents", "echo.view.json"));
+    expect(() => loadRegistry({ packRoots: [pack] })).toThrow(
+      /resource resolves outside canonical pack root/,
+    );
+  });
+
+  test("loaded definitions retain the verified prompt snapshot after filesystem replacement", () => {
+    const pack = tempPack();
+    const registry = loadRegistry({ packRoots: [pack] });
+    const def = getAgent(registry, "sample/echo@1");
+    const verified = def.promptText;
+    writeFileSync(def.promptPath, "replacement after registry load\n");
+    expect(def.promptText).toBe(verified);
+    expect(def.promptText).not.toContain("replacement after registry load");
+    expect(Object.getOwnPropertyDescriptor(def, "promptText")?.writable).toBe(
+      false,
+    );
   });
 
   test("merged validation accepts a loader with no filesystem access", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#965

Review the pack containment boundary and verified prompt snapshot handoff; security authorisation `operator:preapproved-2026-08-29` decided `2026-08-29T18:05:43.689Z` matched the current description.

## Validation

| Check                | Command                                                                                           | Result  | Notes                  |
| -------------------- | ------------------------------------------------------------------------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/registry.test.mjs event-runtime/lib/api-registry.test.mjs` | pass    | 72 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`                         | pass    | 1709 pass, emit clean  |
| UX critique          | factory-ux-critic                                                                                 | not run | no user-facing surface |

UX critique: skipped — no user-facing surface
- Post-review (58283319): merged origin/develop (worker.mjs both sides kept); `createFsPackLoader` now raises `RegistryError` for a missing pack root instead of raw ENOENT; registry/adapters/worker tests (460 pass) and `bun run check` green.
