### PR TITLE
perf(merge): coalesce webhook merge requests

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1622,6 +1622,31 @@ function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
   return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
 }
 
+/**
+ * GitHub sends a delivery for each CI state change. Unlike an operator or
+ * schedule request, those deliveries do not each deserve an auditable
+ * proposal: one live repo-wide merge scan will read the current GitHub state
+ * when it runs. Mark later deliveries as consumed without creating the noisy
+ * noop proposals that otherwise flood the merge lane.
+ */
+function coalesceWebhookMergeRequest(db, event, envelope, agentRef) {
+  if (
+    event.source !== "github" ||
+    event.type !== "factory.merge.requested" ||
+    typeof envelope.payload?.repo !== "string"
+  ) {
+    return null;
+  }
+  const blockingRun = liveRunForInput(db, agentRef, {
+    repo: envelope.payload.repo,
+  });
+  if (!blockingRun) return null;
+
+  const reason = "webhook_merge_scan_already_live";
+  setEventStatus(db, event, "noop", reason);
+  return { decision: "noop", runId: blockingRun.run_id, reason };
+}
+
 function humanNeeded(db, event, reason, at, ttlSeconds) {
   const proposal = insertProposal(db, {
     id: newProposalId(),
@@ -1865,6 +1890,19 @@ export function planEvent(
         );
       }
     }
+
+    // CI emits a separate GitHub delivery for every check transition. A merge
+    // scan is repo-wide, so a live scan already observes the final state of a
+    // burst; suppress the later webhook deliveries before they can create
+    // duplicate noop proposals. Schedule, operator, and chain requests retain
+    // their ordinary idempotency and proposal semantics.
+    const webhookMergeCoalesced = coalesceWebhookMergeRequest(
+      db,
+      event,
+      envelope,
+      mapping.agent,
+    );
+    if (webhookMergeCoalesced) return webhookMergeCoalesced;
 
     // §5 singleton is agent policy, not clock-envelope policy: operator and
     // chain origins mapped to an enabled singleton agent must not bypass it by

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -268,6 +268,90 @@ describe("planEvent", () => {
     expect(event.status).toBe("noop");
   });
 
+  test("GitHub CI bursts coalesce per repo without proposals; schedule and other repos remain distinct", () => {
+    const db = openDb(":memory:");
+    const webhook = (eventId, repo = "factory") => ({
+      eventId,
+      type: "factory.merge.requested",
+      source: "github",
+      subject: repo,
+      correlationId: eventId,
+      payload: { repo },
+    });
+    const firstRef = admit(db, webhook("check-1"));
+    const first = planEvent(db, registry, firstRef, {
+      now: NOW,
+      policyVersion: "git:test",
+    });
+    expect(first.decision).toBe("run");
+
+    for (const eventId of ["check-2", "check-3", "check-4", "check-5"]) {
+      const next = planEvent(db, registry, admit(db, webhook(eventId)), {
+        now: NOW + 1000,
+        policyVersion: "git:test",
+      });
+      expect(next).toEqual({
+        decision: "noop",
+        runId: first.runId,
+        reason: "webhook_merge_scan_already_live",
+      });
+    }
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(1);
+
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    const clockRef = admit(db, {
+      eventId: "clock:merge-factory:2026-08-12T10:30:00.000Z",
+      type: "factory.merge.requested",
+      source: "schedule",
+      subject: "factory",
+      correlationId: "clock:merge-factory:2026-08-12T10:30:00.000Z",
+      payload: {
+        repo: "factory",
+        loop: "merge-factory",
+        slot: "2026-08-12T10:30:00.000Z",
+        cadenceSeconds: 14400,
+        skippedSlots: 0,
+      },
+    });
+    const clock = planEvent(db, registry, clockRef, {
+      now: NOW + 2000,
+      policyVersion: "git:test",
+    });
+    expect(clock.decision).toBe("run");
+
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
+      transition(db, { runId: clock.runId, to, actor: "test" });
+    }
+
+    const other = planEvent(
+      db,
+      registry,
+      admit(db, webhook("other-check", "bj29")),
+      { now: NOW + 3000, policyVersion: "git:test" },
+    );
+    expect(other.decision).toBe("run");
+    expect(other.runId).not.toBe(first.runId);
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(3);
+  });
+
   test("repeat remediations with identical payload but distinct correlationId produce distinct runs (OPS-419)", () => {
     const db = openDb(":memory:");
     const ref1 = admit(db, {


### PR DESCRIPTION
Fixes #1184

Webhook CI bursts now reuse one live repo merge scan without creating redundant proposals.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/planner.test.mjs` | pass | 87 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1,724 pass, 9 skip; emit check passed |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend planner change with no user-facing surface