### PR TITLE
fix(ci): isolate test runs from the operator's live runtime home

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,14 @@ jobs:
     runs-on: ${{ fromJSON(needs.route.outputs.shadow_labels) }}
     timeout-minutes: 15
     steps:
+      # Every later step resolves the runtime home here, never the operator's
+      # real ~/.factory/event-runtime: self-hosted CI runs on the operator box,
+      # and a migration-carrying branch once upgraded the live runtime.db from
+      # a test (2026-08-29). Steps that need their own home (E2E seed) still
+      # override it. (`runner.temp` is not available in job-level `env`.)
+      - name: Isolate the factory runtime home from the operator's ~/.factory
+        shell: bash
+        run: echo "FACTORY_EVENT_HOME=$RUNNER_TEMP/factory-event-home" >> "$GITHUB_ENV"
       - name: Sweep stale shared-host temp directories
         if: runner.environment == 'self-hosted'
         shell: bash
@@ -277,6 +285,14 @@ jobs:
     runs-on: ${{ fromJSON(needs.route.outputs.shadow_labels) }}
     timeout-minutes: 20
     steps:
+      # Every later step resolves the runtime home here, never the operator's
+      # real ~/.factory/event-runtime: self-hosted CI runs on the operator box,
+      # and a migration-carrying branch once upgraded the live runtime.db from
+      # a test (2026-08-29). Steps that need their own home (E2E seed) still
+      # override it. (`runner.temp` is not available in job-level `env`.)
+      - name: Isolate the factory runtime home from the operator's ~/.factory
+        shell: bash
+        run: echo "FACTORY_EVENT_HOME=$RUNNER_TEMP/factory-event-home" >> "$GITHUB_ENV"
       - name: Sweep stale shared-host temp directories
         if: runner.environment == 'self-hosted'
         shell: bash
@@ -404,6 +420,14 @@ jobs:
     # Runaway guard only — queue time is now spent in GitHub's queue, not here.
     timeout-minutes: 45
     steps:
+      # Every later step resolves the runtime home here, never the operator's
+      # real ~/.factory/event-runtime: self-hosted CI runs on the operator box,
+      # and a migration-carrying branch once upgraded the live runtime.db from
+      # a test (2026-08-29). Steps that need their own home (E2E seed) still
+      # override it. (`runner.temp` is not available in job-level `env`.)
+      - name: Isolate the factory runtime home from the operator's ~/.factory
+        shell: bash
+        run: echo "FACTORY_EVENT_HOME=$RUNNER_TEMP/factory-event-home" >> "$GITHUB_ENV"
       - name: Sweep stale shared-host temp directories
         if: runner.environment == 'self-hosted'
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,14 @@ jobs:
     runs-on: [self-hosted, verify-lane]
     timeout-minutes: 45
     steps:
+      # Every later step resolves the runtime home here, never the operator's
+      # real ~/.factory/event-runtime: self-hosted CI runs on the operator box,
+      # and a migration-carrying branch once upgraded the live runtime.db from
+      # a test (2026-08-29). Steps that need their own home (E2E seed) still
+      # override it. (`runner.temp` is not available in job-level `env`.)
+      - name: Isolate the factory runtime home from the operator's ~/.factory
+        shell: bash
+        run: echo "FACTORY_EVENT_HOME=$RUNNER_TEMP/factory-event-home" >> "$GITHUB_ENV"
       - name: Sweep stale shared-host temp directories
         if: runner.environment == 'self-hosted'
         shell: bash

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -91,11 +91,32 @@ export function initializeLocalConfig({ root = FACTORY_ROOT } = {}) {
   });
 }
 
