### PR TITLE
fix(worker): stop permanent artifact retries

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -802,22 +802,42 @@ function failureCount(db, runId, cause) {
 }
 
 /** Called after the current attempt is finalized, so counts include this failure. */
-function retryDecision(db, runId, spec, reasonCode) {
+function retryDecision(
+  db,
+  runId,
+  spec,
+  reasonCode,
+  { includeCurrentFailure = false } = {},
+) {
   const cause = classifyFailureCause(reasonCode);
   if (cause === "environment") {
+    const failures =
+      failureCount(db, runId, cause) + (includeCurrentFailure ? 1 : 0);
     return {
       cause,
-      retry: failureCount(db, runId, cause) <= maxEnvironmentRetries(spec),
+      retry: failures <= maxEnvironmentRetries(spec),
     };
   }
   if (cause === "agent_error") {
-    return { cause, retry: failureCount(db, runId, cause) < spec.maxAttempts };
+    const failures =
+      failureCount(db, runId, cause) + (includeCurrentFailure ? 1 : 0);
+    return { cause, retry: failures < spec.maxAttempts };
   }
   return { cause, retry: false };
 }
 
 function typedFailureReason(reasonCode, detail = reasonCode) {
   return `failure:${classifyFailureCause(reasonCode)}:${detail}`;
+}
+
+function terminalFailureReason(decision, reasonCode, detail = reasonCode) {
+  if (decision.cause === "environment" && !decision.retry) {
+    return typedFailureReason(
+      reasonCode,
+      `${detail}; environment_retry_budget_exhausted`,
+    );
+  }
+  return typedFailureReason(reasonCode, detail);
 }
 
 function resolveNow(now) {
@@ -2125,12 +2145,15 @@ export async function executeClaimed(
       const expectFrom = db
         .query(`SELECT state FROM runs WHERE run_id = ?`)
         .get(runId)?.state;
+      const decision = retryDecision(db, runId, spec, reasonCode, {
+        includeCurrentFailure: true,
+      });
       transition(db, {
         runId,
         to,
         expectFrom,
         actor: owner,
-        reason: typedFailureReason(reasonCode, journalReason),
+        reason: terminalFailureReason(decision, reasonCode, journalReason),
         attempt,
         policyVersion,
         now: currentNow,
@@ -2144,7 +2167,6 @@ export async function executeClaimed(
         currentNow,
         attemptUsage,
       );
-      const decision = retryDecision(db, runId, spec, reasonCode);
       if (decision.retry) {
         transition(db, {
           runId,
@@ -2622,17 +2644,29 @@ export async function executeClaimed(
       }
     }
 
-    const created = createWorkspace({
-      root: workspacesRoot,
-      runId,
-      attempt,
-      input: spec.input,
-      workspace: spec.workspace,
-      artifactStore,
-      adapter: adapterKey,
-      ticketLeaseOwner,
-      workerLeasesDir: leasesDir,
-    });
+    let created;
+    try {
+      created = createWorkspace({
+        root: workspacesRoot,
+        runId,
+        attempt,
+        input: spec.input,
+        workspace: spec.workspace,
+        artifactStore,
+        adapter: adapterKey,
+        ticketLeaseOwner,
+        workerLeasesDir: leasesDir,
+      });
+    } catch (err) {
+      // Missing declared inputs are permanent: re-queuing cannot repopulate an
+      // artifact store entry that the run has already pinned by hash. This
+      // boundary is deliberately narrow so a similarly worded later error is
+      // not mistaken for an input-materialization failure.
+      if (/^artifact [a-f0-9]{64} is not in the store$/.test(err?.message)) {
+        err.code = "input_artifact_missing";
+      }
+      throw err;
+    }
     workspaceDir = created.dir;
     assertSandboxWorkspaceSupported(workspaceDir, def);
     checkoutPath = created.checkout?.path ?? null;
@@ -3098,12 +3132,15 @@ export async function executeClaimed(
           });
           return { fenced: true };
         }
+        const decision = retryDecision(db, runId, spec, reasonCode, {
+          includeCurrentFailure: true,
+        });
         transition(db, {
           runId,
           to: "FAILED",
           expectFrom: "VERIFYING",
           actor: owner,
-          reason: typedFailureReason(reasonCode, failureReason),
+          reason: terminalFailureReason(decision, reasonCode, failureReason),
           attempt,
           policyVersion,
           now: currentNow,
@@ -3117,7 +3154,6 @@ export async function executeClaimed(
           currentNow,
           attemptUsage,
         );
-        const decision = retryDecision(db, runId, spec, reasonCode);
         if (decision.retry) {
           transition(db, {
             runId,
@@ -3465,6 +3501,7 @@ export async function executeClaimed(
       err?.code === "worktree_sandbox_unsupported";
     const isWorkspaceProvisioning =
       err?.code === "workspace_provisioning_error";
+    const isInputArtifactMissing = err?.code === "input_artifact_missing";
     const reasonCode = isCliNotFound
       ? "cli_not_found"
       : isSandboxUnsupported
@@ -3473,7 +3510,9 @@ export async function executeClaimed(
           ? "worktree_sandbox_unsupported"
           : isWorkspaceProvisioning
             ? "workspace_provisioning_error"
-            : "adapter_error";
+            : isInputArtifactMissing
+              ? "input_artifact_missing"
+              : "adapter_error";
     const journalReason = `${reasonCode}: ${err?.message ?? String(err)}`;
     let res;
     try {
@@ -3657,7 +3696,10 @@ export function reapExpiredLeases(
       .all(iso(currentNow));
     for (const row of rows) {
       const spec = JSON.parse(row.spec_json);
-      const failureReason = typedFailureReason("lease_expired");
+      const decision = retryDecision(db, row.run_id, spec, "lease_expired", {
+        includeCurrentFailure: true,
+      });
+      const failureReason = terminalFailureReason(decision, "lease_expired");
 
       // VERIFYING cannot transition directly to QUEUED; record its failure first.
       if (row.state === "VERIFYING") {
@@ -3679,8 +3721,6 @@ export function reapExpiredLeases(
         "lease_expired",
         currentNow,
       );
-      const decision = retryDecision(db, row.run_id, spec, "lease_expired");
-
       if (decision.retry) {
         transition(db, {
           runId: row.run_id,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2168,6 +2168,7 @@ describe("worker", () => {
       "cli_not_found",
       "sandbox_unsupported",
       "worktree_sandbox_unsupported",
+      "input_artifact_missing",
       "unknown_adapter",
       "agent_definition_mismatch",
       "policy_denied:Bash",
@@ -2254,7 +2255,7 @@ describe("worker", () => {
     ).toBe(false);
   });
 
-  test("repeated environment failures dead-letter after the dedicated retry ceiling", async () => {
+  test("repeated environment failures stop at the dedicated retry ceiling", async () => {
     const db = openDb(":memory:");
     const throwingAdapter = {
       execute: async () => {
@@ -2297,6 +2298,53 @@ describe("worker", () => {
         (event) => event.reason === "retry:environment",
       ),
     ).toHaveLength(2);
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toContain(
+      "environment_retry_budget_exhausted",
+    );
+  });
+
+  test("a missing declared input artifact is fatal and never reaches the adapter", async () => {
+    const db = openDb(":memory:");
+    const missingSha = "a".repeat(64);
+    let executed = false;
+    const observingAdapter = {
+      async execute() {
+        executed = true;
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const spec = queueRun(
+      db,
+      makeSpec({
+        workspace: {
+          type: "artifacts",
+          inputs: [{ from: missingSha, as: "input.json" }],
+        },
+        maxEnvironmentRetries: 5,
+      }),
+    );
+
+    const summary = await runOnce(
+      db,
+      registry,
+      { fake: observingAdapter },
+      opts({ artifactStore: freshRoot() }),
+    );
+
+    expect(executed).toBe(false);
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "input_artifact_missing",
+    });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(
+      db
+        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).reason_code,
+    ).toBe("input_artifact_missing");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toContain(
+      "failure:fatal:input_artifact_missing",
+    );
   });
 
   test("environment failures do not consume agent_exit retry attempts", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1187

Missing input artifacts now fail terminally, and exhausted environment retries record their terminal cause.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/worker.test.mjs` | pass | 140 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1724 tests, emit clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

## Handoff

### Post-review

- Merged `origin/develop` (worker.mjs rewritten by #1207 pack-prompt/def-hash gate and #1215 workspace confinement / `guestEnvironment` / `isSandboxGuarded`); conflict was only the `createWorkspace` call site — kept both: develop's earlier `adapterKey` binding plus this branch's narrow try/catch classifying `artifact <sha256> is not in the store` as `input_artifact_missing` (fatal). Prettier applied.
- AC#2 ("bounded on every requeue path") is only partially met: `releaseStalledWorkerLease` still requeues on bare `attempts < maxAttempts` without consulting `retryDecision`. Tracked by #1212.
