### PR TITLE
fix(connectors): block prototype-polluting secret paths

### DIFF
--- a/event-runtime/lib/connectors.mjs
+++ b/event-runtime/lib/connectors.mjs
@@ -57,6 +57,11 @@ export const CONNECTOR_ID_PATTERN =
 export const CONNECTOR_START_TIMEOUT_MS = 10_000;
 
 const SECRET_KEY_HEURISTIC = /nsec|token|secret|key|password/i;
+const FORBIDDEN_CONFIG_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
 
 /** Typed error for a module that fails the connector contract. */
 export class ConnectorError extends Error {
@@ -304,6 +309,7 @@ export function splitConfigSecrets(values, secretFields = []) {
   const config = cloneJson(values) ?? {};
   const secrets = {};
   const move = (keyPath) => {
+    if (keyPath.some((key) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key))) return;
     let node = values;
     for (const key of keyPath) {
       if (
@@ -326,6 +332,9 @@ function moveHeuristic(from, secrets, path) {
   if (!from || typeof from !== "object" || Array.isArray(from)) return;
   for (const [key, inner] of Object.entries(from)) {
     const next = [...path, key];
+    if (next.some((segment) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(segment))) {
+      continue;
+    }
     if (SECRET_KEY_HEURISTIC.test(key) && !isPlainObject(inner)) {
       setAt(secrets, next, inner);
       delete from[key];
@@ -340,23 +349,49 @@ function isPlainObject(value) {
 }
 
 function setAt(obj, keyPath, value) {
+  if (
+    keyPath.length === 0 ||
+    keyPath.some((key) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key))
+  )
+    return;
   let node = obj;
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
-    if (!isPlainObject(node[key])) node[key] = {};
+    if (!isPlainObject(node)) return;
+    if (!Object.hasOwn(node, key) || !isPlainObject(node[key])) {
+      Object.defineProperty(node, key, {
+        value: {},
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
     node = node[key];
   }
-  node[keyPath[keyPath.length - 1]] = value;
+  if (!isPlainObject(node)) return;
+  Object.defineProperty(node, keyPath[keyPath.length - 1], {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 function deleteAt(obj, keyPath) {
+  if (
+    keyPath.length === 0 ||
+    keyPath.some((key) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key))
+  )
+    return;
   let node = obj;
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
+    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return;
     if (!isPlainObject(node[key])) return;
     node = node[key];
   }
-  delete node[keyPath[keyPath.length - 1]];
+  const key = keyPath[keyPath.length - 1];
+  if (isPlainObject(node) && Object.hasOwn(node, key)) delete node[key];
 }
 
 function connectorLog(log, extension, name) {

--- a/event-runtime/lib/connectors.test.mjs
+++ b/event-runtime/lib/connectors.test.mjs
@@ -59,6 +59,12 @@ afterEach(async () => {
   await stopConnectors();
 });
 
+afterEach(() => {
+  for (const key of ["token", "apiKey", "nested"]) {
+    delete Object.prototype[key];
+  }
+});
+
 describe("validateConnectorModule", () => {
   test("requires a default start function and a shaped id", () => {
     expect(() => validateConnectorModule(null)).toThrow(/ES module/);
@@ -95,6 +101,51 @@ describe("splitConfigSecrets", () => {
       nested: { signingKey: "k" },
     });
     expect(values.apiToken).toBe("sk-live");
+  });
+
+  test("does not traverse a __proto__ config key", () => {
+    for (const values of [
+      { __proto__: { token: "x" } },
+      JSON.parse('{"__proto__":{"token":"x"}}'),
+    ]) {
+      const { secrets } = splitConfigSecrets(values);
+      expect(Object.prototype.token).toBeUndefined();
+      expect(Object.hasOwn(secrets, "__proto__")).toBe(false);
+    }
+  });
+
+  test("does not traverse constructor.prototype config keys", () => {
+    const { secrets } = splitConfigSecrets(
+      JSON.parse('{"constructor":{"prototype":{"apiKey":"x"}}}'),
+    );
+    expect(Object.prototype.apiKey).toBeUndefined();
+    expect(Object.hasOwn(secrets, "constructor")).toBe(false);
+  });
+
+  test("ignores explicit secret paths containing forbidden segments", () => {
+    const values = JSON.parse(
+      '{"nested":{"value":"x"},"constructor":{"prototype":{"apiKey":"y"}}}',
+    );
+    const { secrets } = splitConfigSecrets(values, [
+      { path: ["nested", "__proto__", "value"] },
+      { path: ["constructor", "prototype", "apiKey"] },
+    ]);
+    expect(Object.prototype.token).toBeUndefined();
+    expect(Object.prototype.apiKey).toBeUndefined();
+    expect(secrets).toEqual({});
+  });
+
+  test("does not write through an inherited intermediate object", () => {
+    Object.prototype.nested = {};
+    const { secrets } = splitConfigSecrets(
+      { nested: { token: "x" } },
+      [{ path: ["nested", "token"] }],
+    );
+    expect(Object.prototype.token).toBeUndefined();
+    expect(Object.hasOwn(secrets, "nested")).toBe(true);
+    expect(secrets.nested).not.toBe(Object.prototype.nested);
+    expect(secrets.nested.token).toBe("x");
+    expect(Object.prototype.nested.token).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1205

Harden connector secret-path traversal against prototype pollution without changing the exported splitConfigSecrets API.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/connectors.test.mjs --timeout 20000 && bun run check` | pass    | 17 tests, 0 failures; generated files match |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | event-runtime/lib suite and generated-files check completed |
| UX critique          | factory-ux-critic                | not run | backend/security hardening; no user-facing surface |

UX critique: skipped — backend/security hardening; no user-facing surface