### PR TITLE
sec(cli): control API clients present the operator bearer (#1132)

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -207,9 +207,16 @@ case "$cmd" in
           || (!issue && !pr ? prefix.match(/^(\S+)/) : null);
         if (repo) refs.repo = repo[1];
         try {
+          // #1132: the control API requires the operator bearer when
+          // FACTORY_CONTROL_API_TOKEN is set (#1152); unset means no header.
+          // The value is only ever placed in the header — never printed.
+          const token = process.env.FACTORY_CONTROL_API_TOKEN;
           const response = await fetch(`http://127.0.0.1:${process.env.FACTORY_EVENT_PORT || "7381"}/inbox`, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: {
+              "content-type": "application/json",
+              ...(token ? { authorization: `Bearer ${token}` } : {}),
+            },
             body: JSON.stringify({
               kind,
               title: message,
@@ -217,6 +224,12 @@ case "$cmd" in
               source: process.env.FACTORY_INBOX_SOURCE,
             }),
           });
+          if (response.status === 401) {
+            console.error(token
+              ? "notify: control API rejected FACTORY_CONTROL_API_TOKEN"
+              : "notify: control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env");
+            process.exit(10);
+          }
           if (!response.ok) process.exit(10);
           const body = await response.json();
           // Durable record succeeded; the serve-side notify.py projection did

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -61,6 +61,7 @@ function runNotify({ args, stdin = "", exitCode = "0", env = {} }) {
 async function withInboxStub(response, fn) {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-inbox-server-"));
   const requestFile = path.join(dir, "request.json");
+  const headersFile = path.join(dir, "headers.json");
   const serverScript = path.join(dir, "server.py");
   writeFileSync(
     serverScript,
@@ -72,6 +73,8 @@ class Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length", "0"))
         with open(${JSON.stringify(requestFile)}, "w") as f:
             f.write(self.rfile.read(length).decode())
+        with open(${JSON.stringify(headersFile)}, "w") as f:
+            f.write(json.dumps({k.lower(): v for k, v in self.headers.items()}))
         body = json.dumps(json.loads(${JSON.stringify(JSON.stringify(response))})).encode()
         self.send_response(201)
         self.send_header("content-type", "application/json")
@@ -93,7 +96,7 @@ server.handle_request()
   const { value } = await reader.read();
   const port = Number(new TextDecoder().decode(value).trim());
   try {
-    return await fn({ port, requestFile });
+    return await fn({ port, requestFile, headersFile });
   } finally {
     server.kill();
     await server.exited;
@@ -145,6 +148,56 @@ test("factory notify posts a structured inbox item when serve is reachable", asy
           refs: { issue: "WM-1" },
           source: "agent:run_test",
         });
+      } finally {
+        result.cleanup();
+      }
+    },
+  );
+});
+
+// #1132: the durable /inbox POST must present the operator credential when
+// FACTORY_CONTROL_API_TOKEN is configured (#1152), and stay header-free when
+// it is not. Note that runNotify spreads process.env, so the unset case has to
+// override any token the operator's shell carries.
+test("factory notify sends the bearer on /inbox when FACTORY_CONTROL_API_TOKEN is set", async () => {
+  const token = "notify-test-token-1132";
+  await withInboxStub(
+    { delivery: { ok: true } },
+    async ({ port, headersFile }) => {
+      const result = runNotify({
+        args: ["BLOCKED", "WM-1:", "choose policy"],
+        env: {
+          FACTORY_EVENT_PORT: String(port),
+          FACTORY_CONTROL_API_TOKEN: token,
+        },
+      });
+      try {
+        expect(result.status).toBe(0);
+        const headers = JSON.parse(readFileSync(headersFile, "utf8"));
+        expect(headers.authorization).toBe(`Bearer ${token}`);
+        expect(result.stderr).not.toContain(token);
+      } finally {
+        result.cleanup();
+      }
+    },
+  );
+});
+
+test("factory notify sends no authorization header when FACTORY_CONTROL_API_TOKEN is unset", async () => {
+  await withInboxStub(
+    { delivery: { ok: true } },
+    async ({ port, headersFile }) => {
+      const result = runNotify({
+        args: ["BLOCKED", "WM-1:", "choose policy"],
+        env: {
+          FACTORY_EVENT_PORT: String(port),
+          FACTORY_CONTROL_API_TOKEN: "",
+        },
+      });
+      try {
+        expect(result.status).toBe(0);
+        const headers = JSON.parse(readFileSync(headersFile, "utf8"));
+        expect(headers.authorization).toBeUndefined();
       } finally {
         result.cleanup();
       }

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -240,6 +240,7 @@ try {
     console.error(`seed: ${err.message}`);
     process.exit(1);
   }
+  throw err;
 }
 
 // Guard: never seed a real-adapter runtime. The adapter lands in each spec at

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -230,6 +230,18 @@ if (!health) {
   process.exit(1);
 }
 
+// GET /health is bearer-exempt, so the credential is only checked on the
+// first privileged call. Probe it here to fail with an actionable message
+// (which variable, which file) instead of a stack trace mid-seed (#1132).
+try {
+  await client.runs();
+} catch (err) {
+  if (err.status === 401) {
+    console.error(`seed: ${err.message}`);
+    process.exit(1);
+  }
+}
+
 // Guard: never seed a real-adapter runtime. The adapter lands in each spec at
 // planning time, so probe with a throwaway event and inspect its proposal.
 const probeId = `${prefix}-adapter-probe`;

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -52,6 +52,7 @@ try {
     console.error(`verify: ${err.message}`);
     process.exit(1);
   }
+  throw err;
 }
 check("GET /health reports ok: true", health.ok === true);
 check("runtime is in fake adapter mode", health.env?.adapter === "fake");

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -43,6 +43,16 @@ if (!health) {
   console.error(`verify: no control API on 127.0.0.1:${port}`);
   process.exit(1);
 }
+// GET /health is bearer-exempt; the credential is first checked on a
+// privileged route. Probe it so a 401 prints which variable to set (#1132).
+try {
+  await client.runs();
+} catch (err) {
+  if (err.status === 401) {
+    console.error(`verify: ${err.message}`);
+    process.exit(1);
+  }
+}
 check("GET /health reports ok: true", health.ok === true);
 check("runtime is in fake adapter mode", health.env?.adapter === "fake");
 

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -9,6 +9,17 @@
  */
 import { API_HOST, DEFAULT_PORT } from "./config.mjs";
 
+/**
+ * Actionable text for a control-API 401 (#1132). Names the variable and the
+ * file the operator has to touch, and never the credential itself — the
+ * message reaches stderr, transcripts and PR bodies.
+ */
+export function unauthorizedMessage(tokenPresent) {
+  return tokenPresent
+    ? "control API rejected FACTORY_CONTROL_API_TOKEN"
+    : "control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env";
+}
+
 export function apiClient({
   port = DEFAULT_PORT,
   host = API_HOST,
@@ -40,10 +51,12 @@ export function apiClient({
     }
     if (!res.ok) {
       const message =
-        json?.error ??
-        (Array.isArray(json?.errors)
-          ? json.errors.join("; ")
-          : `HTTP ${res.status}`);
+        res.status === 401
+          ? unauthorizedMessage(Boolean(token))
+          : (json?.error ??
+            (Array.isArray(json?.errors)
+              ? json.errors.join("; ")
+              : `HTTP ${res.status}`));
       const err = new Error(message);
       err.status = res.status;
       err.body = json;

--- a/event-runtime/lib/client.test.mjs
+++ b/event-runtime/lib/client.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * apiClient() credential handling (#1132, follow-up to #1152/#956): the bearer
+ * goes on the wire when a token is configured, stays off when it is not, and a
+ * 401 comes back as an actionable message that never carries the token value.
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { apiClient, unauthorizedMessage } from "./client.mjs";
+
+const TOKEN = "test-secret-token-1132";
+let server;
+let port;
+let lastAuthorization;
+
+beforeAll(() => {
+  server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      lastAuthorization = req.headers.get("authorization");
+      if (url.pathname === "/health") {
+        return Response.json({ ok: true });
+      }
+      if (url.pathname === "/runs") {
+        if (lastAuthorization !== `Bearer ${TOKEN}`) {
+          return Response.json({ error: "unauthorized" }, { status: 401 });
+        }
+        return Response.json({ runs: [] });
+      }
+      return Response.json({ error: "not found" }, { status: 404 });
+    },
+  });
+  port = server.port;
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+test("sends the bearer when a token is passed", async () => {
+  const client = apiClient({ port, token: TOKEN });
+  lastAuthorization = undefined;
+  await expect(client.runs()).resolves.toEqual({ runs: [] });
+  expect(lastAuthorization).toBe(`Bearer ${TOKEN}`);
+});
+
+test("sends no authorization header when the token is unset", async () => {
+  const client = apiClient({ port, token: null });
+  lastAuthorization = undefined;
+  await client.health();
+  expect(lastAuthorization).toBeNull();
+});
+
+test("401 without a token maps to the actionable message", async () => {
+  const client = apiClient({ port, token: null });
+  let err;
+  await client.runs().catch((e) => (err = e));
+  expect(err).toBeInstanceOf(Error);
+  expect(err.status).toBe(401);
+  expect(err.message).toBe(
+    "control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env",
+  );
+  expect(err.message).toBe(unauthorizedMessage(false));
+});
+
+test("401 with a rejected token names the variable, never the value", async () => {
+  const wrong = "wrong-token-value-1132";
+  const client = apiClient({ port, token: wrong });
+  let err;
+  await client.runs().catch((e) => (err = e));
+  expect(err.status).toBe(401);
+  expect(err.message).toBe("control API rejected FACTORY_CONTROL_API_TOKEN");
+  expect(err.message).toBe(unauthorizedMessage(true));
+  expect(err.message).not.toContain(wrong);
+  expect(String(err.stack)).not.toContain(wrong);
+});
+
+test("non-401 errors keep the server's message and status", async () => {
+  const client = apiClient({ port, token: TOKEN });
+  let err;
+  await client.repos().catch((e) => (err = e));
+  expect(err.status).toBe(404);
+  expect(err.message).toBe("not found");
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1132

## Summary

Follow-up to #1152 / #956: the last control-API clients that did not present the operator credential now do, and a `401` is actionable instead of bare.

- **`bin/factory notify`**: the direct `/inbox` POST sends `Authorization: Bearer <FACTORY_CONTROL_API_TOKEN>` when the variable is set and no `authorization` header when it is unset (pre-token behaviour preserved). A `401` prints which variable/file to set on stderr before the existing exit 10.
- **`event-runtime/lib/client.mjs`**: `apiClient()` maps a `401` to `control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env` (token unset) or `control API rejected FACTORY_CONTROL_API_TOKEN` (token set but rejected). `.status = 401` kept; the token value is never part of the message. New exported `unauthorizedMessage(tokenPresent)`.
- **`event-runtime/demo/seed.mjs` / `verify.mjs`**: `GET /health` is bearer-exempt, so both now probe `GET /runs` right after the health check and exit 1 with the same message instead of an unhandled-rejection stack trace mid-run.
- **Tests**: new `event-runtime/lib/client.test.mjs` (Bun.serve stub: bearer present, header absent, 401 mapping, token absent from message/stack, non-401 passthrough); `bin/factory.test.mjs` stub inbox now records request headers and covers notify with and without the token.

`event-runtime/web/src/api.ts` untouched — the serve proxy owns the bearer (#1152 design).

## Handoff

**Verification**

```
bun test event-runtime/lib/client.test.mjs event-runtime/lib/api.test.mjs bin/factory.test.mjs --timeout 20000 && bun run check
 37 pass / 0 fail / 227 expect() calls (3 files)
bun run check: exit 0 (emits a pre-existing "floor delivery stale" note about the operator's live checkout, unrelated to this branch)
prettier --check on all changed files: clean
```

Diff grep for `token` in `console.*`/stderr paths: only `console.error(token ? A : B)` (boolean branch, never the value) and the test asserting stderr does **not** contain it.

**UX critique**: not applicable — CLI/library change, no user-completable UI journey.

**File scope** (all within Owned Paths): `bin/factory`, `bin/factory.test.mjs`, `event-runtime/lib/client.mjs`, `event-runtime/lib/client.test.mjs`, `event-runtime/demo/seed.mjs`, `event-runtime/demo/verify.mjs`.

**Risks**
- `notify` 401 now writes one line to stderr before exit 10; previously silent. Exit code unchanged, so shell callers are unaffected.
- The demo scripts issue one extra `GET /runs` at startup; harmless on a fake-adapter runtime.
- `bin/factory.test.mjs` bearer tests spread `process.env`, so the "unset" case explicitly overrides `FACTORY_CONTROL_API_TOKEN=""` to stay deterministic on the operator box where the variable is exported.


**Post-review** (13161cf6): the `GET /runs` bearer probe in `event-runtime/demo/seed.mjs` and `event-runtime/demo/verify.mjs` now rethrows non-401 errors instead of swallowing them (`throw err;` after the 401 branch). Re-ran the Verification Command (37 pass / 0 fail), `bun run check` exit 0, prettier clean. Branch merged with `origin/develop` (82d88425) before the fix.
