### PR TITLE
sec(runtime): reserve schedule provenance at external admission (#960)

### DIFF
--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -248,7 +248,19 @@ export function translateGitHubEvent({
  *         | { admitted: false, duplicate: true, event: object }
  *         | { admitted: false, duplicate: false, errors: string[] }}
  */
-export const RESERVED_INTERNAL_SOURCES = new Set(["chain", "handoff"]);
+/**
+ * Provenance a caller may never select. `chain` is durable proof the chain
+ * resolver created the event; `handoff` proof the handoff boundary did; and
+ * `schedule` proof the in-process tick loop did — the fact
+ * `autoApproveScheduled` reads as authority to approve a run nobody watched
+ * (#960). Each is written only by a trusted in-process producer that calls
+ * `admitEvent` (or a narrow wrapper) directly.
+ */
+export const RESERVED_INTERNAL_SOURCES = new Set([
+  "chain",
+  "handoff",
+  "schedule",
+]);
 
 function reservedSourceRefusal(envelope, allowed = new Set()) {
   if (
@@ -281,7 +293,8 @@ export function admitExternalEvent(db, registry, envelope, options = {}) {
 /**
  * Persist an envelope after the existing factory HMAC boundary authenticated
  * its exact bytes. Handoff is the one reserved provenance that boundary may
- * admit; chain remains in-process-only and caller text can never select it.
+ * admit; chain and schedule remain in-process-only, so a holder of the shared
+ * event secret cannot forge scheduler provenance and inherit auto-approval.
  */
 export function admitSignedEvent(db, registry, envelope, options = {}) {
   const refusal = reservedSourceRefusal(envelope, new Set(["handoff"]));

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -215,7 +215,7 @@ describe("admitEvent", () => {
   });
 
   test("external admission rejects all reserved provenance before persistence", () => {
-    for (const source of ["chain", "handoff"]) {
+    for (const source of ["chain", "handoff", "schedule"]) {
       const db = openDb(":memory:");
       const result = admitExternalEvent(
         db,
@@ -258,6 +258,32 @@ describe("admitEvent", () => {
       duplicate: false,
       errors: ['source: reserved internal provenance "chain"'],
     });
+  });
+
+  test("a signed caller cannot forge schedule provenance to inherit auto-approval (#960)", () => {
+    const db = openDb(":memory:");
+    // The concrete attack from #960: a holder of the shared event secret posts
+    // a merge request wearing the enabled auto-approved loop's provenance.
+    const forged = envelope({
+      source: "schedule",
+      eventId: "clock:merge-factory:2026-08-12T10:30:00.000Z",
+      type: "factory.merge.requested",
+      payload: { loop: "merge-factory", repo: "factory" },
+    });
+    expect(admitSignedEvent(db, registry, forged, { now: NOW })).toEqual({
+      admitted: false,
+      duplicate: false,
+      errors: ['source: reserved internal provenance "schedule"'],
+    });
+    expect(admitExternalEvent(db, registry, forged, { now: NOW })).toEqual({
+      admitted: false,
+      duplicate: false,
+      errors: ['source: reserved internal provenance "schedule"'],
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+
+    // The in-process scheduler still owns the provenance it writes.
+    expect(admitEvent(db, registry, forged, { now: NOW }).admitted).toBe(true);
   });
 
   test("schema-invalid envelope returns errors and writes no row", () => {

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -10,9 +10,17 @@
  * the part that decides whether a restart double-fires — is testable without
  * a clock or a runtime.
  */
+import { canonicalJson } from "./canonical.mjs";
 import { admitEvent } from "./intake.mjs";
 
 export const SCHEDULE_SOURCE = "schedule";
+/** Fields emitDueTicks always stamps itself, overriding a static payload. */
+const TICK_PAYLOAD_FIELDS = new Set([
+  "loop",
+  "slot",
+  "cadenceSeconds",
+  "skippedSlots",
+]);
 export const CATCH_UP_MODES = ["none", "last", "all"];
 export const APPROVAL_MODES = ["watched", "auto"];
 
@@ -283,6 +291,35 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
 }
 
 /**
+ * Does this admitted event look exactly like the tick `emitDueTicks` would
+ * have emitted for `loop`? Auto-approval is the one path that runs work with
+ * nobody watching, so it binds to the configured event type, the
+ * `clock:<loop>:<slot>` identity the tick loop mints, and the schedule's
+ * static payload — a stored event that drifts from any of those is left as an
+ * ordinary open proposal for a human.
+ */
+function matchesConfiguredTick(envelope, row, loop, schedule) {
+  const slot = envelope.payload?.slot;
+  if (typeof slot !== "string" || slot === "") return false;
+  if (row.event_id !== tickEventId(loop, slot)) return false;
+  if (row.type !== schedule.eventType) return false;
+  const payload = envelope.payload ?? {};
+  for (const [key, value] of Object.entries(schedule.payload ?? {})) {
+    // The tick fields always win over a schedule's static payload
+    // (see emitDueTicks), so they are not part of the static binding.
+    if (TICK_PAYLOAD_FIELDS.has(key)) continue;
+    if (value === undefined) continue;
+    if (!Object.hasOwn(payload, key)) return false;
+    try {
+      if (canonicalJson(payload[key]) !== canonicalJson(value)) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Approve open proposals belonging to loops that declare `approval: auto`
  * (§6). Separate from planning on purpose: auto-approval is the step that
  * changes what the runtime may do unattended, so it is one explicit call
@@ -300,23 +337,35 @@ export function autoApproveScheduled(
 ) {
   const approved = [];
   const errors = [];
-  const autoLoops = new Set(
-    Object.entries(registry.schedules ?? {})
-      .filter(([, s]) => s.enabled && (s.approval ?? "watched") === "auto")
-      .map(([loop]) => loop),
+  const autoLoops = new Map(
+    Object.entries(registry.schedules ?? {}).filter(
+      ([, s]) => s.enabled && (s.approval ?? "watched") === "auto",
+    ),
   );
   if (autoLoops.size === 0) return { approved, errors };
 
   const rows = db
     .query(
-      `SELECT p.id, e.envelope_json FROM proposals p
+      `SELECT p.id, e.event_id, e.type, e.envelope_json FROM proposals p
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE p.status = 'open' AND p.decision = 'run' AND e.source = ?`,
     )
     .all(SCHEDULE_SOURCE);
   for (const row of rows) {
-    const loop = JSON.parse(row.envelope_json).payload?.loop;
-    if (!autoLoops.has(loop)) continue;
+    let envelope;
+    try {
+      envelope = JSON.parse(row.envelope_json);
+    } catch {
+      continue;
+    }
+    const loop = envelope.payload?.loop;
+    const schedule = autoLoops.get(loop);
+    if (!schedule) continue;
+    // Defense in depth (#960): reserved `schedule` provenance is the primary
+    // control, but auto-approval also refuses anything that is not shaped like
+    // the tick this loop's configuration emits — its event type, its
+    // `clock:<loop>:<slot>` identity, and its static payload verbatim.
+    if (!matchesConfiguredTick(envelope, row, loop, schedule)) continue;
     try {
       const outcome = approve(db, registry, row.id, {
         actor: SCHEDULE_SOURCE,

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -4,11 +4,12 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { openDb } from "./db.mjs";
-import { admitEvent } from "./intake.mjs";
+import { admitEvent, admitExternalEvent, admitSignedEvent } from "./intake.mjs";
 import { planAdmittedEvents, planEvent } from "./planner.mjs";
 import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 import {
+  SCHEDULE_SOURCE,
   autoApproveScheduled,
   dueSlots,
   emitDueTicks,
@@ -458,6 +459,86 @@ describe("planning a tick (§5, §6)", () => {
       .get(runId);
     expect(approval.actor).toBe("schedule");
     expect(approval.actor).not.toBe("operator");
+  });
+
+  test("reserved schedule provenance is refused at the external boundary but the tick loop still admits (#960)", () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+    const forged = {
+      schemaVersion: "factory.event/v1",
+      eventId: tickEventId("reaper", "2026-08-13T21:00:00.000Z"),
+      type: "clock.tick.reaper",
+      source: SCHEDULE_SOURCE,
+      subject: "reaper",
+      occurredAt: "2026-08-13T21:00:00.000Z",
+      correlationId: "forged",
+      causationId: null,
+      payload: { loop: "reaper", slot: "2026-08-13T21:00:00.000Z" },
+    };
+    const now = at("2026-08-13T21:00:05Z");
+    for (const admit of [admitExternalEvent, admitSignedEvent]) {
+      expect(admit(d, registry, forged, { now })).toEqual({
+        admitted: false,
+        duplicate: false,
+        errors: ['source: reserved internal provenance "schedule"'],
+      });
+    }
+    expect(d.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+
+    // The internal scheduler is unaffected: it emits, plans and auto-approves.
+    expect(emitDueTicks(d, registry, { now }).emitted).toHaveLength(1);
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    expect(
+      autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV })
+        .approved,
+    ).toHaveLength(1);
+  });
+
+  test("auto-approval binds to the configured event type and static payload (#960)", () => {
+    const d = db();
+    const registry = withLoop({
+      eventType: "factory.merge.requested",
+      payload: { repo: "factory" },
+      approval: "auto",
+    });
+    // A schedule-sourced event that is not the tick this loop is configured to
+    // emit: same loop, different repo binding and a non-tick identity.
+    const now = at("2026-08-17T10:30:45Z");
+    const admitted = admitEvent(
+      d,
+      registry,
+      {
+        schemaVersion: "factory.event/v1",
+        eventId: "manual:reaper:2026-08-17T10:30:00.000Z",
+        type: "factory.merge.requested",
+        source: SCHEDULE_SOURCE,
+        subject: "reaper",
+        occurredAt: "2026-08-17T10:30:00.000Z",
+        correlationId: "smuggled",
+        causationId: null,
+        payload: {
+          loop: "reaper",
+          slot: "2026-08-17T10:30:00.000Z",
+          repo: "other-repo",
+        },
+      },
+      { now },
+    );
+    expect(admitted.admitted).toBe(true);
+    planAdmittedEvents(d, registry, { policyVersion: PV, now });
+
+    const outcome = autoApproveScheduled(d, registry, approveProposal, {
+      now,
+      policyVersion: PV,
+    });
+    expect(outcome.approved).toEqual([]);
+    // It stays an ordinary open proposal for a human, not a queued run.
+    expect(
+      openProposals(d, {}).filter((p) => p.status === "open").length,
+    ).toBeGreaterThan(0);
+    expect(
+      d.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'QUEUED'`).get().n,
+    ).toBe(0);
   });
 
   test("singleton: a loop whose previous run is in flight plans a NOOP, not a queue", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#960

## Summary

Authenticated callers of `POST /events` could submit an envelope with
caller-selected `source: "schedule"`. External admission reserved only `chain`
and `handoff`, while `autoApproveScheduled()` treats `source=schedule` plus
`payload.loop` as durable proof that the in-process tick loop emitted the
event — so a holder of the shared event HMAC secret could impersonate an
enabled auto-approved loop (e.g. `factory.merge.requested` with
`payload.loop: "merge-factory"`) and skip watched approval entirely.

- `event-runtime/lib/intake.mjs` — `schedule` joins `chain`/`handoff` in
  `RESERVED_INTERNAL_SOURCES`, so both `admitExternalEvent` (public/operator
  boundary, GitHub webhook translation, connectors) and `admitSignedEvent`
  (the factory-HMAC `POST /events` boundary) refuse it before persistence,
  fail closed, and write no row. The internal scheduler keeps writing that
  provenance through the trusted `admitEvent` primitive, so `emitDueTicks` is
  unchanged; operator ad-hoc `/schedules/<loop>/run` triggers already use
  source `operator` and are likewise unaffected.
- `event-runtime/lib/schedules.mjs` — defense in depth: `autoApproveScheduled`
  now approves only proposals whose stored event matches the loop's configured
  tick shape — its `eventType`, its `clock:<loop>:<slot>` identity, and the
  schedule's static payload verbatim (tick-stamped fields excepted, since
  `emitDueTicks` always overrides those). Anything that drifts stays an
  ordinary open proposal for a human rather than an unattended run.
- Regression coverage in both test files: rejection through
  `admitExternalEvent` and `admitSignedEvent` including the concrete
  merge-forgery envelope; continued internal emission → planning →
  auto-approval; and a schedule-sourced event that is not the configured tick
  being left unapproved with no QUEUED run.

## Handoff

**Verification**

- `bun test --timeout 20000 event-runtime/lib/intake.test.mjs event-runtime/lib/schedules.test.mjs` → `47 pass, 0 fail, 193 expect() calls`
- `bun test event-runtime/lib --timeout 20000` → `1736 pass, 10 skip, 1 fail` across 93 files. The single failure is
  `event-runtime/lib/adapters/cursor.test.mjs` › "executes the verified prompt snapshot after its path changes and captures trace", where the local cursor CLI emits only
  `{"type":"system","subtype":"init","model":"Composer 2.5"}` — pre-existing and environmental, untouched by this diff (no file under `adapters/` changed).
- `bun build/emit.mjs --check` → `ok — 94 generated files match shared/` (exit 0; the "floor delivery stale" line refers to the operator's live checkout, not this branch)
- `bun run check` → exit 0
- `prettier --write` on the four changed files → clean; `eslint` → 0 errors (one pre-existing `no-unused-vars` warning on `tx` in `intake.mjs`)
- No agent `.md`/`.json` changed, so `update-pins` was not needed.

**UX critique**: not applicable — runtime event intake and scheduler
authorization, no user-completable UI flow.

**File scope**: strictly the four Owned Paths — `event-runtime/lib/intake.mjs`,
`event-runtime/lib/intake.test.mjs`, `event-runtime/lib/schedules.mjs`,
`event-runtime/lib/schedules.test.mjs`. No callers outside them needed
changing: internal producers already use `admitEvent`/`admitChainEvent`.

**Risks**

- Behavior change at the boundary: any external integration that was posting
  `source: "schedule"` to `POST /events` now gets a 422
  `source: reserved internal provenance "schedule"`. That is the point of the
  fix; a legitimate external caller should use its own source, and an operator
  should use `POST /schedules/<loop>/run`.
- The defense-in-depth binding is deliberately strict: if a schedule's static
  payload is edited while an old tick's proposal is still open, that proposal
  will no longer auto-approve and waits for a human instead of running with
  stale config. Fail-closed by design.
- Auth-boundary change: implemented under the operator's explicit 2026-08-29
  pre-approval of factory security tickets and the ticket's
  `humanDecision.authorisation`; still warrants human diff review before merge.


## Post-review note

Review finding: `admitSignedEvent` (`event-runtime/lib/intake.mjs`) has no production caller — `POST /events` and the GitHub webhook translation both admit through `admitExternalEvent` (`api-intake.mjs`). The `schedule` reservation and its tests on `admitSignedEvent` are therefore defensive coverage for a dormant boundary; the live boundary is covered via `admitExternalEvent`. Follow-up filed to wire or remove `admitSignedEvent`.
