### PR TITLE
fix(verify): scrub handoff instance environment

### DIFF
--- a/docs/event-runtime-worker-protocol.md
+++ b/docs/event-runtime-worker-protocol.md
@@ -367,11 +367,15 @@ outside the model process — runs in the delegated worktree, in this order:
    `dispatch.owned_paths_conformance: strict` (config/policy.yaml, default
    `advisory`) they refuse the handoff.
 
-Handoff commands use a scrubbed copy of the worker environment: every
-`FACTORY_*` variable associated with the live instance is removed, then
-`FACTORY_REPOS_ROOT` is set explicitly to the delegated worktree. This keeps
-repo resolution, instance paths, and endpoints confined to the worktree rather
-than inheriting the live worker stack.
+Handoff commands use a scrubbed copy of the worker environment: the scrub is
+total, every `FACTORY_*` variable is removed (instance paths and endpoints
+such as `FACTORY_ROOT`, `FACTORY_EVENT_HOME`, `FACTORY_EVENT_PORT`, and also
+`FACTORY_REPO_VERIFY_TIMEOUT_MS`, which the worker has already applied as the
+spawn timeout), then `FACTORY_REPOS_ROOT` is set explicitly to the delegated
+worktree root at every call site, including the web build, which runs with
+`event-runtime/web` as its working directory. This keeps repo resolution,
+instance paths, and endpoints confined to the worktree rather than inheriting
+the live worker stack.
 
 Each command runs with the repo-verify timeout (`FACTORY_REPO_VERIFY_TIMEOUT_MS`,
 default 600 s) and its full output lands in the workspace (`.verify.log`,

--- a/docs/event-runtime-worker-protocol.md
+++ b/docs/event-runtime-worker-protocol.md
@@ -367,6 +367,12 @@ outside the model process — runs in the delegated worktree, in this order:
    `dispatch.owned_paths_conformance: strict` (config/policy.yaml, default
    `advisory`) they refuse the handoff.
 
+Handoff commands use a scrubbed copy of the worker environment: every
+`FACTORY_*` variable associated with the live instance is removed, then
+`FACTORY_REPOS_ROOT` is set explicitly to the delegated worktree. This keeps
+repo resolution, instance paths, and endpoints confined to the worktree rather
+than inheriting the live worker stack.
+
 Each command runs with the repo-verify timeout (`FACTORY_REPO_VERIFY_TIMEOUT_MS`,
 default 600 s) and its full output lands in the workspace (`.verify.log`,
 `.verify.ticket.log`, `.verify.web.log`). Failure-shaped outcomes:

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -113,25 +113,20 @@ export const HANDOFF_COMMENT_HEADING =
 
 /**
  * Handoff commands inspect the candidate worktree, never the worker's live
- * runtime. Keep this as a wildcard instead of enumerating today's instance
- * variables: a new FACTORY_* path or endpoint must be scrubbed by default.
- * #967 shares this seam for its credential-specific handoff sanitisation.
+ * runtime. The scrub is a `FACTORY_*` wildcard, not an enumeration of today's
+ * instance variables: a new FACTORY_* path or endpoint is dropped by default,
+ * and so is FACTORY_REPO_VERIFY_TIMEOUT_MS (the parent already applied it as
+ * the spawn timeout). #967 shares this seam for its credential-specific
+ * handoff sanitisation.
  */
-export const HANDOFF_FACTORY_ENV_DENYLIST = Object.freeze(["FACTORY_*"]);
-
 function handoffEnvironment(worktreePath) {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
-    if (
-      HANDOFF_FACTORY_ENV_DENYLIST.some(
-        (pattern) => pattern === "FACTORY_*" && key.startsWith("FACTORY_"),
-      )
-    ) {
-      delete env[key];
-    }
+    if (key.startsWith("FACTORY_")) delete env[key];
   }
   // reposRoot() is the one Factory setting handoff commands need. Pin it
-  // after scrubbing so the command always resolves files in this worktree.
+  // after scrubbing so the command always resolves files in this worktree,
+  // whatever directory the command itself runs from.
   env.FACTORY_REPOS_ROOT = worktreePath;
   return env;
 }
