### PR TITLE
fix(control-plane): trust issue authors by repo permission when the App viewer cannot see org membership (WM-879)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -30,6 +30,7 @@ import {
   validateLabels,
 } from "./labels.mjs";
 import {
+  isTrustedAssociation,
   parseReadyPin,
   readyPinMarker,
 } from "../../event-runtime/lib/triage.mjs";
@@ -105,6 +106,14 @@ const PROJECT_ITEMS = `query ProjectItems($projectId: ID!, $statusField: String!
     }
   }
 }`;
+
+/**
+ * Resolved repo-permission associations, keyed `"<repo> <login>"`, held for
+ * the process lifetime (WM-879). Permission changes are rare and a factory
+ * process is short-lived, so this trades staleness for not paying a
+ * `collaborators/{login}/permission` request on every plan.
+ */
+const collaboratorAssociationCache = new Map();
 
 const PAGE_SIZE = 100;
 const MAX_PAGES = 50;
@@ -1000,7 +1009,11 @@ export function githubControlPlane(options = {}) {
    */
   async function resolveLastEditorAssociation(repo, number, issue) {
     const authorLogin = issue.user?.login ?? null;
-    const authorAssociation = issue.author_association ?? null;
+    const authorAssociation = await resolveAuthorAssociation(
+      repo,
+      authorLogin,
+      issue.author_association ?? null,
+    );
     let edits;
     try {
       const [owner, name] = repo.split("/");
@@ -1027,26 +1040,58 @@ export function githubControlPlane(options = {}) {
   }
 
   /**
+   * `author_association` is reported relative to the API *viewer*, not
+   * absolutely. When the control plane authenticates as the GitHub App
+   * installation (FACTORY_GH_APP_*), the App cannot see org membership, so
+   * GitHub reports an org member — including the operator — as
+   * `CONTRIBUTOR`, which would refuse every human-authored ticket with
+   * `ticket_untrusted_author` and collapse dispatch supply. So whenever the
+   * raw association is not already trusted, fall back to the same repo
+   * permission approximation used for a non-author editor. A raw association
+   * that is already trusted is kept as-is and costs no extra request.
+   */
+  async function resolveAuthorAssociation(repo, login, raw) {
+    if (isTrustedAssociation(raw)) return raw;
+    return (await collaboratorAssociation(repo, login)) ?? raw;
+  }
+
+  /**
    * A non-author editor's association is not directly queryable (GitHub's
    * `authorAssociation` is only meaningful in the context of a specific
    * issue/comment they authored), so it is approximated from their repo
    * permission level — admin/maintain/write reads as COLLABORATOR-trusted,
    * anything weaker or unfetchable reads as untrusted/unknown.
+   *
+   * The App installation needs repository `Metadata: read` for
+   * `GET repos/{repo}/collaborators/{login}/permission`; a 403/404 (the App
+   * not installed on the repo, or the login not a collaborator) resolves to
+   * null/NONE and stays fail-closed.
+   *
+   * Cached per (repo, login) for the process lifetime — one plan reads the
+   * author and possibly the same login as editor, and a scan reads the same
+   * handful of operators over and over. Only resolved answers are cached; a
+   * transient failure (null) is retried rather than pinned untrusted.
    */
   async function collaboratorAssociation(repo, login) {
     if (!login) return null;
+    const key = `${repo} ${login}`;
+    if (collaboratorAssociationCache.has(key))
+      return collaboratorAssociationCache.get(key);
+    let resolved = null;
     try {
       const perm = await call(
         "GET",
         `repos/${repo}/collaborators/${login}/permission`,
       );
       const level = perm?.permission;
-      if (["admin", "maintain", "write"].includes(level)) return "COLLABORATOR";
-      if (level) return "NONE";
-      return null;
+      if (["admin", "maintain", "write"].includes(level))
+        resolved = "COLLABORATOR";
+      else if (level) resolved = "NONE";
     } catch {
       return null;
     }
+    if (resolved) collaboratorAssociationCache.set(key, resolved);
+    return resolved;
   }
 
   /**

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1105,6 +1105,129 @@ describe("trusted-author + body-hash-pin gates (GH-879)", () => {
     );
   });
 
+  test("an App-viewer CONTRIBUTOR author with repo write access reads as trusted", async () => {
+    const seed = freshSeed();
+    addIssue(seed, REPO, {
+      id: 206,
+      node_id: "I_206",
+      number: 10,
+      title: "org member seen as CONTRIBUTOR by the App installation",
+      // What GitHub reports to a GitHub App installation viewer, which
+      // cannot see org membership, for an org member's own issue.
+      authorAssociation: "CONTRIBUTOR",
+      authorLogin: "appblindmember",
+      labels: [],
+      status: "Todo",
+    });
+    seed.collaboratorPermissions[REPO] = { appblindmember: "admin" };
+    const cp = githubControlPlane({
+      api: fakeApi(seed),
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    const t = await cp.getTicket(`${REPO}#10`);
+    expect(t.authorAssociation).toBe("COLLABORATOR");
+    // No edit since creation: the author is still the last editor, and
+    // carries the same upgraded association.
+    expect(t.lastEditorAssociation).toBe("COLLABORATOR");
+  });
+
+  test("an untrusted author without write access stays untrusted", async () => {
+    const seed = freshSeed();
+    addIssue(seed, REPO, {
+      id: 207,
+      node_id: "I_207",
+      number: 11,
+      title: "read-only outsider",
+      authorAssociation: "CONTRIBUTOR",
+      authorLogin: "readonlyrando",
+      labels: [],
+      status: "Todo",
+    });
+    addIssue(seed, REPO, {
+      id: 208,
+      node_id: "I_208",
+      number: 12,
+      title: "not a collaborator at all",
+      authorAssociation: "CONTRIBUTOR",
+      authorLogin: "unknownrando",
+      labels: [],
+      status: "Todo",
+    });
+    seed.collaboratorPermissions[REPO] = { readonlyrando: "read" };
+    const cp = githubControlPlane({
+      api: fakeApi(seed),
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    expect((await cp.getTicket(`${REPO}#11`)).authorAssociation).toBe("NONE");
+    // 404 on the permission endpoint is unresolvable: keep the raw
+    // association, which is untrusted either way.
+    expect((await cp.getTicket(`${REPO}#12`)).authorAssociation).toBe(
+      "CONTRIBUTOR",
+    );
+  });
+
+  test("an already-trusted author costs no permission request", async () => {
+    const seed = freshSeed();
+    addIssue(seed, REPO, {
+      id: 209,
+      node_id: "I_209",
+      number: 13,
+      title: "PAT-viewer member",
+      authorAssociation: "MEMBER",
+      authorLogin: "patmember",
+      labels: [],
+      status: "Todo",
+    });
+    const paths = [];
+    const inner = fakeApi(seed);
+    const cp = githubControlPlane({
+      api: (method, pathName, opts) => {
+        paths.push(pathName);
+        return inner(method, pathName, opts);
+      },
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    expect((await cp.getTicket(`${REPO}#13`)).authorAssociation).toBe("MEMBER");
+    expect(paths.some((p) => p.includes("/collaborators/"))).toBe(false);
+  });
+
+  test("the permission lookup is cached per repo+login", async () => {
+    const seed = freshSeed();
+    for (const n of [14, 15]) {
+      addIssue(seed, REPO, {
+        id: 200 + n,
+        node_id: `I_2${n}`,
+        number: n,
+        title: `cached ${n}`,
+        authorAssociation: "CONTRIBUTOR",
+        authorLogin: "cachedmember",
+        labels: [],
+        status: "Todo",
+      });
+    }
+    seed.collaboratorPermissions[REPO] = { cachedmember: "write" };
+    let permCalls = 0;
+    const inner = fakeApi(seed);
+    const cp = githubControlPlane({
+      api: (method, pathName, opts) => {
+        if (pathName.includes("/collaborators/")) permCalls++;
+        return inner(method, pathName, opts);
+      },
+      repo: REPO,
+      teams: { WM: REPO },
+    });
+    expect((await cp.getTicket(`${REPO}#14`)).authorAssociation).toBe(
+      "COLLABORATOR",
+    );
+    expect((await cp.getTicket(`${REPO}#15`)).authorAssociation).toBe(
+      "COLLABORATOR",
+    );
+    expect(permCalls).toBe(1);
+  });
+
   test("adding ai:agent-ready via transition() stamps a ready-pin comment", async () => {
     const { cp } = makePlane();
     await cp.transition(`${REPO}#3`, "Todo", { add: [AGENT_READY_LABEL] });


### PR DESCRIPTION
Fixes #1248

## Problem

`author_association` is reported relative to the API **viewer**. With the control plane authenticating as the GitHub App installation (FACTORY_GH_APP_*, #1148), the App cannot see org membership, so GitHub reports org member `hdkiller` as `CONTRIBUTOR`. WM-879 gate 1 (`isTrustedAssociation`) then refuses **every** human-authored ticket with `ticket_untrusted_author` and dispatch supply collapses.

## Change

`lib/control-plane/github.mjs` already approximated a non-author *editor's* trust from repo permission level. This applies the same fallback to the **author** (and, when the last editor is the author, to that too): if the raw association is not already trusted, resolve it via `GET repos/{repo}/collaborators/{login}/permission` (admin/maintain/write => COLLABORATOR, weaker => NONE, unfetchable => keep the raw untrusted value). Fail-closed throughout; an already-trusted raw association costs no extra request. Resolved answers are cached per (repo, login) for the process lifetime; transient failures are not cached.

App permission check (installation token, today):

```
GET /repos/watt-mind/factory/collaborators/hdkiller/permission -> 200 {"permission":"admin"}
```

so the documented `Metadata: read` on the installation is sufficient and no `orgs/{org}/members/{login}` fallback is needed.

## Handoff

**Verification**

```
$ bun test lib/control-plane/github.test.mjs --timeout 20000
 86 pass  0 fail  260 expect() calls
$ bun test lib/control-plane --timeout 20000
 157 pass  0 fail  442 expect() calls
$ bun test event-runtime/lib/planner.test.mjs --timeout 20000
 88 pass  0 fail  452 expect() calls
$ bun run check
ok - 94 generated files match shared/   (exit 0)
$ prettier --check lib/control-plane/github.mjs lib/control-plane/github.test.mjs
All matched files use Prettier code style!
$ eslint lib/control-plane/github.mjs lib/control-plane/github.test.mjs   (clean)
```

New tests (mocked `call`): App-viewer CONTRIBUTOR author with `admin` permission => COLLABORATOR (trusted); `read` => NONE and 404 => raw CONTRIBUTOR (both untrusted); an already-trusted MEMBER author issues no `/collaborators/` request; the permission lookup is cached per repo+login. Existing editor-path tests unchanged and passing.

**UX**: n/a - no user-facing surface.

**File scope**: `lib/control-plane/github.mjs`, `lib/control-plane/github.test.mjs`.

**Risk**: low-moderate. It widens gate 1 admission by exactly one rule - a repo write-or-better permission level - which is the same trust signal already accepted for editors. A stranger with no write access stays refused, and every error path keeps the untrusted value. The added request fires only for not-already-trusted authors and is cached, so a PAT-authenticated deployment pays nothing.
