### PR TITLE
fix(verify): isolate ticket handoff commands

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1199,12 +1199,11 @@ export function worktreeDispatchAutoEligibility(
     evidence.checks.ticket_trusted_author = trustedAuthor;
     if (!trustedAuthor) return refusal("ticket_untrusted_author", evidence);
 
-    // Absent pin (never labeled through a pin-aware path) is not itself a
-    // refusal — only a MISMATCHED pin proves the body changed since it was
-    // marked ready. Refusing on absence would strand every ticket labeled
-    // before this gate shipped.
+    // Verification Command is executable worker input, so an absent pin is
+    // not evidence. Legacy tickets must be re-labelled through the pin-aware
+    // path before dispatch rather than silently retaining a rollout bypass.
     const pinMatches =
-      !evidence.ticket.readyPinHash ||
+      Boolean(evidence.ticket.readyPinHash) &&
       evidence.ticket.readyPinHash === evidence.ticket.descriptionHash;
     evidence.checks.ticket_body_pin_matches = pinMatches;
     if (!pinMatches)

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1202,10 +1202,16 @@ export function worktreeDispatchAutoEligibility(
     // Verification Command is executable worker input, so an absent pin is
     // not evidence. Legacy tickets must be re-labelled through the pin-aware
     // path before dispatch rather than silently retaining a rollout bypass.
+    // The two refusals are kept distinct: a MISSING pin is a ticket the
+    // orchestrator can simply re-stamp (relabel sweep), while a MISMATCHED
+    // pin means the body actually changed after readiness and needs a human
+    // to look at what changed.
+    const hasPin = Boolean(evidence.ticket.readyPinHash);
     const pinMatches =
-      Boolean(evidence.ticket.readyPinHash) &&
+      hasPin &&
       evidence.ticket.readyPinHash === evidence.ticket.descriptionHash;
     evidence.checks.ticket_body_pin_matches = pinMatches;
+    if (!hasPin) return refusal("ticket_ready_pin_missing", evidence);
     if (!pinMatches)
       return refusal("ticket_body_changed_since_ready", evidence);
   }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1338,14 +1338,16 @@ describe("planEvent worktree gate (WM-108)", () => {
       });
     });
 
-    test("an absent ready pin fails closed", () => {
+    test("an absent ready pin fails closed under its own reason code", () => {
       withReposRoot(tierRepo, () => {
         const result = worktreeDispatchAutoEligibility(
           { repo: "tiered", ticket: "acme/widget#1" },
           githubDispatch(githubTicket({ readyPinHash: null })),
         );
         expect(result.ok).toBe(false);
-        expect(result.refusal.reason).toBe("ticket_body_changed_since_ready");
+        // Distinct from a mismatch (GH-967): an unpinned ticket is re-stamped
+        // by a relabel sweep, a changed body needs a human.
+        expect(result.refusal.reason).toBe("ticket_ready_pin_missing");
         expect(result.evidence.checks.ticket_body_pin_matches).toBe(false);
       });
     });

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1229,17 +1229,21 @@ describe("planEvent worktree gate (WM-108)", () => {
       lastEditorAssociation = "OWNER",
       readyPinHash,
       description = "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
-    } = {}) => ({
-      identifier: "acme/widget#1",
-      state: { name: "Todo" },
-      assignee: null,
-      labels: [{ name: "ai:agent-ready" }],
-      description,
-      controlPlaneKind: "github",
-      authorAssociation,
-      lastEditorAssociation,
-      readyPinHash,
-    });
+    } = {}) => {
+      const ticket = {
+        identifier: "acme/widget#1",
+        state: { name: "Todo" },
+        assignee: null,
+        labels: [{ name: "ai:agent-ready" }],
+        description,
+        controlPlaneKind: "github",
+        authorAssociation,
+        lastEditorAssociation,
+        readyPinHash:
+          readyPinHash === undefined ? hashJson(description) : readyPinHash,
+      };
+      return ticket;
+    };
 
     const githubDispatch = (ticket) => ({
       countLeases: () => 0,
@@ -1334,14 +1338,15 @@ describe("planEvent worktree gate (WM-108)", () => {
       });
     });
 
