### PR TITLE
fix(dispatch): include registry digest baseline in ownership closure

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -56,6 +56,10 @@ repos:
           requires:
             - dist/**
             - plugins/core/**
+        # Registry inputs change the tracked zero-pack digest baseline.
+        - source: event-runtime/agents/**
+          requires:
+            - event-runtime/lib/registry.test.mjs
       pin_manifests:
         - event-runtime/agents/*.json
     merge_ci:

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -23,6 +23,18 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
+/** Inputs whose changes alter the zero-pack merged registry digest. */
+export const REGISTRY_INPUT_GLOBS = [
+  "event-runtime/agents/**",
+  "event-runtime/event-types.json",
+  "event-runtime/edges.json",
+  "event-runtime/schedules.json",
+];
+
+/** The tracked zero-pack registry digest baseline. */
+export const REGISTRY_DIGEST_BASELINE_PATH =
+  "event-runtime/lib/registry.test.mjs";
+
 /**
  * Extract the Owned Paths bullet list (levels 2-4) from a Linear issue description.
  * Returns [] when the section is missing or fails to parse — for dispatch,
@@ -592,6 +604,20 @@ export function ownedPathsClosureGaps({
     }
   }
 
+  const registryInput = own.find((owned) =>
+    REGISTRY_INPUT_GLOBS.some((input) => globsOverlap(owned, input)),
+  );
+  if (
+    registryInput &&
+    !own.some((owned) => globsOverlap(owned, REGISTRY_DIGEST_BASELINE_PATH))
+  ) {
+    addGap({
+      rule: "registry-digest",
+      requiredPath: REGISTRY_DIGEST_BASELINE_PATH,
+      requiredBy: registryInput,
+    });
+  }
+
   return gaps;
 }
 
@@ -600,6 +626,9 @@ export function formatOwnedPathClosureGaps(gaps = []) {
   return gaps.map((gap) => {
     if (gap.rule === "direct") {
       return `Missing required Owned Paths entry: ${gap.requiredPath} (required by ${gap.requiredBy})`;
+    }
+    if (gap.rule === "registry-digest") {
+      return `own ${gap.requiredPath}: registry input ${gap.requiredBy} changes the zero-pack digest baseline`;
     }
     return `Missing required Owned Paths entry: ${gap.requiredPath} (required by ${gap.requiredBy} from ${gap.manifestPath})`;
   });

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -25,6 +25,8 @@ import {
   nextDispatchable,
   readPinManifestRequirements,
   ownedPathsClosureGaps,
+  formatOwnedPathClosureGaps,
+  REGISTRY_DIGEST_BASELINE_PATH,
 } from "./owned-paths.mjs";
 
 test("parses the Owned Paths section of a real ticket", () => {
@@ -264,6 +266,54 @@ test("owned path closure passes when required paths are also owned", () => {
   );
 });
 
+test("registry inputs require owning the zero-pack digest baseline", () => {
+  const ownedPaths = [
+    "event-runtime/agents/triage-scan.md",
+    "event-runtime/agents/triage-scan.json",
+  ];
+  const expectedGap = {
+    rule: "registry-digest",
+    requiredPath: REGISTRY_DIGEST_BASELINE_PATH,
+    requiredBy: "event-runtime/agents/triage-scan.md",
+  };
+
+  expectEqual(ownedPathsClosureGaps({ ownedPaths }), [expectedGap]);
+  expectEqual(
+    ownedPathsClosureGaps({
+      ownedPaths: [...ownedPaths, REGISTRY_DIGEST_BASELINE_PATH],
+    }),
+    [],
+  );
+  expectEqual(formatOwnedPathClosureGaps([expectedGap]), [
+    "own event-runtime/lib/registry.test.mjs: registry input event-runtime/agents/triage-scan.md changes the zero-pack digest baseline",
+  ]);
+});
+
+test("each registry data input requires the digest baseline, but unrelated paths do not", () => {
+  for (const input of [
+    "event-runtime/event-types.json",
+    "event-runtime/edges.json",
+    "event-runtime/schedules.json",
+  ]) {
+    expectEqual(ownedPathsClosureGaps({ ownedPaths: [input] }), [
+      {
+        rule: "registry-digest",
+        requiredPath: REGISTRY_DIGEST_BASELINE_PATH,
+        requiredBy: input,
+      },
+    ]);
+  }
+
+  expectEqual(
+    ownedPathsClosureGaps({ ownedPaths: ["event-runtime/lib/planner.mjs"] }),
+    [],
+  );
+});
+
+test("a broad glob that owns the baseline satisfies registry digest closure", () => {
+  expectEqual(ownedPathsClosureGaps({ ownedPaths: ["event-runtime/**"] }), []);
+});
+
 test("pin manifests require owning generated output manifests", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "owned-paths-closure-"));
   try {
@@ -340,7 +390,10 @@ test("pin-manifest gap: shipped layout (agents/*.md keys) flags the missing JSON
     // Owning the prompt but not its JSON manifest is a pin-manifest gap.
     expectEqual(
       ownedPathsClosureGaps({
-        ownedPaths: ["event-runtime/agents/triage-scan.md"],
+        ownedPaths: [
+          "event-runtime/agents/triage-scan.md",
+          REGISTRY_DIGEST_BASELINE_PATH,
+        ],
         ownedPathsPolicy: {
           direct: [],
           pinManifests: ["event-runtime/agents/*.json"],
@@ -363,6 +416,7 @@ test("pin-manifest gap: shipped layout (agents/*.md keys) flags the missing JSON
         ownedPaths: [
           "event-runtime/agents/triage-scan.md",
           "event-runtime/agents/triage-scan.json",
+          REGISTRY_DIGEST_BASELINE_PATH,
         ],
         ownedPathsPolicy: {
           direct: [],


### PR DESCRIPTION
Fixes watt-mind/factory#1206

Registry-input tickets must own the tracked zero-pack digest baseline before becoming agent-ready.

## Validation

| Check                | Command                                                          | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/owned-paths.test.mjs --timeout 20000 && bun run check` | pass    | 39 tests, emit check passed   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1,723 pass, 9 skipped         |
| UX critique          | factory-ux-critic                                                | not run | no user-facing surface        |

UX critique: skipped