### PR TITLE
feat(inbox): hide expired open items by default (#1198)

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1011,9 +1011,16 @@ export function inboxCounts(db) {
   const totals = db
     .query(
       `SELECT
-       SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NULL THEN 1 ELSE 0 END) AS open,
-       SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NOT NULL THEN 1 ELSE 0 END) AS acked
-     FROM inbox_items`,
+       SUM(CASE WHEN i.resolved_at IS NULL AND i.acked_at IS NULL
+                      AND NOT (i.kind = 'proposal_expired' OR EXISTS (
+                        SELECT 1 FROM proposals p
+                         WHERE p.id = json_extract(i.refs_json, '$.proposalId')
+                           AND p.status = 'open'
+                           AND p.ttl_seconds > 0
+                           AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
+                      )) THEN 1 ELSE 0 END) AS open,
+       SUM(CASE WHEN i.resolved_at IS NULL AND i.acked_at IS NOT NULL THEN 1 ELSE 0 END) AS acked
+     FROM inbox_items i`,
     )
     .get();
   const byKind = {};

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1008,6 +1008,8 @@ export function resolveInboxItem(
 }
 
 export function inboxCounts(db) {
+  // The expiry predicate below must agree with `isExpiredInboxItem` in
+  // event-runtime/web/src/views/Inbox.tsx (badge vs. Open tab count).
   const totals = db
     .query(
       `SELECT

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -641,6 +641,32 @@ describe("human inbox ledger (WM-285)", () => {
     });
   });
 
+  test("inbox counts omit expired open items", () => {
+    const db = openDb(":memory:");
+    const expiredAt = new Date(Date.now() - 61_000).toISOString();
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES ('expired-proposal', 'test', 'evt', 'run', 'open', ?, 60)`,
+    ).run(expiredAt);
+    createInboxItem(db, { kind: "BLOCKED", title: "active" }, { id: "active" });
+    createInboxItem(
+      db,
+      { kind: "proposal_expired", title: "expired by kind" },
+      { id: "expired-kind" },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "expired by proposal",
+        refs: { proposalId: "expired-proposal" },
+      },
+      { id: "expired-proposal-item" },
+    );
+
+    expect(inboxCounts(db)).toMatchObject({ open: 1, acked: 0 });
+  });
+
   test("runtime-owned referents auto-resolve after leaving their waiting state", () => {
     const db = openDb(":memory:");
     insertProposal(db, { id: "prop-1" });

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -221,6 +221,20 @@ describe("cold query rendering (WM-266)", () => {
 });
 
 describe("sidebar navigation accessibility", () => {
+  test("does not render an Inbox badge or title count when the status excludes expired items", async () => {
+    currentStatus = {
+      ...STATUS,
+      inbox: { open: 0, acked: 2, byKind: { proposal_expired: 2 } },
+    };
+    const { sidebar, queryClient } = renderApp();
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["status"])?.status).toBe("success");
+    });
+    const inbox = sidebar.getByRole("button", { name: "Inbox" });
+    expect(inbox.hasAttribute("aria-describedby")).toBe(false);
+    expect(document.title).toBe("factory · Overview");
+  });
+
   test("detail routes keep their parent navigation entry current", () => {
     expect(navIsCurrent("runs", "run")).toBe(true);
     expect(navIsCurrent("tickets", "prs")).toBe(true);

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -414,6 +414,44 @@ describe("Inbox view", () => {
     expect(view.queryByText("CI RED")).toBeNull();
   });
 
+  test("hides expired open items by default and shows only them from the Expired chip", async () => {
+    ledger = [
+      item({ id: "active", kind: "BLOCKED", title: "Active decision" }),
+      item({
+        id: "expired-kind",
+        kind: "proposal_expired",
+        title: "Expired by kind",
+      }),
+      item({
+        id: "expired-proposal",
+        kind: "decision_needed",
+        title: "Expired by proposal",
+        refs: { proposalId: "expired-proposal-id" },
+      }),
+    ];
+    api.proposals = mock(async () => ({
+      proposals: [
+        {
+          id: "expired-proposal-id",
+          status: "open",
+          created_at: new Date(Date.now() - 61_000).toISOString(),
+          ttl_seconds: 60,
+        } as Proposal,
+      ],
+    }));
+
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("Active decision"));
+    expect(view.queryByText("Expired by kind")).toBeNull();
+    expect(view.queryByText("Expired by proposal")).toBeNull();
+    expect(view.getByRole("tab", { name: /Open/ }).textContent).toContain("1");
+
+    fireEvent.click(view.getByRole("button", { name: "Expired (2)" }));
+    await waitFor(() => view.getByText("Expired by kind"));
+    expect(view.getByText("Expired by proposal")).toBeTruthy();
+    expect(view.queryByText("Active decision")).toBeNull();
+  });
+
   test("proposal rows show a live right-aligned TTL and hide it without one", async () => {
     ledger = [
       item({

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -445,6 +445,7 @@ describe("Inbox view", () => {
     expect(view.queryByText("Expired by kind")).toBeNull();
     expect(view.queryByText("Expired by proposal")).toBeNull();
     expect(view.getByRole("tab", { name: /Open/ }).textContent).toContain("1");
+    expect(view.getByRole("tab", { name: /All/ }).textContent).toContain("1");
 
     fireEvent.click(view.getByRole("button", { name: "Expired (2)" }));
     await waitFor(() => view.getByText("Expired by kind"));

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -38,7 +38,7 @@ import {
   matchesFilterQuery,
   parseFilterQuery,
 } from "../filterQuery";
-import type { InboxItem } from "../types";
+import type { InboxItem, Proposal } from "../types";
 import {
   Ago,
   BulkActionBar,
@@ -407,6 +407,23 @@ export function proposalTtlLabel(
   return `${minutes}m left`;
 }
 
+/** Expired items stay available in the Open tab, but are not actionable by default. */
+export function isExpiredInboxItem(
+  item: InboxItem,
+  proposalsById: Map<string, Proposal>,
+  now: number,
+): boolean {
+  if (item.kind === "proposal_expired") return true;
+  const proposal = item.refs.proposalId
+    ? proposalsById.get(item.refs.proposalId)
+    : undefined;
+  return (
+    proposal?.status === "open" &&
+    proposalTtlLabel(proposal.created_at, proposal.ttl_seconds, now) ===
+      "expired"
+  );
+}
+
 /** WM-559 will move this precision into shared `Ago`; keep the Inbox local until then. */
 export function inboxAge(iso: string, now: number): string {
   const seconds = Math.max(
@@ -735,7 +752,7 @@ export function Inbox({
     ...refetchIntervals.primary,
   });
   const proposalsById = useMemo(() => {
-    const map = new Map<string, { created_at: string; ttl_seconds: number }>();
+    const map = new Map<string, Proposal>();
     for (const proposal of proposalsQuery.data?.proposals ?? []) {
       map.set(proposal.id, proposal);
     }
@@ -743,7 +760,17 @@ export function Inbox({
   }, [proposalsQuery.data]);
 
   const [tab, setTab] = useState<InboxTab>("open");
+  const [expiredOnly, setExpiredOnly] = useState(false);
   const [filter, setFilter] = useState("");
+  const expiredOpenItems = useMemo(
+    () =>
+      items.filter(
+        (item) =>
+          itemStatus(item) === "open" &&
+          isExpiredInboxItem(item, proposalsById, now),
+      ),
+    [items, now, proposalsById],
+  );
   const counts = useMemo(() => {
     const c: Record<InboxTab, number> = {
       open: 0,
@@ -751,13 +778,28 @@ export function Inbox({
       resolved: 0,
       all: items.length,
     };
-    for (const it of items) c[itemStatus(it)] += 1;
+    for (const it of items) {
+      if (
+        itemStatus(it) === "open" &&
+        isExpiredInboxItem(it, proposalsById, now)
+      ) {
+        continue;
+      }
+      c[itemStatus(it)] += 1;
+    }
     return c;
-  }, [items]);
+  }, [items, now, proposalsById]);
 
   const byTab = useMemo(
-    () => items.filter((item) => matchesTab(item, tab)),
-    [items, tab],
+    () =>
+      items.filter((item) => {
+        if (!matchesTab(item, tab)) return false;
+        if (tab !== "open") return true;
+        return (
+          isExpiredInboxItem(item, proposalsById, now) === expiredOnly
+        );
+      }),
+    [expiredOnly, items, now, proposalsById, tab],
   );
   const parsed = useMemo(
     () => parseFilterQuery(filter, INBOX_FACETS),
@@ -1046,6 +1088,7 @@ export function Inbox({
   const selectTab = (t: InboxTab) => {
     lastInteractedId.current = null;
     setTab(t);
+    setExpiredOnly(false);
     onSelectItem(null);
     setSelectedIds(new Set());
   };
@@ -1216,6 +1259,25 @@ export function Inbox({
                     </PrimitiveButton>
                   ))}
                 </div>
+                {tab === "open" && expiredOpenItems.length > 0 && (
+                  <PrimitiveButton
+                    bare
+                    type="button"
+                    aria-pressed={expiredOnly}
+                    onClick={() => {
+                      setExpiredOnly((current) => !current);
+                      onSelectItem(null);
+                      setSelectedIds(new Set());
+                    }}
+                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                      expiredOnly
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1)"
+                    }`}
+                  >
+                    Expired ({expiredOpenItems.length})
+                  </PrimitiveButton>
+                )}
                 <span className="ml-auto">
                   <DisplayOptions
                     config={INBOX_DISPLAY}

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -407,7 +407,11 @@ export function proposalTtlLabel(
   return `${minutes}m left`;
 }
 
