### PR TITLE
fix: allow audited workspace scan fallback

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -7,12 +7,41 @@ extensions: []
 
 # Workspace-only model runs fail closed when this host cannot provide the
 # Gondolin guest boundary. An operator may temporarily accept host execution
-# for definitions that do not carry their own `sandbox:` block by uncommenting
-# the exact opt-out below. Every admitted run records
-# `filesystemConfinement.status: unconfined` in its receipt. Prefer installing
-# QEMU/Gondolin and leaving this absent; see docs/event-runtime-adapters.md.
+# by naming, one by one, the agents they accept running unconfined. Nothing is
+# enabled by default: absent, malformed, and unknown values all keep the
+# refusal. An agent missing from `agents` is refused exactly as before, with a
+# reason naming the missing host capability (`sandbox_unavailable:qemu`).
+#
+# The grant applies ONLY on a host whose sandbox preflight fails, and only to
+# definitions that carry no `sandbox:` block of their own — an authored
+# definition policy always wins. Mutating agents never reach this gate.
+# Every admitted run records `filesystemConfinement.status: unconfined` in its
+# receipt. Prefer installing QEMU/Gondolin and leaving this absent; see
+# docs/event-runtime-adapters.md.
 # sandbox:
-#   workspace_only_fallback: host
+#   workspace_only_fallback:
+#     mode: host
+#     agents:
+#       - work-scan
+#       - triage-scan
+#       - ci-doctor
+#       - ci-log-capture
+#       - janitor-scan
+#       - merge-scan
+#       - merge-review
+#       - merge-plan
+#       - sweep-scan
+#       - ship-scan
+#       - unblock-scan
+#       - unblock-digest
+#       - run-postmortem
+#       - factory-status-report
+#       - disk-diagnose
+#
+# The bare string form `workspace_only_fallback: host` is still accepted for
+# instances configured before the allow-list landed. It means "every
+# workspace-only agent", logs a loud warning on every claim, and should be
+# replaced by the explicit form above.
 
 chain_auto_approval:
   # New installations may opt into this closed set after reviewing their

--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -5,6 +5,15 @@
 packs: []
 extensions: []
 
+# Workspace-only model runs fail closed when this host cannot provide the
+# Gondolin guest boundary. An operator may temporarily accept host execution
+# for definitions that do not carry their own `sandbox:` block by uncommenting
+# the exact opt-out below. Every admitted run records
+# `filesystemConfinement.status: unconfined` in its receipt. Prefer installing
+# QEMU/Gondolin and leaving this absent; see docs/event-runtime-adapters.md.
+# sandbox:
+#   workspace_only_fallback: host
+
 chain_auto_approval:
   # New installations may opt into this closed set after reviewing their
   # tracker, credentials, and merge policy.

--- a/docs/event-runtime-adapters.md
+++ b/docs/event-runtime-adapters.md
@@ -1,0 +1,79 @@
+# Event-runtime adapters and workspace confinement
+
+Model-backed adapters can execute tools chosen by a model. A non-mutating
+agent definition with `capabilities.filesystem: workspace-only` therefore
+promises more than a convenient working directory: by default the worker must
+prove that the selected adapter enters a Gondolin guest before it starts the
+model process.
+
+## Fail-closed behavior
+
+Without an operator opt-out, a worker that cannot provide Gondolin refuses the
+run before creating its workspace or spawning the adapter. The stable result
+code remains `filesystem_confinement_unavailable`; the lifecycle detail names
+the missing host capability, for example:
+
+```text
+work-scan@1: sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH
+```
+
+Other preflight tokens include `sandbox_unavailable:node` and
+`sandbox_unavailable:sdk`. `factory watchdog` and `factory pulse` surface
+recent refusals so a stopped scan supply loop is not mistaken for an idle
+factory.
+
+An explicit `sandbox:` block on an agent definition is always strict. It is
+never eligible for host fallback: unsupported adapters, invalid policies, and
+unavailable guest infrastructure continue to refuse.
+
+## Explicit host fallback
+
+An operator may temporarily run otherwise eligible workspace-only scans on a
+host that lacks Gondolin by setting the instance-local policy:
+
+```yaml
+sandbox:
+  workspace_only_fallback: host
+```
+
+This is an opt-out from filesystem enforcement, not another sandbox provider.
+It applies only when all of these conditions hold:
+
+- the agent is explicitly non-mutating;
+- its filesystem capability is exactly `workspace-only`;
+- a model-backed adapter was selected; and
+- the agent definition has no explicit `sandbox:` block.
+
+The value must be exactly `host`. Missing, misspelled, malformed, or unknown
+values fail closed. The downgrade is never silent: every terminal run receipt
+that used it contains this worker-controlled attestation:
+
+```json
+{
+  "filesystemConfinement": {
+    "status": "unconfined",
+    "declared": "workspace-only",
+    "fallback": "host",
+    "source": "policy:sandbox.workspace_only_fallback"
+  }
+}
+```
+
+The worker writes this field after any agent-authored receipt data so the agent
+cannot overwrite the audit marker.
+
+## Operator procedure
+
+1. Confirm Gondolin is unavailable with
+   `bun event-runtime/cli.mjs sandbox doctor`.
+2. Add the exact host fallback to the live `config/policy.yaml`.
+3. Restart the event-runtime worker processes so they read the new policy.
+4. Confirm the affected scan runs complete and their receipts say
+   `filesystemConfinement.status: unconfined`.
+5. Install the missing Gondolin/QEMU prerequisites, remove the fallback, restart
+   workers, and confirm a sandboxed smoke run succeeds.
+
+The tracked `config/policy.example.yaml` leaves the opt-out commented because
+new installations must remain fail-closed by default. Factory follow-up #1259
+tracks installing Gondolin/QEMU on the current operator runner so the interim
+host fallback can be removed.

--- a/docs/event-runtime-adapters.md
+++ b/docs/event-runtime-adapters.md
@@ -26,27 +26,62 @@ An explicit `sandbox:` block on an agent definition is always strict. It is
 never eligible for host fallback: unsupported adapters, invalid policies, and
 unavailable guest infrastructure continue to refuse.
 
-## Explicit host fallback
+## Explicit host fallback (an allow-list, never a switch)
 
-An operator may temporarily run otherwise eligible workspace-only scans on a
-host that lacks Gondolin by setting the instance-local policy:
+An operator may temporarily run _named_ workspace-only scans on a host that
+lacks Gondolin by adding this to the instance-local `config/policy.yaml`:
 
 ```yaml
 sandbox:
-  workspace_only_fallback: host
+  workspace_only_fallback:
+    mode: host
+    agents:
+      - work-scan
+      - triage-scan
+      - ci-doctor
 ```
 
-This is an opt-out from filesystem enforcement, not another sandbox provider.
+This is an opt-out from filesystem enforcement, not another sandbox provider,
+so it is deliberately not a single global switch: the operator writes down
+exactly which agents they accept running unconfined, and every other
+workspace-only agent keeps refusing. Adding an agent to the list is a
+reviewable one-line change; forgetting to remove one is visible in the policy
+file rather than hidden behind a boolean.
+
 It applies only when all of these conditions hold:
 
+- this host's sandbox preflight fails — a host that _can_ sandbox never falls
+  back, whatever the allow-list says;
 - the agent is explicitly non-mutating;
 - its filesystem capability is exactly `workspace-only`;
-- a model-backed adapter was selected; and
-- the agent definition has no explicit `sandbox:` block.
+- a model-backed adapter was selected;
+- the agent definition has no explicit `sandbox:` block; and
+- `agents` names the agent (bare name, no `@version`, no pack namespace).
 
-The value must be exactly `host`. Missing, misspelled, malformed, or unknown
-values fail closed. The downgrade is never silent: every terminal run receipt
-that used it contains this worker-controlled attestation:
+An agent absent from `agents` is refused exactly as it was before this
+fallback existed, with the reason naming the missing host capability
+(`sandbox_unavailable:qemu`) rather than the policy shape.
+
+Missing, misspelled, malformed, and unknown values all fail closed — including
+`mode: host` with an empty or absent `agents` list, which grants nobody.
+
+### The legacy blanket form
+
+```yaml
+sandbox:
+  workspace_only_fallback: host # deprecated
+```
+
+The bare string is still accepted for instances configured before the
+allow-list landed. It means "every non-mutating workspace-only agent" and logs
+a loud warning on every claim. Replace it with the object form.
+
+### The audit marker
+
+The downgrade is never silent: every terminal run receipt written by a run
+that used it — completed _and_ refused — contains this worker-controlled
+attestation, and the failure paths that write no receipt record the same
+object on the attempt trace:
 
 ```json
 {
@@ -54,7 +89,9 @@ that used it contains this worker-controlled attestation:
     "status": "unconfined",
     "declared": "workspace-only",
     "fallback": "host",
-    "source": "policy:sandbox.workspace_only_fallback"
+    "source": "policy:sandbox.workspace_only_fallback",
+    "agent": "work-scan",
+    "hostCapability": "qemu"
   }
 }
 ```
@@ -66,7 +103,8 @@ cannot overwrite the audit marker.
 
 1. Confirm Gondolin is unavailable with
    `bun event-runtime/cli.mjs sandbox doctor`.