@@ -166,14 +161,17 @@ export function outputTail(output, lines = HANDOFF_TAIL_LINES) {
 /**
  * Run one handoff command as ordinary code in the worktree, capturing the
  * whole output to `logPath` and returning an observation the worker can quote.
+ * `cwd` is where the command runs (may be a subdirectory such as the web
+ * package); `worktreePath` is always the worktree root and is what
+ * FACTORY_REPOS_ROOT is pinned to.
  */
-function runHandoffCommand({ command, cwd, logPath, timeoutMs }) {
+function runHandoffCommand({ command, cwd, worktreePath, logPath, timeoutMs }) {
   const fd = openSync(logPath, "w");
   let res;
   try {
     res = spawnSync("/bin/bash", ["-c", command], {
       cwd,
-      env: handoffEnvironment(cwd),
+      env: handoffEnvironment(worktreePath),
       stdio: ["ignore", fd, fd],
       timeout: timeoutMs,
     });
@@ -1022,6 +1020,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: worktreeRecord.verify,
         cwd: worktreePath,
+        worktreePath,
         logPath: path.join(workspaceDir, ".verify.log"),
         timeoutMs: verifyTimeoutMs,
       });
@@ -1047,6 +1046,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: ticketCommand,
         cwd: worktreePath,
+        worktreePath,
         logPath: path.join(workspaceDir, ".verify.ticket.log"),
         timeoutMs: verifyTimeoutMs,
       });
