### PR TITLE
fix(demo): verify fetches /artifacts/:sha with the control API bearer (#1251)

### DIFF
--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -216,9 +216,9 @@ if (artifactRun) {
   );
 
   if (reportArtifact?.sha256) {
-    const artRes = await fetch(
-      `http://127.0.0.1:${port}/artifacts/${reportArtifact.sha256}`,
-    );
+    // Through the client so the bearer rides along: a bare fetch answered
+    // 401 whenever the demo serve inherited FACTORY_CONTROL_API_TOKEN.
+    const artRes = await client.artifact(reportArtifact.sha256);
     check(
       "GET /artifacts/:sha returns 200 for declared report",
       artRes.status === 200,

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -133,6 +133,18 @@ export function apiClient({
     runs: (state) =>
       call("GET", `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`),
     run: (id) => call("GET", `/runs/${encodeURIComponent(id)}`),
+    /**
+     * Raw artifact bytes by content address (GET /artifacts/:sha). The route
+     * sits behind the bearer gate like every other control route, so callers
+     * must go through here rather than a bare fetch (#1132 follow-up): a demo
+     * serve spawned under FACTORY_CONTROL_API_TOKEN answered a bare fetch
+     * with 401 and failed every worktree-up fixture verify. Returns the
+     * Response so callers can inspect status and read the body themselves.
+     */
+    artifact: (sha256) =>
+      fetch(`${base}/artifacts/${encodeURIComponent(sha256)}`, {
+        headers: { ...authHeader },
+      }),
     /** Live agent trace (factory.trace/v1): pass head back as since to poll. */
     trace: (id, { since = 0, limit = 100 } = {}) =>
       call(

--- a/event-runtime/lib/client.test.mjs
+++ b/event-runtime/lib/client.test.mjs
@@ -27,6 +27,14 @@ beforeAll(() => {
         }
         return Response.json({ runs: [] });
       }
+      if (url.pathname.startsWith("/artifacts/")) {
+        if (lastAuthorization !== `Bearer ${TOKEN}`) {
+          return Response.json({ error: "unauthorized" }, { status: 401 });
+        }
+        return new Response("fake report body", {
+          headers: { "content-type": "text/plain" },
+        });
+      }
       return Response.json({ error: "not found" }, { status: 404 });
     },
   });
@@ -81,4 +89,17 @@ test("non-401 errors keep the server's message and status", async () => {
   await client.repos().catch((e) => (err = e));
   expect(err.status).toBe(404);
   expect(err.message).toBe("not found");
+});
+
+test("artifact() presents the bearer on GET /artifacts/:sha and returns the raw body", async () => {
+  const res = await apiClient({ port, token: TOKEN }).artifact("a".repeat(64));
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("fake report body");
+  expect(lastAuthorization).toBe(`Bearer ${TOKEN}`);
+});
+
+test("artifact() without a token gets the gate's 401 (regression: worktree-up verify)", async () => {
+  const res = await apiClient({ port, token: null }).artifact("a".repeat(64));
+  expect(res.status).toBe(401);
+  expect(lastAuthorization).toBeNull();
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1251

## Problem
Since the live workers export `FACTORY_CONTROL_API_TOKEN`, every dispatch dies at workspace provisioning:

```
worktree_up failed …: verify: 3 check(s) failed — reseed with: bun event-runtime/demo/seed.mjs --port <port>
  - GET /artifacts/:sha returns 200 for declared report
  - artifact content matches expected body
  - artifact body matches declared sha256 checksum
```

`event-runtime/demo/verify.mjs` fetched the declared report artifact with a bare `fetch()` (no `Authorization`), while every other call goes through `apiClient()` and its bearer (#1234/#1132). The demo serve `bin/worktree-up.sh` spawns inherits the token from the worker env and gates `/artifacts/*`, so the bare fetch got 401.

## Fix
- `apiClient().artifact(sha)`: authenticated raw `GET /artifacts/:sha`, returns the `Response`
- `verify.mjs` uses it
- `client.test.mjs`: bearer presented on the artifact route; no token → the gate's 401

## Verification
- Repro: `FACTORY_CONTROL_API_TOKEN=x bin/worktree-up.sh watt-mind/factory#999901` on origin/develop → 3 checks fail; same provisioning of this branch (`worktree-up.sh --here` with the token) → `verify: seeded demo fixture fully intact and verified`, exit 0.
- `bun test event-runtime/lib/client.test.mjs` (7 pass), `bun run check` clean, prettier clean.
- `event-runtime/lib/api-artifacts.test.mjs` has 2 pre-existing failures on develop (runtimeHome guard when run without the test helper), unrelated.

## Handoff
- Not the #1234 401 probe (that exits before any check) nor the runtimeHome/sandbox-policy guards — checked both.
- No other bare `/artifacts/` fetches outside `web/` in bin or event-runtime; the web UI was not audited here.
- Once merged, a release to /opt/factory/current is needed for the live workers to pick it up.
