### PR TITLE
test: harden execute-side tests under concurrent CI load

### DIFF
--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -510,7 +510,9 @@ if (behavior === "emit_error_tool_result") {
       spec: { ...defaultSpec, model: "composer-2.5" },
       def: { ...defaultDef, promptPath: replacedPrompt },
       workspaceDir,
-      timeoutMs: 5000,
+      // The stub still has to spawn and flush a real child; stretch its
+      // liveness ceiling when concurrent CI runs report shared-host load.
+      timeoutMs: loadAdjustedTimeout(5_000),
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
         CURSOR_API_KEY: "sk-must-be-passed",

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4826,7 +4826,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
   test(
     "worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments",
-    { timeout: 45_000 },
+    // This test provisions real git worktrees and child processes twice. The
+    // 45s ceiling has headroom over the ~9s observed under the 8-run burst
+    // (load ~76 on 32 CPUs), and scales with the shared-runner load factor.
+    { timeout: loadAdjustedTimeout(45_000) },
     async () => {
       const repoRoot = process.cwd();
       const repoName = "wm-baseline-real";


### PR DESCRIPTION
Fixes watt-mind/factory#1186

Scale the two execute-side test ceilings with CI_LOAD_FACTOR so shared-runner bursts retain their assertions without timing out healthy runs.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/worker.test.mjs event-runtime/lib/adapters/cursor.test.mjs` | pass    | 174 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1,743 pass, 10 skipped, 0 failures; 94 generated files match  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend/infrastructure test-only change; no user-facing surface.