-2. Add the exact host fallback to the live `config/policy.yaml`.
+2. Add the allow-list stanza to the live `config/policy.yaml`, naming only
+   the agents you accept running unconfined.
 3. Restart the event-runtime worker processes so they read the new policy.
 4. Confirm the affected scan runs complete and their receipts say
    `filesystemConfinement.status: unconfined`.

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -147,30 +147,91 @@ export function sandboxRequested(def) {
 }
 
 /**
+ * The bare agent name behind a definition, with any pack namespace and
+ * `@version` suffix stripped — the identity an operator writes in the
+ * `sandbox.workspace_only_fallback.agents` allow-list.
+ */
+export function definitionAgentName(def) {
+  const raw =
+    typeof def?.id === "string" && def.id !== ""
+      ? def.id
+      : typeof def?.ref === "string"
+        ? def.ref
+        : null;
+  if (!raw) return null;
+  const name = raw.split("@")[0].split("/").pop();
+  return name === "" ? null : name;
+}
+
+/**
+ * Normalize `sandbox.workspace_only_fallback` into `{ mode, agents }` or
+ * `null`. Everything unknown, malformed, or empty normalizes to `null`, so
+ * the gate keeps failing closed on a typo.
+ *
+ * The object form is the supported shape: it names exactly which agents may
+ * run unconfined. The bare string `host` is still accepted for the operator
+ * who wrote it before this narrowing landed — it means "every workspace-only
+ * agent" and is deliberately loud, because it is a blanket grant.
+ */
+export function normalizeWorkspaceOnlyFallback(
+  value,
+  { warn = console.warn } = {},
+) {
+  if (value === "host") {
+    warn(
+      'sandbox.workspace_only_fallback: "host" is the legacy blanket form — it admits EVERY ' +
+        "non-mutating workspace-only agent unconfined on this host. Replace it with the explicit " +
+        'allow-list form { mode: "host", agents: [...] } naming only the scans you accept.',
+    );
+    return { mode: "host", agents: null };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (value.mode !== "host") return null;
+  const agents = Array.isArray(value.agents)
+    ? value.agents.filter((a) => typeof a === "string" && a !== "")
+    : [];
+  // An object form that names nobody grants nobody: fail closed rather than
+  // silently widening to the blanket meaning.
+  return agents.length > 0 ? { mode: "host", agents } : null;
+}
+
+/**
  * Whether the operator explicitly accepted host execution for this otherwise
- * workspace-only run. An explicit definition-level sandbox request always
- * wins: the instance fallback may relax an implicit workspace boundary, but
- * it may never erase a sandbox policy authored on the agent itself.
+ * workspace-only run. Three things must all hold:
+ *
+ *   1. the definition is non-mutating and only ever promised workspace-only;
+ *   2. it carries no `sandbox:` block of its own — an explicit definition
+ *      policy always wins, the instance fallback may relax an *implicit*
+ *      workspace boundary but never erase an authored one;
+ *   3. the policy allow-list names this agent (or is the loud blanket form).
+ *
+ * The caller is responsible for only consulting this when the host actually
+ * has no sandbox; `filesystemConfinementRefusal` enforces that ordering.
  */
 export function workspaceOnlyHostFallback(def, runtime = {}) {
-  return (
-    def?.mutating === false &&
-    def?.capabilities?.filesystem === "workspace-only" &&
-    !sandboxRequested(def) &&
-    runtime.workspaceOnlyFallback === "host"
-  );
+  if (def?.mutating !== false) return false;
+  if (def?.capabilities?.filesystem !== "workspace-only") return false;
+  if (sandboxRequested(def)) return false;
+  const fallback = runtime.workspaceOnlyFallback;
+  if (!fallback || fallback.mode !== "host") return false;
+  if (fallback.agents === null) return true;
+  const name = definitionAgentName(def);
+  return name !== null && fallback.agents.includes(name);
+}
+
+/** Which host capability Gondolin's preflight found missing. */
+export function sandboxUnavailableCapability(report) {
+  if (!report || report.available !== false) return null;
+  if (!report.qemu) return "qemu";
+  if (!report.node || !report.nodeVersion) return "node";
+  if (!report.sdk) return "sdk";
+  return "host";
 }
 
 /** Turn Gondolin's detailed preflight report into a stable audit token. */
 export function sandboxUnavailableDetail(report) {
-  if (!report || report.available !== false) return null;
-  const capability = !report.qemu
-    ? "qemu"
-    : !report.node || !report.nodeVersion
-      ? "node"
-      : !report.sdk
-        ? "sdk"
-        : "host";
+  const capability = sandboxUnavailableCapability(report);
+  if (!capability) return null;
   return `sandbox_unavailable:${capability}${report.reason ? ` — ${report.reason}` : ""}`;
 }
 
@@ -209,10 +270,15 @@ export function filesystemConfinementRefusal(adapter, def, runtime = {}) {
     detail: `${def?.ref ?? "definition"}: ${detail}`,
   });
 
-  if (workspaceOnlyHostFallback(def, runtime)) return null;
-
+  // Host capability comes first: when this machine cannot virtualize, the
+  // refusal must name the missing capability rather than the policy shape.
+  // The operator opt-out is consulted only on that branch — a host that CAN
+  // sandbox never falls back, whatever the allow-list says.
   const unavailable = sandboxUnavailableDetail(runtime.sandboxAvailability);
