### PR TITLE
fix(evals): resolve pinned agent prompts

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,11 @@ cases/<skill>/<case-name>/
   expect.md     what a correct response must contain, and must not
 ```
 
+The directory name may be either a shared skill or a pinned
+`event-runtime/agents/<name>.md` prompt. Source resolution checks the shared
+skill first, then the emitted `plugins/core` skill, then the agent prompt, so a
+skill with the same name always wins. `--dry-run` prints the resolved path.
+
 `expect.md` is graded, not diffed — the wording will vary. State observable properties ("names a Verification Command that runs", "does not promote"), never exact phrasing.
 
 ## Choosing cases
@@ -25,7 +30,7 @@ Freeze a case once it's written. A case edited to match new behavior is no longe
     node evals/run.mjs                 # all
     node evals/run.mjs --skill ticket-spec
 
-One case is two model calls: the **subject** run puts the skill's own prompt (`shared/skills/<skill>/SKILL.md`, falling back to the emitted `plugins/core/skills/…`) in front of `input.md` and captures what it produces, then the **grader** judges that response against `expect.md` and answers with one line — `PASS: <reason>` or `FAIL: <reason>`. The subject may read the repo; the grader gets no tools, because it is judging text, not looking things up. Nothing is mutated: the subject is told this is an offline evaluation and is denied write tools.
+One case is two model calls: the **subject** run puts the case's own prompt (`shared/skills/<skill>/SKILL.md`, falling back to the emitted `plugins/core/skills/…`, then `event-runtime/agents/<name>.md`) in front of `input.md` and captures what it produces, then the **grader** judges that response against `expect.md` and answers with one line — `PASS: <reason>` or `FAIL: <reason>`. The subject may read the repo; the grader gets no tools, because it is judging text, not looking things up. Nothing is mutated: the subject is told this is an offline evaluation and is denied write tools.
 
 A grader that hangs, crashes, or answers with prose instead of a verdict **fails that case**, never the run.
 

--- a/evals/lib/cases.mjs
+++ b/evals/lib/cases.mjs
@@ -17,14 +17,17 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
 /**
- * Where a skill's prompt lives, most authoritative first. `shared/` is the
+ * Where a case prompt lives, most authoritative first. `shared/` is the
  * source of truth; `plugins/core/` is emitted from it (`bun build/emit.mjs`)
  * and is the fallback for a checkout where only the emitted tree is present.
+ * Pinned event-runtime agents are the final fallback because their prompts
+ * are not skills, but can still be exercised by the eval runner.
  */
-export function skillSourceCandidates(repoRoot, skill) {
+export function skillSourceCandidates(repoRoot, name) {
   return [
-    path.join(repoRoot, "shared", "skills", skill, "SKILL.md"),
-    path.join(repoRoot, "plugins", "core", "skills", skill, "SKILL.md"),
+    path.join(repoRoot, "shared", "skills", name, "SKILL.md"),
+    path.join(repoRoot, "plugins", "core", "skills", name, "SKILL.md"),
+    path.join(repoRoot, "event-runtime", "agents", `${name}.md`),
   ];
 }
 

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -164,6 +164,38 @@ describe("discovery", () => {
       expect(entry.problem).toBeNull();
     }));
 
+  test("resolves a pinned event-runtime agent prompt", () =>
+    withTmpDir("evals-discovery-agent-", (dir) => {
+      const { repoRoot, evalsDir } = buildFixture(dir, {
+        skills: {},
+        cases: { "dispatch/a": { input: "i", expect: "e" } },
+      });
+      const agentDir = path.join(repoRoot, "event-runtime", "agents");
+      mkdirSync(agentDir, { recursive: true });
+      const agentPrompt = path.join(agentDir, "dispatch.md");
+      writeFileSync(agentPrompt, "# dispatch\n");
+
+      const [entry] = discoverCases({ evalsDir, repoRoot });
+      expect(entry.skillSource).toBe(agentPrompt);
+      expect(entry.problem).toBeNull();
+    }));
+
+  test("prefers a shared skill over an agent prompt with the same name", () =>
+    withTmpDir("evals-discovery-precedence-", (dir) => {
+      const { repoRoot, evalsDir } = buildFixture(dir, {
+        skills: { dispatch: "# shared dispatch" },
+        cases: { "dispatch/a": { input: "i", expect: "e" } },
+      });
+      const agentDir = path.join(repoRoot, "event-runtime", "agents");
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(path.join(agentDir, "dispatch.md"), "# dispatch\n");
+
+      const [entry] = discoverCases({ evalsDir, repoRoot });
+      expect(entry.skillSource).toBe(
+        path.join(repoRoot, "shared", "skills", "dispatch", "SKILL.md"),
+      );
+    }));
+
   test("a case missing expect.md, or naming an unknown skill, is reported not skipped", () =>
     withTmpDir("evals-discovery-broken-", (dir) => {
       const { repoRoot, evalsDir } = buildFixture(dir, {
@@ -179,7 +211,9 @@ describe("discovery", () => {
         ]),
       );
       expect(problems["ticket-spec/no-expect"]).toBe("missing expect.md");
-      expect(problems["ghost-skill/orphan"]).toContain("no skill source");
+      expect(problems["ghost-skill/orphan"]).toBe(
+        'no skill source for "ghost-skill" (looked in shared/skills/ghost-skill/SKILL.md, plugins/core/skills/ghost-skill/SKILL.md, event-runtime/agents/ghost-skill.md)',
+      );
     }));
 
   test("discovers the repo's own cases against the real skill tree", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1178

Review the eval source precedence and malformed-case coverage before merging.

## Validation

| Check                | Command                                                        | Result | Notes                  |
| -------------------- | -------------------------------------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 evals/run.test.mjs && node evals/run.mjs --dry-run` | pass    | 36 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1734 tests, 10 skipped; generated files match |
| UX critique          | factory-ux-critic                                             | not run | no user-facing surface |

UX critique: skipped