@@ -1079,6 +1079,7 @@ function verifyCompleted({
       const obs = runHandoffCommand({
         command: HANDOFF_WEB_BUILD_COMMAND,
         cwd: path.join(worktreePath, HANDOFF_WEB_BUILD_DIR),
+        worktreePath,
         logPath: path.join(workspaceDir, ".verify.web.log"),
         timeoutMs: verifyTimeoutMs,
       });

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -111,6 +111,31 @@ export const DEFAULT_OWNED_PATHS_CONFORMANCE = "advisory";
 export const HANDOFF_COMMENT_HEADING =
   "## Handoff verification (worker-observed)";
 
+/**
+ * Handoff commands inspect the candidate worktree, never the worker's live
+ * runtime. Keep this as a wildcard instead of enumerating today's instance
+ * variables: a new FACTORY_* path or endpoint must be scrubbed by default.
+ * #967 shares this seam for its credential-specific handoff sanitisation.
+ */
+export const HANDOFF_FACTORY_ENV_DENYLIST = Object.freeze(["FACTORY_*"]);
+
+function handoffEnvironment(worktreePath) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      HANDOFF_FACTORY_ENV_DENYLIST.some(
+        (pattern) => pattern === "FACTORY_*" && key.startsWith("FACTORY_"),
+      )
+    ) {
+      delete env[key];
+    }
+  }
+  // reposRoot() is the one Factory setting handoff commands need. Pin it
+  // after scrubbing so the command always resolves files in this worktree.
+  env.FACTORY_REPOS_ROOT = worktreePath;
+  return env;
+}
+
 /** `dispatch.owned_paths_conformance` in config/policy.yaml: advisory (default) | strict. */
 export function policyOwnedPathsConformance(root = reposRoot()) {
   const file = resolveConfigPath("policy", { root });
@@ -148,6 +173,7 @@ function runHandoffCommand({ command, cwd, logPath, timeoutMs }) {
   try {
     res = spawnSync("/bin/bash", ["-c", command], {
       cwd,
+      env: handoffEnvironment(cwd),
       stdio: ["ignore", fd, fd],
       timeout: timeoutMs,
     });

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1068,7 +1068,7 @@ describe("worktree baseline verification (WM-334)", () => {
   test("handoff commands scrub instance FACTORY_* values and pin the worktree root", () => {
     const instanceRoot = tmpDir("evrt-handoff-instance-");
     const { dir, record } = worktreeWorkspace(
-      "printf 'repos=%s\\nroot=%s\\nhome=%s\\nport=%s\\n' \"$FACTORY_REPOS_ROOT\" \"${FACTORY_ROOT-unset}\" \"${FACTORY_EVENT_HOME-unset}\" \"${FACTORY_EVENT_PORT-unset}\"",
+      'printf \'repos=%s\\nroot=%s\\nhome=%s\\nport=%s\\n\' "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_EVENT_HOME-unset}" "${FACTORY_EVENT_PORT-unset}"',
       null,
     );
     const keys = [
@@ -1077,7 +1077,9 @@ describe("worktree baseline verification (WM-334)", () => {
       "FACTORY_EVENT_HOME",
       "FACTORY_EVENT_PORT",
     ];
-    const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+    const previous = Object.fromEntries(
+      keys.map((key) => [key, process.env[key]]),
+    );
     Object.assign(process.env, {
       FACTORY_REPOS_ROOT: instanceRoot,
       FACTORY_ROOT: instanceRoot,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1110,6 +1110,68 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
+  test("the web build pins FACTORY_REPOS_ROOT to the worktree root, not its web cwd", () => {
+    const instanceRoot = tmpDir("evrt-handoff-instance-");
+    const { dir, record } = worktreeWorkspace("true", null);
+    record.base = "develop";
+    const repo = record.path;
+    const git = (...args) => execFileSync("git", args, { cwd: repo });
+    git("init", "-q", "-b", "develop");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    const webDir = path.join(repo, "event-runtime", "web");
+    mkdirSync(path.join(webDir, "src"), { recursive: true });
+    writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({
+        name: "web-fixture",
+        scripts: {
+          build:
+            'printf \'cwd=%s\\nrepos=%s\\nroot=%s\\ntimeout=%s\\n\' "$PWD" "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_REPO_VERIFY_TIMEOUT_MS-unset}"',
+        },
+      }),
+    );
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/develop", "HEAD");
+    git("checkout", "-qb", "feat/x");
+    writeFileSync(path.join(webDir, "src", "app.ts"), "export {};\n");
+    git("add", "-A");
+    git("commit", "-qm", "work");
+    const keys = ["FACTORY_REPOS_ROOT", "FACTORY_ROOT"];
+    const previous = Object.fromEntries(
+      keys.map((key) => [key, process.env[key]]),
+    );
+    Object.assign(process.env, {
+      FACTORY_REPOS_ROOT: instanceRoot,
+      FACTORY_ROOT: instanceRoot,
+    });
+    try {
+      const out = verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      expect(out.kind).toBe("completed");
+      expect(out.result.verification.checks).toContain("web_build_passed");
+      const observed = out.handoff.webBuild.output;
+      expect(observed).toContain(`cwd=${webDir}`);
+      expect(observed).toContain(`repos=${repo}`);
+      expect(observed).not.toContain(`repos=${webDir}`);
+      expect(observed).toContain("root=unset");
+      expect(observed).toContain("timeout=unset");
+      expect(observed).not.toContain(instanceRoot);
+    } finally {
+      for (const key of keys) {
+        if (previous[key] === undefined) delete process.env[key];
+        else process.env[key] = previous[key];
+      }
+    }
+  });
+
   test("later error noise cannot displace a failing test name from the bounded reason", () => {
     const { dir, record } = worktreeWorkspace(
       "printf '(fail) billing > rejects a duplicate charge\\n'; i=1; while [ \"$i\" -le 45 ]; do printf 'error: detail %s\\n' \"$i\"; i=$((i + 1)); done; exit 1",

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1035,7 +1035,7 @@ describe("worktree baseline verification (WM-334)", () => {
 
   test("a multi-line verification failure retains the failing test name and full log", () => {
     const { dir, record } = worktreeWorkspace(
-      "printf 'suite start\\n(pass) parser > reads bun (fail) and ✗ lines\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
+      "printf 'suite start\\n(pass) timing-test registry (WM-918) > parseFailingTests reads bun (fail) and ✗ lines\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
       null,
     );
     try {
@@ -1055,7 +1055,7 @@ describe("worktree baseline verification (WM-334)", () => {
       );
       expect(err.violations[0]).toContain("error: expected 400, received 200");
       // A passing test whose name contains "(fail)" is not a failure marker.
-      expect(err.violations[0]).not.toContain("(pass) parser");
+      expect(err.violations[0]).not.toContain("(pass) timing-test registry");
     }
 
     const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");
@@ -1063,6 +1063,49 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(verifyLog).toContain("(fail) totals > rejects an invalid total");
     expect(verifyLog).toContain("Ran 2045 tests across 150 files.");
     expect(verifyLog).toContain("error: expected 400, received 200");
+  });
+
+  test("handoff commands scrub instance FACTORY_* values and pin the worktree root", () => {
+    const instanceRoot = tmpDir("evrt-handoff-instance-");
+    const { dir, record } = worktreeWorkspace(
+      "printf 'repos=%s\\nroot=%s\\nhome=%s\\nport=%s\\n' \"$FACTORY_REPOS_ROOT\" \"${FACTORY_ROOT-unset}\" \"${FACTORY_EVENT_HOME-unset}\" \"${FACTORY_EVENT_PORT-unset}\"",
+      null,
+    );
+    const keys = [
+      "FACTORY_REPOS_ROOT",
+      "FACTORY_ROOT",
+      "FACTORY_EVENT_HOME",
+      "FACTORY_EVENT_PORT",
+    ];
+    const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+    Object.assign(process.env, {
+      FACTORY_REPOS_ROOT: instanceRoot,
+      FACTORY_ROOT: instanceRoot,
+      FACTORY_EVENT_HOME: instanceRoot,
+      FACTORY_EVENT_PORT: "9999",
+    });
+    try {
+      const out = verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      expect(out.kind).toBe("completed");
+      const observed = out.handoff.repoVerify.output;
+      expect(observed).toContain(`repos=${record.path}`);
+      expect(observed).toContain("root=unset");
+      expect(observed).toContain("home=unset");
+      expect(observed).toContain("port=unset");
+      expect(observed).not.toContain(instanceRoot);
+    } finally {
+      for (const key of keys) {
+        if (previous[key] === undefined) delete process.env[key];
+        else process.env[key] = previous[key];
+      }
+    }
   });
 
   test("later error noise cannot displace a failing test name from the bounded reason", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1214

Handoff gates now scrub live Factory environment variables and pin repo resolution to the delegated worktree.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs --timeout 20000` | pass | 50 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1724 pass, 9 skipped; generated files match |
| UX critique | factory-ux-critic | not run | skipped — no user-facing surface |

UX critique: skipped — backend verification and docs only; no user-facing surface


## Handoff

### Post-review (7e40db9d)

- `runHandoffCommand` now takes an explicit `worktreePath`; all three call sites (repo verify, ticket command, web build) pin `FACTORY_REPOS_ROOT` to the worktree root while `cwd` stays as before. Previously the web build pinned it to `event-runtime/web`.
- Dropped the fake `HANDOFF_FACTORY_ENV_DENYLIST` seam; the `FACTORY_*` wildcard scrub is documented inline instead.
- Docs: scrubbing is total (all `FACTORY_*`, including `FACTORY_REPO_VERIFY_TIMEOUT_MS`, which the worker applies as the spawn timeout).
- New test: web-build call site asserts `FACTORY_REPOS_ROOT === worktree` with cwd = web dir. `bun test event-runtime/lib/verify.test.mjs` 51 pass; `bun run check` ok; prettier clean.
