### PR TITLE
sec(runtime): enforce workspace model confinement (#962)

### DIFF
--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -35,9 +35,55 @@
  * the whole of `process.env`) is not forwarded, because keeping the worker's
  * credentials out of a model-controlled guest is the point of the exercise.
  */
-import { createWriteStream } from "node:fs";
+import { createWriteStream, realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { runInSandbox } from "../sandbox/gondolin.mjs";
+import { normalizePolicy } from "../sandbox/policy.mjs";
+import { MODEL_ADAPTERS } from "../registry.mjs";
+import { FACTORY_ROOT } from "../config.mjs";
+
+/**
+ * Stable refusal code shared by the planner and worker. A workspace-only
+ * declaration is a security boundary, not documentation: model execution is
+ * admitted only when this module can prove that the selected adapter enters a
+ * disposable guest rather than spawning on the worker host.
+ */
+export const FILESYSTEM_CONFINEMENT_REASON =
+  "filesystem_confinement_unavailable";
+
+/** Model-process adapters: registry model routes plus Hermes' fixed LLM harness. */
+export const MODEL_BACKED_ADAPTERS = Object.freeze(
+  [...new Set([...MODEL_ADAPTERS, "hermes"])].sort(),
+);
+const MODEL_BACKED_ADAPTER_SET = new Set(MODEL_BACKED_ADAPTERS);
+
+const RAW_CREDENTIAL_PATH =
+  /(?:^|\/)\.(?:aws|azure|claude|config\/gcloud|config\/gh|cursor|factory|gnupg|kube|ssh)(?:\/|$)|(?:^|\/)(?:credentials|hosts\.yml|secrets\.env)(?:\/|$)|(?:^|\/)\.worktrees(?:\/|$)/;
+
+function pathContains(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+/** A runtime mount must not expose a broad host root or a raw credential store. */
+function unsafeHostMountReason(hostPath) {
+  const resolved = path.resolve(hostPath);
+  if (pathContains(resolved, homedir())) return "contains the operator home";
+  if (resolved === "/root" || /^\/(?:home|Users)\/[^/]+$/.test(resolved))
+    return "names a broad host user home";
+  if (pathContains(resolved, FACTORY_ROOT))
+    return "contains the Factory runtime checkout";
+  if (resolved === "/tmp") return "contains the shared host temporary root";
+  if (["/dev", "/etc", "/proc", "/run", "/sys", "/var"].includes(resolved))
+    return "names a broad host system root";
+  if (RAW_CREDENTIAL_PATH.test(resolved))
+    return "names a raw credential store or sibling worktree";
+  return null;
+}
 
 /**
  * Where an agent-CLI adapter expects its binary inside the guest, per the
@@ -56,6 +102,7 @@ export const GUEST_BINARIES = Object.freeze({
 export const GUEST_PATH = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 export const GUEST_HOME = "/root";
 export const GUEST_SHELL = "/bin/sh";
+export const GUEST_XDG_ROOT = "/tmp/factory-xdg";
 
 /**
  * Guest console capture: boot timing, guest stderr, exit/timeout/failure, in
@@ -83,6 +130,96 @@ export class SandboxUnsupportedError extends Error {
 /** Does this definition ask to be sandboxed? Anything but absent/null counts, so a malformed block is refused later, not ignored. */
 export function sandboxRequested(def) {
   return def?.sandbox !== undefined && def?.sandbox !== null;
+}
+
+/**
+ * Return a typed admission refusal when a non-mutating model run promises a
+ * workspace-only filesystem but the selected adapter cannot enforce it.
+ *
+ * Today pi is the only admitted model adapter: it owns the Gondolin execution
+ * path. agy, Cursor, Claude and Hermes deliberately fail closed until they
+ * have an equivalent guest route. Extra host mounts are accepted only when
+ * explicitly declared read-only; the workspace itself remains the one
+ * writable mount.
+ * `normalizePolicy()` also proves that secrets are named host variables scoped
+ * to allowed hosts rather than raw values copied into the guest.
+ *
+ * Non-model adapters and mutating definitions are outside this ticket's
+ * boundary and retain their existing admission semantics.
+ *
+ * @param {{ sandboxSupport?: string|null }} [runtime] - worker-side attestation
+ *   from the actual selected adapter module; omitted by the deterministic
+ *   planner, which admits the built-in pi route by name.
+ * @returns {{ code: string, detail: string } | null}
+ */
+export function filesystemConfinementRefusal(adapter, def, runtime = {}) {
+  if (
+    def?.mutating !== false ||
+    def?.capabilities?.filesystem !== "workspace-only" ||
+    !MODEL_BACKED_ADAPTER_SET.has(adapter)
+  ) {
+    return null;
+  }
+
+  const refuse = (detail) => ({
+    code: FILESYSTEM_CONFINEMENT_REASON,
+    detail: `${def?.ref ?? "definition"}: ${detail}`,
+  });
+
+  if (adapter !== "pi") {
+    return refuse(
+      `adapter "${adapter}" has no enforced workspace-only guest path; refusing before model spawn`,
+    );
+  }
+  if (
+    Object.hasOwn(runtime, "sandboxSupport") &&
+    runtime.sandboxSupport !== "gondolin"
+  ) {
+    return refuse(
+      `selected adapter "pi" reports SANDBOX_SUPPORT=${JSON.stringify(runtime.sandboxSupport)} instead of "gondolin"`,
+    );
+  }
+  if (!sandboxRequested(def)) {
+    return refuse(
+      'adapter "pi" requires an explicit sandbox policy for capabilities.filesystem="workspace-only"',
+    );
+  }
+
+  let policy;
+  try {
+    policy = normalizePolicy(def.sandbox);
+  } catch (err) {
+    return refuse(`sandbox policy is not enforceable: ${err.message}`);
+  }
+  const writableAsset = policy.mounts.find((mount) => !mount.readonly);
+  if (writableAsset) {
+    return refuse(
+      `sandbox runtime mount ${JSON.stringify(writableAsset.guestPath)} must be read-only; only the declared workspace may be writable`,
+    );
+  }
+  for (const mount of policy.mounts) {
+    let unsafe = unsafeHostMountReason(mount.hostPath);
+    if (unsafe) {
+      return refuse(
+        `sandbox runtime mount ${JSON.stringify(mount.hostPath)} ${unsafe}; credentials must use the declared secret broker`,
+      );
+    }
+    let realHostPath;
+    try {
+      realHostPath = realpathSync(mount.hostPath);
+    } catch (err) {
+      return refuse(
+        `sandbox runtime mount ${JSON.stringify(mount.hostPath)} cannot be resolved before admission: ${err.message}`,
+      );
+    }
+    unsafe = unsafeHostMountReason(realHostPath);
+    if (unsafe) {
+      return refuse(
+        `sandbox runtime mount ${JSON.stringify(mount.hostPath)} resolves to ${JSON.stringify(realHostPath)}, which ${unsafe}; credentials must use the declared secret broker`,
+      );
+    }
+  }
+  return null;
 }
 
 /**
@@ -118,12 +255,23 @@ export function guestBinary(def, adapter) {
  * @param {Record<string,string|undefined>} [hostEnv]
  */
 export function guestEnvironment(extra = {}, hostEnv = process.env) {
-  const env = { HOME: GUEST_HOME, PATH: GUEST_PATH, TERM: "dumb" };
+  const env = {
+    HOME: GUEST_HOME,
+    PATH: GUEST_PATH,
+    TERM: "dumb",
+    XDG_CONFIG_HOME: `${GUEST_XDG_ROOT}/config`,
+    XDG_CACHE_HOME: `${GUEST_XDG_ROOT}/cache`,
+    XDG_DATA_HOME: `${GUEST_XDG_ROOT}/data`,
+    XDG_RUNTIME_DIR: `${GUEST_XDG_ROOT}/run`,
+  };
   for (const key of GUEST_LOCALE_ENV) {
     if (typeof hostEnv[key] === "string" && hostEnv[key] !== "")
       env[key] = hostEnv[key];
   }
-  return { ...env, ...extra };
+  // Adapter additions cannot replace confinement-critical paths. Secret
+  // placeholders are injected later by the broker and do not travel through
+  // this escape hatch.
+  return { ...extra, ...env };
 }
 
 /**

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -211,10 +211,7 @@ describe("workspace-only model admission (#962)", () => {
   test("non-model adapters and mutating definitions retain their existing semantics", () => {
     expect(filesystemConfinementRefusal("fake", confinedDef())).toBeNull();
     expect(
-      filesystemConfinementRefusal(
-        "claude",
-        confinedDef({ mutating: true }),
-      ),
+      filesystemConfinementRefusal("claude", confinedDef({ mutating: true })),
     ).toBeNull();
   });
 });
@@ -499,17 +496,20 @@ describe("real guest filesystem confinement (#962)", () => {
             [
               'if cat "$0" >/dev/null 2>&1; then read_result=ESCAPED; else read_result=blocked; fi',
               'if printf guest-write > "$1" 2>/dev/null; then write_result=guest-only; else write_result=blocked; fi',
-              "printf '%s %s\\n' \"$read_result\" \"$write_result\" > ./absolute-path-results",
+              'printf \'%s %s\\n\' "$read_result" "$write_result" > ./absolute-path-results',
             ].join("\n"),
             hostSecret,
             hostEscape,
           ],
-          env: guestEnvironment({}, {
-            HOME: "/home/operator",
-            GITHUB_TOKEN: "ghp-host-only",
-            CURSOR_API_KEY: "cursor-host-only",
-            SSH_AUTH_SOCK: "/tmp/host-agent.sock",
-          }),
+          env: guestEnvironment(
+            {},
+            {
+              HOME: "/home/operator",
+              GITHUB_TOKEN: "ghp-host-only",
+              CURSOR_API_KEY: "cursor-host-only",
+              SSH_AUTH_SOCK: "/tmp/host-agent.sock",
+            },
+          ),
           timeoutMs: 120_000,
         });
 
@@ -520,9 +520,7 @@ describe("real guest filesystem confinement (#962)", () => {
             "utf8",
           ),
         ).toMatch(/^blocked (guest-only|blocked)\n$/);
-        expect(readFileSync(hostSecret, "utf8")).toBe(
-          "raw-host-credential\n",
-        );
+        expect(readFileSync(hostSecret, "utf8")).toBe("raw-host-credential\n");
         expect(existsSync(hostEscape)).toBe(false);
       } finally {
         rmSync(hostSecret, { force: true });

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -9,14 +9,24 @@ import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapte
  * behaviour is proven in pi.test.mjs behind `preflight()`.
  */
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
-import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
+import { preflight, SandboxExecutionError } from "../sandbox/gondolin.mjs";
 import { builtinAdapters } from "./index.mjs";
 import {
   GUEST_BINARIES,
   GUEST_HOME,
   GUEST_PATH,
+  GUEST_XDG_ROOT,
+  FILESYSTEM_CONFINEMENT_REASON,
+  filesystemConfinementRefusal,
   guestBinary,
   guestEnvironment,
   refuseSandbox,
@@ -31,6 +41,13 @@ const ws = () => tmpDir("evrt-sandboxed-");
 const sandboxDef = (extra = {}) => ({
   ref: "sandboxed@1",
   sandbox: { provider: "gondolin", allowedHosts: [] },
+  ...extra,
+});
+
+const confinedDef = (extra = {}) => ({
+  ref: "confined@1",
+  mutating: false,
+  capabilities: { filesystem: "workspace-only", services: [] },
   ...extra,
 });
 
@@ -67,6 +84,141 @@ describe("sandboxRequested / refuseSandbox", () => {
   });
 });
 
+describe("workspace-only model admission (#962)", () => {
+  test("unsupported model adapters fail closed with one typed reason", () => {
+    for (const adapter of ["agy", "claude", "cursor", "hermes"]) {
+      expect(filesystemConfinementRefusal(adapter, confinedDef())).toEqual({
+        code: FILESYSTEM_CONFINEMENT_REASON,
+        detail: expect.stringContaining(
+          `adapter "${adapter}" has no enforced workspace-only guest path`,
+        ),
+      });
+    }
+  });
+
+  test("pi is admitted only with a valid Gondolin policy and read-only runtime mounts", () => {
+    const runtimeAssets = ws();
+    expect(filesystemConfinementRefusal("pi", confinedDef())).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("requires an explicit sandbox policy"),
+    });
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({ sandbox: { provider: "invalid" } }),
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("sandbox policy is not enforceable"),
+    });
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({
+          sandbox: {
+            provider: "gondolin",
+            mounts: { "/opt/tools": { path: runtimeAssets } },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("must be read-only"),
+    });
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({
+          sandbox: {
+            provider: "gondolin",
+            mounts: {
+              "/opt/tools": { path: runtimeAssets, readonly: true },
+            },
+          },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({ sandbox: { provider: "gondolin" } }),
+        { sandboxSupport: "unsupported" },
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining('SANDBOX_SUPPORT="unsupported"'),
+    });
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({
+          sandbox: {
+            provider: "gondolin",
+            mounts: {
+              "/opt/auth": {
+                path: "/home/operator/.config/gh",
+                readonly: true,
+              },
+            },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("raw credential store"),
+    });
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({
+          sandbox: {
+            provider: "gondolin",
+            mounts: {
+              "/opt/home": {
+                path: "/home/operator",
+                readonly: true,
+              },
+            },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("broad host user home"),
+    });
+
+    const aliasRoot = ws();
+    const homeAlias = path.join(aliasRoot, "runtime-assets");
+    symlinkSync(homedir(), homeAlias);
+    expect(
+      filesystemConfinementRefusal(
+        "pi",
+        confinedDef({
+          sandbox: {
+            provider: "gondolin",
+            mounts: {
+              "/opt/tools": { path: homeAlias, readonly: true },
+            },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("resolves to"),
+    });
+  });
+
+  test("non-model adapters and mutating definitions retain their existing semantics", () => {
+    expect(filesystemConfinementRefusal("fake", confinedDef())).toBeNull();
+    expect(
+      filesystemConfinementRefusal(
+        "claude",
+        confinedDef({ mutating: true }),
+      ),
+    ).toBeNull();
+  });
+});
+
 describe("guest environment and binaries", () => {
   test("guestEnvironment is built from constants plus locale — the caller's env is not a source", () => {
     const env = guestEnvironment(
@@ -83,10 +235,37 @@ describe("guest environment and binaries", () => {
       HOME: GUEST_HOME,
       PATH: GUEST_PATH,
       TERM: "dumb",
+      XDG_CONFIG_HOME: `${GUEST_XDG_ROOT}/config`,
+      XDG_CACHE_HOME: `${GUEST_XDG_ROOT}/cache`,
+      XDG_DATA_HOME: `${GUEST_XDG_ROOT}/data`,
+      XDG_RUNTIME_DIR: `${GUEST_XDG_ROOT}/run`,
       LANG: "en_US.UTF-8",
       PI_OFFLINE: "1",
     });
     expect(GUEST_PATH.split(":")).toContain("/usr/local/bin");
+  });
+
+  test("adapter additions cannot override disposable HOME/XDG or guest command paths", () => {
+    const env = guestEnvironment({
+      HOME: "/home/operator",
+      PATH: "/host/bin",
+      XDG_CONFIG_HOME: "/home/operator/.config",
+      XDG_CACHE_HOME: "/home/operator/.cache",
+      XDG_DATA_HOME: "/home/operator/.local/share",
+      XDG_RUNTIME_DIR: "/run/user/1000",
+      TERM: "xterm-host",
+      PI_OFFLINE: "1",
+    });
+    expect(env).toMatchObject({
+      HOME: GUEST_HOME,
+      PATH: GUEST_PATH,
+      TERM: "dumb",
+      XDG_CONFIG_HOME: `${GUEST_XDG_ROOT}/config`,
+      XDG_CACHE_HOME: `${GUEST_XDG_ROOT}/cache`,
+      XDG_DATA_HOME: `${GUEST_XDG_ROOT}/data`,
+      XDG_RUNTIME_DIR: `${GUEST_XDG_ROOT}/run`,
+      PI_OFFLINE: "1",
+    });
   });
 
   test("guestBinary defaults to the image contract path and honours an absolute per-definition override", () => {
@@ -286,6 +465,72 @@ describe("runSandboxed", () => {
       trace.find((t) => t.payload?.note === "sandbox_console").payload.error,
     ).toContain("sandbox_runner_crashed");
   });
+});
+
+describe("real guest filesystem confinement (#962)", () => {
+  const report = preflight();
+  const itVM = report.available ? test : test.skip;
+  if (!report.available) {
+    console.warn(
+      `[GH-962] skipping real-VM absolute-path confinement test — ${report.reason}`,
+    );
+  }
+
+  itVM(
+    "sandboxed pi cannot read or write host absolute paths outside its workspace",
+    async () => {
+      const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const hostSecret = `/tmp/factory-host-secret-${nonce}`;
+      const hostEscape = `/tmp/factory-host-escape-${nonce}`;
+      const workspaceDir = ws();
+      writeFileSync(hostSecret, "raw-host-credential\n", { mode: 0o600 });
+      rmSync(hostEscape, { force: true });
+
+      try {
+        const outcome = await runSandboxed({
+          adapter: "pi",
+          def: confinedDef({
+            sandbox: { provider: "gondolin", allowedHosts: [] },
+          }),
+          workspaceDir,
+          argv: [
+            "/bin/sh",
+            "-c",
+            [
+              'if cat "$0" >/dev/null 2>&1; then read_result=ESCAPED; else read_result=blocked; fi',
+              'if printf guest-write > "$1" 2>/dev/null; then write_result=guest-only; else write_result=blocked; fi',
+              "printf '%s %s\\n' \"$read_result\" \"$write_result\" > ./absolute-path-results",
+            ].join("\n"),
+            hostSecret,
+            hostEscape,
+          ],
+          env: guestEnvironment({}, {
+            HOME: "/home/operator",
+            GITHUB_TOKEN: "ghp-host-only",
+            CURSOR_API_KEY: "cursor-host-only",
+            SSH_AUTH_SOCK: "/tmp/host-agent.sock",
+          }),
+          timeoutMs: 120_000,
+        });
+
+        expect(outcome).toMatchObject({ exitCode: 0, timedOut: false });
+        expect(
+          readFileSync(
+            path.join(workspaceDir, "absolute-path-results"),
+            "utf8",
+          ),
+        ).toMatch(/^blocked (guest-only|blocked)\n$/);
+        expect(readFileSync(hostSecret, "utf8")).toBe(
+          "raw-host-credential\n",
+        );
+        expect(existsSync(hostEscape)).toBe(false);
+      } finally {
+        rmSync(hostSecret, { force: true });
+        rmSync(hostEscape, { force: true });
+      }
+    },
+    180_000,
+  );
 });
 
 /**

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -376,6 +376,13 @@ export function buildRunSpec(
     // otherwise identical planner inputs nondeterministic.
     defHash: computeDefHash(def),
     capabilities: def.capabilities.services,
+    // Pin workspace-only intent into new RunSpecs so the worker's execution
+    // backstop does not depend solely on a mutable live definition. Legacy
+    // model specs without defHash are refused by the worker instead.
+    ...(def.mutating === false &&
+    def.capabilities.filesystem === "workspace-only"
+      ? { filesystem: "workspace-only" }
+      : {}),
     // Declared repo scope (WM-64) rides in the spec so the proposal the
     // operator approves names it, same as capabilities.
     ...(def.repos ? { repos: def.repos } : {}),

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -150,6 +150,22 @@ describe("merge concurrency policy", () => {
 });
 
 describe("planEvent", () => {
+  test("pins workspace-only intent into the RunSpec for the execute-time admission backstop (#962)", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, {
+      eventId: "workspace-only-pin",
+      correlationId: "workspace-only-pin",
+    });
+    const outcome = planEvent(db, registry, ref, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(outcome.decision).toBe("run");
+    expect(JSON.parse(outcome.proposal.spec_json).filesystem).toBe(
+      "workspace-only",
+    );
+  });
+
   test("run decision: PROPOSED run + open proposal with the §5.2 spec", () => {
     const db = openDb(":memory:");
     const ref = admit(db);
@@ -182,6 +198,7 @@ describe("planEvent", () => {
       // verifyDefHash consumes.
       defHash: computeDefHash(registry.agents.get("factory-status-report@1")),
       capabilities: ["tracker:read"],
+      filesystem: "workspace-only",
       // Model-tier routing (WM-135): the committed definition declares
       // standard, policy maps it to models.pi.standard (WM-215 made pi the
       // default harness), and the planner pins the resolution.

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -39,6 +39,11 @@ import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT, resolveConfigPath } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
+import {
+  filesystemConfinementRefusal,
+  MODEL_BACKED_ADAPTERS,
+} from "./adapters/sandboxed.mjs";
+import { isSandboxGuarded } from "./adapters/index.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
 import {
   HARNESS_KINDS,
@@ -752,6 +757,7 @@ const ENVIRONMENT_FAILURES = new Set([
 const AGENT_FAILURES = new Set(["contract_violation", ...HANDOFF_REASON_CODES]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
+  "filesystem_confinement_unavailable",
   "sandbox_unsupported",
   "worktree_sandbox_unsupported",
   "unknown_adapter",
@@ -2282,6 +2288,68 @@ export async function executeClaimed(
       return { fenced: true };
     }
 
+    const adapterKey = adapterOverride ?? spec.adapter;
+    const selectedAdapter = adapters[adapterKey];
+    // Production entry points supply only registry-wrapped adapters. Unit and
+    // integration tests may inject a raw non-model contract stub under a model
+    // route; that stub spawns no model and is outside this boundary.
+    const modelRuntimeSelected =
+      MODEL_BACKED_ADAPTERS.includes(adapterKey) &&
+      isSandboxGuarded(selectedAdapter);
+    const missingModelDefinitionPin =
+      def?.mutating === false &&
+      modelRuntimeSelected &&
+      !spec.defHash;
+    if (missingModelDefinitionPin || (def && !verifyDefHash(spec, def))) {
+      const refusedRes = refuseTerminal(
+        "agent_definition_mismatch",
+        [missingModelDefinitionPin ? "def_hash_missing" : "def_hash_mismatch"],
+        { causeTyped: true },
+      );
+      stopCancellationMonitor();
+      if (refusedRes?.fenced) return { fenced: true };
+      return {
+        runId,
+        attempt,
+        terminalState: "REFUSED",
+        reasonCode: "agent_definition_mismatch",
+        receipt: refusedRes.receipt,
+      };
+    }
+    const filesystemIntent =
+      spec.filesystem ?? def?.capabilities?.filesystem ?? null;
+    const confinementDef =
+      filesystemIntent === def?.capabilities?.filesystem
+        ? def
+        : {
+            ...def,
+            capabilities: {
+              ...(def?.capabilities ?? {}),
+              filesystem: filesystemIntent,
+            },
+          };
+    const confinementRefusal = modelRuntimeSelected
+      ? filesystemConfinementRefusal(adapterKey, confinementDef, {
+          sandboxSupport: selectedAdapter?.SANDBOX_SUPPORT ?? null,
+        })
+      : null;
+    if (confinementRefusal) {
+      const res = refuseTerminal(
+        confinementRefusal.code,
+        ["filesystem_confinement"],
+        { detail: confinementRefusal.detail },
+      );
+      stopCancellationMonitor();
+      if (res?.fenced) return { fenced: true };
+      return {
+        runId,
+        attempt,
+        terminalState: "REFUSED",
+        reasonCode: confinementRefusal.code,
+        receipt: res?.receipt,
+      };
+    }
+
     if (isWorktree && repoName && ticketId) {
       if (!linearConfigured) {
         const res = failTerminal(
@@ -2555,7 +2623,6 @@ export async function executeClaimed(
       }
     }
 
-    const adapterKey = adapterOverride ?? spec.adapter;
     const created = createWorkspace({
       root: workspacesRoot,
       runId,
@@ -2595,23 +2662,6 @@ export async function executeClaimed(
       };
     }
     if (!def) def = getAgent(registry, spec.agent);
-
-    if (!verifyDefHash(spec, def)) {
-      const refusedRes = refuseTerminal(
-        "agent_definition_mismatch",
-        ["def_hash_mismatch"],
-        { causeTyped: true },
-      );
-      cleanupWorkspace();
-      if (refusedRes?.fenced) return { fenced: true };
-      return {
-        runId,
-        attempt,
-        terminalState: "REFUSED",
-        reasonCode: "agent_definition_mismatch",
-        receipt: refusedRes.receipt,
-      };
-    }
 
     try {
       const writtenHarness = materializeRunHarness({

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2298,9 +2298,7 @@ export async function executeClaimed(
       MODEL_BACKED_ADAPTERS.includes(adapterKey) &&
       isSandboxGuarded(selectedAdapter);
     const missingModelDefinitionPin =
-      def?.mutating === false &&
-      modelRuntimeSelected &&
-      !spec.defHash;
+      def?.mutating === false && modelRuntimeSelected && !spec.defHash;
     if (missingModelDefinitionPin || (def && !verifyDefHash(spec, def))) {
       const refusedRes = refuseTerminal(
         "agent_definition_mismatch",

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -37,6 +37,7 @@ import {
 } from "./adapters/claude.mjs";
 import * as fake from "./adapters/fake.mjs";
 import { buildPiArgv, execute as executePi } from "./adapters/pi.mjs";
+import { createAdapterRegistry } from "./adapters/index.mjs";
 import { SandboxUnsupportedError } from "./adapters/sandboxed.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
 import { admitEvent } from "./intake.mjs";
@@ -1480,7 +1481,25 @@ describe("worker", () => {
 
   test("attempt 2 resumes the prior harness session and stale attempt 1 remains fenced", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ adapter: "claude", maxAttempts: 2 }));
+    const resumeRegistry = {
+      ...registry,
+      agents: new Map(registry.agents),
+    };
+    resumeRegistry.agents.set("factory-status-report@1", {
+      ...getAgent(registry, "factory-status-report@1"),
+      // This test owns resume/fencing, not workspace-only admission.
+      capabilities: { filesystem: "read-only", services: ["tracker:read"] },
+    });
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "claude",
+        maxAttempts: 2,
+        defHash: computeDefHash(
+          resumeRegistry.agents.get("factory-status-report@1"),
+        ),
+      }),
+    );
     const o = opts();
     const stale = claimNext(db, o);
     const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
@@ -1512,7 +1531,7 @@ describe("worker", () => {
     };
     const done = await executeClaimed(
       db,
-      registry,
+      resumeRegistry,
       { claude: resumeAdapter },
       fresh,
       { ...o, now: afterExpiry },
@@ -1526,7 +1545,7 @@ describe("worker", () => {
 
     const zombie = await executeClaimed(
       db,
-      registry,
+      resumeRegistry,
       { claude: resumeAdapter },
       stale,
       { ...o, now: afterExpiry },
@@ -1542,7 +1561,25 @@ describe("worker", () => {
 
   test("attempt 2 cold-starts cleanly when the prior transcript has no resumable session", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ adapter: "claude", maxAttempts: 2 }));
+    const resumeRegistry = {
+      ...registry,
+      agents: new Map(registry.agents),
+    };
+    resumeRegistry.agents.set("factory-status-report@1", {
+      ...getAgent(registry, "factory-status-report@1"),
+      // This test owns resume extraction, not workspace-only admission.
+      capabilities: { filesystem: "read-only", services: ["tracker:read"] },
+    });
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "claude",
+        maxAttempts: 2,
+        defHash: computeDefHash(
+          resumeRegistry.agents.get("factory-status-report@1"),
+        ),
+      }),
+    );
     const o = opts();
     claimNext(db, o);
     const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
@@ -1580,7 +1617,7 @@ describe("worker", () => {
     };
     const done = await executeClaimed(
       db,
-      registry,
+      resumeRegistry,
       { claude: coldAdapter },
       fresh,
       { ...o, now: afterExpiry },
@@ -1788,6 +1825,92 @@ describe("worker", () => {
     const summary = await runOnce(db, registry, adapters, opts());
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("unknown_adapter");
+  });
+
+  test("workspace-only model execution is refused before workspace creation or adapter spawn (#962)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "claude",
+        defHash: computeDefHash(
+          getAgent(registry, "factory-status-report@1"),
+        ),
+      }),
+    );
+    const workspacesRoot = freshRoot();
+    let executed = false;
+    const guardedAdapters = createAdapterRegistry({
+      builtins: {
+        claude: {
+          SANDBOX_SUPPORT: "unsupported",
+          async execute() {
+            executed = true;
+            throw new Error("model adapter must not spawn");
+          },
+        },
+      },
+    }).toMap();
+
+    const summary = await runOnce(
+      db,
+      registry,
+      guardedAdapters,
+      opts({ workspacesRoot }),
+    );
+
+    expect(summary).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "filesystem_confinement_unavailable",
+    });
+    expect(executed).toBe(false);
+    expect(readdirSync(workspacesRoot)).toEqual([]);
+    expect(runState(db, spec.runId)).toBe("REFUSED");
+    expect(
+      JSON.parse(
+        db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(
+          spec.runId,
+        ).result_json,
+      ).verification,
+    ).toEqual({ status: "passed", checks: ["filesystem_confinement"] });
+  });
+
+  test("legacy non-mutating model specs without a definition pin fail closed before using the live definition (#962)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "hermes" }));
+    const workspacesRoot = freshRoot();
+    let executed = false;
+    const guardedAdapters = createAdapterRegistry({
+      builtins: {
+        hermes: {
+          SANDBOX_SUPPORT: "unsupported",
+          async execute() {
+            executed = true;
+          },
+        },
+      },
+    }).toMap();
+
+    const summary = await runOnce(
+      db,
+      registry,
+      guardedAdapters,
+      opts({ workspacesRoot }),
+    );
+
+    expect(summary).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "agent_definition_mismatch",
+    });
+    expect(executed).toBe(false);
+    expect(readdirSync(workspacesRoot)).toEqual([]);
+    expect(
+      JSON.parse(
+        db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(
+          spec.runId,
+        ).result_json,
+      ).verification.checks,
+    ).toEqual(["def_hash_missing"]);
   });
 
   test("cancelRun on a QUEUED run → CANCELLED; on a terminal run → IllegalTransition", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1931,9 +1931,7 @@ describe("worker", () => {
       db,
       makeSpec({
         adapter: "claude",
-        defHash: computeDefHash(
-          getAgent(registry, "factory-status-report@1"),
-        ),
+        defHash: computeDefHash(getAgent(registry, "factory-status-report@1")),
       }),
     );
     const workspacesRoot = freshRoot();
@@ -1966,9 +1964,9 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("REFUSED");
     expect(
       JSON.parse(
-        db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(
-          spec.runId,
-        ).result_json,
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).result_json,
       ).verification,
     ).toEqual({ status: "passed", checks: ["filesystem_confinement"] });
   });
@@ -2004,9 +2002,9 @@ describe("worker", () => {
     expect(readdirSync(workspacesRoot)).toEqual([]);
     expect(
       JSON.parse(
-        db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(
-          spec.runId,
-        ).result_json,
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).result_json,
       ).verification.checks,
     ).toEqual(["def_hash_missing"]);
   });


### PR DESCRIPTION
## Summary
- pin non-mutating `workspace-only` intent into new RunSpecs and enforce it again immediately before execution
- refuse model-backed host adapters with a typed, operator-visible reason; allow only sandboxed Gondolin `pi`
- harden Gondolin policy admission against unsafe network settings, broad/sensitive/symlinked host mounts, and writable runtime mounts
- fail closed for stale model RunSpecs without a definition hash, before workspace creation or adapter spawn
- add planner, worker, helper, adapter conformance, and conditional real-VM confinement coverage

## Verification
- `bun test --timeout 20000 event-runtime/lib/planner.test.mjs event-runtime/lib/worker.test.mjs event-runtime/lib/adapters/sandboxed.test.mjs` — 252 pass, 1 skip, 0 fail
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` — 1718 pass, 10 skip, 0 fail; 94 generated files match
- not run — real Gondolin/QEMU integration cases require `qemu-system-x86_64`, which is not installed on this worker

Fixes watt-mind/factory#962


## Handoff
- Verification (merge-stage, on `feat/gh-962` merged with `origin/develop` at `1cd4bb9b`):
  - `bunx prettier --write event-runtime/lib/adapters/sandboxed.test.mjs event-runtime/lib/worker.mjs event-runtime/lib/worker.test.mjs` then `bun run format:check` — `All matched files use Prettier code style!`
  - `bun test --timeout 20000 event-runtime/lib/adapters/sandboxed.test.mjs event-runtime/lib/worker.test.mjs` — 167 tests across 2 files: 166 pass, 1 skip, 0 fail (1454 expect() calls)
  - `bun run check` — `ok — 94 generated files match shared/`, exit 0
- UX critique: not applicable — adapter/worker internals, no user-completable journey changed.
- File scope: the 6 owned paths only — `event-runtime/lib/adapters/sandboxed.mjs`, `event-runtime/lib/adapters/sandboxed.test.mjs`, `event-runtime/lib/planner.mjs`, `event-runtime/lib/planner.test.mjs`, `event-runtime/lib/worker.mjs`, `event-runtime/lib/worker.test.mjs`.
