### PR TITLE
refactor(extensions): pass secret field context as options

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -365,6 +365,34 @@ directory):
 }
 ```
 
+### Where secrets may live
+
+`format: "secret"` is accepted only on fixed object properties declared in
+`properties`, at any nesting depth. A secret under `items`, under
+`additionalProperties`, or at the schema root is rejected when the extension
+loads: the extension is disabled, its `values` are `null`, and an anomaly
+records `config schema ... declares format "secret" beneath ...`.
+
+Rejected (dynamic location):
+
+```json
+{
+  "type": "array",
+  "items": { "type": "string", "format": "secret" }
+}
+```
+
+Accepted (fixed property):
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "apiToken": { "type": "string", "format": "secret" }
+  }
+}
+```
+
 Values (`config/policy.yaml`) — non-secret settings only:
 
 ```yaml

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -785,37 +785,28 @@ function collectSecretFieldsUnchecked(
   if (isPlainObject(schema.properties)) {
     for (const [key, sub] of Object.entries(schema.properties)) {
       out.push(
-        ...collectSecretFieldsUnchecked(
-          sub,
-          [...path, key],
-          { schemaPath: `${schemaPath}.${key}`, dynamicLocation },
-        ),
+        ...collectSecretFieldsUnchecked(sub, [...path, key], {
+          schemaPath: `${schemaPath}.${key}`,
+          dynamicLocation,
+        }),
       );
     }
   }
   if (isPlainObject(schema.items)) {
     out.push(
-      ...collectSecretFieldsUnchecked(
-        schema.items,
-        path,
-        {
-          schemaPath: `${schemaPath}[]`,
-          dynamicLocation: dynamicLocation ?? `schema.items at ${schemaPath}`,
-        },
-      ),
+      ...collectSecretFieldsUnchecked(schema.items, path, {
+        schemaPath: `${schemaPath}[]`,
+        dynamicLocation: dynamicLocation ?? `schema.items at ${schemaPath}`,
+      }),
     );
   }
   if (isPlainObject(schema.additionalProperties)) {
     out.push(
-      ...collectSecretFieldsUnchecked(
-        schema.additionalProperties,
-        path,
-        {
-          schemaPath: `${schemaPath}.*`,
-          dynamicLocation:
-            dynamicLocation ?? `schema.additionalProperties at ${schemaPath}`,
-        },
-      ),
+      ...collectSecretFieldsUnchecked(schema.additionalProperties, path, {
+        schemaPath: `${schemaPath}.*`,
+        dynamicLocation:
+          dynamicLocation ?? `schema.additionalProperties at ${schemaPath}`,
+      }),
     );
   }
   return out;

--- a/event-runtime/lib/extensions.mjs
+++ b/event-runtime/lib/extensions.mjs
@@ -763,9 +763,8 @@ export function collectSecretFields(schema, path = []) {
 
 function collectSecretFieldsUnchecked(
   schema,
-  path = [],
-  schemaPath = "$",
-  dynamicLocation = null,
+  path,
+  { schemaPath = "$", dynamicLocation = null } = {},
 ) {
   if (!isPlainObject(schema)) return [];
   if (schema.format === "secret") {
@@ -789,8 +788,7 @@ function collectSecretFieldsUnchecked(
         ...collectSecretFieldsUnchecked(
           sub,
           [...path, key],
-          `${schemaPath}.${key}`,
-          dynamicLocation,
+          { schemaPath: `${schemaPath}.${key}`, dynamicLocation },
         ),
       );
     }
@@ -800,8 +798,10 @@ function collectSecretFieldsUnchecked(
       ...collectSecretFieldsUnchecked(
         schema.items,
         path,
-        `${schemaPath}[]`,
-        dynamicLocation ?? `schema.items at ${schemaPath}`,
+        {
+          schemaPath: `${schemaPath}[]`,
+          dynamicLocation: dynamicLocation ?? `schema.items at ${schemaPath}`,
+        },
       ),
     );
   }
@@ -810,8 +810,11 @@ function collectSecretFieldsUnchecked(
       ...collectSecretFieldsUnchecked(
         schema.additionalProperties,
         path,
-        `${schemaPath}.*`,
-        dynamicLocation ?? `schema.additionalProperties at ${schemaPath}`,
+        {
+          schemaPath: `${schemaPath}.*`,
+          dynamicLocation:
+            dynamicLocation ?? `schema.additionalProperties at ${schemaPath}`,
+        },
       ),
     );
   }


### PR DESCRIPTION
Fixes watt-mind/factory#1226

Refactor secret-schema traversal context and document supported secret locations for extension authors.

## Validation

| Check                | Command                                               | Result | Notes                  |
| -------------------- | ----------------------------------------------------- | ------ | ---------------------- |
| Verification Command | `bun test event-runtime/lib/extensions.test.mjs --timeout 20000 && bun run check` | pass   | 61 tests, 0 failures; emit check clean |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass   | 1795 pass, 10 skipped, 0 failures |
| UX critique          | factory-ux-critic                                     | not run | no user-facing surface |

UX critique: skipped — backend/docs maintenance with no user-facing surface


## Handoff

- Verification: `bun test event-runtime/lib/extensions.test.mjs --timeout 20000 && bun run check` — pass (61 tests, 0 failures; emit check clean). Re-run by the lander after merging `origin/develop` into the branch.
- Repo verify: the factory run's repo-verify failure was environment contamination (shared `FACTORY_EVENT_HOME`), not a code defect; re-run with an isolated `FACTORY_EVENT_HOME` passes.
- UX: n/a — backend/docs maintenance, no user-facing surface.
- File scope: `event-runtime/lib/extensions.mjs`, `docs/extensions.md`.
