### PR TITLE
perf(serve): bound chain resolution history scan

### DIFF
--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -17,6 +17,7 @@
  * watched like any other.
  */
 import { admitEvent } from "./intake.mjs";
+import { tx } from "./db.mjs";
 
 export const CHAIN_SOURCE = "chain";
 
@@ -79,7 +80,7 @@ function chainEventId(edge, row, context, fallback, { mixed = false } = {}) {
   });
 }
 
-/** Completed runs whose agent has registered edges and no derived chain event yet. */
+/** Completed edge-agent runs that have not reached a durable chain terminal. */
 function chainCandidates(db, edges) {
   const agents = Object.keys(edges);
   if (agents.length === 0) return [];
@@ -93,9 +94,39 @@ function chainCandidates(db, edges) {
        JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE r.state = 'COMPLETED'
+         AND r.chain_resolved_at IS NULL
          AND json_extract(r.spec_json, '$.agent') IN (${placeholders})`,
     )
     .all(...agents);
+}
+
+/**
+ * Fetch every existing child for this tick's unresolved edge-agent population
+ * in one indexed statement. Keeping this outside the candidate loop is the
+ * important bound: historical fan-out is one events lookup, not one per run.
+ */
+function existingChainEvents(db, edges) {
+  const agents = Object.keys(edges);
+  if (agents.length === 0) return new Map();
+  const placeholders = agents.map(() => "?").join(", ");
+  const byRun = new Map();
+  const rows = db
+    .query(
+      `SELECT child.causation_id, child.event_id
+         FROM runs r
+         JOIN events child
+           ON child.causation_id = r.run_id AND child.source = ?
+        WHERE r.state = 'COMPLETED'
+          AND r.chain_resolved_at IS NULL
+          AND json_extract(r.spec_json, '$.agent') IN (${placeholders})`,
+    )
+    .all(CHAIN_SOURCE, ...agents);
+  for (const row of rows) {
+    const ids = byRun.get(row.causation_id) ?? new Set();
+    ids.add(row.event_id);
+    byRun.set(row.causation_id, ids);
+  }
+  return byRun;
 }
 
 /**
@@ -110,8 +141,13 @@ function chainCandidates(db, edges) {
 export function resolveChains(db, registry, { now = Date.now() } = {}) {
   const edges = registry.edges ?? {};
   const outcome = { emitted: 0, skipped: 0, errors: [] };
+  const candidates = chainCandidates(db, edges);
+  if (candidates.length === 0) return outcome;
+  const existingByRun = existingChainEvents(db, edges);
+  const resolvedRunIds = [];
+  const resolvedAt = new Date(now).toISOString();
 
-  for (const row of chainCandidates(db, edges)) {
+  for (const row of candidates) {
     const spec = JSON.parse(row.spec_json);
     const result = JSON.parse(row.result_json);
     const rule = edges[spec.agent];
@@ -168,8 +204,10 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
           })();
       if (selectedEdges.length === 0) {
         // An unmapped value or an independent result with no actionable items
-        // is a legitimate terminal — record nothing, chain nothing.
+        // is a legitimate terminal — record nothing, chain nothing, and do
+        // not re-parse the same accepted result on every later tick.
         outcome.skipped += 1;
+        resolvedRunIds.push(row.run_id);
         continue;
       }
 
@@ -295,30 +333,46 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       // set. Reconstruct the full set and admit only the missing siblings. An
       // event from an older routing configuration is a durable completion
       // marker, not permission to backfill stale actions under today's edges.
-      const existingIds = new Set(
-        db
-          .query(
-            `SELECT event_id FROM events WHERE source = ? AND causation_id = ?`,
-          )
-          .all(CHAIN_SOURCE, row.run_id)
-          .map((event) => event.event_id),
-      );
-      if ([...existingIds].some((eventId) => !ids.includes(eventId))) continue;
+      const existingIds = existingByRun.get(row.run_id) ?? new Set();
+      if ([...existingIds].some((eventId) => !ids.includes(eventId))) {
+        resolvedRunIds.push(row.run_id);
+        continue;
+      }
       const pending = envelopes.filter(
         (envelope) => !existingIds.has(envelope.eventId),
       );
       for (const envelope of pending) {
         const admitted = admitChainEvent(db, registry, envelope, { now });
-        if (admitted.admitted) outcome.emitted += 1;
-        else if (admitted.duplicate) outcome.skipped += 1;
-        else
+        if (admitted.admitted) {
+          outcome.emitted += 1;
+          existingIds.add(envelope.eventId);
+        } else if (admitted.duplicate) {
+          outcome.skipped += 1;
+          if (admitted.event?.causation_id === row.run_id) {
+            existingIds.add(envelope.eventId);
+          }
+        } else {
           outcome.errors.push(
             `${envelope.eventId}: ${admitted.errors.join("; ")}`,
           );
+        }
+      }
+      if (envelopes.every((envelope) => existingIds.has(envelope.eventId))) {
+        resolvedRunIds.push(row.run_id);
       }
     } catch (err) {
       outcome.errors.push(`chain-${row.run_id}: ${err.message}`);
     }
+  }
+  if (resolvedRunIds.length > 0) {
+    const markResolved = db.query(
+      `UPDATE runs
+          SET chain_resolved_at = ?
+        WHERE run_id = ? AND chain_resolved_at IS NULL`,
+    );
+    tx(db, () => {
+      for (const runId of resolvedRunIds) markResolved.run(resolvedAt, runId);
+    });
   }
   return outcome;
 }

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -13,6 +13,7 @@ import { planAdmittedEvents } from "./planner.mjs";
 import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry, RegistryError } from "./registry.mjs";
 import { runOnce } from "./worker.mjs";
+import { tick } from "../cli/serve.mjs";
 
 const registry = loadRegistry();
 const PV = "git:test-pv";
@@ -419,6 +420,14 @@ describe("multi-emit chain resolution (WM-119)", () => {
     ).run(runId, JSON.stringify({ artifact }), now);
   }
 
+  function seedChainChild(db, runId, eventId) {
+    const now = new Date().toISOString();
+    db.query(
+      `INSERT INTO events (source, event_id, type, subject, occurred_at, received_at, correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
+       VALUES ('chain', ?, 'factory.work.requested', 'perf-edge@1', ?, ?, ?, ?, '{}', 'hash', 'admitted', ?)`,
+    ).run(eventId, now, now, `corr-${runId}`, runId, now);
+  }
+
   test("fans out N planned items into N admitted chain events with chain-<runId>-<itemKey> IDs", () => {
     const dir = tmpDir("evrt-chain-multi-");
     const db = openDb(path.join(dir, "runtime.db"));
@@ -460,6 +469,161 @@ describe("multi-emit chain resolution (WM-119)", () => {
       skipped: 0,
       errors: [],
     });
+  });
+
+  test("partially emitted fan-out resumes missing siblings before marking the run resolved", () => {
+    const db = openDb(":memory:");
+    seedCompletedRun(db, {
+      runId: "run-partial-fanout",
+      agent: "work-scan@1",
+      input: { repo: "wm/partial" },
+      artifact: {
+        recommendation: "DISPATCH",
+        repo: "wm/partial",
+        plan: [
+          { ticket: "WM-301" },
+          { ticket: "WM-302" },
+          { ticket: "WM-303" },
+        ],
+      },
+    });
+    seedChainChild(
+      db,
+      "run-partial-fanout",
+      "chain-run-partial-fanout-WM-301",
+    );
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 2,
+      skipped: 0,
+      errors: [],
+    });
+    expect(
+      db
+        .query(
+          `SELECT chain_resolved_at FROM runs WHERE run_id = 'run-partial-fanout'`,
+        )
+        .get().chain_resolved_at,
+    ).not.toBeNull();
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  test("production-shaped resolved history keeps a no-planning tick and health responsive", async () => {
+    const db = openDb(":memory:");
+    const perfRegistry = {
+      ...registry,
+      edges: {
+        "perf-edge@1": {
+          recommendationField: "recommendation",
+          edges: {
+            NEXT: {
+              eventType: "factory.work.requested",
+              input: { repo: "$.input.repo" },
+            },
+          },
+        },
+      },
+    };
+
+    // Production had ~1,300 completed edge runs and ~6,000 chain events. Use
+    // 2,000/6,000 so this guards both that shape and future history growth.
+    db.transaction(() => {
+      for (let i = 0; i < 2_000; i += 1) {
+        const runId = `run-perf-${i}`;
+        seedCompletedRun(db, {
+          runId,
+          agent: "perf-edge@1",
+          input: { repo: "factory" },
+          artifact: { recommendation: "NEXT" },
+        });
+        seedChainChild(db, runId, `chain-${runId}`);
+        seedChainChild(db, runId, `chain-${runId}-legacy-a`);
+        seedChainChild(db, runId, `chain-${runId}-legacy-b`);
+      }
+    })();
+
+    let childEventLookups = 0;
+    const instrumented = new Proxy(db, {
+      get(target, property) {
+        if (property === "query") {
+          return (sql) => {
+            if (/JOIN events child\s+ON child\.causation_id/s.test(sql)) {
+              childEventLookups += 1;
+            }
+            return target.query(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const noPlanning = Object.fromEntries(
+      [
+        "tick emit",
+        "plan",
+        "auto-approve",
+        "auto-approve-chains",
+        "announce",
+        "inbox",
+        "notify",
+        "reap",
+        "announce-after",
+        "outbox",
+        "GC",
+      ].map((name) => [name, () => {}]),
+    );
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      const healthRequests = Array.from({ length: 20 }, async () => {
+        const started = performance.now();
+        const response = await fetch(
+          `http://127.0.0.1:${server.port}/health`,
+        );
+        expect(response.status).toBe(200);
+        return performance.now() - started;
+      });
+      const tickStarted = performance.now();
+      await tick({
+        db: instrumented,
+        registry: perfRegistry,
+        policyVersion: PV,
+        subsystems: noPlanning,
+        log: () => {},
+      });
+      const tickMs = performance.now() - tickStarted;
+      const healthMs = (await Promise.all(healthRequests)).sort(
+        (a, b) => a - b,
+      );
+      const healthP95 = healthMs[Math.ceil(healthMs.length * 0.95) - 1];
+
+      console.info(
+        `chain benchmark: tick=${tickMs.toFixed(1)}ms health_p95=${healthP95.toFixed(1)}ms child_event_lookups=${childEventLookups}`,
+      );
+      expect(childEventLookups).toBe(1); // one bulk lookup, never 2,000
+      expect(tickMs).toBeLessThan(200);
+      expect(healthP95).toBeLessThan(500);
+
+      childEventLookups = 0;
+      expect(resolveChains(instrumented, perfRegistry)).toEqual({
+        emitted: 0,
+        skipped: 0,
+        errors: [],
+      });
+      expect(childEventLookups).toBe(0); // resolved history is not re-examined
+    } finally {
+      server.stop(true);
+      db.close();
+    }
   });
 
   test("empty plan skips cleanly without error", () => {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -14,6 +14,10 @@ import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry, RegistryError } from "./registry.mjs";
 import { runOnce } from "./worker.mjs";
 import { tick } from "../cli/serve.mjs";
+// Importing test-helpers pins FACTORY_EVENT_HOME/FACTORY_HOME to an isolated
+// temp home for this whole file, so default-home lookups (artifactsRoot(),
+// dbPath()) never reach the operator's real ~/.factory (OPS-425).
+import { realFactorySnapshot } from "../test-helpers.mjs";
 
 const registry = loadRegistry();
 const PV = "git:test-pv";
@@ -509,6 +513,8 @@ describe("multi-emit chain resolution (WM-119)", () => {
   });
 
   test("production-shaped resolved history keeps a no-planning tick and health responsive", async () => {
+    const realHomeBefore = realFactorySnapshot();
+    expect(process.env.FACTORY_EVENT_HOME).toBeDefined();
     const db = openDb(":memory:");
     const perfRegistry = {
       ...registry,
@@ -607,6 +613,9 @@ describe("multi-emit chain resolution (WM-119)", () => {
       expect(tickMs).toBeLessThan(200);
       // /health p95 is measured against the stub Bun.serve above: it proves the tick does not block the event loop, not real API latency.
       expect(healthP95).toBeLessThan(500);
+      // The production-shaped benchmark must never touch the operator's real
+      // ~/.factory/event-runtime/runtime.db (no default-home openDb/migration).
+      expect(realFactorySnapshot().dbMtime).toBe(realHomeBefore.dbMtime);
 
       childEventLookups = 0;
       expect(resolveChains(instrumented, perfRegistry)).toEqual({

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -487,11 +487,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
         ],
       },
     });
-    seedChainChild(
-      db,
-      "run-partial-fanout",
-      "chain-run-partial-fanout-WM-301",
-    );
+    seedChainChild(db, "run-partial-fanout", "chain-run-partial-fanout-WM-301");
 
     expect(resolveChains(db, registry)).toEqual({
       emitted: 2,
@@ -586,9 +582,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
     try {
       const healthRequests = Array.from({ length: 20 }, async () => {
         const started = performance.now();
-        const response = await fetch(
-          `http://127.0.0.1:${server.port}/health`,
-        );
+        const response = await fetch(`http://127.0.0.1:${server.port}/health`);
         expect(response.status).toBe(200);
         return performance.now() - started;
       });
@@ -611,6 +605,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
       );
       expect(childEventLookups).toBe(1); // one bulk lookup, never 2,000
       expect(tickMs).toBeLessThan(200);
+      // /health p95 is measured against the stub Bun.serve above: it proves the tick does not block the event loop, not real API latency.
       expect(healthP95).toBeLessThan(500);
 
       childEventLookups = 0;

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -425,6 +425,25 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 14,
+    name: "chain_resolution_indexes",
+    up(db) {
+      const columns = db
+        .query(`PRAGMA table_info(runs)`)
+        .all()
+        .map((row) => row.name);
+      if (!columns.includes("chain_resolved_at")) {
+        db.exec(`ALTER TABLE runs ADD COLUMN chain_resolved_at TEXT;`);
+      }
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_events_causation
+          ON events (causation_id, source);
+        CREATE INDEX IF NOT EXISTS idx_runs_chain_unresolved
+          ON runs (state, chain_resolved_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -130,7 +130,56 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     const db = openDb(file);
     expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
     assertSchema(db);
+    expect(
+      db
+        .query(
+          `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_causation'`,
+        )
+        .get()?.sql,
+    ).toContain("events (causation_id, source)");
     db.close();
+  });
+
+  test("chain lookup indexes migrate idempotently onto an existing v13 database", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    migrateDb(db, { targetVersion: 13 });
+    expect(getSchemaVersion(db)).toBe(13);
+    expect(
+      db
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_causation'`,
+        )
+        .get(),
+    ).toBeNull();
+    db.close();
+
+    const migrated = openDb(file);
+    expect(getSchemaVersion(migrated)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(
+      migrated
+        .query(
+          `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_causation'`,
+        )
+        .get()?.sql,
+    ).toContain("events (causation_id, source)");
+    expect(
+      migrated
+        .query(`PRAGMA table_info(runs)`)
+        .all()
+        .map((row) => row.name),
+    ).toContain("chain_resolved_at");
+
+    // Re-running the idempotent DDL is safe and preserves the index.
+    MIGRATIONS.find((entry) => entry.version === 14).up(migrated);
+    expect(
+      migrated
+        .query(
+          `SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_causation'`,
+        )
+        .get().n,
+    ).toBe(1);
+    migrated.close();
   });
 
   test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1528,10 +1528,13 @@ describe("merge transition chains", () => {
     ]);
 
     // A process interruption after one admission must not suppress the other
-    // three actions when the same accepted result is resolved again.
+    // three actions when the same accepted result is resolved again. The
+    // chain terminal marker is only written after every sibling exists, so an
+    // interrupted pass leaves chain_resolved_at NULL alongside the lone child.
     db.query(
       `DELETE FROM events WHERE source='chain' AND event_id != 'chain-scan-mixed-escalate'`,
     ).run();
+    db.query(`UPDATE runs SET chain_resolved_at = NULL`).run();
     expect(resolveChains(db, registry)).toEqual({
       emitted: 3,
       skipped: 0,


### PR DESCRIPTION
Fixes watt-mind/factory#1197

Review migration 14 and the durable chain-resolution marker; production-shaped coverage on the final rebased commit measures a 58.4 ms tick and 62.4 ms health p95 with one bulk child-event lookup.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/chain.test.mjs event-runtime/lib/db.test.mjs --timeout 20000 && bun run check` | pass | 43 tests, 0 failures; generated-file check passed; tick 58.4 ms, health p95 62.4 ms |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1,733 passed, 0 failures; 10 skipped; 94 generated files matched |
| UX critique          | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend database and chain resolver have no user-facing surface


- Post-review (3d78c288): prettier on chain.test.mjs; benchmark comment notes /health p95 is against a stub Bun.serve (proves the tick does not block the loop, not real API latency). Merged origin/develop.

- Post-review (80e34fb6): chain.test.mjs now imports test-helpers.mjs (pins FACTORY_EVENT_HOME/FACTORY_HOME to an isolated temp home for the file; worker tests previously leaked artifact blobs into ~/.factory/event-runtime/artifacts) and the production-shaped benchmark asserts the real runtime.db mtime is unchanged. Verified with a fake HOME: nothing is created under $HOME/.factory.
