### PR TITLE
feat(event-runtime): BlockRenderer + `inspect` text rendering; triage-scan presentation pilot (#833)

### DIFF
--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -18,7 +18,7 @@
   "limits": { "timeout_seconds": 900, "attempts": 1 },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:4cd1792187f1009b047b2634ab01e233e6757a6c2bb0ed331ef04cd1be076823",
+    "agents/triage-scan.md": "sha256:464b324d2a2ef543542f6c1aa99de833dc48e933610856c9907b0cfe37cfe0ec",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:7f9776d3e3c99cd59beb04a04fc15286bf63ecf33c1f790152c55b5a29ef8bcb"
   }

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -15,13 +15,10 @@
     "filesystem": "workspace-only",
     "services": ["tracker:read", "repo:read"]
   },
-  "limits": {
-    "timeout_seconds": 900,
-    "attempts": 1
-  },
+  "limits": { "timeout_seconds": 900, "attempts": 1 },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:cc255d038a3ce53dc85af4f63f83116c52ea87593b93ced93399478bd53f3d98",
+    "agents/triage-scan.md": "sha256:4cd1792187f1009b047b2634ab01e233e6757a6c2bb0ed331ef04cd1be076823",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:7f9776d3e3c99cd59beb04a04fc15286bf63ecf33c1f790152c55b5a29ef8bcb"
   }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -219,7 +219,7 @@ Worked example, based on the contract sample:
     "blocks": [
       {
         "type": "heading",
-        "text": "58 issues in Triage; 14 can be made agent-ready today"
+        "text": "The backlog has a concrete path forward"
       },
       {
         "type": "keyvalue",
@@ -228,11 +228,6 @@ Worked example, based on the contract sample:
             "label": "Recommendation",
             "value": { "$ref": "/recommendation" },
             "format": "state"
-          },
-          {
-            "label": "Issues seen",
-            "value": { "$ref": "/evidence/issuesSeen" },
-            "format": "count"
           }
         ]
       },
@@ -241,8 +236,8 @@ Worked example, based on the contract sample:
         "label": "Needs a human",
         "items": [
           {
-            "text": "WM-312 — production infra; incompatible deploy paths",
-            "ref": "/plan/7",
+            "text": "The first plan item needs operator attention",
+            "ref": "/plan/0",
             "tone": "warn"
           }
         ]

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -197,6 +197,72 @@ headings above, check lexical ordering and unique identifiers, and check
 validly, replace it with a valid `needs-detail` or `needs-human` decision rather
 than emitting a best-effort malformed item.
 
+## Optional presentation
+
+This human-facing scan is the presentation pilot. Add a `presentation` beside
+`artifact` using `factory.presentation/v1`.
+
+- Lead with the one-sentence finding as a `heading`.
+- Put every number, identifier, and verdict the reader should trust behind a
+  `$ref` into `artifact`; literal prose is interpretation, not evidence.
+- Use a toned `list` for the items that need attention.
+- Put method and caveats in a collapsed `section`.
+- Stay under 40 blocks and 16 KiB, and never nest sections.
+- Do not restate the whole artifact; its schema-derived view appears below.
+
+Worked example, based on the contract sample:
+
+```json
+{
+  "presentation": {
+    "schemaVersion": "factory.presentation/v1",
+    "blocks": [
+      {
+        "type": "heading",
+        "text": "58 issues in Triage; 14 can be made agent-ready today"
+      },
+      {
+        "type": "keyvalue",
+        "items": [
+          {
+            "label": "Recommendation",
+            "value": { "$ref": "/recommendation" },
+            "format": "state"
+          },
+          {
+            "label": "Issues seen",
+            "value": { "$ref": "/evidence/issuesSeen" },
+            "format": "count"
+          }
+        ]
+      },
+      {
+        "type": "list",
+        "label": "Needs a human",
+        "items": [
+          {
+            "text": "WM-312 — production infra; incompatible deploy paths",
+            "ref": "/plan/7",
+            "tone": "warn"
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "label": "Method",
+        "collapsed": true,
+        "blocks": [
+          {
+            "type": "markdown",
+            "text": "Complete, lexically sorted scan of Triage and Todo."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## Output
 
 ````json

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -385,10 +385,7 @@ export async function inspectWithPresentation(args) {
   const extra = [];
   if (detail?.result?.presentation) {
     const rendered = renderText(
-      resolveRefs(
-        detail.result.presentation,
-        detail.result.artifact ?? {},
-      ),
+      resolveRefs(detail.result.presentation, detail.result.artifact ?? {}),
       { width: Math.max(40, Number(process.stdout.columns ?? 80) - 2) },
     );
     extra.push("  presentation");

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -16,6 +16,8 @@ import {
 } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
+import { resolveRefs } from "./lib/presentation.mjs";
+import { renderText } from "./lib/presentation-text.mjs";
 import {
   contributionCounts,
   formatContributionCounts,
@@ -361,6 +363,56 @@ export function initCommand(args = []) {
   return results;
 }
 
+/** Add optional Layer B text to the split inspect command, before its artifact. */
+export async function inspectWithPresentation(args) {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...values) => lines.push(values.join(" "));
+  try {
+    await COMMANDS.inspect(args);
+  } finally {
+    console.log = originalLog;
+  }
+
+  let detail = null;
+  if (args[0]) {
+    try {
+      detail = await callControl("GET", `/runs/${encodeURIComponent(args[0])}`);
+    } catch {
+      // Inspect already produced the useful ground truth; presentation is garnish.
+    }
+  }
+  const extra = [];
+  if (detail?.result?.presentation) {
+    const rendered = renderText(
+      resolveRefs(
+        detail.result.presentation,
+        detail.result.artifact ?? {},
+      ),
+      { width: Math.max(40, Number(process.stdout.columns ?? 80) - 2) },
+    );
+    extra.push("  presentation");
+    for (const line of rendered.split("\n")) extra.push(`  ${line}`);
+  } else if (detail?.result?.presentationErrors?.length) {
+    const errors = detail.result.presentationErrors;
+    extra.push(`  the agent's summary was dropped: ${errors.length} errors`);
+    for (const error of errors) extra.push(`    - ${error}`);
+  }
+
+  if (extra.length > 0) {
+    const artifactAt = lines.findIndex((line) => /^  artifact /.test(line));
+    const resultAt = lines.findIndex((line) => line === "result");
+    const at =
+      artifactAt >= 0
+        ? artifactAt
+        : resultAt >= 0
+          ? resultAt + 1
+          : lines.length;
+    lines.splice(at, 0, ...extra);
+  }
+  for (const line of lines) originalLog(line);
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
   if (command === "init") return initCommand(args);
@@ -370,6 +422,7 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "extensions") return extensionsCommand(args);
   if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);