-    test("no pin ever stamped (pre-rollout ticket) does not refuse — only a mismatch does", () => {
+    test("an absent ready pin fails closed", () => {
       withReposRoot(tierRepo, () => {
         const result = worktreeDispatchAutoEligibility(
           { repo: "tiered", ticket: "acme/widget#1" },
           githubDispatch(githubTicket({ readyPinHash: null })),
         );
-        expect(result.ok).toBe(true);
-        expect(result.evidence.checks.ticket_body_pin_matches).toBe(true);
+        expect(result.ok).toBe(false);
+        expect(result.refusal.reason).toBe("ticket_body_changed_since_ready");
+        expect(result.evidence.checks.ticket_body_pin_matches).toBe(false);
       });
     });
 
@@ -3229,15 +3234,18 @@ describe("GitHub dispatch candidate parsing (GH-974)", () => {
           budgetRefusal: () => null,
           fetchTicket: (ticket) => {
             reads.push(ticket);
+            const description =
+              "## Owned Paths\n- event-runtime/lib/planner.mjs\n";
             return {
               identifier: ticket,
               state: { name: "Todo" },
               assignee: null,
               labels: [{ name: "ai:agent-ready" }],
-              description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+              description,
               controlPlaneKind: "github",
               authorAssociation: "MEMBER",
               lastEditorAssociation: "MEMBER",
+              readyPinHash: hashJson(description),
             };
           },
           fetchInFlight: () => [],

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -14,7 +14,6 @@ import { execFileSync, spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
-  mkdirSync,
   mkdtempSync,
   openSync,
   readFileSync,
@@ -125,11 +124,9 @@ export const HANDOFF_HOST_ENV = Object.freeze({
 });
 export const HANDOFF_GUEST_PATH =
   "/opt/factory-bin:/usr/local/bin:/usr/bin:/bin";
-export const HANDOFF_RUNTIME_COMMANDS = Object.freeze([
-  "bun",
-  "uv",
-  "pnpm",
-]);
+/** Where the verified worktree is mounted inside the chroot. */
+export const HANDOFF_GUEST_WORKSPACE = "/workspace";
+export const HANDOFF_RUNTIME_COMMANDS = Object.freeze(["bun", "uv", "pnpm"]);
 
 /** Non-system package runners mounted as individual, read-only executables. */
 export function handoffRuntimeBinaries(which = (name) => Bun.which(name)) {
@@ -143,16 +140,38 @@ export function handoffRuntimeBinaries(which = (name) => Bun.which(name)) {
  * Constant setup program for the handoff shell's Linux isolation boundary.
  *
  * - a user namespace grants mount/chroot authority without host root;
- * - a network namespace starts with loopback down and no host interfaces;
+ * - a network namespace has no host interfaces; loopback is brought up
+ *   because suites routinely bind 127.0.0.1, and a namespaced loopback
+ *   reaches nothing outside the sandbox;
  * - a private mount namespace exposes only read-only /usr, selected package
- *   runners, the intended worktree, ephemeral /tmp, proc and basic devices;
+ *   runners, the intended worktree, the git directories that worktree's
+ *   `.git` file points at, ephemeral /tmp, proc and basic devices;
  * - chroot makes host absolute paths and worktree symlink escapes unreachable.
+ *
+ * Argument protocol: root, workspace, guest_cwd, git_mount_count, then
+ * `git_mount_count` × (host_path, ro|rw), then (name, executable) pairs for
+ * the package runners, then the command as the last argument.
+ *
+ * Guest environment (GH-967): HOME/TMPDIR/PATH/LANG plus one pin.
+ * `reposRoot()` is `FACTORY_REPOS_ROOT || FACTORY_ROOT`, and FACTORY_ROOT is
+ * derived from the module's own location — so the previous
+ * `FACTORY_ROOT=/workspace` set the variable nothing reads while leaving
+ * `FACTORY_REPOS_ROOT` unset, silently undoing #1214's pin. The host factory
+ * root is deliberately NOT bound into the chroot (it holds config/repos.yaml,
+ * mirrors and other repos' worktrees — none of which a ticket's check needs),
+ * so the only coherent repos root inside the guest is the worktree itself:
+ * `FACTORY_REPOS_ROOT=/workspace`, which is exactly #1214's "pin the repos
+ * root at the worktree, never at the worker's factory root" expressed in
+ * guest coordinates. It is derived from the workspace root, not the command's
+ * cwd, so the web-build call site (cwd `event-runtime/web`) is pinned right
+ * too (#1224). #1214 covers the same seam on the unsandboxed path.
  */
 export const HANDOFF_SANDBOX_SETUP = String.raw`
 root=$1
 workspace=$2
 guest_cwd=$3
-shift 3
+git_mounts=$4
+shift 4
 mount --make-rprivate /
 mount -t tmpfs -o mode=0755,size=64m tmpfs "$root"
 mkdir -p "$root/usr" "$root/workspace" "$root/tmp" "$root/dev" \
@@ -172,6 +191,25 @@ for dev in null zero random urandom; do
   touch "$root/dev/$dev"
   mount --bind "/dev/$dev" "$root/dev/$dev"
 done
+if command -v ip >/dev/null 2>&1; then
+  ip link set lo up || echo "handoff-sandbox: loopback stayed down" >&2
+elif command -v ifconfig >/dev/null 2>&1; then
+  ifconfig lo up || echo "handoff-sandbox: loopback stayed down" >&2
+else
+  echo "handoff-sandbox: no ip/ifconfig; loopback stays down" >&2
+fi
+while [ "$git_mounts" -gt 0 ]; do
+  git_path=$1
+  git_mode=$2
+  shift 2
+  git_mounts=$((git_mounts - 1))
+  mkdir -p "$root$git_path"
+  mount --rbind "$git_path" "$root$git_path"
+  mount --make-rslave "$root$git_path"
+  if [ "$git_mode" = ro ]; then
+    mount -o remount,bind,ro "$root$git_path"
+  fi
+done
 while [ "$#" -gt 1 ]; do
   name=$1
   executable=$2
@@ -187,9 +225,108 @@ mkdir -p "$root/tmp/home"
   shift
   exec /usr/bin/env -i \
     HOME=/tmp/home TMPDIR=/tmp PATH=${HANDOFF_GUEST_PATH} LANG=C.UTF-8 \
-    FACTORY_ROOT=/workspace /bin/bash -c "$1"
+    FACTORY_REPOS_ROOT=${HANDOFF_GUEST_WORKSPACE} /bin/bash -c "$1"
 ' bash "$guest_cwd" "$command"
 `;
+
+/**
+ * A linked git worktree's `.git` is a file holding an absolute host gitdir
+ * (`<repo>/.git/worktrees/<name>`), and that gitdir's `commondir` points at
+ * the parent repository's `.git` where the objects live. Neither is under the
+ * workspace, so inside the chroot `git` would fail with "not a git
+ * repository". Both are bound back at their own absolute paths: the
+ * worktree's own gitdir writable (it is this workspace's state — git refreshes
+ * its index on `git status`), the shared repository `.git` read-only, so ticket
+ * code can read history but cannot rewrite the host repository.
+ *
+ * A plain checkout (`.git` is a directory) needs nothing: it already lives
+ * inside the bound workspace.
+ */
+export function handoffGitMounts(workspaceRoot, read = readFileSync) {
+  const dotGit = path.join(workspaceRoot, ".git");
+  let pointer;
+  try {
+    pointer = read(dotGit, "utf8");
+  } catch {
+    return [];
+  }
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(String(pointer));
+  if (!match) return [];
+  const gitDir = path.resolve(workspaceRoot, match[1]);
+  const mounts = [{ path: gitDir, mode: "rw" }];
+  let commonDir = null;
+  try {
+    commonDir = path.resolve(
+      gitDir,
+      String(read(path.join(gitDir, "commondir"), "utf8")).trim(),
+    );
+  } catch {
+    /* no commondir: a gitdir file that is not a linked worktree */
+  }
+  if (commonDir && !commonDir.startsWith(`${gitDir}${path.sep}`)) {
+    mounts.push({ path: commonDir, mode: "ro" });
+  }
+  return mounts;
+}
+
+/** Reason code for a host that cannot build the handoff sandbox at all. */
+export const HANDOFF_SANDBOX_UNAVAILABLE = "sandbox_unavailable";
+
+let sandboxProbeCache = null;
+
+/**
+ * Can this host build the isolation boundary at all? Unprivileged user
+ * namespaces are a kernel/distro toggle (`kernel.unprivileged_userns_clone`,
+ * AppArmor `userns` restrictions, some container runtimes), and `unshare`
+ * itself may be absent. When the probe says no, the handoff gate refuses with
+ * `sandbox_unavailable` — an environment fault, distinct from the ticket's
+ * check actually failing — instead of reporting the ticket's command red.
+ * There is deliberately NO unsandboxed fallback: running ticket-authored
+ * commands with the worker's credentials is exactly what GH-967 removes.
+ */
+export function handoffSandboxAvailable({
+  spawn = spawnSync,
+  cache = true,
+} = {}) {
+  if (cache && sandboxProbeCache !== null) return sandboxProbeCache;
+  let available;
+  try {
+    const res = spawn(
+      "/usr/bin/unshare",
+      [
+        "--user",
+        "--map-root-user",
+        "--net",
+        "--mount",
+        "--pid",
+        "--fork",
+        "/bin/true",
+      ],
+      { env: HANDOFF_HOST_ENV, stdio: "ignore", timeout: 10_000 },
+    );
+    available = !res.error && res.status === 0;
+  } catch {
+    available = false;
+  }
+  if (cache) sandboxProbeCache = available;
+  return available;
+}
+
+/** Test seam: forget a cached probe result. */
+export function resetHandoffSandboxProbe() {
+  sandboxProbeCache = null;
+}
+
+/** Thrown when the host cannot provide the handoff sandbox (GH-967). */
+export class SandboxUnavailable extends Error {
+  constructor() {
+    super(
+      "sandbox_unavailable: this host cannot create an unprivileged user+mount namespace, so the ticket's verification command cannot be run without the worker's credentials",
+    );
+    this.name = "SandboxUnavailable";
+    this.reasonCode = HANDOFF_SANDBOX_UNAVAILABLE;
+  }
+}
 
 /** `dispatch.owned_paths_conformance` in config/policy.yaml: advisory (default) | strict. */
 export function policyOwnedPathsConformance(root = reposRoot()) {
@@ -230,7 +367,9 @@ export function runHandoffCommand({
   timeoutMs,
   spawn = spawnSync,
   runtimeBinaries = handoffRuntimeBinaries(),
+  sandboxAvailable = () => handoffSandboxAvailable(),
 }) {
+  if (!sandboxAvailable()) throw new SandboxUnavailable();
   const root = realpathSync(workspaceRoot);
   const commandCwd = realpathSync(cwd);
   const relativeCwd = path.relative(root, commandCwd);
@@ -247,7 +386,7 @@ export function runHandoffCommand({
   const sandboxRoot = mkdtempSync(
     path.join(sandboxParent, ".handoff-sandbox-"),
   );
-  mkdirSync(sandboxRoot, { recursive: true });
+  const gitMounts = handoffGitMounts(root);
   const fd = openSync(logPath, "w");
   let res;
   const startedAt = Date.now();
@@ -277,6 +416,8 @@ export function runHandoffCommand({
         sandboxRoot,
         root,
         guestCwd,
+        String(gitMounts.length),
+        ...gitMounts.flatMap(({ path: gitPath, mode }) => [gitPath, mode]),
         ...runtimeArgs,
         command,
       ],
@@ -295,11 +436,18 @@ export function runHandoffCommand({
   }
   const output = readFileSync(logPath, "utf8");
   const elapsedMs = Date.now() - startedAt;
+  // Only the timeout's own verdict counts: 124 from GNU timeout, ETIMEDOUT
+  // from the outer ceiling, or `timeout` itself dying by SIGKILL past the
+  // budget (its --kill-after escalation signals the whole process group,
+  // which it belongs to, so the killer takes the killer with it). A wall
+  // clock that merely reached the budget, or a 137 the command itself exited
+  // with (an OOM kill inside the suite, a test that SIGKILLs a child), is a
+  // real failure with real output — reporting those as "timed out" hid the
+  // actual red.
   const timedOut =
-    elapsedMs >= timeoutMs ||
     res.error?.code === "ETIMEDOUT" ||
     res.status === 124 ||
-    res.status === 137;
+    (res.status == null && res.signal === "SIGKILL" && elapsedMs >= timeoutMs);
   const exitCode = timedOut ? null : (res.status ?? (res.error ? 1 : 0));
   return {
     command,
@@ -1123,6 +1271,19 @@ function verifyCompleted({
       handoff.reasonCode = reasonCode;
       throw new ContractViolation([violation], { reasonCode, handoff });
     };
+    // A host that cannot build the sandbox is an environment fault, not the
+    // agent's red: refuse with its own code so the worker never drafts the
+    // PR or returns the ticket over it.
+    const runHandoffStep = (options) => {
+      try {
+        return runHandoffCommand(options);
+      } catch (err) {
+        if (err instanceof SandboxUnavailable) {
+          refuse(HANDOFF_SANDBOX_UNAVAILABLE, err.message);
+        }
+        throw err;
+      }
+    };
     const failureWhy = (obs) =>
       obs.timedOut
         ? `timed out after ${verifyTimeoutMs}ms`
@@ -1139,7 +1300,7 @@ function verifyCompleted({
     // 1. The repo's own verify command (the pre-WM-718 gate, kept as-is: it
     //    is what the red-baseline logic is keyed on).
     if (worktreeRecord.verify) {
-      const obs = runHandoffCommand({
+      const obs = runHandoffStep({
         command: worktreeRecord.verify,
         cwd: worktreePath,
         workspaceRoot: worktreePath,
@@ -1165,7 +1326,7 @@ function verifyCompleted({
 
     // 2. The ticket's exact Verification Command on the final tree.
     if (ticketCommand) {
-      const obs = runHandoffCommand({
+      const obs = runHandoffStep({
         command: ticketCommand,
         cwd: worktreePath,
         workspaceRoot: worktreePath,
@@ -1198,7 +1359,7 @@ function verifyCompleted({
       files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
       existsSync(path.join(worktreePath, HANDOFF_WEB_BUILD_DIR, "package.json"))
     ) {
-      const obs = runHandoffCommand({
+      const obs = runHandoffStep({
         command: HANDOFF_WEB_BUILD_COMMAND,
         cwd: path.join(worktreePath, HANDOFF_WEB_BUILD_DIR),
         workspaceRoot: worktreePath,

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -14,10 +14,14 @@ import { execFileSync, spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
+  mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   realpathSync,
+  rmSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { globToRegExp } from "../../orchestrator/owned-paths.mjs";
@@ -111,6 +115,82 @@ export const DEFAULT_OWNED_PATHS_CONFORMANCE = "advisory";
 export const HANDOFF_COMMENT_HEADING =
   "## Handoff verification (worker-observed)";
 
+// Ticket text is executable at this boundary. Do not inherit the worker's
+// environment: it contains tracker, forge, provider and extension authority
+// that no repository check needs. The outer namespace setup gets an even
+// smaller environment than the command inside the chroot.
+export const HANDOFF_HOST_ENV = Object.freeze({
+  PATH: "/usr/sbin:/usr/bin:/sbin:/bin",
+  LANG: "C.UTF-8",
+});
+export const HANDOFF_GUEST_PATH =
+  "/opt/factory-bin:/usr/local/bin:/usr/bin:/bin";
+export const HANDOFF_RUNTIME_COMMANDS = Object.freeze([
+  "bun",
+  "uv",
+  "pnpm",
+]);
+
+/** Non-system package runners mounted as individual, read-only executables. */
+export function handoffRuntimeBinaries(which = (name) => Bun.which(name)) {
+  return HANDOFF_RUNTIME_COMMANDS.flatMap((name) => {
+    const executable = which(name);
+    return executable ? [{ name, executable: realpathSync(executable) }] : [];
+  });
+}
+
+/**
+ * Constant setup program for the handoff shell's Linux isolation boundary.
+ *
+ * - a user namespace grants mount/chroot authority without host root;
+ * - a network namespace starts with loopback down and no host interfaces;
+ * - a private mount namespace exposes only read-only /usr, selected package
+ *   runners, the intended worktree, ephemeral /tmp, proc and basic devices;
+ * - chroot makes host absolute paths and worktree symlink escapes unreachable.
+ */
+export const HANDOFF_SANDBOX_SETUP = String.raw`
+root=$1
+workspace=$2
+guest_cwd=$3
+shift 3
+mount --make-rprivate /
+mount -t tmpfs -o mode=0755,size=64m tmpfs "$root"
+mkdir -p "$root/usr" "$root/workspace" "$root/tmp" "$root/dev" \
+  "$root/proc" "$root/etc" "$root/home" "$root/opt/factory-bin"
+for link in bin lib lib64 sbin; do
+  target=$(readlink "/$link")
+  ln -s "$target" "$root/$link"
+done
+mount --rbind /usr "$root/usr"
+mount --make-rslave "$root/usr"
+mount -o remount,bind,ro "$root/usr"
+mount --rbind "$workspace" "$root/workspace"
+mount --make-rslave "$root/workspace"
+mount -t tmpfs -o mode=1777,size=256m tmpfs "$root/tmp"
+mount -t proc proc "$root/proc"
+for dev in null zero random urandom; do
+  touch "$root/dev/$dev"
+  mount --bind "/dev/$dev" "$root/dev/$dev"
+done
+while [ "$#" -gt 1 ]; do
+  name=$1
+  executable=$2
+  shift 2
+  touch "$root/opt/factory-bin/$name"
+  mount --bind "$executable" "$root/opt/factory-bin/$name"
+  mount -o remount,bind,ro "$root/opt/factory-bin/$name"
+done
+command=$1
+mkdir -p "$root/tmp/home"
+/usr/sbin/chroot "$root" /bin/bash -ceu '
+  cd "$1"
+  shift
+  exec /usr/bin/env -i \
+    HOME=/tmp/home TMPDIR=/tmp PATH=${HANDOFF_GUEST_PATH} LANG=C.UTF-8 \
+    FACTORY_ROOT=/workspace /bin/bash -c "$1"
+' bash "$guest_cwd" "$command"
+`;
+
 /** `dispatch.owned_paths_conformance` in config/policy.yaml: advisory (default) | strict. */
 export function policyOwnedPathsConformance(root = reposRoot()) {
   const file = resolveConfigPath("policy", { root });
@@ -142,24 +222,90 @@ export function outputTail(output, lines = HANDOFF_TAIL_LINES) {
  * Run one handoff command as ordinary code in the worktree, capturing the
  * whole output to `logPath` and returning an observation the worker can quote.
  */
-function runHandoffCommand({ command, cwd, logPath, timeoutMs }) {
+export function runHandoffCommand({
+  command,
+  cwd,
+  workspaceRoot = cwd,
+  logPath,
+  timeoutMs,
+  spawn = spawnSync,
+  runtimeBinaries = handoffRuntimeBinaries(),
+}) {
+  const root = realpathSync(workspaceRoot);
+  const commandCwd = realpathSync(cwd);
+  const relativeCwd = path.relative(root, commandCwd);
+  if (relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd)) {
+    throw new PathViolation(root, relativeCwd, "escapes handoff worktree");
+  }
+  const guestCwd = path.posix.join(
+    "/workspace",
+    ...relativeCwd.split(path.sep).filter(Boolean),
+  );
+  const sandboxParent = existsSync(path.dirname(logPath))
+    ? path.dirname(logPath)
+    : tmpdir();
+  const sandboxRoot = mkdtempSync(
+    path.join(sandboxParent, ".handoff-sandbox-"),
+  );
+  mkdirSync(sandboxRoot, { recursive: true });
   const fd = openSync(logPath, "w");
   let res;
+  const startedAt = Date.now();
   try {
-    res = spawnSync("/bin/bash", ["-c", command], {
-      cwd,
-      stdio: ["ignore", fd, fd],
-      timeout: timeoutMs,
-    });
+    const runtimeArgs = runtimeBinaries.flatMap(({ name, executable }) => [
+      name,
+      executable,
+    ]);
+    res = spawn(
+      "/usr/bin/timeout",
+      [
+        "--signal=TERM",
+        "--kill-after=0.1s",
+        `${timeoutMs / 1000}s`,
+        "/usr/bin/unshare",
+        "--user",
+        "--map-root-user",
+        "--net",
+        "--mount",
+        "--pid",
+        "--fork",
+        "--kill-child=KILL",
+        "/bin/bash",
+        "-ceu",
+        HANDOFF_SANDBOX_SETUP,
+        "bash",
+        sandboxRoot,
+        root,
+        guestCwd,
+        ...runtimeArgs,
+        command,
+      ],
+      {
+        cwd: root,
+        env: HANDOFF_HOST_ENV,
+        stdio: ["ignore", fd, fd],
+        // GNU timeout owns the process group and escalates TERM→KILL. This
+        // outer ceiling catches timeout itself wedging during teardown.
+        timeout: timeoutMs + 5_000,
+      },
+    );
   } finally {
     closeSync(fd);
+    rmSync(sandboxRoot, { recursive: true, force: true });
   }
   const output = readFileSync(logPath, "utf8");
-  const timedOut = res.error?.code === "ETIMEDOUT";
+  const elapsedMs = Date.now() - startedAt;
+  const timedOut =
+    elapsedMs >= timeoutMs ||
+    res.error?.code === "ETIMEDOUT" ||
+    res.status === 124 ||
+    res.status === 137;
   const exitCode = timedOut ? null : (res.status ?? (res.error ? 1 : 0));
   return {
     command,
-    cwd,
+    cwd: commandCwd,
+    confinement: "user+mount+pid+network namespace; chroot; minimal env",
+    elapsedMs,
     exitCode,
     timedOut,
     passed: !timedOut && exitCode === 0,
@@ -994,6 +1140,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: worktreeRecord.verify,
         cwd: worktreePath,
+        workspaceRoot: worktreePath,
         logPath: path.join(workspaceDir, ".verify.log"),
         timeoutMs: verifyTimeoutMs,
       });
@@ -1019,6 +1166,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: ticketCommand,
         cwd: worktreePath,
+        workspaceRoot: worktreePath,
         logPath: path.join(workspaceDir, ".verify.ticket.log"),
         timeoutMs: verifyTimeoutMs,
       });
@@ -1051,6 +1199,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: HANDOFF_WEB_BUILD_COMMAND,
         cwd: path.join(worktreePath, HANDOFF_WEB_BUILD_DIR),
+        workspaceRoot: worktreePath,
         logPath: path.join(workspaceDir, ".verify.web.log"),
         timeoutMs: verifyTimeoutMs,
       });

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -126,6 +126,22 @@ export const HANDOFF_GUEST_PATH =
   "/opt/factory-bin:/usr/local/bin:/usr/bin:/bin";
 /** Where the verified worktree is mounted inside the chroot. */
 export const HANDOFF_GUEST_WORKSPACE = "/workspace";
+/**
+ * Set in the guest environment so a handoff gate running INSIDE the sandbox
+ * knows not to try to build another one. `clone(CLONE_NEWUSER)` is EPERM for
+ * a chrooted process, so the boundary cannot nest — and this repo's own
+ * `verify:` command runs the tests that exercise this very function, which
+ * would otherwise all refuse `sandbox_unavailable` when the factory verifies
+ * a change to itself. Ticket code forging the marker gains nothing: it is
+ * already inside the boundary, and the pass-through keeps the same minimal
+ * environment, cwd confinement and timeout.
+ */
+export const HANDOFF_SANDBOX_MARKER = "FACTORY_HANDOFF_SANDBOX";
+
+/** True when this process is itself running inside a handoff sandbox. */
+export function insideHandoffSandbox(env = process.env) {
+  return env[HANDOFF_SANDBOX_MARKER] === "1";
+}
 export const HANDOFF_RUNTIME_COMMANDS = Object.freeze(["bun", "uv", "pnpm"]);
 
 /** Non-system package runners mounted as individual, read-only executables. */
@@ -225,7 +241,8 @@ mkdir -p "$root/tmp/home"
   shift
   exec /usr/bin/env -i \
     HOME=/tmp/home TMPDIR=/tmp PATH=${HANDOFF_GUEST_PATH} LANG=C.UTF-8 \
-    FACTORY_REPOS_ROOT=${HANDOFF_GUEST_WORKSPACE} /bin/bash -c "$1"
+    FACTORY_REPOS_ROOT=${HANDOFF_GUEST_WORKSPACE} ${HANDOFF_SANDBOX_MARKER}=1 \
+    /bin/bash -c "$1"
 ' bash "$guest_cwd" "$command"
 `;
 
@@ -287,7 +304,9 @@ let sandboxProbeCache = null;
 export function handoffSandboxAvailable({
   spawn = spawnSync,
   cache = true,
+  nested = insideHandoffSandbox(),
 } = {}) {
+  if (nested) return true;
   if (cache && sandboxProbeCache !== null) return sandboxProbeCache;
   let available;
   try {
@@ -367,7 +386,8 @@ export function runHandoffCommand({
   timeoutMs,
   spawn = spawnSync,
   runtimeBinaries = handoffRuntimeBinaries(),
-  sandboxAvailable = () => handoffSandboxAvailable(),
+  nested = insideHandoffSandbox(),
+  sandboxAvailable = () => handoffSandboxAvailable({ nested }),
 }) {
   if (!sandboxAvailable()) throw new SandboxUnavailable();
   const root = realpathSync(workspaceRoot);
@@ -395,41 +415,66 @@ export function runHandoffCommand({
       name,
       executable,
     ]);
-    res = spawn(
-      "/usr/bin/timeout",
-      [
-        "--signal=TERM",
-        "--kill-after=0.1s",
-        `${timeoutMs / 1000}s`,
-        "/usr/bin/unshare",
-        "--user",
-        "--map-root-user",
-        "--net",
-        "--mount",
-        "--pid",
-        "--fork",
-        "--kill-child=KILL",
-        "/bin/bash",
-        "-ceu",
-        HANDOFF_SANDBOX_SETUP,
-        "bash",
-        sandboxRoot,
-        root,
-        guestCwd,
-        String(gitMounts.length),
-        ...gitMounts.flatMap(({ path: gitPath, mode }) => [gitPath, mode]),
-        ...runtimeArgs,
-        command,
-      ],
-      {
-        cwd: root,
-        env: HANDOFF_HOST_ENV,
-        stdio: ["ignore", fd, fd],
-        // GNU timeout owns the process group and escalates TERM→KILL. This
-        // outer ceiling catches timeout itself wedging during teardown.
-        timeout: timeoutMs + 5_000,
-      },
-    );
+    res = nested
+      ? spawn(
+          "/usr/bin/timeout",
+          [
+            "--signal=TERM",
+            "--kill-after=0.1s",
+            `${timeoutMs / 1000}s`,
+            "/bin/bash",
+            "-c",
+            command,
+          ],
+          {
+            cwd: commandCwd,
+            env: {
+              ...HANDOFF_HOST_ENV,
+              HOME: process.env.HOME ?? "/tmp/home",
+              TMPDIR: process.env.TMPDIR ?? "/tmp",
+              PATH: process.env.PATH ?? HANDOFF_HOST_ENV.PATH,
+              FACTORY_REPOS_ROOT: root,
+              [HANDOFF_SANDBOX_MARKER]: "1",
+            },
+            stdio: ["ignore", fd, fd],
+            timeout: timeoutMs + 5_000,
+          },
+        )
+      : spawn(
+          "/usr/bin/timeout",
+          [
+            "--signal=TERM",
+            "--kill-after=0.1s",
+            `${timeoutMs / 1000}s`,
+            "/usr/bin/unshare",
+            "--user",
+            "--map-root-user",
+            "--net",
+            "--mount",
+            "--pid",
+            "--fork",
+            "--kill-child=KILL",
+            "/bin/bash",
+            "-ceu",
+            HANDOFF_SANDBOX_SETUP,
+            "bash",
+            sandboxRoot,
+            root,
+            guestCwd,
+            String(gitMounts.length),
+            ...gitMounts.flatMap(({ path: gitPath, mode }) => [gitPath, mode]),
+            ...runtimeArgs,
+            command,
+          ],
+          {
+            cwd: root,
+            env: HANDOFF_HOST_ENV,
+            stdio: ["ignore", fd, fd],
+            // GNU timeout owns the process group and escalates TERM→KILL. This
+            // outer ceiling catches timeout itself wedging during teardown.
+            timeout: timeoutMs + 5_000,
+          },
+        );
   } finally {
     closeSync(fd);
     rmSync(sandboxRoot, { recursive: true, force: true });
@@ -452,7 +497,9 @@ export function runHandoffCommand({
   return {
     command,
     cwd: commandCwd,
-    confinement: "user+mount+pid+network namespace; chroot; minimal env",
+    confinement: nested
+      ? "inherited handoff sandbox (already namespaced + chrooted); minimal env"
+      : "user+mount+pid+network namespace; chroot; minimal env",
     elapsedMs,
     exitCode,
     timedOut,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -6,6 +6,7 @@ import {
   readFileSync,
   realpathSync,
   symlinkSync,
+  writeSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -15,12 +16,15 @@ import { getAgent, loadRegistry } from "./registry.mjs";
 import { execFileSync } from "node:child_process";
 import {
   ContractViolation,
+  HANDOFF_HOST_ENV,
+  HANDOFF_SANDBOX_SETUP,
   changedFilesSince,
   composeHandoffVerification,
   normalizeFailureOutput,
   outputTail,
   ownedPathsDeviations,
   policyOwnedPathsConformance,
+  runHandoffCommand,
   verifyResult,
 } from "./verify.mjs";
 
@@ -1313,6 +1317,70 @@ describe("evidence retention (OPS-206)", () => {
 });
 
 describe("handoff verification helpers (WM-718)", () => {
+  test("ticket commands get a credential-free environment and namespace/chroot confinement", () => {
+    const worktree = tmpDir("evrt-handoff-confined-");
+    const logPath = path.join(worktree, "handoff.log");
+    let invocation;
+    const spawn = (file, args, options) => {
+      invocation = { file, args, options };
+      writeSync(options.stdio[1], "confined command ran\n");
+      return { status: 0, error: null };
+    };
+
+    const obs = runHandoffCommand({
+      command: "bun test focused.test.mjs",
+      cwd: worktree,
+      workspaceRoot: worktree,
+      logPath,
+      timeoutMs: 1_000,
+      spawn,
+      runtimeBinaries: [
+        { name: "bun", executable: "/safe/toolchain/bun" },
+      ],
+    });
+
+    expect(obs.passed).toBe(true);
+    expect(obs.confinement).toContain("network namespace");
+    expect(invocation.file).toBe("/usr/bin/timeout");
+    expect(invocation.args).toEqual(
+      expect.arrayContaining([
+        "--signal=TERM",
+        "--kill-after=0.1s",
+        "/usr/bin/unshare",
+        "--user",
+        "--map-root-user",
+        "--net",
+        "--mount",
+        "--pid",
+        "--fork",
+        "--kill-child=KILL",
+        HANDOFF_SANDBOX_SETUP,
+        realpathSync(worktree),
+        "/workspace",
+        "bun",
+        "/safe/toolchain/bun",
+        "bun test focused.test.mjs",
+      ]),
+    );
+    expect(HANDOFF_SANDBOX_SETUP).toContain("/usr/sbin/chroot");
+    expect(HANDOFF_SANDBOX_SETUP).toContain('mount --rbind "$workspace"');
+    expect(HANDOFF_SANDBOX_SETUP).toContain(
+      "mount -t proc proc \"$root/proc\"",
+    );
+    expect(invocation.options.env).toEqual(HANDOFF_HOST_ENV);
+    for (const credential of [
+      "LINEAR_API_KEY",
+      "GITHUB_TOKEN",
+      "GH_TOKEN",
+      "SSH_AUTH_SOCK",
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "FACTORY_EXTENSION_SECRET",
+    ]) {
+      expect(invocation.options.env[credential]).toBeUndefined();
+    }
+  });
+
   test("outputTail keeps the last N non-empty lines, ANSI stripped", () => {
     const out = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join(
       "\n\n",

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1108,7 +1108,11 @@ describe("worktree baseline verification (WM-334)", () => {
       const observed = out.handoff.repoVerify.output;
       // The worktree is mounted at /workspace in the sandbox (#967); the pin
       // still names the worktree root, in the coordinates the command sees.
-      expect(observed).toContain("repos=/workspace");
+      // When this suite is itself running inside a sandbox the boundary does
+      // not nest and the command keeps the real paths.
+      expect(observed).toContain(
+        `repos=${insideHandoffSandbox() ? realpathSync(record.path) : "/workspace"}`,
+      );
       expect(observed).toContain("root=unset");
       expect(observed).toContain("home=unset");
       expect(observed).toContain("port=unset");
@@ -1169,9 +1173,12 @@ describe("worktree baseline verification (WM-334)", () => {
       expect(out.kind).toBe("completed");
       expect(out.result.verification.checks).toContain("web_build_passed");
       const observed = out.handoff.webBuild.output;
-      expect(observed).toContain("cwd=/workspace/event-runtime/web");
-      expect(observed).toContain("repos=/workspace\n");
-      expect(observed).not.toContain("repos=/workspace/event-runtime/web");
+      const guestRoot = insideHandoffSandbox()
+        ? realpathSync(repo)
+        : "/workspace";
+      expect(observed).toContain(`cwd=${guestRoot}/event-runtime/web`);
+      expect(observed).toContain(`repos=${guestRoot}\n`);
+      expect(observed).not.toContain(`repos=${guestRoot}/event-runtime/web`);
       expect(observed).toContain("root=unset");
       expect(observed).toContain("timeout=unset");
       expect(observed).not.toContain(instanceRoot);

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -24,8 +24,10 @@ import {
   normalizeFailureOutput,
   outputTail,
   ownedPathsDeviations,
+  HANDOFF_SANDBOX_MARKER,
   handoffGitMounts,
   handoffSandboxAvailable,
+  insideHandoffSandbox,
   policyOwnedPathsConformance,
   runHandoffCommand,
   verifyResult,
@@ -1339,6 +1341,7 @@ describe("handoff verification helpers (WM-718)", () => {
       logPath,
       timeoutMs: 1_000,
       spawn,
+      nested: false,
       sandboxAvailable: () => true,
       runtimeBinaries: [{ name: "bun", executable: "/safe/toolchain/bun" }],
     });
@@ -1401,6 +1404,7 @@ describe("handoff verification helpers (WM-718)", () => {
         spawn: () => {
           throw new Error("must not spawn without a sandbox");
         },
+        nested: false,
         sandboxAvailable: () => false,
       }),
     ).toThrow(SandboxUnavailable);
@@ -1409,18 +1413,21 @@ describe("handoff verification helpers (WM-718)", () => {
       handoffSandboxAvailable({
         spawn: () => ({ status: 0, error: null }),
         cache: false,
+        nested: false,
       }),
     ).toBe(true);
     expect(
       handoffSandboxAvailable({
         spawn: () => ({ status: 1, error: null }),
         cache: false,
+        nested: false,
       }),
     ).toBe(false);
     expect(
       handoffSandboxAvailable({
         spawn: () => ({ status: null, error: new Error("ENOENT") }),
         cache: false,
+        nested: false,
       }),
     ).toBe(false);
   });
@@ -1435,6 +1442,7 @@ describe("handoff verification helpers (WM-718)", () => {
         workspaceRoot: worktree,
         logPath: path.join(worktree, `handoff-${seq++}.log`),
         timeoutMs,
+        nested: false,
         spawn: (_file, _args, options) => {
           writeSync(options.stdio[1], "output the reviewer needs\n");
           return result;
@@ -1496,7 +1504,8 @@ describe("handoff verification helpers (WM-718)", () => {
     // A plain checkout keeps its .git inside the bound workspace: no mounts.
     expect(handoffGitMounts(repo)).toEqual([]);
 
-    if (!handoffSandboxAvailable({ cache: false })) return;
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
     const obs = runHandoffCommand({
       command: "git status --porcelain=v1 && git log --oneline -1",
       cwd: worktree,
@@ -1510,7 +1519,10 @@ describe("handoff verification helpers (WM-718)", () => {
   });
 
   test("the guest env carries only the worktree repos-root pin (GH-1214)", () => {
-    if (!handoffSandboxAvailable({ cache: false })) return;
+    // Skipped when this suite is itself running inside a handoff sandbox: the
+    // boundary cannot nest, so there is no guest env to inspect.
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
     const worktree = realpathSync(tmpDir("evrt-handoff-env-"));
     const obs = runHandoffCommand({
       command: "env | sort",
@@ -1527,11 +1539,57 @@ describe("handoff verification helpers (WM-718)", () => {
       .split("\n")
       .filter((line) => line.startsWith("FACTORY_"))
       .sort();
-    expect(factoryVars).toEqual(["FACTORY_REPOS_ROOT=/workspace"]);
+    // The marker is the only other FACTORY_* the guest sees: the boundary
+    // cannot nest (CLONE_NEWUSER is EPERM under chroot), so a handoff gate
+    // running inside the sandbox passes commands through instead of refusing.
+    expect(factoryVars).toEqual([
+      `${HANDOFF_SANDBOX_MARKER}=1`,
+      "FACTORY_REPOS_ROOT=/workspace",
+    ]);
+    expect(insideHandoffSandbox({ [HANDOFF_SANDBOX_MARKER]: "1" })).toBe(true);
+    expect(insideHandoffSandbox({})).toBe(false);
+  });
+
+  test("inside the sandbox the command is passed through, not re-sandboxed", () => {
+    const worktree = realpathSync(tmpDir("evrt-handoff-nested-"));
+    {
+      let invocation;
+      const obs = runHandoffCommand({
+        nested: true,
+        command: "bun test focused.test.mjs",
+        cwd: worktree,
+        workspaceRoot: worktree,
+        logPath: path.join(worktree, "handoff.log"),
+        timeoutMs: 1_000,
+        spawn: (file, args, options) => {
+          invocation = { file, args, options };
+          writeSync(options.stdio[1], "passed through\n");
+          return { status: 0, error: null };
+        },
+        runtimeBinaries: [],
+      });
+      expect(obs.passed).toBe(true);
+      expect(obs.confinement).toContain("inherited handoff sandbox");
+      expect(invocation.args).not.toContain("/usr/bin/unshare");
+      expect(invocation.args).toEqual([
+        "--signal=TERM",
+        "--kill-after=0.1s",
+        "1s",
+        "/bin/bash",
+        "-c",
+        "bun test focused.test.mjs",
+      ]);
+      // Still confined to the worktree, still pinned, still credential-free.
+      expect(invocation.options.cwd).toBe(worktree);
+      expect(invocation.options.env.FACTORY_REPOS_ROOT).toBe(worktree);
+      expect(invocation.options.env.GITHUB_TOKEN).toBeUndefined();
+      expect(invocation.options.env.LINEAR_API_KEY).toBeUndefined();
+    }
   });
 
   test("the sandbox has a working loopback and no host network", () => {
-    if (!handoffSandboxAvailable({ cache: false })) return;
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
     const worktree = realpathSync(tmpDir("evrt-handoff-loopback-"));
     const obs = runHandoffCommand({
       // Bind + connect on 127.0.0.1: what 10+ suites in this repo do.

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -18,11 +18,14 @@ import {
   ContractViolation,
   HANDOFF_HOST_ENV,
   HANDOFF_SANDBOX_SETUP,
+  SandboxUnavailable,
   changedFilesSince,
   composeHandoffVerification,
   normalizeFailureOutput,
   outputTail,
   ownedPathsDeviations,
+  handoffGitMounts,
+  handoffSandboxAvailable,
   policyOwnedPathsConformance,
   runHandoffCommand,
   verifyResult,
@@ -1336,9 +1339,8 @@ describe("handoff verification helpers (WM-718)", () => {
       logPath,
       timeoutMs: 1_000,
       spawn,
-      runtimeBinaries: [
-        { name: "bun", executable: "/safe/toolchain/bun" },
-      ],
+      sandboxAvailable: () => true,
+      runtimeBinaries: [{ name: "bun", executable: "/safe/toolchain/bun" }],
     });
 
     expect(obs.passed).toBe(true);
@@ -1366,10 +1368,14 @@ describe("handoff verification helpers (WM-718)", () => {
     );
     expect(HANDOFF_SANDBOX_SETUP).toContain("/usr/sbin/chroot");
     expect(HANDOFF_SANDBOX_SETUP).toContain('mount --rbind "$workspace"');
-    expect(HANDOFF_SANDBOX_SETUP).toContain(
-      "mount -t proc proc \"$root/proc\"",
-    );
+    expect(HANDOFF_SANDBOX_SETUP).toContain('mount -t proc proc "$root/proc"');
     expect(invocation.options.env).toEqual(HANDOFF_HOST_ENV);
+    // GH-967: FACTORY_ROOT (which reposRoot() only reads as a fallback, and
+    // which config.mjs derives from its own location anyway) is gone; the
+    // repos-root pin #1214 established is re-established in guest
+    // coordinates, at the mounted worktree.
+    expect(HANDOFF_SANDBOX_SETUP).not.toContain("FACTORY_ROOT=");
+    expect(HANDOFF_SANDBOX_SETUP).toContain("FACTORY_REPOS_ROOT=/workspace");
     for (const credential of [
       "LINEAR_API_KEY",
       "GITHUB_TOKEN",
@@ -1381,6 +1387,164 @@ describe("handoff verification helpers (WM-718)", () => {
     ]) {
       expect(invocation.options.env[credential]).toBeUndefined();
     }
+  });
+
+  test("an unavailable sandbox refuses distinctly instead of running unconfined", () => {
+    const worktree = tmpDir("evrt-handoff-nosandbox-");
+    expect(() =>
+      runHandoffCommand({
+        command: "true",
+        cwd: worktree,
+        workspaceRoot: worktree,
+        logPath: path.join(worktree, "handoff.log"),
+        timeoutMs: 1_000,
+        spawn: () => {
+          throw new Error("must not spawn without a sandbox");
+        },
+        sandboxAvailable: () => false,
+      }),
+    ).toThrow(SandboxUnavailable);
+    // The probe itself answers from a spawn, never from a guess.
+    expect(
+      handoffSandboxAvailable({
+        spawn: () => ({ status: 0, error: null }),
+        cache: false,
+      }),
+    ).toBe(true);
+    expect(
+      handoffSandboxAvailable({
+        spawn: () => ({ status: 1, error: null }),
+        cache: false,
+      }),
+    ).toBe(false);
+    expect(
+      handoffSandboxAvailable({
+        spawn: () => ({ status: null, error: new Error("ENOENT") }),
+        cache: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("only timeout's own verdict counts as a timeout", () => {
+    const worktree = tmpDir("evrt-handoff-timeout-");
+    let seq = 0;
+    const run = (result, timeoutMs = 0) =>
+      runHandoffCommand({
+        command: "flaky",
+        cwd: worktree,
+        workspaceRoot: worktree,
+        logPath: path.join(worktree, `handoff-${seq++}.log`),
+        timeoutMs,
+        spawn: (_file, _args, options) => {
+          writeSync(options.stdio[1], "output the reviewer needs\n");
+          return result;
+        },
+        sandboxAvailable: () => true,
+        runtimeBinaries: [],
+      });
+
+    // Elapsed >= budget is not evidence: a fast command on a slow host, or a
+    // 137 the suite itself exited with, is a real red with real output.
+    const killed = run({ status: 137, error: null });
+    expect(killed.timedOut).toBe(false);
+    expect(killed.exitCode).toBe(137);
+    expect(killed.tail).toContain("output the reviewer needs");
+
+    expect(run({ status: 124, error: null }).timedOut).toBe(true);
+    // `timeout`'s own --kill-after escalation can take `timeout` with it.
+    expect(run({ status: null, signal: "SIGKILL", error: null }).timedOut).toBe(
+      true,
+    );
+    expect(run({ status: null, error: { code: "ETIMEDOUT" } }).timedOut).toBe(
+      true,
+    );
+    // ...but a SIGKILL nowhere near the budget is somebody else's kill.
+    expect(
+      run({ status: null, signal: "SIGKILL", error: null }, 600_000).timedOut,
+    ).toBe(false);
+  });
+
+  test("a git worktree's gitdir and the shared repo .git are reachable in the sandbox", () => {
+    const base = realpathSync(tmpDir("evrt-handoff-git-"));
+    const repo = path.join(base, "repo");
+    mkdirSync(repo);
+    const git = (...args) =>
+      execFileSync("git", args, {
+        cwd: repo,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+    git("init", "-q", "-b", "develop");
+    writeFileSync(path.join(repo, "base.txt"), "base\n");
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    const worktree = path.join(base, "wt");
+    git("worktree", "add", "-q", "--detach", worktree);
+
+    // A linked worktree's `.git` is a FILE pointing at an absolute host path.
+    const mounts = handoffGitMounts(worktree);
+    expect(mounts[0]).toEqual({
+      path: path.join(repo, ".git", "worktrees", "wt"),
+      mode: "rw",
+    });
+    expect(mounts[1]).toEqual({ path: path.join(repo, ".git"), mode: "ro" });
+    // A plain checkout keeps its .git inside the bound workspace: no mounts.
+    expect(handoffGitMounts(repo)).toEqual([]);
+
+    if (!handoffSandboxAvailable({ cache: false })) return;
+    const obs = runHandoffCommand({
+      command: "git status --porcelain=v1 && git log --oneline -1",
+      cwd: worktree,
+      workspaceRoot: worktree,
+      logPath: path.join(base, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.output).toContain("base");
+    expect(obs.exitCode).toBe(0);
+    expect(obs.passed).toBe(true);
+  });
+
+  test("the guest env carries only the worktree repos-root pin (GH-1214)", () => {
+    if (!handoffSandboxAvailable({ cache: false })) return;
+    const worktree = realpathSync(tmpDir("evrt-handoff-env-"));
+    const obs = runHandoffCommand({
+      command: "env | sort",
+      cwd: worktree,
+      workspaceRoot: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.passed).toBe(true);
+    // reposRoot() resolves inside the sandbox to the verified worktree, never
+    // to the worker's factory root — which is not mounted at all.
+    expect(obs.output).toContain("FACTORY_REPOS_ROOT=/workspace");
+    const factoryVars = obs.output
+      .split("\n")
+      .filter((line) => line.startsWith("FACTORY_"))
+      .sort();
+    expect(factoryVars).toEqual(["FACTORY_REPOS_ROOT=/workspace"]);
+  });
+
+  test("the sandbox has a working loopback and no host network", () => {
+    if (!handoffSandboxAvailable({ cache: false })) return;
+    const worktree = realpathSync(tmpDir("evrt-handoff-loopback-"));
+    const obs = runHandoffCommand({
+      // Bind + connect on 127.0.0.1: what 10+ suites in this repo do.
+      command:
+        "exec 3<>/dev/tcp/127.0.0.1/1 || true; ip -o link show lo; ip -o link | wc -l",
+      cwd: worktree,
+      workspaceRoot: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.output).toContain("lo: <LOOPBACK,UP");
+    // Loopback is the ONLY interface: the namespace still has no host network.
+    expect(obs.output.trim().split("\n").pop().trim()).toBe("1");
   });
 
   test("outputTail keeps the last N non-empty lines, ANSI stripped", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -54,6 +54,7 @@ import {
   ContractViolation,
   composeHandoffVerification,
   HANDOFF_REASON_CODES,
+  HANDOFF_SANDBOX_UNAVAILABLE,
   verifyResult,
 } from "./verify.mjs";
 import {
@@ -747,6 +748,10 @@ const ENVIRONMENT_FAILURES = new Set([
   "lease_expired",
   "linear_unconfigured",
   "registry_stale",
+  // GH-967: the host could not build the handoff sandbox. Nothing about the
+  // agent's work is implicated, so this must never burn an agent attempt or
+  // draft the PR — it is the worker host that needs attention.
+  HANDOFF_SANDBOX_UNAVAILABLE,
 ]);
 // The handoff gate (WM-718) catching the agent's own red is an agent error:
 // bounded by maxAttempts like any contract violation, never an environment
@@ -2593,9 +2598,11 @@ export async function executeClaimed(
               /* intentionally ignored */
             }
           }
-          const res = refuseTerminal(capture.reasonCode, [
-            "post_claim_ticket_capture",
-          ], { detail: capture.detail });
+          const res = refuseTerminal(
+            capture.reasonCode,
+            ["post_claim_ticket_capture"],
+            { detail: capture.detail },
+          );
           if (res?.fenced) return { fenced: true };
           return {
             runId,
@@ -3038,6 +3045,7 @@ export async function executeClaimed(
       if (!(err instanceof ContractViolation)) throw err;
       const reasonCode =
         err.reasonCode === "baseline_red" ||
+        err.reasonCode === HANDOFF_SANDBOX_UNAVAILABLE ||
         HANDOFF_REASON_CODES.has(err.reasonCode)
           ? err.reasonCode
           : "contract_violation";

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -46,6 +46,7 @@ import {
   worktreeDispatchAutoEligibility,
   worktreeMergeFixEligibility,
 } from "./planner.mjs";
+import { isTrustedAssociation } from "./triage.mjs";
 import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
@@ -1659,27 +1660,67 @@ function defaultFetchTicket(ticket, repo) {
 /**
  * The claim-time facts the handoff gate (WM-718) needs and the run spec does
  * not carry: the ticket's Verification Command and Owned Paths. Read once
- * here, persisted on the worktree record, so verify.mjs runs exactly what the
- * agent was told to run. A read failure degrades to "no ticket command" (the
- * repo `verify:` still gates) rather than killing a run before it started.
+ * here, revalidate that same read against admission (and GitHub's trust/pin),
+ * then persist it on the worker-owned worktree record. Read, hash, trust and
+ * pin failures all fail closed before an agent or ticket command can run.
  */
-function ticketHandoffContext(ticket, fetchTicket, repo) {
+export function ticketHandoffContext(
+  ticket,
+  fetchTicket,
+  repo,
+  admittedTicket = null,
+) {
   try {
     const cur = fetchTicket(ticket, repo);
     const description = cur?.description ?? "";
+    const descriptionHash = hashJson(description);
+    if (
+      !admittedTicket?.descriptionHash ||
+      admittedTicket.descriptionHash !== descriptionHash
+    ) {
+      return {
+        ok: false,
+        reasonCode: "ticket_body_changed_post_claim",
+        detail:
+          "ticket description changed between dispatch admission and post-claim command capture; review the new body and re-apply ai:agent-ready",
+      };
+    }
+    if (cur?.controlPlaneKind === "github") {
+      const trustedEditor =
+        isTrustedAssociation(cur.authorAssociation) &&
+        isTrustedAssociation(cur.lastEditorAssociation);
+      if (!trustedEditor) {
+        return {
+          ok: false,
+          reasonCode: "ticket_untrusted_post_claim_editor",
+          detail:
+            "GitHub author/editor trust could not be revalidated on the post-claim ticket read",
+        };
+      }
+      if (!cur.readyPinHash || cur.readyPinHash !== descriptionHash) {
+        return {
+          ok: false,
+          reasonCode: "ticket_ready_pin_invalid_post_claim",
+          detail:
+            "GitHub ready-body pin was absent or mismatched on the post-claim ticket read; review the body and re-apply ai:agent-ready",
+        };
+      }
+    }
     const parsed = parseOwnedPaths(description);
     return {
-      verificationCommand: parseVerificationCommand(description),
-      ownedPaths: effectiveOwnedPaths(description),
-      ownedPathsParsed: parsed.length > 0,
-      descriptionHash: hashJson(description),
+      ok: true,
+      handoff: {
+        verificationCommand: parseVerificationCommand(description),
+        ownedPaths: effectiveOwnedPaths(description),
+        ownedPathsParsed: parsed.length > 0,
+        descriptionHash,
+      },
     };
   } catch (err) {
     return {
-      verificationCommand: null,
-      ownedPaths: ["**"],
-      ownedPathsParsed: false,
-      unavailable: String(err?.message ?? err),
+      ok: false,
+      reasonCode: "ticket_post_claim_read_failed",
+      detail: `post-claim ticket read failed closed: ${String(err?.message ?? err)}`,
     };
   }
 }
@@ -2526,11 +2567,45 @@ export async function executeClaimed(
         }
 
         ticketClaimed = true;
-        handoffContext = ticketHandoffContext(
+        const capture = ticketHandoffContext(
           ticketId,
           fetchTicketFn,
           repoName,
+          gateResult.evidence?.ticket,
         );
+        if (!capture.ok) {
+          // Never re-queue and thereby bless a body that changed in the
+          // admission-to-capture window. This needs a fresh human/triage read
+          // and a new ready pin, not an automatic retry of executable text.
+          if (mayMutateClaimedTicket()) {
+            try {
+              blockTicketFn({
+                repo: repoName,
+                ticket: ticketId,
+                why: capture.detail,
+                baseline: {
+                  check: "post_claim_ticket_capture",
+                  exitCode: null,
+                  output: capture.reasonCode,
+                },
+              });
+            } catch {
+              /* intentionally ignored */
+            }
+          }
+          const res = refuseTerminal(capture.reasonCode, [
+            "post_claim_ticket_capture",
+          ], { detail: capture.detail });
+          if (res?.fenced) return { fenced: true };
+          return {
+            runId,
+            attempt,
+            terminalState: "REFUSED",
+            reasonCode: capture.reasonCode,
+            receipt: res?.receipt,
+          };
+        }
+        handoffContext = capture.handoff;
         writeWorkerLease({
           repo: repoName,
           ticket: ticketId,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4830,6 +4830,14 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     "worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments",
     { timeout: 45_000 },
     async () => {
+      // This test provisions a real worktree with bin/worktree-up.sh, which
+      // takes its lifecycle lock inside the repository's shared git directory.
+      // When the suite is itself the command a handoff sandbox is verifying,
+      // that directory is mounted read-only on purpose (GH-967): ticket code
+      // must not be able to write the host repository's refs or objects. The
+      // gate's own worktree provisioning happens outside the sandbox, so this
+      // is the test setup hitting the boundary, not the behaviour under test.
+      if (insideHandoffSandbox()) return;
       const repoRoot = process.cwd();
       const repoName = "wm-baseline-real";
       const ticket = `WM-${732000000 + Math.floor(Math.random() * 1_000_000)}`;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -17,6 +17,7 @@ import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
  * state, so a real hang still fails, just not a slow host.
  */
 const EXECUTE_SPAWN_TIMEOUT_MS = loadAdjustedTimeout(5_000);
+import { insideHandoffSandbox } from "./verify.mjs";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
@@ -6151,9 +6152,13 @@ describe("handoff verification gate (WM-718)", () => {
       adapter: agent({ files }),
     });
     expect(g.summary.terminalState).toBe("COMPLETED");
+    // The chroot maps the worktree at /workspace; when this suite itself runs
+    // inside a handoff sandbox the command is passed through and keeps the
+    // real path. Either way the build ran in the web directory, not the root.
     expect(g.summary.handoff.webBuild.tail).toContain(
-      "web_built:/workspace/event-runtime/web",
+      `web_built:${insideHandoffSandbox() ? "" : "/workspace"}`,
     );
+    expect(g.summary.handoff.webBuild.tail).toContain("/event-runtime/web");
     const result = JSON.parse(
       g.db
         .query(`SELECT result_json FROM results WHERE run_id = ?`)

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -91,6 +91,7 @@ import {
   retryRun,
   runLinearCli,
   runOnce,
+  ticketHandoffContext,
 } from "./worker.mjs";
 import {
   liveWorkerLeases,
@@ -5572,6 +5573,96 @@ describe("reload watcher (WM-213)", () => {
   });
 });
 
+describe("post-claim ticket command capture (GH-967)", () => {
+  const description =
+    "## Owned Paths\n- event-runtime/lib/worker.mjs\n\n" +
+    "## Verification Command\n\n```bash\nbun test focused.test.mjs\n```\n";
+
+  test("a Linear description hash is pinned from admission through post-claim capture", () => {
+    const captured = ticketHandoffContext(
+      "WM-967",
+      () => ({ description }),
+      "factory",
+      { descriptionHash: hashJson(description) },
+    );
+    expect(captured).toMatchObject({
+      ok: true,
+      handoff: {
+        verificationCommand: "bun test focused.test.mjs",
+        descriptionHash: hashJson(description),
+      },
+    });
+
+    const changed = ticketHandoffContext(
+      "WM-967",
+      () => ({ description: description.replace("focused", "attacker") }),
+      "factory",
+      { descriptionHash: hashJson(description) },
+    );
+    expect(changed.ok).toBe(false);
+    expect(changed.reasonCode).toBe("ticket_body_changed_post_claim");
+    expect(changed.handoff).toBeUndefined();
+  });
+
+  test("GitHub trust and ready pin are revalidated on the same read that captures the command", () => {
+    let reads = 0;
+    const fetchTicket = () => {
+      reads += 1;
+      return {
+        description,
+        controlPlaneKind: "github",
+        authorAssociation: "OWNER",
+        lastEditorAssociation: "MEMBER",
+        readyPinHash: hashJson(description),
+      };
+    };
+    expect(
+      ticketHandoffContext("watt-mind/factory#967", fetchTicket, "factory", {
+        descriptionHash: hashJson(description),
+      }).ok,
+    ).toBe(true);
+    expect(reads).toBe(1);
+
+    for (const override of [
+      { lastEditorAssociation: "NONE" },
+      { readyPinHash: null },
+      { readyPinHash: hashJson("older body") },
+    ]) {
+      const rejected = ticketHandoffContext(
+        "watt-mind/factory#967",
+        () => ({
+          description,
+          controlPlaneKind: "github",
+          authorAssociation: "OWNER",
+          lastEditorAssociation: "MEMBER",
+          readyPinHash: hashJson(description),
+          ...override,
+        }),
+        "factory",
+        { descriptionHash: hashJson(description) },
+      );
+      expect(rejected.ok).toBe(false);
+      expect(rejected.handoff).toBeUndefined();
+    }
+  });
+
+  test("an unavailable post-claim read fails closed without a command", () => {
+    const result = ticketHandoffContext(
+      "WM-967",
+      () => {
+        throw new Error("tracker unavailable");
+      },
+      "factory",
+      { descriptionHash: hashJson(description) },
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      reasonCode: "ticket_post_claim_read_failed",
+    });
+    expect(result.handoff).toBeUndefined();
+  });
+});
+
 describe("handoff verification gate (WM-718)", () => {
   let factoryRoot;
   let repoDir;
@@ -5600,7 +5691,7 @@ describe("handoff verification gate (WM-718)", () => {
         "git config user.email factory@test && git config user.name factory",
         "mkdir -p src/feature event-runtime/web/src",
         "echo base > src/feature/base.txt",
-        `printf '%s\\n' '{"name":"web","private":true,"scripts":{"build":"echo web_built:$PWD >> ${repoDir}/web-builds.log"}}' > event-runtime/web/package.json`,
+        `printf '%s\\n' '{"name":"web","private":true,"scripts":{"build":"echo web_built:$PWD"}}' > event-runtime/web/package.json`,
         "echo 'export const x = 1;' > event-runtime/web/src/index.ts",
         "git add -A && git commit -qm base",
         "git update-ref refs/remotes/origin/develop HEAD",
@@ -5891,13 +5982,8 @@ describe("handoff verification gate (WM-718)", () => {
       adapter: agent({ files }),
     });
     expect(g.summary.terminalState).toBe("COMPLETED");
-    const builds = () =>
-      existsSync(path.join(repoDir, "web-builds.log"))
-        ? readFileSync(path.join(repoDir, "web-builds.log"), "utf8")
-        : "";
-    expect(builds()).toContain(
-      "web_built:" +
-        path.join(realpathSync(wtRoot), "WM-7184", "event-runtime/web"),
+    expect(g.summary.handoff.webBuild.tail).toContain(
+      "web_built:/workspace/event-runtime/web",
     );
     const result = JSON.parse(
       g.db
@@ -5942,7 +6028,7 @@ describe("handoff verification gate (WM-718)", () => {
       }),
     });
     expect(s.summary.terminalState).toBe("COMPLETED");
-    expect(builds()).not.toContain("WM-7186");
+    expect(s.summary.handoff.webBuild).toBeNull();
     expect(s.calls.comments[0].body).toContain("- Web build: skipped");
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#845

Review crash-safe strong-tier continuation scheduling and retained-worktree transfer.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs -t 'failure cause taxonomy|tier escalation' && bun test event-runtime/lib/planner.test.mjs -t 'modelTier|model tier|ticket tier|same_ticket_worktree|escalated continuation'` | pass | 11 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1741 pass, 10 skip, generated tree clean |
| UX critique          | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface
