### PR TITLE
feat(event-runtime): escalate exhausted dispatches to strong tier

### DIFF
--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -187,6 +187,14 @@ attributable comment naming both run IDs. Projection failures are retained and
 retried. Existing trust, budget, capacity, Owned Paths, security, and sensitive
 path gates still run at continuation claim time.
 
+Escalation never widens authority. The `ai:escalated`/`type:security` operator
+bypass carries into a continuation only when the failed run's own originating
+event was operator-sourced AND the durable escalation record authenticates this
+run as that failed run's continuation. It is never read out of an inherited
+spec field: `approvalPolicy.dispatchEvidence` is copied onto chain runs, so
+trusting it would give every descendant of one operator dispatch a permanent
+bypass.
+
 ## Extension pack pin repair metadata boundary (gh-857)
 
 Decided 2026-08-25. `update-pins --pack <name>` may discover packs contributed

--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -164,6 +164,29 @@ Promotion does not clear the runtime overrides. Clearing the overlay is a
 separate explicit action the operator takes after the promoted defaults have
 deployed, so the fast loop keeps winning until the fleet default catches up.
 
+## Exhausted dispatches escalate once to the strong tier (gh-845)
+
+Decided 2026-08-25. When an admitted `light` or `standard` dispatch exhausts
+its ordinary agent-error attempts with a verification failure, contract
+violation, or `agent_exit_*`, the runtime schedules exactly one `strong`
+continuation. Timeout, environment/lease failure, cancellation, refusal,
+human/policy/security denial, fatal failure, and an already-strong run do not
+escalate.
+
+The continuation is a runtime-authenticated, auto-approved handoff under the
+original admission authority. It has a new run ID, keeps the root correlation
+and ticket, names `escalatedFromRunId`, and reuses the exact retained checkout.
+Durable workspace ownership transfers before the continuation can become
+runnable; no second worktree or abandoned-work preservation/reset is allowed.
+
+Scheduling and tracker projection are separate crash-safe phases. The unique
+root handoff prevents a restart from creating a second continuation. The
+continuation remains approved but not queued until the control plane has
+replaced every prior `tier:*` label with `tier:strong` and posted an
+attributable comment naming both run IDs. Projection failures are retained and
+retried. Existing trust, budget, capacity, Owned Paths, security, and sensitive
+path gates still run at continuation claim time.
+
 ## Extension pack pin repair metadata boundary (gh-857)
 
 Decided 2026-08-25. `update-pins --pack <name>` may discover packs contributed

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -426,7 +426,11 @@ export const MIGRATIONS = [
     },
   },
   {
-    version: 14,
+    // 15, not 14: #1230 (#1197) also introduces a migration 14 and lands
+    // first. Guarded/idempotent like the rest, and the runner applies any
+    // migration above the database's user_version, so a v13 or v14 database
+    // and a fresh one all converge on 15.
+    version: 15,
     name: "tier_escalations",
     up(db) {
       db.exec(`

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -425,6 +425,30 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 14,
+    name: "tier_escalations",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS tier_escalations (
+          root_run_id         TEXT PRIMARY KEY,
+          failed_run_id       TEXT NOT NULL UNIQUE,
+          continuation_run_id TEXT NOT NULL UNIQUE,
+          repo                TEXT NOT NULL,
+          ticket              TEXT NOT NULL,
+          workspace_path      TEXT NOT NULL,
+          source_workspace_path TEXT NOT NULL,
+          projection_state    TEXT NOT NULL DEFAULT 'pending',
+          projection_attempts INTEGER NOT NULL DEFAULT 0,
+          projection_error    TEXT,
+          created_at          TEXT NOT NULL,
+          projected_at        TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_tier_escalations_projection
+          ON tier_escalations (projection_state, created_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =
@@ -448,6 +472,7 @@ export const CORE_TABLES = [
   "merge_reviews",
   "runtime_overrides",
   "runtime_override_journal",
+  "tier_escalations",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -133,6 +133,25 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
+  test("tier escalation handoffs migrate with unique root and continuation ownership", () => {
+    const db = openDb(freshFile());
+    const columns = db
+      .query(`PRAGMA table_info(tier_escalations)`)
+      .all()
+      .map((row) => row.name);
+    expect(columns).toEqual(
+      expect.arrayContaining([
+        "root_run_id",
+        "failed_run_id",
+        "continuation_run_id",
+        "workspace_path",
+        "source_workspace_path",
+        "projection_state",
+      ]),
+    );
+    db.close();
+  });
+
   test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {
     const file = freshFile();
     const db = new Database(file);

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -133,6 +133,32 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
+  test("tier escalation handoffs reach schema 15 from a fresh and from a v14 database", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(15);
+    const fresh = openDb(freshFile());
+    expect(getSchemaVersion(fresh)).toBe(15);
+    fresh.close();
+
+    // #1230 (#1197) owns migration 14 and lands first; a database already at
+    // 14 must pick up 15 alone, and the guarded DDL must survive re-running.
+    const file = freshFile();
+    const at14 = new Database(file);
+    migrateDb(at14, { targetVersion: 13 });
+    at14.exec("PRAGMA user_version = 14;");
+    migrateDb(at14);
+    expect(getSchemaVersion(at14)).toBe(15);
+    migrateDb(at14);
+    expect(getSchemaVersion(at14)).toBe(15);
+    expect(
+      at14
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'tier_escalations'`,
+        )
+        .get()?.name,
+    ).toBe("tier_escalations");
+    at14.close();
+  });
+
   test("tier escalation handoffs migrate with unique root and continuation ownership", () => {
     const db = openDb(freshFile());
     const columns = db

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1089,6 +1089,10 @@ export function worktreeDispatchAutoEligibility(
     fetchViewer = fetchViewerDefault,
     fetchInFlight = fetchInFlightDefault,
     countLeases = (repoName) => liveWorkerLeases(repoName).length,
+    hasTicketLease = (repoName, ticket) =>
+      liveWorkerLeases(repoName).some(
+        (lease) => String(lease.ticket) === String(ticket),
+      ),
     maxInFlightFallback,
     budgetRefusal = defaultBudgetRefusal,
     claimedRetry = null,
@@ -1148,6 +1152,16 @@ export function worktreeDispatchAutoEligibility(
   }
   evidence.checks.ticket_identifier_parseable = true;
 
+  const canResumeEscalation = Boolean(
+    escalatedContinuation?.failedRunId &&
+      escalatedContinuation?.continuationRunId &&
+      escalatedContinuation?.rootRunId &&
+      escalatedContinuation?.projectionState === "applied" &&
+      escalatedContinuation?.repo === payload?.repo &&
+      String(escalatedContinuation?.ticket) === String(payload?.ticket) &&
+      payload?.modelTier === "strong",
+  );
+
   let budgetReason;
   try {
     budgetReason = budgetRefusal();
@@ -1157,7 +1171,24 @@ export function worktreeDispatchAutoEligibility(
   if (budgetReason) return refusal(budgetReason, evidence);
   evidence.checks.budget_available = true;
 
-  if (live >= cap) return refusal("capacity_full", evidence);
+  // A tier escalation transfers one already-live ticket lease rather than
+  // admitting another dispatch. At a full cap, discount only the exact
+  // ticket lease authenticated by the durable continuation handoff; if the
+  // failed worker has already released it, the ordinary capacity count wins.
+  let transferredLease = false;
+  if (live >= cap && canResumeEscalation) {
+    try {
+      transferredLease = hasTicketLease(repo.name, payload?.ticket) === true;
+    } catch {
+      transferredLease = false;
+    }
+  }
+  const effectiveLive = live - (transferredLease ? 1 : 0);
+  if (canResumeEscalation) {
+    evidence.repo.capTransferred = transferredLease;
+    evidence.repo.capEffective = effectiveLive;
+  }
+  if (effectiveLive >= cap) return refusal("capacity_full", evidence);
   evidence.checks.cap_available = true;
 
   const ticket = fetchTicket(payload?.ticket, payload?.repo);
@@ -1191,15 +1222,6 @@ export function worktreeDispatchAutoEligibility(
     Number.isInteger(claimedRetry?.priorAttempt) &&
     claimedRetry.priorAttempt > 0 &&
     claimedRetry?.reasonCode === "lease_expired",
-  );
-  const canResumeEscalation = Boolean(
-    escalatedContinuation?.failedRunId &&
-      escalatedContinuation?.continuationRunId &&
-      escalatedContinuation?.rootRunId &&
-      escalatedContinuation?.projectionState === "applied" &&
-      escalatedContinuation?.repo === payload?.repo &&
-      String(escalatedContinuation?.ticket) === String(payload?.ticket) &&
-      payload?.modelTier === "strong",
   );
   let retryClaimedByFactory = false;
   let resumingOwnClaim = false;

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -450,13 +450,15 @@ export function buildEscalatedContinuationSpec(
       source: "handoff",
       mode: "auto",
       eventType: "factory.dispatch.requested",
+      // `operatorAuthorized` is decided by the caller from the ORIGINATING
+      // event source of the failed run. It is never read back out of the
+      // failed spec's own approvalPolicy: dispatchEvidence is inherited by
+      // chain runs, so sourcing it there would launder an operator bypass
+      // through any descendant of one operator dispatch.
       escalation: {
         rootRunId,
         failedRunId: failedSpec.runId,
-        operatorAuthorized:
-          operatorAuthorized === true ||
-          failedSpec.approvalPolicy?.dispatchEvidence?.checks
-            ?.operator_authorized === true,
+        operatorAuthorized: operatorAuthorized === true,
       },
       ...(failedSpec.approvalPolicy?.dispatchEvidence
         ? {
@@ -1154,12 +1156,12 @@ export function worktreeDispatchAutoEligibility(
 
   const canResumeEscalation = Boolean(
     escalatedContinuation?.failedRunId &&
-      escalatedContinuation?.continuationRunId &&
-      escalatedContinuation?.rootRunId &&
-      escalatedContinuation?.projectionState === "applied" &&
-      escalatedContinuation?.repo === payload?.repo &&
-      String(escalatedContinuation?.ticket) === String(payload?.ticket) &&
-      payload?.modelTier === "strong",
+    escalatedContinuation?.continuationRunId &&
+    escalatedContinuation?.rootRunId &&
+    escalatedContinuation?.projectionState === "applied" &&
+    escalatedContinuation?.repo === payload?.repo &&
+    String(escalatedContinuation?.ticket) === String(payload?.ticket) &&
+    payload?.modelTier === "strong",
   );
 
   let budgetReason;
@@ -1246,8 +1248,7 @@ export function worktreeDispatchAutoEligibility(
     resumingOwnClaim = true;
     if (canResumeEscalation) {
       evidence.checks.ticket_claim_escalation = true;
-      evidence.ticket.escalatedFromRunId =
-        escalatedContinuation.failedRunId;
+      evidence.ticket.escalatedFromRunId = escalatedContinuation.failedRunId;
       evidence.ticket.escalatedContinuationRunId =
         escalatedContinuation.continuationRunId;
     } else {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -416,6 +416,50 @@ export function buildRunSpec(
   };
 }
 
+/** Build the immutable strong-tier continuation for one admitted dispatch. */
+export function buildEscalatedContinuationSpec(
+  registry,
+  failedSpec,
+  { runId, operatorAuthorized = false } = {},
+) {
+  if (!runId) throw new Error("tier escalation continuation needs a runId");
+  const def = getAgent(registry, failedSpec.agent);
+  const planned = plannedDef(def, { modelTierOverride: "strong" });
+  const rootRunId = failedSpec.rootRunId ?? failedSpec.runId;
+  const input = { ...failedSpec.input, modelTier: "strong" };
+  return {
+    ...failedSpec,
+    runId,
+    input,
+    inputHash: hashJson(input),
+    modelTier: "strong",
+    model: resolveModel(planned, failedSpec.adapter, registry.modelTiers),
+    timeoutSeconds: def.limits.timeout_seconds,
+    maxAttempts: def.limits.attempts,
+    idempotencyKey: `${failedSpec.idempotencyKey}:tier-escalation:${rootRunId}`,
+    rootRunId,
+    escalatedFromRunId: failedSpec.runId,
+    approvalPolicy: {
+      source: "handoff",
+      mode: "auto",
+      eventType: "factory.dispatch.requested",
+      escalation: {
+        rootRunId,
+        failedRunId: failedSpec.runId,
+        operatorAuthorized:
+          operatorAuthorized === true ||
+          failedSpec.approvalPolicy?.dispatchEvidence?.checks
+            ?.operator_authorized === true,
+      },
+      ...(failedSpec.approvalPolicy?.dispatchEvidence
+        ? {
+            dispatchEvidence: failedSpec.approvalPolicy.dispatchEvidence,
+          }
+        : {}),
+    },
+  };
+}
+
 function resolveNow(now) {
   return typeof now === "function" ? now() : now;
 }
@@ -1041,6 +1085,7 @@ export function worktreeDispatchAutoEligibility(
     maxInFlightFallback,
     budgetRefusal = defaultBudgetRefusal,
     claimedRetry = null,
+    escalatedContinuation = null,
     operatorAuthorized = false,
     now = Date.now(),
   } = {},
@@ -1140,10 +1185,20 @@ export function worktreeDispatchAutoEligibility(
     claimedRetry.priorAttempt > 0 &&
     claimedRetry?.reasonCode === "lease_expired",
   );
+  const canResumeEscalation = Boolean(
+    escalatedContinuation?.failedRunId &&
+      escalatedContinuation?.continuationRunId &&
+      escalatedContinuation?.rootRunId &&
+      escalatedContinuation?.projectionState === "applied" &&
+      escalatedContinuation?.repo === payload?.repo &&
+      String(escalatedContinuation?.ticket) === String(payload?.ticket) &&
+      payload?.modelTier === "strong",
+  );
   let retryClaimedByFactory = false;
   let resumingOwnClaim = false;
   if (ticket.assignee) {
-    if (!canResumeClaim) return refusal("ticket_assigned", evidence);
+    if (!canResumeClaim && !canResumeEscalation)
+      return refusal("ticket_assigned", evidence);
     const viewer = fetchViewer();
     if (!viewer?.id || ticket.assignee.id !== viewer.id)
       return refusal("ticket_assigned", evidence);
@@ -1153,13 +1208,24 @@ export function worktreeDispatchAutoEligibility(
   }
 
   if (ticket.state?.name !== "Todo") {
-    if (!(retryClaimedByFactory && ticket.state?.name === "In Progress")) {
+    const resumableState = canResumeEscalation
+      ? ["In Progress", "In Review"].includes(ticket.state?.name)
+      : ticket.state?.name === "In Progress";
+    if (!(retryClaimedByFactory && resumableState)) {
       return refusal("ticket_not_todo", evidence);
     }
     resumingOwnClaim = true;
-    evidence.checks.ticket_claim_retry = true;
-    evidence.checks.ticket_in_progress_retry = true;
-    evidence.ticket.claimedRetryRunId = claimedRetry.runId;
+    if (canResumeEscalation) {
+      evidence.checks.ticket_claim_escalation = true;
+      evidence.ticket.escalatedFromRunId =
+        escalatedContinuation.failedRunId;
+      evidence.ticket.escalatedContinuationRunId =
+        escalatedContinuation.continuationRunId;
+    } else {
+      evidence.checks.ticket_claim_retry = true;
+      evidence.checks.ticket_in_progress_retry = true;
+      evidence.ticket.claimedRetryRunId = claimedRetry.runId;
+    }
   } else {
     // Assignment alone is not a surviving factory claim. Requiring the state
     // transition as well prevents an own-assigned Todo ticket from bypassing
@@ -1169,9 +1235,11 @@ export function worktreeDispatchAutoEligibility(
   }
 
   if (!evidence.ticket.labels.includes("ai:agent-ready")) {
-    if (!(
-      resumingOwnClaim && evidence.ticket.labels.includes("ai:in-progress")
-    )) {
+    const claimedLabel =
+      evidence.ticket.labels.includes("ai:in-progress") ||
+      (canResumeEscalation &&
+        evidence.ticket.labels.includes("ai:needs-review"));
+    if (!(resumingOwnClaim && claimedLabel)) {
       return refusal("ticket_not_agent_ready", evidence);
     }
     evidence.checks.ticket_in_progress_label_retry = true;

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -895,7 +895,7 @@ describe("planEvent worktree gate (WM-108)", () => {
 
   const tierRepo =
     `repos:\n  - name: tiered\n    path: /tmp/nowhere\n    base: develop\n` +
-    `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+    `    team: WM\n    project: Factory\n    max_in_flight: 1\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
     `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`;
 
   const tierTicket = (tierLabels = []) => ({
@@ -978,7 +978,7 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
-  test("tier escalation continuation pins a fresh strong-tier spec and authenticated claim proof", () => {
+  test("escalated continuation pins a fresh strong-tier spec and authenticated claim proof", () => {
     const base = {
       schemaVersion: "factory.run-spec/v1",
       runId: "run_light_failed",
@@ -1046,6 +1046,34 @@ describe("planEvent worktree gate (WM-108)", () => {
       );
       expect(authenticated.ok).toBe(true);
       expect(authenticated.evidence.checks.ticket_claim_escalation).toBe(true);
+
+      const fullCapacity = {
+        ...dispatch,
+        countLeases: () => 1,
+        hasTicketLease: () => false,
+        escalatedContinuation: {
+          failedRunId: base.runId,
+          continuationRunId: continuation.runId,
+          rootRunId: base.runId,
+          repo: "tiered",
+          ticket: "WM-694",
+          projectionState: "applied",
+        },
+      };
+      expect(
+        worktreeDispatchAutoEligibility(continuation.input, fullCapacity)
+          .refusal.reason,
+      ).toBe("capacity_full");
+      const transferredCapacity = worktreeDispatchAutoEligibility(
+        continuation.input,
+        { ...fullCapacity, hasTicketLease: () => true },
+      );
+      expect(transferredCapacity.ok).toBe(true);
+      expect(transferredCapacity.evidence.repo).toMatchObject({
+        capCurrent: 1,
+        capEffective: 0,
+        capTransferred: true,
+      });
     });
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -9,6 +9,7 @@ import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
 import {
+  buildEscalatedContinuationSpec,
   buildRunSpec,
   createLinearReadCache,
   DEFAULT_MAX_IN_FLIGHT as PLANNER_DEFAULT_MAX_IN_FLIGHT,
@@ -633,7 +634,7 @@ describe("planEvent", () => {
     });
   });
 
-  test("a duplicate dispatch for a ticket with a live dispatch is refused at plan time (WM-491)", () => {
+  test("same_ticket_worktree: a duplicate dispatch with a live run is refused at plan time (WM-491)", () => {
     const synthetic = { ...registry, agents: new Map(registry.agents) };
     synthetic.agents.set("dispatch@1", {
       ...registry.agents.get("dispatch@1"),
@@ -957,6 +958,77 @@ describe("planEvent worktree gate (WM-108)", () => {
         expect(spec.modelTier).toBe(item.tier);
         expect(spec.model).toBe(item.model);
       }
+    });
+  });
+
+  test("tier escalation continuation pins a fresh strong-tier spec and authenticated claim proof", () => {
+    const base = {
+      schemaVersion: "factory.run-spec/v1",
+      runId: "run_light_failed",
+      agent: "dispatch@1",
+      input: { repo: "tiered", ticket: "WM-694", modelTier: "light" },
+      inputHash: hashJson({ repo: "tiered", ticket: "WM-694", modelTier: "light" }),
+      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      adapter: "cursor",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.dispatch-result/v1",
+      capabilities: ["tracker:write", "repo:write", "github:write"],
+      modelTier: "light",
+      model: "cursor-grok-4.6-low-fast",
+      timeoutSeconds: 5400,
+      maxAttempts: 1,
+      idempotencyKey: "dispatch-light",
+    };
+    const continuation = buildEscalatedContinuationSpec(registry, base, {
+      runId: "run_strong_continuation",
+      operatorAuthorized: true,
+    });
+    expect(continuation).toMatchObject({
+      runId: "run_strong_continuation",
+      rootRunId: "run_light_failed",
+      escalatedFromRunId: "run_light_failed",
+      modelTier: "strong",
+      model: "cursor-grok-4.6-high",
+      timeoutSeconds: 5400,
+      maxAttempts: 1,
+      approvalPolicy: {
+        source: "handoff",
+        mode: "auto",
+        escalation: { operatorAuthorized: true },
+      },
+    });
+
+    withReposRoot(tierRepo, () => {
+      const assigned = tierTicket(["tier:light"]);
+      assigned.state = { name: "In Progress" };
+      assigned.assignee = { id: "factory-viewer", name: "Factory" };
+      assigned.labels.nodes.push({ name: "ai:in-progress" });
+      const dispatch = {
+        ...tierDispatch(["tier:light"]),
+        fetchTicket: () => assigned,
+        fetchViewer: () => ({ id: "factory-viewer" }),
+      };
+      expect(
+        worktreeDispatchAutoEligibility(continuation.input, dispatch).refusal
+          .reason,
+      ).toBe("ticket_assigned");
+      const authenticated = worktreeDispatchAutoEligibility(
+        continuation.input,
+        {
+          ...dispatch,
+          escalatedContinuation: {
+            failedRunId: base.runId,
+            continuationRunId: continuation.runId,
+            rootRunId: base.runId,
+            repo: "tiered",
+            ticket: "WM-694",
+            projectionState: "applied",
+          },
+        },
+      );
+      expect(authenticated.ok).toBe(true);
+      expect(authenticated.evidence.checks.ticket_claim_escalation).toBe(true);
     });
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1068,8 +1068,16 @@ describe("planEvent worktree gate (WM-108)", () => {
       runId: "run_light_failed",
       agent: "dispatch@1",
       input: { repo: "tiered", ticket: "WM-694", modelTier: "light" },
-      inputHash: hashJson({ repo: "tiered", ticket: "WM-694", modelTier: "light" }),
-      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      inputHash: hashJson({
+        repo: "tiered",
+        ticket: "WM-694",
+        modelTier: "light",
+      }),
+      workspace: {
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      },
       adapter: "cursor",
       promptVersion: "git:test",
       policyVersion: "git:test",

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2292,6 +2292,7 @@ export async function executeClaimed(
   const retain = spec.workspace?.retainOnFailure === true;
   let workspaceDir = null;
   let checkoutPath = null;
+  let worktreePath = null;
   let checkoutBaseline;
   let worktreeRecord;
   const cleanupWorkspace = ({ retainWorkspace = false } = {}) => {
@@ -2493,7 +2494,7 @@ export async function executeClaimed(
         });
       } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
         escalation = scheduleTierEscalation(db, registry, spec, {
-          workspacePath: checkoutPath,
+          workspacePath: worktreePath ?? checkoutPath,
           sourceWorkspacePath: workspaceDir,
           actor: owner,
           policyVersion,
@@ -2996,7 +2997,12 @@ export async function executeClaimed(
     });
     workspaceDir = created.dir;
     assertSandboxWorkspaceSupported(workspaceDir, def);
-    checkoutPath = created.checkout?.path ?? created.worktree?.path ?? null;
+    // Repository checkouts receive instance-local config and integrity
+    // baselining. Delegated worktrees already provision their own instance and
+    // must not be mutated by that repository-only setup; retain their path
+    // separately for an escalation ownership transfer.
+    checkoutPath = created.checkout?.path ?? null;
+    worktreePath = created.worktree?.path ?? null;
     provisionInstanceLocalConfigs({ checkoutPath });
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
     worktreeRecord = created.worktree
@@ -3507,7 +3513,7 @@ export async function executeClaimed(
           });
         } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
           escalation = scheduleTierEscalation(db, registry, spec, {
-            workspacePath: checkoutPath,
+            workspacePath: worktreePath ?? checkoutPath,
             sourceWorkspacePath: workspaceDir,
             actor: owner,
             policyVersion,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2859,6 +2859,12 @@ export async function executeClaimed(
             ...(dispatchOpts ?? {}),
             claimedRetry: claimedRetryFor(db, runId, attempt),
             escalatedContinuation: worktreeHandoff,
+            hasTicketLease:
+              dispatchOpts?.hasTicketLease ??
+              ((repo, ticket) =>
+                liveWorkerLeases(repo, { dir: leasesDir }).some(
+                  (lease) => String(lease.ticket) === String(ticket),
+                )),
             // Match the planner's operator-only bypass from the immutable
             // proposal that admitted this run. Never trust caller options here:
             // chain and schedule runs must keep the security/escalation gate.

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -44,11 +44,7 @@ import {
   MODEL_BACKED_ADAPTERS,
 } from "./adapters/sandboxed.mjs";
 import { isSandboxGuarded } from "./adapters/index.mjs";
-import {
-  createRun,
-  IllegalTransition,
-  transition,
-} from "./lifecycle.mjs";
+import { createRun, IllegalTransition, transition } from "./lifecycle.mjs";
 import {
   buildEscalatedContinuationSpec,
   HARNESS_KINDS,
@@ -761,11 +757,7 @@ const ENVIRONMENT_FAILURES = new Set([
 // The handoff gate (WM-718) catching the agent's own red is an agent error:
 // bounded by maxAttempts like any contract violation, never an environment
 // retry and never fatal — the ticket is already back in Todo + agent-ready.
-const AGENT_FAILURES = new Set([
-  "contract_violation",
-  "verification_failed",
-  ...HANDOFF_REASON_CODES,
-]);
+const AGENT_FAILURES = new Set(["contract_violation", ...HANDOFF_REASON_CODES]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
   "filesystem_confinement_unavailable",
@@ -798,17 +790,20 @@ export function classifyFailureCause(reasonCode) {
 /** Closed eligibility predicate; a continuation can never escalate again. */
 export function tierEscalationEligibility(spec, reasonCode) {
   const rootRunId = spec?.rootRunId ?? spec?.runId ?? null;
+  // The ticket's acceptance criteria name `verification_failed`; the code the
+  // runtime actually emits for that condition is `handoff_verification_failed`
+  // (verify.mjs HANDOFF_REASON_CODES). Match the emitted codes only — a
+  // reason code no producer writes is dead weight that reads as coverage.
   const eligibleReason =
-    reasonCode === "verification_failed" ||
-    reasonCode === "handoff_verification_failed" ||
+    HANDOFF_REASON_CODES.has(reasonCode) ||
     reasonCode === "contract_violation" ||
     String(reasonCode).startsWith("agent_exit_");
   const eligible = Boolean(
     spec?.agent === "dispatch@1" &&
-      spec?.workspace?.type === "worktree" &&
-      ["light", "standard"].includes(spec?.modelTier) &&
-      !spec?.escalatedFromRunId &&
-      eligibleReason,
+    spec?.workspace?.type === "worktree" &&
+    ["light", "standard"].includes(spec?.modelTier) &&
+    !spec?.escalatedFromRunId &&
+    eligibleReason,
   );
   return { eligible, rootRunId };
 }
@@ -1249,7 +1244,8 @@ export function reconcileTierEscalations(
       continuationRunId: row.continuation_run_id,
       fetchTicket,
     });
-    if (projected === false) throw new Error("tracker projection returned false");
+    if (projected === false)
+      throw new Error("tracker projection returned false");
   } catch (err) {
     db.query(
       `UPDATE tier_escalations
@@ -1330,8 +1326,7 @@ export function claimNext(
     now,
     policyVersion,
   });
-  if (!pendingEscalation.ok)
-    onTierEscalationProjectionError(pendingEscalation);
+  if (!pendingEscalation.ok) onTierEscalationProjectionError(pendingEscalation);
   // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
   // not both read the same QUEUED row before either writes (OPS-233).
   return txImmediate(db, () => {
@@ -2869,11 +2864,24 @@ export async function executeClaimed(
             // Match the planner's operator-only bypass from the immutable
             // proposal that admitted this run. Never trust caller options here:
             // chain and schedule runs must keep the security/escalation gate.
+            //
+            // A spec field alone can never carry this authorisation: chain and
+            // schedule runs inherit approvalPolicy (dispatchEvidence included,
+            // via stableChainApprovalPolicyForHash) from the dispatch they
+            // descend from, so trusting `dispatchEvidence.checks
+            // .operator_authorized` would hand every descendant of one operator
+            // dispatch a permanent ai:escalated/security bypass. The escalation
+            // claim is only believed when the durable tier_escalations row read
+            // for THIS run authenticates it as the continuation of the exact
+            // failed run the spec names.
             operatorAuthorized:
               originatingEvent(db, runId)?.source === "operator" ||
-              spec.approvalPolicy?.escalation?.operatorAuthorized === true ||
-              spec.approvalPolicy?.dispatchEvidence?.checks
-                ?.operator_authorized === true,
+              (worktreeHandoff !== null &&
+                spec.approvalPolicy?.escalation?.operatorAuthorized === true &&
+                spec.approvalPolicy.escalation.failedRunId ===
+                  worktreeHandoff.failedRunId &&
+                spec.approvalPolicy.escalation.rootRunId ===
+                  worktreeHandoff.rootRunId),
           });
         }
       } catch (err) {
@@ -4123,15 +4131,18 @@ export function reapExpiredLeases(
 
 /** Claim and execute one run, or return a typed refusal/null without execution. */
 export async function runOnce(db, registry, adapters, opts = {}) {
-  const pending = reconcileTierEscalations(db, {
+  // claimNext already reconciles pending escalation projections and logs a
+  // failed one without abandoning the claim: a tracker outage on one
+  // escalation must never stall claiming of every other queued run. Forward
+  // the dispatch-scoped tracker hooks so it uses the same ones this call does.
+  const claim = claimNext(db, {
+    ...opts,
     projectTierEscalation:
-      opts.dispatch?.projectTierEscalation ?? defaultProjectTierEscalation,
-    fetchTicket: opts.dispatch?.fetchTicket,
-    now: opts.now ?? Date.now(),
-    policyVersion: opts.policyVersion,
+      opts.projectTierEscalation ??
+      opts.dispatch?.projectTierEscalation ??
+      defaultProjectTierEscalation,
+    fetchTicket: opts.fetchTicket ?? opts.dispatch?.fetchTicket,
   });
-  if (!pending.ok) return pending;
-  const claim = claimNext(db, opts);
   if (!claim || claim.refused) return claim;
   return executeClaimed(db, registry, adapters, claim, opts);
 }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -39,13 +39,19 @@ import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT, resolveConfigPath } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
-import { IllegalTransition, transition } from "./lifecycle.mjs";
 import {
+  createRun,
+  IllegalTransition,
+  transition,
+} from "./lifecycle.mjs";
+import {
+  buildEscalatedContinuationSpec,
   HARNESS_KINDS,
   HARNESS_NAME_PATTERN,
   worktreeDispatchAutoEligibility,
   worktreeMergeFixEligibility,
 } from "./planner.mjs";
+import { newRunId } from "./ids.mjs";
 import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
@@ -749,7 +755,11 @@ const ENVIRONMENT_FAILURES = new Set([
 // The handoff gate (WM-718) catching the agent's own red is an agent error:
 // bounded by maxAttempts like any contract violation, never an environment
 // retry and never fatal — the ticket is already back in Todo + agent-ready.
-const AGENT_FAILURES = new Set(["contract_violation", ...HANDOFF_REASON_CODES]);
+const AGENT_FAILURES = new Set([
+  "contract_violation",
+  "verification_failed",
+  ...HANDOFF_REASON_CODES,
+]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
   "sandbox_unsupported",
@@ -776,6 +786,24 @@ export function classifyFailureCause(reasonCode) {
     return "fatal";
   }
   return "fatal";
+}
+
+/** Closed eligibility predicate; a continuation can never escalate again. */
+export function tierEscalationEligibility(spec, reasonCode) {
+  const rootRunId = spec?.rootRunId ?? spec?.runId ?? null;
+  const eligibleReason =
+    reasonCode === "verification_failed" ||
+    reasonCode === "handoff_verification_failed" ||
+    reasonCode === "contract_violation" ||
+    String(reasonCode).startsWith("agent_exit_");
+  const eligible = Boolean(
+    spec?.agent === "dispatch@1" &&
+      spec?.workspace?.type === "worktree" &&
+      ["light", "standard"].includes(spec?.modelTier) &&
+      !spec?.escalatedFromRunId &&
+      eligibleReason,
+  );
+  return { eligible, rootRunId };
 }
 
 function maxEnvironmentRetries(spec) {
@@ -981,7 +1009,7 @@ function originatingEvent(db, runId) {
   return (
     db
       .query(
-        `SELECT e.type, e.correlation_id, e.causation_id, p.event_source AS source
+        `SELECT e.type, e.event_id, e.correlation_id, e.causation_id, p.event_source AS source
        FROM proposals p
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE p.run_id = ?
@@ -989,6 +1017,275 @@ function originatingEvent(db, runId) {
       )
       .get(runId) ?? null
   );
+}
+
+function tierEscalationForContinuation(db, runId) {
+  const row = db
+    .query(
+      `SELECT * FROM tier_escalations WHERE continuation_run_id = ? AND projection_state = 'applied'`,
+    )
+    .get(runId);
+  if (!row) return null;
+  return {
+    rootRunId: row.root_run_id,
+    failedRunId: row.failed_run_id,
+    continuationRunId: row.continuation_run_id,
+    repo: row.repo,
+    ticket: row.ticket,
+    workspacePath: row.workspace_path,
+    sourceWorkspacePath: row.source_workspace_path,
+    projectionState: row.projection_state,
+  };
+}
+
+/** Create exactly one auto-approved continuation and durable workspace transfer. */
+export function scheduleTierEscalation(
+  db,
+  registry,
+  failedSpec,
+  {
+    workspacePath,
+    sourceWorkspacePath,
+    actor = "worker",
+    policyVersion = failedSpec.policyVersion,
+    now = Date.now(),
+    continuationRunId = newRunId(),
+    reasonCode,
+  } = {},
+) {
+  const rootRunId = failedSpec.rootRunId ?? failedSpec.runId;
+  const existing = db
+    .query(`SELECT * FROM tier_escalations WHERE root_run_id = ?`)
+    .get(rootRunId);
+  if (existing) return existing;
+  if (!tierEscalationEligibility(failedSpec, reasonCode).eligible) return null;
+  if (!workspacePath || !sourceWorkspacePath)
+    throw new Error("tier escalation requires the retained workspace paths");
+
+  const origin = originatingEvent(db, failedSpec.runId);
+  const spec = buildEscalatedContinuationSpec(registry, failedSpec, {
+    runId: continuationRunId,
+    operatorAuthorized: origin?.source === "operator",
+  });
+  const at = iso(now);
+  const eventId = `tier-escalation:${rootRunId}`;
+  const envelope = {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type: origin?.type ?? "factory.dispatch.requested",
+    source: "handoff",
+    subject: failedSpec.agent,
+    occurredAt: at,
+    correlationId: origin?.correlation_id ?? rootRunId,
+    causationId: failedSpec.runId,
+    payload: spec.input,
+  };
+  db.query(
+    `INSERT OR IGNORE INTO events
+       (source, event_id, type, subject, occurred_at, received_at,
+        correlation_id, causation_id, envelope_json, payload_hash, status,
+        admitted_at)
+     VALUES ('handoff', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'planned', ?)`,
+  ).run(
+    eventId,
+    envelope.type,
+    failedSpec.agent,
+    at,
+    at,
+    envelope.correlationId,
+    failedSpec.runId,
+    canonicalJson(envelope),
+    hashJson(spec.input),
+    at,
+  );
+  createRun(db, {
+    runId: continuationRunId,
+    idempotencyKey: spec.idempotencyKey,
+    spec,
+    specJson: canonicalJson(spec),
+    specHash: hashJson(spec),
+    actor,
+    correlationId: envelope.correlationId,
+    causationId: failedSpec.runId,
+    policyVersion,
+    now,
+  });
+  transition(db, {
+    runId: continuationRunId,
+    to: "APPROVED",
+    expectFrom: "PROPOSED",
+    actor,
+    reason: `auto_approved:tier-escalation:${failedSpec.runId}`,
+    correlationId: envelope.correlationId,
+    causationId: failedSpec.runId,
+    policyVersion,
+    now,
+  });
+  db.query(
+    `INSERT INTO proposals
+       (id, event_source, event_id, run_id, decision, spec_json, spec_hash,
+        idempotency_key, status, reason, created_at, ttl_seconds, decided_at,
+        decided_by)
+     VALUES (?, 'handoff', ?, ?, 'run', ?, ?, ?, 'approved', ?, ?, 0, ?, ?)`,
+  ).run(
+    `tier-escalation:${rootRunId}`,
+    eventId,
+    continuationRunId,
+    canonicalJson(spec),
+    hashJson(spec),
+    spec.idempotencyKey,
+    `escalated_from:${failedSpec.runId}`,
+    at,
+    at,
+    actor,
+  );
+  db.query(
+    `INSERT INTO tier_escalations
+       (root_run_id, failed_run_id, continuation_run_id, repo, ticket,
+        workspace_path, source_workspace_path, projection_state, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)`,
+  ).run(
+    rootRunId,
+    failedSpec.runId,
+    continuationRunId,
+    failedSpec.input.repo,
+    String(failedSpec.input.ticket),
+    workspacePath,
+    sourceWorkspacePath,
+    at,
+  );
+  return db
+    .query(`SELECT * FROM tier_escalations WHERE root_run_id = ?`)
+    .get(rootRunId);
+}
+
+const TIER_ESCALATION_COMMENT_MARKER = "factory:tier-escalation:";
+
+export function defaultProjectTierEscalation({
+  repo,
+  ticket,
+  failedRunId,
+  continuationRunId,
+  fetchTicket,
+  runCli = runLinearCli,
+}) {
+  const current =
+    typeof fetchTicket === "function"
+      ? fetchTicket(ticket, repo)
+      : JSON.parse(runCli(["get", ticket, "--json"], { repo }));
+  const names = (
+    Array.isArray(current?.labels)
+      ? current.labels
+      : (current?.labels?.nodes ?? [])
+  )
+    .map((label) => label?.name)
+    .filter(Boolean);
+  const tierLabels = names.filter(
+    (name) => name.startsWith("tier:") && name !== "tier:strong",
+  );
+  runCli(
+    [
+      "labels",
+      ticket,
+      "--add",
+      "tier:strong",
+      ...tierLabels.flatMap((name) => ["--remove", name]),
+    ],
+    { repo },
+  );
+  const marker = `${TIER_ESCALATION_COMMENT_MARKER}${failedRunId}:${continuationRunId}`;
+  let alreadyCommented = false;
+  try {
+    const comments = JSON.parse(
+      runCli(["comments", ticket, "--json"], { repo }),
+    );
+    alreadyCommented = comments.some((entry) =>
+      String(entry?.body ?? "").includes(marker),
+    );
+  } catch {
+    // A comment read is an idempotency optimization. Posting remains required.
+  }
+  if (!alreadyCommented) {
+    runCli(
+      [
+        "comment",
+        ticket,
+        `Tier escalation scheduled: failed run \`${failedRunId}\` continues as strong run \`${continuationRunId}\` in the same retained worktree.\n\n<!-- ${marker} -->`,
+      ],
+      { repo },
+    );
+  }
+  return true;
+}
+
+/** Retry pending tracker projections before a continuation can become runnable. */
+export function reconcileTierEscalations(
+  db,
+  {
+    projectTierEscalation = defaultProjectTierEscalation,
+    fetchTicket,
+    now = Date.now(),
+    policyVersion = "unknown",
+  } = {},
+) {
+  const row = db
+    .query(
+      `SELECT * FROM tier_escalations WHERE projection_state = 'pending' ORDER BY created_at LIMIT 1`,
+    )
+    .get();
+  if (!row) return { ok: true, projected: 0 };
+  try {
+    const projected = projectTierEscalation({
+      repo: row.repo,
+      ticket: row.ticket,
+      failedRunId: row.failed_run_id,
+      continuationRunId: row.continuation_run_id,
+      fetchTicket,
+    });
+    if (projected === false) throw new Error("tracker projection returned false");
+  } catch (err) {
+    db.query(
+      `UPDATE tier_escalations
+          SET projection_attempts = projection_attempts + 1,
+              projection_error = ?
+        WHERE root_run_id = ?`,
+    ).run(String(err?.message ?? err), row.root_run_id);
+    return {
+      ok: false,
+      reasonCode: "tier_escalation_writeback_failed",
+      continuationRunId: row.continuation_run_id,
+      error: String(err?.message ?? err),
+    };
+  }
+  txImmediate(db, () => {
+    const at = iso(now);
+    db.query(
+      `UPDATE tier_escalations
+          SET projection_state = 'applied', projection_attempts = projection_attempts + 1,
+              projection_error = NULL, projected_at = ?
+        WHERE root_run_id = ? AND projection_state = 'pending'`,
+    ).run(at, row.root_run_id);
+    const state = db
+      .query(`SELECT state FROM runs WHERE run_id = ?`)
+      .get(row.continuation_run_id)?.state;
+    if (state === "APPROVED") {
+      transition(db, {
+        runId: row.continuation_run_id,
+        to: "QUEUED",
+        expectFrom: "APPROVED",
+        actor: "tier-escalation",
+        reason: `tracker_projection_applied:${row.failed_run_id}`,
+        causationId: row.failed_run_id,
+        policyVersion,
+        now,
+      });
+    }
+  });
+  return {
+    ok: true,
+    projected: 1,
+    continuationRunId: row.continuation_run_id,
+  };
 }
 
 /**
@@ -1008,8 +1305,26 @@ export function claimNext(
     labels = {},
     adapters = null,
     adapterOverride,
+    projectTierEscalation = defaultProjectTierEscalation,
+    fetchTicket,
+    onTierEscalationProjectionError = (entry) =>
+      console.error(
+        `[worker] ${entry.reasonCode} for ${entry.continuationRunId}: ${entry.error}`,
+      ),
   } = {},
 ) {
+  // Production workers call claimNext() directly rather than runOnce(). Do
+  // this before looking for QUEUED work so a restart cannot strand a durable
+  // escalation in APPROVED after the scheduling transaction committed but
+  // before its tracker projection completed.
+  const pendingEscalation = reconcileTierEscalations(db, {
+    projectTierEscalation,
+    fetchTicket,
+    now,
+    policyVersion,
+  });
+  if (!pendingEscalation.ok)
+    onTierEscalationProjectionError(pendingEscalation);
   // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
   // not both read the same QUEUED row before either writes (OPS-233).
   return txImmediate(db, () => {
@@ -1994,6 +2309,7 @@ export async function executeClaimed(
   const repoName = spec.input?.repoPin?.repo ?? spec.input?.repo ?? null;
   const ticketId = spec.input?.ticket ?? null;
   const isWorktree = spec.workspace?.type === "worktree";
+  const worktreeHandoff = tierEscalationForContinuation(db, runId);
 
   let leaseHeartbeat = null;
   let ticketClaimed = false;
@@ -2071,9 +2387,27 @@ export async function executeClaimed(
     dispatchOpts?.holdPullRequest ?? defaultHoldPullRequest;
   const fetchHandoffPullRequestFn =
     dispatchOpts?.fetchHandoffPullRequest ?? defaultFetchHandoffPullRequest;
+  const projectTierEscalationFn =
+    dispatchOpts?.projectTierEscalation ?? defaultProjectTierEscalation;
   let handoffContext = null;
 
   const nowFn = typeof now === "function" ? now : () => now ?? Date.now();
+
+  const tierEscalationDue = (reasonCode) => {
+    const eligibility = tierEscalationEligibility(spec, reasonCode);
+    if (!eligibility.eligible) return false;
+    return failureCount(db, runId, "agent_error") + 1 >= spec.maxAttempts;
+  };
+
+  const projectScheduledEscalation = (scheduled) =>
+    scheduled
+      ? reconcileTierEscalations(db, {
+          projectTierEscalation: projectTierEscalationFn,
+          fetchTicket: fetchTicketFn,
+          now: nowFn,
+          policyVersion,
+        })
+      : null;
 
   const abortController = new AbortController();
   ACTIVE_EXECUTIONS.set(runId, {
@@ -2138,6 +2472,7 @@ export async function executeClaimed(
         attemptUsage,
       );
       const decision = retryDecision(db, runId, spec, reasonCode);
+      let escalation = null;
       if (decision.retry) {
         transition(db, {
           runId,
@@ -2149,8 +2484,22 @@ export async function executeClaimed(
           policyVersion,
           now: nowFn(),
         });
+      } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
+        escalation = scheduleTierEscalation(db, registry, spec, {
+          workspacePath: checkoutPath,
+          sourceWorkspacePath: workspaceDir,
+          actor: owner,
+          policyVersion,
+          now: currentNow,
+          reasonCode,
+        });
       }
-      return { ok: true, cause: decision.cause, requeued: decision.retry };
+      return {
+        ok: true,
+        cause: decision.cause,
+        requeued: decision.retry,
+        escalation,
+      };
     });
 
   let def = null;
@@ -2442,11 +2791,15 @@ export async function executeClaimed(
           gateResult = worktreeDispatchAutoEligibility(spec.input, {
             ...(dispatchOpts ?? {}),
             claimedRetry: claimedRetryFor(db, runId, attempt),
+            escalatedContinuation: worktreeHandoff,
             // Match the planner's operator-only bypass from the immutable
             // proposal that admitted this run. Never trust caller options here:
             // chain and schedule runs must keep the security/escalation gate.
             operatorAuthorized:
-              originatingEvent(db, runId)?.source === "operator",
+              originatingEvent(db, runId)?.source === "operator" ||
+              spec.approvalPolicy?.escalation?.operatorAuthorized === true ||
+              spec.approvalPolicy?.dispatchEvidence?.checks
+                ?.operator_authorized === true,
           });
         }
       } catch (err) {
@@ -2495,7 +2848,8 @@ export async function executeClaimed(
         // redundant, that could steal the ticket if ownership changed in the
         // narrow interval after the gate read.
         const resumedClaim =
-          gateResult.evidence?.checks?.ticket_claim_retry === true;
+          gateResult.evidence?.checks?.ticket_claim_retry === true ||
+          gateResult.evidence?.checks?.ticket_claim_escalation === true;
         if (!resumedClaim) {
           let claimRes;
           try {
@@ -2566,10 +2920,11 @@ export async function executeClaimed(
       adapter: adapterKey,
       ticketLeaseOwner,
       workerLeasesDir: leasesDir,
+      worktreeHandoff,
     });
     workspaceDir = created.dir;
     assertSandboxWorkspaceSupported(workspaceDir, def);
-    checkoutPath = created.checkout?.path ?? null;
+    checkoutPath = created.checkout?.path ?? created.worktree?.path ?? null;
     provisionInstanceLocalConfigs({ checkoutPath });
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
     worktreeRecord = created.worktree
@@ -2872,23 +3227,36 @@ export async function executeClaimed(
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
     if (!lateCompletion && exitCode !== 0) {
-      if (mayMutateClaimedTicket()) {
+      const reasonCode = `agent_exit_${exitCode}`;
+      const escalating = tierEscalationDue(reasonCode);
+      if (mayMutateClaimedTicket() && !escalating) {
         try {
           unclaimTicketFn({
             repo: repoName,
             ticket: ticketId,
-            why: `agent_exit_${exitCode}`,
+            why: reasonCode,
             log: null,
           });
         } catch {
           /* intentionally ignored */
         }
       }
-      const reasonCode = `agent_exit_${exitCode}`;
       const res = failTerminal("FAILED", reasonCode, reasonCode);
-      cleanupWorkspace({ retainWorkspace: retain });
+      const projection = projectScheduledEscalation(res?.escalation);
+      if (!res?.escalation) cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "FAILED", reasonCode };
+      return {
+        runId,
+        attempt,
+        terminalState: "FAILED",
+        reasonCode,
+        ...(res?.escalation
+          ? {
+              escalatedRunId: res.escalation.continuation_run_id,
+              escalationProjection: projection,
+            }
+          : {}),
+      };
     }
 
     // The settings policy is preventative; this is the independent, durable
@@ -2970,6 +3338,7 @@ export async function executeClaimed(
       const handoffBody = handoff
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${err.violations.join("; ")}`
         : null;
+      const escalating = tierEscalationDue(reasonCode);
       // WM-718: the PR is the agent's, already opened; the structural hold is
       // to draft it and quote the observed failure where the reviewer looks.
       if (
@@ -2989,7 +3358,7 @@ export async function executeClaimed(
           /* intentionally ignored */
         }
       }
-      if (mayMutateClaimedTicket()) {
+      if (mayMutateClaimedTicket() && !escalating) {
         if (HANDOFF_REASON_CODES.has(reasonCode)) {
           try {
             const returned = returnHandoffTicketFn({
@@ -3069,6 +3438,7 @@ export async function executeClaimed(
           attemptUsage,
         );
         const decision = retryDecision(db, runId, spec, reasonCode);
+        let escalation = null;
         if (decision.retry) {
           transition(db, {
             runId,
@@ -3080,10 +3450,20 @@ export async function executeClaimed(
             policyVersion,
             now: nowFn(),
           });
+        } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
+          escalation = scheduleTierEscalation(db, registry, spec, {
+            workspacePath: checkoutPath,
+            sourceWorkspacePath: workspaceDir,
+            actor: owner,
+            policyVersion,
+            now: currentNow,
+            reasonCode,
+          });
         }
-        return { ok: true };
+        return { ok: true, escalation };
       });
-      cleanupWorkspace({ retainWorkspace: retain });
+      const projection = projectScheduledEscalation(res?.escalation);
+      if (!res?.escalation) cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return {
         runId,
@@ -3092,6 +3472,12 @@ export async function executeClaimed(
         reasonCode,
         detail: failureReason,
         ...(handoff ? { handoff } : {}),
+        ...(res?.escalation
+          ? {
+              escalatedRunId: res.escalation.continuation_run_id,
+              escalationProjection: projection,
+            }
+          : {}),
       };
     }
 
@@ -3658,6 +4044,14 @@ export function reapExpiredLeases(
 
 /** Claim and execute one run, or return a typed refusal/null without execution. */
 export async function runOnce(db, registry, adapters, opts = {}) {
+  const pending = reconcileTierEscalations(db, {
+    projectTierEscalation:
+      opts.dispatch?.projectTierEscalation ?? defaultProjectTierEscalation,
+    fetchTicket: opts.dispatch?.fetchTicket,
+    now: opts.now ?? Date.now(),
+    policyVersion: opts.policyVersion,
+  });
+  if (!pending.ok) return pending;
   const claim = claimNext(db, opts);
   if (!claim || claim.refused) return claim;
   return executeClaimed(db, registry, adapters, claim, opts);

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -67,6 +67,7 @@ import {
   createReloadWatcher,
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultLocksDir,
+  defaultProjectTierEscalation,
   defaultReturnHandoffTicket,
   defaultUnclaimTicket,
   dispatchLockPath,
@@ -85,6 +86,9 @@ import {
   repositoryStatus,
   provisionInstanceLocalConfigs,
   resolveLinearApiKey,
+  reconcileTierEscalations,
+  scheduleTierEscalation,
+  tierEscalationEligibility,
   retryRun,
   runLinearCli,
   runOnce,
@@ -1959,6 +1963,206 @@ describe("worker", () => {
     expect(DEFAULT_MAX_ENVIRONMENT_RETRIES).toBe(3);
   });
 
+  test("tier escalation eligibility is closed to exhausted agent-caused light and standard dispatch failures", () => {
+    const light = makeSpec({
+      agent: "dispatch@1",
+      input: { repo: "factory", ticket: "WM-845" },
+      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      modelTier: "light",
+      maxAttempts: 1,
+    });
+    for (const reasonCode of [
+      "verification_failed",
+      "handoff_verification_failed",
+      "contract_violation",
+      "agent_exit_1",
+    ]) {
+      expect(tierEscalationEligibility(light, reasonCode)).toEqual({
+        eligible: true,
+        rootRunId: light.runId,
+      });
+    }
+    for (const reasonCode of [
+      "timeout",
+      "lease_expired",
+      "adapter_error",
+      "needs_human",
+      "policy_denied:Bash",
+      "cancelled",
+    ]) {
+      expect(tierEscalationEligibility(light, reasonCode).eligible).toBe(false);
+    }
+    expect(
+      tierEscalationEligibility({ ...light, modelTier: "strong" }, "agent_exit_1")
+        .eligible,
+    ).toBe(false);
+    expect(
+      tierEscalationEligibility(
+        { ...light, rootRunId: "run_root", escalatedFromRunId: "run_prior" },
+        "agent_exit_1",
+      ).eligible,
+    ).toBe(false);
+  });
+
+  test("tier escalation schedules exactly once and retries projection before the continuation is runnable", () => {
+    const databaseFile = path.join(
+      tmpDir("tier-escalation-restart-"),
+      "runtime.db",
+    );
+    let db = openDb(databaseFile);
+    const spec = queueRun(
+      db,
+      makeSpec({
+        runId: "run_tier_root",
+        agent: "dispatch@1",
+        input: { repo: "factory", ticket: "WM-845", modelTier: "light" },
+        workspace: {
+          type: "worktree",
+          checkoutDir: "repo",
+          retainOnFailure: true,
+        },
+        modelTier: "light",
+        model: null,
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, spec.runId, {
+      type: "factory.dispatch.requested",
+      correlationId: "root-correlation",
+    });
+    const checkout = tmpDir("tier-escalation-checkout-");
+    const wrapper = tmpDir("tier-escalation-wrapper-");
+    const first = scheduleTierEscalation(db, registry, spec, {
+      workspacePath: checkout,
+      sourceWorkspacePath: wrapper,
+      continuationRunId: "run_tier_strong",
+      now: T0,
+      reasonCode: "contract_violation",
+    });
+    db.close();
+    db = openDb(databaseFile);
+    const again = scheduleTierEscalation(db, registry, spec, {
+      workspacePath: checkout,
+      sourceWorkspacePath: wrapper,
+      continuationRunId: "run_tier_duplicate",
+      now: T0,
+      reasonCode: "contract_violation",
+    });
+    expect(first.continuation_run_id).toBe("run_tier_strong");
+    expect(again.continuation_run_id).toBe("run_tier_strong");
+    expect(db.query(`SELECT COUNT(*) AS n FROM tier_escalations`).get().n).toBe(1);
+    expect(runState(db, "run_tier_strong")).toBe("APPROVED");
+    expect(db.query(`SELECT * FROM runs WHERE run_id = 'run_tier_duplicate'`).get()).toBeNull();
+    const continuation = JSON.parse(
+      db.query(`SELECT spec_json FROM runs WHERE run_id = 'run_tier_strong'`).get()
+        .spec_json,
+    );
+    expect(continuation).toMatchObject({
+      rootRunId: spec.runId,
+      escalatedFromRunId: spec.runId,
+      modelTier: "strong",
+    });
+    const event = db
+      .query(`SELECT * FROM events WHERE source = 'handoff'`)
+      .get();
+    expect(event.correlation_id).toBe("root-correlation");
+    expect(event.causation_id).toBe(spec.runId);
+
+    const projectionErrors = [];
+    expect(
+      claimNext(db, {
+        owner: "restart-worker",
+        adapters: [],
+        projectTierEscalation: () => {
+          throw new Error("tracker unavailable");
+        },
+        now: T0,
+        policyVersion: "test",
+        onTierEscalationProjectionError: (entry) =>
+          projectionErrors.push(entry),
+      }),
+    ).toBeNull();
+    expect(projectionErrors[0]).toMatchObject({
+      reasonCode: "tier_escalation_writeback_failed",
+      continuationRunId: "run_tier_strong",
+      error: "tracker unavailable",
+    });
+    expect(runState(db, "run_tier_strong")).toBe("APPROVED");
+
+    const writes = [];
+    expect(
+      claimNext(db, {
+        owner: "restart-worker",
+        adapters: [],
+        projectTierEscalation: (entry) => (writes.push(entry), true),
+        now: T0,
+        policyVersion: "test",
+      }),
+    ).toBeNull();
+    expect(writes[0]).toMatchObject({
+      failedRunId: spec.runId,
+      continuationRunId: "run_tier_strong",
+    });
+    expect(runState(db, "run_tier_strong")).toBe("QUEUED");
+
+    const noPendingProjection = reconcileTierEscalations(db, {
+      projectTierEscalation: () => {
+        throw new Error("tracker unavailable");
+      },
+      now: T0,
+      policyVersion: "test",
+    });
+    expect(noPendingProjection).toEqual({ ok: true, projected: 0 });
+    expect(
+      lifecycleOf(db, "run_tier_strong").map((entry) => entry.reason),
+    ).toEqual(
+      expect.arrayContaining([
+        `auto_approved:tier-escalation:${spec.runId}`,
+        `tracker_projection_applied:${spec.runId}`,
+      ]),
+    );
+    db.close();
+  });
+
+  test("tier escalation projection replaces every tier label and comments both run ids idempotently", () => {
+    const calls = [];
+    const runCli = (args) => {
+      calls.push(args);
+      if (args[0] === "comments") return "[]";
+      return "{}";
+    };
+    expect(
+      defaultProjectTierEscalation({
+        repo: "factory",
+        ticket: "WM-845",
+        failedRunId: "run_light",
+        continuationRunId: "run_strong",
+        fetchTicket: () => ({
+          labels: [
+            { name: "tier:light" },
+            { name: "tier:standard" },
+            { name: "tier:strong" },
+            { name: "type:feature" },
+          ],
+        }),
+        runCli,
+      }),
+    ).toBe(true);
+    expect(calls[0]).toEqual([
+      "labels",
+      "WM-845",
+      "--add",
+      "tier:strong",
+      "--remove",
+      "tier:light",
+      "--remove",
+      "tier:standard",
+    ]);
+    expect(calls.at(-1)[0]).toBe("comment");
+    expect(calls.at(-1)[2]).toContain("run_light");
+    expect(calls.at(-1)[2]).toContain("run_strong");
+  });
+
   test("adapter_error with maxAttempts 1 requeues and succeeds without consuming the agent budget", async () => {
     const db = openDb(":memory:");
     let calls = 0;
@@ -3133,6 +3337,100 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       return { exitCode: 0, timedOut: false };
     },
   };
+
+  test("tier escalation transfers a failed dispatch checkout and claim to one strong continuation", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({
+        runId: "run_dispatch_light_failure",
+        input: {
+          repo: "wt-worker",
+          ticket: "WM-845",
+          modelTier: "light",
+        },
+        modelTier: "light",
+        model: null,
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, spec.runId, {
+      type: "factory.dispatch.requested",
+      correlationId: "dispatch-tier-root",
+    });
+    const unclaims = [];
+    const projections = [];
+    const summary = await runOnce(
+      db,
+      registry,
+      {
+        fake: {
+          async execute({ workspaceDir }) {
+            writeFileSync(
+              path.join(workspaceDir, "repo", "useful-change.txt"),
+              "keep this exact checkout\n",
+            );
+            return { exitCode: 1, timedOut: false };
+          },
+        },
+      },
+      opts({
+        dispatch: {
+          locksDir: tmpDir("tier-escalation-locks-"),
+          leasesDir: tmpDir("tier-escalation-leases-"),
+          fetchTicket: () =>
+            readyDispatchTicket("WM-845", {
+              labels: {
+                nodes: [
+                  { name: "ai:agent-ready" },
+                  { name: "tier:light" },
+                ],
+              },
+            }),
+          fetchViewer: () => ({ id: "factory" }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          claimTicket: () => ({ ok: true }),
+          unclaimTicket: (entry) => (unclaims.push(entry), true),
+          projectTierEscalation: (entry) => (projections.push(entry), true),
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "agent_exit_1",
+      escalationProjection: { ok: true },
+    });
+    expect(summary.escalatedRunId).toMatch(/^run_/);
+    expect(unclaims).toHaveLength(0);
+    expect(projections).toHaveLength(1);
+    expect(projections[0]).toMatchObject({
+      failedRunId: spec.runId,
+      continuationRunId: summary.escalatedRunId,
+    });
+    expect(runState(db, summary.escalatedRunId)).toBe("QUEUED");
+    const strongSpec = JSON.parse(
+      db
+        .query(`SELECT spec_json FROM runs WHERE run_id = ?`)
+        .get(summary.escalatedRunId).spec_json,
+    );
+    expect(strongSpec).toMatchObject({
+      rootRunId: spec.runId,
+      escalatedFromRunId: spec.runId,
+      modelTier: "strong",
+    });
+    expect(
+      readFileSync(path.join(wtRoot, "WM-845", "useful-change.txt"), "utf8"),
+    ).toBe("keep this exact checkout\n");
+    expect(
+      readFileSync(callsLog, "utf8")
+        .trim()
+        .split("\n")
+        .filter((call) => call === "up WM-845"),
+    ).toHaveLength(1);
+  });
 
   test("resolves Linear credentials from env first, then the shared env file", () => {
     const dir = tmpDir("evrt-linear-key-");

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2186,13 +2186,17 @@ describe("worker", () => {
     const light = makeSpec({
       agent: "dispatch@1",
       input: { repo: "factory", ticket: "WM-845" },
-      workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: true },
+      workspace: {
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      },
       modelTier: "light",
       maxAttempts: 1,
     });
     for (const reasonCode of [
-      "verification_failed",
       "handoff_verification_failed",
+      "handoff_owned_paths_violation",
       "contract_violation",
       "agent_exit_1",
     ]) {
@@ -2208,12 +2212,18 @@ describe("worker", () => {
       "needs_human",
       "policy_denied:Bash",
       "cancelled",
+      // The acceptance criteria name `verification_failed`; nothing emits it.
+      // The real code is `handoff_verification_failed` (verify.mjs), so the
+      // invented spelling must not silently widen the predicate.
+      "verification_failed",
     ]) {
       expect(tierEscalationEligibility(light, reasonCode).eligible).toBe(false);
     }
     expect(
-      tierEscalationEligibility({ ...light, modelTier: "strong" }, "agent_exit_1")
-        .eligible,
+      tierEscalationEligibility(
+        { ...light, modelTier: "strong" },
+        "agent_exit_1",
+      ).eligible,
     ).toBe(false);
     expect(
       tierEscalationEligibility(
@@ -2269,12 +2279,17 @@ describe("worker", () => {
     });
     expect(first.continuation_run_id).toBe("run_tier_strong");
     expect(again.continuation_run_id).toBe("run_tier_strong");
-    expect(db.query(`SELECT COUNT(*) AS n FROM tier_escalations`).get().n).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM tier_escalations`).get().n).toBe(
+      1,
+    );
     expect(runState(db, "run_tier_strong")).toBe("APPROVED");
-    expect(db.query(`SELECT * FROM runs WHERE run_id = 'run_tier_duplicate'`).get()).toBeNull();
+    expect(
+      db.query(`SELECT * FROM runs WHERE run_id = 'run_tier_duplicate'`).get(),
+    ).toBeNull();
     const continuation = JSON.parse(
-      db.query(`SELECT spec_json FROM runs WHERE run_id = 'run_tier_strong'`).get()
-        .spec_json,
+      db
+        .query(`SELECT spec_json FROM runs WHERE run_id = 'run_tier_strong'`)
+        .get().spec_json,
     );
     expect(continuation).toMatchObject({
       rootRunId: spec.runId,
@@ -3646,10 +3661,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           fetchTicket: () =>
             readyDispatchTicket("WM-845", {
               labels: {
-                nodes: [
-                  { name: "ai:agent-ready" },
-                  { name: "tier:light" },
-                ],
+                nodes: [{ name: "ai:agent-ready" }, { name: "tier:light" }],
               },
             }),
           fetchViewer: () => ({ id: "factory" }),
@@ -3695,6 +3707,135 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         .split("\n")
         .filter((call) => call === "up WM-845"),
     ).toHaveLength(1);
+  });
+
+  test("only a durable escalation handoff authorises the operator bypass at execute time (GH-845)", async () => {
+    // Regression: an inherited spec field must never be an authorisation.
+    // approvalPolicy — dispatchEvidence included — is copied onto chain runs
+    // by stableChainApprovalPolicyForHash, so a chain descended from one
+    // operator dispatch would otherwise carry a permanent security bypass.
+    const laundered = openDb(":memory:");
+    const chainSpec = queueRun(
+      laundered,
+      makeDispatchSpec({
+        runId: "run_chain_launders_operator",
+        input: { repo: "wt-worker", ticket: "WM-847" },
+        approvalPolicy: {
+          source: "chain",
+          mode: "auto",
+          eventType: "factory.dispatch.requested",
+          escalation: {
+            rootRunId: "run_some_other_root",
+            failedRunId: "run_some_other_root",
+            operatorAuthorized: true,
+          },
+          dispatchEvidence: { checks: { operator_authorized: true } },
+        },
+      }),
+    );
+    linkEvent(laundered, chainSpec.runId, {
+      type: "factory.dispatch.requested",
+      source: "chain",
+    });
+    const launderedSummary = await runOnce(
+      laundered,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({
+        dispatch: {
+          locksDir: tmpDir("evrt-gh845-chain-locks-"),
+          leasesDir: tmpDir("evrt-gh845-chain-leases-"),
+          fetchTicket: () =>
+            readyDispatchTicket("WM-847", {
+              labels: {
+                nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
+              },
+            }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      }),
+    );
+    expect(launderedSummary).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "ticket_security",
+    });
+    laundered.close();
+
+    // The same bypass IS granted to a continuation the durable
+    // tier_escalations row authenticates, when the failed run it continues
+    // was operator-sourced.
+    const db = openDb(":memory:");
+    const failed = queueRun(
+      db,
+      makeDispatchSpec({
+        runId: "run_operator_security_light",
+        input: { repo: "wt-worker", ticket: "WM-848", modelTier: "light" },
+        modelTier: "light",
+        model: null,
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, failed.runId, {
+      type: "factory.dispatch.requested",
+      source: "operator",
+    });
+    let ticket = readyDispatchTicket("WM-848", {
+      labels: {
+        nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
+      },
+    });
+    const dispatchOpts = {
+      locksDir: tmpDir("evrt-gh845-escalation-locks-"),
+      leasesDir: tmpDir("evrt-gh845-escalation-leases-"),
+      fetchTicket: () => ticket,
+      fetchViewer: () => ({ id: "factory" }),
+      fetchInFlight: () => [],
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      claimTicket: () => ({ ok: true }),
+      unclaimTicket: () => true,
+      projectTierEscalation: () => true,
+    };
+    const failure = await runOnce(
+      db,
+      registry,
+      {
+        fake: {
+          async execute() {
+            return { exitCode: 1, timedOut: false };
+          },
+        },
+      },
+      opts({ dispatch: dispatchOpts }),
+    );
+    expect(failure).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "agent_exit_1",
+    });
+    expect(runState(db, failure.escalatedRunId)).toBe("QUEUED");
+
+    // The continuation resumes the factory's own claim: assigned, In
+    // Progress, and still carrying the security label that only an operator
+    // dispatch may pass.
+    ticket = readyDispatchTicket("WM-848", {
+      state: { name: "In Progress" },
+      assignee: { id: "factory" },
+      labels: {
+        nodes: [{ name: "ai:in-progress" }, { name: "type:security" }],
+      },
+    });
+    const continued = await runOnce(
+      db,
+      registry,
+      { fake: dispatchFakeAdapter },
+      opts({ dispatch: dispatchOpts }),
+    );
+    expect(continued.runId).toBe(failure.escalatedRunId);
+    expect(continued.reasonCode).not.toBe("ticket_security");
+    expect(continued.terminalState).toBe("COMPLETED");
+    db.close();
   });
 
   test("resolves Linear credentials from env first, then the shared env file", () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -460,6 +460,7 @@ function materializeWorktree({
   workerLeasesDir,
   ownershipConflict,
   preservationComment,
+  handoff = null,
 }) {
   const repoName = input?.repo;
   const ticket = input?.ticket;
@@ -478,7 +479,23 @@ function materializeWorktree({
   // directory, this looks it up. A mismatch searches a path that was never
   // created and reads as "worktree_up succeeded but produced nothing" (#884).
   const worktreePath = path.join(repo.worktreeRoot, ticketSlug(ticket));
-  if (existsSync(worktreePath)) {
+  const authenticatedHandoff =
+    handoff?.continuationRunId === runId &&
+    handoff?.repo === repoName &&
+    String(handoff?.ticket) === String(ticket) &&
+    handoff?.projectionState === "applied" &&
+    path.resolve(handoff?.workspacePath ?? "") === path.resolve(worktreePath);
+  if (handoff && !authenticatedHandoff) {
+    throw new WorktreeError(
+      `worktree_handoff_invalid: durable transfer does not authenticate ${runId}`,
+    );
+  }
+  if (authenticatedHandoff && !existsSync(worktreePath)) {
+    throw new WorktreeError(
+      `worktree_handoff_missing: transferred checkout ${worktreePath} no longer exists`,
+    );
+  }
+  if (existsSync(worktreePath) && !authenticatedHandoff) {
     const conflict = ownershipConflict({
       repo: repoName,
       ticket,
@@ -505,6 +522,13 @@ function materializeWorktree({
     // branch and addresses the opened PR by its GitHub slug.
     base: repo.base ?? null,
     github: repo.github ?? null,
+    ...(authenticatedHandoff
+      ? {
+          escalatedFromRunId: handoff.failedRunId,
+          rootRunId: handoff.rootRunId,
+          transferred: true,
+        }
+      : {}),
   };
   // Persist teardown facts before bring-up starts. A script can create its
   // worktree and daemons before timing out; the marker lets the janitor find
@@ -514,6 +538,19 @@ function materializeWorktree({
     `${canonicalJson(record)}\n`,
     "utf8",
   );
+
+  if (authenticatedHandoff) {
+    symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
+    // The marker is the filesystem ownership token. Move it only after the
+    // continuation wrapper is complete, so a crash always leaves one owner
+    // able to delegate teardown to the repo script.
+    if (handoff.sourceWorkspacePath) {
+      rmSync(path.join(handoff.sourceWorkspacePath, WORKTREE_MARKER), {
+        force: true,
+      });
+    }
+    return record;
+  }
 
   // Repo-owned bring-up may discover a red project baseline after the usable
   // worktree already exists. It reports that condition out-of-band and still
@@ -666,6 +703,7 @@ export function createWorkspace({
   workerLeasesDir,
   worktreeOwnershipConflict = detectWorktreeOwnershipConflict,
   worktreePreservationComment = commentOnPreservedWorktree,
+  worktreeHandoff = null,
 }) {
   // Lease loss can leave the prior attempt's scratch directory behind. Read
   // recognized harness session metadata before creating the new attempt;
@@ -736,6 +774,7 @@ export function createWorkspace({
         workerLeasesDir,
         ownershipConflict: worktreeOwnershipConflict,
         preservationComment: worktreePreservationComment,
+        handoff: worktreeHandoff,
       });
     } catch (err) {
       if (err instanceof WorktreeError) throw err;

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -565,11 +565,21 @@ function materializeWorktree({
     symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
     // The marker is the filesystem ownership token. Move it only after the
     // continuation wrapper is complete, so a crash always leaves one owner
-    // able to delegate teardown to the repo script.
-    if (handoff.sourceWorkspacePath) {
-      rmSync(path.join(handoff.sourceWorkspacePath, WORKTREE_MARKER), {
-        force: true,
-      });
+    // able to delegate teardown to the repo script. Once ownership has moved,
+    // the failed run's wrapper is dead weight — dropping only its marker would
+    // leak one scratch directory per escalation. rmSync unlinks the wrapper's
+    // `checkout` symlink rather than following it, so the transferred worktree
+    // itself is untouched; guard the paths anyway.
+    const source = handoff.sourceWorkspacePath
+      ? path.resolve(handoff.sourceWorkspacePath)
+      : null;
+    if (
+      source &&
+      source !== path.resolve(workspaceDir) &&
+      source !== path.resolve(worktreePath)
+    ) {
+      rmSync(path.join(source, WORKTREE_MARKER), { force: true });
+      rmSync(source, { recursive: true, force: true });
     }
     return record;
   }

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -449,10 +449,14 @@ describe("worktree workspaces (WM-108)", () => {
     expect(calls().filter((call) => call.startsWith("up WM-845"))).toEqual(
       upCalls,
     );
-    expect(readFileSync(path.join(strong.dir, "repo", "useful-change"), "utf8")).toBe(
-      "retain me\n",
-    );
-    expect(existsSync(path.join(first.dir, ".worktree.json"))).toBe(false);
+    expect(
+      readFileSync(path.join(strong.dir, "repo", "useful-change"), "utf8"),
+    ).toBe("retain me\n");
+    // The failed run's wrapper is destroyed once ownership has moved, so an
+    // escalation does not leak one scratch directory per handoff. The
+    // transferred worktree itself survives.
+    expect(existsSync(first.dir)).toBe(false);
+    expect(existsSync(path.join(tree, "useful-change"))).toBe(true);
     expect(strong.worktree.transferred).toBe(true);
     expect(destroyWorkspace(strong.dir)).toBe(true);
   });

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -381,6 +381,35 @@ describe("worktree workspaces (WM-108)", () => {
     expect(destroyWorkspace(dir)).toBe(true);
   });
 
+  test("tier escalation handoff reuses the exact checkout without a second bring-up", () => {
+    const first = make("wtrepo", "WM-845", "run_light");
+    const tree = path.join(wtRoot, "WM-845");
+    writeFileSync(path.join(tree, "useful-change"), "retain me\n");
+    const upCalls = calls().filter((call) => call.startsWith("up WM-845"));
+
+    const strong = make("wtrepo", "WM-845", "run_strong", {
+      worktreeHandoff: {
+        rootRunId: "run_light",
+        failedRunId: "run_light",
+        continuationRunId: "run_strong",
+        repo: "wtrepo",
+        ticket: "WM-845",
+        workspacePath: tree,
+        sourceWorkspacePath: first.dir,
+        projectionState: "applied",
+      },
+    });
+    expect(calls().filter((call) => call.startsWith("up WM-845"))).toEqual(
+      upCalls,
+    );
+    expect(readFileSync(path.join(strong.dir, "repo", "useful-change"), "utf8")).toBe(
+      "retain me\n",
+    );
+    expect(existsSync(path.join(first.dir, ".worktree.json"))).toBe(false);
+    expect(strong.worktree.transferred).toBe(true);
+    expect(destroyWorkspace(strong.dir)).toBe(true);
+  });
+
   test("a refusing worktree_down retains everything, with a filtered reason and raw evidence", () => {
     const { dir } = make("refusing-down", "WM-4", "run_wt4");
     expect(destroyWorkspace(dir, { retain: true })).toBe(false);


### PR DESCRIPTION
Fixes watt-mind/factory#845

Review crash-safe strong-tier continuation scheduling and retained-worktree transfer.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs -t 'failure cause taxonomy|tier escalation' && bun test event-runtime/lib/planner.test.mjs -t 'modelTier|model tier|ticket tier|same_ticket_worktree|escalated continuation'` | pass | 11 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1741 pass, 10 skip, generated tree clean |
| UX critique          | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

## Handoff

### Post-review (2026-08-29)

Review findings addressed on `feat/gh-845`; still a draft.

1. **Security regression fixed (blocking).** The execute-time gate call in
   `executeClaimed` no longer accepts
   `approvalPolicy.dispatchEvidence.checks.operator_authorized`. That field is
   copied into `approvalPolicy` at plan time (`planner.mjs`) and inherited by
   chain runs through `stableChainApprovalPolicyForHash`, so trusting it gave
   every chain/schedule run descended from one operator dispatch a permanent
   `ai:escalated`/`type:security` bypass. `escalation.operatorAuthorized` is now
   believed only when the durable `tier_escalations` row read for *this* run
   authenticates it as the continuation of the exact `failedRunId`/`rootRunId`
   the spec names — the same worktree-handoff record the workspace transfer is
   authenticated by. `buildEscalatedContinuationSpec` also stopped seeding
   `escalation.operatorAuthorized` from the failed spec's inherited
   `dispatchEvidence`; it comes solely from the failed run's originating event
   source. New test
   `only a durable escalation handoff authorises the operator bypass at execute time (GH-845)`
   covers both directions: a chain run carrying
   `dispatchEvidence.checks.operator_authorized=true` (and an escalation-shaped
   `approvalPolicy`) is refused `ticket_security`, while an escalation
   continuation of an operator-sourced failed run completes. Verified red
   against the pre-fix gate.

2. **`runOnce` resilience (blocking).** `runOnce` no longer returns on a failed
   tracker projection, which stalled claiming of every queued run behind one
   escalation's tracker outage. It now forwards the dispatch-scoped tracker
   hooks to `claimNext`, whose single reconcile already logs the failure via
   `onTierEscalationProjectionError` and continues claiming (this also removes
   the double reconcile that ran the projection twice per tick).

3. **Leaked wrapper workspace.** The escalation path skipped
   `cleanupWorkspace` and removed only the failed run's `.worktree.json`,
   leaking one wrapper directory per escalation. `materializeWorktree` now
   destroys the source wrapper after the continuation's marker is written
   (marker first, so a crash always leaves exactly one owner). `rmSync` unlinks
   the wrapper's `checkout` symlink rather than following it, and the source
   path is guarded against the new workspace and the worktree itself.

4. **Dead reason code.** `verification_failed` was added to `AGENT_FAILURES`
   and to the eligibility predicate but is emitted nowhere; the real code is
   `handoff_verification_failed` (`verify.mjs` `HANDOFF_REASON_CODES`). The
   invented spelling is removed from both, the predicate matches the emitted
   `HANDOFF_REASON_CODES` set, and the eligibility test now asserts
   `verification_failed` is *not* eligible, so nothing is silently
   reclassified. The ticket's acceptance criterion naming
   `verification_failed` is satisfied by `handoff_verification_failed`.

5. **Migration renumbered 14 → 15.** #1230 (#1197) also introduces a migration
   14 and lands first. `tier_escalations` is now migration 15, guarded and
   idempotent like the rest. **#1230 had not merged when this was written** —
   15 is used regardless, per the migration-ordering decision; the runner
   applies any migration above the database's `user_version`, so v13, v14 and
   fresh databases all converge on 15. New `db.test.mjs` case asserts
   `CURRENT_SCHEMA_VERSION === 15`, a fresh DB reaching 15, and a v14 DB
   upgrading to 15 (re-run idempotently).

Also merged `origin/develop` (was 4 behind) and recorded the authorisation
scoping in `docs/product-decisions.md`.

Re-verified with an isolated `FACTORY_EVENT_HOME`: `worker`, `db`, `planner`,
`workspace`, `auto-approval`, `verify` suites — 376 pass / 0 fail; the ticket's
Verification Command — 11 pass / 0 fail; `bun run check` clean; prettier clean;
eslint no new errors. The operator's live runtime DB stayed at `user_version` 13
before and after.