-/** Expired items stay available in the Open tab, but are not actionable by default. */
+/**
+ * Expired items stay available in the Open tab, but are not actionable by default.
+ * Must agree with the `open` count predicate in `inboxCounts` (event-runtime/lib/inbox.mjs)
+ * so the sidebar badge and the Open tab count match.
+ */
 export function isExpiredInboxItem(
   item: InboxItem,
   proposalsById: Map<string, Proposal>,
@@ -776,8 +780,10 @@ export function Inbox({
       open: 0,
       acked: 0,
       resolved: 0,
-      all: items.length,
+      all: 0,
     };
+    // Expired open items live behind the Expired chip, so every tab count
+    // excludes them and open + acked + resolved === all.
     for (const it of items) {
       if (
         itemStatus(it) === "open" &&
@@ -786,6 +792,7 @@ export function Inbox({
         continue;
       }
       c[itemStatus(it)] += 1;
+      c.all += 1;
     }
     return c;
   }, [items, now, proposalsById]);
@@ -794,10 +801,9 @@ export function Inbox({
     () =>
       items.filter((item) => {
         if (!matchesTab(item, tab)) return false;
-        if (tab !== "open") return true;
-        return (
-          isExpiredInboxItem(item, proposalsById, now) === expiredOnly
-        );
+        if (itemStatus(item) !== "open") return true;
+        const expired = isExpiredInboxItem(item, proposalsById, now);
+        return tab === "open" ? expired === expiredOnly : !expired;
       }),
     [expiredOnly, items, now, proposalsById, tab],
   );


### PR DESCRIPTION
Fixes watt-mind/factory#1198

Expired Open inbox items are hidden by default and available through the Expired filter. The `open` count in `inboxCounts` (sidebar badge) and `isExpiredInboxItem` (Open tab) share one expiry predicate; tab counts exclude expired open items so open + acked + resolved = all.

## Validation

| Check                | Command                                                                                                           | Result | Notes                                      |
| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------ |
| Verification Command | `cd event-runtime/web && bun test src/views/Inbox.test.tsx src/App.test.tsx && cd ../.. && bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/api-status-view.test.mjs` | pass   | 81 + 40 tests, 0 failures (re-run after merging develop) |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`                                     | fail (unrelated) | worker run exited 1 on develop-side gh-860 / WM-440 suites, not touched by this branch; fixed on develop by #1209. `bun run check` passes on the merged branch. |
| Web typecheck        | `cd event-runtime/web && bunx tsc --noEmit`                                                                       | pass   |                                            |
| UX critique          | `factory-ux-critic`                                                                                              | pass   | required — SHIP; http://127.0.0.1:7613/#/inbox |

## Handoff

- Verification: Verification Command pass (81 web + 40 lib tests, 0 fail); `bunx tsc --noEmit` clean; `bun run check` exit 0 on the branch merged with `origin/develop`.
- UX verdict: factory-ux-critic — SHIP (Expired chip toggles expired open items; badge and Open tab agree).
- File scope: `event-runtime/web/src/views/Inbox.tsx`, `event-runtime/web/src/views/Inbox.test.tsx`, `event-runtime/web/src/App.tsx`, `event-runtime/web/src/App.test.tsx`, `event-runtime/lib/inbox.mjs`, `event-runtime/lib/inbox.test.mjs` — all within the ticket's Owned Paths.
- Known follow-up (filed separately): the Open tab evaluates expiry against a single unpaged `api.proposals()` page while `inboxCounts` is unbounded, so the tab count can exceed the badge on large proposal sets.
