### PR TITLE
fix(test): pin FACTORY_REPOS_ROOT in gh-860 promotion tests; anchor verify (fail) marker (WM-918 verify gate)

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -36,7 +36,7 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
-import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
+import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 import { handleRegistryApiRoute } from "./api-registry.mjs";
 import { KIND_EVENT_TYPE, putOverride } from "./runtime-overrides.mjs";
 
@@ -461,6 +461,18 @@ describe("runtime overlay API (WM-887)", () => {
 
 describe("overlay promotion routes (gh-860)", () => {
   const reg = loadRegistry();
+  // Promotion resolves targets relative to reposRoot(); pin it to the checkout
+  // the registry above was loaded from so a worker's FACTORY_REPOS_ROOT (the
+  // checkout it serves) cannot put every target "outside the registry root".
+  let previousReposRoot;
+  beforeAll(() => {
+    previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = FACTORY_ROOT;
+  });
+  afterAll(() => {
+    if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  });
   const reposFn = () =>
     loadRepos({
       root: (() => {

--- a/event-runtime/lib/runtime-overrides.test.mjs
+++ b/event-runtime/lib/runtime-overrides.test.mjs
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { openDb } from "./db.mjs";
 import { loadRegistry } from "./registry.mjs";
-import { reposRoot } from "./repos.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
 import {
   KIND_AGENT,
   KIND_EVENT_TYPE,
@@ -22,7 +22,10 @@ import {
 } from "./runtime-overrides.mjs";
 
 const registry = loadRegistry();
-const REPO_ROOT = reposRoot();
+// The checkout under test, not reposRoot(): a factory worker exports
+// FACTORY_REPOS_ROOT for the checkout it serves, and promotion resolves its
+// targets relative to that root — which is outside the registry loaded here.
+const REPO_ROOT = FACTORY_ROOT;
 
 /** The event type + agent this repo ships that we can diverge in a preview. */
 const PROMO_TYPE = "factory.status-report.requested";
@@ -197,6 +200,16 @@ describe("runtime-overrides (WM-887)", () => {
 });
 
 describe("overlay promotion (gh-860)", () => {
+  let previousReposRoot;
+  beforeAll(() => {
+    previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = REPO_ROOT;
+  });
+  afterAll(() => {
+    if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  });
+
   test("preview snapshots divergent rows with stable keys, targets, and digest", () => {
     const db = openDb(":memory:");
     seedDivergentOverrides(db);

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -381,7 +381,9 @@ function matchesRedBaseline(baseline, verifyOutput) {
 
 const REPO_VERIFY_REASON_MAX_LINES = 40;
 const REPO_VERIFY_REASON_MAX_CHARS = 8 * 1024;
-const REPO_VERIFY_TEST_FAILURE_LINE = /\(fail\)|✗/i;
+// Anchored: a passing test whose *name* mentions "(fail)" must not be reported
+// as the failure (WM-918's own registry test says "reads bun (fail) and ✗").
+const REPO_VERIFY_TEST_FAILURE_LINE = /^\s*(?:\(fail\)|✗)/i;
 const REPO_VERIFY_ERROR_LINE = /\berror\b/i;
 
 function boundedDiagnostic(lines) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1035,7 +1035,7 @@ describe("worktree baseline verification (WM-334)", () => {
 
   test("a multi-line verification failure retains the failing test name and full log", () => {
     const { dir, record } = worktreeWorkspace(
-      "printf 'suite start\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
+      "printf 'suite start\\n(pass) parser > reads bun (fail) and ✗ lines\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
       null,
     );
     try {
@@ -1054,6 +1054,8 @@ describe("worktree baseline verification (WM-334)", () => {
         "(fail) totals > rejects an invalid total",
       );
       expect(err.violations[0]).toContain("error: expected 400, received 200");
+      // A passing test whose name contains "(fail)" is not a failure marker.
+      expect(err.violations[0]).not.toContain("(pass) parser");
     }
 
     const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");


### PR DESCRIPTION
## Why

Every factory dispatch since ~20:10 today is refused at the handoff gate with
`repo_verify_failed: (pass) timing-test registry (WM-918) > parseFailingTests reads bun (fail) and ✗ lines`.

That line is a **passing** test. The real failures (9, in every `.verify.log`) are `overlay promotion (gh-860)` in `runtime-overrides.test.mjs` and `overlay promotion routes (gh-860)` in `api-registry.test.mjs`. They fail deterministically only in the worker environment, which exports `FACTORY_REPOS_ROOT=/opt/factory/current`; on a plain shell `bun test event-runtime/lib` is green on develop.

## What

1. `event-runtime/lib/verify.mjs` — `REPO_VERIFY_TEST_FAILURE_LINE` is now anchored (`/^\s*(?:\(fail\)|✗)/i`) so a passing test whose *name* contains `(fail)` is no longer reported as the failure. Covered by an extra assertion in the existing multi-line verify test.
2. `event-runtime/lib/runtime-overrides.test.mjs`, `event-runtime/lib/api-registry.test.mjs` — the gh-860 describe blocks pin `FACTORY_REPOS_ROOT` to `FACTORY_ROOT` (the checkout the registry under test was loaded from) with beforeAll/afterAll save-restore, the same convention `registry`/`workspace`/`planner` tests already use. `buildPromotionPreview`/`applyPromotion` default `root = reposRoot()`; with the worker's value every target resolved "outside the registry root" and the preview came back empty.

No production behaviour change beyond the excerpt regex.

## Handoff

**Verification** (scratch worktree at origin/develop `0da10a5c` + this commit):

```
$ FACTORY_REPOS_ROOT=/opt/factory/current bun test event-runtime/lib/runtime-overrides.test.mjs event-runtime/lib/api-registry.test.mjs event-runtime/lib/verify.test.mjs event-runtime/lib/test-helpers-timing.test.mjs --timeout 20000   # x3, and x3 without the env
 87 pass
 0 fail

$ FACTORY_REPOS_ROOT=/opt/factory/current bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
 1705 pass
 0 fail
Ran 1714 tests across 93 files. [44.59s]
emit exit=0

$ bunx prettier --check <4 files>   # All matched files use Prettier code style!
$ bunx eslint <4 files>             # 0 errors (20 pre-existing warnings)
```

Before the fix, the same command with the worker env reproduces exactly the dispatch failure: 9 fail, all `overlay promotion (gh-860)`.

**UX verdict:** not-applicable (test + failure-excerpt change, no user-facing flow).

**File scope:**
- event-runtime/lib/verify.mjs
- event-runtime/lib/verify.test.mjs
- event-runtime/lib/runtime-overrides.test.mjs
- event-runtime/lib/api-registry.test.mjs