+  if (command === "inspect") return inspectWithPresentation(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -404,7 +404,7 @@ export async function inspectWithPresentation(args) {
   }
 
   if (extra.length > 0) {
-    const artifactAt = lines.findIndex((line) => /^  artifact /.test(line));
+    const artifactAt = lines.findIndex((line) => /^ {2}artifact /.test(line));
     const resultAt = lines.findIndex((line) => line.trim() === "result");
     const at =
       artifactAt >= 0

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -386,7 +386,7 @@ export async function inspectWithPresentation(args) {
   if (detail?.result?.presentation) {
     const rendered = renderText(
       resolveRefs(detail.result.presentation, detail.result.artifact ?? {}),
-      { width: Math.max(40, Number(process.stdout.columns ?? 80) - 2) },
+      { width: Math.max(20, Number(process.stdout.columns ?? 80) - 2) },
     );
     extra.push("  presentation");
     for (const line of rendered.split("\n")) extra.push(`  ${line}`);

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -384,12 +384,19 @@ export async function inspectWithPresentation(args) {
   }
   const extra = [];
   if (detail?.result?.presentation) {
-    const rendered = renderText(
-      resolveRefs(detail.result.presentation, detail.result.artifact ?? {}),
-      { width: Math.max(20, Number(process.stdout.columns ?? 80) - 2) },
-    );
-    extra.push("  presentation");
-    for (const line of rendered.split("\n")) extra.push(`  ${line}`);
+    try {
+      const rendered = renderText(
+        resolveRefs(detail.result.presentation, detail.result.artifact ?? {}),
+        { width: Math.max(20, Number(process.stdout.columns ?? 80) - 2) },
+      );
+      extra.push("  presentation");
+      for (const line of rendered.split("\n")) extra.push(`  ${line}`);
+    } catch (error) {
+      // Garnish must never mask the buffered inspect output.
+      console.warn(
+        `warning: presentation not rendered: ${error?.message ?? error}`,
+      );
+    }
   } else if (detail?.result?.presentationErrors?.length) {
     const errors = detail.result.presentationErrors;
     extra.push(`  the agent's summary was dropped: ${errors.length} errors`);
@@ -398,7 +405,7 @@ export async function inspectWithPresentation(args) {
 
   if (extra.length > 0) {
     const artifactAt = lines.findIndex((line) => /^  artifact /.test(line));
-    const resultAt = lines.findIndex((line) => line === "result");
+    const resultAt = lines.findIndex((line) => line.trim() === "result");
     const at =
       artifactAt >= 0
         ? artifactAt

--- a/event-runtime/lib/presentation-text.mjs
+++ b/event-runtime/lib/presentation-text.mjs
@@ -46,22 +46,30 @@ function tableLines(block, width) {
       Math.max(...rows.map((row) => String(row[column] ?? "").length)),
     ),
   );
-  const crop = (value, column) => {
+  const wrap = (value, column) => {
     const raw = String(value ?? "");
     const limit = widths[column];
-    return raw.length <= limit
-      ? raw
-      : `${raw.slice(0, Math.max(1, limit - 1))}…`;
+    if (!raw) return [""];
+    const chunks = [];
+    for (let start = 0; start < raw.length; start += limit) {
+      chunks.push(raw.slice(start, start + limit));
+    }
+    return chunks;
   };
-  const line = (row) =>
-    row
-      .map((cell, column) => crop(cell, column).padEnd(widths[column]))
-      .join(" | ")
-      .trimEnd();
+  const lines = (row) => {
+    const cells = row.map(wrap);
+    const height = Math.max(...cells.map((cell) => cell.length));
+    return Array.from({ length: height }, (_, physicalRow) =>
+      cells
+        .map((cell, column) => (cell[physicalRow] ?? "").padEnd(widths[column]))
+        .join(" | ")
+        .trimEnd(),
+    );
+  };
   return [
-    line(block.columns),
+    ...lines(block.columns),
     widths.map((n) => "-".repeat(n)).join("-+-"),
-    ...block.rows.map((row) => line(row.map(text))),
+    ...block.rows.flatMap((row) => lines(row.map(text))),
   ];
 }
 

--- a/event-runtime/lib/presentation-text.mjs
+++ b/event-runtime/lib/presentation-text.mjs
@@ -24,7 +24,8 @@ const sourceValue = (value) =>
 
 const text = (value) => {
   const resolved = sourceValue(value);
-  if (resolved === undefined || resolved === null || resolved === "") return "—";
+  if (resolved === undefined || resolved === null || resolved === "")
+    return "—";
   if (typeof resolved === "string") return resolved;
   if (["number", "boolean"].includes(typeof resolved)) return String(resolved);
   return JSON.stringify(resolved);
@@ -40,16 +41,28 @@ function tableLines(block, width) {
   const available = Math.max(8, width - (block.columns.length - 1) * 3);
   const maxCell = Math.max(4, Math.floor(available / block.columns.length));
   const widths = block.columns.map((_, column) =>
-    Math.min(maxCell, Math.max(...rows.map((row) => String(row[column] ?? "").length))),
+    Math.min(
+      maxCell,
+      Math.max(...rows.map((row) => String(row[column] ?? "").length)),
+    ),
   );
   const crop = (value, column) => {
     const raw = String(value ?? "");
     const limit = widths[column];
-    return raw.length <= limit ? raw : `${raw.slice(0, Math.max(1, limit - 1))}…`;
+    return raw.length <= limit
+      ? raw
+      : `${raw.slice(0, Math.max(1, limit - 1))}…`;
   };
   const line = (row) =>
-    row.map((cell, column) => crop(cell, column).padEnd(widths[column])).join(" | ").trimEnd();
-  return [line(block.columns), widths.map((n) => "-".repeat(n)).join("-+-"), ...block.rows.map((row) => line(row.map(text)))];
+    row
+      .map((cell, column) => crop(cell, column).padEnd(widths[column]))
+      .join(" | ")
+      .trimEnd();
+  return [
+    line(block.columns),
+    widths.map((n) => "-".repeat(n)).join("-+-"),
+    ...block.rows.map((row) => line(row.map(text))),
+  ];
 }
 
 function renderBlock(block, width) {
@@ -63,14 +76,21 @@ function renderBlock(block, width) {
     case "list":
       return [
         ...(block.label ? [block.label] : []),
-        ...block.items.map((item) => `${GLYPHS[item.tone ?? "neutral"]} ${item.text}`),
+        ...block.items.map(
+          (item) => `${GLYPHS[item.tone ?? "neutral"]} ${item.text}`,
+        ),
       ];
     case "table":
-      return [...(block.label ? [block.label] : []), ...tableLines(block, width)];
+      return [
+        ...(block.label ? [block.label] : []),
+        ...tableLines(block, width),
+      ];
     case "badge":
       return [`${GLYPHS[block.tone] ?? "•"} ${block.text}`];
     case "code":
-      return String(block.text).split("\n").map((line) => `    ${line}`);
+      return String(block.text)
+        .split("\n")
+        .map((line) => `    ${line}`);
     case "section": {
       const children = block.blocks.flatMap((child, index) => [
         ...(index ? [""] : []),
@@ -81,7 +101,8 @@ function renderBlock(block, width) {
     case "links":
       return block.items.map((item) => {
         const key = ["issue", "pr", "run", "url"].find(
-          (candidate) => item[candidate] !== undefined && item[candidate] !== null,
+          (candidate) =>
+            item[candidate] !== undefined && item[candidate] !== null,
         );
         return `${item.label} <${key ? text(item[key]) : "—"}>`;
       });
@@ -92,7 +113,9 @@ function renderBlock(block, width) {
 
 /** Linearise a validated (optionally reference-resolved) presentation. */
 export function renderText(presentation, { width = 80 } = {}) {
-  const lineWidth = Number.isFinite(width) ? Math.max(20, Math.floor(width)) : 80;
+  const lineWidth = Number.isFinite(width)
+    ? Math.max(20, Math.floor(width))
+    : 80;
   if (!presentation || !Array.isArray(presentation.blocks)) return "";
   return presentation.blocks
     .flatMap((block, index) => [

--- a/event-runtime/lib/presentation-text.mjs
+++ b/event-runtime/lib/presentation-text.mjs
@@ -1,0 +1,103 @@
+/** Plain-text renderer for `factory.presentation/v1` (design §3.4). */
+
+const GLYPHS = {
+  ok: "✓",
+  warn: "!",
+  error: "×",
+  muted: "·",
+  neutral: "•",
+};
+
+const sourceValue = (value) =>
+  value &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  Object.hasOwn(value, "value") &&
+  typeof value.ref === "string"
+    ? value.value
+    : value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        typeof value.$ref === "string"
+      ? value.$ref
+      : value;
+
+const text = (value) => {
+  const resolved = sourceValue(value);
+  if (resolved === undefined || resolved === null || resolved === "") return "—";
+  if (typeof resolved === "string") return resolved;
+  if (["number", "boolean"].includes(typeof resolved)) return String(resolved);
+  return JSON.stringify(resolved);
+};
+
+const indent = (lines, spaces) => {
+  const prefix = " ".repeat(spaces);
+  return lines.map((line) => `${prefix}${line}`);
+};
+
+function tableLines(block, width) {
+  const rows = [block.columns, ...block.rows.map((row) => row.map(text))];
+  const available = Math.max(8, width - (block.columns.length - 1) * 3);
+  const maxCell = Math.max(4, Math.floor(available / block.columns.length));
+  const widths = block.columns.map((_, column) =>
+    Math.min(maxCell, Math.max(...rows.map((row) => String(row[column] ?? "").length))),
+  );
+  const crop = (value, column) => {
+    const raw = String(value ?? "");
+    const limit = widths[column];
+    return raw.length <= limit ? raw : `${raw.slice(0, Math.max(1, limit - 1))}…`;
+  };
+  const line = (row) =>
+    row.map((cell, column) => crop(cell, column).padEnd(widths[column])).join(" | ").trimEnd();
+  return [line(block.columns), widths.map((n) => "-".repeat(n)).join("-+-"), ...block.rows.map((row) => line(row.map(text)))];
+}
+
+function renderBlock(block, width) {
+  switch (block.type) {
+    case "heading":
+      return [`# ${block.text}`];
+    case "markdown":
+      return String(block.text).split("\n");
+    case "keyvalue":
+      return block.items.map((item) => `${item.label}: ${text(item.value)}`);
+    case "list":
+      return [
+        ...(block.label ? [block.label] : []),
+        ...block.items.map((item) => `${GLYPHS[item.tone ?? "neutral"]} ${item.text}`),
+      ];
+    case "table":
+      return [...(block.label ? [block.label] : []), ...tableLines(block, width)];
+    case "badge":
+      return [`${GLYPHS[block.tone] ?? "•"} ${block.text}`];
+    case "code":
+      return String(block.text).split("\n").map((line) => `    ${line}`);
+    case "section": {
+      const children = block.blocks.flatMap((child, index) => [
+        ...(index ? [""] : []),
+        ...renderBlock(child, Math.max(20, width - 2)),
+      ]);
+      return [`${block.label}:`, ...indent(children, 2)];
+    }
+    case "links":
+      return block.items.map((item) => {
+        const key = ["issue", "pr", "run", "url"].find(
+          (candidate) => item[candidate] !== undefined && item[candidate] !== null,
+        );
+        return `${item.label} <${key ? text(item[key]) : "—"}>`;
+      });
+    default:
+      return [];
+  }
+}
+
+/** Linearise a validated (optionally reference-resolved) presentation. */
+export function renderText(presentation, { width = 80 } = {}) {
+  const lineWidth = Number.isFinite(width) ? Math.max(20, Math.floor(width)) : 80;
+  if (!presentation || !Array.isArray(presentation.blocks)) return "";
+  return presentation.blocks
+    .flatMap((block, index) => [
+      ...(index ? [""] : []),
+      ...renderBlock(block, lineWidth),
+    ])
+    .join("\n");
+}

--- a/event-runtime/lib/presentation-text.test.mjs
+++ b/event-runtime/lib/presentation-text.test.mjs
@@ -4,13 +4,20 @@ import { resolveRefs } from "./presentation.mjs";
 import { renderText } from "./presentation-text.mjs";
 
 const fixture = JSON.parse(
-  readFileSync(new URL("./fixtures/presentation-cases.json", import.meta.url), "utf8"),
+  readFileSync(
+    new URL("./fixtures/presentation-cases.json", import.meta.url),
+    "utf8",
+  ),
 );
 
 describe("renderText", () => {
   test("snapshots every fixture block as bounded plain text", () => {
-    const presentation = resolveRefs(fixture.cases[0].presentation, fixture.artifact);
-    expect(renderText(presentation, { width: 60 })).toBe(`# 58 issues in Triage; 14 can be made agent-ready today
+    const presentation = resolveRefs(
+      fixture.cases[0].presentation,
+      fixture.artifact,
+    );
+    expect(renderText(presentation, { width: 60 }))
+      .toBe(`# 58 issues in Triage; 14 can be made agent-ready today
 
 Most of the backlog is under-specified rather than wrong.
 
@@ -51,6 +58,8 @@ Repo <https://github.com/watt-mind/factory>`);
       },
       { width: 24 },
     );
-    expect(Math.max(...output.split("\n").map((line) => line.length))).toBeLessThanOrEqual(24);
+    expect(
+      Math.max(...output.split("\n").map((line) => line.length)),
+    ).toBeLessThanOrEqual(24);
   });
 });

--- a/event-runtime/lib/presentation-text.test.mjs
+++ b/event-runtime/lib/presentation-text.test.mjs
@@ -61,5 +61,7 @@ Repo <https://github.com/watt-mind/factory>`);
     expect(
       Math.max(...output.split("\n").map((line) => line.length)),
     ).toBeLessThanOrEqual(24);
+    expect(output.replaceAll(/\s|\|/g, "")).toContain("averylongvalue");
+    expect(output.replaceAll(/\s|\|/g, "")).toContain("anotherlongvalue");
   });
 });

--- a/event-runtime/lib/presentation-text.test.mjs
+++ b/event-runtime/lib/presentation-text.test.mjs
@@ -61,7 +61,12 @@ Repo <https://github.com/watt-mind/factory>`);
     expect(
       Math.max(...output.split("\n").map((line) => line.length)),
     ).toBeLessThanOrEqual(24);
-    expect(output.replaceAll(/\s|\|/g, "")).toContain("averylongvalue");
-    expect(output.replaceAll(/\s|\|/g, "")).toContain("anotherlongvalue");
+    const physicalRows = output.split("\n").slice(2);
+    expect(physicalRows.map((line) => line.split("|")[0].trim()).join("")).toBe(
+      "a very long value",
+    );
+    expect(physicalRows.map((line) => line.split("|")[1].trim()).join("")).toBe(
+      "another long value",
+    );
   });
 });

--- a/event-runtime/lib/presentation-text.test.mjs
+++ b/event-runtime/lib/presentation-text.test.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolveRefs } from "./presentation.mjs";
+import { renderText } from "./presentation-text.mjs";
+
+const fixture = JSON.parse(
+  readFileSync(new URL("./fixtures/presentation-cases.json", import.meta.url), "utf8"),
+);
+
+describe("renderText", () => {
+  test("snapshots every fixture block as bounded plain text", () => {
+    const presentation = resolveRefs(fixture.cases[0].presentation, fixture.artifact);
+    expect(renderText(presentation, { width: 60 })).toBe(`# 58 issues in Triage; 14 can be made agent-ready today
+
+Most of the backlog is under-specified rather than wrong.
+
+Recommendation: DISPATCH
+Issues seen: 58
+Note: computed by hand
+
+Needs a human
+! WM-312 — production infra; incompatible deploy paths
+! WM-336 — tool allowlist; wants a security owner
+
+Duplicates
+Issue  | Duplicate of
+-------+-------------
+WM-201 | WM-201
+WM-118 | WM-118
+
+✓ DISPATCH
+
+    { "ok": true }
+
+Method:
+  How this was computed.
+
+Repo <https://github.com/watt-mind/factory>`);
+  });
+
+  test("honours the width when aligning long table cells", () => {
+    const output = renderText(
+      {
+        blocks: [
+          {
+            type: "table",
+            columns: ["A", "B"],
+            rows: [["a very long value", "another long value"]],
+          },
+        ],
+      },
+      { width: 24 },
+    );
+    expect(Math.max(...output.split("\n").map((line) => line.length))).toBeLessThanOrEqual(24);
+  });
+});

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -297,8 +297,13 @@ describe("registry", () => {
     // adversarial gate-skipping directives to the blocking security-finding
     // ESCALATE behavior. Prompt text and its pin only — no schema, contract,
     // route, capability, or model tier changed.
+    // Regenerated (#833): triage-scan.md gains the shared presentation brief
+    // section plus one worked example, so the agent authors a
+    // `result.presentation` document (Layer B pilot); triage-scan.json is
+    // re-pinned. Prompt text and its pin only — no schema, contract, route,
+    // capability, or model tier changed.
     const expected =
-      "sha256:83e5c34c4b2312efbac585f811c8bc5425a8d179c539c11295e98bedacd3c1f4";
+      "sha256:91a5c728b78852bfe450a71eebddd87a17231e43dbe739c0b590de81cfda34ab";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/web/src/components/BlockRenderer.test.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.test.tsx
@@ -1,0 +1,49 @@
+import "../test-dom";
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { Presentation } from "../types";
+import { BlockRenderer, PresentationPanel } from "./BlockRenderer";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const presentation: Presentation = {
+  schemaVersion: "factory.presentation/v1",
+  blocks: [
+    { type: "heading", text: "Finding" },
+    { type: "markdown", text: "Interpretation" },
+    { type: "keyvalue", items: [{ label: "Count", value: { $ref: "/count" }, format: "count" }] },
+    { type: "list", label: "Attention", items: [{ text: "Review this", ref: "/issue", tone: "warn" }] },
+    { type: "table", label: "Rows", columns: ["Issue"], rows: [[{ $ref: "/issue" }]], formats: ["issue"] },
+    { type: "badge", text: "SHIP", tone: "ok" },
+    { type: "code", language: "json", text: "{}" },
+    { type: "section", label: "Method", collapsed: true, blocks: [{ type: "markdown", text: "Details" }] },
+    { type: "links", items: [{ label: "Run", run: { $ref: "/run" } }] },
+  ],
+};
+const artifact = { count: 1200, issue: "WM-12", run: "run_1234567890" };
+
+test("renders every block and exposes resolved sources", () => {
+  const view = render(<BlockRenderer presentation={presentation} artifact={artifact} />);
+  expect(view.getByText("Finding")).toBeTruthy();
+  expect(view.getByText("Interpretation")).toBeTruthy();
+  expect(
+    view.getByText("1,200").closest("[data-presentation-source]")?.getAttribute("title"),
+  ).toBe("Source: /count");
+  expect(view.getByText("!")).toBeTruthy();
+  expect(view.getAllByText("WM-12").length).toBeGreaterThan(0);
+  expect(view.getByText("SHIP")).toBeTruthy();
+  expect(view.getByText("{}")).toBeTruthy();
+  const method = view.getByText("Method").closest("details");
+  expect(method?.open).toBe(false);
+  expect(view.getByText("run_12345678")).toBeTruthy();
+});
+
+test("presentation owns an independent raw toggle", () => {
+  const view = render(<PresentationPanel presentation={presentation} artifact={artifact} />);
+  fireEvent.click(view.getByText("Raw"));
+  expect(view.container.querySelector("[data-presentation-view]")).toBeNull();
+  expect(view.getByText("View")).toBeTruthy();
+});

--- a/event-runtime/web/src/components/BlockRenderer.test.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.test.tsx
@@ -72,3 +72,31 @@ test("presentation owns an independent raw toggle", () => {
   expect(view.container.querySelector("[data-presentation-view]")).toBeNull();
   expect(view.getByText("View")).toBeTruthy();
 });
+
+test("rejects a malformed client document without throwing", () => {
+  const view = render(
+    <PresentationPanel
+      presentation={
+        {
+          schemaVersion: "factory.presentation/v1",
+          blocks: [{ type: "list", items: "not-an-array" }],
+        } as unknown as Presentation
+      }
+      artifact={artifact}
+    />,
+  );
+  expect(
+    view.getByText("the agent's summary was dropped: 1 errors"),
+  ).toBeTruthy();
+  expect(view.queryByText("Raw")).toBeNull();
+});
+
+test("run chips preserve the active project context", () => {
+  window.location.hash = "#/runs?project=factory";
+  const view = render(
+    <BlockRenderer presentation={presentation} artifact={artifact} />,
+  );
+  expect(
+    view.getByText("run_12345678").closest("a")?.getAttribute("href"),
+  ).toBe("#/runs/run_1234567890?project=factory");
+});

--- a/event-runtime/web/src/components/BlockRenderer.test.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.test.tsx
@@ -14,23 +14,46 @@ const presentation: Presentation = {
   blocks: [
     { type: "heading", text: "Finding" },
     { type: "markdown", text: "Interpretation" },
-    { type: "keyvalue", items: [{ label: "Count", value: { $ref: "/count" }, format: "count" }] },
-    { type: "list", label: "Attention", items: [{ text: "Review this", ref: "/issue", tone: "warn" }] },
-    { type: "table", label: "Rows", columns: ["Issue"], rows: [[{ $ref: "/issue" }]], formats: ["issue"] },
+    {
+      type: "keyvalue",
+      items: [{ label: "Count", value: { $ref: "/count" }, format: "count" }],
+    },
+    {
+      type: "list",
+      label: "Attention",
+      items: [{ text: "Review this", ref: "/issue", tone: "warn" }],
+    },
+    {
+      type: "table",
+      label: "Rows",
+      columns: ["Issue"],
+      rows: [[{ $ref: "/issue" }]],
+      formats: ["issue"],
+    },
     { type: "badge", text: "SHIP", tone: "ok" },
     { type: "code", language: "json", text: "{}" },
-    { type: "section", label: "Method", collapsed: true, blocks: [{ type: "markdown", text: "Details" }] },
+    {
+      type: "section",
+      label: "Method",
+      collapsed: true,
+      blocks: [{ type: "markdown", text: "Details" }],
+    },
     { type: "links", items: [{ label: "Run", run: { $ref: "/run" } }] },
   ],
 };
 const artifact = { count: 1200, issue: "WM-12", run: "run_1234567890" };
 
 test("renders every block and exposes resolved sources", () => {
-  const view = render(<BlockRenderer presentation={presentation} artifact={artifact} />);
+  const view = render(
+    <BlockRenderer presentation={presentation} artifact={artifact} />,
+  );
   expect(view.getByText("Finding")).toBeTruthy();
   expect(view.getByText("Interpretation")).toBeTruthy();
   expect(
-    view.getByText("1,200").closest("[data-presentation-source]")?.getAttribute("title"),
+    view
+      .getByText("1,200")
+      .closest("[data-presentation-source]")
+      ?.getAttribute("title"),
   ).toBe("Source: /count");
   expect(view.getByText("!")).toBeTruthy();
   expect(view.getAllByText("WM-12").length).toBeGreaterThan(0);
@@ -42,7 +65,9 @@ test("renders every block and exposes resolved sources", () => {
 });
 
 test("presentation owns an independent raw toggle", () => {
-  const view = render(<PresentationPanel presentation={presentation} artifact={artifact} />);
+  const view = render(
+    <PresentationPanel presentation={presentation} artifact={artifact} />,
+  );
   fireEvent.click(view.getByText("Raw"));
   expect(view.container.querySelector("[data-presentation-view]")).toBeNull();
   expect(view.getByText("View")).toBeTruthy();

--- a/event-runtime/web/src/components/BlockRenderer.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.tsx
@@ -1,11 +1,12 @@
 import { Fragment, useMemo, useState, type ReactNode } from "react";
+import { hashPath, hashProject, withProject } from "../hash";
 import {
   formatValue,
   TONE_HUES,
   toneFor,
   type Formatted,
 } from "../lib/artifactView";
-import { resolveRefs } from "../lib/presentation";
+import { resolveRefs, validatePresentation } from "../lib/presentation";
 import type {
   ArtifactFormat,
   ArtifactTone,
@@ -69,10 +70,31 @@ const unwrapped = (value: unknown): unknown =>
   sourceOf(value) ? (value as { value: unknown }).value : value;
 
 function runHref(runId: string): string {
-  return `#/runs/${encodeURIComponent(runId)}`;
+  return `#/${withProject(hashPath("runs", runId), hashProject(window.location.hash))}`;
 }
 
-function FormattedValue({ value }: { value: Formatted }) {
+function TonePill({ text, tone }: { text: string; tone: ArtifactTone }) {
+  const hue = TONE_HUES[tone];
+  return (
+    <span
+      className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium"
+      style={{
+        color: hue,
+        background: `color-mix(in oklch, ${hue} 12%, transparent)`,
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function FormattedValue({
+  value,
+  tone,
+}: {
+  value: Formatted;
+  tone?: ArtifactTone;
+}) {
   switch (value.kind) {
     case "empty":
       return <span className="text-(--text-faint)">—</span>;
@@ -96,7 +118,7 @@ function FormattedValue({ value }: { value: Formatted }) {
         <JumpLink
           href={href}
           title={`Open ${value.chip} ${value.id}`}
-          className="rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-(--accent)"
+          className="mono text-(--accent) hover:underline"
         >
           {value.text}
         </JumpLink>
@@ -105,8 +127,13 @@ function FormattedValue({ value }: { value: Formatted }) {
     case "json":
       return <JsonBlock value={value.value} />;
     case "text":
+      if (tone && tone !== "muted")
+        return <TonePill text={value.text} tone={tone} />;
       return (
-        <span className={value.mono ? "mono" : undefined} title={value.title}>
+        <span
+          className={`${value.mono ? "mono" : ""} ${tone === "muted" ? "text-(--text-faint)" : ""}`}
+          title={value.title}
+        >
           {value.text}
         </span>
       );
@@ -126,7 +153,10 @@ function Value({
 }) {
   const source = sourceOf(value);
   const body = (
-    <FormattedValue value={formatValue(unwrapped(value), format, { github })} />
+    <FormattedValue
+      value={formatValue(unwrapped(value), format, { github })}
+      tone={tone}
+    />
   );
   return (
     <span
@@ -376,6 +406,10 @@ export function PresentationPanel({
   artifact: unknown;
 }) {
   const [raw, setRawState] = useState(loadRaw);
+  const validation = useMemo(
+    () => validatePresentation(presentation, artifact),
+    [presentation, artifact],
+  );
   const setRaw = (next: boolean) => {
     setRawState(next);
     try {
@@ -384,6 +418,28 @@ export function PresentationPanel({
       /* local preference is best effort */
     }
   };
+  if (!validation.valid)
+    return (
+      <div
+        role="status"
+        className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] text-(--hue-warn)"
+      >
+        <div>
+          the agent&apos;s summary was dropped: {validation.errors.length}{" "}
+          errors
+        </div>
+        <details className="mt-1">
+          <summary className="cursor-pointer text-[11px] text-(--text-dim)">
+            presentation errors
+          </summary>
+          <ul className="mono m-0 list-disc space-y-1 pl-5 text-[11px] text-(--text-dim)">
+            {validation.errors.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </ul>
+        </details>
+      </div>
+    );
   if (raw)
     return (
       <div>

--- a/event-runtime/web/src/components/BlockRenderer.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.tsx
@@ -1,0 +1,243 @@
+import { Fragment, useMemo, useState, type ReactNode } from "react";
+import {
+  formatValue,
+  TONE_HUES,
+  toneFor,
+  type Formatted,
+} from "../lib/artifactView";
+import { resolveRefs } from "../lib/presentation";
+import type {
+  ArtifactFormat,
+  ArtifactTone,
+  Presentation,
+  PresentationBlock,
+} from "../types";
+import { RawToggle } from "./ArtifactView";
+import { JsonBlock, JumpLink, StateBadge, Table, Th } from "./ui";
+
+export const PRESENTATION_RAW_KEY = "evrt-presentation-raw";
+
+const sourceOf = (value: unknown): string | undefined =>
+  value !== null &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  typeof (value as { ref?: unknown }).ref === "string" &&
+  Object.prototype.hasOwnProperty.call(value, "value")
+    ? (value as { ref: string }).ref
+    : undefined;
+const unwrapped = (value: unknown): unknown =>
+  sourceOf(value)
+    ? (value as { value: unknown }).value
+    : value;
+
+function runHref(runId: string): string {
+  return `#/runs/${encodeURIComponent(runId)}`;
+}
+
+function FormattedValue({ value }: { value: Formatted }) {
+  switch (value.kind) {
+    case "empty":
+      return <span className="text-(--text-faint)">—</span>;
+    case "state":
+      return <StateBadge state={value.state} />;
+    case "link":
+      return (
+        <a
+          href={value.href}
+          target="_blank"
+          rel="noreferrer"
+          className="break-all text-(--accent) hover:underline"
+        >
+          {value.text}
+        </a>
+      );
+    case "chip": {
+      const href = value.chip === "run" ? runHref(value.id) : value.href;
+      if (!href) return <span className="mono">{value.text}</span>;
+      return (
+        <JumpLink
+          href={href}
+          title={`Open ${value.chip} ${value.id}`}
+          className="rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-(--accent)"
+        >
+          {value.text}
+        </JumpLink>
+      );
+    }
+    case "json":
+      return <JsonBlock value={value.value} />;
+    case "text":
+      return (
+        <span className={value.mono ? "mono" : undefined} title={value.title}>
+          {value.text}
+        </span>
+      );
+  }
+}
+
+function Value({
+  value,
+  format,
+  tone,
+  github,
+}: {
+  value: unknown;
+  format?: ArtifactFormat;
+  tone?: ArtifactTone;
+  github?: string | null;
+}) {
+  const source = sourceOf(value);
+  const body = (
+    <FormattedValue value={formatValue(unwrapped(value), format, { github })} />
+  );
+  return (
+    <span
+      title={source ? `Source: ${source}` : undefined}
+      data-presentation-source={source}
+      className="min-w-0"
+      style={tone ? { color: TONE_HUES[tone] } : undefined}
+    >
+      {body}
+    </span>
+  );
+}
+
+const glyph: Record<ArtifactTone, string> = {
+  ok: "✓",
+  warn: "!",
+  error: "×",
+  muted: "·",
+  neutral: "•",
+};
+
+function label(text: string | undefined, count?: number) {
+  if (!text) return null;
+  return (
+    <div className="mb-1 flex items-baseline gap-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+      <span>{text}</span>
+      {count !== undefined && <span className="tabular-nums normal-case">{count}</span>}
+    </div>
+  );
+}
+
+function Block({ block, github }: { block: PresentationBlock; github?: string | null }) {
+  switch (block.type) {
+    case "heading":
+      return <h3 className="display m-0 text-[15px] font-semibold text-(--text)">{block.text}</h3>;
+    case "markdown":
+      return <p className="m-0 text-[12.5px] leading-relaxed whitespace-pre-wrap text-(--text-dim)">{block.text}</p>;
+    case "keyvalue":
+      return (
+        <div className="text-[12px]">
+          {block.items.map((item, index) => (
+            <div key={`${item.label}:${index}`} className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
+              <span className="truncate text-(--text-faint)" title={item.label}>{item.label}</span>
+              <Value value={item.value} format={item.format} tone={item.tone} github={github} />
+            </div>
+          ))}
+        </div>
+      );
+    case "list":
+      return (
+        <section aria-label={block.label ?? "list"}>
+          {label(block.label, block.items.length)}
+          <ul className="m-0 list-none p-0 text-[12px]">
+            {block.items.map((item, index) => {
+              const tone = item.tone ?? "neutral";
+              return (
+                <li key={index} title={item.ref ? `Source: ${item.ref}` : undefined} className="flex gap-2 py-[3px] text-(--text-dim)">
+                  <span aria-hidden style={{ color: TONE_HUES[tone] }}>{glyph[tone]}</span>
+                  <span>{item.text}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      );
+    case "badge":
+      return (
+        <span className="inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium" style={{ color: TONE_HUES[block.tone], background: `color-mix(in oklch, ${TONE_HUES[block.tone]} 12%, transparent)` }}>
+          {block.text}
+        </span>
+      );
+    case "code":
+      return <pre data-language={block.language} className="mono m-0 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap">{block.text}</pre>;
+    case "table":
+      return (
+        <section aria-label={block.label ?? "table"}>
+          {label(block.label, block.rows.length)}
+          <div className="overflow-x-auto rounded-md border border-(--border)">
+            <Table className="w-full border-separate border-spacing-0">
+              <thead><tr className="text-left">{block.columns.map((column) => <Th key={column} label={column} />)}</tr></thead>
+              <tbody>
+                {block.rows.map((row, r) => (
+                  <tr key={r}>
+                    {row.map((cell, c) => {
+                      const toneMap = typeof block.tone === "object" && block.tone !== null
+                        ? (block.tone as Record<string, unknown>)[block.columns[c]]
+                        : undefined;
+                      const tone = typeof block.tone === "string" ? block.tone : toneFor(unwrapped(cell), toneMap);
+                      return <td key={c} className="border-b border-(--border) px-3 py-1.5 align-top"><Value value={cell} format={block.formats?.[c]} tone={tone} github={github} /></td>;
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        </section>
+      );
+    case "section":
+      return (
+        <details className="rounded-md border border-(--border) bg-(--surface-0)" open={!block.collapsed}>
+          <summary className="cursor-pointer px-3 py-2 text-[12px] font-medium text-(--text)">{block.label}</summary>
+          <div className="space-y-3 border-t border-(--border) px-3 py-3">
+            {block.blocks.map((child, index) => <Block key={index} block={child} github={github} />)}
+          </div>
+        </details>
+      );
+    case "links":
+      return (
+        <div className="flex flex-wrap gap-1.5">
+          {block.items.map((item, index) => {
+            const target = (["issue", "pr", "run", "url"] as const).find((key) => item[key] != null);
+            if (!target) return null;
+            return (
+              <Fragment key={`${item.label}:${index}`}>
+                <span className="inline-flex items-center gap-1 rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px]">
+                  <span className="text-(--text-faint)">{item.label}</span>
+                  <Value value={item[target]} format={target} github={github} />
+                </span>
+              </Fragment>
+            );
+          })}
+        </div>
+      );
+  }
+}
+
+export function BlockRenderer({ presentation, artifact, actions }: { presentation: Presentation; artifact: unknown; actions?: ReactNode }) {
+  const resolved = useMemo(() => resolveRefs(presentation, artifact), [presentation, artifact]);
+  const github = artifact !== null && typeof artifact === "object" && !Array.isArray(artifact)
+    ? String((artifact as Record<string, unknown>).github ?? "") || null
+    : null;
+  return (
+    <div data-presentation-view className="space-y-3 text-[12px]">
+      {actions && <div className="flex justify-end">{actions}</div>}
+      {resolved.blocks.map((block, index) => <Block key={`${block.type}:${index}`} block={block} github={github} />)}
+    </div>
+  );
+}
+
+function loadRaw(): boolean {
+  try { return localStorage.getItem(PRESENTATION_RAW_KEY) === "1"; } catch { return false; }
+}
+
+export function PresentationPanel({ presentation, artifact }: { presentation: Presentation; artifact: unknown }) {
+  const [raw, setRawState] = useState(loadRaw);
+  const setRaw = (next: boolean) => {
+    setRawState(next);
+    try { localStorage.setItem(PRESENTATION_RAW_KEY, next ? "1" : "0"); } catch { /* local preference is best effort */ }
+  };
+  if (raw) return <div><div className="mb-2 flex justify-end"><RawToggle raw onChange={setRaw} /></div><JsonBlock value={presentation} /></div>;
+  return <BlockRenderer presentation={presentation} artifact={artifact} actions={<RawToggle raw={false} onChange={setRaw} />} />;
+}

--- a/event-runtime/web/src/components/BlockRenderer.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.tsx
@@ -12,10 +12,50 @@ import type {
   Presentation,
   PresentationBlock,
 } from "../types";
-import { RawToggle } from "./ArtifactView";
-import { JsonBlock, JumpLink, StateBadge, Table, Th } from "./ui";
+import {
+  Button as PrimitiveButton,
+  JsonBlock,
+  JumpLink,
+  StateBadge,
+  Table,
+  Th,
+} from "./ui";
 
 export const PRESENTATION_RAW_KEY = "evrt-presentation-raw";
+
+function PresentationRawToggle({
+  raw,
+  onChange,
+}: {
+  raw: boolean;
+  onChange: (raw: boolean) => void;
+}) {
+  const option = (value: boolean, label: string) => (
+    <PrimitiveButton
+      bare
+      type="button"
+      aria-pressed={raw === value}
+      onClick={() => onChange(value)}
+      className={`cursor-pointer rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+        raw === value
+          ? "bg-(--surface-3) text-(--text)"
+          : "text-(--text-faint) hover:text-(--text-dim)"
+      }`}
+    >
+      {label}
+    </PrimitiveButton>
+  );
+  return (
+    <span
+      role="group"
+      aria-label="Presentation rendering"
+      className="inline-flex shrink-0 items-center gap-0.5 rounded-md border border-(--border) bg-(--surface-1) p-0.5"
+    >
+      {option(false, "View")}
+      {option(true, "Raw")}
+    </span>
+  );
+}
 
 const sourceOf = (value: unknown): string | undefined =>
   value !== null &&
@@ -26,9 +66,7 @@ const sourceOf = (value: unknown): string | undefined =>
     ? (value as { ref: string }).ref
     : undefined;
 const unwrapped = (value: unknown): unknown =>
-  sourceOf(value)
-    ? (value as { value: unknown }).value
-    : value;
+  sourceOf(value) ? (value as { value: unknown }).value : value;
 
 function runHref(runId: string): string {
   return `#/runs/${encodeURIComponent(runId)}`;
@@ -115,24 +153,50 @@ function label(text: string | undefined, count?: number) {
   return (
     <div className="mb-1 flex items-baseline gap-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
       <span>{text}</span>
-      {count !== undefined && <span className="tabular-nums normal-case">{count}</span>}
+      {count !== undefined && (
+        <span className="tabular-nums normal-case">{count}</span>
+      )}
     </div>
   );
 }
 
-function Block({ block, github }: { block: PresentationBlock; github?: string | null }) {
+function Block({
+  block,
+  github,
+}: {
+  block: PresentationBlock;
+  github?: string | null;
+}) {
   switch (block.type) {
     case "heading":
-      return <h3 className="display m-0 text-[15px] font-semibold text-(--text)">{block.text}</h3>;
+      return (
+        <h3 className="display m-0 text-[15px] font-semibold text-(--text)">
+          {block.text}
+        </h3>
+      );
     case "markdown":
-      return <p className="m-0 text-[12.5px] leading-relaxed whitespace-pre-wrap text-(--text-dim)">{block.text}</p>;
+      return (
+        <p className="m-0 text-[12.5px] leading-relaxed whitespace-pre-wrap text-(--text-dim)">
+          {block.text}
+        </p>
+      );
     case "keyvalue":
       return (
         <div className="text-[12px]">
           {block.items.map((item, index) => (
-            <div key={`${item.label}:${index}`} className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
-              <span className="truncate text-(--text-faint)" title={item.label}>{item.label}</span>
-              <Value value={item.value} format={item.format} tone={item.tone} github={github} />
+            <div
+              key={`${item.label}:${index}`}
+              className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]"
+            >
+              <span className="truncate text-(--text-faint)" title={item.label}>
+                {item.label}
+              </span>
+              <Value
+                value={item.value}
+                format={item.format}
+                tone={item.tone}
+                github={github}
+              />
             </div>
           ))}
         </div>
@@ -145,8 +209,14 @@ function Block({ block, github }: { block: PresentationBlock; github?: string | 
             {block.items.map((item, index) => {
               const tone = item.tone ?? "neutral";
               return (
-                <li key={index} title={item.ref ? `Source: ${item.ref}` : undefined} className="flex gap-2 py-[3px] text-(--text-dim)">
-                  <span aria-hidden style={{ color: TONE_HUES[tone] }}>{glyph[tone]}</span>
+                <li
+                  key={index}
+                  title={item.ref ? `Source: ${item.ref}` : undefined}
+                  className="flex gap-2 py-[3px] text-(--text-dim)"
+                >
+                  <span aria-hidden style={{ color: TONE_HUES[tone] }}>
+                    {glyph[tone]}
+                  </span>
                   <span>{item.text}</span>
                 </li>
               );
@@ -156,28 +226,65 @@ function Block({ block, github }: { block: PresentationBlock; github?: string | 
       );
     case "badge":
       return (
-        <span className="inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium" style={{ color: TONE_HUES[block.tone], background: `color-mix(in oklch, ${TONE_HUES[block.tone]} 12%, transparent)` }}>
+        <span
+          className="inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium"
+          style={{
+            color: TONE_HUES[block.tone],
+            background: `color-mix(in oklch, ${TONE_HUES[block.tone]} 12%, transparent)`,
+          }}
+        >
           {block.text}
         </span>
       );
     case "code":
-      return <pre data-language={block.language} className="mono m-0 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap">{block.text}</pre>;
+      return (
+        <pre
+          data-language={block.language}
+          className="mono m-0 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap"
+        >
+          {block.text}
+        </pre>
+      );
     case "table":
       return (
         <section aria-label={block.label ?? "table"}>
           {label(block.label, block.rows.length)}
           <div className="overflow-x-auto rounded-md border border-(--border)">
             <Table className="w-full border-separate border-spacing-0">
-              <thead><tr className="text-left">{block.columns.map((column) => <Th key={column} label={column} />)}</tr></thead>
+              <thead>
+                <tr className="text-left">
+                  {block.columns.map((column) => (
+                    <Th key={column} label={column} />
+                  ))}
+                </tr>
+              </thead>
               <tbody>
                 {block.rows.map((row, r) => (
                   <tr key={r}>
                     {row.map((cell, c) => {
-                      const toneMap = typeof block.tone === "object" && block.tone !== null
-                        ? (block.tone as Record<string, unknown>)[block.columns[c]]
-                        : undefined;
-                      const tone = typeof block.tone === "string" ? block.tone : toneFor(unwrapped(cell), toneMap);
-                      return <td key={c} className="border-b border-(--border) px-3 py-1.5 align-top"><Value value={cell} format={block.formats?.[c]} tone={tone} github={github} /></td>;
+                      const toneMap =
+                        typeof block.tone === "object" && block.tone !== null
+                          ? (block.tone as Record<string, unknown>)[
+                              block.columns[c]
+                            ]
+                          : undefined;
+                      const tone =
+                        typeof block.tone === "string"
+                          ? block.tone
+                          : toneFor(unwrapped(cell), toneMap);
+                      return (
+                        <td
+                          key={c}
+                          className="border-b border-(--border) px-3 py-1.5 align-top"
+                        >
+                          <Value
+                            value={cell}
+                            format={block.formats?.[c]}
+                            tone={tone}
+                            github={github}
+                          />
+                        </td>
+                      );
                     })}
                   </tr>
                 ))}
@@ -188,10 +295,17 @@ function Block({ block, github }: { block: PresentationBlock; github?: string | 
       );
     case "section":
       return (
-        <details className="rounded-md border border-(--border) bg-(--surface-0)" open={!block.collapsed}>
-          <summary className="cursor-pointer px-3 py-2 text-[12px] font-medium text-(--text)">{block.label}</summary>
+        <details
+          className="rounded-md border border-(--border) bg-(--surface-0)"
+          open={!block.collapsed}
+        >
+          <summary className="cursor-pointer px-3 py-2 text-[12px] font-medium text-(--text)">
+            {block.label}
+          </summary>
           <div className="space-y-3 border-t border-(--border) px-3 py-3">
-            {block.blocks.map((child, index) => <Block key={index} block={child} github={github} />)}
+            {block.blocks.map((child, index) => (
+              <Block key={index} block={child} github={github} />
+            ))}
           </div>
         </details>
       );
@@ -199,7 +313,9 @@ function Block({ block, github }: { block: PresentationBlock; github?: string | 
       return (
         <div className="flex flex-wrap gap-1.5">
           {block.items.map((item, index) => {
-            const target = (["issue", "pr", "run", "url"] as const).find((key) => item[key] != null);
+            const target = (["issue", "pr", "run", "url"] as const).find(
+              (key) => item[key] != null,
+            );
             if (!target) return null;
             return (
               <Fragment key={`${item.label}:${index}`}>
@@ -215,29 +331,73 @@ function Block({ block, github }: { block: PresentationBlock; github?: string | 
   }
 }
 
-export function BlockRenderer({ presentation, artifact, actions }: { presentation: Presentation; artifact: unknown; actions?: ReactNode }) {
-  const resolved = useMemo(() => resolveRefs(presentation, artifact), [presentation, artifact]);
-  const github = artifact !== null && typeof artifact === "object" && !Array.isArray(artifact)
-    ? String((artifact as Record<string, unknown>).github ?? "") || null
-    : null;
+export function BlockRenderer({
+  presentation,
+  artifact,
+  actions,
+}: {
+  presentation: Presentation;
+  artifact: unknown;
+  actions?: ReactNode;
+}) {
+  const resolved = useMemo(
+    () => resolveRefs(presentation, artifact),
+    [presentation, artifact],
+  );
+  const github =
+    artifact !== null &&
+    typeof artifact === "object" &&
+    !Array.isArray(artifact)
+      ? String((artifact as Record<string, unknown>).github ?? "") || null
+      : null;
   return (
     <div data-presentation-view className="space-y-3 text-[12px]">
       {actions && <div className="flex justify-end">{actions}</div>}
-      {resolved.blocks.map((block, index) => <Block key={`${block.type}:${index}`} block={block} github={github} />)}
+      {resolved.blocks.map((block, index) => (
+        <Block key={`${block.type}:${index}`} block={block} github={github} />
+      ))}
     </div>
   );
 }
 
 function loadRaw(): boolean {
-  try { return localStorage.getItem(PRESENTATION_RAW_KEY) === "1"; } catch { return false; }
+  try {
+    return localStorage.getItem(PRESENTATION_RAW_KEY) === "1";
+  } catch {
+    return false;
+  }
 }
 
-export function PresentationPanel({ presentation, artifact }: { presentation: Presentation; artifact: unknown }) {
+export function PresentationPanel({
+  presentation,
+  artifact,
+}: {
+  presentation: Presentation;
+  artifact: unknown;
+}) {
   const [raw, setRawState] = useState(loadRaw);
   const setRaw = (next: boolean) => {
     setRawState(next);
-    try { localStorage.setItem(PRESENTATION_RAW_KEY, next ? "1" : "0"); } catch { /* local preference is best effort */ }
+    try {
+      localStorage.setItem(PRESENTATION_RAW_KEY, next ? "1" : "0");
+    } catch {
+      /* local preference is best effort */
+    }
   };
-  if (raw) return <div><div className="mb-2 flex justify-end"><RawToggle raw onChange={setRaw} /></div><JsonBlock value={presentation} /></div>;
-  return <BlockRenderer presentation={presentation} artifact={artifact} actions={<RawToggle raw={false} onChange={setRaw} />} />;
+  if (raw)
+    return (
+      <div>
+        <div className="mb-2 flex justify-end">
+          <PresentationRawToggle raw onChange={setRaw} />
+        </div>
+        <JsonBlock value={presentation} />
+      </div>
+    );
+  return (
+    <BlockRenderer
+      presentation={presentation}
+      artifact={artifact}
+      actions={<PresentationRawToggle raw={false} onChange={setRaw} />}
+    />
+  );
 }

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -197,7 +197,8 @@ describe("presentation result rendering", () => {
     const artifact = r.getByText("artifact").closest("details");
     expect(summary && artifact).toBeTruthy();
     expect(
-      summary!.compareDocumentPosition(artifact!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      summary!.compareDocumentPosition(artifact!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(summary!.querySelectorAll("button")).not.toHaveLength(0);
   });

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -34,6 +34,7 @@ import type { RunDetail, RunState } from "../types";
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
   restoreApi();
 });
 
@@ -167,6 +168,57 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
     expect(isCancellable("TIMED_OUT")).toBe(false);
     expect(isCancellable("CANCELLED")).toBe(false);
     expect(isCancellable("REFUSED")).toBe(false);
+  });
+});
+
+describe("presentation result rendering", () => {
+  test("renders a presentation above the artifact with its own Raw toggle", async () => {
+    const r = renderBlocks(
+      createRunDetailFixture({
+        result: {
+          terminalState: "completed",
+          reasonCode: null,
+          artifact: { recommendation: "TRIAGE", count: 2 },
+          presentation: {
+            schemaVersion: "factory.presentation/v1",
+            blocks: [
+              { type: "heading", text: "Two issues need attention" },
+              {
+                type: "keyvalue",
+                items: [{ label: "Issues", value: { $ref: "/count" } }],
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(await r.findByText("Two issues need attention")).toBeTruthy();
+    const summary = r.getByText("agent summary").closest("details");
+    const artifact = r.getByText("artifact").closest("details");
+    expect(summary && artifact).toBeTruthy();
+    expect(
+      summary!.compareDocumentPosition(artifact!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(summary!.querySelectorAll("button")).not.toHaveLength(0);
+  });
+
+  test("shows dropped presentation errors while keeping Layer A", async () => {
+    const r = renderBlocks(
+      createRunDetailFixture({
+        result: {
+          terminalState: "completed",
+          reasonCode: null,
+          artifact: { recommendation: "TRIAGE" },
+          presentationErrors: ["bad ref", "bad block"],
+        },
+      }),
+    );
+    expect(
+      r.getByText("the agent's summary was dropped: 2 errors"),
+    ).toBeTruthy();
+    expect(r.getByText("artifact")).toBeTruthy();
+    fireEvent.click(r.getByText("presentation errors"));
+    expect(r.getByText("bad ref")).toBeTruthy();
   });
 });
 

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -1140,8 +1140,8 @@ export function RunDetailBlocks({
                 className="mb-3 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] text-(--hue-warn)"
               >
                 <div>
-                  the agent&apos;s summary was dropped: {d.result.presentationErrors.length}{" "}
-                  errors
+                  the agent&apos;s summary was dropped:{" "}
+                  {d.result.presentationErrors.length} errors
                 </div>
                 <Disclosure label="presentation errors">
                   <ul className="mono m-0 list-disc space-y-1 pl-5 text-[11px] text-(--text-dim)">

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -44,6 +44,9 @@ import { Button as PrimitiveButton } from "./ui";
 const ArtifactPanel = lazy(() =>
   import("./ArtifactView").then((m) => ({ default: m.ArtifactPanel })),
 );
+const PresentationPanel = lazy(() =>
+  import("./BlockRenderer").then((m) => ({ default: m.PresentationPanel })),
+);
 
 /**
  * The per-ticket Decisions block (WM-594) rides its own chunk for the same
@@ -1119,6 +1122,36 @@ export function RunDetailBlocks({
           id="run-result"
           title={`Result · ${d.result.terminalState}${d.result.reasonCode ? ` · ${d.result.reasonCode}` : ""}`}
         >
+          {d.result.presentation && (
+            <Disclosure label="agent summary" defaultOpen>
+              <Suspense fallback={<JsonBlock value={d.result.presentation} />}>
+                <PresentationPanel
+                  presentation={d.result.presentation}
+                  artifact={d.result.artifact ?? {}}
+                />
+              </Suspense>
+            </Disclosure>
+          )}
+          {!d.result.presentation &&
+            d.result.presentationErrors &&
+            d.result.presentationErrors.length > 0 && (
+              <div
+                role="status"
+                className="mb-3 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] text-(--hue-warn)"
+              >
+                <div>
+                  the agent&apos;s summary was dropped: {d.result.presentationErrors.length}{" "}
+                  errors
+                </div>
+                <Disclosure label="presentation errors">
+                  <ul className="mono m-0 list-disc space-y-1 pl-5 text-[11px] text-(--text-dim)">
+                    {d.result.presentationErrors.map((error, index) => (
+                      <li key={index}>{error}</li>
+                    ))}
+                  </ul>
+                </Disclosure>
+              </div>
+            )}
           {d.result.artifact !== undefined ? (
             <Disclosure label="artifact" defaultOpen>
               <Suspense fallback={<JsonBlock value={d.result.artifact} />}>

--- a/event-runtime/web/src/lib/presentation.test.ts
+++ b/event-runtime/web/src/lib/presentation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { Presentation } from "../types";
+import { resolveRefs, validatePresentation } from "./presentation";
+
+interface PresentationFixture {
+  artifact: unknown;
+  cases: Array<{ name: string; valid: boolean; presentation: Presentation }>;
+}
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL("../../../lib/fixtures/presentation-cases.json", import.meta.url),
+    "utf8",
+  ),
+) as PresentationFixture;
+
+describe("browser presentation port", () => {
+  test("agrees with every server fixture verdict", () => {
+    for (const entry of fixture.cases) {
+      expect(
+        validatePresentation(entry.presentation, fixture.artifact).valid,
+        entry.name,
+      ).toBe(entry.valid);
+    }
+  });
+
+  test("resolves values while retaining their source pointer", () => {
+    const resolved = resolveRefs(fixture.cases[0].presentation, fixture.artifact);
+    const keyvalue = resolved.blocks[2] as {
+      items: Array<{ value: unknown }>;
+    };
+    expect(keyvalue.items[0].value).toEqual({
+      value: "DISPATCH",
+      ref: "/recommendation",
+    });
+  });
+});

--- a/event-runtime/web/src/lib/presentation.test.ts
+++ b/event-runtime/web/src/lib/presentation.test.ts
@@ -26,7 +26,10 @@ describe("browser presentation port", () => {
   });
 
   test("resolves values while retaining their source pointer", () => {
-    const resolved = resolveRefs(fixture.cases[0].presentation, fixture.artifact);
+    const resolved = resolveRefs(
+      fixture.cases[0].presentation,
+      fixture.artifact,
+    );
     const keyvalue = resolved.blocks[2] as {
       items: Array<{ value: unknown }>;
     };

--- a/event-runtime/web/src/lib/presentation.test.ts
+++ b/event-runtime/web/src/lib/presentation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+// The server contract is JavaScript and intentionally has no web-facing types.
+// @ts-expect-error compare this browser port directly with the canonical module.
+import { validatePresentation as validateServerPresentation } from "../../../lib/presentation.mjs";
 import type { Presentation } from "../types";
 import { resolveRefs, validatePresentation } from "./presentation";
 
@@ -18,10 +21,18 @@ const fixture = JSON.parse(
 describe("browser presentation port", () => {
   test("agrees with every server fixture verdict", () => {
     for (const entry of fixture.cases) {
-      expect(
-        validatePresentation(entry.presentation, fixture.artifact).valid,
-        entry.name,
-      ).toBe(entry.valid);
+      const server = validateServerPresentation(
+        entry.presentation,
+        fixture.artifact,
+      );
+      const browser = validatePresentation(
+        entry.presentation,
+        fixture.artifact,
+      );
+      expect(browser.valid, entry.name).toBe(server.valid);
+      expect(browser.valid, `${entry.name} fixture expectation`).toBe(
+        entry.valid,
+      );
     }
   });
 
@@ -37,5 +48,30 @@ describe("browser presentation port", () => {
       value: "DISPATCH",
       ref: "/recommendation",
     });
+  });
+
+  test("rejects schema bounds before malformed blocks reach React", () => {
+    const invalid = {
+      schemaVersion: "factory.presentation/v1",
+      blocks: [
+        {
+          type: "section",
+          label: "",
+          blocks: [
+            {
+              type: "code",
+              text: "ok",
+              language: "x".repeat(41),
+            },
+          ],
+        },
+      ],
+    };
+    const result = validatePresentation(invalid, fixture.artifact);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.includes("label"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("language"))).toBe(
+      true,
+    );
   });
 });

--- a/event-runtime/web/src/lib/presentation.ts
+++ b/event-runtime/web/src/lib/presentation.ts
@@ -66,6 +66,21 @@ const scalarOrRef = (value: unknown): boolean =>
   ref(value);
 const bytes = (value: string): number => new TextEncoder().encode(value).length;
 
+function stringField(
+  value: unknown,
+  at: string,
+  errors: string[],
+  { min = 0, max = Infinity }: { min?: number; max?: number } = {},
+): value is string {
+  if (typeof value !== "string") {
+    errors.push(`${at}: expected string`);
+    return false;
+  }
+  if (value.length < min) errors.push(`${at}: shorter than ${min}`);
+  if (value.length > max) errors.push(`${at}: longer than ${max}`);
+  return true;
+}
+
 function keys(
   value: Record<string, unknown>,
   allowed: string[],
@@ -90,22 +105,35 @@ function checkValue(
     errors.push(`${at}: expected scalar, null, or $ref`);
     return;
   }
-  if (ref(value) && resolvePointer(artifact, value.$ref) === undefined)
-    errors.push(`${at}: $ref "${value.$ref}" does not resolve in the artifact`);
+  if (ref(value)) {
+    if (value.$ref.length === 0) errors.push(`${at}.$ref: shorter than 1`);
+    else if (resolvePointer(artifact, value.$ref) === undefined)
+      errors.push(
+        `${at}: $ref "${value.$ref}" does not resolve in the artifact`,
+      );
+  }
 }
 
-function checkTone(value: unknown, at: string, errors: string[]) {
+function checkTone(
+  value: unknown,
+  at: string,
+  errors: string[],
+  nested = false,
+) {
   if (typeof value === "string") {
     if (!TONES.includes(value as ArtifactTone))
       errors.push(`${at}: invalid tone`);
     return;
   }
   if (!object(value)) {
-    errors.push(`${at}: invalid tone map`);
+    // The server's deliberately small schema constrains the outer value to an
+    // object but does not constrain nested leaves. Keep parity with its
+    // defensive recursion: only string leaves can be invalid tones.
+    if (!nested) errors.push(`${at}: invalid tone map`);
     return;
   }
   for (const [key, child] of Object.entries(value))
-    checkTone(child, `${at}.${key}`, errors);
+    checkTone(child, `${at}.${key}`, errors, true);
 }
 
 function checkBlock(
@@ -126,27 +154,31 @@ function checkBlock(
   const type = value.type;
   const textBlock = (limit: number, byteLimit = false) => {
     keys(value, ["type", "text"], ["text"], at, errors);
-    if (typeof value.text !== "string")
-      errors.push(`${at}.text: expected string`);
-    else if ((byteLimit ? bytes(value.text) : value.text.length) > limit)
+    if (
+      stringField(value.text, `${at}.text`, errors) &&
+      (byteLimit ? bytes(value.text) : value.text.length) > limit
+    )
       errors.push(`${at}: ${type} text is over ${limit}`);
   };
   if (type === "heading") return textBlock(LIMITS.heading);
   if (type === "markdown") return textBlock(LIMITS.markdown, true);
   if (type === "code") {
     keys(value, ["type", "text", "language"], ["text"], at, errors);
-    if (typeof value.text !== "string")
-      errors.push(`${at}.text: expected string`);
-    else if (bytes(value.text) > LIMITS.code)
+    if (
+      stringField(value.text, `${at}.text`, errors) &&
+      bytes(value.text) > LIMITS.code
+    )
       errors.push(`${at}: code text is over ${LIMITS.code}`);
-    if (value.language !== undefined && typeof value.language !== "string")
-      errors.push(`${at}.language: expected string`);
+    if (value.language !== undefined)
+      stringField(value.language, `${at}.language`, errors, {
+        min: 1,
+        max: 40,
+      });
     return;
   }
   if (type === "badge") {
     keys(value, ["type", "text", "tone"], ["text", "tone"], at, errors);
-    if (typeof value.text !== "string")
-      errors.push(`${at}.text: expected string`);
+    stringField(value.text, `${at}.text`, errors);
     if (!TONES.includes(value.tone as ArtifactTone))
       errors.push(`${at}.tone: invalid tone`);
     return;
@@ -155,6 +187,11 @@ function checkBlock(
     const allowed =
       type === "list" ? ["type", "label", "items"] : ["type", "items"];
     keys(value, allowed, ["items"], at, errors);
+    if (type === "list" && value.label !== undefined)
+      stringField(value.label, `${at}.label`, errors, {
+        min: 1,
+        max: 120,
+      });
     if (!Array.isArray(value.items)) {
       errors.push(`${at}.items: expected array`);
       return;
@@ -172,8 +209,10 @@ function checkBlock(
           itemAt,
           errors,
         );
-        if (typeof item.label !== "string")
-          errors.push(`${itemAt}.label: expected string`);
+        stringField(item.label, `${itemAt}.label`, errors, {
+          min: 1,
+          max: 120,
+        });
         if (own(item, "value"))
           checkValue(item.value, `${itemAt}.value`, artifact, errors);
         if (
@@ -188,12 +227,15 @@ function checkBlock(
           errors.push(`${itemAt}.tone: invalid tone`);
       } else if (type === "list") {
         keys(item, ["text", "ref", "tone"], ["text"], itemAt, errors);
-        if (typeof item.text !== "string")
-          errors.push(`${itemAt}.text: expected string`);
+        stringField(item.text, `${itemAt}.text`, errors, {
+          min: 1,
+          max: 2048,
+        });
         if (item.ref !== undefined) {
-          if (typeof item.ref !== "string")
-            errors.push(`${itemAt}.ref: expected string`);
-          else if (resolvePointer(artifact, item.ref) === undefined)
+          if (
+            stringField(item.ref, `${itemAt}.ref`, errors, { min: 1 }) &&
+            resolvePointer(artifact, item.ref) === undefined
+          )
             errors.push(
               `${itemAt}: ref "${item.ref}" does not resolve in the artifact`,
             );
@@ -205,6 +247,11 @@ function checkBlock(
           errors.push(`${itemAt}.tone: invalid tone`);
       } else {
         keys(item, ["label", "issue", "pr", "run", "url"], [], itemAt, errors);
+        if (item.label !== undefined)
+          stringField(item.label, `${itemAt}.label`, errors, {
+            min: 1,
+            max: 120,
+          });
         const targets = ["issue", "pr", "run", "url"].filter(
           (key) => own(item, key) && item[key] !== null,
         );
@@ -227,14 +274,24 @@ function checkBlock(
       at,
       errors,
     );
+    if (value.label !== undefined)
+      stringField(value.label, `${at}.label`, errors, {
+        min: 1,
+        max: 120,
+      });
     if (
       !Array.isArray(value.columns) ||
       value.columns.length < 1 ||
       value.columns.length > LIMITS.columns
     )
       errors.push(`${at}.columns: expected 1-${LIMITS.columns} columns`);
-    else if (value.columns.some((column) => typeof column !== "string"))
-      errors.push(`${at}.columns: expected strings`);
+    else
+      value.columns.forEach((column, index) =>
+        stringField(column, `${at}.columns[${index}]`, errors, {
+          min: 1,
+          max: 120,
+        }),
+      );
     if (!Array.isArray(value.rows))
       return errors.push(`${at}.rows: expected array`);
     if (value.rows.length > LIMITS.rows)
@@ -276,8 +333,10 @@ function checkBlock(
       errors,
     );
     if (depth > 0) errors.push(`${at}: section nesting exceeds one level`);
-    if (typeof value.label !== "string")
-      errors.push(`${at}.label: expected string`);
+    stringField(value.label, `${at}.label`, errors, {
+      min: 1,
+      max: 120,
+    });
     if (value.collapsed !== undefined && typeof value.collapsed !== "boolean")
       errors.push(`${at}.collapsed: expected boolean`);
     if (!Array.isArray(value.blocks))

--- a/event-runtime/web/src/lib/presentation.ts
+++ b/event-runtime/web/src/lib/presentation.ts
@@ -1,0 +1,246 @@
+/** Browser port of the presentation contract in `lib/presentation.mjs`. */
+import type {
+  ArtifactFormat,
+  ArtifactTone,
+  Presentation,
+  PresentationBlock,
+} from "../types";
+import { resolvePointer } from "./artifactView";
+
+export const PRESENTATION_SCHEMA_VERSION = "factory.presentation/v1";
+export const BLOCK_TYPES = [
+  "heading",
+  "markdown",
+  "keyvalue",
+  "table",
+  "list",
+  "badge",
+  "code",
+  "section",
+  "links",
+] as const;
+const FORMATS: ArtifactFormat[] = [
+  "issue",
+  "pr",
+  "url",
+  "sha",
+  "repo",
+  "run",
+  "duration",
+  "datetime",
+  "state",
+  "bytes",
+  "count",
+];
+const TONES: ArtifactTone[] = ["ok", "warn", "error", "muted", "neutral"];
+const LIMITS = {
+  bytes: 16 * 1024,
+  blocks: 40,
+  heading: 120,
+  markdown: 2 * 1024,
+  code: 4 * 1024,
+  keyvalue: 16,
+  list: 30,
+  links: 12,
+  columns: 6,
+  rows: 50,
+  section: 20,
+};
+
+export interface PresentationValidation {
+  valid: boolean;
+  errors: string[];
+}
+
+const object = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const own = (value: unknown, key: string): boolean =>
+  object(value) && Object.prototype.hasOwnProperty.call(value, key);
+const ref = (value: unknown): value is { $ref: string } =>
+  object(value) &&
+  Object.keys(value).length === 1 &&
+  typeof value.$ref === "string";
+const scalarOrRef = (value: unknown): boolean =>
+  value === null ||
+  ["string", "number", "boolean"].includes(typeof value) ||
+  ref(value);
+const bytes = (value: string): number => new TextEncoder().encode(value).length;
+
+function keys(
+  value: Record<string, unknown>,
+  allowed: string[],
+  required: string[],
+  at: string,
+  errors: string[],
+) {
+  for (const key of Object.keys(value))
+    if (!allowed.includes(key)) errors.push(`${at}: unknown property "${key}"`);
+  for (const key of required)
+    if (!own(value, key)) errors.push(`${at}: missing required property "${key}"`);
+}
+
+function checkValue(value: unknown, at: string, artifact: unknown, errors: string[]) {
+  if (!scalarOrRef(value)) {
+    errors.push(`${at}: expected scalar, null, or $ref`);
+    return;
+  }
+  if (ref(value) && resolvePointer(artifact, value.$ref) === undefined)
+    errors.push(`${at}: $ref "${value.$ref}" does not resolve in the artifact`);
+}
+
+function checkTone(value: unknown, at: string, errors: string[]) {
+  if (typeof value === "string") {
+    if (!TONES.includes(value as ArtifactTone)) errors.push(`${at}: invalid tone`);
+    return;
+  }
+  if (!object(value)) {
+    errors.push(`${at}: invalid tone map`);
+    return;
+  }
+  for (const [key, child] of Object.entries(value))
+    checkTone(child, `${at}.${key}`, errors);
+}
+
+function checkBlock(
+  value: unknown,
+  at: string,
+  artifact: unknown,
+  errors: string[],
+  depth: number,
+) {
+  if (!object(value) || typeof value.type !== "string") {
+    errors.push(`${at}: block requires a type`);
+    return;
+  }
+  if (!BLOCK_TYPES.includes(value.type as (typeof BLOCK_TYPES)[number])) {
+    errors.push(`${at}.type: value not in enum`);
+    return;
+  }
+  const type = value.type;
+  const textBlock = (limit: number, byteLimit = false) => {
+    keys(value, ["type", "text"], ["text"], at, errors);
+    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
+    else if ((byteLimit ? bytes(value.text) : value.text.length) > limit)
+      errors.push(`${at}: ${type} text is over ${limit}`);
+  };
+  if (type === "heading") return textBlock(LIMITS.heading);
+  if (type === "markdown") return textBlock(LIMITS.markdown, true);
+  if (type === "code") {
+    keys(value, ["type", "text", "language"], ["text"], at, errors);
+    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
+    else if (bytes(value.text) > LIMITS.code) errors.push(`${at}: code text is over ${LIMITS.code}`);
+    if (value.language !== undefined && typeof value.language !== "string")
+      errors.push(`${at}.language: expected string`);
+    return;
+  }
+  if (type === "badge") {
+    keys(value, ["type", "text", "tone"], ["text", "tone"], at, errors);
+    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
+    if (!TONES.includes(value.tone as ArtifactTone)) errors.push(`${at}.tone: invalid tone`);
+    return;
+  }
+  if (type === "keyvalue" || type === "list" || type === "links") {
+    const allowed = type === "list" ? ["type", "label", "items"] : ["type", "items"];
+    keys(value, allowed, ["items"], at, errors);
+    if (!Array.isArray(value.items)) {
+      errors.push(`${at}.items: expected array`);
+      return;
+    }
+    const limit = LIMITS[type];
+    if (value.items.length > limit) errors.push(`${at}.items: too many items`);
+    value.items.forEach((item, index) => {
+      const itemAt = `${at}.items[${index}]`;
+      if (!object(item)) return errors.push(`${itemAt}: expected object`);
+      if (type === "keyvalue") {
+        keys(item, ["label", "value", "format", "tone"], ["label", "value"], itemAt, errors);
+        if (typeof item.label !== "string") errors.push(`${itemAt}.label: expected string`);
+        if (own(item, "value")) checkValue(item.value, `${itemAt}.value`, artifact, errors);
+        if (item.format !== undefined && !FORMATS.includes(item.format as ArtifactFormat))
+          errors.push(`${itemAt}.format: invalid format`);
+        if (item.tone !== undefined && !TONES.includes(item.tone as ArtifactTone))
+          errors.push(`${itemAt}.tone: invalid tone`);
+      } else if (type === "list") {
+        keys(item, ["text", "ref", "tone"], ["text"], itemAt, errors);
+        if (typeof item.text !== "string") errors.push(`${itemAt}.text: expected string`);
+        if (item.ref !== undefined) {
+          if (typeof item.ref !== "string") errors.push(`${itemAt}.ref: expected string`);
+          else if (resolvePointer(artifact, item.ref) === undefined)
+            errors.push(`${itemAt}: ref "${item.ref}" does not resolve in the artifact`);
+        }
+        if (item.tone !== undefined && !TONES.includes(item.tone as ArtifactTone))
+          errors.push(`${itemAt}.tone: invalid tone`);
+      } else {
+        keys(item, ["label", "issue", "pr", "run", "url"], [], itemAt, errors);
+        const targets = ["issue", "pr", "run", "url"].filter((key) => own(item, key) && item[key] !== null);
+        if (targets.length !== 1) errors.push(`${itemAt}: a links item needs exactly one non-null target`);
+        for (const target of ["issue", "pr", "run", "url"])
+          if (own(item, target)) checkValue(item[target], `${itemAt}.${target}`, artifact, errors);
+      }
+    });
+    return;
+  }
+  if (type === "table") {
+    keys(value, ["type", "label", "columns", "rows", "formats", "tone"], ["columns", "rows"], at, errors);
+    if (!Array.isArray(value.columns) || value.columns.length < 1 || value.columns.length > LIMITS.columns)
+      errors.push(`${at}.columns: expected 1-${LIMITS.columns} columns`);
+    else if (value.columns.some((column) => typeof column !== "string"))
+      errors.push(`${at}.columns: expected strings`);
+    if (!Array.isArray(value.rows)) return errors.push(`${at}.rows: expected array`);
+    if (value.rows.length > LIMITS.rows) errors.push(`${at}.rows: too many rows`);
+    value.rows.forEach((row, r) => {
+      if (!Array.isArray(row)) return errors.push(`${at}.rows[${r}]: expected array`);
+      if (Array.isArray(value.columns) && row.length !== value.columns.length)
+        errors.push(`${at}.rows[${r}]: ${row.length} cells != ${value.columns.length} columns`);
+      row.forEach((cell, c) => checkValue(cell, `${at}.rows[${r}][${c}]`, artifact, errors));
+    });
+    if (value.formats !== undefined) {
+      if (!Array.isArray(value.formats) || value.formats.some((format) => !FORMATS.includes(format as ArtifactFormat)))
+        errors.push(`${at}.formats: invalid formats`);
+      else if (Array.isArray(value.columns) && value.formats.length > value.columns.length)
+        errors.push(`${at}.formats: more formats than columns`);
+    }
+    if (value.tone !== undefined) checkTone(value.tone, `${at}.tone`, errors);
+    return;
+  }
+  if (type === "section") {
+    keys(value, ["type", "label", "collapsed", "blocks"], ["label", "blocks"], at, errors);
+    if (depth > 0) errors.push(`${at}: section nesting exceeds one level`);
+    if (typeof value.label !== "string") errors.push(`${at}.label: expected string`);
+    if (value.collapsed !== undefined && typeof value.collapsed !== "boolean")
+      errors.push(`${at}.collapsed: expected boolean`);
+    if (!Array.isArray(value.blocks)) return errors.push(`${at}.blocks: expected array`);
+    if (value.blocks.length > LIMITS.section) errors.push(`${at}.blocks: too many blocks`);
+    value.blocks.forEach((block, index) => checkBlock(block, `${at}.blocks[${index}]`, artifact, errors, depth + 1));
+  }
+}
+
+/** Validate the document and every artifact citation. Never throws. */
+export function validatePresentation(value: unknown, artifact: unknown): PresentationValidation {
+  const errors: string[] = [];
+  if (!object(value)) return { valid: false, errors: ["$: expected object"] };
+  keys(value, ["schemaVersion", "blocks"], ["schemaVersion", "blocks"], "$", errors);
+  if (value.schemaVersion !== PRESENTATION_SCHEMA_VERSION)
+    errors.push("$.schemaVersion: expected factory.presentation/v1");
+  if (!Array.isArray(value.blocks)) errors.push("$.blocks: expected array");
+  else {
+    if (value.blocks.length < 1 || value.blocks.length > LIMITS.blocks)
+      errors.push(`$.blocks: expected 1-${LIMITS.blocks} blocks`);
+    value.blocks.forEach((block, index) => checkBlock(block, `blocks[${index}]`, artifact ?? {}, errors, 0));
+  }
+  if (bytes(JSON.stringify(value)) > LIMITS.bytes)
+    errors.push(`$: serialised presentation is over ${LIMITS.bytes} bytes`);
+  return { valid: errors.length === 0, errors };
+}
+
+/** Deep-copy a presentation, replacing `$ref` values with value+source pairs. */
+export function resolveRefs(presentation: Presentation, artifact: unknown): Presentation {
+  const map = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(map);
+    if (ref(value)) return { value: resolvePointer(artifact ?? {}, value.$ref), ref: value.$ref };
+    if (object(value)) return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, map(child)]));
+    return value;
+  };
+  return map(presentation) as Presentation;
+}
+
+export type { Presentation, PresentationBlock };

--- a/event-runtime/web/src/lib/presentation.ts
+++ b/event-runtime/web/src/lib/presentation.ts
@@ -76,10 +76,16 @@ function keys(
   for (const key of Object.keys(value))
     if (!allowed.includes(key)) errors.push(`${at}: unknown property "${key}"`);
   for (const key of required)
-    if (!own(value, key)) errors.push(`${at}: missing required property "${key}"`);
+    if (!own(value, key))
+      errors.push(`${at}: missing required property "${key}"`);
 }
 
-function checkValue(value: unknown, at: string, artifact: unknown, errors: string[]) {
+function checkValue(
+  value: unknown,
+  at: string,
+  artifact: unknown,
+  errors: string[],
+) {
   if (!scalarOrRef(value)) {
     errors.push(`${at}: expected scalar, null, or $ref`);
     return;
@@ -90,7 +96,8 @@ function checkValue(value: unknown, at: string, artifact: unknown, errors: strin
 
 function checkTone(value: unknown, at: string, errors: string[]) {
   if (typeof value === "string") {
-    if (!TONES.includes(value as ArtifactTone)) errors.push(`${at}: invalid tone`);
+    if (!TONES.includes(value as ArtifactTone))
+      errors.push(`${at}: invalid tone`);
     return;
   }
   if (!object(value)) {
@@ -119,7 +126,8 @@ function checkBlock(
   const type = value.type;
   const textBlock = (limit: number, byteLimit = false) => {
     keys(value, ["type", "text"], ["text"], at, errors);
-    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
+    if (typeof value.text !== "string")
+      errors.push(`${at}.text: expected string`);
     else if ((byteLimit ? bytes(value.text) : value.text.length) > limit)
       errors.push(`${at}: ${type} text is over ${limit}`);
   };
@@ -127,20 +135,25 @@ function checkBlock(
   if (type === "markdown") return textBlock(LIMITS.markdown, true);
   if (type === "code") {
     keys(value, ["type", "text", "language"], ["text"], at, errors);
-    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
-    else if (bytes(value.text) > LIMITS.code) errors.push(`${at}: code text is over ${LIMITS.code}`);
+    if (typeof value.text !== "string")
+      errors.push(`${at}.text: expected string`);
+    else if (bytes(value.text) > LIMITS.code)
+      errors.push(`${at}: code text is over ${LIMITS.code}`);
     if (value.language !== undefined && typeof value.language !== "string")
       errors.push(`${at}.language: expected string`);
     return;
   }
   if (type === "badge") {
     keys(value, ["type", "text", "tone"], ["text", "tone"], at, errors);
-    if (typeof value.text !== "string") errors.push(`${at}.text: expected string`);
-    if (!TONES.includes(value.tone as ArtifactTone)) errors.push(`${at}.tone: invalid tone`);
+    if (typeof value.text !== "string")
+      errors.push(`${at}.text: expected string`);
+    if (!TONES.includes(value.tone as ArtifactTone))
+      errors.push(`${at}.tone: invalid tone`);
     return;
   }
   if (type === "keyvalue" || type === "list" || type === "links") {
-    const allowed = type === "list" ? ["type", "label", "items"] : ["type", "items"];
+    const allowed =
+      type === "list" ? ["type", "label", "items"] : ["type", "items"];
     keys(value, allowed, ["items"], at, errors);
     if (!Array.isArray(value.items)) {
       errors.push(`${at}.items: expected array`);
@@ -152,80 +165,154 @@ function checkBlock(
       const itemAt = `${at}.items[${index}]`;
       if (!object(item)) return errors.push(`${itemAt}: expected object`);
       if (type === "keyvalue") {
-        keys(item, ["label", "value", "format", "tone"], ["label", "value"], itemAt, errors);
-        if (typeof item.label !== "string") errors.push(`${itemAt}.label: expected string`);
-        if (own(item, "value")) checkValue(item.value, `${itemAt}.value`, artifact, errors);
-        if (item.format !== undefined && !FORMATS.includes(item.format as ArtifactFormat))
+        keys(
+          item,
+          ["label", "value", "format", "tone"],
+          ["label", "value"],
+          itemAt,
+          errors,
+        );
+        if (typeof item.label !== "string")
+          errors.push(`${itemAt}.label: expected string`);
+        if (own(item, "value"))
+          checkValue(item.value, `${itemAt}.value`, artifact, errors);
+        if (
+          item.format !== undefined &&
+          !FORMATS.includes(item.format as ArtifactFormat)
+        )
           errors.push(`${itemAt}.format: invalid format`);
-        if (item.tone !== undefined && !TONES.includes(item.tone as ArtifactTone))
+        if (
+          item.tone !== undefined &&
+          !TONES.includes(item.tone as ArtifactTone)
+        )
           errors.push(`${itemAt}.tone: invalid tone`);
       } else if (type === "list") {
         keys(item, ["text", "ref", "tone"], ["text"], itemAt, errors);
-        if (typeof item.text !== "string") errors.push(`${itemAt}.text: expected string`);
+        if (typeof item.text !== "string")
+          errors.push(`${itemAt}.text: expected string`);
         if (item.ref !== undefined) {
-          if (typeof item.ref !== "string") errors.push(`${itemAt}.ref: expected string`);
+          if (typeof item.ref !== "string")
+            errors.push(`${itemAt}.ref: expected string`);
           else if (resolvePointer(artifact, item.ref) === undefined)
-            errors.push(`${itemAt}: ref "${item.ref}" does not resolve in the artifact`);
+            errors.push(
+              `${itemAt}: ref "${item.ref}" does not resolve in the artifact`,
+            );
         }
-        if (item.tone !== undefined && !TONES.includes(item.tone as ArtifactTone))
+        if (
+          item.tone !== undefined &&
+          !TONES.includes(item.tone as ArtifactTone)
+        )
           errors.push(`${itemAt}.tone: invalid tone`);
       } else {
         keys(item, ["label", "issue", "pr", "run", "url"], [], itemAt, errors);
-        const targets = ["issue", "pr", "run", "url"].filter((key) => own(item, key) && item[key] !== null);
-        if (targets.length !== 1) errors.push(`${itemAt}: a links item needs exactly one non-null target`);
+        const targets = ["issue", "pr", "run", "url"].filter(
+          (key) => own(item, key) && item[key] !== null,
+        );
+        if (targets.length !== 1)
+          errors.push(
+            `${itemAt}: a links item needs exactly one non-null target`,
+          );
         for (const target of ["issue", "pr", "run", "url"])
-          if (own(item, target)) checkValue(item[target], `${itemAt}.${target}`, artifact, errors);
+          if (own(item, target))
+            checkValue(item[target], `${itemAt}.${target}`, artifact, errors);
       }
     });
     return;
   }
   if (type === "table") {
-    keys(value, ["type", "label", "columns", "rows", "formats", "tone"], ["columns", "rows"], at, errors);
-    if (!Array.isArray(value.columns) || value.columns.length < 1 || value.columns.length > LIMITS.columns)
+    keys(
+      value,
+      ["type", "label", "columns", "rows", "formats", "tone"],
+      ["columns", "rows"],
+      at,
+      errors,
+    );
+    if (
+      !Array.isArray(value.columns) ||
+      value.columns.length < 1 ||
+      value.columns.length > LIMITS.columns
+    )
       errors.push(`${at}.columns: expected 1-${LIMITS.columns} columns`);
     else if (value.columns.some((column) => typeof column !== "string"))
       errors.push(`${at}.columns: expected strings`);
-    if (!Array.isArray(value.rows)) return errors.push(`${at}.rows: expected array`);
-    if (value.rows.length > LIMITS.rows) errors.push(`${at}.rows: too many rows`);
+    if (!Array.isArray(value.rows))
+      return errors.push(`${at}.rows: expected array`);
+    if (value.rows.length > LIMITS.rows)
+      errors.push(`${at}.rows: too many rows`);
     value.rows.forEach((row, r) => {
-      if (!Array.isArray(row)) return errors.push(`${at}.rows[${r}]: expected array`);
+      if (!Array.isArray(row))
+        return errors.push(`${at}.rows[${r}]: expected array`);
       if (Array.isArray(value.columns) && row.length !== value.columns.length)
-        errors.push(`${at}.rows[${r}]: ${row.length} cells != ${value.columns.length} columns`);
-      row.forEach((cell, c) => checkValue(cell, `${at}.rows[${r}][${c}]`, artifact, errors));
+        errors.push(
+          `${at}.rows[${r}]: ${row.length} cells != ${value.columns.length} columns`,
+        );
+      row.forEach((cell, c) =>
+        checkValue(cell, `${at}.rows[${r}][${c}]`, artifact, errors),
+      );
     });
     if (value.formats !== undefined) {
-      if (!Array.isArray(value.formats) || value.formats.some((format) => !FORMATS.includes(format as ArtifactFormat)))
+      if (
+        !Array.isArray(value.formats) ||
+        value.formats.some(
+          (format) => !FORMATS.includes(format as ArtifactFormat),
+        )
+      )
         errors.push(`${at}.formats: invalid formats`);
-      else if (Array.isArray(value.columns) && value.formats.length > value.columns.length)
+      else if (
+        Array.isArray(value.columns) &&
+        value.formats.length > value.columns.length
+      )
         errors.push(`${at}.formats: more formats than columns`);
     }
     if (value.tone !== undefined) checkTone(value.tone, `${at}.tone`, errors);
     return;
   }
   if (type === "section") {
-    keys(value, ["type", "label", "collapsed", "blocks"], ["label", "blocks"], at, errors);
+    keys(
+      value,
+      ["type", "label", "collapsed", "blocks"],
+      ["label", "blocks"],
+      at,
+      errors,
+    );
     if (depth > 0) errors.push(`${at}: section nesting exceeds one level`);
-    if (typeof value.label !== "string") errors.push(`${at}.label: expected string`);
+    if (typeof value.label !== "string")
+      errors.push(`${at}.label: expected string`);
     if (value.collapsed !== undefined && typeof value.collapsed !== "boolean")
       errors.push(`${at}.collapsed: expected boolean`);
-    if (!Array.isArray(value.blocks)) return errors.push(`${at}.blocks: expected array`);
-    if (value.blocks.length > LIMITS.section) errors.push(`${at}.blocks: too many blocks`);
-    value.blocks.forEach((block, index) => checkBlock(block, `${at}.blocks[${index}]`, artifact, errors, depth + 1));
+    if (!Array.isArray(value.blocks))
+      return errors.push(`${at}.blocks: expected array`);
+    if (value.blocks.length > LIMITS.section)
+      errors.push(`${at}.blocks: too many blocks`);
+    value.blocks.forEach((block, index) =>
+      checkBlock(block, `${at}.blocks[${index}]`, artifact, errors, depth + 1),
+    );
   }
 }
 
 /** Validate the document and every artifact citation. Never throws. */
-export function validatePresentation(value: unknown, artifact: unknown): PresentationValidation {
+export function validatePresentation(
+  value: unknown,
+  artifact: unknown,
+): PresentationValidation {
   const errors: string[] = [];
   if (!object(value)) return { valid: false, errors: ["$: expected object"] };
-  keys(value, ["schemaVersion", "blocks"], ["schemaVersion", "blocks"], "$", errors);
+  keys(
+    value,
+    ["schemaVersion", "blocks"],
+    ["schemaVersion", "blocks"],
+    "$",
+    errors,
+  );
   if (value.schemaVersion !== PRESENTATION_SCHEMA_VERSION)
     errors.push("$.schemaVersion: expected factory.presentation/v1");
   if (!Array.isArray(value.blocks)) errors.push("$.blocks: expected array");
   else {
     if (value.blocks.length < 1 || value.blocks.length > LIMITS.blocks)
       errors.push(`$.blocks: expected 1-${LIMITS.blocks} blocks`);
-    value.blocks.forEach((block, index) => checkBlock(block, `blocks[${index}]`, artifact ?? {}, errors, 0));
+    value.blocks.forEach((block, index) =>
+      checkBlock(block, `blocks[${index}]`, artifact ?? {}, errors, 0),
+    );
   }
   if (bytes(JSON.stringify(value)) > LIMITS.bytes)
     errors.push(`$: serialised presentation is over ${LIMITS.bytes} bytes`);
@@ -233,11 +320,21 @@ export function validatePresentation(value: unknown, artifact: unknown): Present
 }
 
 /** Deep-copy a presentation, replacing `$ref` values with value+source pairs. */
-export function resolveRefs(presentation: Presentation, artifact: unknown): Presentation {
+export function resolveRefs(
+  presentation: Presentation,
+  artifact: unknown,
+): Presentation {
   const map = (value: unknown): unknown => {
     if (Array.isArray(value)) return value.map(map);
-    if (ref(value)) return { value: resolvePointer(artifact ?? {}, value.$ref), ref: value.$ref };
-    if (object(value)) return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, map(child)]));
+    if (ref(value))
+      return {
+        value: resolvePointer(artifact ?? {}, value.$ref),
+        ref: value.$ref,
+      };
+    if (object(value))
+      return Object.fromEntries(
+        Object.entries(value).map(([key, child]) => [key, map(child)]),
+      );
     return value;
   };
   return map(presentation) as Presentation;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -439,6 +439,8 @@ export interface RunDetail {
     terminalState: string;
     reasonCode: string | null;
     artifact?: unknown;
+    presentation?: Presentation;
+    presentationErrors?: string[];
     artifactHash?: string;
     artifacts?: ArtifactRef[];
     evidence?: unknown;
@@ -498,6 +500,63 @@ export type ArtifactFormat =
   | "count";
 export type ArtifactSectionKind =
   "table" | "keyvalue" | "list" | "badge" | "code" | "prose";
+
+/** `factory.presentation/v1` — the optional, agent-authored Layer B document. */
+export type PresentationValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { $ref: string };
+export type ResolvedPresentationValue =
+  | Exclude<PresentationValue, { $ref: string }>
+  | { value: unknown; ref: string };
+export type PresentationBlock =
+  | { type: "heading" | "markdown"; text: string }
+  | {
+      type: "keyvalue";
+      items: Array<{
+        label: string;
+        value: PresentationValue;
+        format?: ArtifactFormat;
+        tone?: ArtifactTone;
+      }>;
+    }
+  | {
+      type: "table";
+      label?: string;
+      columns: string[];
+      rows: PresentationValue[][];
+      formats?: ArtifactFormat[];
+      tone?: ArtifactTone | Record<string, unknown>;
+    }
+  | {
+      type: "list";
+      label?: string;
+      items: Array<{ text: string; ref?: string; tone?: ArtifactTone }>;
+    }
+  | { type: "badge"; text: string; tone: ArtifactTone }
+  | { type: "code"; text: string; language?: string }
+  | {
+      type: "section";
+      label: string;
+      collapsed?: boolean;
+      blocks: Exclude<PresentationBlock, { type: "section" }>[];
+    }
+  | {
+      type: "links";
+      items: Array<{
+        label: string;
+        issue?: PresentationValue;
+        pr?: PresentationValue;
+        run?: PresentationValue;
+        url?: PresentationValue;
+      }>;
+    };
+export interface Presentation {
+  schemaVersion: "factory.presentation/v1";
+  blocks: PresentationBlock[];
+}
 export interface ArtifactViewSection {
   /** RFC 6901 pointer into the artifact; `""` is the whole document. */
   path: string;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -503,11 +503,7 @@ export type ArtifactSectionKind =
 
 /** `factory.presentation/v1` — the optional, agent-authored Layer B document. */
 export type PresentationValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { $ref: string };
+  string | number | boolean | null | { $ref: string };
 export type ResolvedPresentationValue =
   | Exclude<PresentationValue, { $ref: string }>
   | { value: unknown; ref: string };

--- a/shared/presentation.md
+++ b/shared/presentation.md
@@ -1,0 +1,14 @@
+## Optional presentation
+
+For a human-facing terminal result, you may add a `presentation` beside
+`artifact` using `factory.presentation/v1`.
+
+- Lead with the one-sentence finding as a `heading`.
+- Put every number, identifier, and verdict the reader should trust behind a
+  `$ref` into `artifact`; literal prose is interpretation, not evidence.
+- Use a toned `list` for the items that need attention.
+- Put method and caveats in a collapsed `section`.
+- Stay inside the contract bounds: at most 40 blocks and 16 KiB overall; do
+  not nest sections.
+- Do not restate the whole artifact. The schema-derived artifact view renders
+  immediately below the presentation.


### PR DESCRIPTION
Fixes watt-mind/factory#833

## Summary

Renders the presentation v1 block contract on both surfaces and pilots it on `triage-scan`:

- `web/src/lib/presentation.ts` ports `resolveRefs` + the client-side validator; a test runs the shared fixture `lib/fixtures/presentation-cases.json` and asserts agreement with the server.
- `web/src/components/BlockRenderer.tsx` renders every block type using the shared `artifactView.ts` format/tone helpers; `$ref` values show the resolved value with the pointer on hover; `section` honours `collapsed`; `links` reuse the shared chips; no branching on agent name.
- `RunDetailBlocks.tsx`: `result.presentation` renders above the ArtifactView with its own Raw toggle; `result.presentationErrors` renders the one-line drop notice with errors in a disclosure while Layer A renders as usual. `types.ts` gains `RunResult.presentation?/presentationErrors?`.
- `lib/presentation-text.mjs` `renderText(presentation, { width })` linearises blocks to plain text; `cli.mjs inspect <runId>` prints it before the artifact (or the drop notice). Snapshot-tested.
- `shared/presentation.md` is the shared brief section (§3.6 rules); only `agents/triage-scan.md` opts in (section + one worked example), `triage-scan.json` re-pinned.
- `lib/registry.test.mjs`: zero-pack digest baseline re-pinned with the reason comment — `triage-scan.md` is a registry input, so the pin change moves the merged-view digest. Prompt text and its pin only; no schema, contract, route, capability, or model tier changed.

Not in this PR (need the live stack / elapsed time): the three observed real `triage-scan` runs, the deliberately malformed presentation, and the ≥5-run comparison note. Those are recorded on the ticket after this lands and the pilot runs.

## Handoff

### Verification

Ticket Verification Command:

```
bun test event-runtime/web event-runtime/lib/presentation-text.test.mjs
  1295 pass, 0 fail, 5314 expect() calls (82 files)
bun run --cwd event-runtime/web build
  ✓ built in 11.99s (chunk-size warning only, pre-existing)
bun build/emit.mjs --check
  ok — 94 generated files match shared/   (exit 0; floor-delivery note refers to the operator checkout's AGENTS.md, not this branch)
bun event-runtime/cli.mjs update-pins --check
  pins already current
bun run format:check
  All matched files use Prettier code style!
```

Repo gate:

```
bun test event-runtime/lib --timeout 20000
  1736 pass, 10 skip, 0 fail, 8776 expect() calls (94 files)
bun run check
  exit 0
```

### UX critique

Not assessed. The change adds a new block above the ArtifactView on the run detail page and a new text section in `cli.mjs inspect`, but there is no real `triage-scan` run with a `result.presentation` on the live stack yet (the brief only starts emitting one once this lands), so the journey could not be exercised end-to-end; covered by unit tests (`BlockRenderer.test.tsx`, `RunDetailBlocks.test.tsx`, `presentation-text.test.mjs` snapshot) and by the on-ticket observation criteria after merge.

### File scope

All 14 changed files are within the ticket's Owned Paths: `event-runtime/web/src/components/BlockRenderer.*`, `event-runtime/web/src/lib/presentation.*`, `event-runtime/web/src/components/RunDetailBlocks.tsx` + `.test.tsx`, `event-runtime/web/src/types.ts`, `event-runtime/lib/presentation-text.mjs` + `.test.mjs`, `event-runtime/cli.mjs`, `shared/presentation.md`, `event-runtime/agents/triage-scan.md` + `.json`, `event-runtime/lib/registry.test.mjs`. No new dependencies.



### Post-review

- 5302b34 `fix(inspect)`: the `result` anchor in `inspectWithPresentation` now matches `line.trim() === "result"` (inspect prints `"\nresult"`), so presentation text lands after the result header instead of at the tail.
- The `resolveRefs`/`renderText` garnish is wrapped in try/catch: a throw logs a one-line `warning: presentation not rendered: ...` and the buffered inspect output is still printed in full.
- Verified: `bun test event-runtime/cli.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/presentation-text.test.mjs`, `bun run check`, `bun run format:check`, `update-pins --check` (pins current; no agent .md/.json change).
