### PR TITLE
fix(worker): derive stalled lease retry cause via retryDecision

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3734,15 +3734,17 @@ export function releaseStalledWorkerLease(
           now: currentNow,
         });
       }
-      transition(db, {
-        runId: heldRunId,
-        to: "FAILED",
-        actor,
-        reason: failureReason,
-        attempt: run.attempts,
-        policyVersion,
-        now: currentNow,
-      });
+      if (run.state !== "VERIFYING") {
+        transition(db, {
+          runId: heldRunId,
+          to: "FAILED",
+          actor,
+          reason: failureReason,
+          attempt: run.attempts,
+          policyVersion,
+          now: currentNow,
+        });
+      }
     }
     db.query(
       `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3634,9 +3634,9 @@ export async function executeClaimed(
  * Explicit operator recovery for a worker that stopped heartbeating while it
  * still owned a run. This mirrors the lease reaper's retry/exhaustion rules,
  * but targets exactly the selected worker/run. When the run is retried it is
- * re-queued with the fixed `retry:environment` reason (matching the reaper's
- * lease-expiry requeue); operator provenance is carried by `actor` (default
- * "operator") on the recorded transitions, not by the reason string.
+ * re-queued with the retry cause derived from the same decision as the reaper;
+ * operator provenance is carried by `actor` (default "operator") on the
+ * recorded transitions, not by the reason string.
  */
 export function releaseStalledWorkerLease(
   db,
@@ -3688,36 +3688,36 @@ export function releaseStalledWorkerLease(
     }
 
     const spec = JSON.parse(run.spec_json);
-    const reason = "operator_release_stalled_worker";
+    const failureReason = typedFailureReason("lease_expired");
     db.query(
       `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
     ).run(iso(currentNow - 1), heldRunId, run.attempts);
-    if (run.attempts < spec.maxAttempts) {
-      const failureReason = typedFailureReason("lease_expired");
-      if (run.state === "VERIFYING") {
-        transition(db, {
-          runId: heldRunId,
-          to: "FAILED",
-          actor,
-          reason: failureReason,
-          attempt: run.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-      }
-      finishAttempt(
-        db,
-        heldRunId,
-        run.attempts,
-        "FAILED",
-        "lease_expired",
-        currentNow,
-      );
+    if (run.state === "VERIFYING") {
+      transition(db, {
+        runId: heldRunId,
+        to: "FAILED",
+        actor,
+        reason: failureReason,
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
+      });
+    }
+    finishAttempt(
+      db,
+      heldRunId,
+      run.attempts,
+      "FAILED",
+      "lease_expired",
+      currentNow,
+    );
+    const decision = retryDecision(db, heldRunId, spec, "lease_expired");
+    if (decision.retry) {
       transition(db, {
         runId: heldRunId,
         to: "QUEUED",
         actor,
-        reason: "retry:environment",
+        reason: `retry:${decision.cause}`,
         attempt: run.attempts,
         policyVersion,
         now: currentNow,
@@ -3728,7 +3728,7 @@ export function releaseStalledWorkerLease(
           runId: heldRunId,
           to: "RUNNING",
           actor,
-          reason,
+          reason: failureReason,
           attempt: run.attempts,
           policyVersion,
           now: currentNow,
@@ -3738,19 +3738,11 @@ export function releaseStalledWorkerLease(
         runId: heldRunId,
         to: "FAILED",
         actor,
-        reason,
+        reason: failureReason,
         attempt: run.attempts,
         policyVersion,
         now: currentNow,
       });
-      finishAttempt(
-        db,
-        heldRunId,
-        run.attempts,
-        "FAILED",
-        "stalled_worker_released",
-        currentNow,
-      );
     }
     db.query(
       `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2556,6 +2556,63 @@ describe("worker", () => {
     });
   });
 
+  test("releasing a stalled worker honors the environment retry ceiling", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(
+      db,
+      makeSpec({ maxAttempts: 5, maxEnvironmentRetries: 0 }),
+    );
+    db.query(`UPDATE runs SET attempts = 1 WHERE run_id = ?`).run(spec.runId);
+    db.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      spec.runId,
+      1,
+      1,
+      new Date(T0 - 1).toISOString(),
+      "FAILED",
+      "lease_expired",
+    );
+    db.query(`INSERT INTO counters (name, value) VALUES (?, ?)`).run(
+      "fencing",
+      1,
+    );
+    const claim = claimNext(db, opts());
+    const staleAt = T0 - 90_001;
+    db.query(
+      `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "w1",
+      "test-host",
+      1,
+      "{}",
+      "fake",
+      new Date(T0).toISOString(),
+      new Date(staleAt).toISOString(),
+      "busy",
+      spec.runId,
+    );
+
+    expect(
+      releaseStalledWorkerLease(
+        db,
+        { workerId: "w1", runId: spec.runId },
+        { now: T0, policyVersion: "test" },
+      ),
+    ).toEqual({ released: true, runId: spec.runId });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(claim.attempt).toBe(2);
+    expect(
+      db
+        .query(
+          `SELECT terminal_state, reason_code FROM attempts WHERE run_id = ? AND attempt = ?`,
+        )
+        .get(spec.runId, claim.attempt),
+    ).toEqual({ terminal_state: "FAILED", reason_code: "lease_expired" });
+  });
+
   test("cancelRun on a RUNNING attempt aborts adapter immediately and records attempt (OPS-417)", async () => {
     const db = openDb(":memory:");
     let aborted = false;


### PR DESCRIPTION
Fixes watt-mind/factory#1212

Align operator lease recovery with the shared retry budget so exhausted environment failures are dead-lettered consistently.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/reaper.test.mjs --timeout 20000 && bun run check` | pass    | 152 tests, 0 failures; check passed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1775 tests, 10 skipped, 0 failures; emit check passed |
| UX critique          | factory-ux-critic                | not run | backend-only change; no user-facing surface |

UX critique: skipped — backend-only change; no user-facing surface

Post-review: merged origin/develop (post #1256) and re-verified (worker.test.mjs 147 pass, `bun run check` ok). The `releaseStalledWorkerLease` exhaustion reason-string divergence from `terminalFailureReason` (reaper parity) is tracked separately as a follow-up maintenance issue.