-export function runtimeHome() {
+/**
+ * True when this process is a test or CI run: `bun test` sets NODE_ENV=test
+ * for the test process (inherited by CLIs it spawns), and CI runners export
+ * CI=true. Such a process must never resolve the operator's real runtime home.
+ */
+export function isTestOrCiProcess(env = process.env) {
   return (
-    process.env.FACTORY_EVENT_HOME ||
-    path.join(homedir(), ".factory", "event-runtime")
+    env.NODE_ENV === "test" ||
+    env.BUN_ENV === "test" ||
+    (env.CI !== undefined && env.CI !== "" && env.CI !== "false")
   );
+}
+
+export function runtimeHome(env = process.env) {
+  if (env.FACTORY_EVENT_HOME) return env.FACTORY_EVENT_HOME;
+  if (isTestOrCiProcess(env)) {
+    // Fail closed: CI runs on the operator's own machine, and a test that
+    // reached the default home once migrated the live runtime.db to a schema
+    // newer than the running workers (2026-08-29).
+    throw new Error(
+      "refusing to use the default runtime home (~/.factory/event-runtime) " +
+        "from a test or CI process: set FACTORY_EVENT_HOME to an isolated " +
+        "directory (event-runtime/test-helpers.mjs does this on import)",
+    );
+  }
+  return path.join(homedir(), ".factory", "event-runtime");
 }
 
 export function dbPath(home = runtimeHome()) {

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -11,6 +11,7 @@ import {
   utimesSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import {
   CURRENT_SCHEMA_VERSION,
@@ -25,6 +26,7 @@ import {
   txImmediate,
   usageSpend,
 } from "./db.mjs";
+import { dbPath, isTestOrCiProcess, runtimeHome } from "./config.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
 const freshFile = () => path.join(tmpDir("evrt-db-"), "runtime.db");
@@ -577,6 +579,63 @@ describe("hermetic execution guard (OPS-425)", () => {
       expect(() => expectRealDbUnchanged(before, after)).toThrow();
     } finally {
       rmSync(factoryHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("default runtime home guard (fail closed in tests/CI)", () => {
+  const liveDefault = path.join(homedir(), ".factory", "event-runtime");
+
+  test("bun test runs with NODE_ENV=test, so the guard is armed here", () => {
+    expect(process.env.NODE_ENV).toBe("test");
+    expect(isTestOrCiProcess(process.env)).toBe(true);
+  });
+
+  test("refuses the default home when FACTORY_EVENT_HOME is unset in a test or CI process", () => {
+    for (const env of [
+      { NODE_ENV: "test" },
+      { BUN_ENV: "test" },
+      { CI: "true" },
+      { CI: "1" },
+    ]) {
+      expect(() => runtimeHome(env)).toThrow(
+        /refusing to use the default runtime home/,
+      );
+      expect(() => dbPath(runtimeHome(env))).toThrow();
+    }
+  });
+
+  test("honours FACTORY_EVENT_HOME in a test or CI process", () => {
+    const isolated = trackTmpDir(createIsolatedHome("evrt-guard-home-"));
+    expect(
+      runtimeHome({ NODE_ENV: "test", FACTORY_EVENT_HOME: isolated }),
+    ).toBe(isolated);
+    expect(runtimeHome({ CI: "true", FACTORY_EVENT_HOME: isolated })).toBe(
+      isolated,
+    );
+  });
+
+  test("plain operator processes still resolve ~/.factory/event-runtime", () => {
+    for (const env of [
+      {},
+      { CI: "" },
+      { CI: "false" },
+      { NODE_ENV: "production" },
+    ]) {
+      expect(isTestOrCiProcess(env)).toBe(false);
+      expect(runtimeHome(env)).toBe(liveDefault);
+    }
+  });
+
+  test("openDb() with no path cannot reach the live database from this test process", () => {
+    const saved = process.env.FACTORY_EVENT_HOME;
+    delete process.env.FACTORY_EVENT_HOME;
+    try {
+      expect(() => openDb()).toThrow(
+        /refusing to use the default runtime home/,
+      );
+    } finally {
+      process.env.FACTORY_EVENT_HOME = saved;
     }
   });
 });

--- a/event-runtime/merge-apply.test.mjs
+++ b/event-runtime/merge-apply.test.mjs
@@ -1,3 +1,6 @@
+// Side effect: pins FACTORY_EVENT_HOME to a temp dir before any spawned CLI
+// (merge-apply.mjs) can resolve the operator's live runtime home.
+import "./test-helpers.mjs";
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1,4 +1,7 @@
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-merge-test-mjs";
+// Side effect: pins FACTORY_EVENT_HOME to a temp dir before any spawned CLI
+// (merge-apply.mjs) can resolve the operator's live runtime home.
+import "./test-helpers.mjs";
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {


### PR DESCRIPTION
Fixes #1245

CI runs on the operator's own box. `event-runtime/merge.test.mjs` (WM-412) and `event-runtime/merge-apply.test.mjs` (WM-432) spawn `event-runtime/lib/merge-apply.mjs` with `...process.env` and never set `FACTORY_EVENT_HOME`, so `runMergeApply({ db = openDb() })` (`merge-apply.mjs:258`) resolved `~/.factory/event-runtime/runtime.db` — the live production DB — and `migrateDb()` upgraded it to schema 14 on 2026-08-29, killing every v13 worker.

## Fix (two layers)

1. **Workflows** (`ci.yml` fast-unit-tests / timing-bound-tests / verify, `e2e.yml`): first step exports `FACTORY_EVENT_HOME=$RUNNER_TEMP/factory-event-home` via `$GITHUB_ENV` (job-level `env:` cannot reference `runner.temp`; actionlint rejects it). The E2E seed step keeps its own per-run override.
2. **Runtime** (`event-runtime/lib/config.mjs`): `runtimeHome()` fails closed with a clear error when `NODE_ENV=test` (Bun sets this for every `bun test` process and spawned children inherit it), `BUN_ENV=test`, or `CI` is set while `FACTORY_EVENT_HOME` is unset. Operator CLI use (none of those set) is unchanged. `isTestOrCiProcess()` exported for tests.
3. `merge.test.mjs` / `merge-apply.test.mjs` import `test-helpers.mjs` so the spawned CLI inherits an isolated temp home. `db.test.mjs` gains a "default runtime home guard" suite (guard armed under `bun test`, refuses on each trigger, honours `FACTORY_EVENT_HOME`, plain operator env still resolves `~/.factory/event-runtime`, `openDb()` with no path throws).

Other default-home call sites now covered by the guard: `janitor.mjs:231`, `merge-verify.mjs:302`, `merge-reviews.mjs:942/972`, `cli.mjs:331`.

## Handoff

**Verification** (FACTORY_EVENT_HOME unset in shell):
```
bun test event-runtime/merge.test.mjs event-runtime/merge-apply.test.mjs event-runtime/lib/db.test.mjs --timeout 20000
 72 pass / 0 fail / 317 expect() calls — Ran 72 tests across 3 files
bun test (full root suite): 3217 tests, 0 guard hits; 2 pre-existing serve.test.mjs notifier failures
  (operator's local config appends a factory.watt-mind.com inbox URL — unrelated) + web/ module-missing errors (web node_modules not installed locally)
bun run check: exit 0
actionlint .github/workflows/*.yml: clean
prettier --check .: clean
PRAGMA user_version of ~/.factory/event-runtime/runtime.db: 13 before and 13 after all test runs (read-only check)
```
**UX**: n/a (CI/harness only).
**File scope**: `.github/workflows/ci.yml`, `.github/workflows/e2e.yml`, `event-runtime/lib/config.mjs`, `event-runtime/lib/db.test.mjs`, `event-runtime/merge.test.mjs`, `event-runtime/merge-apply.test.mjs`.
**Risk**: none for production paths — the guard only fires when `NODE_ENV=test`/`BUN_ENV=test`/`CI` is set without `FACTORY_EVENT_HOME`; serve/work/CLI under the live stack set neither.