-  if (unavailable) return refuse(unavailable);
+  if (unavailable) {
+    if (workspaceOnlyHostFallback(def, runtime)) return null;
+    return refuse(unavailable);
+  }
 
   if (adapter !== "pi") {
     return refuse(

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -147,6 +147,34 @@ export function sandboxRequested(def) {
 }
 
 /**
+ * Whether the operator explicitly accepted host execution for this otherwise
+ * workspace-only run. An explicit definition-level sandbox request always
+ * wins: the instance fallback may relax an implicit workspace boundary, but
+ * it may never erase a sandbox policy authored on the agent itself.
+ */
+export function workspaceOnlyHostFallback(def, runtime = {}) {
+  return (
+    def?.mutating === false &&
+    def?.capabilities?.filesystem === "workspace-only" &&
+    !sandboxRequested(def) &&
+    runtime.workspaceOnlyFallback === "host"
+  );
+}
+
+/** Turn Gondolin's detailed preflight report into a stable audit token. */
+export function sandboxUnavailableDetail(report) {
+  if (!report || report.available !== false) return null;
+  const capability = !report.qemu
+    ? "qemu"
+    : !report.node || !report.nodeVersion
+      ? "node"
+      : !report.sdk
+        ? "sdk"
+        : "host";
+  return `sandbox_unavailable:${capability}${report.reason ? ` — ${report.reason}` : ""}`;
+}
+
+/**
  * Return a typed admission refusal when a non-mutating model run promises a
  * workspace-only filesystem but the selected adapter cannot enforce it.
  *
@@ -161,8 +189,9 @@ export function sandboxRequested(def) {
  * Non-model adapters and mutating definitions are outside this ticket's
  * boundary and retain their existing admission semantics.
  *
- * @param {{ sandboxSupport?: string|null }} [runtime] - worker-side attestation
- *   from the actual selected adapter module; omitted by the deterministic
+ * @param {{ sandboxSupport?: string|null, sandboxAvailability?: object,
+ *   workspaceOnlyFallback?: string|null }} [runtime] - worker-side
+ *   attestations and explicit instance fallback; omitted by the deterministic
  *   planner, which admits the built-in pi route by name.
  * @returns {{ code: string, detail: string } | null}
  */
@@ -179,6 +208,11 @@ export function filesystemConfinementRefusal(adapter, def, runtime = {}) {
     code: FILESYSTEM_CONFINEMENT_REASON,
     detail: `${def?.ref ?? "definition"}: ${detail}`,
   });
+
+  if (workspaceOnlyHostFallback(def, runtime)) return null;
+
+  const unavailable = sandboxUnavailableDetail(runtime.sandboxAvailability);
+  if (unavailable) return refuse(unavailable);
 
   if (adapter !== "pi") {
     return refuse(

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -32,8 +32,10 @@ import {
   refuseSandbox,
   runSandboxed,
   SANDBOX_CONSOLE_FILE,
+  sandboxUnavailableDetail,
   sandboxRequested,
   SandboxUnsupportedError,
+  workspaceOnlyHostFallback,
   withStdinFile,
 } from "./sandboxed.mjs";
 
@@ -85,6 +87,57 @@ describe("sandboxRequested / refuseSandbox", () => {
 });
 
 describe("workspace-only model admission (#962)", () => {
+  test("an explicit host fallback admits only definitions without their own sandbox policy (#1250)", () => {
+    const runtime = {
+      workspaceOnlyFallback: "host",
+      sandboxAvailability: {
+        available: false,
+        qemu: null,
+        reason: "qemu-system-x86_64 is not on PATH",
+      },
+    };
+
+    expect(workspaceOnlyHostFallback(confinedDef(), runtime)).toBe(true);
+    for (const adapter of ["agy", "claude", "cursor", "hermes", "pi"]) {
+      expect(
+        filesystemConfinementRefusal(adapter, confinedDef(), runtime),
+      ).toBeNull();
+    }
+
+    const explicitlySandboxed = confinedDef({
+      sandbox: { provider: "gondolin" },
+    });
+    expect(workspaceOnlyHostFallback(explicitlySandboxed, runtime)).toBe(false);
+    expect(
+      filesystemConfinementRefusal("pi", explicitlySandboxed, runtime),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("sandbox_unavailable:qemu"),
+    });
+  });
+
+  test("host preflight failures name the missing capability before policy shape (#1250)", () => {
+    const runtime = {
+      sandboxAvailability: {
+        available: false,
+        qemu: null,
+        node: null,
+        nodeVersion: null,
+        sdk: false,
+        reason: "qemu-system-x86_64 is not on PATH",
+      },
+    };
+    expect(sandboxUnavailableDetail(runtime.sandboxAvailability)).toBe(
+      "sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH",
+    );
+    expect(
+      filesystemConfinementRefusal("pi", confinedDef(), runtime),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("sandbox_unavailable:qemu"),
+    });
+  });
+
   test("unsupported model adapters fail closed with one typed reason", () => {
     for (const adapter of ["agy", "claude", "cursor", "hermes"]) {
       expect(filesystemConfinementRefusal(adapter, confinedDef())).toEqual({

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -32,6 +32,7 @@ import {
   refuseSandbox,
   runSandboxed,
   SANDBOX_CONSOLE_FILE,
+  normalizeWorkspaceOnlyFallback,
   sandboxUnavailableDetail,
   sandboxRequested,
   SandboxUnsupportedError,
@@ -87,26 +88,64 @@ describe("sandboxRequested / refuseSandbox", () => {
 });
 
 describe("workspace-only model admission (#962)", () => {
-  test("an explicit host fallback admits only definitions without their own sandbox policy (#1250)", () => {
-    const runtime = {
-      workspaceOnlyFallback: "host",
-      sandboxAvailability: {
-        available: false,
-        qemu: null,
-        reason: "qemu-system-x86_64 is not on PATH",
-      },
-    };
+  const NO_QEMU = {
+    available: false,
+    qemu: null,
+    node: "/usr/bin/node",
+    nodeVersion: "v22.6.0",
+    sdk: true,
+    reason: "qemu-system-x86_64 is not on PATH",
+  };
+  const allowList = (...agents) => ({
+    workspaceOnlyFallback: { mode: "host", agents },
+    sandboxAvailability: NO_QEMU,
+  });
 
-    expect(workspaceOnlyHostFallback(confinedDef(), runtime)).toBe(true);
+  test("the host fallback admits only agents the policy names (#1250)", () => {
+    const listed = confinedDef({ id: "work-scan", ref: "work-scan@1" });
+    const runtime = allowList("work-scan", "triage-scan");
+
+    expect(workspaceOnlyHostFallback(listed, runtime)).toBe(true);
     for (const adapter of ["agy", "claude", "cursor", "hermes", "pi"]) {
-      expect(
-        filesystemConfinementRefusal(adapter, confinedDef(), runtime),
-      ).toBeNull();
+      expect(filesystemConfinementRefusal(adapter, listed, runtime)).toBeNull();
     }
 
+    // An agent the operator did not name is refused exactly as before, and the
+    // reason names the missing HOST capability rather than the policy shape.
+    const unlisted = confinedDef({ id: "ci-doctor", ref: "ci-doctor@2" });
+    expect(workspaceOnlyHostFallback(unlisted, runtime)).toBe(false);
+    for (const adapter of ["agy", "claude", "cursor", "hermes", "pi"]) {
+      expect(
+        filesystemConfinementRefusal(adapter, unlisted, runtime),
+      ).toMatchObject({
+        code: FILESYSTEM_CONFINEMENT_REASON,
+        detail: expect.stringContaining("sandbox_unavailable:qemu"),
+      });
+    }
+  });
+
+  test("mutating agents never reach the confinement gate (#1250)", () => {
+    const mutating = confinedDef({
+      id: "label-guard",
+      ref: "label-guard@1",
+      mutating: true,
+    });
+    const runtime = allowList("label-guard");
+    expect(workspaceOnlyHostFallback(mutating, runtime)).toBe(false);
+    for (const adapter of ["agy", "claude", "pi"]) {
+      expect(
+        filesystemConfinementRefusal(adapter, mutating, runtime),
+      ).toBeNull();
+    }
+  });
+
+  test("a definition-authored sandbox policy always outranks the allow-list (#1250)", () => {
     const explicitlySandboxed = confinedDef({
+      id: "work-scan",
+      ref: "work-scan@1",
       sandbox: { provider: "gondolin" },
     });
+    const runtime = allowList("work-scan");
     expect(workspaceOnlyHostFallback(explicitlySandboxed, runtime)).toBe(false);
     expect(
       filesystemConfinementRefusal("pi", explicitlySandboxed, runtime),
@@ -114,6 +153,65 @@ describe("workspace-only model admission (#962)", () => {
       code: FILESYSTEM_CONFINEMENT_REASON,
       detail: expect.stringContaining("sandbox_unavailable:qemu"),
     });
+  });
+
+  test("a host that can sandbox never falls back (#1250)", () => {
+    const listed = confinedDef({ id: "work-scan", ref: "work-scan@1" });
+    const runtime = {
+      workspaceOnlyFallback: { mode: "host", agents: ["work-scan"] },
+      sandboxAvailability: { available: true, reason: null },
+    };
+    expect(
+      filesystemConfinementRefusal("claude", listed, runtime),
+    ).toMatchObject({
+      code: FILESYSTEM_CONFINEMENT_REASON,
+      detail: expect.stringContaining("no enforced workspace-only guest path"),
+    });
+  });
+
+  test("normalizeWorkspaceOnlyFallback fails closed on everything but an explicit grant (#1250)", () => {
+    const warn = () => {};
+    for (const value of [
+      undefined,
+      null,
+      "",
+      "HOST",
+      "yes",
+      true,
+      ["work-scan"],
+      { mode: "guest", agents: ["work-scan"] },
+      { mode: "host" },
+      { mode: "host", agents: [] },
+      { mode: "host", agents: [null, ""] },
+    ]) {
+      expect(normalizeWorkspaceOnlyFallback(value, { warn })).toBeNull();
+    }
+    expect(
+      normalizeWorkspaceOnlyFallback(
+        { mode: "host", agents: ["work-scan", 7] },
+        { warn },
+      ),
+    ).toEqual({ mode: "host", agents: ["work-scan"] });
+  });
+
+  test("the legacy blanket string still works but warns loudly (#1250)", () => {
+    const warnings = [];
+    const blanket = normalizeWorkspaceOnlyFallback("host", {
+      warn: (message) => warnings.push(message),
+    });
+    expect(blanket).toEqual({ mode: "host", agents: null });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("EVERY");
+
+    const runtime = {
+      workspaceOnlyFallback: blanket,
+      sandboxAvailability: NO_QEMU,
+    };
+    for (const id of ["work-scan", "some-other-scan"]) {
+      expect(
+        workspaceOnlyHostFallback(confinedDef({ id, ref: `${id}@1` }), runtime),
+      ).toBe(true);
+    }
   });
 
   test("host preflight failures name the missing capability before policy shape (#1250)", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -42,8 +42,10 @@ import { getAgent } from "./registry.mjs";
 import {
   filesystemConfinementRefusal,
   MODEL_BACKED_ADAPTERS,
+  workspaceOnlyHostFallback,
 } from "./adapters/sandboxed.mjs";
 import { isSandboxGuarded } from "./adapters/index.mjs";
+import { preflight as sandboxPreflight } from "./sandbox/gondolin.mjs";
 import { createRun, IllegalTransition, transition } from "./lifecycle.mjs";
 import {
   buildEscalatedContinuationSpec,
@@ -406,6 +408,21 @@ export function policyMaxRunMinutes(root = FACTORY_ROOT) {
       readFileSync(resolveConfigPath("policy", { root }), "utf8"),
     )?.limits?.max_run_minutes;
     return Number.isFinite(value) && value > 0 ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Explicit operator opt-out for workspace-only model confinement. Unknown,
+ * malformed, and absent values all fail closed.
+ */
+export function policyWorkspaceOnlyFallback(root = FACTORY_ROOT) {
+  try {
+    const policy = Bun.YAML.parse(
+      readFileSync(resolveConfigPath("policy", { root }), "utf8"),
+    );
+    return policy?.sandbox?.workspace_only_fallback === "host" ? "host" : null;
   } catch {
     return null;
   }
@@ -2341,6 +2358,7 @@ export async function executeClaimed(
     dispatch,
     resolveLinearKey = resolveLinearApiKey,
     policyRoot = FACTORY_ROOT,
+    sandboxAvailability,
   } = {},
 ) {
   const { runId, attempt, fencingToken, spec } = claim;
@@ -2755,9 +2773,17 @@ export async function executeClaimed(
               filesystem: filesystemIntent,
             },
           };
+    const workspaceOnlyFallback = policyWorkspaceOnlyFallback(policyRoot);
+    const unconfinedWorkspaceOnly =
+      modelRuntimeSelected &&
+      workspaceOnlyHostFallback(confinementDef, { workspaceOnlyFallback });
     const confinementRefusal = modelRuntimeSelected
       ? filesystemConfinementRefusal(adapterKey, confinementDef, {
           sandboxSupport: selectedAdapter?.SANDBOX_SUPPORT ?? null,
+          sandboxAvailability: unconfinedWorkspaceOnly
+            ? null
+            : (sandboxAvailability ?? sandboxPreflight()),
+          workspaceOnlyFallback,
         })
       : null;
     if (confinementRefusal) {
@@ -2776,6 +2802,16 @@ export async function executeClaimed(
         receipt: res?.receipt,
       };
     }
+    const filesystemConfinementReceipt = unconfinedWorkspaceOnly
+      ? {
+          filesystemConfinement: {
+            status: "unconfined",
+            declared: "workspace-only",
+            fallback: "host",
+            source: "policy:sandbox.workspace_only_fallback",
+          },
+        }
+      : null;
 
     if (isWorktree && repoName && ticketId) {
       if (!linearConfigured) {
@@ -3776,6 +3812,7 @@ export async function executeClaimed(
           evidenceSetHash: null,
           journalHead: latestJournalHash(db, runId),
           verificationStatus: "passed",
+          extraReceipt: filesystemConfinementReceipt,
           harnessPins: materializedHarnessPins,
         });
         db.query(
@@ -3875,7 +3912,12 @@ export async function executeClaimed(
         evidenceSetHash: verified.result.evidenceSetHash,
         journalHead: latestJournalHash(db, runId),
         verificationStatus: "passed",
-        extraReceipt: verified.receipt,
+        extraReceipt: filesystemConfinementReceipt
+          ? {
+              ...(verified.receipt ?? {}),
+              ...filesystemConfinementReceipt,
+            }
+          : verified.receipt,
         harnessPins: materializedHarnessPins,
       });
       const { result } = verified;

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -40,8 +40,11 @@ import { artifactsRoot, FACTORY_ROOT, resolveConfigPath } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import {
+  definitionAgentName,
   filesystemConfinementRefusal,
   MODEL_BACKED_ADAPTERS,
+  normalizeWorkspaceOnlyFallback,
+  sandboxUnavailableCapability,
   workspaceOnlyHostFallback,
 } from "./adapters/sandboxed.mjs";
 import { isSandboxGuarded } from "./adapters/index.mjs";
@@ -414,18 +417,40 @@ export function policyMaxRunMinutes(root = FACTORY_ROOT) {
 }
 
 /**
- * Explicit operator opt-out for workspace-only model confinement. Unknown,
- * malformed, and absent values all fail closed.
+ * Explicit operator opt-out for workspace-only model confinement, normalized
+ * to `{ mode: "host", agents: string[]|null }` or `null`. Unknown, malformed,
+ * and absent values all fail closed.
  */
 export function policyWorkspaceOnlyFallback(root = FACTORY_ROOT) {
   try {
     const policy = Bun.YAML.parse(
       readFileSync(resolveConfigPath("policy", { root }), "utf8"),
     );
-    return policy?.sandbox?.workspace_only_fallback === "host" ? "host" : null;
+    return normalizeWorkspaceOnlyFallback(
+      policy?.sandbox?.workspace_only_fallback,
+    );
   } catch {
     return null;
   }
+}
+
+/**
+ * Gondolin's preflight shells out to QEMU and Node, so it must not run per
+ * claim: a host's virtualization capability does not change inside a worker
+ * process. Memoized here (rather than in the sandbox module) because this is
+ * the hot caller.
+ */
+let SANDBOX_PREFLIGHT_CACHE;
+export function cachedSandboxPreflight() {
+  if (SANDBOX_PREFLIGHT_CACHE === undefined) {
+    SANDBOX_PREFLIGHT_CACHE = sandboxPreflight();
+  }
+  return SANDBOX_PREFLIGHT_CACHE;
+}
+
+/** Test seam: forget the memoized host capability report. */
+export function resetSandboxPreflightCache() {
+  SANDBOX_PREFLIGHT_CACHE = undefined;
 }
 
 /**
@@ -2613,6 +2638,13 @@ export async function executeClaimed(
     /* intentionally ignored */
   }
 
+  // The `unconfined` attestation, once admission has decided. Declared here so
+  // that EVERY terminal receipt this execution writes carries it — a refusal
+  // or a failure after an unconfined admission is exactly the record an
+  // auditor needs, so it must not be attached to the success path alone.
+  // Null until admission runs, and null for every confined run.
+  let filesystemConfinementReceipt = null;
+
   const refuseTerminal = (
     reasonCode,
     checks = ["dispatch_gate"],
@@ -2666,6 +2698,7 @@ export async function executeClaimed(
         evidenceSetHash: null,
         journalHead: latestJournalHash(db, runId),
         verificationStatus: "passed",
+        extraReceipt: filesystemConfinementReceipt,
         harnessPins: materializedHarnessPins,
       });
       const result = {
@@ -2774,15 +2807,19 @@ export async function executeClaimed(
             },
           };
     const workspaceOnlyFallback = policyWorkspaceOnlyFallback(policyRoot);
+    const hostSandbox = modelRuntimeSelected
+      ? (sandboxAvailability ?? cachedSandboxPreflight())
+      : null;
+    // The fallback is a *host-capability* escape hatch, never a way to opt an
+    // agent out of a sandbox this machine can actually provide.
     const unconfinedWorkspaceOnly =
       modelRuntimeSelected &&
+      hostSandbox?.available === false &&
       workspaceOnlyHostFallback(confinementDef, { workspaceOnlyFallback });
     const confinementRefusal = modelRuntimeSelected
       ? filesystemConfinementRefusal(adapterKey, confinementDef, {
           sandboxSupport: selectedAdapter?.SANDBOX_SUPPORT ?? null,
-          sandboxAvailability: unconfinedWorkspaceOnly
-            ? null
-            : (sandboxAvailability ?? sandboxPreflight()),
+          sandboxAvailability: hostSandbox,
           workspaceOnlyFallback,
         })
       : null;
@@ -2802,13 +2839,15 @@ export async function executeClaimed(
         receipt: res?.receipt,
       };
     }
-    const filesystemConfinementReceipt = unconfinedWorkspaceOnly
+    filesystemConfinementReceipt = unconfinedWorkspaceOnly
       ? {
           filesystemConfinement: {
             status: "unconfined",
             declared: "workspace-only",
             fallback: "host",
             source: "policy:sandbox.workspace_only_fallback",
+            agent: definitionAgentName(confinementDef),
+            hostCapability: sandboxUnavailableCapability(hostSandbox),
           },
         }
       : null;
@@ -3250,6 +3289,14 @@ export async function executeClaimed(
         // swallow: trace is observability, not correctness
       }
     };
+
+    // FAILED / TIMED_OUT / CANCELLED write no results receipt, so the
+    // unconfined attestation would otherwise exist only for runs that reached
+    // COMPLETED or REFUSED. Recording it on the attempt trace makes the
+    // audit line survive every terminal path.
+    if (filesystemConfinementReceipt) {
+      onTrace("lifecycle", filesystemConfinementReceipt);
+    }
 
     const onUsage = (usage) => {
       attemptUsage = { adapter: adapterKey, ...(usage ?? {}) };

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2011,9 +2011,12 @@ describe("worker", () => {
     mkdirSync(path.join(policyRoot, "config"), { recursive: true });
     writeFileSync(
       path.join(policyRoot, "config", "policy.yaml"),
-      "sandbox:\n  workspace_only_fallback: host\n",
+      "sandbox:\n  workspace_only_fallback:\n    mode: host\n    agents:\n      - factory-status-report\n",
     );
-    expect(policyWorkspaceOnlyFallback(policyRoot)).toBe("host");
+    expect(policyWorkspaceOnlyFallback(policyRoot)).toEqual({
+      mode: "host",
+      agents: ["factory-status-report"],
+    });
 
     const guardedAdapters = createAdapterRegistry({
       builtins: {
@@ -2042,6 +2045,8 @@ describe("worker", () => {
       declared: "workspace-only",
       fallback: "host",
       source: "policy:sandbox.workspace_only_fallback",
+      agent: "factory-status-report",
+      hostCapability: "qemu",
     };
     expect(summary).toMatchObject({
       terminalState: "COMPLETED",
@@ -2054,6 +2059,117 @@ describe("worker", () => {
           .get(spec.runId).receipt_json,
       ).filesystemConfinement,
     ).toEqual(expected);
+  });
+
+  test("an agent the fallback allow-list omits is still refused for the missing host capability (#1250)", async () => {
+    const db = openDb(":memory:");
+    const def = getAgent(registry, "factory-status-report@1");
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "claude", defHash: computeDefHash(def) }),
+    );
+    const policyRoot = freshRoot();
+    mkdirSync(path.join(policyRoot, "config"), { recursive: true });
+    // The stanza exists, but it names a different agent.
+    writeFileSync(
+      path.join(policyRoot, "config", "policy.yaml"),
+      "sandbox:\n  workspace_only_fallback:\n    mode: host\n    agents:\n      - work-scan\n",
+    );
+
+    const guardedAdapters = createAdapterRegistry({
+      builtins: { claude: { ...fake, SANDBOX_SUPPORT: "unsupported" } },
+    }).toMap();
+    const summary = await runOnce(
+      db,
+      registry,
+      guardedAdapters,
+      opts({
+        policyRoot,
+        sandboxAvailability: {
+          available: false,
+          qemu: null,
+          node: null,
+          nodeVersion: null,
+          sdk: false,
+          reason: "qemu-system-x86_64 is not on PATH",
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({ terminalState: "REFUSED" });
+    expect(runState(db, spec.runId)).toBe("REFUSED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toContain(
+      "sandbox_unavailable:qemu",
+    );
+    expect(
+      JSON.parse(
+        db
+          .query(`SELECT receipt_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).receipt_json,
+      ).filesystemConfinement,
+    ).toBeUndefined();
+  });
+
+  test("an unconfined admission is attested on non-receipt terminal paths too (#1250)", async () => {
+    const db = openDb(":memory:");
+    const def = getAgent(registry, "factory-status-report@1");
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "claude",
+        defHash: computeDefHash(def),
+        maxAttempts: 1,
+      }),
+    );
+    const policyRoot = freshRoot();
+    mkdirSync(path.join(policyRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(policyRoot, "config", "policy.yaml"),
+      "sandbox:\n  workspace_only_fallback:\n    mode: host\n    agents:\n      - factory-status-report\n",
+    );
+
+    // FAILED writes no results receipt, so the attestation has to survive on
+    // the attempt trace or it would exist only for runs that completed.
+    const guardedAdapters = createAdapterRegistry({
+      builtins: {
+        claude: {
+          ...fake,
+          SANDBOX_SUPPORT: "unsupported",
+          execute: async () => {
+            throw new Error("adapter blew up");
+          },
+        },
+      },
+    }).toMap();
+    const summary = await runOnce(
+      db,
+      registry,
+      guardedAdapters,
+      opts({
+        policyRoot,
+        sandboxAvailability: {
+          available: false,
+          qemu: null,
+          node: null,
+          nodeVersion: null,
+          sdk: false,
+          reason: "qemu-system-x86_64 is not on PATH",
+        },
+      }),
+    );
+
+    expect(summary.terminalState).toBe("FAILED");
+    const attested = db
+      .query(`SELECT payload_json FROM attempt_trace WHERE run_id = ?`)
+      .all(spec.runId)
+      .map((row) => JSON.parse(row.payload_json))
+      .filter((payload) => payload?.filesystemConfinement);
+    expect(attested).toHaveLength(1);
+    expect(attested[0].filesystemConfinement).toMatchObject({
+      status: "unconfined",
+      agent: "factory-status-report",
+      hostCapability: "qemu",
+    });
   });
 
   test("legacy non-mutating model specs without a definition pin fail closed before using the live definition (#962)", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,4 +1,5 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-worker-test-mjs";
+import "../test-helpers.mjs";
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
@@ -85,6 +86,7 @@ import {
   forceFailRun,
   LEASE_GRACE_SECONDS,
   policyMaxRunMinutes,
+  policyWorkspaceOnlyFallback,
   materializeRunHarness,
   reapExpiredLeases,
   releaseStalledWorkerLease,
@@ -1966,7 +1968,17 @@ describe("worker", () => {
       db,
       registry,
       guardedAdapters,
-      opts({ workspacesRoot }),
+      opts({
+        workspacesRoot,
+        sandboxAvailability: {
+          available: false,
+          qemu: null,
+          node: null,
+          nodeVersion: null,
+          sdk: false,
+          reason: "qemu-system-x86_64 is not on PATH",
+        },
+      }),
     );
 
     expect(summary).toMatchObject({
@@ -1976,6 +1988,9 @@ describe("worker", () => {
     expect(executed).toBe(false);
     expect(readdirSync(workspacesRoot)).toEqual([]);
     expect(runState(db, spec.runId)).toBe("REFUSED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toContain(
+      "sandbox_unavailable:qemu",
+    );
     expect(
       JSON.parse(
         db
@@ -1983,6 +1998,62 @@ describe("worker", () => {
           .get(spec.runId).result_json,
       ).verification,
     ).toEqual({ status: "passed", checks: ["filesystem_confinement"] });
+  });
+
+  test("explicit host fallback runs workspace-only models and attests the unconfined receipt (#1250)", async () => {
+    const db = openDb(":memory:");
+    const def = getAgent(registry, "factory-status-report@1");
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "claude", defHash: computeDefHash(def) }),
+    );
+    const policyRoot = freshRoot();
+    mkdirSync(path.join(policyRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(policyRoot, "config", "policy.yaml"),
+      "sandbox:\n  workspace_only_fallback: host\n",
+    );
+    expect(policyWorkspaceOnlyFallback(policyRoot)).toBe("host");
+
+    const guardedAdapters = createAdapterRegistry({
+      builtins: {
+        claude: { ...fake, SANDBOX_SUPPORT: "unsupported" },
+      },
+    }).toMap();
+    const summary = await runOnce(
+      db,
+      registry,
+      guardedAdapters,
+      opts({
+        policyRoot,
+        sandboxAvailability: {
+          available: false,
+          qemu: null,
+          node: null,
+          nodeVersion: null,
+          sdk: false,
+          reason: "qemu-system-x86_64 is not on PATH",
+        },
+      }),
+    );
+
+    const expected = {
+      status: "unconfined",
+      declared: "workspace-only",
+      fallback: "host",
+      source: "policy:sandbox.workspace_only_fallback",
+    };
+    expect(summary).toMatchObject({
+      terminalState: "COMPLETED",
+      receipt: { filesystemConfinement: expected },
+    });
+    expect(
+      JSON.parse(
+        db
+          .query(`SELECT receipt_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).receipt_json,
+      ).filesystemConfinement,
+    ).toEqual(expected);
   });
 
   test("legacy non-mutating model specs without a definition pin fail closed before using the live definition (#962)", async () => {

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -15,6 +15,7 @@ import { homedir } from "node:os";
 import { ROOT } from "../lib/schedule.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadForge } from "../lib/forge/index.mjs";
+import { fetchRecentSandboxRefusals } from "./watchdog.mjs";
 
 const c = {
   bold: (s) => `\x1b[1m${s}\x1b[0m`,
@@ -77,7 +78,7 @@ export async function gatherPulse({
       web: { ok: false, port: webPort },
       workers: { total: 0, busy: 0, idle: 0, list: [] },
     },
-    runs: { active: [], proposed: 0, byState: {} },
+    runs: { active: [], proposed: 0, byState: {}, sandboxRefusals: [] },
     supply: {
       repo: repoName,
       team: "WM",
@@ -136,17 +137,19 @@ export async function gatherPulse({
   // 3. Status & Workers & Runs from API (if alive)
   if (pulse.stack.api.ok) {
     try {
-      const [statusRes, workersRes, runsRes] = await Promise.all([
-        fetch(`http://${host}:${port}/status`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/workers`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/runs?state=RUNNING`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
-      ]);
+      const [statusRes, workersRes, runsRes, sandboxRefusals] =
+        await Promise.all([
+          fetch(`http://${host}:${port}/status`, {
+            signal: AbortSignal.timeout(3000),
+          }).then((r) => r.json()),
+          fetch(`http://${host}:${port}/workers`, {
+            signal: AbortSignal.timeout(3000),
+          }).then((r) => r.json()),
+          fetch(`http://${host}:${port}/runs?state=RUNNING`, {
+            signal: AbortSignal.timeout(3000),
+          }).then((r) => r.json()),
+          fetchRecentSandboxRefusals({ host, port }),
+        ]);
 
       if (workersRes?.workers) {
         const workers = workersRes.workers;
@@ -181,6 +184,7 @@ export async function gatherPulse({
           updated_at: r.updated_at,
         }));
       }
+      pulse.runs.sandboxRefusals = sandboxRefusals;
     } catch {
       // partial fetch failure handled gracefully
     }
@@ -329,6 +333,15 @@ export function formatPulse(pulse) {
       ? `${workers.total} registered (${c.green(`${workers.busy} busy`)}, ${workers.idle} idle)`
       : c.yellow("0 registered");
   lines.push(`  Workers:         ${workerDetail}`);
+  const sandboxRefusals = pulse.runs.sandboxRefusals ?? [];
+  if (sandboxRefusals.length > 0) {
+    const agents = [...new Set(sandboxRefusals.map((entry) => entry.agent))]
+      .sort()
+      .join(", ");
+    lines.push(
+      `  ${c.red("Scan loops refused: sandbox unavailable")} (${agents})`,
+    );
+  }
   lines.push("");
 
   // In-Flight Runs

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -24,58 +24,63 @@ const c = {
 };
 
 export const SANDBOX_REFUSAL_WINDOW_MS = 60 * 60 * 1000;
-const SCAN_AGENT = /^(?:work-scan|triage-scan|ci-doctor)@\d+$/;
-
-export function isScanLoopAgent(agent) {
-  return typeof agent === "string" && SCAN_AGENT.test(agent);
-}
 
 /**
- * Find recent run refusals caused by a missing Gondolin host capability.
- * Kept as the pure join/filter seam for tests and API consumers that already
- * hold both projections.
+ * Every non-mutating `capabilities.filesystem: "workspace-only"` agent in
+ * event-runtime/agents — i.e. exactly the set the #962 confinement gate can
+ * refuse for a missing host sandbox. Mutating agents (dispatch, label-guard,
+ * ci-notify …) never reach that gate and are deliberately absent.
+ *
+ * Kept as a literal rather than derived from the registry so the watchdog
+ * stays a dependency-light health probe that runs without loading packs;
+ * watchdog.test.mjs re-derives it from event-runtime/agents to keep it honest.
  */
-export function recentSandboxRefusals(
-  journal,
-  runs,
-  { now = Date.now(), windowMs = SANDBOX_REFUSAL_WINDOW_MS } = {},
-) {
-  const agentsByRun = new Map(
-    (runs?.runs ?? [])
-      .filter((run) => isScanLoopAgent(run.agent))
-      .map((run) => [run.runId, run.agent]),
-  );
-  const cutoff = now - windowMs;
-  const seen = new Set();
-  const refusals = [];
-  for (const entry of journal?.entries ?? []) {
-    const observedAt = Date.parse(entry?.at);
-    if (
-      entry?.to !== "REFUSED" ||
-      !agentsByRun.has(entry.runId) ||
-      typeof entry.reason !== "string" ||
-      !entry.reason.includes("sandbox_unavailable:") ||
-      !Number.isFinite(observedAt) ||
-      observedAt < cutoff ||
-      seen.has(entry.runId)
-    ) {
-      continue;
-    }
-    seen.add(entry.runId);
-    refusals.push({
-      runId: entry.runId,
-      agent: agentsByRun.get(entry.runId) ?? "unknown",
-      reason: entry.reason,
-      at: entry.at,
-    });
-  }
-  return refusals;
+export const SCAN_LOOP_AGENTS = Object.freeze([
+  "agy-smoke",
+  "ci-doctor",
+  "ci-log-capture",
+  "cursor-smoke",
+  "disk-diagnose",
+  "factory-status-report",
+  "janitor-scan",
+  "merge-plan",
+  "merge-review",
+  "merge-scan",
+  "pi-smoke",
+  "run-postmortem",
+  "ship-scan",
+  "sweep-scan",
+  "triage-scan",
+  "unblock-digest",
+  "unblock-scan",
+  "work-scan",
+]);
+const SCAN_LOOP_AGENT_SET = new Set(SCAN_LOOP_AGENTS);
+
+/** Match on the bare agent name, ignoring pack namespace and `@version`. */
+export function isScanLoopAgent(agent) {
+  if (typeof agent !== "string" || agent === "") return false;
+  return SCAN_LOOP_AGENT_SET.has(agent.split("@")[0].split("/").pop());
 }
 
+// A health probe must never become the slow thing it is watching. The refusal
+// scan is therefore bounded three ways — pages, runs, and wall clock — so a
+// backlog of thousands of refused runs costs a bounded amount of work on
+// every watchdog tick and every `factory pulse`.
+export const SANDBOX_REFUSAL_MAX_PAGES = 2;
+export const SANDBOX_REFUSAL_MAX_RUNS = 50;
+export const SANDBOX_REFUSAL_DETAIL_CONCURRENCY = 4;
+export const SANDBOX_REFUSAL_BUDGET_MS = 5_000;
+
 /**
- * Read every scan refusal whose terminal transition is inside the alert
- * window. The run API's terminal population is time-bounded server-side, and
- * cursor pagination avoids losing an incident behind fixed collection limits.
+ * Read recent scan refusals caused by a missing host sandbox capability.
+ *
+ * Bounded by construction: at most `SANDBOX_REFUSAL_MAX_PAGES` listing pages,
+ * at most `SANDBOX_REFUSAL_MAX_RUNS` detail fetches, at most
+ * `SANDBOX_REFUSAL_DETAIL_CONCURRENCY` of those in flight, and the whole
+ * thing abandons what it has not read once `budgetMs` elapses. The result is
+ * an alert signal, not an inventory: seeing *some* refusals is enough to
+ * raise it, so truncation cannot produce a false "all clear".
  */
 export async function fetchRecentSandboxRefusals({
   host = "127.0.0.1",
@@ -83,52 +88,72 @@ export async function fetchRecentSandboxRefusals({
   fetchFn = fetch,
   now = Date.now(),
   windowMs = SANDBOX_REFUSAL_WINDOW_MS,
+  maxPages = SANDBOX_REFUSAL_MAX_PAGES,
+  maxRuns = SANDBOX_REFUSAL_MAX_RUNS,
+  concurrency = SANDBOX_REFUSAL_DETAIL_CONCURRENCY,
+  budgetMs = SANDBOX_REFUSAL_BUDGET_MS,
+  clock = () => Date.now(),
 } = {}) {
+  const deadline = clock() + budgetMs;
+  const outOfBudget = () => clock() >= deadline;
   const runs = [];
   const seenCursors = new Set();
   let before = null;
-  do {
+  for (let page = 0; page < maxPages; page += 1) {
+    if (runs.length >= maxRuns || outOfBudget()) break;
     const url = new URL(`http://${host}:${port}/runs`);
     url.searchParams.set("state", "REFUSED");
     url.searchParams.set("population", "terminal");
     url.searchParams.set("from", new Date(now - windowMs).toISOString());
     url.searchParams.set("to", new Date(now + 1_000).toISOString());
-    url.searchParams.set("limit", "200");
+    url.searchParams.set("limit", String(maxRuns));
     if (before) url.searchParams.set("before", before);
-    const page = await fetchFn(url, {
+    const body = await fetchFn(url, {
       signal: AbortSignal.timeout(3000),
     }).then((response) => response.json());
-    runs.push(...(page?.runs ?? []).filter((run) => isScanLoopAgent(run.agent)));
-    before = page?.nextBefore ?? null;
-    if (before && seenCursors.has(before)) break;
-    if (before) seenCursors.add(before);
-  } while (before);
+    for (const run of body?.runs ?? []) {
+      if (!isScanLoopAgent(run.agent)) continue;
+      runs.push(run);
+      if (runs.length >= maxRuns) break;
+    }
+    before = body?.nextBefore ?? null;
+    if (!before || seenCursors.has(before)) break;
+    seenCursors.add(before);
+  }
 
-  const details = await Promise.all(
-    runs.map(async (run) => {
-      const detail = await fetchFn(
-        `http://${host}:${port}/runs/${encodeURIComponent(run.runId)}`,
-        { signal: AbortSignal.timeout(3000) },
-      ).then((response) => response.json());
-      const refusal = [...(detail?.lifecycle ?? [])]
-        .reverse()
-        .find(
-          (entry) =>
-            entry?.to_state === "REFUSED" &&
-            typeof entry.reason === "string" &&
-            entry.reason.includes("sandbox_unavailable:"),
-        );
-      return refusal
-        ? {
-            runId: run.runId,
-            agent: run.agent,
-            reason: refusal.reason,
-            at: refusal.at,
-          }
-        : null;
-    }),
+  const refusals = [];
+  let next = 0;
+  const readOne = async (run) => {
+    const detail = await fetchFn(
+      `http://${host}:${port}/runs/${encodeURIComponent(run.runId)}`,
+      { signal: AbortSignal.timeout(3000) },
+    ).then((response) => response.json());
+    const refusal = [...(detail?.lifecycle ?? [])]
+      .reverse()
+      .find(
+        (entry) =>
+          entry?.to_state === "REFUSED" &&
+          typeof entry.reason === "string" &&
+          entry.reason.includes("sandbox_unavailable:"),
+      );
+    if (refusal) {
+      refusals.push({
+        runId: run.runId,
+        agent: run.agent,
+        reason: refusal.reason,
+        at: refusal.at,
+      });
+    }
+  };
+  const worker = async () => {
+    while (next < runs.length && !outOfBudget()) {
+      await readOne(runs[next++]);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, runs.length) }, worker),
   );
-  return details.filter(Boolean);
+  return refusals;
 }
 
 export async function runWatchdogCheck({

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -23,6 +23,114 @@ const c = {
   red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
 
+export const SANDBOX_REFUSAL_WINDOW_MS = 60 * 60 * 1000;
+const SCAN_AGENT = /^(?:work-scan|triage-scan|ci-doctor)@\d+$/;
+
+export function isScanLoopAgent(agent) {
+  return typeof agent === "string" && SCAN_AGENT.test(agent);
+}
+
+/**
+ * Find recent run refusals caused by a missing Gondolin host capability.
+ * Kept as the pure join/filter seam for tests and API consumers that already
+ * hold both projections.
+ */
+export function recentSandboxRefusals(
+  journal,
+  runs,
+  { now = Date.now(), windowMs = SANDBOX_REFUSAL_WINDOW_MS } = {},
+) {
+  const agentsByRun = new Map(
+    (runs?.runs ?? [])
+      .filter((run) => isScanLoopAgent(run.agent))
+      .map((run) => [run.runId, run.agent]),
+  );
+  const cutoff = now - windowMs;
+  const seen = new Set();
+  const refusals = [];
+  for (const entry of journal?.entries ?? []) {
+    const observedAt = Date.parse(entry?.at);
+    if (
+      entry?.to !== "REFUSED" ||
+      !agentsByRun.has(entry.runId) ||
+      typeof entry.reason !== "string" ||
+      !entry.reason.includes("sandbox_unavailable:") ||
+      !Number.isFinite(observedAt) ||
+      observedAt < cutoff ||
+      seen.has(entry.runId)
+    ) {
+      continue;
+    }
+    seen.add(entry.runId);
+    refusals.push({
+      runId: entry.runId,
+      agent: agentsByRun.get(entry.runId) ?? "unknown",
+      reason: entry.reason,
+      at: entry.at,
+    });
+  }
+  return refusals;
+}
+
+/**
+ * Read every scan refusal whose terminal transition is inside the alert
+ * window. The run API's terminal population is time-bounded server-side, and
+ * cursor pagination avoids losing an incident behind fixed collection limits.
+ */
+export async function fetchRecentSandboxRefusals({
+  host = "127.0.0.1",
+  port = 7381,
+  fetchFn = fetch,
+  now = Date.now(),
+  windowMs = SANDBOX_REFUSAL_WINDOW_MS,
+} = {}) {
+  const runs = [];
+  const seenCursors = new Set();
+  let before = null;
+  do {
+    const url = new URL(`http://${host}:${port}/runs`);
+    url.searchParams.set("state", "REFUSED");
+    url.searchParams.set("population", "terminal");
+    url.searchParams.set("from", new Date(now - windowMs).toISOString());
+    url.searchParams.set("to", new Date(now + 1_000).toISOString());
+    url.searchParams.set("limit", "200");
+    if (before) url.searchParams.set("before", before);
+    const page = await fetchFn(url, {
+      signal: AbortSignal.timeout(3000),
+    }).then((response) => response.json());
+    runs.push(...(page?.runs ?? []).filter((run) => isScanLoopAgent(run.agent)));
+    before = page?.nextBefore ?? null;
+    if (before && seenCursors.has(before)) break;
+    if (before) seenCursors.add(before);
+  } while (before);
+
+  const details = await Promise.all(
+    runs.map(async (run) => {
+      const detail = await fetchFn(
+        `http://${host}:${port}/runs/${encodeURIComponent(run.runId)}`,
+        { signal: AbortSignal.timeout(3000) },
+      ).then((response) => response.json());
+      const refusal = [...(detail?.lifecycle ?? [])]
+        .reverse()
+        .find(
+          (entry) =>
+            entry?.to_state === "REFUSED" &&
+            typeof entry.reason === "string" &&
+            entry.reason.includes("sandbox_unavailable:"),
+        );
+      return refusal
+        ? {
+            runId: run.runId,
+            agent: run.agent,
+            reason: refusal.reason,
+            at: refusal.at,
+          }
+        : null;
+    }),
+  );
+  return details.filter(Boolean);
+}
+
 export async function runWatchdogCheck({
   host = "127.0.0.1",
   port = 7381,
@@ -38,6 +146,7 @@ export async function runWatchdogCheck({
     runningRuns: 0,
     wedgedRuns: 0,
     queuedRuns: 0,
+    sandboxRefusals: [],
     anomalies: [],
   };
 
@@ -84,17 +193,19 @@ export async function runWatchdogCheck({
 
   // 3. Workers & Runs Status from API
   try {
-    const [statusRes, workersRes, runningRes] = await Promise.all([
-      fetch(`http://${host}:${port}/status`, {
-        signal: AbortSignal.timeout(3000),
-      }).then((r) => r.json()),
-      fetch(`http://${host}:${port}/workers`, {
-        signal: AbortSignal.timeout(3000),
-      }).then((r) => r.json()),
-      fetch(`http://${host}:${port}/runs?state=RUNNING`, {
-        signal: AbortSignal.timeout(3000),
-      }).then((r) => r.json()),
-    ]);
+    const [statusRes, workersRes, runningRes, sandboxRefusals] =
+      await Promise.all([
+        fetch(`http://${host}:${port}/status`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/workers`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/runs?state=RUNNING`, {
+          signal: AbortSignal.timeout(3000),
+        }).then((r) => r.json()),
+        fetchRecentSandboxRefusals({ host, port }),
+      ]);
 
     const workers = workersRes?.workers ?? [];
     metrics.workersCount = workers.length;
@@ -130,6 +241,17 @@ export async function runWatchdogCheck({
     }
 
     metrics.queuedRuns = statusRes?.runs?.byState?.QUEUED ?? 0;
+    metrics.sandboxRefusals = sandboxRefusals;
+    if (metrics.sandboxRefusals.length > 0) {
+      const agents = [
+        ...new Set(metrics.sandboxRefusals.map((entry) => entry.agent)),
+      ].sort();
+      issues.push({
+        severity: "CRITICAL",
+        code: "SCAN_SANDBOX_UNAVAILABLE",
+        message: `Scan loops refused: sandbox unavailable (${agents.join(", ")})`,
+      });
+    }
     const idleWorkers = workers.filter((w) => w.state === "idle").length;
     if (
       metrics.queuedRuns > 0 &&

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -1,9 +1,14 @@
 import { test, expect } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
 import {
   fetchRecentSandboxRefusals,
   formatWatchdogReport,
-  recentSandboxRefusals,
+  isScanLoopAgent,
   runWatchdogCheck,
+  SANDBOX_REFUSAL_MAX_PAGES,
+  SANDBOX_REFUSAL_MAX_RUNS,
+  SCAN_LOOP_AGENTS,
 } from "./watchdog.mjs";
 
 test("formatWatchdogReport formats clean watchdog status", () => {
@@ -61,51 +66,110 @@ test("formatWatchdogReport formats critical issues", () => {
   expect(formatted).toContain("WEB_DOWN");
 });
 
-test("recentSandboxRefusals joins recent typed journal entries to agents", () => {
-  const now = Date.parse("2026-08-29T20:00:00Z");
-  const refusals = recentSandboxRefusals(
-    {
-      entries: [
-        {
-          runId: "run_recent",
-          to: "REFUSED",
-          reason:
-            "work-scan@1: sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH",
-          at: "2026-08-29T19:45:00Z",
-        },
-        {
-          runId: "run_old",
-          to: "REFUSED",
-          reason: "sandbox_unavailable:qemu",
-          at: "2026-08-29T18:00:00Z",
-        },
-        {
-          runId: "run_other",
-          to: "REFUSED",
-          reason: "permission_denied",
-          at: "2026-08-29T19:50:00Z",
-        },
-      ],
-    },
-    {
-      runs: [
-        { runId: "run_recent", agent: "work-scan@1" },
-        { runId: "run_old", agent: "triage-scan@1" },
-        { runId: "run_other", agent: "factory-status-report@1" },
-      ],
-    },
-    { now },
-  );
+test("SCAN_LOOP_AGENTS is exactly the set the confinement gate can refuse", () => {
+  // Derive from the shipped definitions: a new non-mutating workspace-only
+  // agent must be added here, or its refusals go unnoticed the way #1250's
+  // did with a three-agent hardcoded regex.
+  const agentsDir = path.join(import.meta.dir, "..", "event-runtime", "agents");
+  const derived = readdirSync(agentsDir)
+    .filter((file) => file.endsWith(".json") && !file.includes(".view."))
+    .map((file) => JSON.parse(readFileSync(path.join(agentsDir, file), "utf8")))
+    .filter(
+      (def) =>
+        def?.mutating === false &&
+        def?.capabilities?.filesystem === "workspace-only",
+    )
+    .map((def) => def.id)
+    .sort();
 
-  expect(refusals).toEqual([
-    {
-      runId: "run_recent",
-      agent: "work-scan@1",
-      reason:
-        "work-scan@1: sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH",
-      at: "2026-08-29T19:45:00Z",
-    },
-  ]);
+  expect([...SCAN_LOOP_AGENTS].sort()).toEqual(derived);
+  expect(isScanLoopAgent("work-scan@1")).toBe(true);
+  expect(isScanLoopAgent("acme/work-scan@1")).toBe(true);
+  expect(isScanLoopAgent("dispatch@1")).toBe(false);
+  expect(isScanLoopAgent("label-guard@1")).toBe(false);
+  expect(isScanLoopAgent(undefined)).toBe(false);
+});
+
+test("fetchRecentSandboxRefusals is bounded in pages, runs, and wall clock", async () => {
+  const listings = [];
+  let details = 0;
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const fetchFn = async (input) => {
+    const url = new URL(input);
+    if (url.pathname.startsWith("/runs/")) {
+      details += 1;
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await Bun.sleep(1);
+      inFlight -= 1;
+      return Response.json({
+        lifecycle: [
+          {
+            to_state: "REFUSED",
+            reason: "work-scan@1: sandbox_unavailable:qemu",
+            at: "2026-08-29T19:50:00Z",
+          },
+        ],
+      });
+    }
+    listings.push(url);
+    // An unbounded scan would follow this cursor forever.
+    return Response.json({
+      runs: Array.from({ length: 400 }, (_, index) => ({
+        runId: `run_${listings.length}_${index}`,
+        agent: "work-scan@1",
+      })),
+      nextBefore: `page-${listings.length + 1}`,
+    });
+  };
+
+  const refusals = await fetchRecentSandboxRefusals({ fetchFn });
+
+  expect(listings.length).toBeLessThanOrEqual(SANDBOX_REFUSAL_MAX_PAGES);
+  expect(listings[0].searchParams.get("limit")).toBe(
+    String(SANDBOX_REFUSAL_MAX_RUNS),
+  );
+  expect(details).toBe(SANDBOX_REFUSAL_MAX_RUNS);
+  expect(refusals).toHaveLength(SANDBOX_REFUSAL_MAX_RUNS);
+  expect(peakInFlight).toBeLessThanOrEqual(4);
+});
+
+test("fetchRecentSandboxRefusals abandons the scan when its time budget is spent", async () => {
+  let clock = 0;
+  const fetchFn = async (input) => {
+    const url = new URL(input);
+    clock += 100;
+    if (url.pathname.startsWith("/runs/")) {
+      return Response.json({
+        lifecycle: [
+          {
+            to_state: "REFUSED",
+            reason: "work-scan@1: sandbox_unavailable:qemu",
+            at: "2026-08-29T19:50:00Z",
+          },
+        ],
+      });
+    }
+    return Response.json({
+      runs: [
+        { runId: "run_a", agent: "work-scan@1" },
+        { runId: "run_b", agent: "work-scan@1" },
+        { runId: "run_c", agent: "work-scan@1" },
+      ],
+      nextBefore: null,
+    });
+  };
+
+  // Budget covers the listing plus one detail read; the rest is abandoned
+  // rather than allowed to run long on a busy box.
+  const refusals = await fetchRecentSandboxRefusals({
+    fetchFn,
+    budgetMs: 150,
+    concurrency: 1,
+    clock: () => clock,
+  });
+  expect(refusals).toHaveLength(1);
 });
 
 test("fetchRecentSandboxRefusals paginates the terminal window and ignores non-scan agents", async () => {
@@ -126,9 +190,9 @@ test("fetchRecentSandboxRefusals paginates the terminal window and ignores non-s
     }
     if (!url.searchParams.has("before")) {
       return Response.json({
-        runs: Array.from({ length: 200 }, (_, index) => ({
+        runs: Array.from({ length: 40 }, (_, index) => ({
           runId: `run_other_${index}`,
-          agent: "factory-status-report@1",
+          agent: "dispatch@1",
         })),
         nextBefore: "page-2",
       });

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { formatWatchdogReport, runWatchdogCheck } from "./watchdog.mjs";
+import {
+  fetchRecentSandboxRefusals,
+  formatWatchdogReport,
+  recentSandboxRefusals,
+  runWatchdogCheck,
+} from "./watchdog.mjs";
 
 test("formatWatchdogReport formats clean watchdog status", () => {
   const cleanResult = {
@@ -54,6 +59,160 @@ test("formatWatchdogReport formats critical issues", () => {
   expect(formatted).toContain("WEDGED_RUN");
   expect(formatted).toContain("[WARNING]");
   expect(formatted).toContain("WEB_DOWN");
+});
+
+test("recentSandboxRefusals joins recent typed journal entries to agents", () => {
+  const now = Date.parse("2026-08-29T20:00:00Z");
+  const refusals = recentSandboxRefusals(
+    {
+      entries: [
+        {
+          runId: "run_recent",
+          to: "REFUSED",
+          reason:
+            "work-scan@1: sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH",
+          at: "2026-08-29T19:45:00Z",
+        },
+        {
+          runId: "run_old",
+          to: "REFUSED",
+          reason: "sandbox_unavailable:qemu",
+          at: "2026-08-29T18:00:00Z",
+        },
+        {
+          runId: "run_other",
+          to: "REFUSED",
+          reason: "permission_denied",
+          at: "2026-08-29T19:50:00Z",
+        },
+      ],
+    },
+    {
+      runs: [
+        { runId: "run_recent", agent: "work-scan@1" },
+        { runId: "run_old", agent: "triage-scan@1" },
+        { runId: "run_other", agent: "factory-status-report@1" },
+      ],
+    },
+    { now },
+  );
+
+  expect(refusals).toEqual([
+    {
+      runId: "run_recent",
+      agent: "work-scan@1",
+      reason:
+        "work-scan@1: sandbox_unavailable:qemu — qemu-system-x86_64 is not on PATH",
+      at: "2026-08-29T19:45:00Z",
+    },
+  ]);
+});
+
+test("fetchRecentSandboxRefusals paginates the terminal window and ignores non-scan agents", async () => {
+  const requests = [];
+  const fetchFn = async (input) => {
+    const url = new URL(input);
+    requests.push(url);
+    if (url.pathname === "/runs/run_scan") {
+      return Response.json({
+        lifecycle: [
+          {
+            to_state: "REFUSED",
+            reason: "ci-doctor@2: sandbox_unavailable:qemu",
+            at: "2026-08-29T19:50:00Z",
+          },
+        ],
+      });
+    }
+    if (!url.searchParams.has("before")) {
+      return Response.json({
+        runs: Array.from({ length: 200 }, (_, index) => ({
+          runId: `run_other_${index}`,
+          agent: "factory-status-report@1",
+        })),
+        nextBefore: "page-2",
+      });
+    }
+    return Response.json({
+      runs: [{ runId: "run_scan", agent: "ci-doctor@2" }],
+      nextBefore: null,
+    });
+  };
+
+  await expect(
+    fetchRecentSandboxRefusals({
+      fetchFn,
+      now: Date.parse("2026-08-29T20:00:00Z"),
+    }),
+  ).resolves.toEqual([
+    {
+      runId: "run_scan",
+      agent: "ci-doctor@2",
+      reason: "ci-doctor@2: sandbox_unavailable:qemu",
+      at: "2026-08-29T19:50:00Z",
+    },
+  ]);
+  expect(requests.filter((url) => url.pathname === "/runs")).toHaveLength(2);
+  expect(requests[0].searchParams.get("population")).toBe("terminal");
+  expect(requests[1].searchParams.get("before")).toBe("page-2");
+});
+
+test("runWatchdogCheck surfaces sandbox-unavailable scan refusals", async () => {
+  const at = new Date().toISOString();
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/health") return Response.json({ ok: true });
+      if (url.pathname === "/status") {
+        return Response.json({ runs: { byState: {} }, anomalies: {} });
+      }
+      if (url.pathname === "/workers") {
+        return Response.json({
+          workers: [{ workerId: "worker_1", state: "idle" }],
+        });
+      }
+      if (url.pathname === "/runs/run_scan") {
+        return Response.json({
+          lifecycle: [
+            {
+              to_state: "REFUSED",
+              reason: "work-scan@1: sandbox_unavailable:qemu",
+              at,
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/runs") {
+        return Response.json(
+          url.searchParams.get("state") === "REFUSED"
+            ? {
+                runs: [{ runId: "run_scan", agent: "work-scan@1" }],
+                nextBefore: null,
+              }
+            : { runs: [] },
+        );
+      }
+      return new Response("ok");
+    },
+  });
+
+  try {
+    const result = await runWatchdogCheck({
+      port: server.port,
+      webPort: server.port,
+      checkShadowFleet: false,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.metrics.sandboxRefusals).toHaveLength(1);
+    expect(result.issues).toContainEqual({
+      severity: "CRITICAL",
+      code: "SCAN_SANDBOX_UNAVAILABLE",
+      message: "Scan loops refused: sandbox unavailable (work-scan@1)",
+    });
+  } finally {
+    server.stop(true);
+  }
 });
 
 test("runWatchdogCheck detects unreachable API as critical", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1250

Review the explicit audited host fallback and enable it only until #1259 installs Gondolin/QEMU.

## Post-review — narrowed from a switch to an allow-list

The first round exposed one policy key that turned filesystem confinement off for **every** workspace-only agent at once. That breadth is gone.

- `sandbox.workspace_only_fallback` is now an object: `{ mode: host, agents: [...] }`. The operator writes down exactly which agents they accept running unconfined; every agent not named is refused precisely as before, with the reason naming the missing **host capability** (`sandbox_unavailable:qemu`), not the policy shape.
- The grant applies **only** on a host whose Gondolin preflight fails. A host that can sandbox never falls back, whatever the allow-list says.
- A definition that carries its own `sandbox:` block is never eligible — an authored policy always outranks the instance fallback.
- Mutating agents never reach the gate and are unaffected.
- Everything unknown, malformed, or empty fails closed — including `mode: host` with an empty `agents:` list, which grants nobody.
- The legacy bare string `workspace_only_fallback: host` is still accepted for instances configured before this landed. It means "all workspace-only agents", is documented as such, and logs a loud warning on every claim.

**Nothing is enabled by default.** `config/policy.example.yaml` ships the stanza commented out; enabling it requires the operator/orchestrator to add it to the instance-local `config/policy.yaml` and restart the workers.

Also in this round:

- The `unconfined` attestation is attached at **every** terminal receipt write (COMPLETED, both REFUSED paths), and — because FAILED / TIMED_OUT / CANCELLED write no receipt at all — the same object is recorded on the attempt trace, so no terminal path loses the audit line. It now also carries `agent` and `hostCapability`.
- `fetchRecentSandboxRefusals` (watchdog + pulse) is bounded three ways: ≤2 listing pages, ≤50 refused runs, ≤4 concurrent detail fetches, and a 5 s wall-clock budget after which it returns what it has. A health probe must not become the slow thing it is watching.
- `SCAN_AGENT`'s three-agent regex is replaced by `SCAN_LOOP_AGENTS`, the full set of 18 non-mutating workspace-only agents; a test re-derives it from `event-runtime/agents/*.json` so a new scan agent cannot silently go unmonitored. Namespaced and versioned refs match.
- The dead `recentSandboxRefusals` export (test-only, no production caller) is removed.
- `sandboxPreflight()` spawned QEMU and Node on every claim; it is now memoized per worker process via `cachedSandboxPreflight()`.

## Enabling the scan loops on the operator runner

```yaml
sandbox:
  workspace_only_fallback:
    mode: host
    agents:
      - work-scan
      - triage-scan
      - ci-doctor
```

## Handoff

| Check | Command | Result |
| --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/adapters/sandboxed.test.mjs event-runtime/lib/worker.test.mjs orchestrator/watchdog.test.mjs --timeout 20000` | **pass** — 220 pass, 1 skip, 0 fail (221 across 3 files) |
| Repo gate (tests) | `bun test event-runtime/lib --timeout 20000` | **pass** — 1864 pass, 10 skip, 0 fail (1874 across 95 files) |
| Repo gate (emit) | `bun build/emit.mjs --check` | **pass** — `ok — 94 generated files match shared/` |
| Repo check | `bun run check` | **pass** — exit 0 |
| Formatting | `npx prettier --check 'orchestrator/*.mjs' 'event-runtime/lib/**/*.mjs'` | **pass** — All matched files use Prettier code style |

New tests: allow-listed agent admitted unconfined with the receipt; unlisted agent refused naming the host capability; mutating agents unaffected; definition-authored sandbox outranks the allow-list; an available host never falls back; `normalizeWorkspaceOnlyFallback` fails closed on 11 malformed inputs; the blanket string warns loudly; the attestation survives the FAILED path on the attempt trace; the refusal scan is bounded in pages/runs/concurrency and abandons work when its budget is spent; `SCAN_LOOP_AGENTS` matches the shipped definitions.

All changes are inside the ticket's 9 Owned Paths.

UX critique: skipped — infrastructure/runtime policy change with no user-facing surface.
